### PR TITLE
fix: honor wake_mode on drain-ack

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -753,8 +753,8 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 			sleepReason := session.Metadata["sleep_reason"]
 			isDraining := sleepReason == "idle" || sleepReason == "idle-timeout" ||
 				sleepReason == "no-wake-reason" || sleepReason == "config-drift" ||
-				sleepReason == "drained" || sleepReason == "user-hold" ||
-				sleepReason == "wait-hold"
+				(sleepReason == "drained" && session.Metadata["wake_mode"] != "fresh") ||
+				sleepReason == "user-hold" || sleepReason == "wait-hold"
 			if !isDraining && (prevState == "active" || prevState == "awake" || prevState == "creating") {
 				batch["session_key"] = ""
 				batch["started_config_hash"] = ""

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1204,6 +1204,7 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 		name                   string
 		prevState              string
 		sleepReason            string
+		wakeMode               string
 		sessionKey             string
 		startedConfigHash      string
 		wantKeyCleared         bool
@@ -1294,10 +1295,21 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 			name:                   "drained — resume metadata preserved",
 			prevState:              "active",
 			sleepReason:            "drained",
+			wakeMode:               "resume",
 			sessionKey:             "abc-123",
 			startedConfigHash:      "hash-before",
 			wantKeyCleared:         false,
 			wantStartedHashCleared: false,
+		},
+		{
+			name:                   "drained with wake_mode=fresh — resume metadata cleared",
+			prevState:              "active",
+			sleepReason:            "drained",
+			wakeMode:               "fresh",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			wantKeyCleared:         true,
+			wantStartedHashCleared: true,
 		},
 		{
 			name:                   "asleep prev state — resume metadata preserved (not in active set)",
@@ -1326,6 +1338,7 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 			session := makeBead("b1", map[string]string{
 				"state":               tt.prevState,
 				"sleep_reason":        tt.sleepReason,
+				"wake_mode":           tt.wakeMode,
 				"session_key":         tt.sessionKey,
 				"started_config_hash": tt.startedConfigHash,
 			})

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -358,8 +358,23 @@ func reconcileSessionBeadsTraced(
 					Message: "drain acknowledged by agent",
 				})
 				if store != nil && session.ID != "" {
-					_ = store.SetMetadata(session.ID, "state", "drained")
+					batch := map[string]string{
+						"state":        "drained",
+						"last_woke_at": "",
+					}
+					if session.Metadata["wake_mode"] == "fresh" {
+						batch["session_key"] = ""
+						batch["started_config_hash"] = ""
+						batch["continuation_reset_pending"] = "true"
+					}
+					_ = store.SetMetadataBatch(session.ID, batch)
 					session.Metadata["state"] = "drained"
+					session.Metadata["last_woke_at"] = ""
+					if session.Metadata["wake_mode"] == "fresh" {
+						session.Metadata["session_key"] = ""
+						session.Metadata["started_config_hash"] = ""
+						session.Metadata["continuation_reset_pending"] = "true"
+					}
 				}
 				continue
 			}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -278,6 +278,231 @@ func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_DrainAckResumeModePreservesSessionIdentity(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"wake_mode":           "resume",
+		"session_key":         "resume-key",
+		"started_config_hash": "hash-before-drain",
+	})
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state"] != "drained" {
+		t.Fatalf("state = %q, want drained", got.Metadata["state"])
+	}
+	if got.Metadata["session_key"] != "resume-key" {
+		t.Fatalf("session_key = %q, want preserved resume key", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "hash-before-drain" {
+		t.Fatalf("started_config_hash = %q, want preserved hash", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "" {
+		t.Fatalf("continuation_reset_pending = %q, want empty", got.Metadata["continuation_reset_pending"])
+	}
+}
+
+func TestReconcileSessionBeads_DrainAckFreshModeClearsSessionIdentity(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"wake_mode":           "fresh",
+		"session_key":         "fresh-key",
+		"started_config_hash": "hash-before-drain",
+	})
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state"] != "drained" {
+		t.Fatalf("state = %q, want drained", got.Metadata["state"])
+	}
+	if got.Metadata["session_key"] != "" {
+		t.Fatalf("session_key = %q, want cleared for wake_mode=fresh", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want cleared for wake_mode=fresh", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", got.Metadata["continuation_reset_pending"])
+	}
+}
+
+func TestReconcileSessionBeads_DrainAckResumeModeNotClassifiedAsCrashNextTick(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"wake_mode":           "resume",
+		"session_key":         "resume-key",
+		"started_config_hash": "hash-before-drain",
+	})
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) after drain-ack: %v", session.ID, err)
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared after drain-ack", got.Metadata["last_woke_at"])
+	}
+
+	woken = reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{got},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("second tick woken = %d, want 0", woken)
+	}
+
+	got, err = env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) after second tick: %v", session.ID, err)
+	}
+	if got.Metadata["session_key"] != "resume-key" {
+		t.Fatalf("session_key = %q after second tick, want preserved resume key", got.Metadata["session_key"])
+	}
+	if got.Metadata["wake_attempts"] != "" {
+		t.Fatalf("wake_attempts = %q, want empty for intentional drain", got.Metadata["wake_attempts"])
+	}
+}
+
 func TestReconcileSessionBeads_DrainAckHonoredAfterSessionExit(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{


### PR DESCRIPTION
Supersedes #98.

Fixes the drain-ack / `wake_mode` slice of #322 and the `gc runtime drain-ack` portion of #76, but does not close either broader issue.

## Summary
- make `gc runtime drain-ack` honor `wake_mode`: preserve session identity for `resume`, clear it for `fresh`
- clear `last_woke_at` on drain-ack so an intentional drain is not misclassified as a crash/churn on the next tick
- teach `healState()` that `sleep_reason=drained` only preserves resume metadata when the session is actually `wake_mode=resume`
- add regression tests for drain-ack identity handling and next-tick crash suppression

## Bugs Fixed
- `wake_mode=fresh` sessions kept `session_key` and `started_config_hash` after drain-ack, so the lifecycle metadata still looked resumable
- manual drain-ack left `last_woke_at` intact, so the next dead-session tick could record a false crash and wipe preserved resume identity

## Test Plan
- [x] `TMPDIR=/tmp/gctmp GOCACHE=/tmp/gccache go test ./cmd/gc -run 'Test(ReconcileSessionBeads_DrainAck(ResumeModePreservesSessionIdentity|FreshModeClearsSessionIdentity|ResumeModeNotClassifiedAsCrashNextTick)|HealState_ClearsStaleResumeMetadata)' -count=1`
- [x] `TMPDIR=/tmp/gctmp GOCACHE=/tmp/gccache go test ./cmd/gc -run 'Test(ReconcileSessionBeads_|HealState_|CompleteDrain_|SelectOrCreatePoolSessionBead_|ComputePoolDesiredStates_)' -count=1`
- [x] `TMPDIR=/tmp/gctmp GOCACHE=/tmp/gccache go test ./cmd/gc -count=1`
