### PR TITLE
fix: register 'wait' as required custom bead type

### DIFF
--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -13,7 +13,7 @@ import (
 var RequiredCustomTypes = []string{
 	"molecule", "convoy", "message", "event", "gate",
 	"merge-request", "agent", "role", "rig", "session", "spec",
-	"nudge",
+	"nudge", "wait",
 }
 
 // CustomTypesCheck verifies that all required Gas City custom bead

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -52,7 +52,7 @@ func TestCustomTypesCheck_RequiredTypesComplete(t *testing.T) {
 		"molecule": true, "convoy": true, "message": true,
 		"event": true, "gate": true, "merge-request": true,
 		"agent": true, "role": true, "rig": true,
-		"session": true, "spec": true, "nudge": true,
+		"session": true, "spec": true, "nudge": true, "wait": true,
 	}
 	for _, typ := range RequiredCustomTypes {
 		if !expected[typ] {


### PR DESCRIPTION
## Summary
- Adds `wait` to `RequiredCustomTypes` so `gc doctor --fix` registers it as a valid bead type
- Fixes `gc session wake` failing with `invalid issue type "wait"` error

## Test plan
- [x] `go test ./internal/doctor/` passes
- [x] `TestCustomTypesCheck_RequiredTypesComplete` validates both `nudge` and `wait` are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)