### PR TITLE
fix: keep supervisor city registrations on startup failures

### DIFF
--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -169,7 +169,7 @@ func registerCityWithSupervisor(cityPath string, stdout, stderr io.Writer, comma
 	fmt.Fprintf(stdout, "Registered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
 
 	if ensureSupervisorRunningHook(stdout, stderr) != 0 {
-		rollbackRegisteredCity(reg, entry, stderr, commandName, "supervisor did not start", false)
+		keepRegisteredCity(entry, stderr, commandName, "supervisor did not start")
 		return 1
 	}
 	if reloadSupervisorHook(io.Discard, io.Discard) != 0 {
@@ -182,11 +182,11 @@ func registerCityWithSupervisor(cityPath string, stdout, stderr io.Writer, comma
 			time.Sleep(250 * time.Millisecond)
 		}
 		if ensureSupervisorRunningHook(stdout, stderr) != 0 {
-			rollbackRegisteredCity(reg, entry, stderr, commandName, "supervisor did not start after retry", false)
+			keepRegisteredCity(entry, stderr, commandName, "supervisor did not start after retry")
 			return 1
 		}
 		if reloadSupervisorHook(stdout, stderr) != 0 {
-			rollbackRegisteredCity(reg, entry, stderr, commandName, "reconcile failed", true)
+			keepRegisteredCity(entry, stderr, commandName, "reconcile failed")
 			return 1
 		}
 	}
@@ -197,7 +197,7 @@ func registerCityWithSupervisor(cityPath string, stdout, stderr io.Writer, comma
 			fmt.Fprintln(stdout, "Waiting for supervisor to start city...") //nolint:errcheck // best-effort stdout
 		}
 		if err := waitForSupervisorCity(cityPath, true, supervisorCityStartTimeout(cityPath), stdout); err != nil {
-			rollbackRegisteredCity(reg, entry, stderr, commandName, err.Error(), true)
+			keepRegisteredCity(entry, stderr, commandName, err.Error())
 			fmt.Fprintf(stderr, "%s: check 'gc supervisor logs' for details\n", commandName) //nolint:errcheck // best-effort stderr
 			return 1
 		}
@@ -205,22 +205,9 @@ func registerCityWithSupervisor(cityPath string, stdout, stderr io.Writer, comma
 	return 0
 }
 
-func rollbackRegisteredCity(reg *supervisor.Registry, entry supervisor.CityEntry, stderr io.Writer, commandName, reason string, stopLaunchedCity bool) {
-	if err := reg.Unregister(entry.Path); err != nil {
-		fmt.Fprintf(stderr, "%s: %s; rollback failed for '%s': %v\n", commandName, reason, entry.Path, err) //nolint:errcheck // best-effort stderr
-		return
-	}
-	fmt.Fprintf(stderr, "%s: %s; registration rolled back for '%s'\n", commandName, reason, entry.EffectiveName()) //nolint:errcheck // best-effort stderr
-	if !stopLaunchedCity || supervisorAliveHook() == 0 {
-		return
-	}
-	if reloadSupervisorHook(io.Discard, stderr) != 0 {
-		fmt.Fprintf(stderr, "%s: registration rolled back for '%s', but stopping the launched city may require 'gc supervisor reload'\n", commandName, entry.EffectiveName()) //nolint:errcheck // best-effort stderr
-		return
-	}
-	if err := waitForSupervisorCity(entry.Path, false, supervisorCityReadyTimeout, nil); err != nil {
-		fmt.Fprintf(stderr, "%s: registration rolled back for '%s', but the launched city may still be stopping: %v\n", commandName, entry.EffectiveName(), err) //nolint:errcheck // best-effort stderr
-	}
+func keepRegisteredCity(entry supervisor.CityEntry, stderr io.Writer, commandName, reason string) {
+	_, _ = fmt.Fprintf(stderr, "%s: %s; keeping registration for '%s' so the supervisor can retry automatically\n",
+		commandName, reason, entry.EffectiveName())
 }
 
 func waitForSupervisorCity(cityPath string, wantRunning bool, timeout time.Duration, stdout io.Writer) error {

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -77,14 +77,14 @@ func TestRegisterCityWithSupervisorRollsBackWhenCityNeverBecomesReady(t *testing
 
 	var stdout, stderr bytes.Buffer
 	code := registerCityWithSupervisor(cityPath, &stdout, &stderr, "gc register", true)
+	// The command reports failure (exit code 1) when the city doesn't start,
+	// but keeps the registration so the supervisor can retry automatically.
 	if code != 1 {
 		t.Fatalf("registerCityWithSupervisor code = %d, want 1", code)
 	}
-	if !strings.Contains(stderr.String(), "registration rolled back") {
-		t.Fatalf("stderr = %q, want rollback message", stderr.String())
-	}
-	if reloads != 2 {
-		t.Fatalf("reloadSupervisorHook called %d times, want 2 (start + rollback cleanup)", reloads)
+	// The key behavioral change: registration is KEPT, not rolled back.
+	if strings.Contains(stderr.String(), "registration rolled back") {
+		t.Fatalf("stderr = %q, should NOT contain rollback message (registration should be kept)", stderr.String())
 	}
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
@@ -92,8 +92,8 @@ func TestRegisterCityWithSupervisorRollsBackWhenCityNeverBecomesReady(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 0 {
-		t.Fatalf("expected empty registry after rollback, got %v", entries)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (kept for retry), got %d", len(entries))
 	}
 }
 

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -297,8 +297,10 @@ kill_imposter() {
     sleep 1
 }
 
-# quarantine_phantom_dbs removes dirs with .dolt/ but missing noms/manifest.
-# A phantom database crashes the entire dolt server on startup.
+# quarantine_phantom_dbs moves dirs with .dolt/ but missing noms/manifest
+# to a quarantine directory. A phantom database crashes the entire dolt
+# server on startup, so it must be removed from DATA_DIR. The data is
+# preserved in case recovery is possible.
 quarantine_phantom_dbs() {
     [ -d "$DATA_DIR" ] || return 0
     local dir
@@ -307,8 +309,10 @@ quarantine_phantom_dbs() {
         if [ -d "$dir/.dolt" ] && [ ! -f "$dir/.dolt/noms/manifest" ]; then
             local name
             name=$(basename "$dir")
-            echo "quarantining phantom database: $name (missing noms/manifest)" >&2
-            rm -rf "$dir"
+            local quarantine_dir="$DATA_DIR/.quarantine/$(date +%Y%m%dT%H%M%S)-$name"
+            mkdir -p "$DATA_DIR/.quarantine"
+            echo "quarantining phantom database: $name (missing noms/manifest) → $quarantine_dir" >&2
+            mv "$dir" "$quarantine_dir"
         fi
     done
 }


### PR DESCRIPTION
## Summary
- Replace rollback-on-failure behavior with keep-registration: when a supervised city fails to start, the registration is preserved so the supervisor can retry automatically
- Remove the `rollbackRegisteredCity` function and replace with simpler `keepRegisteredCity` that logs a message without unregistering
- Quarantine phantom databases to a timestamped directory instead of deleting them, preserving data for potential recovery

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)