### PR TITLE
fix: keep namepool agents as pools

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -162,8 +162,7 @@ func buildDesiredStateWithSessionBeads(
 			continue
 		}
 
-		isExplicitMultiSession := cfg.Agents[i].MaxActiveSessions != nil && *cfg.Agents[i].MaxActiveSessions != 1
-		if sp.Max == 1 && !isExplicitMultiSession {
+		if sp.Max == 1 && !isMultiSessionCfgAgent(&cfg.Agents[i]) {
 			// Fixed agent.
 			rigName := configuredRigName(cityPath, &cfg.Agents[i], cfg.Rigs)
 			if rigName != "" && suspendedRigPaths[filepath.Clean(rigRootForName(rigName, cfg.Rigs))] {
@@ -230,7 +229,7 @@ func buildDesiredStateWithSessionBeads(
 				// If multi-instance (max > 1 or unlimited), use themed name
 				// (from namepool) or {name}-{N} suffix.
 				name := cfg.Agents[pw.agentIdx].Name
-				isMultiInstance := pw.sp.Max != 1
+				isMultiInstance := isMultiSessionCfgAgent(&cfg.Agents[pw.agentIdx])
 				if isMultiInstance {
 					name = poolInstanceName(cfg.Agents[pw.agentIdx].Name, slot, &cfg.Agents[pw.agentIdx])
 				}
@@ -346,10 +345,10 @@ func buildDesiredStateWithSessionBeads(
 }
 
 // collectAssignedWorkBeads queries each store (city + rigs) for work beads
-// that have an assignee. Two queries per store: bd list --status=in_progress
-// and bd ready. Results are filtered to only beads with a non-empty assignee.
-// The caller cross-references these with session beads to determine which
-// sessions have active work and must stay alive.
+// that have an assignee. It includes in-progress assigned work plus
+// open assigned work that is actually ready. The caller cross-references
+// these with session beads to determine which sessions have active work
+// and must stay alive.
 func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
@@ -369,24 +368,31 @@ func collectAssignedWorkBeads(
 	}
 
 	var result []beads.Bead
+	seen := make(map[string]struct{})
 	for _, s := range stores {
 		// In-progress beads with an assignee (active work).
 		if inProgress, err := s.List("in_progress"); err == nil {
-			appendAssigned(&result, inProgress)
+			appendAssignedUnique(&result, inProgress, seen)
 		}
-		// Ready beads with an assignee (claimed but not started).
+		// Ready beads with an assignee (queued direct handoff work that is
+		// actually runnable, not merely open).
 		if ready, err := s.Ready(); err == nil {
-			appendAssigned(&result, ready)
+			appendAssignedUnique(&result, ready, seen)
 		}
 	}
 	return result
 }
 
-func appendAssigned(dst *[]beads.Bead, beadList []beads.Bead) {
+func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[string]struct{}) {
 	for _, b := range beadList {
-		if strings.TrimSpace(b.Assignee) != "" {
-			*dst = append(*dst, b)
+		if strings.TrimSpace(b.Assignee) == "" {
+			continue
 		}
+		if _, ok := seen[b.ID]; ok {
+			continue
+		}
+		seen[b.ID] = struct{}{}
+		*dst = append(*dst, b)
 	}
 }
 
@@ -554,8 +560,7 @@ func ensureDependencyOnlyTemplate(
 
 	if bp.beadStore == nil {
 		name := cfgAgent.Name
-		sp := scaleParamsFor(cfgAgent)
-		isMultiInstance := sp.Max != 1
+		isMultiInstance := isMultiSessionCfgAgent(cfgAgent)
 		if isMultiInstance {
 			name = poolInstanceName(cfgAgent.Name, 1, cfgAgent)
 		}
@@ -772,6 +777,9 @@ func installAgentSideEffects(bp *agentBuildParams, cfgAgent *config.Agent, tp Te
 func isMultiSessionCfgAgent(a *config.Agent) bool {
 	if a == nil {
 		return false
+	}
+	if strings.TrimSpace(a.Namepool) != "" || len(a.NamepoolNames) > 0 {
+		return true
 	}
 	maxSess := a.EffectiveMaxActiveSessions()
 	return maxSess == nil || *maxSess != 1

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -22,6 +22,66 @@ func (s listFailStore) List(_ ...string) ([]beads.Bead, error) {
 	return nil, errors.New("list failed")
 }
 
+func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T) {
+	store := beads.NewMemStore()
+	handoff, err := store.Create(beads.Bead{
+		Title:    "merge me",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create handoff bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued pool work",
+		Type:   "task",
+		Status: "open",
+	}); err != nil {
+		t.Fatalf("create queued bead: %v", err)
+	}
+
+	got := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1: %#v", len(got), got)
+	}
+	if got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %q, want %q", got[0].ID, handoff.ID)
+	}
+	if got[0].Assignee != "repo/refinery" || got[0].Status != "open" {
+		t.Fatalf("assigned handoff bead = assignee %q status %q, want repo/refinery open", got[0].Assignee, got[0].Status)
+	}
+}
+
+func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.T) {
+	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{
+		Title:  "blocker",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("create blocker bead: %v", err)
+	}
+	handoff, err := store.Create(beads.Bead{
+		Title:    "merge me later",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create handoff bead: %v", err)
+	}
+	if err := store.DepAdd(handoff.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("add blocking dep: %v", err)
+	}
+
+	got := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	if len(got) != 0 {
+		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0: %#v", len(got), got)
+	}
+}
+
 func TestBuildDesiredState_SingletonTemplateDoesNotRealizeDependencyPoolFloorWithoutSession(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -103,7 +103,7 @@ func resolveAgentIdentity(cfg *config.City, input, currentRigDir string) (config
 func resolvePoolInstance(cfg *config.City, input string) (config.Agent, bool) {
 	for _, a := range cfg.Agents {
 		sp := scaleParamsFor(&a)
-		if sp.Max == 1 {
+		if !isMultiSessionCfgAgent(&a) {
 			continue
 		}
 		prefix := a.QualifiedName() + "-"
@@ -129,7 +129,7 @@ func resolvePoolInstance(cfg *config.City, input string) (config.Agent, bool) {
 // pattern (e.g., "polecat-2" matches agent "polecat"). Returns the synthesized instance.
 func matchPoolInstance(a config.Agent, input string) (config.Agent, bool) {
 	sp := scaleParamsFor(&a)
-	if sp.Max == 1 {
+	if !isMultiSessionCfgAgent(&a) {
 		return config.Agent{}, false
 	}
 	prefix := a.Name + "-"

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -165,7 +165,7 @@ func doCityStatus(
 			suspended := a.Suspended || (a.Dir != "" && suspendedRigs[a.Dir])
 			sp0 := scaleParamsFor(&a)
 
-			if sp0.Max != 1 {
+			if isMultiSessionCfgAgent(&a) {
 				// Multi-session agent — show header then instances.
 				maxDisplay := fmt.Sprintf("max=%d", sp0.Max)
 				if sp0.Max < 0 {
@@ -269,7 +269,7 @@ func doCityStatusJSON(
 			scope = "rig"
 		}
 
-		if sp0.Max != 1 {
+		if isMultiSessionCfgAgent(&a) {
 			// Multi-session agent — emit each instance.
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, cfg.Workspace.SessionTemplate, sp) {
 				_, instanceName := config.ParseQualifiedName(qualifiedInstance)

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -262,8 +262,7 @@ func persistPrimeHookSessionID(sessionID string) {
 // matches a configured pool agent in the same dir.
 func isPoolInstance(cfg *config.City, a config.Agent) bool {
 	for _, ca := range cfg.Agents {
-		sp := scaleParamsFor(&ca)
-		if sp.Max == 1 {
+		if !isMultiSessionCfgAgent(&ca) {
 			continue
 		}
 		if ca.Dir != a.Dir {
@@ -290,8 +289,8 @@ func findAgentByName(cfg *config.City, name string) (config.Agent, bool) {
 	}
 	// Pool suffix stripping: "polecat-3" → try "polecat" if it's a pool.
 	for _, a := range cfg.Agents {
-		sp := scaleParamsFor(&a)
-		if sp.Max != 1 {
+		if isMultiSessionCfgAgent(&a) {
+			sp := scaleParamsFor(&a)
 			prefix := a.Name + "-"
 			if strings.HasPrefix(name, prefix) {
 				suffix := name[len(prefix):]

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -124,7 +124,7 @@ func doRigRestart(
 	var targets []stopTarget
 	for _, a := range agents {
 		sp0 := scaleParamsFor(&a)
-		if sp0.Max == 1 {
+		if !isMultiSessionCfgAgent(&a) {
 			// Single agent.
 			sn := lookupSessionNameOrLegacy(store, cityName, a.QualifiedName(), sessionTemplate)
 			if sp.IsRunning(sn) {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -457,7 +457,7 @@ func cliPoolDesired(cfg *config.City) map[string]int {
 	counts := make(map[string]int)
 	for _, a := range cfg.Agents {
 		sp := scaleParamsFor(&a)
-		if sp.Max != 1 && sp.Max > 0 {
+		if isMultiSessionCfgAgent(&a) && sp.Max > 0 {
 			counts[a.QualifiedName()] = sp.Max
 		}
 	}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -33,6 +33,22 @@ func startupSessionName(cityName, agentName, sessionTemplate string) string {
 	return agent.SessionNameFor(cityName, agentName, sessionTemplate)
 }
 
+func standaloneBuildAgentsFnWithSessionBeads(
+	cityName, cityPath string,
+	beaconTime time.Time,
+	stderr io.Writer,
+) func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot) DesiredStateResult {
+	return func(
+		c *config.City,
+		currentSP runtime.Provider,
+		store beads.Store,
+		rigStores map[string]beads.Store,
+		sessionBeads *sessionBeadSnapshot,
+	) DesiredStateResult {
+		return buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, c, currentSP, store, rigStores, sessionBeads, stderr)
+	}
+}
+
 // computeSuspendedNames builds a set of session names for agents marked
 // suspended in the config or belonging to suspended rigs. Also includes
 // all agents when the city itself is suspended (workspace.suspended).
@@ -88,7 +104,7 @@ func computePoolSessions(cfg *config.City, cityName, _ string, sp runtime.Provid
 	st := cfg.Workspace.SessionTemplate
 	for _, a := range cfg.Agents {
 		sp0 := scaleParamsFor(&a)
-		if sp0.Max == 1 {
+		if !isMultiSessionCfgAgent(&a) {
 			continue
 		}
 		timeout := a.DrainTimeoutDuration()
@@ -113,7 +129,7 @@ func computePoolDeathHandlers(cfg *config.City, cityName, cityPath string, sp ru
 	st := cfg.Workspace.SessionTemplate
 	for _, a := range cfg.Agents {
 		sp0 := scaleParamsFor(&a)
-		if sp0.Max == 1 {
+		if !isMultiSessionCfgAgent(&a) {
 			continue
 		}
 		for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, st, sp) {
@@ -166,16 +182,16 @@ func buildIdleTracker(cfg *config.City, cityName, _ string, sp runtime.Provider)
 			continue
 		}
 		sp0 := scaleParamsFor(&a)
-		if sp0.Max != 1 {
+		if isMultiSessionCfgAgent(&a) {
 			// Register each pool instance (worker-1, worker-2, ...).
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, st, sp) {
 				sn := startupSessionName(cityName, qualifiedInstance, st)
 				it.setTimeout(sn, timeout)
 			}
-		} else {
-			sn := startupSessionName(cityName, a.QualifiedName(), st)
-			it.setTimeout(sn, timeout)
+			continue
 		}
+		sn := startupSessionName(cityName, a.QualifiedName(), st)
+		it.setTimeout(sn, timeout)
 	}
 	return it
 }
@@ -509,9 +525,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	buildAgents := func(c *config.City, currentSP runtime.Provider, store beads.Store) DesiredStateResult {
 		return buildDesiredState(cityName, cityPath, beaconTime, c, currentSP, store, stderr)
 	}
-	buildAgentsWithSessionBeads := func(c *config.City, currentSP runtime.Provider, store beads.Store, _ map[string]beads.Store, sessionBeads *sessionBeadSnapshot) DesiredStateResult {
-		return buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, c, currentSP, store, nil, sessionBeads, stderr)
-	}
+	buildAgentsWithSessionBeads := standaloneBuildAgentsFnWithSessionBeads(cityName, cityPath, beaconTime, stderr)
 
 	recorder := events.Discard
 	var eventProv events.Provider // nil when events disabled or FileRecorder fails

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
 )
 
 func TestMergeEnvEmptyMaps(t *testing.T) {
@@ -44,6 +48,59 @@ func TestPassthroughEnvOmitsUnset(t *testing.T) {
 	got := passthroughEnv()
 	if _, ok := got["GC_DOLT"]; ok {
 		t.Error("passthroughEnv() should omit empty GC_DOLT")
+	}
+}
+
+func TestComputePoolSessions_NamepoolMaxOneUsesPoolInstance(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:              "polecat",
+				Dir:               "repo",
+				MaxActiveSessions: intPtr(1),
+				Namepool:          "namepools/mad-max.txt",
+				NamepoolNames:     []string{"furiosa"},
+			},
+		},
+	}
+
+	got := computePoolSessions(cfg, "city", "", runtime.NewFake())
+	want := startupSessionName("city", "repo/furiosa", cfg.Workspace.SessionTemplate)
+	if _, ok := got[want]; !ok {
+		t.Fatalf("computePoolSessions missing %q in %v", want, got)
+	}
+	if len(got) != 1 {
+		t.Fatalf("computePoolSessions len = %d, want 1 (%v)", len(got), got)
+	}
+}
+
+func TestStandaloneBuildAgentsFnWithSessionBeads_UsesRigStoresForAssignedWork(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	handoff, err := rigStore.Create(beads.Bead{
+		Title:    "merge me",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("rigStore.Create: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "repo", Path: t.TempDir()},
+		},
+	}
+
+	buildFn := standaloneBuildAgentsFnWithSessionBeads("city", "/tmp/city", time.Now().UTC(), io.Discard)
+	result := buildFn(cfg, runtime.NewFake(), cityStore, map[string]beads.Store{"repo": rigStore}, nil)
+	if len(result.AssignedWorkBeads) != 1 {
+		t.Fatalf("AssignedWorkBeads len = %d, want 1 (%#v)", len(result.AssignedWorkBeads), result.AssignedWorkBeads)
+	}
+	if result.AssignedWorkBeads[0].ID != handoff.ID {
+		t.Fatalf("AssignedWorkBeads[0].ID = %q, want %q", result.AssignedWorkBeads[0].ID, handoff.ID)
 	}
 }
 

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -103,7 +103,7 @@ func doRigStatus(
 
 	for _, a := range agents {
 		sp0 := scaleParamsFor(&a)
-		if sp0.Max == 1 {
+		if !isMultiSessionCfgAgent(&a) {
 			sn := cliSessionName(cityPath, cityName, a.QualifiedName(), sessionTemplate)
 			status := agentStatusLine(sp, dops, sn, a.Suspended)
 			fmt.Fprintf(stdout, "    %-12s%s\n", a.QualifiedName(), status) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -102,7 +102,7 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 	for _, a := range cfg.Agents {
 		sp0 := scaleParamsFor(&a)
 		qn := a.QualifiedName()
-		if sp0.Max == 1 {
+		if !isMultiSessionCfgAgent(&a) {
 			// Single agent.
 			sn := lookupSessionNameOrLegacy(store, cityName, qn, st)
 			sessionNames = append(sessionNames, sn)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -579,14 +579,18 @@ func runController(
 		Stderr:                  stderr,
 	})
 
+	// Install controller-managed bead stores even when the HTTP API is
+	// disabled. Standalone runtime still needs cached city/rig stores for
+	// session-bead sync and rig-scoped wake decisions.
+	cs := newControllerState(cfg, sp, eventProv, cityName, cityPath)
+	cs.ct = cr.crashTrack()
+	cs.pokeCh = pokeCh
+	cs.services = cr.svc
+	cs.startBeadEventWatcher(ctx)
+	cr.setControllerState(cs)
+
 	// Start API server if configured.
 	if cfg.API.Port > 0 {
-		cs := newControllerState(cfg, sp, eventProv, cityName, cityPath)
-		cs.ct = cr.crashTrack()
-		cs.pokeCh = pokeCh
-		cs.services = cr.svc
-		cs.startBeadEventWatcher(ctx)
-		cr.setControllerState(cs)
 		bind := cfg.API.BindOrDefault()
 		nonLocal := bind != "127.0.0.1" && bind != "localhost" && bind != "::1"
 		var apiSrv *api.Server

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -80,6 +80,19 @@ func TestEvaluatePoolNonInteger(t *testing.T) {
 	}
 }
 
+func TestIsMultiSessionCfgAgent_NamepoolMaxOneIsStillPool(t *testing.T) {
+	a := &config.Agent{
+		Name:              "polecat",
+		MaxActiveSessions: intPtr(1),
+		Namepool:          "namepools/mad-max.txt",
+		NamepoolNames:     []string{"furiosa"},
+	}
+
+	if !isMultiSessionCfgAgent(a) {
+		t.Fatal("expected namepool-backed max=1 agent to remain multi-session")
+	}
+}
+
 func TestEvaluatePoolWhitespace(t *testing.T) {
 	pool := scaleParams{Min: 0, Max: 10, Check: "echo 3"}
 	runner := func(_, _ string) (string, error) { return " 3\n", nil }


### PR DESCRIPTION
## Summary
- keep namepool and namepool_names agents on the pool/session-discovery path even when `max_active_sessions = 1`
- only treat assigned `open` work as wakeable when it is actually present in `bd ready`
- make standalone controllers always install controller-managed city/rig bead stores so rig handoffs wake named sessions correctly

## Testing
- `make fmt-check lint test`
- `go test ./cmd/gc -run 'Test(StandaloneBuildAgentsFnWithSessionBeads_UsesRigStoresForAssignedWork|CollectAssignedWorkBeads_(IncludesReadyOpenAssignedHandoff|ExcludesBlockedOpenAssignedHandoff)|IsMultiSessionCfgAgent_NamepoolMaxOneIsStillPool|ComputePoolSessions_NamepoolMaxOneUsesPoolInstance|CityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup)' -count=1`
- real Gastown pack E2E on the combined validated change set: outer bead -> polecat claim -> refinery wake -> merge to `origin/main`
