### PR TITLE
fix: replace Ctrl-C drain with deferred GC_DRAIN_ACK + idle recovery

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -57,6 +57,7 @@ type CityRuntime struct {
 
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	ir            *idleRecovery // detects and recovers stuck idle pool sessions
 
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
@@ -228,6 +229,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// Initialize bead-driven drain tracker when bead store is available.
 	if cr.cityBeadStore() != nil && cr.tomlPath != "" {
 		cr.sessionDrains = newDrainTracker()
+		cr.ir = newIdleRecovery(2 * time.Minute)
 	}
 	if ctx.Err() != nil {
 		return
@@ -661,6 +663,12 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	)
 	if err := dispatchReadyWaitNudges(cr.cityPath, store, cr.sp, time.Now()); err != nil {
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
+	}
+
+	// Idle recovery: detect pool sessions stuck at the prompt after
+	// an interrupt and either nudge them (has work) or drain them (no work).
+	if cr.ir != nil {
+		cr.ir.recoverIdleSessions(cr.sp, open, result.AssignedWorkBeads, time.Now(), cr.stdout)
 	}
 }
 

--- a/cmd/gc/idle_recovery.go
+++ b/cmd/gc/idle_recovery.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// idleRecovery detects pool sessions that are alive but idle at the CLI
+// prompt (not processing). This catches sessions that were interrupted
+// (by Claude Code bugs, stray signals, etc.) and are now stuck.
+//
+// On each call it does a single capture-pane per alive pool session.
+// If the session is idle:
+//   - Has assigned work → nudge it to resume
+//   - No assigned work  → set GC_DRAIN_ACK to clean it up
+//
+// The grace period prevents acting on sessions that are briefly idle
+// between tool calls (inter-turn gap).
+type idleRecovery struct {
+	firstIdle map[string]time.Time // session name → first observed idle
+	grace     time.Duration        // how long to wait before acting
+}
+
+func newIdleRecovery(grace time.Duration) *idleRecovery {
+	return &idleRecovery{
+		firstIdle: make(map[string]time.Time),
+		grace:     grace,
+	}
+}
+
+// recoverIdleSessions checks alive pool sessions for idle-at-prompt state.
+// Called once per reconciler tick.
+func (ir *idleRecovery) recoverIdleSessions(
+	sp runtime.Provider,
+	sessions []beads.Bead,
+	assignedWorkBeads []beads.Bead,
+	now time.Time,
+	stdout io.Writer,
+) {
+	// Build lookup: session name → has assigned work
+	workBySession := buildWorkBySession(sessions, assignedWorkBeads)
+
+	// Track which sessions we visited so we can prune stale entries.
+	visited := make(map[string]bool, len(sessions))
+
+	for i := range sessions {
+		s := &sessions[i]
+		if s.Metadata["pool_managed"] != "true" {
+			continue // only pool sessions
+		}
+		name := s.Metadata["session_name"]
+		if name == "" || !sp.IsRunning(name) {
+			continue
+		}
+		visited[name] = true
+
+		idle := isSessionIdleAtPrompt(sp, name)
+		if !idle {
+			delete(ir.firstIdle, name)
+			continue
+		}
+
+		// Track when we first saw it idle.
+		if _, ok := ir.firstIdle[name]; !ok {
+			ir.firstIdle[name] = now
+			continue
+		}
+
+		// Check grace period.
+		if now.Sub(ir.firstIdle[name]) < ir.grace {
+			continue
+		}
+
+		// Session has been idle past the grace period. Act on it.
+		if workBySession[name] {
+			// Has work — nudge it to resume.
+			content := runtime.TextContent(
+				"You were interrupted. Check your current work with " +
+					"`bd list --assignee=\"$GC_SESSION_NAME\" --status=in_progress` " +
+					"and resume where you left off.",
+			)
+			if err := sp.Nudge(name, content); err != nil {
+				fmt.Fprintf(stdout, "idle-recovery: nudge %s failed: %v\n", name, err) //nolint:errcheck
+			} else {
+				fmt.Fprintf(stdout, "idle-recovery: nudged %s (has assigned work)\n", name) //nolint:errcheck
+			}
+		} else {
+			// No work — drain it.
+			_ = sp.SetMeta(name, "GC_DRAIN_ACK", "1")
+			fmt.Fprintf(stdout, "idle-recovery: set GC_DRAIN_ACK on %s (no assigned work)\n", name) //nolint:errcheck
+		}
+
+		// Reset timer so we don't spam every tick.
+		delete(ir.firstIdle, name)
+	}
+
+	// Prune entries for sessions no longer tracked.
+	for name := range ir.firstIdle {
+		if !visited[name] {
+			delete(ir.firstIdle, name)
+		}
+	}
+}
+
+// buildWorkBySession returns a set of session names that have in_progress
+// or open work assigned to them.
+func buildWorkBySession(sessions []beads.Bead, workBeads []beads.Bead) map[string]bool {
+	// Build reverse lookup: any identifier → session name
+	idToName := make(map[string]string, len(sessions)*2)
+	for _, s := range sessions {
+		name := s.Metadata["session_name"]
+		if name == "" {
+			continue
+		}
+		idToName[s.ID] = name
+		idToName[name] = name
+	}
+
+	result := make(map[string]bool)
+	for _, wb := range workBeads {
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if wb.Status != "open" && wb.Status != "in_progress" {
+			continue
+		}
+		if name, ok := idToName[assignee]; ok {
+			result[name] = true
+		}
+	}
+	return result
+}
+
+// isSessionIdleAtPrompt does a single capture-pane and checks whether
+// Claude CLI is at its idle prompt (❯) with no busy indicator.
+func isSessionIdleAtPrompt(sp runtime.Provider, name string) bool {
+	output, err := sp.Peek(name, 10)
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(output, "\n")
+
+	// If busy indicator is present, not idle.
+	for _, line := range lines {
+		if strings.Contains(line, "esc to interrupt") {
+			return false
+		}
+	}
+
+	// Check for prompt prefix in the captured lines.
+	promptPrefix := "❯"
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, promptPrefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gc/idle_recovery_test.go
+++ b/cmd/gc/idle_recovery_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestIdleRecovery_NudgesSessionWithWork(t *testing.T) {
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "claude-mc-abc", runtime.Config{})
+	// Simulate idle prompt in pane
+	sp.SetPeekOutput("claude-mc-abc", "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt")
+	// Wait, that has "esc to interrupt" — that means busy. Fix:
+	sp.SetPeekOutput("claude-mc-abc", "\n\n❯ \n")
+
+	session := beads.Bead{
+		ID:     "b1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "claude-mc-abc",
+			"pool_managed": "true",
+		},
+	}
+	workBead := beads.Bead{
+		ID:       "w1",
+		Status:   "in_progress",
+		Assignee: "claude-mc-abc",
+	}
+
+	ir := newIdleRecovery(0) // no grace for test
+	var stdout bytes.Buffer
+
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, []beads.Bead{workBead}, time.Now(), &stdout)
+
+	// First call records first-seen-idle, doesn't act yet.
+	if strings.Contains(stdout.String(), "nudged") {
+		t.Fatal("should not nudge on first observation")
+	}
+
+	// Second call — past grace (0) — should nudge.
+	stdout.Reset()
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, []beads.Bead{workBead}, time.Now(), &stdout)
+
+	if !strings.Contains(stdout.String(), "nudged claude-mc-abc") {
+		t.Errorf("expected nudge, got: %s", stdout.String())
+	}
+
+	// Should have called Nudge, not SetMeta(GC_DRAIN_ACK).
+	for _, c := range sp.Calls {
+		if c.Method == "SetMeta" && strings.Contains(c.Name, "GC_DRAIN_ACK") {
+			t.Error("should nudge, not drain, when session has work")
+		}
+	}
+}
+
+func TestIdleRecovery_DrainsSessionWithoutWork(t *testing.T) {
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "claude-mc-xyz", runtime.Config{})
+	sp.SetPeekOutput("claude-mc-xyz", "\n\n❯ \n")
+
+	session := beads.Bead{
+		ID:     "b2",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "claude-mc-xyz",
+			"pool_managed": "true",
+		},
+	}
+
+	ir := newIdleRecovery(0)
+	var stdout bytes.Buffer
+
+	// First call records idle.
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &stdout)
+	// Second call — should drain.
+	stdout.Reset()
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &stdout)
+
+	if !strings.Contains(stdout.String(), "GC_DRAIN_ACK") {
+		t.Errorf("expected drain, got: %s", stdout.String())
+	}
+
+	ack, _ := sp.GetMeta("claude-mc-xyz", "GC_DRAIN_ACK")
+	if ack != "1" {
+		t.Errorf("GC_DRAIN_ACK = %q, want \"1\"", ack)
+	}
+}
+
+func TestIdleRecovery_SkipsBusySessions(t *testing.T) {
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "claude-mc-busy", runtime.Config{})
+	// Has busy indicator
+	sp.SetPeekOutput("claude-mc-busy", "● Working on something...\n  ⏵⏵ bypass permissions on · esc to interrupt\n❯ ")
+
+	session := beads.Bead{
+		ID:     "b3",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "claude-mc-busy",
+			"pool_managed": "true",
+		},
+	}
+
+	ir := newIdleRecovery(0)
+	var stdout bytes.Buffer
+
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &stdout)
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &stdout)
+
+	if stdout.String() != "" {
+		t.Errorf("should not act on busy session, got: %s", stdout.String())
+	}
+}
+
+func TestIdleRecovery_RespectsGracePeriod(t *testing.T) {
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "claude-mc-grace", runtime.Config{})
+	sp.SetPeekOutput("claude-mc-grace", "\n❯ \n")
+
+	session := beads.Bead{
+		ID:     "b4",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "claude-mc-grace",
+			"pool_managed": "true",
+		},
+	}
+
+	ir := newIdleRecovery(5 * time.Minute)
+	var stdout bytes.Buffer
+	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC)
+
+	// First observation.
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, now, &stdout)
+	// 1 minute later — still within grace.
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, now.Add(1*time.Minute), &stdout)
+	if stdout.String() != "" {
+		t.Errorf("should not act within grace period, got: %s", stdout.String())
+	}
+
+	// 6 minutes later — past grace.
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, now.Add(6*time.Minute), &stdout)
+	if !strings.Contains(stdout.String(), "GC_DRAIN_ACK") {
+		t.Errorf("should drain after grace period, got: %s", stdout.String())
+	}
+}
+
+func TestIdleRecovery_SkipsNonPoolSessions(t *testing.T) {
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "mayor", runtime.Config{})
+	sp.SetPeekOutput("mayor", "\n❯ \n")
+
+	session := beads.Bead{
+		ID:     "b5",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "mayor",
+			// no pool_managed
+		},
+	}
+
+	ir := newIdleRecovery(0)
+	var stdout bytes.Buffer
+
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &stdout)
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &stdout)
+
+	if stdout.String() != "" {
+		t.Errorf("should skip non-pool sessions, got: %s", stdout.String())
+	}
+}
+
+func TestIdleRecovery_ClearsTimerWhenNoLongerIdle(t *testing.T) {
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "claude-mc-flip", runtime.Config{})
+	sp.SetPeekOutput("claude-mc-flip", "\n❯ \n")
+
+	session := beads.Bead{
+		ID:     "b6",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "claude-mc-flip",
+			"pool_managed": "true",
+		},
+	}
+
+	ir := newIdleRecovery(5 * time.Minute)
+	var stdout bytes.Buffer
+	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC)
+
+	// First observation — records idle.
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, now, &stdout)
+	if _, ok := ir.firstIdle["claude-mc-flip"]; !ok {
+		t.Fatal("should track idle time")
+	}
+
+	// Session becomes busy — timer should clear.
+	sp.SetPeekOutput("claude-mc-flip", "● Running tool...\n  ⏵⏵ esc to interrupt\n")
+	ir.recoverIdleSessions(sp, []beads.Bead{session}, nil, now.Add(1*time.Minute), &stdout)
+	if _, ok := ir.firstIdle["claude-mc-flip"]; ok {
+		t.Error("idle timer should be cleared when session is no longer idle")
+	}
+}

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -136,6 +137,9 @@ func beginSessionDrain(
 	})
 
 	name := session.Metadata["session_name"]
+	if os.Getenv("GC_TMUX_TRACE") == "1" {
+		log.Printf("[DRAIN-TRACE] beginSessionDrain session=%s reason=%s", name, reason)
+	}
 	telemetry.RecordDrainTransition(context.Background(), name, reason, "begin")
 }
 
@@ -260,6 +264,9 @@ func advanceSessionDrainsWithSessions(
 		// sees it on the next tick and calls sp.Stop() for a clean
 		// SIGTERM/SIGKILL — no Ctrl-C keystroke injection into the pane.
 		if !ds.ackSet {
+			if os.Getenv("GC_TMUX_TRACE") == "1" {
+				log.Printf("[DRAIN-TRACE] advanceSessionDrains: setting GC_DRAIN_ACK session=%s reason=%s", name, ds.reason)
+			}
 			_ = sp.SetMeta(name, "GC_DRAIN_ACK", "1")
 			ds.ackSet = true
 		}


### PR DESCRIPTION
## Summary

- `beginSessionDrain` sent Ctrl-C (tmux send-keys C-c) to interrupt agents during drain. This interrupted working agents on transient bead store failures (false-orphan) and caused pool agents to hang forever at Claude CLI's "What should Claude do instead?" prompt.
- Replace Ctrl-C with `GC_DRAIN_ACK` env var — the same mechanism agents use via `gc runtime drain-ack`. Phase 1 drain-ack check picks it up next tick and calls `sp.Stop()` for clean SIGTERM/SIGKILL.
- Defer signal by one tick so false-orphan drains are canceled before any signal reaches the process.
- Clear `GC_DRAIN_ACK` from tmux env on drain cancel to prevent stale acks from killing sessions.
- Add idle recovery: detects pool sessions stuck at the prompt after interrupt. Has work → nudge to resume. No work → set `GC_DRAIN_ACK`.

Supersedes #280.

## Test plan

- [x] `TestBeginSessionDrain` — no interrupt sent
- [x] `TestAdvanceSessionDrains_DeferredInterrupt_CanceledBeforeSignal` — non-cancelable drain sets GC_DRAIN_ACK, no Ctrl-C
- [x] `TestAdvanceSessionDrains_DeferredInterrupt_CancelableNoSignal` — cancelable drain canceled before any signal
- [x] `TestCancelSessionDrain_ClearsAck` — GC_DRAIN_ACK cleared on cancel
- [x] `TestIdleRecovery_NudgesSessionWithWork` — idle session with work gets nudged
- [x] `TestIdleRecovery_DrainsSessionWithoutWork` — idle session without work gets drained
- [x] `TestIdleRecovery_SkipsBusySessions` — busy sessions not touched
- [x] `TestIdleRecovery_RespectsGracePeriod` — 2min grace before acting
- [x] All existing drain/wake/reconciler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)