### PR TITLE
fix: defer beads init when --skip-provider-readiness is set

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -115,9 +115,9 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 //
 // Returns (deferred bool, err). deferred=true means the bd provider
 // skipped init — the caller should tell the user it's deferred to gc start.
-func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
+func initDirIfReady(cityPath, dir, prefix string, skipProviderReadiness bool) (deferred bool, err error) {
 	if rawBeadsProvider(cityPath) == "bd" {
-		if os.Getenv("GC_DOLT") == "skip" {
+		if skipProviderReadiness || os.Getenv("GC_DOLT") == "skip" {
 			// Defer to controller/startup without forcing a new dolt_database:
 			// preserve existing metadata identity when present.
 			seedDeferredManagedBeads(dir, prefix, "")

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -264,7 +264,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 	// if the probe fails (e.g. Dolt not yet ready), falls back to
 	// direct init — the city is likely already running and the probe
 	// script may just be checking the wrong state.
-	deferred, err := initDirIfReady(cityPath, rigPath, prefix)
+	deferred, err := initDirIfReady(cityPath, rigPath, prefix, false)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -82,7 +82,7 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		return 1
 	}
 	prefix := config.EffectiveHQPrefix(cfg)
-	if _, err := initDirIfReady(cityPath, cityPath, prefix); err != nil {
+	if _, err := initDirIfReady(cityPath, cityPath, prefix, opts.skipProviderReadiness); err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", opts.commandName, err)        //nolint:errcheck // best-effort stderr
 		fmt.Fprintln(stderr, `hint: run "gc doctor" for diagnostics`) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -97,7 +97,7 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 
 	// Phase 1: gc init — initDirIfReady for city root.
 	prefix := "tc"
-	deferred, err := initDirIfReady(cityPath, cityPath, prefix)
+	deferred, err := initDirIfReady(cityPath, cityPath, prefix, false)
 	if err != nil {
 		t.Fatalf("initDirIfReady (city): %v", err)
 	}
@@ -123,7 +123,7 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 
 	// Phase 2: gc rig add — initDirIfReady for rig.
 	rigPrefix := "mr"
-	deferred, err = initDirIfReady(cityPath, rigPath, rigPrefix)
+	deferred, err = initDirIfReady(cityPath, rigPath, rigPrefix, false)
 	if err != nil {
 		t.Fatalf("initDirIfReady (rig): %v", err)
 	}
@@ -251,7 +251,7 @@ func TestLifecycleCoordination_InitDirIfReady_BdDeferred(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
 
-	deferred, err := initDirIfReady(dir, dir, "test")
+	deferred, err := initDirIfReady(dir, dir, "test", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestLifecycleCoordination_InitDirIfReady_BdDeferredPreservesExistingDoltDat
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
 
-	deferred, err := initDirIfReady(dir, dir, "gc")
+	deferred, err := initDirIfReady(dir, dir, "gc", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -316,6 +316,54 @@ func TestLifecycleCoordination_InitDirIfReady_BdDeferredPreservesExistingDoltDat
 	}
 	if got := strings.TrimSpace(fmt.Sprint(meta["dolt_database"])); got != "gascity" {
 		t.Fatalf("dolt_database = %q, want %q", got, "gascity")
+	}
+}
+
+// TestLifecycleCoordination_InitDirIfReady_SkipProviderReadinessDefers verifies
+// that initDirIfReady defers beads init for the bd provider when
+// skipProviderReadiness is true, without requiring GC_DOLT=skip. This matches
+// the K8s init container flow: gc init --skip-provider-readiness should not
+// start a local Dolt or generate a project_id.
+func TestLifecycleCoordination_InitDirIfReady_SkipProviderReadinessDefers(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	MaterializeBeadsBdScript(dir) //nolint:errcheck
+	t.Setenv("GC_BEADS", "bd")
+	// Explicitly NOT setting GC_DOLT=skip — skipProviderReadiness alone
+	// should trigger the deferred path.
+
+	deferred, err := initDirIfReady(dir, dir, "test", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deferred {
+		t.Fatal("expected bd provider to defer init when skipProviderReadiness=true")
+	}
+
+	// Verify deferred metadata was seeded (no project_id).
+	metaData, err := os.ReadFile(filepath.Join(dir, ".beads", "metadata.json"))
+	if err != nil {
+		t.Fatalf("read deferred metadata: %v", err)
+	}
+	metaText := string(metaData)
+	for _, needle := range []string{`"backend": "dolt"`, `"database": "dolt"`, `"dolt_mode": "server"`, `"dolt_database": "test"`} {
+		if !strings.Contains(metaText, needle) {
+			t.Fatalf("deferred metadata missing %s:\n%s", needle, metaText)
+		}
+	}
+	if strings.Contains(metaText, "project_id") {
+		t.Fatalf("deferred metadata should not contain project_id:\n%s", metaText)
+	}
+
+	// Verify config was seeded with dolt.auto-start: false.
+	configData, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read deferred config: %v", err)
+	}
+	if !strings.Contains(string(configData), "dolt.auto-start: false") {
+		t.Fatalf("deferred config missing dolt.auto-start guard:\n%s", string(configData))
 	}
 }
 


### PR DESCRIPTION
## Summary

- `initDirIfReady` previously ignored `--skip-provider-readiness` for the `bd` provider, falling through to start a local Dolt and run `bd init --server`
- In K8s init containers this generated a fresh `project_id` on every restart, mismatching the persistent Dolt database and causing `PROJECT IDENTITY MISMATCH` errors in agent pods
- Thread `skipProviderReadiness` into `initDirIfReady` so it takes the deferred path (same as `GC_DOLT=skip`) — seeding metadata without starting Dolt or generating a `project_id`

## Test plan

- New test `TestLifecycleCoordination_InitDirIfReady_SkipProviderReadinessDefers` verifies deferred init with `skipProviderReadiness=true` and no `GC_DOLT=skip`
- All existing lifecycle coordination tests updated and passing
- Full `go test ./cmd/gc/` passes
- Deployed and verified on K8s — controller starts clean with no PROJECT IDENTITY MISMATCH