### PR TITLE
test: add acceptance tests for CLI basics and session management

### DIFF
--- a/test/acceptance/cli_basics_test.go
+++ b/test/acceptance/cli_basics_test.go
@@ -1,0 +1,112 @@
+//go:build acceptance_a
+
+// CLI basics acceptance tests.
+//
+// These exercise the foundational gc commands that every user touches:
+// version, help, hook, and stop. These are the first things a new user
+// runs and must work correctly.
+package acceptance_test
+
+import (
+	"strings"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+// --- gc version ---
+
+func TestVersion_PrintsVersion(t *testing.T) {
+	out, err := helpers.RunGC(testEnv, "", "version")
+	if err != nil {
+		t.Fatalf("gc version: %v\n%s", err, out)
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		t.Fatal("gc version produced empty output")
+	}
+}
+
+func TestVersion_Long_IncludesCommitInfo(t *testing.T) {
+	out, err := helpers.RunGC(testEnv, "", "version", "--long")
+	if err != nil {
+		t.Fatalf("gc version --long: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "commit:") {
+		t.Errorf("expected 'commit:' in long version output, got:\n%s", out)
+	}
+}
+
+// --- gc help ---
+
+func TestHelp_ListsSubcommands(t *testing.T) {
+	out, err := helpers.RunGC(testEnv, "", "help")
+	if err != nil {
+		t.Fatalf("gc help: %v\n%s", err, out)
+	}
+	for _, cmd := range []string{"init", "start", "stop", "status", "rig", "config"} {
+		if !strings.Contains(out, cmd) {
+			t.Errorf("gc help should mention %q subcommand, got:\n%s", cmd, out)
+		}
+	}
+}
+
+// --- gc hook ---
+
+func TestHook_NoAgent_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("hook")
+	if err == nil {
+		t.Fatal("expected error for 'gc hook' without agent, got success")
+	}
+	if !strings.Contains(out, "agent not specified") {
+		t.Errorf("expected 'agent not specified' message, got:\n%s", out)
+	}
+}
+
+func TestHook_UnknownAgent_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("hook", "nonexistent-agent-xyz")
+	if err == nil {
+		t.Fatal("expected error for unknown agent, got success")
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected 'not found' message, got:\n%s", out)
+	}
+}
+
+func TestHook_Inject_NoAgent_ExitsZero(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	// --inject should always exit 0, even without an agent.
+	_, err := c.GC("hook", "--inject")
+	if err != nil {
+		t.Fatalf("gc hook --inject should exit 0, got: %v", err)
+	}
+}
+
+// --- gc stop ---
+
+func TestStop_NotInitialized_ReturnsError(t *testing.T) {
+	emptyDir := t.TempDir()
+	_, err := helpers.RunGC(testEnv, emptyDir, "stop", emptyDir)
+	if err == nil {
+		t.Fatal("expected error for stop on non-city directory, got success")
+	}
+}
+
+func TestStop_InitializedNeverStarted_Succeeds(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	// Stop on a city that was never started should not error.
+	_, err := c.GC("stop", c.Dir)
+	if err != nil {
+		t.Fatalf("gc stop on never-started city should succeed, got: %v", err)
+	}
+}

--- a/test/acceptance/session_test.go
+++ b/test/acceptance/session_test.go
@@ -1,0 +1,167 @@
+//go:build acceptance_a
+
+// Session management acceptance tests.
+//
+// These exercise gc session subcommands as a black box. Sessions are
+// the primary mechanism for interactive agent chat — testing their CLI
+// is high-value because every user interacts with sessions.
+package acceptance_test
+
+import (
+	"strings"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+// --- gc session (bare command) ---
+
+func TestSession_NoSubcommand_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("session")
+	if err == nil {
+		t.Fatal("expected error for bare 'gc session', got success")
+	}
+	if !strings.Contains(out, "missing subcommand") {
+		t.Errorf("expected 'missing subcommand' message, got:\n%s", out)
+	}
+}
+
+func TestSession_UnknownSubcommand_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("session", "bogus")
+	if err == nil {
+		t.Fatal("expected error for 'gc session bogus', got success")
+	}
+	if !strings.Contains(out, "unknown subcommand") {
+		t.Errorf("expected 'unknown subcommand' message, got:\n%s", out)
+	}
+}
+
+// --- gc session list ---
+
+func TestSessionList_EmptyCity_ShowsNoSessions(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("session", "list")
+	if err != nil {
+		t.Fatalf("gc session list: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "No sessions") {
+		t.Errorf("expected 'No sessions' message on fresh city, got:\n%s", out)
+	}
+}
+
+func TestSessionList_JSON_ReturnsValidOutput(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("session", "list", "--json")
+	if err != nil {
+		t.Fatalf("gc session list --json: %v\n%s", err, out)
+	}
+	trimmed := strings.TrimSpace(out)
+	// Empty list should be a JSON array.
+	if trimmed != "[]" && trimmed != "null" {
+		// At minimum it should start with [ (array) or be "null".
+		if !strings.HasPrefix(trimmed, "[") {
+			t.Errorf("expected JSON array for empty session list, got:\n%s", out)
+		}
+	}
+}
+
+// --- gc session prune ---
+
+func TestSessionPrune_EmptyCity_ShowsNone(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	out, err := c.GC("session", "prune")
+	if err != nil {
+		t.Fatalf("gc session prune: %v\n%s", err, out)
+	}
+	// With no sessions, prune should indicate nothing to do.
+	if !strings.Contains(strings.ToLower(out), "no sessions") && !strings.Contains(out, "0") {
+		t.Errorf("expected indication of no sessions to prune, got:\n%s", out)
+	}
+}
+
+// --- gc session new ---
+
+func TestSessionNew_NonexistentTemplate_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	_, err := c.GC("session", "new", "nonexistent-agent-xyz")
+	if err == nil {
+		t.Fatal("expected error for nonexistent template, got success")
+	}
+}
+
+func TestSessionNew_MissingTemplate_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	// cobra.ExactArgs(1) handles the missing argument — just verify it errors.
+	_, err := c.GC("session", "new")
+	if err == nil {
+		t.Fatal("expected error for 'gc session new' without template, got success")
+	}
+}
+
+// --- gc session close/kill/wake on nonexistent sessions ---
+
+func TestSessionClose_NonexistentSession_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	_, err := c.GC("session", "close", "nonexistent-session")
+	if err == nil {
+		t.Fatal("expected error for closing nonexistent session, got success")
+	}
+}
+
+func TestSessionKill_NonexistentSession_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	_, err := c.GC("session", "kill", "nonexistent-session")
+	if err == nil {
+		t.Fatal("expected error for killing nonexistent session, got success")
+	}
+}
+
+func TestSessionWake_NonexistentSession_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	_, err := c.GC("session", "wake", "nonexistent-session")
+	if err == nil {
+		t.Fatal("expected error for waking nonexistent session, got success")
+	}
+}
+
+func TestSessionPeek_NonexistentSession_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	_, err := c.GC("session", "peek", "nonexistent-session")
+	if err == nil {
+		t.Fatal("expected error for peeking nonexistent session, got success")
+	}
+}
+
+func TestSessionRename_NonexistentSession_ReturnsError(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	_, err := c.GC("session", "rename", "nonexistent-session", "new-name")
+	if err == nil {
+		t.Fatal("expected error for renaming nonexistent session, got success")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `cli_basics_test.go`: version output, help subcommands, hook errors (no agent, unknown agent, --inject), stop errors (not initialized, never started) — 8 tests
- Adds `session_test.go`: bare command, unknown subcommand, list/prune on empty city, JSON output, session new errors, close/kill/wake/peek/rename on nonexistent sessions — 12 tests
- All Tier A (subprocess/file/skip providers)

## Test plan
- [x] All 20 tests pass locally
- [x] `go vet` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)