### PR TITLE
fix: preserve formula bead priorities and edits

### DIFF
--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"sort"
 
@@ -137,6 +139,7 @@ func (s *Server) handleBeadCreate(w http.ResponseWriter, r *http.Request) {
 		Rig         string   `json:"rig"`
 		Title       string   `json:"title"`
 		Type        string   `json:"type"`
+		Priority    *int     `json:"priority"`
 		Assignee    string   `json:"assignee"`
 		Description string   `json:"description"`
 		Labels      []string `json:"labels"`
@@ -170,6 +173,7 @@ func (s *Server) handleBeadCreate(w http.ResponseWriter, r *http.Request) {
 	b, err := store.Create(beads.Bead{
 		Title:       body.Title,
 		Type:        body.Type,
+		Priority:    body.Priority,
 		Assignee:    body.Assignee,
 		Description: body.Description,
 		Labels:      body.Labels,
@@ -204,18 +208,35 @@ func (s *Server) handleBeadClose(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadUpdate(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	payload, err := decodeBodyBytes(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	var raw map[string]json.RawMessage
+	if len(bytes.TrimSpace(payload)) > 0 {
+		if err := json.Unmarshal(payload, &raw); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid", err.Error())
+			return
+		}
+	}
 	var body struct {
 		Title        *string           `json:"title"`
 		Status       *string           `json:"status"`
 		Type         *string           `json:"type"`
+		Priority     *int              `json:"priority"`
 		Assignee     *string           `json:"assignee"`
 		Description  *string           `json:"description"`
 		Labels       []string          `json:"labels"`
 		RemoveLabels []string          `json:"remove_labels"`
 		Metadata     map[string]string `json:"metadata"`
 	}
-	if err := decodeBody(r, &body); err != nil {
+	if err := json.Unmarshal(payload, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		return
+	}
+	if rawPriority, ok := raw["priority"]; ok && bytes.Equal(bytes.TrimSpace(rawPriority), []byte("null")) {
+		writeError(w, http.StatusBadRequest, "invalid", "clearing priority is not supported")
 		return
 	}
 
@@ -224,6 +245,7 @@ func (s *Server) handleBeadUpdate(w http.ResponseWriter, r *http.Request) {
 		Title:        body.Title,
 		Status:       body.Status,
 		Type:         body.Type,
+		Priority:     body.Priority,
 		Assignee:     body.Assignee,
 		Description:  body.Description,
 		Labels:       body.Labels,
@@ -396,4 +418,9 @@ func sortedRigNames(stores map[string]beads.Store) []string {
 func decodeBody(r *http.Request, v any) error {
 	r.Body = http.MaxBytesReader(nil, r.Body, 1<<20) // 1 MiB
 	return json.NewDecoder(r.Body).Decode(v)
+}
+
+func decodeBodyBytes(r *http.Request) ([]byte, error) {
+	r.Body = http.MaxBytesReader(nil, r.Body, 1<<20) // 1 MiB
+	return io.ReadAll(r.Body)
 }

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -209,6 +209,49 @@ func TestBeadPatchAlias(t *testing.T) {
 	}
 }
 
+func TestBeadUpdatePriority(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	b, _ := store.Create(beads.Bead{Title: "Test"})
+	srv := New(state)
+
+	body := `{"priority":1}`
+	req := newPostRequest("/v0/bead/"+b.ID+"/update", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	got, _ := store.Get(b.ID)
+	if got.Priority == nil || *got.Priority != 1 {
+		t.Fatalf("Priority = %v, want 1", got.Priority)
+	}
+}
+
+func TestBeadUpdateRejectsNullPriority(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	priority := 1
+	b, _ := store.Create(beads.Bead{Title: "Test", Priority: &priority})
+	srv := New(state)
+
+	body := `{"priority":null}`
+	req := newPostRequest("/v0/bead/"+b.ID+"/update", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("update status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	got, _ := store.Get(b.ID)
+	if got.Priority == nil || *got.Priority != 1 {
+		t.Fatalf("Priority = %v, want unchanged 1", got.Priority)
+	}
+}
+
 func TestBeadReopen(t *testing.T) {
 	state := newFakeState(t)
 	store := state.stores["myrig"]

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -446,6 +447,9 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 	}
 	if opts.Type != nil {
 		args = append(args, "--type", *opts.Type)
+	}
+	if opts.Priority != nil {
+		args = append(args, "--priority", strconv.Itoa(*opts.Priority))
 	}
 	if opts.Description != nil {
 		args = append(args, "--description", *opts.Description)

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -363,6 +363,23 @@ func TestBdStoreUpdateEmptyOpts(t *testing.T) {
 	}
 }
 
+func TestBdStoreUpdatePassesPriority(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"bd-42","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	priority := 0
+	if err := s.Update("bd-42", beads.UpdateOpts{Priority: &priority}); err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--priority 0") {
+		t.Fatalf("args = %q, want priority flag", args)
+	}
+}
+
 func TestBdStoreCloseCLIError(t *testing.T) {
 	// CLI error should NOT be wrapped as ErrNotFound.
 	runner := func(_, _ string, _ ...string) ([]byte, error) {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -17,6 +17,7 @@ type Bead struct {
 	Title       string            `json:"title"`
 	Status      string            `json:"status"` // "open", "in_progress", "closed"
 	Type        string            `json:"type"`   // "task" default
+	Priority    *int              `json:"priority,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
 	Assignee    string            `json:"assignee,omitempty"`
 	From        string            `json:"from,omitempty"`
@@ -33,12 +34,21 @@ type UpdateOpts struct {
 	Title        *string // set title (nil = no change)
 	Status       *string // set status (nil = no change)
 	Type         *string // set issue type (nil = no change)
+	Priority     *int    // set priority (nil = no change)
 	Description  *string
 	ParentID     *string
 	Assignee     *string  // set assignee (nil = no change)
 	Labels       []string // append these labels (nil = no change)
 	RemoveLabels []string // remove these labels (nil = no change)
 	Metadata     map[string]string
+}
+
+func cloneIntPtr(v *int) *int {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
 }
 
 // containerTypes enumerates bead types that group child beads for

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -395,8 +395,10 @@ esac
 	s := NewStore(script)
 
 	desc := "new description"
+	priority := 2
 	err := s.Update("EX-1", beads.UpdateOpts{
 		Description: &desc,
+		Priority:    &priority,
 		Labels:      []string{"extra"},
 	})
 	if err != nil {
@@ -410,6 +412,9 @@ esac
 	stdin := string(data)
 	if !strings.Contains(stdin, `"description":"new description"`) {
 		t.Errorf("stdin missing description, got: %s", stdin)
+	}
+	if !strings.Contains(stdin, `"priority":2`) {
+		t.Errorf("stdin missing priority, got: %s", stdin)
 	}
 	if !strings.Contains(stdin, `"extra"`) {
 		t.Errorf("stdin missing label, got: %s", stdin)

--- a/internal/beads/exec/json.go
+++ b/internal/beads/exec/json.go
@@ -31,6 +31,7 @@ type createRequest struct {
 type updateRequest struct {
 	Title        *string           `json:"title,omitempty"`
 	Status       *string           `json:"status,omitempty"`
+	Priority     *int              `json:"priority,omitempty"`
 	Description  *string           `json:"description,omitempty"`
 	ParentID     *string           `json:"parent_id,omitempty"`
 	Assignee     *string           `json:"assignee,omitempty"`
@@ -79,6 +80,7 @@ func marshalUpdate(opts beads.UpdateOpts) ([]byte, error) {
 	r := updateRequest{
 		Title:        opts.Title,
 		Status:       opts.Status,
+		Priority:     opts.Priority,
 		Description:  opts.Description,
 		ParentID:     opts.ParentID,
 		Assignee:     opts.Assignee,

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -116,6 +116,9 @@ func (m *MemStore) Update(id string, opts UpdateOpts) error {
 			if opts.Description != nil {
 				m.beads[i].Description = *opts.Description
 			}
+			if opts.Priority != nil {
+				m.beads[i].Priority = cloneIntPtr(opts.Priority)
+			}
 			if opts.ParentID != nil {
 				m.beads[i].ParentID = *opts.ParentID
 			}


### PR DESCRIPTION
## Summary
- Add `Priority *int` field to `Bead` struct for priority-aware bead creation and tracking
- Add `Priority` to `UpdateOpts` with `strconv`-based bd CLI passthrough
- Improve `handleBeadUpdate` API to parse raw JSON for null detection and priority support

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)