### PR TITLE
Gastown pack: fall back to repo CLAUDE.md or AGENTS.md for quality-gate guidance

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -148,6 +148,10 @@ func doPrimeWithMode(args []string, stdout, _ io.Writer, hookMode bool) int { //
 		}
 		if ok && a.PromptTemplate != "" {
 			ctx := buildPrimeContext(cityPath, &a, cfg.Rigs)
+			// Resolve provider to get InstructionsFile for quality-gate fallback.
+			if rp, rpErr := config.ResolveProvider(&a, &cfg.Workspace, cfg.Providers, exec.LookPath); rpErr == nil {
+				ctx.InstructionsFile = rp.InstructionsFile
+			}
 			fragments := mergeFragmentLists(cfg.Workspace.GlobalFragments, a.InjectFragments)
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, io.Discard,
 				cfg.PackDirs, fragments, nil)

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -17,18 +17,19 @@ import (
 
 // PromptContext holds template data for prompt rendering.
 type PromptContext struct {
-	CityRoot      string
-	AgentName     string // qualified: "rig/polecat-1" or "mayor"
-	TemplateName  string // config name: "polecat" (pool template) or "mayor" (singleton)
-	RigName       string
-	RigRoot       string
-	WorkDir       string
-	IssuePrefix   string
-	Branch        string
-	DefaultBranch string            // e.g. "main" — from git symbolic-ref origin/HEAD
-	WorkQuery     string            // command to find available work (from Agent.EffectiveWorkQuery)
-	SlingQuery    string            // command template to route work to this agent (from Agent.EffectiveSlingQuery)
-	Env           map[string]string // from Agent.Env — custom vars
+	CityRoot         string
+	AgentName        string // qualified: "rig/polecat-1" or "mayor"
+	TemplateName     string // config name: "polecat" (pool template) or "mayor" (singleton)
+	RigName          string
+	RigRoot          string
+	WorkDir          string
+	IssuePrefix      string
+	Branch           string
+	DefaultBranch    string            // e.g. "main" — from git symbolic-ref origin/HEAD
+	WorkQuery        string            // command to find available work (from Agent.EffectiveWorkQuery)
+	SlingQuery       string            // command template to route work to this agent (from Agent.EffectiveSlingQuery)
+	InstructionsFile string            // provider-specific instructions file (e.g. "CLAUDE.md", "AGENTS.md")
+	Env              map[string]string // from Agent.Env — custom vars
 }
 
 // renderPrompt reads a prompt template file and renders it with the given
@@ -53,7 +54,7 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	raw := string(data)
 
 	tmpl := template.New("prompt").
-		Funcs(promptFuncMap(cityName, sessionTemplate, store)).
+		Funcs(promptFuncMap(cityName, sessionTemplate, store, fs)).
 		Option("missingkey=zero")
 
 	// Load shared templates from pack dirs (lower priority).
@@ -150,6 +151,7 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["DefaultBranch"] = ctx.DefaultBranch
 	m["WorkQuery"] = ctx.WorkQuery
 	m["SlingQuery"] = ctx.SlingQuery
+	m["InstructionsFile"] = ctx.InstructionsFile
 	return m
 }
 
@@ -178,8 +180,9 @@ func defaultBranchFor(dir string) string {
 // promptFuncMap returns template functions available in prompt templates.
 // sessionTemplate is the custom session naming template (empty = default).
 // store is used by the "session" function to look up bead-derived session
-// names; nil falls back to legacy naming.
-func promptFuncMap(cityName, sessionTemplate string, store beads.Store) template.FuncMap {
+// names; nil falls back to legacy naming. pfs is used by the quality_gates
+// function to read the repo instructions file; pass nil to use the real FS.
+func promptFuncMap(cityName, sessionTemplate string, store beads.Store, pfs fsys.FS) template.FuncMap {
 	return template.FuncMap{
 		"cmd": func() string {
 			return filepath.Base(os.Args[0])
@@ -191,5 +194,78 @@ func promptFuncMap(cityName, sessionTemplate string, store beads.Store) template
 			_, name := config.ParseQualifiedName(qualifiedName)
 			return name
 		},
+		"quality_gates": qualityGatesFunc(pfs),
 	}
+}
+
+// qualityGatesFunc returns a template function that extracts the
+// "Code quality gates" section from a repo's instructions file
+// (CLAUDE.md, AGENTS.md, etc.). The returned function takes workDir
+// and instructionsFile as arguments. Returns empty string if the file
+// doesn't exist or has no quality-gates section.
+func qualityGatesFunc(pfs fsys.FS) func(string, string) string {
+	return func(workDir, instructionsFile string) string {
+		if workDir == "" || instructionsFile == "" {
+			return ""
+		}
+		filePath := filepath.Join(workDir, instructionsFile)
+		var data []byte
+		var err error
+		if pfs != nil {
+			data, err = pfs.ReadFile(filePath)
+		} else {
+			data, err = os.ReadFile(filePath)
+		}
+		if err != nil {
+			return ""
+		}
+		return extractQualityGates(string(data))
+	}
+}
+
+// extractQualityGates finds and returns the "Code quality gates" section
+// from a markdown file. It looks for a heading containing "quality gate"
+// (case-insensitive) and returns everything up to the next heading of the
+// same or higher level. Returns empty string if no such section exists.
+func extractQualityGates(content string) string {
+	lines := strings.Split(content, "\n")
+	var start int
+	var level int
+	found := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !found {
+			// Look for a heading containing "quality gate".
+			if isMarkdownHeading(trimmed) && strings.Contains(strings.ToLower(trimmed), "quality gate") {
+				level = headingLevel(trimmed)
+				start = i + 1
+				found = true
+			}
+			continue
+		}
+		// Found start — look for end (next heading of same or higher level).
+		if isMarkdownHeading(trimmed) && headingLevel(trimmed) <= level {
+			return strings.TrimSpace(strings.Join(lines[start:i], "\n"))
+		}
+	}
+	if found {
+		return strings.TrimSpace(strings.Join(lines[start:], "\n"))
+	}
+	return ""
+}
+
+// isMarkdownHeading returns true if the line starts with one or more '#'.
+func isMarkdownHeading(line string) bool {
+	return len(line) > 0 && line[0] == '#'
+}
+
+// headingLevel returns the heading level (number of leading '#' chars).
+func headingLevel(line string) int {
+	for i, ch := range line {
+		if ch != '#' {
+			return i
+		}
+	}
+	return len(line)
 }

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -466,6 +466,287 @@ func TestRenderPromptGlobalAndPerAgent(t *testing.T) {
 	}
 }
 
+func TestExtractQualityGates(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "no quality gates section",
+			content: "# README\n\nSome text.\n",
+			want:    "",
+		},
+		{
+			name: "h2 quality gates section",
+			content: `# Project
+
+## Code quality gates
+
+- go test ./...
+- go vet ./...
+
+## Next section
+
+Other stuff.
+`,
+			want: "- go test ./...\n- go vet ./...",
+		},
+		{
+			name: "h3 quality gates section",
+			content: `## Development
+
+### Quality Gates
+
+Run tests before merging.
+
+### Other
+`,
+			want: "Run tests before merging.",
+		},
+		{
+			name: "quality gates at end of file",
+			content: `# Project
+
+## Quality gate checks
+
+` + "```bash\nmake test\nmake lint\n```",
+			want: "```bash\nmake test\nmake lint\n```",
+		},
+		{
+			name: "case insensitive match",
+			content: "## QUALITY GATES\n\nRun all tests.\n\n## Other\n",
+			want:    "Run all tests.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractQualityGates(tt.content)
+			if got != tt.want {
+				t.Errorf("extractQualityGates() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQualityGatesFuncWithFakeFS(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/work/CLAUDE.md"] = []byte(`# Project
+
+## Code quality gates
+
+- go test ./...
+- go vet ./...
+
+## Other
+`)
+	fn := qualityGatesFunc(f)
+	got := fn("/work", "CLAUDE.md")
+	want := "- go test ./...\n- go vet ./..."
+	if got != want {
+		t.Errorf("quality_gates() = %q, want %q", got, want)
+	}
+}
+
+func TestQualityGatesFuncMissingFile(t *testing.T) {
+	f := fsys.NewFake()
+	fn := qualityGatesFunc(f)
+	got := fn("/work", "CLAUDE.md")
+	if got != "" {
+		t.Errorf("quality_gates(missing) = %q, want empty", got)
+	}
+}
+
+func TestQualityGatesFuncEmptyArgs(t *testing.T) {
+	fn := qualityGatesFunc(nil)
+	if got := fn("", "CLAUDE.md"); got != "" {
+		t.Errorf("quality_gates(empty workdir) = %q, want empty", got)
+	}
+	if got := fn("/work", ""); got != "" {
+		t.Errorf("quality_gates(empty file) = %q, want empty", got)
+	}
+}
+
+func TestQualityGatesTemplateFunction(t *testing.T) {
+	f := fsys.NewFake()
+	// Instructions file in the work directory.
+	f.Files["/work/CLAUDE.md"] = []byte(`# Dev Guide
+
+## Code quality gates
+
+- make test
+- make lint
+
+## Architecture
+`)
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(
+		`Gates: {{ quality_gates .WorkDir .InstructionsFile }}`)
+	ctx := PromptContext{
+		WorkDir:          "/work",
+		InstructionsFile: "CLAUDE.md",
+	}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	if !strings.Contains(got, "make test") {
+		t.Errorf("quality_gates in template = %q, want to contain 'make test'", got)
+	}
+}
+
+func TestQualityGatesTemplateFallback(t *testing.T) {
+	f := fsys.NewFake()
+	// No instructions file — quality_gates returns empty, template should handle gracefully.
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(
+		`{{ $g := quality_gates .WorkDir .InstructionsFile }}{{ if $g }}{{ $g }}{{ else }}default gates{{ end }}`)
+	ctx := PromptContext{
+		WorkDir:          "/work",
+		InstructionsFile: "CLAUDE.md",
+	}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	if got != "default gates" {
+		t.Errorf("fallback = %q, want %q", got, "default gates")
+	}
+}
+
+func TestQualityGatesProviderAware(t *testing.T) {
+	f := fsys.NewFake()
+	// AGENTS.md has different quality gates than CLAUDE.md.
+	f.Files["/work/AGENTS.md"] = []byte(`# Project
+
+## Quality gates
+
+- npm test
+- npm run lint
+
+## Other
+`)
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(
+		`{{ quality_gates .WorkDir .InstructionsFile }}`)
+	ctx := PromptContext{
+		WorkDir:          "/work",
+		InstructionsFile: "AGENTS.md",
+	}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	if !strings.Contains(got, "npm test") {
+		t.Errorf("AGENTS.md gates = %q, want to contain 'npm test'", got)
+	}
+}
+
+func TestBuildTemplateDataInstructionsFile(t *testing.T) {
+	ctx := PromptContext{
+		InstructionsFile: "CLAUDE.md",
+	}
+	data := buildTemplateData(ctx)
+	if data["InstructionsFile"] != "CLAUDE.md" {
+		t.Errorf("InstructionsFile = %q, want %q", data["InstructionsFile"], "CLAUDE.md")
+	}
+}
+
+func TestQualityGatesSharedTemplateWithRepoFallback(t *testing.T) {
+	f := fsys.NewFake()
+	// Shared quality-gates template that mirrors the real one.
+	f.Files["/city/prompts/shared/quality-gates.md.tmpl"] = []byte(
+		`{{ define "quality-gates" -}}
+{{ $gates := quality_gates .WorkDir .InstructionsFile -}}
+{{ if $gates -}}
+{{ $gates }}
+{{ else -}}
+go test ./...
+golangci-lint run ./...
+{{ end -}}
+{{ end -}}`)
+	// Main template uses the shared quality-gates template.
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(
+		`Quality gates:
+{{ template "quality-gates" . }}`)
+	// Repo CLAUDE.md with quality gates section.
+	f.Files["/work/CLAUDE.md"] = []byte(`# Project
+
+## Code quality gates
+
+- npm test
+- npm run lint
+
+## Other
+`)
+	ctx := PromptContext{
+		WorkDir:          "/work",
+		InstructionsFile: "CLAUDE.md",
+	}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	// Should use the repo's quality gates, not the hardcoded defaults.
+	if !strings.Contains(got, "npm test") {
+		t.Errorf("expected repo quality gates, got: %q", got)
+	}
+	if strings.Contains(got, "golangci-lint") {
+		t.Errorf("should NOT contain hardcoded defaults when repo gates exist, got: %q", got)
+	}
+}
+
+func TestQualityGatesSharedTemplateDefaultFallback(t *testing.T) {
+	f := fsys.NewFake()
+	// Shared quality-gates template.
+	f.Files["/city/prompts/shared/quality-gates.md.tmpl"] = []byte(
+		`{{ define "quality-gates" -}}
+{{ $gates := quality_gates .WorkDir .InstructionsFile -}}
+{{ if $gates -}}
+{{ $gates }}
+{{ else -}}
+go test ./...
+golangci-lint run ./...
+{{ end -}}
+{{ end -}}`)
+	// Main template uses the shared quality-gates template.
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(
+		`Quality gates:
+{{ template "quality-gates" . }}`)
+	// No instructions file exists — should fall back to hardcoded defaults.
+	ctx := PromptContext{
+		WorkDir:          "/work",
+		InstructionsFile: "CLAUDE.md",
+	}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	if !strings.Contains(got, "golangci-lint") {
+		t.Errorf("expected hardcoded defaults when no repo gates, got: %q", got)
+	}
+}
+
+func TestQualityGatesSharedTemplateNoQualitySection(t *testing.T) {
+	f := fsys.NewFake()
+	// Shared quality-gates template.
+	f.Files["/city/prompts/shared/quality-gates.md.tmpl"] = []byte(
+		`{{ define "quality-gates" -}}
+{{ $gates := quality_gates .WorkDir .InstructionsFile -}}
+{{ if $gates -}}
+{{ $gates }}
+{{ else -}}
+go test ./...
+golangci-lint run ./...
+{{ end -}}
+{{ end -}}`)
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(
+		`{{ template "quality-gates" . }}`)
+	// AGENTS.md exists but has no quality gates section.
+	f.Files["/work/AGENTS.md"] = []byte(`# Project
+
+## Getting Started
+
+Just run it.
+`)
+	ctx := PromptContext{
+		WorkDir:          "/work",
+		InstructionsFile: "AGENTS.md",
+	}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	// No quality gates section in AGENTS.md → should fall back to defaults.
+	if !strings.Contains(got, "golangci-lint") {
+		t.Errorf("expected defaults when no quality section in AGENTS.md, got: %q", got)
+	}
+}
+
 func TestMergeFragmentLists(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -148,17 +148,18 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if resolved.PromptMode != "none" {
 		fragments := mergeFragmentLists(p.globalFragments, cfgAgent.InjectFragments)
 		prompt = renderPrompt(p.fs, p.cityPath, p.cityName, cfgAgent.PromptTemplate, PromptContext{
-			CityRoot:      p.cityPath,
-			AgentName:     qualifiedName,
-			TemplateName:  cfgAgent.Name,
-			RigName:       rigName,
-			RigRoot:       rigRoot,
-			WorkDir:       workDir,
-			IssuePrefix:   findRigPrefix(rigName, p.rigs),
-			DefaultBranch: defaultBranchFor(workDir),
-			WorkQuery:     cfgAgent.EffectiveWorkQuery(),
-			SlingQuery:    cfgAgent.EffectiveSlingQuery(),
-			Env:           cfgAgent.Env,
+			CityRoot:         p.cityPath,
+			AgentName:        qualifiedName,
+			TemplateName:     cfgAgent.Name,
+			RigName:          rigName,
+			RigRoot:          rigRoot,
+			WorkDir:          workDir,
+			IssuePrefix:      findRigPrefix(rigName, p.rigs),
+			DefaultBranch:    defaultBranchFor(workDir),
+			WorkQuery:        cfgAgent.EffectiveWorkQuery(),
+			SlingQuery:       cfgAgent.EffectiveSlingQuery(),
+			InstructionsFile: resolved.InstructionsFile,
+			Env:              cfgAgent.Env,
 		}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
 		hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name)
 		beacon := runtime.FormatBeaconAt(p.cityName, qualifiedName, !hasHooks, p.beaconTime)

--- a/examples/gastown/packs/gastown/prompts/crew.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/crew.md.tmpl
@@ -319,10 +319,7 @@ you are!" - that is a FAILURE. YOU must push, not the user.
    ```
 
 2. **Run quality gates** (only if code changes were made):
-   ```bash
-   go test ./...             # or: make test
-   golangci-lint run ./...   # or: make lint
-   ```
+   {{ template "quality-gates" . }}
    File P0 beads if quality gates are broken.
 
 3. **Update beads** - close finished work, update status:

--- a/examples/gastown/packs/gastown/prompts/shared/quality-gates.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/shared/quality-gates.md.tmpl
@@ -1,0 +1,13 @@
+{{ define "quality-gates" -}}
+{{ $gates := quality_gates .WorkDir .InstructionsFile -}}
+{{ if $gates -}}
+{{ $gates }}
+{{ else -}}
+Before considering any task complete, run quality gates:
+
+```bash
+go test ./...             # or: make test
+golangci-lint run ./...   # or: make lint
+```
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
## Summary

- When pack-specific quality-gate guidance is missing or empty, agents now fall back to the repo's own instructions file (CLAUDE.md for Claude, AGENTS.md for other providers) instead of effectively skipping quality gates
- Adds `quality_gates` template function that extracts the quality-gates section from the provider-specific instructions file
- Creates shared `quality-gates.md.tmpl` template in the Gastown pack with hardcoded defaults as final fallback
- Wires `InstructionsFile` from the resolved provider through `PromptContext` into template data

## Test plan

- [x] `extractQualityGates` parses markdown headings correctly (6 subtests)
- [x] `quality_gates` function reads from fake FS, handles missing files and empty args
- [x] Template integration: function in templates, fallback behavior, provider awareness (CLAUDE.md vs AGENTS.md)
- [x] Shared template integration: repo fallback, default fallback, no-quality-section case
- [x] All existing prompt tests pass unchanged
- [x] Full `go test ./...` and `go vet ./...` clean

Closes w-d4dba7b056

🤖 Generated with [Claude Code](https://claude.com/claude-code)