### PR TITLE
Fix rig-context resolution for city CLI commands

### DIFF
--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -85,18 +85,7 @@ all agents with running status, rigs, and a summary count.`,
 
 // cmdCityStatus is the CLI entry point for the city status overview.
 func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
-	var cityPath string
-	var err error
-	if len(args) > 0 {
-		cityPath, err = filepath.Abs(args[0])
-		if err != nil {
-			fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		cityPath, err = findCity(cityPath)
-	} else {
-		cityPath, err = resolveCity()
-	}
+	cityPath, err := resolveCommandCity(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -548,19 +548,24 @@ database remains accessible. Use "gc rig resume" to restore.`,
 
 // cmdRigSuspend is the CLI entry point for suspending a rig.
 func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
-	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig suspend: missing rig name") //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cityPath, err := resolveCity()
+	ctx, err := resolveContext()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	rigName := ctx.RigName
+	if len(args) > 0 {
+		rigName = args[0]
+	}
+	if rigName == "" {
+		fmt.Fprintln(stderr, "gc rig suspend: missing rig name") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cityPath := ctx.CityPath
 	if c := apiClient(cityPath); c != nil {
-		err := c.SuspendRig(args[0])
+		err := c.SuspendRig(rigName)
 		if err == nil {
-			fmt.Fprintf(stdout, "Suspended rig '%s'\n", args[0]) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "Suspended rig '%s'\n", rigName) //nolint:errcheck // best-effort stdout
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -569,7 +574,7 @@ func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 		}
 		// Connection error — fall through to direct mutation.
 	}
-	return doRigSuspend(fsys.OSFS{}, cityPath, args[0], stdout, stderr)
+	return doRigSuspend(fsys.OSFS{}, cityPath, rigName, stdout, stderr)
 }
 
 // doRigSuspend sets suspended=true on the named rig in city.toml.
@@ -628,19 +633,24 @@ The reconciler will start the rig's agents on its next tick.`,
 
 // cmdRigResume is the CLI entry point for resuming a suspended rig.
 func cmdRigResume(args []string, stdout, stderr io.Writer) int {
-	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig resume: missing rig name") //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cityPath, err := resolveCity()
+	ctx, err := resolveContext()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	rigName := ctx.RigName
+	if len(args) > 0 {
+		rigName = args[0]
+	}
+	if rigName == "" {
+		fmt.Fprintln(stderr, "gc rig resume: missing rig name") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cityPath := ctx.CityPath
 	if c := apiClient(cityPath); c != nil {
-		err := c.ResumeRig(args[0])
+		err := c.ResumeRig(rigName)
 		if err == nil {
-			fmt.Fprintf(stdout, "Resumed rig '%s'\n", args[0]) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "Resumed rig '%s'\n", rigName) //nolint:errcheck // best-effort stdout
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -649,7 +659,7 @@ func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 		}
 		// Connection error — fall through to direct mutation.
 	}
-	return doRigResume(fsys.OSFS{}, cityPath, args[0], stdout, stderr)
+	return doRigResume(fsys.OSFS{}, cityPath, rigName, stdout, stderr)
 }
 
 // doRigResume clears suspended on the named rig in city.toml.

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -293,7 +293,7 @@ func resolveStartDir(args []string) (string, error) {
 }
 
 func requireBootstrappedCity(dir string) (string, error) {
-	cityPath, err := findCity(dir)
+	ctx, err := resolveContextFromPath(dir)
 	if err != nil {
 		absDir, absErr := filepath.Abs(dir)
 		if absErr == nil {
@@ -301,6 +301,7 @@ func requireBootstrappedCity(dir string) (string, error) {
 		}
 		return "", fmt.Errorf("%w; run \"gc init\" first", err)
 	}
+	cityPath := ctx.CityPath
 	if !citylayout.HasRuntimeRoot(cityPath) {
 		return "", fmt.Errorf("city runtime not bootstrapped at %s; run \"gc init %s\" first", cityPath, cityPath)
 	}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -41,21 +40,7 @@ running, delegates shutdown to it.`,
 // cmdStop stops the city by terminating all configured agent sessions.
 // If a path is given, operates there; otherwise uses cwd.
 func cmdStop(args []string, stdout, stderr io.Writer) int {
-	var dir string
-	var err error
-	switch {
-	case len(args) > 0:
-		dir, err = filepath.Abs(args[0])
-	case cityFlag != "":
-		dir, err = filepath.Abs(cityFlag)
-	default:
-		dir, err = os.Getwd()
-	}
-	if err != nil {
-		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cityPath, err := findCity(dir)
+	cityPath, err := resolveCommandCity(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -101,14 +101,7 @@ func cmdResume(args []string, stdout, stderr io.Writer) int {
 
 // resolveSuspendDir resolves the city directory from args or the current city.
 func resolveSuspendDir(args []string) (string, error) {
-	if len(args) > 0 {
-		p, err := filepath.Abs(args[0])
-		if err != nil {
-			return "", err
-		}
-		return findCity(p)
-	}
-	return resolveCity()
+	return resolveCommandCity(args)
 }
 
 // doSuspendCity sets or clears workspace.suspended in city.toml.

--- a/cmd/gc/command_context_test.go
+++ b/cmd/gc/command_context_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+type registeredRigFixture struct {
+	cityPath string
+	rigDir   string
+	workDir  string
+	rigName  string
+}
+
+func setupRegisteredRigFixture(t *testing.T, insideCity, suspended bool) registeredRigFixture {
+	t.Helper()
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+
+	cityPath := setupCity(t, "demo-city")
+	rigName := "frontend"
+
+	var rigDir string
+	var rigPath string
+	if insideCity {
+		rigDir = filepath.Join(cityPath, "rigs", rigName)
+		rigPath = filepath.Join("rigs", rigName)
+	} else {
+		rigDir = filepath.Join(t.TempDir(), rigName)
+		rigPath = rigDir
+	}
+	workDir := filepath.Join(rigDir, "src", "deep")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	toml := fmt.Sprintf(`[workspace]
+name = "demo-city"
+
+[session]
+provider = "fake"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+
+[[rigs]]
+name = %q
+path = %q
+`, rigName, rigPath)
+	if suspended {
+		toml += "suspended = true\n"
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registryAt(t, os.Getenv("GC_HOME"))
+	if err := reg.RegisterRig(rigDir, rigName, cityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	return registeredRigFixture{
+		cityPath: cityPath,
+		rigDir:   rigDir,
+		workDir:  workDir,
+		rigName:  rigName,
+	}
+}
+
+func TestRigAnywhere_ResolveCommandContext(t *testing.T) {
+	cases := []struct {
+		name       string
+		insideCity bool
+		useArg     bool
+	}{
+		{name: "cwd_inside_city", insideCity: true},
+		{name: "cwd_outside_city", insideCity: false},
+		{name: "arg_inside_city", insideCity: true, useArg: true},
+		{name: "arg_outside_city", insideCity: false, useArg: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := setupRegisteredRigFixture(t, tc.insideCity, false)
+
+			args := []string(nil)
+			if tc.useArg {
+				setCwd(t, t.TempDir())
+				args = []string{fx.workDir}
+			} else {
+				setCwd(t, fx.workDir)
+			}
+
+			ctx, err := resolveCommandContext(args)
+			if err != nil {
+				t.Fatalf("resolveCommandContext() error: %v", err)
+			}
+			if ctx.CityPath != fx.cityPath {
+				t.Fatalf("CityPath = %q, want %q", ctx.CityPath, fx.cityPath)
+			}
+			if ctx.RigName != fx.rigName {
+				t.Fatalf("RigName = %q, want %q", ctx.RigName, fx.rigName)
+			}
+		})
+	}
+}
+
+func TestRigAnywhere_RequireBootstrappedCityFromRigDir(t *testing.T) {
+	for _, insideCity := range []bool{true, false} {
+		name := "outside_city"
+		if insideCity {
+			name = "inside_city"
+		}
+		t.Run(name, func(t *testing.T) {
+			fx := setupRegisteredRigFixture(t, insideCity, false)
+
+			got, err := requireBootstrappedCity(fx.workDir)
+			if err != nil {
+				t.Fatalf("requireBootstrappedCity(%q): %v", fx.workDir, err)
+			}
+			if got != fx.cityPath {
+				t.Fatalf("requireBootstrappedCity(%q) = %q, want %q", fx.workDir, got, fx.cityPath)
+			}
+		})
+	}
+}
+
+func TestRigAnywhere_CmdStopFromRigDir(t *testing.T) {
+	for _, insideCity := range []bool{true, false} {
+		name := "outside_city"
+		if insideCity {
+			name = "inside_city"
+		}
+		t.Run(name, func(t *testing.T) {
+			fx := setupRegisteredRigFixture(t, insideCity, false)
+			setCwd(t, fx.workDir)
+
+			var stdout, stderr bytes.Buffer
+			code := cmdStop(nil, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "City stopped.") {
+				t.Fatalf("stdout = %q, want City stopped.", stdout.String())
+			}
+			if strings.Contains(stderr.String(), "city.toml") {
+				t.Fatalf("stderr = %q, should not contain city.toml resolution failures", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRigAnywhere_CmdRigSuspendFromRigDir(t *testing.T) {
+	for _, insideCity := range []bool{true, false} {
+		name := "outside_city"
+		if insideCity {
+			name = "inside_city"
+		}
+		t.Run(name, func(t *testing.T) {
+			fx := setupRegisteredRigFixture(t, insideCity, false)
+			setCwd(t, fx.workDir)
+
+			var stdout, stderr bytes.Buffer
+			code := cmdRigSuspend(nil, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("cmdRigSuspend() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Suspended rig '"+fx.rigName+"'") {
+				t.Fatalf("stdout = %q, want rig suspend confirmation", stdout.String())
+			}
+
+			cfg, err := config.Load(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
+			if err != nil {
+				t.Fatalf("load city config: %v", err)
+			}
+			if len(cfg.Rigs) != 1 || !cfg.Rigs[0].Suspended {
+				t.Fatalf("rig suspended = %v, want true", cfg.Rigs)
+			}
+		})
+	}
+}
+
+func TestRigAnywhere_CmdRigResumeFromRigDir(t *testing.T) {
+	for _, insideCity := range []bool{true, false} {
+		name := "outside_city"
+		if insideCity {
+			name = "inside_city"
+		}
+		t.Run(name, func(t *testing.T) {
+			fx := setupRegisteredRigFixture(t, insideCity, true)
+			setCwd(t, fx.workDir)
+
+			var stdout, stderr bytes.Buffer
+			code := cmdRigResume(nil, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("cmdRigResume() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Resumed rig '"+fx.rigName+"'") {
+				t.Fatalf("stdout = %q, want rig resume confirmation", stdout.String())
+			}
+
+			cfg, err := config.Load(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
+			if err != nil {
+				t.Fatalf("load city config: %v", err)
+			}
+			if len(cfg.Rigs) != 1 || cfg.Rigs[0].Suspended {
+				t.Fatalf("rig suspended = %v, want false", cfg.Rigs)
+			}
+		})
+	}
+}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -225,6 +225,26 @@ type resolvedContext struct {
 	RigName  string // rig name (empty if not in a rig context)
 }
 
+// resolveCommandContext resolves city+rig context for commands that accept an
+// optional path argument. With no args, it uses the full flag/env/cwd resolver.
+// With a path arg, it treats that path as either a city path or a rig path and
+// resolves the containing city via the rig registry before falling back to
+// walking up for city.toml.
+func resolveCommandContext(args []string) (resolvedContext, error) {
+	if len(args) == 0 {
+		return resolveContext()
+	}
+	return resolveContextFromPath(args[0])
+}
+
+func resolveCommandCity(args []string) (string, error) {
+	ctx, err := resolveCommandContext(args)
+	if err != nil {
+		return "", err
+	}
+	return ctx.CityPath, nil
+}
+
 // resolveContext resolves the city and optional rig context using the
 // following priority chain:
 //  1. --city + --rig flags (explicit both, validated)
@@ -321,6 +341,27 @@ func resolveCity() (string, error) {
 	return ctx.CityPath, nil
 }
 
+func resolveContextFromPath(path string) (resolvedContext, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	if ctx, ok, err := resolveRigPathToContext(abs); ok {
+		if err != nil {
+			return resolvedContext{}, err
+		}
+		return ctx, nil
+	}
+	cityPath, err := findCity(abs)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	return resolvedContext{
+		CityPath: cityPath,
+		RigName:  rigFromCwdDir(cityPath, abs),
+	}, nil
+}
+
 // validateCityPath resolves and validates a path as a city directory.
 func validateCityPath(p string) (string, error) {
 	abs, err := filepath.Abs(p)
@@ -361,6 +402,19 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	}
 
 	return resolvedContext{}, fmt.Errorf("rig %q is not registered in any city", nameOrPath)
+}
+
+func resolveRigPathToContext(dir string) (resolvedContext, bool, error) {
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entry, ok := reg.LookupRigByPath(dir)
+	if !ok {
+		return resolvedContext{}, false, nil
+	}
+	ctx, err := resolveRigEntryCity(reg, entry)
+	if err != nil {
+		return resolvedContext{}, true, err
+	}
+	return ctx, true, nil
 }
 
 // resolveRigEntryCity resolves a rig entry to a city. Uses default_city if


### PR DESCRIPTION
## Summary
- route path-based city commands through a shared rig-aware resolver
- infer rig names for `gc rig suspend` and `gc rig resume` from the current rig context
- add regression coverage for rig-inside-city and rig-outside-city command contexts

## Testing
- `go test ./cmd/gc`

Closes #401
Closes #402