### PR TITLE
docs: clarify managedCityStopTimeout rationale (supersedes #133)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -332,6 +332,10 @@ type managedCity struct {
 	tombstoned atomic.Bool   // set before Remove() in shutdown paths for teardown safety
 }
 
+// managedCityStopTimeout returns the grace period for a city stop.
+// Only ShutdownTimeoutDuration is used — startup and drift-drain timeouts
+// are intentionally excluded because they govern unrelated lifecycle phases.
+// The 5s nil-config fallback matches ShutdownTimeoutDuration's own default.
 func managedCityStopTimeout(mc *managedCity) time.Duration {
 	if mc == nil || mc.cr == nil || mc.cr.cfg == nil {
 		return 5 * time.Second


### PR DESCRIPTION
## Summary

Maintainer follow-up from PR #133 (`fix: harden supervisor city restarts`).

The core fixes from #133 have already been merged into main. This PR adds a doc comment clarifying why `managedCityStopTimeout` uses only `ShutdownTimeoutDuration` (not the max of all timeout fields).

## Review

Multi-model review (Claude + Codex) was completed on the original PR. Both reviewers approved with no blockers. This is the maintainer fixup commit from that review.

Supersedes #133.

## Test plan

- [ ] `go vet ./...` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)