### PR TITLE
fix: route all POST /v0/sling through gc sling CLI

### DIFF
--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -1,22 +1,43 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"net/http"
-
-	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/molecule"
-	"github.com/gastownhall/gascity/internal/runtime"
-	"github.com/gastownhall/gascity/internal/telemetry"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
 )
 
+type slingBody struct {
+	Rig            string            `json:"rig"`
+	Target         string            `json:"target"`
+	Bead           string            `json:"bead"`
+	Formula        string            `json:"formula"`
+	AttachedBeadID string            `json:"attached_bead_id"`
+	Title          string            `json:"title"`
+	Vars           map[string]string `json:"vars"`
+}
+
+type slingResponse struct {
+	Status         string `json:"status"`
+	Target         string `json:"target"`
+	Formula        string `json:"formula,omitempty"`
+	Bead           string `json:"bead,omitempty"`
+	WorkflowID     string `json:"workflow_id,omitempty"`
+	RootBeadID     string `json:"root_bead_id,omitempty"`
+	AttachedBeadID string `json:"attached_bead_id,omitempty"`
+	Mode           string `json:"mode,omitempty"`
+}
+
+// slingCommandRunner is the function that executes gc sling as a subprocess.
+// Replaceable in tests.
+var slingCommandRunner = runSlingCommand
+
 func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Rig     string `json:"rig"`
-		Target  string `json:"target"`
-		Bead    string `json:"bead"`
-		Formula string `json:"formula"`
-	}
+	var body slingBody
 	if err := decodeBody(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid", err.Error())
 		return
@@ -27,9 +48,7 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate target agent exists in config.
-	cfg := s.state.Config()
-	agentCfg, ok := findAgent(cfg, body.Target)
-	if !ok {
+	if _, ok := findAgent(s.state.Config(), body.Target); !ok {
 		writeError(w, http.StatusNotFound, "not_found", "target agent "+body.Target+" not found")
 		return
 	}
@@ -42,81 +61,128 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid", "bead and formula are mutually exclusive")
 		return
 	}
-
-	// Derive rig from target agent's config if not explicitly provided.
-	rig := body.Rig
-	if rig == "" {
-		rig = agentCfg.Dir
+	if body.Bead != "" && body.AttachedBeadID != "" {
+		writeError(w, http.StatusBadRequest, "invalid", "bead and attached_bead_id are mutually exclusive")
+		return
 	}
-	store := s.findStore(rig)
-	if store == nil {
-		writeError(w, http.StatusBadRequest, "invalid", "no bead store available")
+	if body.Formula == "" && (body.AttachedBeadID != "" || len(body.Vars) > 0 || body.Title != "") {
+		writeError(w, http.StatusBadRequest, "invalid", "formula is required when attached_bead_id, vars, or title are provided")
 		return
 	}
 
-	// If a bead is specified, assign it to the target agent.
-	if body.Bead != "" {
-		assignee := body.Target
-		if err := store.Update(body.Bead, beads.UpdateOpts{
-			Assignee: &assignee,
-		}); err != nil {
-			writeStoreError(w, err)
-			return
-		}
+	// All sling paths go through `gc sling` CLI to ensure full semantics:
+	// sling query execution, default formula application, auto-convoy,
+	// controller poke, and nudge.
+	resp, status, code, message := s.execSling(r.Context(), body)
+	if code != "" {
+		writeError(w, status, code, message)
+		return
 	}
+	writeJSON(w, status, resp)
+}
 
-	// If a formula is specified, cook a molecule and assign to target.
-	// Note: cook+assign is not atomic — if assign fails after cook, the molecule
-	// exists unassigned. Acceptable for v0 single-process server; true atomicity
-	// requires transactional store operations (future work).
-	if body.Formula != "" {
-		cookResult, err := molecule.Cook(r.Context(), store, body.Formula, cfg.FormulaLayers.SearchPaths(rig), molecule.Options{
-			Title: body.Formula,
-		})
-		if err != nil {
-			writeStoreError(w, err)
-			return
-		}
-		rootID := cookResult.RootID
-		// Assign root bead to target agent (matching bead path semantics).
-		assignee := body.Target
-		if err := store.Update(rootID, beads.UpdateOpts{Assignee: &assignee}); err != nil {
-			writeStoreError(w, err)
-			return
-		}
-		// Nudge target agent.
-		sp := s.state.SessionProvider()
-		sessionName := agentSessionName(s.state.CityName(), body.Target, cfg.Workspace.SessionTemplate)
-		resp := map[string]string{"status": "slung", "molecule": rootID, "target": body.Target}
-		if err := sp.Nudge(sessionName, runtime.TextContent("New molecule assigned: "+rootID)); err != nil {
-			resp["nudge_error"] = err.Error()
-			telemetry.RecordNudge(context.Background(), body.Target, err)
+// execSling builds gc sling CLI args from the request body and shells out.
+// Both plain-bead and formula paths use the same subprocess entry point so
+// the HTTP API has identical semantics to the CLI.
+func (s *Server) execSling(ctx context.Context, body slingBody) (*slingResponse, int, string, string) {
+	args := []string{"--city", s.state.CityPath(), "sling", body.Target}
+
+	isFormula := body.Formula != ""
+	mode := "direct"
+
+	if isFormula {
+		if beadID := strings.TrimSpace(body.AttachedBeadID); beadID != "" {
+			mode = "attached"
+			args = append(args, beadID, "--on", body.Formula)
 		} else {
-			telemetry.RecordNudge(context.Background(), body.Target, nil)
+			mode = "standalone"
+			args = append(args, body.Formula, "--formula")
 		}
-		// Poke unconditionally: even if nudge succeeded, the target may be
-		// asleep and need a reconciler tick to wake via WakeWork. The poke
-		// coalesces via buffered(1) channel so extra pokes are harmless.
-		s.state.Poke()
-		writeJSON(w, http.StatusCreated, resp)
-		return
-	}
-
-	// Nudge the target agent if session provider supports it.
-	sp := s.state.SessionProvider()
-	sessionName := agentSessionName(s.state.CityName(), body.Target, cfg.Workspace.SessionTemplate)
-	resp := map[string]string{"status": "slung", "target": body.Target, "bead": body.Bead}
-	if err := sp.Nudge(sessionName, runtime.TextContent("New work assigned: "+body.Bead)); err != nil {
-		resp["nudge_error"] = err.Error()
-		telemetry.RecordNudge(context.Background(), body.Target, err)
+		if title := strings.TrimSpace(body.Title); title != "" {
+			args = append(args, "--title", title)
+		}
+		if len(body.Vars) > 0 {
+			keys := make([]string, 0, len(body.Vars))
+			for key := range body.Vars {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				args = append(args, "--var", key+"="+body.Vars[key])
+			}
+		}
 	} else {
-		telemetry.RecordNudge(context.Background(), body.Target, nil)
+		// Plain bead sling: gc sling <target> <bead>
+		args = append(args, body.Bead)
 	}
 
-	// Poke unconditionally: even if nudge succeeded, the target may be
-	// asleep and need a reconciler tick to wake via WakeWork. The poke
-	// coalesces via buffered(1) channel so extra pokes are harmless.
-	s.state.Poke()
+	stdout, stderr, err := slingCommandRunner(ctx, s.state.CityPath(), args)
+	if err != nil {
+		message := strings.TrimSpace(stderr)
+		if message == "" {
+			message = strings.TrimSpace(stdout)
+		}
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, http.StatusBadRequest, "invalid", message
+	}
 
-	writeJSON(w, http.StatusOK, resp)
+	resp := &slingResponse{
+		Status: "slung",
+		Target: body.Target,
+		Bead:   body.Bead,
+		Mode:   mode,
+	}
+
+	if isFormula {
+		resp.Formula = body.Formula
+		resp.AttachedBeadID = strings.TrimSpace(body.AttachedBeadID)
+		workflowID := parseWorkflowIDFromSlingOutput(stdout)
+		if workflowID == "" {
+			workflowID = parseWorkflowIDFromSlingOutput(stderr)
+		}
+		if workflowID == "" {
+			return nil, http.StatusInternalServerError, "internal", "gc sling did not report a workflow id"
+		}
+		resp.WorkflowID = workflowID
+		resp.RootBeadID = workflowID
+		return resp, http.StatusCreated, "", ""
+	}
+
+	return resp, http.StatusOK, "", ""
+}
+
+func runSlingCommand(ctx context.Context, cityPath string, args []string) (string, string, error) {
+	gcBin, err := os.Executable()
+	if err != nil {
+		return "", "", err
+	}
+
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, gcBin, args...)
+	cmd.Dir = cityPath
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func parseWorkflowIDFromSlingOutput(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		for _, prefix := range []string{"Started workflow ", "Attached workflow "} {
+			if rest, ok := strings.CutPrefix(line, prefix); ok {
+				workflowID, _, _ := strings.Cut(rest, " ")
+				return strings.TrimSpace(workflowID)
+			}
+		}
+	}
+	return ""
 }

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -1,27 +1,30 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/gastownhall/gascity/internal/beads"
 )
 
 func TestSlingWithBead(t *testing.T) {
 	state := newFakeMutatorState(t)
 	srv := New(state)
 
-	// Create a bead to sling.
-	store := state.stores["myrig"]
-	b, err := store.Create(beads.Bead{Title: "task"})
-	if err != nil {
-		t.Fatalf("create: %v", err)
+	oldRunner := slingCommandRunner
+	defer func() { slingCommandRunner = oldRunner }()
+
+	var gotArgs []string
+	slingCommandRunner = func(_ context.Context, _ string, args []string) (string, string, error) {
+		gotArgs = args
+		return "Slung test-1 → myrig/worker\n", "", nil
 	}
 
-	body := `{"target":"myrig/worker","bead":"` + b.ID + `"}`
+	body := `{"target":"myrig/worker","bead":"test-1"}`
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
 
@@ -35,6 +38,13 @@ func TestSlingWithBead(t *testing.T) {
 	}
 	if resp["status"] != "slung" {
 		t.Fatalf("status = %q, want %q", resp["status"], "slung")
+	}
+	if resp["mode"] != "direct" {
+		t.Fatalf("mode = %q, want %q", resp["mode"], "direct")
+	}
+	// Verify CLI args: --city <path> sling <target> <bead>
+	if len(gotArgs) < 4 || gotArgs[2] != "sling" || gotArgs[3] != "myrig/worker" || gotArgs[4] != "test-1" {
+		t.Fatalf("unexpected args: %v", gotArgs)
 	}
 }
 
@@ -94,12 +104,139 @@ func TestSlingBeadNotFound(t *testing.T) {
 	state := newFakeMutatorState(t)
 	srv := New(state)
 
+	oldRunner := slingCommandRunner
+	defer func() { slingCommandRunner = oldRunner }()
+
+	slingCommandRunner = func(_ context.Context, _ string, _ []string) (string, string, error) {
+		return "", "bead nonexistent not found", errors.New("exit status 1")
+	}
+
 	body := `{"target":"myrig/worker","bead":"nonexistent"}`
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
 
-	// Update on nonexistent bead should return 404 (via writeStoreError).
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	// gc sling returns non-zero for missing beads; HTTP handler surfaces as 400.
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSlingFormulaDelegatesToGcSling(t *testing.T) {
+	state := newFakeMutatorState(t)
+	srv := New(state)
+
+	oldRunner := slingCommandRunner
+	defer func() { slingCommandRunner = oldRunner }()
+
+	var gotCityPath string
+	var gotArgs []string
+	slingCommandRunner = func(_ context.Context, cityPath string, args []string) (string, string, error) {
+		gotCityPath = cityPath
+		gotArgs = append([]string(nil), args...)
+		return "Started workflow wf_123 (formula \"mol-review\") → myrig/worker\n", "", nil
+	}
+
+	body := `{"target":"myrig/worker","formula":"mol-review","vars":{"pr_url":"https://example.test/pr/123"}}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+	if gotCityPath != state.CityPath() {
+		t.Fatalf("cityPath = %q, want %q", gotCityPath, state.CityPath())
+	}
+	wantArgs := []string{
+		"--city", state.CityPath(),
+		"sling", "myrig/worker", "mol-review", "--formula",
+		"--var", "pr_url=https://example.test/pr/123",
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+
+	var resp slingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.WorkflowID != "wf_123" || resp.RootBeadID != "wf_123" {
+		t.Fatalf("response = %+v, want workflow/root wf_123", resp)
+	}
+	if resp.Mode != "standalone" {
+		t.Fatalf("mode = %q, want %q", resp.Mode, "standalone")
+	}
+}
+
+func TestSlingAttachedFormulaDelegatesToGcSling(t *testing.T) {
+	state := newFakeMutatorState(t)
+	srv := New(state)
+
+	oldRunner := slingCommandRunner
+	defer func() { slingCommandRunner = oldRunner }()
+
+	var gotArgs []string
+	slingCommandRunner = func(_ context.Context, _ string, args []string) (string, string, error) {
+		gotArgs = append([]string(nil), args...)
+		return "Attached workflow wf_456 (formula \"mol-review\") to BD-42\n", "", nil
+	}
+
+	body := `{"target":"myrig/worker","formula":"mol-review","attached_bead_id":"BD-42","vars":{"issue":"BD-42"}}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+	wantArgs := []string{
+		"--city", state.CityPath(),
+		"sling", "myrig/worker", "BD-42", "--on", "mol-review",
+		"--var", "issue=BD-42",
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+
+	var resp slingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mode != "attached" || resp.AttachedBeadID != "BD-42" {
+		t.Fatalf("response = %+v, want attached workflow on BD-42", resp)
+	}
+}
+
+func TestSlingRejectsVarsWithoutFormula(t *testing.T) {
+	state := newFakeMutatorState(t)
+	srv := New(state)
+
+	body := `{"target":"myrig/worker","bead":"BD-42","vars":{"issue":"BD-42"}}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSlingFormulaRunnerErrorSurfacesAsBadRequest(t *testing.T) {
+	state := newFakeMutatorState(t)
+	srv := New(state)
+
+	oldRunner := slingCommandRunner
+	defer func() { slingCommandRunner = oldRunner }()
+
+	slingCommandRunner = func(_ context.Context, _ string, _ []string) (string, string, error) {
+		return "", "gc sling: could not resolve session name", errors.New("exit status 1")
+	}
+
+	body := `{"target":"myrig/worker","formula":"mol-review"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "could not resolve session name") {
+		t.Fatalf("body = %s, want session resolution error", rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Unified both plain-bead and formula sling HTTP paths into `execSling()` which shells out to `gc sling` CLI
- Ensures the HTTP API has identical semantics to the CLI: sling query execution, default formula application, auto-convoy, controller poke, and nudge
- Removes direct store.Update + molecule.Cook inline handler in favor of subprocess approach

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)