### PR TITLE
fix(mail): use shared city directory for cross-pod name resolution

### DIFF
--- a/contrib/mail-scripts/gc-mail-mcp-agent-mail
+++ b/contrib/mail-scripts/gc-mail-mcp-agent-mail
@@ -25,22 +25,45 @@ MCP_URL="${GC_MCP_MAIL_URL:-http://127.0.0.1:8765}"
 MCP_TOKEN="${GC_MCP_MAIL_TOKEN:-}"
 PROJECT="${GC_MCP_MAIL_PROJECT:-$(pwd)}"
 
-# Cache directory for name mappings and message→recipient tracking.
-# mcp_agent_mail requires Adjective+Noun agent names, so we map gc
-# names (alice, bob) to valid names (SilverFox, CoralPeak) and cache
-# the mapping per-project.
+# Cache directories for name mappings and message state.
 #
-# When GC_CITY is set (controller passes it), use the city directory so
-# the cache is shared across K8s pods via the city volume mount. This
-# solves cross-pod name resolution without coupling to mcp_agent_mail's
-# whois API. Falls back to /tmp for non-K8s or standalone use.
+# Layout:
+#   name-map/     gc-name → mcp-name (Adjective+Noun) mapping
+#   msg-agent/    msg-id → recipient gc-name (repopulated on inbox/check)
+#   msg-read/     msg-id → local "read" / "archived" filter state
+#   msg-thread/   msg-id → locally-generated thread id
+#   msg-reply-to/ msg-id → parent msg-id (set on reply)
+#
+# Only name-map is shared across K8s pods. When GC_CITY is set (the
+# controller passes it via the city volume mount), name-map lives under
+# the city directory so every pod sharing that volume sees the same
+# gc → mcp mapping. This is what enables cross-pod name resolution:
+# a receiving pod can reverse-map an mcp sender name back to its gc
+# name without calling mcp_agent_mail's whois API.
+#
+# Message state (msg-agent, msg-read, msg-thread, msg-reply-to) stays
+# pod-local in /tmp even when GC_CITY is set. Each pod repopulates these
+# on demand from mcp_agent_mail (fetch_inbox populates msg-agent; send/
+# reply populate msg-thread/msg-reply-to). Keeping them pod-local
+# minimises the sharing surface to only what's needed for the fix, and
+# avoids leaking transient per-process state across pods.
+#
+# Cross-pod sharing contract: both GC_CITY and GC_MCP_MAIL_PROJECT must
+# be identical across pods for the shared cache to actually be shared.
+# PROJECT_HASH is derived from GC_MCP_MAIL_PROJECT, so pods with
+# divergent project keys land in different PROJECT_HASH subdirectories
+# under the same GC_CITY and get isolated caches — by design, since
+# they reference different mcp_agent_mail projects. The controller is
+# responsible for setting both env vars consistently on every pod it
+# spawns (see contrib/session-scripts/gc-session-k8s).
 PROJECT_HASH="$(printf '%s' "$PROJECT" | md5sum | cut -d' ' -f1)"
+CACHE_DIR="/tmp/gc-mcp-mail-cache/${PROJECT_HASH}"
 if [ -n "${GC_CITY:-}" ]; then
-  CACHE_DIR="${GC_CITY}/.gc/mail-cache/${PROJECT_HASH}"
+  NAME_MAP_DIR="${GC_CITY}/.gc/mail-cache/${PROJECT_HASH}/name-map"
 else
-  CACHE_DIR="/tmp/gc-mcp-mail-cache/${PROJECT_HASH}"
+  NAME_MAP_DIR="${CACHE_DIR}/name-map"
 fi
-mkdir -p "$CACHE_DIR/name-map" "$CACHE_DIR/msg-agent" "$CACHE_DIR/msg-read" "$CACHE_DIR/msg-thread"
+mkdir -p "$NAME_MAP_DIR" "$CACHE_DIR/msg-agent" "$CACHE_DIR/msg-read" "$CACHE_DIR/msg-thread"
 
 # --- Name mapping ---
 
@@ -74,7 +97,7 @@ gc_to_mcp_name() {
   local gc_name="$1"
   # Check cache first.
   local cached
-  cached=$(cat "$CACHE_DIR/name-map/$gc_name" 2>/dev/null || true)
+  cached=$(cat "$NAME_MAP_DIR/$gc_name" 2>/dev/null || true)
   if [ -n "$cached" ]; then
     echo "$cached"
     return
@@ -86,8 +109,8 @@ gc_to_mcp_name() {
   adj_idx=$(( 16#${hash:0:8} % ${#ADJECTIVES[@]} ))
   noun_idx=$(( 16#${hash:8:8} % ${#NOUNS[@]} ))
   local mcp_name="${ADJECTIVES[$adj_idx]}${NOUNS[$noun_idx]}"
-  mkdir -p "$(dirname "$CACHE_DIR/name-map/$gc_name")"
-  printf '%s' "$mcp_name" > "$CACHE_DIR/name-map/$gc_name"
+  mkdir -p "$(dirname "$NAME_MAP_DIR/$gc_name")"
+  printf '%s' "$mcp_name" > "$NAME_MAP_DIR/$gc_name"
   echo "$mcp_name"
 }
 
@@ -101,10 +124,10 @@ mcp_to_gc_name() {
     mapped=$(cat "$f")
     if [ "$mapped" = "$mcp_name" ]; then
       # Return the gc name as the path relative to name-map/.
-      echo "${f#"$CACHE_DIR/name-map/"}"
+      echo "${f#"$NAME_MAP_DIR/"}"
       return
     fi
-  done < <(find "$CACHE_DIR/name-map" -type f 2>/dev/null)
+  done < <(find "$NAME_MAP_DIR" -type f 2>/dev/null)
   # Fallback: return the mcp name as-is.
   echo "$mcp_name"
 }
@@ -116,10 +139,10 @@ build_name_map_json() {
   while IFS= read -r f; do
     [ -f "$f" ] || continue
     local gc_name mcp_name
-    gc_name="${f#"$CACHE_DIR/name-map/"}"
+    gc_name="${f#"$NAME_MAP_DIR/"}"
     mcp_name=$(cat "$f")
     map=$(echo "$map" | jq --arg k "$mcp_name" --arg v "$gc_name" '. + {($k): $v}')
-  done < <(find "$CACHE_DIR/name-map" -type f 2>/dev/null)
+  done < <(find "$NAME_MAP_DIR" -type f 2>/dev/null)
   echo "$map"
 }
 

--- a/internal/mail/exec/mcp_conformance_test.go
+++ b/internal/mail/exec/mcp_conformance_test.go
@@ -62,6 +62,10 @@ func TestMCPMailConformance(t *testing.T) {
 // two independent provider instances (simulating separate K8s pods) share
 // the name cache via the city directory, allowing the receiver to resolve
 // the sender's gc name without calling mcp_agent_mail's whois API.
+//
+// Only the name-map subdir lives under GC_CITY. Per-message state
+// (msg-agent, msg-read, msg-thread, msg-reply-to) stays pod-local so
+// transient per-process state does not leak across pods.
 func TestMCPMailCrossPodNameResolution(t *testing.T) {
 	if _, err := osexec.LookPath("jq"); err != nil {
 		t.Skip("jq not on PATH")
@@ -132,10 +136,102 @@ func TestMCPMailCrossPodNameResolution(t *testing.T) {
 		t.Errorf("pod B Inbox[0].From = %q, want %q (shared cache should resolve gc name)", msgs[0].From, "mayor")
 	}
 
-	// Verify cache is under city dir, not /tmp.
+	// Verify name-map is under city dir.
 	cacheGlob, _ := filepath.Glob(filepath.Join(cityDir, ".gc", "mail-cache", "*", "name-map", "mayor"))
 	if len(cacheGlob) == 0 {
 		t.Error("name cache not found under GC_CITY/.gc/mail-cache/")
+	}
+
+	// Verify per-message state subdirs are NOT under city dir — they stay
+	// pod-local so transient per-process state does not leak between pods.
+	for _, sub := range []string{"msg-agent", "msg-read", "msg-thread", "msg-reply-to"} {
+		leaked, _ := filepath.Glob(filepath.Join(cityDir, ".gc", "mail-cache", "*", sub, "*"))
+		if len(leaked) > 0 {
+			t.Errorf("%s entries leaked into GC_CITY: %v (should be pod-local)", sub, leaked)
+		}
+	}
+}
+
+// TestMCPMailProjectKeyIsolation verifies the cross-pod sharing contract:
+// if two pods share GC_CITY but compute different GC_MCP_MAIL_PROJECT values,
+// the name cache is isolated by PROJECT_HASH and no sharing occurs. This
+// documents that cross-pod name resolution requires the controller to set
+// identical GC_MCP_MAIL_PROJECT on every pod that shares a city volume.
+func TestMCPMailProjectKeyIsolation(t *testing.T) {
+	if _, err := osexec.LookPath("jq"); err != nil {
+		t.Skip("jq not on PATH")
+	}
+	scriptPath, err := findMCPScript()
+	if err != nil {
+		t.Skipf("MCP mail script not found: %v", err)
+	}
+
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared mock MCP state — the mock doesn't segregate by project_key,
+	// so both "pods" see each other's messages regardless of project value.
+	// This lets us isolate the cache-sharing behavior from mcp-side routing.
+	stateDir := filepath.Join(dir, "state")
+	for _, sub := range []string{"agents", "messages"} {
+		if err := os.MkdirAll(filepath.Join(stateDir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "next_id"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "curl"), []byte(mcpMockCurl(stateDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pod A uses project-a; pod B uses project-b. Same GC_CITY, divergent keys.
+	projectA := filepath.Join(dir, "project-a")
+	projectB := filepath.Join(dir, "project-b")
+
+	wrapperA := filepath.Join(dir, "pod-a")
+	if err := os.WriteFile(wrapperA, []byte(mcpWrapperWithProject(binDir, scriptPath, stateDir, cityDir, projectA)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	podA := NewProvider(wrapperA)
+
+	if _, err := podA.Send("mayor", "clerk", "hello", "test message"); err != nil {
+		t.Fatalf("pod A Send: %v", err)
+	}
+
+	wrapperB := filepath.Join(dir, "pod-b")
+	if err := os.WriteFile(wrapperB, []byte(mcpWrapperWithProject(binDir, scriptPath, stateDir, cityDir, projectB)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	podB := NewProvider(wrapperB)
+
+	msgs, err := podB.Inbox("clerk")
+	if err != nil {
+		t.Fatalf("pod B Inbox: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("pod B Inbox returned 0 messages, want 1")
+	}
+	// Pod B can see the message (mock is shared), but because its project
+	// key hashes to a different PROJECT_HASH subdir under GC_CITY, its
+	// name cache is isolated. Pod B cannot reverse-map "mayor" — it falls
+	// back to the raw mcp name.
+	if msgs[0].From == "mayor" {
+		t.Errorf("pod B resolved gc name despite divergent GC_MCP_MAIL_PROJECT — sharing should be isolated by PROJECT_HASH")
+	}
+
+	// Verify two separate PROJECT_HASH subdirs were created under cityDir.
+	hashDirs, _ := filepath.Glob(filepath.Join(cityDir, ".gc", "mail-cache", "*"))
+	if len(hashDirs) < 2 {
+		t.Errorf("expected >=2 PROJECT_HASH subdirs under cityDir, got %d: %v", len(hashDirs), hashDirs)
 	}
 }
 
@@ -165,10 +261,17 @@ func mcpWrapper(binDir, scriptPath, stateDir string) string {
 	return mcpWrapperWithCity(binDir, scriptPath, stateDir, "")
 }
 
-// mcpWrapperWithCity returns a wrapper that also sets GC_CITY for shared cache.
+// mcpWrapperWithCity returns a wrapper that also sets GC_CITY for shared
+// cache. Uses stateDir as the project key — unique per test, and an
+// absolute path as required by mcp_agent_mail's human_key validation.
 func mcpWrapperWithCity(binDir, scriptPath, stateDir, cityDir string) string {
-	// Use stateDir as the project key — unique per test, and an absolute
-	// path as required by mcp_agent_mail's human_key validation.
+	return mcpWrapperWithProject(binDir, scriptPath, stateDir, cityDir, stateDir)
+}
+
+// mcpWrapperWithProject returns a wrapper that sets GC_CITY and an
+// explicit GC_MCP_MAIL_PROJECT, decoupling the project key from the mock
+// state directory. Used to simulate pods with divergent project keys.
+func mcpWrapperWithProject(binDir, scriptPath, stateDir, cityDir, projectKey string) string {
 	cityExport := ""
 	if cityDir != "" {
 		cityExport = `export GC_CITY="` + cityDir + `"` + "\n"
@@ -178,7 +281,7 @@ set -euo pipefail
 export PATH="` + binDir + `:$PATH"
 export GC_MOCK_STATE_DIR="` + stateDir + `"
 export GC_MCP_MAIL_URL="http://127.0.0.1:8765"
-export GC_MCP_MAIL_PROJECT="` + stateDir + `"
+export GC_MCP_MAIL_PROJECT="` + projectKey + `"
 ` + cityExport + `exec "` + scriptPath + `" "$@"
 `
 }


### PR DESCRIPTION
## Summary

- The mail bridge cached gc→mcp name mappings in `/tmp`, which is per-pod in Kubernetes. When agent A sent to agent B across separate pods, B could not reverse-map A's mcp name back to the gc name, falling back to the raw mcp name (e.g. "QuietRiver" instead of "mayor").
- Use `$GC_CITY/.gc/mail-cache/` when `GC_CITY` is set (the controller already passes this env var). The city directory is shared storage across K8s pods via volume mount, so the name cache is automatically shared.
- Falls back to `/tmp` when `GC_CITY` is unset (standalone/tutorial use).
- Adds a cross-pod conformance test: two independent provider instances sharing a city directory verify that sender gc names resolve correctly on the receiver side.

Supersedes #373 — solves the same cross-pod name resolution problem without coupling to mcp_agent_mail's `whois` API or `task_description` field.