### PR TITLE
fix: merge provider option defaults into API-created agent sessions

### DIFF
--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -253,7 +253,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 
 	var resolved *config.ResolvedProvider
 	var workDir, transport, template string
-	var extraArgs []string
 	var optMeta map[string]string
 
 	var templateOverrides string
@@ -324,10 +323,21 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Merge extra args from options into the command string.
+	// Merge explicit options with provider effective defaults.
+	// User-specified options override defaults; unspecified options get the
+	// provider's EffectiveDefaults (e.g., permission_mode=unrestricted for claude).
 	command := resolved.CommandString()
-	if len(extraArgs) > 0 {
-		command = config.ReplaceSchemaFlags(command, resolved.OptionsSchema, extraArgs)
+	if len(resolved.OptionsSchema) > 0 {
+		mergedOptions := make(map[string]string)
+		for k, v := range resolved.EffectiveDefaults {
+			mergedOptions[k] = v
+		}
+		for k, v := range body.Options {
+			mergedOptions[k] = v
+		}
+		if mergedArgs, err := config.ResolveExplicitOptions(resolved.OptionsSchema, mergedOptions); err == nil && len(mergedArgs) > 0 {
+			command = config.ReplaceSchemaFlags(command, resolved.OptionsSchema, mergedArgs)
+		}
 	}
 
 	// Build template_overrides metadata. Includes schema overrides AND

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1076,6 +1076,145 @@ func TestHandleSessionCreateCanonicalizesBareTemplate(t *testing.T) {
 	}
 }
 
+// newSessionFakeStateWithOptions creates a test state where the provider has
+// OptionsSchema and OptionDefaults, mimicking the builtin claude provider.
+func newSessionFakeStateWithOptions(t *testing.T) *fakeState {
+	t.Helper()
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	fs.cfg.Providers = map[string]config.ProviderSpec{
+		"test-agent": {
+			DisplayName: "Test Agent",
+			Command:     "echo",
+			OptionDefaults: map[string]string{
+				"permission_mode": "unrestricted",
+				"effort":          "max",
+			},
+			OptionsSchema: []config.ProviderOption{
+				{
+					Key: "permission_mode", Label: "Permission Mode", Type: "select",
+					Default: "auto-edit",
+					Choices: []config.OptionChoice{
+						{Value: "auto-edit", Label: "Auto edit", FlagArgs: []string{"--permission-mode", "auto-edit"}},
+						{Value: "unrestricted", Label: "Unrestricted", FlagArgs: []string{"--skip-permissions"}},
+						{Value: "plan", Label: "Plan", FlagArgs: []string{"--permission-mode", "plan"}},
+					},
+				},
+				{
+					Key: "effort", Label: "Effort", Type: "select",
+					Default: "",
+					Choices: []config.OptionChoice{
+						{Value: "", Label: "Default", FlagArgs: nil},
+						{Value: "low", Label: "Low", FlagArgs: []string{"--effort", "low"}},
+						{Value: "max", Label: "Max", FlagArgs: []string{"--effort", "max"}},
+						{Value: "high", Label: "High", FlagArgs: []string{"--effort", "high"}},
+					},
+				},
+			},
+		},
+	}
+	return fs
+}
+
+func TestHandleSessionCreateAppliesProviderDefaults(t *testing.T) {
+	fs := newSessionFakeStateWithOptions(t)
+	srv := New(fs)
+
+	body := `{"kind":"agent","name":"myrig/worker"}`
+	req := newPostRequest("/v0/sessions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusAccepted, w.Body.String())
+	}
+
+	var resp sessionResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	b, err := fs.cityBeadStore.Get(resp.ID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	cmd := b.Metadata["command"]
+	if !strings.Contains(cmd, "--skip-permissions") {
+		t.Errorf("command %q should contain --skip-permissions from provider default permission_mode=unrestricted", cmd)
+	}
+	if !strings.Contains(cmd, "--effort max") {
+		t.Errorf("command %q should contain --effort max from provider default effort=max", cmd)
+	}
+}
+
+func TestHandleSessionCreateMergesPartialOptionsWithDefaults(t *testing.T) {
+	fs := newSessionFakeStateWithOptions(t)
+	srv := New(fs)
+
+	body := `{"kind":"agent","name":"myrig/worker","options":{"effort":"high"}}`
+	req := newPostRequest("/v0/sessions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusAccepted, w.Body.String())
+	}
+
+	var resp sessionResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	b, err := fs.cityBeadStore.Get(resp.ID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	cmd := b.Metadata["command"]
+	if !strings.Contains(cmd, "--skip-permissions") {
+		t.Errorf("command %q should contain --skip-permissions from unspecified default permission_mode=unrestricted", cmd)
+	}
+	if !strings.Contains(cmd, "--effort high") {
+		t.Errorf("command %q should contain --effort high from explicit option", cmd)
+	}
+	if strings.Contains(cmd, "--effort max") {
+		t.Errorf("command %q should NOT contain --effort max — user specified high", cmd)
+	}
+}
+
+func TestHandleSessionCreateExplicitOptionsOverrideDefaults(t *testing.T) {
+	fs := newSessionFakeStateWithOptions(t)
+	srv := New(fs)
+
+	body := `{"kind":"agent","name":"myrig/worker","options":{"permission_mode":"plan","effort":"low"}}`
+	req := newPostRequest("/v0/sessions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusAccepted, w.Body.String())
+	}
+
+	var resp sessionResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	b, err := fs.cityBeadStore.Get(resp.ID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	cmd := b.Metadata["command"]
+	if !strings.Contains(cmd, "--permission-mode plan") {
+		t.Errorf("command %q should contain --permission-mode plan from explicit option", cmd)
+	}
+	if strings.Contains(cmd, "--skip-permissions") {
+		t.Errorf("command %q should NOT contain --skip-permissions — user specified plan", cmd)
+	}
+	if !strings.Contains(cmd, "--effort low") {
+		t.Errorf("command %q should contain --effort low from explicit option", cmd)
+	}
+}
+
 func TestHandleSessionMessageResumesSuspendedSession(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)


### PR DESCRIPTION
## Summary

- `POST /v0/sessions` with `kind=agent` was not applying the provider's `EffectiveDefaults` to the session command
- Sessions created via the API got bare `claude` without `--dangerously-skip-permissions` or `--effort max`
- The reconciler path (named sessions, `template_resolve`) correctly applied these via `ResolveDefaultArgs()`
- The fix merges `EffectiveDefaults` with any user-specified options before building the command

**Merge behavior:**
| User sends | Result |
|---|---|
| No options | Full provider defaults (e.g., `--dangerously-skip-permissions --effort max`) |
| `{effort: high}` | Defaults + override (`--dangerously-skip-permissions --effort high`) |
| `{permission_mode: plan, effort: low}` | User values only (`--permission-mode plan --effort low`) |

## Test plan

- [x] `TestHandleSessionCreateAppliesProviderDefaults` — no options → defaults applied
- [x] `TestHandleSessionCreateMergesPartialOptionsWithDefaults` — partial → merged
- [x] `TestHandleSessionCreateExplicitOptionsOverrideDefaults` — full override → user wins
- [x] All 10 existing session creation tests pass
- [x] Full `./internal/api/...` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)