### PR TITLE
fix(dashboard): guard meta tag access for standalone controller mode

### DIFF
--- a/cmd/gc/dashboard/static/dashboard.js
+++ b/cmd/gc/dashboard/static/dashboard.js
@@ -7,8 +7,9 @@
     // Selected city: prefer URL query param, fall back to server-rendered meta tag.
     // The meta tag ensures the first load (no ?city= in URL) still scopes API calls
     // to the city the server selected as default.
+    var _cityMeta = document.querySelector('meta[name="selected-city"]');
     var _selectedCity = new URLSearchParams(window.location.search).get('city') ||
-        (document.querySelector('meta[name="selected-city"]') || {}).getAttribute('content') || '';
+        (_cityMeta ? _cityMeta.getAttribute('content') : '') || '';
 
     // ============================================
     // CSRF PROTECTION


### PR DESCRIPTION
## Summary
- In controller mode (no supervisor), the `selected-city` meta tag is absent from the page
- The fallback `|| {}` creates a plain object where `getAttribute` is undefined, throwing `TypeError` and breaking the SSE EventSource connection
- Uses the same null-check pattern already used for the CSRF token meta tag on line 19