### PR TITLE
Add gc session reset command

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -40,7 +40,7 @@ continuity.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, close, rename, prune, peek, kill, nudge, logs, wake, wait)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, reset, close, rename, prune, peek, kill, nudge, logs, wake, wait)") //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stderr, "gc session: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
 			}
@@ -53,6 +53,7 @@ continuity.`,
 		newSessionAttachCmd(stdout, stderr),
 		newSessionSubmitCmd(stdout, stderr),
 		newSessionSuspendCmd(stdout, stderr),
+		newSessionResetCmd(stdout, stderr),
 		newSessionCloseCmd(stdout, stderr),
 		newSessionRenameCmd(stdout, stderr),
 		newSessionPruneCmd(stdout, stderr),

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// newSessionResetCmd creates the "gc session reset <id-or-alias>" command.
+func newSessionResetCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset <session-id-or-alias>",
+		Short: "Restart a session fresh while preserving the bead",
+		Long: `Request a fresh restart for an existing session without closing its bead.
+
+The controller stops the current runtime and starts the same session again with
+fresh provider conversation state. Session identity, alias, mail, and queued
+work remain attached to the existing session bead.
+
+Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if cmdSessionReset(args, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+}
+
+// cmdSessionReset is the CLI entry point for "gc session reset".
+//
+// This command intentionally requires a managed controller. The controller owns
+// the fresh restart lifecycle, including key rotation and immediate restart of
+// already-desired sessions.
+func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
+	store, code := openCityStore(stderr, "gc session reset")
+	if store == nil {
+		return code
+	}
+
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !cityUsesManagedReconciler(cityPath) {
+		fmt.Fprintln(stderr, "gc session reset: a managed controller must be running") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := pokeController(cityPath); err != nil {
+		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	if err := store.SetMetadataBatch(sessionID, map[string]string{
+		"restart_requested":          "true",
+		"continuation_reset_pending": "true",
+	}); err != nil {
+		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	_ = pokeController(cityPath)
+
+	fmt.Fprintf(stdout, "Session %s reset requested. Controller will restart it fresh.\n", sessionID) //nolint:errcheck // best-effort stdout
+	return 0
+}

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:  "manual mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:mayor"},
+		Metadata: map[string]string{
+			"alias":                      "sky",
+			"template":                   "mayor",
+			"session_name":               "s-gc-reset-test",
+			"state":                      "awake",
+			"session_key":                "original-key",
+			"started_config_hash":        "hash-before-reset",
+			"continuation_reset_pending": "",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	commands := make(chan string, 3)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(commands)
+		for i := 0; i < 3; i++ {
+			conn, err := lis.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			buf := make([]byte, 64)
+			n, err := conn.Read(buf)
+			if err != nil {
+				conn.Close() //nolint:errcheck
+				errCh <- err
+				return
+			}
+			cmd := string(buf[:n])
+			commands <- cmd
+			reply := "ok\n"
+			if cmd == "ping\n" {
+				reply = "123\n"
+			}
+			if _, err := conn.Write([]byte(reply)); err != nil {
+				conn.Close() //nolint:errcheck
+				errCh <- err
+				return
+			}
+			conn.Close() //nolint:errcheck
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionReset([]string{"sky"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionReset(controller) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	gotCommands := make([]string, 0, 3)
+	deadline := time.After(2 * time.Second)
+	for len(gotCommands) < 3 {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("controller socket: %v", err)
+			}
+		case cmd, ok := <-commands:
+			if !ok {
+				if len(gotCommands) != 3 {
+					t.Fatalf("controller commands = %v, want ping plus 2 pokes", gotCommands)
+				}
+				break
+			}
+			gotCommands = append(gotCommands, cmd)
+		case <-deadline:
+			t.Fatalf("timed out waiting for controller pokes, got %v", gotCommands)
+		}
+	}
+	wantCommands := []string{"ping\n", "poke\n", "poke\n"}
+	for i, want := range wantCommands {
+		if gotCommands[i] != want {
+			t.Fatalf("controller command %d = %q, want %q", i, gotCommands[i], want)
+		}
+	}
+
+	reloaded, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(reload): %v", err)
+	}
+	got, err := reloaded.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", bead.ID, err)
+	}
+	if got.Metadata["restart_requested"] != "true" {
+		t.Fatalf("restart_requested = %q, want true", got.Metadata["restart_requested"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", got.Metadata["continuation_reset_pending"])
+	}
+	if got.Metadata["session_key"] != "original-key" {
+		t.Fatalf("session_key = %q, want original key preserved until reconcile", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "hash-before-reset" {
+		t.Fatalf("started_config_hash = %q, want original hash preserved until reconcile", got.Metadata["started_config_hash"])
+	}
+}

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -329,7 +329,7 @@ func TestCmdSessionNew_AllowsReservedNamedAliasWithController(t *testing.T) {
 
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir, "test-city", "mayor")
+	writeNamedSessionCityTOML(t, cityDir)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
@@ -420,7 +420,7 @@ func TestCmdSessionNew_AllowsReservedNamedAliasWithoutController(t *testing.T) {
 
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir, "test-city", "mayor")
+	writeNamedSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
 	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", true, &stdout, &stderr); code != 0 {
@@ -444,7 +444,7 @@ func TestCmdSessionNew_IgnoresUnmanagedSupervisorSocket(t *testing.T) {
 
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir, "test-city", "mayor")
+	writeNamedSessionCityTOML(t, cityDir)
 
 	if err := os.MkdirAll(filepath.Dir(supervisorSocketPath()), 0o755); err != nil {
 		t.Fatalf("MkdirAll(supervisor socket dir): %v", err)
@@ -497,24 +497,24 @@ func TestCmdSessionNew_IgnoresUnmanagedSupervisorSocket(t *testing.T) {
 	}
 }
 
-func writeNamedSessionCityTOML(t *testing.T, dir, cityName, agentName string) {
+func writeNamedSessionCityTOML(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
 	data := []byte(`[workspace]
-name = "` + cityName + `"
+name = "test-city"
 
 [beads]
 provider = "file"
 
 [[agent]]
-name = "` + agentName + `"
+name = "mayor"
 provider = "codex"
 start_command = "echo"
 
 [[named_session]]
-template = "` + agentName + `"
+template = "mayor"
 `)
 	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -404,8 +404,10 @@ func reconcileSessionBeadsTraced(
 		// Restart-requested: agent asked for a fresh session
 		// (gc runtime request-restart / gc handoff). Rotate session_key
 		// to a fresh value and clear started_config_hash so the next wake
-		// builds a first-start command (--session-id <new_key>). Then stop
-		// immediately; the next tick will re-create and re-wake.
+		// builds a first-start command (--session-id <new_key>). Also set
+		// continuation_reset_pending so the next wake bumps the continuation
+		// epoch instead of silently reusing the prior continuation lineage.
+		// Then stop immediately; the next tick will re-create and re-wake.
 		//
 		// Check both tmux metadata (dops) and bead metadata. The bead
 		// metadata flag survives tmux session death, so this works even
@@ -426,9 +428,10 @@ func reconcileSessionBeadsTraced(
 				// last_woke_at masks the intentional death from crash
 				// and churn trackers (both check last_woke_at first).
 				batch := map[string]string{
-					"restart_requested":   "",
-					"started_config_hash": "",
-					"last_woke_at":        "",
+					"restart_requested":          "",
+					"started_config_hash":        "",
+					"continuation_reset_pending": "true",
+					"last_woke_at":               "",
 				}
 				if newKey, err := sessionpkg.GenerateSessionKey(); err == nil {
 					batch["session_key"] = newKey
@@ -437,6 +440,7 @@ func reconcileSessionBeadsTraced(
 				_ = store.SetMetadataBatch(session.ID, batch)
 				session.Metadata["restart_requested"] = ""
 				session.Metadata["started_config_hash"] = ""
+				session.Metadata["continuation_reset_pending"] = "true"
 				session.Metadata["last_woke_at"] = ""
 				if alive {
 					if err := sp.Stop(name); err != nil {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -900,6 +900,9 @@ func TestReconcileSessionBeads_PreservedRunningNamedSessionHonorsRestartRequest(
 	if got.Metadata["started_config_hash"] != "" {
 		t.Fatalf("started_config_hash = %q, want cleared", got.Metadata["started_config_hash"])
 	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", got.Metadata["continuation_reset_pending"])
+	}
 	if got.Metadata["session_key"] == "" || got.Metadata["session_key"] == "original-key" {
 		t.Fatalf("session_key = %q, want rotated key", got.Metadata["session_key"])
 	}
@@ -1872,6 +1875,9 @@ func TestReconcileSessionBeads_BeadMetadataRestartRequestedWhenSessionDead(t *te
 	}
 	if got.Metadata["started_config_hash"] != "" {
 		t.Fatalf("started_config_hash = %q, want cleared", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", got.Metadata["continuation_reset_pending"])
 	}
 	if got.Metadata["session_key"] == "" || got.Metadata["session_key"] == "original-key" {
 		t.Fatalf("session_key = %q, want rotated key", got.Metadata["session_key"])


### PR DESCRIPTION
## Summary
- add `gc session reset <id-or-alias>` as a managed-controller fresh-restart command that preserves the existing session bead
- set `continuation_reset_pending` when the reconciler processes `restart_requested` so fresh restarts bump continuation lineage
- add direct regression coverage for the new reset command and for dead/running restart-requested sessions

## Validation
- `TMPDIR=/tmp/gctmp GOCACHE=/tmp/gccache go test -p 1 ./... -count=1`
- `TMPDIR=/tmp/gctmp GOCACHE=/tmp/gccache go test ./cmd/gc -count=1`
- `GOLANGCI_LINT_CACHE=/tmp/gclcache /home/ubuntu/go/bin/golangci-lint fmt --diff ./...`
- `GOLANGCI_LINT_CACHE=/tmp/gclcache /home/ubuntu/go/bin/golangci-lint run ./...`

Addresses #76 (the external `gc session reset` slice only; other issue discussion remains out of scope here).