### PR TITLE
fix: allow closed configured named sessions to release session names

### DIFF
--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -276,7 +276,16 @@ func ensureSessionNameAvailable(store beads.Store, name string) error {
 		}
 		// Explicit session names are permanent identities; once claimed by any
 		// session bead, including a closed one, they are never reused.
+		//
+		// Exception: closed beads that belong to a configured named session
+		// (configured_named_session=true) release their session_name so the
+		// reconciler can re-materialize a fresh canonical bead for the same
+		// identity. The design doc specifies: "Closed historical beads do not
+		// poison future canonical materialization of the reserved identity."
 		if strings.TrimSpace(b.Metadata["session_name"]) == name {
+			if b.Status == "closed" && strings.TrimSpace(b.Metadata["configured_named_session"]) == "true" {
+				continue
+			}
 			return fmt.Errorf("%w: %q already belongs to %s", ErrSessionNameExists, name, b.ID)
 		}
 		if b.Status == "closed" {

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -165,6 +165,58 @@ func TestEnsureSessionNameAvailable_RejectsLiveAliasHistoryCollisions(t *testing
 	}
 }
 
+func TestEnsureSessionNameAvailable_AllowsClosedConfiguredNamedSession(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Create a configured named session bead and close it.
+	bead, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name":              "witness",
+			"configured_named_session":  "true",
+			"configured_named_identity": "myrig/witness",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// A closed configured named session should NOT block reuse of the
+	// session name. The design doc states: "Closed historical beads do not
+	// poison future canonical materialization of the reserved identity."
+	if err := ensureSessionNameAvailable(store, "witness"); err != nil {
+		t.Fatalf("ensureSessionNameAvailable(closed configured named) = %v, want nil", err)
+	}
+}
+
+func TestEnsureSessionNameAvailable_RejectsClosedAdHocSession(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Create an ad-hoc session (no configured_named_session) and close it.
+	bead, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "my-custom-session",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Ad-hoc session names remain permanent even after close.
+	if err := ensureSessionNameAvailable(store, "my-custom-session"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("ensureSessionNameAvailable(closed ad-hoc) = %v, want %v", err, ErrSessionNameExists)
+	}
+}
+
 func TestEnsureAliasAvailableWithConfig_RejectsLiveAliasHistoryCollision(t *testing.T) {
 	store := beads.NewMemStore()
 	_, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary

- Closed beads with `configured_named_session=true` no longer permanently block reuse of their `session_name`
- Ad-hoc session names remain permanent (unchanged behavior)
- Aligns implementation with the named configured sessions design doc: "Closed historical beads do not poison future canonical materialization of the reserved identity"

Fixes #135

## Test plan

- [x] New test: `TestEnsureSessionNameAvailable_AllowsClosedConfiguredNamedSession` — verifies closed configured named session beads release their session name
- [x] New test: `TestEnsureSessionNameAvailable_RejectsClosedAdHocSession` — verifies ad-hoc session names remain permanent
- [x] All existing session name tests pass
- [ ] Manual: restart supervisor with named sessions (witness, refinery) — verify reconciler creates new beads without SQL cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)