### PR TITLE
fix: simplify Homebrew install to one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ to your `city.toml`.
 Install from Homebrew:
 
 ```bash
-brew tap gastownhall/gascity
-brew install gascity
+brew install gastownhall/gascity/gascity
 gc version
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,8 +26,7 @@ exactly, start there.
 Homebrew:
 
 ```bash
-brew tap gastownhall/gascity
-brew install --cask gascity
+brew install gastownhall/gascity/gascity
 gc version
 ```
 


### PR DESCRIPTION
## Summary
- Replace two-step `brew tap` + `brew install` with single `brew install gastownhall/gascity/gascity` (auto-taps)
- Fix `installation.md` which incorrectly used `--cask` (goreleaser produces a formula, not a cask)

## Test plan
- [ ] Verify `brew install gastownhall/gascity/gascity` works on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)