### PR TITLE
test: support external gc binaries in acceptance

### DIFF
--- a/test/acceptance/helpers/binary.go
+++ b/test/acceptance/helpers/binary.go
@@ -4,12 +4,28 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // BuildGC compiles the gc binary to dir and returns its path.
 // Panics on failure — intended for TestMain.
 func BuildGC(dir string) string {
+	if override := strings.TrimSpace(os.Getenv("GC_ACCEPTANCE_GC_BIN")); override != "" {
+		bin, err := filepath.Abs(override)
+		if err != nil {
+			panic("acceptance: resolving GC_ACCEPTANCE_GC_BIN: " + err.Error())
+		}
+		info, err := os.Stat(bin)
+		if err != nil {
+			panic("acceptance: GC_ACCEPTANCE_GC_BIN: " + err.Error())
+		}
+		if info.IsDir() {
+			panic("acceptance: GC_ACCEPTANCE_GC_BIN points to a directory: " + bin)
+		}
+		return bin
+	}
+
 	bin := filepath.Join(dir, "gc")
 	cmd := exec.Command("go", "build", "-o", bin, "./cmd/gc")
 	cmd.Dir = FindModuleRoot()

--- a/test/acceptance/helpers/binary_test.go
+++ b/test/acceptance/helpers/binary_test.go
@@ -1,0 +1,54 @@
+package acceptancehelpers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildGCUsesOverrideBinary(t *testing.T) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	override := filepath.Join(tmpDir, "gc-external")
+	if err := os.WriteFile(override, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write override binary: %v", err)
+	}
+
+	t.Setenv("GC_ACCEPTANCE_GC_BIN", override)
+
+	got := BuildGC(t.TempDir())
+	if got != override {
+		t.Fatalf("BuildGC() = %q, want %q", got, override)
+	}
+}
+
+func TestRunGCUsesExactBinaryOverridePath(t *testing.T) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	gcHome := filepath.Join(tmpDir, "home")
+	runtimeDir := filepath.Join(tmpDir, "runtime")
+	if err := os.MkdirAll(gcHome, 0o755); err != nil {
+		t.Fatalf("mkdir gcHome: %v", err)
+	}
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("mkdir runtimeDir: %v", err)
+	}
+
+	override := filepath.Join(tmpDir, "custom-binary-name")
+	script := "#!/bin/sh\necho override:$0 $*\n"
+	if err := os.WriteFile(override, []byte(script), 0o755); err != nil {
+		t.Fatalf("write override binary: %v", err)
+	}
+
+	env := NewEnv(override, gcHome, runtimeDir)
+	out, err := RunGC(env, "", "version")
+	if err != nil {
+		t.Fatalf("RunGC: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "override:"+override+" version") {
+		t.Fatalf("RunGC() output = %q, want override invocation for %q", out, override)
+	}
+}

--- a/test/acceptance/helpers/env.go
+++ b/test/acceptance/helpers/env.go
@@ -38,6 +38,7 @@ func NewEnv(gcBinary, gcHome, runtimeDir string) *Env {
 
 	// Prepend gc binary dir to PATH.
 	if gcBinary != "" {
+		e.vars["GC_ACCEPTANCE_GC_BIN"] = gcBinary
 		e.vars["PATH"] = filepath.Dir(gcBinary) + ":" + e.vars["PATH"]
 	}
 
@@ -110,9 +111,9 @@ func reservePort() (int, error) {
 
 // RunGC runs the gc binary with the given args in the given environment.
 func RunGC(env *Env, dir string, args ...string) (string, error) {
-	gcPath := findInPath(env.Get("PATH"), "gc")
-	if gcPath == "" {
-		return "", fmt.Errorf("gc not found in PATH")
+	gcPath, err := ResolveGCPath(env)
+	if err != nil {
+		return "", err
 	}
 	cmd := exec.Command(gcPath, args...)
 	if dir != "" {
@@ -121,6 +122,21 @@ func RunGC(env *Env, dir string, args ...string) (string, error) {
 	cmd.Env = env.List()
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// ResolveGCPath returns the exact gc binary path for this acceptance env.
+func ResolveGCPath(env *Env) (string, error) {
+	if env == nil {
+		return "", fmt.Errorf("gc env is nil")
+	}
+	if gcPath := strings.TrimSpace(env.Get("GC_ACCEPTANCE_GC_BIN")); gcPath != "" {
+		return gcPath, nil
+	}
+	gcPath := findInPath(env.Get("PATH"), "gc")
+	if gcPath == "" {
+		return "", fmt.Errorf("gc not found in PATH")
+	}
+	return gcPath, nil
 }
 
 func findInPath(pathEnv, name string) string {

--- a/test/acceptance/helpers/lifecycle.go
+++ b/test/acceptance/helpers/lifecycle.go
@@ -30,9 +30,9 @@ func (c *City) StartForeground() {
 		c.Stop()
 	}
 
-	gcPath := findInPath(c.Env.Get("PATH"), "gc")
-	if gcPath == "" {
-		c.t.Fatal("gc not found in PATH")
+	gcPath, err := ResolveGCPath(c.Env)
+	if err != nil {
+		c.t.Fatal(err)
 	}
 
 	logPath := filepath.Join(c.Dir, ".gc", "acceptance-controller.log")

--- a/test/acceptance/tier_c/fresh_install_spawn_test.go
+++ b/test/acceptance/tier_c/fresh_install_spawn_test.go
@@ -68,9 +68,9 @@ func TestFreshInit_SlingSpawnsDefaultPoolWorker(t *testing.T) {
 }
 
 func runGCWithTimeout(timeout time.Duration, env *helpers.Env, dir string, args ...string) (string, error) {
-	gcPath, err := exec.LookPath("gc")
+	gcPath, err := helpers.ResolveGCPath(env)
 	if err != nil {
-		return "", fmt.Errorf("gc not found in PATH: %w", err)
+		return "", fmt.Errorf("gc path: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
## Summary
- add `GC_ACCEPTANCE_GC_BIN` support so acceptance tiers can run against an externally built `gc` binary
- route helper entry points through the exact configured binary path instead of rediscovering `gc` by name
- include the fresh-install Tier C repro for `gc init` + `gc sling` default pool spawn

## Verification
- `go test ./test/acceptance/helpers -count=1`
- `GC_ACCEPTANCE_GC_BIN=/tmp/gc-acceptance-external-wrap GC_TIERC_FORCE=1 go test ./test/acceptance/tier_c -tags=acceptance_c -run TestFreshInit_SlingSpawnsDefaultPoolWorker -count=1 -timeout 15m -v`
