### PR TITLE
fix: migrate durable waits off invalid wait bead type

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -787,7 +787,7 @@ func blockedQueuedNudgeReason(store beads.Store, item queuedNudge) (string, bool
 		}
 		return "", false, err
 	}
-	if wait.Type != waitBeadType {
+	if !session.IsWaitBead(wait) {
 		return "wait-reference-invalid", true, nil
 	}
 	switch wait.Metadata["state"] {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -612,6 +612,37 @@ func TestSplitQueuedNudgesForDelivery_BlocksCanceledWaitNudge(t *testing.T) {
 	}
 }
 
+func TestSplitQueuedNudgesForDelivery_AllowsReadyLegacyWaitNudge(t *testing.T) {
+	store := beads.NewMemStore()
+	wait, err := store.Create(beads.Bead{
+		Type:   session.LegacyWaitBeadType,
+		Labels: []string{waitBeadLabel},
+		Metadata: map[string]string{
+			"session_id": "gc-session",
+			"state":      waitStateReady,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create legacy wait bead: %v", err)
+	}
+
+	deliverable, blocked, err := splitQueuedNudgesForDelivery(store, []queuedNudge{{
+		ID:        "n1",
+		Agent:     "worker",
+		Source:    "wait",
+		Reference: &nudgeReference{Kind: "bead", ID: wait.ID},
+	}})
+	if err != nil {
+		t.Fatalf("splitQueuedNudgesForDelivery: %v", err)
+	}
+	if len(deliverable) != 1 || deliverable[0].ID != "n1" {
+		t.Fatalf("deliverable = %#v, want n1", deliverable)
+	}
+	if len(blocked) != 0 {
+		t.Fatalf("blocked = %#v, want empty", blocked)
+	}
+}
+
 func TestWithNudgeTargetFence_FillsSessionMetadata(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionBead, err := store.Create(beads.Bead{

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -295,7 +295,7 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc wait inspect: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	if b.Type != waitBeadType {
+	if !sessionpkg.IsWaitBead(b) {
 		fmt.Fprintf(stderr, "gc wait inspect: %s is not a wait\n", waitID) //nolint:errcheck
 		return 1
 	}
@@ -321,7 +321,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	if b.Type != waitBeadType {
+	if !sessionpkg.IsWaitBead(b) {
 		fmt.Fprintf(stderr, "gc wait: %s is not a wait\n", waitID) //nolint:errcheck
 		return 1
 	}
@@ -414,7 +414,7 @@ func loadWaitBeadsByLabel(store beads.Store, label string) ([]beads.Bead, error)
 		if item.Status == "closed" {
 			continue
 		}
-		if item.Type != waitBeadType {
+		if !sessionpkg.IsWaitBead(item) {
 			continue
 		}
 		result = append(result, item)

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 type waitErrorStore struct {
@@ -349,6 +350,9 @@ func TestRetryClosedWait_CreatesReplacement(t *testing.T) {
 	if retried.ID == wait.ID {
 		t.Fatal("retryClosedWait reused original wait ID")
 	}
+	if retried.Type != waitBeadType {
+		t.Fatalf("retried type = %q, want %q", retried.Type, waitBeadType)
+	}
 	if retried.Metadata["state"] != waitStateReady {
 		t.Fatalf("retried state = %q, want %q", retried.Metadata["state"], waitStateReady)
 	}
@@ -668,6 +672,32 @@ func TestCancelWaitsForSession(t *testing.T) {
 	}
 	if updated.Status != "closed" {
 		t.Fatalf("wait status = %q, want closed", updated.Status)
+	}
+}
+
+func TestLoadSessionWaitBeads_IncludesLegacyWaitType(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionID := "gc-session"
+	if _, err := store.Create(beads.Bead{
+		Type:   sessionpkg.LegacyWaitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionID},
+		Metadata: map[string]string{
+			"session_id": sessionID,
+			"state":      waitStatePending,
+		},
+	}); err != nil {
+		t.Fatalf("create legacy wait bead: %v", err)
+	}
+
+	waits, err := loadSessionWaitBeads(store, sessionID)
+	if err != nil {
+		t.Fatalf("loadSessionWaitBeads: %v", err)
+	}
+	if len(waits) != 1 {
+		t.Fatalf("loadSessionWaitBeads returned %d waits, want 1", len(waits))
+	}
+	if waits[0].Type != sessionpkg.LegacyWaitBeadType {
+		t.Fatalf("wait type = %q, want legacy %q", waits[0].Type, sessionpkg.LegacyWaitBeadType)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -143,14 +143,14 @@ type waitFailStore struct {
 }
 
 func (s waitFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if query.Label == WaitBeadLabel {
+	if query.Label == WaitBeadLabel || strings.HasPrefix(query.Label, "session:") {
 		return nil, errors.New("wait list failed")
 	}
 	return s.MemStore.List(query)
 }
 
 func (s waitFailStore) ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
-	if label == WaitBeadLabel {
+	if label == WaitBeadLabel || strings.HasPrefix(label, "session:") {
 		return nil, errors.New("wait list failed")
 	}
 	return s.MemStore.ListByLabel(label, limit, opts...)

--- a/internal/session/waits.go
+++ b/internal/session/waits.go
@@ -8,7 +8,10 @@ import (
 
 const (
 	// WaitBeadType identifies durable wait beads associated with sessions.
-	WaitBeadType = "wait"
+	WaitBeadType = "gate"
+	// LegacyWaitBeadType is the historical durable wait bead type kept for
+	// backward-compatible reads against older stores.
+	LegacyWaitBeadType = "wait"
 	// WaitBeadLabel is the common label used to locate session wait beads.
 	WaitBeadLabel = "gc:wait"
 
@@ -28,6 +31,30 @@ func IsWaitTerminalState(state string) bool {
 	}
 }
 
+// IsWaitBeadType reports whether the bead type is recognized as a durable
+// session wait.
+func IsWaitBeadType(typ string) bool {
+	switch typ {
+	case WaitBeadType, LegacyWaitBeadType:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsWaitBead reports whether a bead is a durable session wait. New waits are
+// stored as gate beads, while legacy stores may still contain type "wait".
+func IsWaitBead(b beads.Bead) bool {
+	if !IsWaitBeadType(b.Type) {
+		return false
+	}
+	if beadHasLabel(b, WaitBeadLabel) {
+		return true
+	}
+	sessionID := b.Metadata["session_id"]
+	return sessionID != "" && beadHasLabel(b, "session:"+sessionID)
+}
+
 // WaitNudgeIDs returns queued nudge IDs for the session's currently open waits.
 func WaitNudgeIDs(store beads.Store, sessionID string) ([]string, error) {
 	if store == nil || sessionID == "" {
@@ -35,7 +62,6 @@ func WaitNudgeIDs(store beads.Store, sessionID string) ([]string, error) {
 	}
 	waits, err := store.List(beads.ListQuery{
 		Label: "session:" + sessionID,
-		Type:  WaitBeadType,
 	})
 	if err != nil {
 		return nil, err
@@ -46,7 +72,7 @@ func WaitNudgeIDs(store beads.Store, sessionID string) ([]string, error) {
 		if wait.Status == "closed" {
 			continue
 		}
-		if wait.Type != WaitBeadType {
+		if !IsWaitBead(wait) {
 			continue
 		}
 		if wait.Metadata["session_id"] != sessionID {
@@ -99,7 +125,6 @@ func CancelWaits(store beads.Store, sessionID string, now time.Time) error {
 	}
 	waits, err := store.List(beads.ListQuery{
 		Label: "session:" + sessionID,
-		Type:  WaitBeadType,
 	})
 	if err != nil {
 		return err
@@ -109,7 +134,7 @@ func CancelWaits(store beads.Store, sessionID string, now time.Time) error {
 		if wait.Status == "closed" {
 			continue
 		}
-		if wait.Type != WaitBeadType {
+		if !IsWaitBead(wait) {
 			continue
 		}
 		if wait.Metadata["session_id"] != sessionID {
@@ -129,4 +154,13 @@ func CancelWaits(store beads.Store, sessionID string, now time.Time) error {
 		}
 	}
 	return nil
+}
+
+func beadHasLabel(b beads.Bead, want string) bool {
+	for _, label := range b.Labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/session/waits_test.go
+++ b/internal/session/waits_test.go
@@ -1,0 +1,72 @@
+package session
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+type rejectLegacyWaitTypeQueryStore struct {
+	*beads.MemStore
+}
+
+func (s rejectLegacyWaitTypeQueryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Type == LegacyWaitBeadType {
+		return nil, errors.New("legacy wait type query should not be used")
+	}
+	return s.MemStore.List(query)
+}
+
+func TestWaitNudgeIDs_AcceptsLegacyWaitBeadsWithoutLegacyTypeQuery(t *testing.T) {
+	store := rejectLegacyWaitTypeQueryStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Type:   LegacyWaitBeadType,
+		Labels: []string{WaitBeadLabel, "session:gc-session"},
+		Metadata: map[string]string{
+			"session_id": "gc-session",
+			"state":      "pending",
+			"nudge_id":   "wait-nudge",
+		},
+	}); err != nil {
+		t.Fatalf("create legacy wait: %v", err)
+	}
+
+	got, err := WaitNudgeIDs(store, "gc-session")
+	if err != nil {
+		t.Fatalf("WaitNudgeIDs: %v", err)
+	}
+	if len(got) != 1 || got[0] != "wait-nudge" {
+		t.Fatalf("WaitNudgeIDs = %#v, want [wait-nudge]", got)
+	}
+}
+
+func TestCancelWaits_CancelsLegacyWaitBeadsWithoutLegacyTypeQuery(t *testing.T) {
+	store := rejectLegacyWaitTypeQueryStore{MemStore: beads.NewMemStore()}
+	wait, err := store.Create(beads.Bead{
+		Type:   LegacyWaitBeadType,
+		Labels: []string{WaitBeadLabel, "session:gc-session"},
+		Metadata: map[string]string{
+			"session_id": "gc-session",
+			"state":      "pending",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create legacy wait: %v", err)
+	}
+
+	if err := CancelWaits(store, "gc-session", time.Now().UTC()); err != nil {
+		t.Fatalf("CancelWaits: %v", err)
+	}
+	updated, err := store.Get(wait.ID)
+	if err != nil {
+		t.Fatalf("Get(wait): %v", err)
+	}
+	if updated.Metadata["state"] != waitStateCanceled {
+		t.Fatalf("state = %q, want %q", updated.Metadata["state"], waitStateCanceled)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed", updated.Status)
+	}
+}


### PR DESCRIPTION
Fix the session wait subsystem to create supported `gate` beads while keeping wake/wait/nudge compatibility with legacy `wait`-typed beads. Adds regression coverage for the live wake path and legacy-bead reads.