### PR TITLE
fix: session kill accepts awake state and checks provider liveness

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -34,6 +34,9 @@ const (
 	// work completing). The pool routing label has been removed so no new
 	// work is routed to this session.
 	StateDraining State = "draining"
+	// StateAwake is equivalent to StateActive. Written by the reconciler's
+	// healState when a session transitions from asleep to running.
+	StateAwake State = "awake"
 	// StateArchived means the session completed its drain and is retained
 	// for history. Does NOT count against pool occupancy.
 	StateArchived State = "archived"
@@ -605,9 +608,17 @@ func (m *Manager) Kill(id string) error {
 	if err != nil {
 		return err
 	}
+	// Accept any state where a runtime process could plausibly exist.
+	// The reconciler uses "awake" as equivalent to "active", and metadata
+	// state can lag behind reality, so also check provider liveness.
 	state := State(b.Metadata["state"])
-	if state != StateActive && state != StateCreating && state != StateDraining {
-		return fmt.Errorf("session %s is not active", id)
+	switch state {
+	case StateActive, StateCreating, StateDraining, StateAwake:
+		// Known live states — proceed.
+	default:
+		if !m.sp.IsRunning(sessName) {
+			return fmt.Errorf("session %s is not active", id)
+		}
 	}
 	return m.sp.Stop(sessName)
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1984,3 +1984,77 @@ func TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback
 		t.Errorf("TranscriptPath = %q, want %q", path, codexPath)
 	}
 }
+
+func TestKill_ActiveState(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.CreateNamedWithTransport(context.Background(), "sky", "helper", "test", "claude", "/tmp", "claude", "", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Session is active (started by CreateNamedWithTransport).
+	if err := mgr.Kill(info.ID); err != nil {
+		t.Fatalf("Kill active session: %v", err)
+	}
+}
+
+func TestKill_AwakeState(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.CreateNamedWithTransport(context.Background(), "sky", "helper", "test", "claude", "/tmp", "claude", "", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Simulate reconciler setting state to "awake".
+	if err := store.SetMetadata(info.ID, "state", string(StateAwake)); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if err := mgr.Kill(info.ID); err != nil {
+		t.Fatalf("Kill awake session: %v", err)
+	}
+}
+
+func TestKill_StoppedState_NotRunning(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	b, err := store.Create(beads.Bead{
+		Title:    "helper",
+		Type:     BeadType,
+		Labels:   []string{LabelSession},
+		Metadata: map[string]string{"session_name": "sky", "state": "stopped"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Session is stopped and not running — Kill should fail.
+	if err := mgr.Kill(b.ID); err == nil {
+		t.Fatal("expected Kill to fail for stopped non-running session")
+	}
+}
+
+func TestKill_UnknownState_ButRunning(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "sky", runtime.Config{Command: "claude"})
+	mgr := NewManager(store, sp)
+
+	b, err := store.Create(beads.Bead{
+		Title:    "helper",
+		Type:     BeadType,
+		Labels:   []string{LabelSession},
+		Metadata: map[string]string{"session_name": "sky", "state": "some-future-state"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Unknown state but runtime is alive — Kill should succeed via liveness fallback.
+	if err := mgr.Kill(b.ID); err != nil {
+		t.Fatalf("Kill running session with unknown state: %v", err)
+	}
+}


### PR DESCRIPTION
Kill rejected running sessions with state=awake because it only checked active/creating/draining. Adds StateAwake constant and falls back to provider liveness for unrecognized states.