### PR TITLE
hooks: upgrade stale claude and cursor compaction hooks

### DIFF
--- a/internal/hooks/config/cursor.json
+++ b/internal/hooks/config/cursor.json
@@ -8,7 +8,7 @@
     ],
     "preCompact": [
       {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff \"context cycle\""
       }
     ],
     "beforeSubmitPrompt": [

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -114,22 +114,27 @@ func Install(fs fsys.FS, cityDir, workDir string, providers []string) error {
 func installClaude(fs fsys.FS, cityDir string) error {
 	hookDst := filepath.Join(cityDir, citylayout.ClaudeHookFile)
 	runtimeDst := filepath.Join(cityDir, ".gc", "settings.json")
+	embedded, err := readEmbedded("config/claude.json")
+	if err != nil {
+		return err
+	}
 
 	data, err := fs.ReadFile(hookDst)
 	if err != nil {
 		data, err = fs.ReadFile(runtimeDst)
 		if err != nil {
-			data, err = readEmbedded("config/claude.json")
-			if err != nil {
-				return err
-			}
+			data = embedded
+		} else if claudeFileNeedsUpgrade(data) {
+			data = embedded
 		}
+	} else if claudeFileNeedsUpgrade(data) {
+		data = embedded
 	}
 
-	if err := writeEmbeddedManaged(fs, hookDst, data, nil); err != nil {
+	if err := writeEmbeddedManaged(fs, hookDst, data, claudeFileNeedsUpgrade); err != nil {
 		return err
 	}
-	return writeEmbeddedManaged(fs, runtimeDst, data, nil)
+	return writeEmbeddedManaged(fs, runtimeDst, data, claudeFileNeedsUpgrade)
 }
 
 // installGemini writes .gemini/settings.json in the working directory.
@@ -168,7 +173,11 @@ func installCopilot(fs fsys.FS, workDir string) error {
 // installCursor writes .cursor/hooks.json in the working directory.
 func installCursor(fs fsys.FS, workDir string) error {
 	dst := filepath.Join(workDir, ".cursor", "hooks.json")
-	return writeEmbedded(fs, "config/cursor.json", dst)
+	data, err := readEmbedded("config/cursor.json")
+	if err != nil {
+		return err
+	}
+	return writeEmbeddedManaged(fs, dst, data, cursorFileNeedsUpgrade)
 }
 
 // installPi writes .pi/extensions/gc-hooks.js in the working directory.
@@ -231,4 +240,21 @@ func geminiFileNeedsUpgrade(existing []byte) bool {
 		strings.Contains(content, `gc nudge drain --inject`) ||
 		strings.Contains(content, `gc mail check --inject`) ||
 		strings.Contains(content, `gc hook --inject`)
+}
+
+func claudeFileNeedsUpgrade(existing []byte) bool {
+	return matchesStaleManagedFile(existing, "config/claude.json")
+}
+
+func cursorFileNeedsUpgrade(existing []byte) bool {
+	return matchesStaleManagedFile(existing, "config/cursor.json")
+}
+
+func matchesStaleManagedFile(existing []byte, embedPath string) bool {
+	current, err := readEmbedded(embedPath)
+	if err != nil {
+		return false
+	}
+	stale := strings.Replace(string(current), `gc handoff "context cycle"`, `gc prime --hook`, 1)
+	return string(existing) == stale
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,12 +1,49 @@
 package hooks
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
+
+func claudeHookCommand(t *testing.T, data []byte, event string) string {
+	t.Helper()
+	var cfg struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal claude hooks: %v", err)
+	}
+	entries := cfg.Hooks[event]
+	if len(entries) == 0 || len(entries[0].Hooks) == 0 {
+		t.Fatalf("missing claude hook for %s", event)
+	}
+	return entries[0].Hooks[0].Command
+}
+
+func cursorHookCommand(t *testing.T, data []byte, event string) string {
+	t.Helper()
+	var cfg struct {
+		Hooks map[string][]struct {
+			Command string `json:"command"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal cursor hooks: %v", err)
+	}
+	entries := cfg.Hooks[event]
+	if len(entries) == 0 {
+		t.Fatalf("missing cursor hook for %s", event)
+	}
+	return entries[0].Command
+}
 
 func TestSupportedProviders(t *testing.T) {
 	got := SupportedProviders()
@@ -70,13 +107,10 @@ func TestInstallClaude(t *testing.T) {
 	if string(runtimeData) != string(data) {
 		t.Error("runtime Claude settings should mirror hooks/claude.json")
 	}
-	if !strings.Contains(s, "gc prime") {
-		t.Error("claude settings should contain gc prime (for SessionStart)")
+	if !strings.Contains(claudeHookCommand(t, data, "SessionStart"), "gc prime --hook") {
+		t.Error("claude SessionStart hook should contain gc prime --hook")
 	}
-	// PreCompact should use gc handoff, not gc prime. SessionStart already handles
-	// the resume case; re-injecting the full context block on compaction too causes
-	// context accumulation in long sessions.
-	if !strings.Contains(s, `gc handoff`) {
+	if !strings.Contains(claudeHookCommand(t, data, "PreCompact"), `gc handoff "context cycle"`) {
 		t.Error("claude PreCompact hook should use gc handoff (not gc prime) to avoid context accumulation on compaction")
 	}
 	if !strings.Contains(s, "gc nudge drain --inject") {
@@ -90,6 +124,30 @@ func TestInstallClaude(t *testing.T) {
 	}
 	if !strings.Contains(s, `$HOME/go/bin`) {
 		t.Error("claude hook commands should include PATH export")
+	}
+}
+
+func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
+	fs := fsys.NewFake()
+	current, err := readEmbedded("config/claude.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	stale := strings.Replace(string(current), `gc handoff "context cycle"`, `gc prime --hook`, 1)
+	fs.Files["/city/hooks/claude.json"] = []byte(stale)
+	fs.Files["/city/.gc/settings.json"] = []byte(stale)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	hookData := fs.Files["/city/hooks/claude.json"]
+	runtimeData := fs.Files["/city/.gc/settings.json"]
+	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff "context cycle"`) {
+		t.Fatalf("upgraded claude hook missing gc handoff:\n%s", string(hookData))
+	}
+	if string(runtimeData) != string(hookData) {
+		t.Fatalf("runtime Claude settings should mirror upgraded hook settings:\n%s", string(runtimeData))
 	}
 }
 
@@ -305,14 +363,51 @@ func TestInstallCursor(t *testing.T) {
 	if !strings.Contains(string(data), "sessionStart") {
 		t.Error("cursor hooks should contain sessionStart")
 	}
-	if !strings.Contains(string(data), "gc prime --hook") {
-		t.Error("cursor hooks should contain gc prime --hook")
+	if !strings.Contains(cursorHookCommand(t, data, "sessionStart"), "gc prime --hook") {
+		t.Error("cursor sessionStart hook should contain gc prime --hook")
+	}
+	if !strings.Contains(cursorHookCommand(t, data, "preCompact"), `gc handoff "context cycle"`) {
+		t.Error("cursor preCompact hook should contain gc handoff \"context cycle\"")
 	}
 	if !strings.Contains(string(data), "gc mail check --inject") {
 		t.Error("cursor hooks should contain gc mail check --inject")
 	}
 	if !strings.Contains(string(data), "gc nudge drain --inject") {
 		t.Error("cursor hooks should contain gc nudge drain --inject")
+	}
+}
+
+func TestInstallCursorUpgradesStaleGeneratedFile(t *testing.T) {
+	fs := fsys.NewFake()
+	current, err := readEmbedded("config/cursor.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	stale := strings.Replace(string(current), `gc handoff "context cycle"`, `gc prime --hook`, 1)
+	fs.Files["/work/.cursor/hooks.json"] = []byte(stale)
+
+	if err := Install(fs, "/city", "/work", []string{"cursor"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := fs.Files["/work/.cursor/hooks.json"]
+	if !strings.Contains(cursorHookCommand(t, got, "preCompact"), `gc handoff "context cycle"`) {
+		t.Fatalf("upgraded cursor hooks missing gc handoff:\n%s", string(got))
+	}
+}
+
+func TestInstallCursorPreservesExistingCustomFile(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := `{"version":1,"hooks":{"sessionStart":[{"command":"custom-start"}],"preCompact":[{"command":"custom-compact"}]}}`
+	fs.Files["/work/.cursor/hooks.json"] = []byte(custom)
+
+	if err := Install(fs, "/city", "/work", []string{"cursor"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.cursor/hooks.json"])
+	if got != custom {
+		t.Errorf("Install overwrote custom cursor hooks: got %q want %q", got, custom)
 	}
 }
 


### PR DESCRIPTION
Post-merge fixup for #313 after maintainer review found two remaining gaps.

Changes:
- switch the embedded Cursor `preCompact` hook to `gc handoff "context cycle"`
- add stale managed-file upgrade detection for Claude and Cursor so existing cities get the corrected compaction hook
- tighten hook install tests to assert the actual compaction command and cover both upgrade and preserve-custom-file paths

Validation:
- `go test ./internal/hooks -count=1`
- external Claude review on the branch diff returned: `No blockers or majors.`