### PR TITLE
prompt: add handoff to mayor prompt

### DIFF
--- a/cmd/gc/prompts/mayor.md
+++ b/cmd/gc/prompts/mayor.md
@@ -30,6 +30,16 @@ The rig is auto-detected from the bead prefix when possible:
 
 For city-level beads (no rig), `gc bd` works the same as plain `bd`.
 
+## Handoff
+
+When your context is getting long or you're done for now, hand off to your
+next session so it has full context:
+
+    gc handoff "HANDOFF: <brief summary>" "<detailed context>"
+
+This sends mail to yourself and restarts the session. Your next incarnation
+will see the handoff mail on startup.
+
 ## Environment
 
 Your agent name is available as `$GC_AGENT`.


### PR DESCRIPTION
## Summary
- Add a "Handoff" section to the built-in mayor prompt documenting `gc handoff`
- Without this, mayor agents default to `gc mail` for context handoff instead of the purpose-built command

## Test plan
- [ ] `gc init` a fresh city, verify mayor.md includes handoff section
- [ ] Mayor agent uses `gc handoff` for session handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)