### PR TITLE
fix: stop template_overrides write from clobbering initial_message

### DIFF
--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -255,8 +255,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	var workDir, transport, template string
 	var optMeta map[string]string
 
-	var templateOverrides string
-
 	switch kind {
 	case "agent":
 		var err error
@@ -291,13 +289,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusBadRequest, "invalid_option_value", err.Error())
 				return
 			}
-			overridesJSON, marshalErr := json.Marshal(body.Options)
-			if marshalErr != nil {
-				s.idem.unreserve(idemKey)
-				writeError(w, http.StatusInternalServerError, "internal", marshalErr.Error())
-				return
-			}
-			templateOverrides = string(overridesJSON)
 		}
 
 	case "provider":
@@ -390,12 +381,11 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Persist kind, option metadata, and project_id on the bead.
+	// NOTE: template_overrides (options + initial_message) is already set via
+	// extraMeta in CreateAliasedBeadOnlyNamedWithMetadata above. Do NOT
+	// overwrite it here — the old code clobbered initial_message by writing
+	// only the options portion.
 	s.persistSessionMeta(store, info.ID, "agent", body.ProjectID, optMeta)
-	if templateOverrides != "" {
-		if err := store.SetMetadata(info.ID, "template_overrides", templateOverrides); err != nil {
-			log.Printf("session %s: storing template_overrides: %v", info.ID, err)
-		}
-	}
 	s.state.Poke() // wake reconciler to start the agent
 
 	// Auto-generate a title from the user's message if no explicit title was provided.

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1215,6 +1215,47 @@ func TestHandleSessionCreateExplicitOptionsOverrideDefaults(t *testing.T) {
 	}
 }
 
+func TestHandleSessionCreatePreservesInitialMessageWithOptions(t *testing.T) {
+	fs := newSessionFakeStateWithOptions(t)
+	srv := New(fs)
+
+	// Create session with BOTH options AND a message.
+	// Regression: the old code overwrote template_overrides with just the
+	// options, clobbering the initial_message that was set at creation time.
+	body := `{"kind":"agent","name":"myrig/worker","message":"Hello from Discord!","options":{"effort":"high"}}`
+	req := newPostRequest("/v0/sessions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusAccepted, w.Body.String())
+	}
+
+	var resp sessionResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	b, err := fs.cityBeadStore.Get(resp.ID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	ovr := b.Metadata["template_overrides"]
+	if ovr == "" {
+		t.Fatal("template_overrides not set")
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(ovr), &parsed); err != nil {
+		t.Fatalf("parse template_overrides: %v", err)
+	}
+	if parsed["initial_message"] != "Hello from Discord!" {
+		t.Errorf("initial_message = %q, want %q", parsed["initial_message"], "Hello from Discord!")
+	}
+	if parsed["effort"] != "high" {
+		t.Errorf("effort = %q, want %q", parsed["effort"], "high")
+	}
+}
+
 func TestHandleSessionMessageResumesSuspendedSession(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)


### PR DESCRIPTION
## Summary

- When `POST /v0/sessions` included both `options` and `message`, the handler wrote `template_overrides` twice
- The first write (via `CreateAliasedBeadOnlyNamedWithMetadata`) correctly included `{options + initial_message}`
- The second write (line 393) overwrote with just `{options}`, clobbering `initial_message`
- This broke Discord session creation where both options (`permission_mode`, `effort`) and an initial message (the Discord envelope) are sent together
- Fix: remove the redundant second write since `extraMeta` already handles the full `template_overrides`

## Test plan

- [x] `TestHandleSessionCreatePreservesInitialMessageWithOptions` — message + options → both preserved
- [x] All 14 session creation tests pass
- [x] Full `./internal/api/...` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)