### PR TITLE
fix: polecat→refinery handoff sets assignee for on-demand wake

### DIFF
--- a/examples/gastown/packs/gastown/prompts/polecat.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/polecat.md.tmpl
@@ -191,7 +191,7 @@ bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-bd update <work-bead> --status=open --assignee="" --set-metadata gc.routed_to={{ .RigName }}/refinery
+bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/packs/gastown/prompts/shared/approval-fallacy.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/shared/approval-fallacy.md.tmpl
@@ -41,7 +41,7 @@ bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-bd update <work-bead> --status=open --assignee="" --set-metadata gc.routed_to={{ .RigName }}/refinery
+bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit
 ```


### PR DESCRIPTION
## Summary
Sets `assignee=<rig>/refinery` alongside `routed_to` in the polecat done sequence. Without assignee, `hasAssignedWork` in `ComputeAwakeSet` doesn't see demand for the on-demand refinery session — it never wakes.

## Validated
- 3/3 consecutive Tier C passes with zero interrupts
- Refinery wakes immediately after polecat handoff (no witness recovery needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)