### PR TITLE
test: add gastown acceptance regression coverage

### DIFF
--- a/test/acceptance/helpers/city.go
+++ b/test/acceptance/helpers/city.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,6 +20,8 @@ type City struct {
 	Dir     string
 	Env     *Env
 	started bool
+	cmd     *exec.Cmd
+	logFile *os.File
 }
 
 // NewCity creates a temp directory for a city and returns the DSL handle.
@@ -100,6 +103,26 @@ func (c *City) Stop() {
 	c.started = false
 	// Best-effort stop — don't fail the test on cleanup errors.
 	RunGC(c.Env, c.Dir, "stop", c.Dir) //nolint:errcheck
+	if c.cmd != nil {
+		done := make(chan struct{})
+		go func() {
+			_ = c.cmd.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			if c.cmd.Process != nil {
+				_ = c.cmd.Process.Kill()
+			}
+			<-done
+		}
+		c.cmd = nil
+	}
+	if c.logFile != nil {
+		_ = c.logFile.Close()
+		c.logFile = nil
+	}
 }
 
 // AgentEnv reads an agent's environment by inspecting the session metadata.

--- a/test/acceptance/helpers/lifecycle.go
+++ b/test/acceptance/helpers/lifecycle.go
@@ -3,6 +3,7 @@ package acceptancehelpers
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -16,6 +17,42 @@ func (c *City) StartWithSupervisor() {
 	if err != nil {
 		c.t.Fatalf("gc start failed: %v\n%s", err, out)
 	}
+	c.started = true
+	c.t.Cleanup(func() { c.Stop() })
+}
+
+// StartForeground starts gc in --foreground mode in the background and
+// leaves it running until Stop is called. The controller log is written
+// to .gc/acceptance-controller.log inside the city.
+func (c *City) StartForeground() {
+	c.t.Helper()
+	if c.started {
+		c.Stop()
+	}
+
+	gcPath := findInPath(c.Env.Get("PATH"), "gc")
+	if gcPath == "" {
+		c.t.Fatal("gc not found in PATH")
+	}
+
+	logPath := filepath.Join(c.Dir, ".gc", "acceptance-controller.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		c.t.Fatalf("creating foreground controller log: %v", err)
+	}
+
+	cmd := exec.Command(gcPath, "start", "--foreground", c.Dir)
+	cmd.Dir = c.Dir
+	cmd.Env = c.Env.List()
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		c.t.Fatalf("starting gc --foreground: %v", err)
+	}
+
+	c.cmd = cmd
+	c.logFile = logFile
 	c.started = true
 	c.t.Cleanup(func() { c.Stop() })
 }

--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -13,6 +13,7 @@
 package tierc_test
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,11 +42,20 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "gc-acceptance-c-*")
+	tmpRoot, err := acceptanceTempRoot()
+	if err != nil {
+		panic("acceptance-c: preparing temp root: " + err.Error())
+	}
+	if err := os.Setenv("TMPDIR", tmpRoot); err != nil {
+		panic("acceptance-c: setting TMPDIR: " + err.Error())
+	}
+	tmpDir, err := os.MkdirTemp(tmpRoot, "gcac-*")
 	if err != nil {
 		panic("acceptance-c: creating temp dir: " + err.Error())
 	}
-	defer os.RemoveAll(tmpDir)
+	if os.Getenv("GC_ACCEPTANCE_KEEP") != "1" {
+		defer os.RemoveAll(tmpDir)
+	}
 
 	gcBinary := helpers.BuildGC(tmpDir)
 
@@ -70,15 +80,12 @@ func TestMain(m *testing.M) {
 		panic("acceptance-c: " + err.Error())
 	}
 
-	// Symlink real Claude credentials into the isolated home so agents
-	// can authenticate via OAuth. Only the credentials file is needed.
+	// Copy the minimum Claude OAuth/config files into the isolated home.
+	// Symlinking the whole host tree leaks runtime state and still leaves
+	// Claude in first-run interactive setup if .claude.json is absent.
 	realHome, _ := os.UserHomeDir()
-	realClaudeDir := filepath.Join(realHome, ".claude")
-	testClaudeDir := filepath.Join(gcHome, ".claude")
-	if _, err := os.Stat(realClaudeDir); err == nil {
-		if err := os.Symlink(realClaudeDir, testClaudeDir); err != nil {
-			panic("acceptance-c: symlinking .claude: " + err.Error())
-		}
+	if err := stageClaudeOAuth(realHome, gcHome); err != nil {
+		panic("acceptance-c: staging Claude oauth: " + err.Error())
 	}
 
 	testEnvC = helpers.NewEnv(gcBinary, gcHome, runtimeDir).
@@ -123,7 +130,7 @@ func TestSwarm_SlingWorkCoderCommits(t *testing.T) {
 	// Limit pool sizes to reduce cost.
 	c.AppendToConfig("\n[[rigs.overrides]]\nagent = \"coder\"\n[rigs.overrides.pool]\nmin = 1\nmax = 1\n")
 
-	c.StartWithSupervisor()
+	c.StartForeground()
 
 	// Wait for supervisor + dolt + agents to initialize.
 	time.Sleep(15 * time.Second)
@@ -166,49 +173,97 @@ func TestGastown_PolecatImplementsRefineryMerges(t *testing.T) {
 
 	c := helpers.NewCity(t, testEnvC)
 	c.InitFrom(filepath.Join(helpers.ExamplesDir(), "gastown"))
+	unregisterOut, unregisterErr := c.GC("unregister", c.Dir)
+	require.NoError(t, unregisterErr, "gc unregister after init: %s", unregisterOut)
 
 	// Add the rig via gc rig add (initializes beads, hooks, routes).
 	c.RigAdd(rigDir, "packs/gastown")
 
-	// Limit pool to 1 polecat.
-	c.AppendToConfig("\n[[rigs.overrides]]\nagent = \"polecat\"\n[rigs.overrides.pool]\nmin = 1\nmax = 1\n")
+	// Start with polecat suspended so we can verify the attached-formula
+	// queue invariants before any worker claims the work.
+	c.AppendToConfig("\n[[rigs.overrides]]\nagent = \"polecat\"\nsuspended = true\n[rigs.overrides.pool]\nmin = 0\nmax = 1\n")
 
-	c.StartWithSupervisor()
+	c.StartForeground()
 
-	// Wait for supervisor + dolt + agents to initialize.
-	time.Sleep(15 * time.Second)
+	require.Eventually(t, func() bool {
+		_, err := bdCmd(testEnvC, rigDir, "list", "--json", "--limit=1")
+		return err == nil
+	}, 2*time.Minute, 2*time.Second, "rig bead store did not become ready")
 
-	// Sling work to the polecat pool.
-	out, err := c.GC("sling", rigName+"/polecat", "Create a file called feature.txt containing 'new feature'")
+	// Sling attached formula work while the pool is suspended.
+	out, err := c.GC("sling", rigName+"/polecat", "Create a file called feature.txt containing 'new feature'", "--on", "mol-polecat-work")
 	if err != nil {
 		t.Fatalf("gc sling: %v\n%s", err, out)
 	}
 	t.Logf("Slung work to polecat: %s", strings.TrimSpace(out))
 
-	// Poll for outcome: a feature branch should eventually appear.
-	deadline := 5 * time.Minute
-	found := pollForCondition(t, deadline, 10*time.Second, func() bool {
-		branches := gitCmd(t, rigDir, "branch", "--list", "--no-color")
-		for _, line := range strings.Split(branches, "\n") {
-			branch := strings.TrimSpace(strings.TrimPrefix(line, "*"))
-			if branch != "" && branch != "main" && branch != "master" {
-				return true
-			}
-		}
-		return false
+	routeKey := rigName + "/polecat"
+	readyOut, err := bdCmd(testEnvC, rigDir, "ready", "--metadata-field", "gc.routed_to="+routeKey, "--unassigned", "--json", "--limit=20")
+	require.NoError(t, err, "bd ready")
+	var ready []beadJSON
+	require.NoError(t, json.Unmarshal([]byte(readyOut), &ready), "unmarshal ready queue")
+	require.Len(t, ready, 1, "expected only the outer bead in the routed ready queue")
+	require.NotContains(t, ready[0].ID, ".", "expected outer bead id, not a step id")
+
+	outerID := ready[0].ID
+	outerOut, err := bdCmd(testEnvC, rigDir, "show", outerID, "--json")
+	require.NoError(t, err, "bd show outer")
+	var outer []beadJSON
+	require.NoError(t, json.Unmarshal([]byte(outerOut), &outer), "unmarshal outer bead")
+	require.Len(t, outer, 1, "expected one outer bead")
+	moleculeID := strings.TrimSpace(outer[0].Metadata["molecule_id"])
+	require.NotEmpty(t, moleculeID, "outer bead should carry molecule_id metadata")
+
+	rootOut, err := bdCmd(testEnvC, rigDir, "show", moleculeID, "--json")
+	require.NoError(t, err, "bd show molecule root")
+	var root []beadJSON
+	require.NoError(t, json.Unmarshal([]byte(rootOut), &root), "unmarshal molecule root")
+	require.Len(t, root, 1, "expected one molecule root")
+	require.Empty(t, strings.TrimSpace(root[0].ParentID), "attached molecule root should not have a parent")
+
+	// Enable polecat and restart the city so execution can begin.
+	c.WriteConfig(strings.Replace(c.ReadFile("city.toml"),
+		"\n[[rigs.overrides]]\nagent = \"polecat\"\nsuspended = true\n[rigs.overrides.pool]\nmin = 0\nmax = 1\n",
+		"\n[[rigs.overrides]]\nagent = \"polecat\"\n[rigs.overrides.pool]\nmin = 1\nmax = 1\n",
+		1,
+	))
+	c.StartForeground()
+
+	// Poll for outcome: refinery must eventually merge the work to origin/main.
+	deadline := 8 * time.Minute
+	merged := pollForCondition(t, deadline, 15*time.Second, func() bool {
+		_ = gitCmd(t, rigDir, "fetch", "origin")
+		content := gitCmd(t, rigDir, "show", "origin/main:feature.txt")
+		return strings.TrimSpace(content) == "new feature"
 	})
 
-	if !found {
+	if !merged {
+		_ = gitCmd(t, rigDir, "fetch", "origin")
 		gitLog := gitCmd(t, rigDir, "log", "--all", "--oneline", "-10")
 		branches := gitCmd(t, rigDir, "branch", "-a")
+		originMain := gitCmd(t, rigDir, "log", "--oneline", "-5", "origin/main")
 		status, _ := c.GC("status")
-		t.Fatalf("no feature branch created within %s\nbranches:\n%s\ngit log:\n%s\nstatus:\n%s",
-			deadline, branches, gitLog, status)
+		sessionList, _ := c.GC("session", "list")
+		polecatLogs, _ := c.GC("session", "logs", "repo/polecat-1")
+		refineryLogs, _ := c.GC("session", "logs", "repo/refinery-1")
+		outerFinal, _ := bdCmd(testEnvC, rigDir, "show", outerID, "--json")
+		refineryAssigned, _ := bdCmd(testEnvC, rigDir, "list", "--assignee=repo/refinery", "--json", "--limit=20")
+		refineryInProgress, _ := bdCmd(testEnvC, rigDir, "list", "--status=in_progress", "--assignee=repo/refinery", "--json", "--limit=20")
+		controllerLog := tailFile(filepath.Join(c.Dir, ".gc", "acceptance-controller.log"), 200)
+		t.Fatalf("feature.txt was not merged to origin/main within %s\nbranches:\n%s\ngit log:\n%s\norigin/main:\n%s\nstatus:\n%s",
+			deadline, branches, gitLog, originMain, status+
+				"\nsessions:\n"+sessionList+
+				"\npolecat logs:\n"+polecatLogs+
+				"\nrefinery logs:\n"+refineryLogs+
+				"\nouter bead:\n"+outerFinal+
+				"\nrefinery assigned:\n"+refineryAssigned+
+				"\nrefinery in_progress:\n"+refineryInProgress+
+				"\ncontroller log tail:\n"+controllerLog)
 	}
 
-	t.Logf("Feature branch created")
-	mainLog := gitCmd(t, rigDir, "log", "--oneline", "-5", "main")
-	t.Logf("Main branch commits:\n%s", mainLog)
+	t.Log("Refinery merged feature.txt to origin/main")
+	mainLog := gitCmd(t, rigDir, "log", "--oneline", "-5", "origin/main")
+	t.Logf("origin/main commits:\n%s", mainLog)
 }
 
 // TestGastown_PolecatLifecycle verifies the full polecat lifecycle:
@@ -321,20 +376,24 @@ func TestGastown_MayorDispatchPipeline(t *testing.T) {
 
 func setupThrowawayRepo(t *testing.T) string {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), "repo")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	root := t.TempDir()
+	originDir := filepath.Join(root, "origin.git")
+	repoDir := filepath.Join(root, "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	gitCmd(t, dir, "init")
-	gitCmd(t, dir, "config", "user.email", "test@test.com")
-	gitCmd(t, dir, "config", "user.name", "Test")
-	readme := filepath.Join(dir, "README.md")
+	gitCmd(t, root, "init", "--bare", "--initial-branch=main", originDir)
+	gitCmd(t, root, "clone", originDir, repoDir)
+	gitCmd(t, repoDir, "config", "user.email", "test@test.com")
+	gitCmd(t, repoDir, "config", "user.name", "Test")
+	readme := filepath.Join(repoDir, "README.md")
 	if err := os.WriteFile(readme, []byte("# Test Repo\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	gitCmd(t, dir, "add", ".")
-	gitCmd(t, dir, "commit", "-m", "initial commit")
-	return dir
+	gitCmd(t, repoDir, "add", ".")
+	gitCmd(t, repoDir, "commit", "-m", "initial commit")
+	gitCmd(t, repoDir, "push", "-u", "origin", "main")
+	return repoDir
 }
 
 func gitCmd(t *testing.T, dir string, args ...string) string {
@@ -360,8 +419,26 @@ func pollForCondition(t *testing.T, timeout, interval time.Duration, check func(
 	return false
 }
 
+type beadJSON struct {
+	ID       string            `json:"id"`
+	ParentID string            `json:"parent_id"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+func bdCmd(env *helpers.Env, dir string, args ...string) (string, error) {
+	bdPath := "bd"
+	if path, err := exec.LookPath("bd"); err == nil {
+		bdPath = path
+	}
+	cmd := exec.Command(bdPath, args...)
+	cmd.Dir = dir
+	cmd.Env = env.List()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // oauthCredentialsExist checks if Claude CLI OAuth credentials are
-// available at ~/.claude/credentials.json. When running locally with
+// available at ~/.claude/.credentials.json. When running locally with
 // Claude Max, ANTHROPIC_API_KEY is not set, but the CLI authenticates
 // via these OAuth tokens.
 func oauthCredentialsExist() bool {
@@ -369,8 +446,64 @@ func oauthCredentialsExist() bool {
 	if err != nil {
 		return false
 	}
-	// Claude CLI stores OAuth tokens in ~/.claude/
-	credFile := filepath.Join(home, ".claude", "credentials.json")
-	_, err = os.Stat(credFile)
-	return err == nil
+	for _, candidate := range []string{
+		filepath.Join(home, ".claude", ".credentials.json"),
+		filepath.Join(home, ".claude", "credentials.json"),
+	} {
+		if _, err := os.Stat(candidate); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func stageClaudeOAuth(realHome, gcHome string) error {
+	srcClaudeDir := filepath.Join(realHome, ".claude")
+	dstClaudeDir := filepath.Join(gcHome, ".claude")
+	if err := os.MkdirAll(dstClaudeDir, 0o755); err != nil {
+		return err
+	}
+	for _, name := range []string{".credentials.json", "settings.json"} {
+		if err := copyFileIfExists(filepath.Join(srcClaudeDir, name), filepath.Join(dstClaudeDir, name), 0o600); err != nil {
+			return err
+		}
+	}
+	return copyFileIfExists(filepath.Join(realHome, ".claude.json"), filepath.Join(gcHome, ".claude.json"), 0o600)
+}
+
+func copyFileIfExists(src, dst string, perm os.FileMode) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return os.WriteFile(dst, data, perm)
+}
+
+func acceptanceTempRoot() (string, error) {
+	root := strings.TrimSpace(os.Getenv("GC_ACCEPTANCE_TMPDIR"))
+	if root == "" {
+		root = filepath.Join("/tmp", "gcac")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			root = filepath.Join(os.TempDir(), "gcac")
+		}
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func tailFile(path string, maxLines int) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err.Error()
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) <= maxLines {
+		return string(data)
+	}
+	return strings.Join(lines[len(lines)-maxLines:], "\n")
 }


### PR DESCRIPTION
## Summary
- add a foreground acceptance helper path so Tier C can exercise the real standalone controller flow used by the passing Gastown repro
- harden Tier C local mode with short temp-root selection, optional keep-on-fail artifacts, and minimal Claude OAuth staging instead of symlinking the whole host config tree
- upgrade `TestGastown_PolecatImplementsRefineryMerges` to verify the attached-formula queue invariant before activation and then require the full polecat -> refinery -> origin/main merge path

## Verification
- `make lint`
- `TMPDIR=/data/gca GOCACHE=/data/projects/gascity/.cache/go-build GC_ACCEPTANCE_TMPDIR=/data/gca GC_ACCEPTANCE_KEEP=1 GC_TIERC_FORCE=1 go test -tags acceptance_c -timeout 20m -run TestGastown_PolecatImplementsRefineryMerges -v ./test/acceptance/tier_c`

## Notes
- this PR is intentionally scoped to Acceptance C/nightly regression coverage on top of runtime-core PR #255
- `StartWithSupervisor()` is left unchanged from `main`; the new foreground helper is used only by the Gastown Tier C regression so the harness change stays isolated
