### PR TITLE
fix: harden pre-start and supervisor shutdown

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -46,7 +46,7 @@ type CityRuntime struct {
 	od   orderDispatcher
 
 	rec events.Recorder
-	cs  *controllerState // nil when API is disabled
+	cs  *controllerState // nil when controller-managed bead stores are unavailable
 	svc *workspacesvc.Manager
 
 	poolSessions      map[string]time.Duration
@@ -212,8 +212,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// Enforce restrictive permissions on .gc/ and its subdirectories.
 	enforceGCPermissions(cr.cityPath, cr.stderr)
 
-	// Open standalone city bead store when API is disabled.
-	// When API is enabled, controllerState manages the store.
+	// Open standalone city bead store when controllerState is unavailable.
+	// When controllerState is present, it manages the cached city store.
 	if cr.cs == nil {
 		if store, err := openCityStoreAt(cityRoot); err != nil {
 			fmt.Fprintf(cr.stderr, "%s: city bead store: %v (auto-suspend disabled)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
@@ -228,6 +228,9 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// Initialize bead-driven drain tracker when bead store is available.
 	if cr.cityBeadStore() != nil && cr.tomlPath != "" {
 		cr.sessionDrains = newDrainTracker()
+	}
+	if ctx.Err() != nil {
+		return
 	}
 
 	// Adoption barrier: ensure every running session has a bead.
@@ -249,9 +252,15 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			fmt.Fprintf(cr.stderr, "%s: adoption barrier: %d session(s) failed bead creation\n", cr.logPrefix, result.Skipped) //nolint:errcheck
 		}
 	}
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Initialize convergence handler (requires bead store).
 	cr.initConvergenceHandler()
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
@@ -259,6 +268,9 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	sessionBeads := cr.loadSessionBeadSnapshot()
 	result := cr.buildDesiredState(sessionBeads)
 	sessionBeads = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Mark city as started. Convergence startup reconciliation runs on
 	// the first tick (it calls List() which waits for the full async prime).
@@ -273,12 +285,18 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	if cr.sessionDrains != nil {
 		cr.beadReconcileTick(ctx, result, sessionBeads)
 	}
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Convergence startup reconciliation: recover in-progress convergence
 	// beads that were interrupted by a controller crash. Runs after "City
 	// started" so it doesn't block readiness. List() waits for the full
 	// CachingStore prime, then serves from memory.
 	cr.convergenceStartupReconcile(ctx)
+	if ctx.Err() != nil {
+		return
+	}
 
 	interval := cr.cfg.Daemon.PatrolIntervalDuration()
 	ticker := time.NewTicker(interval)

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -192,6 +193,51 @@ func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty for same-revision reload", stdout.String())
+	}
+}
+
+func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	sp := runtime.NewFake()
+	var stdout bytes.Buffer
+	var started bool
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			cancel()
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:      newDrainOps(sp),
+		Rec:       events.Discard,
+		OnStarted: func() { started = true },
+		Stdout:    &stdout,
+		Stderr:    io.Discard,
+	})
+
+	cs := newControllerState(cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = beads.NewMemStore()
+	cr.setControllerState(cs)
+
+	cr.run(ctx)
+
+	if started {
+		t.Fatal("OnStarted called after cancellation")
+	}
+	if strings.Contains(stdout.String(), "City started.") {
+		t.Fatalf("stdout = %q, want no started banner after cancellation", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -348,6 +348,13 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
 	if timeout > 0 {
 		select {
 		case <-mc.done:
+			if err := shutdownBeadsProvider(cityPath); err != nil {
+				fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
+			}
+			if mc.closer != nil {
+				mc.closer.Close() //nolint:errcheck
+			}
+			return
 		case <-time.After(timeout):
 			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after cancel; forcing shutdown\n", mc.name, timeout) //nolint:errcheck
 		}
@@ -357,6 +364,13 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
 			defer func() { recover() }() //nolint:errcheck
 			mc.cr.shutdown()
 		}()
+	}
+	if timeout > 0 {
+		select {
+		case <-mc.done:
+		case <-time.After(timeout):
+			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, timeout) //nolint:errcheck
+		}
 	}
 	if err := shutdownBeadsProvider(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -38,6 +38,18 @@ func supervisorCityStartTimeout(cityPath string) time.Duration {
 	return timeout
 }
 
+func supervisorCityStopTimeout(cityPath string) time.Duration {
+	timeout := supervisorCityReadyTimeout
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		return timeout
+	}
+	if shutdown := cfg.Daemon.ShutdownTimeoutDuration() + 5*time.Second; shutdown > timeout {
+		timeout = shutdown
+	}
+	return timeout
+}
+
 func fetchCityPacksIfNeeded(cityPath string) error {
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	if quickCfg, qErr := config.Load(fsys.OSFS{}, tomlPath); qErr == nil && len(quickCfg.Packs) > 0 {
@@ -324,9 +336,19 @@ func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer, com
 			}
 			return true, 1
 		}
+		if err := waitForSupervisorControllerStopHook(cityPath, supervisorCityStopTimeout(cityPath)); err != nil {
+			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {
+				fmt.Fprintf(stderr, "%s: %v; restore failed for '%s': %v\n", commandName, err, entry.EffectiveName(), reErr) //nolint:errcheck
+			} else {
+				fmt.Fprintf(stderr, "%s: %v; restored registration for '%s'\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
+			}
+			return true, 1
+		}
 	}
 	return true, 0
 }
+
+var waitForSupervisorControllerStopHook = waitForStandaloneControllerStop
 
 func supervisorAPIBaseURL() (string, error) {
 	cfg, err := supervisor.LoadConfig(supervisor.ConfigPath())

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -26,6 +26,7 @@ func withSupervisorTestHooks(t *testing.T, ensure func(stdout, stderr io.Writer)
 	oldReload := reloadSupervisorHook
 	oldAlive := supervisorAliveHook
 	oldRunning := supervisorCityRunningHook
+	oldWaitForStop := waitForSupervisorControllerStopHook
 	oldRegister := registerCityWithSupervisorTestHook
 	oldTimeout := supervisorCityReadyTimeout
 	oldPoll := supervisorCityPollInterval
@@ -34,6 +35,7 @@ func withSupervisorTestHooks(t *testing.T, ensure func(stdout, stderr io.Writer)
 	reloadSupervisorHook = reload
 	supervisorAliveHook = alive
 	supervisorCityRunningHook = running
+	waitForSupervisorControllerStopHook = waitForStandaloneControllerStop
 	registerCityWithSupervisorTestHook = nil
 	supervisorCityReadyTimeout = timeout
 	supervisorCityPollInterval = poll
@@ -43,6 +45,7 @@ func withSupervisorTestHooks(t *testing.T, ensure func(stdout, stderr io.Writer)
 		reloadSupervisorHook = oldReload
 		supervisorAliveHook = oldAlive
 		supervisorCityRunningHook = oldRunning
+		waitForSupervisorControllerStopHook = oldWaitForStop
 		registerCityWithSupervisorTestHook = oldRegister
 		supervisorCityReadyTimeout = oldTimeout
 		supervisorCityPollInterval = oldPoll
@@ -348,6 +351,104 @@ func TestUnregisterCityFromSupervisorRestoresRegistrationOnReloadFailure(t *test
 	}
 	// Registry.Register resolves symlinks (e.g. /var → /private/var on macOS),
 	// so compare against the resolved path.
+	resolvedCityPath, _ := filepath.EvalSymlinks(cityPath)
+	if len(entries) != 1 || entries[0].Path != resolvedCityPath {
+		t.Fatalf("expected restored registry entry for %s, got %v", resolvedCityPath, entries)
+	}
+}
+
+func TestUnregisterCityFromSupervisorWaitsForControllerStop(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	var waitedPath string
+	var waitedTimeout time.Duration
+	waitForSupervisorControllerStopHook = func(path string, timeout time.Duration) error {
+		waitedPath = path
+		waitedTimeout = timeout
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	if !handled || code != 0 {
+		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 0)", handled, code)
+	}
+	if waitedPath != cityPath {
+		t.Fatalf("waited for %q, want %q", waitedPath, cityPath)
+	}
+	if waitedTimeout != supervisorCityStopTimeout(cityPath) {
+		t.Fatalf("wait timeout = %s, want %s", waitedTimeout, supervisorCityStopTimeout(cityPath))
+	}
+}
+
+func TestUnregisterCityFromSupervisorRestoresRegistrationWhenControllerStopWaitFails(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error {
+		return io.EOF
+	}
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	if !handled || code != 1 {
+		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 1)", handled, code)
+	}
+	if !strings.Contains(stderr.String(), "restored registration") {
+		t.Fatalf("stderr = %q, want restore message", stderr.String())
+	}
+
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
 	resolvedCityPath, _ := filepath.EvalSymlinks(cityPath)
 	if len(entries) != 1 || entries[0].Path != resolvedCityPath {
 		t.Fatalf("expected restored registry entry for %s, got %v", resolvedCityPath, entries)

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -265,6 +265,55 @@ func TestWorktreeSetupBootstrapsPrepopulatedTargetDir(t *testing.T) {
 	}
 }
 
+func TestWorktreeSetupBootstrapsPrepopulatedNestedRuntimeTree(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	city := filepath.Join(tmp, "city")
+	script := filepath.Join(exampleDir(), "packs", "gastown", "scripts", "worktree-setup.sh")
+
+	runCmd(t, tmp, "git", "init", repo)
+	runCmd(t, repo, "git", "config", "user.email", "test@example.com")
+	runCmd(t, repo, "git", "config", "user.name", "Gastown Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("writing repo README: %v", err)
+	}
+	runCmd(t, repo, "git", "add", ".")
+	runCmd(t, repo, "git", "commit", "-m", "init")
+
+	worktree := filepath.Join(city, ".gc", "worktrees", filepath.Base(repo), "polecat")
+	stagedFiles := map[string]string{
+		filepath.Join(worktree, ".gc", "scripts", "agent-menu.sh"): "#!/bin/sh\n",
+		filepath.Join(worktree, ".gc", "scripts", "bind-key.sh"):   "#!/bin/sh\n",
+		filepath.Join(worktree, ".gc", "settings.json"):            "{}\n",
+	}
+	for path, contents := range stagedFiles {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("creating staged dir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatalf("writing staged file %s: %v", path, err)
+		}
+	}
+
+	runCmd(t, tmp, "sh", script, repo, worktree, "polecat")
+
+	if got := runCmd(t, tmp, "git", "-C", worktree, "rev-parse", "--is-inside-work-tree"); got != "true" {
+		t.Fatalf("worktree bootstrap did not produce a git worktree, got %q", got)
+	}
+	for path := range stagedFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("staged runtime file missing after bootstrap: %v", err)
+		}
+	}
+	stageGlobs, err := filepath.Glob(filepath.Join(filepath.Dir(worktree), ".gascity-worktree-stage.*"))
+	if err != nil {
+		t.Fatalf("glob stage dirs: %v", err)
+	}
+	if len(stageGlobs) != 0 {
+		t.Fatalf("unexpected leftover stage dirs: %v", stageGlobs)
+	}
+}
+
 func TestWorktreeSetupPreservesTrackedFilesInPrepopulatedTargetDir(t *testing.T) {
 	tmp := t.TempDir()
 	repo := filepath.Join(tmp, "repo")

--- a/examples/gastown/packs/gastown/scripts/worktree-setup.sh
+++ b/examples/gastown/packs/gastown/scripts/worktree-setup.sh
@@ -65,7 +65,7 @@ mkdir -p "$(dirname "$WT")"
 
 STAGE=""
 
-merge_stage_entry() {
+merge_stage_entry() (
     SRC="$1"
     DST="$2"
 
@@ -76,14 +76,14 @@ merge_stage_entry() {
             merge_stage_entry "$ENTRY" "$DST/$(basename "$ENTRY")"
         done
         rmdir "$SRC" 2>/dev/null || true
-        return 0
+        exit 0
     fi
 
     if [ -e "$DST" ]; then
-        return 0
+        exit 0
     fi
     mv "$SRC" "$DST"
-}
+)
 
 restore_stage() {
     [ -n "$STAGE" ] || return 0

--- a/internal/agent/hints.go
+++ b/internal/agent/hints.go
@@ -15,7 +15,7 @@ type StartupHints struct {
 	// Used for CLI agents that don't accept command-line prompts.
 	Nudge string
 	// PreStart is a list of shell commands run before session creation.
-	// Already template-expanded by the caller.
+	// Already template-expanded by the caller. Failures abort startup.
 	PreStart []string
 	// SessionSetup is a list of shell commands run after session creation.
 	// Already template-expanded by the caller.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -236,6 +236,7 @@ type Config struct {
 
 	// PreStart is a list of shell commands run before session creation,
 	// on the target filesystem. Used for directory/worktree preparation.
+	// Failures abort startup so agents never launch into an unprepared workDir.
 	PreStart []string
 
 	// SessionSetup is a list of shell commands run after session creation,

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -433,7 +433,9 @@ func (o *tmuxStartOps) runSetupCommand(ctx context.Context, cmd string, env map[
 // session_setup, session_setup_script, and pre_start commands.
 func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.Config, setupTimeout time.Duration) error {
 	// Step 0: Run pre-start commands (directory/worktree preparation).
-	runPreStart(ctx, ops, name, cfg, os.Stderr, setupTimeout)
+	if err := runPreStart(ctx, ops, name, cfg, setupTimeout); err != nil {
+		return fmt.Errorf("running pre_start: %w", err)
+	}
 
 	// Step 1: Ensure fresh session (zombie detection).
 	if err := ensureFreshSession(ops, name, cfg); err != nil {
@@ -549,10 +551,12 @@ func runSessionLive(ctx context.Context, ops startOps, name string, cfg runtime.
 }
 
 // runPreStart runs pre_start commands before session creation.
-// Used for directory/worktree preparation. Non-fatal: warnings on failure.
-func runPreStart(ctx context.Context, ops startOps, _ string, cfg runtime.Config, stderr io.Writer, setupTimeout time.Duration) {
+// Used for directory/worktree preparation. Failures are fatal because
+// launching into an unprepared workDir can point agents at the wrong repo or
+// skip required bootstrap state entirely.
+func runPreStart(ctx context.Context, ops startOps, _ string, cfg runtime.Config, setupTimeout time.Duration) error {
 	if len(cfg.PreStart) == 0 {
-		return
+		return nil
 	}
 	setupEnv := make(map[string]string, len(cfg.Env))
 	for k, v := range cfg.Env {
@@ -560,9 +564,10 @@ func runPreStart(ctx context.Context, ops startOps, _ string, cfg runtime.Config
 	}
 	for i, cmd := range cfg.PreStart {
 		if err := ops.runSetupCommand(ctx, cmd, setupEnv, setupTimeout); err != nil {
-			_, _ = fmt.Fprintf(stderr, "gc: pre_start[%d] warning: %v\n", i, err)
+			return fmt.Errorf("pre_start[%d]: %w", i, err)
 		}
 	}
+	return nil
 }
 
 // ensureFreshSession creates a session, handling stale tmux state.

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -623,7 +623,7 @@ func TestDoStartSession_NoSetupConfigured(t *testing.T) {
 	}
 }
 
-func TestDoStartSession_SetupFailureNonFatal(t *testing.T) {
+func TestDoStartSession_SessionSetupFailureNonFatal(t *testing.T) {
 	ops := &fakeStartOps{
 		hasSessionResult:   true,
 		runSetupCommandErr: errors.New("tmux option not supported"),
@@ -707,6 +707,55 @@ func TestDoStartSession_SetupScriptOnlyTriggersHints(t *testing.T) {
 	if !hasSetup {
 		t.Error("expected runSetupCommand call for script")
 	}
+}
+
+func TestDoStartSession_PreStartRunsBeforeCreate(t *testing.T) {
+	ops := &fakeStartOps{
+		hasSessionResult: true,
+	}
+
+	cfg := runtime.Config{
+		Command:  "claude",
+		WorkDir:  "/proj",
+		PreStart: []string{"setup-worktree"},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runSetupCommand", "createSession", "setRemainOnExit", "hasSession"})
+
+	pre := ops.calls[0]
+	if pre.command != "setup-worktree" {
+		t.Errorf("pre_start command = %q, want %q", pre.command, "setup-worktree")
+	}
+	if pre.timeout != DefaultConfig().SetupTimeout {
+		t.Errorf("pre_start timeout = %v, want %v", pre.timeout, DefaultConfig().SetupTimeout)
+	}
+}
+
+func TestDoStartSession_PreStartFailureIsFatal(t *testing.T) {
+	ops := &fakeStartOps{
+		runSetupCommandErr: errors.New("context canceled"),
+	}
+
+	cfg := runtime.Config{
+		Command:  "claude",
+		WorkDir:  "/proj",
+		PreStart: []string{"setup-worktree"},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "running pre_start") {
+		t.Fatalf("error = %q, want running pre_start", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runSetupCommand"})
 }
 
 func TestDoStartSession_SetupEnvPassthrough(t *testing.T) {


### PR DESCRIPTION
## Summary
- make `pre_start` failures fatal so sessions do not launch into an unprepared worktree
- fix Gastown worktree bootstrap recursion so nested runtime files land in the right path
- wait for standalone controllers to fully stop during supervisor unregister/shutdown and avoid reporting a city as started after cancellation during startup

## Testing
- `make fmt-check lint test`
- `go test ./internal/runtime/tmux -run 'TestDoStartSession_(PreStartRunsBeforeCreate|PreStartFailureIsFatal)' -count=1`
- `go test ./cmd/gc -run 'Test(UnregisterCityFromSupervisorWaitsForControllerStop|UnregisterCityFromSupervisorRestoresRegistrationWhenControllerStopWaitFails|CityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup)' -count=1`
- `go test ./examples/gastown -run 'TestWorktreeSetupBootstrapsPrepopulatedNestedRuntimeTree' -count=1`
