### PR TITLE
Default session bead title to template name when empty

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -206,6 +206,9 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 	if err != nil {
 		return Info{}, err
 	}
+	if title == "" {
+		title = template
+	}
 	var info Info
 	err = withSessionIdentifierReservationLocks([]string{alias, explicitName}, func() error {
 		if err := ensureSessionAliasAvailable(m.store, nil, alias, "", ""); err != nil {
@@ -408,6 +411,9 @@ func (m *Manager) createAliasedBeadOnlyNamed(alias, explicitName, template, titl
 	explicitName, err = ValidateExplicitName(explicitName)
 	if err != nil {
 		return Info{}, err
+	}
+	if title == "" {
+		title = template
 	}
 	var info Info
 	err = withSessionIdentifierReservationLocks([]string{alias, explicitName}, func() error {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -152,6 +152,42 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreateDefaultsTitleToTemplate(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if b.Title != "helper" {
+		t.Errorf("Title = %q, want %q", b.Title, "helper")
+	}
+}
+
+func TestCreateBeadOnlyDefaultsTitleToTemplate(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.CreateBeadOnly("helper", "", "claude", "/tmp", "claude", "", nil, ProviderResume{})
+	if err != nil {
+		t.Fatalf("CreateBeadOnly: %v", err)
+	}
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if b.Title != "helper" {
+		t.Errorf("Title = %q, want %q", b.Title, "helper")
+	}
+}
+
 func TestCreateBeadOnly(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary

- `CreateAliasedNamedWithTransport` and `CreateAliasedBeadOnlyNamed` passed an empty title through to the beads backend, which rejects it with `title is required`.
- `gc session new mayor` (without `--title`) fails because the `--title` flag defaults to `""` and no fallback is applied.
- The reconciler's CREATE path already defaults to `agentName` at `session_beads.go:215` — this aligns the manual creation paths to match.