### PR TITLE
fix: pass Claude auth env into managed sessions

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -850,8 +850,9 @@ func passthroughEnv() map[string]string {
 	}
 	// USER/LOGNAME are required on macOS for Keychain access — without them
 	// providers like Claude Code cannot read stored OAuth credentials.
-	for _, key := range []string{"USER", "LOGNAME"} {
-	for _, key := range []string{"HOME", "USER", "LOGNAME", "XDG_CONFIG_HOME", "XDG_STATE_HOME", "CLAUDE_CONFIG_DIR", "CLAUDE_CODE_OAUTH_TOKEN"} {
+	// CLAUDE_CONFIG_DIR and CLAUDE_CODE_OAUTH_TOKEN let managed Claude
+	// sessions find stored credentials and token-based auth.
+	for _, key := range []string{"USER", "LOGNAME", "CLAUDE_CONFIG_DIR", "CLAUDE_CODE_OAUTH_TOKEN"} {
 		if v := os.Getenv(key); v != "" {
 			m[key] = v
 		}
@@ -869,6 +870,10 @@ func passthroughEnv() map[string]string {
 	} else if home := os.Getenv("HOME"); home != "" {
 		m["XDG_STATE_HOME"] = filepath.Join(home, ".local", "state")
 	}
+	// Pass through all GC_* and ANTHROPIC_* vars. Agent credentials are
+	// included in the global baseline because the SDK cannot know which
+	// agent uses which provider (zero hardcoded roles); the trust boundary
+	// is the managed session itself.
 	for _, entry := range os.Environ() {
 		key, val, ok := strings.Cut(entry, "=")
 		if !ok || val == "" {

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -192,6 +192,35 @@ func TestPassthroughEnvIncludesClaudeAuthContext(t *testing.T) {
 	}
 }
 
+func TestPassthroughEnvXDGFallbackFromHOME(t *testing.T) {
+	t.Setenv("HOME", "/tmp/gc-home")
+	// Explicitly unset XDG vars so fallback logic fires.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+
+	got := passthroughEnv()
+
+	if got["XDG_CONFIG_HOME"] != "/tmp/gc-home/.config" {
+		t.Errorf("XDG_CONFIG_HOME = %q, want %q (fallback from HOME)", got["XDG_CONFIG_HOME"], "/tmp/gc-home/.config")
+	}
+	if got["XDG_STATE_HOME"] != "/tmp/gc-home/.local/state" {
+		t.Errorf("XDG_STATE_HOME = %q, want %q (fallback from HOME)", got["XDG_STATE_HOME"], "/tmp/gc-home/.local/state")
+	}
+}
+
+func TestPassthroughEnvOmitsEmptyAnthropicVars(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+
+	got := passthroughEnv()
+
+	for _, key := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("passthroughEnv() should omit empty %s", key)
+		}
+	}
+}
+
 func TestPassthroughEnvStripsClaudeNesting(t *testing.T) {
 	t.Setenv("CLAUDECODE", "1")
 	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "cli")


### PR DESCRIPTION
## Summary

- pass Claude auth/home environment through managed session startup
- preserve the existing Claude nesting-var clearing behavior
- add regression coverage for Claude auth env passthrough

Managed tmux sessions were only inheriting `PATH`, `GC_*`, and telemetry vars.
That made Claude Code authentication brittle under managed launches because the
session could lose the home/config/auth context Claude needs to find stored
credentials or token-based auth.

This change forwards the minimal context needed for managed Claude sessions:

- `HOME`
- `USER`
- `LOGNAME`
- `XDG_CONFIG_HOME`
- `XDG_STATE_HOME`
- `CLAUDE_CONFIG_DIR`
- `CLAUDE_CODE_OAUTH_TOKEN`
- `ANTHROPIC_*`

I also manually validated the patched managed-session path against clean tmux
servers and real project workdirs.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
  - not needed; no docs changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
  - attempted, but the repo is currently red outside this patch:
    - `internal/beads/exec`: `TestBrProviderConformance`
    - `test/integration`: build errors (`repoRoot`, `filterEnvMany` undefined)

Additional validation:

- [x] `go test ./... -count=1`
- [x] live managed Claude auth probe on a clean tmux server
- [x] live managed project probe against `/home/nuc/hermes-agent`
- [x] live managed project probe against `/home/nuc/Projects/gc-AutoSafe/rigs/AutoSafe`

## Checklist

- [x] Linked an issue, or explained why one is not needed
  - no issue; this is a tight bugfix with a direct repro
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
  - not needed; internal env-plumbing fix only
- [x] Called out breaking changes or migration notes
  - none
