### PR TITLE
Fix bd-backed mail queries for message beads

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -545,7 +545,7 @@ func (s *BdStore) Close(id string) error {
 
 // List returns all beads via bd list.
 func (s *BdStore) List() ([]Bead, error) {
-	out, err := s.runner(s.dir, "bd", "list", "--json", "--limit", "0", "--all")
+	out, err := s.runner(s.dir, "bd", "list", "--json", "--limit", "0", "--all", "--include-infra")
 	if err != nil {
 		return nil, fmt.Errorf("bd list: %w", err)
 	}
@@ -561,7 +561,7 @@ func (s *BdStore) List() ([]Bead, error) {
 // Limit controls max results (0 = unlimited). Results are ordered by bd's
 // default sort (newest first).
 func (s *BdStore) ListByLabel(label string, limit int) ([]Bead, error) {
-	args := []string{"list", "--json", "--label=" + label, "--all", "--limit", fmt.Sprintf("%d", limit)}
+	args := []string{"list", "--json", "--label=" + label, "--all", "--include-infra", "--limit", fmt.Sprintf("%d", limit)}
 	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd list: %w", err)
@@ -577,7 +577,7 @@ func (s *BdStore) ListByLabel(label string, limit int) ([]Bead, error) {
 // ListByAssignee returns beads assigned to the given agent with the specified
 // status via bd list --assignee --status. Limit controls max results (0 = unlimited).
 func (s *BdStore) ListByAssignee(assignee, status string, limit int) ([]Bead, error) {
-	args := []string{"list", "--json", "--assignee=" + assignee, "--status=" + status, "--limit", fmt.Sprintf("%d", limit)}
+	args := []string{"list", "--json", "--assignee=" + assignee, "--status=" + status, "--include-infra", "--limit", fmt.Sprintf("%d", limit)}
 	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd list: %w", err)
@@ -593,7 +593,7 @@ func (s *BdStore) ListByAssignee(assignee, status string, limit int) ([]Bead, er
 // ListByMetadata returns beads matching all given metadata key=value filters.
 // Limit controls max results (0 = unlimited). Results use bd's default order.
 func (s *BdStore) ListByMetadata(filters map[string]string, limit int) ([]Bead, error) {
-	args := []string{"list", "--json", "--all", "--limit", fmt.Sprintf("%d", limit)}
+	args := []string{"list", "--json", "--all", "--include-infra", "--limit", fmt.Sprintf("%d", limit)}
 	if len(filters) > 0 {
 		keys := make([]string, 0, len(filters))
 		for k := range filters {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -388,7 +388,7 @@ func TestBdStoreList(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --limit 0 --all`: {
+		`bd list --json --limit 0 --all --include-infra`: {
 			out: []byte(`[{"id":"bd-aaa","title":"first","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},{"id":"bd-bbb","title":"second","status":"closed","issue_type":"bug","created_at":"2025-01-15T10:31:00Z"}]`),
 		},
 	})
@@ -413,7 +413,7 @@ func TestBdStoreListEmpty(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --limit 0 --all`: {out: []byte(`[]`)},
+		`bd list --json --limit 0 --all --include-infra`: {out: []byte(`[]`)},
 	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.List()
@@ -436,6 +436,21 @@ func TestBdStoreListError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bd list") {
 		t.Errorf("error = %q, want to contain 'bd list'", err)
+	}
+}
+
+func TestBdStoreListIncludesInfra(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`[]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.List(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strings.Join(gotArgs, " "), "--include-infra") {
+		t.Fatalf("args = %q, want --include-infra", strings.Join(gotArgs, " "))
 	}
 }
 
@@ -860,7 +875,7 @@ func TestBdStoreListByLabel(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=order-run:digest --all --limit 5`: {
+		`bd list --json --label=order-run:digest --all --include-infra --limit 5`: {
 			out: []byte(`[{"id":"bd-aaa","title":"digest wisp","status":"open","issue_type":"task","created_at":"2026-02-27T10:00:00Z","labels":["order-run:digest"]}]`),
 		},
 	})
@@ -885,7 +900,7 @@ func TestBdStoreListByLabelEmpty(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=order-run:none --all --limit 1`: {out: []byte(`[]`)},
+		`bd list --json --label=order-run:none --all --include-infra --limit 1`: {out: []byte(`[]`)},
 	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.ListByLabel("order-run:none", 1)
@@ -925,6 +940,50 @@ func TestBdStoreListByLabelZeroLimit(t *testing.T) {
 	args := strings.Join(gotArgs, " ")
 	if !strings.Contains(args, "--limit 0") {
 		t.Errorf("args = %q, want --limit 0 for unlimited", args)
+	}
+	if !strings.Contains(args, "--include-infra") {
+		t.Errorf("args = %q, want --include-infra", args)
+	}
+}
+
+func TestBdStoreListByAssigneeIncludesInfra(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`[]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.ListByAssignee("mayor", "open", 0); err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--assignee=mayor") {
+		t.Fatalf("args = %q, want --assignee=mayor", args)
+	}
+	if !strings.Contains(args, "--status=open") {
+		t.Fatalf("args = %q, want --status=open", args)
+	}
+	if !strings.Contains(args, "--include-infra") {
+		t.Fatalf("args = %q, want --include-infra", args)
+	}
+}
+
+func TestBdStoreListByMetadataIncludesInfra(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`[]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.ListByMetadata(map[string]string{"alias": "mayor"}, 0); err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--metadata-field alias=mayor") {
+		t.Fatalf("args = %q, want metadata filter", args)
+	}
+	if !strings.Contains(args, "--include-infra") {
+		t.Fatalf("args = %q, want --include-infra", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `BdStore` list queries to include infrastructure beads so `message` beads are visible to mail commands backed by `bd`.
- Add adapter regression tests for `List`, `ListByLabel`, `ListByAssignee`, and `ListByMetadata` to pin the `--include-infra` behavior.
- Closes #73.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
  No breaking changes or migration notes.
