### PR TITLE
fix(session): pass singleton owner to alias check in gc session new

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -150,16 +150,9 @@ func cmdSessionNew(args []string, alias, title string, noAttach bool, stdout, st
 	// Store the canonical qualified name so the reconciler can match it
 	// via findAgentByTemplate (which compares against QualifiedName()).
 	canonicalTemplate := found.QualifiedName()
+	singletonOwner := sessionNewAliasOwner(cfg, &found)
 
 	// Try reconciler-first path: create bead, poke controller.
-	// For singleton agents, pass the canonical template name as selfOwner
-	// so the alias reservation check recognises a new session bead as the
-	// legitimate owner of the singleton's reserved alias.
-	singletonOwner := ""
-	if !found.IsPool() {
-		singletonOwner = canonicalTemplate
-	}
-
 	if pokeErr := pokeController(cityPath); pokeErr == nil {
 		// Controller is running — create bead only, let reconciler start it.
 		var info session.Info
@@ -263,6 +256,17 @@ func resolveSessionTemplate(cfg *config.City, input, currentRigDir string) (conf
 		}
 	}
 	return config.Agent{}, false
+}
+
+func sessionNewAliasOwner(cfg *config.City, agent *config.Agent) string {
+	if cfg == nil || agent == nil {
+		return ""
+	}
+	owner := agent.QualifiedName()
+	if config.FindNamedSession(cfg, owner) == nil {
+		return ""
+	}
+	return owner
 }
 
 // waitForSession polls the provider until the session is running or timeout.

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestFormatDuration(t *testing.T) {
@@ -150,4 +155,170 @@ func TestShouldAttachNewSession(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSessionNewAliasOwner_UsesConfiguredNamedIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "mayor"},
+			{Name: "worker", MaxActiveSessions: intPtr(3)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor"},
+		},
+	}
+
+	if got := sessionNewAliasOwner(cfg, &cfg.Agents[0]); got != "mayor" {
+		t.Fatalf("sessionNewAliasOwner(mayor) = %q, want mayor", got)
+	}
+	if got := sessionNewAliasOwner(cfg, &cfg.Agents[1]); got != "" {
+		t.Fatalf("sessionNewAliasOwner(worker) = %q, want empty", got)
+	}
+}
+
+func TestCmdSessionNew_AllowsReservedNamedAliasWithController(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir, "test-city", "mayor")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	commands := make(chan string, 2)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(commands)
+		for i := 0; i < 2; i++ {
+			conn, err := lis.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			buf := make([]byte, 64)
+			n, err := conn.Read(buf)
+			if err != nil {
+				conn.Close() //nolint:errcheck
+				errCh <- err
+				return
+			}
+			commands <- string(buf[:n])
+			if _, err := conn.Write([]byte("ok\n")); err != nil {
+				conn.Close() //nolint:errcheck
+				errCh <- err
+				return
+			}
+			conn.Close() //nolint:errcheck
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionNew(controller) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	gotCommands := make([]string, 0, 2)
+	deadline := time.After(2 * time.Second)
+	for len(gotCommands) < 2 {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("controller socket: %v", err)
+			}
+		case cmd, ok := <-commands:
+			if !ok {
+				if len(gotCommands) != 2 {
+					t.Fatalf("controller commands = %v, want 2 pokes", gotCommands)
+				}
+				break
+			}
+			gotCommands = append(gotCommands, cmd)
+		case <-deadline:
+			t.Fatalf("timed out waiting for controller pokes, got %v", gotCommands)
+		}
+	}
+	for i, cmd := range gotCommands {
+		if cmd != "poke\n" {
+			t.Fatalf("controller command %d = %q, want %q", i, cmd, "poke\n")
+		}
+	}
+
+	b := onlySessionBead(t, cityDir)
+	if got := b.Metadata["alias"]; got != "mayor" {
+		t.Fatalf("alias = %q, want mayor", got)
+	}
+	if got := b.Metadata["state"]; got != "creating" {
+		t.Fatalf("state = %q, want creating", got)
+	}
+}
+
+func TestCmdSessionNew_AllowsReservedNamedAliasWithoutController(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir, "test-city", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionNew(fallback) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	b := onlySessionBead(t, cityDir)
+	if got := b.Metadata["alias"]; got != "mayor" {
+		t.Fatalf("alias = %q, want mayor", got)
+	}
+	if got := b.Metadata["session_name"]; got == "" {
+		t.Fatal("session_name should be populated on fallback create")
+	}
+}
+
+func writeNamedSessionCityTOML(t *testing.T, dir, cityName, agentName string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	data := []byte(`[workspace]
+name = "` + cityName + `"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "` + agentName + `"
+provider = "codex"
+start_command = "echo"
+
+[[named_session]]
+template = "` + agentName + `"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+}
+
+func onlySessionBead(t *testing.T, cityDir string) beads.Bead {
+	t.Helper()
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel(session): %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(all))
+	}
+	return all[0]
 }


### PR DESCRIPTION
gc session new called EnsureAliasAvailableWithConfig (no owner) instead of EnsureAliasAvailableWithConfigForOwner for both the reconciler and fallback paths. Without an owner identity, the singleton reservation check in ensureSessionAliasAvailable always rejected the alias with "reserved for configured singleton", making it impossible to create sessions for any singleton agent.

Pass the canonical template name as selfOwner for non-pool agents so the reservation check recognises the new bead as the legitimate owner.

Fixes #104 

## Summary

- Explain the change and why it is needed.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [x] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
