### PR TITLE
Expand provider and supervisor search paths

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/searchpath"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/spf13/cobra"
 )
@@ -270,13 +271,14 @@ func buildSupervisorServiceData() (*supervisorServiceData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("finding executable: %w", err)
 	}
+	homeDir, _ := os.UserHomeDir()
 	home := supervisor.DefaultHome()
 	return &supervisorServiceData{
 		GCPath:   gcPath,
 		LogPath:  supervisorLogPath(),
 		GCHome:   home,
 		SafeName: sanitizeServiceName(filepath.Base(home)),
-		Path:     os.Getenv("PATH"),
+		Path:     searchpath.ExpandPath(homeDir, goruntime.GOOS, os.Getenv("PATH")),
 	}, nil
 }
 

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -191,6 +192,24 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 		if !strings.Contains(content, check) {
 			t.Fatalf("systemd template missing %q", check)
 		}
+	}
+}
+
+func TestBuildSupervisorServiceDataExpandsUserManagedPath(t *testing.T) {
+	homeDir := t.TempDir()
+	nvmBin := filepath.Join(homeDir, ".nvm", "versions", "node", "v22.14.0", "bin")
+	if err := os.MkdirAll(nvmBin, 0o755); err != nil {
+		t.Fatalf("mkdir nvm bin: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	if !slices.Contains(filepath.SplitList(data.Path), nvmBin) {
+		t.Fatalf("buildSupervisorServiceData PATH %q missing nvm bin %q", data.Path, nvmBin)
 	}
 }
 

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/searchpath"
 	"gopkg.in/yaml.v3"
 )
 
@@ -573,7 +574,7 @@ func probeGitHubCLIAuthStatus(ctx context.Context, homeDir, ghPath string) provi
 }
 
 func findProbeBinary(name, homeDir string) (string, bool) {
-	// Readiness probes use a curated, deterministic path rather than the
+	// Readiness probes use a deterministic, user-aware path rather than the
 	// ambient process PATH so API calls do not depend on shell-specific edits.
 	for _, dir := range providerProbeSearchDirs(homeDir, providerProbeGOOS, providerProbePathEnv) {
 		dir = strings.TrimSpace(dir)
@@ -594,51 +595,15 @@ func findProbeBinary(name, homeDir string) (string, bool) {
 }
 
 func providerProbeSearchDirs(homeDir, goos, basePath string) []string {
-	var dirs []string
-	if homeDir != "" {
-		dirs = append(dirs,
-			filepath.Join(homeDir, ".local", "bin"),
-			filepath.Join(homeDir, "bin"),
-		)
-	}
-	dirs = append(dirs, strings.Split(basePath, string(os.PathListSeparator))...)
-	switch goos {
-	case "darwin":
-		dirs = append(dirs,
-			"/opt/homebrew/bin",
-			"/opt/homebrew/sbin",
-			"/opt/local/bin",
-			"/opt/local/sbin",
-		)
-	case "linux":
-		dirs = append(dirs,
-			"/snap/bin",
-			"/home/linuxbrew/.linuxbrew/bin",
-			"/home/linuxbrew/.linuxbrew/sbin",
-		)
-	}
-	return dedupeProbeSearchDirs(dirs)
+	return searchpath.Expand(homeDir, goos, basePath)
 }
 
 func dedupeProbeSearchDirs(dirs []string) []string {
-	seen := make(map[string]struct{}, len(dirs))
-	out := make([]string, 0, len(dirs))
-	for _, dir := range dirs {
-		dir = strings.TrimSpace(dir)
-		if dir == "" {
-			continue
-		}
-		if _, ok := seen[dir]; ok {
-			continue
-		}
-		seen[dir] = struct{}{}
-		out = append(out, dir)
-	}
-	return out
+	return searchpath.Dedupe(dirs)
 }
 
 func providerProbeSearchPath(homeDir string) string {
-	return strings.Join(providerProbeSearchDirs(homeDir, providerProbeGOOS, providerProbePathEnv), string(os.PathListSeparator))
+	return searchpath.ExpandPath(homeDir, providerProbeGOOS, providerProbePathEnv)
 }
 
 func runProbeCommand(

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -138,6 +138,33 @@ func TestFindProbeBinaryUsesUserLocalInstallDir(t *testing.T) {
 	}
 }
 
+func TestFindProbeBinaryUsesNVMInstallDir(t *testing.T) {
+	homeDir := t.TempDir()
+	nvmBin := filepath.Join(homeDir, ".nvm", "versions", "node", "v22.14.0", "bin")
+	if err := os.MkdirAll(nvmBin, 0o755); err != nil {
+		t.Fatalf("mkdir nvm bin: %v", err)
+	}
+	writeExecutable(t, nvmBin, "claude", "#!/bin/sh\nexit 0\n")
+
+	originalPathEnv := providerProbePathEnv
+	originalGOOS := providerProbeGOOS
+	providerProbePathEnv = "/usr/local/bin:/usr/bin:/bin"
+	providerProbeGOOS = "darwin"
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+		providerProbeGOOS = originalGOOS
+	}()
+
+	got, ok := findProbeBinary("claude", homeDir)
+	if !ok {
+		t.Fatal("findProbeBinary did not find nvm-installed claude")
+	}
+	want := filepath.Join(nvmBin, "claude")
+	if got != want {
+		t.Fatalf("findProbeBinary = %q, want %q", got, want)
+	}
+}
+
 func TestProbeCommandEnvUsesCuratedProbePath(t *testing.T) {
 	homeDir := t.TempDir()
 
@@ -163,6 +190,38 @@ func TestProbeCommandEnvUsesCuratedProbePath(t *testing.T) {
 	}, string(os.PathListSeparator))
 	if !slices.Contains(env, wantPath) {
 		t.Fatalf("probeCommandEnv missing curated PATH %q in %v", wantPath, env)
+	}
+}
+
+func TestProbeCommandEnvIncludesNVMInstallDir(t *testing.T) {
+	homeDir := t.TempDir()
+	nvmBin := filepath.Join(homeDir, ".nvm", "versions", "node", "v22.14.0", "bin")
+	if err := os.MkdirAll(nvmBin, 0o755); err != nil {
+		t.Fatalf("mkdir nvm bin: %v", err)
+	}
+
+	originalPathEnv := providerProbePathEnv
+	originalGOOS := providerProbeGOOS
+	providerProbePathEnv = "/usr/local/bin:/usr/bin:/bin"
+	providerProbeGOOS = "darwin"
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+		providerProbeGOOS = originalGOOS
+	}()
+
+	env := probeCommandEnv(homeDir)
+	pathEntry := ""
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			pathEntry = strings.TrimPrefix(entry, "PATH=")
+			break
+		}
+	}
+	if pathEntry == "" {
+		t.Fatalf("probeCommandEnv missing PATH in %v", env)
+	}
+	if !slices.Contains(filepath.SplitList(pathEntry), nvmBin) {
+		t.Fatalf("probeCommandEnv PATH %q missing nvm bin %q", pathEntry, nvmBin)
 	}
 }
 

--- a/internal/searchpath/searchpath.go
+++ b/internal/searchpath/searchpath.go
@@ -1,0 +1,120 @@
+package searchpath
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Expand returns a deterministic PATH search order that preserves the caller's
+// base PATH while adding common user-managed install locations.
+func Expand(homeDir, goos, basePath string) []string {
+	var dirs []string
+	if homeDir = strings.TrimSpace(homeDir); homeDir != "" {
+		dirs = append(dirs,
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, "bin"),
+		)
+	}
+	dirs = append(dirs, splitPath(basePath)...)
+	dirs = append(dirs, userManagedDirs(homeDir)...)
+	switch goos {
+	case "darwin":
+		dirs = append(dirs,
+			"/opt/homebrew/bin",
+			"/opt/homebrew/sbin",
+			"/opt/local/bin",
+			"/opt/local/sbin",
+		)
+	case "linux":
+		dirs = append(dirs,
+			"/snap/bin",
+			"/home/linuxbrew/.linuxbrew/bin",
+			"/home/linuxbrew/.linuxbrew/sbin",
+		)
+	}
+	return Dedupe(dirs)
+}
+
+// ExpandPath joins [Expand] using the platform PATH list separator.
+func ExpandPath(homeDir, goos, basePath string) string {
+	return strings.Join(Expand(homeDir, goos, basePath), string(os.PathListSeparator))
+}
+
+// Dedupe removes empty entries while preserving the first occurrence.
+func Dedupe(dirs []string) []string {
+	seen := make(map[string]struct{}, len(dirs))
+	out := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		out = append(out, dir)
+	}
+	return out
+}
+
+func splitPath(basePath string) []string {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" {
+		return nil
+	}
+	return strings.Split(basePath, string(os.PathListSeparator))
+}
+
+func userManagedDirs(homeDir string) []string {
+	if homeDir == "" {
+		return nil
+	}
+	dirs := existingDirs(
+		filepath.Join(homeDir, "go", "bin"),
+		filepath.Join(homeDir, ".cargo", "bin"),
+		filepath.Join(homeDir, ".bun", "bin"),
+		filepath.Join(homeDir, ".deno", "bin"),
+		filepath.Join(homeDir, ".volta", "bin"),
+		filepath.Join(homeDir, ".nvm", "current", "bin"),
+		filepath.Join(homeDir, ".asdf", "shims"),
+		filepath.Join(homeDir, ".nodenv", "shims"),
+		filepath.Join(homeDir, ".local", "share", "mise", "shims"),
+		filepath.Join(homeDir, ".local", "share", "rtx", "shims"),
+		filepath.Join(homeDir, ".nodebrew", "current", "bin"),
+	)
+	dirs = append(dirs, globExistingDirs(
+		filepath.Join(homeDir, ".nvm", "versions", "node", "*", "bin"),
+		filepath.Join(homeDir, ".fnm", "node-versions", "*", "installation", "bin"),
+		filepath.Join(homeDir, ".local", "share", "fnm", "node-versions", "*", "installation", "bin"),
+		filepath.Join(homeDir, ".nodebrew", "node", "*", "bin"),
+	)...)
+	return dirs
+}
+
+func existingDirs(paths ...string) []string {
+	out := make([]string, 0, len(paths))
+	for _, dir := range paths {
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		out = append(out, dir)
+	}
+	return out
+}
+
+func globExistingDirs(patterns ...string) []string {
+	var out []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		sort.Strings(matches)
+		out = append(out, existingDirs(matches...)...)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add a shared deterministic search-path helper that augments PATH with existing user-managed install dirs under HOME, including nvm/fnm/nodebrew/asdf/mise locations
- use that helper for provider readiness binary discovery and probe subprocess PATH construction
- use the same expansion when generating supervisor service PATH so background controllers see the same binaries as readiness checks

## Testing
- go test ./internal/api -run 'TestFindProbeBinaryUsesNVMInstallDir|TestProbeCommandEnvIncludesNVMInstallDir' -count=1
- go test ./cmd/gc -run TestBuildSupervisorServiceDataExpandsUserManagedPath -count=1
- go test ./internal/searchpath -count=1

Fixes #97