### PR TITLE
fix: route rig bugflow launches to the correct bead store

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -48,9 +48,12 @@ func bdStoreForRig(rigDir, cityPath string, cfg *config.City) *beads.BdStore {
 // city-level Dolt config. Otherwise falls back to bdRuntimeEnv(cityPath).
 func bdRuntimeEnvForRig(cityPath string, cfg *config.City, rigPath string) map[string]string {
 	env := bdRuntimeEnv(cityPath)
-	// Clear BEADS_DIR so bd discovers .beads/ from cwd
-	// (the rig directory) instead of the city root.
-	delete(env, "BEADS_DIR")
+	rigPath = filepath.Clean(rigPath)
+	// Pin the rig store explicitly. The gc-beads-bd provider derives its Dolt
+	// data root from GC_CITY_PATH unless BEADS_DIR is set, so cwd-based
+	// discovery is not sufficient for rig-scoped operations.
+	env["BEADS_DIR"] = filepath.Join(rigPath, ".beads")
+	env["GC_RIG_ROOT"] = rigPath
 	if cfg != nil {
 		for _, r := range cfg.Rigs {
 			rp := r.Path
@@ -58,6 +61,7 @@ func bdRuntimeEnvForRig(cityPath string, cfg *config.City, rigPath string) map[s
 				rp = filepath.Join(cityPath, rp)
 			}
 			if filepath.Clean(rp) == filepath.Clean(rigPath) {
+				env["GC_RIG"] = r.Name
 				if r.DoltHost != "" || r.DoltPort != "" {
 					if r.DoltHost != "" {
 						env["GC_DOLT_HOST"] = r.DoltHost

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -369,9 +369,14 @@ func TestBdStoreForRig_DoesNotExist(t *testing.T) {
 	if rigEnv["BEADS_DOLT_PORT"] != "3307" {
 		t.Errorf("BEADS_DOLT_PORT = %q, want %q", rigEnv["BEADS_DOLT_PORT"], "3307")
 	}
-	// BEADS_DIR should be cleared so bd discovers .beads from rig cwd.
-	if _, hasBeadsDir := rigEnv["BEADS_DIR"]; hasBeadsDir {
-		t.Error("BEADS_DIR should be cleared for rig-level routing")
+	if got := rigEnv["BEADS_DIR"]; got != filepath.Join(rigDir, ".beads") {
+		t.Errorf("BEADS_DIR = %q, want %q", got, filepath.Join(rigDir, ".beads"))
+	}
+	if got := rigEnv["GC_RIG"]; got != "myrig" {
+		t.Errorf("GC_RIG = %q, want %q", got, "myrig")
+	}
+	if got := rigEnv["GC_RIG_ROOT"]; got != rigDir {
+		t.Errorf("GC_RIG_ROOT = %q, want %q", got, rigDir)
 	}
 }
 
@@ -400,6 +405,9 @@ func TestBdRuntimeEnvForRigUsesManagedRigPort(t *testing.T) {
 	}
 	if got := env["BEADS_DOLT_PORT"]; got != "31364" {
 		t.Fatalf("BEADS_DOLT_PORT = %q, want %q", got, "31364")
+	}
+	if got := env["BEADS_DIR"]; got != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", got, filepath.Join(rigDir, ".beads"))
 	}
 }
 
@@ -440,6 +448,9 @@ func TestBdRuntimeEnvForRigFallsBackToManagedCityPort(t *testing.T) {
 	}
 	if got := env["BEADS_DOLT_PORT"]; got != want {
 		t.Fatalf("BEADS_DOLT_PORT = %q, want %q", got, want)
+	}
+	if got := env["BEADS_DIR"]; got != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", got, filepath.Join(rigDir, ".beads"))
 	}
 }
 
@@ -494,5 +505,14 @@ func TestBdRuntimeEnvForRigPrefersExplicitRigDoltConfigOverManagedCity(t *testin
 	}
 	if got := env["BEADS_DOLT_PORT"]; got != "3307" {
 		t.Fatalf("BEADS_DOLT_PORT = %q, want %q", got, "3307")
+	}
+	if got := env["BEADS_DIR"]; got != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", got, filepath.Join(rigDir, ".beads"))
+	}
+	if got := env["GC_RIG"]; got != "repo" {
+		t.Fatalf("GC_RIG = %q, want %q", got, "repo")
+	}
+	if got := env["GC_RIG_ROOT"]; got != rigDir {
+		t.Fatalf("GC_RIG_ROOT = %q, want %q", got, rigDir)
 	}
 }

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -71,9 +71,10 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	// Build env: strip BEADS_DIR so bd discovers .beads/ from cwd,
-	// and inject rig-level Dolt host/port when configured.
+	// Build env: pin BEADS_DIR to the selected store so rig-scoped calls don't
+	// fall back to the city store via gc-beads-bd's GC_CITY_PATH handling.
 	env := removeEnvKey(os.Environ(), "BEADS_DIR")
+	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
 	if dir != cityPath {
 		for _, r := range cfg.Rigs {
 			rp := r.Path
@@ -81,6 +82,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 				rp = filepath.Join(cityPath, rp)
 			}
 			if filepath.Clean(rp) == filepath.Clean(dir) {
+				env = append(env, "GC_RIG="+r.Name, "GC_RIG_ROOT="+dir)
 				if r.DoltHost != "" {
 					env = append(env, "BEADS_DOLT_HOST="+r.DoltHost)
 				}
@@ -90,6 +92,8 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 				break
 			}
 		}
+	} else {
+		env = append(env, "GC_RIG=", "GC_RIG_ROOT=")
 	}
 	cmd.Env = env
 

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -62,6 +62,8 @@ func loadSessionProviderContext() sessionProviderContext {
 	return ctx
 }
 
+var openSessionProviderStore = openCityStoreAt
+
 // tmuxConfigFromSession converts a config.SessionConfig into a
 // sessiontmux.Config with resolved durations and defaults. If the
 // config has no explicit socket name, cityName is used.
@@ -140,15 +142,23 @@ func newSessionProviderByName(name string, sc config.SessionConfig, cityName, ci
 // routes per-session. Startup path — exits on error.
 func newSessionProvider() runtime.Provider {
 	ctx := loadSessionProviderContext()
-	var sessionBeads *sessionBeadSnapshot
-	if ctx.cityPath != "" {
-		if store, err := openCityStoreAt(ctx.cityPath); err == nil {
-			if all, err := store.List(beads.ListQuery{Label: sessionBeadLabel, Type: sessionBeadType}); err == nil {
-				sessionBeads = newSessionBeadSnapshot(all)
-			}
-		}
-	}
+	sessionBeads := loadProviderSessionSnapshot(ctx)
 	return newSessionProviderFromContext(ctx, sessionBeads)
+}
+
+func loadProviderSessionSnapshot(ctx sessionProviderContext) *sessionBeadSnapshot {
+	if ctx.cityPath == "" || ctx.providerName == "acp" || !hasACPAgents(ctx.agents) {
+		return nil
+	}
+	store, err := openSessionProviderStore(ctx.cityPath)
+	if err != nil {
+		return nil
+	}
+	all, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		return nil
+	}
+	return newSessionBeadSnapshot(all)
 }
 
 func newSessionProviderFromContext(ctx sessionProviderContext, sessionBeads *sessionBeadSnapshot) runtime.Provider {

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -102,6 +102,72 @@ func TestNewSessionProvider_PreregistersACPBeadAndLegacyNames(t *testing.T) {
 	}
 }
 
+func TestLoadProviderSessionSnapshotSkipsStoreWithoutACPAgents(t *testing.T) {
+	oldOpen := openSessionProviderStore
+	t.Cleanup(func() { openSessionProviderStore = oldOpen })
+
+	calls := 0
+	openSessionProviderStore = func(string) (beads.Store, error) {
+		calls++
+		return beads.NewMemStore(), nil
+	}
+
+	snapshot := loadProviderSessionSnapshot(sessionProviderContext{
+		providerName: "tmux",
+		cityPath:     "/tmp/city",
+		agents: []config.Agent{
+			{Name: "mayor"},
+		},
+	})
+	if snapshot != nil {
+		t.Fatalf("loadProviderSessionSnapshot() = %#v, want nil", snapshot)
+	}
+	if calls != 0 {
+		t.Fatalf("openSessionProviderStore called %d times, want 0", calls)
+	}
+}
+
+func TestLoadProviderSessionSnapshotLoadsOpenACPAgents(t *testing.T) {
+	oldOpen := openSessionProviderStore
+	t.Cleanup(func() { openSessionProviderStore = oldOpen })
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:reviewer"},
+		Metadata: map[string]string{
+			"template":     "reviewer",
+			"agent_name":   "reviewer",
+			"session_name": "custom-reviewer",
+		},
+	}); err != nil {
+		t.Fatalf("Create(session bead): %v", err)
+	}
+
+	calls := 0
+	openSessionProviderStore = func(string) (beads.Store, error) {
+		calls++
+		return store, nil
+	}
+
+	snapshot := loadProviderSessionSnapshot(sessionProviderContext{
+		providerName: "tmux",
+		cityPath:     "/tmp/city",
+		agents: []config.Agent{
+			{Name: "reviewer", Session: "acp"},
+		},
+	})
+	if calls != 1 {
+		t.Fatalf("openSessionProviderStore called %d times, want 1", calls)
+	}
+	if snapshot == nil {
+		t.Fatal("loadProviderSessionSnapshot() = nil, want snapshot")
+	}
+	if got := snapshot.FindSessionNameByTemplate("reviewer"); got != "custom-reviewer" {
+		t.Fatalf("snapshot.FindSessionNameByTemplate(reviewer) = %q, want %q", got, "custom-reviewer")
+	}
+}
+
 func writeACPRouteCityTOML(t *testing.T, dir, cityName string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {


### PR DESCRIPTION
## Summary
- pin rig-scoped `bd` operations to the rig `.beads` store instead of letting `gc-beads-bd` fall back through `GC_CITY_PATH`
- carry rig identity through `gc bd` env setup so rig-targeted workflow/bead operations resolve consistently
- avoid opening the city bead store during provider startup unless ACP agent routing actually needs the session snapshot

## Testing
- `TMPDIR=/var/tmp GOTMPDIR=/var/tmp/gotmp GOCACHE=/var/tmp/gocache go test ./cmd/gc -run 'TestBdRuntimeEnvForRigUsesManagedRigPort|TestBdRuntimeEnvForRigPrefersExplicitRigDoltConfigOverManagedCity|TestLoadProviderSessionSnapshotSkipsStoreWithoutACPAgents|TestLoadProviderSessionSnapshotLoadsOpenACPAgents' -count=1`