### PR TITLE
docs: document binary install and upgrade paths

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,89 +1,185 @@
 ---
 title: Installation
-description: Build Gas City locally and install the contributor toolchain.
+description: Install Gas City from Homebrew, a release tarball, or source.
 ---
+
+## Which method should I use?
+
+| Method | Best for | Installs deps? | Auto-upgrades? |
+|--------|----------|----------------|----------------|
+| [Homebrew](#homebrew-recommended) | macOS / Linux daily use | Yes (all 6) | `brew upgrade` |
+| [Direct download](#direct-download) | CI, containers, air-gapped hosts | No | Manual |
+| [Source build](#build-from-source) | Contributors, bleeding-edge | No | Manual |
+
+**Most users should use Homebrew.** It installs all runtime dependencies
+automatically and keeps `gc` on your PATH. Choose direct download when you
+cannot use Homebrew (CI images, Docker layers, machines without package
+managers). Choose source when you need unreleased changes or plan to contribute.
 
 ## Prerequisites
 
-For the default local workflow, install:
+Gas City requires a small set of runtime tools. Homebrew installs all of them
+for you; the other methods require manual installation.
 
-- Go 1.25 or newer
-- `tmux`
-- `jq`
-- the Beads CLI (`bd`)
+| Tool | Required | macOS | Linux | Notes |
+|------|----------|-------|-------|-------|
+| tmux | Yes | `brew install tmux` | `apt install tmux` | Session management |
+| jq | Yes | `brew install jq` | `apt install jq` | JSON processing |
+| git | Yes | (built-in) | (built-in) | Version control |
+| dolt | Yes | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
+| bd (Beads CLI) | Yes | `brew install beads` | [releases](https://github.com/steveyegge/beads/releases) | Issue tracking |
+| flock | Yes | `brew install flock` | (built-in via util-linux) | File locking |
+| Go 1.25+ | Source only | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
 
-Optional dependencies:
+The exact versions CI pins are in [`deps.env`](https://github.com/gastownhall/gascity/blob/main/deps.env).
 
-- `dolt` for bd-backed integration flows and some advanced local setups
-- Docker for container and image workflows
-- Kubernetes tooling for the native K8s provider
-
-The CI pin set lives in [`deps.env`](https://github.com/gastownhall/gascity/blob/main/deps.env). If you need to match CI
-exactly, start there.
-
-## Install From A Release
-
-Homebrew:
+## Homebrew (recommended)
 
 ```bash
 brew install gastownhall/gascity/gascity
+```
+
+This taps the `gastownhall/gascity` formula, builds or fetches the `gc` binary,
+and installs all six runtime dependencies (tmux, jq, git, dolt, flock, beads).
+
+Verify the installation:
+
+```bash
 gc version
 ```
 
-Direct download:
+### Upgrading via Homebrew
 
 ```bash
-VERSION=0.13.0
+brew update
+brew upgrade gascity
+```
+
+After upgrading, restart any running city so the supervisor picks up the new
+binary:
+
+```bash
+gc service restart     # restarts the launchd/systemd service
+```
+
+`gc start` auto-regenerates the service file on each invocation, so a
+`brew upgrade` followed by `gc start` always picks up template changes
+(see [v0.13.3 release notes](https://github.com/gastownhall/gascity/releases/tag/v0.13.3)).
+
+### Uninstalling via Homebrew
+
+```bash
+gc stop <city-path>                        # stop running city first
+brew uninstall gascity
+brew untap gastownhall/gascity             # remove the tap
+```
+
+## Direct download
+
+Release tarballs are published for every tagged version. Supported platforms:
+
+| OS | Architecture | Archive name |
+|----|-------------|--------------|
+| macOS (darwin) | Apple Silicon (arm64) | `gascity_VERSION_darwin_arm64.tar.gz` |
+| macOS (darwin) | Intel (amd64) | `gascity_VERSION_darwin_amd64.tar.gz` |
+| Linux | x86_64 (amd64) | `gascity_VERSION_linux_amd64.tar.gz` |
+| Linux | ARM (arm64) | `gascity_VERSION_linux_arm64.tar.gz` |
+
+### Download and install
+
+```bash
+# Set the version you want (check https://github.com/gastownhall/gascity/releases)
+VERSION=0.13.3
+
+# Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 case "$ARCH" in
-  x86_64) ARCH=amd64 ;;
-  aarch64|arm64) ARCH=arm64 ;;
+  x86_64)         ARCH=amd64 ;;
+  aarch64|arm64)  ARCH=arm64 ;;
 esac
 
+# Download and extract
 curl -fsSLO "https://github.com/gastownhall/gascity/releases/download/v${VERSION}/gascity_${VERSION}_${OS}_${ARCH}.tar.gz"
 tar -xzf "gascity_${VERSION}_${OS}_${ARCH}.tar.gz"
-./gc version
-```
 
-## Build `gc` From Source
+# Move to a directory on your PATH
+sudo install -m 755 gc /usr/local/bin/gc
 
-From a clean clone:
-
-```bash
-make install
+# Verify
 gc version
 ```
 
-If you do not want to install globally, build the local binary instead:
+### Upgrading a direct-download install
+
+Repeat the download steps above with the new version number. The `gc` binary is
+a single static file — overwriting it is safe.
+
+<Tip>
+You still need to install the [prerequisites](#prerequisites) separately when
+using direct download. Homebrew handles this automatically.
+</Tip>
+
+## Build from source
+
+Requires Go 1.25+ (pinned in `go.mod`).
 
 ```bash
-make build
+git clone https://github.com/gastownhall/gascity.git
+cd gascity
+make install        # builds and installs to $(GOPATH)/bin/gc
+gc version
+```
+
+To build without installing globally:
+
+```bash
+make build          # outputs bin/gc in the repo root
 ./bin/gc version
 ```
 
-## Contributor Setup
+On macOS, `make build` automatically ad-hoc code-signs the binary (`codesign -s -`).
 
-Install local dev tooling and hooks:
+### Contributor setup
+
+After building, install the dev toolchain and pre-commit hooks:
 
 ```bash
 make setup
-make check
+make check          # runs fmt, lint, vet, and unit tests
 ```
 
-`make check` runs the fast Go quality gates, including the repo's docs sync and
-local-link tests.
+See [CONTRIBUTING.md](https://github.com/gastownhall/gascity/blob/main/CONTRIBUTING.md)
+for the full contributor workflow.
 
-## Docs Preview
+## Verify your installation
 
-The docs site now uses Mintlify. Preview it locally with:
+Regardless of install method, confirm everything is working:
+
+```bash
+gc version          # should print the installed version and commit
+```
+
+Then create your first city:
+
+```bash
+gc init ~/my-city
+cd ~/my-city
+gc start
+```
+
+See the [Quickstart](./quickstart) for a complete walkthrough.
+
+## Docs preview
+
+The docs site uses [Mintlify](https://mintlify.com). Preview locally:
 
 ```bash
 cd docs
 npx --yes mint@latest dev
 ```
 
-Run a local docs check without starting the preview server:
+Or run a link check without starting the server:
 
 ```bash
 make check-docs


### PR DESCRIPTION
## Summary

- Expanded `installation.md` with a decision matrix (Homebrew vs direct download vs source) so users know which method to pick
- Added full platform/arch table for release tarballs (darwin/linux × amd64/arm64)
- Documented Homebrew upgrade and uninstall flows
- Added prerequisites table with per-OS install commands
- Included verification steps and next-steps links

Addresses Wasteland bounty `w-69e89917e8`.

## Test plan

- [x] Smoke-check `brew install gastownhall/gascity/gascity` from a clean environment
- [x] Smoke-check direct download curl commands for darwin/arm64
- [x] Run `make check-docs` to validate internal links
- [ ] Verify `gc version` works after each install method
   - ❓ I don't think the `version` subcommand is working. It looks like only git clone logs
```zsh
zsh ❯ gc version
Enumerating objects: 37440, done.
Counting objects: 100% (37440/37440), done.
Delta compression using up to 32 threads
Compressing objects: 100% (11646/11646), done.
Writing objects: 100% (37440/37440), done.
Total 37440 (delta 23880), reused 37440 (delta 23880), pack-reused 0 (from 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)