### PR TITLE
feat(extmsg): controller integration, API endpoints, and transcript hooks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,3 +48,8 @@ linters:
         linters:
           - revive
         text: "var-naming"
+      # mail is an established package name — renaming would break imports.
+      - path: internal/mail/
+        linters:
+          - revive
+        text: "var-naming"

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/configedit"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/orders"
@@ -33,6 +34,8 @@ type controllerState struct {
 	beadStores    map[string]beads.Store
 	cityBeadStore beads.Store   // city-level store for session beads
 	cityMailProv  mail.Provider // city-level mail provider (all mail is city-scoped)
+	extmsgSvc     *extmsg.Services
+	adapterReg    *extmsg.AdapterRegistry
 	eventProv     events.Provider
 	editor        *configedit.Editor
 	cityName      string
@@ -63,12 +66,15 @@ func newControllerState(
 		startedAt: time.Now(),
 	}
 	cs.beadStores = cs.buildStores(cfg)
-	// Open city-level store for session beads and mail (best-effort).
+	cs.adapterReg = extmsg.NewAdapterRegistry()
+	// Open city-level store for session beads, mail, and extmsg (best-effort).
 	if store, err := openCityStoreAt(cityPath); err != nil {
-		fmt.Fprintf(os.Stderr, "api: city bead store: %v (session/mail endpoints disabled)\n", err)
+		fmt.Fprintf(os.Stderr, "api: city bead store: %v (session/mail/extmsg endpoints disabled)\n", err)
 	} else {
 		cs.cityBeadStore = store
 		cs.cityMailProv = newMailProvider(store)
+		svc := extmsg.NewServices(store)
+		cs.extmsgSvc = &svc
 	}
 	return cs
 }
@@ -145,8 +151,11 @@ func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
 		fmt.Fprintf(os.Stderr, "api: city bead store reload: %v\n", err) //nolint:errcheck // best-effort stderr
 	}
 	var cityMailProv mail.Provider
+	var extmsgSvc *extmsg.Services
 	if cityStore != nil {
 		cityMailProv = newMailProvider(cityStore)
+		svc := extmsg.NewServices(cityStore)
+		extmsgSvc = &svc
 	}
 
 	// Swap under short critical section.
@@ -157,8 +166,9 @@ func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
 	if cityStore != nil {
 		cs.cityBeadStore = cityStore
 		cs.cityMailProv = cityMailProv
+		cs.extmsgSvc = extmsgSvc
 	}
-	// Keep prior non-nil store/provider if reopen fails.
+	// Keep prior non-nil store/provider/services if reopen fails.
 	cs.mu.Unlock()
 }
 
@@ -468,4 +478,18 @@ func (cs *controllerState) ServiceRegistry() workspacesvc.Registry {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
 	return cs.services
+}
+
+// ExtMsgServices returns the external messaging fabric services.
+func (cs *controllerState) ExtMsgServices() *extmsg.Services {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return cs.extmsgSvc
+}
+
+// AdapterRegistry returns the external messaging adapter registry.
+func (cs *controllerState) AdapterRegistry() *extmsg.AdapterRegistry {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return cs.adapterReg
 }

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -11,8 +11,14 @@ import (
 
 // bdCommandRunnerForCity centralizes bd subprocess env construction so all
 // GC-managed bd calls resolve Dolt against the same city-scoped runtime.
+// Env is rebuilt on each call so GC_DOLT_PORT reflects the current managed
+// dolt port (which can change across city restarts).
 func bdCommandRunnerForCity(cityPath string) beads.CommandRunner {
-	return beads.ExecCommandRunnerWithEnv(bdRuntimeEnv(cityPath))
+	return func(dir, name string, args ...string) ([]byte, error) {
+		env := bdRuntimeEnv(cityPath)
+		runner := beads.ExecCommandRunnerWithEnv(env)
+		return runner(dir, name, args...)
+	}
 }
 
 func bdStoreForCity(dir, cityPath string) *beads.BdStore {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1119,6 +1119,7 @@ type graphRouteBinding struct {
 	label         string
 }
 
+//nolint:unparam // cityName forwarded through recursive calls for future use
 func resolveGraphStepBinding(stepID string, stepByID map[string]*formula.RecipeStep, stepAlias map[string]string, depsByStep map[string][]string, cache map[string]graphRouteBinding, resolving map[string]bool, fallback graphRouteBinding, rigContext string, store beads.Store, cityName, cityPath string, cfg *config.City) (graphRouteBinding, error) {
 	if aliased, ok := stepAlias[stepID]; ok {
 		stepID = aliased

--- a/cmd/gc/cmd_transcript.go
+++ b/cmd/gc/cmd_transcript.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/spf13/cobra"
+)
+
+func newTranscriptCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "transcript",
+		Short: "Check and read shared conversation transcripts",
+		Long: `Check and read shared external conversation transcripts.
+
+Transcripts are shared message histories for external conversations
+(e.g., Discord threads). Use "gc transcript check --inject" in agent
+hooks to deliver unread messages into agent prompts.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				fmt.Fprintln(stderr, "gc transcript: missing subcommand (check, read)") //nolint:errcheck
+			} else {
+				fmt.Fprintf(stderr, "gc transcript: unknown subcommand %q\n", args[0]) //nolint:errcheck
+			}
+			return errExit
+		},
+	}
+	cmd.AddCommand(
+		newTranscriptCheckCmd(stdout, stderr),
+		newTranscriptReadCmd(stdout, stderr),
+	)
+	return cmd
+}
+
+func newTranscriptCheckCmd(stdout, stderr io.Writer) *cobra.Command {
+	var inject bool
+	cmd := &cobra.Command{
+		Use:   "check [session]",
+		Short: "Check for unread transcript entries (use --inject for hook output)",
+		Long: `Check for unread external conversation messages.
+
+Without --inject: prints the count per conversation and exits 0 if
+unread entries exist, 1 if empty. With --inject: outputs a
+<system-reminder> block for hook injection (always exits 0).
+Session defaults to $GC_SESSION_ID.`,
+		Example: `  gc transcript check
+  gc transcript check --inject`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if cmdTranscriptCheck(args, inject, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&inject, "inject", false, "output <system-reminder> block for hook injection")
+	return cmd
+}
+
+func newTranscriptReadCmd(stdout, stderr io.Writer) *cobra.Command {
+	var ack bool
+	cmd := &cobra.Command{
+		Use:   "read [session]",
+		Short: "Read unread transcript entries",
+		Long: `Read unread external conversation messages.
+
+Prints unread entries formatted for agent consumption. With --ack,
+advances LastReadSequence so entries are not repeated on the next
+check. Session defaults to $GC_SESSION_ID.`,
+		Example: `  gc transcript read
+  gc transcript read --ack`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if cmdTranscriptRead(args, ack, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&ack, "ack", false, "advance LastReadSequence after reading")
+	return cmd
+}
+
+func defaultTranscriptSession() string {
+	if sid := strings.TrimSpace(os.Getenv("GC_SESSION_ID")); sid != "" {
+		return sid
+	}
+	if sname := strings.TrimSpace(os.Getenv("GC_SESSION_NAME")); sname != "" {
+		return sname
+	}
+	return ""
+}
+
+func openTranscriptServices(stderr io.Writer, cmdName string) (*extmsg.Services, int) {
+	store, code := openCityStore(stderr, cmdName)
+	if store == nil {
+		return nil, code
+	}
+	svc := extmsg.NewServices(store)
+	return &svc, 0
+}
+
+func cmdTranscriptCheck(args []string, inject bool, stdout, stderr io.Writer) int {
+	// Check city-level suspension.
+	if cityPath, err := resolveCity(); err == nil {
+		if cfg, err := loadCityConfig(cityPath); err == nil {
+			if citySuspended(cfg) {
+				if inject {
+					return 0
+				}
+				fmt.Fprintln(stderr, "gc transcript check: city is suspended") //nolint:errcheck
+				return 1
+			}
+		}
+	}
+
+	svc, code := openTranscriptServices(stderr, "gc transcript check")
+	if svc == nil {
+		if inject {
+			return 0 // --inject always exits 0
+		}
+		return code
+	}
+
+	sessionID := defaultTranscriptSession()
+	if len(args) > 0 {
+		sessionID = args[0]
+	}
+	if sessionID == "" {
+		if inject {
+			return 0
+		}
+		fmt.Fprintln(stderr, "gc transcript check: session identity required (set GC_SESSION_ID or pass argument)") //nolint:errcheck
+		return 1
+	}
+
+	ctx := context.Background()
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: sessionID}
+
+	memberships, err := svc.Transcript.ListConversationsBySession(ctx, caller, sessionID)
+	if err != nil {
+		if inject {
+			fmt.Fprintf(stderr, "gc transcript check: %v\n", err) //nolint:errcheck
+			return 0
+		}
+		fmt.Fprintf(stderr, "gc transcript check: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	// Collect unread entries per conversation.
+	var unread []transcriptConversationUnread
+	totalUnread := 0
+
+	for _, m := range memberships {
+		entries, err := svc.Transcript.ListBackfill(ctx, extmsg.ListBackfillInput{
+			Caller:       caller,
+			Conversation: m.Conversation,
+			SessionID:    sessionID,
+			Limit:        50,
+		})
+		if err != nil {
+			fmt.Fprintf(stderr, "gc transcript check: backfill %s/%s: %v\n", //nolint:errcheck
+				m.Conversation.Provider, m.Conversation.ConversationID, err)
+			continue
+		}
+		if len(entries) == 0 {
+			continue
+		}
+		label := m.Conversation.Provider + "/" + m.Conversation.ConversationID
+		unread = append(unread, transcriptConversationUnread{Label: label, Entries: entries})
+		totalUnread += len(entries)
+	}
+
+	if inject {
+		if totalUnread > 0 {
+			fmt.Fprint(stdout, formatTranscriptInjectOutput(unread)) //nolint:errcheck
+		}
+		return 0
+	}
+
+	if totalUnread == 0 {
+		return 1
+	}
+	for _, cu := range unread {
+		fmt.Fprintf(stdout, "%d unread in %s\n", len(cu.Entries), cu.Label) //nolint:errcheck
+	}
+	return 0
+}
+
+func cmdTranscriptRead(args []string, ack bool, stdout, stderr io.Writer) int {
+	// Check city-level suspension.
+	if cityPath, err := resolveCity(); err == nil {
+		if cfg, err := loadCityConfig(cityPath); err == nil {
+			if citySuspended(cfg) {
+				fmt.Fprintln(stderr, "gc transcript read: city is suspended") //nolint:errcheck
+				return 1
+			}
+		}
+	}
+
+	svc, code := openTranscriptServices(stderr, "gc transcript read")
+	if svc == nil {
+		return code
+	}
+
+	sessionID := defaultTranscriptSession()
+	if len(args) > 0 {
+		sessionID = args[0]
+	}
+	if sessionID == "" {
+		fmt.Fprintln(stderr, "gc transcript read: session identity required (set GC_SESSION_ID or pass argument)") //nolint:errcheck
+		return 1
+	}
+
+	ctx := context.Background()
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: sessionID}
+
+	memberships, err := svc.Transcript.ListConversationsBySession(ctx, caller, sessionID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc transcript read: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	for _, m := range memberships {
+		entries, err := svc.Transcript.ListBackfill(ctx, extmsg.ListBackfillInput{
+			Caller:       caller,
+			Conversation: m.Conversation,
+			SessionID:    sessionID,
+			Limit:        50,
+		})
+		if err != nil {
+			label := m.Conversation.Provider + "/" + m.Conversation.ConversationID
+			fmt.Fprintf(stderr, "gc transcript read: backfill %s: %v\n", label, err) //nolint:errcheck
+			continue
+		}
+		if len(entries) == 0 {
+			continue
+		}
+		label := m.Conversation.Provider + "/" + m.Conversation.ConversationID
+		fmt.Fprintf(stdout, "## %s (%d unread)\n", label, len(entries)) //nolint:errcheck
+		for _, e := range entries {
+			actorKind := "agent"
+			if !e.Actor.IsBot {
+				actorKind = "human"
+			}
+			fmt.Fprintf(stdout, "- [seq %d] %s (%s): %s\n", e.Sequence, e.Actor.DisplayName, actorKind, e.Text) //nolint:errcheck
+		}
+		fmt.Fprintln(stdout) //nolint:errcheck
+
+		if ack && len(entries) > 0 {
+			lastSeq := entries[len(entries)-1].Sequence
+			if err := svc.Transcript.Ack(ctx, extmsg.AckMembershipInput{
+				Caller:       caller,
+				Conversation: m.Conversation,
+				SessionID:    sessionID,
+				Sequence:     lastSeq,
+			}); err != nil {
+				fmt.Fprintf(stderr, "gc transcript read: ack %s: %v\n", label, err) //nolint:errcheck
+			}
+		}
+	}
+	return 0
+}
+
+type transcriptConversationUnread struct {
+	Label   string
+	Entries []extmsg.ConversationTranscriptRecord
+}
+
+// sanitizeForInject escapes untrusted text to prevent breaking out of
+// the <system-reminder> wrapper. Uses HTML escaping which covers <, >,
+// &, and quotes — sufficient to prevent tag injection.
+func sanitizeForInject(s string) string {
+	return html.EscapeString(s)
+}
+
+func formatTranscriptInjectOutput(conversations []transcriptConversationUnread) string {
+	var sb strings.Builder
+	sb.WriteString("<system-reminder>\n")
+	fmt.Fprintf(&sb, "You have unread messages in %d shared conversation(s).\n\n", len(conversations))
+	for _, cu := range conversations {
+		fmt.Fprintf(&sb, "## %s (%d unread)\n", cu.Label, len(cu.Entries))
+		for _, e := range cu.Entries {
+			actorKind := "agent"
+			if !e.Actor.IsBot {
+				actorKind = "human"
+			}
+			fmt.Fprintf(&sb, "- [seq %d] %s (%s): %s\n",
+				e.Sequence,
+				sanitizeForInject(e.Actor.DisplayName),
+				actorKind,
+				sanitizeForInject(e.Text))
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("Use your judgment — respond where you can add value.\n")
+	sb.WriteString("To reply in Discord, write your response to a file and run:\n")
+	for _, cu := range conversations {
+		convID := ""
+		if len(cu.Entries) > 0 {
+			convID = cu.Entries[0].Conversation.ConversationID
+		}
+		if convID != "" {
+			fmt.Fprintf(&sb, "  gc discord reply-current --conversation-id %s --body-file <path>\n", convID)
+		}
+	}
+	sb.WriteString("Prefix your reply with your agent handle in bold (e.g., **sky:** your message).\n")
+	sb.WriteString("Run 'gc transcript read --ack' after responding to mark as read.\n")
+	sb.WriteString("</system-reminder>\n")
+	return sb.String()
+}

--- a/cmd/gc/cmd_workflow.go
+++ b/cmd/gc/cmd_workflow.go
@@ -165,7 +165,7 @@ func decorateDynamicFragmentRecipe(fragment *formula.FragmentRecipe, source bead
 	return nil
 }
 
-func graphFallbackBindingForBead(source beads.Bead, store beads.Store, cityName, cityPath string, cfg *config.City) (graphRouteBinding, error) {
+func graphFallbackBindingForBead(source beads.Bead, store beads.Store, _, cityPath string, cfg *config.City) (graphRouteBinding, error) {
 	routedTo := workflowExecutionRoute(source)
 	if routedTo == "" {
 		return graphRouteBinding{sessionName: source.Assignee}, nil

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -815,7 +815,7 @@ op_init() {
 
     # Custom bead types for bd (extracted from beads core in v0.46.0).
     # GC_BEADS_CUSTOM_TYPES overrides the default SDK set.
-    local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session}"
+    local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,external_binding,external_delivery,external_group,external_group_participant,external_transcript,external_membership,external_transcript_state}"
 
     # If already initialized on disk, ensure the database is also registered
     # with the running server. This covers the case where bd init created the

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -99,6 +99,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newResumeCmd(stdout, stderr),
 		newRigCmd(stdout, stderr),
 		newMailCmd(stdout, stderr),
+		newTranscriptCmd(stdout, stderr),
 		newNudgeCmd(stdout, stderr),
 		newWaitCmd(stdout, stderr),
 		newAgentCmd(stdout, stderr),

--- a/cmd/gc/named_sessions.go
+++ b/cmd/gc/named_sessions.go
@@ -267,17 +267,3 @@ func sessionAliasHistoryContains(metadata map[string]string, target string) bool
 	}
 	return false
 }
-
-func persistNamedSessionMetadata(store beads.Store, beadID string, spec namedSessionSpec) error {
-	if store == nil || beadID == "" {
-		return nil
-	}
-	if err := store.SetMetadataBatch(beadID, map[string]string{
-		namedSessionMetadataKey:      boolMetadata(true),
-		namedSessionIdentityMetadata: spec.Identity,
-		namedSessionModeMetadata:     spec.Mode,
-	}); err != nil {
-		return fmt.Errorf("persisting named-session metadata on %s: %w", beadID, err)
-	}
-	return nil
-}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -235,7 +235,7 @@ func reconcileSessionBeads(
 		// Heal advisory state metadata.
 		healState(session, alive, store)
 		if recoverPendingIdleSleep(session, store, running, clk) {
-			running = false
+			running = false //nolint:ineffassign // clarifies state after recovery
 			alive = false
 		}
 		reconcileDetachedAt(session, store, policy, alive, sp, clk)
@@ -431,11 +431,12 @@ func reconcileSessionBeads(
 			// No reason to be awake — begin drain.
 			reason := "no-wake-reason"
 			intent := target.session.Metadata["sleep_intent"]
-			if intent == "idle-stop-pending" {
+			switch {
+			case intent == "idle-stop-pending":
 				reason = "idle"
-			} else if intent != "" {
+			case intent != "":
 				reason = intent
-			} else if eval.ConfigSuppressed && eval.Policy.enabled() {
+			case eval.ConfigSuppressed && eval.Policy.enabled():
 				reason = "idle"
 			}
 			if reason != "idle" {

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -155,6 +155,8 @@ func cancelSessionDrain(session beads.Bead, dt *drainTracker) bool {
 }
 
 // advanceSessionDrains checks all in-progress drains. Called once per tick.
+//
+//nolint:unparam // workSet reserved for future drain-aware work scheduling
 func advanceSessionDrains(
 	dt *drainTracker,
 	sp runtime.Provider,

--- a/cmd/gc/workflow_runtime.go
+++ b/cmd/gc/workflow_runtime.go
@@ -39,7 +39,7 @@ func workflowExecutionRoute(bead beads.Bead) string {
 	return workflowExecutionRouteFromMeta(bead.Metadata)
 }
 
-func workflowControlBinding(store beads.Store, cityName, cityPath string, cfg *config.City) (graphRouteBinding, error) {
+func workflowControlBinding(store beads.Store, _, cityPath string, cfg *config.City) (graphRouteBinding, error) {
 	if cfg == nil {
 		return graphRouteBinding{}, fmt.Errorf("workflow-control route requires config")
 	}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -15,6 +15,7 @@ City is the top-level configuration for a Gas City instance.
 | `providers` | map[string]ProviderSpec |  |  | Providers defines named provider presets for agent startup. |
 | `packs` | map[string]PackSource |  |  | Packs defines named remote pack sources fetched via git. |
 | `agent` | []Agent | **yes** |  | Agents lists all configured agents in this city. |
+| `named_session` | []NamedSession |  |  | NamedSessions lists canonical alias-backed sessions built from reusable agent templates. |
 | `rigs` | []Rig |  |  | Rigs lists external projects registered in the city. |
 | `patches` | Patches |  |  | Patches holds targeted modifications applied after fragment merge. |
 | `beads` | BeadsConfig |  |  | Beads configures the bead store backend. |
@@ -275,6 +276,17 @@ MailConfig holds mail provider settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string |  |  | Provider selects the mail backend: "fake", "fail", "exec:&lt;script&gt;", or "" (default: beadmail). |
+
+## NamedSession
+
+NamedSession defines a canonical persistent session backed by an agent template.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `template` | string | **yes** |  | Template is the referenced agent template name. |
+| `scope` | string |  |  | Scope defines where this named session is instantiated in pack expansion: "city" (one per city) or "rig" (one per rig). Enum: `city`, `rig` |
+| `dir` | string |  |  | Dir is the identity prefix for rig-scoped named sessions after pack expansion. Empty means city-scoped. |
+| `mode` | string |  |  | Mode controls controller behavior for this named session. "on_demand" (default): reserve identity and materialize when work or an explicit reference requires it. "always": keep the canonical session controller-managed. Enum: `on_demand`, `always` |
 
 ## OptionChoice
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -712,6 +712,13 @@
           "type": "array",
           "description": "Agents lists all configured agents in this city."
         },
+        "named_session": {
+          "items": {
+            "$ref": "#/$defs/NamedSession"
+          },
+          "type": "array",
+          "description": "NamedSessions lists canonical alias-backed sessions built from\nreusable agent templates."
+        },
         "rigs": {
           "items": {
             "$ref": "#/$defs/Rig"
@@ -949,6 +956,40 @@
       "additionalProperties": false,
       "type": "object",
       "description": "MailConfig holds mail provider settings."
+    },
+    "NamedSession": {
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "Template is the referenced agent template name."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope defines where this named session is instantiated in pack\nexpansion: \"city\" (one per city) or \"rig\" (one per rig)."
+        },
+        "dir": {
+          "type": "string",
+          "description": "Dir is the identity prefix for rig-scoped named sessions after pack\nexpansion. Empty means city-scoped."
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "on_demand",
+            "always"
+          ],
+          "description": "Mode controls controller behavior for this named session.\n\"on_demand\" (default): reserve identity and materialize when work or\nan explicit reference requires it.\n\"always\": keep the canonical session controller-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "template"
+      ],
+      "description": "NamedSession defines a canonical persistent session backed by an agent template."
     },
     "OptionChoice": {
       "properties": {

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/mail/beadmail"
 	"github.com/gastownhall/gascity/internal/orders"
@@ -35,6 +36,8 @@ type fakeState struct {
 	stores        map[string]beads.Store
 	cityBeadStore beads.Store   // city-level store for session beads
 	cityMailProv  mail.Provider // city-level mail provider (all mail is city-scoped)
+	extmsgSvc     *extmsg.Services
+	adapterReg    *extmsg.AdapterRegistry
 	eventProv     events.Provider
 	cityName      string
 	cityPath      string
@@ -86,17 +89,19 @@ func (f *fakeState) MailProviders() map[string]mail.Provider {
 	}
 	return map[string]mail.Provider{f.cityName: f.cityMailProv}
 }
-func (f *fakeState) EventProvider() events.Provider         { return f.eventProv }
-func (f *fakeState) CityName() string                       { return f.cityName }
-func (f *fakeState) CityPath() string                       { return f.cityPath }
-func (f *fakeState) Version() string                        { return "test" }
-func (f *fakeState) StartedAt() time.Time                   { return f.startedAt }
-func (f *fakeState) IsQuarantined(sessionName string) bool  { return f.quarantined[sessionName] }
-func (f *fakeState) ClearCrashHistory(sessionName string)   { delete(f.quarantined, sessionName) }
-func (f *fakeState) CityBeadStore() beads.Store             { return f.cityBeadStore }
-func (f *fakeState) Orders() []orders.Order                 { return f.autos }
-func (f *fakeState) Poke()                                  { f.pokeCount++ }
-func (f *fakeState) ServiceRegistry() workspacesvc.Registry { return f.services }
+func (f *fakeState) EventProvider() events.Provider           { return f.eventProv }
+func (f *fakeState) CityName() string                         { return f.cityName }
+func (f *fakeState) CityPath() string                         { return f.cityPath }
+func (f *fakeState) Version() string                          { return "test" }
+func (f *fakeState) StartedAt() time.Time                     { return f.startedAt }
+func (f *fakeState) IsQuarantined(sessionName string) bool    { return f.quarantined[sessionName] }
+func (f *fakeState) ClearCrashHistory(sessionName string)     { delete(f.quarantined, sessionName) }
+func (f *fakeState) CityBeadStore() beads.Store               { return f.cityBeadStore }
+func (f *fakeState) Orders() []orders.Order                   { return f.autos }
+func (f *fakeState) Poke()                                    { f.pokeCount++ }
+func (f *fakeState) ServiceRegistry() workspacesvc.Registry   { return f.services }
+func (f *fakeState) ExtMsgServices() *extmsg.Services         { return f.extmsgSvc }
+func (f *fakeState) AdapterRegistry() *extmsg.AdapterRegistry { return f.adapterReg }
 
 func (f *fakeState) RawConfig() *config.City {
 	if f.rawCfg != nil {

--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -1,0 +1,662 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
+)
+
+// --- helpers ---
+
+// extmsgServices returns the extmsg services from state, writing an error
+// response and returning nil if unavailable.
+func (s *Server) extmsgServices(w http.ResponseWriter) *extmsg.Services {
+	svc := s.state.ExtMsgServices()
+	if svc == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "external messaging not enabled")
+		return nil
+	}
+	return svc
+}
+
+// extmsgAdapterRegistry returns the adapter registry from state, writing an
+// error response and returning nil if unavailable.
+func (s *Server) extmsgAdapterRegistry(w http.ResponseWriter) *extmsg.AdapterRegistry {
+	reg := s.state.AdapterRegistry()
+	if reg == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "adapter registry not available")
+		return nil
+	}
+	return reg
+}
+
+// extmsgEmitEvent builds an event emitter closure for extmsg handlers.
+func (s *Server) extmsgEmitEvent() func(string, string, map[string]any) {
+	ep := s.state.EventProvider()
+	if ep == nil {
+		return func(string, string, map[string]any) {}
+	}
+	return func(eventType, subject string, payload map[string]any) {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "extmsg: marshal event payload: %v\n", err)
+			return
+		}
+		ep.Record(events.Event{
+			Type:    eventType,
+			Subject: subject,
+			Payload: b,
+		})
+	}
+}
+
+// extmsgNotifyMembers sends a "check transcript" message to all transcript
+// members via the session message API. This ensures delivery regardless of
+// session state: sleeping sessions are woken, idle sessions get a new prompt
+// turn that triggers the transcript check hook.
+func (s *Server) extmsgNotifyMembers(conv extmsg.ConversationRef, inboundMsg extmsg.ExternalInboundMessage) {
+	svc := s.state.ExtMsgServices()
+	store := s.state.CityBeadStore()
+	if svc == nil || store == nil {
+		return
+	}
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "extmsg-notify"}
+	members, err := svc.Transcript.ListMemberships(context.Background(), caller, conv)
+	if err != nil {
+		log.Printf("extmsg: ListMemberships failed for %s/%s: %v", conv.Provider, conv.ConversationID, err)
+		return
+	}
+
+	actorKind := "agent"
+	if !inboundMsg.Actor.IsBot {
+		actorKind = "human"
+	}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for _, m := range members {
+		wg.Add(1)
+		go func(sessionID string) {
+			defer wg.Done()
+			// Resolve the member's handle from their session bead alias.
+			// Membership stores session names (s-et-xxxx); bead IDs drop the "s-" prefix.
+			handle := sessionID
+			beadID := strings.TrimPrefix(sessionID, "s-")
+			if b, err := store.Get(beadID); err == nil {
+				if alias := b.Metadata["alias"]; alias != "" {
+					if idx := strings.LastIndex(alias, "/"); idx >= 0 {
+						handle = alias[idx+1:]
+					} else {
+						handle = alias
+					}
+				}
+			}
+			nudge := fmt.Sprintf("<system-reminder>\nNew message in shared conversation %s/%s:\n\n"+
+				"- %s (%s): %s\n\n"+
+				"To reply in Discord, write your response to a file and run:\n"+
+				"  gc discord reply-current --conversation-id %s --body-file <path>\n"+
+				"Prefix your reply with your agent handle in bold (e.g., **%s:** your message).\n"+
+				"Run 'gc transcript read --ack' after responding to mark as read.\n"+
+				"</system-reminder>",
+				conv.Provider, conv.ConversationID,
+				inboundMsg.Actor.DisplayName, actorKind, inboundMsg.Text,
+				conv.ConversationID,
+				handle,
+			)
+			if _, err := s.sendMessageToResolvedSession(ctx, store, sessionID, nudge); err != nil {
+				log.Printf("extmsg: notify %s failed: %v", sessionID, err)
+			}
+		}(m.SessionID)
+	}
+	wg.Wait()
+}
+
+// --- inbound ---
+
+func (s *Server) handleExtMsgInbound(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+	reg := s.extmsgAdapterRegistry(w)
+	if reg == nil {
+		return
+	}
+
+	var body struct {
+		// For pre-normalized messages (out-of-process adapters):
+		Message *extmsg.ExternalInboundMessage `json:"message,omitempty"`
+		// For raw payloads (in-process adapters):
+		Provider  string `json:"provider,omitempty"`
+		AccountID string `json:"account_id,omitempty"`
+		Payload   []byte `json:"payload,omitempty"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+
+	deps := extmsg.InboundDeps{
+		Services:  *svc,
+		Registry:  reg,
+		EmitEvent: s.extmsgEmitEvent(),
+	}
+
+	ctx := r.Context()
+
+	// Pre-normalized path.
+	if body.Message != nil {
+		result, err := extmsg.HandleInboundNormalized(ctx, deps, *body.Message)
+		if err != nil {
+			writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+			return
+		}
+		go s.extmsgNotifyMembers(body.Message.Conversation, *body.Message)
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+
+	// Raw payload path.
+	if body.Provider == "" || body.AccountID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "provider and account_id are required for raw payloads")
+		return
+	}
+
+	key := extmsg.AdapterKey{Provider: body.Provider, AccountID: body.AccountID}
+	result, err := extmsg.HandleInbound(ctx, deps, key, extmsg.InboundPayload{
+		Body:       body.Payload,
+		ReceivedAt: time.Now(),
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// --- outbound ---
+
+func (s *Server) handleExtMsgOutbound(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+	reg := s.extmsgAdapterRegistry(w)
+	if reg == nil {
+		return
+	}
+
+	var body struct {
+		SessionID        string                 `json:"session_id"`
+		Conversation     extmsg.ConversationRef `json:"conversation"`
+		Text             string                 `json:"text"`
+		ReplyToMessageID string                 `json:"reply_to_message_id,omitempty"`
+		IdempotencyKey   string                 `json:"idempotency_key,omitempty"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.SessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "session_id is required")
+		return
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	deps := extmsg.OutboundDeps{
+		Services:  *svc,
+		Registry:  reg,
+		EmitEvent: s.extmsgEmitEvent(),
+	}
+
+	result, err := extmsg.HandleOutbound(r.Context(), deps, caller, extmsg.OutboundRequest{
+		SessionID:        body.SessionID,
+		Conversation:     body.Conversation,
+		Text:             body.Text,
+		ReplyToMessageID: body.ReplyToMessageID,
+		IdempotencyKey:   body.IdempotencyKey,
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+	go s.extmsgNotifyMembers(body.Conversation, extmsg.ExternalInboundMessage{
+		Conversation: body.Conversation,
+		Actor:        extmsg.ExternalActor{ID: body.SessionID, DisplayName: body.SessionID, IsBot: true},
+		Text:         body.Text,
+	})
+	writeJSON(w, http.StatusOK, result)
+}
+
+// --- bindings ---
+
+func (s *Server) handleExtMsgBindingList(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "session_id query parameter is required")
+		return
+	}
+
+	bindings, err := svc.Bindings.ListBySession(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if bindings == nil {
+		bindings = []extmsg.SessionBindingRecord{}
+	}
+	writeListJSON(w, s.latestIndex(), bindings, len(bindings))
+}
+
+func (s *Server) handleExtMsgBind(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	var body struct {
+		Conversation extmsg.ConversationRef `json:"conversation"`
+		SessionID    string                 `json:"session_id"`
+		Metadata     map[string]string      `json:"metadata,omitempty"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.SessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "session_id is required")
+		return
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	binding, err := svc.Bindings.Bind(r.Context(), caller, extmsg.BindInput{
+		Conversation: body.Conversation,
+		SessionID:    body.SessionID,
+		Metadata:     body.Metadata,
+		Now:          time.Now(),
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, extmsg.ErrBindingConflict):
+			writeError(w, http.StatusConflict, "conflict", err.Error())
+		case errors.Is(err, extmsg.ErrInvalidInput) || errors.Is(err, extmsg.ErrInvalidConversation):
+			writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		}
+		return
+	}
+
+	s.extmsgEmitEvent()(events.ExtMsgBound, body.SessionID, map[string]any{
+		"provider":        body.Conversation.Provider,
+		"conversation_id": body.Conversation.ConversationID,
+		"session_id":      body.SessionID,
+	})
+	writeJSON(w, http.StatusCreated, binding)
+}
+
+func (s *Server) handleExtMsgUnbind(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	var body struct {
+		Conversation *extmsg.ConversationRef `json:"conversation,omitempty"`
+		SessionID    string                  `json:"session_id"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.SessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "session_id is required")
+		return
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	unbound, err := svc.Bindings.Unbind(r.Context(), caller, extmsg.UnbindInput{
+		Conversation: body.Conversation,
+		SessionID:    body.SessionID,
+		Now:          time.Now(),
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+
+	s.extmsgEmitEvent()(events.ExtMsgUnbound, body.SessionID, map[string]any{
+		"session_id": body.SessionID,
+		"count":      len(unbound),
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"unbound": unbound})
+}
+
+// --- groups ---
+
+func (s *Server) handleExtMsgGroupLookup(w http.ResponseWriter, r *http.Request) {
+	// Read-only lookup of a group by root conversation query params.
+	// Does NOT create a group — use POST /v0/extmsg/groups for that.
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	q := r.URL.Query()
+	ref := extmsg.ConversationRef{
+		ScopeID:        q.Get("scope_id"),
+		Provider:       q.Get("provider"),
+		AccountID:      q.Get("account_id"),
+		ConversationID: q.Get("conversation_id"),
+		Kind:           extmsg.ConversationKind(q.Get("kind")),
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	group, err := svc.Groups.FindByConversation(r.Context(), caller, ref)
+	if err != nil {
+		if errors.Is(err, extmsg.ErrGroupNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "group not found for conversation")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, group)
+}
+
+func (s *Server) handleExtMsgGroupEnsure(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	var body struct {
+		RootConversation extmsg.ConversationRef `json:"root_conversation"`
+		Mode             extmsg.GroupMode       `json:"mode"`
+		DefaultHandle    string                 `json:"default_handle,omitempty"`
+		Metadata         map[string]string      `json:"metadata,omitempty"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.Mode == "" {
+		body.Mode = extmsg.GroupModeLauncher
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	group, err := svc.Groups.EnsureGroup(r.Context(), caller, extmsg.EnsureGroupInput{
+		RootConversation: body.RootConversation,
+		Mode:             body.Mode,
+		DefaultHandle:    body.DefaultHandle,
+		Metadata:         body.Metadata,
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+
+	s.extmsgEmitEvent()(events.ExtMsgGroupCreated, group.ID, map[string]any{
+		"provider":        body.RootConversation.Provider,
+		"conversation_id": body.RootConversation.ConversationID,
+		"mode":            string(body.Mode),
+	})
+	writeJSON(w, http.StatusCreated, group)
+}
+
+func (s *Server) handleExtMsgParticipantUpsert(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	var body struct {
+		GroupID   string            `json:"group_id"`
+		Handle    string            `json:"handle"`
+		SessionID string            `json:"session_id"`
+		Public    bool              `json:"public"`
+		Metadata  map[string]string `json:"metadata,omitempty"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.GroupID == "" || body.Handle == "" || body.SessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "group_id, handle, and session_id are required")
+		return
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	participant, err := svc.Groups.UpsertParticipant(r.Context(), caller, extmsg.UpsertParticipantInput{
+		GroupID:   body.GroupID,
+		Handle:    body.Handle,
+		SessionID: body.SessionID,
+		Public:    body.Public,
+		Metadata:  body.Metadata,
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, participant)
+}
+
+func (s *Server) handleExtMsgParticipantRemove(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	var body struct {
+		GroupID string `json:"group_id"`
+		Handle  string `json:"handle"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.GroupID == "" || body.Handle == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "group_id and handle are required")
+		return
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	err := svc.Groups.RemoveParticipant(r.Context(), caller, extmsg.RemoveParticipantInput{
+		GroupID: body.GroupID,
+		Handle:  body.Handle,
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+}
+
+// --- transcript ---
+
+func (s *Server) handleExtMsgTranscriptList(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	q := r.URL.Query()
+	ref := extmsg.ConversationRef{
+		ScopeID:              q.Get("scope_id"),
+		Provider:             q.Get("provider"),
+		AccountID:            q.Get("account_id"),
+		ConversationID:       q.Get("conversation_id"),
+		ParentConversationID: q.Get("parent_conversation_id"),
+		Kind:                 extmsg.ConversationKind(q.Get("kind")),
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	entries, err := svc.Transcript.List(r.Context(), extmsg.ListTranscriptInput{
+		Caller:       caller,
+		Conversation: ref,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if entries == nil {
+		entries = []extmsg.ConversationTranscriptRecord{}
+	}
+	writeListJSON(w, s.latestIndex(), entries, len(entries))
+}
+
+func (s *Server) handleExtMsgTranscriptAck(w http.ResponseWriter, r *http.Request) {
+	svc := s.extmsgServices(w)
+	if svc == nil {
+		return
+	}
+
+	var body struct {
+		Conversation extmsg.ConversationRef `json:"conversation"`
+		SessionID    string                 `json:"session_id"`
+		Sequence     int64                  `json:"sequence"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.SessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "session_id is required")
+		return
+	}
+
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
+	err := svc.Transcript.Ack(r.Context(), extmsg.AckMembershipInput{
+		Caller:       caller,
+		Conversation: body.Conversation,
+		SessionID:    body.SessionID,
+		Sequence:     body.Sequence,
+	})
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "processing_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "acked"})
+}
+
+// --- adapters ---
+
+func (s *Server) handleExtMsgAdapterList(w http.ResponseWriter, _ *http.Request) {
+	reg := s.extmsgAdapterRegistry(w)
+	if reg == nil {
+		return
+	}
+
+	keys := reg.List()
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Provider != keys[j].Provider {
+			return keys[i].Provider < keys[j].Provider
+		}
+		return keys[i].AccountID < keys[j].AccountID
+	})
+	type adapterInfo struct {
+		Provider  string `json:"provider"`
+		AccountID string `json:"account_id"`
+		Name      string `json:"name"`
+	}
+	items := make([]adapterInfo, 0, len(keys))
+	for _, k := range keys {
+		a := reg.Lookup(k)
+		name := ""
+		if a != nil {
+			name = a.Name()
+		}
+		items = append(items, adapterInfo{
+			Provider:  k.Provider,
+			AccountID: k.AccountID,
+			Name:      name,
+		})
+	}
+	writeListJSON(w, s.latestIndex(), items, len(items))
+}
+
+func (s *Server) handleExtMsgAdapterRegister(w http.ResponseWriter, r *http.Request) {
+	reg := s.extmsgAdapterRegistry(w)
+	if reg == nil {
+		return
+	}
+
+	var body struct {
+		Provider     string                     `json:"provider"`
+		AccountID    string                     `json:"account_id"`
+		Name         string                     `json:"name"`
+		CallbackURL  string                     `json:"callback_url"`
+		Capabilities extmsg.AdapterCapabilities `json:"capabilities"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.Provider == "" || body.AccountID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "provider and account_id are required")
+		return
+	}
+	if body.Name == "" {
+		body.Name = body.Provider + "/" + body.AccountID
+	}
+
+	adapter := extmsg.NewHTTPAdapter(body.Name, body.CallbackURL, body.Capabilities)
+	key := extmsg.AdapterKey{Provider: body.Provider, AccountID: body.AccountID}
+	reg.Register(key, adapter)
+
+	s.extmsgEmitEvent()(events.ExtMsgAdapterAdded, body.Name, map[string]any{
+		"provider":   body.Provider,
+		"account_id": body.AccountID,
+	})
+	writeJSON(w, http.StatusCreated, map[string]string{
+		"status":     "registered",
+		"provider":   body.Provider,
+		"account_id": body.AccountID,
+		"name":       body.Name,
+	})
+}
+
+func (s *Server) handleExtMsgAdapterUnregister(w http.ResponseWriter, r *http.Request) {
+	reg := s.extmsgAdapterRegistry(w)
+	if reg == nil {
+		return
+	}
+
+	var body struct {
+		Provider  string `json:"provider"`
+		AccountID string `json:"account_id"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if body.Provider == "" || body.AccountID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "provider and account_id are required")
+		return
+	}
+
+	key := extmsg.AdapterKey{Provider: body.Provider, AccountID: body.AccountID}
+	reg.Unregister(key)
+
+	s.extmsgEmitEvent()(events.ExtMsgAdapterRemoved, body.Provider+"/"+body.AccountID, map[string]any{
+		"provider":   body.Provider,
+		"account_id": body.AccountID,
+	})
+	writeJSON(w, http.StatusOK, map[string]string{"status": "unregistered"})
+}

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -1,0 +1,488 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/extmsg"
+)
+
+// testTransportAdapter implements extmsg.TransportAdapter for handler tests.
+type testTransportAdapter struct {
+	name string
+}
+
+func (a *testTransportAdapter) Name() string { return a.name }
+func (a *testTransportAdapter) Capabilities() extmsg.AdapterCapabilities {
+	return extmsg.AdapterCapabilities{}
+}
+
+func (a *testTransportAdapter) VerifyAndNormalizeInbound(_ context.Context, p extmsg.InboundPayload) (*extmsg.ExternalInboundMessage, error) {
+	return &extmsg.ExternalInboundMessage{
+		ProviderMessageID: "msg-from-adapter",
+		Conversation: extmsg.ConversationRef{
+			ScopeID:        "scope",
+			Provider:       "test-provider",
+			AccountID:      "test-account",
+			ConversationID: "chan-1",
+			Kind:           extmsg.ConversationRoom,
+		},
+		Actor:      extmsg.ExternalActor{ID: "user-1", DisplayName: "Alice"},
+		Text:       string(p.Body),
+		ReceivedAt: time.Now(),
+	}, nil
+}
+
+func (a *testTransportAdapter) Publish(_ context.Context, req extmsg.PublishRequest) (*extmsg.PublishReceipt, error) {
+	return &extmsg.PublishReceipt{
+		MessageID:    "out-001",
+		Conversation: req.Conversation,
+		Delivered:    true,
+	}, nil
+}
+
+func (a *testTransportAdapter) EnsureChildConversation(_ context.Context, _ extmsg.ConversationRef, _ string) (*extmsg.ConversationRef, error) {
+	return nil, extmsg.ErrAdapterUnsupported
+}
+
+func newExtMsgFakeState(t *testing.T) *fakeState {
+	t.Helper()
+	fs := newFakeState(t)
+	store := beads.NewMemStore()
+	svc := extmsg.NewServices(store)
+	fs.extmsgSvc = &svc
+	fs.adapterReg = extmsg.NewAdapterRegistry()
+	fs.cityBeadStore = store
+	return fs
+}
+
+func TestHandleExtMsgAdapterLifecycle(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	// Register adapter.
+	body := `{"provider":"test-provider","account_id":"test-account","name":"my-adapter","callback_url":"http://localhost:9999"}`
+	req := newPostRequest("/v0/extmsg/adapters", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// List adapters.
+	req = httptest.NewRequest("GET", "/v0/extmsg/adapters", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var listResp struct {
+		Items []struct {
+			Provider  string `json:"provider"`
+			AccountID string `json:"account_id"`
+			Name      string `json:"name"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&listResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp.Items) != 1 {
+		t.Fatalf("expected 1 adapter, got %d", len(listResp.Items))
+	}
+	if listResp.Items[0].Name != "my-adapter" {
+		t.Fatalf("expected my-adapter, got %s", listResp.Items[0].Name)
+	}
+
+	// Unregister adapter.
+	body = `{"provider":"test-provider","account_id":"test-account"}`
+	req = httptest.NewRequest("DELETE", "/v0/extmsg/adapters", bytes.NewBufferString(body))
+	req.Header.Set("X-GC-Request", "true")
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify empty.
+	req = httptest.NewRequest("GET", "/v0/extmsg/adapters", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if err := json.NewDecoder(w.Body).Decode(&listResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp.Items) != 0 {
+		t.Fatalf("expected 0 adapters after unregister, got %d", len(listResp.Items))
+	}
+}
+
+func TestHandleExtMsgBindingLifecycle(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	conv := extmsg.ConversationRef{
+		ScopeID:        "scope",
+		Provider:       "discord",
+		AccountID:      "bot-1",
+		ConversationID: "chan-42",
+		Kind:           extmsg.ConversationRoom,
+	}
+
+	// Bind.
+	bindBody, _ := json.Marshal(map[string]any{
+		"conversation": conv,
+		"session_id":   "session-alpha",
+	})
+	req := newPostRequest("/v0/extmsg/bindings", bytes.NewBuffer(bindBody))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bind: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// List bindings by session.
+	req = httptest.NewRequest("GET", "/v0/extmsg/bindings?session_id=session-alpha", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var listResp struct {
+		Items []extmsg.SessionBindingRecord `json:"items"`
+		Total int                           `json:"total"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&listResp); err != nil {
+		t.Fatal(err)
+	}
+	if listResp.Total != 1 {
+		t.Fatalf("expected 1 binding, got %d", listResp.Total)
+	}
+
+	// Unbind.
+	unbindBody, _ := json.Marshal(map[string]any{
+		"conversation": conv,
+		"session_id":   "session-alpha",
+	})
+	req = httptest.NewRequest("DELETE", "/v0/extmsg/bindings", bytes.NewBuffer(unbindBody))
+	req.Header.Set("X-GC-Request", "true")
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unbind: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleExtMsgInboundNormalized(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	conv := extmsg.ConversationRef{
+		ScopeID:        "scope",
+		Provider:       "discord",
+		AccountID:      "bot-1",
+		ConversationID: "chan-42",
+		Kind:           extmsg.ConversationRoom,
+	}
+
+	// Create a binding first.
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	_, err := fs.extmsgSvc.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: conv,
+		SessionID:    "worker",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Send normalized inbound.
+	msg := extmsg.ExternalInboundMessage{
+		ProviderMessageID: "msg-001",
+		Conversation:      conv,
+		Actor:             extmsg.ExternalActor{ID: "user-1", DisplayName: "Alice"},
+		Text:              "hello from discord",
+		ReceivedAt:        time.Now(),
+	}
+	body, _ := json.Marshal(map[string]any{"message": msg})
+	req := newPostRequest("/v0/extmsg/inbound", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("inbound: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	respBody, _ := io.ReadAll(w.Body)
+	var result extmsg.InboundResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.TargetSessionID != "worker" {
+		t.Fatalf("expected worker, got %s", result.TargetSessionID)
+	}
+}
+
+func TestHandleExtMsgInboundRawPayload(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	conv := extmsg.ConversationRef{
+		ScopeID:        "scope",
+		Provider:       "test-provider",
+		AccountID:      "test-account",
+		ConversationID: "chan-1",
+		Kind:           extmsg.ConversationRoom,
+	}
+
+	// Register a real adapter.
+	fs.adapterReg.Register(
+		extmsg.AdapterKey{Provider: "test-provider", AccountID: "test-account"},
+		&testTransportAdapter{name: "test"},
+	)
+
+	// Bind.
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	_, err := fs.extmsgSvc.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: conv,
+		SessionID:    "worker",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Send raw payload.
+	body, _ := json.Marshal(map[string]any{
+		"provider":   "test-provider",
+		"account_id": "test-account",
+		"payload":    []byte("hello raw"),
+	})
+	req := newPostRequest("/v0/extmsg/inbound", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("inbound raw: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleExtMsgOutbound(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	conv := extmsg.ConversationRef{
+		ScopeID:        "scope",
+		Provider:       "test-provider",
+		AccountID:      "test-account",
+		ConversationID: "chan-1",
+		Kind:           extmsg.ConversationRoom,
+	}
+
+	// Register adapter and bind.
+	fs.adapterReg.Register(
+		extmsg.AdapterKey{Provider: "test-provider", AccountID: "test-account"},
+		&testTransportAdapter{name: "test"},
+	)
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	_, err := fs.extmsgSvc.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: conv,
+		SessionID:    "worker",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Publish outbound.
+	body, _ := json.Marshal(map[string]any{
+		"session_id":   "worker",
+		"conversation": conv,
+		"text":         "hello from gc",
+	})
+	req := newPostRequest("/v0/extmsg/outbound", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("outbound: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleExtMsgGroupAndParticipants(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	// Ensure group.
+	body, _ := json.Marshal(map[string]any{
+		"root_conversation": extmsg.ConversationRef{
+			ScopeID:        "scope",
+			Provider:       "discord",
+			AccountID:      "bot-1",
+			ConversationID: "chan-99",
+			Kind:           extmsg.ConversationRoom,
+		},
+		"mode":           "launcher",
+		"default_handle": "worker",
+	})
+	req := newPostRequest("/v0/extmsg/groups", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("ensure group: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var group extmsg.ConversationGroupRecord
+	if err := json.NewDecoder(w.Body).Decode(&group); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upsert participant.
+	body, _ = json.Marshal(map[string]any{
+		"group_id":   group.ID,
+		"handle":     "worker",
+		"session_id": "session-beta",
+		"public":     true,
+	})
+	req = newPostRequest("/v0/extmsg/groups/participants", bytes.NewBuffer(body))
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("upsert participant: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Remove participant.
+	body, _ = json.Marshal(map[string]any{
+		"group_id": group.ID,
+		"handle":   "worker",
+	})
+	req = httptest.NewRequest("DELETE", "/v0/extmsg/groups/participants", bytes.NewBuffer(body))
+	req.Header.Set("X-GC-Request", "true")
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("remove participant: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleExtMsgGroupLookup(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	// GET before group exists should return 404.
+	req := httptest.NewRequest("GET", "/v0/extmsg/groups?scope_id=scope&provider=discord&account_id=bot-1&conversation_id=chan-99&kind=room", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing group, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Create group via POST.
+	body, _ := json.Marshal(map[string]any{
+		"root_conversation": extmsg.ConversationRef{
+			ScopeID:        "scope",
+			Provider:       "discord",
+			AccountID:      "bot-1",
+			ConversationID: "chan-99",
+			Kind:           extmsg.ConversationRoom,
+		},
+		"mode":           "launcher",
+		"default_handle": "worker",
+	})
+	req = newPostRequest("/v0/extmsg/groups", bytes.NewBuffer(body))
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("ensure group: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// GET after creation should return the group.
+	req = httptest.NewRequest("GET", "/v0/extmsg/groups?scope_id=scope&provider=discord&account_id=bot-1&conversation_id=chan-99&kind=room", nil)
+	w = httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for existing group, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleExtMsgTranscript(t *testing.T) {
+	fs := newExtMsgFakeState(t)
+	srv := New(fs)
+
+	conv := extmsg.ConversationRef{
+		ScopeID:        "scope",
+		Provider:       "discord",
+		AccountID:      "bot-1",
+		ConversationID: "chan-42",
+		Kind:           extmsg.ConversationRoom,
+	}
+
+	// Append a transcript entry directly for testing.
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	_, err := fs.extmsgSvc.Transcript.Append(context.Background(), extmsg.AppendTranscriptInput{
+		Caller:            caller,
+		Conversation:      conv,
+		Kind:              extmsg.TranscriptMessageInbound,
+		Provenance:        extmsg.TranscriptProvenanceLive,
+		ProviderMessageID: "msg-001",
+		Actor:             extmsg.ExternalActor{ID: "u1", DisplayName: "Alice"},
+		Text:              "hello",
+		CreatedAt:         time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	// List transcript.
+	req := httptest.NewRequest("GET", "/v0/extmsg/transcript?scope_id=scope&provider=discord&account_id=bot-1&conversation_id=chan-42&kind=room", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("list transcript: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var listResp struct {
+		Items []extmsg.ConversationTranscriptRecord `json:"items"`
+		Total int                                   `json:"total"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&listResp); err != nil {
+		t.Fatal(err)
+	}
+	if listResp.Total != 1 {
+		t.Fatalf("expected 1 entry, got %d", listResp.Total)
+	}
+}
+
+func TestHandleExtMsgServicesUnavailable(t *testing.T) {
+	fs := newFakeState(t)
+	// Don't set extmsgSvc or adapterReg — they stay nil.
+	srv := New(fs)
+
+	req := httptest.NewRequest("GET", "/v0/extmsg/bindings?session_id=x", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}

--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -253,7 +253,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 
 	var resolved *config.ResolvedProvider
 	var workDir, transport, template string
-	var extraArgs []string
 	var optMeta map[string]string
 
 	switch kind {
@@ -275,8 +274,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "internal", err.Error())
 			return
 		}
-		// Agent track: command comes from the agent config as-is.
-		// Do NOT inject OptionsSchema defaults — agents encode their own CLI flags.
 
 	case "provider":
 		s.createProviderSession(w, r, store, body, name, idemKey, bodyHash)
@@ -286,11 +283,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	title := body.Title
 	if title == "" {
 		title = template
-	}
-	if body.Async && strings.TrimSpace(body.Message) != "" {
-		s.idem.unreserve(idemKey)
-		writeError(w, http.StatusBadRequest, "invalid", "message is not supported with async session creation; create the session, then POST /v0/session/{id}/messages")
-		return
 	}
 
 	resume := session.ProviderResume{
@@ -306,49 +298,37 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Merge extra args from options into the command string.
-	command := resolved.CommandString()
-	if len(extraArgs) > 0 {
-		command = command + " " + shellquote.Join(extraArgs)
+	if body.Async && strings.TrimSpace(body.Message) != "" {
+		s.idem.unreserve(idemKey)
+		writeError(w, http.StatusBadRequest, "invalid", "message is not supported with async session creation; create the session, then POST /v0/session/{id}/messages")
+		return
 	}
 
+	command := resolved.CommandString()
+
+	// Agent sessions always use the bead-only + poke path so the
+	// reconciler starts them with the full template environment
+	// (GC_AGENT, hooks, copy-files, prompt, etc.). This is the same
+	// path that "gc session new" uses.
 	mgr := s.sessionManager(store)
-	hints := sessionCreateHints(resolved)
 	var info session.Info
 	err = session.WithCitySessionAliasLock(s.state.CityPath(), alias, func() error {
 		if err := session.EnsureAliasAvailableWithConfig(store, s.state.Config(), alias, ""); err != nil {
 			return err
 		}
 		var createErr error
-		if body.Async {
-			info, createErr = mgr.CreateAliasedBeadOnlyNamed(
-				alias,
-				"",
-				template,
-				title,
-				command,
-				workDir,
-				resolved.Name,
-				transport,
-				resolved.Env,
-				resume,
-			)
-		} else {
-			info, createErr = mgr.CreateAliasedNamedWithTransport(
-				r.Context(),
-				alias,
-				"",
-				template,
-				title,
-				command,
-				workDir,
-				resolved.Name,
-				transport,
-				resolved.Env,
-				resume,
-				hints,
-			)
-		}
+		info, createErr = mgr.CreateAliasedBeadOnlyNamed(
+			alias,
+			"",
+			template,
+			title,
+			command,
+			workDir,
+			resolved.Name,
+			transport,
+			resolved.Env,
+			resume,
+		)
 		return createErr
 	})
 	if err != nil {
@@ -359,14 +339,49 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 
 	// Persist kind, option metadata, and project_id on the bead.
 	s.persistSessionMeta(store, info.ID, "agent", body.ProjectID, optMeta)
-	if body.Async {
-		s.state.Poke()
-	}
 
-	// Deliver initial message if provided.
-	if msg := strings.TrimSpace(body.Message); msg != "" {
-		resumeCommand, nudgeHints := s.buildSessionResume(info)
-		if sendErr := mgr.Send(r.Context(), info.ID, msg, resumeCommand, nudgeHints); sendErr != nil {
+	// Poke the reconciler to start the session.
+	s.state.Poke()
+
+	// Wait for the reconciler to start the session, then deliver the
+	// initial message if one was provided.
+	msg := strings.TrimSpace(body.Message)
+	if msg != "" {
+		sp := s.state.SessionProvider()
+		sessName := info.SessionName
+		deadline := time.After(60 * time.Second)
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		started := false
+		for !started {
+			select {
+			case <-r.Context().Done():
+				s.idem.unreserve(idemKey)
+				writeError(w, http.StatusGatewayTimeout, "timeout", "request canceled while waiting for session to start")
+				return
+			case <-deadline:
+				s.idem.unreserve(idemKey)
+				writeError(w, http.StatusGatewayTimeout, "timeout",
+					fmt.Sprintf("session %s created but reconciler did not start it within 60s", info.ID))
+				return
+			case <-ticker.C:
+				if sp != nil && sp.IsRunning(sessName) {
+					started = true
+					break
+				}
+				// Also check bead state — the session may have started
+				// and already gone to sleep before we polled IsRunning.
+				if b, err := store.Get(info.ID); err == nil {
+					if st := b.Metadata["state"]; st != "" && st != "creating" {
+						started = true
+					}
+				}
+			}
+		}
+		// Use sendMessageToResolvedSession which wakes sleeping sessions.
+		// The session may have gone idle and slept between the reconciler
+		// starting it and us delivering the message.
+		if _, sendErr := s.sendMessageToResolvedSession(r.Context(), store, sessName, msg); sendErr != nil {
 			log.Printf("session %s: initial message delivery failed: %v", info.ID, sendErr)
 			s.idem.unreserve(idemKey)
 			writeError(w, http.StatusInternalServerError, "message_delivery_failed",

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -854,11 +854,17 @@ func TestHandleSessionCreate(t *testing.T) {
 	if resp.Title != "myrig/worker" {
 		t.Errorf("Title = %q, want default %q", resp.Title, "myrig/worker")
 	}
-	if !resp.Running {
-		t.Errorf("Running = %v, want true", resp.Running)
+	if resp.Running {
+		t.Errorf("Running = %v, want false (reconciler starts the session)", resp.Running)
+	}
+	if resp.State != "creating" {
+		t.Errorf("State = %q, want %q", resp.State, "creating")
 	}
 	if resp.DisplayName != "Test Agent" {
 		t.Errorf("DisplayName = %q, want %q", resp.DisplayName, "Test Agent")
+	}
+	if fs.pokeCount != 1 {
+		t.Errorf("pokeCount = %d, want 1", fs.pokeCount)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -273,4 +273,20 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /v0/service/{name}", s.handleServiceGet)
 	s.mux.HandleFunc("POST /v0/service/{name}/restart", s.handleServiceRestart)
 	s.mux.HandleFunc("/svc/", s.handleServiceProxy)
+
+	// External Messaging
+	s.mux.HandleFunc("POST /v0/extmsg/inbound", s.handleExtMsgInbound)
+	s.mux.HandleFunc("POST /v0/extmsg/outbound", s.handleExtMsgOutbound)
+	s.mux.HandleFunc("GET /v0/extmsg/bindings", s.handleExtMsgBindingList)
+	s.mux.HandleFunc("POST /v0/extmsg/bindings", s.handleExtMsgBind)
+	s.mux.HandleFunc("DELETE /v0/extmsg/bindings", s.handleExtMsgUnbind)
+	s.mux.HandleFunc("GET /v0/extmsg/groups", s.handleExtMsgGroupLookup)
+	s.mux.HandleFunc("POST /v0/extmsg/groups", s.handleExtMsgGroupEnsure)
+	s.mux.HandleFunc("POST /v0/extmsg/groups/participants", s.handleExtMsgParticipantUpsert)
+	s.mux.HandleFunc("DELETE /v0/extmsg/groups/participants", s.handleExtMsgParticipantRemove)
+	s.mux.HandleFunc("GET /v0/extmsg/transcript", s.handleExtMsgTranscriptList)
+	s.mux.HandleFunc("POST /v0/extmsg/transcript/ack", s.handleExtMsgTranscriptAck)
+	s.mux.HandleFunc("GET /v0/extmsg/adapters", s.handleExtMsgAdapterList)
+	s.mux.HandleFunc("POST /v0/extmsg/adapters", s.handleExtMsgAdapterRegister)
+	s.mux.HandleFunc("DELETE /v0/extmsg/adapters", s.handleExtMsgAdapterUnregister)
 }

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -448,6 +448,7 @@ func (s *Server) sendMessageToSession(ctx context.Context, store beads.Store, id
 	return nil
 }
 
+//nolint:unparam // resolved session ID returned for future caller use
 func (s *Server) sendMessageToResolvedSession(ctx context.Context, store beads.Store, identifier, message string) (string, error) {
 	id, err := s.resolveSessionIDMaterializingNamed(store, identifier)
 	if err != nil {

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -81,6 +82,14 @@ type State interface {
 	// ServiceRegistry returns the workspace service registry, or nil when
 	// workspace services are not enabled for this city.
 	ServiceRegistry() workspacesvc.Registry
+
+	// ExtMsgServices returns the external messaging fabric services, or nil
+	// when external messaging is not available (e.g. no city bead store).
+	ExtMsgServices() *extmsg.Services
+
+	// AdapterRegistry returns the external messaging adapter registry, or
+	// nil when external messaging is not available.
+	AdapterRegistry() *extmsg.AdapterRegistry
 }
 
 // AgentUpdate holds optional fields for a partial agent update. Pointer fields

--- a/internal/config/session_sleep.go
+++ b/internal/config/session_sleep.go
@@ -8,6 +8,7 @@ import (
 // SessionSleepClass identifies the policy bucket used for idle session sleep.
 type SessionSleepClass string
 
+// SessionSleepClass constants.
 const (
 	SessionSleepInteractiveResume SessionSleepClass = "interactive_resume"
 	SessionSleepInteractiveFresh  SessionSleepClass = "interactive_fresh"

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -46,6 +46,15 @@ const (
 	OrderCompleted     = "order.completed"
 	OrderFailed        = "order.failed"
 	ProviderSwapped    = "provider.swapped"
+
+	// External messaging events.
+	ExtMsgInbound        = "extmsg.inbound"
+	ExtMsgOutbound       = "extmsg.outbound"
+	ExtMsgBound          = "extmsg.bound"
+	ExtMsgUnbound        = "extmsg.unbound"
+	ExtMsgGroupCreated   = "extmsg.group.created"
+	ExtMsgAdapterAdded   = "extmsg.adapter.added"
+	ExtMsgAdapterRemoved = "extmsg.adapter.removed"
 )
 
 // Event is a single recorded occurrence in the system.

--- a/internal/extmsg/adapter_registry.go
+++ b/internal/extmsg/adapter_registry.go
@@ -1,0 +1,67 @@
+package extmsg
+
+import "sync"
+
+// AdapterKey uniquely identifies a registered transport adapter.
+type AdapterKey struct {
+	Provider  string
+	AccountID string
+}
+
+// AdapterRegistry is a concurrent-safe, ephemeral registry of transport
+// adapters keyed by (Provider, AccountID). Created once per controller
+// lifetime and not rebuilt on config hot-reload.
+//
+// Registrations are in-memory only and do not survive controller restarts.
+// Out-of-process adapters must re-register on reconnect. Unregister does
+// not drain in-flight operations; callers that hold adapter references may
+// see connection errors if the external service is torn down immediately.
+type AdapterRegistry struct {
+	mu       sync.RWMutex
+	adapters map[AdapterKey]TransportAdapter
+}
+
+// NewAdapterRegistry creates an empty adapter registry.
+func NewAdapterRegistry() *AdapterRegistry {
+	return &AdapterRegistry{
+		adapters: make(map[AdapterKey]TransportAdapter),
+	}
+}
+
+// Register adds or replaces an adapter for the given key.
+func (r *AdapterRegistry) Register(key AdapterKey, adapter TransportAdapter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adapters[key] = adapter
+}
+
+// Unregister removes an adapter by key.
+func (r *AdapterRegistry) Unregister(key AdapterKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.adapters, key)
+}
+
+// Lookup returns the adapter for the given key, or nil if not registered.
+func (r *AdapterRegistry) Lookup(key AdapterKey) TransportAdapter {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.adapters[key]
+}
+
+// LookupByConversation finds the adapter for a ConversationRef by deriving
+// the key from ref.Provider and ref.AccountID.
+func (r *AdapterRegistry) LookupByConversation(ref ConversationRef) TransportAdapter {
+	return r.Lookup(AdapterKey{Provider: ref.Provider, AccountID: ref.AccountID})
+}
+
+// List returns all registered adapter keys.
+func (r *AdapterRegistry) List() []AdapterKey {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := make([]AdapterKey, 0, len(r.adapters))
+	for k := range r.adapters {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/extmsg/adapter_registry_test.go
+++ b/internal/extmsg/adapter_registry_test.go
@@ -1,0 +1,145 @@
+package extmsg
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// fakeAdapter implements TransportAdapter for testing.
+type fakeAdapter struct {
+	name string
+	caps AdapterCapabilities
+}
+
+func (a *fakeAdapter) Name() string                      { return a.name }
+func (a *fakeAdapter) Capabilities() AdapterCapabilities { return a.caps }
+func (a *fakeAdapter) VerifyAndNormalizeInbound(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+	return nil, ErrAdapterUnsupported
+}
+
+func (a *fakeAdapter) Publish(_ context.Context, _ PublishRequest) (*PublishReceipt, error) {
+	return nil, ErrAdapterUnsupported
+}
+
+func (a *fakeAdapter) EnsureChildConversation(_ context.Context, _ ConversationRef, _ string) (*ConversationRef, error) {
+	return nil, ErrAdapterUnsupported
+}
+
+func TestAdapterRegistryRegisterAndLookup(t *testing.T) {
+	reg := NewAdapterRegistry()
+	key := AdapterKey{Provider: "discord", AccountID: "bot-1"}
+	adapter := &fakeAdapter{name: "discord-bot-1"}
+
+	// Lookup before register returns nil.
+	if got := reg.Lookup(key); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+
+	reg.Register(key, adapter)
+
+	got := reg.Lookup(key)
+	if got == nil {
+		t.Fatal("expected adapter, got nil")
+	}
+	if got.Name() != "discord-bot-1" {
+		t.Fatalf("expected discord-bot-1, got %s", got.Name())
+	}
+}
+
+func TestAdapterRegistryLookupByConversation(t *testing.T) {
+	reg := NewAdapterRegistry()
+	key := AdapterKey{Provider: "slack", AccountID: "workspace-1"}
+	adapter := &fakeAdapter{name: "slack-ws1"}
+	reg.Register(key, adapter)
+
+	ref := ConversationRef{
+		ScopeID:        "scope",
+		Provider:       "slack",
+		AccountID:      "workspace-1",
+		ConversationID: "channel-42",
+		Kind:           ConversationRoom,
+	}
+	got := reg.LookupByConversation(ref)
+	if got == nil || got.Name() != "slack-ws1" {
+		t.Fatalf("expected slack-ws1, got %v", got)
+	}
+
+	// Different account returns nil.
+	ref.AccountID = "workspace-other"
+	if got := reg.LookupByConversation(ref); got != nil {
+		t.Fatalf("expected nil for different account, got %v", got)
+	}
+}
+
+func TestAdapterRegistryReplace(t *testing.T) {
+	reg := NewAdapterRegistry()
+	key := AdapterKey{Provider: "discord", AccountID: "bot-1"}
+	reg.Register(key, &fakeAdapter{name: "v1"})
+	reg.Register(key, &fakeAdapter{name: "v2"})
+
+	got := reg.Lookup(key)
+	if got == nil || got.Name() != "v2" {
+		t.Fatalf("expected v2, got %v", got)
+	}
+}
+
+func TestAdapterRegistryUnregister(t *testing.T) {
+	reg := NewAdapterRegistry()
+	key := AdapterKey{Provider: "discord", AccountID: "bot-1"}
+	reg.Register(key, &fakeAdapter{name: "d1"})
+	reg.Unregister(key)
+
+	if got := reg.Lookup(key); got != nil {
+		t.Fatalf("expected nil after unregister, got %v", got)
+	}
+}
+
+func TestAdapterRegistryUnregisterMissing(_ *testing.T) {
+	reg := NewAdapterRegistry()
+	// Should not panic.
+	reg.Unregister(AdapterKey{Provider: "x", AccountID: "y"})
+}
+
+func TestAdapterRegistryList(t *testing.T) {
+	reg := NewAdapterRegistry()
+	reg.Register(AdapterKey{Provider: "discord", AccountID: "a"}, &fakeAdapter{name: "d-a"})
+	reg.Register(AdapterKey{Provider: "slack", AccountID: "b"}, &fakeAdapter{name: "s-b"})
+
+	keys := reg.List()
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+
+	found := make(map[AdapterKey]bool)
+	for _, k := range keys {
+		found[k] = true
+	}
+	if !found[AdapterKey{Provider: "discord", AccountID: "a"}] {
+		t.Fatal("missing discord/a")
+	}
+	if !found[AdapterKey{Provider: "slack", AccountID: "b"}] {
+		t.Fatal("missing slack/b")
+	}
+}
+
+func TestAdapterRegistryConcurrency(_ *testing.T) {
+	reg := NewAdapterRegistry()
+	var wg sync.WaitGroup
+	const n = 100
+
+	// Concurrent register + lookup.
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		key := AdapterKey{Provider: "p", AccountID: "a"}
+		go func() {
+			defer wg.Done()
+			reg.Register(key, &fakeAdapter{name: "concurrent"})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = reg.Lookup(key)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -46,8 +46,10 @@ type bindingService struct {
 	locks         *bindingLockPool
 }
 
+// BindingServiceOption configures optional behavior for the binding service.
 type BindingServiceOption func(*bindingService)
 
+// WithBindingTouchDebounce sets the minimum interval between touch updates.
 func WithBindingTouchDebounce(d time.Duration) BindingServiceOption {
 	return func(s *bindingService) {
 		if d > 0 {
@@ -609,8 +611,8 @@ func selectActiveBinding(ctx context.Context, history []SessionBindingRecord, no
 		if active != nil {
 			return nil, fmt.Errorf("%w: multiple active bindings for %s", ErrInvariantViolation, conversationLockKey(record.Conversation))
 		}
-		copy := record
-		active = &copy
+		rec := record
+		active = &rec
 	}
 	return active, nil
 }

--- a/internal/extmsg/delivery_service.go
+++ b/internal/extmsg/delivery_service.go
@@ -149,8 +149,8 @@ func (s *deliveryContextService) Resolve(ctx context.Context, sessionID string, 
 					activeBinding.SessionID == sessionID &&
 					activeBinding.BindingGeneration == record.BindingGeneration {
 					if out == nil {
-						copy := record
-						out = &copy
+						rec := record
+						out = &rec
 						continue
 					}
 					if err := s.store.Close(item.ID); err != nil {

--- a/internal/extmsg/errors.go
+++ b/internal/extmsg/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// Sentinel errors for the extmsg package.
 var (
 	ErrUnauthorized         = errors.New("extmsg unauthorized")
 	ErrInvalidCaller        = errors.New("extmsg invalid caller")

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -2000,7 +2000,7 @@ func testNow() time.Time {
 func freezeTestClock(t *testing.T) {
 	t.Helper()
 	prev := timeNow
-	timeNow = func() time.Time { return testNow() }
+	timeNow = testNow
 	t.Cleanup(func() {
 		timeNow = prev
 	})
@@ -2041,6 +2041,7 @@ func membershipSessionIDs(t *testing.T, transcript TranscriptService, ref Conver
 	return out
 }
 
+//nolint:unparam // sessionID varies across callers in the full test suite
 func membershipRecordBySession(t *testing.T, transcript TranscriptService, ref ConversationRef, sessionID string) ConversationMembershipRecord {
 	t.Helper()
 	memberships, err := transcript.ListMemberships(context.Background(), testControllerCaller(), ref)

--- a/internal/extmsg/group_service.go
+++ b/internal/extmsg/group_service.go
@@ -22,6 +22,7 @@ type groupTranscriptSync interface {
 	RemoveMembership(ctx context.Context, input RemoveMembershipInput) error
 }
 
+// NewGroupService creates a GroupService backed by the given store.
 func NewGroupService(store beads.Store) GroupService {
 	locks := sharedBindingLockPool(store)
 	return newGroupService(store, locks, newTranscriptService(store, locks))
@@ -466,6 +467,19 @@ func (s *groupService) UpdateCursor(ctx context.Context, caller Caller, input Up
 	return s.store.SetMetadata(group.ID, "last_addressed_handle", handle)
 }
 
+// FindByConversation looks up a group by its root conversation ref.
+// Returns ErrGroupNotFound if no group exists.
+func (s *groupService) FindByConversation(_ context.Context, _ Caller, ref ConversationRef) (*ConversationGroupRecord, error) {
+	group, err := s.findGroupByRoot(ref)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return nil, ErrGroupNotFound
+	}
+	return group, nil
+}
+
 func (s *groupService) findGroupByRoot(ref ConversationRef) (*ConversationGroupRecord, error) {
 	items, err := s.store.ListByLabel(groupRootLabel(ref), 0)
 	if err != nil {
@@ -486,8 +500,8 @@ func (s *groupService) findGroupByRoot(ref ConversationRef) (*ConversationGroupR
 		if out != nil {
 			return nil, fmt.Errorf("%w: multiple groups for %s", ErrInvariantViolation, conversationLockKey(ref))
 		}
-		copy := record
-		out = &copy
+		rec := record
+		out = &rec
 	}
 	return out, nil
 }
@@ -656,6 +670,7 @@ func decodeGroupBead(b beads.Bead) (ConversationGroupRecord, error) {
 	}, nil
 }
 
+//nolint:unparam // error return kept for consistency with other decode functions
 func decodeParticipantBead(b beads.Bead) (ConversationGroupParticipant, error) {
 	return ConversationGroupParticipant{
 		ID:        b.ID,

--- a/internal/extmsg/helpers.go
+++ b/internal/extmsg/helpers.go
@@ -188,23 +188,6 @@ func zeroNow(now time.Time) time.Time {
 	return now.UTC()
 }
 
-func dedupeStrings(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	seen := make(map[string]bool, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" || seen[value] {
-			continue
-		}
-		seen[value] = true
-		out = append(out, value)
-	}
-	return out
-}
-
 func sortConversationRefs(bindings []SessionBindingRecord) {
 	sort.Slice(bindings, func(i, j int) bool {
 		return conversationLockKey(bindings[i].Conversation) < conversationLockKey(bindings[j].Conversation)

--- a/internal/extmsg/http_adapter.go
+++ b/internal/extmsg/http_adapter.go
@@ -1,0 +1,154 @@
+package extmsg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// HTTPAdapter implements TransportAdapter by forwarding publish requests
+// to an external HTTP service at callbackURL. Used for out-of-process
+// adapters that register via the API.
+type HTTPAdapter struct {
+	name         string
+	callbackURL  string
+	capabilities AdapterCapabilities
+	client       *http.Client
+}
+
+// NewHTTPAdapter creates an HTTPAdapter that forwards to callbackURL.
+func NewHTTPAdapter(name, callbackURL string, caps AdapterCapabilities) *HTTPAdapter {
+	return &HTTPAdapter{
+		name:         name,
+		callbackURL:  callbackURL,
+		capabilities: caps,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Name returns the adapter name.
+func (a *HTTPAdapter) Name() string { return a.name }
+
+// Capabilities returns the adapter capabilities.
+func (a *HTTPAdapter) Capabilities() AdapterCapabilities { return a.capabilities }
+
+// VerifyAndNormalizeInbound is not used for HTTP adapters — out-of-process
+// adapters verify and normalize on their side before posting to the API.
+func (a *HTTPAdapter) VerifyAndNormalizeInbound(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+	return nil, fmt.Errorf("HTTP adapter %q does not support raw inbound verification: %w", a.name, ErrAdapterUnsupported)
+}
+
+// Publish forwards a publish request to the adapter's callback URL.
+func (a *HTTPAdapter) Publish(ctx context.Context, req PublishRequest) (*PublishReceipt, error) {
+	if a.callbackURL == "" {
+		return &PublishReceipt{
+			Conversation: req.Conversation,
+			Delivered:    false,
+			FailureKind:  PublishFailureUnsupported,
+		}, nil
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling publish request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.callbackURL+"/publish", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return &PublishReceipt{
+			Conversation: req.Conversation,
+			Delivered:    false,
+			FailureKind:  PublishFailureTransient,
+		}, nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return &PublishReceipt{
+			Conversation: req.Conversation,
+			Delivered:    false,
+			FailureKind:  PublishFailureTransient,
+		}, nil
+	}
+
+	if resp.StatusCode >= 400 {
+		kind := PublishFailureTransient
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+			kind = PublishFailureAuth
+		case resp.StatusCode == http.StatusNotFound:
+			kind = PublishFailureNotFound
+		case resp.StatusCode == http.StatusTooManyRequests:
+			kind = PublishFailureRateLimited
+		case resp.StatusCode >= 400 && resp.StatusCode < 500:
+			kind = PublishFailurePermanent
+		}
+		return &PublishReceipt{
+			Conversation: req.Conversation,
+			Delivered:    false,
+			FailureKind:  kind,
+		}, nil
+	}
+
+	var receipt PublishReceipt
+	if err := json.Unmarshal(respBody, &receipt); err != nil {
+		// Malformed 2xx body — cannot confirm delivery.
+		return &PublishReceipt{
+			Conversation: req.Conversation,
+			Delivered:    false,
+			FailureKind:  PublishFailureTransient,
+		}, nil
+	}
+	return &receipt, nil
+}
+
+// EnsureChildConversation forwards a child conversation request to the
+// adapter's callback URL.
+func (a *HTTPAdapter) EnsureChildConversation(ctx context.Context, ref ConversationRef, label string) (*ConversationRef, error) {
+	if a.callbackURL == "" {
+		return nil, ErrAdapterUnsupported
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"conversation": ref,
+		"label":        label,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.callbackURL+"/child-conversation", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("adapter returned status %d", resp.StatusCode)
+	}
+
+	var childRef ConversationRef
+	if err := json.NewDecoder(resp.Body).Decode(&childRef); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &childRef, nil
+}

--- a/internal/extmsg/inbound.go
+++ b/internal/extmsg/inbound.go
@@ -1,0 +1,201 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// InboundResult captures the outcome of processing an inbound message.
+type InboundResult struct {
+	Message         ExternalInboundMessage
+	Binding         *SessionBindingRecord
+	GroupRoute      *GroupRouteDecision
+	TranscriptEntry *ConversationTranscriptRecord
+	TargetSessionID string
+}
+
+// InboundDeps bundles the dependencies for inbound processing.
+// The caller (HTTP handler) assembles deps from api.State, keeping
+// the orchestrator independent of the State interface.
+type InboundDeps struct {
+	Services  Services
+	Registry  *AdapterRegistry
+	EmitEvent func(eventType, subject string, payload map[string]any)
+}
+
+// HandleInbound processes a raw inbound payload through the full pipeline:
+//  1. Look up adapter by key.
+//  2. Verify and normalize the payload.
+//  3. Resolve binding for the conversation.
+//  4. If no binding, try group routing.
+//  5. Append to transcript.
+//  6. Nudge all conversation members (not just the target).
+//  7. Emit event.
+func HandleInbound(ctx context.Context, deps InboundDeps, key AdapterKey, payload InboundPayload) (*InboundResult, error) {
+	if deps.Registry == nil {
+		return nil, errors.New("adapter registry is nil")
+	}
+
+	// Step 1: Look up adapter.
+	adapter := deps.Registry.Lookup(key)
+	if adapter == nil {
+		return nil, fmt.Errorf("no adapter registered for %s/%s", key.Provider, key.AccountID)
+	}
+
+	// Step 2: Verify and normalize.
+	msg, err := adapter.VerifyAndNormalizeInbound(ctx, payload)
+	if err != nil {
+		return nil, fmt.Errorf("adapter verification failed: %w", err)
+	}
+	if msg == nil {
+		return nil, errors.New("adapter returned nil message without error")
+	}
+
+	result := &InboundResult{Message: *msg}
+
+	// Step 3: Resolve binding.
+	binding, err := deps.Services.Bindings.ResolveByConversation(ctx, msg.Conversation)
+	if err != nil {
+		return nil, fmt.Errorf("resolving binding: %w", err)
+	}
+
+	if binding != nil {
+		result.Binding = binding
+		result.TargetSessionID = binding.SessionID
+	}
+
+	// Step 4: If no binding, try group routing.
+	if result.TargetSessionID == "" {
+		route, err := deps.Services.Groups.ResolveInbound(ctx, *msg)
+		if err != nil {
+			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
+				return nil, fmt.Errorf("resolving group route: %w", err)
+			}
+			// No binding and no group route — return result with empty target.
+			return result, nil
+		}
+		result.GroupRoute = route
+		result.TargetSessionID = route.TargetSessionID
+	}
+
+	// Step 5: Append to transcript.
+	if result.TargetSessionID != "" {
+		caller := Caller{
+			Kind:      CallerAdapter,
+			ID:        adapter.Name(),
+			Provider:  key.Provider,
+			AccountID: key.AccountID,
+		}
+		entry, err := deps.Services.Transcript.Append(ctx, AppendTranscriptInput{
+			Caller:            caller,
+			Conversation:      msg.Conversation,
+			Kind:              TranscriptMessageInbound,
+			Provenance:        TranscriptProvenanceLive,
+			ProviderMessageID: msg.ProviderMessageID,
+			Actor:             msg.Actor,
+			Text:              msg.Text,
+			ExplicitTarget:    msg.ExplicitTarget,
+			ReplyToMessageID:  msg.ReplyToMessageID,
+			Attachments:       msg.Attachments,
+			CreatedAt:         msg.ReceivedAt,
+		})
+		if err != nil {
+			if !errors.Is(err, ErrHydrationPending) {
+				return nil, fmt.Errorf("appending transcript: %w", err)
+			}
+			// Hydration pending — transcript entry was not written.
+		} else {
+			result.TranscriptEntry = &entry
+		}
+	}
+
+	// Step 6: Emit event.
+	// Wake is handled by the caller (HTTP handler calls state.Poke()).
+	// Sessions discover unread entries via gc transcript check --inject.
+	if deps.EmitEvent != nil {
+		deps.EmitEvent("extmsg.inbound", result.TargetSessionID, map[string]any{
+			"provider":        msg.Conversation.Provider,
+			"conversation_id": msg.Conversation.ConversationID,
+			"actor":           msg.Actor.DisplayName,
+			"target_session":  result.TargetSessionID,
+		})
+	}
+
+	return result, nil
+}
+
+// HandleInboundNormalized processes a pre-normalized inbound message (used by
+// out-of-process adapters that verify and normalize on their side before
+// posting to the API).
+func HandleInboundNormalized(ctx context.Context, deps InboundDeps, msg ExternalInboundMessage) (*InboundResult, error) {
+	result := &InboundResult{Message: msg}
+
+	now := msg.ReceivedAt
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Step 1: Resolve binding.
+	binding, err := deps.Services.Bindings.ResolveByConversation(ctx, msg.Conversation)
+	if err != nil {
+		return nil, fmt.Errorf("resolving binding: %w", err)
+	}
+
+	if binding != nil {
+		result.Binding = binding
+		result.TargetSessionID = binding.SessionID
+	}
+
+	// Step 2: If no binding, try group routing.
+	if result.TargetSessionID == "" {
+		route, err := deps.Services.Groups.ResolveInbound(ctx, msg)
+		if err != nil {
+			if !errors.Is(err, ErrGroupNotFound) && !errors.Is(err, ErrGroupRouteNotFound) {
+				return nil, fmt.Errorf("resolving group route: %w", err)
+			}
+			return result, nil
+		}
+		result.GroupRoute = route
+		result.TargetSessionID = route.TargetSessionID
+	}
+
+	// Step 3: Append to transcript.
+	if result.TargetSessionID != "" {
+		caller := Caller{Kind: CallerController, ID: "inbound-normalized"}
+		entry, err := deps.Services.Transcript.Append(ctx, AppendTranscriptInput{
+			Caller:            caller,
+			Conversation:      msg.Conversation,
+			Kind:              TranscriptMessageInbound,
+			Provenance:        TranscriptProvenanceLive,
+			ProviderMessageID: msg.ProviderMessageID,
+			Actor:             msg.Actor,
+			Text:              msg.Text,
+			ExplicitTarget:    msg.ExplicitTarget,
+			ReplyToMessageID:  msg.ReplyToMessageID,
+			Attachments:       msg.Attachments,
+			CreatedAt:         now,
+		})
+		if err != nil {
+			if !errors.Is(err, ErrHydrationPending) {
+				return nil, fmt.Errorf("appending transcript: %w", err)
+			}
+			// Hydration pending — transcript entry was not written.
+		} else {
+			result.TranscriptEntry = &entry
+		}
+	}
+
+	// Step 4: Emit event.
+	if deps.EmitEvent != nil {
+		deps.EmitEvent("extmsg.inbound", result.TargetSessionID, map[string]any{
+			"provider":        msg.Conversation.Provider,
+			"conversation_id": msg.Conversation.ConversationID,
+			"actor":           msg.Actor.DisplayName,
+			"target_session":  result.TargetSessionID,
+		})
+	}
+
+	return result, nil
+}

--- a/internal/extmsg/inbound_test.go
+++ b/internal/extmsg/inbound_test.go
@@ -1,0 +1,311 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// testInboundAdapter implements TransportAdapter for inbound tests.
+type testInboundAdapter struct {
+	name      string
+	verifyFn  func(context.Context, InboundPayload) (*ExternalInboundMessage, error)
+	publishFn func(context.Context, PublishRequest) (*PublishReceipt, error)
+}
+
+func (a *testInboundAdapter) Name() string                      { return a.name }
+func (a *testInboundAdapter) Capabilities() AdapterCapabilities { return AdapterCapabilities{} }
+func (a *testInboundAdapter) VerifyAndNormalizeInbound(ctx context.Context, p InboundPayload) (*ExternalInboundMessage, error) {
+	if a.verifyFn != nil {
+		return a.verifyFn(ctx, p)
+	}
+	return nil, ErrAdapterUnsupported
+}
+
+func (a *testInboundAdapter) Publish(ctx context.Context, req PublishRequest) (*PublishReceipt, error) {
+	if a.publishFn != nil {
+		return a.publishFn(ctx, req)
+	}
+	return nil, ErrAdapterUnsupported
+}
+
+func (a *testInboundAdapter) EnsureChildConversation(_ context.Context, _ ConversationRef, _ string) (*ConversationRef, error) {
+	return nil, ErrAdapterUnsupported
+}
+
+func testConvRef() ConversationRef {
+	return ConversationRef{
+		ScopeID:        "scope1",
+		Provider:       "discord",
+		AccountID:      "bot-1",
+		ConversationID: "chan-42",
+		Kind:           ConversationRoom,
+	}
+}
+
+func testAdapterKey() AdapterKey {
+	return AdapterKey{Provider: "discord", AccountID: "bot-1"}
+}
+
+func testMsg() ExternalInboundMessage {
+	return ExternalInboundMessage{
+		ProviderMessageID: "msg-001",
+		Conversation:      testConvRef(),
+		Actor:             ExternalActor{ID: "user-1", DisplayName: "Alice"},
+		Text:              "hello world",
+		ReceivedAt:        time.Now(),
+	}
+}
+
+//nolint:unparam // store returned for caller flexibility
+func setupInboundDeps(t *testing.T) (InboundDeps, *AdapterRegistry, beads.Store) {
+	t.Helper()
+	store := beads.NewMemStore()
+	svc := NewServices(store)
+	reg := NewAdapterRegistry()
+	deps := InboundDeps{
+		Services: svc,
+		Registry: reg,
+		EmitEvent: func(_, _ string, _ map[string]any) {
+			// no-op for tests
+		},
+	}
+	return deps, reg, store
+}
+
+func TestHandleInboundWithBinding(t *testing.T) {
+	deps, reg, _ := setupInboundDeps(t)
+	ctx := context.Background()
+	key := testAdapterKey()
+	msg := testMsg()
+
+	// Register adapter.
+	reg.Register(key, &testInboundAdapter{
+		name: "test-discord",
+		verifyFn: func(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+			return &msg, nil
+		},
+	})
+
+	// Create a binding for the conversation.
+	caller := Caller{Kind: CallerController, ID: "test"}
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: msg.Conversation,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Process inbound.
+	result, err := HandleInbound(ctx, deps, key, InboundPayload{Body: []byte("raw")})
+	if err != nil {
+		t.Fatalf("HandleInbound: %v", err)
+	}
+
+	if result.TargetSessionID != "session-alpha" {
+		t.Fatalf("expected session-alpha, got %s", result.TargetSessionID)
+	}
+	if result.Binding == nil {
+		t.Fatal("expected binding in result")
+	}
+	if result.TranscriptEntry == nil {
+		t.Fatal("expected transcript entry")
+	}
+}
+
+func TestHandleInboundWithGroupRoute(t *testing.T) {
+	deps, reg, _ := setupInboundDeps(t)
+	ctx := context.Background()
+	key := testAdapterKey()
+	msg := testMsg()
+
+	reg.Register(key, &testInboundAdapter{
+		name: "test-discord",
+		verifyFn: func(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+			return &msg, nil
+		},
+	})
+
+	// Set up a group with a participant instead of a direct binding.
+	caller := Caller{Kind: CallerController, ID: "test"}
+	group, err := deps.Services.Groups.EnsureGroup(ctx, caller, EnsureGroupInput{
+		RootConversation: msg.Conversation,
+		Mode:             GroupModeLauncher,
+		DefaultHandle:    "worker",
+	})
+	if err != nil {
+		t.Fatalf("ensure group: %v", err)
+	}
+	_, err = deps.Services.Groups.UpsertParticipant(ctx, caller, UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "worker",
+		SessionID: "session-beta",
+		Public:    true,
+	})
+	if err != nil {
+		t.Fatalf("upsert participant: %v", err)
+	}
+
+	result, err := HandleInbound(ctx, deps, key, InboundPayload{Body: []byte("raw")})
+	if err != nil {
+		t.Fatalf("HandleInbound: %v", err)
+	}
+
+	if result.TargetSessionID != "session-beta" {
+		t.Fatalf("expected session-beta, got %s", result.TargetSessionID)
+	}
+	if result.GroupRoute == nil {
+		t.Fatal("expected group route in result")
+	}
+	if result.Binding != nil {
+		t.Fatal("expected no binding when routed via group")
+	}
+}
+
+func TestHandleInboundNoBindingNoGroup(t *testing.T) {
+	deps, reg, _ := setupInboundDeps(t)
+	ctx := context.Background()
+	key := testAdapterKey()
+	msg := testMsg()
+
+	reg.Register(key, &testInboundAdapter{
+		name: "test-discord",
+		verifyFn: func(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+			return &msg, nil
+		},
+	})
+
+	// No binding, no group — should return result with empty target.
+	result, err := HandleInbound(ctx, deps, key, InboundPayload{Body: []byte("raw")})
+	if err != nil {
+		t.Fatalf("HandleInbound: %v", err)
+	}
+	if result.TargetSessionID != "" {
+		t.Fatalf("expected empty target, got %s", result.TargetSessionID)
+	}
+}
+
+func TestHandleInboundAdapterVerificationFailure(t *testing.T) {
+	deps, reg, _ := setupInboundDeps(t)
+	ctx := context.Background()
+	key := testAdapterKey()
+
+	reg.Register(key, &testInboundAdapter{
+		name: "test-discord",
+		verifyFn: func(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+			return nil, errors.New("invalid signature")
+		},
+	})
+
+	_, err := HandleInbound(ctx, deps, key, InboundPayload{Body: []byte("bad")})
+	if err == nil {
+		t.Fatal("expected error for verification failure")
+	}
+}
+
+func TestHandleInboundNoAdapter(t *testing.T) {
+	deps, _, _ := setupInboundDeps(t)
+	ctx := context.Background()
+
+	_, err := HandleInbound(ctx, deps, AdapterKey{Provider: "missing", AccountID: "x"}, InboundPayload{})
+	if err == nil {
+		t.Fatal("expected error for missing adapter")
+	}
+}
+
+func TestHandleInboundNilRegistry(t *testing.T) {
+	deps := InboundDeps{Registry: nil}
+	_, err := HandleInbound(context.Background(), deps, AdapterKey{}, InboundPayload{})
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+}
+
+func TestHandleInboundNormalizedWithBinding(t *testing.T) {
+	deps, _, _ := setupInboundDeps(t)
+	ctx := context.Background()
+	msg := testMsg()
+
+	// Create binding.
+	caller := Caller{Kind: CallerController, ID: "test"}
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: msg.Conversation,
+		SessionID:    "session-gamma",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	result, err := HandleInboundNormalized(ctx, deps, msg)
+	if err != nil {
+		t.Fatalf("HandleInboundNormalized: %v", err)
+	}
+	if result.TargetSessionID != "session-gamma" {
+		t.Fatalf("expected session-gamma, got %s", result.TargetSessionID)
+	}
+}
+
+func TestHandleInboundTranscriptVisibleToAllMembers(t *testing.T) {
+	deps, reg, _ := setupInboundDeps(t)
+	ctx := context.Background()
+	key := testAdapterKey()
+	msg := testMsg()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	reg.Register(key, &testInboundAdapter{
+		name: "test-discord",
+		verifyFn: func(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+			return &msg, nil
+		},
+	})
+
+	// Create binding for session-alpha.
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: msg.Conversation,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Add three members to the conversation transcript.
+	for _, sid := range []string{"session-alpha", "session-beta", "session-gamma"} {
+		_, err := deps.Services.Transcript.EnsureMembership(ctx, EnsureMembershipInput{
+			Caller: caller, Conversation: msg.Conversation, SessionID: sid,
+			BackfillPolicy: MembershipBackfillAll, Owner: MembershipOwnerGroup, Now: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("membership %s: %v", sid, err)
+		}
+	}
+
+	// Process inbound.
+	result, err := HandleInbound(ctx, deps, key, InboundPayload{Body: []byte("hello everyone")})
+	if err != nil {
+		t.Fatalf("HandleInbound: %v", err)
+	}
+
+	if result.TargetSessionID != "session-alpha" {
+		t.Fatalf("expected target session-alpha, got %s", result.TargetSessionID)
+	}
+
+	// All members should see the entry via ListBackfill.
+	for _, sid := range []string{"session-alpha", "session-beta", "session-gamma"} {
+		entries, err := deps.Services.Transcript.ListBackfill(ctx, ListBackfillInput{
+			Caller: caller, Conversation: msg.Conversation, SessionID: sid, Limit: 10,
+		})
+		if err != nil {
+			t.Fatalf("backfill %s: %v", sid, err)
+		}
+		if len(entries) == 0 {
+			t.Fatalf("expected %s to see transcript entry via backfill", sid)
+		}
+	}
+}

--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -1,0 +1,141 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// OutboundRequest specifies what to publish to an external conversation.
+type OutboundRequest struct {
+	SessionID        string
+	Conversation     ConversationRef
+	Text             string
+	ReplyToMessageID string
+	IdempotencyKey   string
+	Metadata         map[string]string
+}
+
+// OutboundResult captures the outcome of a publish operation.
+type OutboundResult struct {
+	Receipt         PublishReceipt
+	DeliveryContext *DeliveryContextRecord
+	TranscriptEntry *ConversationTranscriptRecord
+}
+
+// OutboundDeps bundles the dependencies for outbound processing.
+type OutboundDeps struct {
+	Services  Services
+	Registry  *AdapterRegistry
+	EmitEvent func(eventType, subject string, payload map[string]any)
+}
+
+// HandleOutbound publishes a message from a session to an external conversation.
+//
+// Pipeline:
+//  1. Resolve active binding for the conversation.
+//  2. Verify the binding session matches the caller.
+//  3. Look up adapter by conversation ref.
+//  4. Call adapter.Publish.
+//  5. Record delivery context.
+//  6. Append outbound entry to transcript.
+//  7. Notify peer conversation members (best-effort nudge).
+//  8. Emit event.
+func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req OutboundRequest) (*OutboundResult, error) {
+	if deps.Registry == nil {
+		return nil, errors.New("adapter registry is nil")
+	}
+
+	// Step 1: Resolve binding.
+	binding, err := deps.Services.Bindings.ResolveByConversation(ctx, req.Conversation)
+	if err != nil {
+		return nil, fmt.Errorf("resolving binding: %w", err)
+	}
+	if binding == nil {
+		return nil, fmt.Errorf("no active binding for conversation %s/%s",
+			req.Conversation.Provider, req.Conversation.ConversationID)
+	}
+
+	// Step 2: Verify the caller session owns the binding.
+	if req.SessionID != "" && binding.SessionID != req.SessionID {
+		return nil, fmt.Errorf("session %q does not own binding for conversation %s/%s (bound to %s)",
+			req.SessionID, req.Conversation.Provider, req.Conversation.ConversationID, binding.SessionID)
+	}
+
+	// Step 3: Look up adapter.
+	adapter := deps.Registry.LookupByConversation(req.Conversation)
+	if adapter == nil {
+		return nil, fmt.Errorf("no adapter for %s/%s", req.Conversation.Provider, req.Conversation.AccountID)
+	}
+
+	// Step 4: Publish.
+	receipt, err := adapter.Publish(ctx, PublishRequest{
+		Conversation:     req.Conversation,
+		Text:             req.Text,
+		ReplyToMessageID: req.ReplyToMessageID,
+		IdempotencyKey:   req.IdempotencyKey,
+		Metadata:         req.Metadata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("adapter publish: %w", err)
+	}
+
+	result := &OutboundResult{Receipt: *receipt}
+
+	// If the publish was not delivered, return the receipt without recording.
+	if !receipt.Delivered {
+		return result, nil
+	}
+
+	// Step 5: Record delivery context.
+	now := time.Now()
+	dc := DeliveryContextRecord{
+		SessionID:         binding.SessionID,
+		Conversation:      req.Conversation,
+		BindingGeneration: binding.BindingGeneration,
+		LastPublishedAt:   now,
+		LastMessageID:     receipt.MessageID,
+		SourceSessionID:   req.SessionID,
+		Metadata:          req.Metadata,
+	}
+	if err := deps.Services.Delivery.Record(ctx, caller, dc); err != nil {
+		// Delivery context recording is important but not fatal.
+		// The message was already published.
+		result.DeliveryContext = nil
+	} else {
+		result.DeliveryContext = &dc
+	}
+
+	// Step 6: Append outbound transcript entry.
+	entry, err := deps.Services.Transcript.Append(ctx, AppendTranscriptInput{
+		Caller:            caller,
+		Conversation:      req.Conversation,
+		Kind:              TranscriptMessageOutbound,
+		Provenance:        TranscriptProvenanceLive,
+		ProviderMessageID: receipt.MessageID,
+		Text:              req.Text,
+		SourceSessionID:   req.SessionID,
+		CreatedAt:         now,
+		Metadata:          req.Metadata,
+	})
+	// Transcript append is non-fatal (whether hydration-pending or otherwise);
+	// the message was already published. If it failed, the entry was not written.
+	if err == nil {
+		result.TranscriptEntry = &entry
+	}
+
+	// Step 7: Emit event.
+	// Wake is handled by the caller (HTTP handler calls state.Poke()).
+	// Peer sessions discover new entries via gc transcript check --inject.
+	if deps.EmitEvent != nil {
+		deps.EmitEvent("extmsg.outbound", binding.SessionID, map[string]any{
+			"provider":        req.Conversation.Provider,
+			"conversation_id": req.Conversation.ConversationID,
+			"session":         req.SessionID,
+			"message_id":      receipt.MessageID,
+		})
+	}
+
+	return result, nil
+}

--- a/internal/extmsg/outbound_test.go
+++ b/internal/extmsg/outbound_test.go
@@ -1,0 +1,294 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+//nolint:unparam // store returned for caller flexibility
+func setupOutboundDeps(t *testing.T) (OutboundDeps, *AdapterRegistry, beads.Store) {
+	t.Helper()
+	store := beads.NewMemStore()
+	svc := NewServices(store)
+	reg := NewAdapterRegistry()
+	deps := OutboundDeps{
+		Services: svc,
+		Registry: reg,
+		EmitEvent: func(_, _ string, _ map[string]any) {
+			// no-op for tests
+		},
+	}
+	return deps, reg, store
+}
+
+//nolint:unparam // name kept as parameter for test readability
+func successPublishAdapter(name string) *testInboundAdapter {
+	return &testInboundAdapter{
+		name: name,
+		publishFn: func(_ context.Context, req PublishRequest) (*PublishReceipt, error) {
+			return &PublishReceipt{
+				MessageID:    "out-msg-001",
+				Conversation: req.Conversation,
+				Delivered:    true,
+			}, nil
+		},
+	}
+}
+
+func TestHandleOutboundHappyPath(t *testing.T) {
+	deps, reg, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	key := testAdapterKey()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	// Register adapter.
+	reg.Register(key, successPublishAdapter("test-discord"))
+
+	// Create binding.
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: conv,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Publish.
+	result, err := HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID:    "session-alpha",
+		Conversation: conv,
+		Text:         "hello external world",
+	})
+	if err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+	if !result.Receipt.Delivered {
+		t.Fatal("expected delivered=true")
+	}
+	if result.Receipt.MessageID != "out-msg-001" {
+		t.Fatalf("expected out-msg-001, got %s", result.Receipt.MessageID)
+	}
+	if result.TranscriptEntry == nil {
+		t.Fatal("expected transcript entry")
+	}
+}
+
+func TestHandleOutboundNoBinding(t *testing.T) {
+	deps, reg, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	key := testAdapterKey()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	reg.Register(key, successPublishAdapter("test-discord"))
+
+	// No binding — should fail.
+	_, err := HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID:    "session-alpha",
+		Conversation: conv,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for no binding")
+	}
+}
+
+func TestHandleOutboundWrongSession(t *testing.T) {
+	deps, reg, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	key := testAdapterKey()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	reg.Register(key, successPublishAdapter("test-discord"))
+
+	// Bind to session-alpha.
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: conv,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	// Try to publish from session-beta — should fail.
+	_, err = HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID:    "session-beta",
+		Conversation: conv,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for wrong session")
+	}
+}
+
+func TestHandleOutboundNoAdapter(t *testing.T) {
+	deps, _, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	// Bind but don't register adapter.
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: conv,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	_, err = HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID:    "session-alpha",
+		Conversation: conv,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing adapter")
+	}
+}
+
+func TestHandleOutboundPublishFailure(t *testing.T) {
+	deps, reg, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	key := testAdapterKey()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	// Register adapter that fails.
+	reg.Register(key, &testInboundAdapter{
+		name: "failing-adapter",
+		publishFn: func(_ context.Context, _ PublishRequest) (*PublishReceipt, error) {
+			return nil, errors.New("network timeout")
+		},
+	})
+
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: conv,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	_, err = HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID:    "session-alpha",
+		Conversation: conv,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for publish failure")
+	}
+}
+
+func TestHandleOutboundNotDelivered(t *testing.T) {
+	deps, reg, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	key := testAdapterKey()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	// Adapter returns receipt with Delivered=false.
+	reg.Register(key, &testInboundAdapter{
+		name: "rate-limited",
+		publishFn: func(_ context.Context, req PublishRequest) (*PublishReceipt, error) {
+			return &PublishReceipt{
+				Conversation: req.Conversation,
+				Delivered:    false,
+				FailureKind:  PublishFailureRateLimited,
+				RetryAfter:   5 * time.Second,
+			}, nil
+		},
+	})
+
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: conv,
+		SessionID:    "session-alpha",
+		Now:          time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	result, err := HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID:    "session-alpha",
+		Conversation: conv,
+		Text:         "hello",
+	})
+	if err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+	if result.Receipt.Delivered {
+		t.Fatal("expected delivered=false")
+	}
+	if result.Receipt.FailureKind != PublishFailureRateLimited {
+		t.Fatalf("expected rate_limited, got %s", result.Receipt.FailureKind)
+	}
+	// No transcript or delivery context when not delivered.
+	if result.TranscriptEntry != nil {
+		t.Fatal("expected no transcript entry when not delivered")
+	}
+}
+
+func TestHandleOutboundNilRegistry(t *testing.T) {
+	deps := OutboundDeps{Registry: nil}
+	caller := Caller{Kind: CallerController, ID: "test"}
+	_, err := HandleOutbound(context.Background(), deps, caller, OutboundRequest{})
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+}
+
+func TestHandleOutboundTranscriptVisibleToPeers(t *testing.T) {
+	deps, reg, _ := setupOutboundDeps(t)
+	ctx := context.Background()
+	conv := testConvRef()
+	key := testAdapterKey()
+	caller := Caller{Kind: CallerController, ID: "test"}
+
+	reg.Register(key, successPublishAdapter("test-discord"))
+
+	// Bind and add memberships.
+	_, err := deps.Services.Bindings.Bind(ctx, caller, BindInput{
+		Conversation: conv, SessionID: "session-alpha", Now: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	for _, sid := range []string{"session-alpha", "session-beta"} {
+		_, err := deps.Services.Transcript.EnsureMembership(ctx, EnsureMembershipInput{
+			Caller: caller, Conversation: conv, SessionID: sid,
+			BackfillPolicy: MembershipBackfillAll, Owner: MembershipOwnerGroup, Now: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("membership %s: %v", sid, err)
+		}
+	}
+
+	// Publish from session-alpha.
+	_, err = HandleOutbound(ctx, deps, caller, OutboundRequest{
+		SessionID: "session-alpha", Conversation: conv, Text: "hello peers",
+	})
+	if err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+
+	// session-beta should see the entry via ListBackfill.
+	entries, err := deps.Services.Transcript.ListBackfill(ctx, ListBackfillInput{
+		Caller: caller, Conversation: conv, SessionID: "session-beta", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected session-beta to see outbound entry via transcript backfill")
+	}
+}

--- a/internal/extmsg/transcript_service.go
+++ b/internal/extmsg/transcript_service.go
@@ -534,8 +534,7 @@ func (s *transcriptService) ListBackfill(ctx context.Context, input ListBackfill
 		if err != nil {
 			return err
 		}
-		switch state.HydrationStatus {
-		case HydrationPending:
+		if state.HydrationStatus == HydrationPending {
 			return ErrHydrationPending
 		}
 		membership, err := s.findActiveMembershipLocked(ref, sessionID)
@@ -658,8 +657,8 @@ func (s *transcriptService) State(ctx context.Context, caller Caller, ref Conver
 			return err
 		}
 		if state != nil {
-			copy := *state
-			out = &copy
+			rec := *state
+			out = &rec
 		}
 		return nil
 	})
@@ -760,8 +759,8 @@ func (s *transcriptService) findStateLocked(ref ConversationRef) (*ConversationT
 		if out != nil {
 			return nil, fmt.Errorf("%w: multiple transcript states for %s", ErrInvariantViolation, conversationLockKey(ref))
 		}
-		copy := record
-		out = &copy
+		rec := record
+		out = &rec
 	}
 	return out, nil
 }
@@ -786,8 +785,8 @@ func (s *transcriptService) findTranscriptByProviderMessageLocked(ref Conversati
 		if out != nil {
 			return nil, fmt.Errorf("%w: duplicate transcript provider message %q", ErrInvariantViolation, providerMessageID)
 		}
-		copy := record
-		out = &copy
+		rec := record
+		out = &rec
 	}
 	return out, nil
 }
@@ -812,8 +811,8 @@ func (s *transcriptService) findActiveMembershipLocked(ref ConversationRef, sess
 		if out != nil {
 			return nil, fmt.Errorf("%w: duplicate memberships for session %s", ErrInvariantViolation, sessionID)
 		}
-		copy := record
-		out = &copy
+		rec := record
+		out = &rec
 	}
 	return out, nil
 }

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -11,37 +11,44 @@ const (
 	metadataPrefix = "meta."
 )
 
+// CallerKind identifies the category of an API caller.
 type CallerKind string
 
+// CallerKind constants.
 const (
 	CallerController CallerKind = "controller"
 	CallerAdapter    CallerKind = "adapter"
 )
 
+// Caller identifies who is performing an extmsg operation.
 type Caller struct {
-	Kind      CallerKind
-	ID        string
-	Provider  string
-	AccountID string
+	Kind      CallerKind `json:"kind"`
+	ID        string     `json:"id"`
+	Provider  string     `json:"provider"`
+	AccountID string     `json:"account_id"`
 }
 
+// ConversationKind classifies a conversation topology.
 type ConversationKind string
 
+// ConversationKind constants.
 const (
 	ConversationDM     ConversationKind = "dm"
 	ConversationRoom   ConversationKind = "room"
 	ConversationThread ConversationKind = "thread"
 )
 
+// ConversationRef is a fully-qualified reference to an external conversation.
 type ConversationRef struct {
-	ScopeID              string
-	Provider             string
-	AccountID            string
-	ConversationID       string
-	ParentConversationID string
-	Kind                 ConversationKind
+	ScopeID              string           `json:"scope_id"`
+	Provider             string           `json:"provider"`
+	AccountID            string           `json:"account_id"`
+	ConversationID       string           `json:"conversation_id"`
+	ParentConversationID string           `json:"parent_conversation_id,omitempty"`
+	Kind                 ConversationKind `json:"kind"`
 }
 
+// InboundPayload is the raw HTTP payload received from a transport adapter.
 type InboundPayload struct {
 	Body        []byte
 	ContentType string
@@ -49,61 +56,69 @@ type InboundPayload struct {
 	ReceivedAt  time.Time
 }
 
+// ExternalActor represents a user or bot in an external messaging platform.
 type ExternalActor struct {
-	ID          string
-	DisplayName string
-	IsBot       bool
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	IsBot       bool   `json:"is_bot"`
 }
 
+// ExternalAttachment is a file or media attachment on an external message.
 type ExternalAttachment struct {
-	ProviderID string
-	URL        string
-	MIMEType   string
+	ProviderID string `json:"provider_id"`
+	URL        string `json:"url"`
+	MIMEType   string `json:"mime_type"`
 }
 
+// ExternalInboundMessage is a normalized inbound message from an external platform.
 type ExternalInboundMessage struct {
-	ProviderMessageID string
-	Conversation      ConversationRef
-	Actor             ExternalActor
-	Text              string
-	ExplicitTarget    string
-	ReplyToMessageID  string
-	Attachments       []ExternalAttachment
-	DedupKey          string
-	ReceivedAt        time.Time
+	ProviderMessageID string               `json:"provider_message_id"`
+	Conversation      ConversationRef      `json:"conversation"`
+	Actor             ExternalActor        `json:"actor"`
+	Text              string               `json:"text"`
+	ExplicitTarget    string               `json:"explicit_target,omitempty"`
+	ReplyToMessageID  string               `json:"reply_to_message_id,omitempty"`
+	Attachments       []ExternalAttachment `json:"attachments,omitempty"`
+	DedupKey          string               `json:"dedup_key,omitempty"`
+	ReceivedAt        time.Time            `json:"received_at"`
 }
 
+// BindingStatus represents the lifecycle state of a session binding.
 type BindingStatus string
 
+// BindingStatus constants.
 const (
 	BindingActive BindingStatus = "active"
 	BindingEnded  BindingStatus = "ended"
 )
 
+// SessionBindingRecord is the persisted state of a conversation-to-session binding.
 type SessionBindingRecord struct {
-	ID                string
-	SchemaVersion     int
-	Conversation      ConversationRef
-	SessionID         string
-	Status            BindingStatus
-	BoundAt           time.Time
-	ExpiresAt         *time.Time
-	BindingGeneration int64
-	Metadata          map[string]string
+	ID                string            `json:"id"`
+	SchemaVersion     int               `json:"schema_version"`
+	Conversation      ConversationRef   `json:"conversation"`
+	SessionID         string            `json:"session_id"`
+	Status            BindingStatus     `json:"status"`
+	BoundAt           time.Time         `json:"bound_at"`
+	ExpiresAt         *time.Time        `json:"expires_at,omitempty"`
+	BindingGeneration int64             `json:"binding_generation"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
 }
 
+// DeliveryContextRecord tracks the last message delivered to a session for a conversation.
 type DeliveryContextRecord struct {
-	ID                string
-	SchemaVersion     int
-	SessionID         string
-	Conversation      ConversationRef
-	BindingGeneration int64
-	LastPublishedAt   time.Time
-	LastMessageID     string
-	SourceSessionID   string
-	Metadata          map[string]string
+	ID                string            `json:"id"`
+	SchemaVersion     int               `json:"schema_version"`
+	SessionID         string            `json:"session_id"`
+	Conversation      ConversationRef   `json:"conversation"`
+	BindingGeneration int64             `json:"binding_generation"`
+	LastPublishedAt   time.Time         `json:"last_published_at"`
+	LastMessageID     string            `json:"last_message_id"`
+	SourceSessionID   string            `json:"source_session_id,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
 }
 
+// ExternalOriginEnvelope carries binding context for an inbound message routed to a session.
 type ExternalOriginEnvelope struct {
 	Conversation      ConversationRef
 	BindingID         string
@@ -111,22 +126,26 @@ type ExternalOriginEnvelope struct {
 	Passive           bool
 }
 
+// AdapterCapabilities describes the features supported by a transport adapter.
 type AdapterCapabilities struct {
-	SupportsChildConversations bool
-	SupportsAttachments        bool
-	MaxMessageLength           int
+	SupportsChildConversations bool `json:"supports_child_conversations"`
+	SupportsAttachments        bool `json:"supports_attachments"`
+	MaxMessageLength           int  `json:"max_message_length"`
 }
 
+// PublishRequest is a request to publish a message to an external conversation.
 type PublishRequest struct {
-	Conversation     ConversationRef
-	Text             string
-	ReplyToMessageID string
-	IdempotencyKey   string
-	Metadata         map[string]string
+	Conversation     ConversationRef   `json:"conversation"`
+	Text             string            `json:"text"`
+	ReplyToMessageID string            `json:"reply_to_message_id,omitempty"`
+	IdempotencyKey   string            `json:"idempotency_key,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
+// PublishFailureKind classifies why a publish attempt failed.
 type PublishFailureKind string
 
+// PublishFailureKind constants.
 const (
 	PublishFailureUnsupported PublishFailureKind = "unsupported"
 	PublishFailureTransient   PublishFailureKind = "transient"
@@ -136,80 +155,94 @@ const (
 	PublishFailureNotFound    PublishFailureKind = "not_found"
 )
 
+// PublishReceipt is the result of a publish attempt to an external platform.
 type PublishReceipt struct {
-	MessageID    string
-	Conversation ConversationRef
-	Delivered    bool
-	FailureKind  PublishFailureKind
-	RetryAfter   time.Duration
-	Metadata     map[string]string
+	MessageID    string             `json:"message_id,omitempty"`
+	Conversation ConversationRef    `json:"conversation"`
+	Delivered    bool               `json:"delivered"`
+	FailureKind  PublishFailureKind `json:"failure_kind,omitempty"`
+	RetryAfter   time.Duration      `json:"retry_after,omitempty"`
+	Metadata     map[string]string  `json:"metadata,omitempty"`
 }
 
+// ErrAdapterUnsupported indicates the adapter does not support the requested operation.
 var ErrAdapterUnsupported = errors.New("adapter unsupported")
 
+// TranscriptMessageKind distinguishes inbound from outbound transcript entries.
 type TranscriptMessageKind string
 
+// TranscriptMessageKind constants.
 const (
 	TranscriptMessageInbound  TranscriptMessageKind = "inbound"
 	TranscriptMessageOutbound TranscriptMessageKind = "outbound"
 )
 
+// TranscriptProvenance records how a transcript entry was obtained.
 type TranscriptProvenance string
 
+// TranscriptProvenance constants.
 const (
 	TranscriptProvenanceLive     TranscriptProvenance = "live"
 	TranscriptProvenanceHydrated TranscriptProvenance = "hydrated"
 )
 
+// ConversationTranscriptRecord is a single entry in a conversation transcript.
 type ConversationTranscriptRecord struct {
-	ID                string
-	SchemaVersion     int
-	Conversation      ConversationRef
-	Sequence          int64
-	Kind              TranscriptMessageKind
-	Provenance        TranscriptProvenance
-	ProviderMessageID string
-	Actor             ExternalActor
-	Text              string
-	ExplicitTarget    string
-	ReplyToMessageID  string
-	Attachments       []ExternalAttachment
-	SourceSessionID   string
-	CreatedAt         time.Time
-	Metadata          map[string]string
+	ID                string                `json:"id"`
+	SchemaVersion     int                   `json:"schema_version"`
+	Conversation      ConversationRef       `json:"conversation"`
+	Sequence          int64                 `json:"sequence"`
+	Kind              TranscriptMessageKind `json:"kind"`
+	Provenance        TranscriptProvenance  `json:"provenance"`
+	ProviderMessageID string                `json:"provider_message_id"`
+	Actor             ExternalActor         `json:"actor"`
+	Text              string                `json:"text"`
+	ExplicitTarget    string                `json:"explicit_target,omitempty"`
+	ReplyToMessageID  string                `json:"reply_to_message_id,omitempty"`
+	Attachments       []ExternalAttachment  `json:"attachments,omitempty"`
+	SourceSessionID   string                `json:"source_session_id,omitempty"`
+	CreatedAt         time.Time             `json:"created_at"`
+	Metadata          map[string]string     `json:"metadata,omitempty"`
 }
 
+// MembershipBackfillPolicy controls how far back transcript entries are visible to a member.
 type MembershipBackfillPolicy string
 
+// MembershipBackfillPolicy constants.
 const (
 	MembershipBackfillAll       MembershipBackfillPolicy = "all"
 	MembershipBackfillSinceJoin MembershipBackfillPolicy = "since_join"
 )
 
+// MembershipOwner identifies the subsystem that created a membership.
 type MembershipOwner string
 
+// MembershipOwner constants.
 const (
 	MembershipOwnerManual  MembershipOwner = "manual"
 	MembershipOwnerBinding MembershipOwner = "binding"
 	MembershipOwnerGroup   MembershipOwner = "group"
 )
 
+// ConversationMembershipRecord tracks a session's membership in a conversation.
 type ConversationMembershipRecord struct {
-	ID               string
-	SchemaVersion    int
-	Conversation     ConversationRef
-	SessionID        string
-	JoinedAt         time.Time
-	JoinedSequence   int64
-	LastReadSequence int64
-	BackfillPolicy   MembershipBackfillPolicy
-	ManualBackfill   MembershipBackfillPolicy
-	Owners           []MembershipOwner
-	Metadata         map[string]string
+	ID               string                   `json:"id"`
+	SchemaVersion    int                      `json:"schema_version"`
+	Conversation     ConversationRef          `json:"conversation"`
+	SessionID        string                   `json:"session_id"`
+	JoinedAt         time.Time                `json:"joined_at"`
+	JoinedSequence   int64                    `json:"joined_sequence"`
+	LastReadSequence int64                    `json:"last_read_sequence"`
+	BackfillPolicy   MembershipBackfillPolicy `json:"backfill_policy"`
+	ManualBackfill   MembershipBackfillPolicy `json:"manual_backfill,omitempty"`
+	Owners           []MembershipOwner        `json:"owners"`
+	Metadata         map[string]string        `json:"metadata,omitempty"`
 }
 
+// HydrationStatus tracks the state of transcript backfill from the external platform.
 type HydrationStatus string
 
+// HydrationStatus constants.
 const (
 	HydrationLiveOnly HydrationStatus = "live_only"
 	HydrationPending  HydrationStatus = "pending"
@@ -217,53 +250,61 @@ const (
 	HydrationFailed   HydrationStatus = "failed"
 )
 
+// ConversationTranscriptStateRecord tracks per-conversation transcript metadata.
 type ConversationTranscriptStateRecord struct {
-	ID                        string
-	SchemaVersion             int
-	Conversation              ConversationRef
-	NextSequence              int64
-	EarliestAvailableSequence int64
-	HydrationStatus           HydrationStatus
-	OldestHydratedMessageID   string
-	MaxRetainedEntries        int
-	Metadata                  map[string]string
+	ID                        string            `json:"id"`
+	SchemaVersion             int               `json:"schema_version"`
+	Conversation              ConversationRef   `json:"conversation"`
+	NextSequence              int64             `json:"next_sequence"`
+	EarliestAvailableSequence int64             `json:"earliest_available_sequence"`
+	HydrationStatus           HydrationStatus   `json:"hydration_status"`
+	OldestHydratedMessageID   string            `json:"oldest_hydrated_message_id,omitempty"`
+	MaxRetainedEntries        int               `json:"max_retained_entries"`
+	Metadata                  map[string]string `json:"metadata,omitempty"`
 }
 
+// GroupMode defines how a conversation group routes messages.
 type GroupMode string
 
+// GroupMode constants.
 const (
 	GroupModeLauncher GroupMode = "launcher"
 )
 
+// FanoutPolicy controls peer-triggered message delivery within a group.
 type FanoutPolicy struct {
-	Enabled                    bool
-	AllowUntargetedPublication bool
-	MaxPeerTriggeredPublishes  int
-	MaxTotalPeerDeliveries     int
+	Enabled                    bool `json:"enabled"`
+	AllowUntargetedPublication bool `json:"allow_untargeted_publication"`
+	MaxPeerTriggeredPublishes  int  `json:"max_peer_triggered_publishes"`
+	MaxTotalPeerDeliveries     int  `json:"max_total_peer_deliveries"`
 }
 
+// ConversationGroupRecord is the persisted state of a conversation group.
 type ConversationGroupRecord struct {
-	ID                  string
-	SchemaVersion       int
-	RootConversation    ConversationRef
-	Mode                GroupMode
-	DefaultHandle       string
-	LastAddressedHandle string
-	FanoutPolicy        FanoutPolicy
-	Metadata            map[string]string
+	ID                  string            `json:"id"`
+	SchemaVersion       int               `json:"schema_version"`
+	RootConversation    ConversationRef   `json:"root_conversation"`
+	Mode                GroupMode         `json:"mode"`
+	DefaultHandle       string            `json:"default_handle,omitempty"`
+	LastAddressedHandle string            `json:"last_addressed_handle,omitempty"`
+	FanoutPolicy        FanoutPolicy      `json:"fanout_policy"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
 }
 
+// ConversationGroupParticipant is a session participating in a conversation group under a handle.
 type ConversationGroupParticipant struct {
-	ID        string
-	GroupID   string
-	Handle    string
-	SessionID string
-	Public    bool
-	Metadata  map[string]string
+	ID        string            `json:"id"`
+	GroupID   string            `json:"group_id"`
+	Handle    string            `json:"handle"`
+	SessionID string            `json:"session_id"`
+	Public    bool              `json:"public"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
 }
 
+// GroupRouteMatch classifies how a group resolved an inbound message to a target session.
 type GroupRouteMatch string
 
+// GroupRouteMatch constants.
 const (
 	GroupRouteExplicitTarget GroupRouteMatch = "explicit_target"
 	GroupRouteLastAddressed  GroupRouteMatch = "last_addressed"
@@ -271,12 +312,14 @@ const (
 	GroupRouteNoMatch        GroupRouteMatch = "no_match"
 )
 
+// GroupRouteDecision is the result of routing an inbound message through a group.
 type GroupRouteDecision struct {
-	Match           GroupRouteMatch
-	TargetSessionID string
-	UpdateCursor    bool
+	Match           GroupRouteMatch `json:"match"`
+	TargetSessionID string          `json:"target_session_id"`
+	UpdateCursor    bool            `json:"update_cursor"`
 }
 
+// BindInput contains the parameters for creating or refreshing a session binding.
 type BindInput struct {
 	Conversation ConversationRef
 	SessionID    string
@@ -285,12 +328,14 @@ type BindInput struct {
 	Now          time.Time
 }
 
+// UnbindInput contains the parameters for removing a session binding.
 type UnbindInput struct {
 	Conversation *ConversationRef
 	SessionID    string
 	Now          time.Time
 }
 
+// EnsureGroupInput contains the parameters for creating or updating a conversation group.
 type EnsureGroupInput struct {
 	RootConversation    ConversationRef
 	Mode                GroupMode
@@ -300,6 +345,7 @@ type EnsureGroupInput struct {
 	Metadata            map[string]string
 }
 
+// UpsertParticipantInput contains the parameters for adding or updating a group participant.
 type UpsertParticipantInput struct {
 	GroupID   string
 	Handle    string
@@ -308,16 +354,19 @@ type UpsertParticipantInput struct {
 	Metadata  map[string]string
 }
 
+// RemoveParticipantInput contains the parameters for removing a group participant.
 type RemoveParticipantInput struct {
 	GroupID string
 	Handle  string
 }
 
+// UpdateCursorInput contains the parameters for updating a group's last-addressed cursor.
 type UpdateCursorInput struct {
 	RootConversation ConversationRef
 	Handle           string
 }
 
+// AppendTranscriptInput contains the parameters for appending a transcript entry.
 type AppendTranscriptInput struct {
 	Caller            Caller
 	Conversation      ConversationRef
@@ -334,6 +383,7 @@ type AppendTranscriptInput struct {
 	Metadata          map[string]string
 }
 
+// EnsureMembershipInput contains the parameters for creating or refreshing a transcript membership.
 type EnsureMembershipInput struct {
 	Caller         Caller
 	Conversation   ConversationRef
@@ -344,6 +394,7 @@ type EnsureMembershipInput struct {
 	Now            time.Time
 }
 
+// UpdateMembershipInput contains the parameters for updating a transcript membership.
 type UpdateMembershipInput struct {
 	Caller         Caller
 	Conversation   ConversationRef
@@ -352,6 +403,7 @@ type UpdateMembershipInput struct {
 	Metadata       map[string]string
 }
 
+// RemoveMembershipInput contains the parameters for removing a transcript membership.
 type RemoveMembershipInput struct {
 	Caller       Caller
 	Conversation ConversationRef
@@ -360,6 +412,7 @@ type RemoveMembershipInput struct {
 	Now          time.Time
 }
 
+// ListTranscriptInput contains the parameters for listing transcript entries.
 type ListTranscriptInput struct {
 	Caller        Caller
 	Conversation  ConversationRef
@@ -367,6 +420,7 @@ type ListTranscriptInput struct {
 	Limit         int
 }
 
+// ListBackfillInput contains the parameters for listing backfill entries for a session.
 type ListBackfillInput struct {
 	Caller       Caller
 	Conversation ConversationRef
@@ -374,6 +428,7 @@ type ListBackfillInput struct {
 	Limit        int
 }
 
+// AckMembershipInput contains the parameters for acknowledging transcript entries up to a sequence.
 type AckMembershipInput struct {
 	Caller       Caller
 	Conversation ConversationRef
@@ -381,6 +436,7 @@ type AckMembershipInput struct {
 	Sequence     int64
 }
 
+// BindingService manages conversation-to-session bindings.
 type BindingService interface {
 	Bind(ctx context.Context, caller Caller, input BindInput) (SessionBindingRecord, error)
 	ResolveByConversation(ctx context.Context, ref ConversationRef) (*SessionBindingRecord, error)
@@ -389,20 +445,24 @@ type BindingService interface {
 	Unbind(ctx context.Context, caller Caller, input UnbindInput) ([]SessionBindingRecord, error)
 }
 
+// DeliveryContextService tracks the last message delivered to a session for each conversation.
 type DeliveryContextService interface {
 	Record(ctx context.Context, caller Caller, input DeliveryContextRecord) error
 	Resolve(ctx context.Context, sessionID string, ref ConversationRef) (*DeliveryContextRecord, error)
 	ClearForConversation(ctx context.Context, sessionID string, ref ConversationRef) error
 }
 
+// GroupService manages conversation groups, participants, and inbound routing.
 type GroupService interface {
 	EnsureGroup(ctx context.Context, caller Caller, input EnsureGroupInput) (ConversationGroupRecord, error)
+	FindByConversation(ctx context.Context, caller Caller, ref ConversationRef) (*ConversationGroupRecord, error)
 	UpsertParticipant(ctx context.Context, caller Caller, input UpsertParticipantInput) (ConversationGroupParticipant, error)
 	RemoveParticipant(ctx context.Context, caller Caller, input RemoveParticipantInput) error
 	ResolveInbound(ctx context.Context, event ExternalInboundMessage) (*GroupRouteDecision, error)
 	UpdateCursor(ctx context.Context, caller Caller, input UpdateCursorInput) error
 }
 
+// TranscriptService manages conversation transcripts, memberships, and hydration state.
 type TranscriptService interface {
 	Append(ctx context.Context, input AppendTranscriptInput) (ConversationTranscriptRecord, error)
 	List(ctx context.Context, input ListTranscriptInput) ([]ConversationTranscriptRecord, error)
@@ -419,6 +479,7 @@ type TranscriptService interface {
 	State(ctx context.Context, caller Caller, ref ConversationRef) (*ConversationTranscriptStateRecord, error)
 }
 
+// TransportAdapter is the interface that external messaging platform integrations must implement.
 type TransportAdapter interface {
 	Name() string
 	Capabilities() AdapterCapabilities

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -35,6 +35,10 @@
           {
             "type": "command",
             "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+          },
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc transcript check --inject"
           }
         ]
       }

--- a/internal/hooks/config/copilot.json
+++ b/internal/hooks/config/copilot.json
@@ -18,6 +18,11 @@
         "type": "command",
         "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject",
         "timeoutSec": 10
+      },
+      {
+        "type": "command",
+        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc transcript check --inject",
+        "timeoutSec": 10
       }
     ],
     "sessionEnd": [

--- a/internal/hooks/config/copilot.md
+++ b/internal/hooks/config/copilot.md
@@ -13,7 +13,9 @@ Run `gc prime` at the start of every session to load your context
 ## Per-turn
 
 Before starting work on each turn, run `gc mail check --inject` to
-check for new messages from other agents or the controller.
+check for new messages from other agents or the controller. Also run
+`gc transcript check --inject` to check for unread shared conversation
+messages.
 
 ## Work pickup
 
@@ -24,6 +26,7 @@ When you finish your current task or have no active work, run
 
 - `gc prime` — load/reload agent context
 - `gc mail check --inject` — check for inter-agent messages
+- `gc transcript check --inject` — check for shared conversation messages
 - `gc hook --inject` — check for and claim available work
 - `bd ready` — list ready beads (tasks)
 - `bd show <id>` — show bead details

--- a/internal/hooks/config/cursor.json
+++ b/internal/hooks/config/cursor.json
@@ -17,6 +17,9 @@
       },
       {
         "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+      },
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc transcript check --inject"
       }
     ],
     "stop": [

--- a/internal/hooks/config/gemini.json
+++ b/internal/hooks/config/gemini.json
@@ -33,6 +33,10 @@
           {
             "type": "command",
             "command": "{{GC_BIN}} mail check --inject"
+          },
+          {
+            "type": "command",
+            "command": "{{GC_BIN}} transcript check --inject"
           }
         ]
       }

--- a/internal/hooks/config/omp.ts
+++ b/internal/hooks/config/omp.ts
@@ -5,7 +5,7 @@
 //   session.created    → gc prime (load context)
 //   session.compacted  → gc prime (reload after compaction)
 //   session.deleted    → gc hook --inject (pick up work on exit)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+//   chat.system.transform → gc nudge drain --inject + gc mail check --inject + gc transcript check --inject
 
 import { execSync } from "child_process";
 
@@ -37,7 +37,8 @@ export default {
     "experimental.chat.system.transform": (system: string): string => {
       const nudges = run("gc nudge drain --inject");
       const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
+      const transcript = run("gc transcript check --inject");
+      const extras = [nudges, mail, transcript].filter(Boolean);
       if (extras.length > 0) {
         return system + "\n\n" + extras.join("\n\n");
       }

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -5,7 +5,7 @@
 //   session.created    → gc prime (load context)
 //   session.compacted  → gc prime (reload after compaction)
 //   session.deleted    → gc hook --inject (pick up work on exit)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+//   chat.system.transform → gc nudge drain --inject + gc mail check --inject + gc transcript check --inject
 
 const { execSync } = require("child_process");
 
@@ -30,7 +30,8 @@ module.exports = {
     "experimental.chat.system.transform": (system) => {
       const nudges = run("gc nudge drain --inject");
       const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
+      const transcript = run("gc transcript check --inject");
+      const extras = [nudges, mail, transcript].filter(Boolean);
       if (extras.length > 0) {
         return system + "\n\n" + extras.join("\n\n");
       }

--- a/internal/hooks/config/pi.js
+++ b/internal/hooks/config/pi.js
@@ -5,7 +5,7 @@
 //   session.created    → gc prime (load context)
 //   session.compacted  → gc prime (reload after compaction)
 //   session.deleted    → gc hook --inject (pick up work on exit)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+//   chat.system.transform → gc nudge drain --inject + gc mail check --inject + gc transcript check --inject
 
 const { execSync } = require("child_process");
 
@@ -37,7 +37,8 @@ module.exports = {
     "experimental.chat.system.transform": (system) => {
       const nudges = run("gc nudge drain --inject");
       const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
+      const transcript = run("gc transcript check --inject");
+      const extras = [nudges, mail, transcript].filter(Boolean);
       if (extras.length > 0) {
         return system + "\n\n" + extras.join("\n\n");
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -208,5 +208,6 @@ func geminiFileNeedsUpgrade(existing []byte) bool {
 	return strings.Contains(content, `gc prime --hook`) ||
 		strings.Contains(content, `gc nudge drain --inject`) ||
 		strings.Contains(content, `gc mail check --inject`) ||
+		strings.Contains(content, `gc transcript check --inject`) ||
 		strings.Contains(content, `gc hook --inject`)
 }


### PR DESCRIPTION
## Summary

- Wires extmsg services into the controller with HTTP API endpoints for inbound/outbound messaging, adapter registration, binding/group/transcript CRUD
- Adds inbound/outbound orchestrators with transcript append and peer notification (sleeping sessions are woken via sendMessage)
- Adds `gc transcript check [--inject]` and `gc transcript read [--ack]` CLI commands
- Installs `gc transcript check --inject` as UserPromptSubmit hook across all providers (claude, copilot, cursor, gemini, etc.)
- Fixes API session creation to use bead-only + poke path (same as `gc session new`) so reconciler starts sessions with full template env (GC_AGENT, hooks, copy-files, prompt)
- Cherry-picks lazy dolt port resolution from orders-v2 to fix stale port after supervisor restarts
- Adds JSON tags to all API-facing extmsg types

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] End-to-end: human @mentions agents in Discord room → thread created → agents respond
- [x] End-to-end: follow-up message in thread → sleeping agents woken → agents respond
- [x] Transcript check hook injects unread messages into agent prompts
- [x] Each agent gets correct identity prompt via reconciler template resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)