### PR TITLE
fix: detect on-demand named session demand from gc.routed_to metadata

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -260,14 +260,19 @@ func buildDesiredStateWithSessionBeads(
 		namedSpecs[identity] = spec
 	}
 	namedWorkReady := make(map[string]bool, len(namedSpecs))
-	// Check assigned work beads: if any work bead's Assignee matches a
-	// named session's identity (alias), that session has demand.
-	// This handles cross-agent handoff (e.g., polecat assigns work to
-	// refinery by setting Assignee to the refinery's alias).
+	// Check assigned work beads: if any work bead's Assignee or gc.routed_to
+	// matches a named session's identity, that session has demand.
+	// Assignee is set by formula-dispatched work; gc.routed_to is set by
+	// the default sling query (metadata-based routing).
 	for identity := range namedSpecs {
 		for _, wb := range assignedWorkBeads {
-			if strings.TrimSpace(wb.Assignee) == identity && (wb.Status == "open" || wb.Status == "in_progress") {
-				fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, wb.Assignee, wb.Status) //nolint:errcheck
+			if wb.Status != "open" && wb.Status != "in_progress" {
+				continue
+			}
+			assignee := strings.TrimSpace(wb.Assignee)
+			routedTo := strings.TrimSpace(wb.Metadata["gc.routed_to"])
+			if assignee == identity || routedTo == identity {
+				fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s routed_to=%s status=%s)\n", identity, wb.ID, assignee, routedTo, wb.Status) //nolint:errcheck
 				namedWorkReady[identity] = true
 				break
 			}
@@ -377,7 +382,7 @@ func collectAssignedWorkBeads(
 
 func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[string]struct{}) {
 	for _, b := range beadList {
-		if strings.TrimSpace(b.Assignee) == "" {
+		if strings.TrimSpace(b.Assignee) == "" && strings.TrimSpace(b.Metadata["gc.routed_to"]) == "" {
 			continue
 		}
 		if _, ok := seen[b.ID]; ok {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -83,6 +83,34 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 	}
 }
 
+func TestCollectAssignedWorkBeads_IncludesRoutedToMetadataBeads(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	routed, err := store.Create(beads.Bead{
+		Title:    "check alpha",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "seth"},
+	})
+	if err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "unrouted work",
+		Type:   "task",
+		Status: "open",
+	}); err != nil {
+		t.Fatalf("create unrouted bead: %v", err)
+	}
+	got := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1", len(got))
+	}
+	if got[0].ID != routed.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %q, want %q", got[0].ID, routed.ID)
+	}
+}
+
 func TestBuildDesiredState_SingletonTemplateDoesNotRealizeDependencyPoolFloorWithoutSession(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1279,13 +1279,13 @@ func TestHandleSessionMessageResumesSuspendedSession(t *testing.T) {
 	}
 	found := false
 	for _, call := range fs.sp.Calls {
-		if call.Method == "Nudge" && call.Name == info.SessionName && call.Message == "hello" {
+		if call.Method == "NudgeNow" && call.Name == info.SessionName && call.Message == "hello" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("calls = %#v, want Nudge hello", fs.sp.Calls)
+		t.Fatalf("calls = %#v, want immediate nudge hello", fs.sp.Calls)
 	}
 }
 
@@ -1328,12 +1328,12 @@ func TestHandleSessionMessageMaterializesNamedSession(t *testing.T) {
 	}
 	nudgeCount := 0
 	for _, call := range fs.sp.Calls {
-		if call.Method == "Nudge" && call.Name == sessionName && call.Message == "hello" {
+		if call.Method == "NudgeNow" && call.Name == sessionName && call.Message == "hello" {
 			nudgeCount++
 		}
 	}
 	if nudgeCount != 1 {
-		t.Fatalf("Nudge count for %q = %d, want 1; calls=%#v", sessionName, nudgeCount, fs.sp.Calls)
+		t.Fatalf("NudgeNow count for %q = %d, want 1; calls=%#v", sessionName, nudgeCount, fs.sp.Calls)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1520,6 +1520,44 @@ func TestSendResumesSuspendedSession(t *testing.T) {
 	}
 }
 
+func TestSendImmediateUsesImmediateNudge(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	if err := mgr.SendImmediate(context.Background(), info.ID, "hello", "claude --resume "+info.SessionKey, runtime.Config{WorkDir: "/tmp"}); err != nil {
+		t.Fatalf("SendImmediate: %v", err)
+	}
+
+	foundImmediate := false
+	foundRegular := false
+	for _, call := range sp.Calls {
+		if call.Name != info.SessionName || call.Message != "hello" {
+			continue
+		}
+		if call.Method == "NudgeNow" {
+			foundImmediate = true
+		}
+		if call.Method == "Nudge" {
+			foundRegular = true
+		}
+	}
+	if !foundImmediate {
+		t.Fatalf("calls = %#v, want immediate nudge", sp.Calls)
+	}
+	if foundRegular {
+		t.Fatalf("calls = %#v, did not want regular Nudge when immediate transport is available", sp.Calls)
+	}
+}
+
 func TestSendResumesSuspendedSession_SyncsGCDirFromBeadWorkDir(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary
- **Bug**: `gc sling` routes work via `gc.routed_to` metadata, but `collectAssignedWorkBeads` only collected beads with a non-empty `Assignee` field, and `namedWorkReady` only matched on `Assignee`. On-demand named sessions never saw raw-slung work.
- **Root cause**: Introduced in 8ec76d42 which moved sling to metadata routing but left collection/matching on `Assignee` only. Formula-dispatched work was unaffected (formulas set `Assignee` directly).
- **Fix**: `appendAssignedUnique` now includes beads with `gc.routed_to` set. `namedWorkReady` matches on both `Assignee` and `gc.routed_to`.

## Test plan
- [x] `TestCollectAssignedWorkBeads_IncludesRoutedToMetadataBeads` — new test, verifies collection
- [x] Existing `TestCollectAssignedWorkBeads_*` tests pass (no regression)
- [x] Full `TestBuildDesiredState_*` + `TestSelectOrCreatePoolSessionBead_*` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)