### PR TITLE
[bug] gc prime silently returns raw templates when rendering fails (ga-72c)

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3260,6 +3260,52 @@ prompt_template = "prompts/mayor.md"
 	}
 }
 
+func TestDoPrimeSurfacesTemplateErrors(t *testing.T) {
+	// Verify that template errors are written to stderr, not silenced.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptsDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Template with a parse error (unclosed action).
+	if err := os.WriteFile(filepath.Join(promptsDir, "bad.md"), []byte("Bad: {{ .Unclosed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/bad.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_AGENT", "worker")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_RIG", "")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrime([]string{"worker"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doPrime = %d, want 0", code)
+	}
+	// With the fix, stderr should contain the template error.
+	if !strings.Contains(stderr.String(), "prompt template") {
+		t.Errorf("stderr = %q, want warning about prompt template error", stderr.String())
+	}
+}
+
 // --- findEnclosingRig tests ---
 
 func TestFindEnclosingRig(t *testing.T) {

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -40,7 +40,7 @@ type PromptContext struct {
 // sibling shared/ dir). injectFragments are named templates to append to
 // the output after rendering. Returns empty string if templatePath is empty
 // or the file doesn't exist. On parse or execute error, logs a warning to
-// stderr and returns the raw text (graceful fallback).
+// stderr and returns empty string (triggering default prompt fallback).
 func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx PromptContext, sessionTemplate string, stderr io.Writer, packDirs []string, injectFragments []string, store beads.Store) string {
 	if templatePath == "" {
 		return ""
@@ -72,14 +72,14 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	tmpl, err = tmpl.Parse(raw)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc: prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
-		return raw
+		return ""
 	}
 
 	td := buildTemplateData(ctx)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, td); err != nil {
 		fmt.Fprintf(stderr, "gc: prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
-		return raw
+		return ""
 	}
 
 	// Append injected fragments.

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -161,9 +161,24 @@ func TestRenderPromptParseErrorFallback(t *testing.T) {
 	f.Files["/city/prompts/bad.md.tmpl"] = []byte("Bad: {{ .Unclosed")
 	var stderr strings.Builder
 	got := renderPrompt(f, "/city", "", "prompts/bad.md.tmpl", PromptContext{}, "", &stderr, nil, nil, nil)
-	// Should return raw text on parse error.
-	if got != "Bad: {{ .Unclosed" {
-		t.Errorf("renderPrompt(parse error) = %q, want raw text", got)
+	// Should return empty string on parse error (triggers default prompt fallback).
+	if got != "" {
+		t.Errorf("renderPrompt(parse error) = %q, want empty string", got)
+	}
+	if !strings.Contains(stderr.String(), "prompt template") {
+		t.Errorf("stderr = %q, want warning about prompt template", stderr.String())
+	}
+}
+
+func TestRenderPromptExecuteErrorFallback(t *testing.T) {
+	f := fsys.NewFake()
+	// A template that parses fine but fails on execute (calls a missing template).
+	f.Files["/city/prompts/exec-err.md.tmpl"] = []byte(`{{ template "nonexistent" . }}`)
+	var stderr strings.Builder
+	got := renderPrompt(f, "/city", "", "prompts/exec-err.md.tmpl", PromptContext{}, "", &stderr, nil, nil, nil)
+	// Should return empty string on execute error (triggers default prompt fallback).
+	if got != "" {
+		t.Errorf("renderPrompt(execute error) = %q, want empty string", got)
 	}
 	if !strings.Contains(stderr.String(), "prompt template") {
 		t.Errorf("stderr = %q, want warning about prompt template", stderr.String())


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery.

- Issue: ga-72c
- Branch: polecat/ga-72c-prime-template-errors
- Target: main