### PR TITLE
fix(beads-k8s): harden pod security and add operational config

### DIFF
--- a/contrib/beads-scripts/README.md
+++ b/contrib/beads-scripts/README.md
@@ -61,7 +61,10 @@ from the controller's laptop.
 
 **Dependencies:** `kubectl`, `jq`, `bash`
 
-**Container requirements:** `bd`, `jq`, `bash`, `git` (same image as agent pods)
+**Container requirements:** `bd`, `jq`, `bash`, `git` (same image as agent pods).
+The image must support running as non-root UID 1000 (the pod uses restricted
+Pod Security Standards with `runAsUser: 1000`). Ensure `/workspace` is writable
+by UID 1000 or does not require pre-existing ownership.
 
 **Usage:**
 

--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -112,13 +112,17 @@ join_labels() {
 case "$op" in
   start|ensure-ready)
     if [ -z "$IMAGE" ]; then
-      echo "ensure-ready: GC_K8S_IMAGE is required" >&2
+      echo "$op: GC_K8S_IMAGE is required" >&2
       exit 1
     fi
 
     # 1. Check if pod already Running.
     phase=$("${KUBECTL[@]}" get pod "$POD_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || true)
     if [ "$phase" = "Running" ]; then
+      # Reconcile custom types on already-running pods (idempotent).
+      if [ -n "$CUSTOM_TYPES" ]; then
+        run_bd config set types.custom "$CUSTOM_TYPES" >/dev/null 2>&1 || true
+      fi
       exit 0
     fi
 
@@ -167,7 +171,7 @@ case "$op" in
             },
             workingDir: "/workspace",
             command: ["/bin/sh", "-c"],
-            args: ["git init --quiet 2>/dev/null; exec tail -f /dev/null"],
+            args: ["mkdir -p /workspace && git init --quiet 2>/dev/null; exec tail -f /dev/null"],
             env: [
               {name: "GC_DOLT_HOST", value: $dolt_host},
               {name: "GC_DOLT_PORT", value: $dolt_port}
@@ -185,7 +189,7 @@ case "$op" in
     # 4. Wait for Ready.
     if ! "${KUBECTL[@]}" wait --for=condition=Ready "pod/$POD_NAME" --timeout=120s >/dev/null 2>&1; then
       pod_phase=$("${KUBECTL[@]}" get pod "$POD_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || true)
-      echo "ensure-ready: pod $POD_NAME not ready after 120s (phase: ${pod_phase:-unknown})" >&2
+      echo "$op: pod $POD_NAME not ready after 120s (phase: ${pod_phase:-unknown})" >&2
       exit 1
     fi
 


### PR DESCRIPTION
## Summary

- Apply restricted Pod Security Standards to the beads runner pod: `runAsNonRoot` with UID/GID 1000, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, drop all capabilities
- Simplify working directory to `/workspace` (removes redundant `mkdir -p && cd`) and use `exec tail -f /dev/null` to avoid zombie shell process
- Add `GC_K8S_IMAGE_PULL_SECRET` env var for optional `imagePullSecrets` (omitted if empty)
- Add `GC_K8S_CUSTOM_TYPES` env var for optional custom bead types on init
- Add `start`/`stop` as aliases for `ensure-ready`/`shutdown`
- Update README with new env vars and operation aliases