### PR TITLE
fix(exec-beads): use native bd metadata in gc-beads-k8s

### DIFF
--- a/contrib/beads-scripts/gc-beads-br
+++ b/contrib/beads-scripts/gc-beads-br
@@ -9,8 +9,10 @@
 #
 # Label conventions:
 #   parent:<id>  — tracks parent-child relationships
-#   meta:<k>=<v> — stores metadata as labels
 #   needs:<id>   — tracks step dependencies
+#
+# Metadata is reconstructed from meta:<k>=<v> labels on read.
+# br does not yet support native --metadata; metadata is still written as labels.
 #
 # Operations that Gas City composes in Go (exit 2):
 #   mol-cook  — composed from Create calls by exec.Store
@@ -43,7 +45,11 @@ br_to_gc() {
     ref: (.ref // ""),
     needs: [.labels // [] | .[] | select(startswith("needs:")) | ltrimstr("needs:")],
     description: (.description // ""),
-    labels: [.labels // [] | .[] | select((startswith("parent:") or startswith("meta:") or startswith("needs:")) | not)]
+    labels: [.labels // [] | .[] | select((startswith("parent:") or startswith("meta:") or startswith("needs:")) | not)],
+    metadata: ((
+      ([.labels // [] | .[] | select(startswith("meta:")) | ltrimstr("meta:") | split("=") | {(.[0]): (.[1:] | join("="))}] | add // {})
+      + (.metadata // {})
+    ) | map_values(tostring))
   }'
 }
 
@@ -62,7 +68,11 @@ br_list_to_gc() {
     ref: (.ref // ""),
     needs: [.labels // [] | .[] | select(startswith("needs:")) | ltrimstr("needs:")],
     description: (.description // ""),
-    labels: [.labels // [] | .[] | select((startswith("parent:") or startswith("meta:") or startswith("needs:")) | not)]
+    labels: [.labels // [] | .[] | select((startswith("parent:") or startswith("meta:") or startswith("needs:")) | not)],
+    metadata: ((
+      ([.labels // [] | .[] | select(startswith("meta:")) | ltrimstr("meta:") | split("=") | {(.[0]): (.[1:] | join("="))}] | add // {})
+      + (.metadata // {})
+    ) | map_values(tostring))
   }]'
 }
 
@@ -96,6 +106,12 @@ case "$op" in
       [ -n "$need" ] && all_labels+=("needs:$need")
     done < <(echo "$input" | jq -r '.needs // [] | .[]')
 
+    # Convert metadata entries to meta:<key>=<value> labels.
+    # br does not support native --metadata; metadata is stored as labels.
+    while IFS= read -r meta_label; do
+      [ -n "$meta_label" ] && all_labels+=("$meta_label")
+    done < <(echo "$input" | jq -r '.metadata // {} | to_entries[] | "meta:\(.key)=\(.value)"')
+
     # Build create command.
     cmd_args=(br create --json --type="$bead_type")
     [ -n "$description" ] && cmd_args+=(--description "$description")
@@ -128,6 +144,12 @@ case "$op" in
     # Handle parent_id change.
     parent_id=$(echo "$input" | jq -r '.parent_id // empty')
     [ -n "$parent_id" ] && cmd_args+=(--add-label "parent:$parent_id")
+
+    # Convert metadata entries to meta:<key>=<value> labels.
+    # br does not support native --metadata; metadata is stored as labels.
+    while IFS= read -r meta_label; do
+      [ -n "$meta_label" ] && cmd_args+=(--add-label "$meta_label")
+    done < <(echo "$input" | jq -r '.metadata // {} | to_entries[] | "meta:\(.key)=\(.value)"')
 
     "${cmd_args[@]}" > /dev/null
     ;;

--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -280,6 +280,9 @@ case "$op" in
     [ -n "$parent_id" ] && cmd_args+=(--add-label "parent:$parent_id")
 
     # Handle metadata via --metadata (avoids CSV quoting issues with --add-label).
+    # bd --metadata uses merge semantics: new keys are added, existing keys are
+    # overwritten, and keys not in the payload are preserved. Verified against
+    # bd 0.62+ (see TestUpdate_metadataRoundTripsViaConformance).
     metadata_json=$(echo "$input" | jq -c '.metadata // empty')
     [ -n "$metadata_json" ] && cmd_args+=(--metadata "$metadata_json")
 

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -318,6 +318,11 @@ func TestSetMetadata_deduplicatesViaConformance(t *testing.T) {
 	}
 }
 
+// TestCreate_metadataWithSpecialCharsRoundTrips validates the exec.Store
+// protocol contract: metadata values containing quotes and commas must
+// round-trip correctly. This exercises conformance.sh (the reference
+// provider), not gc-beads-k8s directly. The gc-beads-k8s fix was verified
+// via K8s homelab deployment (see PR #367).
 func TestCreate_metadataWithSpecialCharsRoundTrips(t *testing.T) {
 	if _, err := exec.LookPath("jq"); err != nil {
 		t.Skip("jq not available")
@@ -364,6 +369,10 @@ func TestCreate_metadataWithSpecialCharsRoundTrips(t *testing.T) {
 	}
 }
 
+// TestCreate_numericLookingMetadataStaysString validates the exec.Store
+// protocol contract: numeric-looking metadata values must round-trip as
+// strings. This exercises conformance.sh (the reference provider), not
+// gc-beads-k8s directly.
 func TestCreate_numericLookingMetadataStaysString(t *testing.T) {
 	if _, err := exec.LookPath("jq"); err != nil {
 		t.Skip("jq not available")


### PR DESCRIPTION
## Summary

Supersedes #367 by @GraemeF, which correctly identified and fixed the metadata CSV quoting bug in `gc-beads-k8s`. This PR includes that fix plus maintainer fixups from the adoption review.

Credit: Original fix by @GraemeF (commit preserved with original authorship).

### Original fix (by @GraemeF)
- `gc-beads-k8s` encoded metadata as `meta:key=value` labels joined with commas into bd's `--labels` flag. bd's CSV parser breaks on values containing quotes or commas (e.g. `--settings "/city/.gc/settings.json"`), blocking session bead creation entirely.
- Switch `create` and `update` to bd's native `--metadata` flag (JSON), and `set-metadata` to `--set-metadata`. No CSV quoting issues since metadata is passed as a JSON string.
- `bd_to_gc` / `bd_list_to_gc` now merge both native `.metadata` and legacy `meta:` labels for backward compatibility.
- Added conformance tests for metadata with quotes, commas, and numeric-looking values.

### Maintainer fixups (adoption review)
- Port metadata reconstruction jq block to `gc-beads-br` (`br_to_gc`/`br_list_to_gc`) for cross-provider parity.
- Add metadata-to-label conversion on `gc-beads-br` create/update write paths so metadata round-trips correctly (br stores metadata as `meta:<k>=<v>` labels).
- Clarify test scope: new conformance tests validate the `exec.Store` protocol contract, not `gc-beads-k8s` directly.
- Document `bd --metadata` merge semantics in the update operation.

## Verified

- `go test ./internal/beads/exec/...` passes
- `go vet ./...` clean
- Three-round multi-model review (Claude + Codex + Gemini) — no remaining blockers or majors