### PR TITLE
feat(nudge): generalize nudge poller via NudgePollMode provider field

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -147,7 +147,7 @@ func newNudgePollCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "poll [agent]",
 		Short:  "Poll and deliver queued nudges for runtimes without turn hooks",
-		Long:   "Poll and deliver queued nudges for runtimes without turn hooks. Used internally for Codex sessions.",
+		Long:   "Poll and deliver queued nudges for runtimes without turn hooks. Used for providers with nudge_poll_mode = \"poll\" (e.g. Codex).",
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: true,
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -671,8 +671,11 @@ func pollerSessionIdleEnough(sp runtime.Provider, sessionName string, quiescence
 	return time.Since(last) >= quiescence
 }
 
-func maybeStartCodexNudgePoller(target nudgeTarget) {
-	if target.resolved == nil || target.resolved.Name != "codex" {
+// maybeStartNudgePoller starts the background nudge poller for providers that
+// use poll-based delivery (NudgePollMode == "poll") instead of a hook-triggered
+// drain. It is a no-op for providers with a UserPromptSubmit-equivalent hook.
+func maybeStartNudgePoller(target nudgeTarget) {
+	if target.resolved == nil || target.resolved.NudgePollMode != "poll" {
 		return
 	}
 	if target.sessionName == "" {
@@ -681,6 +684,14 @@ func maybeStartCodexNudgePoller(target nudgeTarget) {
 	if err := startNudgePoller(target.cityPath, target.agentKey(), target.sessionName); err != nil {
 		return
 	}
+}
+
+// maybeStartCodexNudgePoller is kept for call-site compatibility; delegates to
+// maybeStartNudgePoller which now checks NudgePollMode instead of provider name.
+//
+// Deprecated: call maybeStartNudgePoller directly.
+func maybeStartCodexNudgePoller(target nudgeTarget) {
+	maybeStartNudgePoller(target)
 }
 
 func withNudgeTargetFence(store beads.Store, target nudgeTarget) nudgeTarget {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,7 @@ gc [flags]
 | [gc doctor](#gc-doctor) | Check workspace health |
 | [gc event](#gc-event) | Event operations |
 | [gc events](#gc-events) | Show the event log |
+| [gc formula](#gc-formula) | Manage and inspect formulas |
 | [gc graph](#gc-graph) | Show dependency graph for beads |
 | [gc handoff](#gc-handoff) | Send handoff mail and restart agent session |
 | [gc help](#gc-help) | Help about any command |
@@ -54,8 +55,9 @@ gc [flags]
 | [gc supervisor](#gc-supervisor) | Manage the machine-wide supervisor |
 | [gc suspend](#gc-suspend) | Suspend the city (all agents effectively suspended) |
 | [gc unregister](#gc-unregister) | Remove a city from the machine-wide supervisor |
-| [gc version](#gc-version) | Print gc version information |
+| [gc version](#gc-version) | Print gc version |
 | [gc wait](#gc-wait) | Inspect and manage durable session waits |
+| [gc workflow](#gc-workflow) | Run explicit graph-first workflow control beads |
 
 ## gc agent
 
@@ -420,6 +422,7 @@ gc convoy
 | [gc convoy list](#gc-convoy-list) | List open convoys with progress |
 | [gc convoy status](#gc-convoy-status) | Show detailed convoy status |
 | [gc convoy stranded](#gc-convoy-stranded) | Find convoys with ready work but no workers |
+| [gc convoy target](#gc-convoy-target) | Set the target branch on a convoy |
 
 ## gc convoy add
 
@@ -471,13 +474,16 @@ gc convoy create <name> [issue-ids...] [flags]
 gc convoy create sprint-42
   gc convoy create sprint-42 issue-1 issue-2 issue-3
   gc convoy create deploy --owner mayor --notify mayor --merge mr
+  gc convoy create auth-rewrite --owned --target integration/auth-rewrite
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--merge` | string |  | merge strategy: direct, mr, local |
 | `--notify` | string |  | notification target on completion |
+| `--owned` | bool |  | mark convoy as owned (manual lifecycle, no auto-close) |
 | `--owner` | string |  | convoy owner (who manages it) |
+| `--target` | string |  | target branch inherited by child work beads |
 
 ## gc convoy land
 
@@ -535,6 +541,17 @@ Useful for identifying bottlenecks in convoy processing.
 
 ```
 gc convoy stranded
+```
+
+## gc convoy target
+
+Set the target branch metadata on a convoy.
+
+Child work beads can inherit this target branch when slung with
+feature-branch formulas such as mol-polecat-work.
+
+```
+gc convoy target <convoy-id> <branch>
 ```
 
 ## gc dashboard
@@ -653,14 +670,74 @@ gc events
 | `--type` | string |  | Filter by event type (e.g. bead.created) |
 | `--watch` | bool |  | Block until matching events arrive (exits after first match) |
 
+## gc formula
+
+Manage and inspect formulas
+
+```
+gc formula
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc formula cook](#gc-formula-cook) | Instantiate a formula into the current bead store |
+| [gc formula list](#gc-formula-list) | List available formulas |
+| [gc formula show](#gc-formula-show) | Show a compiled formula recipe |
+
+## gc formula cook
+
+Compile and instantiate a formula as real beads in the current store.
+
+This is a low-level workflow construction tool. It creates the formula root
+and all compiled step beads without routing any work.
+
+```
+gc formula cook <formula-name> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--meta` | stringArray |  | set root bead metadata after cook (key=value, repeatable) |
+| `-t`, `--title` | string |  | override root bead title |
+| `--var` | stringArray |  | variable substitution for formula (key=value, repeatable) |
+
+## gc formula list
+
+List all formulas available in the city's formula search paths.
+
+Formulas are discovered from city-level and rig-level formula directories
+configured via packs and formulas_dir settings.
+
+```
+gc formula list
+```
+
+## gc formula show
+
+Compile and display a formula recipe.
+
+By default, shows the recipe with &#123;&#123;variable&#125;&#125; placeholders intact.
+Use --var to substitute variables and preview the resolved output.
+
+Examples:
+  gc formula show mol-feature
+  gc formula show mol-feature --var title="Auth system" --var branch=main
+
+```
+gc formula show <formula-name> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--var` | stringArray |  | variable substitution for preview (key=value) |
+
 ## gc graph
 
 Show the dependency graph for a set of beads or a convoy.
 
 Resolves dependencies via the bead store and prints each bead with its
 status and what blocks it. Convoys are expanded to their children
-automatically. Epics are treated as ordinary beads. Readiness is
-computed within the displayed set.
+automatically. Readiness is computed within the displayed set.
 
 By default prints a table. Use --tree for a Unicode tree view or
 --mermaid for a Mermaid.js flowchart you can paste into Markdown.
@@ -767,6 +844,7 @@ gc init
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
+| `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
 
 ## gc mail
 
@@ -1369,6 +1447,7 @@ gc service
 |------------|-------------|
 | [gc service doctor](#gc-service-doctor) | Show detailed workspace service status |
 | [gc service list](#gc-service-list) | List workspace services |
+| [gc service restart](#gc-service-restart) | Restart a workspace service |
 
 ## gc service doctor
 
@@ -1384,6 +1463,17 @@ List workspace services
 
 ```
 gc service list
+```
+
+## gc service restart
+
+Stop and restart a workspace service by name.
+
+The controller closes the current service process and starts a fresh one.
+Useful after updating pack scripts without a full city restart.
+
+```
+gc service restart <name>
 ```
 
 ## gc session
@@ -1865,11 +1955,15 @@ gc unregister [path]
 
 Print the gc version string.
 
-Use `gc version --long` to include git commit and build date metadata.
+Use --long to include git commit and build date metadata.
 
 ```
-gc version
+gc version [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-l`, `--long` | bool |  | Include git commit and build date metadata |
 
 ## gc wait
 
@@ -1922,3 +2016,24 @@ Manually mark a wait ready
 ```
 gc wait ready <wait-id>
 ```
+
+## gc workflow
+
+Run explicit graph-first workflow control beads
+
+```
+gc workflow
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc workflow control](#gc-workflow-control) | Execute a graph.v2 control bead in the current city |
+
+## gc workflow control
+
+Execute a graph.v2 control bead in the current city
+
+```
+gc workflow control <bead-id>
+```
+

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -410,6 +410,7 @@ ProviderSpec defines a named provider's startup parameters.
 | `session_id_flag` | string |  |  | SessionIDFlag is the CLI flag for creating a session with a specific ID. Enables the Generate & Pass strategy for session key management. Example: "--session-id" (claude) |
 | `permission_modes` | map[string]string |  |  | PermissionModes maps permission mode names to CLI flags. Example: &#123;"unrestricted": "--dangerously-skip-permissions", "plan": "--permission-mode plan"&#125; This is a config-only lookup table consumed by external clients (e.g., Mission Control) to populate permission mode dropdowns. Launch-time flag substitution is planned for a follow-up PR — currently no runtime code reads this field. |
 | `options_schema` | []ProviderOption |  |  | OptionsSchema declares the configurable options this provider supports. Each option maps to CLI args via its Choices[].FlagArgs field. Serialized via a dedicated DTO (not directly to JSON) so FlagArgs stays server-side. |
+| `nudge_poll_mode` | string |  |  | NudgePollMode controls how queued nudges are delivered between turns. "poll" — the runtime polls for queued nudges on an interval and injects          them when the session is idle. Use for providers that have no          UserPromptSubmit-equivalent hook to trigger delivery at a safe          turn boundary (e.g. Codex). ""     — the provider's hook mechanism delivers queued nudges directly;          no background poller is needed. Enum: `poll`, `` |
 
 ## Rig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1355,6 +1355,14 @@
           },
           "type": "array",
           "description": "OptionsSchema declares the configurable options this provider supports.\nEach option maps to CLI args via its Choices[].FlagArgs field.\nSerialized via a dedicated DTO (not directly to JSON) so FlagArgs stays server-side."
+        },
+        "nudge_poll_mode": {
+          "type": "string",
+          "enum": [
+            "poll",
+            ""
+          ],
+          "description": "NudgePollMode controls how queued nudges are delivered between turns.\n\"poll\" — the runtime polls for queued nudges on an interval and injects\n         them when the session is idle. Use for providers that have no\n         UserPromptSubmit-equivalent hook to trigger delivery at a safe\n         turn boundary (e.g. Codex).\n\"\"     — the provider's hook mechanism delivers queued nudges directly;\n         no background poller is needed."
         }
       },
       "additionalProperties": false,

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -89,6 +89,14 @@ type ProviderSpec struct {
 	// Each option maps to CLI args via its Choices[].FlagArgs field.
 	// Serialized via a dedicated DTO (not directly to JSON) so FlagArgs stays server-side.
 	OptionsSchema []ProviderOption `toml:"options_schema,omitempty" json:"-"`
+	// NudgePollMode controls how queued nudges are delivered between turns.
+	// "poll" — the runtime polls for queued nudges on an interval and injects
+	//          them when the session is idle. Use for providers that have no
+	//          UserPromptSubmit-equivalent hook to trigger delivery at a safe
+	//          turn boundary (e.g. Codex).
+	// ""     — the provider's hook mechanism delivers queued nudges directly;
+	//          no background poller is needed.
+	NudgePollMode string `toml:"nudge_poll_mode,omitempty" jsonschema:"enum=poll,enum="`
 }
 
 // ResolvedProvider is the fully-merged, ready-to-use provider config.
@@ -113,6 +121,8 @@ type ResolvedProvider struct {
 	SessionIDFlag          string
 	PermissionModes        map[string]string
 	OptionsSchema          []ProviderOption
+	// NudgePollMode mirrors ProviderSpec.NudgePollMode after resolution.
+	NudgePollMode string
 }
 
 // CommandString returns the full command line: command followed by args.
@@ -217,6 +227,9 @@ func BuiltinProviders() map[string]ProviderSpec {
 			ProcessNames:     []string{"codex"},
 			SupportsHooks:    true,
 			InstructionsFile: "AGENTS.md",
+			// Codex has no UserPromptSubmit-equivalent hook, so queued nudges
+			// must be delivered via the background poller.
+			NudgePollMode: "poll",
 			PermissionModes: map[string]string{
 				"suggest":      "--ask-for-approval untrusted --sandbox read-only",
 				"auto-edit":    "--full-auto",

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -143,6 +143,7 @@ func specToResolved(name string, spec *ProviderSpec) *ResolvedProvider {
 		ResumeStyle:            spec.ResumeStyle,
 		ResumeCommand:          spec.ResumeCommand,
 		SessionIDFlag:          spec.SessionIDFlag,
+		NudgePollMode:          spec.NudgePollMode,
 	}
 	// Deep-copy OptionsSchema to avoid aliasing the spec's slice.
 	if len(spec.OptionsSchema) > 0 {


### PR DESCRIPTION
## Summary

- Adds `NudgePollMode string` to `ProviderSpec` and `ResolvedProvider` — providers set `nudge_poll_mode = "poll"` to opt in to interval-based nudge delivery instead of hook-triggered drain
- Sets `NudgePollMode: "poll"` on the Codex preset (the only provider currently confirmed to lack a `UserPromptSubmit`-equivalent hook)
- Renames `maybeStartCodexNudgePoller` → `maybeStartNudgePoller`; the condition is now `resolved.NudgePollMode == "poll"` rather than `resolved.Name == "codex"`
- Keeps `maybeStartCodexNudgePoller` as a deprecated wrapper for compatibility
- Regenerates schema and config docs

## Motivation

This is one of the HIGH items from the non-Claude parity audit (PR #48, gap #6). The Codex nudge poller was the right mechanism but was hardcoded to a single provider. Other providers that also lack turn-boundary hooks (Gemini, Cursor, OpenCode) can now be opted in by adding `nudge_poll_mode = "poll"` to their preset — no code change needed.

## What's NOT changed

The poller interval and quiescence values are unchanged. The poll infrastructure (`gc nudge poll`, `startNudgePoller`, `acquireNudgePollerLease`) is untouched — this PR only changes the condition that decides whether to start the poller.

## Test plan

- [ ] `go build ./...` passes (pre-existing `cmd/gc` test build failure unrelated to this PR: `testFormulaDir` undefined in `cmd_sling_test.go`)
- [ ] `go test ./internal/config/...` passes — all provider resolution and AgentHasHooks tests green
- [ ] `gc nudge poll --help` shows updated description referencing `nudge_poll_mode` rather than "Codex sessions"
- [ ] On a Codex session, `gc prime` still starts the nudge poller (behavior unchanged)
- [ ] On a Claude session, no poller is started (behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)