### PR TITLE
fix: inject BEADS_DOLT_PORT in pool scale_check for rig-scoped agents

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -44,11 +44,23 @@ func evaluatePendingPools(
 	var wg sync.WaitGroup
 	for j, pw := range pendingPools {
 		wg.Add(1)
+		// For rig-scoped agents with an external Dolt server, prefix
+		// the pool check command with BEADS_DOLT_PORT so bd connects
+		// to the correct server (matching computeWorkSet behaviour).
+		sp := pw.sp
+		if dir := cfg.Agents[pw.agentIdx].Dir; dir != "" {
+			for _, r := range cfg.Rigs {
+				if r.Name == dir && r.DoltPort != "" {
+					sp.Check = "BEADS_DOLT_PORT=" + r.DoltPort + " " + sp.Check
+					break
+				}
+			}
+		}
 		go func(idx int, name string, sp scaleParams, dir string) {
 			defer wg.Done()
 			d, err := evaluatePool(name, sp, dir, shellScaleCheck)
 			evalResults[idx] = poolEvalResult{desired: d, err: err}
-		}(j, cfg.Agents[pw.agentIdx].Name, pw.sp, pw.poolDir)
+		}(j, cfg.Agents[pw.agentIdx].Name, sp, pw.poolDir)
 	}
 	wg.Wait()
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -521,6 +521,103 @@ func TestBuildDesiredState_ZeroScaledPoolSessionKeepsDependencyFloorWhileDrainin
 	}
 }
 
+func TestBuildDesiredState_PoolCheckInjectsDoltPortForRigScopedAgent(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "myrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The check command outputs "2" only when BEADS_DOLT_PORT is set.
+	// If the fix works, buildDesiredState prefixes the command with
+	// BEADS_DOLT_PORT=9876, so the inner shell sees the variable.
+	checkCmd := `sh -c 'test -n "$BEADS_DOLT_PORT" && printf 2 || printf 0'`
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name:     "myrig",
+			Path:     rigPath,
+			DoltPort: "9876",
+		}},
+		Agents: []config.Agent{
+			{
+				Name: "worker",
+				Dir:  "myrig",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5), ScaleCheck: checkCmd,
+			},
+		},
+	}
+
+	desired := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), nil, io.Discard)
+	workerSlots := 0
+	for _, tp := range desired.State {
+		if tp.TemplateName == "myrig/worker" {
+			workerSlots++
+		}
+	}
+	if workerSlots != 2 {
+		t.Fatalf("worker desired slots = %d, want 2 (BEADS_DOLT_PORT injection should make check output 2)", workerSlots)
+	}
+}
+
+func TestBuildDesiredState_PoolCheckOmitsDoltPortForCityScopedAgent(t *testing.T) {
+	cityPath := t.TempDir()
+	// Same check command but for a city-scoped agent (no rig). BEADS_DOLT_PORT
+	// should NOT be injected, so the check outputs 0.
+	checkCmd := `sh -c 'test -n "$BEADS_DOLT_PORT" && printf 2 || printf 0'`
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name: "worker",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5), ScaleCheck: checkCmd,
+			},
+		},
+	}
+
+	desired := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), nil, io.Discard)
+	workerSlots := 0
+	for _, tp := range desired.State {
+		if tp.TemplateName == "worker" {
+			workerSlots++
+		}
+	}
+	if workerSlots != 0 {
+		t.Fatalf("worker desired slots = %d, want 0 (no DoltPort for city-scoped agent)", workerSlots)
+	}
+}
+
+func TestBuildDesiredState_PoolCheckOmitsDoltPortWhenRigHasNoDoltPort(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "myrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Rig exists but has no DoltPort configured.
+	checkCmd := `sh -c 'test -n "$BEADS_DOLT_PORT" && printf 2 || printf 0'`
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name: "myrig",
+			Path: rigPath,
+		}},
+		Agents: []config.Agent{
+			{
+				Name: "worker",
+				Dir:  "myrig",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5), ScaleCheck: checkCmd,
+			},
+		},
+	}
+
+	desired := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), nil, io.Discard)
+	workerSlots := 0
+	for _, tp := range desired.State {
+		if tp.TemplateName == "myrig/worker" {
+			workerSlots++
+		}
+	}
+	if workerSlots != 0 {
+		t.Fatalf("worker desired slots = %d, want 0 (rig has no DoltPort)", workerSlots)
+	}
+}
+
 func TestBuildDesiredState_ManualPoolSessionInSuspendedRigStaysStopped(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "payments")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -259,6 +259,11 @@ type Rig struct {
 	// SessionSleep overrides workspace-level idle sleep defaults for agents in
 	// this rig.
 	SessionSleep SessionSleepConfig `toml:"session_sleep,omitempty"`
+	// DoltPort is the port number for a rig-local Dolt SQL server.
+	// When set, controller commands (scale_check, work_query) prefix their
+	// shell invocations with BEADS_DOLT_PORT=<port> so bd connects to the
+	// correct server instead of the city-level default.
+	DoltPort string `toml:"dolt_port,omitempty"`
 }
 
 // AgentOverride modifies a pack-stamped agent for a specific rig.


### PR DESCRIPTION
## Summary

- Rig-scoped pool agents with a dedicated Dolt server (`dolt_port` in city.toml) fail pool evaluation because `bd ready` can't connect without `BEADS_DOLT_PORT` in the environment
- Pool eval falls back to `min` (0), so sling-created sessions never enter `desiredState` and never wake
- Prefixes pool check commands with `BEADS_DOLT_PORT=<port>` for rig-scoped agents, matching the existing pattern in `computeWorkSet`
- Adds `DoltPort` field to the `Rig` config struct

## Test plan

- [x] 3 new unit tests covering injection, city-scoped omission, and no-port omission
- [ ] Manual: sling work to a rig pool agent and verify session wakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)