### PR TITLE
Shell scripts use stale GC_DOLT_PORT with no port file fallback — breaks after any dolt restart (ga-bys)

### DIFF
--- a/examples/dolt/scripts/resolve-port.sh
+++ b/examples/dolt/scripts/resolve-port.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# resolve-port.sh — canonical dolt port resolution for shell scripts.
+#
+# Source this file and call resolve_dolt_port to get the current port.
+# Mirrors the priority of currentDoltPort() in Go (beads_provider_lifecycle.go):
+#   port file → runtime state file → GC_DOLT_PORT env var → error.
+#
+# The env var is checked LAST because it is set once at session birth and
+# goes stale after any dolt server restart. The port file and state file
+# are written on each server start and are always current.
+#
+# Usage:
+#   . /path/to/resolve-port.sh
+#   port=$(resolve_dolt_port) || exit 1
+
+# resolve_dolt_port — prints the current dolt port to stdout.
+# Returns 1 and prints an error to stderr if no port can be determined.
+resolve_dolt_port() {
+    local city="${GC_CITY_ROOT:-${GC_CITY_PATH:-.}}"
+    local port=""
+
+    # 1. Port file — written on each server start, most authoritative.
+    local port_file="$city/.beads/dolt-server.port"
+    if [ -f "$port_file" ]; then
+        port=$(cat "$port_file" 2>/dev/null | tr -d '[:space:]')
+    fi
+
+    # 2. Runtime state file (controller-managed dolt-state.json).
+    if [ -z "$port" ]; then
+        local runtime_dir="${GC_CITY_RUNTIME_DIR:-$city/.gc/runtime}"
+        local state_file="$runtime_dir/packs/dolt/dolt-state.json"
+        if [ -f "$state_file" ]; then
+            port=$(sed -n 's/.*"port"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$state_file" | head -1)
+        fi
+    fi
+
+    # 3. Env var — may be stale in long-lived sessions, lowest priority.
+    if [ -z "$port" ]; then
+        port="${GC_DOLT_PORT:-}"
+    fi
+
+    if [ -z "$port" ]; then
+        echo "ERROR: cannot determine dolt port (no port file, no state file, no GC_DOLT_PORT)" >&2
+        return 1
+    fi
+
+    echo "$port"
+}

--- a/examples/dolt/scripts/resolve-port_test.sh
+++ b/examples/dolt/scripts/resolve-port_test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Tests for resolve-port.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+
+# Each test runs in a subshell to isolate env vars from the real session.
+
+# --- Test 1: port file takes priority over env var ---
+test_port_file_beats_env() {
+    local city="$TMPDIR_ROOT/t1"
+    mkdir -p "$city/.beads"
+    echo "4200" > "$city/.beads/dolt-server.port"
+
+    result=$(
+        export GC_CITY_ROOT="$city" GC_CITY_PATH="$city" GC_DOLT_PORT="9999"
+        unset GC_CITY_RUNTIME_DIR
+        . "$SCRIPT_DIR/resolve-port.sh"
+        resolve_dolt_port
+    )
+
+    if [ "$result" = "4200" ]; then
+        pass "port file beats env var"
+    else
+        fail "port file beats env var (got '$result', want '4200')"
+    fi
+}
+
+# --- Test 2: state file used when no port file ---
+test_state_file_fallback() {
+    local city="$TMPDIR_ROOT/t2"
+    mkdir -p "$city/.gc/runtime/packs/dolt"
+    echo '{"port": 5555, "running": true}' > "$city/.gc/runtime/packs/dolt/dolt-state.json"
+
+    result=$(
+        export GC_CITY_ROOT="$city" GC_CITY_PATH="$city" GC_DOLT_PORT=""
+        unset GC_CITY_RUNTIME_DIR
+        . "$SCRIPT_DIR/resolve-port.sh"
+        resolve_dolt_port
+    )
+
+    if [ "$result" = "5555" ]; then
+        pass "state file fallback works"
+    else
+        fail "state file fallback (got '$result', want '5555')"
+    fi
+}
+
+# --- Test 3: env var used as last resort ---
+test_env_var_last_resort() {
+    local city="$TMPDIR_ROOT/t3"
+    mkdir -p "$city"
+
+    result=$(
+        export GC_CITY_ROOT="$city" GC_CITY_PATH="$city" GC_DOLT_PORT="7777"
+        unset GC_CITY_RUNTIME_DIR
+        . "$SCRIPT_DIR/resolve-port.sh"
+        resolve_dolt_port
+    )
+
+    if [ "$result" = "7777" ]; then
+        pass "env var used as last resort"
+    else
+        fail "env var last resort (got '$result', want '7777')"
+    fi
+}
+
+# --- Test 4: error when no source available ---
+test_error_when_no_port() {
+    local city="$TMPDIR_ROOT/t4"
+    mkdir -p "$city"
+
+    if (
+        export GC_CITY_ROOT="$city" GC_CITY_PATH="$city" GC_DOLT_PORT=""
+        unset GC_CITY_RUNTIME_DIR
+        . "$SCRIPT_DIR/resolve-port.sh"
+        resolve_dolt_port
+    ) >/dev/null 2>&1; then
+        fail "should error when no port source available"
+    else
+        pass "errors when no port source available"
+    fi
+}
+
+# --- Test 5: port file with whitespace is trimmed ---
+test_port_file_whitespace() {
+    local city="$TMPDIR_ROOT/t5"
+    mkdir -p "$city/.beads"
+    printf "  4201\n  " > "$city/.beads/dolt-server.port"
+
+    result=$(
+        export GC_CITY_ROOT="$city" GC_CITY_PATH="$city" GC_DOLT_PORT=""
+        unset GC_CITY_RUNTIME_DIR
+        . "$SCRIPT_DIR/resolve-port.sh"
+        resolve_dolt_port
+    )
+
+    if [ "$result" = "4201" ]; then
+        pass "port file whitespace trimmed"
+    else
+        fail "port file whitespace (got '$result', want '4201')"
+    fi
+}
+
+# --- Test 6: state file beats env var ---
+test_state_file_beats_env() {
+    local city="$TMPDIR_ROOT/t6"
+    mkdir -p "$city/.gc/runtime/packs/dolt"
+    echo '{"port": 6666}' > "$city/.gc/runtime/packs/dolt/dolt-state.json"
+
+    result=$(
+        export GC_CITY_ROOT="$city" GC_CITY_PATH="$city" GC_DOLT_PORT="8888"
+        unset GC_CITY_RUNTIME_DIR
+        . "$SCRIPT_DIR/resolve-port.sh"
+        resolve_dolt_port
+    )
+
+    if [ "$result" = "6666" ]; then
+        pass "state file beats env var"
+    else
+        fail "state file beats env var (got '$result', want '6666')"
+    fi
+}
+
+# Run all tests
+test_port_file_beats_env
+test_state_file_fallback
+test_env_var_last_resort
+test_error_when_no_port
+test_port_file_whitespace
+test_state_file_beats_env
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/examples/dolt/scripts/runtime.sh
+++ b/examples/dolt/scripts/runtime.sh
@@ -27,15 +27,14 @@ DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-state.json"
 
 GC_BEADS_BD_SCRIPT="$GC_CITY_PATH/.gc/system/bin/gc-beads-bd"
 
-# Resolve GC_DOLT_PORT if not already set by the caller.
-# Priority: env override > port file > state file > default 3307.
-if [ -z "$GC_DOLT_PORT" ]; then
-  _port_file="$GC_CITY_PATH/.beads/dolt-server.port"
-  if [ -f "$_port_file" ]; then
-    GC_DOLT_PORT=$(cat "$_port_file" 2>/dev/null)
-  fi
-  if [ -z "$GC_DOLT_PORT" ] && [ -f "$DOLT_STATE_FILE" ]; then
-    GC_DOLT_PORT=$(sed -n 's/.*"port"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$DOLT_STATE_FILE" | head -1)
-  fi
-  : "${GC_DOLT_PORT:=3307}"
+# Resolve dolt port via the shared helper.
+# Priority: port file > state file > GC_DOLT_PORT env > error.
+# Always re-resolve — the env var may be stale after a dolt restart.
+_resolve_port_script="$(cd "$(dirname "$0")" && pwd)/resolve-port.sh"
+if [ -f "$_resolve_port_script" ]; then
+  . "$_resolve_port_script"
+  GC_DOLT_PORT=$(resolve_dolt_port) || { echo "runtime.sh: failed to resolve dolt port" >&2; exit 1; }
+else
+  echo "runtime.sh: resolve-port.sh not found at $_resolve_port_script" >&2
+  exit 1
 fi

--- a/examples/gastown/packs/maintenance/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/scripts/jsonl-export.sh
@@ -9,7 +9,15 @@
 set -euo pipefail
 
 CITY="${GC_CITY_ROOT:-.}"
-DOLT_PORT="${GC_DOLT_PORT:-3307}"
+
+# Resolve dolt port from authoritative sources (port file > state file > env var).
+_resolve_port="$CITY/.gc/system/packs/dolt/scripts/resolve-port.sh"
+if [ ! -f "$_resolve_port" ]; then
+  # Development/test fallback: source from examples directory.
+  _resolve_port="$(cd "$(dirname "$0")/../../../../.." && pwd)/examples/dolt/scripts/resolve-port.sh"
+fi
+. "$_resolve_port"
+DOLT_PORT=$(resolve_dolt_port) || exit 1
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
 LEGACY_ARCHIVE_REPO="$CITY/.gc/jsonl-archive"
 LEGACY_STATE_FILE="$CITY/.gc/jsonl-export-state.json"

--- a/examples/gastown/packs/maintenance/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/scripts/reaper.sh
@@ -9,7 +9,15 @@
 set -euo pipefail
 
 CITY="${GC_CITY_ROOT:-.}"
-DOLT_PORT="${GC_DOLT_PORT:-3307}"
+
+# Resolve dolt port from authoritative sources (port file > state file > env var).
+_resolve_port="$CITY/.gc/system/packs/dolt/scripts/resolve-port.sh"
+if [ ! -f "$_resolve_port" ]; then
+  # Development/test fallback: source from examples directory.
+  _resolve_port="$(cd "$(dirname "$0")/../../../../.." && pwd)/examples/dolt/scripts/resolve-port.sh"
+fi
+. "$_resolve_port"
+DOLT_PORT=$(resolve_dolt_port) || exit 1
 
 # Configurable thresholds (defaults match the old formula).
 MAX_AGE="${GC_REAPER_MAX_AGE:-24h}"


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery.

- Issue: ga-bys
- Branch: polecat/ga-bys
- Target: main