### PR TITLE
fix: spawn pool workers for gc sling routed beads with no assignee

### DIFF
--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -107,26 +107,38 @@ func computePoolDesiredStates(
 
 		// Resume tier: assigned work beads whose assignee resolves to a
 		// non-closed session bead. These sessions must stay alive.
+		// New tier (bead-driven): work beads routed to this template
+		// but with no assignee — on-demand work from gc sling that
+		// needs a new pool worker to be spawned.
 		for _, wb := range assignedWorkBeads {
 			routedTo := wb.Metadata["gc.routed_to"]
 			if routedTo != template {
 				continue
 			}
-			assignee := strings.TrimSpace(wb.Assignee)
-			sessionBeadID := assigneeToSessionBeadID[assignee]
-			if sessionBeadID == "" {
-				continue
-			}
 			if wb.Status != "in_progress" && wb.Status != "open" {
 				continue
 			}
-			allRequests = append(allRequests, SessionRequest{
-				Template:      template,
-				BeadPriority:  beadPriority(wb),
-				Tier:          "resume",
-				SessionBeadID: sessionBeadID,
-				WorkBeadID:    wb.ID,
-			})
+			assignee := strings.TrimSpace(wb.Assignee)
+			sessionBeadID := assigneeToSessionBeadID[assignee]
+			if sessionBeadID != "" {
+				allRequests = append(allRequests, SessionRequest{
+					Template:      template,
+					BeadPriority:  beadPriority(wb),
+					Tier:          "resume",
+					SessionBeadID: sessionBeadID,
+					WorkBeadID:    wb.ID,
+				})
+			} else if assignee == "" {
+				// Routed but unassigned — demand for a new worker.
+				allRequests = append(allRequests, SessionRequest{
+					Template:     template,
+					BeadPriority: beadPriority(wb),
+					Tier:         "new",
+					WorkBeadID:   wb.ID,
+				})
+			}
+			// Else: assignee set but session closed/unknown — orphaned
+			// work, not our job to respawn.
 		}
 	}
 

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -547,3 +547,57 @@ func TestResumeTier_AsleepSessionWithAssignedWork(t *testing.T) {
 		t.Fatal("resume tier must fire for asleep session with assigned work")
 	}
 }
+
+// Regression for #286: gc sling routes work to a pool agent via gc.routed_to
+// metadata but leaves Assignee empty. The pool scheduler must create a "new"
+// tier request so the reconciler spawns a worker.
+func TestComputePoolDesiredStates_RoutedButUnassignedSpawnsNew(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", nil, 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "claude", "", "open", 5),
+	}
+
+	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if len(result[0].Requests) != 1 {
+		t.Fatalf("len(requests) = %d, want 1 (unassigned routed bead needs new worker)", len(result[0].Requests))
+	}
+	req := result[0].Requests[0]
+	if req.Tier != "new" {
+		t.Errorf("tier = %q, want new", req.Tier)
+	}
+	if req.WorkBeadID != "w1" {
+		t.Errorf("work bead = %q, want w1", req.WorkBeadID)
+	}
+}
+
+// Regression for #286: same as above but for a rig-scoped agent.
+func TestComputePoolDesiredStates_RoutedRigScopedSpawnsNew(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "myrig", nil, 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "myrig/claude", "", "open", 3),
+	}
+
+	result := ComputePoolDesiredStates(cfg, work, nil, nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if len(result[0].Requests) != 1 {
+		t.Fatalf("len(requests) = %d, want 1", len(result[0].Requests))
+	}
+	req := result[0].Requests[0]
+	if req.Tier != "new" {
+		t.Errorf("tier = %q, want new", req.Tier)
+	}
+	if req.Template != "myrig/claude" {
+		t.Errorf("template = %q, want myrig/claude", req.Template)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix pool workers never spawning for `gc sling` routed work when Assignee is empty
- Restructure `computePoolDesiredStates` matching logic to generate "new" tier requests for routed-but-unassigned beads
- Add two regression tests covering basic and rig-scoped agent cases

Fixes #286

## Test plan

- [ ] `go test ./cmd/gc/ -run TestComputePoolDesiredStates_RoutedButUnassigned`
- [ ] `go test ./cmd/gc/ -run TestComputePoolDesiredStates_RoutedRigScoped`
- [ ] Manual: `gc init`, `gc sling claude "test"`, verify pool worker spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)