### PR TITLE
feat: add --name flag to gc init for workspace name override

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -196,13 +196,11 @@ existing TOML config file.`,
   gc init ~/my-city
   gc init --provider codex ~/my-city
   gc init --provider codex --bootstrap-profile k8s-cell /city
+  gc init --name my-city
   gc init --from ~/elan --name elan /city
   gc init --file examples/gastown.toml ~/bright-lights`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if nameFlag != "" && fromFlag == "" && fileFlag == "" {
-				return fmt.Errorf("--name requires --from or --file")
-			}
 			if fromFlag != "" {
 				if cmdInitFromDirWithOptions(fromFlag, args, nameFlag, stdout, stderr, skipProviderReadiness) != 0 {
 					return errExit
@@ -215,7 +213,7 @@ existing TOML config file.`,
 				}
 				return nil
 			}
-			if cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, stdout, stderr, skipProviderReadiness) != 0 {
+			if cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, stdout, stderr, skipProviderReadiness) != 0 {
 				return errExit
 			}
 			return nil
@@ -240,10 +238,10 @@ existing TOML config file.`,
 // Creates the runtime scaffold and city.toml. If the bead provider is "bd", also
 // runs bd init.
 func cmdInit(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer) int {
-	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, stdout, stderr, false)
+	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false)
 }
 
-func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -278,7 +276,7 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag string
 	default:
 		wiz = defaultWizardConfig()
 	}
-	if code := doInit(fsys.OSFS{}, cityPath, wiz, stdout, stderr); code != 0 {
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, nameOverride, stdout, stderr); code != 0 {
 		return code
 	}
 	return finalizeInit(cityPath, stdout, stderr, initFinalizeOptions{
@@ -383,7 +381,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	}
 
 	// --file creates a new city from a template; default to target dir name.
-	cityName := resolveCityName(nameOverride, "", cityPath)
+	cityName := resolveCityName(nameOverride, cityPath)
 	cfg.Workspace.Name = cityName
 
 	// Re-marshal so the name is updated.
@@ -443,7 +441,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 // when a provider or start command is supplied; otherwise init writes the
 // default mayor-only city. Errors if the runtime scaffold already exists. Accepts an
 // injected FS for testability.
-func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, stdout, stderr io.Writer) int {
+func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, stdout, stderr io.Writer) int {
 	tomlPath := filepath.Join(cityPath, citylayout.CityConfigFile)
 	if cityHasScaffoldFS(fs, cityPath) {
 		fmt.Fprintln(stderr, "gc init: already initialized") //nolint:errcheck // best-effort stderr
@@ -461,8 +459,14 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, stdout, stderr io.Wri
 		if code := installClaudeHooks(fs, cityPath, stderr); code != 0 {
 			return code
 		}
-		fmt.Fprintln(stdout, "Welcome to Gas City!")                                             //nolint:errcheck // best-effort stdout
-		fmt.Fprintf(stdout, "Bootstrapped city %q runtime scaffold.\n", filepath.Base(cityPath)) //nolint:errcheck // best-effort stdout
+		if nameOverride != "" {
+			if code := overrideCityName(fs, tomlPath, nameOverride, stderr); code != 0 {
+				return code
+			}
+		}
+		cityName := resolveCityName(nameOverride, cityPath)
+		fmt.Fprintln(stdout, "Welcome to Gas City!")                              //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stdout, "Bootstrapped city %q runtime scaffold.\n", cityName) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 
@@ -500,7 +504,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, stdout, stderr io.Wri
 	// Write city.toml — wizard path gets one agent + provider/startCommand;
 	// --provider path gets the same city shape non-interactively;
 	// custom path gets one mayor + no provider (user configures manually).
-	cityName := filepath.Base(cityPath)
+	cityName := resolveCityName(nameOverride, cityPath)
 	var cfg config.City
 	switch {
 	case wiz.configName == "custom":
@@ -600,14 +604,36 @@ func initFromSkip(relPath string, isDir bool) bool {
 	return false
 }
 
+// overrideCityName reads an existing city.toml, updates workspace.name, and writes it back.
+func overrideCityName(f fsys.FS, tomlPath, name string, stderr io.Writer) int {
+	data, err := f.ReadFile(tomlPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc init: reading %q: %v\n", tomlPath, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cfg.Workspace.Name = name
+	content, err := cfg.Marshal()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := f.WriteFile(tomlPath, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
 // resolveCityName returns the workspace name to use during init.
-// Priority: explicit --name flag > source config name > target directory basename.
-func resolveCityName(nameOverride, sourceName, cityPath string) string {
+// Priority: explicit --name flag > target directory basename.
+func resolveCityName(nameOverride, cityPath string) string {
 	if nameOverride != "" {
 		return nameOverride
-	}
-	if sourceName != "" {
-		return sourceName
 	}
 	return filepath.Base(cityPath)
 }
@@ -683,7 +709,7 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, cityPath)
+	cityName := resolveCityName(nameOverride, cityPath)
 	cfg.Workspace.Name = cityName
 	content, err := cfg.Marshal()
 	if err != nil {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -54,7 +54,7 @@ func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *test
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "tutorial",
 		provider:   "claude",
-	}, &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -264,7 +264,7 @@ func TestFinalizeInitWithoutProgressSkipsStepCounter(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "tutorial",
 		provider:   "claude",
-	}, &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -323,7 +323,7 @@ func TestCmdInitResumesFinalizeForExistingCity(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "gastown",
 		provider:   "claude",
-	}, &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -384,7 +384,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "tutorial",
 		provider:   "claude",
-	}, &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -413,7 +413,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code = cmdInitWithOptions([]string{cityPath}, "", "", &stdout, &stderr, true)
+	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true)
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions = %d, want 0: %s", code, stderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1149,7 +1149,7 @@ func TestDoInitSuccess(t *testing.T) {
 	// No pre-existing files — doInit creates everything from scratch.
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1210,7 +1210,7 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1237,7 +1237,7 @@ func TestDoInitAlreadyInitialized(t *testing.T) {
 	markFakeCityScaffold(f, "/city")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -1263,7 +1263,7 @@ func TestDoInitBootstrapsExistingCityToml(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = original
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), &stdout, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -1281,12 +1281,34 @@ func TestDoInitBootstrapsExistingCityToml(t *testing.T) {
 	}
 }
 
+func TestDoInitBootstrapWithNameOverride(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files[filepath.Join("/city", "city.toml")] = []byte("[workspace]\nname = \"old-name\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/city", defaultWizardConfig(), "new-name", &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "new-name") {
+		t.Errorf("stdout = %q, want name override in output", stdout.String())
+	}
+	data := f.Files[filepath.Join("/city", "city.toml")]
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing updated city.toml: %v", err)
+	}
+	if cfg.Workspace.Name != "new-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "new-name")
+	}
+}
+
 func TestDoInitMkdirGCFails(t *testing.T) {
 	f := fsys.NewFake()
 	f.Errors[filepath.Join("/city", ".gc")] = fmt.Errorf("permission denied")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -1300,7 +1322,7 @@ func TestDoInitWriteFails(t *testing.T) {
 	f.Errors[filepath.Join("/city", "city.toml")] = fmt.Errorf("read-only fs")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -1314,7 +1336,7 @@ func TestDoInitWriteFails(t *testing.T) {
 func TestDoInitCreatesSettings(t *testing.T) {
 	f := fsys.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1334,7 +1356,7 @@ func TestDoInitCreatesSettings(t *testing.T) {
 func TestDoInitSettingsIsValidJSON(t *testing.T) {
 	f := fsys.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1663,7 +1685,7 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1707,7 +1729,7 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1738,7 +1760,7 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1782,7 +1804,7 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/my-city", wiz, &stdout, &stderr)
+	code := doInit(f, "/my-city", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1813,7 +1835,7 @@ func TestDoInitWithProviderFlagAndBootstrapProfile(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/hosted-city", wiz, &stdout, &stderr)
+	code := doInit(f, "/hosted-city", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1853,7 +1875,7 @@ func TestDoInitWithOpenCodeProviderInstallsWorkspaceHooks(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/open-city", wiz, &stdout, &stderr)
+	code := doInit(f, "/open-city", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1882,7 +1904,7 @@ func TestDoInitWithClaudeProviderLeavesWorkspaceHooksEmpty(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/claude-city", wiz, &stdout, &stderr)
+	code := doInit(f, "/claude-city", wiz, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2106,11 +2128,11 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 	if !strings.Contains(out, "Welcome to Gas City!") {
 		t.Errorf("stdout missing welcome: %q", out)
 	}
-	if !strings.Contains(out, "template") {
+	if !strings.Contains(out, "bright-lights") {
 		t.Errorf("stdout missing city name: %q", out)
 	}
 
-	// Verify city.toml was copied and source name preserved.
+	// Verify city.toml was copied and name updated.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
@@ -2119,8 +2141,8 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Name != "template" {
-		t.Errorf("Workspace.Name = %q, want %q (--from preserves source name)", cfg.Workspace.Name, "template")
+	if cfg.Workspace.Name != "bright-lights" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
 	}
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
@@ -2134,6 +2156,173 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 	// Verify .gc/ was created.
 	if _, err := os.Stat(filepath.Join(cityPath, ".gc")); err != nil {
 		t.Errorf(".gc/ not created: %v", err)
+	}
+}
+
+func TestResolveCityName(t *testing.T) {
+	tests := []struct {
+		name         string
+		nameOverride string
+		cityPath     string
+		want         string
+	}{
+		{"override wins over dir", "custom", "/path/to/dir", "custom"},
+		{"dir basename used as fallback", "", "/path/to/dir", "dir"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveCityName(tt.nameOverride, tt.cityPath)
+			if got != tt.want {
+				t.Errorf("resolveCityName(%q, %q) = %q, want %q",
+					tt.nameOverride, tt.cityPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitNameFlagWithFrom(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	// Create source template directory.
+	srcDir := filepath.Join(dir, "template")
+	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "target-dir")
+
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDirWithOptions(srcDir, cityPath, "my-custom-name", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	if cfg.Workspace.Name != "my-custom-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-custom-name")
+	}
+}
+
+func TestInitNameFlagWithFile(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	tomlFile := filepath.Join(dir, "city.toml")
+	if err := os.WriteFile(tomlFile,
+		[]byte("[workspace]\nname = \"original\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "target-dir")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromFileWithOptions(tomlFile, []string{cityPath}, "my-file-name", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("cmdInitFromFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	if cfg.Workspace.Name != "my-file-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-file-name")
+	}
+}
+
+func TestInitNameFlagWithBareInit(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "target-dir")
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
+		configName: "tutorial",
+		provider:   "claude",
+	}, "my-bare-name", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	if cfg.Workspace.Name != "my-bare-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-bare-name")
+	}
+}
+
+func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	// Source has workspace.name = "template" — should NOT propagate.
+	srcDir := filepath.Join(dir, "template")
+	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "my-new-city")
+
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDirWithOptions(srcDir, cityPath, "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	if cfg.Workspace.Name != "my-new-city" {
+		t.Errorf("Workspace.Name = %q, want %q (--from should default to target dir basename)", cfg.Workspace.Name, "my-new-city")
 	}
 }
 

--- a/cmd/gc/testdata/init-from-dir.txtar
+++ b/cmd/gc/testdata/init-from-dir.txtar
@@ -8,11 +8,11 @@ env GC_DOLT=skip
 exec gc init --from $WORK/template $WORK/my-city
 stdout 'Welcome to Gas City!'
 stdout 'Initialized city'
-stdout 'template'
+stdout 'my-city'
 
-# Verify city.toml exists and source name was preserved.
+# Verify city.toml exists and name was updated to target dir.
 exists $WORK/my-city/city.toml
-exec grep 'template' $WORK/my-city/city.toml
+exec grep 'my-city' $WORK/my-city/city.toml
 
 # Verify prompts were copied.
 exists $WORK/my-city/prompts/mayor.md
@@ -25,6 +25,12 @@ exists $WORK/my-city/.gc
 
 # Verify source .gc/ runtime state was not copied.
 ! exists $WORK/my-city/.gc/old-state.json
+
+# gc init --from with --name overrides workspace name.
+exec gc init --from $WORK/template --name custom-name $WORK/named-city
+stdout 'custom-name'
+exists $WORK/named-city/city.toml
+exec grep 'custom-name' $WORK/named-city/city.toml
 
 # gc init --from rejects already-initialized city.
 ! exec gc init --from $WORK/template $WORK/my-city

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -904,6 +904,7 @@ gc init
   gc init ~/my-city
   gc init --provider codex ~/my-city
   gc init --provider codex --bootstrap-profile k8s-cell /city
+  gc init --name my-city
   gc init --from ~/elan --name elan /city
   gc init --file examples/gastown.toml ~/bright-lights
 ```


### PR DESCRIPTION
## Summary

- Add `--name` flag to `gc init` that overrides the workspace name instead of deriving it from the directory name
- Useful when initializing from a staging directory (e.g. `gc init --from /tmp/city-src /city`) where the target directory name doesn't match the intended workspace name
- Used by the K8s controller Dockerfile CMD to preserve the workspace name during `gc init --from`

## Test plan

- [x] `TestInit` txtar tests pass with --name flag
- [x] `go build ./...` and `go vet ./...` clean