### PR TITLE
Bound implicit findCity walk-up under HOME

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -204,7 +204,7 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 
 func cityForStoreDir(dir string) string {
 	if gcCity := os.Getenv("GC_CITY"); gcCity != "" {
-		if p, err := findCity(gcCity); err == nil {
+		if p, err := validateCityPath(gcCity); err == nil {
 			return p
 		}
 	}

--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+)
+
+type cityDiscoveryOptions struct {
+	ceilingDirs          []string
+	ignoredLegacyRuntime []string
+}
+
+// findCity walks dir upward looking for a directory containing city.toml.
+// Implicit discovery is bounded so it does not accidentally resolve unrelated
+// ancestors such as $HOME or the supervisor's global ~/.gc runtime root.
+func findCity(dir string) (string, error) {
+	return findCityWithOptions(dir, implicitCityDiscoveryOptions())
+}
+
+func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	var legacy string
+	for !isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
+		if citylayout.HasCityConfig(dir) {
+			return dir, nil
+		}
+		if legacy == "" && citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
+			legacy = dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	if legacy != "" {
+		return legacy, nil
+	}
+	return "", fmt.Errorf("not in a city directory (no city.toml or .gc/ found)")
+}
+
+func implicitCityDiscoveryOptions() cityDiscoveryOptions {
+	return cityDiscoveryOptions{
+		ceilingDirs:          implicitCityDiscoveryCeilings(),
+		ignoredLegacyRuntime: implicitIgnoredLegacyRuntimeRoots(),
+	}
+}
+
+func implicitCityDiscoveryCeilings() []string {
+	if raw := strings.TrimSpace(os.Getenv("GC_CEILING_DIRECTORIES")); raw != "" {
+		return normalizeDiscoveryPaths(strings.Split(raw, string(os.PathListSeparator)))
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return nil
+	}
+	return normalizeDiscoveryPaths([]string{home})
+}
+
+func implicitIgnoredLegacyRuntimeRoots() []string {
+	runtimeRoot := configuredSupervisorRuntimeRoot()
+	if runtimeRoot == "" {
+		return nil
+	}
+	return []string{runtimeRoot}
+}
+
+func configuredSupervisorRuntimeRoot() string {
+	if gcHome := strings.TrimSpace(os.Getenv("GC_HOME")); gcHome != "" {
+		return normalizeDiscoveryPath(gcHome)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(normalizeDiscoveryPath(home), citylayout.RuntimeRoot)
+}
+
+func isCityDiscoveryCeiling(dir string, ceilings []string) bool {
+	dir = normalizeDiscoveryPath(dir)
+	for _, ceiling := range ceilings {
+		if dir == ceiling {
+			return true
+		}
+	}
+	return false
+}
+
+func isIgnoredLegacyRuntimeRoot(dir string, ignored []string) bool {
+	runtimeRoot := filepath.Join(normalizeDiscoveryPath(dir), citylayout.RuntimeRoot)
+	for _, candidate := range ignored {
+		if runtimeRoot == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeDiscoveryPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = normalizeDiscoveryPath(path)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	return out
+}
+
+func normalizeDiscoveryPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}

--- a/cmd/gc/command_context_test.go
+++ b/cmd/gc/command_context_test.go
@@ -118,6 +118,33 @@ func TestRigAnywhere_ResolveCommandContext(t *testing.T) {
 	}
 }
 
+func TestResolveCommandContextPathValidatesExactCityRootAtHomeBoundary(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	resetFlags(t)
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cityPath := homeDir
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"home-city\"\n\n[[agent]]\nname = \"mayor\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setCwd(t, t.TempDir())
+
+	ctx, err := resolveCommandContext([]string{cityPath})
+	if err != nil {
+		t.Fatalf("resolveCommandContext() error: %v", err)
+	}
+	if ctx.CityPath != cityPath {
+		t.Fatalf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+	}
+	if ctx.RigName != "" {
+		t.Fatalf("RigName = %q, want empty", ctx.RigName)
+	}
+}
+
 func TestRigAnywhere_RequireBootstrappedCityFromRigDir(t *testing.T) {
 	for _, insideCity := range []bool{true, false} {
 		name := "outside_city"

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -193,32 +193,6 @@ func cliSessionName(cityPath, cityName, agentName, sessionTemplate string) strin
 	return sessionName(store, cityName, agentName, sessionTemplate)
 }
 
-// findCity walks dir upward looking for a directory containing city.toml.
-// Falls back to legacy .gc/ markers for compatibility.
-func findCity(dir string) (string, error) {
-	dir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", err
-	}
-	var legacy string
-	for {
-		if citylayout.HasCityConfig(dir) {
-			return dir, nil
-		}
-		if legacy == "" && citylayout.HasRuntimeRoot(dir) {
-			legacy = dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			if legacy != "" {
-				return legacy, nil
-			}
-			return "", fmt.Errorf("not in a city directory (no city.toml or .gc/ found)")
-		}
-		dir = parent
-	}
-}
-
 // resolvedContext holds the result of city+rig resolution.
 type resolvedContext struct {
 	CityPath string // absolute path to city root
@@ -347,6 +321,12 @@ func resolveContextFromPath(path string) (resolvedContext, error) {
 			return resolvedContext{}, err
 		}
 		return ctx, nil
+	}
+	if cityPath, err := validateCityPath(abs); err == nil {
+		return resolvedContext{
+			CityPath: cityPath,
+			RigName:  rigFromCwdDir(cityPath, abs),
+		}, nil
 	}
 	cityPath, err := findCity(abs)
 	if err != nil {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -295,6 +295,100 @@ func TestFindCity(t *testing.T) {
 			t.Errorf("error = %q, want 'not in a city directory'", err)
 		}
 	})
+
+	t.Run("not_found_ignores_stray_home_city_toml", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		if err := os.WriteFile(filepath.Join(homeDir, "city.toml"), []byte("[workspace]\nname = \"stray\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(homeDir, "project", "deep")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := findCity(dir)
+		if err == nil {
+			t.Fatal("findCity() should fail when only a stray $HOME/city.toml exists")
+		}
+		if !strings.Contains(err.Error(), "not in a city directory") {
+			t.Errorf("error = %q, want 'not in a city directory'", err)
+		}
+	})
+
+	t.Run("not_found_ignores_supervisor_home_runtime_root", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		if err := os.MkdirAll(filepath.Join(homeDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(homeDir, "project", "deep")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := findCity(dir)
+		if err == nil {
+			t.Fatal("findCity() should fail when only supervisor $HOME/.gc exists")
+		}
+		if !strings.Contains(err.Error(), "not in a city directory") {
+			t.Errorf("error = %q, want 'not in a city directory'", err)
+		}
+	})
+
+	t.Run("nested_city_below_home_boundary_still_found", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		cityDir := filepath.Join(homeDir, "cities", "alpha")
+		if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"alpha\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(cityDir, "project", "deep")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := findCity(dir)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", dir, err)
+		}
+		if got != cityDir {
+			t.Errorf("findCity(%q) = %q, want %q", dir, got, cityDir)
+		}
+	})
+
+	t.Run("respects_gc_ceiling_directories", func(t *testing.T) {
+		root := t.TempDir()
+		parent := filepath.Join(root, "parent")
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(parent, "city.toml"), []byte("[workspace]\nname = \"parent\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(parent, "child", "deep")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GC_CEILING_DIRECTORIES", parent)
+
+		_, err := findCity(dir)
+		if err == nil {
+			t.Fatal("findCity() should fail when GC_CEILING_DIRECTORIES excludes the ancestor city root")
+		}
+		if !strings.Contains(err.Error(), "not in a city directory") {
+			t.Errorf("error = %q, want 'not in a city directory'", err)
+		}
+	})
 }
 
 // --- resolveCity ---


### PR DESCRIPTION
## Summary
- bound implicit city discovery with a default HOME ceiling and `GC_CEILING_DIRECTORIES` override
- ignore the supervisor runtime home when considering legacy `.gc/` city markers
- preserve explicit city paths by validating the exact path before bounded parent discovery

## Testing
- make fmt-check
- make lint
- make vet
- make test

Fixes #366