### PR TITLE
fix: preserve pending-create wake for named sessions

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -84,6 +84,7 @@ func buildAwakeInputFromReconciler(
 			Template:       b.Metadata["template"],
 			State:          normalizeBeadState(b.Metadata["state"]),
 			ManualSession:  b.Metadata["manual_session"] == "true",
+			PendingCreate:  b.Metadata["pending_create_claim"] == "true",
 			DependencyOnly: b.Metadata["dependency_only"] == "true",
 			NamedIdentity:  namedSessionIdentity(*b),
 			Drained:        isDrainedSessionMetadata(b.Metadata),
@@ -127,6 +128,8 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 		var reasons []WakeReason
 		if d.ShouldWake {
 			switch d.Reason {
+			case "pending-create":
+				reasons = []WakeReason{WakeCreate}
 			case "attached":
 				reasons = []WakeReason{WakeAttached}
 			case "pending":

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -52,6 +52,7 @@ type AwakeSessionBead struct {
 	Template         string
 	State            string // "creating", "active", "asleep", "drained", "closed"
 	ManualSession    bool
+	PendingCreate    bool      // controller claimed this bead for initial start
 	DependencyOnly   bool      // only wakeable via dependency gate
 	NamedIdentity    string    // non-empty for named session beads
 	Drained          bool      // state=="drained" or sleep_reason=="drained"
@@ -94,6 +95,16 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// Step 1: Build desired set.
 	// Drained and dependency_only beads are excluded from demand-driven wake.
 	desired := make(map[string]string) // sessionName → reason
+
+	// Newly created beads that still carry a controller create claim must be
+	// launched at least once, even if the work signal that materialized them
+	// is no longer visible on the very next tick.
+	for _, bead := range input.SessionBeads {
+		if bead.Drained || !bead.PendingCreate {
+			continue
+		}
+		desired[bead.SessionName] = "pending-create"
+	}
 
 	// Named sessions
 	for _, ns := range input.NamedSessions {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -160,6 +160,24 @@ func TestNamedOnDemand_AssigneeMatches(t *testing.T) {
 	assertAwake(t, result, "hello-world--refinery")
 }
 
+func TestNamedOnDemand_PendingCreateWakesWithoutDemand(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:            "mc-1",
+			SessionName:   "hello-world--refinery",
+			Template:      "hello-world/refinery",
+			State:         "stopped",
+			PendingCreate: true,
+			NamedIdentity: "hello-world/refinery",
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "pending-create")
+}
+
 func TestNamedOnDemand_WorkDone_StaysAwakeUntilIdle(t *testing.T) {
 	// On-demand session with work done: still running, no demand.
 	// Stays awake via on-demand:running override — drains only after

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -133,11 +133,15 @@ func reopenClosedConfiguredNamedSessionBead(
 			return nil
 		}
 		bead.Status = "open"
+		pendingCreateClaim := ""
+		if state != "active" {
+			pendingCreateClaim = "true"
+		}
 		batch := map[string]string{
 			"state":                state,
 			"close_reason":         "",
 			"closed_at":            "",
-			"pending_create_claim": "",
+			"pending_create_claim": pendingCreateClaim,
 			"synced_at":            now.Format("2006-01-02T15:04:05Z07:00"),
 		}
 		if setMetaBatch(store, bead.ID, batch, stderr) == nil {
@@ -348,6 +352,9 @@ func syncSessionBeadsWithSnapshot(
 				"instance_token":     session.NewInstanceToken(),
 				"state":              state,
 				"synced_at":          now.Format("2006-01-02T15:04:05Z07:00"),
+			}
+			if state != "active" {
+				meta["pending_create_claim"] = "true"
 			}
 			if tp.DependencyOnly {
 				meta["dependency_only"] = boolMetadata(true)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -416,6 +416,9 @@ func TestSyncSessionBeads_ReopensClosedConfiguredNamedSession(t *testing.T) {
 	if got := all[0].Metadata["close_reason"]; got != "" {
 		t.Fatalf("close_reason = %q, want empty", got)
 	}
+	if got := all[0].Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
 	if got := all[0].Metadata["session_name"]; got != sessionName {
 		t.Fatalf("session_name = %q, want %q", got, sessionName)
 	}
@@ -1102,6 +1105,9 @@ func TestSyncSessionBeads_StoppedAgent(t *testing.T) {
 	}
 	if all[0].Metadata["state"] != "stopped" {
 		t.Errorf("state = %q, want %q", all[0].Metadata["state"], "stopped")
+	}
+	if all[0].Metadata["pending_create_claim"] != "true" {
+		t.Errorf("pending_create_claim = %q, want true", all[0].Metadata["pending_create_claim"])
 	}
 }
 

--- a/cmd/gc/session_template_start_test.go
+++ b/cmd/gc/session_template_start_test.go
@@ -105,7 +105,7 @@ func TestEnsureSessionForTemplate_ReopensClosedNamedSessionWithCleanMetadata(t *
 	if reopened.Metadata["closed_at"] != "" {
 		t.Fatalf("closed_at = %q, want empty", reopened.Metadata["closed_at"])
 	}
-	if reopened.Metadata["pending_create_claim"] != "" {
-		t.Fatalf("pending_create_claim = %q, want empty", reopened.Metadata["pending_create_claim"])
+	if reopened.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", reopened.Metadata["pending_create_claim"])
 	}
 }


### PR DESCRIPTION
## Summary
- preserve `pending_create_claim` when reopening or materializing non-active named session beads
- teach the awake-set bridge to wake sessions for the `pending-create` reason
- add regressions for reopened named sessions, stopped sessions, and ensureSessionForTemplate reopen behavior

## Test plan
- go test ./cmd/gc -run 'TestNamedOnDemand_PendingCreateWakesWithoutDemand|TestSyncSessionBeads_ReopensClosedConfiguredNamedSession|TestSyncSessionBeads_StoppedAgent' -count=1
- go test ./cmd/gc -count=1