### PR TITLE
fix: use absolute path for --settings flag in claude entrypoint

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -623,9 +623,9 @@ func printDryRunPreview(desiredState map[string]TemplateParams, cfg *config.City
 }
 
 // settingsArgs returns "--settings <path>" to append to a Claude command
-// if settings.json exists for this city. Uses a path relative to the session
-// working directory so it works for both local and remote providers (the
-// .gc directory is staged via CopyFiles).
+// if settings.json exists for this city. Uses the absolute city-root path so
+// it resolves correctly regardless of the session's working directory. The K8s
+// provider remaps city-root references to /workspace automatically.
 // Returns empty string for non-Claude providers or if no settings file is present.
 func settingsArgs(cityPath, providerName string) string {
 	if providerName != "claude" {
@@ -635,7 +635,7 @@ func settingsArgs(cityPath, providerName string) string {
 	if _, err := os.Stat(settingsPath); err != nil {
 		return ""
 	}
-	return "--settings .gc/settings.json"
+	return "--settings " + filepath.Join(cityPath, ".gc", "settings.json")
 }
 
 // stageHookFiles adds hook files installed by hooks.Install() to the

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -635,7 +636,7 @@ func settingsArgs(cityPath, providerName string) string {
 	if _, err := os.Stat(settingsPath); err != nil {
 		return ""
 	}
-	return "--settings " + filepath.Join(cityPath, ".gc", "settings.json")
+	return fmt.Sprintf("--settings %q", filepath.Join(cityPath, ".gc", "settings.json"))
 }
 
 // stageHookFiles adds hook files installed by hooks.Install() to the
@@ -643,31 +644,44 @@ func settingsArgs(cityPath, providerName string) string {
 // Docker doesn't need this (bind-mount), but the extra entries are harmless.
 // Avoids duplicating .gc/settings.json if settingsArgs already added it.
 func stageHookFiles(copyFiles []runtime.CopyEntry, cityPath, workDir string) []runtime.CopyEntry {
+	// Compute the relative path from cityPath to workDir so that
+	// container-side RelDst places files under the agent's WorkingDir
+	// (/workspace/<relWorkDir>/), not always at /workspace/.
+	// When workDir == cityPath, relWorkDir is "." and path.Join collapses it.
+	relWorkDir := "."
+	if workDir != cityPath {
+		if r, err := filepath.Rel(cityPath, workDir); err == nil {
+			relWorkDir = r
+		}
+	}
+
 	// workDir-based hooks: gemini, codex, opencode, copilot, pi, omp.
+	// Use path.Join for RelDst (container-target, always forward slashes).
 	for _, rel := range []string{
-		filepath.Join(".gemini", "settings.json"),
-		filepath.Join(".codex", "hooks.json"),
-		filepath.Join(".opencode", "plugins", "gascity.js"),
-		filepath.Join(".github", "hooks", "gascity.json"),
-		filepath.Join(".github", "copilot-instructions.md"),
-		filepath.Join(".pi", "extensions", "gc-hooks.js"),
-		filepath.Join(".omp", "hooks", "gc-hook.ts"),
+		path.Join(".gemini", "settings.json"),
+		path.Join(".codex", "hooks.json"),
+		path.Join(".opencode", "plugins", "gascity.js"),
+		path.Join(".github", "hooks", "gascity.json"),
+		path.Join(".github", "copilot-instructions.md"),
+		path.Join(".pi", "extensions", "gc-hooks.js"),
+		path.Join(".omp", "hooks", "gc-hook.ts"),
 	} {
 		abs := filepath.Join(workDir, rel)
 		if _, err := os.Stat(abs); err == nil {
-			copyFiles = append(copyFiles, runtime.CopyEntry{Src: abs, RelDst: rel})
+			copyFiles = append(copyFiles, runtime.CopyEntry{Src: abs, RelDst: path.Join(relWorkDir, rel)})
 		}
 	}
 	// Stage Claude skills directory (if materialized).
 	skillsDir := filepath.Join(workDir, ".claude", "skills")
 	if info, err := os.Stat(skillsDir); err == nil && info.IsDir() {
 		copyFiles = append(copyFiles, runtime.CopyEntry{
-			Src: skillsDir, RelDst: filepath.Join(".claude", "skills"),
+			Src: skillsDir, RelDst: path.Join(relWorkDir, ".claude", "skills"),
 		})
 	}
 	// cityDir-based hooks: claude (.gc/settings.json).
 	// Skip if settingsArgs already added it.
-	settingsRel := filepath.Join(".gc", "settings.json")
+	// These are city-root relative, so no relWorkDir prefix needed.
+	settingsRel := path.Join(".gc", "settings.json")
 	settingsAbs := citylayout.ClaudeHookFilePath(cityPath)
 	if _, err := os.Stat(settingsAbs); err == nil {
 		alreadyStaged := false

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -139,17 +140,18 @@ func TestPassthroughEnvClearsClaudeNestingUnconditionally(t *testing.T) {
 func TestStageHookFilesIncludesCodexAndCopilotExecutableHooks(t *testing.T) {
 	cityDir := filepath.Join(t.TempDir(), "city")
 	workDir := filepath.Join(cityDir, "worker")
-	for _, rel := range []string{
-		filepath.Join(".codex", "hooks.json"),
-		filepath.Join(".github", "hooks", "gascity.json"),
-		filepath.Join(".github", "copilot-instructions.md"),
-	} {
-		path := filepath.Join(workDir, rel)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
+	hookRels := []string{
+		path.Join(".codex", "hooks.json"),
+		path.Join(".github", "hooks", "gascity.json"),
+		path.Join(".github", "copilot-instructions.md"),
+	}
+	for _, rel := range hookRels {
+		p := filepath.Join(workDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", p, err)
 		}
-		if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", p, err)
 		}
 	}
 
@@ -158,13 +160,12 @@ func TestStageHookFilesIncludesCodexAndCopilotExecutableHooks(t *testing.T) {
 	for _, entry := range got {
 		rels[entry.RelDst] = true
 	}
-	for _, rel := range []string{
-		filepath.Join(".codex", "hooks.json"),
-		filepath.Join(".github", "hooks", "gascity.json"),
-		filepath.Join(".github", "copilot-instructions.md"),
-	} {
-		if !rels[rel] {
-			t.Errorf("stageHookFiles() missing %q", rel)
+	// RelDst must include the relative workDir prefix so K8s staging
+	// places files under the agent's container WorkingDir, not at /workspace/.
+	for _, rel := range hookRels {
+		want := path.Join("worker", rel)
+		if !rels[want] {
+			t.Errorf("stageHookFiles() missing %q (got %v)", want, rels)
 		}
 	}
 }
@@ -182,7 +183,8 @@ func TestStageHookFilesIncludesCanonicalClaudeHook(t *testing.T) {
 
 	got := stageHookFiles(nil, cityDir, workDir)
 	for _, entry := range got {
-		if entry.RelDst == filepath.Join(".gc", "settings.json") {
+		// City-root-relative hook: no workDir prefix in RelDst.
+		if entry.RelDst == path.Join(".gc", "settings.json") {
 			if entry.Src != hookPath {
 				t.Fatalf("stageHookFiles() staged %q, want %q", entry.Src, hookPath)
 			}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1356,7 +1356,9 @@ func TestSettingsArgsClaude(t *testing.T) {
 	}
 
 	got := settingsArgs(dir, "claude")
-	want := "--settings .gc/settings.json"
+	// Must be absolute so K8s command remapping converts cityPath → /workspace.
+	// A relative path breaks agents whose workingDir differs from the city root.
+	want := "--settings " + filepath.Join(dir, ".gc", "settings.json")
 	if got != want {
 		t.Errorf("settingsArgs(claude) = %q, want %q", got, want)
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1358,9 +1358,34 @@ func TestSettingsArgsClaude(t *testing.T) {
 	got := settingsArgs(dir, "claude")
 	// Must be absolute so K8s command remapping converts cityPath → /workspace.
 	// A relative path breaks agents whose workingDir differs from the city root.
-	want := "--settings " + filepath.Join(dir, ".gc", "settings.json")
+	// Path is quoted to handle spaces in city paths.
+	want := fmt.Sprintf("--settings %q", filepath.Join(dir, ".gc", "settings.json"))
 	if got != want {
 		t.Errorf("settingsArgs(claude) = %q, want %q", got, want)
+	}
+}
+
+// TestSettingsArgsRemapping verifies that the absolute path produced by
+// settingsArgs survives K8s command remapping (strings.ReplaceAll of cityPath
+// with /workspace) and resolves to the correct container path.
+func TestSettingsArgsRemapping(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "claude.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sa := settingsArgs(dir, "claude")
+	command := "claude " + sa
+
+	// Simulate K8s pod.go remapping: replace cityPath with /workspace.
+	remapped := strings.ReplaceAll(command, dir, "/workspace")
+	want := fmt.Sprintf("claude --settings %q", "/workspace/.gc/settings.json")
+	if remapped != want {
+		t.Errorf("remapped command = %q, want %q", remapped, want)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -13,6 +13,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -119,11 +120,11 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if sa := settingsArgs(p.cityPath, resolved.Name); sa != "" {
 		command = command + " " + sa
 		settingsFile := citylayout.ClaudeHookFilePath(p.cityPath)
-		copyFiles = append(copyFiles, runtime.CopyEntry{Src: settingsFile, RelDst: filepath.Join(".gc", "settings.json")})
+		copyFiles = append(copyFiles, runtime.CopyEntry{Src: settingsFile, RelDst: path.Join(".gc", "settings.json")})
 	}
 	scriptsDir := citylayout.ScriptsPath(p.cityPath)
 	if info, sErr := os.Stat(scriptsDir); sErr == nil && info.IsDir() {
-		copyFiles = append(copyFiles, runtime.CopyEntry{Src: scriptsDir, RelDst: filepath.Join(".gc", "scripts")})
+		copyFiles = append(copyFiles, runtime.CopyEntry{Src: scriptsDir, RelDst: path.Join(".gc", "scripts")})
 	}
 	copyFiles = stageHookFiles(copyFiles, p.cityPath, workDir)
 


### PR DESCRIPTION
## Summary

`settingsArgs` returns `--settings .gc/settings.json` — a relative path that resolves against the container's `WorkingDir`. For agents whose `work_dir` differs from the city root (e.g. deacon at `.gc/agents/deacon`), the K8s provider sets `WorkingDir` to `/workspace/.gc/agents/deacon`, so the relative path resolves to `/workspace/.gc/agents/deacon/.gc/settings.json` which doesn't exist.

Meanwhile `stageHookFiles` stages the file to `/workspace/.gc/settings.json` (via `RelDst`), so the file is in the right place — but the command points to the wrong location.

## Fix

Use the absolute city-root path (`filepath.Join(cityPath, ".gc", "settings.json")`) so the K8s command remapper (`strings.ReplaceAll(agentCmd, ctrlCity, "/workspace")`) converts it to `/workspace/.gc/settings.json` automatically.

This is consistent with how `pre_start` commands are already remapped (pod.go lines 54-58).

## Why not fix staging instead?

An alternative would be to make K8s staging use `podWorkDir` instead of hardcoded `/workspace/`. However, the init container always mounts at `/workspace` and staging writes relative to that mount, so changing the staging target would break the init container coordination. The command-side fix is simpler and correct.