### PR TITLE
fix: city providers inherit built-in defaults when command matches

### DIFF
--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -126,8 +126,13 @@ func lookupProvider(name string, cityProviders map[string]ProviderSpec, lookPath
 
 // mergeProviderOverBuiltin layers city-level provider fields over a built-in
 // base. Non-zero city fields override; zero-value fields inherit the built-in
-// defaults. Slice fields (Args, ACPArgs, ProcessNames) replace entirely when
-// non-nil. Env merges additively (city keys override base keys).
+// defaults. Slice fields (Args, ProcessNames, OptionsSchema) replace entirely
+// when non-nil. Map fields (Env, PermissionModes) merge additively (city keys
+// override base keys).
+//
+// Note: booleans are one-directional (can enable, not disable) due to TOML
+// zero-value ambiguity — city providers cannot override a built-in's true
+// to false for EmitsPermissionWarning, SupportsACP, or SupportsHooks.
 func mergeProviderOverBuiltin(base, city ProviderSpec) ProviderSpec {
 	result := base
 

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -773,5 +774,64 @@ func TestResolveProviderResumeCommandAgentOverride(t *testing.T) {
 	// ResumeFlag should still be set from builtin (not cleared by ResumeCommand).
 	if rp.ResumeFlag != "--resume" {
 		t.Errorf("ResumeFlag = %q, want %q (builtin preserved)", rp.ResumeFlag, "--resume")
+	}
+}
+
+// --- mergeProviderOverBuiltin field sync ---
+
+// TestMergeProviderOverBuiltinFieldSync uses reflection to verify that
+// mergeProviderOverBuiltin handles every field on ProviderSpec. When a
+// new field is added to ProviderSpec, the merge function must be updated
+// or this test will fail.
+//
+// Approach: set every ProviderSpec field to a non-zero value on the city
+// side, merge over a zero-value base, and verify no field remains at its
+// zero value. This catches fields that were added to the struct but not
+// wired into the merge function.
+func TestMergeProviderOverBuiltinFieldSync(t *testing.T) {
+	city := ProviderSpec{
+		DisplayName:            "Custom",
+		Command:                "custom-cmd",
+		Args:                   []string{"--flag"},
+		PromptMode:             "flag",
+		PromptFlag:             "--prompt",
+		ReadyDelayMs:           5000,
+		ReadyPromptPrefix:      "$ ",
+		ProcessNames:           []string{"custom"},
+		EmitsPermissionWarning: true,
+		Env:                    map[string]string{"K": "V"},
+		PathCheck:              "custom-bin",
+		SupportsACP:            true,
+		SupportsHooks:          true,
+		InstructionsFile:       "CUSTOM.md",
+		ResumeFlag:             "--resume",
+		ResumeStyle:            "flag",
+		ResumeCommand:          "custom-cmd --resume {{.SessionKey}}",
+		SessionIDFlag:          "--session-id",
+		PermissionModes:        map[string]string{"yolo": "--yolo"},
+		OptionsSchema:          []ProviderOption{{Key: "model"}},
+	}
+
+	// Verify every field on city is non-zero (catches new fields not added to test data).
+	cv := reflect.ValueOf(city)
+	ct := cv.Type()
+	for i := 0; i < ct.NumField(); i++ {
+		f := ct.Field(i)
+		if cv.Field(i).IsZero() {
+			t.Errorf("ProviderSpec field %q is zero in test city data — add it to the test", f.Name)
+		}
+	}
+
+	// Merge city over a zero-value base.
+	base := ProviderSpec{}
+	result := mergeProviderOverBuiltin(base, city)
+
+	// Every field on the result should be non-zero (city values should propagate).
+	rv := reflect.ValueOf(result)
+	for i := 0; i < ct.NumField(); i++ {
+		f := ct.Field(i)
+		if rv.Field(i).IsZero() {
+			t.Errorf("mergeProviderOverBuiltin did not propagate field %q from city to result", f.Name)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

When a city-level provider tier like `[providers.fast]` defines `command = "copilot"` with custom args, it loses all built-in provider metadata (PromptMode, PromptFlag, ReadyDelayMs, ReadyPromptPrefix, SupportsACP, etc.).

This causes copilot provider tiers to pass prompts as positional arguments (`PromptMode` defaults to `"arg"`) instead of using the `--prompt` flag, making agents crash on startup with:

```
error: too many arguments. Expected 0 arguments but got 1.
```

## Fix

In `lookupProvider()`, when a city-level provider's `Command` matches a built-in provider name, the built-in spec is used as a base with city fields layered on top via `mergeProviderOverBuiltin()`.

**Merge semantics:**
- Scalar fields: city overrides if non-zero, otherwise inherits built-in
- Slice fields (Args, ProcessNames): city replaces entirely if non-nil
- Map fields (Env, PermissionModes): merge additively, city keys win

## Testing

Added tests for:
- `TestLookupProviderCityInheritsBuiltin` — verifies inheritance of PromptMode, ReadyDelayMs, etc.
- `TestLookupProviderCityOverridesInheritedField` — verifies city can override inherited fields
- `TestLookupProviderCityNoMergeForUnknownCommand` — verifies no merge for non-builtin commands
- `TestMergeProviderOverBuiltin` — unit test for the merge function