### PR TITLE
feat: nudge idle sessions that have assigned work

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -58,6 +58,7 @@ type CityRuntime struct {
 
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	idleNudge     *idleNudger   // nudges idle sessions that have assigned work
 
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
@@ -230,6 +231,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// Initialize bead-driven drain tracker when bead store is available.
 	if cr.cityBeadStore() != nil && cr.tomlPath != "" {
 		cr.sessionDrains = newDrainTracker()
+		cr.idleNudge = newIdleNudger()
 	}
 	if ctx.Err() != nil {
 		return
@@ -790,7 +792,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
 	}
 
-	// Idle recovery: detect pool sessions stuck at the prompt after
+	// Nudge sessions that are idle at the prompt but have assigned work.
+	// Catches sessions stuck after Claude Code's "Interrupted" bug.
+	if cr.idleNudge != nil {
+		cr.idleNudge.nudgeIdleSessions(cr.sp, open, result.AssignedWorkBeads, time.Now(), cr.stdout)
+	}
 }
 
 func sweepUndesiredPoolSessionBeads(

--- a/cmd/gc/idle_nudge.go
+++ b/cmd/gc/idle_nudge.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// idleNudger detects sessions that are alive and idle at the CLI prompt
+// but have open or in_progress work assigned. This catches sessions stuck
+// after a Claude Code "Interrupted" bug — they land at the ❯ prompt with
+// work still assigned and sit there forever.
+//
+// On each tick it checks alive sessions. If a session has been idle at the
+// prompt for longer than the grace period AND has assigned work, it nudges
+// the session to resume.
+//
+// It does NOT drain idle sessions without work — that's handled by the
+// existing idle sleep timers (sleep_after_idle, idle_timeout) via
+// ComputeAwakeSet.
+type idleNudger struct {
+	firstIdle map[string]time.Time // session name → first observed idle
+	grace     time.Duration        // how long to wait before nudging
+}
+
+const defaultIdleNudgeGrace = 2 * time.Minute
+
+func newIdleNudger() *idleNudger {
+	return &idleNudger{
+		firstIdle: make(map[string]time.Time),
+		grace:     defaultIdleNudgeGrace,
+	}
+}
+
+// nudgeIdleSessions checks alive sessions for idle-at-prompt state with
+// assigned work. Called once per reconciler tick.
+func (in *idleNudger) nudgeIdleSessions(
+	sp runtime.Provider,
+	sessions []beads.Bead,
+	assignedWorkBeads []beads.Bead,
+	now time.Time,
+	stdout io.Writer,
+) {
+	workBySession := buildSessionWorkLookup(sessions, assignedWorkBeads)
+
+	visited := make(map[string]bool, len(sessions))
+
+	for i := range sessions {
+		s := &sessions[i]
+		name := s.Metadata["session_name"]
+		if name == "" || !sp.IsRunning(name) {
+			continue
+		}
+		visited[name] = true
+
+		// Only nudge sessions that have assigned work.
+		if !workBySession[name] {
+			delete(in.firstIdle, name)
+			continue
+		}
+
+		idle := isIdleAtPrompt(sp, name)
+		if !idle {
+			delete(in.firstIdle, name)
+			continue
+		}
+
+		// Track when we first saw it idle.
+		if _, ok := in.firstIdle[name]; !ok {
+			in.firstIdle[name] = now
+			continue
+		}
+
+		// Check grace period.
+		if now.Sub(in.firstIdle[name]) < in.grace {
+			continue
+		}
+
+		// Session has assigned work and has been idle past grace. Nudge it.
+		content := runtime.TextContent(
+			"You were interrupted. Check your current work with " +
+				"`bd list --assignee=\"$GC_SESSION_NAME\" --status=in_progress` " +
+				"and resume where you left off. If no in_progress work, check " +
+				"`bd ready --assignee=\"$GC_SESSION_NAME\"` for assigned ready work.",
+		)
+		if err := sp.Nudge(name, content); err != nil {
+			fmt.Fprintf(stdout, "idle-nudge: nudge %s failed: %v\n", name, err) //nolint:errcheck
+		} else {
+			fmt.Fprintf(stdout, "idle-nudge: nudged %s (idle with assigned work)\n", name) //nolint:errcheck
+		}
+
+		// Reset timer so we don't spam every tick.
+		delete(in.firstIdle, name)
+	}
+
+	// Prune entries for sessions no longer tracked.
+	for name := range in.firstIdle {
+		if !visited[name] {
+			delete(in.firstIdle, name)
+		}
+	}
+}
+
+// buildSessionWorkLookup returns a set of session names that have open or
+// in_progress work assigned to them via any identifier (bead ID, session
+// name, or alias).
+func buildSessionWorkLookup(sessions []beads.Bead, workBeads []beads.Bead) map[string]bool {
+	// Build reverse lookup: any identifier → session name
+	idToName := make(map[string]string, len(sessions)*3)
+	for _, s := range sessions {
+		name := s.Metadata["session_name"]
+		if name == "" {
+			continue
+		}
+		idToName[s.ID] = name
+		idToName[name] = name
+		if alias := strings.TrimSpace(s.Metadata["configured_named_identity"]); alias != "" {
+			idToName[alias] = name
+		}
+	}
+
+	result := make(map[string]bool)
+	for _, wb := range workBeads {
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if wb.Status != "open" && wb.Status != "in_progress" {
+			continue
+		}
+		if name, ok := idToName[assignee]; ok {
+			result[name] = true
+		}
+	}
+	return result
+}
+
+// isIdleAtPrompt does a single capture-pane and checks whether Claude CLI
+// is at its idle prompt (❯) with no busy indicator.
+func isIdleAtPrompt(sp runtime.Provider, name string) bool {
+	output, err := sp.Peek(name, 10)
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(output, "\n")
+
+	// If busy indicator is present, not idle.
+	for _, line := range lines {
+		if strings.Contains(line, "esc to interrupt") {
+			return false
+		}
+	}
+
+	// Check for prompt prefix in the captured lines.
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "❯") {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gc/idle_nudge_test.go
+++ b/cmd/gc/idle_nudge_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestIdleNudge_NudgesIdleSessionWithWork(t *testing.T) {
+	sp := runtime.NewFake()
+	sp.Start(context.TODO(), "worker-1", runtime.Config{}) //nolint:errcheck
+	sp.SetPeekOutput("worker-1", "❯ \n  bypass permissions on")
+
+	session := beads.Bead{
+		ID:       "s-1",
+		Status:   "open",
+		Type:     "session",
+		Metadata: map[string]string{"session_name": "worker-1"},
+	}
+	work := beads.Bead{
+		ID:       "w-1",
+		Status:   "in_progress",
+		Assignee: "worker-1",
+	}
+
+	in := newIdleNudger()
+	in.grace = 0 // no grace for test
+	var out bytes.Buffer
+
+	// First call: records idle timestamp.
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, time.Now(), &out)
+	if out.Len() > 0 {
+		t.Fatalf("first call should not nudge (recording idle): %s", out.String())
+	}
+
+	// Second call: past grace → nudge.
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, time.Now().Add(time.Second), &out)
+	if !bytes.Contains(out.Bytes(), []byte("idle-nudge: nudged worker-1")) {
+		t.Fatalf("expected nudge, got: %s", out.String())
+	}
+}
+
+func TestIdleNudge_SkipsSessionWithoutWork(t *testing.T) {
+	sp := runtime.NewFake()
+	sp.Start(context.TODO(), "worker-1", runtime.Config{}) //nolint:errcheck
+	sp.SetPeekOutput("worker-1", "❯ \n  bypass permissions on")
+
+	session := beads.Bead{
+		ID:       "s-1",
+		Status:   "open",
+		Type:     "session",
+		Metadata: map[string]string{"session_name": "worker-1"},
+	}
+
+	in := newIdleNudger()
+	in.grace = 0
+	var out bytes.Buffer
+
+	// No work beads.
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, nil, time.Now(), &out)
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, nil, time.Now().Add(time.Minute), &out)
+	if out.Len() > 0 {
+		t.Fatalf("should not nudge session without work: %s", out.String())
+	}
+}
+
+func TestIdleNudge_SkipsBusySession(t *testing.T) {
+	sp := runtime.NewFake()
+	sp.Start(context.TODO(), "worker-1", runtime.Config{}) //nolint:errcheck
+	sp.SetPeekOutput("worker-1", "● Bash(git fetch 2>&1)\n  esc to interrupt")
+
+	session := beads.Bead{
+		ID:       "s-1",
+		Status:   "open",
+		Type:     "session",
+		Metadata: map[string]string{"session_name": "worker-1"},
+	}
+	work := beads.Bead{
+		ID:       "w-1",
+		Status:   "in_progress",
+		Assignee: "worker-1",
+	}
+
+	in := newIdleNudger()
+	in.grace = 0
+	var out bytes.Buffer
+
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, time.Now(), &out)
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, time.Now().Add(time.Minute), &out)
+	if out.Len() > 0 {
+		t.Fatalf("should not nudge busy session: %s", out.String())
+	}
+}
+
+func TestIdleNudge_RespectsGracePeriod(t *testing.T) {
+	sp := runtime.NewFake()
+	sp.Start(context.TODO(), "worker-1", runtime.Config{}) //nolint:errcheck
+	sp.SetPeekOutput("worker-1", "❯ \n  bypass permissions on")
+
+	session := beads.Bead{
+		ID:       "s-1",
+		Status:   "open",
+		Type:     "session",
+		Metadata: map[string]string{"session_name": "worker-1"},
+	}
+	work := beads.Bead{
+		ID:       "w-1",
+		Status:   "in_progress",
+		Assignee: "worker-1",
+	}
+
+	in := newIdleNudger()
+	in.grace = 5 * time.Minute
+	var out bytes.Buffer
+	now := time.Now()
+
+	// First call: records idle.
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, now, &out)
+	// 1 minute later: within grace.
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, now.Add(time.Minute), &out)
+	if out.Len() > 0 {
+		t.Fatalf("should not nudge within grace period: %s", out.String())
+	}
+
+	// 6 minutes later: past grace.
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, now.Add(6*time.Minute), &out)
+	if !bytes.Contains(out.Bytes(), []byte("idle-nudge: nudged worker-1")) {
+		t.Fatalf("expected nudge after grace, got: %s", out.String())
+	}
+}
+
+func TestIdleNudge_MatchesWorkByAlias(t *testing.T) {
+	sp := runtime.NewFake()
+	sp.Start(context.TODO(), "repo--refinery", runtime.Config{}) //nolint:errcheck
+	sp.SetPeekOutput("repo--refinery", "❯ \n  bypass permissions on")
+
+	session := beads.Bead{
+		ID:     "s-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"session_name":              "repo--refinery",
+			"configured_named_identity": "repo/refinery",
+		},
+	}
+	// Work assigned to alias, not session name.
+	work := beads.Bead{
+		ID:       "w-1",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}
+
+	in := newIdleNudger()
+	in.grace = 0
+	var out bytes.Buffer
+
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, time.Now(), &out)
+	in.nudgeIdleSessions(sp, []beads.Bead{session}, []beads.Bead{work}, time.Now().Add(time.Second), &out)
+	if !bytes.Contains(out.Bytes(), []byte("idle-nudge: nudged repo--refinery")) {
+		t.Fatalf("expected nudge via alias match, got: %s", out.String())
+	}
+}


### PR DESCRIPTION
## Summary
Detects sessions stuck at Claude CLI's `❯` prompt after the "Interrupted" bug. If a session has open or in_progress work assigned and has been idle past a 2-minute grace period, nudges it to resume.

- Covers both pool and named sessions
- Multi-identifier work lookup (bead ID, session name, alias)
- Does NOT drain idle sessions without work — existing idle timers handle that
- Grace period prevents false positives during inter-turn gaps
- Resets timer after nudge to prevent spamming

## Test plan
- [x] `TestIdleNudge_NudgesIdleSessionWithWork` — idle + work → nudge
- [x] `TestIdleNudge_SkipsSessionWithoutWork` — idle + no work → skip
- [x] `TestIdleNudge_SkipsBusySession` — busy indicator → skip
- [x] `TestIdleNudge_RespectsGracePeriod` — within grace → skip, past grace → nudge
- [x] `TestIdleNudge_MatchesWorkByAlias` — work assigned to alias → nudge
- [x] All existing tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)