### PR TITLE
fix: close workflow root before finalize bead to prevent stranded workflows

### DIFF
--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -250,11 +250,16 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead) (ControlResult,
 		return ControlResult{}, fmt.Errorf("%s: resolving workflow outcome: %w", bead.ID, err)
 	}
 
-	if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: completing workflow finalizer: %w", bead.ID, err)
-	}
+	// Close the root BEFORE the finalize bead. If the root close fails and
+	// the control-dispatcher crashes, the finalize bead stays open so the
+	// next serve cycle will retry. Closing the finalize first would make it
+	// non-retriable (ProcessControl skips closed beads), stranding the root
+	// as in_progress forever.
 	if err := setOutcomeAndClose(store, rootID, outcome); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: completing workflow head: %w", rootID, err)
+	}
+	if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
+		return ControlResult{}, fmt.Errorf("%s: completing workflow finalizer: %w", bead.ID, err)
 	}
 	return ControlResult{Processed: true, Action: "workflow-" + outcome}, nil
 }


### PR DESCRIPTION
## Summary
- **Bug**: FormulaV2 workflows get permanently stuck as `in_progress`/`pending` after all steps complete
- **Root cause**: `processWorkflowFinalize` closes the finalize bead first (line 253), then the root (line 256). If the root close fails, the control-dispatcher crashes. On restart, the finalize bead is already closed → `ProcessControl` skips it → root stays `in_progress` forever.
- **Fix**: Swap the close order — root first, then finalize bead. If root close fails, the finalize bead stays open and the operation retries on the next cycle.

## Test plan
- [x] `go test ./internal/dispatch/... -count=1` passes (including `TestProcessWorkflowFinalizeClosesWorkflow`)
- [x] `go test ./cmd/gc/... -run "TestConvoy|TestWorkflow|TestFinalize|TestGraph"` passes
- [x] Manually verified: 5 stuck quinn/adopt-pr workflows were visible as permanently "pending" in MC's Formulas tab; after closing them manually the tab cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)