### PR TITLE
test: clear tmux session env in gc test helper

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -151,6 +151,7 @@ func TestWorkQueryHasReadyWorkNonEmptyJSONArray(t *testing.T) {
 }
 
 func TestCmdHookUsesAgentCityAndRigRoot(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
@@ -221,6 +222,7 @@ max = 5
 }
 
 func TestCmdHookPoolInstanceUsesTemplatePoolLabel(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
@@ -292,6 +294,7 @@ max = 5
 }
 
 func TestCmdHookExportsResolvedIdentityForFixedAgentQuery(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	fakeBin := t.TempDir()
@@ -318,8 +321,6 @@ name = "worker"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
-	t.Setenv("GC_AGENT", "")
-	t.Setenv("GC_SESSION_NAME", "")
 
 	var stdout, stderr bytes.Buffer
 	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
@@ -340,6 +341,7 @@ name = "worker"
 }
 
 func TestCmdHookExportsResolvedIdentityFromRigContext(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
@@ -376,8 +378,6 @@ dir = "myrig"
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_DIR", rigDir)
-	t.Setenv("GC_AGENT", "")
-	t.Setenv("GC_SESSION_NAME", "")
 
 	wantAgent := "myrig/worker"
 	wantSession := cliSessionName(cityDir, "test-city", wantAgent, "")

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -2,21 +2,21 @@ package main
 
 import "testing"
 
-// gcEnvVars lists all GC_* environment variables that tests should
-// clear to isolate from host session state (e.g., running inside a
-// gc-managed tmux session where GC_ALIAS, GC_SESSION_NAME, etc. are
-// set).
+// gcEnvVars lists the GC_* identity and session-routing variables that
+// tests should clear to isolate from host session state (e.g., running
+// inside a gc-managed tmux session).
 var gcEnvVars = []string{
 	"GC_ALIAS",
 	"GC_AGENT",
 	"GC_SESSION_ID",
 	"GC_SESSION_NAME",
+	"GC_TMUX_SESSION",
 	"GC_CITY",
 }
 
-// clearGCEnv clears all GC_* session environment variables for the
-// duration of the test, preventing host session state from leaking
-// into tests. Uses t.Setenv so values are automatically restored.
+// clearGCEnv clears GC_* identity and session-routing variables for the
+// duration of the test, preventing host session state from leaking into
+// tests. Uses t.Setenv so values are automatically restored.
 func clearGCEnv(t *testing.T) {
 	t.Helper()
 	for _, k := range gcEnvVars {


### PR DESCRIPTION
Post-merge fixup for #310 after a maintainer review found one remaining managed-session leak.

Changes:
- include `GC_TMUX_SESSION` in `clearGCEnv`
- seed hostile `GC_TMUX_SESSION` values in the affected hook tests so the leak stays covered
- remove redundant manual `t.Setenv` calls already handled by the helper

Validation:
- `GC_TMUX_SESSION=host-session go test ./cmd/gc -run 'TestCmdHook(UsesAgentCityAndRigRoot|PoolInstanceUsesTemplatePoolLabel|ExportsResolvedIdentityForFixedAgentQuery|ExportsResolvedIdentityFromRigContext)$' -count=1`\n- `go test ./cmd/gc -run 'Test(DoEventEmit(DefaultActor|GCAgentEnv)|SessionNameTmuxOverride)$' -count=1`\n- `/tmp/review-pr/20260405T182919Z-ac8941d0` returned `## Decision: approve` with no blockers or majors.