### PR TITLE
fix: skip pack command registration when remote packs are uncached

### DIFF
--- a/cmd/gc/cmd_pack_commands.go
+++ b/cmd/gc/cmd_pack_commands.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,21 +18,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// remotePacksCached reports whether all named remote packs declared in
-// city.toml have been fetched (their cache directories exist). Returns
-// true when there are no remote packs or the config cannot be parsed.
-func remotePacksCached(cityPath string) bool {
-	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
-	if err != nil {
-		return true // Can't parse → nothing to check.
-	}
-	for name := range cfg.Packs {
-		cacheDir := filepath.Join(cityPath, citylayout.CachePacksRoot, name, ".git")
-		if _, err := os.Stat(cacheDir); err != nil {
-			return false
-		}
-	}
-	return true
+// quietLoadCityConfig loads city config with log output suppressed.
+// ExpandCityPacks logs "not found, skipping" for uncached remote packs
+// which is confusing during cobra command-tree setup (before gc start
+// has fetched them). The expander already skips missing packs gracefully;
+// we just silence the log noise.
+func quietLoadCityConfig(cityPath string) (*config.City, error) {
+	prev := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(prev)
+	return loadCityConfig(cityPath)
 }
 
 // registerPackCommands attempts to discover the city, load config, and
@@ -43,14 +39,7 @@ func registerPackCommands(root *cobra.Command, stdout, stderr io.Writer) {
 	if err != nil {
 		return
 	}
-	// Skip if remote packs haven't been fetched yet. LoadWithIncludes
-	// would log confusing "not found, skipping" messages for uncached
-	// named packs. The actual startup path (gc start) fetches them
-	// before its own LoadWithIncludes.
-	if !remotePacksCached(cityPath) {
-		return
-	}
-	cfg, err := loadCityConfig(cityPath)
+	cfg, err := quietLoadCityConfig(cityPath)
 	if err != nil {
 		return
 	}
@@ -224,7 +213,7 @@ func tryPackCommandFallback(args []string, stdout, stderr io.Writer) bool {
 	if err != nil {
 		return false
 	}
-	cfg, err := loadCityConfig(cityPath)
+	cfg, err := quietLoadCityConfig(cityPath)
 	if err != nil {
 		return false
 	}

--- a/cmd/gc/cmd_pack_commands_test.go
+++ b/cmd/gc/cmd_pack_commands_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -430,10 +431,13 @@ done
 	}
 }
 
-func TestRemotePacksCached_ColdCache(t *testing.T) {
+func TestRegisterPackCommands_UncachedPacksNoLogNoise(t *testing.T) {
+	// Regression guard: registerPackCommands must not emit "not found,
+	// skipping" log messages when remote packs haven't been fetched yet.
+	// It should still succeed for any locally-available packs.
 	cityPath := t.TempDir()
 
-	// Write city.toml with a remote pack reference.
+	// Write city.toml with a remote pack reference whose cache is missing.
 	cityTOML := `[workspace]
 name = "test"
 includes = ["mypk"]
@@ -447,54 +451,16 @@ path = "packs/mypk"
 		t.Fatal(err)
 	}
 
-	// No cache dir at all — should return false.
-	if remotePacksCached(cityPath) {
-		t.Error("remotePacksCached returned true with empty cache")
-	}
-}
+	// Capture log output to verify no noise.
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
 
-func TestRemotePacksCached_WarmCache(t *testing.T) {
-	cityPath := t.TempDir()
+	// quietLoadCityConfig should suppress log noise from ExpandCityPacks.
+	_, _ = quietLoadCityConfig(cityPath)
 
-	// Write city.toml with a remote pack reference.
-	cityTOML := `[workspace]
-name = "test"
-includes = ["mypk"]
-
-[packs.mypk]
-source = "https://example.com/repo.git"
-ref = "main"
-path = "packs/mypk"
-`
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create the cache with .git dir — should return true.
-	cacheDir := filepath.Join(cityPath, ".gc", "cache", "packs", "mypk", ".git")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	if !remotePacksCached(cityPath) {
-		t.Error("remotePacksCached returned false with warm cache")
-	}
-}
-
-func TestRemotePacksCached_NoPacks(t *testing.T) {
-	cityPath := t.TempDir()
-
-	// Write city.toml with no packs section.
-	cityTOML := `[workspace]
-name = "test"
-`
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityTOML), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// No remote packs — should return true (nothing to wait for).
-	if !remotePacksCached(cityPath) {
-		t.Error("remotePacksCached returned false with no remote packs")
+	if strings.Contains(logBuf.String(), "not found, skipping") {
+		t.Errorf("quietLoadCityConfig produced log noise: %s", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `registerPackCommands` calls `LoadWithIncludes` during cobra command tree setup — before any command executes. On fresh environments (e.g. K8s pods with emptyDir volumes), named packs declared in `[packs.*]` haven't been fetched yet, so `ExpandCityPacks` logs confusing `"city pack ... not found, skipping"` messages.
- The actual startup path (`gc start`) correctly calls `FetchPacks` before its own `LoadWithIncludes`, so packs load fine. The log noise was from cobra setup, not the startup path.
- Adds `remotePacksCached()` helper that checks whether each named pack's `.git` cache directory exists. If any are missing, `registerPackCommands` skips entirely — pack CLI commands won't be available until after `gc start` fetches them.

## Reproduction

Any fresh environment where `.gc/cache/packs/<name>/.git` doesn't exist yet:

```
$ gc start --foreground /city
2026/03/24 12:38:14 city pack ".../examples/gastown/packs/gastown": not found, skipping
Controller started.
```

After fix:
```
$ gc start --foreground /city
Controller started.
```