### PR TITLE
fix: recover standalone rig worker reconciliation

### DIFF
--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -121,15 +121,6 @@ func runAdoptionBarrier(
 
 	// Step 3: For each running session, adopt if no open bead exists.
 	for _, sessionName := range running {
-		if bySessionName[sessionName] {
-			result.AlreadyHadBead++
-			result.Details = append(result.Details, adoptionDetail{
-				SessionName: sessionName,
-				HasBead:     true,
-			})
-			continue
-		}
-
 		// Find matching config agent.
 		// First try exact session name match, then try resolving pool
 		// instances by stripping the numeric suffix and matching the
@@ -142,6 +133,18 @@ func runAdoptionBarrier(
 				isConfigAgent = true
 				isPoolInstance = true
 			}
+		}
+		if !sp.ProcessAlive(sessionName, processHints(cfgAgent)) {
+			result.Total--
+			continue
+		}
+		if bySessionName[sessionName] {
+			result.AlreadyHadBead++
+			result.Details = append(result.Details, adoptionDetail{
+				SessionName: sessionName,
+				HasBead:     true,
+			})
+			continue
 		}
 
 		// Build bead metadata. Config/live hashes are left empty —
@@ -250,4 +253,11 @@ func parsePoolSlot(sessionName string) int {
 		return 0
 	}
 	return slot
+}
+
+func processHints(a *config.Agent) []string {
+	if a == nil {
+		return nil
+	}
+	return a.ProcessNames
 }

--- a/cmd/gc/adoption_barrier_test.go
+++ b/cmd/gc/adoption_barrier_test.go
@@ -15,10 +15,18 @@ import (
 type fakeAdoptionProvider struct {
 	runtime.Provider
 	running []string
+	alive   map[string]bool
 }
 
 func (f *fakeAdoptionProvider) ListRunning(_ string) ([]string, error) {
 	return f.running, nil
+}
+
+func (f *fakeAdoptionProvider) ProcessAlive(name string, _ []string) bool {
+	if f.alive == nil {
+		return true
+	}
+	return f.alive[name]
 }
 
 func TestAdoptionBarrier_NoRunning(t *testing.T) {
@@ -202,6 +210,42 @@ func TestAdoptionBarrier_DryRun(t *testing.T) {
 	beadList, _ := store.ListByLabel(sessionBeadLabel, 0)
 	if len(beadList) != 0 {
 		t.Errorf("dry run created %d beads, want 0", len(beadList))
+	}
+}
+
+func TestAdoptionBarrier_SkipsDeadSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &fakeAdoptionProvider{
+		running: []string{"test-city-mayor", "test-city-worker"},
+		alive: map[string]bool{
+			"test-city-mayor":  true,
+			"test-city-worker": false,
+		},
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "mayor", MaxActiveSessions: intPtr(1)},
+			{Name: "worker"},
+		},
+	}
+	var stderr bytes.Buffer
+
+	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	if !passed {
+		t.Fatalf("barrier should pass, stderr: %s", stderr.String())
+	}
+	if result.Total != 1 {
+		t.Fatalf("Total = %d, want 1 live session", result.Total)
+	}
+	if result.Adopted != 1 {
+		t.Fatalf("Adopted = %d, want 1", result.Adopted)
+	}
+	beadList, _ := store.ListByLabel(sessionBeadLabel, 0)
+	if len(beadList) != 1 {
+		t.Fatalf("beads count = %d, want 1", len(beadList))
+	}
+	if beadList[0].Metadata["session_name"] != "test-city-mayor" {
+		t.Fatalf("adopted bead = %q, want live mayor", beadList[0].Metadata["session_name"])
 	}
 }
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -438,14 +438,19 @@ func controlDispatcherOnlyConfig(cfg *config.City) *config.City {
 	if cfg == nil {
 		return nil
 	}
-	// Only include city-scoped control-dispatcher. Rig-scoped instances are
-	// handled by the main reconcile loop which has per-rig stores.
-	agentCfg, ok := resolveAgentIdentity(cfg, config.ControlDispatcherAgentName, "")
-	if !ok {
+	// Include every configured control-dispatcher so standalone mode can
+	// recover rig-scoped dispatcher instances as well as the city one.
+	var agents []config.Agent
+	for _, agentCfg := range cfg.Agents {
+		if agentCfg.Name == config.ControlDispatcherAgentName {
+			agents = append(agents, agentCfg)
+		}
+	}
+	if len(agents) == 0 {
 		return nil
 	}
 	cfgCopy := *cfg
-	cfgCopy.Agents = []config.Agent{agentCfg}
+	cfgCopy.Agents = agents
 	return &cfgCopy
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -55,6 +55,7 @@ type CityRuntime struct {
 	suspendedNames    map[string]bool
 
 	standaloneCityStore beads.Store // non-nil when API disabled; for chat auto-suspend
+	standaloneRigStores map[string]beads.Store
 
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
@@ -223,6 +224,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		} else {
 			cr.standaloneCityStore = store
 		}
+		cr.standaloneRigStores = buildStandaloneRigStores(cr.cfg, cr.cityPath, cr.stderr)
 	}
 
 	// Record bead store health metric.
@@ -607,6 +609,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		} else {
 			cr.standaloneCityStore = s
 		}
+		cr.standaloneRigStores = buildStandaloneRigStores(nextCfg, cr.cityPath, cr.stderr)
 	}
 
 	// Ensure drain tracker is initialized when bead store becomes available.
@@ -850,7 +853,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		filteredCfg,
 		cr.sp,
 		store,
-		nil,
+		cr.rigBeadStores(),
 		sessionBeads,
 		nil,
 		cr.stderr,
@@ -918,6 +921,15 @@ func (cr *CityRuntime) cityBeadStore() beads.Store {
 	return cr.standaloneCityStore
 }
 
+func (cr *CityRuntime) rigBeadStores() map[string]beads.Store {
+	if cr.cs != nil {
+		stores := cr.cs.BeadStores()
+		delete(stores, cr.cityName)
+		return stores
+	}
+	return cr.standaloneRigStores
+}
+
 func (cr *CityRuntime) loadSessionBeadSnapshot() *sessionBeadSnapshot {
 	store := cr.cityBeadStore()
 	if store == nil {
@@ -946,14 +958,30 @@ func filterSessionBeadsByName(snapshot *sessionBeadSnapshot, names map[string]bo
 
 func (cr *CityRuntime) buildDesiredState(sessionBeads *sessionBeadSnapshot, trace *sessionReconcilerTraceCycle) DesiredStateResult {
 	store := cr.cityBeadStore()
-	var rigStores map[string]beads.Store
-	if cr.cs != nil {
-		rigStores = cr.cs.BeadStores()
-	}
+	rigStores := cr.rigBeadStores()
 	if cr.buildFnWithSessionBeads != nil {
 		return cr.buildFnWithSessionBeads(cr.cfg, cr.sp, store, rigStores, sessionBeads, trace)
 	}
 	return cr.buildFn(cr.cfg, cr.sp, store)
+}
+
+func buildStandaloneRigStores(cfg *config.City, cityPath string, stderr io.Writer) map[string]beads.Store {
+	if cfg == nil || len(cfg.Rigs) == 0 {
+		return nil
+	}
+	stores := make(map[string]beads.Store, len(cfg.Rigs))
+	for _, rig := range cfg.Rigs {
+		store, err := openStoreAtForCity(rig.Path, cityPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc supervisor: rig bead store %q: %v\n", rig.Name, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		stores[rig.Name] = store
+	}
+	if len(stores) == 0 {
+		return nil
+	}
+	return stores
 }
 
 func (cr *CityRuntime) beginTraceCycle(trigger, detail string, sessionBeads *sessionBeadSnapshot) *sessionReconcilerTraceCycle {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -266,6 +266,61 @@ func TestCityRuntimeBeadReconcileTick_KeepsAssignedPoolWorkerAwake(t *testing.T)
 	}
 }
 
+func TestControlDispatcherOnlyConfig_IncludesRigScopedDispatchers(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "claude"},
+			{Name: config.ControlDispatcherAgentName},
+			{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		},
+	}
+
+	filtered := controlDispatcherOnlyConfig(cfg)
+	if filtered == nil {
+		t.Fatal("filtered config = nil")
+	}
+	if len(filtered.Agents) != 2 {
+		t.Fatalf("len(filtered.Agents) = %d, want 2", len(filtered.Agents))
+	}
+	if filtered.Agents[0].QualifiedName() != "control-dispatcher" {
+		t.Fatalf("filtered city dispatcher = %q, want control-dispatcher", filtered.Agents[0].QualifiedName())
+	}
+	if filtered.Agents[1].QualifiedName() != "gascity/control-dispatcher" {
+		t.Fatalf("filtered rig dispatcher = %q, want gascity/control-dispatcher", filtered.Agents[1].QualifiedName())
+	}
+}
+
+func TestCityRuntimeBuildDesiredState_StandaloneIncludesRigStores(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	var gotRigStores map[string]beads.Store
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Rigs: []config.Rig{{Name: "gascity"}}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: cityStore,
+		standaloneRigStores: map[string]beads.Store{"gascity": rigStore},
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, store beads.Store, rigStores map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			if store != cityStore {
+				t.Fatalf("store = %v, want city store", store)
+			}
+			gotRigStores = rigStores
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	cr.buildDesiredState(nil, nil)
+
+	if len(gotRigStores) != 1 {
+		t.Fatalf("len(rigStores) = %d, want 1", len(gotRigStores))
+	}
+	if gotRigStores["gascity"] != rigStore {
+		t.Fatalf("rigStores[gascity] = %v, want rig store", gotRigStores["gascity"])
+	}
+}
+
 func TestCityRuntimeReloadProviderSwapPreservesDrainTracker(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -337,6 +337,34 @@ func reconcileSessionBeadsTraced(
 			continue
 		}
 
+		// Drain-ack: agent signaled it's done (gc runtime drain-ack).
+		// Honor the ack even if the agent exited before this tick; otherwise
+		// the session falls through to orphan handling and can block the next
+		// worker wave until the stale awake bead ages out.
+		if dops != nil {
+			if acked, _ := dops.isDrainAcked(name); acked {
+				_ = dops.clearDrain(name)
+				if alive {
+					if err := sp.Stop(name); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: stopping drain-acked %s: %v\n", name, err) //nolint:errcheck
+					} else {
+						fmt.Fprintf(stdout, "Stopped drain-acked session '%s'\n", name) //nolint:errcheck
+					}
+				}
+				rec.Record(events.Event{
+					Type:    events.SessionStopped,
+					Actor:   "gc",
+					Subject: tp.DisplayName(),
+					Message: "drain acknowledged by agent",
+				})
+				if store != nil && session.ID != "" {
+					_ = store.SetMetadata(session.ID, "state", "drained")
+					session.Metadata["state"] = "drained"
+				}
+				continue
+			}
+		}
+
 		policy := resolveSessionSleepPolicy(*session, cfg, sp)
 
 		// Heal advisory state metadata.
@@ -358,32 +386,6 @@ func reconcileSessionBeadsTraced(
 		if alive && shouldRollbackPendingCreate(session) {
 			if err := clearPendingCreateClaim(session, store); err != nil {
 				fmt.Fprintf(stderr, "session reconciler: clearing pending create claim for %s: %v\n", name, err) //nolint:errcheck
-			}
-		}
-
-		// Drain-ack: agent signaled it's done (gc runtime drain-ack).
-		// Stop the session and close its bead. The bead becomes a permanent
-		// historical record of this incarnation. The next work item gets a
-		// brand-new session bead with a fresh session key and clean context.
-		if alive && dops != nil {
-			if acked, _ := dops.isDrainAcked(name); acked {
-				_ = dops.clearDrain(name)
-				if err := sp.Stop(name); err != nil {
-					fmt.Fprintf(stderr, "session reconciler: stopping drain-acked %s: %v\n", name, err) //nolint:errcheck
-				} else {
-					fmt.Fprintf(stdout, "Stopped drain-acked session '%s'\n", name) //nolint:errcheck
-					rec.Record(events.Event{
-						Type:    events.SessionStopped,
-						Actor:   "gc",
-						Subject: tp.DisplayName(),
-						Message: "drain acknowledged by agent",
-					})
-				}
-				if store != nil && session.ID != "" {
-					_ = store.SetMetadata(session.ID, "state", "drained")
-					session.Metadata["state"] = "drained"
-				}
-				continue
 			}
 		}
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -278,6 +278,66 @@ func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_DrainAckHonoredAfterSessionExit(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+	if err := env.sp.Stop("worker"); err != nil {
+		t.Fatalf("Stop(worker): %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if env.sp.IsRunning("worker") {
+		t.Fatal("worker should remain stopped after drain-ack")
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
+	}
+	if got.Metadata["state"] != "drained" {
+		t.Fatalf("state = %q, want drained", got.Metadata["state"])
+	}
+}
+
 // --- buildDepsMap tests ---
 
 func TestBuildDepsMap_NilConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- include rig-scoped dispatcher agents and rig bead stores during standalone reconciliation
- honor drain-ack before orphan handling so completed pool workers drain cleanly
- skip dead sessions in the adoption barrier so stale tmux names are not re-adopted

## Testing
- TMPDIR=/var/tmp GOTMPDIR=/var/tmp/gotmp GOCACHE=/var/tmp/gocache go test ./cmd/gc ./internal/api -count=1