### PR TITLE
fix: harden supervisor city restarts

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -440,6 +440,83 @@ func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
 	}
 }
 
+func TestGcBeadsBdInitRetriesRootStoreVerification(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"mc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script, err := MaterializeBeadsBdScript(cityPath)
+	if err != nil {
+		t.Fatalf("MaterializeBeadsBdScript: %v", err)
+	}
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	listCountFile := filepath.Join(t.TempDir(), "bd-list-count")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := `#!/bin/sh
+set -eu
+count_file="` + listCountFile + `"
+cmd="${1:-}"
+case "$cmd" in
+  list)
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(cat "$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$count_file"
+    if [ "$count" -lt 3 ]; then
+      exit 1
+    fi
+    exit 0
+    ;;
+  config)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "mc")
+	cmd.Env = append(os.Environ(),
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(listCountFile)
+	if err != nil {
+		t.Fatalf("read list retry count: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "3" {
+		t.Fatalf("expected bd list to retry until third attempt, got %q", strings.TrimSpace(string(data)))
+	}
+}
+
 func listenOnRandomPort(t *testing.T) net.Listener {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -331,20 +331,10 @@ type managedCity struct {
 }
 
 func managedCityStopTimeout(mc *managedCity) time.Duration {
-	timeout := supervisorCityReadyTimeout
 	if mc == nil || mc.cr == nil || mc.cr.cfg == nil {
-		return timeout
+		return 5 * time.Second
 	}
-	if startup := mc.cr.cfg.Session.StartupTimeoutDuration(); startup > timeout {
-		timeout = startup
-	}
-	if shutdown := mc.cr.cfg.Daemon.ShutdownTimeoutDuration(); shutdown > timeout {
-		timeout = shutdown
-	}
-	if drain := mc.cr.cfg.Daemon.DriftDrainTimeoutDuration(); drain > timeout {
-		timeout = drain
-	}
-	return timeout
+	return mc.cr.cfg.Daemon.ShutdownTimeoutDuration()
 }
 
 func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
@@ -353,13 +343,12 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
 	}
 	mc.cancel()
 	timeout := managedCityStopTimeout(mc)
-	if timeout <= 0 {
-		timeout = supervisorCityReadyTimeout
-	}
-	select {
-	case <-mc.done:
-	case <-time.After(timeout):
-		fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after cancel; forcing shutdown\n", mc.name, timeout) //nolint:errcheck
+	if timeout > 0 {
+		select {
+		case <-mc.done:
+		case <-time.After(timeout):
+			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after cancel; forcing shutdown\n", mc.name, timeout) //nolint:errcheck
+		}
 	}
 	if mc.cr != nil {
 		func() {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -414,12 +414,6 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	script := writeSpyScript(t, logFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
 
-	oldReadyTimeout := supervisorCityReadyTimeout
-	supervisorCityReadyTimeout = 20 * time.Millisecond
-	t.Cleanup(func() {
-		supervisorCityReadyTimeout = oldReadyTimeout
-	})
-
 	closer := &closerSpy{}
 	mc := &managedCity{
 		name:   "bright-lights",
@@ -449,6 +443,55 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "did not exit within") {
 		t.Fatalf("stderr = %q, want forced-timeout warning", stderr.String())
+	}
+	if !closer.closed {
+		t.Fatal("expected closer to be closed after forced cleanup")
+	}
+
+	ops := readOpLog(t, logFile)
+	if len(ops) != 1 {
+		t.Fatalf("expected bead provider stop, got %v", ops)
+	}
+	if !strings.HasPrefix(ops[0], "stop") {
+		t.Fatalf("unexpected bead provider op: %v", ops)
+	}
+}
+
+func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
+	cityPath := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "ops.log")
+	script := writeSpyScript(t, logFile)
+	t.Setenv("GC_BEADS", "exec:"+script)
+
+	closer := &closerSpy{}
+	mc := &managedCity{
+		name:   "bright-lights",
+		cancel: func() {},
+		done:   make(chan struct{}),
+		closer: closer,
+		cr: &CityRuntime{
+			cfg: &config.City{
+				Session: config.SessionConfig{StartupTimeout: "3m"},
+				Daemon: config.DaemonConfig{
+					ShutdownTimeout:   "20ms",
+					DriftDrainTimeout: "2m",
+				},
+			},
+			sp:     runtime.NewFake(),
+			rec:    events.Discard,
+			stdout: io.Discard,
+			stderr: io.Discard,
+		},
+	}
+
+	var stderr bytes.Buffer
+	start := time.Now()
+	stopManagedCity(mc, cityPath, &stderr)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("stopManagedCity took %s, want shutdown-timeout bound", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "20ms") {
+		t.Fatalf("stderr = %q, want shutdown-timeout warning", stderr.String())
 	}
 	if !closer.closed {
 		t.Fatal("expected closer to be closed after forced cleanup")

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -673,7 +673,11 @@ op_start() {
         fi
         # Server process exists but unreachable — kill it and start fresh.
         kill -9 "$existing_pid" 2>/dev/null || true
-        sleep 1
+        local waited=0
+        while [ "$waited" -lt 20 ] && kill -0 "$existing_pid" 2>/dev/null; do
+            sleep 0.5 2>/dev/null || sleep 1
+            waited=$((waited + 1))
+        done
     fi
 
     # Check if a process already holds the port.
@@ -712,9 +716,10 @@ op_start() {
     # Save state.
     save_state "$server_pid" true
 
-    # Wait for server: combined PID alive + TCP reachable check.
+    # Wait for server: combined PID alive + TCP reachable + query-ready check.
     # 60 iterations × 500ms = 30s max. Large data dirs with many databases
-    # can take 10-20s to start.
+    # can take 10-20s to start, and the TCP listener can come up before
+    # the SQL layer is ready to answer queries.
     local attempt=0
     while [ "$attempt" -lt 60 ]; do
         # Fail fast if process crashed during startup.
@@ -724,8 +729,8 @@ op_start() {
             die "dolt server exited during startup (check $LOG_FILE)"
         fi
 
-        # Check TCP reachability.
-        if tcp_check; then
+        # Check TCP reachability and a lightweight query probe.
+        if tcp_check && do_query_probe; then
             break
         fi
         sleep 0.5 2>/dev/null || sleep 1
@@ -737,7 +742,7 @@ op_start() {
         kill "$server_pid" 2>/dev/null || true
         rm -f "$PID_FILE"
         save_state 0 false
-        die "dolt server started (PID $server_pid) but not accepting connections after 30s (check $LOG_FILE)"
+        die "dolt server started (PID $server_pid) but did not become query-ready after 30s (check $LOG_FILE)"
     fi
 
     # Sync port files to city and all rig .beads/ directories so agents
@@ -788,8 +793,17 @@ YAML
 # bd init wrote the database somewhere else.
 verify_root_store() {
     local beads_dir="$1"
+    local attempt=0
 
-    BEADS_DIR="$beads_dir" bd list --limit 1 --no-pager >/dev/null 2>&1
+    while [ "$attempt" -lt 20 ]; do
+        if BEADS_DIR="$beads_dir" bd list --limit 1 --no-pager >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.5 2>/dev/null || sleep 1
+        attempt=$((attempt + 1))
+    done
+
+    return 1
 }
 
 # op_init initializes beads in a directory.


### PR DESCRIPTION
## Summary
- Simplify `managedCityStopTimeout` to use only the shutdown timeout (not startup or drift drain timeouts) so city stops are bounded tightly
- Add retry loop for root store verification in `gc-beads-bd` init to handle slow bead store startup
- Add poll-based wait when killing stale dolt server PIDs, and require query-readiness (not just TCP reachability) before declaring the server started

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)