### PR TITLE
fix: closed session beads release their explicit name

### DIFF
--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -227,7 +227,7 @@ func TestCreateNamedWithTransport_RejectsReusedName(t *testing.T) {
 	}
 }
 
-func TestCreateNamedWithTransport_ClosedSessionStillReservesName(t *testing.T) {
+func TestCreateNamedWithTransport_ClosedSessionReleasesName(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()
 	mgr := NewManager(store, sp)
@@ -240,10 +240,9 @@ func TestCreateNamedWithTransport_ClosedSessionStillReservesName(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	if _, err := mgr.CreateNamedWithTransport(context.Background(), "sky", "helper", "second", "claude", "/tmp", "claude", "", nil, ProviderResume{}, runtime.Config{}); err == nil {
-		t.Fatal("expected closed session to keep reserving its explicit name")
-	} else if !errors.Is(err, ErrSessionNameExists) {
-		t.Fatalf("expected ErrSessionNameExists, got %v", err)
+	// Closed sessions release their explicit name so restarts can reuse it.
+	if _, err := mgr.CreateNamedWithTransport(context.Background(), "sky", "helper", "second", "claude", "/tmp", "claude", "", nil, ProviderResume{}, runtime.Config{}); err != nil {
+		t.Fatalf("expected closed session to release name, got: %v", err)
 	}
 }
 

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -274,13 +274,14 @@ func ensureSessionNameAvailable(store beads.Store, name string) error {
 		if b.Type != BeadType {
 			continue
 		}
-		// Explicit session names are permanent identities; once claimed by any
-		// session bead, including a closed one, they are never reused.
-		if strings.TrimSpace(b.Metadata["session_name"]) == name {
-			return fmt.Errorf("%w: %q already belongs to %s", ErrSessionNameExists, name, b.ID)
-		}
 		if b.Status == "closed" {
 			continue
+		}
+		// Explicit session names are reserved by open beads only. Closed beads
+		// release their names so that controller restarts and gc session new
+		// can reuse deterministic names like "mayor".
+		if strings.TrimSpace(b.Metadata["session_name"]) == name {
+			return fmt.Errorf("%w: %q already belongs to %s", ErrSessionNameExists, name, b.ID)
 		}
 		if strings.TrimSpace(b.Metadata["alias"]) == name {
 			return fmt.Errorf("%w: %q conflicts with live alias on %s", ErrSessionNameExists, name, b.ID)


### PR DESCRIPTION
Closed beads no longer permanently reserve explicit session names. This fixes the restart bug where gc stop + gc start fails with 'session name already exists' because the old closed bead still held the name claim.