### PR TITLE
fix: use valid bead type for nudge queue beads (ga-bwl)

### DIFF
--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	nudgeBeadType  = "nudge"
+	nudgeBeadType  = "chore"
 	nudgeBeadLabel = "gc:nudge"
 )
 


### PR DESCRIPTION
## Summary
- Fixes `gc session nudge` which was trying to create beads with invalid type `nudge`
- Changes the bead type to a valid registered type so nudge queue operations work correctly

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (pre-existing failures in subprocess/supervisor unrelated to this change)
- [x] Single file change: `cmd/gc/nudge_beads.go` (1 line)

Closes ga-bwl

🤖 Generated with [Claude Code](https://claude.com/claude-code)