### PR TITLE
fix: include HQ city bead store in BeadStores() map

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -185,12 +185,17 @@ func (cs *controllerState) BeadStore(rig string) beads.Store {
 	return cs.beadStores[rig]
 }
 
-// BeadStores returns all rig names and their stores.
+// BeadStores returns all rig names and their stores, including the HQ city store.
 func (cs *controllerState) BeadStores() map[string]beads.Store {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
 	// Return a copy to avoid races.
-	m := make(map[string]beads.Store, len(cs.beadStores))
+	m := make(map[string]beads.Store, len(cs.beadStores)+1)
+	// Include the HQ (city-level) bead store so the /v0/beads endpoint
+	// returns beads from the city root, not just from external rigs.
+	if cs.cityBeadStore != nil {
+		m[cs.cityName] = cs.cityBeadStore
+	}
 	for k, v := range cs.beadStores {
 		m[k] = v
 	}


### PR DESCRIPTION
## Summary
- The /v0/beads endpoint only queried per-rig stores built from cfg.Rigs, missing the HQ (city-level) bead store entirely
- Cities with no external rigs returned zero beads despite having an initialized beads database at the city root
- BeadStores() now includes cityBeadStore keyed by cityName so the HQ rig's beads are visible alongside external rig beads

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)