### PR TITLE
fix: add flock to FileStore to prevent concurrent ID collisions

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -549,10 +549,12 @@ func openStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
 	}
 	switch provider {
 	case "file":
-		store, err := beads.OpenFileStore(fsys.OSFS{}, filepath.Join(runtimeCityPath, ".gc", "beads.json"))
+		beadsPath := filepath.Join(runtimeCityPath, ".gc", "beads.json")
+		store, err := beads.OpenFileStore(fsys.OSFS{}, beadsPath)
 		if err != nil {
 			return nil, err
 		}
+		store.SetLocker(beads.NewFileFlock(beadsPath + ".lock"))
 		return store, nil
 	default: // "bd" or unrecognized → use bd
 		if _, err := exec.LookPath("bd"); err != nil {

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -22,9 +22,10 @@ type fileData struct {
 // write. Fine for Tutorial 01 volumes.
 type FileStore struct {
 	*MemStore
-	fmu  sync.Mutex // guards mutate-then-save atomicity
-	fs   fsys.FS
-	path string
+	fmu    sync.Mutex // guards mutate-then-save atomicity
+	fs     fsys.FS
+	path   string
+	locker Locker // cross-process file lock; nopLocker when unset
 }
 
 // OpenFileStore opens or creates a file-backed bead store at path. All file
@@ -39,7 +40,7 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &FileStore{MemStore: NewMemStore(), fs: fs, path: path}, nil
+			return &FileStore{MemStore: NewMemStore(), fs: fs, path: path, locker: nopLocker{}}, nil
 		}
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
@@ -48,7 +49,34 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 	if err := json.Unmarshal(data, &fd); err != nil {
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
-	return &FileStore{MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps), fs: fs, path: path}, nil
+	return &FileStore{MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps), fs: fs, path: path, locker: nopLocker{}}, nil
+}
+
+// SetLocker sets a cross-process Locker (typically a FileFlock). When set,
+// every mutating operation acquires the lock and reloads from disk before
+// writing — preventing ID collisions between the CLI and controller daemon.
+func (fs *FileStore) SetLocker(l Locker) {
+	fs.locker = l
+}
+
+// reloadFromDisk re-reads the store file and replaces the in-memory state.
+// Must be called with fmu held. Used after acquiring a cross-process flock to
+// pick up changes made by other processes since we last read.
+func (fs *FileStore) reloadFromDisk() error {
+	data, err := fs.fs.ReadFile(fs.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File hasn't been created yet — keep current in-memory state.
+			return nil
+		}
+		return fmt.Errorf("reloading file store: %w", err)
+	}
+	var fd fileData
+	if err := json.Unmarshal(data, &fd); err != nil {
+		return fmt.Errorf("reloading file store: %w", err)
+	}
+	fs.restoreFrom(fd.Seq, fd.Beads, fd.Deps)
+	return nil
 }
 
 // Create delegates to MemStore.Create and flushes to disk.
@@ -57,6 +85,13 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 func (fs *FileStore) Create(b Bead) (Bead, error) {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return Bead{}, err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return Bead{}, err
+	}
 	snap := fs.snapshotLocked()
 	result, err := fs.MemStore.Create(b)
 	if err != nil {
@@ -74,6 +109,13 @@ func (fs *FileStore) Create(b Bead) (Bead, error) {
 func (fs *FileStore) Update(id string, opts UpdateOpts) error {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.Update(id, opts); err != nil {
 		return err
@@ -90,6 +132,13 @@ func (fs *FileStore) Update(id string, opts UpdateOpts) error {
 func (fs *FileStore) Close(id string) error {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.Close(id); err != nil {
 		return err
@@ -105,6 +154,13 @@ func (fs *FileStore) Close(id string) error {
 func (fs *FileStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return 0, err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return 0, err
+	}
 	snap := fs.snapshotLocked()
 	closed, err := fs.MemStore.CloseAll(ids, metadata)
 	if err != nil {
@@ -124,6 +180,13 @@ func (fs *FileStore) CloseAll(ids []string, metadata map[string]string) (int, er
 func (fs *FileStore) SetMetadata(id, key, value string) error {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.SetMetadata(id, key, value); err != nil {
 		return err
@@ -140,6 +203,13 @@ func (fs *FileStore) SetMetadata(id, key, value string) error {
 func (fs *FileStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.SetMetadataBatch(id, kvs); err != nil {
 		return err
@@ -161,6 +231,13 @@ func (fs *FileStore) Ping() error {
 func (fs *FileStore) DepAdd(issueID, dependsOnID, depType string) error {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.DepAdd(issueID, dependsOnID, depType); err != nil {
 		return err
@@ -177,6 +254,13 @@ func (fs *FileStore) DepAdd(issueID, dependsOnID, depType string) error {
 func (fs *FileStore) DepRemove(issueID, dependsOnID string) error {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.DepRemove(issueID, dependsOnID); err != nil {
 		return err

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -274,6 +275,77 @@ func TestFileStoreSaveRenameFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "rename failed") {
 		t.Errorf("error = %q, want 'rename failed'", err)
+	}
+}
+
+// TestFileStoreConcurrentCreateWithFlock verifies that two FileStore instances
+// backed by flock on the same file produce unique IDs (no collisions).
+func TestFileStoreConcurrentCreateWithFlock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock not available on Windows")
+	}
+
+	dir := t.TempDir()
+	beadsPath := filepath.Join(dir, "beads.json")
+	lockPath := beadsPath + ".lock"
+
+	const perStore = 20
+
+	// Open two stores on the same file, each with its own flock.
+	open := func() *beads.FileStore {
+		s, err := beads.OpenFileStore(fsys.OSFS{}, beadsPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.SetLocker(beads.NewFileFlock(lockPath))
+		return s
+	}
+
+	s1 := open()
+	s2 := open()
+
+	// Run creates concurrently from both stores.
+	var wg sync.WaitGroup
+	ids := make(chan string, perStore*2)
+
+	createN := func(s *beads.FileStore, prefix string) {
+		defer wg.Done()
+		for i := 0; i < perStore; i++ {
+			b, err := s.Create(beads.Bead{Title: fmt.Sprintf("%s-%d", prefix, i)})
+			if err != nil {
+				t.Errorf("Create failed: %v", err)
+				return
+			}
+			ids <- b.ID
+		}
+	}
+
+	wg.Add(2)
+	go createN(s1, "s1")
+	go createN(s2, "s2")
+	wg.Wait()
+	close(ids)
+
+	// All IDs must be unique.
+	seen := make(map[string]bool)
+	for id := range ids {
+		if seen[id] {
+			t.Errorf("duplicate ID: %s", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != perStore*2 {
+		t.Errorf("got %d unique IDs, want %d", len(seen), perStore*2)
+	}
+
+	// Reopen and verify all beads survived.
+	s3 := open()
+	all, err := s3.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != perStore*2 {
+		t.Errorf("after reopen: %d beads, want %d", len(all), perStore*2)
 	}
 }
 

--- a/internal/beads/flock.go
+++ b/internal/beads/flock.go
@@ -1,0 +1,61 @@
+package beads
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Locker abstracts file-level locking for cross-process synchronization.
+// FileStore uses it to serialize concurrent writers (CLI + controller).
+type Locker interface {
+	// Lock acquires an exclusive lock, blocking until available.
+	Lock() error
+	// Unlock releases the lock.
+	Unlock() error
+}
+
+// FileFlock implements Locker using flock(2) on the given path.
+// The lock file is created if it does not exist.
+type FileFlock struct {
+	path string
+	f    *os.File
+}
+
+// NewFileFlock returns a new FileFlock that locks the given path.
+func NewFileFlock(path string) *FileFlock {
+	return &FileFlock{path: path}
+}
+
+// Lock acquires an exclusive flock, creating the lock file if needed.
+func (fl *FileFlock) Lock() error {
+	f, err := os.OpenFile(fl.path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("flock open: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return fmt.Errorf("flock lock: %w", err)
+	}
+	fl.f = f
+	return nil
+}
+
+// Unlock releases the flock and closes the lock file.
+func (fl *FileFlock) Unlock() error {
+	if fl.f == nil {
+		return nil
+	}
+	// Unlock then close; ignore unlock error if close succeeds.
+	syscall.Flock(int(fl.f.Fd()), syscall.LOCK_UN) //nolint:errcheck // best-effort unlock before close
+	err := fl.f.Close()
+	fl.f = nil
+	return err
+}
+
+// nopLocker is a no-op Locker for use when file locking is not needed
+// (e.g., tests with in-memory filesystems).
+type nopLocker struct{}
+
+func (nopLocker) Lock() error   { return nil }
+func (nopLocker) Unlock() error { return nil }


### PR DESCRIPTION
## Summary
- The CLI (`gc handoff`) and controller daemon open separate FileStore instances with independent in-memory `seq` counters, allowing both to produce the same bead ID — the second writer silently overwrites the first
- Adds a `Locker` interface backed by `flock(2)` that serializes cross-process writes to `beads.json`
- After acquiring the lock, FileStore reloads from disk before mutating, so it always picks up the latest seq counter from other processes

## Test plan
- [x] All existing FileStore tests pass (no behavior change when locker is not set — defaults to no-op)
- [x] New `TestFileStoreConcurrentCreateWithFlock` verifies two FileStore instances writing concurrently produce unique IDs and all beads survive a reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)