### PR TITLE
fix: keep routed queue work out of assigned demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -23,7 +23,7 @@ import (
 type DesiredStateResult struct {
 	State             map[string]TemplateParams
 	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
-	AssignedWorkBeads []beads.Bead   // work beads with non-empty Assignee
+	AssignedWorkBeads []beads.Bead   // actionable assigned work: in_progress or ready+assigned
 	// StoreQueryPartial is true when one or more bead store queries failed
 	// during collectAssignedWorkBeads. When set, the reconciler must NOT
 	// drain sessions based on the (incomplete) desired state — a transient
@@ -375,11 +375,12 @@ func buildDesiredStateWithSessionBeads(
 	return DesiredStateResult{State: desired, ScaleCheckCounts: scaleCheckCounts, AssignedWorkBeads: assignedWorkBeads, StoreQueryPartial: storePartial}
 }
 
-// collectAssignedWorkBeads queries each store (city + rigs) for work beads
-// that have an assignee. It includes in-progress assigned work plus
-// open assigned work that is actually ready. The caller cross-references
-// these with session beads to determine which sessions have active work
-// and must stay alive.
+// collectAssignedWorkBeads queries each store (city + rigs) for actionable
+// assigned work. It includes in-progress assigned work plus open assigned
+// work that is actually ready. Routed-but-unassigned pool queue work is
+// intentionally excluded here; new session demand comes from scale_check
+// (and work_query as a defense-in-depth wake signal), while this helper is
+// only for preserving sessions that already own actionable work.
 func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
@@ -423,7 +424,7 @@ func collectAssignedWorkBeads(
 
 func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[string]struct{}) {
 	for _, b := range beadList {
-		if strings.TrimSpace(b.Assignee) == "" && strings.TrimSpace(b.Metadata["gc.routed_to"]) == "" && !hasPoolLabel(b) {
+		if strings.TrimSpace(b.Assignee) == "" {
 			continue
 		}
 		if _, ok := seen[b.ID]; ok {
@@ -432,15 +433,6 @@ func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[str
 		seen[b.ID] = struct{}{}
 		*dst = append(*dst, b)
 	}
-}
-
-func hasPoolLabel(b beads.Bead) bool {
-	for _, l := range b.Labels {
-		if strings.HasPrefix(l, "pool:") {
-			return true
-		}
-	}
-	return false
 }
 
 func controlDispatcherOnlyConfig(cfg *config.City) *config.City {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -83,16 +83,15 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 	}
 }
 
-func TestCollectAssignedWorkBeads_IncludesRoutedToMetadataBeads(t *testing.T) {
+func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
-	routed, err := store.Create(beads.Bead{
+	if _, err := store.Create(beads.Bead{
 		Title:    "check alpha",
 		Type:     "task",
 		Status:   "open",
 		Metadata: map[string]string{"gc.routed_to": "seth"},
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("create routed bead: %v", err)
 	}
 	if _, err := store.Create(beads.Bead{
@@ -103,11 +102,50 @@ func TestCollectAssignedWorkBeads_IncludesRoutedToMetadataBeads(t *testing.T) {
 		t.Fatalf("create unrouted bead: %v", err)
 	}
 	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
-	if len(got) != 1 {
-		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1", len(got))
+	if len(got) != 0 {
+		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0", len(got))
 	}
-	if got[0].ID != routed.ID {
-		t.Fatalf("collectAssignedWorkBeads returned %q, want %q", got[0].ID, routed.ID)
+}
+
+func TestBuildDesiredState_RoutedQueueDoesNotCreateOneSessionPerBead(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	for i := 0; i < 12; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  "queued claude work",
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": "claude",
+			},
+		}); err != nil {
+			t.Fatalf("create queued bead %d: %v", i, err)
+		}
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "claude",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(20),
+			ScaleCheck:        "printf 1",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if len(dsResult.AssignedWorkBeads) != 0 {
+		t.Fatalf("AssignedWorkBeads = %d, want 0 for routed-only queue", len(dsResult.AssignedWorkBeads))
+	}
+
+	claudeSessions := 0
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "claude" {
+			claudeSessions++
+		}
+	}
+	if claudeSessions != 1 {
+		t.Fatalf("claude desired sessions = %d, want 1 (scale_check only)", claudeSessions)
 	}
 }
 

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -48,8 +48,11 @@ func PoolDesiredCounts(states []PoolDesiredState) map[string]int {
 }
 
 // ComputePoolDesiredStates computes the desired state for all pool agents.
-// assignedWorkBeads contains work beads that have an assignee matching a
-// session — the cross-reference of in-progress/ready work with live sessions.
+// assignedWorkBeads contains actionable assigned work beads only: in-progress
+// work and open work that was already proven ready upstream. Routed but
+// unassigned pool queue work must not be passed here; new-session demand comes
+// from scale_check, while this function only preserves sessions that already
+// own actionable work.
 // Each bead's gc.routed_to determines which agent template it belongs to.
 // scaleCheckCounts maps agent template → desired count from scale_check.
 // Pass nil for either when unavailable.
@@ -105,11 +108,8 @@ func computePoolDesiredStates(
 		}
 		template := agent.QualifiedName()
 
-		// Resume tier: assigned work beads whose assignee resolves to a
-		// non-closed session bead. These sessions must stay alive.
-		// New tier (bead-driven): work beads routed to this template
-		// but with no assignee — on-demand work from gc sling that
-		// needs a new pool worker to be spawned.
+		// Resume tier: actionable assigned work beads whose assignee resolves
+		// to a non-closed session bead. These sessions must stay alive.
 		for _, wb := range assignedWorkBeads {
 			routedTo := wb.Metadata["gc.routed_to"]
 			if routedTo != template {
@@ -119,6 +119,9 @@ func computePoolDesiredStates(
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)
+			if assignee == "" {
+				continue
+			}
 			sessionBeadID := assigneeToSessionBeadID[assignee]
 			if sessionBeadID != "" {
 				allRequests = append(allRequests, SessionRequest{
@@ -127,14 +130,6 @@ func computePoolDesiredStates(
 					Tier:          "resume",
 					SessionBeadID: sessionBeadID,
 					WorkBeadID:    wb.ID,
-				})
-			} else if assignee == "" {
-				// Routed but unassigned — demand for a new worker.
-				allRequests = append(allRequests, SessionRequest{
-					Template:     template,
-					BeadPriority: beadPriority(wb),
-					Tier:         "new",
-					WorkBeadID:   wb.ID,
 				})
 			}
 			// Else: assignee set but session closed/unknown — orphaned

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -360,23 +360,23 @@ func TestComputePoolDesiredStates_ScaleCheckMerge(t *testing.T) {
 	}
 }
 
-func TestComputePoolDesiredStates_ScaleCheckDoesNotDuplicateBeadDriven(t *testing.T) {
+func TestComputePoolDesiredStates_UnassignedRoutedBeadDoesNotCreateDemand(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(5), 0)},
 	}
-	// 1 bead-driven request + scale_check=2 → total should be 2 (not 3).
+	// Routed but unassigned queue work is handled by scale_check/work_query,
+	// not bead-driven pool demand.
 	work := []beads.Bead{
 		workBead("w1", "rig/claude", "", "open", 5),
 	}
-	scaleCheck := map[string]int{"rig/claude": 2}
-	result := ComputePoolDesiredStates(cfg, work, nil, scaleCheck)
+	result := ComputePoolDesiredStates(cfg, work, nil, map[string]int{"rig/claude": 0})
 
-	if len(result) != 1 {
-		t.Fatalf("len(result) = %d, want 1", len(result))
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
 	}
-	// 1 from bead + 1 deficit from scale_check = 2 total (capped by scale_check=2).
-	if len(result[0].Requests) != 2 {
-		t.Fatalf("len(requests) = %d, want 2", len(result[0].Requests))
+	if total != 0 {
+		t.Fatalf("total requests = %d, want 0", total)
 	}
 }
 
@@ -393,6 +393,28 @@ func TestComputePoolDesiredStates_ScaleCheckRespectsCaps(t *testing.T) {
 	}
 	if len(result[0].Requests) != 3 {
 		t.Fatalf("len(requests) = %d, want 3 (capped at max)", len(result[0].Requests))
+	}
+}
+
+func TestComputePoolDesiredStates_OpenAssignedWorkResumes(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "claude", "sess-1", "open", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-1", "open")}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, nil)
+
+	if len(result) != 1 || len(result[0].Requests) != 1 {
+		t.Fatalf("expected 1 request, got %#v", result)
+	}
+	if result[0].Requests[0].Tier != "resume" {
+		t.Fatalf("tier = %q, want resume", result[0].Requests[0].Tier)
+	}
+	if result[0].Requests[0].SessionBeadID != "sess-1" {
+		t.Fatalf("session = %q, want sess-1", result[0].Requests[0].SessionBeadID)
 	}
 }
 
@@ -548,10 +570,9 @@ func TestResumeTier_AsleepSessionWithAssignedWork(t *testing.T) {
 	}
 }
 
-// Regression for #286: gc sling routes work to a pool agent via gc.routed_to
-// metadata but leaves Assignee empty. The pool scheduler must create a "new"
-// tier request so the reconciler spawns a worker.
-func TestComputePoolDesiredStates_RoutedButUnassignedSpawnsNew(t *testing.T) {
+// Regression: routed-but-unassigned queue work must not directly create pool
+// demand here. New worker creation comes from scale_check/work_query.
+func TestComputePoolDesiredStates_RoutedButUnassignedDoesNotSpawnNew(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "", nil, 0)},
 	}
@@ -561,23 +582,17 @@ func TestComputePoolDesiredStates_RoutedButUnassignedSpawnsNew(t *testing.T) {
 
 	result := ComputePoolDesiredStates(cfg, work, nil, nil)
 
-	if len(result) != 1 {
-		t.Fatalf("len(result) = %d, want 1", len(result))
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
 	}
-	if len(result[0].Requests) != 1 {
-		t.Fatalf("len(requests) = %d, want 1 (unassigned routed bead needs new worker)", len(result[0].Requests))
-	}
-	req := result[0].Requests[0]
-	if req.Tier != "new" {
-		t.Errorf("tier = %q, want new", req.Tier)
-	}
-	if req.WorkBeadID != "w1" {
-		t.Errorf("work bead = %q, want w1", req.WorkBeadID)
+	if total != 0 {
+		t.Fatalf("total requests = %d, want 0", total)
 	}
 }
 
-// Regression for #286: same as above but for a rig-scoped agent.
-func TestComputePoolDesiredStates_RoutedRigScopedSpawnsNew(t *testing.T) {
+// Regression: same as above but for a rig-scoped agent.
+func TestComputePoolDesiredStates_RoutedRigScopedDoesNotSpawnNew(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "myrig", nil, 0)},
 	}
@@ -587,17 +602,11 @@ func TestComputePoolDesiredStates_RoutedRigScopedSpawnsNew(t *testing.T) {
 
 	result := ComputePoolDesiredStates(cfg, work, nil, nil)
 
-	if len(result) != 1 {
-		t.Fatalf("len(result) = %d, want 1", len(result))
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
 	}
-	if len(result[0].Requests) != 1 {
-		t.Fatalf("len(requests) = %d, want 1", len(result[0].Requests))
-	}
-	req := result[0].Requests[0]
-	if req.Tier != "new" {
-		t.Errorf("tier = %q, want new", req.Tier)
-	}
-	if req.Template != "myrig/claude" {
-		t.Errorf("template = %q, want myrig/claude", req.Template)
+	if total != 0 {
+		t.Fatalf("total requests = %d, want 0", total)
 	}
 }


### PR DESCRIPTION
## Summary
- treat `AssignedWorkBeads` as actionable assigned work only
- stop deriving pool `new` requests from routed-but-unassigned beads
- add regressions so bulk graph materialization follows `scale_check` instead of spawning one worker per routed bead

## Why
The reconciler was mixing two different demand signals:
- assigned actionable work used to preserve or resume an existing session
- routed queue work used to create new pool demand

That let materialized formula DAG beads leak into the assigned-work path and inflate pool desired counts.

The intended contract is:
- resume only for assigned `in_progress` work or assigned open work that is already ready
- new session creation comes from `scale_check` / `work_query`, not from routed-unassigned beads in `AssignedWorkBeads`

## Testing
- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeads_|TestComputePoolDesiredStates_|TestBuildDesiredState_' -count=1`
- `go test ./cmd/gc -count=1`