### PR TITLE
fix: pool instances get unique worktree paths

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -700,9 +700,10 @@ func realizePoolDesiredSessions(
 	stderr io.Writer,
 ) {
 	qualifiedName := cfgAgent.QualifiedName()
-	fpExtra := buildFingerprintExtra(cfgAgent)
 	used := make(map[string]bool)
+	slot := 0
 	for _, request := range poolState.Requests {
+		slot++
 		var prefer *beads.Bead
 		if request.SessionBeadID != "" {
 			if bead, ok := findOpenSessionBeadByID(bp.sessionBeads, request.SessionBeadID); ok {
@@ -718,14 +719,27 @@ func realizePoolDesiredSessions(
 			continue
 		}
 		used[sessionBead.ID] = true
-		tp, err := resolveTemplateForSessionBead(bp, cfgAgent, qualifiedName, fpExtra, sessionBead)
+
+		// Create per-instance agent with a unique name so work_dir templates
+		// (e.g., {{.AgentBase}}) expand to distinct paths per pool member.
+		// Without this, all pool instances share the same worktree and collide.
+		instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
+		instanceAgent := deepCopyAgent(cfgAgent, instanceName, cfgAgent.Dir)
+		qualifiedInstance := instanceName
+		if cfgAgent.Dir != "" {
+			qualifiedInstance = cfgAgent.Dir + "/" + instanceName
+		}
+		fpExtra := buildFingerprintExtra(&instanceAgent)
+
+		tp, err := resolveTemplateForSessionBead(bp, &instanceAgent, qualifiedInstance, fpExtra, sessionBead)
 		if err != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: pool %q session %s: %v (skipping)\n", qualifiedName, sessionBead.ID, err) //nolint:errcheck
 			continue
 		}
+		tp.PoolSlot = slot
 		tp.Alias = ""
 		tp.InstanceName = sessionBead.Metadata["session_name"]
-		installAgentSideEffects(bp, cfgAgent, tp, stderr)
+		installAgentSideEffects(bp, &instanceAgent, tp, stderr)
 		desired[tp.SessionName] = tp
 	}
 }


### PR DESCRIPTION
## Summary
- `realizePoolDesiredSessions` (bead-store path) was passing the template config agent directly to `resolveTemplate`, causing all pool instances to resolve `{{.AgentBase}}` as "polecat" and share a single worktree path
- Now creates per-instance agent copies with `deepCopyAgent` + `poolInstanceName`, matching the existing no-store code path
- Each pool instance gets a unique worktree (e.g., `.gc/worktrees/gascity/polecats/furiosa` instead of all sharing `.gc/worktrees/gascity/polecats/polecat`)

## Test plan
- [x] All `TestBuildDesired*` and `TestPool*` tests pass
- [x] All `internal/workdir` tests pass  
- [x] No regressions vs main (pre-existing flaky failures only)
- [ ] Manual: start city with 2+ polecats and verify distinct worktree dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)