### PR TITLE
fix: resolve rig store from city routes instead of returning city store

### DIFF
--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -408,16 +408,8 @@ func (s *Server) resolveStoreByPrefix(prefix string) beads.Store {
 	stores := s.state.BeadStores()
 	cityPath := strings.TrimSpace(s.state.CityPath())
 
-	// Check city-level routes first.
-	if cityPath != "" {
-		if _, ok := resolveRoutePrefix(cityPath, prefix); ok {
-			if cityStore := s.state.CityBeadStore(); cityStore != nil {
-				return cityStore
-			}
-		}
-	}
-
-	// Build rig path → name map for reverse lookup.
+	// Build rig path → name map for reverse lookup (used by both city
+	// and rig route resolution below).
 	rigPathToName := make(map[string]string, len(cfg.Rigs))
 	for _, rig := range cfg.Rigs {
 		rp := strings.TrimSpace(rig.Path)
@@ -428,6 +420,25 @@ func (s *Server) resolveStoreByPrefix(prefix string) beads.Store {
 			rp = filepath.Join(cityPath, rp)
 		}
 		rigPathToName[filepath.Clean(rp)] = rig.Name
+	}
+
+	// Check city-level routes first.
+	if cityPath != "" {
+		if storePath, ok := resolveRoutePrefix(cityPath, prefix); ok {
+			cleanPath := filepath.Clean(storePath)
+			// Route may point to a rig directory — resolve to the rig store.
+			if rigName, found := rigPathToName[cleanPath]; found {
+				if store, exists := stores[rigName]; exists {
+					return store
+				}
+			}
+			// Route points to the city itself (e.g. prefix "mc" → ".").
+			if cleanPath == filepath.Clean(cityPath) {
+				if cityStore := s.state.CityBeadStore(); cityStore != nil {
+					return cityStore
+				}
+			}
+		}
 	}
 
 	// Search routes.jsonl in each rig's .beads/ directory.


### PR DESCRIPTION
## Summary
- **Bug**: All rig-prefixed bead GETs (e.g. `ga-*`) returned 404, while LIST returned them correctly
- **Root cause**: `resolveStoreByPrefix` in `handler_beads.go` read the city-level `routes.jsonl` which maps prefix `ga` → `gascity`, but then returned the city bead store instead of the gascity rig store. The city store only holds `mc-*` beads.
- **Fix**: Build the `rigPathToName` map before the city routes check and use the resolved path to look up the correct rig store. City store is only returned when the route points to the city directory itself.

## Test plan
- [x] `go test ./internal/api/... -run TestBead` passes
- [x] Verified `GET /v0/bead/ga-717n7` returns 200 (was 404)
- [x] Verified `GET /v0/bead/mc-8m88zn` still returns 200 (city beads unaffected)
- [x] All 7 previously-failing bead IDs now return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)