### PR TITLE
Harden GC city context resolution

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -203,10 +203,8 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 }
 
 func cityForStoreDir(dir string) string {
-	if gcCity := os.Getenv("GC_CITY"); gcCity != "" {
-		if p, err := findCity(gcCity); err == nil {
-			return p
-		}
+	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
+		return cityPath
 	}
 	if p, err := findCity(dir); err == nil {
 		return p

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -782,8 +782,8 @@ func providerOpTimeout(op string) time.Duration {
 // runProviderOp runs a lifecycle operation against an exec beads script.
 // Exit 2 = not needed (treated as success, no-op). Used for start,
 // init, health, recover, and stop operations.
-// cityPath is set as GC_CITY_PATH in the subprocess environment so scripts
-// can locate the city root.
+// cityPath is exported via the canonical city runtime env so scripts can
+// locate the city root and runtime directories.
 func runProviderOp(script, cityPath string, args ...string) error {
 	op := ""
 	if len(args) > 0 {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -384,7 +384,7 @@ func TestRunProviderOp_errorNoStderr(t *testing.T) {
 func TestRunProviderOp_setsCityRuntimeEnv(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "check-env.sh")
-	content := "#!/bin/sh\nif [ \"$GC_CITY_PATH\" = \"" + dir + "\" ] && [ \"$GC_CITY_ROOT\" = \"" + dir + "\" ] && [ \"$GC_CITY_RUNTIME_DIR\" = \"" + filepath.Join(dir, ".gc", "runtime") + "\" ]; then exit 0; else exit 1; fi\n"
+	content := "#!/bin/sh\nif [ \"$GC_CITY\" = \"" + dir + "\" ] && [ \"$GC_CITY_PATH\" = \"" + dir + "\" ] && [ \"$GC_CITY_RUNTIME_DIR\" = \"" + filepath.Join(dir, ".gc", "runtime") + "\" ]; then exit 0; else exit 1; fi\n"
 	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -397,13 +397,14 @@ func TestRunProviderOpSanitizesInheritedRuntimeEnv(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "sanitize-env.sh")
 	content := "#!/bin/sh\n" +
+		"test \"$GC_CITY\" = \"" + dir + "\" || exit 1\n" +
 		"test \"$GC_CITY_PATH\" = \"" + dir + "\" || exit 1\n" +
-		"test \"$GC_CITY_ROOT\" = \"" + dir + "\" || exit 1\n" +
 		"test \"$GC_CITY_RUNTIME_DIR\" = \"" + filepath.Join(dir, ".gc", "runtime") + "\" || exit 1\n" +
 		"test -z \"$GC_PACK_STATE_DIR\" || exit 1\n"
 	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("GC_CITY", "/wrong")
 	t.Setenv("GC_CITY_PATH", "/wrong")
 	t.Setenv("GC_CITY_ROOT", "/wrong")
 	t.Setenv("GC_CITY_RUNTIME_DIR", "/wrong/.gc/runtime")

--- a/cmd/gc/city_context.go
+++ b/cmd/gc/city_context.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+func resolveExplicitCityPathEnv() (string, bool) {
+	for _, key := range []string{"GC_CITY", "GC_CITY_PATH", "GC_CITY_ROOT"} {
+		if raw := strings.TrimSpace(os.Getenv(key)); raw != "" {
+			if cityPath, err := validateCityPath(raw); err == nil {
+				return cityPath, true
+			}
+		}
+	}
+	return "", false
+}
+
+func resolveCityPathFromGCDir() (string, bool) {
+	gcDir := strings.TrimSpace(os.Getenv("GC_DIR"))
+	if gcDir == "" {
+		return "", false
+	}
+	cityPath, err := findCity(gcDir)
+	if err != nil {
+		return "", false
+	}
+	return cityPath, true
+}
+
+func resolveCityPathFromCwd() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	cityPath, err := findCity(cwd)
+	if err != nil {
+		return "", false
+	}
+	return cityPath, true
+}
+
+func rigFromGCDirOrCwd(cityPath string) string {
+	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" {
+		if rigName := rigFromCwdDir(cityPath, gcDir); rigName != "" {
+			return rigName
+		}
+	}
+	return rigFromCwd(cityPath)
+}

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -32,7 +32,7 @@ Returns immediately. Equivalent to:
   gc session kill <target>
 
 Self-handoff requires session context (GC_ALIAS or GC_SESSION_ID, plus
-GC_SESSION_NAME and GC_CITY). Remote handoff accepts a session alias or ID.`,
+GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or ID.`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdHandoff(args, target, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_pack_commands_test.go
+++ b/cmd/gc/cmd_pack_commands_test.go
@@ -66,8 +66,8 @@ script = "commands/info.sh"
 	// Write hello.sh script.
 	helloScript := `#!/bin/sh
 echo "hello from $GC_PACK_NAME"
+echo "cityctx=$GC_CITY"
 echo "city=$GC_CITY_PATH"
-echo "cityroot=$GC_CITY_ROOT"
 echo "runtime=$GC_CITY_RUNTIME_DIR"
 echo "packdir=$GC_PACK_DIR"
 echo "packstate=$GC_PACK_STATE_DIR"
@@ -257,8 +257,8 @@ func TestPackCommandExecution(t *testing.T) {
 	if !strings.Contains(out, "city="+cityPath) {
 		t.Errorf("stdout missing city path, got:\n%s", out)
 	}
-	if !strings.Contains(out, "cityroot="+cityPath) {
-		t.Errorf("stdout missing city root, got:\n%s", out)
+	if !strings.Contains(out, "cityctx="+cityPath) {
+		t.Errorf("stdout missing city context, got:\n%s", out)
 	}
 	if !strings.Contains(out, "runtime="+filepath.Join(cityPath, ".gc", "runtime")) {
 		t.Errorf("stdout missing runtime dir, got:\n%s", out)

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -547,6 +549,33 @@ func TestDrainAckNoArgsErrorMessage(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "not in session context") {
 		t.Errorf("stderr = %q, want 'not in session context' error", stderr.String())
+	}
+}
+
+func TestDrainAckNoArgsFallsBackToCityPathEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := newRuntimeDrainAckCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_ID", "gc-42")
+	t.Setenv("GC_SESSION_NAME", "s-gc-42")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("drain-ack should succeed with GC_CITY_PATH fallback: %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Drain acknowledged") {
+		t.Fatalf("stdout = %q, want drain acknowledgement", stdout.String())
 	}
 }
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -250,16 +250,16 @@ func resolveCommandCity(args []string) (string, error) {
 //  1. --city + --rig flags (explicit both, validated)
 //  2. --city only (explicit city, rig from cwd if applicable)
 //  3. --rig only (rig from cities.toml, city from default_city)
-//  4. GC_CITY + GC_RIG env vars
-//  5. GC_CITY only (city set, rig from cwd if applicable)
+//  4. Explicit city env (GC_CITY / GC_CITY_PATH / GC_CITY_ROOT) + GC_RIG
+//  5. Explicit city env only (city set, rig from GC_DIR/cwd if applicable)
 //  6. GC_RIG only (rig from cities.toml, city from default_city)
-//  7. Rig index lookup (cwd prefix match in cities.toml)
-//  8. Walk up from cwd looking for city.toml
-//  9. Fail
+//  7. GC_DIR-derived city path
+//  8. Rig index lookup (cwd prefix match in cities.toml)
+//  9. Walk up from cwd looking for city.toml
+//  10. Fail
 func resolveContext() (resolvedContext, error) {
 	city := cityFlag
 	rig := rigFlag
-	gcCity := os.Getenv("GC_CITY")
 	gcRig := os.Getenv("GC_RIG")
 
 	// Step 1: --city + --rig
@@ -290,19 +290,15 @@ func resolveContext() (resolvedContext, error) {
 		return ctx, nil
 	}
 
-	// Step 4: GC_CITY + GC_RIG
-	if gcCity != "" && gcRig != "" {
-		if cp, err := validateCityPath(gcCity); err == nil {
-			return resolvedContext{CityPath: cp, RigName: gcRig}, nil
-		}
+	// Step 4: explicit city env + GC_RIG
+	if gcCity, ok := resolveExplicitCityPathEnv(); ok && gcRig != "" {
+		return resolvedContext{CityPath: gcCity, RigName: gcRig}, nil
 	}
 
-	// Step 5: GC_CITY only
-	if gcCity != "" {
-		if cp, err := validateCityPath(gcCity); err == nil {
-			rn := rigFromCwd(cp)
-			return resolvedContext{CityPath: cp, RigName: rn}, nil
-		}
+	// Step 5: explicit city env only
+	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
+		rn := rigFromGCDirOrCwd(gcCity)
+		return resolvedContext{CityPath: gcCity, RigName: rn}, nil
 	}
 
 	// Step 6: GC_RIG only
@@ -313,7 +309,13 @@ func resolveContext() (resolvedContext, error) {
 		}
 	}
 
-	// Step 7: Rig index lookup (cwd prefix match in cities.toml).
+	// Step 7: GC_DIR-derived city path.
+	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
+		rn := rigFromCwdDir(gcDirCity, strings.TrimSpace(os.Getenv("GC_DIR")))
+		return resolvedContext{CityPath: gcDirCity, RigName: rn}, nil
+	}
+
+	// Step 8: Rig index lookup (cwd prefix match in cities.toml).
 	cwd, err := os.Getwd()
 	if err != nil {
 		return resolvedContext{}, err
@@ -322,7 +324,7 @@ func resolveContext() (resolvedContext, error) {
 		return ctx, nil
 	}
 
-	// Step 8: Walk up from cwd looking for city.toml.
+	// Step 9: Walk up from cwd looking for city.toml.
 	cityPath, err := findCity(cwd)
 	if err != nil {
 		return resolvedContext{}, err

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -396,6 +396,54 @@ func TestResolveCityFlag(t *testing.T) {
 			t.Errorf("resolveCity() = %q, want %q", got, cityDir)
 		}
 	})
+
+	t.Run("gc_city_path_env_fallback", func(t *testing.T) {
+		cityDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		old := cityFlag
+		cityFlag = ""
+		t.Cleanup(func() { cityFlag = old })
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", cityDir)
+
+		got, err := resolveCity()
+		if err != nil {
+			t.Fatalf("resolveCity() error: %v", err)
+		}
+		if got != cityDir {
+			t.Errorf("resolveCity() = %q, want %q", got, cityDir)
+		}
+	})
+
+	t.Run("gc_dir_env_fallback", func(t *testing.T) {
+		cityDir := t.TempDir()
+		workDir := filepath.Join(cityDir, "rigs", "demo")
+		if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(workDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		old := cityFlag
+		cityFlag = ""
+		t.Cleanup(func() { cityFlag = old })
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", "")
+		t.Setenv("GC_CITY_ROOT", "")
+		t.Setenv("GC_DIR", workDir)
+
+		got, err := resolveCity()
+		if err != nil {
+			t.Fatalf("resolveCity() error: %v", err)
+		}
+		if got != cityDir {
+			t.Errorf("resolveCity() = %q, want %q", got, cityDir)
+		}
+	})
 }
 
 // --- doRigAdd (with fsys.Fake) ---

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -430,14 +430,18 @@ func TestOrderDispatchExecOrderDir(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	foundDir := false
-	foundCityRoot := false
+	foundCity := false
+	foundCityPath := false
 	foundRuntime := false
 	for _, e := range gotEnv {
 		if e == "ORDER_DIR=/city/formulas/orders/poll" {
 			foundDir = true
 		}
-		if e == "GC_CITY_ROOT=/city-root" {
-			foundCityRoot = true
+		if e == "GC_CITY=/city-root" {
+			foundCity = true
+		}
+		if e == "GC_CITY_PATH=/city-root" {
+			foundCityPath = true
 		}
 		if e == "GC_CITY_RUNTIME_DIR=/city-root/.gc/runtime" {
 			foundRuntime = true
@@ -446,8 +450,11 @@ func TestOrderDispatchExecOrderDir(t *testing.T) {
 	if !foundDir {
 		t.Errorf("ORDER_DIR not set correctly, got env: %v", gotEnv)
 	}
-	if !foundCityRoot {
-		t.Errorf("GC_CITY_ROOT not set correctly, got env: %v", gotEnv)
+	if !foundCity {
+		t.Errorf("GC_CITY not set correctly, got env: %v", gotEnv)
+	}
+	if !foundCityPath {
+		t.Errorf("GC_CITY_PATH not set correctly, got env: %v", gotEnv)
 	}
 	if !foundRuntime {
 		t.Errorf("GC_CITY_RUNTIME_DIR not set correctly, got env: %v", gotEnv)

--- a/cmd/gc/session_target.go
+++ b/cmd/gc/session_target.go
@@ -15,10 +15,6 @@ type sessionRuntimeTarget struct {
 }
 
 func currentSessionRuntimeTarget() (sessionRuntimeTarget, error) {
-	cityPath := strings.TrimSpace(os.Getenv("GC_CITY"))
-	if cityPath == "" {
-		return sessionRuntimeTarget{}, fmt.Errorf("not in session context (GC_CITY not set)")
-	}
 	display := defaultMailIdentity()
 	if display == "human" {
 		return sessionRuntimeTarget{}, fmt.Errorf("not in session context (GC_ALIAS/GC_SESSION_ID not set)")
@@ -29,6 +25,15 @@ func currentSessionRuntimeTarget() (sessionRuntimeTarget, error) {
 	}
 	if sessionName == "" {
 		return sessionRuntimeTarget{}, fmt.Errorf("not in session context (GC_SESSION_NAME not set)")
+	}
+	cityPath, ok := resolveExplicitCityPathEnv()
+	if !ok {
+		if cityPath, ok = resolveCityPathFromGCDir(); !ok {
+			cityPath, ok = resolveCityPathFromCwd()
+		}
+	}
+	if !ok {
+		return sessionRuntimeTarget{}, fmt.Errorf("not in session context (city context not set)")
 	}
 	return sessionRuntimeTarget{
 		cityPath:    cityPath,

--- a/cmd/gc/session_target_test.go
+++ b/cmd/gc/session_target_test.go
@@ -1,9 +1,17 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestCurrentSessionRuntimeTargetUsesAlias(t *testing.T) {
-	t.Setenv("GC_CITY", "/tmp/city")
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_ALIAS", "mayor")
 	t.Setenv("GC_SESSION_ID", "gc-42")
 	t.Setenv("GC_SESSION_NAME", "s-gc-42")
@@ -12,14 +20,60 @@ func TestCurrentSessionRuntimeTargetUsesAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("currentSessionRuntimeTarget(): %v", err)
 	}
-	if got.cityPath != "/tmp/city" {
-		t.Fatalf("cityPath = %q, want /tmp/city", got.cityPath)
+	if got.cityPath != cityDir {
+		t.Fatalf("cityPath = %q, want %q", got.cityPath, cityDir)
 	}
 	if got.display != "mayor" {
 		t.Fatalf("display = %q, want mayor", got.display)
 	}
 	if got.sessionName != "s-gc-42" {
 		t.Fatalf("sessionName = %q, want s-gc-42", got.sessionName)
+	}
+}
+
+func TestCurrentSessionRuntimeTargetFallsBackToCityPathEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_ID", "gc-42")
+	t.Setenv("GC_SESSION_NAME", "s-gc-42")
+
+	got, err := currentSessionRuntimeTarget()
+	if err != nil {
+		t.Fatalf("currentSessionRuntimeTarget(): %v", err)
+	}
+	if got.cityPath != cityDir {
+		t.Fatalf("cityPath = %q, want %q", got.cityPath, cityDir)
+	}
+}
+
+func TestCurrentSessionRuntimeTargetFallsBackToGCDir(t *testing.T) {
+	cityDir := t.TempDir()
+	workDir := filepath.Join(cityDir, "rigs", "demo")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", workDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_ID", "gc-42")
+	t.Setenv("GC_SESSION_NAME", "s-gc-42")
+
+	got, err := currentSessionRuntimeTarget()
+	if err != nil {
+		t.Fatalf("currentSessionRuntimeTarget(): %v", err)
+	}
+	if got.cityPath != cityDir {
+		t.Fatalf("cityPath = %q, want %q", got.cityPath, cityDir)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -179,17 +179,13 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 
 	// Step 8: Build agent environment.
 	agentEnv := map[string]string{
-		"GC_SESSION_NAME":     sessName,
-		"GC_SESSION_ID":       sessionBeadID,
-		"GC_TEMPLATE":         templateNameFor(cfgAgent, qualifiedName),
-		"GC_AGENT":            sessionBeadID,
-		"GC_ALIAS":            qualifiedName,
-		"BEADS_ACTOR":         sessName,
-		"GC_CITY":             p.cityPath,
-		"GC_CITY_ROOT":        p.cityPath,
-		"GC_CITY_PATH":        p.cityPath,
-		"GC_CITY_RUNTIME_DIR": citylayout.RuntimeDataDir(p.cityPath),
-		"GC_DIR":              workDir,
+		"GC_SESSION_NAME": sessName,
+		"GC_SESSION_ID":   sessionBeadID,
+		"GC_TEMPLATE":     templateNameFor(cfgAgent, qualifiedName),
+		"GC_AGENT":        sessionBeadID,
+		"GC_ALIAS":        qualifiedName,
+		"BEADS_ACTOR":     sessName,
+		"GC_DIR":          workDir,
 		// Explicit empty values matter here. tmux session creation uses `env -u`
 		// only for keys present with empty strings, which prevents stale rig
 		// scope from leaking out of the tmux server's inherited environment.
@@ -201,6 +197,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		// roots (for example under .gc/agents/... or .gc/worktrees/...).
 		// Rig-scoped agents override the rig-specific keys below.
 		"GT_ROOT": p.cityPath,
+	}
+	for key, value := range citylayout.CityRuntimeEnvMap(p.cityPath) {
+		agentEnv[key] = value
 	}
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe

--- a/internal/citylayout/runtime.go
+++ b/internal/citylayout/runtime.go
@@ -54,21 +54,21 @@ func PackStateDir(cityRoot, packName string) string {
 	return filepath.Join(RuntimePacksDir(cityRoot), packName)
 }
 
-// CityRuntimeEnv returns compatibility-safe city runtime env vars.
+// CityRuntimeEnv returns canonical city runtime env vars.
 func CityRuntimeEnv(cityRoot string) []string {
 	runtimeDir := RuntimeDataDir(cityRoot)
 	return []string{
-		"GC_CITY_ROOT=" + cityRoot,
+		"GC_CITY=" + cityRoot,
 		"GC_CITY_PATH=" + cityRoot,
 		"GC_CITY_RUNTIME_DIR=" + runtimeDir,
 	}
 }
 
-// CityRuntimeEnvMap returns compatibility-safe city runtime env vars.
+// CityRuntimeEnvMap returns canonical city runtime env vars.
 func CityRuntimeEnvMap(cityRoot string) map[string]string {
 	runtimeDir := RuntimeDataDir(cityRoot)
 	return map[string]string{
-		"GC_CITY_ROOT":        cityRoot,
+		"GC_CITY":             cityRoot,
 		"GC_CITY_PATH":        cityRoot,
 		"GC_CITY_RUNTIME_DIR": runtimeDir,
 	}

--- a/internal/citylayout/runtime_test.go
+++ b/internal/citylayout/runtime_test.go
@@ -7,7 +7,7 @@ func TestPackRuntimeEnv(t *testing.T) {
 
 	got := PackRuntimeEnv(cityRoot, "rlm")
 	want := map[string]string{
-		"GC_CITY_ROOT":        cityRoot,
+		"GC_CITY":             cityRoot,
 		"GC_CITY_PATH":        cityRoot,
 		"GC_CITY_RUNTIME_DIR": "/city/.gc/runtime",
 		"GC_PACK_STATE_DIR":   "/city/.gc/runtime/packs/rlm",

--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -80,15 +80,13 @@ func (ce ConditionEnv) Environ() []string {
 		"BEADS_DIR=" + filepath.Join(ce.CityPath, ".beads"),
 		"GC_BEAD_ID=" + ce.BeadID,
 		"GC_ITERATION=" + strconv.Itoa(ce.Iteration),
-		"GC_CITY_ROOT=" + ce.CityPath,
-		"GC_CITY_PATH=" + ce.CityPath,
-		"GC_CITY_RUNTIME_DIR=" + citylayout.RuntimeDataDir(ce.CityPath),
 		"GC_WISP_ID=" + ce.WispID,
 		"GC_ARTIFACT_DIR=" + ce.ArtifactDir,
 		"GC_ITERATION_DURATION_MS=" + strconv.FormatInt(ce.IterationDurationMs, 10),
 		"GC_CUMULATIVE_DURATION_MS=" + strconv.FormatInt(ce.CumulativeDurationMs, 10),
 		"GC_MAX_ITERATIONS=" + strconv.Itoa(ce.MaxIterations),
 	}
+	env = append(env, citylayout.CityRuntimeEnv(ce.CityPath)...)
 
 	// Optional fields: only include if non-empty.
 	if ce.DocPath != "" {

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -40,7 +40,7 @@ func TestConditionEnvEnviron(t *testing.T) {
 		"BEADS_DIR":                 "/home/test/city/.beads",
 		"GC_BEAD_ID":                "bead-123",
 		"GC_ITERATION":              "3",
-		"GC_CITY_ROOT":              "/home/test/city",
+		"GC_CITY":                   "/home/test/city",
 		"GC_CITY_PATH":              "/home/test/city",
 		"GC_CITY_RUNTIME_DIR":       "/home/test/city/.gc/runtime",
 		"GC_WISP_ID":                "wisp-456",

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -513,7 +513,7 @@ func TestProcessRalphCheckRetriesThenPasses(t *testing.T) {
 	t.Parallel()
 
 	cityPath := t.TempDir()
-	checkPath := writeCheckScript(t, cityPath, "retry-check.sh", "#!/bin/bash\nset -euo pipefail\nTARGET=\"$GC_CITY_ROOT/retry-demo.txt\"\n[ -f \"$TARGET\" ]\ngrep -qx \"pass\" \"$TARGET\"\n")
+	checkPath := writeCheckScript(t, cityPath, "retry-check.sh", "#!/bin/bash\nset -euo pipefail\nTARGET=\"$GC_CITY_PATH/retry-demo.txt\"\n[ -f \"$TARGET\" ]\ngrep -qx \"pass\" \"$TARGET\"\n")
 
 	store, logical, run1, check1 := newSimpleRalphLoop(t, "implement", checkPath, 2)
 

--- a/internal/doctor/pack_checks_test.go
+++ b/internal/doctor/pack_checks_test.go
@@ -157,7 +157,7 @@ func TestPackScriptCheckEnvVars(t *testing.T) {
 	cityPath := t.TempDir()
 	// Script echoes env vars to verify they're passed.
 	script := writeCheckScript(t, dir,
-		"#!/bin/sh\necho \"city=$GC_CITY_PATH root=$GC_CITY_ROOT runtime=$GC_CITY_RUNTIME_DIR topo=$GC_PACK_DIR state=$GC_PACK_STATE_DIR\"\nexit 0\n")
+		"#!/bin/sh\necho \"cityctx=$GC_CITY city=$GC_CITY_PATH runtime=$GC_CITY_RUNTIME_DIR topo=$GC_PACK_DIR state=$GC_PACK_STATE_DIR\"\nexit 0\n")
 
 	c := &PackScriptCheck{
 		CheckName: "topo:env",
@@ -171,8 +171,8 @@ func TestPackScriptCheckEnvVars(t *testing.T) {
 	if result.Status != StatusOK {
 		t.Errorf("Status = %d, want StatusOK", result.Status)
 	}
-	expected := "city=" + cityPath +
-		" root=" + cityPath +
+	expected := "cityctx=" + cityPath +
+		" city=" + cityPath +
 		" runtime=" + filepath.Join(cityPath, ".gc", "runtime") +
 		" topo=" + dir +
 		" state=" + filepath.Join(cityPath, ".gc", "runtime", "packs", "topo")

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -58,7 +58,7 @@ func LiveFingerprint(cfg Config) string {
 //
 //	Behavioral (restart needed if changed):
 //	  BEADS_DIR       — where the agent finds work
-//	  GC_CITY*        — city identity and location
+//	  GC_CITY / GC_CITY_PATH — city identity and location
 //	  GC_RIG*         — which rig the agent operates on
 //	  GC_TEMPLATE     — agent template identity
 //	  GC_ALIAS        — agent display identity
@@ -80,7 +80,6 @@ func LiveFingerprint(cfg Config) string {
 var envFingerprintAllow = map[string]bool{
 	// City identity
 	"GC_CITY":      true,
-	"GC_CITY_ROOT": true,
 	"GC_CITY_PATH": true,
 
 	// Rig scope

--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -31,6 +31,12 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 	// Controller resolves dirs relative to its cityPath; pods use /workspace.
 	podWorkDir := "/workspace"
 	ctrlCity := cfg.Env["GC_CITY"]
+	if ctrlCity == "" {
+		ctrlCity = cfg.Env["GC_CITY_PATH"]
+	}
+	if ctrlCity == "" {
+		ctrlCity = cfg.Env["GC_CITY_ROOT"]
+	}
 	if ctrlCity != "" && cfg.WorkDir != "" && cfg.WorkDir != ctrlCity {
 		if rel, ok := strings.CutPrefix(cfg.WorkDir, ctrlCity+"/"); ok {
 			podWorkDir = "/workspace/" + rel
@@ -242,9 +248,11 @@ func buildPodEnv(cfgEnv map[string]string, podWorkDir string) []corev1.EnvVar {
 			continue
 		}
 		val := v
-		// Remap GC_CITY and GC_DIR to pod paths.
+		// Remap city/workdir vars to pod-visible paths.
 		switch k {
 		case "GC_CITY":
+			val = "/workspace"
+		case "GC_CITY_PATH", "GC_CITY_ROOT":
 			val = "/workspace"
 		case "GC_DIR":
 			val = podWorkDir

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -598,6 +598,7 @@ func TestBuildPodEnvRemapsVars(t *testing.T) {
 	cfgEnv := map[string]string{
 		"GC_AGENT":               "mayor",
 		"GC_CITY":                "/host/city",
+		"GC_CITY_PATH":           "/host/city",
 		"GC_DIR":                 "/host/city/rig",
 		"GC_SESSION":             "exec:gc-session-k8s",
 		"GC_BEADS":               "exec:something",
@@ -625,6 +626,9 @@ func TestBuildPodEnvRemapsVars(t *testing.T) {
 	// GC_CITY should be remapped to /workspace.
 	if envMap["GC_CITY"] != "/workspace" {
 		t.Errorf("GC_CITY = %q, want /workspace", envMap["GC_CITY"])
+	}
+	if envMap["GC_CITY_PATH"] != "/workspace" {
+		t.Errorf("GC_CITY_PATH = %q, want /workspace", envMap["GC_CITY_PATH"])
 	}
 
 	// GC_DIR should be remapped to pod work dir.

--- a/internal/workspacesvc/proxy_process_test.go
+++ b/internal/workspacesvc/proxy_process_test.go
@@ -150,7 +150,8 @@ func TestProxyProcessHelper(t *testing.T) {
 	})
 	mux.HandleFunc("/env", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
-			"GC_CITY_ROOT":              os.Getenv("GC_CITY_ROOT"),
+			"GC_CITY":                   os.Getenv("GC_CITY"),
+			"GC_CITY_PATH":              os.Getenv("GC_CITY_PATH"),
 			"GC_CITY_RUNTIME_DIR":       os.Getenv("GC_CITY_RUNTIME_DIR"),
 			"GC_SERVICE_NAME":           os.Getenv("GC_SERVICE_NAME"),
 			"GC_SERVICE_STATE_ROOT":     os.Getenv("GC_SERVICE_STATE_ROOT"),
@@ -229,8 +230,11 @@ func TestProxyProcessPublishesServiceEnv(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
 		t.Fatalf("decode env: %v", err)
 	}
-	if env["GC_CITY_ROOT"] != rt.cityPath {
-		t.Fatalf("GC_CITY_ROOT = %q, want %q", env["GC_CITY_ROOT"], rt.cityPath)
+	if env["GC_CITY"] != rt.cityPath {
+		t.Fatalf("GC_CITY = %q, want %q", env["GC_CITY"], rt.cityPath)
+	}
+	if env["GC_CITY_PATH"] != rt.cityPath {
+		t.Fatalf("GC_CITY_PATH = %q, want %q", env["GC_CITY_PATH"], rt.cityPath)
 	}
 	if env["GC_CITY_RUNTIME_DIR"] != filepath.Join(rt.cityPath, ".gc", "runtime") {
 		t.Fatalf("GC_CITY_RUNTIME_DIR = %q, want %q", env["GC_CITY_RUNTIME_DIR"], filepath.Join(rt.cityPath, ".gc", "runtime"))

--- a/test/acceptance/env_invariant_test.go
+++ b/test/acceptance/env_invariant_test.go
@@ -66,9 +66,9 @@ func TestEnvInvariant_CityPathAlwaysCityRoot(t *testing.T) {
 				rt.Fatalf("GC_CITY_PATH = %q, want %q (agent %s)", v, cityPath, agent.Name)
 			}
 
-			// INVARIANT: GC_CITY_ROOT == cityPath
-			if v := env["GC_CITY_ROOT"]; v != cityPath {
-				rt.Fatalf("GC_CITY_ROOT = %q, want %q (agent %s)", v, cityPath, agent.Name)
+			// INVARIANT: GC_CITY == cityPath
+			if v := env["GC_CITY"]; v != cityPath {
+				rt.Fatalf("GC_CITY = %q, want %q (agent %s)", v, cityPath, agent.Name)
 			}
 
 			// INVARIANT: GT_ROOT == cityPath (never rig root)
@@ -219,7 +219,6 @@ func resolveAgentEnvFromConfig(cityPath, rigName, rigRoot string, agent *config.
 	env := map[string]string{
 		"GC_AGENT":            agent.QualifiedName(),
 		"GC_CITY":             cityPath,
-		"GC_CITY_ROOT":        cityPath,
 		"GC_CITY_PATH":        cityPath,
 		"GC_CITY_RUNTIME_DIR": filepath.Join(cityPath, ".gc", "runtime"),
 		"GT_ROOT":             cityPath,

--- a/test/acceptance/order_env_test.go
+++ b/test/acceptance/order_env_test.go
@@ -20,7 +20,7 @@ import (
 
 // TestOrderEnvInvariant_CityVarsAlwaysPresent verifies that the city
 // runtime env vars (as produced by CityRuntimeEnv) always include
-// GC_CITY_PATH, GC_CITY_ROOT, and GC_CITY_RUNTIME_DIR regardless of
+// GC_CITY, GC_CITY_PATH, and GC_CITY_RUNTIME_DIR regardless of
 // what additional vars are merged.
 //
 // This is the invariant that broke when cityRuntimeProcessEnv called
@@ -45,9 +45,9 @@ func TestOrderEnvInvariant_CityVarsAlwaysPresent(t *testing.T) {
 			rt.Fatalf("GC_CITY_PATH = %q, want %q", v, cityPath)
 		}
 
-		// INVARIANT: GC_CITY_ROOT always present and equals cityPath.
-		if v := env["GC_CITY_ROOT"]; v != cityPath {
-			rt.Fatalf("GC_CITY_ROOT = %q, want %q", v, cityPath)
+		// INVARIANT: GC_CITY always present and equals cityPath.
+		if v := env["GC_CITY"]; v != cityPath {
+			rt.Fatalf("GC_CITY = %q, want %q", v, cityPath)
 		}
 
 		// INVARIANT: GC_CITY_RUNTIME_DIR always present.

--- a/test/acceptance/tier_b/lifecycle_b_test.go
+++ b/test/acceptance/tier_b/lifecycle_b_test.go
@@ -71,7 +71,7 @@ func TestLifecycle_AgentGetsCorrectEnv(t *testing.T) {
 
 	// Core env vars must be present.
 	required := []string{
-		"GC_CITY", "GC_CITY_ROOT", "GC_CITY_PATH",
+		"GC_CITY", "GC_CITY_PATH",
 		"GC_CITY_RUNTIME_DIR", "GC_AGENT", "GC_SESSION_NAME",
 		"GC_TEMPLATE",
 	}

--- a/test/agents/ralph-check.sh
+++ b/test/agents/ralph-check.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-TARGET="${GC_CITY_ROOT}/ralph-demo.txt"
+TARGET="${GC_CITY_PATH}/ralph-demo.txt"
 
 [ -f "$TARGET" ]
 grep -q "hello from ralph" "$TARGET"

--- a/test/agents/ralph-retry-check.sh
+++ b/test/agents/ralph-retry-check.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-TARGET="${GC_CITY_ROOT}/ralph-retry-demo.txt"
+TARGET="${GC_CITY_PATH}/ralph-retry-demo.txt"
 
 [ -f "$TARGET" ]
 grep -qx "pass" "$TARGET"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -286,12 +286,10 @@ func bdDolt(dir string, args ...string) (string, error) {
 	env := integrationEnvDolt()
 	if dir != "" {
 		env = filterEnv(env, "GC_CITY")
-		env = filterEnv(env, "GC_CITY_ROOT")
 		env = filterEnv(env, "GC_CITY_PATH")
 		env = filterEnv(env, "GC_CITY_RUNTIME_DIR")
 		env = append(env,
 			"GC_CITY="+dir,
-			"GC_CITY_ROOT="+dir,
 			"GC_CITY_PATH="+dir,
 			"GC_CITY_RUNTIME_DIR="+filepath.Join(dir, ".gc", "runtime"),
 		)

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -197,7 +197,6 @@ func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {
 	env = filterEnvMany(env,
 		"GC_BEAD_ID",
 		"GC_CITY",
-		"GC_CITY_ROOT",
 		"GC_CITY_PATH",
 		"GC_CITY_RUNTIME_DIR",
 		"GC_DOLT_PORT",
@@ -205,7 +204,6 @@ func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {
 	env = append(env,
 		"GC_BEAD_ID="+beadID,
 		"GC_CITY="+cityDir,
-		"GC_CITY_ROOT="+cityDir,
 		"GC_CITY_PATH="+cityDir,
 		"GC_CITY_RUNTIME_DIR="+filepath.Join(cityDir, ".gc", "runtime"),
 	)


### PR DESCRIPTION
## Summary
- make city context resolution fall back through `GC_CITY`, `GC_CITY_PATH`, `GC_CITY_ROOT`, `GC_DIR`, and cwd for self-targeting commands
- standardize runtime env emission on `GC_CITY`, `GC_CITY_PATH`, and `GC_CITY_RUNTIME_DIR` while preserving compatibility fallbacks
- patch runtime, k8s remapping, scripts, and tests so explicit city path env is passed consistently

## Testing
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`

Closes #101