### PR TITLE
fix: keep named_session beads desired via legacy alias matching

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -366,3 +366,53 @@ func TestBuildDesiredState_ManualPoolSessionInSuspendedRigStaysStopped(t *testin
 		}
 	}
 }
+
+func TestBuildDesiredState_NamedSessionWithLegacyBeadStaysDesired(t *testing.T) {
+	// A [[named_session]] with an existing open bead that uses the legacy
+	// alias-based identity (no configured_named_session metadata) should
+	// remain in desired state. This prevents the reconciler from closing
+	// beads created before the configured_named_* metadata keys existed.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:mayor"},
+		Metadata: map[string]string{
+			"template":     "mayor",
+			"session_name": "mayor",
+			"alias":        "mayor",
+			"state":        "stopped",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "mayor", StartCommand: "echo"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor"},
+		},
+	}
+
+	desired := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	found := false
+	for _, tp := range desired {
+		if tp.TemplateName == "mayor" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected mayor in desired state (legacy bead with alias), got keys: %v", desiredKeys(desired))
+	}
+}
+
+func desiredKeys(d map[string]TemplateParams) []string {
+	keys := make([]string, 0, len(d))
+	for k := range d {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/cmd/gc/named_sessions.go
+++ b/cmd/gc/named_sessions.go
@@ -204,6 +204,11 @@ func findCanonicalNamedSessionBead(sessionBeads *sessionBeadSnapshot, identity s
 		if isNamedSessionBead(b) && namedSessionIdentity(b) == identity {
 			return b, true
 		}
+		// Legacy beads created before configured_named_session metadata
+		// existed use alias matching as the canonical signal.
+		if !isNamedSessionBead(b) && strings.TrimSpace(b.Metadata["alias"]) == identity {
+			return b, true
+		}
 	}
 	return beads.Bead{}, false
 }


### PR DESCRIPTION
## Summary
- `findCanonicalNamedSessionBead` now also matches open beads whose `alias` metadata matches the named session identity, not just beads with the newer `configured_named_session` key
- Prevents the reconciler from sweeping legacy named session beads (e.g. the mayor) that were created before the `configured_named_*` metadata keys existed

## Root cause
The `on_demand` gate in `buildDesiredState` skips named sessions without a canonical bead. Legacy beads lack `configured_named_session=true` metadata, so `findCanonicalNamedSessionBead` returned false, the session fell out of `desiredState`, and `syncSessionBeadsWithSnapshot` closed it as suspended — every tick.

## Test plan
- [x] New test: `TestBuildDesiredState_NamedSessionWithLegacyBeadStaysDesired`
- [x] All existing `TestBuildDesiredState_*` tests pass
- [x] All `TestSyncSessionBeads_*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)