### PR TITLE
fix: skip suspended rigs in gc doctor health checks

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -136,9 +136,13 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	// Custom types check — city store.
 	d.Register(doctor.NewCustomTypesCheck(cityPath, "city"))
 
-	// Per-rig checks.
+	// Per-rig checks. Skip suspended rigs — opening their bead store
+	// triggers bd auto-start of orphan Dolt servers (ga-wzk).
 	if cfgErr == nil {
 		for _, rig := range cfg.Rigs {
+			if rig.Suspended {
+				continue
+			}
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
 			d.Register(doctor.NewRigBeadsCheck(rig, openStore))

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
 )
 
 func TestCollectPackDirsEmpty(t *testing.T) {
@@ -73,5 +76,37 @@ func TestCollectPackDirsMixed(t *testing.T) {
 	dirs := collectPackDirs(cfg)
 	if len(dirs) != 2 {
 		t.Fatalf("expected 2 dirs, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestDoctorSkipsSuspendedRigChecks(t *testing.T) {
+	t.Parallel()
+	activeDir := t.TempDir()
+	suspendedDir := t.TempDir()
+
+	rigs := []config.Rig{
+		{Name: "active-rig", Path: activeDir},
+		{Name: "suspended-rig", Path: suspendedDir, Suspended: true},
+	}
+
+	// Mirror the per-rig registration logic from doDoctor.
+	d := &doctor.Doctor{}
+	for _, rig := range rigs {
+		if rig.Suspended {
+			continue
+		}
+		d.Register(doctor.NewRigPathCheck(rig))
+	}
+
+	var buf bytes.Buffer
+	ctx := &doctor.CheckContext{CityPath: t.TempDir()}
+	d.Run(ctx, &buf, false)
+
+	out := buf.String()
+	if !strings.Contains(out, "active-rig") {
+		t.Error("expected active-rig checks to be registered")
+	}
+	if strings.Contains(out, "suspended-rig") {
+		t.Error("suspended-rig checks should not be registered")
 	}
 }


### PR DESCRIPTION
## Summary
- `gc doctor` health-checks suspended rigs, triggering `bd` auto-start of orphan Dolt servers (~80-90MB RSS each)
- Fix: skip suspended rigs in the per-rig check registration loop
- Added `TestDoctorSkipsSuspendedRigChecks` unit test

**Note:** This branch also contains acceptance test deletions (TestRestart_NotInitialized, TestDashboard_BareCommand, TestOrderRunGastownCity) from the previous polecat that appear unrelated to the fix. Reviewer should verify these removals are intentional.

Closes: ga-wzk