### PR TITLE
fix: clear started_config_hash in recordWakeFailure

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -500,7 +500,13 @@ func recordWakeFailure(session *beads.Bead, store beads.Store, clk clock.Clock) 
 	// UUID; clearing started_config_hash ensures resolveSessionCommand
 	// treats the next wake as a first start (--session-id) rather than a
 	// resume (--resume) of a conversation that no longer exists.
-	if session.Metadata["session_key"] != "" {
+	//
+	// checkStability runs after healState, and healState may already have
+	// cleared session_key for an unexpected death before recordWakeFailure
+	// runs. Clear started_config_hash whenever either field is set so the
+	// recovery remains correct in that call order and for any skewed state
+	// left behind by older builds.
+	if session.Metadata["session_key"] != "" || session.Metadata["started_config_hash"] != "" {
 		_ = store.SetMetadataBatch(session.ID, map[string]string{
 			"session_key":                "",
 			"started_config_hash":        "",
@@ -617,14 +623,15 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 	if session.Metadata["state"] != target {
 		batch := map[string]string{"state": target}
 		// When a session with a resume key dies unexpectedly (no drain
-		// in progress), clear the key so the next start uses a fresh
-		// session instead of retrying a stale resume key. Skip this for
-		// deliberate drains where the key is still valid for future resume.
+		// in progress), clear the resume identity so the next start uses a
+		// fresh conversation instead of retrying stale resume metadata.
+		// Skip this for deliberate drains where the key is still valid for
+		// future resume.
 		//
 		// Default is "clear key" (safe for crash loops). Any new sleep_reason
 		// that represents a deliberate drain must be added here to preserve
 		// the resume key. See sleep_reason assignment sites across the codebase.
-		if target == "asleep" && session.Metadata["session_key"] != "" {
+		if target == "asleep" && (session.Metadata["session_key"] != "" || session.Metadata["started_config_hash"] != "") {
 			prevState := session.Metadata["state"]
 			sleepReason := session.Metadata["sleep_reason"]
 			isDraining := sleepReason == "idle" || sleepReason == "idle-timeout" ||
@@ -633,6 +640,7 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 				sleepReason == "wait-hold"
 			if !isDraining && (prevState == "active" || prevState == "awake" || prevState == "creating") {
 				batch["session_key"] = ""
+				batch["started_config_hash"] = ""
 				batch["continuation_reset_pending"] = "true"
 			}
 		}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -916,6 +916,25 @@ func TestRecordWakeFailure_ClearsStartedConfigHash(t *testing.T) {
 	}
 }
 
+func TestRecordWakeFailure_ClearsStartedConfigHashWhenSessionKeyAlreadyEmpty(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+
+	session := makeBead("b1", map[string]string{
+		"started_config_hash": "abc123",
+	})
+
+	recordWakeFailure(&session, store, clk)
+
+	if session.Metadata["started_config_hash"] != "" {
+		t.Errorf("started_config_hash = %q, want empty", session.Metadata["started_config_hash"])
+	}
+	if session.Metadata["continuation_reset_pending"] != "true" {
+		t.Errorf("continuation_reset_pending = %q, want true", session.Metadata["continuation_reset_pending"])
+	}
+}
+
 func TestClearWakeFailures(t *testing.T) {
 	store := newTestStore()
 
@@ -1180,73 +1199,123 @@ func TestHealState_StaleCreatingWithoutPendingClaimHealsToAsleep(t *testing.T) {
 	}
 }
 
-func TestHealState_ClearsStaleSessionKey(t *testing.T) {
+func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 	tests := []struct {
-		name           string
-		prevState      string
-		sleepReason    string
-		sessionKey     string
-		wantKeyCleared bool
+		name                   string
+		prevState              string
+		sleepReason            string
+		sessionKey             string
+		startedConfigHash      string
+		wantKeyCleared         bool
+		wantStartedHashCleared bool
 	}{
 		{
-			name:      "active with no drain reason — key cleared",
-			prevState: "active", sleepReason: "", sessionKey: "abc-123",
-			wantKeyCleared: true,
+			name:                   "active with no drain reason — resume metadata cleared",
+			prevState:              "active",
+			sleepReason:            "",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         true,
+			wantStartedHashCleared: true,
 		},
 		{
-			name:      "awake with no drain reason — key cleared",
-			prevState: "awake", sleepReason: "", sessionKey: "abc-123",
-			wantKeyCleared: true,
+			name:                   "awake with no drain reason — resume metadata cleared",
+			prevState:              "awake",
+			sleepReason:            "",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         true,
+			wantStartedHashCleared: true,
 		},
 		{
-			name:      "creating with no drain reason — key cleared",
-			prevState: "creating", sleepReason: "", sessionKey: "abc-123",
-			wantKeyCleared: true,
+			name:                   "creating with no drain reason — resume metadata cleared",
+			prevState:              "creating",
+			sleepReason:            "",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         true,
+			wantStartedHashCleared: true,
 		},
 		{
-			name:      "idle drain — key preserved",
-			prevState: "active", sleepReason: "idle", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "idle drain — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "idle",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "idle-timeout drain — key preserved",
-			prevState: "active", sleepReason: "idle-timeout", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "idle-timeout drain — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "idle-timeout",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "no-wake-reason drain — key preserved",
-			prevState: "active", sleepReason: "no-wake-reason", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "no-wake-reason drain — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "no-wake-reason",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "config-drift drain — key preserved",
-			prevState: "active", sleepReason: "config-drift", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "config-drift drain — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "config-drift",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "user-hold drain — key preserved",
-			prevState: "active", sleepReason: "user-hold", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "user-hold drain — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "user-hold",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "wait-hold drain — key preserved",
-			prevState: "active", sleepReason: "wait-hold", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "wait-hold drain — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "wait-hold",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "drained — key preserved",
-			prevState: "active", sleepReason: "drained", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "drained — resume metadata preserved",
+			prevState:              "active",
+			sleepReason:            "drained",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "asleep prev state — key preserved (not in active set)",
-			prevState: "asleep", sleepReason: "", sessionKey: "abc-123",
-			wantKeyCleared: false,
+			name:                   "asleep prev state — resume metadata preserved (not in active set)",
+			prevState:              "asleep",
+			sleepReason:            "",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
 		},
 		{
-			name:      "no session key — nothing to clear",
-			prevState: "active", sleepReason: "", sessionKey: "",
-			wantKeyCleared: false,
+			name:                   "no session key — clear stale started hash",
+			prevState:              "active",
+			sleepReason:            "",
+			sessionKey:             "",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         false,
+			wantStartedHashCleared: true,
 		},
 	}
 
@@ -1255,24 +1324,62 @@ func TestHealState_ClearsStaleSessionKey(t *testing.T) {
 			store := newTestStore()
 			clk := &clock.Fake{Time: time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC)}
 			session := makeBead("b1", map[string]string{
-				"state":        tt.prevState,
-				"sleep_reason": tt.sleepReason,
-				"session_key":  tt.sessionKey,
+				"state":               tt.prevState,
+				"sleep_reason":        tt.sleepReason,
+				"session_key":         tt.sessionKey,
+				"started_config_hash": tt.startedConfigHash,
 			})
 			healState(&session, false, store, clk)
 			keyAfter := session.Metadata["session_key"]
+			startedHashAfter := session.Metadata["started_config_hash"]
 			if tt.wantKeyCleared && keyAfter != "" {
 				t.Errorf("session_key should be cleared, got %q", keyAfter)
 			}
 			if !tt.wantKeyCleared && keyAfter != tt.sessionKey {
 				t.Errorf("session_key should be preserved as %q, got %q", tt.sessionKey, keyAfter)
 			}
-			if tt.wantKeyCleared {
+			if tt.wantStartedHashCleared && startedHashAfter != "" {
+				t.Errorf("started_config_hash should be cleared, got %q", startedHashAfter)
+			}
+			if !tt.wantStartedHashCleared && startedHashAfter != tt.startedConfigHash {
+				t.Errorf("started_config_hash should be preserved as %q, got %q", tt.startedConfigHash, startedHashAfter)
+			}
+			if tt.wantKeyCleared || tt.wantStartedHashCleared {
 				if session.Metadata["continuation_reset_pending"] != "true" {
-					t.Error("continuation_reset_pending should be set when key is cleared")
+					t.Error("continuation_reset_pending should be set when resume metadata is cleared")
 				}
 			}
 		})
+	}
+}
+
+func TestCheckStability_RapidExitAfterHealStateKeepsStartedConfigHashCleared(t *testing.T) {
+	now := time.Date(2026, 4, 4, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+
+	session := makeBead("b1", map[string]string{
+		"state":               "active",
+		"session_key":         "old-key",
+		"started_config_hash": "hash-before",
+		"last_woke_at":        now.Add(-5 * time.Second).UTC().Format(time.RFC3339),
+	})
+
+	healState(&session, false, store, clk)
+	if session.Metadata["session_key"] != "" {
+		t.Fatalf("healState session_key = %q, want empty", session.Metadata["session_key"])
+	}
+	if session.Metadata["started_config_hash"] != "" {
+		t.Fatalf("healState started_config_hash = %q, want empty", session.Metadata["started_config_hash"])
+	}
+	if !checkStability(&session, nil, false, nil, store, clk) {
+		t.Fatal("checkStability should record the rapid exit")
+	}
+	if session.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q after recordWakeFailure, want empty", session.Metadata["started_config_hash"])
+	}
+	if session.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", session.Metadata["continuation_reset_pending"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- `recordWakeFailure` (0a6bd0a6) clears `session_key` with the stated intent of giving the next wake a fresh conversation
- `resolveSessionCommand` (8a1de163, parallel lifecycle waves) checks `started_config_hash` to decide `--resume` vs `--session-id` — this gate is independent of `session_key`
- Without clearing `started_config_hash`, the backfilled fresh key still gets `--resume`, which fails because no conversation exists for the new key
- Fix: clear `started_config_hash` alongside `session_key` so the next wake is treated as a first start

Companion to #128 (post-start liveness check). #128 ensures `recordWakeFailure` fires on immediate session death; this PR ensures it actually produces a working recovery.

## Testing

New test `TestRecordWakeFailure_ClearsStartedConfigHash` — verifies both `session_key` and `started_config_hash` are cleared. All existing `recordWakeFailure` tests pass.

Verified end-to-end on homelab K8s cluster: after controller restart, first wake fails (stale --resume), recordWakeFailure clears both fields, second wake succeeds (fresh --session-id). All three agents (boot, deacon, brewlife/witness) recovered automatically.