### PR TITLE
fix(refinery): exclude epics from work-finding query

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml
@@ -111,7 +111,7 @@ description = """
 Search for work beads assigned to you with branch metadata:
 ```bash
 WORK=$(bd list --assignee=$GC_AGENT --status=open \
-  --limit=1 --json | jq -r '.[0].id // empty')
+  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
 ```
 
 If found: read the bead metadata to confirm it has a branch:


### PR DESCRIPTION
## Summary
The refinery's `mol-refinery-patrol` formula uses `--limit=1` to grab the next assigned work bead, then expects `metadata.branch` on the result. When the patrol wisp epic outranks real work beads in priority order, `--limit=1` returns the wisp's id, the metadata-branch check fails, and refinery loops without merging anything — even with multiple work beads queued.

This adds `--exclude-type=epic` so the query skips patrol wisps and finds the actual work bead.

## Symptom observed
Refinery sat idle with 5 work beads assigned to it. Manually nudging it past the bad query unstuck it temporarily, but the bug recurred on the next patrol cycle whenever the freshly-poured patrol wisp outranked queued work.

## Fix
One-line change in `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml`:

```diff
-WORK=$(bd list --assignee=$GC_AGENT --status=open -  --limit=1 --json | jq -r '.[0].id // empty')
+WORK=$(bd list --assignee=$GC_AGENT --status=open +  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
```

## Test plan
- [ ] Verify refinery picks up next work bead even when its own patrol wisp is the highest-priority bead assigned to it
- [ ] Existing refinery merge flow unaffected