### PR TITLE
fix: align built-in worker prompts with WorkQuery

### DIFF
--- a/cmd/gc/builtin_prompts_test.go
+++ b/cmd/gc/builtin_prompts_test.go
@@ -1,12 +1,65 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
+
+func materializeBuiltinPromptsForTest(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := materializeBuiltinPrompts(dir); err != nil {
+		t.Fatalf("materializeBuiltinPrompts: %v", err)
+	}
+	return dir
+}
+
+func renderBuiltinPromptForTest(t *testing.T, dir, name string, ctx PromptContext) string {
+	t.Helper()
+
+	got := renderPrompt(fsys.OSFS{}, dir, "gastown", filepath.Join(citylayout.PromptsRoot, name), ctx, "", io.Discard, nil, nil, nil)
+	if got == "" {
+		t.Fatalf("renderPrompt(%s) returned empty output", name)
+	}
+	return got
+}
+
+func assertRenderedPromptContains(t *testing.T, rendered, name string, want []string) {
+	t.Helper()
+
+	for _, needle := range want {
+		if strings.Contains(rendered, needle) {
+			continue
+		}
+		t.Errorf("prompt %s missing %q", name, needle)
+	}
+}
+
+func assertRenderedPromptDoesNotContain(t *testing.T, rendered, name string, blocked []string) {
+	t.Helper()
+
+	for _, needle := range blocked {
+		if !strings.Contains(rendered, needle) {
+			continue
+		}
+		t.Errorf("prompt %s unexpectedly contains %q", name, needle)
+	}
+}
+
+func currentHookCommand(target string) string {
+	return "gc " + newHookCmd(io.Discard, io.Discard).Name() + " " + target
+}
+
+func currentSlingCommand(target, bead string) string {
+	return "gc " + newSlingCmd(io.Discard, io.Discard).Name() + " " + target + " " + bead
+}
 
 func TestMaterializeBuiltinPrompts(t *testing.T) {
 	dir := t.TempDir()
@@ -57,6 +110,43 @@ func TestMaterializeBuiltinPromptsOverwrites(t *testing.T) {
 	}
 	if string(data) == "stale" {
 		t.Error("stale content was not overwritten")
+	}
+}
+
+func TestMaterializeBuiltinFixedWorkerPromptsUseCurrentHookCommand(t *testing.T) {
+	dir := materializeBuiltinPromptsForTest(t)
+
+	tests := map[string]PromptContext{
+		"worker.md":        {AgentName: "mayor", TemplateName: "mayor"},
+		"one-shot.md":      {AgentName: "mayor", TemplateName: "mayor"},
+		"scoped-worker.md": {AgentName: "hello-world/worker", TemplateName: "worker", RigName: "hello-world", WorkDir: "/city/hello-world"},
+	}
+	for name, ctx := range tests {
+		rendered := renderBuiltinPromptForTest(t, dir, name, ctx)
+		assertRenderedPromptContains(t, rendered, name, []string{currentHookCommand("$GC_AGENT")})
+		assertRenderedPromptDoesNotContain(t, rendered, name, []string{"gc agent claimed"})
+	}
+}
+
+func TestMaterializeBuiltinLoopPromptsUseCurrentHookAndSlingCommands(t *testing.T) {
+	dir := materializeBuiltinPromptsForTest(t)
+
+	tests := map[string]PromptContext{
+		"loop.md":      {AgentName: "worker", TemplateName: "worker"},
+		"loop-mail.md": {AgentName: "worker", TemplateName: "worker"},
+	}
+	want := []string{
+		currentHookCommand("$GC_AGENT"),
+		currentSlingCommand("$GC_AGENT", "<id>"),
+	}
+	blocked := []string{
+		"gc agent claimed",
+		"gc agent claim",
+	}
+	for name, ctx := range tests {
+		rendered := renderBuiltinPromptForTest(t, dir, name, ctx)
+		assertRenderedPromptContains(t, rendered, name, want)
+		assertRenderedPromptDoesNotContain(t, rendered, name, blocked)
 	}
 }
 

--- a/cmd/gc/builtin_prompts_test.go
+++ b/cmd/gc/builtin_prompts_test.go
@@ -53,10 +53,6 @@ func assertRenderedPromptDoesNotContain(t *testing.T, rendered, name string, blo
 	}
 }
 
-func currentHookCommand(target string) string {
-	return "gc " + newHookCmd(io.Discard, io.Discard).Name() + " " + target
-}
-
 func currentSlingCommand(target, bead string) string {
 	return "gc " + newSlingCmd(io.Discard, io.Discard).Name() + " " + target + " " + bead
 }
@@ -113,30 +109,54 @@ func TestMaterializeBuiltinPromptsOverwrites(t *testing.T) {
 	}
 }
 
-func TestMaterializeBuiltinFixedWorkerPromptsUseCurrentHookCommand(t *testing.T) {
+func TestMaterializeBuiltinFixedWorkerPromptsUseInjectedWorkQuery(t *testing.T) {
 	dir := materializeBuiltinPromptsForTest(t)
 
+	workQuery := "custom-work-query --agent=$GC_SESSION_NAME"
 	tests := map[string]PromptContext{
-		"worker.md":        {AgentName: "mayor", TemplateName: "mayor"},
-		"one-shot.md":      {AgentName: "mayor", TemplateName: "mayor"},
-		"scoped-worker.md": {AgentName: "hello-world/worker", TemplateName: "worker", RigName: "hello-world", WorkDir: "/city/hello-world"},
+		"worker.md": {
+			AgentName:    "mayor",
+			TemplateName: "mayor",
+			WorkQuery:    workQuery,
+		},
+		"one-shot.md": {
+			AgentName:    "mayor",
+			TemplateName: "mayor",
+			WorkQuery:    workQuery,
+		},
+		"scoped-worker.md": {
+			AgentName:    "hello-world/worker",
+			TemplateName: "worker",
+			RigName:      "hello-world",
+			WorkDir:      "/city/hello-world",
+			WorkQuery:    workQuery,
+		},
 	}
 	for name, ctx := range tests {
 		rendered := renderBuiltinPromptForTest(t, dir, name, ctx)
-		assertRenderedPromptContains(t, rendered, name, []string{currentHookCommand("$GC_AGENT")})
+		assertRenderedPromptContains(t, rendered, name, []string{workQuery})
 		assertRenderedPromptDoesNotContain(t, rendered, name, []string{"gc agent claimed"})
 	}
 }
 
-func TestMaterializeBuiltinLoopPromptsUseCurrentHookAndSlingCommands(t *testing.T) {
+func TestMaterializeBuiltinLoopPromptsUseInjectedWorkQueryAndCurrentSlingCommand(t *testing.T) {
 	dir := materializeBuiltinPromptsForTest(t)
 
+	workQuery := "custom-work-query --agent=$GC_SESSION_NAME"
 	tests := map[string]PromptContext{
-		"loop.md":      {AgentName: "worker", TemplateName: "worker"},
-		"loop-mail.md": {AgentName: "worker", TemplateName: "worker"},
+		"loop.md": {
+			AgentName:    "worker",
+			TemplateName: "worker",
+			WorkQuery:    workQuery,
+		},
+		"loop-mail.md": {
+			AgentName:    "worker",
+			TemplateName: "worker",
+			WorkQuery:    workQuery,
+		},
 	}
 	want := []string{
-		currentHookCommand("$GC_AGENT"),
+		workQuery,
 		currentSlingCommand("$GC_AGENT", "<id>"),
 	}
 	blocked := []string{

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -138,7 +138,7 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	if inject {
 		if hasWork {
-			fmt.Fprintf(stdout, "<system-reminder>\nYou have pending work. Pick up the next item:\n\n<work-items>\n%s\n</work-items>\n\nClaim it and start working. Run 'gc hook' to see the full queue.\n</system-reminder>\n", trimmed) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "<system-reminder>\nYou have pending work. Pick up the next item:\n\n<work-items>\n%s\n</work-items>\n\nStart working on it. Run 'gc hook' to see the full queue.\n</system-reminder>\n", trimmed) //nolint:errcheck // best-effort stdout
 		}
 		return 0 // --inject always exits 0
 	}

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -108,6 +108,12 @@ func TestHookInjectFormatsOutput(t *testing.T) {
 	if !strings.Contains(out, "gc hook") {
 		t.Errorf("stdout missing 'gc hook' hint: %q", out)
 	}
+	if !strings.Contains(out, "Start working on it.") {
+		t.Errorf("stdout missing updated work wording: %q", out)
+	}
+	if strings.Contains(out, "Claim it and start working.") {
+		t.Errorf("stdout still contains stale claim wording: %q", out)
+	}
 }
 
 func TestHookInjectAlwaysExitsZero(t *testing.T) {

--- a/cmd/gc/prompts/loop-mail.md
+++ b/cmd/gc/prompts/loop-mail.md
@@ -8,10 +8,10 @@ You are a coding agent that runs in a loop, checking for work and messages.
 2. If you have unread messages, read each one: `gc mail read <id>`
    - If the message asks a question, reply: `gc mail send <from> "<your answer>"`
    - If the message gives you information, incorporate it into your work
-3. Check your claim: `gc agent claimed $GC_AGENT`
-4. If a bead is already claimed by you, execute it and go to step 7
+3. Check your claim: `gc hook $GC_AGENT`
+4. If a bead is already assigned to you, execute it and go to step 7
 5. If your hook is empty, check for available work: `bd ready`
-6. If a bead is available, claim it: `gc agent claim $GC_AGENT <id>`
+6. If a bead is available, route it to yourself: `gc sling $GC_AGENT <id>`
 7. Execute the work described in the bead's title
 8. When done, close it: `bd close <id>`
 9. Go to step 1

--- a/cmd/gc/prompts/loop-mail.md
+++ b/cmd/gc/prompts/loop-mail.md
@@ -8,9 +8,9 @@ You are a coding agent that runs in a loop, checking for work and messages.
 2. If you have unread messages, read each one: `gc mail read <id>`
    - If the message asks a question, reply: `gc mail send <from> "<your answer>"`
    - If the message gives you information, incorporate it into your work
-3. Check your claim: `gc hook $GC_AGENT`
+3. Check your assigned work: `{{ .WorkQuery }}`
 4. If a bead is already assigned to you, execute it and go to step 7
-5. If your hook is empty, check for available work: `bd ready`
+5. If you have no assigned work, check for available work: `bd ready`
 6. If a bead is available, route it to yourself: `gc sling $GC_AGENT <id>`
 7. Execute the work described in the bead's title
 8. When done, close it: `bd close <id>`

--- a/cmd/gc/prompts/loop.md
+++ b/cmd/gc/prompts/loop.md
@@ -3,24 +3,24 @@
 You are a worker agent in a Gas City workspace. You drain the backlog —
 executing tasks one at a time, each with a clean focus.
 
-## GUPP — If you find work claimed by you, YOU RUN IT.
+## GUPP — If you find work assigned to you, YOU RUN IT.
 
 No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc agent claimed $GC_AGENT` — check what's claimed by you
+- `gc hook $GC_AGENT` — check what's assigned to you
 - `bd ready` — see available work items
-- `gc agent claim $GC_AGENT <id>` — claim a work item
+- `gc sling $GC_AGENT <id>` — route a work item to yourself
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc agent claimed $GC_AGENT`
-2. If a bead is already claimed by you, execute it and go to step 5
+1. Check your claim: `gc hook $GC_AGENT`
+2. If a bead is already assigned to you, execute it and go to step 5
 3. If your hook is empty, check for available work: `bd ready`
-4. If a bead is available, claim it: `gc agent claim $GC_AGENT <id>`
+4. If a bead is available, route it to yourself: `gc sling $GC_AGENT <id>`
 5. Execute the work described in the bead's title
 6. When done, close it: `bd close <id>`
 7. Go to step 1

--- a/cmd/gc/prompts/loop.md
+++ b/cmd/gc/prompts/loop.md
@@ -9,7 +9,7 @@ No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc hook $GC_AGENT` — check what's assigned to you
+- `{{ .WorkQuery }}` — check what's assigned to you
 - `bd ready` — see available work items
 - `gc sling $GC_AGENT <id>` — route a work item to yourself
 - `bd show <id>` — see details of a work item
@@ -17,15 +17,15 @@ No confirmation, no waiting. The hook having work IS the assignment.
 
 ## How to work
 
-1. Check your claim: `gc hook $GC_AGENT`
+1. Check your assigned work: `{{ .WorkQuery }}`
 2. If a bead is already assigned to you, execute it and go to step 5
-3. If your hook is empty, check for available work: `bd ready`
+3. If you have no assigned work, check for available work: `bd ready`
 4. If a bead is available, route it to yourself: `gc sling $GC_AGENT <id>`
 5. Execute the work described in the bead's title
 6. When done, close it: `bd close <id>`
 7. Go to step 1
 
-When `bd ready` returns nothing and your hook is empty, the backlog
+When `bd ready` returns nothing and you have no assigned work, the backlog
 is drained. You're done.
 
 Your agent name is available as $GC_AGENT.

--- a/cmd/gc/prompts/one-shot.md
+++ b/cmd/gc/prompts/one-shot.md
@@ -9,13 +9,13 @@ No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc hook $GC_AGENT` — check what's assigned to you
+- `{{ .WorkQuery }}` — check what's assigned to you
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc hook $GC_AGENT`
+1. Check your assigned work: `{{ .WorkQuery }}`
 2. If a bead is assigned to you, execute the work described in its title
 3. When done, close it: `bd close <id>`
 4. You're done. Wait for further instructions.

--- a/cmd/gc/prompts/one-shot.md
+++ b/cmd/gc/prompts/one-shot.md
@@ -3,20 +3,20 @@
 You are a worker agent in a Gas City workspace. You execute a single task
 and stop.
 
-## GUPP — If you find work claimed by you, YOU RUN IT.
+## GUPP — If you find work assigned to you, YOU RUN IT.
 
 No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc agent claimed $GC_AGENT` — check what's claimed by you
+- `gc hook $GC_AGENT` — check what's assigned to you
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc agent claimed $GC_AGENT`
-2. If a bead is claimed by you, execute the work described in its title
+1. Check your claim: `gc hook $GC_AGENT`
+2. If a bead is assigned to you, execute the work described in its title
 3. When done, close it: `bd close <id>`
 4. You're done. Wait for further instructions.
 

--- a/cmd/gc/prompts/scoped-worker.md
+++ b/cmd/gc/prompts/scoped-worker.md
@@ -9,16 +9,16 @@ No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc hook $GC_AGENT` — check what's assigned to you
+- `{{ .WorkQuery }}` — check what's assigned to you
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc hook $GC_AGENT`
+1. Check your assigned work: `{{ .WorkQuery }}`
 2. If a bead is assigned to you, execute the work described in its title
 3. All file operations happen in your directory: $GC_DIR
 4. When done, close it: `bd close <id>`
-5. Check your claim again for more work
+5. Check your assigned work again for more work
 
 Your agent name is $GC_AGENT. Your workspace is $GC_DIR.

--- a/cmd/gc/prompts/scoped-worker.md
+++ b/cmd/gc/prompts/scoped-worker.md
@@ -3,20 +3,20 @@
 You are a worker agent in a Gas City workspace.
 Your working directory is $GC_DIR — all your work happens there.
 
-## GUPP — If you find work claimed by you, YOU RUN IT.
+## GUPP — If you find work assigned to you, YOU RUN IT.
 
 No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc agent claimed $GC_AGENT` — check what's claimed by you
+- `gc hook $GC_AGENT` — check what's assigned to you
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc agent claimed $GC_AGENT`
-2. If a bead is claimed by you, execute the work described in its title
+1. Check your claim: `gc hook $GC_AGENT`
+2. If a bead is assigned to you, execute the work described in its title
 3. All file operations happen in your directory: $GC_DIR
 4. When done, close it: `bd close <id>`
 5. Check your claim again for more work

--- a/cmd/gc/prompts/worker.md
+++ b/cmd/gc/prompts/worker.md
@@ -2,20 +2,20 @@
 
 You are a worker agent in a Gas City workspace.
 
-## GUPP — If you find work claimed by you, YOU RUN IT.
+## GUPP — If you find work assigned to you, YOU RUN IT.
 
 No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc agent claimed $GC_AGENT` — check what's claimed by you
+- `gc hook $GC_AGENT` — check what's assigned to you
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc agent claimed $GC_AGENT`
-2. If a bead is claimed by you, execute the work described in its title
+1. Check your claim: `gc hook $GC_AGENT`
+2. If a bead is assigned to you, execute the work described in its title
 3. When done, close it: `bd close <id>`
 4. Check your claim again for more work
 

--- a/cmd/gc/prompts/worker.md
+++ b/cmd/gc/prompts/worker.md
@@ -8,15 +8,15 @@ No confirmation, no waiting. The hook having work IS the assignment.
 
 ## Your tools
 
-- `gc hook $GC_AGENT` — check what's assigned to you
+- `{{ .WorkQuery }}` — check what's assigned to you
 - `bd show <id>` — see details of a work item
 - `bd close <id>` — mark work as done
 
 ## How to work
 
-1. Check your claim: `gc hook $GC_AGENT`
+1. Check your assigned work: `{{ .WorkQuery }}`
 2. If a bead is assigned to you, execute the work described in its title
 3. When done, close it: `bd close <id>`
-4. Check your claim again for more work
+4. Check your assigned work again for more work
 
 Your agent name is available as $GC_AGENT.


### PR DESCRIPTION
## Summary

This replaces the stale built-in worker prompt commands with the current work-routing semantics.

Changes:
- replace `gc agent claim` / `gc agent claimed` references in built-in worker prompts
- use the runtime-injected `{{ .WorkQuery }}` in worker-style prompts, per the guidance on #40
- keep loop self-routing on `gc sling $GC_AGENT <id>`
- update `gc hook --inject` wording so it no longer tells the model to "claim" work
- add prompt-render regression tests so the embedded prompts stay aligned with the current command surface

## Context

This follows the clarification on #40 that the canonical workflow is:
- `gc hook`
- `gc sling`
- `gc formula`

and that the older `gc agent claim` / `gc agent claimed` and `gc mol ...` semantics are legacy.

This PR supersedes the earlier closed #13.

## Testing

Attempted:
- `go test ./cmd/gc -run 'TestMaterializeBuiltin|TestHook'`

Current result:
- blocked by an unrelated existing package compile failure in `cmd/gc/cmd_sling_test.go` (`undefined: testFormulaDir`)

The updated prompt-render and hook tests are included in this branch, but I could not complete a green package test run until that unrelated compile issue is fixed upstream.
