### PR TITLE
feat: add description_file to formula steps

### DIFF
--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -112,6 +112,11 @@ func (p *Parser) ParseFile(path string) (*Formula, error) {
 	// Set source tracing info on all steps (gt-8tmz.18)
 	SetSourceInfo(formula)
 
+	// Resolve description_file references relative to the formula file's directory.
+	formulaDir := filepath.Dir(absPath)
+	resolveDescriptionFiles(formula.Steps, formulaDir)
+	resolveDescriptionFiles(formula.Template, formulaDir)
+
 	p.cache[absPath] = formula
 
 	// Also cache by name for extends resolution
@@ -469,6 +474,32 @@ func ApplyDefaults(formula *Formula, values map[string]string) map[string]string
 
 // SetSourceInfo sets SourceFormula and SourceLocation on all steps in a formula.
 // Called after parsing to enable source tracing during cooking (gt-8tmz.18).
+// resolveDescriptionFiles walks all steps and replaces DescriptionFile
+// with the file's contents. Paths are resolved relative to baseDir
+// (the formula file's directory).
+func resolveDescriptionFiles(steps []*Step, baseDir string) {
+	for _, step := range steps {
+		if step == nil || step.DescriptionFile == "" {
+			continue
+		}
+		path := step.DescriptionFile
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(baseDir, path)
+		}
+		// #nosec G304 -- path comes from formula author, same trust as description
+		data, err := os.ReadFile(path)
+		if err == nil {
+			step.Description = string(data)
+		}
+		step.DescriptionFile = "" // consumed; don't serialize
+		if len(step.Children) > 0 {
+			resolveDescriptionFiles(step.Children, baseDir)
+		}
+	}
+	// Also handle template steps (expansion formulas).
+}
+
+// SetSourceInfo populates SourceFormula and SourceLocation on all steps in the formula.
 func SetSourceInfo(formula *Formula) {
 	setSourceInfoRecursive(formula.Steps, formula.Formula, "steps")
 	// Also set source info on template steps for expansion formulas

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -197,6 +197,11 @@ type Step struct {
 	// Description is the issue description (supports substitution).
 	Description string `json:"description,omitempty"`
 
+	// DescriptionFile is a path to a file whose contents replace Description.
+	// Resolved relative to the formula file's directory at compile time.
+	// If both Description and DescriptionFile are set, DescriptionFile wins.
+	DescriptionFile string `json:"description_file,omitempty" toml:"description_file,omitempty"`
+
 	// Notes are additional notes for the issue (supports substitution).
 	Notes string `json:"notes,omitempty"`
 


### PR DESCRIPTION
## Summary
- Steps can now use `description_file = "path/to/prompt.md"` instead of inline `description = """..."""` in formula TOML files
- File is read at compile time relative to the formula file's directory and inlined into the step's description field
- Works for both regular steps and expansion template steps

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)