### PR TITLE
fix: skip Ctrl-C interrupt for pool-managed sessions during drain

### DIFF
--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -136,6 +136,20 @@ func beginSessionDrain(
 		generation: gen,
 	})
 
+	// Best-effort drain signal.
+	//
+	// For pool-managed sessions (no human user): skip the Ctrl-C interrupt.
+	// Claude Code shows an interactive "What should Claude do instead?" prompt
+	// on interrupt, which hangs pool workers forever since there's no user to
+	// respond. Instead, let the drain timeout handle cleanup — the worker's
+	// prompt already tells it to call `gc runtime drain-ack` when idle.
+	//
+	// For non-pool sessions (human-interactive): interrupt normally so the
+	// user sees the drain signal.
+	if session.Metadata[poolManagedMetadataKey] != boolMetadata(true) {
+		_ = verifiedInterrupt(session, sp)
+	}
+
 	name := session.Metadata["session_name"]
 	if os.Getenv("GC_TMUX_TRACE") == "1" {
 		log.Printf("[DRAIN-TRACE] beginSessionDrain session=%s reason=%s", name, reason)

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -307,6 +307,55 @@ func TestBeginSessionDrain(t *testing.T) {
 	}
 }
 
+func TestBeginSessionDrain_SkipsInterruptForPoolManagedSessions(t *testing.T) {
+	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	sp := runtime.NewFake()
+	dt := newDrainTracker()
+
+	_ = sp.Start(context.Background(), "pool-worker-1", runtime.Config{})
+
+	// Pool-managed session (has pool_managed: "true")
+	poolSession := makeBead("pool1", map[string]string{
+		"session_name":          "pool-worker-1",
+		"generation":            "1",
+		poolManagedMetadataKey:  boolMetadata(true),
+	})
+	beginSessionDrain(poolSession, sp, dt, "idle", clk, 30*time.Second)
+
+	// Drain should be registered
+	if dt.get("pool1") == nil {
+		t.Fatal("expected drain state for pool session")
+	}
+
+	// But Interrupt should NOT have been called (would hang the agent)
+	for _, call := range sp.Calls {
+		if call.Method == "Interrupt" && call.Name == "pool-worker-1" {
+			t.Error("Interrupt was called on pool-managed session — should be skipped")
+		}
+	}
+
+	// Non-pool session should still get interrupted
+	sp2 := runtime.NewFake()
+	dt2 := newDrainTracker()
+	_ = sp2.Start(context.Background(), "mayor", runtime.Config{})
+	nonPoolSession := makeBead("np1", map[string]string{
+		"session_name": "mayor",
+		"generation":   "1",
+	})
+	beginSessionDrain(nonPoolSession, sp2, dt2, "idle", clk, 30*time.Second)
+
+	found := false
+	for _, call := range sp2.Calls {
+		if call.Method == "Interrupt" && call.Name == "mayor" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Interrupt was NOT called on non-pool session — should be called")
+	}
+}
+
 func TestBeginSessionDrain_AlreadyDraining(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}


### PR DESCRIPTION
## Summary

- Pool workers have no human user. When the reconciler drains a pool session, it sends Ctrl-C via tmux, which causes Claude Code to show "Interrupted — What should Claude do instead?" and hang forever.
- Skip the interrupt for `pool_managed` sessions. The drain timeout still runs and force-stops the session if the agent doesn't `drain-ack` naturally.
- Non-pool sessions (human-interactive) still get interrupted normally.

## Test plan

- [x] `TestBeginSessionDrain_SkipsInterruptForPoolManagedSessions` — pool session: no Interrupt call; non-pool session: Interrupt called
- [x] All existing drain/wake tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)