### PR TITLE
fix: detect session_live drift when live_hash is missing (ga-6jd)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -377,24 +377,22 @@ func reconcileSessionBeads(
 					if sl := session.Metadata["started_live_hash"]; sl != "" {
 						storedLive = sl
 					}
-					if storedLive != "" {
-						currentLive := runtime.LiveFingerprint(agentCfg)
-						if storedLive != currentLive {
-							fmt.Fprintf(stdout, "Live config changed for '%s', re-applying...\n", tp.DisplayName()) //nolint:errcheck
-							if err := sp.RunLive(name, agentCfg); err != nil {
-								fmt.Fprintf(stderr, "session reconciler: RunLive %s: %v\n", name, err) //nolint:errcheck
-							} else {
-								_ = store.SetMetadataBatch(session.ID, map[string]string{
-									"live_hash":         currentLive,
-									"started_live_hash": currentLive,
-								})
-								rec.Record(events.Event{
-									Type:    events.SessionUpdated,
-									Actor:   "gc",
-									Subject: tp.DisplayName(),
-									Message: "session_live re-applied",
-								})
-							}
+					currentLive := runtime.LiveFingerprint(agentCfg)
+					if storedLive != currentLive {
+						fmt.Fprintf(stdout, "Live config changed for '%s', re-applying...\n", tp.DisplayName()) //nolint:errcheck
+						if err := sp.RunLive(name, agentCfg); err != nil {
+							fmt.Fprintf(stderr, "session reconciler: RunLive %s: %v\n", name, err) //nolint:errcheck
+						} else {
+							_ = store.SetMetadataBatch(session.ID, map[string]string{
+								"live_hash":         currentLive,
+								"started_live_hash": currentLive,
+							})
+							rec.Record(events.Event{
+								Type:    events.SessionUpdated,
+								Actor:   "gc",
+								Subject: tp.DisplayName(),
+								Message: "session_live re-applied",
+							})
 						}
 					}
 				}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1324,6 +1324,38 @@ func TestReconcileSessionBeads_LiveDriftReapplied(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_LiveDriftAppliedWhenNoStoredHash(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	// Desired state has session_live from a newly-added pack.
+	env.addDesiredLive("worker", "worker", true, []string{"echo theme-applied"})
+
+	// Create a session bead WITHOUT live_hash — simulates a bead created
+	// before live_hash tracking was added, or via gc session new (which
+	// doesn't set live_hash in its metadata).
+	session := env.createSessionBead("worker", "worker")
+	delete(session.Metadata, "live_hash")
+	_ = env.store.SetMetadata(session.ID, "live_hash", "")
+	env.markSessionActive(&session)
+
+	env.reconcile([]beads.Bead{session})
+
+	// Should NOT drain (core hash matches).
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Errorf("expected no drain for live-only drift, got reason=%q", ds.reason)
+	}
+	// Should have applied session_live and recorded the hash.
+	b, _ := env.store.Get(session.ID)
+	expectedCfg := templateParamsToConfig(env.desiredState["worker"])
+	expectedLive := runtime.LiveFingerprint(expectedCfg)
+	if b.Metadata["live_hash"] != expectedLive {
+		t.Errorf("live_hash not applied: got %q, want %q", b.Metadata["live_hash"], expectedLive)
+	}
+	if b.Metadata["started_live_hash"] != expectedLive {
+		t.Errorf("started_live_hash not applied: got %q, want %q", b.Metadata["started_live_hash"], expectedLive)
+	}
+}
+
 func TestAllDependenciesAlive_WithSessionTemplate(t *testing.T) {
 	session := beads.Bead{Metadata: map[string]string{"template": "worker"}}
 	cfg := &config.City{


### PR DESCRIPTION
## Summary

- Fixes reconciler not auto-applying session_live drift from newly added packs on pre-existing sessions
- Removes storedLive empty guard in session_reconciler.go so live-drift check runs even when session bead has no live_hash
- Adds regression test coverage

## Context

- Issue: ga-6jd
- Branch: polecat/ga-aa2
- Target: main

Automated pull request published by Gastown Refinery.