### PR TITLE
fix: resolve macOS /private symlink, socket path length, and BSD sed test failures (ga-6y3)

### DIFF
--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1635,8 +1635,10 @@ func TestRigAnywhere_ResolveCityByNameOrPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolveCityByNameOrPath error: %v", err)
 		}
-		if got != cityPath {
-			t.Errorf("got %q, want %q", got, cityPath)
+		// Canonicalize to handle macOS /var → /private/var symlink.
+		want, _ := filepath.EvalSymlinks(cityPath)
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	})
 

--- a/contrib/mail-scripts/gc-mail-mcp-agent-mail
+++ b/contrib/mail-scripts/gc-mail-mcp-agent-mail
@@ -121,7 +121,7 @@ mcp_call() {
   local tool="$1"
   local arguments="$2"
   local auth_header=()
-  if [ -n "$MCP_TOKEN" ]; then
+  if [ -n "${MCP_TOKEN:-}" ]; then
     auth_header=(-H "Authorization: Bearer $MCP_TOKEN")
   fi
 
@@ -139,7 +139,7 @@ mcp_call() {
   local response
   response=$(curl -s -X POST "${MCP_URL}/mcp" \
     -H "Content-Type: application/json" \
-    "${auth_header[@]}" \
+    ${auth_header[@]+"${auth_header[@]}"} \
     -d "$body")
 
   # Check for JSON-RPC error.

--- a/internal/mail/exec/conformance_test.go
+++ b/internal/mail/exec/conformance_test.go
@@ -111,7 +111,7 @@ case "$op" in
     thread_id=$(sed -n '8p' "$f")
     reply_to=$(sed -n '9p' "$f")
     # Mark as read.
-    sed -i '7s/.*/read/' "$f"
+    sed '7s/.*/read/' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
     printf '{"id":"%s","from":"%s","to":"%s","subject":"%s","body":"%s","created_at":"%s","read":true,"thread_id":"%s","reply_to":"%s"}\n' "$msgid" "$from" "$msg_to" "$subject" "$body" "$ts" "$thread_id" "$reply_to"
     ;;
   mark-read)
@@ -121,7 +121,7 @@ case "$op" in
       echo "message \"$msgid\" not found" >&2
       exit 1
     fi
-    sed -i '7s/.*/read/' "$f"
+    sed '7s/.*/read/' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
     ;;
   mark-unread)
     msgid="$1"
@@ -130,7 +130,7 @@ case "$op" in
       echo "message \"$msgid\" not found" >&2
       exit 1
     fi
-    sed -i '7s/.*/open/' "$f"
+    sed '7s/.*/open/' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
     ;;
   archive|delete)
     msgid="$1"
@@ -144,7 +144,7 @@ case "$op" in
       echo "already archived" >&2
       exit 1
     fi
-    sed -i '7s/.*/archived/' "$f"
+    sed '7s/.*/archived/' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
     ;;
   reply)
     msgid="$1"

--- a/internal/runtime/acp/acp_test.go
+++ b/internal/runtime/acp/acp_test.go
@@ -15,10 +15,22 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+// shortTempDir returns a temp directory short enough for Unix socket paths
+// (macOS limit is 104 bytes). t.TempDir() paths often exceed this.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "gc-t-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
 // newTestProvider creates an ACP provider with an isolated temp directory.
 func newTestProvider(t *testing.T) *Provider {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), "acp")
+	dir := filepath.Join(shortTempDir(t), "acp")
 	return NewProviderWithDir(dir, Config{
 		HandshakeTimeout:  5 * time.Second,
 		NudgeBusyTimeout:  2 * time.Second,

--- a/internal/runtime/subprocess/subprocess_test.go
+++ b/internal/runtime/subprocess/subprocess_test.go
@@ -13,9 +13,21 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+// shortTempDir returns a temp directory short enough for Unix socket paths
+// (macOS limit is 104 bytes). t.TempDir() paths often exceed this.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "gc-t-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
 func newTestProvider(t *testing.T) *Provider {
 	t.Helper()
-	return NewProviderWithDir(filepath.Join(t.TempDir(), "socks"))
+	return NewProviderWithDir(filepath.Join(shortTempDir(t), "socks"))
 }
 
 func TestStartCreatesProcess(t *testing.T) {
@@ -32,17 +44,23 @@ func TestStartCreatesProcess(t *testing.T) {
 }
 
 func TestStartLongSocketPathUsesShortSocketName(t *testing.T) {
-	root, err := os.MkdirTemp("", "gc-subprocess-sock-")
+	// Use /tmp for a short base path — TMPDIR on macOS (/var/folders/...)
+	// is too long to find a depth where legacy > limit but short < limit.
+	root, err := os.MkdirTemp("/tmp", "gc-sock-")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
 	const name = "control-dispatcher"
+	// macOS socket path limit is 104 bytes; Linux is 108.
+	const sunPathLimit = 104
 	longDir := ""
-	for i := 1; i <= 32; i++ {
-		candidate := filepath.Join(root, strings.Repeat("deep-path-", i), "socks")
+	for i := 1; i <= 200; i++ {
+		// Use single-char increments so the 10-char gap between legacy
+		// and short socket names can straddle the sun_path limit.
+		candidate := filepath.Join(root, strings.Repeat("p", i), "socks")
 		p := NewProviderWithDir(candidate)
-		if len(p.legacySockPath(name)) > 108 && len(p.sockPath(name)) < 108 {
+		if len(p.legacySockPath(name)) > sunPathLimit && len(p.sockPath(name)) < sunPathLimit {
 			longDir = candidate
 			break
 		}
@@ -253,7 +271,9 @@ func TestWorkDirSet(t *testing.T) {
 		data, err := os.ReadFile(marker)
 		if err == nil && len(data) > 0 {
 			got := string(data)
-			want := dir + "\n"
+			// Canonicalize to handle macOS /var → /private/var symlink.
+			canonical, _ := filepath.EvalSymlinks(dir)
+			want := canonical + "\n"
 			if got != want {
 				t.Errorf("workdir = %q, want %q", got, want)
 			}
@@ -316,7 +336,7 @@ func TestSocketGoneAfterProcessDeath(t *testing.T) {
 func TestCrossProcessStopBySocket(t *testing.T) {
 	// Simulate the gc start → gc stop cross-process pattern:
 	// Provider 1 starts a process, Provider 2 (same dir) stops it.
-	dir := filepath.Join(t.TempDir(), "socks")
+	dir := filepath.Join(shortTempDir(t), "socks")
 
 	p1 := NewProviderWithDir(dir)
 	if err := p1.Start(context.Background(), "cross", runtime.Config{Command: "sleep 3600"}); err != nil {
@@ -345,7 +365,7 @@ func TestCrossProcessStopBySocket(t *testing.T) {
 }
 
 func TestCrossProcessInterruptBySocket(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "socks")
+	dir := filepath.Join(shortTempDir(t), "socks")
 
 	p1 := NewProviderWithDir(dir)
 	// Use a command that traps SIGINT.
@@ -365,7 +385,7 @@ func TestCrossProcessInterruptBySocket(t *testing.T) {
 }
 
 func TestIsRunningViaSocket(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "socks")
+	dir := filepath.Join(shortTempDir(t), "socks")
 
 	p1 := NewProviderWithDir(dir)
 	if err := p1.Start(context.Background(), "live", runtime.Config{Command: "sleep 3600"}); err != nil {
@@ -386,7 +406,7 @@ func TestIsRunningViaSocket(t *testing.T) {
 }
 
 func TestListRunningViaSocket(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "socks")
+	dir := filepath.Join(shortTempDir(t), "socks")
 
 	p := NewProviderWithDir(dir)
 	if err := p.Start(context.Background(), "gc-test-a", runtime.Config{Command: "sleep 3600"}); err != nil {


### PR DESCRIPTION
## Summary

- Fixes pre-existing test failures on macOS: /private symlink resolution, socket path too long, BSD sed incompatibility
- Fixed packages: internal/mail/exec, internal/runtime/acp, internal/runtime/subprocess
- Remaining macOS /private symlink issues in convergence, git, supervisor, cmd/gc are tracked separately

## Context

- Issue: ga-6y3
- Branch: polecat/ga-6y3
- Target: main

Automated pull request published by Gastown Refinery.