### PR TITLE
fix(prompt): mayor dispatch uses gc sling instead of raw bd commands

### DIFF
--- a/examples/gastown/packs/gastown/prompts/mayor.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/mayor.md.tmpl
@@ -21,7 +21,7 @@ When you file a bead, default to immediately dispatching it to a polecat:
 
 ```bash
 bd create "Fix the auth timeout bug" -t task --json   # file it
-bd update <bead-id> --set-metadata gc.routed_to=<rig>/polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
+{{ cmd }} sling <rig>/polecat <bead-id>               # dispatch to polecat pool (sets gc.routed_to metadata for controller scale_check)
 ```
 
 **Why this is the default:**
@@ -214,7 +214,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Dispatch work to polecat | `{{ cmd }} sling <rig>/polecat <bead>` | ~~bd update --label=pool:...~~ (labels don't trigger scale_check) |
 | Drain stuck polecat | `{{ cmd }} agent drain <name>` | ~~gc polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |


### PR DESCRIPTION
## Summary

- Replace `bd update --set-metadata gc.routed_to=...` and `bd update --label=pool:...` in the mayor prompt with the canonical `gc sling <rig>/polecat <bead>` command
- The quick-reference table had the label-based pattern, which is especially dangerous: labels alone don't trigger the controller's scale_check, so polecats never spin up

## Context

Discovered in production: a mayor session dispatched 3 beads using `bd update --label=pool:signal-loom/polecat` (following the quick-ref table). The controller's scale_check queries `--metadata-field gc.routed_to=...`, found nothing, and never started polecats. The beads sat idle until force-slung.

Separate issue: `gc sling` idempotency check detects labels as "already routed" even when the metadata it actually writes (`gc.routed_to`) is missing — so running `gc sling` after a label-only dispatch skips the bead without `--force`.

## Test plan

- [ ] Verify `gc prime` for mayor shows `gc sling` in dispatch instructions
- [ ] Verify quick-reference table no longer references `--label=pool:...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)