### PR TITLE
fix: gc mail inbox times out (ga-ki2)

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -603,7 +603,7 @@ func (c *OrphanSessionsCheck) Fix(_ *CheckContext) error {
 
 // --- Data checks ---
 
-// BeadsStoreCheck verifies the bead store opens and an open-bead query succeeds.
+// BeadsStoreCheck verifies the bead store opens and Ping succeeds.
 type BeadsStoreCheck struct {
 	cityPath string
 	newStore func(cityPath string) (beads.Store, error)
@@ -618,9 +618,7 @@ func NewBeadsStoreCheck(cityPath string, newStore func(string) (beads.Store, err
 // Name returns the check identifier.
 func (c *BeadsStoreCheck) Name() string { return "beads-store" }
 
-// Run opens the store and calls List with an explicit open status filter.
-// Using List(Status:"open") avoids an unbounded cross-database query that times
-// out on large Dolt-backed stores (same root cause as gc mail inbox timeout).
+// Run opens the store and pings it to verify accessibility.
 func (c *BeadsStoreCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	store, err := c.newStore(c.cityPath)
@@ -629,14 +627,13 @@ func (c *BeadsStoreCheck) Run(_ *CheckContext) *CheckResult {
 		r.Message = fmt.Sprintf("store open failed: %v", err)
 		return r
 	}
-	list, err := store.List(beads.ListQuery{Status: "open"})
-	if err != nil {
+	if err := store.Ping(); err != nil {
 		r.Status = StatusError
-		r.Message = fmt.Sprintf("store list failed: %v", err)
+		r.Message = fmt.Sprintf("store ping failed: %v", err)
 		return r
 	}
 	r.Status = StatusOK
-	r.Message = fmt.Sprintf("store accessible (%d open beads)", len(list))
+	r.Message = "store accessible"
 	return r
 }
 
@@ -869,8 +866,7 @@ func NewRigBeadsCheck(rig config.Rig, newStore func(string) (beads.Store, error)
 // Name returns the check identifier.
 func (c *RigBeadsCheck) Name() string { return "rig:" + c.rig.Name + ":beads" }
 
-// Run opens the rig's bead store and calls List with an explicit open status
-// filter.
+// Run opens the rig's bead store and pings it to verify accessibility.
 func (c *RigBeadsCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	store, err := c.newStore(c.rig.Path)
@@ -879,14 +875,13 @@ func (c *RigBeadsCheck) Run(_ *CheckContext) *CheckResult {
 		r.Message = fmt.Sprintf("store open failed: %v", err)
 		return r
 	}
-	list, err := store.List(beads.ListQuery{Status: "open"})
-	if err != nil {
+	if err := store.Ping(); err != nil {
 		r.Status = StatusError
-		r.Message = fmt.Sprintf("store list failed: %v", err)
+		r.Message = fmt.Sprintf("store ping failed: %v", err)
 		return r
 	}
 	r.Status = StatusOK
-	r.Message = fmt.Sprintf("store accessible (%d open beads)", len(list))
+	r.Message = "store accessible"
 	return r
 }
 

--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -13,6 +13,7 @@ import (
 var RequiredCustomTypes = []string{
 	"molecule", "convoy", "message", "event", "gate",
 	"merge-request", "agent", "role", "rig", "session", "spec",
+	"nudge",
 }
 
 // CustomTypesCheck verifies that all required Gas City custom bead

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -52,7 +52,7 @@ func TestCustomTypesCheck_RequiredTypesComplete(t *testing.T) {
 		"molecule": true, "convoy": true, "message": true,
 		"event": true, "gate": true, "merge-request": true,
 		"agent": true, "role": true, "rig": true,
-		"session": true, "spec": true,
+		"session": true, "spec": true, "nudge": true,
 	}
 	for _, typ := range RequiredCustomTypes {
 		if !expected[typ] {

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -621,13 +621,8 @@ func TestOrphanSessionsCheck_Fix(t *testing.T) {
 
 func TestBeadsStoreCheck_OK(t *testing.T) {
 	dir := t.TempDir()
-	// Create a file store.
-	store, err := beads.OpenFileStore(fsys.OSFS{}, filepath.Join(dir, "beads.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Create a bead so List returns something.
-	if _, err := store.Create(beads.Bead{Title: "test"}); err != nil {
+	// Create a file store so Ping can verify accessibility.
+	if _, err := beads.OpenFileStore(fsys.OSFS{}, filepath.Join(dir, "beads.json")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -650,14 +645,13 @@ func TestBeadsStoreCheck_OpenError(t *testing.T) {
 	}
 }
 
-func TestBeadsStoreCheck_ListPassesOpenFilter(t *testing.T) {
-	// The check should call List(Status:"open") to avoid unbounded queries
-	// that time out on large stores.
-	var gotQuery beads.ListQuery
-	spy := &spyListStore{
-		listFunc: func(query beads.ListQuery) ([]beads.Bead, error) {
-			gotQuery = query
-			return []beads.Bead{{Title: "x", Status: "open"}}, nil
+func TestBeadsStoreCheck_UsesPing(t *testing.T) {
+	// The check should call Ping() to verify accessibility without loading data.
+	pinged := false
+	spy := &spyPingStore{
+		pingFunc: func() error {
+			pinged = true
+			return nil
 		},
 	}
 	c := NewBeadsStoreCheck(t.TempDir(), func(_ string) (beads.Store, error) {
@@ -667,25 +661,22 @@ func TestBeadsStoreCheck_ListPassesOpenFilter(t *testing.T) {
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if gotQuery.Status != "open" {
-		t.Errorf("List called with status %q, want %q", gotQuery.Status, "open")
-	}
-	if gotQuery.AllowScan {
-		t.Error("List called with AllowScan=true, want false")
+	if !pinged {
+		t.Error("Ping was not called")
 	}
 }
 
-// spyListStore is a minimal Store that records List calls.
-type spyListStore struct {
+// spyPingStore is a minimal Store that records Ping calls.
+type spyPingStore struct {
 	beads.MemStore
-	listFunc func(query beads.ListQuery) ([]beads.Bead, error)
+	pingFunc func() error
 }
 
-func (s *spyListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if s.listFunc != nil {
-		return s.listFunc(query)
+func (s *spyPingStore) Ping() error {
+	if s.pingFunc != nil {
+		return s.pingFunc()
 	}
-	return s.MemStore.List(query)
+	return nil
 }
 
 // --- DoltServerCheck ---
@@ -820,12 +811,12 @@ func TestRigBeadsCheck_Error(t *testing.T) {
 	}
 }
 
-func TestRigBeadsCheck_ListPassesOpenFilter(t *testing.T) {
-	var gotQuery beads.ListQuery
-	spy := &spyListStore{
-		listFunc: func(query beads.ListQuery) ([]beads.Bead, error) {
-			gotQuery = query
-			return []beads.Bead{{Title: "x", Status: "open"}}, nil
+func TestRigBeadsCheck_UsesPing(t *testing.T) {
+	pinged := false
+	spy := &spyPingStore{
+		pingFunc: func() error {
+			pinged = true
+			return nil
 		},
 	}
 	c := NewRigBeadsCheck(config.Rig{Name: "myrig", Path: t.TempDir()}, func(_ string) (beads.Store, error) {
@@ -835,11 +826,8 @@ func TestRigBeadsCheck_ListPassesOpenFilter(t *testing.T) {
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if gotQuery.Status != "open" {
-		t.Errorf("List called with status %q, want %q", gotQuery.Status, "open")
-	}
-	if gotQuery.AllowScan {
-		t.Error("List called with AllowScan=true, want false")
+	if !pinged {
+		t.Error("Ping was not called")
 	}
 }
 

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -188,17 +188,21 @@ func (p *Provider) Thread(threadID string) ([]mail.Message, error) {
 
 // Count returns (total, unread) message counts for a recipient.
 func (p *Provider) Count(recipient string) (int, int, error) {
-	all, err := p.listMessages()
+	candidates, err := p.messageCandidates(recipient)
 	if err != nil {
 		return 0, 0, fmt.Errorf("beadmail count: %w", err)
 	}
 	var total, unread int
-	for _, b := range all {
-		if b.Status == "open" && (recipient == "" || b.Assignee == recipient) {
-			total++
-			if !hasLabel(b.Labels, "read") {
-				unread++
-			}
+	for _, b := range candidates {
+		if b.Status != "open" {
+			continue
+		}
+		if recipient != "" && b.Assignee != recipient {
+			continue
+		}
+		total++
+		if !hasLabel(b.Labels, "read") {
+			unread++
 		}
 	}
 	return total, unread, nil
@@ -207,40 +211,40 @@ func (p *Provider) Count(recipient string) (int, int, error) {
 // filterMessages returns open message beads assigned to the recipient.
 // When includeRead is false, messages with the "read" label are excluded.
 func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Message, error) {
-	all, err := p.listMessages()
+	candidates, err := p.messageCandidates(recipient)
 	if err != nil {
 		return nil, fmt.Errorf("beadmail: listing beads: %w", err)
 	}
 	var msgs []mail.Message
-	for _, b := range all {
-		if b.Status == "open" && (recipient == "" || b.Assignee == recipient) {
-			if !includeRead && hasLabel(b.Labels, "read") {
-				continue
-			}
-			msgs = append(msgs, beadToMessage(b))
+	for _, b := range candidates {
+		if b.Status != "open" {
+			continue
 		}
+		if recipient != "" && b.Assignee != recipient {
+			continue
+		}
+		if !includeRead && hasLabel(b.Labels, "read") {
+			continue
+		}
+		msgs = append(msgs, beadToMessage(b))
 	}
 	return msgs, nil
 }
 
-// listMessages returns message beads by combining the store's generic list with
-// an explicit gc:message label query. Some external stores can retrieve message
-// beads by ID and label query but omit them from the generic list output.
-func (p *Provider) listMessages() ([]beads.Bead, error) {
-	all, err := p.store.List(beads.ListQuery{Type: "message"})
-	if err != nil {
-		return nil, fmt.Errorf("listing beads: %w", err)
-	}
-	labeled, err := p.store.List(beads.ListQuery{
-		Label: "gc:message",
-		Sort:  beads.SortCreatedDesc,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("listing gc:message beads: %w", err)
-	}
-
-	seen := make(map[string]beads.Bead, len(all)+len(labeled))
-	order := make([]string, 0, len(all)+len(labeled))
+// messageCandidates returns message beads relevant to a recipient using
+// targeted queries instead of a broad store scan. This avoids timeouts
+// on stores with many beads.
+//
+// For per-recipient queries, two scoped queries are combined:
+//  1. List by assignee+type+status — targeted to the recipient's open messages
+//  2. List by gc:message label — catches messages that type queries may miss
+//     (some external stores omit messages from generic queries)
+//
+// For global queries (recipient==""), falls back to type-based listing since
+// no assignee filter can be applied.
+func (p *Provider) messageCandidates(recipient string) ([]beads.Bead, error) {
+	seen := make(map[string]beads.Bead)
+	order := make([]string, 0)
 	add := func(bs []beads.Bead) {
 		for _, b := range bs {
 			if !isMessage(b) {
@@ -252,7 +256,36 @@ func (p *Provider) listMessages() ([]beads.Bead, error) {
 			seen[b.ID] = b
 		}
 	}
-	add(all)
+
+	// Primary: targeted query scoped to recipient.
+	if recipient != "" {
+		assigned, err := p.store.List(beads.ListQuery{
+			Assignee: recipient,
+			Type:     "message",
+			Status:   "open",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing by assignee: %w", err)
+		}
+		add(assigned)
+	} else {
+		// No recipient filter — use type-based query for global discovery.
+		all, err := p.store.List(beads.ListQuery{Type: "message"})
+		if err != nil {
+			return nil, fmt.Errorf("listing message beads: %w", err)
+		}
+		add(all)
+	}
+
+	// Supplement: label query catches messages that type/assignee queries
+	// may miss (some external stores omit messages from generic queries).
+	labeled, err := p.store.List(beads.ListQuery{
+		Label: "gc:message",
+		Sort:  beads.SortCreatedDesc,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing gc:message beads: %w", err)
+	}
 	add(labeled)
 
 	result := make([]beads.Bead, 0, len(order))

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -29,6 +29,113 @@ func (s hiddenMessageStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	return beads.ApplyListQuery(filtered, query), nil
 }
 
+// noListScanStore errors when List is called without a filter, proving that
+// Inbox/Count/All use targeted queries (assignee+type or label) instead
+// of broad scans.
+type noListScanStore struct {
+	*beads.MemStore
+}
+
+func (s noListScanStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if !query.HasFilter() {
+		return nil, errors.New("unfiltered List() must not be called — use targeted queries")
+	}
+	return s.MemStore.List(query)
+}
+
+func TestInboxDoesNotCallBroadList(t *testing.T) {
+	base := beads.NewMemStore()
+	p := New(noListScanStore{MemStore: base})
+
+	if _, err := p.Send("human", "mayor", "", "targeted"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := p.Inbox("mayor")
+	if err != nil {
+		t.Fatalf("Inbox should use targeted queries: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("Inbox = %d messages, want 1", len(msgs))
+	}
+}
+
+func TestCountDoesNotCallBroadList(t *testing.T) {
+	base := beads.NewMemStore()
+	p := New(noListScanStore{MemStore: base})
+
+	if _, err := p.Send("human", "mayor", "", "count me"); err != nil {
+		t.Fatal(err)
+	}
+
+	total, unread, err := p.Count("mayor")
+	if err != nil {
+		t.Fatalf("Count should use targeted queries: %v", err)
+	}
+	if total != 1 || unread != 1 {
+		t.Errorf("Count = (%d, %d), want (1, 1)", total, unread)
+	}
+}
+
+func TestAllDoesNotCallBroadList(t *testing.T) {
+	base := beads.NewMemStore()
+	p := New(noListScanStore{MemStore: base})
+
+	if _, err := p.Send("human", "mayor", "", "all msg"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := p.All("mayor")
+	if err != nil {
+		t.Fatalf("All should use targeted queries: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("All = %d messages, want 1", len(msgs))
+	}
+}
+
+// --- Empty-recipient (global) path ---
+
+func TestCountEmptyRecipient(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, err := p.Send("human", "mayor", "", "msg1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Send("human", "deacon", "", "msg2"); err != nil {
+		t.Fatal(err)
+	}
+
+	total, unread, err := p.Count("")
+	if err != nil {
+		t.Fatalf("Count empty recipient: %v", err)
+	}
+	if total != 2 || unread != 2 {
+		t.Errorf("Count(\"\") = (%d, %d), want (2, 2)", total, unread)
+	}
+}
+
+func TestAllEmptyRecipient(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, err := p.Send("human", "mayor", "", "msg1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Send("human", "deacon", "", "msg2"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := p.All("")
+	if err != nil {
+		t.Fatalf("All empty recipient: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Errorf("All(\"\") = %d messages, want 2", len(msgs))
+	}
+}
+
 // --- Send ---
 
 func TestSend(t *testing.T) {


### PR DESCRIPTION
## Summary

Supersedes #257 by @thejosephstevens, rebased onto current main and adapted to the ListQuery API.

- Replace broad store queries with targeted lookups in beadmail
- Use `List(Assignee+Type+Status)` for per-recipient inbox queries (fast, scoped)
- Fall back to `List(Type)` for empty-recipient global queries (preserves semantics)
- Supplement with `List(Label:"gc:message")` for external store fallback
- Use `Ping()` instead of `List(Status)` in doctor beads-store checks
- Register `nudge` as required custom bead type

Credit: Original fix by @thejosephstevens (commit preserved with original authorship).

## Test plan

- [x] `go test ./internal/mail/beadmail/...` — all pass
- [x] `go test ./internal/doctor/...` — all pass
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [x] New tests verify per-recipient queries avoid broad scans
- [x] New tests verify empty-recipient Count/All return correct results

Closes ga-ki2