### PR TITLE
fix: use --no-assignee in default active scale_check

### DIFF
--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -122,6 +123,53 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
 	}
 	if got != 1 {
 		t.Fatalf("evaluatePool with routed work = %d, want 1", got)
+	}
+}
+
+func TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork(t *testing.T) {
+	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
+	if err != nil {
+		t.Skip("bd not installed")
+	}
+	jqPath, err := exec.LookPath("jq")
+	if err != nil {
+		t.Skip("jq not installed")
+	}
+	t.Setenv("PATH", filepath.Dir(bdPath)+":"+filepath.Dir(jqPath)+":"+os.Getenv("PATH"))
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	runExternal(t, dir, bdPath, "init", "-p", "ct", "--skip-hooks", "-q")
+
+	raw := runExternalOutput(t, dir, bdPath, "create", "--json", "active worker job", "-t", "task",
+		"--metadata", `{"gc.routed_to":"worker"}`)
+	if idx := bytes.IndexByte(raw, '{'); idx >= 0 {
+		raw = raw[idx:]
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("parse create output: %v\n%s", err, raw)
+	}
+	if created.ID == "" {
+		t.Fatalf("create output missing id: %s", raw)
+	}
+	runExternal(t, dir, bdPath, "update", created.ID, "--status", "in_progress")
+
+	agent := &config.Agent{
+		Name:              "worker",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(3),
+	}
+	got, err := evaluatePool("worker", scaleParamsFor(agent), dir, shellScaleCheck)
+	if err != nil {
+		t.Fatalf("evaluatePool with routed in-progress work: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("evaluatePool with routed in-progress work = %d, want 1", got)
 	}
 }
 
@@ -805,6 +853,14 @@ func TestShellScaleCheck_NoBEADS_DOLT_SERVER_PORT_Injection(t *testing.T) {
 
 func runExternal(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
+	out := runExternalOutput(t, dir, name, args...)
+	if len(out) != 0 {
+		return
+	}
+}
+
+func runExternalOutput(t *testing.T, dir, name string, args ...string) []byte {
+	t.Helper()
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = os.Environ()
@@ -815,6 +871,7 @@ func runExternal(t *testing.T, dir, name string, args ...string) {
 	if err != nil {
 		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
 	}
+	return out
 }
 
 func findPreferredBinary(name string, preferred ...string) (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1388,7 +1388,7 @@ func (a *Agent) EffectiveScaleCheck() string {
 	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
 		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
 		`active=$(bd list --metadata-field gc.routed_to=` + template +
-		` --status=in_progress --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
+		` --status=in_progress --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
 		`echo "$(( ${ready:-0} + ${active:-0} ))" || echo 0`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1415,6 +1415,9 @@ func TestEffectiveScaleCheckDefaults(t *testing.T) {
 	if !strings.Contains(check, "--status=in_progress") {
 		t.Errorf("EffectiveScaleCheck = %q, want --status=in_progress for active work", check)
 	}
+	if !strings.Contains(check, "--no-assignee") {
+		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for active unassigned work", check)
+	}
 }
 
 func TestEffectiveScaleCheckDefaultsQualified(t *testing.T) {
@@ -1430,6 +1433,9 @@ func TestEffectiveScaleCheckDefaultsQualified(t *testing.T) {
 	}
 	if !strings.Contains(check, "--status=in_progress") {
 		t.Errorf("EffectiveScaleCheck = %q, want --status=in_progress for active work", check)
+	}
+	if !strings.Contains(check, "--no-assignee") {
+		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for active unassigned work", check)
 	}
 }
 


### PR DESCRIPTION
## Summary
- change the generated default active scale_check query from `--unassigned` to `--no-assignee`
- add regression coverage for routed in-progress unassigned work
- assert the generated default scale_check contains the correct active-work flag

## Test plan
- go test ./internal/config -run 'TestEffectiveScaleCheckDefaults|TestEffectiveScaleCheckDefaultsQualified' -count=1
- go test ./cmd/gc -run 'TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork|TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork' -count=1
- go test ./cmd/gc ./internal/config -count=1