### PR TITLE
fix(ci): set GORELEASER_CURRENT_TAG to prevent RC tag resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- Sets `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` in the release workflow so GoReleaser uses the triggering tag instead of discovering it via `git describe`
- Fixes #52 — when a stable tag (v0.13.3) and an RC tag (v0.13.3-rc7) point to the same commit, GoReleaser was picking the RC tag and publishing artifacts under the wrong release

## Test plan

- [ ] Merge this PR
- [ ] Delete and re-push the v0.13.3 tag to re-trigger the release workflow
- [ ] Verify v0.13.3 release has binary assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)