### PR TITLE
fix: ship default overlays for example packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ coverage.txt
 *.test
 .beads/
 .claude/
+!examples/gastown/packs/gastown/overlays/default/.claude/
+!examples/gastown/packs/gastown/overlays/default/.claude/settings.json
+!examples/gastown/packs/maintenance/overlays/default/.claude/
+!examples/gastown/packs/maintenance/overlays/default/.claude/settings.json
+!examples/swarm/packs/swarm/overlays/default/.claude/
+!examples/swarm/packs/swarm/overlays/default/.claude/settings.json
 .gc/
 
 # Dolt database files (added by bd init)

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
@@ -274,6 +275,21 @@ func TestMaterializeGastownPacks(t *testing.T) {
 	promptsDir := filepath.Join(dir, "packs", "gastown", "prompts")
 	if _, err := os.Stat(promptsDir); err != nil {
 		t.Errorf("gastown prompts dir missing: %v", err)
+	}
+
+	// Verify default overlay payloads are materialized for both packs.
+	for _, overlayPath := range []string{
+		filepath.Join(dir, "packs", "gastown", "overlays", "default", ".claude", "settings.json"),
+		filepath.Join(dir, "packs", "maintenance", "overlays", "default", ".claude", "settings.json"),
+	} {
+		data, err := os.ReadFile(overlayPath)
+		if err != nil {
+			t.Errorf("default overlay settings missing at %s: %v", overlayPath, err)
+			continue
+		}
+		if !strings.Contains(string(data), `gc handoff \"context cycle\"`) {
+			t.Errorf("default overlay %s missing context-cycle hook", overlayPath)
+		}
 	}
 
 	// Verify TOML files are not executable.

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -85,6 +85,22 @@ func TestPromptFilesExist(t *testing.T) {
 	}
 }
 
+func TestOverlayDirsExist(t *testing.T) {
+	dir := exampleDir()
+	cfg := loadExpanded(t)
+	for _, a := range cfg.Agents {
+		if a.OverlayDir == "" {
+			continue
+		}
+		path := filepath.Join(dir, a.OverlayDir)
+		if info, err := os.Stat(path); err != nil {
+			t.Errorf("agent %q: overlay_dir %q: %v", a.Name, a.OverlayDir, err)
+		} else if !info.IsDir() {
+			t.Errorf("agent %q: overlay_dir %q is not a directory", a.Name, a.OverlayDir)
+		}
+	}
+}
+
 func TestRefineryPromptSeedsTargetBranchVar(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "prompts", "refinery.md.tmpl")

--- a/examples/gastown/packs/gastown/overlays/default/.claude/settings.json
+++ b/examples/gastown/packs/gastown/overlays/default/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gc handoff \"context cycle\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/gastown/packs/maintenance/embed.go
+++ b/examples/gastown/packs/maintenance/embed.go
@@ -5,5 +5,5 @@ import "embed"
 
 // PackFS contains the maintenance pack files.
 //
-//go:embed pack.toml doctor formulas prompts scripts
+//go:embed pack.toml doctor formulas all:overlays prompts scripts
 var PackFS embed.FS

--- a/examples/gastown/packs/maintenance/overlays/default/.claude/settings.json
+++ b/examples/gastown/packs/maintenance/overlays/default/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gc handoff \"context cycle\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/swarm/packs/swarm/overlays/default/.claude/settings.json
+++ b/examples/swarm/packs/swarm/overlays/default/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gc handoff \"context cycle\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/swarm/swarm_test.go
+++ b/examples/swarm/swarm_test.go
@@ -68,6 +68,22 @@ func TestPromptFilesExist(t *testing.T) {
 	}
 }
 
+func TestOverlayDirsExist(t *testing.T) {
+	dir := exampleDir()
+	cfg := loadExpanded(t)
+	for _, a := range cfg.Agents {
+		if a.OverlayDir == "" {
+			continue
+		}
+		path := filepath.Join(dir, a.OverlayDir)
+		if info, err := os.Stat(path); err != nil {
+			t.Errorf("agent %q: overlay_dir %q: %v", a.Name, a.OverlayDir, err)
+		} else if !info.IsDir() {
+			t.Errorf("agent %q: overlay_dir %q is not a directory", a.Name, a.OverlayDir)
+		}
+	}
+}
+
 // packFileConfig mirrors the pack.toml structure for test parsing.
 type packFileConfig struct {
 	Pack   config.PackMeta `toml:"pack"`


### PR DESCRIPTION
## Summary
- ship tracked `overlays/default/.claude/settings.json` payloads for the Gastown, Maintenance, and Swarm example packs
- include Maintenance overlays in `MaterializeGastownPacks` by embedding `all:overlays`
- add regression coverage for materialized default overlays and for `overlay_dir` references in the Gastown and Swarm examples

## Why
Several example packs already point agents at `overlays/default`, but a clean checkout or `gc init`-materialized Gastown workspace did not reliably ship those paths. In practice that surfaced as `gc doctor --verbose` `config-refs` failures for agents like `mayor`, `deacon`, `boot`, and `dog`.

Two separate repo issues caused that drift:
- the default overlay hook payloads lived under `.claude/`, which the repo ignored, so the example-tree workaround was invisible to git
- the Maintenance embedded pack omitted `overlays`, so `MaterializeGastownPacks` could never ship `packs/maintenance/overlays/default` even when the file existed locally

## Alternatives Considered
1. Change `overlay_dir` references to existing overlays such as `crew` or `witness`.
   This was rejected because those overlays encode different behavior. Repointing default agents there would silently change hook semantics instead of restoring the intended default overlay.
2. Add tracked placeholder files outside `.claude/` just to satisfy `gc doctor`.
   This was rejected because it would only quiet the missing-directory warning. It would not restore the intended `PreCompact` `gc handoff "context cycle"` behavior that the default overlay is supposed to provide.
3. Document a manual setup step to create `overlays/default` after bootstrap.
   This was rejected because the pack model and the shareable-pack docs both treat packs as self-contained. `gc init` and example packs should not produce a broken workspace that requires undocumented repair.
4. Update `.gitignore` alone.
   This was rejected because it would still leave Maintenance broken: its embedded pack definition also needed to ship `overlays`.

## Why This Change
This patch keeps the fix narrow and matches the existing pack design:
- it tracks the real default overlay payload rather than swapping in a different overlay
- it limits `.gitignore` exceptions to the specific example-pack assets that must ship
- it fixes the bootstrap/materialization path by embedding Maintenance overlays
- it adds tests that fail if the example packs or materialized packs drift again

## Testing
- `go test ./cmd/gc -run 'TestMaterializeGastownPacks|TestMaterializeGastownPacks_Idempotent' -count=1`
- `go test ./examples/gastown ./examples/swarm -count=1`
- `make check` *(currently fails on unrelated pre-existing issues in `cmd/gc`, `internal/api`, `internal/convergence`, and `internal/git`, mostly around `/var` vs `/private/var` path normalization and readiness/controller expectations)*
