### PR TITLE
fix: stage hooks to agent workDir .claude/settings.json

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -751,6 +751,13 @@ func stageHookFiles(copyFiles []runtime.CopyEntry, cityPath, workDir string) []r
 		if !alreadyStaged {
 			copyFiles = append(copyFiles, runtime.CopyEntry{Src: settingsAbs, RelDst: settingsRel})
 		}
+		// Also stage into the agent's workDir as .claude/settings.json so
+		// Claude Code discovers hooks via standard project-level settings
+		// (the --settings flag loads hooks but /hooks may not display them).
+		workDirSettings := path.Join(relWorkDir, ".claude", "settings.json")
+		if workDirSettings != settingsRel {
+			copyFiles = append(copyFiles, runtime.CopyEntry{Src: settingsAbs, RelDst: workDirSettings})
+		}
 	}
 	return copyFiles
 }


### PR DESCRIPTION
## Summary

- When starting an agent session, stage the configured hooks into the agent's workDir `.claude/settings.json` so Claude Code picks them up automatically
- Without this, hooks defined in the city config are not available to agents running in K8s pods or other remote environments

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [ ] Deploy a city with hooks configured and verify agents receive them