### PR TITLE
fix: skip pool session beads when pool scaling returns zero

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -220,6 +220,24 @@ func discoverSessionBeads(
 		if cfgAgent == nil {
 			continue
 		}
+		// Pool agents: respect the pool's scaling decision. If the main
+		// config iteration (which ran evaluatePool / scale_check) did not
+		// produce any desired entries for this template, the pool wants 0
+		// instances. Don't re-add stale session beads — that bypasses
+		// scaling and causes infinite wake→drain→stop loops when there's
+		// no work.
+		if cfgAgent.Pool != nil {
+			templateHasDesired := false
+			for _, existing := range desired {
+				if existing.TemplateName == template {
+					templateHasDesired = true
+					break
+				}
+			}
+			if !templateHasDesired {
+				continue
+			}
+		}
 		// Resolve TemplateParams for this bead's session.
 		fpExtra := buildFingerprintExtra(cfgAgent)
 		tp, err := resolveTemplate(bp, cfgAgent, cfgAgent.QualifiedName(), fpExtra)

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -784,6 +784,94 @@ func TestDiscoverSessionBeads_SkipsNoTemplate(t *testing.T) {
 	}
 }
 
+func TestDiscoverSessionBeads_SkipsPoolAgentWithZeroDesired(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// A polecat pool session bead left over from a previous run.
+	_, err := store.Create(beads.Bead{
+		Title:  "polecat-1",
+		Type:   "session",
+		Labels: []string{sessionBeadLabel, "template:polecat"},
+		Metadata: map[string]string{
+			"template":     "polecat",
+			"session_name": "polecat--polecat-1",
+			"state":        "stopped",
+			"pool_slot":    "1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:         "polecat",
+				StartCommand: "echo",
+				Pool:         &config.PoolConfig{Min: 0, Max: -1},
+			},
+		},
+	}
+	sp := runtime.NewFake()
+	bp := newAgentBuildParams("test", t.TempDir(), cfg, sp, time.Now(), store, io.Discard)
+
+	// Empty desired = pool eval returned 0 (no work).
+	desired := make(map[string]TemplateParams)
+	discoverSessionBeads(bp, cfg, desired, io.Discard)
+
+	if len(desired) != 0 {
+		t.Errorf("pool agent with 0 desired should not be re-added from stale bead, got %d entries: %v",
+			len(desired), mapKeys(desired))
+	}
+}
+
+func TestDiscoverSessionBeads_IncludesPoolAgentWithDesired(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Two pool session beads — slot 1 and slot 2.
+	for _, slot := range []string{"1", "2"} {
+		_, err := store.Create(beads.Bead{
+			Title:  "polecat-" + slot,
+			Type:   "session",
+			Labels: []string{sessionBeadLabel, "template:polecat"},
+			Metadata: map[string]string{
+				"template":     "polecat",
+				"session_name": "polecat--polecat-" + slot,
+				"state":        "stopped",
+				"pool_slot":    slot,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:         "polecat",
+				StartCommand: "echo",
+				Pool:         &config.PoolConfig{Min: 0, Max: -1},
+			},
+		},
+	}
+	sp := runtime.NewFake()
+	bp := newAgentBuildParams("test", t.TempDir(), cfg, sp, time.Now(), store, io.Discard)
+
+	// Simulate pool eval returning 1 — slot 1 is in desired.
+	desired := map[string]TemplateParams{
+		"polecat--polecat-1": {TemplateName: "polecat", SessionName: "polecat--polecat-1"},
+	}
+	discoverSessionBeads(bp, cfg, desired, io.Discard)
+
+	// Slot 1 was already desired (should stay), slot 2 should be added
+	// because the pool has desired > 0.
+	if _, ok := desired["polecat--polecat-2"]; !ok {
+		t.Errorf("pool session bead for slot 2 should be included when pool has desired entries, got keys: %v",
+			mapKeys(desired))
+	}
+}
+
 func TestFindSessionNameByTemplate_PrefersAgentNameMatch(t *testing.T) {
 	store := beads.NewMemStore()
 


### PR DESCRIPTION
## Summary

- Pool agents (`min=0`) with stale open session beads entered an infinite wake→drain→stop→wake loop (~1 min cycle), each cycle starting a new Claude session and burning tokens
- `discoverSessionBeads()` added ALL open session beads to `desiredState` regardless of pool scaling — bypassing `evaluatePool` / `scale_check` results
- Fix: skip pool agent beads when no entry for that template exists in `desiredState` (meaning the pool eval returned 0 desired instances)

## Root cause

`discoverSessionBeads()` in `build_desired_state.go` exists to pick up sessions created outside the normal config iteration (e.g., `gc session new`, `gc sling`). However, it didn't check pool scaling — if a polecat session bead was still open from a previous run, it would re-enter desired state on every reconcile tick even when `scale_check` returned 0. This caused:

1. `derivePoolDesired` counted the re-added bead as desired=1
2. `wakeReasons` returned `WakeConfig` for slot 1
3. Session woke, found no work, drained, stopped
4. Next tick: bead still open → repeat from step 1

## Test plan

- [x] `TestDiscoverSessionBeads_SkipsPoolAgentWithZeroDesired` — pool bead not re-added when desired=0
- [x] `TestDiscoverSessionBeads_IncludesPoolAgentWithDesired` — pool bead IS re-added when pool has active desired entries
- [x] All existing `TestDiscoverSessionBeads_*` tests pass (non-pool agents unaffected)
- [x] Full `cmd/gc` test suite passes
- [x] `golangci-lint run ./cmd/gc/` clean

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)