### PR TITLE
fix: classify pool-excess sessions correctly in reconciler drain path

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -572,6 +572,23 @@ func sessionIsQuarantined(session beads.Bead, clk clock.Clock) bool {
 	return clk.Now().Before(t)
 }
 
+// classifyUndesiredSession returns the drain/close reason for a session bead
+// that is not in the desired state. Pool instances from configured multi-session
+// agents get "pool-excess" (cancelable drain). Named/configured sessions get
+// "suspended". Everything else is "orphaned".
+func classifyUndesiredSession(session beads.Bead, cfg *config.City, configuredNames map[string]bool) string {
+	name := session.Metadata["session_name"]
+	if configuredNames[name] {
+		return "suspended"
+	}
+	template := normalizedSessionTemplate(session, cfg)
+	agent := findAgentByTemplate(cfg, template)
+	if agent != nil && isMultiSessionCfgAgent(agent) {
+		return "pool-excess"
+	}
+	return "orphaned"
+}
+
 // isPoolExcess returns true if this session is a pool instance whose slot
 // exceeds the current desired count.
 func isPoolExcess(session beads.Bead, cfg *config.City, poolDesired map[string]int) bool {
@@ -626,7 +643,7 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 			isDraining := sleepReason == "idle" || sleepReason == "idle-timeout" ||
 				sleepReason == "no-wake-reason" || sleepReason == "config-drift" ||
 				sleepReason == "drained" || sleepReason == "user-hold" ||
-				sleepReason == "wait-hold"
+				sleepReason == "wait-hold" || sleepReason == "pool-excess"
 			if !isDraining && (prevState == "active" || prevState == "awake" || prevState == "creating") {
 				batch["session_key"] = ""
 				batch["continuation_reset_pending"] = "true"

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -175,19 +175,12 @@ func reconcileSessionBeads(
 			providerAlive := sp.IsRunning(name)
 			// Heal state using provider liveness, not agent membership.
 			healState(session, providerAlive, store, clk)
+			reason := classifyUndesiredSession(*session, cfg, configuredNames)
 			if providerAlive {
-				reason := "orphaned"
-				if configuredNames[name] {
-					reason = "suspended"
-				}
 				beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout)
 				fmt.Fprintf(stdout, "Draining session '%s': %s\n", name, reason) //nolint:errcheck
 			} else {
 				// Not running and not desired — close the bead.
-				reason := "orphaned"
-				if configuredNames[name] {
-					reason = "suspended"
-				}
 				closeBead(store, session.ID, reason, clk.Now().UTC(), stderr)
 			}
 			continue

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1294,11 +1294,59 @@ func TestReconcileSessionBeads_PoolScaleDownOrphansExcess(t *testing.T) {
 	if d2 == nil {
 		t.Fatal("expected drain for excess pool instance")
 	}
-	if d2.reason != "orphaned" {
-		t.Errorf("drain reason = %q, want %q", d2.reason, "orphaned")
+	if d2.reason != "pool-excess" {
+		t.Errorf("drain reason = %q, want %q", d2.reason, "pool-excess")
 	}
 	if d1 := env.dt.get(s1.ID); d1 != nil {
 		t.Errorf("worker-1 should not be draining, got reason=%q", d1.reason)
+	}
+}
+
+func TestReconcileSessionBeads_PoolExcessDrainCancelableOnDemandReturn(t *testing.T) {
+	t.Parallel()
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	// Start with worker-1 running, worker-2 excess (demand=1).
+	env.addDesired("worker-1", "worker", true)
+	_ = env.sp.Start(context.Background(), "worker-2", runtime.Config{})
+	s1 := env.createSessionBead("worker-1", "worker")
+	_ = env.store.SetMetadata(s1.ID, "pool_slot", "1")
+	s1.Metadata["pool_slot"] = "1"
+	s2 := env.createSessionBead("worker-2", "worker")
+	_ = env.store.SetMetadata(s2.ID, "pool_slot", "2")
+	s2.Metadata["pool_slot"] = "2"
+
+	// First tick: worker-2 excess → pool-excess drain.
+	poolDesired := map[string]int{"worker": 1}
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{s1, s2}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, poolDesired, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+	if d := env.dt.get(s2.ID); d == nil || d.reason != "pool-excess" {
+		t.Fatalf("expected pool-excess drain, got %v", d)
+	}
+
+	// Second tick: demand returns (poolDesired=2), worker-2 back in desired set.
+	env.addDesired("worker-2", "worker", false) // add to desired (already running)
+	poolDesired["worker"] = 2
+	s2Updated, _ := env.store.Get(s2.ID)
+	cfgNames = configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{s1, s2Updated}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, poolDesired, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Drain should be canceled because pool-excess is cancelable.
+	if d := env.dt.get(s2.ID); d != nil {
+		t.Errorf("expected drain to be canceled on demand return, got reason=%q", d.reason)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Correctly classifies pool-excess sessions in the reconciler drain path to enable proper pool scale-down cleanup

## Context

Work bead: `ga-cex` — "Wire isPoolExcess() into session reconciler for pool scale-down cleanup"

## Test plan

- [x] Rebase on origin/main clean (already up to date)
- [x] Pre-existing failures in unrelated packages (tracked in ga-fle)