### PR TITLE
renderPrompt falls back to raw template text on failure instead of empty string (ga-dmr)

### DIFF
--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -40,7 +40,7 @@ type PromptContext struct {
 // sibling shared/ dir). injectFragments are named templates to append to
 // the output after rendering. Returns empty string if templatePath is empty
 // or the file doesn't exist. On parse or execute error, logs a warning to
-// stderr and returns the raw text (graceful fallback).
+// stderr and returns empty string (triggering default prompt fallback).
 func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx PromptContext, sessionTemplate string, stderr io.Writer, packDirs []string, injectFragments []string, store beads.Store) string {
 	if templatePath == "" {
 		return ""
@@ -72,14 +72,14 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	tmpl, err = tmpl.Parse(raw)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc: prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
-		return raw
+		return ""
 	}
 
 	td := buildTemplateData(ctx)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, td); err != nil {
 		fmt.Fprintf(stderr, "gc: prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
-		return raw
+		return ""
 	}
 
 	// Append injected fragments.

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -161,9 +161,9 @@ func TestRenderPromptParseErrorFallback(t *testing.T) {
 	f.Files["/city/prompts/bad.md.tmpl"] = []byte("Bad: {{ .Unclosed")
 	var stderr strings.Builder
 	got := renderPrompt(f, "/city", "", "prompts/bad.md.tmpl", PromptContext{}, "", &stderr, nil, nil, nil)
-	// Should return raw text on parse error.
-	if got != "Bad: {{ .Unclosed" {
-		t.Errorf("renderPrompt(parse error) = %q, want raw text", got)
+	// Should return empty string on parse error (triggers default prompt fallback).
+	if got != "" {
+		t.Errorf("renderPrompt(parse error) = %q, want empty string", got)
 	}
 	if !strings.Contains(stderr.String(), "prompt template") {
 		t.Errorf("stderr = %q, want warning about prompt template", stderr.String())


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery.

- Issue: ga-dmr
- Branch: polecat/ga-dmr-v2
- Target: main