### PR TITLE
fix: pack-level patches match rig-scoped agents by name

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -734,18 +734,29 @@ func adjustPackPatchPaths(patches *Patches, topoDir, cityRoot string) {
 }
 
 // applyPackAgentPatches applies agent patches to a merged agent slice.
-// Patches target agents by name (dir is empty at pack level since agents
-// haven't been rig-stamped yet). Returns an error if a patch targets a
-// nonexistent agent.
+// When a patch has Dir == "", it matches by Name alone — this is the
+// normal case for pack authors who don't know which rig will use their
+// pack (agents are rig-stamped during recursive loadPack before patches
+// run). When Dir is set, both Dir and Name must match.
+// Returns an error if a patch targets a nonexistent agent.
 func applyPackAgentPatches(agents []Agent, patches []AgentPatch) error {
 	for i, p := range patches {
 		target := qualifiedNameFromPatch(p.Dir, p.Name)
 		found := false
 		for j := range agents {
-			if agents[j].Dir == p.Dir && agents[j].Name == p.Name {
-				applyAgentPatchFields(&agents[j], &patches[i])
-				found = true
-				break
+			if p.Dir == "" {
+				// Name-only match: pack patches don't know the rig name.
+				if agents[j].Name == p.Name {
+					applyAgentPatchFields(&agents[j], &patches[i])
+					found = true
+					break
+				}
+			} else {
+				if agents[j].Dir == p.Dir && agents[j].Name == p.Name {
+					applyAgentPatchFields(&agents[j], &patches[i])
+					found = true
+					break
+				}
 			}
 		}
 		if !found {

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3187,6 +3187,65 @@ pre_start_append = ["extra.sh"]
 	}
 }
 
+func TestPackLevelPatches_RigScoped(t *testing.T) {
+	dir := t.TempDir()
+	// Base pack with a rig-scoped agent.
+	writeFile(t, dir, "packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "witness"
+scope = "rig"
+nudge = "patrol"
+start_command = "claude --model opus"
+`)
+	// Overlay pack includes base and patches the agent's start_command.
+	// This is the rig-scoped case: agents get dir-stamped during recursive
+	// loadPack, so the patch must match by name alone (dir = "").
+	writeFile(t, dir, "packs/overlay/pack.toml", `
+[pack]
+name = "overlay"
+schema = 1
+includes = ["../base"]
+
+[[patches.agent]]
+name = "witness"
+start_command = "claude --model sonnet"
+`)
+
+	cfg := &City{
+		Rigs: []Rig{{
+			Name:     "myrig",
+			Path:     dir,
+			Includes: []string{"packs/overlay"},
+		}},
+	}
+	err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil)
+	if err != nil {
+		t.Fatalf("ExpandPacks: %v", err)
+	}
+	// Find the witness agent for myrig.
+	var found *Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "witness" && cfg.Agents[i].Dir == "myrig" {
+			found = &cfg.Agents[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("witness agent not found for myrig")
+	}
+	if found.StartCommand != "claude --model sonnet" {
+		t.Errorf("StartCommand = %q, want %q", found.StartCommand, "claude --model sonnet")
+	}
+	// Nudge should be inherited from base (not cleared by patch).
+	if found.Nudge != "patrol" {
+		t.Errorf("Nudge = %q, want %q (inherited from base)", found.Nudge, "patrol")
+	}
+}
+
 func TestPackDoctorEntriesParsed(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "pack.toml", `


### PR DESCRIPTION
## Summary

- Fixes `applyPackAgentPatches` to match by name alone when the patch has `Dir==""`, allowing pack-level patches to target agents that were rig-stamped during recursive `loadPack`
- Adds `TestPackLevelPatches_RigScoped` covering the exact failure case

## Bug

Pack-level `[[patches.agent]]` worked for city-scoped expansion but failed for rig-scoped agents with:

```
patches.agent[0]: agent "witness" not found in pack
```

The matching logic required `Dir == p.Dir`, but during rig expansion the recursive `loadPack` stamps included agents with the rig name (`Dir="myrig"`) before the parent pack's patches run. Pack authors write `Dir=""` because they don't know which rig will use their pack — so the match always failed.

## Fix

When a patch has `Dir==""`, match by `Name` alone. This is safe: names are unique within a pack's merged agent list after fallback resolution. City-scoped behavior is unchanged (agents also have `Dir=""` in that path).

Closes #328

## Test plan

- [x] `TestPackLevelPatches_RigScoped` — new test for the exact failure case (rig-scoped agent patched by parent pack)
- [x] Existing `TestPackLevelPatches_*` — all 4 pass unchanged (city-scoped behavior preserved)
- [x] Full `go test ./internal/config/...` — passes
- [x] Manual verification with `gc config show` against a local `sonnet-witness` pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)