### PR TITLE
fix: retry without resume flag when session key is stale

### DIFF
--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -7,12 +7,33 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/sessionlog"
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
+
+// staleKeyDetectDelay is how long to wait after starting a session before
+// checking if it died immediately (stale resume key detection).
+const staleKeyDetectDelay = 2 * time.Second
+
+// stripResumeFlag removes the resume flag and session key from a command
+// string, returning a command suitable for a fresh start.
+func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
+	if resumeFlag == "" || sessionKey == "" {
+		return cmd
+	}
+	// Remove "--resume <key>" or similar from the command.
+	target := resumeFlag + " " + sessionKey
+	result := strings.Replace(cmd, " "+target, "", 1)
+	if result == cmd {
+		// Try without the leading space (flag at start of args).
+		result = strings.Replace(cmd, target+" ", "", 1)
+	}
+	return strings.TrimSpace(result)
+}
 
 var (
 	// ErrNotSession reports that the requested bead is not a session bead.
@@ -169,6 +190,27 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 		}
 	} else {
 		started = true
+	}
+
+	// Stale session key detection: if we just started a session with a
+	// resume flag but it died immediately, the session key is likely
+	// invalid (e.g., "No conversation found"). Clear the key and retry
+	// with a fresh start so the user isn't stuck with a dead pane.
+	if started && b.Metadata["session_key"] != "" {
+		time.Sleep(staleKeyDetectDelay)
+		if !m.sp.IsRunning(sessName) {
+			_ = m.store.SetMetadata(id, "session_key", "")
+			freshCmd := stripResumeFlag(resumeCommand, b.Metadata["resume_flag"], b.Metadata["session_key"])
+			if freshCmd != resumeCommand {
+				cfg.Command = freshCmd
+				if err := m.sp.Start(ctx, sessName, cfg); err != nil {
+					if unroute != nil {
+						unroute()
+					}
+					return fmt.Errorf("fresh start after stale key: %w", err)
+				}
+			}
+		}
 	}
 	if b.Metadata["transport"] == "" && (started || transportVerified) {
 		m.persistTransport(id, b.Metadata["provider"], transport)

--- a/internal/session/chat_test.go
+++ b/internal/session/chat_test.go
@@ -46,6 +46,61 @@ func TestSessionMutationLocksArePerSession(t *testing.T) {
 	close(releaseFirst)
 }
 
+func TestStripResumeFlag(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmd        string
+		resumeFlag string
+		sessionKey string
+		want       string
+	}{
+		{
+			name:       "removes resume flag and key",
+			cmd:        "claude --model claude-opus-4-6 --resume abc-123",
+			resumeFlag: "--resume",
+			sessionKey: "abc-123",
+			want:       "claude --model claude-opus-4-6",
+		},
+		{
+			name:       "resume flag at end",
+			cmd:        "claude --resume abc-123",
+			resumeFlag: "--resume",
+			sessionKey: "abc-123",
+			want:       "claude",
+		},
+		{
+			name:       "no resume flag in command",
+			cmd:        "claude --model sonnet",
+			resumeFlag: "--resume",
+			sessionKey: "abc-123",
+			want:       "claude --model sonnet",
+		},
+		{
+			name:       "empty resume flag",
+			cmd:        "claude --resume abc-123",
+			resumeFlag: "",
+			sessionKey: "abc-123",
+			want:       "claude --resume abc-123",
+		},
+		{
+			name:       "empty session key",
+			cmd:        "claude --resume abc-123",
+			resumeFlag: "--resume",
+			sessionKey: "",
+			want:       "claude --resume abc-123",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripResumeFlag(tt.cmd, tt.resumeFlag, tt.sessionKey)
+			if got != tt.want {
+				t.Errorf("stripResumeFlag(%q, %q, %q) = %q, want %q",
+					tt.cmd, tt.resumeFlag, tt.sessionKey, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSessionMutationLocksSerializeSameSession(t *testing.T) {
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})


### PR DESCRIPTION
When ensureRunning starts a session with --resume and the process dies within 2s, clear the stale session_key and retry fresh. Prevents dead panes from stale conversation IDs after controller restarts.