### PR TITLE
fix: catch integration test compile errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Acceptance tests (Tier A)
         run: make test-acceptance
 
+      - name: Integration tests (compile check)
+        run: go test -tags integration -run ^$ -count=0 ./test/integration/...
+
       - name: Integration tests
         continue-on-error: true  # requires provider binaries (claude/codex) not available in CI
         run: make test-integration

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -359,6 +360,21 @@ func filterEnv(env []string, name string) []string {
 		result = append(result, e)
 	}
 	return result
+}
+
+// filterEnvMany returns env with all named variables removed.
+func filterEnvMany(env []string, names ...string) []string {
+	for _, name := range names {
+		env = filterEnv(env, name)
+	}
+	return env
+}
+
+// repoRoot returns the root of the gascity repository by walking up from this
+// file's location (test/integration/).
+func repoRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..")
 }
 
 func integrationEnv() []string {

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -135,7 +135,7 @@ func setupReviewCheckScriptCity(t *testing.T) string {
 	if err := os.MkdirAll(checksDir, 0o755); err != nil {
 		t.Fatalf("mkdir checks: %v", err)
 	}
-	packChecks := filepath.Join(repoRoot(t), "examples", "gastown", "packs", "gastown", "scripts", "checks")
+	packChecks := filepath.Join(repoRoot(), "examples", "gastown", "packs", "gastown", "scripts", "checks")
 	checkEntries, err := os.ReadDir(packChecks)
 	if err != nil {
 		t.Fatalf("reading pack checks: %v", err)


### PR DESCRIPTION
## Summary
- Add a compile-only step (`go test -tags integration -run ^$ -count=0`) before the `continue-on-error` integration test step so compilation failures are never masked
- Fix undefined `filterEnvMany` and `repoRoot` in `review_check_scripts_test.go`

## Test plan
- [ ] New compile-check step fails on compile errors (no `continue-on-error`)
- [ ] Integration test step still uses `continue-on-error` for missing provider binaries
- [ ] `go test ./...` passes locally
- [ ] `go vet ./...` clean