### PR TITLE
fix: CachingStore query methods now include closed beads

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -701,19 +701,18 @@ func (s *BdStore) ListByMetadata(filters map[string]string, limit int) ([]Bead, 
 	return result, nil
 }
 
-// Children returns all beads whose ParentID matches the given ID. The bd CLI
-// does not know about ParentID, so this filters ListOpen() results client-side.
-// Returns empty for now since Tutorial 06 uses FileStore.
+// Children returns all beads whose ParentID matches the given ID, including
+// closed beads. Uses bd list --all --parent for a targeted server-side query.
 func (s *BdStore) Children(parentID string) ([]Bead, error) {
-	all, err := s.ListOpen()
+	args := []string{"list", "--json", "--all", "--include-infra", "--limit", "0", "--parent", parentID}
+	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("bd list children: %w", err)
 	}
-	var result []Bead
-	for _, b := range all {
-		if b.ParentID == parentID {
-			result = append(result, b)
-		}
+	issues := parseIssuesTolerant(extractJSON(out))
+	result := make([]Bead, len(issues))
+	for i := range issues {
+		result[i] = issues[i].toBead()
 	}
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].CreatedAt.Equal(result[j].CreatedAt) {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -419,59 +419,112 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 func (c *CachingStore) Children(parentID string) ([]Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive {
-		var result []Bead
+		var cached []Bead
+		seen := make(map[string]bool)
 		for _, b := range c.beads {
 			if b.ParentID == parentID {
-				result = append(result, cloneBead(b))
+				cached = append(cached, cloneBead(b))
+				seen[b.ID] = true
 			}
 		}
 		c.mu.RUnlock()
-		return result, nil
+
+		// Cache has no closed beads; merge with backing store.
+		all, err := c.backing.Children(parentID)
+		if err != nil {
+			return cached, nil
+		}
+		for _, b := range all {
+			if !seen[b.ID] {
+				cached = append(cached, b)
+			}
+		}
+		return cached, nil
 	}
 	c.mu.RUnlock()
 	return c.backing.Children(parentID)
 }
 
 // ListByLabel returns beads matching the given label.
+// The cache only holds non-closed beads, so we search the cache for open
+// matches and query the backing store for closed matches, then merge.
 func (c *CachingStore) ListByLabel(label string, limit int) ([]Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive || c.state == cachePartial {
-		var result []Bead
+		// Collect open/in-progress matches from cache.
+		var cached []Bead
+		seen := make(map[string]bool)
 		for _, b := range c.beads {
 			for _, l := range b.Labels {
 				if l == label {
-					result = append(result, cloneBead(b))
-					if limit > 0 && len(result) >= limit {
-						c.mu.RUnlock()
-						return result, nil
-					}
+					cached = append(cached, cloneBead(b))
+					seen[b.ID] = true
 					break
 				}
 			}
 		}
 		c.mu.RUnlock()
-		return result, nil
+
+		// Fetch all matches (including closed) from backing store.
+		all, err := c.backing.ListByLabel(label, limit)
+		if err != nil {
+			// If backing fails, return what the cache had.
+			return cached, nil
+		}
+
+		// Merge: add closed beads from backing that aren't in the cache.
+		for _, b := range all {
+			if !seen[b.ID] {
+				cached = append(cached, b)
+				seen[b.ID] = true
+			}
+		}
+
+		// Apply limit.
+		if limit > 0 && len(cached) > limit {
+			cached = cached[:limit]
+		}
+		return cached, nil
 	}
 	c.mu.RUnlock()
 	return c.backing.ListByLabel(label, limit)
 }
 
 // ListByAssignee returns beads assigned to the given agent with matching status.
+// The cache only holds non-closed beads, so queries for closed status must
+// also consult the backing store.
 func (c *CachingStore) ListByAssignee(assignee, status string, limit int) ([]Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive {
-		var result []Bead
+		var cached []Bead
+		seen := make(map[string]bool)
 		for _, b := range c.beads {
 			if b.Assignee == assignee && b.Status == status {
-				result = append(result, cloneBead(b))
-				if limit > 0 && len(result) >= limit {
+				cached = append(cached, cloneBead(b))
+				seen[b.ID] = true
+				if limit > 0 && len(cached) >= limit {
 					c.mu.RUnlock()
-					return result, nil
+					return cached, nil
 				}
 			}
 		}
 		c.mu.RUnlock()
-		return result, nil
+
+		// Cache has no closed beads; fetch from backing if needed.
+		all, err := c.backing.ListByAssignee(assignee, status, limit)
+		if err != nil {
+			return cached, nil
+		}
+		for _, b := range all {
+			if !seen[b.ID] {
+				cached = append(cached, b)
+				seen[b.ID] = true
+			}
+		}
+		if limit > 0 && len(cached) > limit {
+			cached = cached[:limit]
+		}
+		return cached, nil
 	}
 	c.mu.RUnlock()
 	return c.backing.ListByAssignee(assignee, status, limit)
@@ -480,21 +533,35 @@ func (c *CachingStore) ListByAssignee(assignee, status string, limit int) ([]Bea
 // ListByMetadata filters beads by metadata key-value pairs.
 // This is an extension method not on the base Store interface — it's
 // available on BdStore and CachingStore wrapping BdStore.
+// The cache only holds non-closed beads, so we merge cache hits with
+// backing store results to include closed beads.
 func (c *CachingStore) ListByMetadata(filters map[string]string, limit int) ([]Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive {
-		var result []Bead
+		var cached []Bead
+		seen := make(map[string]bool)
 		for _, b := range c.beads {
 			if matchesMetadata(b, filters) {
-				result = append(result, cloneBead(b))
-				if limit > 0 && len(result) >= limit {
-					c.mu.RUnlock()
-					return result, nil
-				}
+				cached = append(cached, cloneBead(b))
+				seen[b.ID] = true
 			}
 		}
 		c.mu.RUnlock()
-		return result, nil
+
+		all, err := c.backing.ListByMetadata(filters, limit)
+		if err != nil {
+			return cached, nil
+		}
+		for _, b := range all {
+			if !seen[b.ID] {
+				cached = append(cached, b)
+				seen[b.ID] = true
+			}
+		}
+		if limit > 0 && len(cached) > limit {
+			cached = cached[:limit]
+		}
+		return cached, nil
 	}
 	c.mu.RUnlock()
 
@@ -502,18 +569,30 @@ func (c *CachingStore) ListByMetadata(filters map[string]string, limit int) ([]B
 	<-c.primeReady
 	c.mu.RLock()
 	if c.state == cacheLive {
-		var result []Bead
+		var cached []Bead
+		seen := make(map[string]bool)
 		for _, b := range c.beads {
 			if matchesMetadata(b, filters) {
-				result = append(result, cloneBead(b))
-				if limit > 0 && len(result) >= limit {
-					c.mu.RUnlock()
-					return result, nil
-				}
+				cached = append(cached, cloneBead(b))
+				seen[b.ID] = true
 			}
 		}
 		c.mu.RUnlock()
-		return result, nil
+
+		all, err := c.backing.ListByMetadata(filters, limit)
+		if err != nil {
+			return cached, nil
+		}
+		for _, b := range all {
+			if !seen[b.ID] {
+				cached = append(cached, b)
+				seen[b.ID] = true
+			}
+		}
+		if limit > 0 && len(cached) > limit {
+			cached = cached[:limit]
+		}
+		return cached, nil
 	}
 	c.mu.RUnlock()
 	// Prime failed — fall through to backing store.


### PR DESCRIPTION
## Summary
- CachingStore.Prime() only loads non-closed beads, but ListByLabel, ListByAssignee, ListByMetadata, and Children were returning cache-only results when live — silently dropping all closed beads
- This broke the orders/history API endpoint (completed formula runs invisible in the dashboard "recent runs" tab) and convoy/molecule tree walks (closed child steps missing)
- Each method now merges cache hits (open/in-progress) with filtered backing store results (including closed), deduplicating by ID
- BdStore.Children replaced its unfiltered `List()` + client-side filter with a targeted `bd list --all --parent=ID` query

## Test plan
- [x] `go build ./...` passes
- [x] `go test -run TestCaching ./internal/beads/` passes
- [x] `go test -run TestOrder ./internal/api/` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)