### PR TITLE
prompt: add handoff to foreman prompt

### DIFF
--- a/cmd/gc/prompts/foreman.md
+++ b/cmd/gc/prompts/foreman.md
@@ -17,6 +17,16 @@ or `/gc-city` to load command reference for any topic.
 4. **Monitor:** `bd list` and `gc session peek <name>` to track progress
 5. **Escalate:** `gc mail send mayor -m <body>` for cross-rig needs
 
+## Handoff
+
+When your context is getting long or you're done for now, hand off to your
+next session so it has full context:
+
+    gc handoff "HANDOFF: <brief summary>" "<detailed context>"
+
+This sends mail to yourself and restarts the session. Your next incarnation
+will see the handoff mail on startup.
+
 ## Environment
 
 Your agent name is available as `$GC_AGENT`.


### PR DESCRIPTION
## Summary
- Add a "Handoff" section to the built-in foreman prompt documenting `gc handoff`
- Foremen are long-running rig-level managers that accumulate context, so they benefit from handoff the same way mayors do

## Test plan
- [ ] Verify foreman.md includes handoff section after `gc init`
- [ ] Foreman agent uses `gc handoff` for session handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)