### PR TITLE
Fix CI: complete hook→claim rename

### DIFF
--- a/docs/tutorials/progression.md
+++ b/docs/tutorials/progression.md
@@ -5,8 +5,8 @@ Internal reference — what each tutorial unlocks and what it requires.
 | Tut | Problem | Config added | Prompts | Infrastructure used |
 |-----|---------|--------------|---------|---------------------|
 | 01 | Context loss kills progress | `[workspace]`, `[[agents]]` | one-shot | beads, session, reconciler |
-| 02 | Named agents for different jobs | Multiple `[[agents]]` | mayor, worker | agent hook (assign to named agent) |
-| 03 | Hand-feeding tasks one at a time | — | loop | hook (atomic self-claim via ready queue) |
+| 02 | Named agents for different jobs | Multiple `[[agents]]` | mayor, worker | agent claim (assign to named agent) |
+| 03 | Hand-feeding tasks one at a time | — | loop | claim (atomic self-claim via ready queue) |
 | 04 | One agent too slow | More `[[agents]]` entries | — | — (just config + existing hooks) |
 | 06 | Restart from scratch on multi-step work | `[formulas]` | — | formula parser, molecules (bead DAG) |
 | 07 | Reusable formulas with specific context | `gc mol create --on` | — | attached molecules, Store.Update |

--- a/internal/session/tmux/adapter_test.go
+++ b/internal/session/tmux/adapter_test.go
@@ -35,9 +35,9 @@ func TestProvider_StartStopIsRunning(t *testing.T) {
 		t.Fatal("session should be running after Start")
 	}
 
-	// Duplicate start should fail.
-	if err := p.Start(name, session.Config{}); err == nil {
-		t.Fatal("expected error on duplicate Start")
+	// Duplicate start is idempotent (zombie detection sees healthy session).
+	if err := p.Start(name, session.Config{}); err != nil {
+		t.Fatalf("duplicate Start should be idempotent: %v", err)
 	}
 
 	if err := p.Stop(name); err != nil {

--- a/test/agents/loop.sh
+++ b/test/agents/loop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Bash agent: loop worker.
 # Implements the same flow as prompts/loop.md using gc CLI commands.
-# Continuously drains the backlog: check hook → claim from ready → close → repeat.
+# Continuously drains the backlog: check claim → claim from ready → close → repeat.
 #
 # Required env vars (set by gc start):
 #   GC_AGENT — this agent's name
@@ -12,7 +12,7 @@ set -euo pipefail
 cd "$GC_CITY"
 
 while true; do
-    # Step 1: Check hook for already-assigned work
+    # Step 1: Check for already-claimed work
     hooked=$(gc agent claimed "$GC_AGENT" 2>/dev/null || true)
 
     if echo "$hooked" | grep -q "^ID:"; then
@@ -28,8 +28,8 @@ while true; do
     if echo "$ready" | grep -q "^gc-"; then
         # Step 4: Claim the first available bead
         id=$(echo "$ready" | grep "^gc-" | head -1 | awk '{print $1}')
-        gc agent hook "$GC_AGENT" "$id" 2>/dev/null || true
-        # Will process on next iteration (now on hook)
+        gc agent claim "$GC_AGENT" "$id" 2>/dev/null || true
+        # Will process on next iteration (now claimed)
         continue
     fi
 

--- a/test/integration/tutorial01_test.go
+++ b/test/integration/tutorial01_test.go
@@ -192,16 +192,16 @@ func TestTutorial01_BashAgent(t *testing.T) {
 		}
 	}
 
-	// Create a bead and hook it to the agent.
+	// Create a bead and claim it for the agent.
 	out, err := gc(cityDir, "bd", "create", "Build a Tower of Hanoi app")
 	if err != nil {
 		t.Fatalf("gc bd create failed: %v\noutput: %s", err, out)
 	}
 	beadID := extractBeadID(t, out)
 
-	out, err = gc(cityDir, "agent", "hook", "mayor", beadID)
+	out, err = gc(cityDir, "agent", "claim", "mayor", beadID)
 	if err != nil {
-		t.Fatalf("gc agent hook failed: %v\noutput: %s", err, out)
+		t.Fatalf("gc agent claim failed: %v\noutput: %s", err, out)
 	}
 
 	// Poll until the bead is closed (agent processed it).

--- a/test/integration/tutorial02_test.go
+++ b/test/integration/tutorial02_test.go
@@ -50,14 +50,14 @@ func TestTutorial02_BashAgent(t *testing.T) {
 	}
 	bobBead := extractBeadID(t, out)
 
-	out, err = gc(cityDir, "agent", "hook", "alice", aliceBead)
+	out, err = gc(cityDir, "agent", "claim", "alice", aliceBead)
 	if err != nil {
-		t.Fatalf("gc agent hook alice failed: %v\noutput: %s", err, out)
+		t.Fatalf("gc agent claim alice failed: %v\noutput: %s", err, out)
 	}
 
-	out, err = gc(cityDir, "agent", "hook", "bob", bobBead)
+	out, err = gc(cityDir, "agent", "claim", "bob", bobBead)
 	if err != nil {
-		t.Fatalf("gc agent hook bob failed: %v\noutput: %s", err, out)
+		t.Fatalf("gc agent claim bob failed: %v\noutput: %s", err, out)
 	}
 
 	// Poll until both beads are closed.

--- a/test/integration/tutorial03_test.go
+++ b/test/integration/tutorial03_test.go
@@ -15,8 +15,8 @@ import (
 // ready queue. The bash script (test/agents/loop.sh) implements
 // prompts/loop.md:
 //
-//  1. Check hook for already-assigned work
-//  2. If nothing on hook, check ready queue
+//  1. Check claim for already-assigned work
+//  2. If nothing claimed, check ready queue
 //  3. Claim first available bead
 //  4. Close it
 //  5. Repeat


### PR DESCRIPTION
## Summary
- Fix integration tests calling `gc agent hook` → `gc agent claim`
- Fix `test/agents/loop.sh` using `gc agent hook` → `gc agent claim`
- Fix tmux adapter test: duplicate Start is now idempotent via zombie detection
- Update docs/tutorials/progression.md terminology

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Lint clean
- [ ] CI integration tests pass (the actual fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)