### PR TITLE
fix(install): recreate ~/.local/bin/gc symlink after removing stale binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,15 @@ install: build
 	@mkdir -p $(INSTALL_DIR)
 	@rm -f $(INSTALL_DIR)/$(BINARY)
 	@cp $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)
-	@# Remove stale binary from the old install location
-	@if [ -f "$(HOME)/.local/bin/$(BINARY)" ] && [ "$(INSTALL_DIR)" != "$(HOME)/.local/bin" ]; then \
-		echo "Removing stale $(HOME)/.local/bin/$(BINARY)"; \
-		rm -f "$(HOME)/.local/bin/$(BINARY)"; \
+	@# Migrate from old install location: replace stale binary with symlink
+	@if [ "$(INSTALL_DIR)" != "$(HOME)/.local/bin" ]; then \
+		if [ -f "$(HOME)/.local/bin/$(BINARY)" ] || [ -L "$(HOME)/.local/bin/$(BINARY)" ]; then \
+			rm -f "$(HOME)/.local/bin/$(BINARY)"; \
+		fi; \
+		if [ -d "$(HOME)/.local/bin" ]; then \
+			ln -sf "$(INSTALL_DIR)/$(BINARY)" "$(HOME)/.local/bin/$(BINARY)"; \
+			echo "Symlinked $(HOME)/.local/bin/$(BINARY) -> $(INSTALL_DIR)/$(BINARY)"; \
+		fi; \
 	fi
 	@echo "Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY)"
 


### PR DESCRIPTION
## Summary

- **Fixes #83**: `make install` now recreates a symlink at `~/.local/bin/gc` pointing to the installed binary in `GOPATH/bin`, instead of only deleting the old file
- Also fixes detection of dangling symlinks by adding a `-L` check (the old `-f` test follows symlinks and misses broken ones)
- Only creates the symlink if `~/.local/bin` exists, so it is safe on systems that don't use that directory

## Test plan

- [x] `make install` creates symlink: `~/.local/bin/gc -> ~/go/bin/gc`
- [x] Running `make install` twice is idempotent
- [x] `~/.local/bin/gc version` returns correct version after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)