### PR TITLE
fix: expose named session status in session API

### DIFF
--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -47,6 +47,10 @@ type sessionResponse struct {
 	// Activity indicates session turn state: "idle", "in-turn", or omitted.
 	Activity string `json:"activity,omitempty"`
 
+	// ConfiguredNamedSession marks canonical singleton sessions materialized from
+	// [[named_session]] configuration.
+	ConfiguredNamedSession bool `json:"configured_named_session,omitempty"`
+
 	// Metadata exposes mc_-prefixed bead metadata for external consumers.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
@@ -106,6 +110,7 @@ func sessionResponseWithReason(info session.Info, b *beads.Bead, cfg *config.Cit
 	case b.Metadata["held_until"] != "":
 		r.Reason = "user-hold"
 	}
+	r.ConfiguredNamedSession = strings.TrimSpace(b.Metadata[apiNamedSessionMetadataKey]) == "true"
 	// Expose only mc_* prefixed metadata keys to API consumers.
 	// Internal fields (session_key, command, work_dir, etc.) are redacted.
 	r.Metadata = filterMetadata(b.Metadata)

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1156,6 +1156,39 @@ func TestHandleSessionMessageMaterializesNamedSession(t *testing.T) {
 	}
 }
 
+func TestHandleSessionGetIncludesConfiguredNamedSessionFlag(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	spec, ok, err := srv.findNamedSessionSpecForTarget(fs.cityBeadStore, "worker")
+	if err != nil {
+		t.Fatalf("findNamedSessionSpecForTarget: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected named session spec for worker")
+	}
+	id, err := srv.materializeNamedSession(fs.cityBeadStore, spec)
+	if err != nil {
+		t.Fatalf("materializeNamedSession: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v0/session/"+id, nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp sessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.ConfiguredNamedSession {
+		t.Fatal("ConfiguredNamedSession = false, want true")
+	}
+}
+
 func TestHandleSessionMessageInvalidNamedTargetDoesNotMaterialize(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)


### PR DESCRIPTION
## Summary
- Add `configured_named_session` boolean field to session API responses
- Sessions materialized from `[[named_session]]` configuration now expose this flag so dashboards can distinguish canonical singleton sessions from ad-hoc ones
- Includes test coverage for the new field

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)