### PR TITLE
fix: wire isPoolExcess() into reconciler drain path for pool scale-down (ga-wix)

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -625,8 +625,8 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 			sleepReason := session.Metadata["sleep_reason"]
 			isDraining := sleepReason == "idle" || sleepReason == "idle-timeout" ||
 				sleepReason == "no-wake-reason" || sleepReason == "config-drift" ||
-				sleepReason == "drained" || sleepReason == "user-hold" ||
-				sleepReason == "wait-hold"
+				sleepReason == "pool-excess" || sleepReason == "drained" ||
+				sleepReason == "user-hold" || sleepReason == "wait-hold"
 			if !isDraining && (prevState == "active" || prevState == "awake" || prevState == "creating") {
 				batch["session_key"] = ""
 				batch["continuation_reset_pending"] = "true"

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1196,6 +1196,11 @@ func TestHealState_ClearsStaleSessionKey(t *testing.T) {
 			wantKeyCleared: false,
 		},
 		{
+			name:      "pool-excess drain — key preserved",
+			prevState: "active", sleepReason: "pool-excess", sessionKey: "abc-123",
+			wantKeyCleared: false,
+		},
+		{
 			name:      "drained — key preserved",
 			prevState: "active", sleepReason: "drained", sessionKey: "abc-123",
 			wantKeyCleared: false,

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -520,6 +520,8 @@ func reconcileSessionBeads(
 				reason = "idle"
 			case eval.ConfigSuppressed:
 				reason = "idle"
+			case isPoolExcess(*target.session, cfg, poolDesired):
+				reason = "pool-excess"
 			default:
 				reason = "no-wake-reason"
 			}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -858,6 +858,24 @@ func TestReconcileSessionBeads_UsesSleepIntentForDrainReason(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_PoolExcessDrainReason(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+
+	// Reconcile with zero pool demand — session is alive but excess.
+	env.reconcileWithPoolDesired([]beads.Bead{session}, map[string]int{})
+
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatal("expected drain for pool-excess session")
+	}
+	if ds.reason != "pool-excess" {
+		t.Fatalf("drain reason = %q, want pool-excess", ds.reason)
+	}
+}
+
 func TestReconcileSessionBeads_StartFailureNoDoubleCounting(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}


### PR DESCRIPTION
## Summary

- Pool instance tmux sessions (polecat-1, polecat-2) were never stopped when pool demand dropped to zero
- `isPoolExcess()` existed but was never called in production; the pool-excess drain reason was defined but unused
- Fix: integrate `isPoolExcess()` into the reconciler drain path so pool scale-down properly stops tmux sessions

- Issue: ga-wix
- Branch: polecat/ga-wix
- Target: main

## Test plan

- [ ] Verify pool instances are stopped when pool demand reaches zero
- [ ] Verify pool scale-up still works correctly when labeled work arrives
- [ ] Verify existing drain reasons (shutdown, config-removed) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)