### PR TITLE
fix(k8s): inject BEADS_DOLT_SERVER_HOST/PORT into pod env

### DIFF
--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -288,23 +288,35 @@ func buildPodEnv(cfgEnv map[string]string, podWorkDir string) []corev1.EnvVar {
 		env = append(env, corev1.EnvVar{Name: "CLAUDE_CONFIG_DIR", Value: "/home/gcagent/.claude"})
 	}
 
-	// Inject K8s Dolt discovery for agent-side bd init.
-	// GC_DOLT_HOST/PORT are stripped (controller-only), so inject K8s-specific
-	// defaults that point to the in-cluster Dolt service.
+	// Inject K8s Dolt discovery for agent-side bd.
+	// GC_DOLT_HOST/PORT and BEADS_DOLT_SERVER_HOST/PORT are all stripped
+	// above (they reference the controller's local managed Dolt). Re-inject
+	// K8s-specific endpoints that point to the in-cluster Dolt service, so
+	// bd can locate the server via env vars (its highest-priority config
+	// source) rather than falling back to metadata.json (which lacks the
+	// port and causes "Port: 0 / Server not reachable").
+	k8sDoltHost := cfgEnv["GC_K8S_DOLT_HOST"]
+	if k8sDoltHost == "" {
+		k8sDoltHost = "dolt.gc.svc.cluster.local"
+	}
+	k8sDoltPort := cfgEnv["GC_K8S_DOLT_PORT"]
+	if k8sDoltPort == "" {
+		k8sDoltPort = "3307"
+	}
 	envMap := make(map[string]bool, len(env))
 	for _, e := range env {
 		envMap[e.Name] = true
 	}
 	if !envMap["GC_K8S_DOLT_HOST"] {
-		env = append(env, corev1.EnvVar{
-			Name: "GC_K8S_DOLT_HOST", Value: "dolt.gc.svc.cluster.local",
-		})
+		env = append(env, corev1.EnvVar{Name: "GC_K8S_DOLT_HOST", Value: k8sDoltHost})
 	}
 	if !envMap["GC_K8S_DOLT_PORT"] {
-		env = append(env, corev1.EnvVar{
-			Name: "GC_K8S_DOLT_PORT", Value: "3307",
-		})
+		env = append(env, corev1.EnvVar{Name: "GC_K8S_DOLT_PORT", Value: k8sDoltPort})
 	}
+	env = append(env,
+		corev1.EnvVar{Name: "BEADS_DOLT_SERVER_HOST", Value: k8sDoltHost},
+		corev1.EnvVar{Name: "BEADS_DOLT_SERVER_PORT", Value: k8sDoltPort},
+	)
 
 	// Inject GITHUB_TOKEN from optional K8s secret for git push in pods.
 	env = append(env, corev1.EnvVar{

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -718,10 +718,20 @@ func TestBuildPodEnvRemapsVars(t *testing.T) {
 
 	// Controller-only connection vars should be removed (host/port are
 	// replaced with K8s-specific endpoints). Auth credentials pass through.
-	for _, key := range []string{"GC_SESSION", "GC_BEADS", "GC_EVENTS", "GC_DOLT_HOST", "GC_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT"} {
+	for _, key := range []string{"GC_SESSION", "GC_BEADS", "GC_EVENTS", "GC_DOLT_HOST", "GC_DOLT_PORT"} {
 		if _, exists := envMap[key]; exists {
 			t.Errorf("controller-only var %s should be removed", key)
 		}
+	}
+	// BEADS_DOLT_SERVER_HOST/PORT come in as controller-side values and
+	// must be replaced with the K8s service endpoint (not simply removed,
+	// which would leave bd with no way to locate the Dolt server).
+	if envMap["BEADS_DOLT_SERVER_HOST"] == "localhost" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST still carries controller value %q; should be replaced with K8s endpoint", envMap["BEADS_DOLT_SERVER_HOST"])
+	}
+	if envMap["BEADS_DOLT_SERVER_PORT"] != "3307" || envMap["BEADS_DOLT_SERVER_HOST"] != "dolt.gc.svc.cluster.local" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST=%q PORT=%q, want default K8s endpoint dolt.gc.svc.cluster.local:3307",
+			envMap["BEADS_DOLT_SERVER_HOST"], envMap["BEADS_DOLT_SERVER_PORT"])
 	}
 	// Auth credentials should pass through to agent pods.
 	for _, key := range []string{"GC_DOLT_USER", "GC_DOLT_PASSWORD", "BEADS_DOLT_SERVER_USER", "BEADS_DOLT_PASSWORD"} {
@@ -825,6 +835,66 @@ func TestBuildPodEnvFallbackCityRoot(t *testing.T) {
 	}
 	if envMap["BEADS_DIR"] != "/workspace/rig/.beads" {
 		t.Errorf("BEADS_DIR = %q, want /workspace/rig/.beads", envMap["BEADS_DIR"])
+	}
+}
+
+// TestBuildPodEnvInjectsBeadsDoltServerFromK8sVars verifies that buildPodEnv
+// re-injects BEADS_DOLT_SERVER_HOST and BEADS_DOLT_SERVER_PORT pointing at
+// the in-cluster Dolt service. bd reads these vars with the highest priority
+// (env vars > metadata.json > config.yaml); without them, agents fall back
+// to metadata.json which lacks the server port and report "Port: 0 / Server
+// not reachable".
+//
+// The controller-side values of BEADS_DOLT_SERVER_HOST/PORT are stripped
+// (they reference the controller's local managed dolt) and then re-injected
+// with the K8s service endpoint, derived from GC_K8S_DOLT_HOST/PORT.
+func TestBuildPodEnvInjectsBeadsDoltServerFromK8sVars(t *testing.T) {
+	cfgEnv := map[string]string{
+		"GC_AGENT": "deacon",
+		// Controller-side values that must be stripped and replaced.
+		"BEADS_DOLT_SERVER_HOST": "localhost",
+		"BEADS_DOLT_SERVER_PORT": "3309",
+		// Explicit K8s service endpoint.
+		"GC_K8S_DOLT_HOST": "dolt.gascity.svc.cluster.local",
+		"GC_K8S_DOLT_PORT": "3307",
+	}
+
+	env := buildPodEnv(cfgEnv, "/workspace")
+
+	envMap := map[string]string{}
+	for _, e := range env {
+		envMap[e.Name] = e.Value
+	}
+
+	if got := envMap["BEADS_DOLT_SERVER_HOST"]; got != "dolt.gascity.svc.cluster.local" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST = %q, want %q (should mirror GC_K8S_DOLT_HOST, not leak controller value)", got, "dolt.gascity.svc.cluster.local")
+	}
+	if got := envMap["BEADS_DOLT_SERVER_PORT"]; got != "3307" {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want %q (should mirror GC_K8S_DOLT_PORT, not leak controller value)", got, "3307")
+	}
+}
+
+// TestBuildPodEnvInjectsBeadsDoltServerDefaults verifies that when neither
+// GC_K8S_DOLT_HOST/PORT nor BEADS_DOLT_SERVER_HOST/PORT are set in cfgEnv,
+// BEADS_DOLT_SERVER_HOST/PORT default to the same values as the
+// GC_K8S_DOLT_HOST/PORT defaults.
+func TestBuildPodEnvInjectsBeadsDoltServerDefaults(t *testing.T) {
+	cfgEnv := map[string]string{
+		"GC_AGENT": "deacon",
+	}
+
+	env := buildPodEnv(cfgEnv, "/workspace")
+
+	envMap := map[string]string{}
+	for _, e := range env {
+		envMap[e.Name] = e.Value
+	}
+
+	if got := envMap["BEADS_DOLT_SERVER_HOST"]; got != "dolt.gc.svc.cluster.local" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST = %q, want %q (default)", got, "dolt.gc.svc.cluster.local")
+	}
+	if got := envMap["BEADS_DOLT_SERVER_PORT"]; got != "3307" {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want %q (default)", got, "3307")
 	}
 }
 


### PR DESCRIPTION
## Summary

`buildPodEnv` strips `BEADS_DOLT_SERVER_HOST` and `BEADS_DOLT_SERVER_PORT` (they reference the controller's local managed Dolt) but only re-injects `GC_K8S_DOLT_HOST/PORT`, which `bd` does not read. With no env vars set, `bd` falls back to `metadata.json`, which lacks the server port and reports `Port: 0 / Server not reachable` on every agent pod connected to an external in-cluster Dolt service.

`bd`'s config-source priority is: env vars (`BEADS_DOLT_*`) > `metadata.json` > `config.yaml`. Re-injecting `BEADS_DOLT_SERVER_HOST/PORT` with the K8s endpoint (the same values used for `GC_K8S_DOLT_HOST/PORT`) lets `bd` locate the server via its highest-priority source, without touching `metadata.json` or the deprecated `.beads/dolt-server.port` file.

Complements #422, which fixed `gc-beads-bd`'s `is_remote()` detection but did not set the env vars that `bd` itself reads.

## Test plan

- New unit tests in `internal/runtime/k8s/provider_test.go`:
  - `TestBuildPodEnvInjectsBeadsDoltServerFromK8sVars` — controller-side `BEADS_DOLT_SERVER_*` values are stripped and replaced with the explicit `GC_K8S_DOLT_HOST/PORT` endpoint, not leaked through.
  - `TestBuildPodEnvInjectsBeadsDoltServerDefaults` — when neither set, falls back to the same default as `GC_K8S_DOLT_HOST/PORT`.
  - `TestBuildPodEnvRemapsVars` updated to assert `BEADS_DOLT_SERVER_*` are *replaced* (not removed) when controller-side values are present.
- Live verification on a homelab K8s pod (`gascity-deacon`): `BEADS_DOLT_SERVER_HOST=dolt.gascity.svc.cluster.local BEADS_DOLT_SERVER_PORT=3307 bd dolt show` turned `Port: 0 / Server not reachable` into `Port: 3307 / Server connection OK`. Full deploy and cold respawn through a fresh controller verified the fix end-to-end on city-level (mayor), rig-pool (polecat), and rig-session (s-bl) pod paths — all three report `bd dolt show: Server connection OK` with no manual repair on the freshly-spawned pod.