### PR TITLE
fix: preserve existing dolt_database in ensure_metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage.txt
 # Pipeline artifacts
 .decompose/
 reports/
+
+# Beads / Dolt files (added by bd init)
+.beads-credential-key

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -571,6 +571,8 @@ ensure_metadata() {
     # Patch missing/wrong fields (preserving other fields).
     # Removes deprecated dolt_server_port and unused dolt_port fields
     # to prevent beads v0.60.0+ deprecation warnings.
+    # NOTE: dolt_database uses //= to preserve existing value — the prefix
+    # and database name may differ (e.g., prefix "gc" but database "gascity").
     local tmp_file
     tmp_file=$(mktemp)
     if jq --arg mode "server" \
@@ -578,7 +580,7 @@ ensure_metadata() {
           --arg user "$DOLT_USER" \
           --arg pass "$DOLT_PASSWORD" \
           --arg prefix "$prefix" \
-          'del(.dolt_server_port, .dolt_port) | .database = "dolt" | .backend = "dolt" | .dolt_mode = $mode | .dolt_database = $prefix | .dolt_host = $host | .dolt_user = $user | if $pass != "" then .dolt_password = $pass else . end' \
+          'del(.dolt_server_port, .dolt_port) | .database = "dolt" | .backend = "dolt" | .dolt_mode = $mode | .dolt_database //= $prefix | .dolt_host = $host | .dolt_user = $user | if $pass != "" then .dolt_password = $pass else . end' \
           "$meta_file" > "$tmp_file" 2>/dev/null; then
         mv "$tmp_file" "$meta_file"
     else


### PR DESCRIPTION
## Summary
- ensure_metadata() unconditionally overwrote .dolt_database with the beads prefix on every startup/reconcile cycle
- Changed .dolt_database = prefix to .dolt_database //= prefix (jq alternative-assignment) so existing values are preserved
- Only sets the field when null or missing

Fixes #145

## Test plan
- Verified with jq: existing value preserved, missing/null gets prefix
- Rebuilt and installed gc locally
- Manual test: metadata.json no longer clobbered after gc start