### PR TITLE
Speed up formula catalog and add formula runs endpoint

### DIFF
--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
@@ -42,6 +44,19 @@ type formulaSummaryResponse struct {
 	RunCount    int                        `json:"run_count"`
 	RecentRuns  []formulaRecentRunResponse `json:"recent_runs"`
 }
+
+type formulaRunsResponse struct {
+	Formula       string                     `json:"formula"`
+	RunCount      int                        `json:"run_count"`
+	RecentRuns    []formulaRecentRunResponse `json:"recent_runs"`
+	Partial       bool                       `json:"partial"`
+	PartialErrors []string                   `json:"partial_errors,omitempty"`
+}
+
+const (
+	defaultFormulaRunsLimit = 3
+	maxFormulaRunsLimit     = 20
+)
 
 type formulaPreviewNodeResponse struct {
 	ID       string `json:"id"`
@@ -83,13 +98,7 @@ func (s *Server) handleFormulaList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runs, err := buildWorkflowRunProjections(s.state, scopeKind, scopeRef)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", "formula run projection failed")
-		return
-	}
-
-	items, err := buildFormulaCatalog(paths, filterFormulaCatalogRuns(scopeKind, scopeRef, runs.Items))
+	items, err := buildFormulaCatalog(paths)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", "formula catalog failed")
 		return
@@ -97,10 +106,42 @@ func (s *Server) handleFormulaList(w http.ResponseWriter, r *http.Request) {
 
 	resp := map[string]any{
 		"items":   items,
-		"partial": runs.Partial,
+		"partial": false,
 	}
-	if len(runs.PartialErrors) > 0 {
-		resp["partial_errors"] = runs.PartialErrors
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleFormulaRuns(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimSpace(r.PathValue("name"))
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "formula name is required")
+		return
+	}
+
+	q := r.URL.Query()
+	scopeKind, scopeRef, scopeErr := parseWorkflowRequestScope(q.Get("scope_kind"), q.Get("scope_ref"))
+	if scopeErr != "" {
+		writeError(w, http.StatusBadRequest, "invalid", scopeErr)
+		return
+	}
+	if _, status, code, msg := s.formulaSearchPaths(scopeKind, scopeRef); status != http.StatusOK {
+		writeError(w, status, code, msg)
+		return
+	}
+	limit := defaultFormulaRunsLimit
+	if raw := strings.TrimSpace(q.Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, "invalid", "limit must be a non-negative integer")
+			return
+		}
+		limit = normalizeFormulaRunsLimit(parsed)
+	}
+
+	resp, err := buildFormulaRuns(s.state, name, scopeKind, scopeRef, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", "formula runs failed")
+		return
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -166,7 +207,7 @@ func (s *Server) formulaSearchPaths(scopeKind, scopeRef string) ([]string, int, 
 	}
 }
 
-func buildFormulaCatalog(paths []string, runs []workflowRunProjection) ([]formulaSummaryResponse, error) {
+func buildFormulaCatalog(paths []string) ([]formulaSummaryResponse, error) {
 	if len(paths) == 0 {
 		return []formulaSummaryResponse{}, nil
 	}
@@ -181,31 +222,16 @@ func buildFormulaCatalog(paths []string, runs []workflowRunProjection) ([]formul
 			}
 			return nil, err
 		}
-		recentRuns := formulaRecentRunsFor(resolved.Formula, runs, 3)
 		items = append(items, formulaSummaryResponse{
 			Name:        resolved.Formula,
 			Description: resolved.Description,
 			Version:     formulaVersionString(resolved),
 			VarDefs:     formulaVarDefs(resolved.Vars),
-			RunCount:    formulaRunCountFor(resolved.Formula, runs),
-			RecentRuns:  recentRuns,
+			RunCount:    0,
+			RecentRuns:  []formulaRecentRunResponse{},
 		})
 	}
 	return items, nil
-}
-
-func filterFormulaCatalogRuns(scopeKind, scopeRef string, runs []workflowRunProjection) []workflowRunProjection {
-	if scopeKind != "city" {
-		return runs
-	}
-
-	filtered := make([]workflowRunProjection, 0, len(runs))
-	for _, run := range runs {
-		if run.ScopeKind == scopeKind && run.ScopeRef == scopeRef {
-			filtered = append(filtered, run)
-		}
-	}
-	return filtered
 }
 
 func formulaRunCountFor(name string, runs []workflowRunProjection) int {
@@ -223,7 +249,11 @@ func formulaRecentRunsFor(name string, runs []workflowRunProjection, limit int) 
 		return []formulaRecentRunResponse{}
 	}
 
-	matching := make([]workflowRunProjection, 0, limit)
+	capHint := limit
+	if len(runs) < capHint {
+		capHint = len(runs)
+	}
+	matching := make([]workflowRunProjection, 0, capHint)
 	for _, run := range runs {
 		if run.FormulaName != name {
 			continue
@@ -253,6 +283,127 @@ func formulaRecentRunsFor(name string, runs []workflowRunProjection, limit int) 
 		})
 	}
 	return items
+}
+
+func normalizeFormulaRunsLimit(limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	if limit > maxFormulaRunsLimit {
+		return maxFormulaRunsLimit
+	}
+	return limit
+}
+
+func buildFormulaRuns(state State, formulaName, requestedScopeKind, requestedScopeRef string, limit int) (*formulaRunsResponse, error) {
+	cityScopeRef := workflowCityScopeRef(state.CityName())
+	includeAllForCity := requestedScopeKind == "city" && requestedScopeRef == cityScopeRef
+	stores := workflowStores(state)
+	projections := make([]workflowRunProjection, 0)
+	partialErrors := make([]string, 0)
+	var requestedScopeErr error
+
+	for _, info := range stores {
+		if info.store == nil {
+			continue
+		}
+		if !includeAllForCity && (info.scopeKind != requestedScopeKind || info.scopeRef != requestedScopeRef) {
+			continue
+		}
+
+		openBeads, err := info.store.ListOpen()
+		if err != nil {
+			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
+				requestedScopeErr = err
+			}
+			if includeAllForCity {
+				msg := info.ref + " store unavailable"
+				log.Printf("api: formula runs open list failed for %s: %v", info.ref, err)
+				partialErrors = append(partialErrors, msg)
+			}
+			continue
+		}
+
+		openChildrenByRoot := make(map[string][]beads.Bead)
+		for _, bead := range openBeads {
+			rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+			if rootID == "" {
+				continue
+			}
+			openChildrenByRoot[rootID] = append(openChildrenByRoot[rootID], bead)
+		}
+
+		roots, err := info.store.ListByMetadata(map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		}, 0, beads.IncludeClosed)
+		if err != nil {
+			log.Printf("api: formula runs workflow root list failed for %s: %v", info.ref, err)
+			partialErrors = append(partialErrors, info.ref+" workflow history incomplete")
+			roots = nil
+			for _, bead := range openBeads {
+				if isWorkflowRoot(bead) && strings.TrimSpace(bead.Metadata["gc.formula_contract"]) == "graph.v2" {
+					roots = append(roots, bead)
+				}
+			}
+		}
+
+		for _, root := range roots {
+			if !isWorkflowRoot(root) || workflowFormulaName(root) != formulaName {
+				continue
+			}
+
+			scopeKind, scopeRef := workflowProjectionScope(info, root, cityScopeRef, requestedScopeKind, requestedScopeRef)
+			if scopeKind != requestedScopeKind || scopeRef != requestedScopeRef {
+				continue
+			}
+
+			runBeads := append([]beads.Bead{root}, openChildrenByRoot[root.ID]...)
+			children, childErr := info.store.ListByMetadata(map[string]string{"gc.root_bead_id": root.ID}, 0, beads.IncludeClosed)
+			if childErr != nil {
+				log.Printf("api: formula runs child list failed for %s root %s: %v", info.ref, root.ID, childErr)
+				partialErrors = append(partialErrors, root.ID+" workflow history incomplete")
+			} else {
+				seen := make(map[string]bool, len(runBeads))
+				for _, existing := range runBeads {
+					seen[existing.ID] = true
+				}
+				for _, child := range children {
+					if seen[child.ID] {
+						continue
+					}
+					runBeads = append(runBeads, child)
+				}
+			}
+
+			projections = append(projections, workflowRunProjection{
+				WorkflowID:     resolvedWorkflowID(root),
+				FormulaName:    workflowFormulaName(root),
+				Title:          workflowProjectionTitle(root),
+				Status:         normalizeMonitorStatus(aggregateWorkflowRunStatus(root, runBeads)),
+				Target:         workflowProjectionTarget(root),
+				StartedAt:      root.CreatedAt,
+				UpdatedAt:      workflowProjectionUpdatedAt(runBeads),
+				ScopeKind:      scopeKind,
+				ScopeRef:       scopeRef,
+				RootBeadID:     root.ID,
+				RootStoreRef:   info.ref,
+				AttachedBeadID: strings.TrimSpace(root.Metadata["gc.source_bead_id"]),
+			})
+		}
+	}
+
+	if len(projections) == 0 && requestedScopeErr != nil && !includeAllForCity {
+		return nil, fmt.Errorf("listing open beads for %s:%s: %w", requestedScopeKind, requestedScopeRef, requestedScopeErr)
+	}
+
+	return &formulaRunsResponse{
+		Formula:       formulaName,
+		RunCount:      formulaRunCountFor(formulaName, projections),
+		RecentRuns:    formulaRecentRunsFor(formulaName, projections, limit),
+		Partial:       len(partialErrors) > 0,
+		PartialErrors: partialErrors,
+	}, nil
 }
 
 func buildFormulaDetail(ctx context.Context, name string, paths []string, _ string, vars map[string]string) (*formulaDetailResponse, error) {

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -68,10 +70,12 @@ title = "Review PR"
 	}
 }
 
-func TestFormulaListIncludesWorkflowRunCountsAndRecentRuns(t *testing.T) {
+func TestFormulaListSkipsWorkflowHistoryQueries(t *testing.T) {
 	state := newFakeState(t)
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}
+	state.stores["alpha"] = failListStore{Store: beads.NewMemStore()}
+	state.cityBeadStore = failListStore{Store: beads.NewMemStore()}
 
 	writeTestFormula(t, formulaDir, "mol-adopt-pr-v2", `
 description = "Review and fix a PR with a retry loop."
@@ -82,53 +86,6 @@ version = 2
 id = "review"
 title = "Review PR"
 `)
-
-	store := state.stores["myrig"]
-	if store == nil {
-		t.Fatal("expected rig store")
-	}
-
-	activeRoot, err := store.Create(beads.Bead{
-		Title: "Adopt PR",
-		Ref:   "mol-adopt-pr-v2",
-		Metadata: map[string]string{
-			"gc.kind":             "workflow",
-			"gc.formula_contract": "graph.v2",
-			"gc.workflow_id":      "wf-active",
-			"gc.run_target":       "myrig/claude",
-			"gc.scope_kind":       "rig",
-			"gc.scope_ref":        "myrig",
-		},
-	})
-	if err != nil {
-		t.Fatalf("create active workflow: %v", err)
-	}
-	statusInProgress := "in_progress"
-	if err := store.Update(activeRoot.ID, beads.UpdateOpts{Status: &statusInProgress}); err != nil {
-		t.Fatalf("set active workflow status: %v", err)
-	}
-
-	doneRoot, err := store.Create(beads.Bead{
-		Title: "Adopt PR Earlier",
-		Ref:   "mol-adopt-pr-v2",
-		Metadata: map[string]string{
-			"gc.kind":             "workflow",
-			"gc.formula_contract": "graph.v2",
-			"gc.workflow_id":      "wf-done",
-			"gc.run_target":       "mayor",
-			"gc.scope_kind":       "city",
-			"gc.scope_ref":        "test-city",
-		},
-	})
-	if err != nil {
-		t.Fatalf("create completed workflow: %v", err)
-	}
-	if err := store.SetMetadata(doneRoot.ID, "gc.outcome", "pass"); err != nil {
-		t.Fatalf("set outcome: %v", err)
-	}
-	if err := store.Close(doneRoot.ID); err != nil {
-		t.Fatalf("close completed workflow: %v", err)
-	}
 
 	server := New(state)
 	req := httptest.NewRequest(http.MethodGet, "/v0/formulas?scope_kind=city&scope_ref=test-city&target=worker", nil)
@@ -148,16 +105,8 @@ title = "Review PR"
 	if len(resp.Items) != 1 {
 		t.Fatalf("items = %+v, want 1 entry", resp.Items)
 	}
-
-	item := resp.Items[0]
-	if item.RunCount != 1 {
-		t.Fatalf("run_count = %d, want 1 city-scoped run", item.RunCount)
-	}
-	if len(item.RecentRuns) != 1 {
-		t.Fatalf("recent_runs = %+v, want 1 city-scoped run", item.RecentRuns)
-	}
-	if item.RecentRuns[0].WorkflowID != "wf-done" || item.RecentRuns[0].Status != "done" {
-		t.Fatalf("recent_runs[0] = %+v, want city workflow only", item.RecentRuns[0])
+	if resp.Items[0].RunCount != 0 || len(resp.Items[0].RecentRuns) != 0 {
+		t.Fatalf("run data = %+v, want empty workflow summaries from cheap catalog", resp.Items[0])
 	}
 }
 
@@ -193,12 +142,11 @@ func TestFormulaRecentRunsForSortsByUpdatedAtDescending(t *testing.T) {
 	}
 }
 
-func TestFormulaListIgnoresUnrelatedStoreListFailures(t *testing.T) {
+func TestFormulaRunsIncludesWorkflowRunCountsAndRecentRuns(t *testing.T) {
 	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}
-	state.stores["alpha"] = failListStore{Store: beads.NewMemStore()}
-	state.cityBeadStore = beads.NewMemStore()
 
 	writeTestFormula(t, formulaDir, "mol-adopt-pr-v2", `
 description = "Review and fix a PR with a retry loop."
@@ -236,7 +184,7 @@ title = "Review PR"
 	}
 
 	server := New(state)
-	req := httptest.NewRequest(http.MethodGet, "/v0/formulas?scope_kind=city&scope_ref=test-city&target=worker", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/mol-adopt-pr-v2/runs?scope_kind=city&scope_ref=test-city&limit=2", nil)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 
@@ -244,30 +192,27 @@ title = "Review PR"
 		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp struct {
-		Items         []formulaSummaryResponse `json:"items"`
-		Partial       bool                     `json:"partial"`
-		PartialErrors []string                 `json:"partial_errors"`
-	}
+	var resp formulaRunsResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("Decode(catalog): %v", err)
+		t.Fatalf("Decode(runs): %v", err)
 	}
-	if len(resp.Items) != 1 {
-		t.Fatalf("items = %+v, want 1 entry", resp.Items)
+	if resp.Formula != "mol-adopt-pr-v2" {
+		t.Fatalf("formula = %q, want mol-adopt-pr-v2", resp.Formula)
 	}
-	if resp.Items[0].RunCount != 1 {
-		t.Fatalf("run_count = %d, want 1", resp.Items[0].RunCount)
+	if resp.RunCount != 1 {
+		t.Fatalf("run_count = %d, want 1", resp.RunCount)
 	}
-	if !resp.Partial {
-		t.Fatalf("partial = false, want true")
+	if len(resp.RecentRuns) != 1 {
+		t.Fatalf("recent_runs = %+v, want 1 city-scoped run", resp.RecentRuns)
 	}
-	if len(resp.PartialErrors) != 1 || resp.PartialErrors[0] != "rig:alpha store unavailable" {
-		t.Fatalf("partial_errors = %v, want rig:alpha store unavailable", resp.PartialErrors)
+	if resp.RecentRuns[0].WorkflowID != "wf-healthy" || resp.RecentRuns[0].Status != "pending" {
+		t.Fatalf("recent_runs[0] = %+v, want wf-healthy pending", resp.RecentRuns[0])
 	}
 }
 
-func TestFormulaListCityScopeExcludesRigRunsWithoutProvenance(t *testing.T) {
+func TestFormulaRunsCityScopeExcludesRigRunsWithoutProvenance(t *testing.T) {
 	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}
 
@@ -307,7 +252,7 @@ title = "Review PR"
 	}
 
 	server := New(state)
-	req := httptest.NewRequest(http.MethodGet, "/v0/formulas?scope_kind=city&scope_ref=test-city&target=worker", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/mol-adopt-pr-v2/runs?scope_kind=city&scope_ref=test-city", nil)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 
@@ -315,21 +260,170 @@ title = "Review PR"
 		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp struct {
-		Items []formulaSummaryResponse `json:"items"`
-	}
+	var resp formulaRunsResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("Decode(catalog): %v", err)
+		t.Fatalf("Decode(runs): %v", err)
 	}
-	if len(resp.Items) != 1 {
-		t.Fatalf("items = %+v, want 1 entry", resp.Items)
+	if resp.RunCount != 0 {
+		t.Fatalf("run_count = %d, want 0 until workflow provenance exists", resp.RunCount)
 	}
-	if resp.Items[0].RunCount != 0 {
-		t.Fatalf("run_count = %d, want 0 until workflow provenance exists", resp.Items[0].RunCount)
+	if len(resp.RecentRuns) != 0 {
+		t.Fatalf("recent_runs = %+v, want none for city formula runs without provenance", resp.RecentRuns)
 	}
-	if len(resp.Items[0].RecentRuns) != 0 {
-		t.Fatalf("recent_runs = %+v, want none for city catalog without provenance", resp.Items[0].RecentRuns)
+}
+
+func TestFormulaRunsReturnsNotFoundForMissingRigScope(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-adopt-pr-v2", `
+description = "Review and fix a PR with a retry loop."
+formula = "mol-adopt-pr-v2"
+version = 2
+
+[[steps]]
+id = "review"
+title = "Review PR"
+`)
+
+	server := New(state)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/mol-adopt-pr-v2/runs?scope_kind=rig&scope_ref=missing", nil)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rec.Code, rec.Body.String())
 	}
+}
+
+func TestFormulaRunsClampsRequestedLimit(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-adopt-pr-v2", `
+description = "Review and fix a PR with a retry loop."
+formula = "mol-adopt-pr-v2"
+version = 2
+
+[[steps]]
+id = "review"
+title = "Review PR"
+`)
+
+	for i := 0; i < maxFormulaRunsLimit+5; i++ {
+		root, err := state.cityBeadStore.Create(beads.Bead{
+			Title: "Workflow root",
+			Ref:   "mol-adopt-pr-v2",
+			Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+				"gc.workflow_id":      fmt.Sprintf("wf-%02d", i),
+				"gc.run_target":       "mayor",
+				"gc.scope_kind":       "city",
+				"gc.scope_ref":        "test-city",
+			},
+		})
+		if err != nil {
+			t.Fatalf("create workflow root %d: %v", i, err)
+		}
+		inProgress := "in_progress"
+		if err := state.cityBeadStore.Update(root.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+			t.Fatalf("set workflow status %d: %v", i, err)
+		}
+	}
+
+	server := New(state)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/mol-adopt-pr-v2/runs?scope_kind=city&scope_ref=test-city&limit=9999", nil)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp formulaRunsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode(runs): %v", err)
+	}
+	if len(resp.RecentRuns) != maxFormulaRunsLimit {
+		t.Fatalf("recent_runs len = %d, want %d", len(resp.RecentRuns), maxFormulaRunsLimit)
+	}
+}
+
+func TestFormulaRunsFallsBackToOpenWorkflowRootsWhenHistoryLookupFails(t *testing.T) {
+	state := newFakeState(t)
+	baseStore := beads.NewMemStore()
+	state.cityBeadStore = failWorkflowRootLookupStore{Store: baseStore}
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-adopt-pr-v2", `
+description = "Review and fix a PR with a retry loop."
+formula = "mol-adopt-pr-v2"
+version = 2
+
+[[steps]]
+id = "review"
+title = "Review PR"
+`)
+
+	root, err := baseStore.Create(beads.Bead{
+		Title: "Open workflow root",
+		Ref:   "mol-adopt-pr-v2",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.workflow_id":      "wf-open-root",
+			"gc.run_target":       "mayor",
+			"gc.scope_kind":       "city",
+			"gc.scope_ref":        "test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := baseStore.Update(root.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set workflow status: %v", err)
+	}
+
+	server := New(state)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/mol-adopt-pr-v2/runs?scope_kind=city&scope_ref=test-city", nil)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp formulaRunsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode(runs): %v", err)
+	}
+	if resp.RunCount != 1 {
+		t.Fatalf("run_count = %d, want 1", resp.RunCount)
+	}
+	if !resp.Partial {
+		t.Fatalf("partial = false, want true")
+	}
+	if len(resp.PartialErrors) == 0 {
+		t.Fatalf("partial_errors = %+v, want fallback warning", resp.PartialErrors)
+	}
+}
+
+type failWorkflowRootLookupStore struct {
+	beads.Store
+}
+
+func (s failWorkflowRootLookupStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	if filters["gc.kind"] == "workflow" && filters["gc.formula_contract"] == "graph.v2" {
+		return nil, errors.New("workflow root lookup failed")
+	}
+	return s.Store.ListByMetadata(filters, limit, opts...)
 }
 
 func TestFormulaDetailReturnsCompiledPreview(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -276,6 +276,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /v0/order/{name}/enable", s.handleOrderEnable)
 	s.mux.HandleFunc("POST /v0/order/{name}/disable", s.handleOrderDisable)
 	s.mux.HandleFunc("GET /v0/formulas", s.handleFormulaList)
+	s.mux.HandleFunc("GET /v0/formulas/{name}/runs", s.handleFormulaRuns)
 	s.mux.HandleFunc("GET /v0/formulas/{name}", s.handleFormulaDetail)
 	s.mux.HandleFunc("GET /v0/formula/{name}", s.handleFormulaDetail)
 	// Backwards-compatible aliases for the old /v0/workflow routes.


### PR DESCRIPTION
## Summary
- make the formula catalog endpoint cheap by removing workflow history expansion
- add a scoped `/v0/formulas/{name}/runs` endpoint for lazy recent-run lookups
- preserve degraded/partial behavior for workflow history lookups in the new runs endpoint

## Validation
- TMPDIR=/var/tmp GOTMPDIR=/var/tmp/gotmp GOCACHE=/var/tmp/gocache go test ./internal/api -count=1