### PR TITLE
fix: pass HOME, USER, XDG dirs to spawned agent sessions

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -840,6 +840,29 @@ func passthroughEnv() map[string]string {
 	if v := os.Getenv("PATH"); v != "" {
 		m["PATH"] = v
 	}
+	if v := os.Getenv("HOME"); v != "" {
+		m["HOME"] = v
+	}
+	// USER/LOGNAME are required on macOS for Keychain access — without them
+	// providers like Claude Code cannot read stored OAuth credentials.
+	for _, key := range []string{"USER", "LOGNAME"} {
+		if v := os.Getenv(key); v != "" {
+			m[key] = v
+		}
+	}
+	// XDG directories are needed for providers to locate config files
+	// (e.g. ~/.config/opencode/opencode.jsonc). When not set, compute
+	// defaults from HOME so spawned sessions always find user config.
+	if v := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); v != "" {
+		m["XDG_CONFIG_HOME"] = v
+	} else if home := os.Getenv("HOME"); home != "" {
+		m["XDG_CONFIG_HOME"] = filepath.Join(home, ".config")
+	}
+	if v := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); v != "" {
+		m["XDG_STATE_HOME"] = v
+	} else if home := os.Getenv("HOME"); home != "" {
+		m["XDG_STATE_HOME"] = filepath.Join(home, ".local", "state")
+	}
 	for _, entry := range os.Environ() {
 		if key, val, ok := strings.Cut(entry, "="); ok && strings.HasPrefix(key, "GC_") && val != "" {
 			m[key] = val


### PR DESCRIPTION
## Summary

- `passthroughEnv()` only propagated `PATH`, `GC_*`, and OTel vars to spawned tmux sessions
- Spawned opencode sessions could not find user config (`~/.config/opencode/opencode.jsonc`) or access macOS Keychain for OAuth
- This caused sessions to fall back to wrong providers or fail authentication entirely

## Changes

Added `HOME`, `USER`, `LOGNAME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME` to `passthroughEnv()` with sensible defaults from `HOME` when unset. Mirrors the pattern already used in `handler_provider_readiness.go`.

## Test plan

- [x] Existing `TestPassthroughEnv*` tests all pass
- [ ] Manual: spawn an opencode session via `gc sling opencode <issue>` with a non-Claude provider configured and verify it uses the correct provider

Closes #271