### PR TITLE
fix: show supervisor city init state in status

### DIFF
--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -28,6 +29,7 @@ type ControllerJSON struct {
 	Running bool   `json:"running"`
 	PID     int    `json:"pid,omitempty"`
 	Mode    string `json:"mode,omitempty"`
+	Status  string `json:"status,omitempty"`
 }
 
 // StatusAgentJSON represents an agent in the JSON status output.
@@ -360,13 +362,35 @@ func controllerStatusForCity(cityPath string) ControllerJSON {
 		ctrl := ControllerJSON{Mode: "supervisor"}
 		if pid := supervisorAliveHook(); pid != 0 {
 			ctrl.PID = pid
-			if running, _, known := supervisorCityRunningHook(cityPath); known {
+			if running, status, known := supervisorCityRunningHook(cityPath); known {
 				ctrl.Running = running
+				ctrl.Status = status
 			}
 		}
 		return ctrl
 	}
 	return ControllerJSON{}
+}
+
+func controllerSupervisorStatusText(status string) string {
+	switch status {
+	case "":
+		return "city stopped"
+	case "loading_config":
+		return "loading configuration"
+	case "starting_bead_store":
+		return "starting bead store"
+	case "resolving_formulas":
+		return "resolving formulas"
+	case "adopting_sessions":
+		return "adopting sessions"
+	case "starting_agents":
+		return "starting agents"
+	case "init_failed":
+		return "init failed"
+	default:
+		return strings.ReplaceAll(status, "_", " ")
+	}
 }
 
 func controllerStatusLine(ctrl ControllerJSON) string {
@@ -376,7 +400,7 @@ func controllerStatusLine(ctrl ControllerJSON) string {
 			return fmt.Sprintf("supervisor (PID %d)", ctrl.PID)
 		}
 		if ctrl.PID != 0 {
-			return fmt.Sprintf("supervisor (PID %d, city stopped)", ctrl.PID)
+			return fmt.Sprintf("supervisor (PID %d, %s)", ctrl.PID, controllerSupervisorStatusText(ctrl.Status))
 		}
 		return "supervisor-managed (supervisor not running)"
 	case "standalone":

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -334,6 +334,16 @@ func TestControllerStatusLine(t *testing.T) {
 			want: "supervisor (PID 4321, city stopped)",
 		},
 		{
+			name: "supervisor city starting bead store",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "starting_bead_store"},
+			want: "supervisor (PID 4321, starting bead store)",
+		},
+		{
+			name: "supervisor city init failed",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "init_failed"},
+			want: "supervisor (PID 4321, init failed)",
+		},
+		{
 			name: "supervisor running",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Running: true},
 			want: "supervisor (PID 4321)",

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -326,6 +326,34 @@ func TestControllerStatusForSupervisorManagedCityStopped(t *testing.T) {
 	}
 }
 
+func TestControllerStatusForSupervisorManagedCityPreservesInitStatus(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	oldAlive := supervisorAliveHook
+	oldRunning := supervisorCityRunningHook
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorCityRunningHook = func(string) (bool, string, bool) { return false, "starting_bead_store", true }
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorCityRunningHook = oldRunning
+	})
+
+	ctrl := controllerStatusForCity(cityPath)
+	if ctrl.Running || ctrl.PID != 4242 || ctrl.Mode != "supervisor" || ctrl.Status != "starting_bead_store" {
+		t.Fatalf("controller status = %+v, want init-progress supervisor PID", ctrl)
+	}
+}
+
 func TestCmdStopSupervisorManagedCityReliesOnSupervisorCleanup(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)


### PR DESCRIPTION
## Summary

- Preserve supervisor city init-progress and init-failure state in `gc status` instead of flattening every non-running supervisor-managed city to `city stopped`.
- Render bootstrap states like `starting bead store` and `init failed` on the controller line so restart and startup status is easier to understand.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- Ran `go test ./cmd/gc -run 'Test(ControllerStatusLine|ControllerStatusForSupervisorManagedCityStopped|ControllerStatusForSupervisorManagedCityPreservesInitStatus|CityStatusJSONEmpty)'`

## Checklist

- [x] Linked an issue, or explained why one is not needed: misleading supervisor status found during live debugging
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes: not needed
- [x] Called out breaking changes or migration notes: none
