### PR TITLE
fix(k8s): add startup grace period to stale pod detection

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -450,6 +450,9 @@ func executePreparedStartWave(
 				outcome = "deadline_exceeded"
 			case startCtx.Err() == context.Canceled:
 				outcome = "canceled"
+			case errors.Is(err, runtime.ErrSessionInitializing):
+				outcome = "session_initializing"
+				err = nil
 			case errors.Is(err, runtime.ErrSessionExists) && sp.IsRunning(item.candidate.name()):
 				if rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
 					outcome = "session_exists_converged"
@@ -500,6 +503,12 @@ func commitStartResultTraced(
 	session := result.prepared.candidate.session
 	name := result.prepared.candidate.name()
 	tp := result.prepared.candidate.tp
+	// Session still starting up — back off silently without recording failure.
+	// The reconciler will retry on the next patrol tick.
+	if result.outcome == "session_initializing" {
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
+		return false
+	}
 	if result.err != nil {
 		if result.rollbackPending {
 			fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck

--- a/internal/runtime/k8s/name.go
+++ b/internal/runtime/k8s/name.go
@@ -19,8 +19,9 @@ const tmuxSession = "main"
 // startupGracePeriod is the maximum time allowed for a pod to complete
 // workspace initialization and start its tmux session. Running pods younger
 // than this with dead tmux are treated as still initializing, not stale.
-// Matches the combined timeouts: waitForPodRunning (120s) + waitForTmux (60s).
-const startupGracePeriod = 180 * time.Second
+// Covers the full startup chain: waitForInitContainer (60s) +
+// waitForPodRunning (120s) + waitForTmux (60s).
+const startupGracePeriod = 240 * time.Second
 
 // SanitizeName converts a session name to a valid K8s resource name.
 // K8s names: lowercase, alphanumeric + '-', max 63 chars, must start/end

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -121,7 +121,7 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 			// be blocking the tmux server from starting. Don't delete pods
 			// that are still within the startup window.
 			if time.Since(pod.CreationTimestamp.Time) < startupGracePeriod {
-				return fmt.Errorf("%w: session %q (pod: %s, still initializing)", runtime.ErrSessionExists, name, pod.Name)
+				return fmt.Errorf("%w: session %q (pod: %s)", runtime.ErrSessionInitializing, name, pod.Name)
 			}
 			// Stale pod — tmux dead and past grace period, recreate.
 		}

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -486,8 +486,8 @@ func TestStartTreatsYoungPodWithDeadTmuxAsInitializing(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start should return error for initializing pod")
 	}
-	if want := "already exists"; !contains(err.Error(), want) {
-		t.Errorf("error = %q, want containing %q", err, want)
+	if !errors.Is(err, runtime.ErrSessionInitializing) {
+		t.Errorf("error = %v, want ErrSessionInitializing", err)
 	}
 
 	// Must NOT have deleted the pod — it's still initializing.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -17,6 +17,11 @@ import (
 // requested name.
 var ErrSessionExists = errors.New("session already exists")
 
+// ErrSessionInitializing reports that a session's infrastructure exists but is
+// still starting up (e.g., K8s pod is running but tmux hasn't started yet).
+// Callers should back off and retry rather than treating it as a failure.
+var ErrSessionInitializing = errors.New("session is initializing")
+
 // ErrInteractionUnsupported reports that a provider does not implement the
 // structured pending/respond interaction capability for the requested session.
 var ErrInteractionUnsupported = errors.New("session interaction is unsupported")


### PR DESCRIPTION
## Summary

- On the first patrol tick after startup, `IsRunning()` finds agent pods in Running phase but `tmux has-session` fails because workspace init (`wsWait` polling for `.gc-workspace-ready`) blocks the tmux server from starting
- `Start()` sees the Running pod with dead tmux, treats it as stale, deletes and recreates — causing one spurious restart cycle on every controller startup
- Fix: check `pod.CreationTimestamp` before treating a Running pod with dead tmux as stale — if the pod is younger than 180s (the combined `waitForPodRunning` 120s + `waitForTmux` 60s timeouts), return `ErrSessionExists` instead of deleting
- The reconciler backs off and retries on the next patrol tick, by which time tmux is up

Affects K8s provider only. Bare-metal tmux adapter and ACP provider are not affected (tmux starts immediately, no workspace init gate).