### PR TITLE
feat(mail): add API recipient resolution with ambiguity rejection

### DIFF
--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail"
 )
@@ -204,6 +205,13 @@ func (s *Server) handleMailSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve recipient against configured agents.
+	resolved, resolveErr := mail.ResolveRecipient(body.To, agentEntries(s.state.Config()))
+	if resolveErr != nil {
+		writeError(w, http.StatusBadRequest, "invalid", resolveErr.Error())
+		return
+	}
+
 	mp := s.findMailProvider(body.Rig)
 	if mp == nil {
 		writeError(w, http.StatusBadRequest, "invalid", "no mail provider available")
@@ -220,7 +228,7 @@ func (s *Server) handleMailSend(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	msg, err := mp.Send(body.From, body.To, body.Subject, body.Body)
+	msg, err := mp.Send(body.From, resolved, body.Subject, body.Body)
 	if err != nil {
 		s.idem.unreserve(idemKey)
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
@@ -475,6 +483,18 @@ func (s *Server) findMailProviderByID(id string) (mail.Provider, string, error) 
 		}
 	}
 	return nil, "", firstErr
+}
+
+// agentEntries converts city config agents to mail.AgentEntry for recipient resolution.
+func agentEntries(cfg *config.City) []mail.AgentEntry {
+	if cfg == nil {
+		return nil
+	}
+	entries := make([]mail.AgentEntry, len(cfg.Agents))
+	for i, a := range cfg.Agents {
+		entries[i] = mail.AgentEntry{Dir: a.Dir, Name: a.Name}
+	}
+	return entries
 }
 
 // sortedProviderNames returns provider names in sorted order, deduplicating

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -15,7 +15,7 @@ func TestMailLifecycle(t *testing.T) {
 	state := newFakeState(t)
 	srv := New(state)
 
-	// Send a message.
+	// Send a message. Bare "worker" resolves to "myrig/worker" (the qualified name).
 	body := `{"from":"mayor","to":"worker","subject":"Review needed","body":"Please check gc-456"}`
 	req := newPostRequest("/v0/mail", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
@@ -30,9 +30,12 @@ func TestMailLifecycle(t *testing.T) {
 	if sent.Subject != "Review needed" {
 		t.Errorf("Subject = %q, want %q", sent.Subject, "Review needed")
 	}
+	if sent.To != "myrig/worker" {
+		t.Errorf("To = %q, want %q (bare name should resolve to qualified)", sent.To, "myrig/worker")
+	}
 
-	// Check inbox.
-	req = httptest.NewRequest("GET", "/v0/mail?agent=worker", nil)
+	// Check inbox using the resolved qualified name.
+	req = httptest.NewRequest("GET", "/v0/mail?agent=myrig/worker", nil)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -55,7 +58,7 @@ func TestMailLifecycle(t *testing.T) {
 	}
 
 	// Inbox should be empty now (only unread).
-	req = httptest.NewRequest("GET", "/v0/mail?agent=worker", nil)
+	req = httptest.NewRequest("GET", "/v0/mail?agent=myrig/worker", nil)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -283,7 +286,7 @@ func TestMailReply(t *testing.T) {
 
 func TestMailListIncludesRig(t *testing.T) {
 	state := newFakeState(t)
-	mp := state.mailProvs["myrig"]
+	mp := state.cityMailProv
 	mp.Send("alice", "bob", "Hi", "hello") //nolint:errcheck
 	srv := New(state)
 
@@ -299,12 +302,12 @@ func TestMailListIncludesRig(t *testing.T) {
 	if len(resp.Items) == 0 {
 		t.Fatal("expected at least 1 message")
 	}
-	if resp.Items[0].Rig != "myrig" {
-		t.Errorf("Items[0].Rig = %q, want %q", resp.Items[0].Rig, "myrig")
+	if resp.Items[0].Rig != "test-city" {
+		t.Errorf("Items[0].Rig = %q, want %q", resp.Items[0].Rig, "test-city")
 	}
 
-	// List with rig filter — single-rig path.
-	req = httptest.NewRequest("GET", "/v0/mail?rig=myrig&status=all", nil)
+	// List with rig filter — single-rig path. The rig param is used as the tag.
+	req = httptest.NewRequest("GET", "/v0/mail?rig=test-city&status=all", nil)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -312,14 +315,14 @@ func TestMailListIncludesRig(t *testing.T) {
 	if len(resp.Items) == 0 {
 		t.Fatal("expected at least 1 message")
 	}
-	if resp.Items[0].Rig != "myrig" {
-		t.Errorf("Items[0].Rig = %q, want %q (single-rig path)", resp.Items[0].Rig, "myrig")
+	if resp.Items[0].Rig != "test-city" {
+		t.Errorf("Items[0].Rig = %q, want %q (single-rig path)", resp.Items[0].Rig, "test-city")
 	}
 }
 
 func TestMailThreadIncludesRig(t *testing.T) {
 	state := newFakeState(t)
-	mp := state.mailProvs["myrig"]
+	mp := state.cityMailProv
 	msg, _ := mp.Send("alice", "bob", "Thread test", "body")
 
 	// Reply to create a thread.
@@ -327,7 +330,7 @@ func TestMailThreadIncludesRig(t *testing.T) {
 
 	srv := New(state)
 
-	req := httptest.NewRequest("GET", "/v0/mail/thread/"+msg.ThreadID+"?rig=myrig", nil)
+	req := httptest.NewRequest("GET", "/v0/mail/thread/"+msg.ThreadID+"?rig=test-city", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -339,8 +342,8 @@ func TestMailThreadIncludesRig(t *testing.T) {
 		t.Fatal("expected thread messages")
 	}
 	for i, m := range resp.Items {
-		if m.Rig != "myrig" {
-			t.Errorf("Items[%d].Rig = %q, want %q", i, m.Rig, "myrig")
+		if m.Rig != "test-city" {
+			t.Errorf("Items[%d].Rig = %q, want %q", i, m.Rig, "test-city")
 		}
 	}
 }
@@ -349,7 +352,7 @@ func TestMailSendIdempotentReplayIncludesRig(t *testing.T) {
 	state := newFakeState(t)
 	srv := New(state)
 
-	body := `{"rig":"myrig","from":"alice","to":"bob","subject":"Hi","body":"hello"}`
+	body := `{"rig":"test-city","from":"alice","to":"worker","subject":"Hi","body":"hello"}`
 	req := newPostRequest("/v0/mail", bytes.NewBufferString(body))
 	req.Header.Set("Idempotency-Key", "mail-send-1")
 	rec := httptest.NewRecorder()
@@ -370,14 +373,14 @@ func TestMailSendIdempotentReplayIncludesRig(t *testing.T) {
 
 	var msg mail.Message
 	json.NewDecoder(rec.Body).Decode(&msg) //nolint:errcheck
-	if msg.Rig != "myrig" {
-		t.Fatalf("replayed send Rig = %q, want %q", msg.Rig, "myrig")
+	if msg.Rig != "test-city" {
+		t.Fatalf("replayed send Rig = %q, want %q", msg.Rig, "test-city")
 	}
 }
 
 func TestMailGetWithoutRigHintIncludesResolvedRig(t *testing.T) {
 	state := newFakeState(t)
-	mp := state.mailProvs["myrig"]
+	mp := state.cityMailProv
 	msg, _ := mp.Send("alice", "bob", "Hi", "hello")
 	srv := New(state)
 
@@ -391,15 +394,15 @@ func TestMailGetWithoutRigHintIncludesResolvedRig(t *testing.T) {
 
 	var got mail.Message
 	json.NewDecoder(rec.Body).Decode(&got) //nolint:errcheck
-	if got.Rig != "myrig" {
-		t.Fatalf("get Rig = %q, want %q", got.Rig, "myrig")
+	if got.Rig != "test-city" {
+		t.Fatalf("get Rig = %q, want %q", got.Rig, "test-city")
 	}
 }
 
 func TestMailMutationEventsUseResolvedRigWithoutHint(t *testing.T) {
 	state := newFakeState(t)
 	ep := state.eventProv.(*events.Fake)
-	mp := state.mailProvs["myrig"]
+	mp := state.cityMailProv
 	msg, _ := mp.Send("alice", "bob", "Hi", "hello")
 	srv := New(state)
 
@@ -420,15 +423,15 @@ func TestMailMutationEventsUseResolvedRigWithoutHint(t *testing.T) {
 	if err := json.Unmarshal(ep.Events[len(ep.Events)-1].Payload, &payload); err != nil {
 		t.Fatalf("unmarshal read payload: %v", err)
 	}
-	if payload.Rig != "myrig" {
-		t.Fatalf("read event rig = %q, want %q", payload.Rig, "myrig")
+	if payload.Rig != "test-city" {
+		t.Fatalf("read event rig = %q, want %q", payload.Rig, "test-city")
 	}
 }
 
 func TestMailReplyWithoutRigHintUsesResolvedRig(t *testing.T) {
 	state := newFakeState(t)
 	ep := state.eventProv.(*events.Fake)
-	mp := state.mailProvs["myrig"]
+	mp := state.cityMailProv
 	msg, _ := mp.Send("alice", "bob", "Hi", "hello")
 	srv := New(state)
 
@@ -443,8 +446,8 @@ func TestMailReplyWithoutRigHintUsesResolvedRig(t *testing.T) {
 
 	var reply mail.Message
 	json.NewDecoder(rec.Body).Decode(&reply) //nolint:errcheck
-	if reply.Rig != "myrig" {
-		t.Fatalf("reply Rig = %q, want %q", reply.Rig, "myrig")
+	if reply.Rig != "test-city" {
+		t.Fatalf("reply Rig = %q, want %q", reply.Rig, "test-city")
 	}
 
 	if len(ep.Events) == 0 {
@@ -458,10 +461,10 @@ func TestMailReplyWithoutRigHintUsesResolvedRig(t *testing.T) {
 	if err := json.Unmarshal(ep.Events[len(ep.Events)-1].Payload, &payload); err != nil {
 		t.Fatalf("unmarshal reply payload: %v", err)
 	}
-	if payload.Rig != "myrig" {
-		t.Fatalf("reply event rig = %q, want %q", payload.Rig, "myrig")
+	if payload.Rig != "test-city" {
+		t.Fatalf("reply event rig = %q, want %q", payload.Rig, "test-city")
 	}
-	if payload.Message.Rig != "myrig" {
-		t.Fatalf("reply event message rig = %q, want %q", payload.Message.Rig, "myrig")
+	if payload.Message.Rig != "test-city" {
+		t.Fatalf("reply event message rig = %q, want %q", payload.Message.Rig, "test-city")
 	}
 }

--- a/internal/mail/resolve.go
+++ b/internal/mail/resolve.go
@@ -1,0 +1,76 @@
+package mail
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AgentEntry represents a configured agent for recipient resolution.
+type AgentEntry struct {
+	Dir  string // rig directory (empty for city-scoped agents)
+	Name string // bare agent name
+}
+
+// QualifiedName returns "Dir/Name" for rig-scoped agents or just "Name".
+func (a AgentEntry) QualifiedName() string {
+	if a.Dir == "" {
+		return a.Name
+	}
+	return a.Dir + "/" + a.Name
+}
+
+// ResolveRecipient resolves a mail recipient to a canonical qualified name.
+//
+// Resolution order:
+//  1. "human" passes through unchanged (reserved recipient).
+//  2. Qualified name ("rig/name") is matched literally.
+//  3. Bare name ("name") is matched against all agents by Name field.
+//     Succeeds only when exactly one agent matches; rejects ambiguous names.
+//
+// Returns the canonical qualified name or an error describing the failure.
+func ResolveRecipient(to string, agents []AgentEntry) (string, error) {
+	to = strings.TrimSpace(to)
+	if to == "" {
+		return "", fmt.Errorf("empty recipient")
+	}
+	if to == "human" {
+		return "human", nil
+	}
+
+	// Qualified name: literal match.
+	if strings.Contains(to, "/") {
+		for _, a := range agents {
+			if a.QualifiedName() == to {
+				return to, nil
+			}
+		}
+		return "", fmt.Errorf("unknown recipient %q", to)
+	}
+
+	// Bare name: find all agents with this Name.
+	var matches []AgentEntry
+	for _, a := range agents {
+		if a.Name == to {
+			matches = append(matches, a)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("unknown recipient %q", to)
+	case 1:
+		return matches[0].QualifiedName(), nil
+	default:
+		qualified := make([]string, len(matches))
+		for i, m := range matches {
+			qualified[i] = m.QualifiedName()
+		}
+		return "", fmt.Errorf("ambiguous recipient %q: matches %s", to, strings.Join(qualified, ", "))
+	}
+}
+
+// AgentEntriesFromConfig builds an AgentEntry slice from agent qualified names.
+// Each entry should have Dir and Name fields set.
+func AgentEntriesFromConfig(agents []AgentEntry) []AgentEntry {
+	return agents
+}

--- a/internal/mail/resolve_test.go
+++ b/internal/mail/resolve_test.go
@@ -1,0 +1,96 @@
+package mail
+
+import "testing"
+
+func TestResolveRecipientHuman(t *testing.T) {
+	got, err := ResolveRecipient("human", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "human" {
+		t.Errorf("got %q, want %q", got, "human")
+	}
+}
+
+func TestResolveRecipientEmpty(t *testing.T) {
+	_, err := ResolveRecipient("", nil)
+	if err == nil {
+		t.Fatal("expected error for empty recipient")
+	}
+}
+
+func TestResolveRecipientQualifiedMatch(t *testing.T) {
+	agents := []AgentEntry{
+		{Dir: "corp", Name: "maya"},
+		{Dir: "corp", Name: "sky"},
+	}
+	got, err := ResolveRecipient("corp/maya", agents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "corp/maya" {
+		t.Errorf("got %q, want %q", got, "corp/maya")
+	}
+}
+
+func TestResolveRecipientQualifiedNotFound(t *testing.T) {
+	agents := []AgentEntry{
+		{Dir: "corp", Name: "maya"},
+	}
+	_, err := ResolveRecipient("ops/maya", agents)
+	if err == nil {
+		t.Fatal("expected error for unknown qualified name")
+	}
+}
+
+func TestResolveRecipientBareUnambiguous(t *testing.T) {
+	agents := []AgentEntry{
+		{Dir: "corp", Name: "maya"},
+		{Dir: "corp", Name: "sky"},
+	}
+	got, err := ResolveRecipient("maya", agents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "corp/maya" {
+		t.Errorf("got %q, want %q", got, "corp/maya")
+	}
+}
+
+func TestResolveRecipientBareCityScoped(t *testing.T) {
+	agents := []AgentEntry{
+		{Dir: "", Name: "mayor"},
+		{Dir: "corp", Name: "sky"},
+	}
+	got, err := ResolveRecipient("mayor", agents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "mayor" {
+		t.Errorf("got %q, want %q", got, "mayor")
+	}
+}
+
+func TestResolveRecipientBareAmbiguous(t *testing.T) {
+	agents := []AgentEntry{
+		{Dir: "corp", Name: "maya"},
+		{Dir: "ops", Name: "maya"},
+	}
+	_, err := ResolveRecipient("maya", agents)
+	if err == nil {
+		t.Fatal("expected error for ambiguous bare name")
+	}
+	if got := err.Error(); got != `ambiguous recipient "maya": matches corp/maya, ops/maya` {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveRecipientBareNotFound(t *testing.T) {
+	agents := []AgentEntry{
+		{Dir: "corp", Name: "sky"},
+	}
+	_, err := ResolveRecipient("maya", agents)
+	if err == nil {
+		t.Fatal("expected error for unknown bare name")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `mail.ResolveRecipient()` that normalizes bare names to qualified agent names and rejects ambiguous recipients
- Wire into HTTP API `handleMailSend` so mission-control compose validates recipients before storage
- Bare name "maya" resolves to "corp/maya" when unambiguous; rejects with clear error when multiple agents match
- Update handler_mail_test.go to use city-scoped provider keys (aligning with Phase 1 city-level store fix from PR #84)

## Test plan
- [x] 8 unit tests for `ResolveRecipient` (human, empty, qualified match/miss, bare unambiguous/ambiguous/city-scoped/not-found)
- [x] `TestMailLifecycle` verifies bare "worker" resolves to "myrig/worker" in API send path
- [x] All 31 mail/resolver tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)