### PR TITLE
fix: use type molecule for formula root beads instead of epic

### DIFF
--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -166,7 +166,7 @@ func toRecipe(f *Formula) (*Recipe, error) {
 	}
 
 	// Root step
-	rootType := "epic"
+	rootType := "molecule"
 	if graphWorkflow {
 		rootType = "task"
 	}

--- a/internal/formula/recipe.go
+++ b/internal/formula/recipe.go
@@ -54,8 +54,8 @@ type RecipeStep struct {
 	// Notes may contain {{variable}} placeholders.
 	Notes string
 
-	// Type is the step type: "task", "bug", "epic", "gate", "chore", etc.
-	// Steps with children are promoted to "epic".
+	// Type is the step type: "molecule", "task", "bug", "epic", "gate", "chore", etc.
+	// Root steps default to "molecule". Steps with children are promoted to "epic".
 	Type string
 
 	// Priority is 0-4 (0 = highest). Nil means default (2).

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -40,7 +40,7 @@ func TestInstantiateSimple(t *testing.T) {
 		Name:        "test-formula",
 		Description: "A test formula",
 		Steps: []formula.RecipeStep{
-			{ID: "test-formula", Title: "{{title}}", Type: "epic", IsRoot: true},
+			{ID: "test-formula", Title: "{{title}}", Type: "molecule", IsRoot: true},
 			{ID: "test-formula.step-a", Title: "Step A", Type: "task"},
 			{ID: "test-formula.step-b", Title: "Step B: {{feature}}", Type: "task"},
 		},
@@ -270,7 +270,7 @@ func TestInstantiatePriorityOverrideCopiesToAllBeads(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "priority-copy",
 		Steps: []formula.RecipeStep{
-			{ID: "priority-copy", Title: "Root", Type: "epic", IsRoot: true, Priority: priorityPtr(4)},
+			{ID: "priority-copy", Title: "Root", Type: "molecule", IsRoot: true, Priority: priorityPtr(4)},
 			{ID: "priority-copy.step-a", Title: "Step A", Type: "task"},
 			{ID: "priority-copy.step-b", Title: "Step B", Type: "task", Priority: priorityPtr(0)},
 		},
@@ -436,7 +436,7 @@ func TestInstantiateWithParentID(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "child-formula",
 		Steps: []formula.RecipeStep{
-			{ID: "child-formula", Title: "Child", Type: "epic", IsRoot: true},
+			{ID: "child-formula", Title: "Child", Type: "molecule", IsRoot: true},
 		},
 	}
 
@@ -596,7 +596,7 @@ func TestInstantiateWithIdempotencyKey(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "idem-formula",
 		Steps: []formula.RecipeStep{
-			{ID: "idem-formula", Title: "Root", Type: "epic", IsRoot: true},
+			{ID: "idem-formula", Title: "Root", Type: "molecule", IsRoot: true},
 		},
 	}
 
@@ -659,7 +659,7 @@ func TestInstantiateRootOnly(t *testing.T) {
 		Name:     "patrol",
 		RootOnly: true,
 		Steps: []formula.RecipeStep{
-			{ID: "patrol", Title: "Patrol", Type: "epic", IsRoot: true},
+			{ID: "patrol", Title: "Patrol", Type: "molecule", IsRoot: true},
 			{ID: "patrol.scan", Title: "Scan", Type: "task"},
 		},
 		Deps: []formula.RecipeDep{
@@ -688,7 +688,7 @@ func TestInstantiateVarDefaults(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "var-test",
 		Steps: []formula.RecipeStep{
-			{ID: "var-test", Title: "{{title}}", Type: "epic", IsRoot: true},
+			{ID: "var-test", Title: "{{title}}", Type: "molecule", IsRoot: true},
 			{ID: "var-test.step", Title: "Branch: {{branch}}", Type: "task"},
 		},
 		Deps: []formula.RecipeDep{
@@ -721,7 +721,7 @@ func TestInstantiateSubstitutesAssigneeVars(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "assignee-vars",
 		Steps: []formula.RecipeStep{
-			{ID: "assignee-vars", Title: "Root", Type: "epic", IsRoot: true},
+			{ID: "assignee-vars", Title: "Root", Type: "molecule", IsRoot: true},
 			{ID: "assignee-vars.step", Title: "Assigned", Type: "task", Assignee: "{{target}}"},
 		},
 		Deps: []formula.RecipeDep{
@@ -784,7 +784,7 @@ func TestInstantiateCreateFailure(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "fail-test",
 		Steps: []formula.RecipeStep{
-			{ID: "fail-test", Title: "Root", Type: "epic", IsRoot: true},
+			{ID: "fail-test", Title: "Root", Type: "molecule", IsRoot: true},
 			{ID: "fail-test.step", Title: "Step", Type: "task"},
 		},
 		Deps: []formula.RecipeDep{
@@ -824,7 +824,7 @@ func TestInstantiateDepFailure(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "dep-fail",
 		Steps: []formula.RecipeStep{
-			{ID: "dep-fail", Title: "Root", Type: "epic", IsRoot: true},
+			{ID: "dep-fail", Title: "Root", Type: "molecule", IsRoot: true},
 			{ID: "dep-fail.b", Title: "B", Type: "task"},
 			{ID: "dep-fail.a", Title: "A", Type: "task"},
 		},


### PR DESCRIPTION
## Summary

- Formula root beads were compiled with type "epic" in `compile.go`, then overridden to "molecule" at instantiation in `molecule.go`. Poured formulas (via `bd cook`) never hit the override, leaving them incorrectly typed as "epic".
- Changes `compile.go` to emit "molecule" directly, making the type consistent across patrol (vapor) and poured (liquid) formulas
- Companion PR in beads: steveyegge/beads (same branch name)

## Test plan

- [x] `internal/formula` tests pass (compile_test.go — intermediate step promotion to "epic" still correct)
- [x] `internal/molecule` tests pass (9 test fixtures updated from "epic" to "molecule")
- [x] `cmd/gc` sling tests pass (molecule type assertions verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)