### PR TITLE
refactor(extmsg): use labels instead of custom bead types

### DIFF
--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -13,8 +13,6 @@ import (
 var RequiredCustomTypes = []string{
 	"molecule", "convoy", "message", "event", "gate",
 	"merge-request", "agent", "role", "rig", "session", "spec",
-	"gc:extmsg-binding", "gc:extmsg-transcript", "gc:extmsg-membership",
-	"gc:extmsg-group", "gc:extmsg-participant",
 }
 
 // CustomTypesCheck verifies that all required Gas City custom bead

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -53,9 +53,6 @@ func TestCustomTypesCheck_RequiredTypesComplete(t *testing.T) {
 		"event": true, "gate": true, "merge-request": true,
 		"agent": true, "role": true, "rig": true,
 		"session": true, "spec": true,
-		"gc:extmsg-binding": true, "gc:extmsg-transcript": true,
-		"gc:extmsg-membership": true, "gc:extmsg-group": true,
-		"gc:extmsg-participant": true,
 	}
 	for _, typ := range RequiredCustomTypes {
 		if !expected[typ] {

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -137,8 +137,8 @@ func (s *bindingService) Bind(ctx context.Context, caller Caller, input BindInpu
 		nextGeneration := nextBindingGeneration(history)
 		b, err := s.store.Create(beads.Bead{
 			Title:  conversationTitle(ref),
-			Type:   "gc:extmsg-binding",
-			Labels: []string{labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel(sessionID)},
+			Type:   "task",
+			Labels: []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel(sessionID)},
 			Metadata: encodeMetadataFields(input.Metadata, map[string]string{
 				"schema_version":         strconv.Itoa(schemaVersion),
 				"scope_id":               ref.ScopeID,
@@ -212,7 +212,7 @@ func (s *bindingService) ListBySession(ctx context.Context, sessionID string) ([
 		if err := checkContext(ctx); err != nil {
 			return nil, err
 		}
-		if item.Type != "gc:extmsg-binding" {
+		if !hasLabel(item, "gc:extmsg-binding") {
 			continue
 		}
 		record, err := decodeBindingBead(item)
@@ -309,7 +309,7 @@ func (s *bindingService) Unbind(ctx context.Context, caller Caller, input Unbind
 			return nil, fmt.Errorf("list bindings by session label: %w", err)
 		}
 		for _, item := range items {
-			if item.Type != "gc:extmsg-binding" {
+			if !hasLabel(item, "gc:extmsg-binding") {
 				continue
 			}
 			record, err := decodeBindingBead(item)
@@ -404,7 +404,7 @@ func (s *bindingService) listBindingsForConversation(ref ConversationRef) ([]Ses
 	}
 	out := make([]SessionBindingRecord, 0, len(items))
 	for _, item := range items {
-		if item.Type != "gc:extmsg-binding" {
+		if !hasLabel(item, "gc:extmsg-binding") {
 			continue
 		}
 		record, err := decodeBindingBead(item)
@@ -547,7 +547,7 @@ func resolveActiveBindingLocked(ctx context.Context, store beads.Store, delivery
 		if err := checkContext(ctx); err != nil {
 			return nil, err
 		}
-		if item.Type != "gc:extmsg-binding" {
+		if !hasLabel(item, "gc:extmsg-binding") {
 			continue
 		}
 		record, err := decodeBindingBead(item)

--- a/internal/extmsg/delivery_service.go
+++ b/internal/extmsg/delivery_service.go
@@ -75,7 +75,7 @@ func (s *deliveryContextService) Record(ctx context.Context, caller Caller, inpu
 				if err := checkContext(ctx); err != nil {
 					return err
 				}
-				if item.Type != "gc:extmsg-delivery" || item.Status == "closed" {
+				if !hasLabel(item, "gc:extmsg-delivery") || item.Status == "closed" {
 					continue
 				}
 				record, err := decodeDeliveryBead(item)
@@ -95,8 +95,8 @@ func (s *deliveryContextService) Record(ctx context.Context, caller Caller, inpu
 			}
 			_, err = s.store.Create(beads.Bead{
 				Title:    title,
-				Type:     "gc:extmsg-delivery",
-				Labels:   []string{labelDeliveryBase, label, deliverySessionLabel(sessionID)},
+				Type:     "task",
+				Labels:   []string{"gc:extmsg-delivery", labelDeliveryBase, label, deliverySessionLabel(sessionID)},
 				Metadata: fields,
 			})
 			if err != nil {
@@ -135,7 +135,7 @@ func (s *deliveryContextService) Resolve(ctx context.Context, sessionID string, 
 				if err := checkContext(ctx); err != nil {
 					return err
 				}
-				if item.Type != "gc:extmsg-delivery" || item.Status == "closed" {
+				if !hasLabel(item, "gc:extmsg-delivery") || item.Status == "closed" {
 					continue
 				}
 				record, err := decodeDeliveryBead(item)
@@ -219,7 +219,7 @@ func (c deliveryCleaner) ClearForConversation(ctx context.Context, sessionID str
 			if err := checkContext(ctx); err != nil {
 				return err
 			}
-			if item.Type != "gc:extmsg-delivery" || item.Status == "closed" {
+			if !hasLabel(item, "gc:extmsg-delivery") || item.Status == "closed" {
 				continue
 			}
 			record, err := decodeDeliveryBead(item)

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -363,8 +363,8 @@ func TestDeliveryContextResolveKeepsValidRouteWhileClosingStaleRoute(t *testing.
 	}
 	if _, err := store.Create(beads.Bead{
 		Title:  "stale delivery",
-		Type:   "gc:extmsg-delivery",
-		Labels: []string{labelDeliveryBase, deliveryRouteLabel(ref, "sess-a"), deliverySessionLabel("sess-a")},
+		Type:   "task",
+		Labels: []string{"gc:extmsg-delivery", labelDeliveryBase, deliveryRouteLabel(ref, "sess-a"), deliverySessionLabel("sess-a")},
 		Metadata: encodeMetadataFields(nil, map[string]string{
 			"schema_version":         strconv.Itoa(schemaVersion),
 			"session_id":             "sess-a",
@@ -781,8 +781,8 @@ func TestBindingServiceResolveByConversationRejectsDuplicateActiveBindings(t *te
 
 	if _, err := store.Create(beads.Bead{
 		Title:  conversationTitle(ref),
-		Type:   "gc:extmsg-binding",
-		Labels: []string{labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel("sess-a")},
+		Type:   "task",
+		Labels: []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel("sess-a")},
 		Metadata: encodeMetadataFields(nil, map[string]string{
 			"schema_version":         strconv.Itoa(schemaVersion),
 			"scope_id":               ref.ScopeID,
@@ -803,8 +803,8 @@ func TestBindingServiceResolveByConversationRejectsDuplicateActiveBindings(t *te
 	}
 	if _, err := store.Create(beads.Bead{
 		Title:  conversationTitle(ref),
-		Type:   "gc:extmsg-binding",
-		Labels: []string{labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel("sess-b")},
+		Type:   "task",
+		Labels: []string{"gc:extmsg-binding", labelBindingBase, bindingConversationLabel(ref), bindingSessionLabel("sess-b")},
 		Metadata: encodeMetadataFields(nil, map[string]string{
 			"schema_version":         strconv.Itoa(schemaVersion),
 			"scope_id":               ref.ScopeID,
@@ -846,8 +846,8 @@ func TestGroupServiceResolveInboundRejectsDuplicateParticipants(t *testing.T) {
 	}
 	if _, err := store.Create(beads.Bead{
 		Title:  group.ID + "/alpha-a",
-		Type:   "gc:extmsg-participant",
-		Labels: []string{labelGroupParticipantBase, groupParticipantLabel(group.ID), groupParticipantSessionLabel("sess-a")},
+		Type:   "task",
+		Labels: []string{"gc:extmsg-participant", labelGroupParticipantBase, groupParticipantLabel(group.ID), groupParticipantSessionLabel("sess-a")},
 		Metadata: encodeMetadataFields(nil, map[string]string{
 			"schema_version": strconv.Itoa(schemaVersion),
 			"group_id":       group.ID,
@@ -860,8 +860,8 @@ func TestGroupServiceResolveInboundRejectsDuplicateParticipants(t *testing.T) {
 	}
 	if _, err := store.Create(beads.Bead{
 		Title:  group.ID + "/alpha-b",
-		Type:   "gc:extmsg-participant",
-		Labels: []string{labelGroupParticipantBase, groupParticipantLabel(group.ID), groupParticipantSessionLabel("sess-b")},
+		Type:   "task",
+		Labels: []string{"gc:extmsg-participant", labelGroupParticipantBase, groupParticipantLabel(group.ID), groupParticipantSessionLabel("sess-b")},
 		Metadata: encodeMetadataFields(nil, map[string]string{
 			"schema_version": strconv.Itoa(schemaVersion),
 			"group_id":       group.ID,

--- a/internal/extmsg/group_service.go
+++ b/internal/extmsg/group_service.go
@@ -85,7 +85,7 @@ func (s *groupService) EnsureGroup(ctx context.Context, caller Caller, input Ens
 			if err := checkContext(ctx); err != nil {
 				return err
 			}
-			if item.Type != "gc:extmsg-group" || item.Status == "closed" {
+			if !hasLabel(item, "gc:extmsg-group") || item.Status == "closed" {
 				continue
 			}
 			record, err := decodeGroupBead(item)
@@ -110,8 +110,8 @@ func (s *groupService) EnsureGroup(ctx context.Context, caller Caller, input Ens
 		}
 		created, err := s.store.Create(beads.Bead{
 			Title:    title,
-			Type:     "gc:extmsg-group",
-			Labels:   []string{labelGroupBase, groupRootLabel(ref)},
+			Type:     "task",
+			Labels:   []string{"gc:extmsg-group", labelGroupBase, groupRootLabel(ref)},
 			Metadata: fields,
 		})
 		if err != nil {
@@ -164,7 +164,7 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 			if err := checkContext(ctx); err != nil {
 				return err
 			}
-			if item.Type != "gc:extmsg-participant" || item.Status == "closed" {
+			if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
 				continue
 			}
 			record, err := decodeParticipantBead(item)
@@ -250,8 +250,8 @@ func (s *groupService) UpsertParticipant(ctx context.Context, caller Caller, inp
 		}
 		created, err := s.store.Create(beads.Bead{
 			Title:    title,
-			Type:     "gc:extmsg-participant",
-			Labels:   []string{labelGroupParticipantBase, groupParticipantLabel(groupID), groupParticipantSessionLabel(sessionID)},
+			Type:     "task",
+			Labels:   []string{"gc:extmsg-participant", labelGroupParticipantBase, groupParticipantLabel(groupID), groupParticipantSessionLabel(sessionID)},
 			Metadata: fields,
 		})
 		if err != nil {
@@ -311,7 +311,7 @@ func (s *groupService) RemoveParticipant(ctx context.Context, caller Caller, inp
 		}
 		seenSessionIDs := make(map[string]struct{})
 		for _, item := range items {
-			if item.Type != "gc:extmsg-participant" {
+			if !hasLabel(item, "gc:extmsg-participant") {
 				continue
 			}
 			record, err := decodeParticipantBead(item)
@@ -486,7 +486,7 @@ func (s *groupService) findGroupByRoot(ref ConversationRef) (*ConversationGroupR
 	}
 	var out *ConversationGroupRecord
 	for _, item := range items {
-		if item.Type != "gc:extmsg-group" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-group") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeGroupBead(item)
@@ -510,7 +510,7 @@ func (s *groupService) getGroupByID(groupID string) (ConversationGroupRecord, er
 	if err != nil {
 		return ConversationGroupRecord{}, fmt.Errorf("get group %s: %w", groupID, err)
 	}
-	if item.Type != "gc:extmsg-group" || item.Status == "closed" {
+	if !hasLabel(item, "gc:extmsg-group") || item.Status == "closed" {
 		return ConversationGroupRecord{}, ErrGroupNotFound
 	}
 	return decodeGroupBead(item)
@@ -524,7 +524,7 @@ func (s *groupService) listParticipants(groupID string) ([]ConversationGroupPart
 	out := make([]ConversationGroupParticipant, 0, len(items))
 	seen := make(map[string]ConversationGroupParticipant)
 	for _, item := range items {
-		if item.Type != "gc:extmsg-participant" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeParticipantBead(item)
@@ -550,7 +550,7 @@ func (s *groupService) activeParticipantSessionCounts(ctx context.Context, group
 		if err := checkContext(ctx); err != nil {
 			return nil, err
 		}
-		if item.Type != "gc:extmsg-participant" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeParticipantBead(item)

--- a/internal/extmsg/helpers.go
+++ b/internal/extmsg/helpers.go
@@ -11,6 +11,16 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
+// hasLabel checks if a bead has a specific label.
+func hasLabel(b beads.Bead, label string) bool {
+	for _, l := range b.Labels {
+		if l == label {
+			return true
+		}
+	}
+	return false
+}
+
 func normalizeConversationRef(ref ConversationRef) ConversationRef {
 	ref.ScopeID = strings.TrimSpace(ref.ScopeID)
 	ref.Provider = strings.ToLower(strings.TrimSpace(ref.Provider))

--- a/internal/extmsg/transcript_service.go
+++ b/internal/extmsg/transcript_service.go
@@ -115,9 +115,9 @@ func (s *transcriptService) Append(ctx context.Context, input AppendTranscriptIn
 		}
 		created, err := s.store.Create(beads.Bead{
 			Title:       fmt.Sprintf("%s#%d", conversationTitle(ref), sequence),
-			Type:        "gc:extmsg-transcript",
+			Type:        "task",
 			Description: text,
-			Labels:      labels,
+			Labels:      append([]string{"gc:extmsg-transcript"}, labels...),
 			Metadata:    fields,
 		})
 		if err != nil {
@@ -367,8 +367,8 @@ func (s *transcriptService) ensureMembershipLocked(input EnsureMembershipInput) 
 	})
 	created, err := s.store.Create(beads.Bead{
 		Title:    sessionID + " -> " + conversationTitle(ref),
-		Type:     "gc:extmsg-membership",
-		Labels:   []string{labelMembershipBase, membershipConversationLabel(ref), membershipExactLabel(ref, sessionID), membershipSessionLabel(sessionID)},
+		Type:     "task",
+		Labels:   []string{"gc:extmsg-membership", labelMembershipBase, membershipConversationLabel(ref), membershipExactLabel(ref, sessionID), membershipSessionLabel(sessionID)},
 		Metadata: fields,
 	})
 	if err != nil {
@@ -451,7 +451,7 @@ func (s *transcriptService) ListMemberships(ctx context.Context, caller Caller, 
 	out := make([]ConversationMembershipRecord, 0, len(items))
 	seen := make(map[string]ConversationMembershipRecord)
 	for _, item := range items {
-		if item.Type != "gc:extmsg-membership" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-membership") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeMembershipBead(item)
@@ -491,7 +491,7 @@ func (s *transcriptService) ListConversationsBySession(ctx context.Context, call
 	out := make([]ConversationMembershipRecord, 0, len(items))
 	seen := make(map[string]bool)
 	for _, item := range items {
-		if item.Type != "gc:extmsg-membership" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-membership") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeMembershipBead(item)
@@ -729,8 +729,8 @@ func (s *transcriptService) ensureStateLocked(ref ConversationRef) (Conversation
 	}
 	created, err := s.store.Create(beads.Bead{
 		Title:    conversationTitle(ref) + "/state",
-		Type:     "gc:extmsg-transcript-state",
-		Labels:   []string{labelTranscriptStateBase, transcriptStateLabel(ref)},
+		Type:     "task",
+		Labels:   []string{"gc:extmsg-transcript-state", labelTranscriptStateBase, transcriptStateLabel(ref)},
 		Metadata: fields,
 	})
 	if err != nil {
@@ -746,7 +746,7 @@ func (s *transcriptService) findStateLocked(ref ConversationRef) (*ConversationT
 	}
 	var out *ConversationTranscriptStateRecord
 	for _, item := range items {
-		if item.Type != "gc:extmsg-transcript-state" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-transcript-state") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeTranscriptStateBead(item)
@@ -772,7 +772,7 @@ func (s *transcriptService) findTranscriptByProviderMessageLocked(ref Conversati
 	}
 	var out *ConversationTranscriptRecord
 	for _, item := range items {
-		if item.Type != "gc:extmsg-transcript" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-transcript") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeTranscriptBead(item)
@@ -798,7 +798,7 @@ func (s *transcriptService) findActiveMembershipLocked(ref ConversationRef, sess
 	}
 	var out *ConversationMembershipRecord
 	for _, item := range items {
-		if item.Type != "gc:extmsg-membership" || item.Status == "closed" {
+		if !hasLabel(item, "gc:extmsg-membership") || item.Status == "closed" {
 			continue
 		}
 		record, err := decodeMembershipBead(item)
@@ -843,7 +843,7 @@ func (s *transcriptService) listTranscriptLocked(ref ConversationRef, after int6
 		}
 		bucketRecords := make([]ConversationTranscriptRecord, 0, len(items))
 		for _, item := range items {
-			if item.Type != "gc:extmsg-transcript" || item.Status == "closed" {
+			if !hasLabel(item, "gc:extmsg-transcript") || item.Status == "closed" {
 				continue
 			}
 			record, err := decodeTranscriptBead(item)


### PR DESCRIPTION
## Summary

- Switch extmsg beads from custom types (`gc:extmsg-group`, etc.) to standard `"task"` type with `gc:extmsg-*` labels
- Eliminates the need to register custom types in bd's `types.custom` config
- The doctor and `gc-beads-bd` kept resetting `types.custom`, breaking extmsg bead creation
- Labels are already the primary query mechanism (`ListByLabel`), so the type field was redundant

## Changes

- All bead creation: `Type: "task"` with `gc:extmsg-*` as first label
- All type checks: `hasLabel(item, "gc:extmsg-*")` instead of `item.Type != "gc:extmsg-*"`
- Remove `gc:extmsg-*` from `RequiredCustomTypes` in doctor
- Add `hasLabel` helper to `extmsg/helpers.go`

## Test plan

- [x] All 40 extmsg tests pass
- [x] Doctor tests pass (updated expected types)
- [x] Full API test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)