### PR TITLE
fix: update gc.routed_to on polecat→refinery handoff

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.formula.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.formula.toml
@@ -176,8 +176,13 @@ This adds the target for the refinery.
 
 **5. Reassign to refinery:**
 ```bash
-bd update {{issue}} --status=open --assignee=<rig>/refinery
+bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
 ```
+
+Update both `assignee` AND `gc.routed_to` so the reconciler stops
+counting this bead for the polecat pool and starts counting it for
+the refinery pool. Without updating `gc.routed_to`, the reconciler
+spawns phantom polecats that can't claim the bead.
 
 The refinery will pick this up, rebase onto {{base_branch}}, run tests,
 merge, and close the bead. If there's a conflict, the refinery puts the

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml
@@ -161,7 +161,8 @@ If rebase FAILED (conflicts):
 2. Put the work bead back in the pool with rejection metadata:
 ```bash
 bd update $WORK --status=open --assignee="" \
-  --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)"
+  --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
+  --set-metadata gc.routed_to=<rig>/polecat
 ```
 3. Do NOT delete the branch (new polecat needs it for conflict resolution).
 4. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`


### PR DESCRIPTION
## Summary

Update `gc.routed_to` metadata when beads move between pools:
- Polecat → refinery handoff: set `gc.routed_to=<rig>/refinery`
- Refinery → polecat rejection: set `gc.routed_to=<rig>/polecat`

## Problem

When a polecat completes work and assigns the bead to the refinery, only `assignee` is updated. `gc.routed_to` stays pointing at the polecat pool. The reconciler uses `gc.routed_to` for `scale_check`, so it keeps spawning polecats for beads they can't claim. These phantom polecats sit idle burning API quota.

See #265 for the full analysis.

## Changes

- `mol-polecat-work.formula.toml`: Add `--set-metadata gc.routed_to=<rig>/refinery` to the reassign step
- `mol-refinery-patrol.formula.toml`: Add `--set-metadata gc.routed_to=<rig>/polecat` to the rejection step

## Test plan

- [ ] Polecat completes work → bead shows `gc.routed_to=<rig>/refinery`
- [ ] No phantom polecats spawn for beads assigned to refinery
- [ ] Refinery rejects → bead shows `gc.routed_to=<rig>/polecat`
- [ ] New polecat picks up rejected bead correctly

Fixes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)