### PR TITLE
fix: pass assigned work beads to pool desired state computation (ga-24g)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -617,7 +617,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// duplicate shell-outs). Resume tier from cross-referenced assigned
 	// work beads + new tier from scale_check + min fill.
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
-		cr.cfg, nil, sessionBeads.Open(), result.ScaleCheckCounts))
+		cr.cfg, result.AssignedWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts))
 	for tmpl, count := range poolDesired {
 		if count > 0 {
 			fmt.Fprintf(cr.stderr, "poolDesired: %s = %d\n", tmpl, count) //nolint:errcheck


### PR DESCRIPTION
## Summary

- Pool agents with `min=0` never scaled up when labeled work arrived because `beadReconcileTick` passed `nil` for `assignedWorkBeads` to `ComputePoolDesiredStates`, preventing the resume tier from firing
- Fix: pass `result.AssignedWorkBeads` instead of `nil`

- Issue: ga-24g
- Branch: polecat/ga-24g
- Target: main

## Test plan

- [ ] Verify pool agents with min=0 scale up when matching labeled work beads arrive
- [ ] Verify existing pool scale-down behavior is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)