### PR TITLE
docs(runtime): add provider capability matrix and conformance tests

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,7 +53,8 @@
           "reference/config",
           "reference/formula",
           "reference/exec-session-provider",
-          "reference/exec-beads-provider"
+          "reference/exec-beads-provider",
+          "reference/provider-capabilities"
         ]
       },
       {

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,0 +1,132 @@
+---
+title: Provider Capability Matrix
+description: What each Gas City session provider supports — core operations, optional extensions, and known gaps.
+---
+
+Gas City supports several session providers selectable via the `GC_SESSION`
+environment variable or the `session` field on a provider preset. This page
+documents what each provider can reliably do so contributors can avoid
+trial-and-error discovery of gaps.
+
+## How to read this matrix
+
+Each row is a capability. Each column is a provider. Values:
+
+| Symbol | Meaning |
+|--------|---------|
+| ✓ | Supported and reliable |
+| ~ | Best-effort or partial (details in footnotes) |
+| — | Not supported; returns zero/nil/false without error |
+| ✗ | Not applicable (the interface method itself is absent) |
+
+## Session Providers
+
+| `GC_SESSION` value | Description |
+|--------------------|-------------|
+| `tmux` | tmux multiplexer (production default) |
+| `subprocess` | In-process subprocess (lightweight, no tmux) |
+| `exec:<script>` | Script-delegated backend (bring-your-own multiplexer) |
+| `acp` | ACP protocol (structured I/O over HTTP) |
+| `auto` | Wraps tmux + ACP; routes by session type |
+| `hybrid` | Wraps local + remote provider pair |
+| `k8s` | Kubernetes pod sessions |
+| `fake` | In-memory test double |
+
+## Core `Provider` Interface
+
+All providers implement the full `runtime.Provider` interface. The table below
+shows which methods return meaningful results vs. silent no-ops.
+
+| Capability | tmux | subprocess | exec | acp | auto | hybrid | k8s |
+|------------|:----:|:----------:|:----:|:---:|:----:|:------:|:---:|
+| `Start` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `Stop` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `Interrupt` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `IsRunning` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `IsAttached` ¹ | ✓ | — | — | — | — | — | — |
+| `Attach` | ✓ | — | — | — | — | — | — |
+| `ProcessAlive` | ✓ | ✓ | ~ ² | — | ✓ | ✓ | — |
+| `Nudge` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `Peek` | ✓ | ✓ | ~ ³ | ✓ | ✓ | ✓ | ✓ |
+| `SetMeta / GetMeta / RemoveMeta` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `ListRunning` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `GetLastActivity` ⁴ | ✓ | — | ~ ³ | — | — | — | ✓ |
+| `ClearScrollback` | ✓ | — | ~ ³ | — | — | — | — |
+| `CopyTo` | ✓ | — | ~ ³ | — | — | — | ✓ |
+| `SendKeys` | ✓ | — | ~ ³ | — | ✓ | ✓ | — |
+| `RunLive` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+## `ProviderCapabilities` Flags
+
+These flags are read by the reconciler to skip wake-reason checks that a
+provider cannot support.
+
+| Flag | tmux | subprocess | exec | acp | auto | hybrid | k8s |
+|------|:----:|:----------:|:----:|:---:|:----:|:------:|:---:|
+| `CanReportAttachment` | ✓ | — | — | — | ✓ ⁵ | ✓ ⁵ | — |
+| `CanReportActivity` | ✓ | — | — | — | ✓ ⁵ | ✓ ⁵ | ✓ |
+
+## Optional Extension Interfaces
+
+Providers implement these interfaces when the capability is available.
+The reconciler uses type assertions to check at runtime.
+
+| Interface | Method | tmux | subprocess | exec | acp | auto | hybrid | k8s |
+|-----------|--------|:----:|:----------:|:----:|:---:|:----:|:------:|:---:|
+| `IdleWaitProvider` | `WaitForIdle` | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ |
+| `InteractionProvider` | `Pending` / `Respond` | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ |
+
+## Footnotes
+
+¹ `IsAttached` returns `false` for all providers except tmux. The reconciler
+skips attachment-gated wake reasons when `CanReportAttachment` is false.
+
+² `exec` delegates `ProcessAlive` to the backing script via the
+`process-alive` operation. Behavior depends on the script implementation;
+the built-in `gc-session-screen` script supports it but custom scripts may
+return `false` unconditionally.
+
+³ `exec` delegates all operations to the backing script. The operations
+`peek`, `get-last-activity`, `clear-scrollback`, `copy-to`, and `send-keys`
+are defined in the exec script protocol — see
+[Exec Session Provider](exec-session-provider.md) — but support depends on
+the script. Gas City's built-in tmux-backend script supports all of them.
+
+⁴ `GetLastActivity` returns meaningful timestamps from tmux's
+`display-message` and from Kubernetes pod activity, but returns zero time for
+subprocess and ACP providers (no scrollback / no activity observable).
+
+⁵ `auto` and `hybrid` compute capabilities as the logical AND of their
+component providers. If both components support a capability, the composite
+does too. In practice: `auto` (tmux + ACP) inherits tmux's attachment and
+activity reporting; `hybrid` (local + remote) depends on what each side is.
+
+## Choosing a Provider
+
+| Scenario | Recommended provider |
+|----------|---------------------|
+| Production: interactive agents with tmux | `tmux` |
+| Production: ACP-native agents (structured I/O) | `acp` or `auto` |
+| Production: agents in Kubernetes | `k8s` |
+| Development: fast, no tmux required | `subprocess` |
+| Development: custom multiplexer or terminal | `exec:<script>` |
+| CI / unit tests | `fake` (via `GC_SESSION=fake`) |
+| CI / acceptance tests | `subprocess` or `fake` |
+| Multi-machine or remote execution | `hybrid` |
+
+## Gap Summary
+
+These capabilities are the most common sources of unexpected behavior when
+switching providers:
+
+- **`IsAttached` is tmux-only.** Code that gates on `IsAttached` silently
+  falls back to `false` on all other providers.
+- **`WaitForIdle` is tmux / auto / hybrid only.** Providers without
+  `IdleWaitProvider` cannot wait for a safe injection window; nudges are
+  delivered immediately.
+- **`Pending` / `Respond` is ACP-based only.** Structured approval flows
+  require ACP, auto, or hybrid.
+- **`Peek` is best-effort on exec.** Scripts that don't implement the `peek`
+  operation return an empty string.
+- **`GetLastActivity` is meaningful on tmux and k8s only.** Activity-gated
+  wake reasons are skipped on other providers.

--- a/internal/runtime/capabilities_test.go
+++ b/internal/runtime/capabilities_test.go
@@ -1,0 +1,114 @@
+package runtime_test
+
+// capabilities_test.go asserts that each provider's Capabilities() return
+// value matches the documented matrix in docs/reference/provider-capabilities.md.
+//
+// These tests serve as a regression guard: if a provider silently changes its
+// capability declarations, this file fails and the maintainer knows to update
+// both the code and the docs together.
+//
+// Provider-specific tests also verify that providers correctly implement (or
+// do not implement) the optional extension interfaces IdleWaitProvider and
+// InteractionProvider.
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/runtime/acp"
+	"github.com/gastownhall/gascity/internal/runtime/exec"
+	"github.com/gastownhall/gascity/internal/runtime/subprocess"
+	tmuxruntime "github.com/gastownhall/gascity/internal/runtime/tmux"
+)
+
+// capabilityRow describes the expected ProviderCapabilities for one provider.
+type capabilityRow struct {
+	name                string
+	canReportAttachment bool
+	canReportActivity   bool
+}
+
+// TestProviderCapabilityMatrix asserts that each concrete provider's
+// Capabilities() return matches the documented matrix. Update this table and
+// the docs together when a provider's capability declarations change.
+func TestProviderCapabilityMatrix(t *testing.T) {
+	rows := []struct {
+		capabilityRow
+		provider runtime.Provider
+	}{
+		{
+			capabilityRow{"tmux", true, true},
+			tmuxruntime.NewProvider(),
+		},
+		{
+			capabilityRow{"subprocess", false, false},
+			subprocess.NewProvider(),
+		},
+		{
+			capabilityRow{"exec", false, false},
+			exec.NewProvider("true"), // "true" is a no-op script available on all platforms
+		},
+		{
+			capabilityRow{"acp", false, false},
+			acp.NewProvider(acp.Config{}),
+		},
+	}
+
+	for _, tt := range rows {
+		t.Run(tt.name, func(t *testing.T) {
+			caps := tt.provider.Capabilities()
+
+			if caps.CanReportAttachment != tt.canReportAttachment {
+				t.Errorf("%s: CanReportAttachment = %v, want %v (see docs/reference/provider-capabilities.md)",
+					tt.name, caps.CanReportAttachment, tt.canReportAttachment)
+			}
+			if caps.CanReportActivity != tt.canReportActivity {
+				t.Errorf("%s: CanReportActivity = %v, want %v (see docs/reference/provider-capabilities.md)",
+					tt.name, caps.CanReportActivity, tt.canReportActivity)
+			}
+		})
+	}
+}
+
+// TestProviderOptionalInterfaces asserts which providers implement the
+// optional extension interfaces. A provider that unexpectedly gains or loses
+// an interface will fail here, prompting a doc update.
+func TestProviderOptionalInterfaces(t *testing.T) {
+	t.Run("IdleWaitProvider", func(t *testing.T) {
+		// tmux: implements IdleWaitProvider.
+		if _, ok := runtime.Provider(tmuxruntime.NewProvider()).(runtime.IdleWaitProvider); !ok {
+			t.Error("tmux: expected IdleWaitProvider implementation")
+		}
+		// subprocess: does NOT implement IdleWaitProvider.
+		if _, ok := runtime.Provider(subprocess.NewProvider()).(runtime.IdleWaitProvider); ok {
+			t.Error("subprocess: unexpected IdleWaitProvider implementation (update docs if intentional)")
+		}
+		// exec: does NOT implement IdleWaitProvider.
+		if _, ok := runtime.Provider(exec.NewProvider("true")).(runtime.IdleWaitProvider); ok {
+			t.Error("exec: unexpected IdleWaitProvider implementation (update docs if intentional)")
+		}
+		// acp: does NOT implement IdleWaitProvider.
+		if _, ok := runtime.Provider(acp.NewProvider(acp.Config{})).(runtime.IdleWaitProvider); ok {
+			t.Error("acp: unexpected IdleWaitProvider implementation (update docs if intentional)")
+		}
+	})
+
+	t.Run("InteractionProvider", func(t *testing.T) {
+		// tmux: does NOT implement InteractionProvider.
+		if _, ok := runtime.Provider(tmuxruntime.NewProvider()).(runtime.InteractionProvider); ok {
+			t.Error("tmux: unexpected InteractionProvider implementation (update docs if intentional)")
+		}
+		// subprocess: does NOT implement InteractionProvider.
+		if _, ok := runtime.Provider(subprocess.NewProvider()).(runtime.InteractionProvider); ok {
+			t.Error("subprocess: unexpected InteractionProvider implementation (update docs if intentional)")
+		}
+		// exec: does NOT implement InteractionProvider.
+		if _, ok := runtime.Provider(exec.NewProvider("true")).(runtime.InteractionProvider); ok {
+			t.Error("exec: unexpected InteractionProvider implementation (update docs if intentional)")
+		}
+		// acp: implements InteractionProvider.
+		if _, ok := runtime.Provider(acp.NewProvider(acp.Config{})).(runtime.InteractionProvider); !ok {
+			t.Error("acp: expected InteractionProvider implementation")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `docs/reference/provider-capabilities.md` — complete capability matrix for all session providers (tmux, subprocess, exec, acp, auto, hybrid, k8s)
- Adds `internal/runtime/capabilities_test.go` — conformance tests that fail when a provider's capability declarations drift from what's documented
- Registers the new page in `docs/docs.json` under the Reference group

## What's documented

**Core Provider interface**: which methods return meaningful results vs. silent no-ops per provider  
**ProviderCapabilities flags**: `CanReportAttachment` and `CanReportActivity` per provider  
**Optional extension interfaces**: which providers implement `IdleWaitProvider` (tmux, auto, hybrid) and `InteractionProvider` (acp, auto, hybrid)  
**Gap summary**: the four most common surprise gaps when switching providers

## Tests

`TestProviderCapabilityMatrix` — instantiates each concrete provider (tmux, subprocess, exec, acp) and asserts their `Capabilities()` matches the matrix. Fails if declarations change without updating docs.

`TestProviderOptionalInterfaces` — asserts interface presence/absence for IdleWaitProvider and InteractionProvider. Fails if a provider silently gains or loses an optional interface.

## Wasteland

Closes [w-159eab2f5e](https://github.com/steveyegge/wl-commons) (Add provider capability matrix and smoke tests for tmux, subprocess, exec, and ACP)

## Pre-existing issue

`go test ./cmd/gc/` fails on main with `undefined: testFormulaDir` in `cmd_sling_test.go` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)