### PR TITLE
feat: configurable Pod Security Standards for K8s session provider

### DIFF
--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -140,7 +140,7 @@ func newSessionProviderByName(name string, sc config.SessionConfig, cityName, ci
 		}
 		return sessionacp.NewProvider(cfg), nil
 	case "k8s":
-		return sessionk8s.NewProvider()
+		return sessionk8s.NewProvider(sc.K8s)
 	case "hybrid":
 		return newHybridProvider(sc, cityName, cityPath)
 	default:
@@ -711,7 +711,7 @@ func openCityEventsProvider(stderr io.Writer, cmdName string) (events.Provider, 
 // local tmux.
 func newHybridProvider(sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
 	local := sessiontmux.NewProviderWithConfig(tmuxConfigFromSession(sc, cityName, cityPath))
-	remote, err := sessionk8s.NewProvider()
+	remote, err := sessionk8s.NewProvider(sc.K8s)
 	if err != nil {
 		return nil, fmt.Errorf("hybrid: k8s backend: %w", err)
 	}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -319,7 +319,9 @@ K8sConfig holds native K8s session provider settings.
 | `mem_request` | string |  | `1Gi` | MemRequest is the pod memory request. Default: "1Gi". |
 | `cpu_limit` | string |  | `2` | CPULimit is the pod CPU limit. Default: "2". |
 | `mem_limit` | string |  | `4Gi` | MemLimit is the pod memory limit. Default: "4Gi". |
+| `service_account` | string |  |  | ServiceAccount is the pod service account name. Default: namespace default. |
 | `prebaked` | boolean |  |  | Prebaked skips init container staging and EmptyDir volumes when true. Use with images built by `gc build-image` that have city content baked in. |
+| `pod_security` | string |  |  | PodSecurity sets the Pod Security Standards profile for agent pods. "restricted" adds full PSS-compliant security context (runAsNonRoot, seccompProfile, drop ALL capabilities). "baseline" adds runAsNonRoot and seccompProfile only. "" or "none" adds no security context (default). |
 
 ## MailConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1194,9 +1194,17 @@
           "description": "MemLimit is the pod memory limit. Default: \"4Gi\".",
           "default": "4Gi"
         },
+        "service_account": {
+          "type": "string",
+          "description": "ServiceAccount is the pod service account name. Default: namespace default."
+        },
         "prebaked": {
           "type": "boolean",
           "description": "Prebaked skips init container staging and EmptyDir volumes when true.\nUse with images built by `gc build-image` that have city content baked in."
+        },
+        "pod_security": {
+          "type": "string",
+          "description": "PodSecurity sets the Pod Security Standards profile for agent pods.\n\"restricted\" adds full PSS-compliant security context (runAsNonRoot,\nseccompProfile, drop ALL capabilities). \"baseline\" adds runAsNonRoot\nand seccompProfile only. \"\" or \"none\" adds no security context (default)."
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1021,9 +1021,16 @@ type K8sConfig struct {
 	CPULimit string `toml:"cpu_limit,omitempty" jsonschema:"default=2"`
 	// MemLimit is the pod memory limit. Default: "4Gi".
 	MemLimit string `toml:"mem_limit,omitempty" jsonschema:"default=4Gi"`
+	// ServiceAccount is the pod service account name. Default: namespace default.
+	ServiceAccount string `toml:"service_account,omitempty"`
 	// Prebaked skips init container staging and EmptyDir volumes when true.
 	// Use with images built by `gc build-image` that have city content baked in.
 	Prebaked bool `toml:"prebaked,omitempty"`
+	// PodSecurity sets the Pod Security Standards profile for agent pods.
+	// "restricted" adds full PSS-compliant security context (runAsNonRoot,
+	// seccompProfile, drop ALL capabilities). "baseline" adds runAsNonRoot
+	// and seccompProfile only. "" or "none" adds no security context (default).
+	PodSecurity string `toml:"pod_security,omitempty"`
 }
 
 // MailConfig holds mail provider settings.

--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -166,6 +166,11 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 	// as root (see securityContext below), creates the user, sets up workspace
 	// ownership, then drops privileges via su for the tmux session.
 	linuxUsername := cfg.Env["LINUX_USERNAME"]
+
+	// Validate: LINUX_USERNAME requires root, which conflicts with restricted PSS.
+	if linuxUsername != "" && p.podSecurity == "restricted" {
+		return nil, fmt.Errorf("LINUX_USERNAME %q conflicts with pod_security=restricted (requires root for user creation)", linuxUsername)
+	}
 	var userSetup string
 	if linuxUsername != "" {
 		userSetup = fmt.Sprintf(
@@ -266,6 +271,7 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 		Spec: corev1.PodSpec{
 			ServiceAccountName: p.serviceAccount,
 			RestartPolicy:      corev1.RestartPolicyNever,
+			SecurityContext:    buildPodSecurityContext(p.podSecurity),
 			Containers: []corev1.Container{{
 				Name:            "agent",
 				Image:           p.image,
@@ -278,7 +284,7 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 				TTY:             true,
 				Resources:       resources,
 				VolumeMounts:    mainVolMounts,
-				SecurityContext: agentSecurityContext(linuxUsername),
+				SecurityContext: agentSecurityContext(linuxUsername, p.podSecurity),
 			}},
 			Volumes: volumes,
 		},
@@ -294,12 +300,14 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 				Name: "city", MountPath: "/city-stage",
 			})
 		}
+		initSC := agentSecurityContext("", p.podSecurity)
 		pod.Spec.InitContainers = []corev1.Container{{
 			Name:            "stage",
 			Image:           p.image,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"sh", "-c", "while [ ! -f /workspace/.gc-ready ]; do sleep 0.5; done"},
 			VolumeMounts:    initVolMounts,
+			SecurityContext: initSC,
 		}}
 	}
 
@@ -309,14 +317,56 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 // agentSecurityContext returns a container security context.
 // When a dynamic linux username is configured, the container starts as root
 // (UID 0) so it can create the user at runtime before dropping privileges.
-// When no dynamic user is set, returns nil (uses Dockerfile default: gcagent).
-func agentSecurityContext(linuxUsername string) *corev1.SecurityContext {
-	if linuxUsername == "" {
+// When podSecurity is "restricted", sets allowPrivilegeEscalation=false and
+// drops all capabilities. When no dynamic user and no podSecurity, returns nil.
+func agentSecurityContext(linuxUsername, podSecurity string) *corev1.SecurityContext {
+	if linuxUsername != "" {
+		var rootUID int64
+		return &corev1.SecurityContext{
+			RunAsUser: &rootUID,
+		}
+	}
+	if podSecurity == "restricted" {
+		return restrictedContainerSecurityContext()
+	}
+	return nil
+}
+
+// buildPodSecurityContext returns a pod-level security context for the given
+// pod_security mode. Returns nil for "" or "none" (backward compat).
+func buildPodSecurityContext(podSecurity string) *corev1.PodSecurityContext {
+	switch podSecurity {
+	case "restricted":
+		var uid, gid int64 = 1000, 1000
+		return &corev1.PodSecurityContext{
+			RunAsNonRoot: boolPtr(true),
+			RunAsUser:    &uid,
+			RunAsGroup:   &gid,
+			FSGroup:      &gid,
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	case "baseline":
+		return &corev1.PodSecurityContext{
+			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	default:
 		return nil
 	}
-	var rootUID int64
+}
+
+// restrictedContainerSecurityContext returns a container-level security context
+// that satisfies the Kubernetes restricted Pod Security Standard.
+func restrictedContainerSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
-		RunAsUser: &rootUID,
+		AllowPrivilegeEscalation: boolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
 	}
 }
 

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -37,20 +38,23 @@ type Provider struct {
 	memRequest         string
 	cpuLimit           string
 	memLimit           string
-	serviceAccount     string        // pod service account name (GC_K8S_SERVICE_ACCOUNT)
+	serviceAccount     string        // pod service account name (cfg.ServiceAccount / GC_K8S_SERVICE_ACCOUNT)
 	prebaked           bool          // skip staging + init container for prebaked images
+	podSecurity        string        // "restricted", "baseline", or "" (none)
 	postStartSettle    time.Duration // settle time before post-start liveness check
 	stderr             io.Writer     // warning output (default os.Stderr)
 }
 
 // NewProvider creates a K8s session provider.
-// Configuration is read from environment variables (matching gc-session-k8s):
+// K8sConfig values from city.toml serve as defaults; environment variables
+// (GC_K8S_*) override them:
 //   - GC_K8S_NAMESPACE — namespace (default: "gc")
 //   - GC_K8S_IMAGE — container image (required for Start)
 //   - GC_K8S_CONTEXT — kubectl context (default: current)
 //   - GC_K8S_SERVICE_ACCOUNT — pod service account name (default: namespace default)
 //   - GC_K8S_CPU_REQUEST, GC_K8S_MEM_REQUEST — resource requests
 //   - GC_K8S_CPU_LIMIT, GC_K8S_MEM_LIMIT — resource limits
+//   - GC_K8S_POD_SECURITY — pod security profile ("restricted", "baseline", "")
 //
 // The in-cluster Dolt service alias defaults to the provider defaults
 // (dolt.gc.svc.cluster.local:3307). Pods receive projected GC_DOLT_* env;
@@ -59,10 +63,10 @@ type Provider struct {
 //
 // Uses rest.InClusterConfig() when running in a pod, falls back to
 // clientcmd.BuildConfigFromFlags() for local development.
-func NewProvider() (*Provider, error) {
-	namespace := envOrDefault("GC_K8S_NAMESPACE", "gc")
-	image := os.Getenv("GC_K8S_IMAGE")
-	k8sContext := os.Getenv("GC_K8S_CONTEXT")
+func NewProvider(cfg config.K8sConfig) (*Provider, error) {
+	namespace := envOrDefault("GC_K8S_NAMESPACE", cfgOrDefault(cfg.Namespace, "gc"))
+	image := envOrDefault("GC_K8S_IMAGE", cfg.Image)
+	k8sContext := envOrDefault("GC_K8S_CONTEXT", cfg.Context)
 
 	restConfig, err := buildRESTConfig(k8sContext)
 	if err != nil {
@@ -90,12 +94,13 @@ func NewProvider() (*Provider, error) {
 		k8sContext:         k8sContext,
 		managedServiceHost: managedServiceHost,
 		managedServicePort: managedServicePort,
-		cpuRequest:         envOrDefault("GC_K8S_CPU_REQUEST", "500m"),
-		memRequest:         envOrDefault("GC_K8S_MEM_REQUEST", "1Gi"),
-		cpuLimit:           envOrDefault("GC_K8S_CPU_LIMIT", "2"),
-		memLimit:           envOrDefault("GC_K8S_MEM_LIMIT", "4Gi"),
-		serviceAccount:     os.Getenv("GC_K8S_SERVICE_ACCOUNT"),
-		prebaked:           os.Getenv("GC_K8S_PREBAKED") == "true",
+		cpuRequest:         envOrDefault("GC_K8S_CPU_REQUEST", cfgOrDefault(cfg.CPURequest, "500m")),
+		memRequest:         envOrDefault("GC_K8S_MEM_REQUEST", cfgOrDefault(cfg.MemRequest, "1Gi")),
+		cpuLimit:           envOrDefault("GC_K8S_CPU_LIMIT", cfgOrDefault(cfg.CPULimit, "2")),
+		memLimit:           envOrDefault("GC_K8S_MEM_LIMIT", cfgOrDefault(cfg.MemLimit, "4Gi")),
+		serviceAccount:     envOrDefault("GC_K8S_SERVICE_ACCOUNT", cfg.ServiceAccount),
+		prebaked:           os.Getenv("GC_K8S_PREBAKED") == "true" || cfg.Prebaked,
+		podSecurity:        envOrDefault("GC_K8S_POD_SECURITY", cfg.PodSecurity),
 		postStartSettle:    3 * time.Second,
 		stderr:             os.Stderr,
 	}, nil
@@ -811,6 +816,14 @@ func managedServiceAlias() (string, string, error) {
 func envOrDefault(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return def
+}
+
+// cfgOrDefault returns val if non-empty, otherwise def.
+func cfgOrDefault(val, def string) string {
+	if val != "" {
+		return val
 	}
 	return def
 }

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -1771,3 +1771,185 @@ func TestInitCityInPodSkipsDolt(t *testing.T) {
 		t.Errorf("gc init should run with GC_DOLT=skip; got cmd=%v", gcInitCmd)
 	}
 }
+
+// --- Pod Security Standards tests ---
+
+func TestBuildPod_PodSecurityRestricted(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.podSecurity = "restricted"
+
+	cfg := runtime.Config{
+		Command: "claude",
+		Env:     map[string]string{"GC_AGENT": "mayor", "GC_CITY": "/workspace"},
+	}
+
+	pod, err := buildPod("gascity-mayor", cfg, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pod-level security context.
+	psc := pod.Spec.SecurityContext
+	if psc == nil {
+		t.Fatal("pod SecurityContext is nil, want restricted")
+	}
+	if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
+		t.Error("RunAsNonRoot not set")
+	}
+	if psc.RunAsUser == nil || *psc.RunAsUser != 1000 {
+		t.Errorf("RunAsUser = %v, want 1000", psc.RunAsUser)
+	}
+	if psc.RunAsGroup == nil || *psc.RunAsGroup != 1000 {
+		t.Errorf("RunAsGroup = %v, want 1000", psc.RunAsGroup)
+	}
+	if psc.FSGroup == nil || *psc.FSGroup != 1000 {
+		t.Errorf("FSGroup = %v, want 1000", psc.FSGroup)
+	}
+	if psc.SeccompProfile == nil || psc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("SeccompProfile not RuntimeDefault")
+	}
+
+	// Agent container security context.
+	agentSC := pod.Spec.Containers[0].SecurityContext
+	if agentSC == nil {
+		t.Fatal("agent container SecurityContext is nil")
+	}
+	if agentSC.AllowPrivilegeEscalation == nil || *agentSC.AllowPrivilegeEscalation {
+		t.Error("AllowPrivilegeEscalation not false")
+	}
+	if agentSC.Capabilities == nil || len(agentSC.Capabilities.Drop) == 0 {
+		t.Error("Capabilities.Drop not set")
+	} else if agentSC.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("Capabilities.Drop = %v, want [ALL]", agentSC.Capabilities.Drop)
+	}
+}
+
+func TestBuildPod_PodSecurityRestricted_InitContainer(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.podSecurity = "restricted"
+
+	cfg := runtime.Config{
+		Command: "claude",
+		WorkDir: "/city/rig",
+		Env:     map[string]string{"GC_AGENT": "polecat", "GC_CITY": "/city"},
+	}
+
+	pod, err := buildPod("gascity-polecat", cfg, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pod.Spec.InitContainers) == 0 {
+		t.Fatal("expected init container for rig agent")
+	}
+	stageSC := pod.Spec.InitContainers[0].SecurityContext
+	if stageSC == nil {
+		t.Fatal("stage init container SecurityContext is nil")
+	}
+	if stageSC.AllowPrivilegeEscalation == nil || *stageSC.AllowPrivilegeEscalation {
+		t.Error("stage AllowPrivilegeEscalation not false")
+	}
+	if stageSC.Capabilities == nil || len(stageSC.Capabilities.Drop) == 0 {
+		t.Error("stage Capabilities.Drop not set")
+	}
+}
+
+func TestBuildPod_PodSecurityBaseline(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.podSecurity = "baseline"
+
+	cfg := runtime.Config{
+		Command: "claude",
+		Env:     map[string]string{"GC_AGENT": "mayor", "GC_CITY": "/workspace"},
+	}
+
+	pod, err := buildPod("gascity-mayor", cfg, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pod-level: runAsNonRoot + seccompProfile.
+	psc := pod.Spec.SecurityContext
+	if psc == nil {
+		t.Fatal("pod SecurityContext is nil, want baseline")
+	}
+	if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
+		t.Error("RunAsNonRoot not set")
+	}
+	if psc.SeccompProfile == nil || psc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("SeccompProfile not RuntimeDefault")
+	}
+
+	// Container-level: no additional constraints.
+	agentSC := pod.Spec.Containers[0].SecurityContext
+	if agentSC != nil && agentSC.AllowPrivilegeEscalation != nil {
+		t.Error("baseline should not set AllowPrivilegeEscalation")
+	}
+}
+
+func TestBuildPod_PodSecurityNone(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	// podSecurity is "" (zero value) = none
+
+	cfg := runtime.Config{
+		Command: "claude",
+		Env:     map[string]string{"GC_AGENT": "mayor", "GC_CITY": "/workspace"},
+	}
+
+	pod, err := buildPod("gascity-mayor", cfg, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No pod-level security context (backward compat).
+	if pod.Spec.SecurityContext != nil {
+		t.Errorf("pod SecurityContext = %+v, want nil for none/empty", pod.Spec.SecurityContext)
+	}
+}
+
+func TestBuildPod_PodSecurityRestrictedRejectsLinuxUsername(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.podSecurity = "restricted"
+
+	cfg := runtime.Config{
+		Command: "claude",
+		Env: map[string]string{
+			"GC_AGENT":       "mayor",
+			"GC_CITY":        "/workspace",
+			"LINUX_USERNAME": "customuser",
+		},
+	}
+
+	_, err := buildPod("gascity-mayor", cfg, p)
+	if err == nil {
+		t.Fatal("expected error for LINUX_USERNAME + restricted")
+	}
+	if !contains(err.Error(), "LINUX_USERNAME") {
+		t.Errorf("error = %q, want mention of LINUX_USERNAME", err)
+	}
+}
+
+func TestBuildPod_PodSecurityBaselineAllowsLinuxUsername(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.podSecurity = "baseline"
+
+	cfg := runtime.Config{
+		Command: "claude",
+		Env: map[string]string{
+			"GC_AGENT":       "mayor",
+			"GC_CITY":        "/workspace",
+			"LINUX_USERNAME": "customuser",
+		},
+	}
+
+	pod, err := buildPod("gascity-mayor", cfg, p)
+	if err != nil {
+		t.Fatalf("baseline + LINUX_USERNAME should succeed: %v", err)
+	}
+
+	// LINUX_USERNAME sets RunAsUser=0.
+	agentSC := pod.Spec.Containers[0].SecurityContext
+	if agentSC == nil || agentSC.RunAsUser == nil || *agentSC.RunAsUser != 0 {
+		t.Error("baseline + LINUX_USERNAME should set RunAsUser=0")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `pod_security` field to `[session.k8s]` config and `GC_K8S_POD_SECURITY` env var
- Three modes: `restricted` (full PSS), `baseline` (partial), `""` (none, default)
- Apply security contexts to pod spec, agent container, and stage init container
- Validate `LINUX_USERNAME` + `restricted` conflict (returns error)
- Wire `K8sConfig` from city.toml through to `NewProvider` (previously parsed but ignored)

## Problem

The K8s session provider creates agent pods with no security context. This works on default k3s clusters but breaks on any cluster enforcing restricted Pod Security Standards at the namespace level.

## Configuration

\`\`\`toml
[session.k8s]
pod_security = "restricted"  # or "baseline" or "none" (default)
\`\`\`

Or via env var: `GC_K8S_POD_SECURITY=restricted`

### Modes

| Mode | Pod-level | Container-level |
|------|-----------|-----------------|
| `restricted` | runAsNonRoot, runAsUser=1000, runAsGroup=1000, fsGroup=1000, seccompProfile=RuntimeDefault | allowPrivilegeEscalation=false, capabilities.drop=[ALL] |
| `baseline` | runAsNonRoot, seccompProfile=RuntimeDefault | (none) |
| `""` / `none` | (none) | (none) — backward compatible |

`LINUX_USERNAME` requires root for dynamic user creation — `restricted` + `LINUX_USERNAME` returns an error. `baseline` and `none` allow it.

## Bonus fix

`K8sConfig` from `city.toml` was parsed but never passed to `NewProvider` — all fields were only readable via env vars. This PR wires the config through so TOML values serve as defaults with env var overrides, matching the documented behavior.