### PR TITLE
fix(reconciler): bound scale_check concurrency and transition creating→active

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -60,7 +60,7 @@ func evaluatePendingPools(
 	// don't stampede the shared dolt sql-server. Without this, ~40+
 	// pool agents launching goroutines in parallel causes per-call
 	// contention that pushes individual probes past their timeout.
-	sem := make(chan struct{}, bdProbeConcurrency)
+	sem := make(chan struct{}, cfg.Daemon.ProbeConcurrencyOrDefault())
 	var wg sync.WaitGroup
 	for j, pw := range pendingPools {
 		wg.Add(1)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -56,6 +56,11 @@ func evaluatePendingPools(
 		err     error
 	}
 	evalResults := make([]poolEvalResult, len(pendingPools))
+	// Bound per-pool scale_check concurrency so bd subprocess probes
+	// don't stampede the shared dolt sql-server. Without this, ~40+
+	// pool agents launching goroutines in parallel causes per-call
+	// contention that pushes individual probes past their timeout.
+	sem := make(chan struct{}, bdProbeConcurrency)
 	var wg sync.WaitGroup
 	for j, pw := range pendingPools {
 		wg.Add(1)
@@ -66,6 +71,8 @@ func evaluatePendingPools(
 		agentIndex := pw.agentIdx
 		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			started := time.Now()
 			d, err := evaluatePool(agentName, sp, dir, shellScaleCheck)
 			evalResults[idx] = poolEvalResult{desired: d, err: err}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -365,7 +365,7 @@ func (cr *CityRuntime) tick(
 		if *prevPoolRunning != nil {
 			for sn, info := range cr.poolDeathHandlers {
 				if (*prevPoolRunning)[sn] && !currentSet[sn] {
-					if _, err := shellScaleCheck(info.Command, info.Dir); err != nil {
+					if _, err := shellRunHook(info.Command, info.Dir); err != nil {
 						fmt.Fprintf(cr.stderr, "on_death %s: %v\n", sn, err) //nolint:errcheck // best-effort stderr
 					}
 				}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -568,7 +568,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// Enforce restrictive permissions on .gc/ and its subdirectories.
 	enforceGCPermissions(cityPath, stderr)
 
-	runPoolOnBoot(cfg, cityPath, shellScaleCheck, stderr)
+	runPoolOnBoot(cfg, cityPath, shellRunHook, stderr)
 
 	var oneShotStore beads.Store
 	if store, err := openCityStoreAt(cityPath); err == nil {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1031,7 +1031,7 @@ func reconcileCities(
 
 		// Run pool on_boot hooks (same as runController does).
 		if err := runPostPrepareStep("running_pool_on_boot", func() error {
-			runPoolOnBoot(cfg, path, shellScaleCheck, stderr)
+			runPoolOnBoot(cfg, path, shellRunHook, stderr)
 			return nil
 		}); err != nil {
 			recordInitFailure(cityName, fmt.Sprintf("pool on_boot: %v", err))

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -636,7 +636,7 @@ func runController(
 		}
 	}
 
-	runPoolOnBoot(cfg, cityPath, shellScaleCheck, stderr)
+	runPoolOnBoot(cfg, cityPath, shellRunHook, stderr)
 	cr.run(ctx)
 	cr.shutdown()
 

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -38,20 +38,28 @@ type poolSessionRef struct {
 // protect it explicitly.
 type ScaleCheckRunner func(command, dir string) (string, error)
 
-// bdProbeConcurrency bounds the number of concurrent bd subprocess
-// probes issued by the pool scale_check path. bd serializes on a
-// shared dolt sql-server, so unbounded parallelism (one goroutine
-// per pool agent) causes contention that makes individual calls
-// miss their timeout even though the work itself is cheap.
-const bdProbeConcurrency = 8
+// Default bd probe concurrency is config.DefaultProbeConcurrency (8).
+// Override via [daemon] probe_concurrency in city.toml. Both
+// evaluatePendingPools and computeWorkSet create independent
+// semaphores from cfg.Daemon.ProbeConcurrencyOrDefault(); since they
+// run sequentially within a single reconciler tick (buildDesiredState
+// completes before beadReconcileTick), the effective concurrency never
+// exceeds this limit at any given moment.
 
-// shellScaleCheck runs a scale_check command via sh -c and returns stdout.
-// dir sets the command's working directory. Times out after 180 seconds.
-// Generous to accommodate bd calls that serialize through a shared dolt
-// sql-server when many pool scale_checks run in parallel; the default of
-// 30s is too tight once several rig-scoped pools share a connection.
-func shellScaleCheck(command, dir string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+// bdProbeTimeout is the timeout for bd subprocess probes (scale_check,
+// work_query). Generous to accommodate bd calls that serialize through
+// a shared dolt sql-server when many pool probes run in parallel.
+const bdProbeTimeout = 180 * time.Second
+
+// hookTimeout is the timeout for lifecycle hook commands (on_death,
+// on_boot). Kept shorter than probe timeout because hooks run
+// synchronously in the reconciler loop and should not stall a tick.
+const hookTimeout = 30 * time.Second
+
+// shellCommand runs a command via sh -c with the given timeout and
+// returns stdout. dir sets the command's working directory.
+func shellCommand(command, dir string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.WaitDelay = 2 * time.Second
@@ -60,9 +68,23 @@ func shellScaleCheck(command, dir string) (string, error) {
 	}
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("running scale_check %q: %w", command, err)
+		return "", fmt.Errorf("running command %q: %w", command, err)
 	}
 	return string(out), nil
+}
+
+// shellScaleCheck runs a scale_check command via sh -c and returns stdout.
+// dir sets the command's working directory. Uses bdProbeTimeout (180s).
+func shellScaleCheck(command, dir string) (string, error) {
+	return shellCommand(command, dir, bdProbeTimeout)
+}
+
+// shellRunHook runs a lifecycle hook command (on_death, on_boot) via
+// sh -c with the shorter hookTimeout (30s). Separated from
+// shellScaleCheck so that hung hooks don't stall the reconciler for
+// the full bd probe timeout.
+func shellRunHook(command, dir string) (string, error) {
+	return shellCommand(command, dir, hookTimeout)
 }
 
 // scaleParams holds the resolved scaling parameters for an agent.

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -30,10 +30,20 @@ type poolSessionRef struct {
 // for rig-scoped pools so bd queries the correct database).
 type ScaleCheckRunner func(command, dir string) (string, error)
 
+// bdProbeConcurrency bounds the number of concurrent bd subprocess
+// probes issued by the pool scale_check path. bd serializes on a
+// shared dolt sql-server, so unbounded parallelism (one goroutine
+// per pool agent) causes contention that makes individual calls
+// miss their timeout even though the work itself is cheap.
+const bdProbeConcurrency = 8
+
 // shellScaleCheck runs a scale_check command via sh -c and returns stdout.
-// dir sets the command's working directory. Times out after 30 seconds.
+// dir sets the command's working directory. Times out after 180 seconds.
+// Generous to accommodate bd calls that serialize through a shared dolt
+// sql-server when many pool scale_checks run in parallel; the default of
+// 30s is too tight once several rig-scoped pools share a connection.
 func shellScaleCheck(command, dir string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.WaitDelay = 2 * time.Second

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -28,6 +28,14 @@ type poolSessionRef struct {
 // ScaleCheckRunner runs a scale_check command and returns stdout.
 // dir specifies the working directory for the command (e.g., rig path
 // for rig-scoped pools so bd queries the correct database).
+//
+// Implementations MUST be safe to invoke concurrently from multiple
+// goroutines. Both evaluatePendingPools and computeWorkSet dispatch
+// runner calls in parallel, bounded by bdProbeConcurrency. The
+// production implementation shellScaleCheck satisfies this trivially
+// because it only reads its arguments and spawns an independent
+// subprocess; test doubles should avoid shared mutable state or
+// protect it explicitly.
 type ScaleCheckRunner func(command, dir string) (string, error)
 
 // bdProbeConcurrency bounds the number of concurrent bd subprocess

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -507,6 +507,21 @@ func commitStartResult(
 	return commitStartResultTraced(result, store, clk, rec, wave, stdout, stderr, nil)
 }
 
+// confirmPendingStart reports whether a session in the given metadata
+// state should be transitioned to "active" after a successful runtime
+// spawn. Empty, "creating", "asleep", and "drained" all indicate the
+// session was pending a spawn; "awake" is treated by the reconciler as
+// equivalent to "active" and is intentionally NOT restamped (a no-op
+// metadata write on every spawn). Any other state ("draining",
+// "archived", "quarantined", ...) is left alone.
+func confirmPendingStart(currentState string) bool {
+	switch sessionpkg.State(strings.TrimSpace(currentState)) {
+	case "", sessionpkg.StateCreating, sessionpkg.StateAsleep, sessionpkg.State("drained"):
+		return true
+	}
+	return false
+}
+
 func commitStartResultTraced(
 	result startResult,
 	store beads.Store,
@@ -565,6 +580,14 @@ func commitStartResultTraced(
 	}
 	if bdj, err := json.Marshal(result.prepared.coreBreakdown); err == nil {
 		metadata["core_hash_breakdown"] = string(bdj)
+	}
+	// Transition creating/asleep/drained beads to active once the runtime
+	// spawn has confirmed. Folded into this metadata batch so the state
+	// write is atomic with the hash writes and avoids a second round-trip
+	// per spawn. See confirmPendingStart for the state gate.
+	if confirmPendingStart(session.Metadata["state"]) {
+		metadata["state"] = string(sessionpkg.StateActive)
+		metadata["state_reason"] = "creation_complete"
 	}
 	if session.Metadata["sleep_reason"] != "" {
 		metadata["sleep_reason"] = ""

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -501,7 +501,7 @@ func commitStartResult(
 	store beads.Store,
 	clk clock.Clock,
 	rec events.Recorder,
-	wave int,
+	wave int, //nolint:unparam // always 0 here but passed through to commitStartResultTraced which uses it
 	stdout, stderr io.Writer,
 ) bool {
 	return commitStartResultTraced(result, store, clk, rec, wave, stdout, stderr, nil)
@@ -600,18 +600,23 @@ func commitStartResultTraced(
 				"error": err.Error(),
 			}, "")
 		}
-	} else {
-		if session.Metadata == nil {
-			session.Metadata = make(map[string]string)
-		}
-		for key, value := range metadata {
-			session.Metadata[key] = value
-		}
-		if trace != nil {
-			trace.recordMutation("bead_metadata", tp.TemplateName, name, "metadata_batch", session.ID, "started_config_hash", "", result.prepared.coreHash, "success", traceRecordPayload{
-				"wave": wave,
-			}, "")
-		}
+		// The runtime started, but we failed to persist metadata
+		// (including the state transition to active). Report failure so
+		// the reconciler retries on the next tick rather than leaving
+		// the session stuck in "creating" where it gets orphan-drained.
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "metadata_batch_failed", result.started, result.finished, err)
+		return false
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string)
+	}
+	for key, value := range metadata {
+		session.Metadata[key] = value
+	}
+	if trace != nil {
+		trace.recordMutation("bead_metadata", tp.TemplateName, name, "metadata_batch", session.ID, "started_config_hash", "", result.prepared.coreHash, "success", traceRecordPayload{
+			"wave": wave,
+		}, "")
 	}
 	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
 	return true

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -807,8 +807,8 @@ func TestCommitStartResult_ClearsPendingCreateClaimBeforeHashBatch(t *testing.T)
 	}
 
 	ok := commitStartResult(result, store, &clock.Fake{Time: time.Date(2026, 3, 18, 12, 0, 1, 0, time.UTC)}, events.Discard, 0, ioDiscard{}, ioDiscard{})
-	if !ok {
-		t.Fatal("commitStartResult returned false, want true when only hash batch fails")
+	if ok {
+		t.Fatal("commitStartResult returned true, want false when metadata batch fails (state transition lost)")
 	}
 
 	got, err := store.Get(bead.ID)
@@ -1965,5 +1965,58 @@ func TestConfirmPendingStart(t *testing.T) {
 				t.Errorf("confirmPendingStart(%q) = %v, want %v", tc.state, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCommitStartResult_TransitionsCreatingToActive(t *testing.T) {
+	// Verify that commitStartResult persists state=active and
+	// state_reason=creation_complete when the session starts in
+	// "creating" state. This is the critical integration seam for
+	// the creating→active fix.
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker-session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-1",
+			"state":        "creating",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := startCandidate{
+		session: &session,
+		tp:      TemplateParams{TemplateName: "worker", InstanceName: "worker-1"},
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: candidate,
+			coreHash:  "core-abc",
+			liveHash:  "live-xyz",
+		},
+		outcome:  "success",
+		started:  time.Unix(100, 0),
+		finished: time.Unix(101, 0),
+	}
+	rec := events.NewFake()
+	ok := commitStartResult(result, store, &clock.Fake{Time: time.Unix(102, 0)}, rec, 0, ioDiscard{}, ioDiscard{})
+	if !ok {
+		t.Fatal("commitStartResult returned false for successful start")
+	}
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["state"] != "active" {
+		t.Errorf("state = %q, want %q", got.Metadata["state"], "active")
+	}
+	if got.Metadata["state_reason"] != "creation_complete" {
+		t.Errorf("state_reason = %q, want %q", got.Metadata["state_reason"], "creation_complete")
+	}
+	if got.Metadata["started_config_hash"] != "core-abc" {
+		t.Errorf("started_config_hash = %q, want %q", got.Metadata["started_config_hash"], "core-abc")
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1932,3 +1932,37 @@ func TestPrepareStartCandidate_PreservesRuntimeConfigAndProviderEnv(t *testing.T
 		t.Fatalf("GC_HOME = %q, want %q", got, "/tmp/gc-home")
 	}
 }
+
+func TestConfirmPendingStart(t *testing.T) {
+	// commitStartResultTraced must transition freshly-spawned pool
+	// session beads from the pending states ("", creating, asleep,
+	// drained) to active. Running states ("awake", "active") are left
+	// alone to avoid wasteful metadata rewrites on every reconcile
+	// cycle; terminal and transitional states ("draining", "archived",
+	// "quarantined", "suspended") are likewise ignored so we don't
+	// resurrect a session the reconciler deliberately wound down.
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{"", true},
+		{"creating", true},
+		{"asleep", true},
+		{"drained", true},
+		{"  creating  ", true}, // trimmed
+		{"active", false},
+		{"awake", false},
+		{"draining", false},
+		{"archived", false},
+		{"quarantined", false},
+		{"suspended", false},
+		{"unknown-future-state", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.state, func(t *testing.T) {
+			if got := confirmPendingStart(tc.state); got != tc.want {
+				t.Errorf("confirmPendingStart(%q) = %v, want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1942,24 +1942,25 @@ func TestConfirmPendingStart(t *testing.T) {
 	// "quarantined", "suspended") are likewise ignored so we don't
 	// resurrect a session the reconciler deliberately wound down.
 	cases := []struct {
+		name  string
 		state string
 		want  bool
 	}{
-		{"", true},
-		{"creating", true},
-		{"asleep", true},
-		{"drained", true},
-		{"  creating  ", true}, // trimmed
-		{"active", false},
-		{"awake", false},
-		{"draining", false},
-		{"archived", false},
-		{"quarantined", false},
-		{"suspended", false},
-		{"unknown-future-state", false},
+		{"<empty>", "", true},
+		{"creating", "creating", true},
+		{"asleep", "asleep", true},
+		{"drained", "drained", true},
+		{"creating_with_whitespace", "  creating  ", true},
+		{"active", "active", false},
+		{"awake", "awake", false},
+		{"draining", "draining", false},
+		{"archived", "archived", false},
+		{"quarantined", "quarantined", false},
+		{"suspended", "suspended", false},
+		{"unknown-future-state", "unknown-future-state", false},
 	}
 	for _, tc := range cases {
-		t.Run(tc.state, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			if got := confirmPendingStart(tc.state); got != tc.want {
 				t.Errorf("confirmPendingStart(%q) = %v, want %v", tc.state, got, tc.want)
 			}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -412,7 +412,7 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 		probes = append(probes, probeWork{qn: qn, wq: wq, dir: agentCommandDir(cityDir, a, cfg.Rigs)})
 	}
 
-	sem := make(chan struct{}, bdProbeConcurrency)
+	sem := make(chan struct{}, cfg.Daemon.ProbeConcurrencyOrDefault())
 	results := make([]bool, len(probes))
 	var wg sync.WaitGroup
 	for i := range probes {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -377,25 +378,56 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	if cfg == nil || runner == nil {
 		return nil
 	}
+	// Collect the per-agent probe work first so the bd subprocess
+	// calls can run concurrently. Each work_query shells out to `bd`,
+	// which serializes on the shared dolt sql-server, so a sequential
+	// loop over 40+ agents takes minutes per reconcile cycle. Bound
+	// concurrency so overlapping probes don't stampede dolt.
+	type probeWork struct {
+		qn  string
+		wq  string
+		dir string
+	}
+	var probes []probeWork
 	work := make(map[string]bool)
 	seen := make(map[string]bool) // deduplicate pool instances
-	for _, a := range cfg.Agents {
+	for i := range cfg.Agents {
+		a := &cfg.Agents[i]
 		qn := a.QualifiedName()
 		if seen[qn] {
 			continue
 		}
 		seen[qn] = true
-		wq := prefixedWorkQueryForProbe(cfg, cityDir, cityName, store, sessionBeads, &a)
+		wq := prefixedWorkQueryForProbe(cfg, cityDir, cityName, store, sessionBeads, a)
 		if wq == "" {
 			continue
 		}
-		dir := agentCommandDir(cityDir, &a, cfg.Rigs)
-		out, err := runner(wq, dir)
-		if err != nil {
-			continue // command failed — treat as no work
-		}
-		if workQueryHasReadyWork(strings.TrimSpace(out)) {
-			work[qn] = true
+		probes = append(probes, probeWork{qn: qn, wq: wq, dir: agentCommandDir(cityDir, a, cfg.Rigs)})
+	}
+
+	sem := make(chan struct{}, bdProbeConcurrency)
+	results := make([]bool, len(probes))
+	var wg sync.WaitGroup
+	for i := range probes {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			out, err := runner(probes[idx].wq, probes[idx].dir)
+			if err != nil {
+				return // command failed — treat as no work
+			}
+			if workQueryHasReadyWork(strings.TrimSpace(out)) {
+				results[idx] = true
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, p := range probes {
+		if results[i] {
+			work[p.qn] = true
 		}
 	}
 	return work

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1,7 +1,14 @@
 // session_reconcile.go contains pure functions for the bead-driven session
-// reconciler. All functions assume single-threaded execution within one
-// reconciler tick. Map mutations on beads.Bead.Metadata are visible to
-// callers by design (maps are reference types).
+// reconciler. Functions in this file assume single-threaded execution
+// within one reconciler tick, with one intentional exception:
+// computeWorkSet parallelizes its per-agent scale_check runner calls
+// under a bounded semaphore (see bdProbeConcurrency in pool.go) so bd
+// subprocess latency doesn't serialize the whole cycle. Any ScaleCheckRunner
+// passed to computeWorkSet must therefore be safe to invoke from multiple
+// goroutines concurrently — shellScaleCheck (the production implementation)
+// is safe because it only reads its arguments and spawns an independent
+// subprocess. Map mutations on beads.Bead.Metadata are visible to callers
+// by design (maps are reference types).
 package main
 
 import (

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -624,13 +624,14 @@ Web dashboard for monitoring the city
 gc dashboard [flags]
 ```
 
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api` | string |  | GC API server URL override (auto-discovered by default) |
+| `--port` | int | `8080` | HTTP port |
+
 | Subcommand | Description |
 |------------|-------------|
 | [gc dashboard serve](#gc-dashboard-serve) | Start the web dashboard |
-
-Starts the dashboard directly and auto-discovers the GC API server when run
-inside a city. Use `gc dashboard serve` if you want the explicit subcommand
-form.
 
 ## gc dashboard serve
 
@@ -851,7 +852,7 @@ Returns immediately. Equivalent to:
   gc session kill &lt;target&gt;
 
 Self-handoff requires session context (GC_ALIAS or GC_SESSION_ID, plus
-GC_SESSION_NAME and GC_CITY). Remote handoff accepts a session alias or ID.
+GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or ID.
 
 ```
 gc handoff <subject> [message] [flags]
@@ -1449,7 +1450,7 @@ The reconciler will restart the agents on its next tick. This is a
 quick way to force-refresh all agents working on a particular project.
 
 ```
-gc rig restart <name>
+gc rig restart [name]
 ```
 
 ## gc rig resume
@@ -1459,7 +1460,7 @@ Resume a suspended rig by clearing suspended in city.toml.
 The reconciler will start the rig's agents on its next tick.
 
 ```
-gc rig resume <name>
+gc rig resume [name]
 ```
 
 ## gc rig status
@@ -1467,7 +1468,7 @@ gc rig resume <name>
 Show rig status and agent running state
 
 ```
-gc rig status <name>
+gc rig status [name]
 ```
 
 ## gc rig suspend
@@ -1479,7 +1480,7 @@ the reconciler skips them and gc hook returns empty. The rig's beads
 database remains accessible. Use "gc rig resume" to restore.
 
 ```
-gc rig suspend <name>
+gc rig suspend [name]
 ```
 
 ## gc runtime
@@ -1631,6 +1632,8 @@ gc session
 | [gc session peek](#gc-session-peek) | View session output without attaching |
 | [gc session prune](#gc-session-prune) | Close old suspended sessions |
 | [gc session rename](#gc-session-rename) | Rename a session |
+| [gc session reset](#gc-session-reset) | Restart a session fresh while preserving the bead |
+| [gc session submit](#gc-session-submit) | Submit a message with semantic delivery intent |
 | [gc session suspend](#gc-session-suspend) | Suspend a session (save state, free resources) |
 | [gc session wait](#gc-session-wait) | Register a dependency wait for a session |
 | [gc session wake](#gc-session-wake) | Wake a session (clear hold and quarantine) |
@@ -1796,6 +1799,43 @@ Rename a session
 ```
 gc session rename <session-id-or-alias> <title>
 ```
+
+## gc session reset
+
+Request a fresh restart for an existing session without closing its bead.
+
+The controller stops the current runtime and starts the same session again with
+fresh provider conversation state. Session identity, alias, mail, and queued
+work remain attached to the existing session bead.
+
+Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).
+
+```
+gc session reset <session-id-or-alias>
+```
+
+## gc session submit
+
+Submit a user message to a session without choosing provider transport details.
+
+The runtime decides whether to wake, inject immediately, or queue the message
+according to the selected semantic intent.
+
+```
+gc session submit <id-or-alias> <message...> [flags]
+```
+
+**Example:**
+
+```
+gc session submit mayor "status update"
+  gc session submit mayor "after this run, handle docs" --intent follow_up
+  gc session submit mayor "stop and do this instead" --intent interrupt_now
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--intent` | string | `default` | submit intent: default, follow_up, or interrupt_now |
 
 ## gc session suspend
 
@@ -2264,3 +2304,4 @@ Manually mark a wait ready
 ```
 gc wait ready <wait-id>
 ```
+

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -246,6 +246,7 @@ DaemonConfig holds controller daemon settings.
 | `wisp_ttl` | string |  |  | WispTTL is how long a closed molecule survives before being purged. Duration string (e.g., "24h", "7d"). Wisp GC is disabled unless both WispGCInterval and WispTTL are set. |
 | `drift_drain_timeout` | string |  | `2m` | DriftDrainTimeout is the maximum time to wait for an agent to acknowledge a drain signal during a config-drift restart. If the agent doesn't ack within this window, the controller force-kills and restarts it. Duration string (e.g., "2m", "5m"). Defaults to "2m". |
 | `observe_paths` | []string |  |  | ObservePaths lists extra directories to search for Claude JSONL session files (e.g., aimux session paths). The default search path (~/.claude/projects/) is always included. |
+| `probe_concurrency` | integer |  | `8` | ProbeConcurrency bounds the number of concurrent bd subprocess probes issued by the pool scale_check and work_query paths. bd serializes on a shared dolt sql-server, so unbounded parallelism causes contention. Nil (unset) defaults to 8. Set higher for workspaces with a fast dedicated dolt server, or lower to reduce contention on slow storage. |
 
 ## DoltConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -938,6 +938,11 @@
           },
           "type": "array",
           "description": "ObservePaths lists extra directories to search for Claude JSONL session\nfiles (e.g., aimux session paths). The default search path\n(~/.claude/projects/) is always included."
+        },
+        "probe_concurrency": {
+          "type": "integer",
+          "description": "ProbeConcurrency bounds the number of concurrent bd subprocess probes\nissued by the pool scale_check and work_query paths. bd serializes on\na shared dolt sql-server, so unbounded parallelism causes contention.\nNil (unset) defaults to 8. Set higher for workspaces with a fast\ndedicated dolt server, or lower to reduce contention on slow storage.",
+          "default": 8
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -982,6 +982,12 @@ type DaemonConfig struct {
 	// files (e.g., aimux session paths). The default search path
 	// (~/.claude/projects/) is always included.
 	ObservePaths []string `toml:"observe_paths,omitempty"`
+	// ProbeConcurrency bounds the number of concurrent bd subprocess probes
+	// issued by the pool scale_check and work_query paths. bd serializes on
+	// a shared dolt sql-server, so unbounded parallelism causes contention.
+	// Nil (unset) defaults to 8. Set higher for workspaces with a fast
+	// dedicated dolt server, or lower to reduce contention on slow storage.
+	ProbeConcurrency *int `toml:"probe_concurrency,omitempty" jsonschema:"default=8"`
 }
 
 // PatrolIntervalDuration returns the patrol interval as a time.Duration.
@@ -1030,6 +1036,24 @@ func (d *DaemonConfig) ShutdownTimeoutDuration() time.Duration {
 		return 5 * time.Second
 	}
 	return dur
+}
+
+// DefaultProbeConcurrency is the default bd probe concurrency limit.
+// Used by ProbeConcurrencyOrDefault and referenced by cmd/gc/pool.go
+// so the default lives in one place.
+const DefaultProbeConcurrency = 8
+
+// ProbeConcurrencyOrDefault returns the bd probe concurrency limit.
+// Nil (unset) defaults to DefaultProbeConcurrency. Values below 1 are
+// clamped to 1 to prevent deadlock on a zero-capacity semaphore.
+func (d *DaemonConfig) ProbeConcurrencyOrDefault() int {
+	if d.ProbeConcurrency == nil {
+		return DefaultProbeConcurrency
+	}
+	if *d.ProbeConcurrency < 1 {
+		return 1
+	}
+	return *d.ProbeConcurrency
 }
 
 // DriftDrainTimeoutDuration returns the drift drain timeout as a time.Duration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1998,6 +1998,70 @@ name = "mayor"
 	}
 }
 
+// --- ProbeConcurrency tests ---
+
+func TestDaemonProbeConcurrencyDefault(t *testing.T) {
+	d := DaemonConfig{}
+	got := d.ProbeConcurrencyOrDefault()
+	if got != DefaultProbeConcurrency {
+		t.Errorf("ProbeConcurrencyOrDefault() = %d, want %d", got, DefaultProbeConcurrency)
+	}
+}
+
+func TestDaemonProbeConcurrencyExplicit(t *testing.T) {
+	v := 16
+	d := DaemonConfig{ProbeConcurrency: &v}
+	got := d.ProbeConcurrencyOrDefault()
+	if got != 16 {
+		t.Errorf("ProbeConcurrencyOrDefault() = %d, want 16", got)
+	}
+}
+
+func TestDaemonProbeConcurrencyZeroClamped(t *testing.T) {
+	v := 0
+	d := DaemonConfig{ProbeConcurrency: &v}
+	got := d.ProbeConcurrencyOrDefault()
+	if got != 1 {
+		t.Errorf("ProbeConcurrencyOrDefault() = %d, want 1 (clamped)", got)
+	}
+}
+
+func TestDaemonProbeConcurrencyNegativeClamped(t *testing.T) {
+	v := -5
+	d := DaemonConfig{ProbeConcurrency: &v}
+	got := d.ProbeConcurrencyOrDefault()
+	if got != 1 {
+		t.Errorf("ProbeConcurrencyOrDefault() = %d, want 1 (clamped)", got)
+	}
+}
+
+func TestParseProbeConcurrency(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test"
+
+[daemon]
+probe_concurrency = 12
+
+[[agent]]
+name = "mayor"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.Daemon.ProbeConcurrency == nil {
+		t.Fatal("Daemon.ProbeConcurrency is nil, want 12")
+	}
+	if *cfg.Daemon.ProbeConcurrency != 12 {
+		t.Errorf("Daemon.ProbeConcurrency = %d, want 12", *cfg.Daemon.ProbeConcurrency)
+	}
+	got := cfg.Daemon.ProbeConcurrencyOrDefault()
+	if got != 12 {
+		t.Errorf("ProbeConcurrencyOrDefault() = %d, want 12", got)
+	}
+}
+
 // --- DrainTimeout tests ---
 
 func TestDrainTimeoutDefault(t *testing.T) {


### PR DESCRIPTION
Fixes #481

## Summary

Two small, universal reconciler fixes that keep pool workers alive. Each fix is independent and reviewable on its own.

### 1. Bound scale_check concurrency + raise timeout to 180s

The pool `scale_check` and `work_query` paths each shell out to `bd` per agent per reconcile cycle. `bd` serializes on a shared dolt sql-server, so launching one goroutine per agent (40+ concurrent bd calls) causes per-call contention that pushes individual probes past the 30s timeout — even when the work itself is cheap. Once timeouts start hitting, the reconciler can't see pool demand and workers never spawn.

Changes:

- `shellScaleCheck` timeout 30s → 180s. Generous enough to tolerate tail-latency spikes under contended dolt.
- New `bdProbeConcurrency = 8` constant, applied via semaphore to both `evaluatePendingPools` (build_desired_state.go) and `computeWorkSet` (session_reconcile.go). Probes still overlap, but 8-way parallelism stays well below where dolt contention kicks in.
- `computeWorkSet` was previously sequential; it now collects probe work first and runs the bd calls in parallel under the same semaphore. Behavior-preserving but much faster for workspaces with many pool agents.

### 2. Transition pool session beads creating → active in parallel reconciler path

`commitStartResultTraced` writes config_hash, live_hash, and friends after a successful runtime spawn but never transitions the session bead's state from "creating" to "active". The equivalent single-session path calls `Manager.ConfirmCreation` (`internal/session/manager.go:707`), which does exactly this — but that path isn't wired into the parallel reconciler.

Without the transition, freshly-spawned pool session beads stay in "creating" state forever. The nudge wait-idle poller uses the state field to decide when to deliver queued work, so slung beads routed to a pool agent sit unclaimed. The next reconcile tick then can't find the session in its desired-state map and drains it as "orphaned", losing any partial progress.

Folded into the existing `SetMetadataBatch` so the state + hash writes are atomic and avoid a second round-trip per spawn. Extracted the state gate into `confirmPendingStart` for testability.

- Pending states that get transitioned: `""`, `creating`, `asleep`, `drained`.
- `awake` is intentionally NOT restamped — the reconciler treats it as equivalent to `active` (see comment at `manager.go:644`), and rewriting the metadata on every spawn would be a wasted store write.
- Terminal/transitional states (`draining`, `archived`, `quarantined`, `suspended`) are left alone so a deliberately-wound-down session isn't resurrected.

## Scope

- 5 files touched, +117/-11
- No new files, no config changes, no bead store API changes, no architectural changes
- Respects `TestNoBdExecOutsideBeads` — no new bd subprocess call sites
- Uses existing `sessionpkg.State*` constants where available; `"drained"` remains a string literal because no `StateDrained` constant exists in `internal/session/manager.go` (it's referenced by string elsewhere in the codebase, e.g. `cmd/gc/session_reconcile.go:175`)

## Test plan

- [x] `go vet ./cmd/gc/...` clean
- [x] `go build ./cmd/gc/...` clean
- [x] `golangci-lint run ./cmd/gc/...` — 0 issues
- [x] `TestConfirmPendingStart` — table-driven test covering pending states (transition), equivalent-to-active states (don't restamp), and terminal states (don't touch)
- [x] Existing `TestComputeWorkSet_*` tests pass — the sequential→parallel rewrite preserves observable behavior
- [x] Runtime smoke on a 10-rig / 40-agent workspace: the creating→active transition fires cleanly and the scale_check semaphore keeps bd probes within their deadline

## Related

- **Supersedes #470** (closed) — the original PR that accumulated scope beyond what was needed. #480 is a minimal subset, focused on the two universally-applicable bug fixes; the broader bulk-query performance work is deferred and lives in #470's closed history for reference.
- **Does NOT fix #482** (stale-assignee starvation) — separate bug where drained workers leave behind in-progress bead claims that block scale_check from re-detecting demand. Composes with #481 to produce the full orphan-drain-then-starvation cycle; #480 addresses #481 only.
- **Does NOT fix #483** (phantom pool demand) — unrelated over-spawn behavior observed during #481/#482 debugging.
- **Does NOT fix #484** (gc.routed_to metadata corruption) — unrelated bad-data bug in the sling path, observed during the same debugging session.
