### PR TITLE
fix: closed legacy beads block configured named session names after cold boot

### DIFF
--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -378,7 +378,7 @@ func ensureConfiguredSessionNameAvailable(store beads.Store, cfg *config.City, n
 		if !isConfiguredNamedSessionRuntimeName(cfg, name, selfOwner) {
 			return err
 		}
-		if !allSessionNameHoldersAreClosed(store, name, selfID) {
+		if !noLiveSessionNameCollisions(store, name, selfID) {
 			return err
 		}
 		// All holders are closed and the name belongs to a configured named
@@ -423,9 +423,12 @@ func isConfiguredNamedSessionRuntimeName(cfg *config.City, name, owner string) b
 	return false
 }
 
-// allSessionNameHoldersAreClosed reports whether every bead that holds the
-// given session_name (excluding selfID) is closed.
-func allSessionNameHoldersAreClosed(store beads.Store, name, selfID string) bool {
+// noLiveSessionNameCollisions reports whether no live bead conflicts with
+// the given name via session_name, alias, alias_history, or identifier
+// fields. This mirrors the full collision check in
+// ensureSessionNameAvailableForSelf so the legacy-bypass path cannot
+// suppress rejections from live alias or identifier collisions.
+func noLiveSessionNameCollisions(store beads.Store, name, selfID string) bool {
 	all, err := store.List(beads.ListQuery{
 		Label:         LabelSession,
 		IncludeClosed: true,
@@ -437,7 +440,25 @@ func allSessionNameHoldersAreClosed(store beads.Store, name, selfID string) bool
 		if !IsSessionBeadOrRepairable(b) || b.ID == selfID {
 			continue
 		}
+		// A live bead holding the name as session_name blocks.
 		if strings.TrimSpace(b.Metadata["session_name"]) == name && b.Status != "closed" {
+			return false
+		}
+		if b.Status == "closed" {
+			continue
+		}
+		// Live alias collision blocks.
+		if strings.TrimSpace(b.Metadata["alias"]) == name {
+			return false
+		}
+		// Live alias history collision blocks.
+		for _, historicalAlias := range AliasHistory(b.Metadata) {
+			if historicalAlias == name {
+				return false
+			}
+		}
+		// Live identifier collision blocks.
+		if sessionNameConflictsWithExistingIdentifier(b, name) {
 			return false
 		}
 	}

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -645,6 +645,142 @@ func TestEnsureConfiguredSessionNameAvailable_AllowsClosedLegacyWithWorkspacePre
 	}
 }
 
+// TestEnsureConfiguredSessionNameAvailable_RejectsLiveAliasCollisionDespiteLegacyBypass
+// verifies that the legacy-bypass path does not suppress rejections from live
+// alias collisions. A live ad-hoc session holding the target name as its alias
+// must still block, even when a closed legacy bead holds the session_name.
+func TestEnsureConfiguredSessionNameAvailable_RejectsLiveAliasCollisionDespiteLegacyBypass(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		ResolvedWorkspaceName: "gc-management",
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor"},
+		},
+	}
+
+	// Closed legacy bead holding the session_name (no configured_named_session flag).
+	b, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "mayor",
+			"close_reason": "orphaned",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create legacy: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close legacy: %v", err)
+	}
+
+	// Live ad-hoc session using "mayor" as an alias.
+	_, err = store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias": "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live alias: %v", err)
+	}
+
+	// Must reject — live alias collision takes precedence over legacy bypass.
+	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "mayor"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(live alias collision) = %v, want ErrSessionNameExists", err)
+	}
+}
+
+// TestEnsureConfiguredSessionNameAvailable_RejectsLiveAliasHistoryCollisionDespiteLegacyBypass
+// verifies that a live bead's alias history blocks the legacy bypass.
+func TestEnsureConfiguredSessionNameAvailable_RejectsLiveAliasHistoryCollisionDespiteLegacyBypass(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		ResolvedWorkspaceName: "gc-management",
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor"},
+		},
+	}
+
+	// Closed legacy bead.
+	b, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "mayor",
+			"close_reason": "orphaned",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create legacy: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close legacy: %v", err)
+	}
+
+	// Live session with "mayor" in alias history.
+	_, err = store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias":         "sky",
+			"alias_history": "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live alias history: %v", err)
+	}
+
+	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "mayor"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(live alias history collision) = %v, want ErrSessionNameExists", err)
+	}
+}
+
+// TestEnsureConfiguredSessionNameAvailable_RejectsLiveIdentifierCollisionDespiteLegacyBypass
+// verifies that a live bead's identifier (template/common_name) blocks the legacy bypass.
+func TestEnsureConfiguredSessionNameAvailable_RejectsLiveIdentifierCollisionDespiteLegacyBypass(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		ResolvedWorkspaceName: "gc-management",
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor"},
+		},
+	}
+
+	// Closed legacy bead.
+	b, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "mayor",
+			"close_reason": "orphaned",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create legacy: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close legacy: %v", err)
+	}
+
+	// Live session with "mayor" as template identifier.
+	_, err = store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"template": "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live identifier: %v", err)
+	}
+
+	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "mayor"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(live identifier collision) = %v, want ErrSessionNameExists", err)
+	}
+}
+
 func TestWithCitySessionLocks_EmptyCityPathSharesIdentifierNamespace(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})


### PR DESCRIPTION
## Summary
- After a cold boot, closed beads that predate the `configured_named_session` flag still hold `session_name` reservations permanently
- The reconciler loops every 30s trying to create a new bead for the configured named session but always fails with `"session name already exists"` because the closed legacy bead is not exempted
- Fix: the config-aware name check (`ensureConfiguredSessionNameAvailable`) now bypasses the base rejection when all current holders are closed and the name maps to the caller's configured named session

## Details
The existing exemption at `ensureSessionNameAvailableForSelf` only skips closed beads with `configured_named_session=true`. Beads created before this flag was introduced (e.g., gc-48 with `close_reason: "orphaned"`) have an empty `configured_named_session` field and permanently poison the session name.

The fix adds a fallback in the config-aware wrapper: if the base check returns `ErrSessionNameExists`, and the caller provides config + owner identity, verify that (1) the name belongs to the owner's configured named session and (2) all holders are closed. This preserves the safety invariant that live beads always block.

## Test plan
- [x] 5 new tests covering: legacy bead bypass, wrong owner rejection, live bead rejection, nil config rejection, workspace-prefixed names
- [x] All 8 existing session name tests still pass
- [x] Full `go test ./internal/session/` passes
- [ ] Manual: cold boot with orphaned legacy bead → `gc session new mayor` → reconciler starts session successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)