### PR TITLE
fix: fall back to repo instructions file for quality-gate guidance

### DIFF
--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -17,18 +17,19 @@ import (
 
 // PromptContext holds template data for prompt rendering.
 type PromptContext struct {
-	CityRoot      string
-	AgentName     string // qualified: "rig/polecat-1" or "mayor"
-	TemplateName  string // config name: "polecat" (pool template) or "mayor" (singleton)
-	RigName       string
-	RigRoot       string
-	WorkDir       string
-	IssuePrefix   string
-	Branch        string
-	DefaultBranch string            // e.g. "main" — from git symbolic-ref origin/HEAD
-	WorkQuery     string            // command to find available work (from Agent.EffectiveWorkQuery)
-	SlingQuery    string            // command template to route work to this agent (from Agent.EffectiveSlingQuery)
-	Env           map[string]string // from Agent.Env — custom vars
+	CityRoot            string
+	AgentName           string // qualified: "rig/polecat-1" or "mayor"
+	TemplateName        string // config name: "polecat" (pool template) or "mayor" (singleton)
+	RigName             string
+	RigRoot             string
+	WorkDir             string
+	IssuePrefix         string
+	Branch              string
+	DefaultBranch       string            // e.g. "main" — from git symbolic-ref origin/HEAD
+	WorkQuery           string            // command to find available work (from Agent.EffectiveWorkQuery)
+	SlingQuery          string            // command template to route work to this agent (from Agent.EffectiveSlingQuery)
+	Env                 map[string]string // from Agent.Env — custom vars
+	InstructionsContent string            // raw content of the provider's instructions file (CLAUDE.md / AGENTS.md)
 }
 
 // renderPrompt reads a prompt template file and renders it with the given
@@ -134,7 +135,7 @@ func mergeFragmentLists(global, perAgent []string) []string {
 // buildTemplateData merges Env (lower priority) with SDK fields (higher
 // priority) into a single map for template execution.
 func buildTemplateData(ctx PromptContext) map[string]string {
-	m := make(map[string]string, len(ctx.Env)+8)
+	m := make(map[string]string, len(ctx.Env)+9)
 	for k, v := range ctx.Env {
 		m[k] = v
 	}
@@ -150,6 +151,7 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["DefaultBranch"] = ctx.DefaultBranch
 	m["WorkQuery"] = ctx.WorkQuery
 	m["SlingQuery"] = ctx.SlingQuery
+	m["InstructionsContent"] = ctx.InstructionsContent
 	return m
 }
 

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -466,6 +466,80 @@ func TestRenderPromptGlobalAndPerAgent(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateDataInstructionsContent(t *testing.T) {
+	ctx := PromptContext{
+		AgentName:           "test-agent",
+		InstructionsContent: "# Quality Gate\nRun tests before merging.\n",
+	}
+	data := buildTemplateData(ctx)
+	if data["InstructionsContent"] != "# Quality Gate\nRun tests before merging.\n" {
+		t.Errorf("InstructionsContent = %q, want instructions content", data["InstructionsContent"])
+	}
+}
+
+func TestBuildTemplateDataInstructionsContentOverridesEnv(t *testing.T) {
+	ctx := PromptContext{
+		InstructionsContent: "sdk-value",
+		Env:                 map[string]string{"InstructionsContent": "env-value"},
+	}
+	data := buildTemplateData(ctx)
+	// SDK field should override Env value.
+	if data["InstructionsContent"] != "sdk-value" {
+		t.Errorf("InstructionsContent = %q, want %q (SDK override)", data["InstructionsContent"], "sdk-value")
+	}
+}
+
+func TestBuildTemplateDataInstructionsContentEmpty(t *testing.T) {
+	ctx := PromptContext{AgentName: "test"}
+	data := buildTemplateData(ctx)
+	if data["InstructionsContent"] != "" {
+		t.Errorf("InstructionsContent = %q, want empty string", data["InstructionsContent"])
+	}
+}
+
+func TestRenderPromptInstructionsContentConditional(t *testing.T) {
+	f := fsys.NewFake()
+	tmpl := `{{if .InstructionsContent}}HAS:{{.InstructionsContent}}{{else}}NONE{{end}}`
+	f.Files["/city/prompts/test.md.tmpl"] = []byte(tmpl)
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "populated: renders content",
+			content: "quality-gate-rules",
+			want:    "HAS:quality-gate-rules",
+		},
+		{
+			name:    "empty: renders else branch",
+			content: "",
+			want:    "NONE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := PromptContext{InstructionsContent: tt.content}
+			got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+			if got != tt.want {
+				t.Errorf("renderPrompt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderPromptInstructionsContentVariable(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/test.md.tmpl"] = []byte("Instructions: {{.InstructionsContent}}")
+	ctx := PromptContext{InstructionsContent: "Follow CLAUDE.md rules"}
+	got := renderPrompt(f, "/city", "", "prompts/test.md.tmpl", ctx, "", io.Discard, nil, nil, nil)
+	if got != "Instructions: Follow CLAUDE.md rules" {
+		t.Errorf("renderPrompt(InstructionsContent) = %q, want %q", got, "Instructions: Follow CLAUDE.md rules")
+	}
+}
+
 func TestMergeFragmentLists(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/shellquote"
 )
@@ -157,19 +158,21 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	// Step 9: Render prompt with beacon.
 	var prompt string
 	if resolved.PromptMode != "none" {
+		instrContent := readInstructionsFile(p.fs, workDir, p.cityPath, resolved.InstructionsFile)
 		fragments := mergeFragmentLists(p.globalFragments, cfgAgent.InjectFragments)
 		prompt = renderPrompt(p.fs, p.cityPath, p.cityName, cfgAgent.PromptTemplate, PromptContext{
-			CityRoot:      p.cityPath,
-			AgentName:     qualifiedName,
-			TemplateName:  cfgAgent.Name,
-			RigName:       rigName,
-			RigRoot:       rigRoot,
-			WorkDir:       workDir,
-			IssuePrefix:   findRigPrefix(rigName, p.rigs),
-			DefaultBranch: defaultBranchFor(workDir),
-			WorkQuery:     cfgAgent.EffectiveWorkQuery(),
-			SlingQuery:    cfgAgent.EffectiveSlingQuery(),
-			Env:           cfgAgent.Env,
+			CityRoot:            p.cityPath,
+			AgentName:           qualifiedName,
+			TemplateName:        cfgAgent.Name,
+			RigName:             rigName,
+			RigRoot:             rigRoot,
+			WorkDir:             workDir,
+			IssuePrefix:         findRigPrefix(rigName, p.rigs),
+			DefaultBranch:       defaultBranchFor(workDir),
+			WorkQuery:           cfgAgent.EffectiveWorkQuery(),
+			SlingQuery:          cfgAgent.EffectiveSlingQuery(),
+			Env:                 cfgAgent.Env,
+			InstructionsContent: instrContent,
 		}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
 		hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name)
 		beacon := runtime.FormatBeaconAt(p.cityName, qualifiedName, !hasHooks, p.beaconTime)
@@ -270,4 +273,25 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 		CopyFiles:              tp.Hints.CopyFiles,
 		FingerprintExtra:       tp.FPExtra,
 	}
+}
+
+// readInstructionsFile reads the provider's instructions file from the agent's
+// working directory, falling back to the city root. Returns empty string if
+// the file doesn't exist in either location. The filename defaults to
+// "AGENTS.md" when instructionsFile is empty.
+func readInstructionsFile(fs fsys.FS, workDir, cityPath, instructionsFile string) string {
+	if instructionsFile == "" {
+		instructionsFile = "AGENTS.md"
+	}
+	// Try WorkDir first (the repo clone).
+	if content, err := fs.ReadFile(filepath.Join(workDir, instructionsFile)); err == nil {
+		return string(content)
+	}
+	// Fallback to CityRoot.
+	if workDir != cityPath {
+		if content, err := fs.ReadFile(filepath.Join(cityPath, instructionsFile)); err == nil {
+			return string(content)
+		}
+	}
+	return ""
 }

--- a/cmd/gc/template_resolve_instructions_test.go
+++ b/cmd/gc/template_resolve_instructions_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestReadInstructionsFile(t *testing.T) {
+	tests := []struct {
+		name             string
+		workDir          string
+		cityPath         string
+		instructionsFile string
+		files            map[string][]byte
+		want             string
+	}{
+		{
+			name:             "happy path: file in workDir",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "CLAUDE.md",
+			files: map[string][]byte{
+				"/repo/CLAUDE.md": []byte("# Instructions\nDo good work.\n"),
+			},
+			want: "# Instructions\nDo good work.\n",
+		},
+		{
+			name:             "fallback: file only in cityPath",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "CLAUDE.md",
+			files: map[string][]byte{
+				"/city/CLAUDE.md": []byte("# City Instructions\n"),
+			},
+			want: "# City Instructions\n",
+		},
+		{
+			name:             "missing everywhere: returns empty string",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "CLAUDE.md",
+			files:            map[string][]byte{},
+			want:             "",
+		},
+		{
+			name:             "empty instructionsFile defaults to AGENTS.md",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "",
+			files: map[string][]byte{
+				"/repo/AGENTS.md": []byte("# Agent Instructions\n"),
+			},
+			want: "# Agent Instructions\n",
+		},
+		{
+			name:             "different provider filename: CLAUDE.md vs AGENTS.md",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "CLAUDE.md",
+			files: map[string][]byte{
+				"/repo/CLAUDE.md":  []byte("claude content"),
+				"/repo/AGENTS.md": []byte("agents content"),
+			},
+			want: "claude content",
+		},
+		{
+			name:             "workDir equals cityPath: no redundant read",
+			workDir:          "/city",
+			cityPath:         "/city",
+			instructionsFile: "CLAUDE.md",
+			files: map[string][]byte{
+				"/city/CLAUDE.md": []byte("same-dir content"),
+			},
+			want: "same-dir content",
+		},
+		{
+			name:             "workDir equals cityPath and file missing: empty string",
+			workDir:          "/city",
+			cityPath:         "/city",
+			instructionsFile: "CLAUDE.md",
+			files:            map[string][]byte{},
+			want:             "",
+		},
+		{
+			name:             "workDir has file, cityPath also has file: workDir wins",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "AGENTS.md",
+			files: map[string][]byte{
+				"/repo/AGENTS.md": []byte("repo version"),
+				"/city/AGENTS.md": []byte("city version"),
+			},
+			want: "repo version",
+		},
+		{
+			name:             "empty default falls back to cityPath AGENTS.md",
+			workDir:          "/repo",
+			cityPath:         "/city",
+			instructionsFile: "",
+			files: map[string][]byte{
+				"/city/AGENTS.md": []byte("city agents fallback"),
+			},
+			want: "city agents fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fsys.NewFake()
+			for path, content := range tt.files {
+				f.Files[path] = content
+			}
+
+			got := readInstructionsFile(f, tt.workDir, tt.cityPath, tt.instructionsFile)
+			if got != tt.want {
+				t.Errorf("readInstructionsFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/examples/gastown/packs/gastown/prompts/crew.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/crew.md.tmpl
@@ -321,10 +321,16 @@ you are!" - that is a FAILURE. YOU must push, not the user.
    ```
 
 2. **Run quality gates** (only if code changes were made):
+{{- if .InstructionsContent }}
+   Follow the quality-gate commands from the project's instructions:
+
+   {{ .InstructionsContent }}
+{{- else }}
    ```bash
    go test ./...             # or: make test
    golangci-lint run ./...   # or: make lint
    ```
+{{- end }}
    File P0 beads if quality gates are broken.
 
 3. **Update beads** - close finished work, update status:


### PR DESCRIPTION
## Summary

- When pack-specific quality-gate guidance is missing or empty, the Gastown pack now falls back to the repo's own instructions file (`CLAUDE.md` or `AGENTS.md`) instead of skipping quality-gate guidance entirely
- Adds `InstructionsContent` field to `PromptContext` with provider-aware file resolution (WorkDir → CityRoot → empty)
- Updates `crew.md.tmpl` with conditional fallback that preserves existing hardcoded commands as the default

## Changes

| File | What |
|------|------|
| `cmd/gc/prompt.go` | `InstructionsContent` field on `PromptContext` + `buildTemplateData` mapping |
| `cmd/gc/template_resolve.go` | `readInstructionsFile` helper + wiring in `resolveTemplate` |
| `crew.md.tmpl` | Conditional: use `InstructionsContent` when available, else keep hardcoded fallback |
| `template_resolve_instructions_test.go` | 9 table-driven tests for the helper |
| `prompt_test.go` | 5 tests for mapping + template rendering |

## Design decisions

- **ZFC compliant**: Go reads the file, templates decide usage — no content interpretation in Go
- **Backward compatible**: `missingkey=zero` ensures empty string default for existing templates
- **Provider-aware**: Resolves `CLAUDE.md` vs `AGENTS.md` from provider config

## Test plan

- [x] `readInstructionsFile` happy path (file in workDir)
- [x] `readInstructionsFile` fallback (file only in cityPath)
- [x] `readInstructionsFile` missing everywhere (empty string)
- [x] `readInstructionsFile` empty filename defaults to AGENTS.md
- [x] `readInstructionsFile` provider-specific filenames (CLAUDE.md vs AGENTS.md)
- [x] `buildTemplateData` includes InstructionsContent key
- [x] Template rendering with conditional (populated and empty)
- [x] No regressions in existing test suite

Resolves: `w-d4dba7b056`