### PR TITLE
perf: add dedicated formulas monitor feed

### DIFF
--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"sort"
@@ -12,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
@@ -145,6 +143,56 @@ func (s *Server) handleFormulaRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleFormulaFeed(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	scopeKind, scopeRef, scopeErr := parseWorkflowRequestScope(q.Get("scope_kind"), q.Get("scope_ref"))
+	if scopeErr != "" {
+		writeError(w, http.StatusBadRequest, "invalid", scopeErr)
+		return
+	}
+	if _, status, code, msg := s.formulaSearchPaths(scopeKind, scopeRef); status != http.StatusOK {
+		writeError(w, status, code, msg)
+		return
+	}
+
+	limit := parseOrdersFeedLimit(q.Get("limit"))
+	index := s.latestIndex()
+	cacheKey := responseCacheKey("formula-feed", r)
+	if body, ok := s.cachedResponse(cacheKey, index); ok {
+		writeCachedJSON(w, r, index, body)
+		return
+	}
+
+	projections, err := buildWorkflowRunProjectionsRootOnly(s.state, scopeKind, scopeRef)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", "formula feed failed")
+		return
+	}
+
+	items := make([]monitorFeedItemResponse, 0, len(projections.Items))
+	for _, run := range projections.Items {
+		items = append(items, workflowRunProjectionFeedItem(run))
+	}
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+
+	resp := map[string]any{
+		"items":   items,
+		"partial": projections.Partial,
+	}
+	if len(projections.PartialErrors) > 0 {
+		resp["partial_errors"] = projections.PartialErrors
+	}
+
+	body, err := s.storeResponse(cacheKey, index, resp)
+	if err != nil {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	writeCachedJSON(w, r, index, body)
 }
 
 func (s *Server) handleFormulaDetail(w http.ResponseWriter, r *http.Request) {
@@ -296,113 +344,28 @@ func normalizeFormulaRunsLimit(limit int) int {
 }
 
 func buildFormulaRuns(state State, formulaName, requestedScopeKind, requestedScopeRef string, limit int) (*formulaRunsResponse, error) {
-	cityScopeRef := workflowCityScopeRef(state.CityName())
-	includeAllForCity := requestedScopeKind == "city" && requestedScopeRef == cityScopeRef
-	stores := workflowStores(state)
-	projections := make([]workflowRunProjection, 0)
-	partialErrors := make([]string, 0)
-	var requestedScopeErr error
-
-	for _, info := range stores {
-		if info.store == nil {
-			continue
-		}
-		if !includeAllForCity && (info.scopeKind != requestedScopeKind || info.scopeRef != requestedScopeRef) {
-			continue
-		}
-
-		openBeads, err := info.store.ListOpen()
-		if err != nil {
-			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
-				requestedScopeErr = err
-			}
-			if includeAllForCity {
-				msg := info.ref + " store unavailable"
-				log.Printf("api: formula runs open list failed for %s: %v", info.ref, err)
-				partialErrors = append(partialErrors, msg)
-			}
-			continue
-		}
-
-		openChildrenByRoot := make(map[string][]beads.Bead)
-		for _, bead := range openBeads {
-			rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
-			if rootID == "" {
-				continue
-			}
-			openChildrenByRoot[rootID] = append(openChildrenByRoot[rootID], bead)
-		}
-
-		roots, err := info.store.ListByMetadata(map[string]string{
-			"gc.kind":             "workflow",
-			"gc.formula_contract": "graph.v2",
-		}, 0, beads.IncludeClosed)
-		if err != nil {
-			log.Printf("api: formula runs workflow root list failed for %s: %v", info.ref, err)
-			partialErrors = append(partialErrors, info.ref+" workflow history incomplete")
-			roots = nil
-			for _, bead := range openBeads {
-				if isWorkflowRoot(bead) && strings.TrimSpace(bead.Metadata["gc.formula_contract"]) == "graph.v2" {
-					roots = append(roots, bead)
-				}
-			}
-		}
-
-		for _, root := range roots {
-			if !isWorkflowRoot(root) || workflowFormulaName(root) != formulaName {
-				continue
-			}
-
-			scopeKind, scopeRef := workflowProjectionScope(info, root, cityScopeRef, requestedScopeKind, requestedScopeRef)
-			if scopeKind != requestedScopeKind || scopeRef != requestedScopeRef {
-				continue
-			}
-
-			runBeads := append([]beads.Bead{root}, openChildrenByRoot[root.ID]...)
-			children, childErr := info.store.ListByMetadata(map[string]string{"gc.root_bead_id": root.ID}, 0, beads.IncludeClosed)
-			if childErr != nil {
-				log.Printf("api: formula runs child list failed for %s root %s: %v", info.ref, root.ID, childErr)
-				partialErrors = append(partialErrors, root.ID+" workflow history incomplete")
-			} else {
-				seen := make(map[string]bool, len(runBeads))
-				for _, existing := range runBeads {
-					seen[existing.ID] = true
-				}
-				for _, child := range children {
-					if seen[child.ID] {
-						continue
-					}
-					runBeads = append(runBeads, child)
-				}
-			}
-
-			projections = append(projections, workflowRunProjection{
-				WorkflowID:     resolvedWorkflowID(root),
-				FormulaName:    workflowFormulaName(root),
-				Title:          workflowProjectionTitle(root),
-				Status:         normalizeMonitorStatus(aggregateWorkflowRunStatus(root, runBeads)),
-				Target:         workflowProjectionTarget(root),
-				StartedAt:      root.CreatedAt,
-				UpdatedAt:      workflowProjectionUpdatedAt(runBeads),
-				ScopeKind:      scopeKind,
-				ScopeRef:       scopeRef,
-				RootBeadID:     root.ID,
-				RootStoreRef:   info.ref,
-				AttachedBeadID: strings.TrimSpace(root.Metadata["gc.source_bead_id"]),
-			})
-		}
+	projectionResult, err := buildWorkflowRunProjectionsRootOnly(state, requestedScopeKind, requestedScopeRef)
+	if err != nil {
+		return nil, fmt.Errorf("listing workflow runs for %s:%s: %w", requestedScopeKind, requestedScopeRef, err)
 	}
 
-	if len(projections) == 0 && requestedScopeErr != nil && !includeAllForCity {
-		return nil, fmt.Errorf("listing open beads for %s:%s: %w", requestedScopeKind, requestedScopeRef, requestedScopeErr)
+	projections := make([]workflowRunProjection, 0, len(projectionResult.Items))
+	for _, projection := range projectionResult.Items {
+		if projection.FormulaName != formulaName {
+			continue
+		}
+		if projection.ScopeKind != requestedScopeKind || projection.ScopeRef != requestedScopeRef {
+			continue
+		}
+		projections = append(projections, projection)
 	}
 
 	return &formulaRunsResponse{
 		Formula:       formulaName,
 		RunCount:      formulaRunCountFor(formulaName, projections),
 		RecentRuns:    formulaRecentRunsFor(formulaName, projections, limit),
-		Partial:       len(partialErrors) > 0,
-		PartialErrors: partialErrors,
+		Partial:       projectionResult.Partial,
+		PartialErrors: projectionResult.PartialErrors,
 	}, nil
 }
 

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -298,6 +298,64 @@ title = "Review PR"
 	}
 }
 
+func TestFormulaFeedReturnsWorkflowRunsOnly(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	store := state.stores["myrig"]
+	if store == nil {
+		t.Fatal("expected rig store")
+	}
+
+	root, err := store.Create(beads.Bead{
+		Title: "Rig workflow run",
+		Ref:   "mol-adopt-pr-v2",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.workflow_id":      "wf-rig-monitor",
+			"gc.run_target":       "myrig/claude",
+			"gc.scope_kind":       "rig",
+			"gc.scope_ref":        "myrig",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create rig workflow root: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(root.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set workflow status: %v", err)
+	}
+
+	if _, err := state.cityBeadStore.Create(beads.Bead{
+		Title:  "order:spawn-storm-detect",
+		Labels: []string{"order-tracking"},
+	}); err != nil {
+		t.Fatalf("create order tracking bead: %v", err)
+	}
+
+	server := New(state)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/feed?scope_kind=city&scope_ref=test-city", nil)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []monitorFeedItemResponse `json:"items"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode(feed): %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items = %+v, want exactly 1 workflow item", resp.Items)
+	}
+	if resp.Items[0].WorkflowID != "wf-rig-monitor" || resp.Items[0].Type != "formula" {
+		t.Fatalf("items[0] = %+v, want rig workflow formula item", resp.Items[0])
+	}
+}
+
 func TestFormulaRunsClampsRequestedLimit(t *testing.T) {
 	state := newFakeState(t)
 	state.cityBeadStore = beads.NewMemStore()
@@ -415,15 +473,81 @@ title = "Review PR"
 	}
 }
 
+func TestFormulaRunsUseFastProjectionWithoutMetadataLookup(t *testing.T) {
+	state := newFakeState(t)
+	baseStore := beads.NewMemStore()
+	state.cityBeadStore = failWorkflowMetadataLookupStore{Store: baseStore}
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-adopt-pr-v2", `
+description = "Review and fix a PR with a retry loop."
+formula = "mol-adopt-pr-v2"
+version = 2
+
+[[steps]]
+id = "review"
+title = "Review PR"
+`)
+
+	root, err := baseStore.Create(beads.Bead{
+		Title: "Open workflow root",
+		Ref:   "mol-adopt-pr-v2",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.workflow_id":      "wf-fast-path",
+			"gc.run_target":       "mayor",
+			"gc.scope_kind":       "city",
+			"gc.scope_ref":        "test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow root: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := baseStore.Update(root.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set workflow status: %v", err)
+	}
+
+	server := New(state)
+	req := httptest.NewRequest(http.MethodGet, "/v0/formulas/mol-adopt-pr-v2/runs?scope_kind=city&scope_ref=test-city", nil)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp formulaRunsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode(runs): %v", err)
+	}
+	if resp.RunCount != 1 || len(resp.RecentRuns) != 1 {
+		t.Fatalf("resp = %+v, want one fast-path run", resp)
+	}
+	if resp.RecentRuns[0].WorkflowID != "wf-fast-path" {
+		t.Fatalf("recent_runs[0] = %+v, want wf-fast-path", resp.RecentRuns[0])
+	}
+}
+
 type failWorkflowRootLookupStore struct {
 	beads.Store
 }
 
-func (s failWorkflowRootLookupStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
-	if filters["gc.kind"] == "workflow" && filters["gc.formula_contract"] == "graph.v2" {
+func (s failWorkflowRootLookupStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Metadata["gc.kind"] == "workflow" && query.Metadata["gc.formula_contract"] == "graph.v2" {
 		return nil, errors.New("workflow root lookup failed")
 	}
-	return s.Store.ListByMetadata(filters, limit, opts...)
+	return s.Store.List(query)
+}
+
+type failWorkflowMetadataLookupStore struct {
+	beads.Store
+}
+
+func (s failWorkflowMetadataLookupStore) ListByMetadata(map[string]string, int, ...beads.QueryOpt) ([]beads.Bead, error) {
+	return nil, errors.New("metadata lookup failed")
 }
 
 func TestFormulaDetailReturnsCompiledPreview(t *testing.T) {

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -84,24 +84,7 @@ func (s *Server) handleOrdersFeed(w http.ResponseWriter, r *http.Request) {
 
 	items := make([]monitorFeedItemResponse, 0, len(workflowRuns.Items)+len(orderRuns))
 	for _, run := range workflowRuns.Items {
-		item := monitorFeedItemResponse{
-			ID:                 run.WorkflowID,
-			Type:               "formula",
-			Status:             run.Status,
-			Title:              run.Title,
-			ScopeKind:          run.ScopeKind,
-			ScopeRef:           run.ScopeRef,
-			Target:             run.Target,
-			StartedAt:          run.StartedAt.Format(time.RFC3339Nano),
-			UpdatedAt:          run.UpdatedAt.Format(time.RFC3339Nano),
-			WorkflowID:         run.WorkflowID,
-			RootBeadID:         run.RootBeadID,
-			RootStoreRef:       run.RootStoreRef,
-			AttachedBeadID:     run.AttachedBeadID,
-			LogicalBeadID:      run.RootBeadID,
-			RunDetailAvailable: true,
-		}
-		items = append(items, item)
+		items = append(items, workflowRunProjectionFeedItem(run))
 	}
 	items = append(items, orderRuns...)
 
@@ -249,17 +232,105 @@ func buildWorkflowRunProjections(state State, requestedScopeKind, requestedScope
 		return workflowRunProjectionResult{}, requestedScopeErr
 	}
 
-	sort.SliceStable(projections, func(i, j int) bool {
-		iRank := monitorStatusRank(projections[i].Status)
-		jRank := monitorStatusRank(projections[j].Status)
-		if iRank != jRank {
-			return iRank < jRank
+	sortWorkflowRunProjections(projections)
+
+	return workflowRunProjectionResult{
+		Items:         projections,
+		Partial:       len(partialErrors) > 0,
+		PartialErrors: partialErrors,
+	}, nil
+}
+
+func buildWorkflowRunProjectionsRootOnly(state State, requestedScopeKind, requestedScopeRef string) (workflowRunProjectionResult, error) {
+	stores := workflowStores(state)
+	projections := make([]workflowRunProjection, 0)
+	partialErrors := make([]string, 0)
+	cityScopeRef := workflowCityScopeRef(state.CityName())
+	includeAllForCity := requestedScopeKind == "city" && requestedScopeRef == cityScopeRef
+	var requestedScopeErr error
+
+	for _, info := range stores {
+		if info.store == nil {
+			continue
 		}
-		if !projections[i].UpdatedAt.Equal(projections[j].UpdatedAt) {
-			return projections[i].UpdatedAt.After(projections[j].UpdatedAt)
+		openBeads, err := listActiveWorkflowProjectionBeads(info.store)
+		if err != nil {
+			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
+				requestedScopeErr = err
+			}
+			if includeAllForCity {
+				msg := info.ref + " store unavailable"
+				log.Printf("api: workflow root projection list failed for %s: %v", info.ref, err)
+				partialErrors = append(partialErrors, msg)
+			}
+			continue
 		}
-		return projections[i].WorkflowID < projections[j].WorkflowID
-	})
+
+		openChildrenByRoot := make(map[string][]beads.Bead)
+		for _, bead := range openBeads {
+			rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+			if rootID == "" {
+				continue
+			}
+			openChildrenByRoot[rootID] = append(openChildrenByRoot[rootID], bead)
+		}
+
+		roots, err := info.store.List(beads.ListQuery{
+			Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			},
+			IncludeClosed: true,
+		})
+		if err != nil {
+			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
+				requestedScopeErr = err
+			}
+			log.Printf("api: workflow root projection closed-root list failed for %s: %v", info.ref, err)
+			roots = nil
+			for _, bead := range openBeads {
+				if isWorkflowRoot(bead) && strings.TrimSpace(bead.Metadata["gc.formula_contract"]) == "graph.v2" {
+					roots = append(roots, bead)
+				}
+			}
+			if includeAllForCity {
+				partialErrors = append(partialErrors, info.ref+" workflow history incomplete")
+			}
+		}
+
+		for _, root := range roots {
+			if !isWorkflowRoot(root) {
+				continue
+			}
+
+			scopeKind, scopeRef := workflowProjectionScope(info, root, cityScopeRef, requestedScopeKind, requestedScopeRef)
+			if !includeAllForCity && (scopeKind != requestedScopeKind || scopeRef != requestedScopeRef) {
+				continue
+			}
+
+			runBeads := append([]beads.Bead{root}, openChildrenByRoot[root.ID]...)
+			projections = append(projections, workflowRunProjection{
+				WorkflowID:     resolvedWorkflowID(root),
+				FormulaName:    workflowFormulaName(root),
+				Title:          workflowProjectionTitle(root),
+				Status:         normalizeMonitorStatus(aggregateWorkflowRunStatus(root, runBeads)),
+				Target:         workflowProjectionTarget(root),
+				StartedAt:      root.CreatedAt,
+				UpdatedAt:      workflowProjectionUpdatedAt(runBeads),
+				ScopeKind:      scopeKind,
+				ScopeRef:       scopeRef,
+				RootBeadID:     root.ID,
+				RootStoreRef:   info.ref,
+				AttachedBeadID: strings.TrimSpace(root.Metadata["gc.source_bead_id"]),
+			})
+		}
+	}
+
+	if len(projections) == 0 && requestedScopeErr != nil && !includeAllForCity {
+		return workflowRunProjectionResult{}, requestedScopeErr
+	}
+
+	sortWorkflowRunProjections(projections)
 
 	return workflowRunProjectionResult{
 		Items:         projections,
@@ -511,6 +582,40 @@ func parseOrdersFeedLimit(raw string) int {
 		return maxOrdersFeedLimit
 	}
 	return limit
+}
+
+func workflowRunProjectionFeedItem(run workflowRunProjection) monitorFeedItemResponse {
+	return monitorFeedItemResponse{
+		ID:                 run.WorkflowID,
+		Type:               "formula",
+		Status:             run.Status,
+		Title:              run.Title,
+		ScopeKind:          run.ScopeKind,
+		ScopeRef:           run.ScopeRef,
+		Target:             run.Target,
+		StartedAt:          run.StartedAt.Format(time.RFC3339Nano),
+		UpdatedAt:          run.UpdatedAt.Format(time.RFC3339Nano),
+		WorkflowID:         run.WorkflowID,
+		RootBeadID:         run.RootBeadID,
+		RootStoreRef:       run.RootStoreRef,
+		AttachedBeadID:     run.AttachedBeadID,
+		LogicalBeadID:      run.RootBeadID,
+		RunDetailAvailable: true,
+	}
+}
+
+func sortWorkflowRunProjections(projections []workflowRunProjection) {
+	sort.SliceStable(projections, func(i, j int) bool {
+		iRank := monitorStatusRank(projections[i].Status)
+		jRank := monitorStatusRank(projections[j].Status)
+		if iRank != jRank {
+			return iRank < jRank
+		}
+		if !projections[i].UpdatedAt.Equal(projections[j].UpdatedAt) {
+			return projections[i].UpdatedAt.After(projections[j].UpdatedAt)
+		}
+		return projections[i].WorkflowID < projections[j].WorkflowID
+	})
 }
 
 func normalizeMonitorStatus(status string) string {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -276,6 +276,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /v0/order/{name}/enable", s.handleOrderEnable)
 	s.mux.HandleFunc("POST /v0/order/{name}/disable", s.handleOrderDisable)
 	s.mux.HandleFunc("GET /v0/formulas", s.handleFormulaList)
+	s.mux.HandleFunc("GET /v0/formulas/feed", s.handleFormulaFeed)
 	s.mux.HandleFunc("GET /v0/formulas/{name}/runs", s.handleFormulaRuns)
 	s.mux.HandleFunc("GET /v0/formulas/{name}", s.handleFormulaDetail)
 	s.mux.HandleFunc("GET /v0/formula/{name}", s.handleFormulaDetail)


### PR DESCRIPTION
## Summary
- add a dedicated /v0/formulas/feed endpoint for formulas monitor views
- build formula monitor rows from workflow roots and open children without loading generic order feeds
- keep formula run summaries on the same fast root-only projection path and add regression coverage

## Testing
- TMPDIR=/var/tmp GOTMPDIR=/var/tmp/gotmp GOCACHE=/var/tmp/gocache go test ./internal/api -run 'TestFormula' -count=1
- TMPDIR=/var/tmp GOTMPDIR=/var/tmp/gotmp GOCACHE=/var/tmp/gocache go test ./internal/api -count=1