### PR TITLE
test: cover formula root molecule type

### DIFF
--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -55,6 +55,9 @@ needs = ["dry", "wet"]
 	if recipe.Steps[0].ID != "pancakes" {
 		t.Errorf("root ID = %q, want %q", recipe.Steps[0].ID, "pancakes")
 	}
+	if recipe.RootStep().Type != "molecule" {
+		t.Errorf("root Type = %q, want %q", recipe.RootStep().Type, "molecule")
+	}
 
 	// Check step IDs are namespaced
 	if recipe.Steps[1].ID != "pancakes.dry" {


### PR DESCRIPTION
Post-merge fixup for #274 after maintainer review found the behavioral fix shipped without a compile-path regression.

Changes:
- add a direct `internal/formula.Compile` assertion that a non-graph formula root compiles as `molecule`

Validation:
- `go test ./internal/formula -run 'TestCompile(SimpleFormula|WithChildren|RalphMarksWorkflowRootAndBlocksOnTopLevelSteps)$' -count=1`\n- `/tmp/review-pr/20260405T184625Z-6ed31c54` returned `## Decision: approve` with no blockers or majors.