### PR TITLE
feat: expose option_defaults in AgentPatch and AgentOverride

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -158,6 +158,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `max_active_sessions` | integer |  |  | MaxActiveSessions overrides the agent-level cap on concurrent sessions. |
 | `min_active_sessions` | integer |  |  | MinActiveSessions overrides the minimum number of sessions to keep alive. |
 | `scale_check` | string |  |  | ScaleCheck overrides the shell command whose output determines desired session count. |
+| `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (override keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
 
 ## AgentPatch
 
@@ -201,6 +202,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `max_active_sessions` | integer |  |  | MaxActiveSessions overrides the agent-level cap on concurrent sessions. |
 | `min_active_sessions` | integer |  |  | MinActiveSessions overrides the minimum number of sessions to keep alive. |
 | `scale_check` | string |  |  | ScaleCheck overrides the shell command whose output determines desired session count. |
+| `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (patch keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
 
 ## BeadsConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -504,6 +504,13 @@
         "scale_check": {
           "type": "string",
           "description": "ScaleCheck overrides the shell command whose output determines desired session count."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults adds or overrides provider option defaults for this agent.\nKeys are option keys, values are choice values. Merges additively\n(override keys win over existing agent keys).\nExample: option_defaults = { model = \"sonnet\" }"
         }
       },
       "additionalProperties": false,
@@ -701,6 +708,13 @@
         "scale_check": {
           "type": "string",
           "description": "ScaleCheck overrides the shell command whose output determines desired session count."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults adds or overrides provider option defaults for this agent.\nKeys are option keys, values are choice values. Merges additively\n(patch keys win over existing agent keys).\nExample: option_defaults = { model = \"sonnet\" }"
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -352,6 +352,11 @@ type AgentOverride struct {
 	MinActiveSessions *int `toml:"min_active_sessions,omitempty"`
 	// ScaleCheck overrides the shell command whose output determines desired session count.
 	ScaleCheck *string `toml:"scale_check,omitempty"`
+	// OptionDefaults adds or overrides provider option defaults for this agent.
+	// Keys are option keys, values are choice values. Merges additively
+	// (override keys win over existing agent keys).
+	// Example: option_defaults = { model = "sonnet" }
+	OptionDefaults map[string]string `toml:"option_defaults,omitempty"`
 }
 
 // PackSource defines a remote pack repository.

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -45,7 +45,6 @@ func TestAgentFieldSync(t *testing.T) {
 		"OnDeath":                "scaling field, patched via PoolOverride.OnDeath",
 		"Namepool":               "agent-specific file path, not a patch concern",
 		"NamepoolNames":          "runtime-only, loaded from Namepool file at config load time",
-		"OptionDefaults":         "provider-level concern, applied during ResolveProvider via mergeAgentOverrides",
 	}
 
 	// Fields on AgentOverride/AgentPatch that don't map 1:1 to Agent fields.
@@ -191,6 +190,7 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		MaxActiveSessions:       intVal(5),
 		MinActiveSessions:       intVal(1),
 		ScaleCheck:              strVal("echo 3"),
+		OptionDefaults:          map[string]string{"model": "sonnet"},
 	}
 
 	// Verify every AgentPatch field is set (non-zero).
@@ -233,8 +233,8 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		if targeting[fname] || modifiers[fname] {
 			continue
 		}
-		// Env and Pool are handled specially (not a direct field copy).
-		if fname == "Env" || fname == "Pool" {
+		// Env, OptionDefaults, and Pool are handled specially (not a direct field copy).
+		if fname == "Env" || fname == "OptionDefaults" || fname == "Pool" {
 			continue
 		}
 		idx, ok := agentFieldByName[fname]
@@ -249,6 +249,10 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 	// Verify Env was merged.
 	if agent.Env["KEY"] != "val" {
 		t.Errorf("Env[KEY] = %q, want %q", agent.Env["KEY"], "val")
+	}
+	// Verify OptionDefaults was merged.
+	if agent.OptionDefaults["model"] != "sonnet" {
+		t.Errorf("OptionDefaults[model] = %q, want %q", agent.OptionDefaults["model"], "sonnet")
 	}
 	// Verify EnvRemove worked.
 	if _, exists := agent.Env["REMOVE_ME"]; exists {
@@ -321,6 +325,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		MaxActiveSessions:       intVal(5),
 		MinActiveSessions:       intVal(1),
 		ScaleCheck:              strVal("echo 3"),
+		OptionDefaults:          map[string]string{"model": "sonnet"},
 	}
 
 	// Verify every AgentOverride field is set (non-zero).
@@ -360,7 +365,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		if targeting[fname] || modifiers[fname] {
 			continue
 		}
-		if fname == "Env" || fname == "Pool" {
+		if fname == "Env" || fname == "OptionDefaults" || fname == "Pool" {
 			continue
 		}
 		idx, ok := agentFieldByName[fname]
@@ -378,6 +383,10 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 	}
 	if _, exists := agent.Env["REMOVE_ME"]; exists {
 		t.Error("EnvRemove did not remove REMOVE_ME from Env")
+	}
+	// Verify OptionDefaults was merged.
+	if agent.OptionDefaults["model"] != "sonnet" {
+		t.Errorf("OptionDefaults[model] = %q, want %q", agent.OptionDefaults["model"], "sonnet")
 	}
 	if agent.MinActiveSessions == nil || *agent.MinActiveSessions != 2 || agent.MaxActiveSessions == nil || *agent.MaxActiveSessions != 10 {
 		t.Errorf("Scaling not applied correctly: min=%v max=%v", agent.MinActiveSessions, agent.MaxActiveSessions)

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -973,6 +973,15 @@ func applyAgentOverride(a *Agent, ov *AgentOverride) {
 	for _, k := range ov.EnvRemove {
 		delete(a.Env, k)
 	}
+	// OptionDefaults: additive merge (override keys win).
+	if len(ov.OptionDefaults) > 0 {
+		if a.OptionDefaults == nil {
+			a.OptionDefaults = make(map[string]string, len(ov.OptionDefaults))
+		}
+		for k, v := range ov.OptionDefaults {
+			a.OptionDefaults[k] = v
+		}
+	}
 	// Pool: sub-field patching.
 	if ov.Pool != nil {
 		applyPoolOverride(a, ov.Pool)

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -96,6 +96,11 @@ type AgentPatch struct {
 	MinActiveSessions *int `toml:"min_active_sessions,omitempty"`
 	// ScaleCheck overrides the shell command whose output determines desired session count.
 	ScaleCheck *string `toml:"scale_check,omitempty"`
+	// OptionDefaults adds or overrides provider option defaults for this agent.
+	// Keys are option keys, values are choice values. Merges additively
+	// (patch keys win over existing agent keys).
+	// Example: option_defaults = { model = "sonnet" }
+	OptionDefaults map[string]string `toml:"option_defaults,omitempty"`
 }
 
 // PoolOverride modifies pool configuration fields. Nil fields are not changed.
@@ -303,6 +308,15 @@ func applyAgentPatchFields(a *Agent, p *AgentPatch) {
 	}
 	if p.ScaleCheck != nil {
 		a.ScaleCheck = *p.ScaleCheck
+	}
+	// OptionDefaults: additive merge (patch keys win).
+	if len(p.OptionDefaults) > 0 {
+		if a.OptionDefaults == nil {
+			a.OptionDefaults = make(map[string]string, len(p.OptionDefaults))
+		}
+		for k, v := range p.OptionDefaults {
+			a.OptionDefaults[k] = v
+		}
 	}
 	// Pool: sub-field patching.
 	if p.Pool != nil {


### PR DESCRIPTION
## Summary

- Adds `option_defaults` field to `AgentPatch` and `AgentOverride` with additive merge semantics (consistent with `Env`)
- Removes the `TestAgentFieldSync` exclusion so drift detection enforces parity going forward
- Regenerates config docs and JSON schema

## Motivation

`OptionDefaults` was excluded from patches/overrides as a "provider-level concern, applied during ResolveProvider." But unlike truly internal provider fields (`Args`, `PromptMode`, `PromptFlag`), it is user-facing configuration that users explicitly set to control provider behavior (model selection, permission mode, etc.). `Provider` and `StartCommand` are also provider concerns and are already patchable — the exclusion was inconsistent.

Without this, the only way to change the model via a patch or rig override is to override `start_command` with all flags baked in, which duplicates provider knowledge and breaks if base args change.

Closes #329

## Test plan

- [x] `TestAgentFieldSync` — exclusion removed, field now required on both structs
- [x] `TestApplyAgentPatchCoversAllFields` — test data + assertion for additive merge
- [x] `TestApplyAgentOverrideCoversAllFields` — test data + assertion for additive merge
- [x] `make check` — lint, vet, tests pass (pre-existing failures in `cmd/gc` unrelated)
- [x] `make check-docs` — docs sync passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)