### PR TITLE
fix: route bead lookups by prefix

### DIFF
--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -91,10 +94,7 @@ func (s *Server) handleBeadReady(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadGet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	stores := s.state.BeadStores()
-
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		b, err := store.Get(id)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
@@ -111,10 +111,7 @@ func (s *Server) handleBeadGet(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadDeps(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	stores := s.state.BeadStores()
-
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		children, err := store.Children(id)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
@@ -185,10 +182,7 @@ func (s *Server) handleBeadCreate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadClose(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	stores := s.state.BeadStores()
-
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		if err := store.Close(id); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
@@ -219,7 +213,6 @@ func (s *Server) handleBeadUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stores := s.state.BeadStores()
 	opts := beads.UpdateOpts{
 		Title:        body.Title,
 		Status:       body.Status,
@@ -230,8 +223,7 @@ func (s *Server) handleBeadUpdate(w http.ResponseWriter, r *http.Request) {
 		RemoveLabels: body.RemoveLabels,
 	}
 
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		if err := store.Update(id, opts); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
@@ -254,11 +246,9 @@ func (s *Server) handleBeadUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadReopen(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	stores := s.state.BeadStores()
 	status := "open"
 
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		b, err := store.Get(id)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
@@ -291,9 +281,7 @@ func (s *Server) handleBeadAssign(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stores := s.state.BeadStores()
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		if err := store.Update(id, beads.UpdateOpts{Assignee: &body.Assignee}); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
@@ -309,10 +297,7 @@ func (s *Server) handleBeadAssign(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadDelete(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	stores := s.state.BeadStores()
-
-	for _, rigName := range sortedRigNames(stores) {
-		store := stores[rigName]
+	for _, store := range s.beadStoresForID(id) {
 		if err := store.Close(id); err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
@@ -365,6 +350,117 @@ func (s *Server) findStore(rig string) beads.Store {
 		return stores[names[0]]
 	}
 	return nil
+}
+
+// beadStoresForID resolves the authoritative store for a bead ID using its
+// prefix/routes mapping when possible. If there is no routed match, it falls
+// back to the legacy store scan order.
+func (s *Server) beadStoresForID(id string) []beads.Store {
+	if prefix := beadPrefix(strings.TrimSpace(id)); prefix != "" {
+		if store := s.resolveStoreByPrefix(prefix); store != nil {
+			return []beads.Store{store}
+		}
+	}
+
+	stores := s.state.BeadStores()
+	rigNames := sortedRigNames(stores)
+	candidates := make([]beads.Store, 0, len(rigNames))
+	for _, rigName := range rigNames {
+		candidates = append(candidates, stores[rigName])
+	}
+	return candidates
+}
+
+// resolveStoreByPrefix finds the rig store that owns a bead prefix
+// by checking each rig's routes.jsonl file and mapping the resolved
+// store path back to the correct rig.
+func (s *Server) resolveStoreByPrefix(prefix string) beads.Store {
+	cfg := s.state.Config()
+	if cfg == nil {
+		return nil
+	}
+	stores := s.state.BeadStores()
+	cityPath := strings.TrimSpace(s.state.CityPath())
+
+	// Build rig path -> name map for reverse lookup.
+	rigPathToName := make(map[string]string, len(cfg.Rigs))
+	for _, rig := range cfg.Rigs {
+		rp := strings.TrimSpace(rig.Path)
+		if rp == "" {
+			continue
+		}
+		if !filepath.IsAbs(rp) && cityPath != "" {
+			rp = filepath.Join(cityPath, rp)
+		}
+		rigPathToName[filepath.Clean(rp)] = rig.Name
+	}
+
+	for _, rig := range cfg.Rigs {
+		rigPath := strings.TrimSpace(rig.Path)
+		if rigPath == "" {
+			continue
+		}
+		if !filepath.IsAbs(rigPath) && cityPath != "" {
+			rigPath = filepath.Join(cityPath, rigPath)
+		}
+		storePath, ok := resolveRoutePrefix(rigPath, prefix)
+		if !ok {
+			continue
+		}
+		cleanPath := filepath.Clean(storePath)
+		if rigName, found := rigPathToName[cleanPath]; found {
+			if store, exists := stores[rigName]; exists {
+				return store
+			}
+		}
+		if store, exists := stores[rig.Name]; exists {
+			return store
+		}
+	}
+	return nil
+}
+
+// beadPrefix extracts the alphabetic prefix from a bead ID (e.g., "ga" from "ga-5b8i").
+func beadPrefix(id string) string {
+	for i, c := range id {
+		if c == '-' {
+			return id[:i]
+		}
+		if c < 'a' || c > 'z' {
+			return ""
+		}
+	}
+	return ""
+}
+
+// resolveRoutePrefix reads routes.jsonl from a rig's .beads/ directory and
+// resolves the given prefix to an absolute store path.
+func resolveRoutePrefix(rigPath, prefix string) (string, bool) {
+	routesPath := filepath.Join(rigPath, ".beads", "routes.jsonl")
+	data, err := os.ReadFile(routesPath)
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Prefix string `json:"prefix"`
+			Path   string `json:"path"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.Prefix == prefix {
+			resolved := entry.Path
+			if !filepath.IsAbs(resolved) {
+				resolved = filepath.Join(rigPath, resolved)
+			}
+			return resolved, true
+		}
+	}
+	return "", false
 }
 
 // sortedRigNames returns rig names from the store map in deterministic sorted order,

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -5,11 +5,242 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
+
+type prefixedAliasStore struct {
+	prefix        string
+	base          *beads.MemStore
+	getCalls      int
+	updateCalls   int
+	closeCalls    int
+	childrenCalls int
+}
+
+func newPrefixedAliasStore(prefix string) *prefixedAliasStore {
+	return &prefixedAliasStore{
+		prefix: prefix,
+		base:   beads.NewMemStore(),
+	}
+}
+
+func (s *prefixedAliasStore) aliasToBase(id string) string {
+	if strings.HasPrefix(id, s.prefix) {
+		return "gc" + strings.TrimPrefix(id, s.prefix)
+	}
+	return id
+}
+
+func (s *prefixedAliasStore) baseToAlias(id string) string {
+	if strings.HasPrefix(id, "gc") {
+		return s.prefix + strings.TrimPrefix(id, "gc")
+	}
+	return id
+}
+
+func (s *prefixedAliasStore) beadToAlias(b beads.Bead) beads.Bead {
+	b.ID = s.baseToAlias(b.ID)
+	if b.ParentID != "" {
+		b.ParentID = s.baseToAlias(b.ParentID)
+	}
+	if len(b.Needs) > 0 {
+		needs := make([]string, 0, len(b.Needs))
+		for _, need := range b.Needs {
+			depType, depID, ok := strings.Cut(need, ":")
+			if ok && depType != "" && depID != "" {
+				needs = append(needs, depType+":"+s.baseToAlias(depID))
+				continue
+			}
+			needs = append(needs, s.baseToAlias(need))
+		}
+		b.Needs = needs
+	}
+	return b
+}
+
+func (s *prefixedAliasStore) depToAlias(dep beads.Dep) beads.Dep {
+	dep.IssueID = s.baseToAlias(dep.IssueID)
+	dep.DependsOnID = s.baseToAlias(dep.DependsOnID)
+	return dep
+}
+
+func (s *prefixedAliasStore) Create(b beads.Bead) (beads.Bead, error) {
+	if b.ParentID != "" {
+		b.ParentID = s.aliasToBase(b.ParentID)
+	}
+	if len(b.Needs) > 0 {
+		needs := make([]string, 0, len(b.Needs))
+		for _, need := range b.Needs {
+			depType, depID, ok := strings.Cut(need, ":")
+			if ok && depType != "" && depID != "" {
+				needs = append(needs, depType+":"+s.aliasToBase(depID))
+				continue
+			}
+			needs = append(needs, s.aliasToBase(need))
+		}
+		b.Needs = needs
+	}
+	created, err := s.base.Create(b)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	return s.beadToAlias(created), nil
+}
+
+func (s *prefixedAliasStore) Get(id string) (beads.Bead, error) {
+	s.getCalls++
+	b, err := s.base.Get(s.aliasToBase(id))
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	return s.beadToAlias(b), nil
+}
+
+func (s *prefixedAliasStore) Update(id string, opts beads.UpdateOpts) error {
+	s.updateCalls++
+	if opts.ParentID != nil {
+		parentID := s.aliasToBase(*opts.ParentID)
+		opts.ParentID = &parentID
+	}
+	return s.base.Update(s.aliasToBase(id), opts)
+}
+
+func (s *prefixedAliasStore) Close(id string) error {
+	s.closeCalls++
+	return s.base.Close(s.aliasToBase(id))
+}
+
+func (s *prefixedAliasStore) List() ([]beads.Bead, error) {
+	items, err := s.base.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Bead, 0, len(items))
+	for _, item := range items {
+		out = append(out, s.beadToAlias(item))
+	}
+	return out, nil
+}
+
+func (s *prefixedAliasStore) Ready() ([]beads.Bead, error) {
+	items, err := s.base.Ready()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Bead, 0, len(items))
+	for _, item := range items {
+		out = append(out, s.beadToAlias(item))
+	}
+	return out, nil
+}
+
+func (s *prefixedAliasStore) Children(parentID string) ([]beads.Bead, error) {
+	s.childrenCalls++
+	items, err := s.base.Children(s.aliasToBase(parentID))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Bead, 0, len(items))
+	for _, item := range items {
+		out = append(out, s.beadToAlias(item))
+	}
+	return out, nil
+}
+
+func (s *prefixedAliasStore) ListByLabel(label string, limit int) ([]beads.Bead, error) {
+	items, err := s.base.ListByLabel(label, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Bead, 0, len(items))
+	for _, item := range items {
+		out = append(out, s.beadToAlias(item))
+	}
+	return out, nil
+}
+
+func (s *prefixedAliasStore) ListByAssignee(assignee, status string, limit int) ([]beads.Bead, error) {
+	items, err := s.base.ListByAssignee(assignee, status, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Bead, 0, len(items))
+	for _, item := range items {
+		out = append(out, s.beadToAlias(item))
+	}
+	return out, nil
+}
+
+func (s *prefixedAliasStore) SetMetadata(id, key, value string) error {
+	return s.base.SetMetadata(s.aliasToBase(id), key, value)
+}
+
+func (s *prefixedAliasStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	return s.base.SetMetadataBatch(s.aliasToBase(id), kvs)
+}
+
+func (s *prefixedAliasStore) Ping() error {
+	return s.base.Ping()
+}
+
+func (s *prefixedAliasStore) DepAdd(issueID, dependsOnID, depType string) error {
+	return s.base.DepAdd(s.aliasToBase(issueID), s.aliasToBase(dependsOnID), depType)
+}
+
+func (s *prefixedAliasStore) DepRemove(issueID, dependsOnID string) error {
+	return s.base.DepRemove(s.aliasToBase(issueID), s.aliasToBase(dependsOnID))
+}
+
+func (s *prefixedAliasStore) DepList(id, direction string) ([]beads.Dep, error) {
+	deps, err := s.base.DepList(s.aliasToBase(id), direction)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Dep, 0, len(deps))
+	for _, dep := range deps {
+		out = append(out, s.depToAlias(dep))
+	}
+	return out, nil
+}
+
+func configureBeadRouteState(t *testing.T) (*fakeState, *prefixedAliasStore, *prefixedAliasStore) {
+	t.Helper()
+
+	state := newFakeState(t)
+	state.cityPath = t.TempDir()
+	state.cfg.Rigs = []config.Rig{
+		{Name: "alpha", Path: "rigs/alpha"},
+		{Name: "beta", Path: "rigs/beta"},
+	}
+
+	alphaStore := newPrefixedAliasStore("ga")
+	betaStore := newPrefixedAliasStore("gb")
+	state.stores = map[string]beads.Store{
+		"alpha": alphaStore,
+		"beta":  betaStore,
+	}
+
+	alphaPath := filepath.Join(state.cityPath, "rigs", "alpha")
+	betaPath := filepath.Join(state.cityPath, "rigs", "beta")
+	if err := os.MkdirAll(filepath.Join(alphaPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(alpha .beads): %v", err)
+	}
+	if err := os.MkdirAll(betaPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(beta): %v", err)
+	}
+	routes := `{"prefix":"ga","path":"."}` + "\n" + `{"prefix":"gb","path":"../beta"}`
+	if err := os.WriteFile(filepath.Join(alphaPath, ".beads", "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("WriteFile(routes.jsonl): %v", err)
+	}
+
+	return state, alphaStore, betaStore
+}
 
 func TestBeadCRUD(t *testing.T) {
 	state := newFakeState(t)
@@ -138,6 +369,37 @@ func TestBeadGetNotFound(t *testing.T) {
 	}
 }
 
+func TestBeadGetUsesRoutePrefixStore(t *testing.T) {
+	state, alphaStore, betaStore := configureBeadRouteState(t)
+	created, err := betaStore.Create(beads.Bead{Title: "Routed beta bead"})
+	if err != nil {
+		t.Fatalf("Create(beta): %v", err)
+	}
+	srv := New(state)
+
+	req := httptest.NewRequest("GET", "/v0/bead/"+created.ID, nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got beads.Bead
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode(): %v", err)
+	}
+	if got.Title != "Routed beta bead" {
+		t.Fatalf("Title = %q, want %q", got.Title, "Routed beta bead")
+	}
+	if alphaStore.getCalls != 0 {
+		t.Fatalf("alphaStore.getCalls = %d, want 0", alphaStore.getCalls)
+	}
+	if betaStore.getCalls != 1 {
+		t.Fatalf("betaStore.getCalls = %d, want 1", betaStore.getCalls)
+	}
+}
+
 func TestBeadReady(t *testing.T) {
 	state := newFakeState(t)
 	store := state.stores["myrig"]
@@ -183,6 +445,75 @@ func TestBeadUpdate(t *testing.T) {
 	}
 	if len(got.Labels) != 1 || got.Labels[0] != "new-label" {
 		t.Errorf("Labels = %v, want [new-label]", got.Labels)
+	}
+}
+
+func TestBeadUpdateUsesRoutePrefixStore(t *testing.T) {
+	state, alphaStore, betaStore := configureBeadRouteState(t)
+	created, err := betaStore.Create(beads.Bead{Title: "Routed beta bead"})
+	if err != nil {
+		t.Fatalf("Create(beta): %v", err)
+	}
+	srv := New(state)
+
+	body := `{"description":"updated via route"}`
+	req := newPostRequest("/v0/bead/"+created.ID+"/update", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	got, err := betaStore.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(beta): %v", err)
+	}
+	if got.Description != "updated via route" {
+		t.Fatalf("Description = %q, want %q", got.Description, "updated via route")
+	}
+	if alphaStore.updateCalls != 0 {
+		t.Fatalf("alphaStore.updateCalls = %d, want 0", alphaStore.updateCalls)
+	}
+	if betaStore.updateCalls != 1 {
+		t.Fatalf("betaStore.updateCalls = %d, want 1", betaStore.updateCalls)
+	}
+}
+
+func TestBeadDepsUsesRoutePrefixStore(t *testing.T) {
+	state, alphaStore, betaStore := configureBeadRouteState(t)
+	parent, err := betaStore.Create(beads.Bead{Title: "Parent"})
+	if err != nil {
+		t.Fatalf("Create(parent): %v", err)
+	}
+	child, err := betaStore.Create(beads.Bead{Title: "Child", ParentID: parent.ID})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	srv := New(state)
+
+	req := httptest.NewRequest("GET", "/v0/bead/"+parent.ID+"/deps", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Children []beads.Bead `json:"children"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode(): %v", err)
+	}
+	if len(resp.Children) != 1 || resp.Children[0].ID != child.ID {
+		t.Fatalf("children = %#v, want [%s]", resp.Children, child.ID)
+	}
+	if alphaStore.childrenCalls != 0 {
+		t.Fatalf("alphaStore.childrenCalls = %d, want 0", alphaStore.childrenCalls)
+	}
+	if betaStore.childrenCalls != 1 {
+		t.Fatalf("betaStore.childrenCalls = %d, want 1", betaStore.childrenCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `beadStoresForID` method that resolves the authoritative store for a bead ID using its prefix via `routes.jsonl`
- Replace inline store iteration in all bead handlers (get, close, update, reopen, assign, delete, deps)
- Add `beadPrefix`, `resolveRoutePrefix`, and `resolveStoreByPrefix` helpers for prefix-based store routing

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)