### PR TITLE
fix: honor provider-specific transcript formats

### DIFF
--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -59,52 +59,64 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 		return 1
 	}
 
-	workDir, sessionKey, ok := "", "", false
+	var logCtx sessionLogContext
+	var ok bool
 	store, err := tryOpenCityStore()
 	if err == nil && store != nil {
-		workDir, sessionKey, ok = resolveSessionLogContext(cityPath, cfg, store, identifier)
+		logCtx, ok = resolveSessionLogContext(cityPath, cfg, store, identifier)
 	}
 	if !ok {
-		workDir, ok = resolveConfiguredSessionLogContext(cityPath, cfg, identifier)
-	}
-	if !ok {
-		fmt.Fprintf(stderr, "gc session logs: session %q not found\n", identifier) //nolint:errcheck // best-effort stderr
-		return 1
+		workDir, found := resolveConfiguredSessionLogContext(cityPath, cfg, identifier)
+		if !found {
+			fmt.Fprintf(stderr, "gc session logs: session %q not found\n", identifier) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		logCtx.workDir = workDir
 	}
 
 	searchPaths := sessionlog.MergeSearchPaths(cfg.Daemon.ObservePaths)
 	var path string
-	if sessionKey != "" {
-		path = sessionlog.FindSessionFileByID(searchPaths, workDir, sessionKey)
+	if logCtx.sessionKey != "" {
+		path = sessionlog.FindSessionFileByID(searchPaths, logCtx.workDir, logCtx.sessionKey)
 	}
 	if path == "" {
-		path = sessionlog.FindSessionFile(searchPaths, workDir)
+		path = sessionlog.FindSessionFileForProvider(searchPaths, logCtx.provider, logCtx.workDir)
 	}
 	if path == "" {
 		fmt.Fprintf(stderr, "gc session logs: no session file found for %q\n", identifier) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	return doSessionLogs(path, follow, tail, stdout, stderr)
+	return doSessionLogs(path, logCtx.provider, follow, tail, stdout, stderr)
 }
 
-func resolveSessionLogContext(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, string, bool) {
+type sessionLogContext struct {
+	workDir    string
+	sessionKey string
+	provider   string
+}
+
+func resolveSessionLogContext(cityPath string, cfg *config.City, store beads.Store, identifier string) (sessionLogContext, bool) {
 	if store == nil {
-		return "", "", false
+		return sessionLogContext{}, false
 	}
 	sessionID, err := resolveSessionIDAllowClosedWithConfig(cityPath, cfg, store, identifier)
 	if err != nil {
-		return "", "", false
+		return sessionLogContext{}, false
 	}
 	b, err := store.Get(sessionID)
 	if err != nil {
-		return "", "", false
+		return sessionLogContext{}, false
 	}
 	workDir := strings.TrimSpace(b.Metadata["work_dir"])
 	if workDir == "" {
-		return "", "", false
+		return sessionLogContext{}, false
 	}
-	return workDir, strings.TrimSpace(b.Metadata["session_key"]), true
+	return sessionLogContext{
+		workDir:    workDir,
+		sessionKey: strings.TrimSpace(b.Metadata["session_key"]),
+		provider:   strings.TrimSpace(b.Metadata["provider"]),
+	}, true
 }
 
 func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, identifier string) (string, bool) {
@@ -142,15 +154,15 @@ func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, ident
 
 // doSessionLogs reads the session file and prints messages. If follow is true,
 // it polls for new messages every 2 seconds.
-func doSessionLogs(path string, follow bool, tail int, stdout, stderr io.Writer) int {
+func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr io.Writer) int {
 	if tail < 0 {
 		fmt.Fprintln(stderr, "gc session logs: --tail must be >= 0") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	sess, err := sessionlog.ReadFile(path, tail)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+	sess, readErr := sessionlog.ReadProviderFile(provider, path, tail)
+	if readErr != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", readErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -168,7 +180,7 @@ func doSessionLogs(path string, follow bool, tail int, stdout, stderr io.Writer)
 	// follow loop don't replay messages that were intentionally excluded by
 	// the initial tail window.
 	if tail > 0 {
-		full, err := sessionlog.ReadFile(path, 0)
+		full, err := readSessionFile(provider, path, 0)
 		if err == nil {
 			for _, msg := range full.Messages {
 				seen[msg.UUID] = true
@@ -184,11 +196,11 @@ func doSessionLogs(path string, follow bool, tail int, stdout, stderr io.Writer)
 	for {
 		time.Sleep(2 * time.Second)
 
-		sess, err = sessionlog.ReadFile(path, 0)
-		if err != nil {
+		sess, readErr = readSessionFile(provider, path, 0)
+		if readErr != nil {
 			consecErrors++
 			if consecErrors >= maxConsecErrors {
-				fmt.Fprintf(stderr, "gc session logs: %d consecutive read errors, last: %v\n", consecErrors, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "gc session logs: %d consecutive read errors, last: %v\n", consecErrors, readErr) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 			continue
@@ -203,6 +215,10 @@ func doSessionLogs(path string, follow bool, tail int, stdout, stderr io.Writer)
 			seen[msg.UUID] = true
 		}
 	}
+}
+
+func readSessionFile(provider, path string, tail int) (*sessionlog.Session, error) {
+	return sessionlog.ReadProviderFile(provider, path, tail)
 }
 
 // resolveMessage handles both message formats found in Claude JSONL files:

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -43,7 +43,7 @@ func TestDoSessionLogsBasic(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs(path, false, 0, &stdout, &stderr)
+	code := doSessionLogs(path, "", false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -86,7 +86,7 @@ func TestDoSessionLogsCompactBoundary(t *testing.T) {
 
 	// tail=1 should show only from the last compact boundary.
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs(path, false, 1, &stdout, &stderr)
+	code := doSessionLogs(path, "", false, 1, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -118,7 +118,7 @@ func TestDoSessionLogsToolUse(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs(path, false, 0, &stdout, &stderr)
+	code := doSessionLogs(path, "", false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -148,7 +148,7 @@ func TestDoSessionLogsStringEncodedMessage(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs(path, false, 0, &stdout, &stderr)
+	code := doSessionLogs(path, "", false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -173,7 +173,7 @@ func TestDoSessionLogsToolResultError(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs(path, false, 0, &stdout, &stderr)
+	code := doSessionLogs(path, "", false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -186,7 +186,7 @@ func TestDoSessionLogsToolResultError(t *testing.T) {
 
 func TestDoSessionLogsNegativeTail(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs("/nonexistent", false, -1, &stdout, &stderr)
+	code := doSessionLogs("/nonexistent", "", false, -1, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1 for negative tail", code)
 	}
@@ -280,7 +280,7 @@ func TestPrintLogEntryTimestamp(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doSessionLogs(path, false, 0, &stdout, &stderr)
+	code := doSessionLogs(path, "", false, 0, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -303,12 +303,12 @@ func TestResolveSessionLogWorkDirByAlias(t *testing.T) {
 		},
 	})
 
-	got, _, ok := resolveSessionLogContext("", nil, store, "worker")
+	got, ok := resolveSessionLogContext("", nil, store, "worker")
 	if !ok {
 		t.Fatal("resolveSessionLogContext() = not found, want found")
 	}
-	if got != "/tmp/myrig" {
-		t.Fatalf("resolveSessionLogContext() workDir = %q, want %q", got, "/tmp/myrig")
+	if got.workDir != "/tmp/myrig" {
+		t.Fatalf("resolveSessionLogContext() workDir = %q, want %q", got.workDir, "/tmp/myrig")
 	}
 }
 
@@ -324,12 +324,12 @@ func TestResolveSessionLogWorkDirBySessionName(t *testing.T) {
 		},
 	})
 
-	got, _, ok := resolveSessionLogContext("", nil, store, "s-gc-77")
+	got, ok := resolveSessionLogContext("", nil, store, "s-gc-77")
 	if !ok {
 		t.Fatal("resolveSessionLogContext() = not found, want found")
 	}
-	if got != "/tmp/myrig" {
-		t.Fatalf("resolveSessionLogContext() workDir = %q, want %q", got, "/tmp/myrig")
+	if got.workDir != "/tmp/myrig" {
+		t.Fatalf("resolveSessionLogContext() workDir = %q, want %q", got.workDir, "/tmp/myrig")
 	}
 }
 
@@ -346,12 +346,12 @@ func TestResolveSessionLogWorkDirByClosedHistoricalAlias(t *testing.T) {
 	})
 	_ = store.Close(b.ID)
 
-	got, _, ok := resolveSessionLogContext("", nil, store, "mayor")
+	got, ok := resolveSessionLogContext("", nil, store, "mayor")
 	if !ok {
 		t.Fatal("resolveSessionLogContext() = not found, want found")
 	}
-	if got != "/tmp/myrig" {
-		t.Fatalf("resolveSessionLogContext() workDir = %q, want %q", got, "/tmp/myrig")
+	if got.workDir != "/tmp/myrig" {
+		t.Fatalf("resolveSessionLogContext() workDir = %q, want %q", got.workDir, "/tmp/myrig")
 	}
 }
 
@@ -429,16 +429,16 @@ func TestResolveSessionLogContext_ReservedNamedTargetIgnoresClosedHistoricalBead
 	})
 	_ = store.Close(b.ID)
 
-	got, _, ok := resolveSessionLogContext(cityPath, cfg, store, "witness")
+	got, ok := resolveSessionLogContext(cityPath, cfg, store, "witness")
 	if ok {
-		t.Fatalf("resolveSessionLogContext() = %q, want not found for reserved named target", got)
+		t.Fatalf("resolveSessionLogContext() = %+v, want not found for reserved named target", got)
 	}
-	got, ok = resolveConfiguredSessionLogContext(cityPath, cfg, "witness")
+	configuredWorkDir, ok := resolveConfiguredSessionLogContext(cityPath, cfg, "witness")
 	if !ok {
 		t.Fatal("resolveConfiguredSessionLogContext() = not found, want configured fallback")
 	}
-	if got != rigPath {
-		t.Fatalf("resolveConfiguredSessionLogContext() workDir = %q, want %q", got, rigPath)
+	if configuredWorkDir != rigPath {
+		t.Fatalf("resolveConfiguredSessionLogContext() workDir = %q, want %q", configuredWorkDir, rigPath)
 	}
 }
 

--- a/internal/api/handler_agent_output.go
+++ b/internal/api/handler_agent_output.go
@@ -66,16 +66,21 @@ func (s *Server) handleAgentOutput(w http.ResponseWriter, r *http.Request, name 
 // found (expected — triggers fallback). Returns (nil, err) if the file
 // exists but cannot be read (unexpected — surface to caller).
 func (s *Server) trySessionLogOutput(r *http.Request, name string, agentCfg config.Agent) (*agentOutputResponse, error) {
+	cfg := s.state.Config()
 	workDir := s.resolveAgentWorkDir(agentCfg, name)
 	if workDir == "" {
 		return nil, nil
 	}
+	provider := strings.TrimSpace(agentCfg.Provider)
+	if provider == "" && cfg != nil {
+		provider = strings.TrimSpace(cfg.Workspace.Provider)
+	}
 
 	searchPaths := s.sessionLogSearchPaths
 	if searchPaths == nil {
-		searchPaths = sessionlog.MergeSearchPaths(s.state.Config().Daemon.ObservePaths)
+		searchPaths = sessionlog.MergeSearchPaths(cfg.Daemon.ObservePaths)
 	}
-	path := sessionlog.FindSessionFile(searchPaths, workDir)
+	path := sessionlog.FindSessionFileForProvider(searchPaths, provider, workDir)
 	if path == "" {
 		return nil, nil
 	}
@@ -91,9 +96,9 @@ func (s *Server) trySessionLogOutput(r *http.Request, name string, agentCfg conf
 	var sess *sessionlog.Session
 	var err error
 	if before != "" {
-		sess, err = sessionlog.ReadFileOlder(path, tail, before)
+		sess, err = sessionlog.ReadProviderFileOlder(provider, path, tail, before)
 	} else {
-		sess, err = sessionlog.ReadFile(path, tail)
+		sess, err = sessionlog.ReadProviderFile(provider, path, tail)
 	}
 	if err != nil {
 		return nil, err
@@ -255,6 +260,10 @@ func (s *Server) handleAgentOutputStream(w http.ResponseWriter, r *http.Request,
 
 	// Try session log streaming first, fall back to peek polling.
 	workDir := s.resolveAgentWorkDir(agentCfg, name)
+	provider := strings.TrimSpace(agentCfg.Provider)
+	if provider == "" {
+		provider = strings.TrimSpace(cfg.Workspace.Provider)
+	}
 	searchPaths := s.sessionLogSearchPaths
 	if searchPaths == nil {
 		searchPaths = sessionlog.MergeSearchPaths(cfg.Daemon.ObservePaths)
@@ -262,7 +271,7 @@ func (s *Server) handleAgentOutputStream(w http.ResponseWriter, r *http.Request,
 
 	var logPath string
 	if workDir != "" {
-		logPath = sessionlog.FindSessionFile(searchPaths, workDir)
+		logPath = sessionlog.FindSessionFileForProvider(searchPaths, provider, workDir)
 	}
 
 	// Check if agent is running.
@@ -301,6 +310,13 @@ func (s *Server) handleAgentOutputStream(w http.ResponseWriter, r *http.Request,
 // Uses file size tracking to skip re-reads when the file hasn't grown, and
 // UUID-based cursor to correctly identify new turns after DAG resolution.
 func (s *Server) streamSessionLog(ctx context.Context, w http.ResponseWriter, name string, logPath string) {
+	// Derive provider from agent config for session log parsing.
+	cfg := s.state.Config()
+	agentCfg, _ := findAgent(cfg, name)
+	provider := strings.TrimSpace(agentCfg.Provider)
+	if provider == "" && cfg != nil {
+		provider = strings.TrimSpace(cfg.Workspace.Provider)
+	}
 	lw := newLogFileWatcher(logPath)
 	defer lw.Close()
 
@@ -321,7 +337,7 @@ func (s *Server) streamSessionLog(ctx context.Context, w http.ResponseWriter, na
 		}
 
 		// Use tail=1 (last compaction segment) to limit parsing scope.
-		sess, err := sessionlog.ReadFile(logPath, 1)
+		sess, err := sessionlog.ReadProviderFile(provider, logPath, 1)
 		if err != nil {
 			return
 		}

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -569,7 +569,11 @@ func (s *Server) enrichSessionMeta(resp *agentResponse, agentCfg config.Agent, q
 	if searchPaths == nil {
 		searchPaths = sessionlog.MergeSearchPaths(cfg.Daemon.ObservePaths)
 	}
-	sessionFile := sessionlog.FindSessionFile(searchPaths, workDir)
+	provider := strings.TrimSpace(agentCfg.Provider)
+	if provider == "" && cfg != nil {
+		provider = strings.TrimSpace(cfg.Workspace.Provider)
+	}
+	sessionFile := sessionlog.FindSessionFileForProvider(searchPaths, provider, workDir)
 	if sessionFile == "" {
 		return
 	}

--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -591,9 +591,9 @@ func (s *Server) handleSessionTranscript(w http.ResponseWriter, r *http.Request)
 			// stream and snapshot paths.
 			var rawSess *sessionlog.Session
 			if before != "" {
-				rawSess, err = sessionlog.ReadFileRawOlder(path, tail, before)
+				rawSess, err = sessionlog.ReadProviderFileRawOlder(info.Provider, path, tail, before)
 			} else {
-				rawSess, err = sessionlog.ReadFileRaw(path, tail)
+				rawSess, err = sessionlog.ReadProviderFileRaw(info.Provider, path, tail)
 			}
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "internal", "reading session log: "+err.Error())
@@ -617,9 +617,9 @@ func (s *Server) handleSessionTranscript(w http.ResponseWriter, r *http.Request)
 
 		var sess *sessionlog.Session
 		if before != "" {
-			sess, err = sessionlog.ReadFileOlder(path, tail, before)
+			sess, err = sessionlog.ReadProviderFileOlder(info.Provider, path, tail, before)
 		} else {
-			sess, err = sessionlog.ReadFile(path, tail)
+			sess, err = sessionlog.ReadProviderFile(info.Provider, path, tail)
 		}
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal", "reading session log: "+err.Error())
@@ -929,7 +929,7 @@ func (s *Server) emitClosedSessionSnapshot(w http.ResponseWriter, info session.I
 	if logPath == "" {
 		return
 	}
-	sess, err := sessionlog.ReadFile(logPath, 0)
+	sess, err := sessionlog.ReadProviderFile(info.Provider, logPath, 0)
 	if err != nil {
 		return
 	}
@@ -965,7 +965,7 @@ func (s *Server) emitClosedSessionSnapshotRaw(w http.ResponseWriter, info sessio
 	if logPath == "" {
 		return
 	}
-	sess, err := sessionlog.ReadFileRaw(logPath, 0)
+	sess, err := sessionlog.ReadProviderFileRaw(info.Provider, logPath, 0)
 	if err != nil {
 		return
 	}
@@ -1018,7 +1018,7 @@ func (s *Server) streamSessionTranscriptLogRaw(ctx context.Context, w http.Respo
 
 		// Use tail=1 (last compaction segment) to limit parsing scope,
 		// consistent with the non-raw streaming path.
-		sess, err := sessionlog.ReadFileRaw(logPath, 1)
+		sess, err := sessionlog.ReadProviderFileRaw(info.Provider, logPath, 1)
 		if err != nil {
 			return
 		}
@@ -1119,7 +1119,7 @@ func (s *Server) streamSessionTranscriptLog(ctx context.Context, w http.Response
 			return
 		}
 
-		sess, err := sessionlog.ReadFile(logPath, 0)
+		sess, err := sessionlog.ReadProviderFile(info.Provider, logPath, 0)
 		if err != nil {
 			return
 		}

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -410,7 +410,7 @@ func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info,
 		if info.SessionKey != "" {
 			sessionFile = sessionlog.FindSessionFileByID(searchPaths, workDir, info.SessionKey)
 		} else {
-			sessionFile = sessionlog.FindSessionFile(searchPaths, workDir)
+			sessionFile = sessionlog.FindSessionFileForProvider(searchPaths, info.Provider, workDir)
 		}
 		if sessionFile != "" {
 			if meta, err := sessionlog.ExtractTailMeta(sessionFile); err == nil && meta != nil {

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -301,6 +301,7 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 	if workDir == "" {
 		return "", nil
 	}
+	provider := strings.TrimSpace(b.Metadata["provider"])
 	if len(searchPaths) == 0 {
 		searchPaths = sessionlog.DefaultSearchPaths()
 	}
@@ -324,6 +325,9 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 		if other.Status == "closed" {
 			continue
 		}
+		if provider != "" && strings.TrimSpace(other.Metadata["provider"]) != provider {
+			continue
+		}
 		if other.Metadata["work_dir"] == workDir {
 			matches++
 			if matches > 1 {
@@ -333,5 +337,5 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 			}
 		}
 	}
-	return sessionlog.FindSessionFile(searchPaths, workDir), nil
+	return sessionlog.FindSessionFileForProvider(searchPaths, provider, workDir), nil
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1911,3 +1911,37 @@ func TestTranscriptPathSkipsAmbiguousWorkDirFallback(t *testing.T) {
 		t.Errorf("TranscriptPath = %q, want empty when workdir fallback is ambiguous", path)
 	}
 }
+
+func TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	if _, err := mgr.Create(context.Background(), "helper", "claude", "claude", workDir, "claude", nil, ProviderResume{}, runtime.Config{}); err != nil {
+		t.Fatalf("Create claude: %v", err)
+	}
+	info, err := mgr.Create(context.Background(), "helper", "codex", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create codex: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	codexPath := filepath.Join(dayDir, "rollout-current.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	if err := os.WriteFile(codexPath, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(info.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != codexPath {
+		t.Errorf("TranscriptPath = %q, want %q", path, codexPath)
+	}
+}

--- a/internal/sessionlog/codex_reader.go
+++ b/internal/sessionlog/codex_reader.go
@@ -1,0 +1,263 @@
+package sessionlog
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ReadCodexFile reads a Codex JSONL session file and converts it to the
+// standard Session format used by gc session logs.
+//
+// Codex entries use a different schema than Claude:
+//   - session_meta: session initialization (skipped)
+//   - event_msg: user messages, agent messages, reasoning, token counts
+//   - response_item: messages, function calls, reasoning (preferred over event_msg)
+//   - turn_context: per-turn configuration (skipped)
+//
+// Port of yepanywhere's CodexSessionReader.convertEntriesToMessages.
+func ReadCodexFile(path string, _ int) (*Session, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+	var entries []codexEntry
+	for scanner.Scan() {
+		var raw codexRawEntry
+		if err := json.Unmarshal(scanner.Bytes(), &raw); err != nil {
+			continue
+		}
+		if raw.Type == "" {
+			continue
+		}
+		entries = append(entries, codexEntry{raw: raw, line: string(scanner.Bytes())})
+	}
+
+	// Check if response_item entries contain user messages (preferred source).
+	hasResponseItemUser := false
+	for _, e := range entries {
+		if e.raw.Type == "response_item" {
+			var ri codexResponseItem
+			if json.Unmarshal(e.raw.Payload, &ri) == nil && ri.Type == "message" && ri.Role == "user" {
+				hasResponseItemUser = true
+				break
+			}
+		}
+	}
+
+	var messages []*Entry
+	idx := 0
+	var lastUUID string
+
+	for _, e := range entries {
+		ts, _ := time.Parse(time.RFC3339Nano, e.raw.Timestamp)
+
+		switch e.raw.Type {
+		case "response_item":
+			entry := convertResponseItem(e.raw.Payload, e.line, idx, ts)
+			if entry != nil {
+				entry.ParentUUID = lastUUID
+				lastUUID = entry.UUID
+				messages = append(messages, entry)
+				idx++
+			}
+
+		case "event_msg":
+			var em codexEventMsg
+			if json.Unmarshal(e.raw.Payload, &em) != nil {
+				continue
+			}
+			switch em.Type {
+			case "user_message":
+				if hasResponseItemUser {
+					continue // prefer response_item user messages
+				}
+				entry := &Entry{
+					UUID:      fmt.Sprintf("codex-event-%d", idx),
+					Type:      "user",
+					Timestamp: ts,
+					Message:   mustMarshal(MessageContent{Role: "user", Content: mustMarshal(em.Message)}),
+					Raw:       json.RawMessage(e.line),
+				}
+				entry.ParentUUID = lastUUID
+				lastUUID = entry.UUID
+				messages = append(messages, entry)
+				idx++
+
+			case "agent_message":
+				// Skip — response_item has the complete text.
+				// Only include if no response_items exist.
+				if hasResponseItemUser {
+					continue
+				}
+				entry := &Entry{
+					UUID:      fmt.Sprintf("codex-event-%d", idx),
+					Type:      "assistant",
+					Timestamp: ts,
+					Message: mustMarshal(MessageContent{
+						Role:    "assistant",
+						Content: mustMarshal([]ContentBlock{{Type: "text", Text: em.Message}}),
+					}),
+					Raw: json.RawMessage(e.line),
+				}
+				entry.ParentUUID = lastUUID
+				lastUUID = entry.UUID
+				messages = append(messages, entry)
+				idx++
+
+			case "agent_reasoning":
+				entry := &Entry{
+					UUID:      fmt.Sprintf("codex-event-%d", idx),
+					Type:      "assistant",
+					Timestamp: ts,
+					Message: mustMarshal(MessageContent{
+						Role:    "assistant",
+						Content: mustMarshal([]ContentBlock{{Type: "thinking", Text: em.Text}}),
+					}),
+					Raw: json.RawMessage(e.line),
+				}
+				entry.ParentUUID = lastUUID
+				lastUUID = entry.UUID
+				messages = append(messages, entry)
+				idx++
+			}
+		}
+	}
+
+	return &Session{
+		ID:       codexSessionID(path),
+		Messages: messages,
+	}, nil
+}
+
+func convertResponseItem(payload json.RawMessage, rawLine string, idx int, ts time.Time) *Entry {
+	var ri codexResponseItem
+	if json.Unmarshal(payload, &ri) != nil {
+		return nil
+	}
+
+	uuid := fmt.Sprintf("codex-%d", idx)
+
+	switch ri.Type {
+	case "message":
+		if ri.Role == "developer" {
+			return nil
+		}
+		// Concatenate all text blocks.
+		var fullText string
+		for _, c := range ri.Content {
+			fullText += c.Text
+		}
+		entryType := ri.Role
+		if entryType == "" {
+			entryType = "assistant"
+		}
+		return &Entry{
+			UUID:      uuid,
+			Type:      entryType,
+			Timestamp: ts,
+			Message: mustMarshal(MessageContent{
+				Role:    ri.Role,
+				Content: mustMarshal([]ContentBlock{{Type: "text", Text: fullText}}),
+			}),
+			Raw: json.RawMessage(rawLine),
+		}
+
+	case "reasoning":
+		var summaryText string
+		for _, s := range ri.Summary {
+			summaryText += s.Text + "\n"
+		}
+		return &Entry{
+			UUID:      uuid,
+			Type:      "assistant",
+			Timestamp: ts,
+			Message: mustMarshal(MessageContent{
+				Role:    "assistant",
+				Content: mustMarshal([]ContentBlock{{Type: "thinking", Text: summaryText}}),
+			}),
+			Raw: json.RawMessage(rawLine),
+		}
+
+	case "function_call":
+		return &Entry{
+			UUID:      uuid,
+			Type:      "assistant",
+			Timestamp: ts,
+			Message: mustMarshal(MessageContent{
+				Role: "assistant",
+				Content: mustMarshal([]ContentBlock{{
+					Type: "tool_use",
+					ID:   ri.CallID,
+					Name: ri.Name,
+				}}),
+			}),
+			Raw: json.RawMessage(rawLine),
+		}
+
+	case "function_call_output":
+		return &Entry{
+			UUID:      uuid,
+			Type:      "tool_result",
+			Timestamp: ts,
+			ToolUseID: ri.CallID,
+			Raw:       json.RawMessage(rawLine),
+		}
+	}
+
+	return nil
+}
+
+func codexSessionID(path string) string {
+	base := filepath.Base(path)
+	if ext := filepath.Ext(base); ext != "" {
+		base = base[:len(base)-len(ext)]
+	}
+	return base
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, _ := json.Marshal(v)
+	return data
+}
+
+// Codex JSONL entry types.
+
+type codexRawEntry struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexEntry struct {
+	raw  codexRawEntry
+	line string
+}
+
+type codexEventMsg struct {
+	Type    string `json:"type"`    // user_message, agent_message, agent_reasoning, token_count
+	Message string `json:"message"` // for user_message, agent_message
+	Text    string `json:"text"`    // for agent_reasoning
+}
+
+type codexResponseItem struct {
+	Type    string             `json:"type"` // message, reasoning, function_call, function_call_output
+	Role    string             `json:"role,omitempty"`
+	Content []codexTextContent `json:"content,omitempty"`
+	Summary []codexTextContent `json:"summary,omitempty"`
+	CallID  string             `json:"call_id,omitempty"`
+	Name    string             `json:"name,omitempty"`
+	Output  string             `json:"output,omitempty"`
+}
+
+type codexTextContent struct {
+	Text string `json:"text"`
+}

--- a/internal/sessionlog/gemini_reader.go
+++ b/internal/sessionlog/gemini_reader.go
@@ -1,0 +1,378 @@
+package sessionlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ReadGeminiFile reads a Gemini session JSON file and converts it to the
+// standard Session format used by GC session transcripts.
+//
+// Gemini stores sessions at ~/.gemini/tmp/<project>/chats/session-*.json as a
+// single JSON object with a linear messages[] array.
+func ReadGeminiFile(path string, _ int) (*Session, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		SessionID string            `json:"sessionId"`
+		Messages  []json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	sessionID := strings.TrimSpace(raw.SessionID)
+	if sessionID == "" {
+		sessionID = geminiSessionID(path)
+	}
+
+	var messages []*Entry
+	for idx, rawMessage := range raw.Messages {
+		entry := parseGeminiMessage(rawMessage, idx)
+		if entry == nil {
+			continue
+		}
+		messages = append(messages, entry)
+	}
+
+	return &Session{
+		ID:       sessionID,
+		Messages: messages,
+	}, nil
+}
+
+func parseGeminiMessage(rawMessage json.RawMessage, idx int) *Entry {
+	var message struct {
+		ID        string           `json:"id"`
+		Timestamp string           `json:"timestamp"`
+		Type      string           `json:"type"`
+		Content   json.RawMessage  `json:"content"`
+		Thoughts  []geminiThought  `json:"thoughts"`
+		ToolCalls []geminiToolCall `json:"toolCalls"`
+		Model     string           `json:"model"`
+	}
+	if err := json.Unmarshal(rawMessage, &message); err != nil {
+		return nil
+	}
+
+	ts, _ := time.Parse(time.RFC3339Nano, message.Timestamp)
+	uuid := strings.TrimSpace(message.ID)
+	if uuid == "" {
+		uuid = deterministicGeminiID(rawMessage, idx)
+	}
+
+	switch message.Type {
+	case "user":
+		text := geminiContentText(message.Content)
+		if text == "" {
+			text = strings.TrimSpace(string(message.Content))
+		}
+		return &Entry{
+			UUID:      uuid,
+			Type:      "user",
+			Timestamp: ts,
+			Message:   mustMarshal(MessageContent{Role: "user", Content: mustMarshal(text)}),
+			Raw:       append(json.RawMessage(nil), rawMessage...),
+		}
+	case "info":
+		text := strings.TrimSpace(geminiContentText(message.Content))
+		if text == "" {
+			text = strings.Trim(strings.TrimSpace(string(message.Content)), `"`)
+		}
+		return &Entry{
+			UUID:      uuid,
+			Type:      "system",
+			Timestamp: ts,
+			Message:   mustMarshal(MessageContent{Role: "system", Content: mustMarshal(text)}),
+			Raw:       append(json.RawMessage(nil), rawMessage...),
+		}
+	case "gemini":
+		content := make([]ContentBlock, 0, len(message.Thoughts)+1+len(message.ToolCalls))
+		for _, thought := range message.Thoughts {
+			text := strings.TrimSpace(thought.Description)
+			subject := strings.TrimSpace(thought.Subject)
+			if subject != "" && text != "" {
+				text = subject + ": " + text
+			} else if subject != "" {
+				text = subject
+			}
+			if text == "" {
+				continue
+			}
+			content = append(content, ContentBlock{Type: "thinking", Text: text})
+		}
+
+		if text := strings.TrimSpace(geminiContentText(message.Content)); text != "" {
+			content = append(content, ContentBlock{Type: "text", Text: text})
+		}
+
+		for _, toolCall := range message.ToolCalls {
+			content = append(content, ContentBlock{
+				Type:  "tool_use",
+				ID:    strings.TrimSpace(toolCall.ID),
+				Name:  strings.TrimSpace(toolCall.Name),
+				Input: toolCall.Args,
+			})
+			for _, result := range toolCall.Result {
+				output := strings.TrimSpace(result.FunctionResponse.Response.Output)
+				if output == "" {
+					continue
+				}
+				content = append(content, ContentBlock{
+					Type:      "tool_result",
+					ToolUseID: firstNonEmpty(result.FunctionResponse.ID, toolCall.ID),
+					Content:   mustMarshal(output),
+				})
+			}
+		}
+
+		return &Entry{
+			UUID:      uuid,
+			Type:      "assistant",
+			Timestamp: ts,
+			Message: mustMarshal(MessageContent{
+				Role:    "assistant",
+				Content: mustMarshal(content),
+			}),
+			Raw: append(json.RawMessage(nil), rawMessage...),
+		}
+	default:
+		return nil
+	}
+}
+
+func geminiContentText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		return strings.TrimSpace(plain)
+	}
+
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var texts []string
+		for _, part := range parts {
+			if strings.TrimSpace(part.Text) == "" {
+				continue
+			}
+			texts = append(texts, part.Text)
+		}
+		return strings.TrimSpace(strings.Join(texts, ""))
+	}
+
+	return ""
+}
+
+// FindGeminiSessionFile searches Gemini's tmp sessions directory
+// (~/.gemini/tmp/<project>/chats/session-*.json) for the most recently
+// modified session matching workDir.
+func FindGeminiSessionFile(searchPaths []string, workDir string) string {
+	if workDir == "" {
+		return ""
+	}
+
+	var (
+		bestPath string
+		bestTime time.Time
+	)
+	for _, root := range mergeGeminiSearchPaths(searchPaths) {
+		path := findGeminiSessionFileIn(root, workDir)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if bestPath == "" || info.ModTime().After(bestTime) {
+			bestPath = path
+			bestTime = info.ModTime()
+		}
+	}
+	return bestPath
+}
+
+func findGeminiSessionFileIn(root, workDir string) string {
+	info, err := os.Stat(root)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	var candidates []string
+	if candidate := geminiProjectDir(root, workDir); candidate != "" {
+		candidates = append(candidates, candidate)
+	}
+
+	if geminiProjectRoot(root) == workDir {
+		candidates = append(candidates, root)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dir := filepath.Join(root, entry.Name())
+			if geminiProjectRoot(dir) == workDir {
+				candidates = append(candidates, dir)
+			}
+		}
+	}
+
+	candidates = uniqueStrings(candidates)
+
+	var (
+		bestPath string
+		bestTime time.Time
+	)
+	for _, candidate := range candidates {
+		path := newestGeminiSessionInChats(filepath.Join(candidate, "chats"))
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if bestPath == "" || info.ModTime().After(bestTime) {
+			bestPath = path
+			bestTime = info.ModTime()
+		}
+	}
+
+	return bestPath
+}
+
+func geminiProjectDir(root, workDir string) string {
+	projectsPath := filepath.Join(filepath.Dir(root), "projects.json")
+	data, err := os.ReadFile(projectsPath)
+	if err != nil {
+		return ""
+	}
+
+	var projects struct {
+		Projects map[string]string `json:"projects"`
+	}
+	if err := json.Unmarshal(data, &projects); err != nil {
+		return ""
+	}
+
+	dirName := strings.TrimSpace(projects.Projects[workDir])
+	if dirName == "" {
+		return ""
+	}
+	return filepath.Join(root, dirName)
+}
+
+func geminiProjectRoot(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, ".project_root"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func newestGeminiSessionInChats(chatsDir string) string {
+	entries, err := os.ReadDir(chatsDir)
+	if err != nil {
+		return ""
+	}
+
+	type candidate struct {
+		path    string
+		modTime time.Time
+	}
+	var files []candidate
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(entry.Name(), "session-") || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(chatsDir, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, candidate{path: path, modTime: info.ModTime()})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].modTime.After(files[j].modTime)
+	})
+	if len(files) == 0 {
+		return ""
+	}
+	return files[0].path
+}
+
+func geminiSessionID(path string) string {
+	base := filepath.Base(path)
+	if ext := filepath.Ext(base); ext != "" {
+		base = base[:len(base)-len(ext)]
+	}
+	return base
+}
+
+func deterministicGeminiID(raw json.RawMessage, idx int) string {
+	return fmt.Sprintf("gemini-%d", idx)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+type geminiThought struct {
+	Subject     string `json:"subject"`
+	Description string `json:"description"`
+}
+
+type geminiToolCall struct {
+	ID     string          `json:"id"`
+	Name   string          `json:"name"`
+	Args   json.RawMessage `json:"args"`
+	Result []struct {
+		FunctionResponse struct {
+			ID       string `json:"id"`
+			Response struct {
+				Output string `json:"output"`
+			} `json:"response"`
+		} `json:"functionResponse"`
+	} `json:"result"`
+}

--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -88,6 +88,18 @@ func ReadFile(path string, tailCompactions int) (*Session, error) {
 	return sess, nil
 }
 
+// ReadProviderFile reads a provider-specific transcript file.
+func ReadProviderFile(provider, path string, tailCompactions int) (*Session, error) {
+	switch providerFamily(provider) {
+	case "codex":
+		return ReadCodexFile(path, tailCompactions)
+	case "gemini":
+		return ReadGeminiFile(path, tailCompactions)
+	default:
+		return ReadFile(path, tailCompactions)
+	}
+}
+
 // ReadFileRaw reads a session file without display-type filtering.
 // All DAG-resolved entries are returned, preserving tool_use, progress,
 // and other non-display types. Used by the raw transcript API.
@@ -117,6 +129,21 @@ func ReadFileRaw(path string, tailCompactions int) (*Session, error) {
 	}
 
 	return sess, nil
+}
+
+// ReadProviderFileRaw reads a provider-specific transcript file without
+// display-type filtering. For Codex, the raw JSONL lines are already preserved
+// on each returned entry, so the Codex reader is sufficient for both raw and
+// conversation views.
+func ReadProviderFileRaw(provider, path string, tailCompactions int) (*Session, error) {
+	switch providerFamily(provider) {
+	case "codex":
+		return ReadCodexFile(path, tailCompactions)
+	case "gemini":
+		return ReadGeminiFile(path, tailCompactions)
+	default:
+		return ReadFileRaw(path, tailCompactions)
+	}
 }
 
 // ReadFileOlder loads older messages before a cursor, returning the
@@ -172,6 +199,34 @@ func ReadFileRawOlder(path string, tailCompactions int, beforeMessageID string) 
 		HasBranches:        dag.HasBranches,
 		Pagination:         info,
 	}, nil
+}
+
+// ReadProviderFileOlder reads an older page of a provider-specific transcript.
+// Codex sessions do not currently support message-ID pagination, so the full
+// provider transcript is returned.
+func ReadProviderFileOlder(provider, path string, tailCompactions int, beforeMessageID string) (*Session, error) {
+	switch providerFamily(provider) {
+	case "codex":
+		return ReadCodexFile(path, tailCompactions)
+	case "gemini":
+		return ReadGeminiFile(path, tailCompactions)
+	default:
+		return ReadFileOlder(path, tailCompactions, beforeMessageID)
+	}
+}
+
+// ReadProviderFileRawOlder reads an older page of a provider-specific raw
+// transcript. Codex sessions do not currently support message-ID pagination, so
+// the full provider transcript is returned.
+func ReadProviderFileRawOlder(provider, path string, tailCompactions int, beforeMessageID string) (*Session, error) {
+	switch providerFamily(provider) {
+	case "codex":
+		return ReadCodexFile(path, tailCompactions)
+	case "gemini":
+		return ReadGeminiFile(path, tailCompactions)
+	default:
+		return ReadFileRawOlder(path, tailCompactions, beforeMessageID)
+	}
 }
 
 // parseFile reads all JSONL lines from a file into entries.
@@ -285,7 +340,20 @@ func FindSessionFile(searchPaths []string, workDir string) string {
 		return path
 	}
 	// Fall back to Codex CWD-based lookup.
-	return FindCodexSessionFile(workDir)
+	return FindCodexSessionFile(searchPaths, workDir)
+}
+
+// FindSessionFileForProvider resolves the best available transcript file for a
+// specific provider.
+func FindSessionFileForProvider(searchPaths []string, provider, workDir string) string {
+	switch providerFamily(provider) {
+	case "codex":
+		return FindCodexSessionFile(searchPaths, workDir)
+	case "gemini":
+		return FindGeminiSessionFile(searchPaths, workDir)
+	default:
+		return FindSessionFile(searchPaths, workDir)
+	}
 }
 
 // FindSessionFileByID resolves a Claude-style session log path using the
@@ -343,13 +411,27 @@ func findSlugSessionFile(searchPaths []string, workDir string) string {
 // session file whose embedded cwd matches workDir. Also searches
 // symlinked session directories (e.g., aimux-managed accounts).
 // Returns "" if no match is found or Codex sessions don't exist.
-func FindCodexSessionFile(workDir string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
+func FindCodexSessionFile(searchPaths []string, workDir string) string {
+	if workDir == "" {
 		return ""
 	}
-	sessDir := filepath.Join(home, ".codex", "sessions")
-	return findCodexSessionFileIn(sessDir, workDir)
+	var bestPath string
+	var bestTime int64
+	for _, root := range mergeCodexSearchPaths(searchPaths) {
+		path := findCodexSessionFileIn(root, workDir)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if mt := info.ModTime().UnixNano(); mt > bestTime {
+			bestTime = mt
+			bestPath = path
+		}
+	}
+	return bestPath
 }
 
 // findCodexSessionFileIn searches a Codex sessions directory for the most
@@ -514,9 +596,41 @@ func DefaultSearchPaths() []string {
 	return []string{filepath.Join(home, ".claude", "projects")}
 }
 
+// DefaultCodexSearchPaths returns the default search paths for Codex JSONL
+// session files (~/.codex/sessions).
+func DefaultCodexSearchPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(home, ".codex", "sessions")}
+}
+
+// DefaultGeminiSearchPaths returns the default search paths for Gemini session
+// files (~/.gemini/tmp).
+func DefaultGeminiSearchPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(home, ".gemini", "tmp")}
+}
+
 // MergeSearchPaths merges default paths with user-configured extra paths,
 // expanding ~ and deduplicating.
 func MergeSearchPaths(extraPaths []string) []string {
+	return mergePaths(DefaultSearchPaths(), extraPaths)
+}
+
+func mergeCodexSearchPaths(extraPaths []string) []string {
+	return mergePaths(DefaultCodexSearchPaths(), extraPaths)
+}
+
+func mergeGeminiSearchPaths(extraPaths []string) []string {
+	return mergePaths(DefaultGeminiSearchPaths(), extraPaths)
+}
+
+func mergePaths(defaults, extras []string) []string {
 	seen := make(map[string]bool)
 	var result []string
 	add := func(p string) {
@@ -531,13 +645,25 @@ func MergeSearchPaths(extraPaths []string) []string {
 			result = append(result, p)
 		}
 	}
-	for _, p := range DefaultSearchPaths() {
+	for _, p := range defaults {
 		add(p)
 	}
-	for _, p := range extraPaths {
+	for _, p := range extras {
 		add(p)
 	}
 	return result
+}
+
+func providerFamily(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	switch {
+	case strings.Contains(p, "codex"):
+		return "codex"
+	case strings.Contains(p, "gemini"):
+		return "gemini"
+	default:
+		return p
+	}
 }
 
 // ProjectSlug converts an absolute path to the project directory slug

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -774,6 +774,25 @@ func TestFindCodexSessionFileInPicksNewest(t *testing.T) {
 	}
 }
 
+func TestFindCodexSessionFileUsesObservedRoots(t *testing.T) {
+	sessDir := t.TempDir()
+	workDir := "/data/projects/myproject"
+	dayDir := filepath.Join(sessDir, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	matchFile := filepath.Join(dayDir, "rollout-current.jsonl")
+	meta := fmt.Sprintf(`{"type":"session_meta","payload":{"cwd":"%s"}}`, workDir)
+	if err := os.WriteFile(matchFile, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindCodexSessionFile([]string{sessDir}, workDir)
+	if got != matchFile {
+		t.Errorf("got %q, want %q", got, matchFile)
+	}
+}
+
 func TestCodexSessionCWD(t *testing.T) {
 	dir := t.TempDir()
 	f := filepath.Join(dir, "test.jsonl")
@@ -801,12 +820,100 @@ func TestCodexSessionCWD(t *testing.T) {
 }
 
 func TestFindSessionFileFallsBackToCodex(t *testing.T) {
-	// No slug-based files exist, but a Codex session matches.
-	// We can't easily test FindCodexSessionFile (uses $HOME), but we can
-	// test that FindSessionFile returns empty when neither strategy matches.
+	// No slug-based files exist and no Codex roots match, so resolution should
+	// return empty.
 	got := FindSessionFile([]string{t.TempDir()}, "/nonexistent/codex/project")
 	if got != "" {
 		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestFindGeminiSessionFileUsesObservedRoots(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "tmp")
+	workDir := "/data/projects/myproject"
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	projects := map[string]any{
+		"projects": map[string]string{
+			workDir: "myproject",
+		},
+	}
+	data, err := json.Marshal(projects)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "projects.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(root, "myproject")
+	if err := os.MkdirAll(filepath.Join(projectDir, "chats"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".project_root"), []byte(workDir), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionFile := filepath.Join(projectDir, "chats", "session-2026-03-27T09-00-abc123.json")
+	session := `{"sessionId":"g-123","projectHash":"p-hash","startTime":"2026-03-27T09:00:00Z","lastUpdated":"2026-03-27T09:05:00Z","messages":[]}`
+	if err := os.WriteFile(sessionFile, []byte(session), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindGeminiSessionFile([]string{root}, workDir)
+	if got != sessionFile {
+		t.Errorf("got %q, want %q", got, sessionFile)
+	}
+}
+
+func TestReadGeminiFileConvertsMessages(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	content := `{
+		"sessionId":"g-123",
+		"projectHash":"project",
+		"startTime":"2026-03-27T09:00:00Z",
+		"lastUpdated":"2026-03-27T09:05:00Z",
+		"messages":[
+			{"id":"u1","timestamp":"2026-03-27T09:00:00Z","type":"user","content":[{"text":"Review this diff"}]},
+			{"id":"a1","timestamp":"2026-03-27T09:00:10Z","type":"gemini","content":"Looks good","thoughts":[{"subject":"Scan","description":"Checking regressions"}],"toolCalls":[{"id":"tool-1","name":"grep_search","args":{"pattern":"TODO"},"result":[{"functionResponse":{"id":"tool-1","response":{"output":"Found 2 matches"}}}]}]},
+			{"id":"i1","timestamp":"2026-03-27T09:00:20Z","type":"info","content":"Request cancelled."}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sess, err := ReadGeminiFile(path, 0)
+	if err != nil {
+		t.Fatalf("ReadGeminiFile: %v", err)
+	}
+	if got := len(sess.Messages); got != 3 {
+		t.Fatalf("messages = %d, want 3", got)
+	}
+	if got := sess.Messages[0].Type; got != "user" {
+		t.Fatalf("first type = %q, want user", got)
+	}
+	if got := sess.Messages[0].TextContent(); got != "Review this diff" {
+		t.Fatalf("first text = %q, want %q", got, "Review this diff")
+	}
+	assistantBlocks := sess.Messages[1].ContentBlocks()
+	if len(assistantBlocks) != 4 {
+		t.Fatalf("assistant block count = %d, want 4", len(assistantBlocks))
+	}
+	if assistantBlocks[0].Type != "thinking" {
+		t.Fatalf("assistant first block = %q, want thinking", assistantBlocks[0].Type)
+	}
+	if assistantBlocks[2].Type != "tool_use" || assistantBlocks[2].Name != "grep_search" {
+		t.Fatalf("assistant tool block = %#v, want grep_search tool_use", assistantBlocks[2])
+	}
+	if assistantBlocks[3].Type != "tool_result" || assistantBlocks[3].ToolUseID != "tool-1" {
+		t.Fatalf("assistant result block = %#v, want tool_result for tool-1", assistantBlocks[3])
+	}
+	if got := sess.Messages[2].Type; got != "system" {
+		t.Fatalf("third type = %q, want system", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make session log lookup provider-aware so transcript resolution honors Claude, Codex, and Gemini formats instead of assuming a single transcript layout
- teach Codex and Gemini readers to search configured observed roots and parse their provider-specific transcript files
- route session transcript APIs and `gc session logs` through the new provider-aware lookup path

## Testing
- go test ./internal/sessionlog -run 'TestFindCodexSessionFileUsesObservedRoots|TestFindGeminiSessionFileUsesObservedRoots|TestReadGeminiFileConvertsMessages'\n- go test ./internal/session -run 'TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback'\n- go test ./internal/api -run 'TestHandleSessionTranscriptUsesSessionKey|TestHandleSessionTranscriptClosedSession|TestHandleSessionTranscriptRawIncludesAllTypes'\n- go test ./cmd/gc -run 'TestDoSessionLogs(Basic|CompactBoundary|ToolUse|StringEncodedMessage|ToolResultError|NegativeTail|FollowSeeding)|TestResolveSessionLogContext_ReservedNamedTargetIgnoresClosedHistoricalBead'\n\n## Notes\n- keeps scope limited to transcript lookup/parsing and session transcript surfaces\n- local city observe-path configuration was updated separately on the maintainer machine and is not part of this repo PR