### PR TITLE
feat: system packs through normal pack expansion

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -20,11 +20,11 @@ import (
 // in cmd_config.go and cmd_start.go that intentionally use config.Load to
 // discover remote packs before fetching them.
 func loadCityConfig(cityPath string) (*config.City, error) {
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	extras := builtinPackIncludes(cityPath)
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), extras...)
 	if err != nil {
 		return nil, err
 	}
-	injectBuiltinPacks(cfg, cityPath)
 	return cfg, nil
 }
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -246,36 +245,9 @@ func cityOrderRoots(cityPath string, cfg *config.City) []orders.ScanRoot {
 		roots = append(roots, root)
 	}
 
-	// 1. On-disk user packs (lowest priority). Scan packs/*/ for order
-	// directories. These packs may exist on disk without being listed
-	// in workspace.includes (e.g. materialized by gc init).
-	packsDir := filepath.Join(cityPath, "packs")
-	if entries, err := os.ReadDir(packsDir); err == nil {
-		for _, e := range entries {
-			if !e.IsDir() {
-				continue
-			}
-			formulaLayer := filepath.Join(packsDir, e.Name(), "formulas")
-			appendRoot(orders.ScanRoot{
-				Dir:          filepath.Join(formulaLayer, "orders"),
-				FormulaLayer: formulaLayer,
-			})
-		}
-	}
-
-	// 2. System + user packs via PackDirs. injectBuiltinPacks adds
-	// system packs to PackDirs but not to FormulaLayers.City, so
-	// orders in those packs would otherwise be invisible.
-	for _, packDir := range cfg.PackDirs {
-		formulaLayer := filepath.Join(packDir, "formulas")
-		appendRoot(orders.ScanRoot{
-			Dir:          filepath.Join(formulaLayer, "orders"),
-			FormulaLayer: formulaLayer,
-		})
-	}
-
-	// 3. Formula layers (highest priority). City-local formulas
-	// override pack formulas when order names collide.
+	// Formula layers include system packs (via LoadWithIncludes extraIncludes)
+	// and user packs (via workspace.includes). City-local formulas are highest
+	// priority and override pack formulas when order names collide.
 	for _, layer := range formulaLayers {
 		formulaRoot := filepath.Join(layer, "orders")
 		if layer == localFormulas {

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -109,98 +109,10 @@ func TestCityOrderRootsDedupesLegacyLocalRoot(t *testing.T) {
 	}
 }
 
-func TestCityOrderRootsIncludesPackDirs(t *testing.T) {
-	cityDir := t.TempDir()
-
-	// Create a pack with a formulas/orders dir.
-	packDir := filepath.Join(cityDir, "packs", "maintenance")
-	ordersDir := filepath.Join(packDir, "formulas", "orders")
-	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.City{}
-	cfg.PackDirs = []string{packDir}
-
-	roots := cityOrderRoots(cityDir, cfg)
-
-	for _, root := range roots {
-		if root.Dir == ordersDir {
-			wantLayer := filepath.Join(packDir, "formulas")
-			if root.FormulaLayer != wantLayer {
-				t.Fatalf("FormulaLayer = %q, want %q", root.FormulaLayer, wantLayer)
-			}
-			return
-		}
-	}
-	t.Fatalf("cityOrderRoots() missing pack order root %q; got %v", ordersDir, roots)
-}
-
-func TestCityOrderRootsScansOnDiskPacks(t *testing.T) {
-	cityDir := t.TempDir()
-
-	// Create an on-disk pack not referenced in PackDirs or FormulaLayers.
-	packDir := filepath.Join(cityDir, "packs", "mypack")
-	ordersDir := filepath.Join(packDir, "formulas", "orders")
-	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.City{} // no PackDirs, no FormulaLayers
-
-	roots := cityOrderRoots(cityDir, cfg)
-
-	for _, root := range roots {
-		if root.Dir == ordersDir {
-			wantLayer := filepath.Join(packDir, "formulas")
-			if root.FormulaLayer != wantLayer {
-				t.Fatalf("FormulaLayer = %q, want %q", root.FormulaLayer, wantLayer)
-			}
-			return
-		}
-	}
-	t.Fatalf("cityOrderRoots() missing on-disk pack order root %q; got %v", ordersDir, roots)
-}
-
-func TestCityOrderRootsLocalOverridesOnDiskPack(t *testing.T) {
-	cityDir := t.TempDir()
-
-	// Create an on-disk pack with an order.
-	packDir := filepath.Join(cityDir, "packs", "mypack")
-	if err := os.MkdirAll(filepath.Join(packDir, "formulas", "orders"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.City{}
-
-	roots := cityOrderRoots(cityDir, cfg)
-
-	// On-disk pack root must appear before local formulas root in the
-	// roots slice (lower priority = earlier index).
-	localFormulasOrders := filepath.Clean(filepath.Join(cityDir, "formulas", "orders"))
-	packOrdersDir := filepath.Clean(filepath.Join(packDir, "formulas", "orders"))
-
-	var packIdx, localIdx int
-	packIdx, localIdx = -1, -1
-	for i, root := range roots {
-		cleanDir := filepath.Clean(root.Dir)
-		if cleanDir == packOrdersDir {
-			packIdx = i
-		}
-		if cleanDir == localFormulasOrders {
-			localIdx = i
-		}
-	}
-	if packIdx == -1 {
-		t.Fatalf("pack order root not found in roots: %v", roots)
-	}
-	if localIdx == -1 {
-		t.Fatalf("local formulas order root not found in roots: %v", roots)
-	}
-	if packIdx >= localIdx {
-		t.Fatalf("pack root (idx=%d) should appear before local root (idx=%d) for lower priority", packIdx, localIdx)
-	}
-}
+// TestCityOrderRootsIncludesPackDirs, TestCityOrderRootsScansOnDiskPacks,
+// and TestCityOrderRootsLocalOverridesOnDiskPack were removed — system packs
+// now go through LoadWithIncludes extraIncludes → ExpandCityPacks → FormulaLayers
+// instead of the old PackDirs and packs/*/ on-disk scan paths.
 
 func TestCityOrderRootsPackDirsDedupe(t *testing.T) {
 	cityDir := t.TempDir()

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -343,7 +343,10 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		}
 	}
 
-	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), extraConfigFiles...)
+	allIncludes := make([]string, 0, len(extraConfigFiles)+3)
+	allIncludes = append(allIncludes, extraConfigFiles...)
+	allIncludes = append(allIncludes, builtinPackIncludes(cityPath)...)
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), allIncludes...)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: %v\n", err)                      //nolint:errcheck // best-effort stderr
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
@@ -392,8 +395,6 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc start: materializing builtin packs: %v\n", err) //nolint:errcheck // best-effort stderr
 		// Non-fatal: only needed if provider = "bd".
 	}
-	injectBuiltinPacks(cfg, cityPath)
-
 	// Materialize builtin prompts and formulas to stay in sync with binary.
 	if err := materializeBuiltinPrompts(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc start: builtin prompts: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -781,7 +781,8 @@ func reconcileCities(
 		}
 
 		// Load city config with provenance so WatchDirs covers included files.
-		cfg, prov, loadErr := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+		// System packs are appended as extra includes for normal pack expansion.
+		cfg, prov, loadErr := config.LoadWithIncludes(fsys.OSFS{}, tomlPath, builtinPackIncludes(path)...)
 		if loadErr != nil {
 			recordInitFailure(name, loadErr.Error())
 			continue
@@ -1300,12 +1301,11 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 		// Non-fatal.
 	}
 
-	// Materialize builtin packs and inject them.
+	// Materialize builtin packs (system packs are auto-included via LoadWithIncludes).
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: city '%s': builtin packs: %v\n", cityName, err) //nolint:errcheck
 		// Non-fatal.
 	}
-	injectBuiltinPacks(cfg, cityPath)
 
 	// Materialize builtin prompts and formulas.
 	if err := materializeBuiltinPrompts(cityPath); err != nil {

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gastownhall/gascity/examples/gastown/packs/gastown"
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
 	"github.com/gastownhall/gascity/internal/citylayout"
-	"github.com/gastownhall/gascity/internal/config"
 )
 
 // builtinPack pairs an embedded FS with the subdirectory name used under .gc/system/packs/.
@@ -22,17 +21,19 @@ type builtinPack struct {
 	name string // e.g. "bd", "dolt"
 }
 
-// builtinPacks lists the packs embedded in the gc binary.
-// Order matters: bd includes dolt, so bd is first.
+// builtinPacks lists all packs embedded in the gc binary. These are
+// materialized to .gc/system/packs/ on every gc start and gc init.
 var builtinPacks = []builtinPack{
 	{fs: bd.PackFS, name: "bd"},
 	{fs: dolt.PackFS, name: "dolt"},
+	{fs: maintenance.PackFS, name: "maintenance"},
+	{fs: gastown.PackFS, name: "gastown"},
 }
 
-// MaterializeBuiltinPacks writes the embedded bd and dolt pack files to
-// .gc/system/packs/bd/ and .gc/system/packs/dolt/ in the city directory. Files are always
-// overwritten to stay in sync with the gc binary version (same pattern as
-// system formulas and gc-beads-bd). Shell scripts get 0755; everything else 0644.
+// MaterializeBuiltinPacks writes all embedded pack files to
+// .gc/system/packs/{name}/ in the city directory. Files are always
+// overwritten to stay in sync with the gc binary version. Shell scripts
+// get 0755; everything else 0644.
 // Idempotent: safe to call on every gc start and gc init.
 func MaterializeBuiltinPacks(cityPath string) error {
 	for _, bp := range builtinPacks {
@@ -44,30 +45,63 @@ func MaterializeBuiltinPacks(cityPath string) error {
 	return nil
 }
 
-// gastownPack pairs an embedded FS with its destination name under packs/.
-type gastownPack struct {
-	fs   fs.FS
-	name string // e.g. "gastown", "maintenance"
-}
+// builtinPackIncludes returns the system pack paths that should be
+// auto-included in config loading. These are appended as extraIncludes
+// to LoadWithIncludes so they go through normal pack expansion
+// (ExpandCityPacks) with dedup/fallback resolution.
+//
+// Maintenance is always included. bd/dolt are included when the beads
+// provider is "bd" (the default). Gastown is never auto-included — it
+// requires an explicit workspace.includes entry.
+func builtinPackIncludes(cityPath string) []string {
+	systemRoot := filepath.Join(cityPath, citylayout.SystemPacksRoot)
 
-// gastownPacks lists the packs materialized for a gastown city init.
-var gastownPacks = []gastownPack{
-	{fs: gastown.PackFS, name: "gastown"},
-	{fs: maintenance.PackFS, name: "maintenance"},
-}
+	// Maintenance is always auto-included.
+	var includes []string
+	if maintenancePath := filepath.Join(systemRoot, "maintenance"); packExists(maintenancePath) {
+		includes = append(includes, maintenancePath)
+	}
 
-// MaterializeGastownPacks writes the embedded gastown and maintenance pack
-// files to packs/gastown/ and packs/maintenance/ in the city directory.
-// Called during "gc init" when the gastown template is selected.
-// Files are always overwritten. Shell scripts get 0755; everything else 0644.
-func MaterializeGastownPacks(cityPath string) error {
-	for _, gp := range gastownPacks {
-		dst := filepath.Join(cityPath, "packs", gp.name)
-		if err := materializeFS(gp.fs, ".", dst); err != nil {
-			return fmt.Errorf("materializing %s pack: %w", gp.name, err)
+	// bd/dolt are gated on the beads provider.
+	provider := os.Getenv("GC_BEADS")
+	if provider == "" {
+		// Peek at city.toml for the provider setting without full config load.
+		provider = peekBeadsProvider(filepath.Join(cityPath, "city.toml"))
+	}
+	if provider == "" || provider == "bd" {
+		if bdPath := filepath.Join(systemRoot, "bd"); packExists(bdPath) {
+			includes = append(includes, bdPath)
+		}
+		if doltPath := filepath.Join(systemRoot, "dolt"); packExists(doltPath) {
+			includes = append(includes, doltPath)
 		}
 	}
-	return nil
+
+	return includes
+}
+
+// packExists checks if a pack.toml exists in the given directory.
+func packExists(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "pack.toml"))
+	return err == nil
+}
+
+// peekBeadsProvider reads just the beads.provider field from a city.toml
+// without doing full config parsing. Returns "" if not set or on error.
+func peekBeadsProvider(tomlPath string) string {
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		return ""
+	}
+	var peek struct {
+		Beads struct {
+			Provider string `toml:"provider"`
+		} `toml:"beads"`
+	}
+	if _, err := toml.Decode(string(data), &peek); err != nil {
+		return ""
+	}
+	return peek.Beads.Provider
 }
 
 // materializeFS walks an embed.FS rooted at root and writes all files to dstDir.
@@ -109,62 +143,9 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 	})
 }
 
-// injectBuiltinPacks appends the materialized bd and dolt pack directories
-// to cfg.PackDirs when the beads provider is "bd" (or default). This makes
-// pack commands, doctor checks, and formulas discoverable without requiring
-// the user to add the packs to city.toml manually.
-//
-// Injection is skipped when:
-//   - the provider is explicitly set to something other than "bd"
-//   - the materialized pack directory doesn't exist
-//   - a pack named "bd" is already loaded (user-supplied pack takes precedence)
-func injectBuiltinPacks(cfg *config.City, cityPath string) {
-	// Check provider: env var overrides config.
-	provider := cfg.Beads.Provider
-	if v := os.Getenv("GC_BEADS"); v != "" {
-		provider = v
-	}
-	// Only inject for "bd" provider (the default when provider is empty).
-	if provider != "" && provider != "bd" {
-		return
-	}
-
-	builtinRoots := map[string]string{
-		"bd":   filepath.Join(cityPath, citylayout.SystemPacksRoot, "bd"),
-		"dolt": filepath.Join(cityPath, citylayout.SystemPacksRoot, "dolt"),
-	}
-	if _, err := os.Stat(filepath.Join(builtinRoots["bd"], "pack.toml")); err != nil {
-		return
-	}
-
-	// Any user-supplied override of bd or dolt suppresses the whole builtin family.
-	for _, dir := range cfg.PackDirs {
-		switch readPackName(dir) {
-		case "bd", "dolt":
-			return
-		}
-	}
-
-	cfg.PackDirs = append(cfg.PackDirs, builtinRoots["bd"])
-	if _, err := os.Stat(filepath.Join(builtinRoots["dolt"], "pack.toml")); err == nil {
-		cfg.PackDirs = append(cfg.PackDirs, builtinRoots["dolt"])
-	}
-}
-
-// readPackName reads the [pack].name field from a pack.toml in the given directory.
-// Returns "" if the file doesn't exist or can't be parsed.
-func readPackName(dir string) string {
-	data, err := os.ReadFile(filepath.Join(dir, "pack.toml"))
-	if err != nil {
-		return ""
-	}
-	var pc struct {
-		Pack struct {
-			Name string `toml:"name"`
-		} `toml:"pack"`
-	}
-	if _, err := toml.Decode(string(data), &pc); err != nil {
-		return ""
-	}
-	return pc.Pack.Name
+// MaterializeGastownPacks is a compatibility shim for callers that still
+// reference it. With all packs now materialized by MaterializeBuiltinPacks,
+// this is a no-op. It will be removed once all callers are updated.
+func MaterializeGastownPacks(_ string) error {
+	return nil
 }

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -3,11 +3,9 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
-	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestMaterializeBuiltinPacks(t *testing.T) {
@@ -102,7 +100,7 @@ func TestMaterializeBuiltinPacks_Idempotent(t *testing.T) {
 	}
 }
 
-func TestInjectBuiltinPacks_BdProvider(t *testing.T) {
+func TestBuiltinPackIncludes_DefaultProvider(t *testing.T) {
 	dir := t.TempDir()
 
 	// Materialize packs first.
@@ -110,200 +108,190 @@ func TestInjectBuiltinPacks_BdProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := &config.City{}
-	// Default provider (empty) → should inject.
-	injectBuiltinPacks(cfg, dir)
+	// Default provider (empty) → should include maintenance, bd, dolt.
+	t.Setenv("GC_BEADS", "")
+	includes := builtinPackIncludes(dir)
 
-	if len(cfg.PackDirs) != 2 {
-		t.Fatalf("PackDirs = %v, want 2 entries", cfg.PackDirs)
+	if len(includes) != 3 {
+		t.Fatalf("builtinPackIncludes() = %v, want 3 entries", includes)
 	}
-	if got := filepath.Base(cfg.PackDirs[0]); got != "bd" {
-		t.Errorf("PackDirs[0] = %q, want bd", got)
+
+	systemRoot := filepath.Join(dir, citylayout.SystemPacksRoot)
+	wantMaintenance := filepath.Join(systemRoot, "maintenance")
+	wantBd := filepath.Join(systemRoot, "bd")
+	wantDolt := filepath.Join(systemRoot, "dolt")
+
+	if includes[0] != wantMaintenance {
+		t.Errorf("includes[0] = %q, want %q", includes[0], wantMaintenance)
 	}
-	if got := filepath.Base(cfg.PackDirs[1]); got != "dolt" {
-		t.Errorf("PackDirs[1] = %q, want dolt", got)
+	if includes[1] != wantBd {
+		t.Errorf("includes[1] = %q, want %q", includes[1], wantBd)
+	}
+	if includes[2] != wantDolt {
+		t.Errorf("includes[2] = %q, want %q", includes[2], wantDolt)
 	}
 }
 
-func TestInjectBuiltinPacks_ExplicitBd(t *testing.T) {
+func TestBuiltinPackIncludes_ExplicitBd(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := MaterializeBuiltinPacks(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg := &config.City{}
-	cfg.Beads.Provider = "bd"
-	injectBuiltinPacks(cfg, dir)
+	// Write a city.toml with provider = "bd".
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[beads]\nprovider = \"bd\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	if len(cfg.PackDirs) != 2 {
-		t.Fatalf("PackDirs = %v, want 2 entries", cfg.PackDirs)
+	t.Setenv("GC_BEADS", "")
+	includes := builtinPackIncludes(dir)
+
+	if len(includes) != 3 {
+		t.Fatalf("builtinPackIncludes() = %v, want 3 entries (maintenance + bd + dolt)", includes)
+	}
+
+	if got := filepath.Base(includes[0]); got != "maintenance" {
+		t.Errorf("includes[0] base = %q, want maintenance", got)
+	}
+	if got := filepath.Base(includes[1]); got != "bd" {
+		t.Errorf("includes[1] base = %q, want bd", got)
+	}
+	if got := filepath.Base(includes[2]); got != "dolt" {
+		t.Errorf("includes[2] base = %q, want dolt", got)
 	}
 }
 
-func TestInjectBuiltinPacks_FileProvider(t *testing.T) {
+func TestBuiltinPackIncludes_NonBdProvider(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := MaterializeBuiltinPacks(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg := &config.City{}
-	cfg.Beads.Provider = "file"
-	injectBuiltinPacks(cfg, dir)
+	// Write a city.toml with a non-bd provider.
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[beads]\nprovider = \"file\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	if len(cfg.PackDirs) != 0 {
-		t.Errorf("PackDirs = %v, want empty for file provider", cfg.PackDirs)
+	t.Setenv("GC_BEADS", "")
+	includes := builtinPackIncludes(dir)
+
+	// Only maintenance, no bd/dolt.
+	if len(includes) != 1 {
+		t.Fatalf("builtinPackIncludes() = %v, want 1 entry (maintenance only)", includes)
+	}
+
+	if got := filepath.Base(includes[0]); got != "maintenance" {
+		t.Errorf("includes[0] base = %q, want maintenance", got)
 	}
 }
 
-func TestInjectBuiltinPacks_EnvOverride(t *testing.T) {
+func TestBuiltinPackIncludes_EnvOverride(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := MaterializeBuiltinPacks(dir); err != nil {
 		t.Fatal(err)
 	}
 
+	// GC_BEADS env var overrides city.toml provider.
 	t.Setenv("GC_BEADS", "file")
-	cfg := &config.City{}
-	injectBuiltinPacks(cfg, dir)
+	includes := builtinPackIncludes(dir)
 
-	if len(cfg.PackDirs) != 0 {
-		t.Errorf("PackDirs = %v, want empty when GC_BEADS=file", cfg.PackDirs)
+	// Only maintenance, no bd/dolt.
+	if len(includes) != 1 {
+		t.Fatalf("builtinPackIncludes() = %v, want 1 entry when GC_BEADS=file", includes)
+	}
+
+	if got := filepath.Base(includes[0]); got != "maintenance" {
+		t.Errorf("includes[0] base = %q, want maintenance", got)
 	}
 }
 
-func TestInjectBuiltinPacks_AlreadyLoaded(t *testing.T) {
+func TestBuiltinPackIncludes_NotMaterialized(t *testing.T) {
+	dir := t.TempDir()
+
+	// Don't materialize — should return empty.
+	t.Setenv("GC_BEADS", "")
+	includes := builtinPackIncludes(dir)
+
+	if len(includes) != 0 {
+		t.Errorf("builtinPackIncludes() = %v, want empty when packs not materialized", includes)
+	}
+}
+
+func TestBuiltinPackIncludes_PathsPointToSystemPacks(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := MaterializeBuiltinPacks(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	// Create a user-supplied bd pack in a separate directory.
-	userBd := filepath.Join(dir, "user-packs", "my-bd")
-	if err := os.MkdirAll(userBd, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(userBd, "pack.toml"), []byte("[pack]\nname = \"bd\"\nschema = 1\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("GC_BEADS", "")
+	includes := builtinPackIncludes(dir)
 
-	cfg := &config.City{}
-	cfg.PackDirs = []string{userBd}
-	injectBuiltinPacks(cfg, dir)
-
-	// Should not inject — user bd pack takes precedence.
-	if len(cfg.PackDirs) != 1 {
-		t.Errorf("PackDirs = %v, want only user bd pack", cfg.PackDirs)
-	}
-}
-
-func TestInjectBuiltinPacks_NotMaterialized(t *testing.T) {
-	dir := t.TempDir()
-
-	// Don't materialize — injection should be a no-op.
-	cfg := &config.City{}
-	injectBuiltinPacks(cfg, dir)
-
-	if len(cfg.PackDirs) != 0 {
-		t.Errorf("PackDirs = %v, want empty when packs not materialized", cfg.PackDirs)
+	systemRoot := filepath.Join(dir, citylayout.SystemPacksRoot)
+	for _, inc := range includes {
+		// Every include path must be under .gc/system/packs/.
+		rel, err := filepath.Rel(systemRoot, inc)
+		if err != nil {
+			t.Errorf("path %q not relative to system root: %v", inc, err)
+			continue
+		}
+		if rel == ".." || len(rel) > 0 && rel[0] == '.' {
+			t.Errorf("path %q escapes system packs root (rel=%q)", inc, rel)
+		}
+		// Each include path should be a directory with pack.toml inside.
+		if _, err := os.Stat(filepath.Join(inc, "pack.toml")); err != nil {
+			t.Errorf("pack.toml missing in %q: %v", inc, err)
+		}
 	}
 }
 
-func TestReadPackName(t *testing.T) {
+func TestBuiltinPackIncludes_AlwaysIncludesMaintenance(t *testing.T) {
 	dir := t.TempDir()
 
-	// Write a pack.toml with a name.
-	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-pack\"\nschema = 1\n"), 0o644); err != nil {
+	if err := MaterializeBuiltinPacks(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := readPackName(dir); got != "test-pack" {
-		t.Errorf("readPackName() = %q, want %q", got, "test-pack")
+	// Even with non-bd provider, maintenance must be present.
+	t.Setenv("GC_BEADS", "file")
+	includes := builtinPackIncludes(dir)
+
+	found := false
+	for _, inc := range includes {
+		if filepath.Base(inc) == "maintenance" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("maintenance pack not found in includes: %v", includes)
 	}
 
-	// Non-existent dir → empty.
-	if got := readPackName(filepath.Join(dir, "nope")); got != "" {
-		t.Errorf("readPackName(nonexistent) = %q, want empty", got)
+	// Also with bd provider.
+	t.Setenv("GC_BEADS", "bd")
+	includes = builtinPackIncludes(dir)
+
+	found = false
+	for _, inc := range includes {
+		if filepath.Base(inc) == "maintenance" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("maintenance pack not found in bd includes: %v", includes)
 	}
 }
 
 func TestMaterializeGastownPacks(t *testing.T) {
 	dir := t.TempDir()
 
+	// MaterializeGastownPacks is a no-op shim — verify it returns nil.
 	if err := MaterializeGastownPacks(dir); err != nil {
 		t.Fatalf("MaterializeGastownPacks() error: %v", err)
-	}
-
-	// Verify gastown pack.toml exists.
-	gastownToml := filepath.Join(dir, "packs", "gastown", "pack.toml")
-	if _, err := os.Stat(gastownToml); err != nil {
-		t.Errorf("gastown pack.toml missing: %v", err)
-	}
-
-	// Verify maintenance pack.toml exists.
-	maintenanceToml := filepath.Join(dir, "packs", "maintenance", "pack.toml")
-	if _, err := os.Stat(maintenanceToml); err != nil {
-		t.Errorf("maintenance pack.toml missing: %v", err)
-	}
-
-	// Verify gastown scripts are executable.
-	scriptsDir := filepath.Join(dir, "packs", "gastown", "scripts")
-	entries, err := os.ReadDir(scriptsDir)
-	if err != nil {
-		t.Fatalf("reading gastown scripts dir: %v", err)
-	}
-	if len(entries) == 0 {
-		t.Fatal("gastown scripts dir is empty")
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil {
-			t.Errorf("stat %s: %v", e.Name(), err)
-			continue
-		}
-		if info.Mode()&0o111 == 0 {
-			t.Errorf("gastown script %s not executable: mode %v", e.Name(), info.Mode())
-		}
-	}
-
-	// Verify gastown prompts exist.
-	promptsDir := filepath.Join(dir, "packs", "gastown", "prompts")
-	if _, err := os.Stat(promptsDir); err != nil {
-		t.Errorf("gastown prompts dir missing: %v", err)
-	}
-
-	// Verify default overlay payloads are materialized for both packs.
-	for _, overlayPath := range []string{
-		filepath.Join(dir, "packs", "gastown", "overlays", "default", ".claude", "settings.json"),
-		filepath.Join(dir, "packs", "maintenance", "overlays", "default", ".claude", "settings.json"),
-	} {
-		data, err := os.ReadFile(overlayPath)
-		if err != nil {
-			t.Errorf("default overlay settings missing at %s: %v", overlayPath, err)
-			continue
-		}
-		if !strings.Contains(string(data), `gc handoff \"context cycle\"`) {
-			t.Errorf("default overlay %s missing context-cycle hook", overlayPath)
-		}
-	}
-
-	// Verify TOML files are not executable.
-	info, err := os.Stat(gastownToml)
-	if err == nil && info.Mode()&0o111 != 0 {
-		t.Errorf("pack.toml should not be executable: mode %v", info.Mode())
-	}
-
-	// Verify pack name is correct.
-	if got := readPackName(filepath.Join(dir, "packs", "gastown")); got != "gastown" {
-		t.Errorf("readPackName(gastown) = %q, want %q", got, "gastown")
-	}
-	if got := readPackName(filepath.Join(dir, "packs", "maintenance")); got != "maintenance" {
-		t.Errorf("readPackName(maintenance) = %q, want %q", got, "maintenance")
 	}
 }
 
@@ -316,10 +304,5 @@ func TestMaterializeGastownPacks_Idempotent(t *testing.T) {
 	// Second call should succeed without error.
 	if err := MaterializeGastownPacks(dir); err != nil {
 		t.Fatalf("second call failed: %v", err)
-	}
-
-	// Files should still exist.
-	if _, err := os.Stat(filepath.Join(dir, "packs", "gastown", "pack.toml")); err != nil {
-		t.Error("gastown pack.toml missing after second call")
 	}
 }

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1731,11 +1731,11 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
 	}
-	if len(cfg.Workspace.Includes) != 1 || cfg.Workspace.Includes[0] != "packs/gastown" {
-		t.Errorf("Workspace.Includes = %v, want [packs/gastown]", cfg.Workspace.Includes)
+	if len(cfg.Workspace.Includes) != 1 || cfg.Workspace.Includes[0] != ".gc/system/packs/gastown" {
+		t.Errorf("Workspace.Includes = %v, want [.gc/system/packs/gastown]", cfg.Workspace.Includes)
 	}
-	if len(cfg.Workspace.DefaultRigIncludes) != 1 || cfg.Workspace.DefaultRigIncludes[0] != "packs/gastown" {
-		t.Errorf("Workspace.DefaultRigIncludes = %v, want [packs/gastown]", cfg.Workspace.DefaultRigIncludes)
+	if len(cfg.Workspace.DefaultRigIncludes) != 1 || cfg.Workspace.DefaultRigIncludes[0] != ".gc/system/packs/gastown" {
+		t.Errorf("Workspace.DefaultRigIncludes = %v, want [.gc/system/packs/gastown]", cfg.Workspace.DefaultRigIncludes)
 	}
 	// No inline agents.
 	if len(cfg.Agents) != 0 {

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -567,7 +567,7 @@ func TestFormulasDir(t *testing.T) {
 	cfg := loadExpanded(t)
 	// Formulas come from packs, not from city.toml directly.
 	// FormulaLayers.City should have formula dirs from both packs.
-	// Note: bd/dolt formulas are auto-injected at runtime by injectBuiltinPacks,
+	// Note: bd/dolt formulas are auto-included at runtime by builtinPackIncludes,
 	// not via pack.toml includes, so they won't appear in static expansion.
 	if len(cfg.FormulaLayers.City) == 0 {
 		t.Fatal("FormulaLayers.City is empty, want pack formulas layers")
@@ -596,7 +596,7 @@ func TestPackDirsPopulated(t *testing.T) {
 		t.Fatal("PackDirs is empty after expansion")
 	}
 	// Should have pack dirs from maintenance and gastown packs.
-	// Note: bd/dolt packs are auto-injected at runtime by injectBuiltinPacks,
+	// Note: bd/dolt packs are auto-included at runtime by builtinPackIncludes,
 	// not via pack.toml includes, so they won't appear in static expansion.
 	var hasMaintenance, hasGastown bool
 	for _, d := range cfg.PackDirs {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -56,9 +57,19 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 
 	// Extract includes for processing. CLI -f files are appended after.
 	// Preserve the original Include value so Marshal() round-trips it.
+	// Pack includes (pack.toml paths) are separated and handled later
+	// via Workspace.Includes → ExpandCityPacks.
 	origInclude := root.Include
 	includes := append([]string{}, root.Include...)
-	includes = append(includes, extraIncludes...)
+	var packIncludes []string
+	for _, inc := range extraIncludes {
+		// Detect pack directories (contain pack.toml) vs TOML fragments.
+		if info, err := fs.Stat(inc); err == nil && info.IsDir() {
+			packIncludes = append(packIncludes, inc)
+		} else {
+			includes = append(includes, inc)
+		}
+	}
 	root.Include = origInclude
 
 	for _, inc := range includes {
@@ -97,6 +108,20 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 		// Merge fragment into root.
 		mergeFragment(root, frag, fragMeta, fragPath, prov)
 		prov.Sources = append(prov.Sources, fragPath)
+	}
+
+	// Inject system pack includes into Workspace.Includes. These are
+	// appended AFTER user includes so user packs override system pack
+	// fallbacks via the normal dedup/fallback resolution.
+	// Skip packs already reachable from user includes (avoids duplicate
+	// agent errors when a user pack transitively includes a system pack).
+	existingPacks := resolvedPackNames(root.Workspace.Includes, fs, cityRoot)
+	for _, inc := range packIncludes {
+		name := readPackNameFromDir(inc)
+		if name != "" && existingPacks[name] {
+			continue
+		}
+		root.Workspace.Includes = append(root.Workspace.Includes, inc)
 	}
 
 	// Resolve named pack references to cache paths before any expansion.
@@ -649,4 +674,65 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 			prov.Workspace[f] = source
 		}
 	}
+}
+
+// resolvedPackNames collects pack names that are reachable from a set of
+// include paths (including transitive includes in pack.toml). Used to
+// skip system pack injection when a pack is already included by the user.
+func resolvedPackNames(includes []string, sysFS fsys.FS, cityRoot string) map[string]bool {
+	names := make(map[string]bool, len(includes))
+	var visit func(ref string)
+	visit = func(ref string) {
+		dir := resolveConfigPath(ref, cityRoot, cityRoot)
+		// Try resolving as a pack directory.
+		packPath := filepath.Join(dir, packFile)
+		data, err := sysFS.ReadFile(packPath)
+		if err != nil {
+			// Maybe it's a remote ref.
+			if resolved, rErr := resolvePackRef(ref, cityRoot, cityRoot); rErr == nil {
+				dir = resolved
+				data, err = sysFS.ReadFile(filepath.Join(dir, packFile))
+			}
+		}
+		if err != nil {
+			return
+		}
+		var pc struct {
+			Pack struct {
+				Name     string   `toml:"name"`
+				Includes []string `toml:"includes"`
+			} `toml:"pack"`
+		}
+		if _, decErr := toml.Decode(string(data), &pc); decErr != nil || pc.Pack.Name == "" {
+			return
+		}
+		if names[pc.Pack.Name] {
+			return
+		}
+		names[pc.Pack.Name] = true
+		for _, sub := range pc.Pack.Includes {
+			visit(resolveConfigPath(sub, dir, cityRoot))
+		}
+	}
+	for _, inc := range includes {
+		visit(inc)
+	}
+	return names
+}
+
+// readPackNameFromDir reads [pack].name from pack.toml in the given directory.
+func readPackNameFromDir(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, packFile))
+	if err != nil {
+		return ""
+	}
+	var pc struct {
+		Pack struct {
+			Name string `toml:"name"`
+		} `toml:"pack"`
+	}
+	if _, err := toml.Decode(string(data), &pc); err != nil {
+		return ""
+	}
+	return pc.Pack.Name
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1879,8 +1879,8 @@ func WizardCity(name, provider, startCommand string) City {
 func GastownCity(name, provider, startCommand string) City {
 	ws := Workspace{
 		Name:               name,
-		Includes:           []string{"packs/gastown"},
-		DefaultRigIncludes: []string{"packs/gastown"},
+		Includes:           []string{".gc/system/packs/gastown"},
+		DefaultRigIncludes: []string{".gc/system/packs/gastown"},
 		GlobalFragments:    []string{"command-glossary", "operational-awareness"},
 	}
 	if startCommand != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -664,11 +664,11 @@ func TestGastownCity(t *testing.T) {
 	if c.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", c.Workspace.Provider, "claude")
 	}
-	if len(c.Workspace.Includes) != 1 || c.Workspace.Includes[0] != "packs/gastown" {
-		t.Errorf("Workspace.Includes = %v, want [packs/gastown]", c.Workspace.Includes)
+	if len(c.Workspace.Includes) != 1 || c.Workspace.Includes[0] != ".gc/system/packs/gastown" {
+		t.Errorf("Workspace.Includes = %v, want [.gc/system/packs/gastown]", c.Workspace.Includes)
 	}
-	if len(c.Workspace.DefaultRigIncludes) != 1 || c.Workspace.DefaultRigIncludes[0] != "packs/gastown" {
-		t.Errorf("Workspace.DefaultRigIncludes = %v, want [packs/gastown]", c.Workspace.DefaultRigIncludes)
+	if len(c.Workspace.DefaultRigIncludes) != 1 || c.Workspace.DefaultRigIncludes[0] != ".gc/system/packs/gastown" {
+		t.Errorf("Workspace.DefaultRigIncludes = %v, want [.gc/system/packs/gastown]", c.Workspace.DefaultRigIncludes)
 	}
 	if len(c.Workspace.GlobalFragments) != 2 {
 		t.Errorf("Workspace.GlobalFragments = %v, want 2 entries", c.Workspace.GlobalFragments)
@@ -716,11 +716,11 @@ func TestGastownCityRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(Marshal output): %v", err)
 	}
-	if len(got.Workspace.Includes) != 1 || got.Workspace.Includes[0] != "packs/gastown" {
-		t.Errorf("round-trip Includes = %v, want [packs/gastown]", got.Workspace.Includes)
+	if len(got.Workspace.Includes) != 1 || got.Workspace.Includes[0] != ".gc/system/packs/gastown" {
+		t.Errorf("round-trip Includes = %v, want [.gc/system/packs/gastown]", got.Workspace.Includes)
 	}
-	if len(got.Workspace.DefaultRigIncludes) != 1 || got.Workspace.DefaultRigIncludes[0] != "packs/gastown" {
-		t.Errorf("round-trip DefaultRigIncludes = %v, want [packs/gastown]", got.Workspace.DefaultRigIncludes)
+	if len(got.Workspace.DefaultRigIncludes) != 1 || got.Workspace.DefaultRigIncludes[0] != ".gc/system/packs/gastown" {
+		t.Errorf("round-trip DefaultRigIncludes = %v, want [.gc/system/packs/gastown]", got.Workspace.DefaultRigIncludes)
 	}
 	if got.Workspace.Provider != "claude" {
 		t.Errorf("round-trip Provider = %q, want %q", got.Workspace.Provider, "claude")

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -314,7 +314,9 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 	}
 
 	// City pack agents go at the front (before user-defined agents).
-	cfg.Agents = append(allAgents, cfg.Agents...)
+	// Run fallback dedup again on the combined set so system pack
+	// fallback agents yield to inline city-level agents.
+	cfg.Agents = resolveFallbackAgents(append(allAgents, cfg.Agents...))
 	cfg.NamedSessions = append(allNamedSessions, cfg.NamedSessions...)
 
 	// Store city-level pack globals.
@@ -410,12 +412,12 @@ func resolveFallbackAgents(agents []Agent) []Agent {
 	// Determine which indices to remove.
 	remove := make(map[int]bool)
 	for _, entries := range groups {
-		// Only care about names from multiple SourceDirs.
+		// Only care about names from multiple sources.
+		// Empty SourceDir means city-level (inline) — count it as a
+		// distinct source so system pack fallbacks yield to inline agents.
 		dirs := make(map[string]bool)
 		for _, e := range entries {
-			if e.srcDir != "" {
-				dirs[e.srcDir] = true
-			}
+			dirs[e.srcDir] = true // "" is a valid key (city-level)
 		}
 		if len(dirs) < 2 {
 			continue


### PR DESCRIPTION
## Summary
- System packs (bd, dolt, maintenance, gastown) are now embedded and auto-included via the normal pack expansion pipeline instead of the old `injectBuiltinPacks` dual-path system
- Every city automatically gets maintenance orders (wisp-compact, orphan-sweep, prune-branches, etc.) without explicit config
- Gastown init template now references `.gc/system/packs/gastown` instead of copying files to `packs/`
- Fallback agent dedup correctly handles system pack agents vs inline city-level agents

## Key changes
- `builtinPackIncludes()` replaces `injectBuiltinPacks()` — returns pack dirs as `extraIncludes` for `LoadWithIncludes`
- `LoadWithIncludes` routes directory includes to `Workspace.Includes` → `ExpandCityPacks`
- Transitive dedup prevents double-loading when user packs already include a system pack
- `resolveFallbackAgents` runs on combined pack+inline agent lists

## Test plan
- [x] `golangci-lint run ./...` — zero issues
- [x] All `TestBuiltinPackIncludes_*` tests pass
- [x] All `TestTutorial01` txtar tests pass (including gastown-config)
- [x] `TestGastownCity*` config tests pass
- [x] Full `cmd/gc`, `internal/config`, `internal/api` test suites pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)