### PR TITLE
fix: repair session beads with empty types instead of crashing

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -122,6 +122,22 @@ func syncSessionBeadsWithSnapshot(
 		return nil, sessionBeads
 	}
 
+	// Repair session beads with empty types. The gc:session label (used by
+	// ListByLabel) is authoritative — if a bead has the label, it's a
+	// session bead. Empty types can occur after bd schema migrations or
+	// crashes that leave partially-written records.
+	for i, b := range existing {
+		if b.Type != "" || b.Status == "closed" {
+			continue
+		}
+		t := sessionBeadType
+		if err := store.Update(b.ID, beads.UpdateOpts{Type: &t}); err != nil {
+			fmt.Fprintf(stderr, "session beads: repairing type for %s: %v\n", b.ID, err) //nolint:errcheck
+		} else {
+			existing[i].Type = sessionBeadType
+		}
+	}
+
 	// Index by session_name for O(1) lookup. Skip closed beads — a closed
 	// bead is a completed lifecycle record, not a live session. If an agent
 	// restarts after its bead was closed, we create a fresh bead.

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1153,6 +1153,50 @@ func TestLoadSessionBeads_SingleBead(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_RepairsEmptyType(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	_ = sp.Start(context.TODO(), "mayor", runtime.Config{Command: "claude"})
+
+	// Create a session bead, then corrupt its type to empty string.
+	// MemStore defaults empty types to "task", so we create normally then
+	// update to empty to simulate the corruption seen in production (BdStore
+	// preserves empty types from the database).
+	b, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "mayor",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyType := ""
+	if err := store.Update(b.ID, beads.UpdateOpts{Type: &emptyType}); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := map[string]TemplateParams{
+		"mayor": {TemplateName: "mayor", Command: "claude"},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	// The bead's type should have been repaired to "session".
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != sessionBeadType {
+		t.Errorf("type after repair = %q, want %q", got.Type, sessionBeadType)
+	}
+}
+
 func TestLoadSessionBeads_NewTypeOnly(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -114,7 +114,17 @@ func (m *Manager) loadSessionBead(id string, allowClosed bool) (beads.Bead, stri
 		return beads.Bead{}, "", fmt.Errorf("getting session: %w", err)
 	}
 	if b.Type != BeadType {
-		return beads.Bead{}, "", fmt.Errorf("%w: bead %s (type=%q)", ErrNotSession, id, b.Type)
+		// If the bead has session metadata but an empty type (e.g., after a
+		// crash or schema migration), repair it rather than rejecting it.
+		if b.Type == "" && b.Metadata["session_name"] != "" {
+			t := BeadType
+			if uerr := m.store.Update(id, beads.UpdateOpts{Type: &t}); uerr != nil {
+				return beads.Bead{}, "", fmt.Errorf("repairing session bead type for %s: %w", id, uerr)
+			}
+			b.Type = BeadType
+		} else {
+			return beads.Bead{}, "", fmt.Errorf("%w: bead %s (type=%q)", ErrNotSession, id, b.Type)
+		}
 	}
 	if !allowClosed && b.Status == "closed" {
 		return beads.Bead{}, "", fmt.Errorf("%w: %s", ErrSessionClosed, id)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1262,6 +1262,48 @@ func TestRenameNonSessionBead(t *testing.T) {
 	}
 }
 
+func TestLoadSessionBead_RepairsEmptyType(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	// Create a bead then corrupt its type to empty (simulates crash/migration).
+	b, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "mayor",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyType := ""
+	if err := store.Update(b.ID, beads.UpdateOpts{Type: &emptyType}); err != nil {
+		t.Fatal(err)
+	}
+
+	// loadSessionBead should repair the type instead of returning ErrNotSession.
+	got, _, err := mgr.loadSessionBead(b.ID, false)
+	if err != nil {
+		t.Fatalf("loadSessionBead should repair empty type, got error: %v", err)
+	}
+	if got.Type != BeadType {
+		t.Errorf("type after repair = %q, want %q", got.Type, BeadType)
+	}
+
+	// Verify the store was updated.
+	stored, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Type != BeadType {
+		t.Errorf("stored type after repair = %q, want %q", stored.Type, BeadType)
+	}
+}
+
 func TestRenameNotFound(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary

- After a crash or bd schema migration, session beads can end up with an empty `issue_type` field, causing `gc session attach` to fail with `bead is not a session: bead gc-115 (type="")` and preventing recovery
- Adds auto-repair at two points: during startup sync (using the `gc:session` label as authoritative) and inline during attach (using `session_name` metadata as signal)
- Includes tests for both repair paths

## Test plan

- [x] `TestSyncSessionBeads_RepairsEmptyType` — verifies startup sync repairs empty-type beads
- [x] `TestLoadSessionBead_RepairsEmptyType` — verifies attach path repairs empty-type beads
- [x] All existing session bead and session manager tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)