### PR TITLE
fix: isolate tests from host GC_* session environment

### DIFF
--- a/cmd/gc/cmd_event_emit_test.go
+++ b/cmd/gc/cmd_event_emit_test.go
@@ -44,6 +44,7 @@ func TestDoEventEmitSuccess(t *testing.T) {
 }
 
 func TestDoEventEmitDefaultActor(t *testing.T) {
+	clearGCEnv(t)
 	ep := events.NewFake()
 
 	var stderr bytes.Buffer
@@ -63,6 +64,7 @@ func TestDoEventEmitDefaultActor(t *testing.T) {
 }
 
 func TestDoEventEmitGCAgentEnv(t *testing.T) {
+	clearGCEnv(t)
 	t.Setenv("GC_AGENT", "worker")
 
 	ep := events.NewFake()

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -151,6 +151,7 @@ func TestWorkQueryHasReadyWorkNonEmptyJSONArray(t *testing.T) {
 }
 
 func TestCmdHookUsesAgentCityAndRigRoot(t *testing.T) {
+	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	workDir := filepath.Join(cityDir, ".gc", "worktrees", "myrig", "polecat-1")
@@ -220,6 +221,7 @@ max = 5
 }
 
 func TestCmdHookPoolInstanceUsesTemplatePoolLabel(t *testing.T) {
+	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	workDir := filepath.Join(cityDir, ".gc", "worktrees", "myrig", "polecat-1")
@@ -290,6 +292,7 @@ max = 5
 }
 
 func TestCmdHookExportsResolvedIdentityForFixedAgentQuery(t *testing.T) {
+	clearGCEnv(t)
 	cityDir := t.TempDir()
 	fakeBin := t.TempDir()
 
@@ -337,6 +340,7 @@ name = "worker"
 }
 
 func TestCmdHookExportsResolvedIdentityFromRigContext(t *testing.T) {
+	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	fakeBin := t.TempDir()

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+// gcEnvVars lists all GC_* environment variables that tests should
+// clear to isolate from host session state (e.g., running inside a
+// gc-managed tmux session where GC_ALIAS, GC_SESSION_NAME, etc. are
+// set).
+var gcEnvVars = []string{
+	"GC_ALIAS",
+	"GC_AGENT",
+	"GC_SESSION_ID",
+	"GC_SESSION_NAME",
+	"GC_CITY",
+}
+
+// clearGCEnv clears all GC_* session environment variables for the
+// duration of the test, preventing host session state from leaking
+// into tests. Uses t.Setenv so values are automatically restored.
+func clearGCEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range gcEnvVars {
+		t.Setenv(k, "")
+	}
+}


### PR DESCRIPTION
## Summary

- 4 tests (`TestDoEventEmitDefaultActor`, `TestDoEventEmitGCAgentEnv`, `TestCmdHookUsesAgentCityAndRigRoot`, `TestCmdHookPoolInstanceUsesTemplatePoolLabel`) fail locally when run inside a gc-managed session because `GC_ALIAS`, `GC_SESSION_ID`, and `GC_SESSION_NAME` leak from the host environment
- Adds `clearGCEnv(t)` test helper in `testenv_test.go` that clears all GC_* session variables — other tests that manually `t.Setenv("GC_ALIAS", "")` can adopt it incrementally
- Passes in CI and locally inside active gc sessions

## Test plan

- [x] All 4 previously-failing tests pass locally (inside gc-managed tmux)
- [x] All session-related tests in cmd/gc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)