### PR TITLE
fix: pin city-scoped bd commands to city store

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -25,6 +26,9 @@ func bdStoreForDir(dir string) *beads.BdStore {
 
 func bdRuntimeEnv(cityPath string) map[string]string {
 	env := citylayout.CityRuntimeEnvMap(cityPath)
+	env["BEADS_DIR"] = filepath.Join(cityPath, ".beads")
+	env["GC_RIG"] = ""
+	env["GC_RIG_ROOT"] = ""
 	if rawBeadsProvider(cityPath) != "bd" {
 		return env
 	}
@@ -66,12 +70,15 @@ func cityForStoreDir(dir string) string {
 
 func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 	keys := []string{
+		"BEADS_DIR",
 		"GC_CITY",
 		"GC_CITY_ROOT",
 		"GC_CITY_PATH",
 		"GC_CITY_RUNTIME_DIR",
 		"GC_DOLT_PORT",
 		"GC_PACK_STATE_DIR",
+		"GC_RIG",
+		"GC_RIG_ROOT",
 	}
 	if len(overrides) > 0 {
 		for key := range overrides {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -41,10 +41,13 @@ func TestOpenStoreAtForCityUsesExplicitCityForExternalRig(t *testing.T) {
 
 func TestMergeRuntimeEnvReplacesInheritedRuntimeKeys(t *testing.T) {
 	env := mergeRuntimeEnv([]string{
+		"BEADS_DIR=/rig/.beads",
 		"PATH=/bin",
 		"GC_CITY_PATH=/wrong",
 		"GC_DOLT_PORT=9999",
 		"GC_PACK_STATE_DIR=/wrong/.gc/runtime/packs/dolt",
+		"GC_RIG=demo",
+		"GC_RIG_ROOT=/rig",
 	}, map[string]string{
 		"GC_CITY_PATH": "/city",
 		"GC_DOLT_PORT": "31364",
@@ -64,7 +67,54 @@ func TestMergeRuntimeEnvReplacesInheritedRuntimeKeys(t *testing.T) {
 	if got["GC_DOLT_PORT"] != "31364" {
 		t.Fatalf("GC_DOLT_PORT = %q, want %q", got["GC_DOLT_PORT"], "31364")
 	}
+	if _, ok := got["BEADS_DIR"]; ok {
+		t.Fatalf("BEADS_DIR should be removed, env = %#v", got)
+	}
 	if _, ok := got["GC_PACK_STATE_DIR"]; ok {
 		t.Fatalf("GC_PACK_STATE_DIR should be removed, env = %#v", got)
+	}
+	if _, ok := got["GC_RIG"]; ok {
+		t.Fatalf("GC_RIG should be removed, env = %#v", got)
+	}
+	if _, ok := got["GC_RIG_ROOT"]; ok {
+		t.Fatalf("GC_RIG_ROOT should be removed, env = %#v", got)
+	}
+}
+
+func TestBdCommandRunnerForCityPinsCityStoreEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("BEADS_DIR", "/rig/.beads")
+	t.Setenv("GC_RIG", "demo-rig")
+	t.Setenv("GC_RIG_ROOT", "/rig")
+
+	runner := bdCommandRunnerForCity(cityDir)
+	out, err := runner(cityDir, "sh", "-c", `printf '%s\n%s\n%s\n%s\n' "$GC_CITY_PATH" "$BEADS_DIR" "$GC_RIG" "$GC_RIG_ROOT"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(string(out), "\n")
+	if len(lines) != 5 {
+		t.Fatalf("lines = %q, want 5 lines including trailing newline", string(out))
+	}
+	lines = lines[:4]
+	if len(lines) != 4 {
+		t.Fatalf("lines = %q, want 4 lines", string(out))
+	}
+	if lines[0] != cityDir {
+		t.Fatalf("GC_CITY_PATH = %q, want %q", lines[0], cityDir)
+	}
+	if lines[1] != filepath.Join(cityDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", lines[1], filepath.Join(cityDir, ".beads"))
+	}
+	if lines[2] != "" {
+		t.Fatalf("GC_RIG = %q, want empty", lines[2])
+	}
+	if lines[3] != "" {
+		t.Fatalf("GC_RIG_ROOT = %q, want empty", lines[3])
 	}
 }


### PR DESCRIPTION
## Summary
- Set `BEADS_DIR` to the city's `.beads` directory and clear `GC_RIG`/`GC_RIG_ROOT` in `bdRuntimeEnv` so city-scoped bd commands always target the city store, not a rig store inherited from the environment
- Add `BEADS_DIR`, `GC_RIG`, and `GC_RIG_ROOT` to the `mergeRuntimeEnv` key list so inherited rig-scoped values are properly stripped
- Add `TestBdCommandRunnerForCityPinsCityStoreEnv` to verify the env pinning behavior

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)