### PR TITLE
fix: wrap tmux nudge messages in system-reminder envelope

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -372,6 +372,11 @@ func (p *Provider) NudgeNow(name string, content []runtime.ContentBlock) error {
 		return nil
 	}
 
+	// Wrap in system-reminder envelope so the LLM treats this as system
+	// context rather than human input. Matches the pattern used by
+	// UserPromptSubmit hooks (see gc-239).
+	message = "<system-reminder>\ngc-nudge: " + message + "\n</system-reminder>"
+
 	if used, err := p.tm.sendHiddenAttachedText(name, message); used {
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- Wraps tmux `send-keys` nudge messages in `<system-reminder>` tags so the LLM treats them as system context rather than human input
- Prevents nudges from derailing active polecat work by making them indistinguishable from hook-injected context
- 1 file changed: `internal/runtime/tmux/adapter.go`

Closes gc-239.

## Test plan
- [ ] Verify nudge messages arrive wrapped in `<system-reminder>` tags
- [ ] Confirm active polecat sessions treat nudges as context, not conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)