### PR TITLE
fix: stamp pending create claim on pool session beads

### DIFF
--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -31,6 +31,7 @@ func createPoolSessionBead(
 		"template":             template,
 		"agent_name":           template,
 		"state":                "creating",
+		"pending_create_claim": "true",
 		"generation":           "1",
 		"continuation_epoch":   "1",
 		"instance_token":       sessionpkg.NewInstanceToken(),

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
+	store := beads.NewMemStore()
+
+	bead, err := createPoolSessionBead(store, "gascity/claude", nil)
+	if err != nil {
+		t.Fatalf("createPoolSessionBead: %v", err)
+	}
+
+	if got := bead.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+
+	stored, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", bead.ID, err)
+	}
+	if got := stored.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("stored pending_create_claim = %q, want true", got)
+	}
+}


### PR DESCRIPTION
## Summary
- stamp `pending_create_claim=true` when creating pool session beads
- add regression coverage for pool-created session beads

## Why
Pool-created session beads were entering `state=creating` without the durable create claim used by the reconciler rollback/recovery paths. That left the pool path behind the other session materialization paths.

## Validation
- `TMPDIR=/var/tmp GOTMPDIR=/var/tmp/gotmp GOCACHE=/var/tmp/gocache go test ./cmd/gc -run 'TestCreatePoolSessionBead_SetsPendingCreateClaim|TestHealState_(PreservesFreshCreatingWithoutPendingClaim|StaleCreatingWithoutPendingClaimHealsToAsleep)|TestReconcileSessionBeads_' -count=1`
