### PR TITLE
fix: skip suspended rigs in gc doctor to prevent zombie Dolt servers

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -136,9 +136,14 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	// Custom types check — city store.
 	d.Register(doctor.NewCustomTypesCheck(cityPath, "city"))
 
-	// Per-rig checks.
+	// Per-rig checks. Skip suspended rigs — their stores aren't on the
+	// main Dolt server, and probing them triggers bd auto-start of orphan
+	// Dolt servers that immediately fail and become zombies (PPID=1).
 	if cfgErr == nil {
 		for _, rig := range cfg.Rigs {
+			if rig.Suspended {
+				continue
+			}
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
 			d.Register(doctor.NewRigBeadsCheck(rig, openStore))


### PR DESCRIPTION
## Summary

- Skips suspended rigs during `gc doctor` checks to prevent spawning zombie Dolt servers for inactive rigs

## Context

Work bead: `ga-bdw` — "gc doctor spawns zombie Dolt servers on suspended rigs"

## Test plan

- [x] `internal/doctor` tests pass (cached, clean)
- [x] Rebase on origin/main clean (already up to date)
- [x] Pre-existing failures in unrelated packages (tracked in ga-fle)