### PR TITLE
feat: LLM Wiki pack 

### DIFF
--- a/cmd/gc/testdata/llm-wiki-init.txtar
+++ b/cmd/gc/testdata/llm-wiki-init.txtar
@@ -1,0 +1,104 @@
+# LLM Wiki init script — validates wiki-init.sh creates correct
+# directory structure and is idempotent.
+
+# --- 1. wiki-init.sh creates the directory structure ---
+
+exec bash $WORK/wiki-init.sh $WORK/testwiki
+stdout 'Wiki initialized at'
+
+exists $WORK/testwiki/index.md
+exists $WORK/testwiki/log.md
+exists $WORK/testwiki/schema.md
+exists $WORK/testwiki/pages
+
+# --- 2. index.md has the expected header ---
+
+exec grep 'Wiki Index' $WORK/testwiki/index.md
+
+# --- 3. log.md has the expected header ---
+
+exec grep 'Wiki Activity Log' $WORK/testwiki/log.md
+
+# --- 4. schema.md has the expected placeholder ---
+
+exec grep 'Wiki Schema' $WORK/testwiki/schema.md
+exec grep 'consumer pack' $WORK/testwiki/schema.md
+
+# --- 5. Idempotent: running again skips ---
+
+exec bash $WORK/wiki-init.sh $WORK/testwiki
+stdout 'already exists'
+
+# --- 6. Default path (wiki) works ---
+
+cd $WORK/defaultdir
+exec bash $WORK/wiki-init.sh
+stdout 'Wiki initialized at wiki'
+exists $WORK/defaultdir/wiki/index.md
+exists $WORK/defaultdir/wiki/log.md
+exists $WORK/defaultdir/wiki/schema.md
+exists $WORK/defaultdir/wiki/pages
+
+# --- 7. Existing content is not clobbered on idempotent run ---
+
+exec bash $WORK/wiki-init.sh $WORK/defaultdir/wiki
+stdout 'already exists'
+
+-- defaultdir/.keep --
+-- wiki-init.sh --
+#!/usr/bin/env bash
+# wiki-init.sh — Create the wiki directory structure with starter files.
+#
+# Usage: wiki-init.sh [wiki_root]
+#   wiki_root defaults to "wiki" in the current directory.
+
+set -euo pipefail
+
+WIKI_ROOT="${1:-wiki}"
+
+if [ -d "$WIKI_ROOT" ]; then
+  echo "Wiki directory already exists at $WIKI_ROOT — skipping."
+  exit 0
+fi
+
+mkdir -p "$WIKI_ROOT/pages"
+
+cat > "$WIKI_ROOT/index.md" <<'IEOF'
+# Wiki Index
+
+Master catalog of all wiki pages. Maintained by the archivist.
+
+<!-- Add pages below as: - [Page Title](pages/path/to/page.md) — One-line summary -->
+IEOF
+
+cat > "$WIKI_ROOT/log.md" <<'LEOF'
+# Wiki Activity Log
+
+Chronological record of all wiki changes. Append-only.
+
+<!-- Format: YYYY-MM-DDTHH:MM:SS | Action | Source | Affected Pages -->
+LEOF
+
+cat > "$WIKI_ROOT/schema.md" <<'SEOF'
+# Wiki Schema
+
+This file defines how wiki pages are organized. It is provided by
+the consumer pack and should not be modified by the archivist.
+
+## Default Schema
+
+Until a domain-specific schema is provided, use a flat structure:
+
+```
+pages/
+└── <entity-name>.md
+```
+
+Replace this file with a domain-specific schema that defines:
+- Page categories and directory structure
+- Naming conventions for pages
+- Required sections within each page type
+- Cross-reference conventions
+SEOF
+
+echo "Wiki initialized at $WIKI_ROOT"

--- a/cmd/gc/testdata/llm-wiki-pack.txtar
+++ b/cmd/gc/testdata/llm-wiki-pack.txtar
@@ -1,0 +1,377 @@
+# LLM Wiki pack — validates pack loading, agent listing, formula
+# discovery, order registration, and prompt rendering.
+#
+# Tests: pack.toml parsing, archivist agent, wiki formulas,
+# wiki-lint dog order, shared template fragment, pack composition.
+
+env GC_BEADS=file
+env GC_DOLT=skip
+env GC_SESSION=fake
+
+cd $WORK/wikicity
+
+# --- 1. Config validates ---
+
+exec gc config show --validate
+stdout 'Config valid.'
+
+# --- 2. Archivist agent is visible (city-scoped) ---
+
+exec gc config show
+stdout 'archivist'
+
+# --- 3. Archivist properties are correct ---
+
+exec gc config show
+stdout 'scope = "city"'
+stdout 'idle_timeout = "1h"'
+
+# --- 4. Without rigs, archivist still appears (city-scoped) ---
+
+exec gc config show
+stdout 'archivist'
+
+# --- 5. Formula list shows all three wiki formulas ---
+
+exec gc formula list
+stdout 'mol-wiki-ingest'
+stdout 'mol-wiki-lint'
+stdout 'mol-wiki-query'
+
+# --- 6. Formula show mol-wiki-ingest displays vars and steps ---
+
+exec gc formula show mol-wiki-ingest
+stdout 'source_bead'
+stdout 'wiki_root'
+stdout 'read-source'
+stdout 'search-wiki'
+stdout 'integrate'
+stdout 'update-index'
+stdout 'log'
+
+# --- 7. Formula show mol-wiki-query displays vars and steps ---
+
+exec gc formula show mol-wiki-query
+stdout 'query_bead'
+stdout 'parse-question'
+stdout 'synthesize'
+stdout 'file-answer'
+
+# --- 8. Formula show mol-wiki-lint displays steps ---
+
+exec gc formula show mol-wiki-lint
+stdout 'scan-index'
+stdout 'check-links'
+stdout 'find-contradictions'
+stdout 'find-gaps'
+stdout 'report'
+
+# --- 9. Order list shows wiki-lint order ---
+
+exec gc order list
+stdout 'wiki-lint'
+
+# --- 10. Order show wiki-lint displays details ---
+
+exec gc order show wiki-lint
+stdout 'wiki-lint'
+stdout 'mol-wiki-lint'
+stdout 'cooldown'
+stdout '4h'
+
+# --- 11. Start launches archivist ---
+
+exec gc start $WORK/wikicity
+stdout 'City started.'
+
+exec gc stop $WORK/wikicity
+stdout 'City stopped.'
+
+# --- 12. Composes with another pack (helper provides dog for orders) ---
+
+cd $WORK/wiki-composed
+
+exec gc config show --validate
+stdout 'Config valid.'
+
+exec gc config show
+stdout 'archivist'
+stdout 'dog'
+
+exec gc formula list
+stdout 'mol-wiki-ingest'
+stdout 'mol-wiki-lint'
+stdout 'mol-wiki-query'
+
+exec gc order list
+stdout 'wiki-lint'
+
+# --- Fixture files: standalone wiki city ---
+
+-- wikicity/.gc/.keep --
+-- wikicity/rigs/.keep --
+-- wikicity/city.toml --
+[workspace]
+name = "wikicity"
+provider = "claude"
+includes = ["packs/llm-wiki"]
+
+[daemon]
+patrol_interval = "30s"
+
+-- wikicity/packs/llm-wiki/pack.toml --
+[pack]
+name = "llm-wiki"
+schema = 1
+
+[formulas]
+dir = "formulas"
+
+[[agent]]
+name = "archivist"
+scope = "city"
+wake_mode = "fresh"
+work_dir = ".gc/agents/archivist"
+prompt_template = "prompts/archivist.md.tmpl"
+nudge = "Check your hook for ingest or query requests."
+idle_timeout = "1h"
+start_command = "echo hello"
+
+-- wikicity/packs/llm-wiki/prompts/archivist.md.tmpl --
+# Archivist Context
+
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
+
+You are the **Archivist** — the single writer to the wiki knowledge base.
+
+{{ template "wiki-conventions" . }}
+
+Work directory: {{ .WorkDir }}
+City root: {{ .CityRoot }}
+
+-- wikicity/packs/llm-wiki/prompts/shared/wiki-conventions.md.tmpl --
+{{ define "wiki-conventions" }}
+## Wiki Directory Layout
+
+The wiki is a structured markdown knowledge base at `{{ .CityRoot }}/wiki/`.
+
+| File | Purpose | Who writes |
+|------|---------|------------|
+| `index.md` | Master catalog | Archivist |
+| `log.md` | Activity log | Archivist |
+| `schema.md` | Domain organization | Consumer pack |
+| `pages/` | Wiki content | Archivist |
+{{ end }}
+
+-- wikicity/packs/llm-wiki/formulas/mol-wiki-ingest.formula.toml --
+description = "Process raw findings into the wiki knowledge base."
+formula = "mol-wiki-ingest"
+version = 1
+
+[vars]
+[vars.source_bead]
+description = "Bead ID containing the raw findings to ingest"
+required = true
+
+[vars.wiki_root]
+description = "Path to the wiki directory"
+default = "wiki"
+
+[[steps]]
+id = "read-source"
+title = "Read the source bead and extract findings"
+
+[[steps]]
+id = "search-wiki"
+title = "Search the wiki for existing related pages"
+needs = ["read-source"]
+
+[[steps]]
+id = "integrate"
+title = "Create or update wiki pages with the new findings"
+needs = ["search-wiki"]
+
+[[steps]]
+id = "update-index"
+title = "Update the master index with any new pages"
+needs = ["integrate"]
+
+[[steps]]
+id = "log"
+title = "Append an entry to the wiki activity log"
+needs = ["update-index"]
+
+-- wikicity/packs/llm-wiki/formulas/mol-wiki-lint.formula.toml --
+description = "Health check the wiki for structural and content issues."
+formula = "mol-wiki-lint"
+version = 1
+
+[vars]
+[vars.wiki_root]
+description = "Path to the wiki directory"
+default = "wiki"
+
+[[steps]]
+id = "scan-index"
+title = "Scan the index and page tree for orphans"
+
+[[steps]]
+id = "check-links"
+title = "Verify all cross-reference links between pages"
+needs = ["scan-index"]
+
+[[steps]]
+id = "find-contradictions"
+title = "Find unresolved contradictions and uncertain claims"
+needs = ["check-links"]
+
+[[steps]]
+id = "find-gaps"
+title = "Identify knowledge gaps and missing pages"
+needs = ["find-contradictions"]
+
+[[steps]]
+id = "report"
+title = "File beads for issues found and write a summary"
+needs = ["find-gaps"]
+
+-- wikicity/packs/llm-wiki/formulas/mol-wiki-query.formula.toml --
+description = "Synthesize an answer to a question using the wiki knowledge base."
+formula = "mol-wiki-query"
+version = 1
+
+[vars]
+[vars.query_bead]
+description = "Bead ID containing the question to answer"
+required = true
+
+[vars.wiki_root]
+description = "Path to the wiki directory"
+default = "wiki"
+
+[[steps]]
+id = "parse-question"
+title = "Read the query bead and understand the question"
+
+[[steps]]
+id = "search-wiki"
+title = "Search the wiki for relevant pages"
+needs = ["parse-question"]
+
+[[steps]]
+id = "read-pages"
+title = "Read the relevant wiki pages"
+needs = ["search-wiki"]
+
+[[steps]]
+id = "synthesize"
+title = "Synthesize an answer with citations"
+needs = ["read-pages"]
+
+[[steps]]
+id = "file-answer"
+title = "File the answer and optionally ingest back into the wiki"
+needs = ["synthesize"]
+
+-- wikicity/packs/llm-wiki/formulas/orders/wiki-lint/order.toml --
+[order]
+description = "Periodic wiki lint — scan for structural and content issues"
+gate = "cooldown"
+interval = "4h"
+formula = "mol-wiki-lint"
+pool = "dog"
+
+# --- Fixture files: composed wiki + helper city ---
+
+-- wiki-composed/.gc/.keep --
+-- wiki-composed/rigs/.keep --
+-- wiki-composed/city.toml --
+[workspace]
+name = "wiki-composed"
+provider = "claude"
+includes = ["packs/llm-wiki", "packs/helper"]
+
+[daemon]
+patrol_interval = "30s"
+
+-- wiki-composed/packs/llm-wiki/pack.toml --
+[pack]
+name = "llm-wiki"
+schema = 1
+
+[formulas]
+dir = "formulas"
+
+[[agent]]
+name = "archivist"
+scope = "city"
+wake_mode = "fresh"
+work_dir = ".gc/agents/archivist"
+prompt_template = "prompts/archivist.md.tmpl"
+nudge = "Check your hook for ingest or query requests."
+idle_timeout = "1h"
+start_command = "echo hello"
+
+-- wiki-composed/packs/llm-wiki/prompts/archivist.md.tmpl --
+# Archivist Context
+{{ template "wiki-conventions" . }}
+
+-- wiki-composed/packs/llm-wiki/prompts/shared/wiki-conventions.md.tmpl --
+{{ define "wiki-conventions" }}
+## Wiki Layout
+The wiki lives at `{{ .CityRoot }}/wiki/`.
+{{ end }}
+
+-- wiki-composed/packs/llm-wiki/formulas/mol-wiki-ingest.formula.toml --
+description = "Process findings into wiki."
+formula = "mol-wiki-ingest"
+version = 1
+
+[vars.source_bead]
+required = true
+
+[[steps]]
+id = "read-source"
+title = "Read source"
+
+-- wiki-composed/packs/llm-wiki/formulas/mol-wiki-lint.formula.toml --
+description = "Wiki health check."
+formula = "mol-wiki-lint"
+version = 1
+
+[[steps]]
+id = "scan-index"
+title = "Scan index"
+
+-- wiki-composed/packs/llm-wiki/formulas/mol-wiki-query.formula.toml --
+description = "Answer from wiki."
+formula = "mol-wiki-query"
+version = 1
+
+[vars.query_bead]
+required = true
+
+[[steps]]
+id = "parse-question"
+title = "Parse question"
+
+-- wiki-composed/packs/llm-wiki/formulas/orders/wiki-lint/order.toml --
+[order]
+description = "Periodic wiki lint"
+gate = "cooldown"
+interval = "4h"
+formula = "mol-wiki-lint"
+pool = "dog"
+
+-- wiki-composed/packs/helper/pack.toml --
+[pack]
+name = "helper"
+schema = 1
+
+[[agent]]
+name = "dog"
+scope = "city"
+start_command = "echo hello"
+min_active_sessions = 0
+max_active_sessions = 3
+scale_check = "echo 0"

--- a/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-ingest.formula.toml
+++ b/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-ingest.formula.toml
@@ -1,0 +1,119 @@
+description = """
+Process raw findings into the wiki knowledge base.
+
+A source bead containing raw findings (in notes or description) is
+integrated into the wiki: existing pages are updated, new pages are
+created, cross-references are wired, and contradictions are flagged.
+
+The archivist is the single writer. This formula is poured onto the
+archivist when another agent files findings for wiki integration.
+
+## Flow
+
+1. Read the source bead
+2. Search the wiki for related existing pages
+3. Create or update entity pages, add cross-references
+4. Update wiki/index.md with any new pages
+5. Append to wiki/log.md
+"""
+formula = "mol-wiki-ingest"
+version = 1
+
+[vars]
+[vars.source_bead]
+description = "Bead ID containing the raw findings to ingest"
+required = true
+
+[vars.wiki_root]
+description = "Path to the wiki directory"
+default = "wiki"
+
+[[steps]]
+id = "read-source"
+title = "Read the source bead and extract findings"
+description = """
+Load the source bead and understand what it contains.
+
+```bash
+bd show {{source_bead}}
+```
+
+Read the bead's notes and description. Identify:
+- What entities or concepts are described
+- What claims are being made
+- What evidence or citations are provided
+- Whether this updates existing knowledge or introduces new topics
+
+**Exit criteria:** You have a clear list of facts to integrate and know
+which wiki pages they relate to.
+"""
+
+[[steps]]
+id = "search-wiki"
+title = "Search the wiki for existing related pages"
+needs = ["read-source"]
+description = """
+Before creating or updating anything, understand the current wiki state.
+
+1. Read `{{wiki_root}}/index.md` to see what pages exist
+2. Read `{{wiki_root}}/schema.md` to understand the organization scheme
+3. Search `{{wiki_root}}/pages/` for pages related to the findings
+4. Note any existing claims that may conflict with the new findings
+
+**Exit criteria:** You know which pages to update, which to create, and
+whether any contradictions exist.
+"""
+
+[[steps]]
+id = "integrate"
+title = "Create or update wiki pages with the new findings"
+needs = ["search-wiki"]
+description = """
+Write the findings into the wiki. Follow these rules:
+
+- **One entity per page.** Split if a topic is too broad.
+- **Cite the source.** Reference {{source_bead}} for every new claim.
+- **Flag contradictions.** If a new finding conflicts with an existing
+  claim, mark both with `[CONTRADICTION]` and note the conflicting
+  sources. Do NOT silently overwrite.
+- **Add cross-references.** Link to related pages using relative markdown
+  links. If a referenced page does not exist, note the gap.
+- **Follow the schema.** Place pages in the directory structure defined
+  by `{{wiki_root}}/schema.md`.
+
+**Exit criteria:** All findings are integrated into wiki pages.
+"""
+
+[[steps]]
+id = "update-index"
+title = "Update the master index with any new pages"
+needs = ["integrate"]
+description = """
+Update `{{wiki_root}}/index.md` to reflect any new pages created.
+
+Each entry should have:
+- Page path (relative to wiki root)
+- One-line summary of what the page covers
+
+Keep the index sorted according to the schema categories.
+
+**Exit criteria:** Every page in `{{wiki_root}}/pages/` has a
+corresponding entry in `{{wiki_root}}/index.md`.
+"""
+
+[[steps]]
+id = "log"
+title = "Append an entry to the wiki activity log"
+needs = ["update-index"]
+description = """
+Append an entry to `{{wiki_root}}/log.md` with:
+
+- Timestamp (ISO 8601)
+- Source: `{{source_bead}}`
+- Action summary: what was created, updated, or flagged
+- Affected pages (list of paths)
+
+The log is append-only. Never edit or remove previous entries.
+
+**Exit criteria:** Log entry written. Ingest complete.
+"""

--- a/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-lint.formula.toml
+++ b/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-lint.formula.toml
@@ -1,0 +1,108 @@
+description = """
+Health check the wiki for structural and content issues.
+
+Scans the wiki for orphan pages, broken links, contradictions, gaps,
+and stale claims. Files beads for each issue found so they can be
+tracked and resolved.
+
+Can be run as a periodic order or on-demand by nudging the archivist.
+
+## Checks
+
+1. Scan index for completeness
+2. Verify all cross-reference links resolve
+3. Find contradiction markers and unresolved conflicts
+4. Identify gaps where cross-references point to missing pages
+5. Report findings as beads
+"""
+formula = "mol-wiki-lint"
+version = 1
+
+[vars]
+[vars.wiki_root]
+description = "Path to the wiki directory"
+default = "wiki"
+
+[[steps]]
+id = "scan-index"
+title = "Scan the index and page tree for orphans"
+description = """
+Compare `{{wiki_root}}/index.md` against the actual files in
+`{{wiki_root}}/pages/`.
+
+Find:
+- **Orphan pages:** files in `pages/` not listed in `index.md`
+- **Phantom entries:** index entries pointing to pages that don't exist
+- **Schema violations:** pages in directories not defined by `schema.md`
+
+Record findings for the report step.
+
+**Exit criteria:** Complete list of index/filesystem mismatches.
+"""
+
+[[steps]]
+id = "check-links"
+title = "Verify all cross-reference links between pages"
+needs = ["scan-index"]
+description = """
+Scan every markdown file in `{{wiki_root}}/pages/` for internal links.
+
+For each link:
+- Does the target file exist?
+- Is it a reciprocal link (target links back)?
+- Is it listed in the index?
+
+Record broken links and one-way references.
+
+**Exit criteria:** Complete list of link issues.
+"""
+
+[[steps]]
+id = "find-contradictions"
+title = "Find unresolved contradictions and uncertain claims"
+needs = ["check-links"]
+description = """
+Search all wiki pages for:
+- `[CONTRADICTION]` markers — unresolved conflicting claims
+- `[UNCERTAIN]` markers — low-confidence claims that may need verification
+- Claims from different sources that make incompatible assertions
+
+For contradictions, note both sides and their sources.
+
+**Exit criteria:** List of all contradictions and uncertain claims.
+"""
+
+[[steps]]
+id = "find-gaps"
+title = "Identify knowledge gaps and missing pages"
+needs = ["find-contradictions"]
+description = """
+Look for gaps in wiki coverage:
+- Cross-references to pages that should exist but don't
+- Schema categories with no pages
+- Topics mentioned repeatedly across pages without their own page
+- Areas where the schema suggests coverage but none exists
+
+**Exit criteria:** List of knowledge gaps with priority estimates.
+"""
+
+[[steps]]
+id = "report"
+title = "File beads for issues found and write a summary"
+needs = ["find-gaps"]
+description = """
+For each issue found (orphans, broken links, contradictions, gaps):
+
+1. File a bead with:
+   - Clear title describing the issue
+   - Category label (e.g., `wiki-orphan`, `wiki-broken-link`,
+     `wiki-contradiction`, `wiki-gap`)
+   - Details in the description
+
+2. Write a summary to `{{wiki_root}}/log.md`:
+   - Timestamp
+   - Lint run summary: counts by category
+   - Bead IDs filed
+
+**Exit criteria:** All issues filed as beads, summary logged.
+"""

--- a/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-lint.formula.toml
+++ b/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-lint.formula.toml
@@ -97,6 +97,7 @@ For each issue found (orphans, broken links, contradictions, gaps):
    - Clear title describing the issue
    - Category label (e.g., `wiki-orphan`, `wiki-broken-link`,
      `wiki-contradiction`, `wiki-gap`)
+   - Label `pool:archivist` so the archivist picks it up to fix
    - Details in the description
 
 2. Write a summary to `{{wiki_root}}/log.md`:

--- a/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-query.formula.toml
+++ b/examples/llm-wiki/packs/llm-wiki/formulas/mol-wiki-query.formula.toml
@@ -1,0 +1,147 @@
+description = """
+Synthesize an answer to a question using the wiki knowledge base.
+
+Receives a query bead, searches the wiki for relevant pages, reads
+and synthesizes an answer with citations, and files the answer back
+to the requester. Good answers that fill knowledge gaps are also
+ingested back into the wiki as new pages.
+
+## Flow
+
+1. Parse the question from the query bead
+2. Search the wiki for relevant pages
+3. Read relevant pages
+4. Synthesize an answer with page citations
+5. File the answer and optionally ingest it back into the wiki
+"""
+formula = "mol-wiki-query"
+version = 1
+
+[vars]
+[vars.query_bead]
+description = "Bead ID containing the question to answer"
+required = true
+
+[vars.wiki_root]
+description = "Path to the wiki directory"
+default = "wiki"
+
+[[steps]]
+id = "parse-question"
+title = "Read the query bead and understand the question"
+description = """
+Load the query bead and extract the question.
+
+```bash
+bd show {{query_bead}}
+```
+
+Identify:
+- The core question being asked
+- Any constraints or context provided
+- Who is asking (for reply routing)
+- Whether this is a factual lookup or requires synthesis across pages
+
+**Exit criteria:** Clear understanding of what is being asked and who
+to reply to.
+"""
+
+[[steps]]
+id = "search-wiki"
+title = "Search the wiki for relevant pages"
+needs = ["parse-question"]
+description = """
+Find pages that are relevant to the question.
+
+1. Check `{{wiki_root}}/index.md` for pages matching key terms
+2. Search `{{wiki_root}}/pages/` for content matches
+3. Follow cross-references from initially matched pages
+4. Check `{{wiki_root}}/schema.md` for category hints
+
+Build a ranked list of relevant pages, most relevant first.
+
+**Exit criteria:** Ranked list of wiki pages to read.
+"""
+
+[[steps]]
+id = "read-pages"
+title = "Read the relevant wiki pages"
+needs = ["search-wiki"]
+description = """
+Read each relevant page identified in the search step.
+
+For each page, note:
+- Key claims relevant to the question
+- Source citations within the page
+- Confidence level (any `[UNCERTAIN]` or `[CONTRADICTION]` markers)
+- Cross-references that might lead to additional useful pages
+
+If cross-references reveal important pages not in the initial list,
+read those too.
+
+**Exit criteria:** All relevant information gathered from the wiki.
+"""
+
+[[steps]]
+id = "synthesize"
+title = "Synthesize an answer with citations"
+needs = ["read-pages"]
+description = """
+Compose an answer to the question.
+
+Structure:
+```markdown
+## Answer
+
+<synthesized answer>
+
+## Sources
+
+- [page-name](path/to/page.md): <what this page contributed>
+- ...
+
+## Confidence
+
+<assessment: high/medium/low with explanation>
+
+## Gaps
+
+<any areas where the wiki lacks information to fully answer>
+```
+
+Rules:
+- Cite specific wiki pages for every claim
+- Note confidence level based on source quality
+- Flag any contradictions found across sources
+- Identify gaps where the wiki cannot fully answer
+
+**Exit criteria:** Complete answer with citations ready to file.
+"""
+
+[[steps]]
+id = "file-answer"
+title = "File the answer and optionally ingest back into the wiki"
+needs = ["synthesize"]
+description = """
+1. **Reply to the requester.**
+   Update the query bead ({{query_bead}}) with the answer in notes:
+   ```bash
+   bd update {{query_bead}} --notes "$(cat answer.md)" --status=closed
+   ```
+   If the requester is a specific agent, also send mail:
+   ```bash
+   gc mail send <requester> -s "Answer: <topic>" -m "<summary>"
+   ```
+
+2. **Ingest good answers back into the wiki.**
+   If the synthesis produced a coherent new perspective or filled a gap:
+   - Create a new wiki page under the appropriate schema category
+   - Update `{{wiki_root}}/index.md`
+   - Append to `{{wiki_root}}/log.md`
+
+   Skip this if the answer was purely a lookup of existing pages with
+   no new synthesis.
+
+**Exit criteria:** Answer filed, requester notified, wiki updated if
+the answer added new knowledge.
+"""

--- a/examples/llm-wiki/packs/llm-wiki/formulas/orders/wiki-lint/order.toml
+++ b/examples/llm-wiki/packs/llm-wiki/formulas/orders/wiki-lint/order.toml
@@ -1,0 +1,11 @@
+# Periodic wiki health check — dispatched to dog pool.
+#
+# Scans for orphan pages, broken links, contradictions, and gaps.
+# Files beads labeled pool:archivist for the archivist to fix.
+
+[order]
+description = "Periodic wiki lint — scan for structural and content issues"
+gate = "cooldown"
+interval = "4h"
+formula = "mol-wiki-lint"
+pool = "dog"

--- a/examples/llm-wiki/packs/llm-wiki/pack.toml
+++ b/examples/llm-wiki/packs/llm-wiki/pack.toml
@@ -1,0 +1,25 @@
+# LLM Wiki — Karpathy-style persistent wiki maintained by an LLM agent.
+#
+# Domain-agnostic wiki infrastructure. The archivist agent maintains a
+# structured markdown knowledge base: ingesting findings, running lint,
+# and answering queries with citations. The consumer pack provides
+# schema.md to define domain-specific page organization.
+#
+# Formulas: mol-wiki-ingest, mol-wiki-lint, mol-wiki-query.
+
+[pack]
+name = "llm-wiki"
+schema = 1
+
+[formulas]
+dir = "formulas"
+
+# -- ARCHIVIST -- Single writer to the wiki. City-scoped singleton. ----
+[[agent]]
+name = "archivist"
+scope = "city"
+wake_mode = "fresh"
+work_dir = ".gc/agents/archivist"
+prompt_template = "prompts/archivist.md.tmpl"
+nudge = "Check your hook for ingest requests, then run wiki lint if idle."
+idle_timeout = "1h"

--- a/examples/llm-wiki/packs/llm-wiki/pack.toml
+++ b/examples/llm-wiki/packs/llm-wiki/pack.toml
@@ -1,11 +1,12 @@
 # LLM Wiki — Karpathy-style persistent wiki maintained by an LLM agent.
 #
-# Domain-agnostic wiki infrastructure. The archivist agent maintains a
-# structured markdown knowledge base: ingesting findings, running lint,
-# and answering queries with citations. The consumer pack provides
-# schema.md to define domain-specific page organization.
+# Domain-agnostic wiki infrastructure. The archivist agent is the single
+# writer to a structured markdown knowledge base: ingesting findings and
+# answering queries with citations. Wiki lint runs as a periodic dog order.
+# The consumer pack provides schema.md to define domain-specific page
+# organization.
 #
-# Formulas: mol-wiki-ingest, mol-wiki-lint, mol-wiki-query.
+# Formulas: mol-wiki-ingest, mol-wiki-query (archivist), mol-wiki-lint (dog order).
 
 [pack]
 name = "llm-wiki"
@@ -15,11 +16,13 @@ schema = 1
 dir = "formulas"
 
 # -- ARCHIVIST -- Single writer to the wiki. City-scoped singleton. ----
+# Reactive: wakes when ingest or query beads land on its hook.
+# Does NOT patrol or lint — dogs handle that via periodic order.
 [[agent]]
 name = "archivist"
 scope = "city"
 wake_mode = "fresh"
 work_dir = ".gc/agents/archivist"
 prompt_template = "prompts/archivist.md.tmpl"
-nudge = "Check your hook for ingest requests, then run wiki lint if idle."
+nudge = "Check your hook for ingest or query requests."
 idle_timeout = "1h"

--- a/examples/llm-wiki/packs/llm-wiki/prompts/archivist.md.tmpl
+++ b/examples/llm-wiki/packs/llm-wiki/prompts/archivist.md.tmpl
@@ -1,0 +1,91 @@
+# Archivist Context
+
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
+
+You are the **Archivist** — the single writer to the wiki knowledge base.
+Your job is wiki maintenance: ingesting findings, updating pages,
+cross-referencing, linting for consistency, and answering queries.
+
+You are NOT a worker. You do not investigate, code, or explore. Other agents
+do that work and file findings as beads. You integrate those findings into
+the wiki.
+
+---
+
+## Wiki Location
+
+The wiki lives at `{{ .CityRoot }}/wiki/`. See the wiki-conventions shared
+fragment for the full layout.
+
+{{ template "wiki-conventions" . }}
+
+---
+
+## Your Responsibilities
+
+### 1. Ingest Findings
+
+When a bead lands on your hook with raw findings:
+1. Read the source bead's notes/description
+2. Search the wiki for existing pages on the topic
+3. Create or update entity pages under `wiki/pages/`
+4. Add cross-references between related pages
+5. Update `wiki/index.md` with any new pages
+6. Append an entry to `wiki/log.md`
+7. Flag contradictions — do NOT silently overwrite conflicting claims
+
+### 2. Lint the Wiki
+
+Periodically (or when asked) scan the wiki for problems:
+- Orphan pages not listed in `wiki/index.md`
+- Broken cross-references (links to pages that don't exist)
+- Contradictions between pages
+- Gaps where cross-references suggest a page should exist but doesn't
+- Stale claims that newer findings have superseded
+
+File a bead for each issue found so it can be tracked and resolved.
+
+### 3. Answer Queries
+
+When a query bead arrives:
+1. Parse the question
+2. Search the wiki for relevant pages
+3. Read and synthesize an answer with page citations
+4. File the answer back (bead notes or mail to requester)
+5. If the answer reveals a gap, file an ingest bead for follow-up
+
+### 4. Respect the Schema
+
+`wiki/schema.md` defines how pages are organized for this domain.
+It is provided by the consumer pack — do not modify it. Follow its
+categories and naming conventions when creating pages.
+
+---
+
+## Writing Conventions
+
+- **One entity per page.** A page covers one concept, function, structure,
+  or system. Split if a page grows beyond a single coherent topic.
+- **Cite sources.** Every claim should note where it came from (bead ID,
+  file path, agent name, or external reference).
+- **Flag uncertainty.** Use `[UNCERTAIN]` for low-confidence claims and
+  `[CONTRADICTION]` when sources disagree. Never silently pick a side.
+- **Chronological log.** `wiki/log.md` is append-only. Each entry has a
+  timestamp, action summary, and affected pages.
+- **Index is authoritative.** If a page exists but is not in `index.md`,
+  it is orphaned. Always update the index when creating pages.
+
+---
+
+## Communication
+
+```bash
+{{ cmd }} mail inbox                                  # Check messages
+{{ cmd }} mail read <id>                              # Read a message
+{{ cmd }} mail send <addr> -s "Subject" -m "Message"  # Send mail
+```
+
+---
+
+Work directory: {{ .WorkDir }}
+City root: {{ .CityRoot }}

--- a/examples/llm-wiki/packs/llm-wiki/prompts/archivist.md.tmpl
+++ b/examples/llm-wiki/packs/llm-wiki/prompts/archivist.md.tmpl
@@ -34,18 +34,7 @@ When a bead lands on your hook with raw findings:
 6. Append an entry to `wiki/log.md`
 7. Flag contradictions — do NOT silently overwrite conflicting claims
 
-### 2. Lint the Wiki
-
-Periodically (or when asked) scan the wiki for problems:
-- Orphan pages not listed in `wiki/index.md`
-- Broken cross-references (links to pages that don't exist)
-- Contradictions between pages
-- Gaps where cross-references suggest a page should exist but doesn't
-- Stale claims that newer findings have superseded
-
-File a bead for each issue found so it can be tracked and resolved.
-
-### 3. Answer Queries
+### 2. Answer Queries
 
 When a query bead arrives:
 1. Parse the question
@@ -53,6 +42,13 @@ When a query bead arrives:
 3. Read and synthesize an answer with page citations
 4. File the answer back (bead notes or mail to requester)
 5. If the answer reveals a gap, file an ingest bead for follow-up
+
+### 3. Fix Lint Findings
+
+Dogs run periodic wiki lint (mol-wiki-lint) and file beads for issues
+found: orphan pages, broken links, contradictions, gaps. When these
+beads land on your hook, fix them — you're the only agent that writes
+to the wiki.
 
 ### 4. Respect the Schema
 

--- a/examples/llm-wiki/packs/llm-wiki/prompts/shared/wiki-conventions.md.tmpl
+++ b/examples/llm-wiki/packs/llm-wiki/prompts/shared/wiki-conventions.md.tmpl
@@ -1,0 +1,39 @@
+{{ define "wiki-conventions" }}
+## Wiki Directory Layout
+
+The wiki is a structured markdown knowledge base at `{{ .CityRoot }}/wiki/`.
+
+```
+wiki/
+├── index.md          # Master catalog of all pages (authoritative)
+├── log.md            # Chronological activity log (append-only)
+├── schema.md         # Domain-specific organization (provided by consumer pack)
+└── pages/            # All wiki pages organized per schema
+    └── ...           # Subdirectories and pages as defined by schema.md
+```
+
+### Files
+
+| File | Purpose | Who writes |
+|------|---------|------------|
+| `index.md` | Master catalog listing every page with a one-line summary | Archivist |
+| `log.md` | Append-only chronological log of all wiki changes | Archivist |
+| `schema.md` | Domain-specific page categories and naming conventions | Consumer pack (read-only for archivist) |
+| `pages/` | All wiki content pages | Archivist |
+
+### Reading the Wiki
+
+Any agent can read the wiki. To find information:
+
+1. Check `wiki/index.md` for the page catalog
+2. Read `wiki/schema.md` to understand the organization scheme
+3. Browse `wiki/pages/` following the schema's directory structure
+4. Check `wiki/log.md` for recent changes
+
+### Writing to the Wiki
+
+Only the archivist writes to the wiki. To request a change:
+
+- File a bead with your findings — the archivist will integrate them
+- Send mail to the archivist with a query — it will synthesize an answer
+{{ end }}

--- a/examples/llm-wiki/packs/llm-wiki/scripts/wiki-init.sh
+++ b/examples/llm-wiki/packs/llm-wiki/scripts/wiki-init.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# wiki-init.sh — Create the wiki directory structure with starter files.
+#
+# Usage: wiki-init.sh [wiki_root]
+#   wiki_root defaults to "wiki" in the current directory.
+
+set -euo pipefail
+
+WIKI_ROOT="${1:-wiki}"
+
+if [ -d "$WIKI_ROOT" ]; then
+  echo "Wiki directory already exists at $WIKI_ROOT — skipping."
+  exit 0
+fi
+
+mkdir -p "$WIKI_ROOT/pages"
+
+cat > "$WIKI_ROOT/index.md" <<'EOF'
+# Wiki Index
+
+Master catalog of all wiki pages. Maintained by the archivist.
+
+<!-- Add pages below as: - [Page Title](pages/path/to/page.md) — One-line summary -->
+EOF
+
+cat > "$WIKI_ROOT/log.md" <<'EOF'
+# Wiki Activity Log
+
+Chronological record of all wiki changes. Append-only.
+
+<!-- Format: YYYY-MM-DDTHH:MM:SS | Action | Source | Affected Pages -->
+EOF
+
+cat > "$WIKI_ROOT/schema.md" <<'EOF'
+# Wiki Schema
+
+This file defines how wiki pages are organized. It is provided by
+the consumer pack and should not be modified by the archivist.
+
+## Default Schema
+
+Until a domain-specific schema is provided, use a flat structure:
+
+```
+pages/
+└── <entity-name>.md
+```
+
+Replace this file with a domain-specific schema that defines:
+- Page categories and directory structure
+- Naming conventions for pages
+- Required sections within each page type
+- Cross-reference conventions
+EOF
+
+echo "Wiki initialized at $WIKI_ROOT"


### PR DESCRIPTION
## `llm-wiki` example pack

Solves https://github.com/gastownhall/gascity/issues/368 

Implements [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (April 3, 2026) as domain-agnostic Gas City infrastructure.

The wiki pattern — persistent markdown knowledge base maintained by an LLM instead of rediscovered from raw sources on every query — maps cleanly onto Gas City primitives. The archivist is a city-scoped singleton (single writer), findings arrive as beads (ingest pipeline), and the core operations become formulas.

### What's in here

**`llm-wiki` example pack** — Domain-agnostic wiki infrastructure:
- **Archivist agent** (city-scoped singleton, reactive) — sole writer to `wiki/`. Wakes only when ingest or query beads land on its hook. No patrol loop.
- **`mol-wiki-ingest`** — process findings into wiki pages with cross-references and contradiction detection
- **`mol-wiki-query`** — synthesize answers with page citations; good answers ingest back into the wiki
- **`mol-wiki-lint`** — health check for orphans, broken links, contradictions, gaps; runs as a **periodic dog order** (4h cooldown gate), files beads labeled `pool:archivist` for the archivist to fix
- **Shared `wiki-conventions` fragment** — any pack's agents can `{{ template }}` it to read the wiki
- **`wiki-init.sh`** — bootstraps the directory structure

The pack is deliberately domain-agnostic. Consumer packs provide `schema.md` to define page organization for their domain. The archivist respects the schema but doesn't own it.

### Design decisions

- **Single writer, many readers.** Concurrent wiki writes from multiple agents create merge hell. The archivist serializes all writes; other agents file beads.
- **Dogs diagnose, archivist writes.** Wiki lint is mechanical periodic work — dogs run the scan and file beads. The archivist fixes what they find. Clean separation of diagnosis from repair.
- **Reactive, not patrolling.** The archivist has no pour-work-burn loop. It wakes when work arrives and idles when done. Simpler and sufficient — the dog order creates lint work on schedule.
- **Contradictions are first-class.** `[CONTRADICTION]` markers are never silently resolved — the archivist flags both sides with sources. This follows Karpathy's insight that the LLM should compile knowledge, not adjudicate it.
- **Index is authoritative.** A page not in `index.md` is orphaned. This eliminates the need for embedding-based search at moderate wiki scale — grep the index.
- **Schema separation.** The wiki infrastructure doesn't know what domain it serves. A CK3 reverse engineering wiki and a codebase architecture wiki use the same archivist, different `schema.md`.

### How to use

```toml
# city.toml — include llm-wiki alongside your domain pack
[[packs]]
path = "examples/llm-wiki/packs/llm-wiki"
```

Then provide `wiki/schema.md` in your rig defining page categories for your domain.

### Not in this PR

The `mol-create-pack` formula used to scaffold this pack is in a separate PR (#1).

### Test plan

- `wiki-init.sh` creates correct directory structure
- Pack composes with a consumer pack providing domain-specific `schema.md`
- `mol-wiki-ingest` creates and updates wiki pages from a test bead
- `mol-wiki-lint` detects orphans, broken links, and contradictions via dog order
- `mol-wiki-query` returns citation-backed answers