### PR TITLE
Fix wait-hold wake suppression

### DIFF
--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -252,7 +252,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// input stays asleep until either its durable wait becomes ready
 		// or it still needs its initial launch.
 		if reason, inDesired := desired[name]; inDesired {
-			if !bead.WaitHold || reason == "pending-create" {
+			if !bead.WaitHold || bead.PendingCreate {
 				decision.ShouldWake = true
 				decision.Reason = reason
 			}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -562,6 +562,19 @@ func TestWaitHold_PendingCreateStillWakes(t *testing.T) {
 	assertReason(t, result, "polecat-mc-1", "pending-create")
 }
 
+func TestWaitHold_PendingCreateStillWakesWithManualDemand(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/claude"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "s-mc-1", Template: "gascity/claude", State: "creating",
+			PendingCreate: true, ManualSession: true, WaitHold: true,
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "s-mc-1")
+	assertReason(t, result, "s-mc-1", "manual")
+}
+
 func TestReadyWait_Wakes(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents: []AwakeAgent{{QualifiedName: "gascity/claude"}},


### PR DESCRIPTION
## Summary
- suppress demand-driven wake reasons for wait-held sessions in `ComputeAwakeSet`
- preserve initial launch by keying the exemption off `PendingCreate` instead of the lossy desired-reason string
- add regression coverage for manual, named-always, assigned-work, and overlapping pending-create demand cases

## Testing
- TMPDIR=/var/tmp/gascity-go-tmp GOTMPDIR=/var/tmp/gascity-go-tmp GOCACHE=/var/tmp/gascity-go-cache go test ./cmd/gc -run '^(TestNamed|TestScaled|TestManual|TestDrained|TestHeld|TestWaitHold|TestReadyWait|TestDependency|TestIdleSleep|TestRegression_|TestWorkSet_)'