### PR TITLE
fix: recover stale convergence active wisps

### DIFF
--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -207,6 +207,51 @@ func TestConvergence_TickProcessesClosedWisp(t *testing.T) {
 	}
 }
 
+func TestConvergence_TickRecoversMissingActiveWisp(t *testing.T) {
+	cr, store := setupConvergenceRuntime(t)
+
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "5",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+
+	adapter := cr.convHandler.Store.(*convergenceStoreAdapter)
+	if err := adapter.populateIndex(); err != nil {
+		t.Fatalf("populateIndex: %v", err)
+	}
+
+	if err := store.Delete(created.FirstWispID); err != nil {
+		t.Fatalf("deleting wisp: %v", err)
+	}
+
+	cr.convergenceTick(context.Background())
+
+	meta, err := cr.convHandler.Store.GetMetadata(created.BeadID)
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if meta[convergence.FieldActiveWisp] == "" {
+		t.Fatal("active_wisp should be repaired after tick recovery")
+	}
+	if meta[convergence.FieldActiveWisp] == created.FirstWispID {
+		t.Fatalf("active_wisp = %q, want replacement wisp", meta[convergence.FieldActiveWisp])
+	}
+	if _, err := store.Get(meta[convergence.FieldActiveWisp]); err != nil {
+		t.Fatalf("repaired active_wisp %q should exist: %v", meta[convergence.FieldActiveWisp], err)
+	}
+}
+
 func TestConvergence_StartupReconcile(t *testing.T) {
 	cr, store := setupConvergenceRuntime(t)
 

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/user"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/convergence"
 )
 
@@ -69,7 +71,21 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 		// Check if the active wisp is closed.
 		wispInfo, wErr := cr.convStoreAdapter.GetBead(activeWisp)
 		if wErr != nil {
-			continue // wisp may not exist yet
+			if !errors.Is(wErr, beads.ErrNotFound) {
+				continue
+			}
+			reconciler := &convergence.Reconciler{Handler: cr.convHandler}
+			report, rErr := reconciler.ReconcileBeads(ctx, []string{beadID})
+			if rErr != nil {
+				fmt.Fprintf(cr.stderr, "%s: convergence: reconcile(%s): %v\n", //nolint:errcheck
+					cr.logPrefix, beadID, rErr)
+				continue
+			}
+			if len(report.Details) > 0 && report.Details[0].Error != nil {
+				fmt.Fprintf(cr.stderr, "%s: convergence: reconcile(%s): %v\n", //nolint:errcheck
+					cr.logPrefix, beadID, report.Details[0].Error)
+			}
+			continue
 		}
 		if wispInfo.Status != "closed" {
 			continue

--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -51,7 +51,9 @@ type BeadInfo struct {
 // Store abstracts bead operations needed by the convergence handler.
 // The bead store adapter implements this interface.
 type Store interface {
-	// GetBead returns basic info about a bead.
+	// GetBead returns basic info about a bead. Missing beads must be
+	// reported with an error that wraps beads.ErrNotFound so recovery code
+	// can distinguish stale references from transient store failures.
 	GetBead(id string) (BeadInfo, error)
 
 	// GetMetadata returns all metadata for a bead.

--- a/internal/convergence/handler_test.go
+++ b/internal/convergence/handler_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // --- Fake ConvergenceStore ---
@@ -23,6 +25,7 @@ type fakeStore struct {
 
 	// PourWispFunc can be set to simulate sling failures.
 	PourWispFunc func(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error)
+	GetBeadFunc  func(id string) (BeadInfo, error)
 
 	pourCounter int // auto-increment for wisp IDs
 
@@ -61,11 +64,14 @@ func (s *fakeStore) addBead(id, status, parentID, idempotencyKey string, meta ma
 }
 
 func (s *fakeStore) GetBead(id string) (BeadInfo, error) {
+	if s.GetBeadFunc != nil {
+		return s.GetBeadFunc(id)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	rec, ok := s.beads[id]
 	if !ok {
-		return BeadInfo{}, fmt.Errorf("bead %q not found", id)
+		return BeadInfo{}, fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
 	}
 	return rec.info, nil
 }
@@ -75,7 +81,7 @@ func (s *fakeStore) GetMetadata(id string) (map[string]string, error) {
 	defer s.mu.Unlock()
 	rec, ok := s.beads[id]
 	if !ok {
-		return nil, fmt.Errorf("bead %q not found", id)
+		return nil, fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
 	}
 	// Return a copy.
 	cp := make(map[string]string, len(rec.metadata))
@@ -90,7 +96,7 @@ func (s *fakeStore) SetMetadata(id, key, value string) error {
 	defer s.mu.Unlock()
 	rec, ok := s.beads[id]
 	if !ok {
-		return fmt.Errorf("bead %q not found", id)
+		return fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
 	}
 	rec.metadata[key] = value
 	s.WriteLog = append(s.WriteLog, key)
@@ -102,7 +108,7 @@ func (s *fakeStore) CloseBead(id string) error {
 	defer s.mu.Unlock()
 	rec, ok := s.beads[id]
 	if !ok {
-		return fmt.Errorf("bead %q not found", id)
+		return fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
 	}
 	rec.info.Status = "closed"
 	rec.info.ClosedAt = time.Now()
@@ -114,7 +120,7 @@ func (s *fakeStore) Children(parentID string) ([]BeadInfo, error) {
 	defer s.mu.Unlock()
 	rec, ok := s.beads[parentID]
 	if !ok {
-		return nil, fmt.Errorf("bead %q not found", parentID)
+		return nil, nil
 	}
 	var result []BeadInfo
 	for _, childID := range rec.children {

--- a/internal/convergence/manual.go
+++ b/internal/convergence/manual.go
@@ -2,7 +2,11 @@ package convergence
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // ApproveHandler processes an operator's approval of a convergence loop
@@ -268,10 +272,22 @@ func (h *Handler) StopHandler(ctx context.Context, beadID, username, _ string) (
 	if activeWisp != "" {
 		wispInfo, err := h.Store.GetBead(activeWisp)
 		if err != nil {
-			return HandlerResult{}, fmt.Errorf("reading active wisp %q: %w", activeWisp, err)
+			if !errors.Is(err, beads.ErrNotFound) {
+				return HandlerResult{}, fmt.Errorf("reading active wisp %q: %w", activeWisp, err)
+			}
+			recoveredWisp, found, recoverErr := h.recoverCurrentActiveWisp(beadID, lastProcessedWisp)
+			if recoverErr != nil {
+				return HandlerResult{}, recoverErr
+			}
+			if !found {
+				activeWisp = ""
+			} else {
+				activeWisp = recoveredWisp.ID
+				wispInfo = recoveredWisp
+			}
 		}
 
-		if wispInfo.Status == "closed" {
+		if activeWisp != "" && wispInfo.Status == "closed" {
 			// Drain: process the completed wisp through the normal handler.
 			_, drainErr := h.HandleWispClosed(ctx, beadID, activeWisp)
 			if drainErr != nil {
@@ -301,9 +317,21 @@ func (h *Handler) StopHandler(ctx context.Context, beadID, username, _ string) (
 	if activeWisp != "" {
 		wispInfo, err := h.Store.GetBead(activeWisp)
 		if err != nil {
-			return HandlerResult{}, fmt.Errorf("reading active wisp %q for force-close: %w", activeWisp, err)
+			if !errors.Is(err, beads.ErrNotFound) {
+				return HandlerResult{}, fmt.Errorf("reading active wisp %q for force-close: %w", activeWisp, err)
+			}
+			recoveredWisp, found, recoverErr := h.recoverCurrentActiveWisp(beadID, lastProcessedWisp)
+			if recoverErr != nil {
+				return HandlerResult{}, recoverErr
+			}
+			if !found {
+				activeWisp = ""
+			} else {
+				activeWisp = recoveredWisp.ID
+				wispInfo = recoveredWisp
+			}
 		}
-		if wispInfo.Status != "closed" {
+		if activeWisp != "" && wispInfo.Status != "closed" {
 			if err := h.Store.CloseBead(activeWisp); err != nil {
 				return HandlerResult{}, fmt.Errorf("force-closing active wisp %q: %w", activeWisp, err)
 			}
@@ -414,4 +442,78 @@ func (h *Handler) StopHandler(ctx context.Context, beadID, username, _ string) (
 		Action:    ActionStopped,
 		Iteration: iterationCount,
 	}, nil
+}
+
+func (h *Handler) recoverCurrentActiveWisp(beadID, lastProcessedWisp string) (BeadInfo, bool, error) {
+	children, err := h.Store.Children(beadID)
+	if err != nil {
+		return BeadInfo{}, false, fmt.Errorf("listing children for stale active wisp recovery: %w", err)
+	}
+
+	nextIter := 0
+	haveNextIter := false
+	if lastProcessedWisp != "" {
+		lastProcessedInfo, err := h.Store.GetBead(lastProcessedWisp)
+		if err != nil {
+			if !errors.Is(err, beads.ErrNotFound) {
+				return BeadInfo{}, false, fmt.Errorf("reading last processed wisp %q: %w", lastProcessedWisp, err)
+			}
+		} else if iter, ok := ParseIterationFromKey(lastProcessedInfo.IdempotencyKey); ok {
+			nextIter = iter + 1
+			haveNextIter = true
+		}
+	}
+
+	if haveNextIter {
+		nextKey := IdempotencyKey(beadID, nextIter)
+		candidateID, found, err := h.Store.FindByIdempotencyKey(nextKey)
+		if err != nil {
+			return BeadInfo{}, false, fmt.Errorf("looking up replacement active wisp %q: %w", nextKey, err)
+		}
+		if found {
+			wispInfo, err := h.Store.GetBead(candidateID)
+			if err != nil {
+				if errors.Is(err, beads.ErrNotFound) {
+					return BeadInfo{}, false, nil
+				}
+				return BeadInfo{}, false, fmt.Errorf("reading replacement active wisp %q: %w", candidateID, err)
+			}
+			return wispInfo, true, nil
+		}
+		return BeadInfo{}, false, nil
+	}
+
+	var bestOpen BeadInfo
+	bestOpenIter := -1
+	var bestClosed BeadInfo
+	bestClosedIter := -1
+	prefix := IdempotencyKeyPrefix(beadID)
+	for _, child := range children {
+		if !strings.HasPrefix(child.IdempotencyKey, prefix) {
+			continue
+		}
+		iter, ok := ParseIterationFromKey(child.IdempotencyKey)
+		if !ok {
+			continue
+		}
+		switch child.Status {
+		case "open", "in_progress":
+			if iter > bestOpenIter {
+				bestOpen = child
+				bestOpenIter = iter
+			}
+		case "closed":
+			if iter > bestClosedIter {
+				bestClosed = child
+				bestClosedIter = iter
+			}
+		}
+	}
+	if bestOpenIter >= 0 {
+		return bestOpen, true, nil
+	}
+	if bestClosedIter >= 0 {
+		return bestClosed, true, nil
+	}
+	return BeadInfo{}, false, nil
 }

--- a/internal/convergence/reconcile.go
+++ b/internal/convergence/reconcile.go
@@ -2,8 +2,11 @@ package convergence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // ReconcileDetail records the outcome of reconciling a single bead.
@@ -373,46 +376,79 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 
 	// Sub-path B: Check active_wisp status.
 	activeWispID := meta[FieldActiveWisp]
+	recoveredActiveWisp := false
 
 	if activeWispID != "" {
 		wispInfo, err := r.Handler.Store.GetBead(activeWispID)
 		if err != nil {
-			return ReconcileDetail{
-				BeadID: beadID, Action: "no_action",
-				Error: fmt.Errorf("reading active wisp %q: %w", activeWispID, err),
-			}
-		}
-
-		switch wispInfo.Status {
-		case "open", "in_progress":
-			// Wisp still running — nothing to do.
-			return ReconcileDetail{BeadID: beadID, Action: "no_action"}
-
-		case "closed":
-			// Wisp is closed. Check if it was already processed.
-			lastProcessed := meta[FieldLastProcessedWisp]
-			if lastProcessed == activeWispID {
-				// Already processed — check if the commit completed.
-				// The commit was done because last_processed_wisp is
-				// set (it is always the last write). Nothing to do.
-				return ReconcileDetail{BeadID: beadID, Action: "no_action"}
-			}
-
-			// Closed but not processed — replay the wisp_closed event.
-			result, err := r.Handler.HandleWispClosed(ctx, beadID, activeWispID)
-			if err != nil {
+			if !errors.Is(err, beads.ErrNotFound) {
 				return ReconcileDetail{
-					BeadID: beadID, Action: "repaired_state",
-					Error: fmt.Errorf("replaying wisp_closed for %q: %w", activeWispID, err),
+					BeadID: beadID, Action: "no_action",
+					Error: fmt.Errorf("reading active wisp %q: %w", activeWispID, err),
 				}
 			}
-			_ = result
-			return ReconcileDetail{BeadID: beadID, Action: "repaired_state"}
+			recoveredWisp, found, recoverErr := r.Handler.recoverCurrentActiveWisp(beadID, meta[FieldLastProcessedWisp])
+			if recoverErr != nil {
+				return ReconcileDetail{
+					BeadID: beadID, Action: "no_action",
+					Error: recoverErr,
+				}
+			}
+			if !found {
+				// A crashed loop can leave active_wisp pointing at a bead that
+				// was later cleaned up. Treat that as stale recovery state and
+				// rebuild the chain from surviving children below.
+				activeWispID = ""
+			} else {
+				activeWispID = recoveredWisp.ID
+				wispInfo = recoveredWisp
+				recoveredActiveWisp = true
+			}
+		}
+		if activeWispID != "" {
+			if recoveredActiveWisp {
+				if err := r.Handler.Store.SetMetadata(beadID, FieldActiveWisp, activeWispID); err != nil {
+					return ReconcileDetail{
+						BeadID: beadID, Action: "repaired_state",
+						Error: fmt.Errorf("setting recovered active wisp %q: %w", activeWispID, err),
+					}
+				}
+			}
+			switch wispInfo.Status {
+			case "open", "in_progress":
+				// Wisp still running — nothing to do.
+				action := "no_action"
+				if recoveredActiveWisp {
+					action = "repaired_state"
+				}
+				return ReconcileDetail{BeadID: beadID, Action: action}
 
-		default:
-			return ReconcileDetail{
-				BeadID: beadID, Action: "no_action",
-				Error: fmt.Errorf("active wisp %q has unexpected status %q", activeWispID, wispInfo.Status),
+			case "closed":
+				// Wisp is closed. Check if it was already processed.
+				lastProcessed := meta[FieldLastProcessedWisp]
+				if lastProcessed == activeWispID {
+					// Already processed — check if the commit completed.
+					// The commit was done because last_processed_wisp is
+					// set (it is always the last write). Nothing to do.
+					return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+				}
+
+				// Closed but not processed — replay the wisp_closed event.
+				result, err := r.Handler.HandleWispClosed(ctx, beadID, activeWispID)
+				if err != nil {
+					return ReconcileDetail{
+						BeadID: beadID, Action: "repaired_state",
+						Error: fmt.Errorf("replaying wisp_closed for %q: %w", activeWispID, err),
+					}
+				}
+				_ = result
+				return ReconcileDetail{BeadID: beadID, Action: "repaired_state"}
+
+			default:
+				return ReconcileDetail{
+					BeadID: beadID, Action: "no_action",
+					Error: fmt.Errorf("active wisp %q has unexpected status %q", activeWispID, wispInfo.Status),
+				}
 			}
 		}
 	}

--- a/internal/convergence/reconcile_test.go
+++ b/internal/convergence/reconcile_test.go
@@ -3,6 +3,8 @@ package convergence
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -401,6 +403,158 @@ func TestReconcile_Active_ClosedUnprocessedWisp_Replays(t *testing.T) {
 	// Verify iteration event was emitted.
 	if _, ok := emitter.findEvent(EventIteration); !ok {
 		t.Error("expected ConvergenceIteration event from replay")
+	}
+}
+
+func TestReconcile_Active_MissingActiveWisp_ReconstructsChain(t *testing.T) {
+	rec, store, _ := setupReconciler(t)
+
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldState:             StateActive,
+		FieldIteration:         "1",
+		FieldMaxIterations:     "5",
+		FieldFormula:           "test-formula",
+		FieldTarget:            "test-agent",
+		FieldGateMode:          GateModeCondition,
+		FieldGateTimeout:       "60s",
+		FieldGateTimeoutAction: TimeoutActionIterate,
+		FieldActiveWisp:        "wisp-iter-2",
+		FieldLastProcessedWisp: "wisp-iter-1",
+	})
+
+	// The previous wisp exists and is closed, but the active wisp was
+	// cleaned up after the crash. Startup recovery should rebuild the chain
+	// from the remaining state instead of stalling on the missing bead.
+	store.addBead("wisp-iter-1", "closed", "root-1", IdempotencyKey("root-1", 1), nil)
+
+	report, err := rec.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	d := report.Details[0]
+	if d.Error != nil {
+		t.Fatalf("reconcile error: %v", d.Error)
+	}
+	if d.Action != "poured_wisp" && d.Action != "adopted_wisp" {
+		t.Fatalf("Action = %q, want %q or %q", d.Action, "poured_wisp", "adopted_wisp")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	activeWisp := meta[FieldActiveWisp]
+	if activeWisp == "" {
+		t.Fatal("active_wisp should be restored after recovery")
+	}
+	if _, err := store.GetBead(activeWisp); err != nil {
+		t.Fatalf("active_wisp %q should point to an existing bead: %v", activeWisp, err)
+	}
+}
+
+func TestReconcile_Active_MissingActiveWisp_ReplaysRecoveredClosedReplacement(t *testing.T) {
+	rec, store, _ := setupReconciler(t)
+
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldState:             StateActive,
+		FieldIteration:         "1",
+		FieldMaxIterations:     "5",
+		FieldFormula:           "test-formula",
+		FieldTarget:            "test-agent",
+		FieldGateMode:          GateModeCondition,
+		FieldGateTimeout:       "60s",
+		FieldGateTimeoutAction: TimeoutActionIterate,
+		FieldActiveWisp:        "wisp-iter-2",
+		FieldLastProcessedWisp: "wisp-iter-1",
+		FieldGateOutcomeWisp:   "wisp-replacement",
+		FieldGateOutcome:       GatePass,
+	})
+	store.addBead("wisp-iter-1", "closed", "root-1", IdempotencyKey("root-1", 1), nil)
+	store.addBead("wisp-replacement", "closed", "root-1", IdempotencyKey("root-1", 2), nil)
+
+	report, err := rec.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	d := report.Details[0]
+	if d.Error != nil {
+		t.Fatalf("reconcile error: %v", d.Error)
+	}
+	if d.Action != "repaired_state" {
+		t.Fatalf("Action = %q, want %q", d.Action, "repaired_state")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateTerminated {
+		t.Fatalf("state = %q, want %q", meta[FieldState], StateTerminated)
+	}
+	if meta[FieldLastProcessedWisp] != "wisp-replacement" {
+		t.Fatalf("last_processed_wisp = %q, want %q", meta[FieldLastProcessedWisp], "wisp-replacement")
+	}
+}
+
+func TestReconcile_Active_MissingActiveWisp_RepairsOpenReplacementMetadata(t *testing.T) {
+	rec, store, _ := setupReconciler(t)
+
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldState:             StateActive,
+		FieldIteration:         "1",
+		FieldMaxIterations:     "5",
+		FieldFormula:           "test-formula",
+		FieldTarget:            "test-agent",
+		FieldGateMode:          GateModeCondition,
+		FieldGateTimeout:       "60s",
+		FieldGateTimeoutAction: TimeoutActionIterate,
+		FieldActiveWisp:        "wisp-iter-2",
+		FieldLastProcessedWisp: "wisp-iter-1",
+	})
+	store.addBead("wisp-iter-1", "closed", "root-1", IdempotencyKey("root-1", 1), nil)
+	store.addBead("wisp-replacement", "in_progress", "root-1", IdempotencyKey("root-1", 2), nil)
+
+	report, err := rec.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	d := report.Details[0]
+	if d.Error != nil {
+		t.Fatalf("reconcile error: %v", d.Error)
+	}
+	if d.Action != "repaired_state" {
+		t.Fatalf("Action = %q, want %q", d.Action, "repaired_state")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldActiveWisp] != "wisp-replacement" {
+		t.Fatalf("active_wisp = %q, want %q", meta[FieldActiveWisp], "wisp-replacement")
+	}
+}
+
+func TestReconcile_Active_StoreErrorReadingActiveWisp_ReportsError(t *testing.T) {
+	rec, store, _ := setupReconciler(t)
+
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldState:      StateActive,
+		FieldFormula:    "test-formula",
+		FieldActiveWisp: "wisp-iter-1",
+	})
+	store.GetBeadFunc = func(id string) (BeadInfo, error) {
+		return BeadInfo{}, fmt.Errorf("store unavailable for %s", id)
+	}
+
+	report, err := rec.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	d := report.Details[0]
+	if d.Error == nil {
+		t.Fatal("expected reconcile error")
+	}
+	if got := d.Error.Error(); !strings.Contains(got, "store unavailable for wisp-iter-1") {
+		t.Fatalf("reconcile error = %q, want store failure", got)
+	}
+	if d.Action != "no_action" {
+		t.Fatalf("Action = %q, want %q", d.Action, "no_action")
 	}
 }
 

--- a/internal/convergence/stop_test.go
+++ b/internal/convergence/stop_test.go
@@ -3,8 +3,11 @@ package convergence
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // setupActiveHandler creates a handler with a root bead in active state,
@@ -227,4 +230,122 @@ func TestStopHandler_FromWaitingManual_NoForceClose(t *testing.T) {
 	}
 
 	_ = store
+}
+
+func TestStopHandler_MissingActiveWisp_StopsGracefully(t *testing.T) {
+	handler, store, emitter := setupActiveHandler(t, "in_progress", nil)
+
+	store.mu.Lock()
+	delete(store.beads, "wisp-iter-2")
+	store.mu.Unlock()
+
+	result, err := handler.StopHandler(context.Background(), "root-1", "alice", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionStopped {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionStopped)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateTerminated {
+		t.Fatalf("state = %q, want %q", meta[FieldState], StateTerminated)
+	}
+	if meta[FieldTerminalReason] != TerminalStopped {
+		t.Fatalf("terminal_reason = %q, want %q", meta[FieldTerminalReason], TerminalStopped)
+	}
+	if _, ok := emitter.findEvent(EventIteration); ok {
+		t.Fatal("should not emit synthetic iteration event when missing active wisp is skipped")
+	}
+	if _, ok := emitter.findEvent(EventManualStop); !ok {
+		t.Fatal("expected ConvergenceManualStop event")
+	}
+}
+
+func TestStopHandler_ActiveWispMissingBeforeForceClose_StopsGracefully(t *testing.T) {
+	handler, store, _ := setupActiveHandler(t, "in_progress", nil)
+
+	calls := 0
+	store.GetBeadFunc = func(id string) (BeadInfo, error) {
+		switch id {
+		case "wisp-iter-1":
+			return BeadInfo{
+				ID:             id,
+				Status:         "closed",
+				ParentID:       "root-1",
+				IdempotencyKey: IdempotencyKey("root-1", 1),
+			}, nil
+		case "wisp-iter-2":
+			calls++
+			if calls == 1 {
+				return BeadInfo{
+					ID:             id,
+					Status:         "in_progress",
+					ParentID:       "root-1",
+					IdempotencyKey: IdempotencyKey("root-1", 2),
+				}, nil
+			}
+			return BeadInfo{}, fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
+		}
+		return BeadInfo{}, fmt.Errorf("unexpected bead lookup %q", id)
+	}
+
+	result, err := handler.StopHandler(context.Background(), "root-1", "alice", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionStopped {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionStopped)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateTerminated {
+		t.Fatalf("state = %q, want %q", meta[FieldState], StateTerminated)
+	}
+}
+
+func TestStopHandler_MissingActiveWisp_RecoversReplacementBeforeForceClose(t *testing.T) {
+	handler, store, _ := setupActiveHandler(t, "in_progress", nil)
+
+	store.mu.Lock()
+	delete(store.beads, "wisp-iter-2")
+	store.mu.Unlock()
+	store.addBead("wisp-replacement", "in_progress", "root-1", IdempotencyKey("root-1", 2), nil)
+
+	result, err := handler.StopHandler(context.Background(), "root-1", "alice", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionStopped {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionStopped)
+	}
+
+	replacement, err := store.GetBead("wisp-replacement")
+	if err != nil {
+		t.Fatalf("reading replacement wisp: %v", err)
+	}
+	if replacement.Status != "closed" {
+		t.Fatalf("replacement status = %q, want %q", replacement.Status, "closed")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldLastProcessedWisp] != "wisp-replacement" {
+		t.Fatalf("last_processed_wisp = %q, want %q", meta[FieldLastProcessedWisp], "wisp-replacement")
+	}
+}
+
+func TestStopHandler_StoreErrorReadingActiveWisp_ReportsError(t *testing.T) {
+	handler, store, _ := setupActiveHandler(t, "in_progress", nil)
+
+	store.GetBeadFunc = func(id string) (BeadInfo, error) {
+		return BeadInfo{}, fmt.Errorf("store unavailable for %s", id)
+	}
+
+	_, err := handler.StopHandler(context.Background(), "root-1", "alice", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "reading active wisp \"wisp-iter-2\": store unavailable for wisp-iter-2" {
+		t.Fatalf("StopHandler error = %q", got)
+	}
 }


### PR DESCRIPTION
## Summary
- recover stale `convergence.active_wisp` references in reconcile, stop, and live tick processing
- preserve and replay surviving replacement wisps instead of skipping closed iterations or leaking open children
- add unit and integration coverage for startup recovery, manual stop recovery, and steady-state tick recovery

## Validation
- `go test ./internal/convergence -count=1`
- `go test ./cmd/gc -run 'TestConvergence_(TickProcessesClosedWisp|TickRecoversMissingActiveWisp|StartupReconcile)' -count=1`
- `review-pr --skip-gemini codex/p1-140` on commit `053a8c7ec`

## Notes
- Gemini quota exhausted during the last review cycle, so the final pass used the review skill's dual-model mode (Claude + Codex)
- final review pass reported no blockers or majors; remaining feedback was minor/nit only
- fixes issue #140
