### PR TITLE
fix: infer rig name from cwd for rig suspend/resume/status/restart

### DIFF
--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -43,9 +43,11 @@ func cmdRestart(args []string, stdout, stderr io.Writer) int {
 // newRigRestartCmd creates the "gc rig restart <name>" subcommand.
 func newRigRestartCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:   "restart <name>",
+		Use:   "restart [name]",
 		Short: "Restart all agents in a rig",
 		Long: `Kill all agent sessions belonging to a rig.
+
+If no name is given, the rig is inferred from the current directory.
 
 The reconciler will restart the agents on its next tick. This is a
 quick way to force-refresh all agents working on a particular project.`,
@@ -62,15 +64,8 @@ quick way to force-refresh all agents working on a particular project.`,
 // cmdRigRestart kills all agent sessions in a rig. The reconciler restarts
 // them on its next tick.
 func cmdRigRestart(args []string, stdout, stderr io.Writer) int {
-	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig restart: missing rig name") //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	rigName := args[0]
-
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc rig restart: %v\n", err) //nolint:errcheck // best-effort stderr
+	cityPath, rigName, ok := resolveRigArg(args, "gc rig restart", stderr)
+	if !ok {
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath)

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -529,9 +529,11 @@ func rigBeadsStatus(fs fsys.FS, dir string) string {
 
 func newRigSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:   "suspend <name>",
+		Use:   "suspend [name]",
 		Short: "Suspend a rig (reconciler will skip its agents)",
 		Long: `Suspend a rig by setting suspended=true in city.toml.
+
+If no name is given, the rig is inferred from the current directory.
 
 All agents scoped to the suspended rig are effectively suspended —
 the reconciler skips them and gc hook returns empty. The rig's beads
@@ -546,21 +548,35 @@ database remains accessible. Use "gc rig resume" to restore.`,
 	}
 }
 
+// resolveRigArg returns the rig name from args[0] if provided, otherwise
+// infers it from cwd via resolveContext. Returns the city path, rig name,
+// and whether resolution succeeded. The cmdName is used in error messages.
+func resolveRigArg(args []string, cmdName string, stderr io.Writer) (cityPath, rigName string, ok bool) {
+	ctx, err := resolveContext()
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+		return "", "", false
+	}
+	if len(args) >= 1 {
+		return ctx.CityPath, args[0], true
+	}
+	if ctx.RigName != "" {
+		return ctx.CityPath, ctx.RigName, true
+	}
+	fmt.Fprintf(stderr, "%s: missing rig name (not inside a rig directory)\n", cmdName) //nolint:errcheck // best-effort stderr
+	return "", "", false
+}
+
 // cmdRigSuspend is the CLI entry point for suspending a rig.
 func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
-	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig suspend: missing rig name") //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+	cityPath, rigName, ok := resolveRigArg(args, "gc rig suspend", stderr)
+	if !ok {
 		return 1
 	}
 	if c := apiClient(cityPath); c != nil {
-		err := c.SuspendRig(args[0])
+		err := c.SuspendRig(rigName)
 		if err == nil {
-			fmt.Fprintf(stdout, "Suspended rig '%s'\n", args[0]) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "Suspended rig '%s'\n", rigName) //nolint:errcheck // best-effort stdout
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -569,7 +585,7 @@ func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 		}
 		// Connection error — fall through to direct mutation.
 	}
-	return doRigSuspend(fsys.OSFS{}, cityPath, args[0], stdout, stderr)
+	return doRigSuspend(fsys.OSFS{}, cityPath, rigName, stdout, stderr)
 }
 
 // doRigSuspend sets suspended=true on the named rig in city.toml.
@@ -611,9 +627,11 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 
 func newRigResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:   "resume <name>",
+		Use:   "resume [name]",
 		Short: "Resume a suspended rig",
 		Long: `Resume a suspended rig by clearing suspended in city.toml.
+
+If no name is given, the rig is inferred from the current directory.
 
 The reconciler will start the rig's agents on its next tick.`,
 		Args: cobra.ArbitraryArgs,
@@ -628,19 +646,14 @@ The reconciler will start the rig's agents on its next tick.`,
 
 // cmdRigResume is the CLI entry point for resuming a suspended rig.
 func cmdRigResume(args []string, stdout, stderr io.Writer) int {
-	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig resume: missing rig name") //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
+	cityPath, rigName, ok := resolveRigArg(args, "gc rig resume", stderr)
+	if !ok {
 		return 1
 	}
 	if c := apiClient(cityPath); c != nil {
-		err := c.ResumeRig(args[0])
+		err := c.ResumeRig(rigName)
 		if err == nil {
-			fmt.Fprintf(stdout, "Resumed rig '%s'\n", args[0]) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "Resumed rig '%s'\n", rigName) //nolint:errcheck // best-effort stdout
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -649,7 +662,7 @@ func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 		}
 		// Connection error — fall through to direct mutation.
 	}
-	return doRigResume(fsys.OSFS{}, cityPath, args[0], stdout, stderr)
+	return doRigResume(fsys.OSFS{}, cityPath, rigName, stdout, stderr)
 }
 
 // doRigResume clears suspended on the named rig in city.toml.

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1296,3 +1296,83 @@ name = "inline-agent"
 		t.Errorf("city.toml should contain new rig:\n%s", data)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// resolveRigArg: cwd inference tests
+// ---------------------------------------------------------------------------
+
+func TestResolveRigArg_ExplicitArgWins(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := setupCity(t, "arg-wins")
+	rigDir := filepath.Join(t.TempDir(), "myrig")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"arg-wins\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"myrig\"\npath = \"" + rigDir + "\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityFlag = cityPath
+	setCwd(t, rigDir)
+
+	var stderr bytes.Buffer
+	gotCity, rigName, ok := resolveRigArg([]string{"other-rig"}, "gc rig test", &stderr)
+	if !ok {
+		t.Fatalf("resolveRigArg failed: %s", stderr.String())
+	}
+	if gotCity != cityPath {
+		t.Errorf("cityPath = %q, want %q", gotCity, cityPath)
+	}
+	if rigName != "other-rig" {
+		t.Errorf("rigName = %q, want %q (explicit arg should win)", rigName, "other-rig")
+	}
+}
+
+func TestResolveRigArg_InfersFromCwd(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := setupCity(t, "cwd-infer")
+	rigDir := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[workspace]\nname = \"cwd-infer\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"" + rigDir + "\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityFlag = cityPath
+	setCwd(t, rigDir)
+
+	var stderr bytes.Buffer
+	gotCity, rigName, ok := resolveRigArg(nil, "gc rig test", &stderr)
+	if !ok {
+		t.Fatalf("resolveRigArg failed: %s", stderr.String())
+	}
+	if gotCity != cityPath {
+		t.Errorf("cityPath = %q, want %q", gotCity, cityPath)
+	}
+	if rigName != "frontend" {
+		t.Errorf("rigName = %q, want %q (should infer from cwd)", rigName, "frontend")
+	}
+}
+
+func TestResolveRigArg_ErrorWhenNoArgAndNotInRig(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityPath := setupCity(t, "no-rig")
+	cityFlag = cityPath
+	setCwd(t, cityPath)
+
+	var stderr bytes.Buffer
+	_, _, ok := resolveRigArg(nil, "gc rig test", &stderr)
+	if ok {
+		t.Fatal("resolveRigArg should fail when not in a rig directory")
+	}
+	if !strings.Contains(stderr.String(), "missing rig name") {
+		t.Errorf("stderr = %q, want 'missing rig name' message", stderr.String())
+	}
+}

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -17,8 +17,9 @@ import (
 // newRigStatusCmd creates the "gc rig status <name>" subcommand.
 func newRigStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:   "status <name>",
+		Use:   "status [name]",
 		Short: "Show rig status and agent running state",
+		Long:  `Show rig status and agent running state. If no name is given, the rig is inferred from the current directory.`,
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdRigStatus(args, stdout, stderr) != 0 {
@@ -31,15 +32,8 @@ func newRigStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 
 // cmdRigStatus is the CLI entry point for showing rig status.
 func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
-	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig status: missing rig name") //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	rigName := args[0]
-
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc rig status: %v\n", err) //nolint:errcheck // best-effort stderr
+	cityPath, rigName, ok := resolveRigArg(args, "gc rig status", stderr)
+	if !ok {
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath)


### PR DESCRIPTION
## Summary
- `gc rig suspend`, `gc rig resume`, `gc rig status`, and `gc rig restart` now infer the rig from the current directory when no name argument is provided
- Extracts `resolveRigArg` helper that uses the existing `resolveContext()` cwd-to-rig inference, falling back to a clear error when not inside a rig directory
- Updates cobra `Use` strings from `<name>` to `[name]` and adds help text noting the cwd inference

Fixes gastownhall/gascity#401

## Test plan
- [x] `TestResolveRigArg_ExplicitArgWins` — explicit arg takes precedence; cityPath verified
- [x] `TestResolveRigArg_InfersFromCwd` — rig name inferred from cwd; cityPath verified
- [x] `TestResolveRigArg_ErrorWhenNoArgAndNotInRig` — clear error when not in a rig directory
- [x] All existing rig suspend/resume/status/restart tests pass
- [x] `go build ./cmd/gc/` and `go vet ./cmd/gc/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)