### PR TITLE
fix: respect dolt.auto-start=false config, don't overwrite port file

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -119,6 +119,15 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 			env["GC_DOLT_PORT"] = port
 		}
 	}
+	// When dolt.auto-start is disabled and no live port was found, propagate
+	// the stale port from the port file so bd will attempt to connect to it
+	// (and fail with a connection error) rather than auto-starting an embedded
+	// dolt server on a random port and overwriting the shared port file.
+	if env["GC_DOLT_PORT"] == "" && doltAutoStartDisabled(cityPath) {
+		if stalePort := staleDoltPort(cityPath); stalePort != "" {
+			env["GC_DOLT_PORT"] = stalePort
+		}
+	}
 	mirrorBeadsDoltEnv(env)
 	return env
 }

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -442,6 +442,17 @@ func readDoltPort(cityPath string) {
 		_ = os.Unsetenv("BEADS_DOLT_HOST")
 		return
 	}
+	// When auto-start is disabled, propagate the stale port so bd subprocess
+	// calls fail fast with "connection refused" rather than auto-starting an
+	// embedded dolt on a random port and overwriting the shared port file.
+	if doltAutoStartDisabled(cityPath) {
+		if stalePort := staleDoltPort(cityPath); stalePort != "" {
+			_ = os.Setenv("GC_DOLT_PORT", stalePort)
+			_ = os.Setenv("BEADS_DOLT_PORT", stalePort)
+			_ = os.Unsetenv("BEADS_DOLT_HOST")
+			return
+		}
+	}
 	_ = os.Unsetenv("GC_DOLT_PORT")
 	_ = os.Unsetenv("BEADS_DOLT_PORT")
 	_ = os.Unsetenv("BEADS_DOLT_HOST")
@@ -455,17 +466,53 @@ type doltRuntimeState struct {
 	StartedAt string `json:"started_at"`
 }
 
+// doltAutoStartDisabled returns true when the .beads/config.yaml in the
+// given directory contains "dolt.auto-start: false". When true, the system
+// must never auto-start a dolt server or overwrite the port file.
+func doltAutoStartDisabled(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "dolt.auto-start:") {
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, "dolt.auto-start:"))
+			return val == "false"
+		}
+	}
+	return false
+}
+
+// staleDoltPort reads the dolt-server.port file without checking
+// reachability. Returns the port string or "" if no file exists.
+func staleDoltPort(cityPath string) string {
+	portFile := filepath.Join(cityPath, ".beads", "dolt-server.port")
+	data, err := os.ReadFile(portFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 // currentDoltPort returns the controller-managed Dolt port for the city.
 // Prefer the runtime state file under .gc/runtime because .beads/dolt-server.port
 // may be stale or missing in rig directories after restarts. Falls back to the
 // legacy city root port file for compatibility.
+//
+// When dolt.auto-start is disabled, stale port files are preserved to prevent
+// bd from auto-starting an embedded server on a random port (which overwrites
+// the shared port file and corrupts the managed server setup).
 func currentDoltPort(cityPath string) string {
 	if port := currentManagedDoltPort(cityPath); port != "" {
 		writeDoltPortFile(cityPath, port)
 		return port
 	}
+	noAutoStart := doltAutoStartDisabled(cityPath)
 	if hasManagedDoltState(cityPath) {
-		removeDoltPortFile(cityPath)
+		if !noAutoStart {
+			removeDoltPortFile(cityPath)
+		}
 		return ""
 	}
 
@@ -475,7 +522,11 @@ func currentDoltPort(cityPath string) string {
 		if port != "" && doltPortReachable(port) {
 			return port
 		}
-		_ = os.Remove(portFile)
+		// When auto-start is disabled, preserve the port file so bd
+		// doesn't fall back to spawning an embedded dolt server.
+		if !noAutoStart {
+			_ = os.Remove(portFile)
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- When `dolt.auto-start: false` is set in `.beads/config.yaml`, `currentDoltPort()` no longer deletes the `dolt-server.port` file when the server is temporarily unreachable
- `bdRuntimeEnv()` and `readDoltPort()` now propagate the stale port via `GC_DOLT_PORT`/`BEADS_DOLT_PORT` env vars so bd gets "connection refused" instead of silently auto-starting an embedded dolt on a random port
- Adds `doltAutoStartDisabled()` helper to read the auto-start config and `staleDoltPort()` to read the port file without reachability checks

## Problem
When the managed dolt server was temporarily down, every bd command would:
1. See no live port (currentDoltPort returns "")
2. Get no GC_DOLT_PORT env var
3. Auto-start an embedded dolt on a random port
4. Overwrite `.beads/dolt-server.port` with the random port

This corrupted the shared server setup despite `dolt.auto-start: false` being configured.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Manual: set `dolt.auto-start: false`, stop dolt, run a bd command -- should get connection error, not auto-start
- [ ] Manual: verify `.beads/dolt-server.port` is preserved after dolt server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)