### PR TITLE
feat: HTTP request metrics and data source tagging

### DIFF
--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -71,7 +71,7 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	if !wantPeek {
 		cacheKey = responseCacheKey("agents", r)
 		if body, ok := s.cachedResponse(cacheKey, index); ok {
-			writeCachedJSON(w, index, body)
+			writeCachedJSON(w, r, index, body)
 			return
 		}
 	}
@@ -182,7 +182,7 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 		writeListJSON(w, index, agents, len(agents))
 		return
 	}
-	writeCachedJSON(w, index, body)
+	writeCachedJSON(w, r, index, body)
 }
 
 func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -39,6 +39,7 @@ func (s *Server) handleBeadList(w http.ResponseWriter, r *http.Request) {
 	} else {
 		rigNames = sortedRigNames(stores)
 	}
+	setDataSource(r, "bd_subprocess")
 	var all []beads.Bead
 	for _, rigName := range rigNames {
 		store := stores[rigName]

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -52,7 +52,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	index := s.latestIndex()
 	cacheKey := responseCacheKey("status", r)
 	if body, ok := s.cachedResponse(cacheKey, index); ok {
-		writeCachedJSON(w, index, body)
+		writeCachedJSON(w, r, index, body)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		writeIndexJSON(w, index, resp)
 		return
 	}
-	writeCachedJSON(w, index, body)
+	writeCachedJSON(w, r, index, body)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,21 +1,48 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"log"
 	"net/http"
 	"runtime/debug"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
-// withLogging wraps a handler with request logging.
+type dataSourceKey struct{}
+
+// setDataSource annotates the request context with the data source used to
+// fulfill it (e.g., "memory", "cache", "bd_subprocess", "sql"). Handlers
+// call this so the logging middleware can include it in metrics.
+func setDataSource(r *http.Request, source string) {
+	if p, ok := r.Context().Value(dataSourceKey{}).(*string); ok {
+		*p = source
+	}
+}
+
+// withLogging wraps a handler with request logging and OTel metrics.
 func withLogging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+		// Inject a mutable data source slot into the context so handlers
+		// can tag what backend they used (memory, cache, sql, bd_subprocess).
+		var source string
+		ctx := context.WithValue(r.Context(), dataSourceKey{}, &source)
+		r = r.WithContext(ctx)
+
 		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rw, r)
-		log.Printf("api: %s %s %d %s", r.Method, r.URL.Path, rw.status, time.Since(start).Round(time.Microsecond))
+
+		dur := time.Since(start)
+		durMs := float64(dur.Microseconds()) / 1000.0
+		if source == "" {
+			source = "memory"
+		}
+		log.Printf("api: %s %s %d %s [%s]", r.Method, r.URL.Path, rw.status, dur.Round(time.Microsecond), source)
+		telemetry.RecordHTTPRequest(r.Context(), r.Method, r.URL.Path, rw.status, durMs, source)
 	})
 }
 

--- a/internal/api/response_cache.go
+++ b/internal/api/response_cache.go
@@ -107,7 +107,10 @@ func (s *Server) storeResponse(key string, index uint64, v any) ([]byte, error) 
 	return body, nil
 }
 
-func writeCachedJSON(w http.ResponseWriter, index uint64, body []byte) {
+func writeCachedJSON(w http.ResponseWriter, r *http.Request, index uint64, body []byte) {
+	if r != nil {
+		setDataSource(r, "cache")
+	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-GC-Index", strconv.FormatUint(index, 10))
 	w.WriteHeader(http.StatusOK)

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -52,6 +52,10 @@ type recorderInstruments struct {
 
 	// Histograms — Phase 2 (1)
 	poolCheckDurationHist metric.Float64Histogram
+
+	// HTTP API request instrumentation
+	httpRequestTotal    metric.Int64Counter
+	httpRequestDuration metric.Float64Histogram
 }
 
 var (
@@ -129,6 +133,15 @@ func initInstruments() {
 		// Histograms — Phase 2
 		inst.poolCheckDurationHist, _ = m.Float64Histogram("gc.pool.check.duration_ms",
 			metric.WithDescription("Pool scale_check command latency in milliseconds"),
+			metric.WithUnit("ms"),
+		)
+
+		// HTTP API request instrumentation
+		inst.httpRequestTotal, _ = m.Int64Counter("gc.http.requests.total",
+			metric.WithDescription("Total HTTP API requests"),
+		)
+		inst.httpRequestDuration, _ = m.Float64Histogram("gc.http.duration_ms",
+			metric.WithDescription("HTTP API request latency in milliseconds"),
 			metric.WithUnit("ms"),
 		)
 	})
@@ -459,6 +472,37 @@ func RecordMailOp(ctx context.Context, operation string, err error) {
 		otellog.String("operation", operation),
 		otellog.String("status", status),
 		errKV(err),
+	)
+}
+
+// RecordHTTPRequest records an API request with method, route, status, duration,
+// and the data source used to fulfill it (memory, cache, bd_subprocess, sql).
+func RecordHTTPRequest(ctx context.Context, method, route string, status int, durationMs float64, dataSource string) {
+	initInstruments()
+	statusStr := "ok"
+	if status >= 500 {
+		statusStr = "error"
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("method", method),
+		attribute.String("route", route),
+		attribute.Int("status", status),
+		attribute.String("data_source", dataSource),
+	)
+	inst.httpRequestTotal.Add(ctx, 1, attrs)
+	inst.httpRequestDuration.Record(ctx, durationMs, attrs)
+
+	sev := otellog.SeverityInfo
+	if durationMs > 1000 {
+		sev = otellog.SeverityWarn
+	}
+	emit(ctx, "http.request", sev,
+		otellog.String("method", method),
+		otellog.String("route", route),
+		otellog.Int("status", status),
+		otellog.Float64("duration_ms", durationMs),
+		otellog.String("data_source", dataSource),
+		otellog.String("status_class", statusStr),
 	)
 }
 


### PR DESCRIPTION
## Summary
- Add HTTP request telemetry recording with method, path, status, and duration via `gc.http.requests.total` counter and `gc.http.duration_ms` histogram
- Tag API responses with data source (memory, cache, bd_subprocess) for observability -- handlers call `setDataSource(r, "...")` and the logging middleware records it in both log lines and OTel metrics
- Cache hits automatically tagged via `writeCachedJSON`

## Test plan
- CI passes
- `go build ./...` clean
- `go test ./internal/telemetry/...` passes
- Pre-existing test compilation issue in `internal/api` (unrelated `CloseAll` interface mismatch) is not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)