### PR TITLE
fix: stamp pool_slot metadata for namepool-themed pool instances

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -233,6 +233,7 @@ func buildDesiredStateWithSessionBeads(
 					fmt.Fprintf(stderr, "buildDesiredState: pool instance %q: %v (skipping)\n", qualifiedInstance, err) //nolint:errcheck
 					continue
 				}
+				tp.PoolSlot = slot
 				installAgentSideEffects(bp, &instanceAgent, tp, stderr)
 				desired[tp.SessionName] = tp
 			}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -265,7 +265,9 @@ func syncSessionBeadsWithSnapshot(
 			} else {
 				meta["template"] = tp.TemplateName
 			}
-			if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
+			if tp.PoolSlot > 0 {
+				meta["pool_slot"] = strconv.Itoa(tp.PoolSlot)
+			} else if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
 				meta["pool_slot"] = strconv.Itoa(slot)
 			}
 			// Store command and resume fields so gc session attach can
@@ -383,7 +385,9 @@ func syncSessionBeadsWithSnapshot(
 			queueMeta(poolManagedMetadataKey, boolMetadata(true))
 		}
 		if b.Metadata["pool_slot"] == "" {
-			if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
+			if tp.PoolSlot > 0 {
+				queueMeta("pool_slot", strconv.Itoa(tp.PoolSlot))
+			} else if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
 				queueMeta("pool_slot", strconv.Itoa(slot))
 			}
 		}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -71,6 +71,11 @@ type TemplateParams struct {
 	// (for example via `gc session new`). These sessions stay desired without
 	// inflating poolDesired for config-managed slots.
 	ManualSession bool
+	// PoolSlot is the 1-based slot number within the pool. Set during
+	// buildDesiredState for pool instances so syncSessionBeads can stamp
+	// pool_slot metadata without reverse-engineering the slot from the name
+	// (which fails for namepool-themed instances like "fenrir").
+	PoolSlot int
 }
 
 // DisplayName returns the name to use for log messages and event subjects.


### PR DESCRIPTION
## Summary
- `resolvePoolSlot()` fails for namepool-themed pool instances (e.g., "fenrir" from `norse.txt`) because it expects a `{template}-{N}` suffix pattern
- Without `pool_slot` metadata, `sessionWithinDesiredConfig()` returns `configEligible=false`, so pool sessions never get a `WakeConfig` reason and stay asleep permanently
- Adds `PoolSlot int` to `TemplateParams`, sets it from the known slot number in `buildDesiredState`, and uses it in `syncSessionBeads` (both create and backfill paths)

## Test plan
- [x] Existing `TestBuildDesiredState`, `TestSyncSession`, `TestReconcile` tests pass
- [x] Verified in live city: pool sessions with namepool names now get `pool_slot` stamped and wake correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)