### PR TITLE
fix: pool reconciler checks city store for cross-rig routed work

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -212,6 +212,19 @@ func buildDesiredStateWithSessionBeads(
 		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir})
 	}
 
+	// For rig-scoped agents using the default pool check, augment the
+	// scale_check command to also query the city-level bead store.
+	// City-prefixed beads routed to a rig-scoped agent (e.g., gm-cxb →
+	// gascity/opus) live in the city store, not the rig store. Without
+	// this, the pool reconciler never sees them and never wakes an agent.
+	for j := range pendingPools {
+		pw := &pendingPools[j]
+		agent := &cfg.Agents[pw.agentIdx]
+		if agent.Dir != "" && agent.ScaleCheck == "" && pw.poolDir != cityPath {
+			pw.sp.Check = crossRigDefaultPoolCheck(agent.QualifiedName(), cityPath)
+		}
+	}
+
 	// scale_check runs in parallel for all pool agents — the authoritative
 	// demand signal for new sessions. Computed once, returned in result.
 	scaleCheckCounts := evaluatePendingPoolsMap(cityPath, cfg, pendingPools, stderr, trace)
@@ -330,6 +343,15 @@ func buildDesiredStateWithSessionBeads(
 		}
 		if workQueryHasReadyWork(strings.TrimSpace(out)) {
 			namedWorkReady[identity] = true
+			continue
+		}
+		// For rig-scoped agents using the default work query, also
+		// check the city-level bead store for cross-rig routed work.
+		if spec.Agent.Dir != "" && spec.Agent.WorkQuery == "" && dir != cityPath {
+			cityOut, cityErr := shellScaleCheck(wq, cityPath)
+			if cityErr == nil && workQueryHasReadyWork(strings.TrimSpace(cityOut)) {
+				namedWorkReady[identity] = true
+			}
 		}
 	}
 	for identity, spec := range namedSpecs {

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -101,6 +101,39 @@ func evaluatePool(agentName string, sp scaleParams, dir string, runner ScaleChec
 	return desired, nil
 }
 
+// crossRigDefaultPoolCheck returns a scale_check command that counts
+// actionable work for a rig-scoped pool agent across BOTH the rig-local
+// bead store (queried via the working directory set by the caller) and the
+// city-level bead store. City-prefixed beads routed to a rig agent (e.g.,
+// via gc sling from city scope) live in the city store and would otherwise
+// be invisible to the rig-scoped bd query.
+//
+// The command runs the standard bd ready / bd list queries twice — once in
+// the default working directory (rig root, set by evaluatePool's dir arg)
+// and once explicitly from cityDir — then sums the counts.
+func crossRigDefaultPoolCheck(template, cityDir string) string {
+	// Rig-local counts (bd runs in the rig root via the dir parameter).
+	rigReady := `rig_ready=$(bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); `
+	rigActive := `rig_active=$(bd list --metadata-field gc.routed_to=` + template +
+		` --status=in_progress --json 2>/dev/null | jq 'length' 2>/dev/null); `
+
+	// City-level counts (cd to city root so bd uses the city bead store).
+	cityReady := `city_ready=$(cd ` + shellQuoteSimple(cityDir) + ` && bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); `
+	cityActive := `city_active=$(cd ` + shellQuoteSimple(cityDir) + ` && bd list --metadata-field gc.routed_to=` + template +
+		` --status=in_progress --json 2>/dev/null | jq 'length' 2>/dev/null); `
+
+	sum := `echo "$(( ${rig_ready:-0} + ${rig_active:-0} + ${city_ready:-0} + ${city_active:-0} ))" || echo 0`
+	return rigReady + rigActive + cityReady + cityActive + sum
+}
+
+// shellQuoteSimple wraps a string in single quotes for safe shell expansion.
+// Only used for trusted paths (city directory), not arbitrary user input.
+func shellQuoteSimple(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 // SessionSetupContext holds template variables for session_setup command expansion.
 type SessionSetupContext struct {
 	Session   string // tmux session name

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -864,3 +864,92 @@ func isTestscriptShim(path string) bool {
 	clean := filepath.Clean(path)
 	return strings.Contains(clean, string(filepath.Separator)+"testscript-")
 }
+
+func TestCrossRigDefaultPoolCheck(t *testing.T) {
+	cmd := crossRigDefaultPoolCheck("myrig/worker", "/home/user/city")
+
+	// Must query both rig-local and city-level stores.
+	if !strings.Contains(cmd, "rig_ready=") {
+		t.Error("missing rig_ready variable")
+	}
+	if !strings.Contains(cmd, "rig_active=") {
+		t.Error("missing rig_active variable")
+	}
+	if !strings.Contains(cmd, "city_ready=") {
+		t.Error("missing city_ready variable")
+	}
+	if !strings.Contains(cmd, "city_active=") {
+		t.Error("missing city_active variable")
+	}
+
+	// City queries must cd to the city directory.
+	if !strings.Contains(cmd, "cd '/home/user/city'") {
+		t.Errorf("city queries should cd to city dir; got: %s", cmd)
+	}
+
+	// Must use gc.routed_to metadata filter.
+	if !strings.Contains(cmd, "gc.routed_to=myrig/worker") {
+		t.Errorf("should filter by gc.routed_to=myrig/worker; got: %s", cmd)
+	}
+
+	// Must sum all four counts.
+	if !strings.Contains(cmd, "${rig_ready:-0} + ${rig_active:-0} + ${city_ready:-0} + ${city_active:-0}") {
+		t.Errorf("should sum all four counts; got: %s", cmd)
+	}
+}
+
+func TestCrossRigDefaultPoolCheckQuotesPath(t *testing.T) {
+	cmd := crossRigDefaultPoolCheck("rig/agent", "/path/with spaces/city")
+	if !strings.Contains(cmd, "'/path/with spaces/city'") {
+		t.Errorf("city path should be shell-quoted; got: %s", cmd)
+	}
+}
+
+func TestComputeWorkSetCrossRigFallback(t *testing.T) {
+	rigRoot := filepath.Join(t.TempDir(), "demo-rig")
+	cityDir := t.TempDir()
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: rigRoot}},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "demo"},
+		},
+	}
+
+	// Runner: rig-scoped query returns no work, city-scoped query returns work.
+	runner := func(cmd, dir string) (string, error) {
+		if dir == cityDir {
+			return `[{"id":"gm-abc"}]`, nil
+		}
+		return "[]", nil // rig store: no work
+	}
+
+	work := computeWorkSet(cfg, runner, "test-city", cityDir, nil, nil)
+	if !work["demo/worker"] {
+		t.Errorf("expected demo/worker to have work via city store fallback; got %v", work)
+	}
+}
+
+func TestComputeWorkSetCrossRigSkipsCustomWorkQuery(t *testing.T) {
+	rigRoot := filepath.Join(t.TempDir(), "demo-rig")
+	cityDir := t.TempDir()
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: rigRoot}},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "demo", WorkQuery: "custom-check"},
+		},
+	}
+
+	calls := 0
+	runner := func(cmd, dir string) (string, error) {
+		calls++
+		return "[]", nil
+	}
+
+	computeWorkSet(cfg, runner, "test-city", cityDir, nil, nil)
+	// Custom work_query: should NOT get a second (city-dir) call.
+	if calls != 1 {
+		t.Errorf("expected 1 runner call for custom work_query; got %d", calls)
+	}
+}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -396,6 +396,17 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 		}
 		if workQueryHasReadyWork(strings.TrimSpace(out)) {
 			work[qn] = true
+			continue
+		}
+		// For rig-scoped pool agents using the default work query,
+		// also check the city-level bead store. City-prefixed beads
+		// routed to a rig agent live in the city store, not the rig
+		// store, so the rig-scoped query above misses them.
+		if a.Dir != "" && a.WorkQuery == "" && dir != cityDir {
+			cityOut, cityErr := runner(wq, cityDir)
+			if cityErr == nil && workQueryHasReadyWork(strings.TrimSpace(cityOut)) {
+				work[qn] = true
+			}
 		}
 	}
 	return work


### PR DESCRIPTION
## Summary
- Pool reconciler now checks the city store for work routed to cross-rig pools
- Fixes agents not waking when work is slung to a pool from a different rig

Extracted from the original #307 bundle per review feedback.

## Test plan
- [ ] Verify cross-rig slung work wakes pool agents
- [ ] Verify local-rig work still wakes agents normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)