### PR TITLE
feat(copilot): prompt flag fix + ACP provider support

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -129,6 +129,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 		command = command + " " + shellquote.Join(defaultArgs)
 	}
+	if cfgAgent.Session == "acp" && len(resolved.ACPArgs) > 0 {
+		command = command + " " + shellquote.Join(resolved.ACPArgs)
+	}
 	if sa := settingsArgs(p.cityPath, resolved.Name); sa != "" {
 		command = command + " " + sa
 		settingsFile, relDst := claudeSettingsSource(p.cityPath)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -419,6 +419,7 @@ ProviderSpec defines a named provider's startup parameters.
 | `env` | map[string]string |  |  | Env sets additional environment variables for the provider process. |
 | `path_check` | string |  |  | PathCheck overrides the binary name used for PATH detection. When set, lookupProvider and detectProviderName use this instead of Command for exec.LookPath checks. Useful when Command is a shell wrapper (e.g. sh -c '...') but we need to verify the real binary is installed. |
 | `supports_acp` | boolean |  |  | SupportsACP indicates the binary speaks the Agent Client Protocol (JSON-RPC 2.0 over stdio). When an agent sets session = "acp", its resolved provider must have SupportsACP = true. |
+| `acp_args` | []string |  |  | ACPArgs are extra command-line arguments appended when session = "acp". Example: ["--acp"] (copilot). Providers that auto-detect ACP mode (e.g., Claude via pipe detection) leave this empty. |
 | `supports_hooks` | boolean |  |  | SupportsHooks indicates the provider has an executable hook mechanism (settings.json, plugins, etc.) for lifecycle events. |
 | `instructions_file` | string |  |  | InstructionsFile is the filename the provider reads for project instructions (e.g., "CLAUDE.md", "AGENTS.md"). Empty defaults to "AGENTS.md". |
 | `resume_flag` | string |  |  | ResumeFlag is the CLI flag for resuming a session by ID. Empty means the provider does not support resume. Examples: "--resume" (claude), "resume" (codex) |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1398,6 +1398,13 @@
           "type": "boolean",
           "description": "SupportsACP indicates the binary speaks the Agent Client Protocol\n(JSON-RPC 2.0 over stdio). When an agent sets session = \"acp\",\nits resolved provider must have SupportsACP = true."
         },
+        "acp_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ACPArgs are extra command-line arguments appended when session = \"acp\".\nExample: [\"--acp\"] (copilot). Providers that auto-detect ACP mode\n(e.g., Claude via pipe detection) leave this empty."
+        },
         "supports_hooks": {
           "type": "boolean",
           "description": "SupportsHooks indicates the provider has an executable hook mechanism\n(settings.json, plugins, etc.) for lifecycle events."

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -456,6 +456,14 @@ func deepMergeProvider(base, frag ProviderSpec, name string, fragMeta toml.MetaD
 		result.Args = make([]string, len(frag.Args))
 		copy(result.Args, frag.Args)
 	}
+	if fragMeta.IsDefined("providers", name, "acp_args") {
+		if len(base.ACPArgs) > 0 {
+			prov.Warnings = append(prov.Warnings,
+				fmt.Sprintf("provider %q.acp_args redefined by %q", name, fragPath))
+		}
+		result.ACPArgs = make([]string, len(frag.ACPArgs))
+		copy(result.ACPArgs, frag.ACPArgs)
+	}
 	if fragMeta.IsDefined("providers", name, "process_names") {
 		if len(base.ProcessNames) > 0 {
 			prov.Warnings = append(prov.Warnings,

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -405,7 +405,7 @@ func BuiltinProviders() map[string]ProviderSpec {
 			ReadyDelayMs:      5000,
 			ProcessNames:      []string{"copilot"},
 			SupportsACP:       true,
-			ACPArgs:           []string{"--acp"},
+			ACPArgs:           []string{"--acp", "--stdio"},
 			SupportsHooks:     true,
 			InstructionsFile:  "AGENTS.md",
 			ResumeFlag:        "--resume",

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -398,7 +398,6 @@ func BuiltinProviders() map[string]ProviderSpec {
 		"copilot": {
 			DisplayName:       "GitHub Copilot",
 			Command:           "copilot",
-			Args:              []string{"--yolo"},
 			PromptMode:        "flag",
 			PromptFlag:        "--prompt",
 			ReadyPromptPrefix: "\u276f ", // ❯

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -394,7 +394,8 @@ func BuiltinProviders() map[string]ProviderSpec {
 			DisplayName:       "GitHub Copilot",
 			Command:           "copilot",
 			Args:              []string{"--yolo"},
-			PromptMode:        "arg",
+			PromptMode:        "flag",
+			PromptFlag:        "--prompt",
 			ReadyPromptPrefix: "\u276f ", // ❯
 			ReadyDelayMs:      5000,
 			ProcessNames:      []string{"copilot"},

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -56,6 +56,10 @@ type ProviderSpec struct {
 	// (JSON-RPC 2.0 over stdio). When an agent sets session = "acp",
 	// its resolved provider must have SupportsACP = true.
 	SupportsACP bool `toml:"supports_acp,omitempty"`
+	// ACPArgs are extra command-line arguments appended when session = "acp".
+	// Example: ["--acp"] (copilot). Providers that auto-detect ACP mode
+	// (e.g., Claude via pipe detection) leave this empty.
+	ACPArgs []string `toml:"acp_args,omitempty"`
 	// SupportsHooks indicates the provider has an executable hook mechanism
 	// (settings.json, plugins, etc.) for lifecycle events.
 	SupportsHooks bool `toml:"supports_hooks,omitempty"`
@@ -121,6 +125,7 @@ type ResolvedProvider struct {
 	EmitsPermissionWarning bool
 	Env                    map[string]string
 	SupportsACP            bool
+	ACPArgs                []string
 	SupportsHooks          bool
 	InstructionsFile       string
 	ResumeFlag             string
@@ -399,8 +404,31 @@ func BuiltinProviders() map[string]ProviderSpec {
 			ReadyPromptPrefix: "\u276f ", // ❯
 			ReadyDelayMs:      5000,
 			ProcessNames:      []string{"copilot"},
+			SupportsACP:       true,
+			ACPArgs:           []string{"--acp"},
 			SupportsHooks:     true,
 			InstructionsFile:  "AGENTS.md",
+			ResumeFlag:        "--resume",
+			ResumeStyle:       "flag",
+			PermissionModes: map[string]string{
+				"unrestricted": "--yolo",
+			},
+			OptionsSchema: []ProviderOption{
+				{
+					Key: "permission_mode", Label: "Permission Mode", Type: "select",
+					Default: "unrestricted",
+					Choices: []OptionChoice{
+						{Value: "unrestricted", Label: "Unrestricted", FlagArgs: []string{"--yolo"}},
+					},
+				},
+				{
+					Key: "model", Label: "Model", Type: "select",
+					Default: "",
+					Choices: []OptionChoice{
+						{Value: "", Label: "Default", FlagArgs: nil},
+					},
+				},
+			},
 		},
 		"amp": {
 			DisplayName:      "Sourcegraph AMP",

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -197,6 +197,9 @@ func MergeProviderOverBuiltin(base, city ProviderSpec) ProviderSpec {
 	if city.Args != nil {
 		result.Args = city.Args
 	}
+	if city.ACPArgs != nil {
+		result.ACPArgs = city.ACPArgs
+	}
 	if city.ProcessNames != nil {
 		result.ProcessNames = city.ProcessNames
 	}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -304,6 +304,11 @@ func specToResolved(name string, spec *ProviderSpec) *ResolvedProvider {
 		copy(rp.Args, spec.Args)
 	}
 
+	if len(spec.ACPArgs) > 0 {
+		rp.ACPArgs = make([]string, len(spec.ACPArgs))
+		copy(rp.ACPArgs, spec.ACPArgs)
+	}
+
 	// Strip schema-managed flags from Args. This handles backward compatibility:
 	// if a city.toml still has schema-managed flags in args (e.g.,
 	// --dangerously-skip-permissions), they get removed because the option is

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -837,6 +837,7 @@ func TestMergeProviderOverBuiltinFieldSync(t *testing.T) {
 		OptionsSchema:          []ProviderOption{{Key: "model"}},
 		PrintArgs:              []string{"-p"},
 		TitleModel:             "haiku",
+		ACPArgs:                []string{"--acp"},
 	}
 
 	// Verify every field on city is non-zero (catches new fields not added to test data).

--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -24,7 +24,7 @@ import (
 
 // Config holds ACP provider settings.
 type Config struct {
-	HandshakeTimeout  time.Duration // default 30s
+	HandshakeTimeout  time.Duration // default 60s
 	NudgeBusyTimeout  time.Duration // default 60s
 	OutputBufferLines int           // default 1000
 }

--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -31,7 +31,7 @@ type Config struct {
 
 func (c *Config) handshakeTimeout() time.Duration {
 	if c.HandshakeTimeout <= 0 {
-		return 30 * time.Second
+		return 60 * time.Second
 	}
 	return c.HandshakeTimeout
 }
@@ -262,7 +262,7 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 	hsTimeoutCtx, hsTimeoutCancel := context.WithTimeout(hsCtx, p.cfg.handshakeTimeout())
 	defer hsTimeoutCancel()
 
-	if err := p.handshake(hsTimeoutCtx, sc); err != nil {
+	if err := p.handshake(hsTimeoutCtx, sc, cfg.WorkDir); err != nil {
 		// Handshake failed — kill the process. The monitor goroutine
 		// handles listener/socket cleanup when the process exits.
 		_ = stdinPipe.Close()
@@ -299,8 +299,10 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 	return nil
 }
 
-// handshake performs the ACP initialize → initialized → session/new sequence.
-func (p *Provider) handshake(ctx context.Context, sc *sessionConn) error {
+// handshake performs the ACP initialize → session/new sequence.
+// Note: no "initialized" notification is sent — ACP does not require it
+// (unlike MCP), and strict implementations like Copilot ignore or reject it.
+func (p *Provider) handshake(ctx context.Context, sc *sessionConn, workDir string) error {
 	// Step 1: Send "initialize" request.
 	initReq, _ := newInitializeRequest()
 	ch, err := sc.sendRequest(initReq)
@@ -321,13 +323,10 @@ func (p *Provider) handshake(ctx context.Context, sc *sessionConn) error {
 		return fmt.Errorf("process exited during initialize")
 	}
 
-	// Step 2: Send "initialized" notification.
-	if err := sc.sendNotification(newInitializedNotification()); err != nil {
-		return fmt.Errorf("sending initialized: %w", err)
-	}
-
-	// Step 3: Send "session/new" request.
-	newReq, _ := newSessionNewRequest()
+	// Step 2: Send "session/new" request with cwd and empty mcpServers.
+	// Copilot requires both fields; it fetches available models during this
+	// call which can take several seconds.
+	newReq, _ := newSessionNewRequest(workDir)
 	ch, err = sc.sendRequest(newReq)
 	if err != nil {
 		return fmt.Errorf("sending session/new: %w", err)

--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -64,9 +64,23 @@ type ServerInfo struct {
 	Version string `json:"version,omitempty"`
 }
 
+// ClientCapabilities advertises client-side capabilities in the initialize request.
+type ClientCapabilities struct {
+	FS       *FileSystemCapabilities `json:"fs,omitempty"`
+	Terminal bool                    `json:"terminal,omitempty"`
+}
+
+// FileSystemCapabilities describes client filesystem support.
+type FileSystemCapabilities struct {
+	ReadTextFile  bool `json:"readTextFile,omitempty"`
+	WriteTextFile bool `json:"writeTextFile,omitempty"`
+}
+
 // InitializeParams is the params for the "initialize" request.
 type InitializeParams struct {
-	ClientInfo ClientInfo `json:"clientInfo"`
+	ProtocolVersion    int                 `json:"protocolVersion"`
+	ClientInfo         ClientInfo          `json:"clientInfo"`
+	ClientCapabilities *ClientCapabilities `json:"clientCapabilities,omitempty"`
 }
 
 // InitializeResult is the result of the "initialize" request.
@@ -123,7 +137,15 @@ func newNotification(method string) JSONRPCMessage {
 // newInitializeRequest creates an "initialize" request.
 func newInitializeRequest() (JSONRPCMessage, int64) {
 	return newRequest("initialize", InitializeParams{
-		ClientInfo: ClientInfo{Name: "gc", Version: "1.0"},
+		ProtocolVersion: 1,
+		ClientInfo:      ClientInfo{Name: "gc", Version: "1.0"},
+		ClientCapabilities: &ClientCapabilities{
+			Terminal: true,
+			FS: &FileSystemCapabilities{
+				ReadTextFile:  true,
+				WriteTextFile: true,
+			},
+		},
 	})
 }
 

--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -88,6 +88,20 @@ type InitializeResult struct {
 	ServerInfo ServerInfo `json:"serverInfo"`
 }
 
+// SessionNewParams is the params for the "session/new" request.
+// Both cwd and mcpServers are required by strict ACP implementations (e.g. Copilot).
+type SessionNewParams struct {
+	Cwd        string      `json:"cwd"`
+	MCPServers []MCPServer `json:"mcpServers"`
+}
+
+// MCPServer describes an MCP server to inject into the session.
+type MCPServer struct {
+	Name    string   `json:"name"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
 // SessionNewResult is the result of the "session/new" request.
 type SessionNewResult struct {
 	SessionID string `json:"sessionId"`
@@ -154,9 +168,13 @@ func newInitializedNotification() JSONRPCMessage {
 	return newNotification("initialized")
 }
 
-// newSessionNewRequest creates a "session/new" request.
-func newSessionNewRequest() (JSONRPCMessage, int64) {
-	return newRequest("session/new", nil)
+// newSessionNewRequest creates a "session/new" request with the given working directory.
+// mcpServers is always sent as an array (empty if none) — Copilot requires both fields.
+func newSessionNewRequest(cwd string) (JSONRPCMessage, int64) {
+	return newRequest("session/new", SessionNewParams{
+		Cwd:        cwd,
+		MCPServers: []MCPServer{},
+	})
 }
 
 // newSessionPromptRequest creates a "session/prompt" request from

--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -155,10 +155,6 @@ func newInitializeRequest() (JSONRPCMessage, int64) {
 		ClientInfo:      ClientInfo{Name: "gc", Version: "1.0"},
 		ClientCapabilities: &ClientCapabilities{
 			Terminal: true,
-			FS: &FileSystemCapabilities{
-				ReadTextFile:  true,
-				WriteTextFile: true,
-			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

Brings the built-in Copilot provider to parity with Claude as a first-class ACP provider in Gas City.

## Changes

### Fix: `--prompt` flag delivery

The Copilot provider was configured with `prompt_mode = "arg"`, passing prompts as bare positional arguments. Copilot CLI expects `--prompt <text>` instead.

Upstream already has all the runtime/adapter/template plumbing for `PromptFlag` delivery — this commit just sets the correct values on the copilot built-in:

- **provider.go**: Switch copilot from `PromptMode: "arg"` → `PromptMode: "flag"`, `PromptFlag: "--prompt"`

### Feat: ACP support for Copilot

- **provider.go**: Add `SupportsACP: true`, `ACPArgs: ["--acp", "--stdio"]`, `ResumeFlag`, `ResumeStyle`, `PermissionModes`, `OptionsSchema` to copilot builtin; add `ACPArgs []string` field to `ProviderSpec` and `ResolvedProvider`
- **compose.go**: Handle `acp_args` slice merging in `deepMergeProvider`
- **resolve.go**: Copy `ACPArgs` in `specToResolved`
- **template_resolve.go**: Append `ACPArgs` to command when `session = "acp"`

### Fix: ACP protocol correctness for Copilot

- **`--stdio` flag**: `copilot --acp` alone starts a TCP server; `--stdio` switches it to JSON-RPC over stdin/stdout (required for Gas City's pipe-based adapter)
- **`protocolVersion`**: Added integer field (`1`) to `InitializeParams` — omitting it causes `-32603 Internal error: expected number, received undefined`
- **`session/new` params**: Copilot requires both `cwd` (string) and `mcpServers` (array); added `SessionNewParams` + `MCPServer` structs and wired `workDir` through to the handshake
- **Removed `initialized` notification**: Gas City was sending an MCP lifecycle notification between `initialize` and `session/new`; not part of the ACP spec, Copilot hangs on it
- **Handshake timeout**: Bumped default from 30s → 60s; Copilot fetches available models from the GitHub API during `session/new` (~5s)

## Testing

```
go test ./internal/config/ ./internal/runtime/... ./cmd/gc/
```

Verified end-to-end: `gc session new` with `session = "acp"` successfully starts a Copilot ACP process and transitions to `awake`.

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #672 — adds first-class Copilot ACP provider support plus the correct `--prompt` flag delivery, one of the non-Claude runtime-parity findings this audit-tracker issue asks to be converted into linked work.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
