### PR TITLE
fix: replace PreCompact gc prime with gc handoff in Claude default hooks

### DIFF
--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff \"context cycle\""
           }
         ]
       }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -71,7 +71,13 @@ func TestInstallClaude(t *testing.T) {
 		t.Error("runtime Claude settings should mirror hooks/claude.json")
 	}
 	if !strings.Contains(s, "gc prime") {
-		t.Error("claude settings should contain gc prime")
+		t.Error("claude settings should contain gc prime (for SessionStart)")
+	}
+	// PreCompact should use gc handoff, not gc prime. SessionStart already handles
+	// the resume case; re-injecting the full context block on compaction too causes
+	// context accumulation in long sessions.
+	if !strings.Contains(s, `gc handoff`) {
+		t.Error("claude PreCompact hook should use gc handoff (not gc prime) to avoid context accumulation on compaction")
 	}
 	if !strings.Contains(s, "gc nudge drain --inject") {
 		t.Error("claude settings should contain gc nudge drain --inject")


### PR DESCRIPTION
## Problem

The default Claude hook config (`internal/hooks/config/claude.json`) registered `gc prime --hook` as the `PreCompact` hook. Since `SessionStart` already fires `gc prime --hook` on session resume, this caused the full agent context block to be injected **twice per compaction cycle** — once from `PreCompact` (right before compaction) and once from `SessionStart` (in the resumed session).

In long-running sessions with multiple compactions, the context block stacked many times. For a typical agent the block is 10–15KB; over a session with several handoffs or compactions it could accumulate 50–100KB of duplicated content, consuming the context window the injection was meant to protect.

## Fix

Change the `PreCompact` hook from `gc prime --hook` to `gc handoff "context cycle"`.

`gc handoff` is already the `PreCompact` behavior in all named pack overlays (`gastown/overlays/default`, `witness`, `crew`) and in individual agent settings. The embedded binary default was the only outlier — new cities initialized from the binary inherited the double-injection bug immediately.

`SessionStart` is unchanged: context injection on session start/resume is correct and intentional.

## Test

Added assertion to `TestInstallClaude` verifying the Claude default hooks contain `gc handoff` (for `PreCompact`) in addition to `gc prime` (for `SessionStart`).

Fixes: Rome-1/gas-city#rt-ivvsrn (internal tracking bead)