### PR TITLE
fix: allow symlinks in ralph check script paths

### DIFF
--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -112,35 +112,23 @@ func ResolveConditionPath(cityPath, conditionPath string) (string, error) {
 		}
 	}
 
-	// Check the file exists.
-	info, err := os.Lstat(absPath)
-	if err != nil {
-		return "", fmt.Errorf("resolving gate condition path: %w", err)
-	}
-
-	// Reject symlinks (checked first since Lstat reports ModeSymlink,
-	// which would otherwise fall through as "not a regular file").
-	if info.Mode()&os.ModeSymlink != 0 {
-		return "", fmt.Errorf("resolving gate condition path: symlinks not allowed: %s", absPath)
-	}
-
-	// Reject non-regular files (directories, devices, etc.).
-	if !info.Mode().IsRegular() {
-		return "", fmt.Errorf("resolving gate condition path: not a regular file: %s", absPath)
-	}
-
-	// Reject non-executable files.
-	if info.Mode().Perm()&0o111 == 0 {
-		return "", fmt.Errorf("resolving gate condition path: file is not executable: %s", absPath)
-	}
-
-	// Double-check via EvalSymlinks to catch symlinks in parent directories.
+	// Resolve symlinks to the real path. Scripts may be symlinked from
+	// a shared tooling directory (e.g., ~/tooling/scripts/).
 	resolved, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
 		return "", fmt.Errorf("resolving gate condition path: %w", err)
 	}
-	if resolved != absPath {
-		return "", fmt.Errorf("resolving gate condition path: symlinks not allowed: %s resolves to %s", absPath, resolved)
+
+	// Check the resolved file exists and is a regular executable.
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolving gate condition path: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("resolving gate condition path: not a regular file: %s", resolved)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("resolving gate condition path: file is not executable: %s", resolved)
 	}
 
 	return absPath, nil

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -144,7 +144,7 @@ func TestResolveConditionPath(t *testing.T) {
 		}
 	})
 
-	t.Run("symlink rejection", func(t *testing.T) {
+	t.Run("symlink allowed", func(t *testing.T) {
 		dir := t.TempDir()
 		realScript := filepath.Join(dir, "real.sh")
 		link := filepath.Join(dir, "link.sh")
@@ -156,12 +156,12 @@ func TestResolveConditionPath(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := ResolveConditionPath(dir, "link.sh")
-		if err == nil {
-			t.Fatal("expected error for symlink, got nil")
+		got, err := ResolveConditionPath(dir, "link.sh")
+		if err != nil {
+			t.Fatalf("unexpected error for symlink: %v", err)
 		}
-		if !strings.Contains(err.Error(), "symlink") {
-			t.Errorf("expected symlink error, got: %v", err)
+		if got != link {
+			t.Errorf("got %q, want %q", got, link)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Replace symlink rejection with symlink resolution in `ResolveConditionPath`: scripts symlinked from shared tooling directories (e.g., `~/tooling/scripts/`) are now followed and validated at the target
- Use `filepath.EvalSymlinks` first, then validate the resolved target is a regular executable file
- Update the test from "symlink rejection" to "symlink allowed" to match the new behavior

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)