### PR TITLE
fix: replace wall-clock polling with WaitGroup sync in idle drain test (#497)

### DIFF
--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -984,14 +984,7 @@ func TestAdvanceSessionDrainsWithSessions_UsesProvidedWakeEvaluations(t *testing
 	}
 }
 
-func waitForIdleProbeReady(t *testing.T, dt *drainTracker, beadID string) {
+func waitForIdleProbeReady(t *testing.T, dt *drainTracker, _ string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if probe, ok := dt.idleProbe(beadID); ok && probe.ready {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("idle probe for %s did not complete", beadID)
+	dt.waitIdleProbes()
 }

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -984,7 +984,22 @@ func TestAdvanceSessionDrainsWithSessions_UsesProvidedWakeEvaluations(t *testing
 	}
 }
 
-func waitForIdleProbeReady(t *testing.T, dt *drainTracker, _ string) {
+func waitForIdleProbeReady(t *testing.T, dt *drainTracker, beadID string) {
 	t.Helper()
-	dt.waitIdleProbes()
+
+	done := make(chan struct{})
+	go func() {
+		dt.waitIdleProbes()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("idle probe for %s did not complete within 10s", beadID)
+	}
+
+	if probe, ok := dt.idleProbe(beadID); !ok || !probe.ready {
+		t.Fatalf("idle probe for %s not ready after waitIdleProbes returned", beadID)
+	}
 }


### PR DESCRIPTION
## Summary

- Replace `waitForIdleProbeReady`'s 5s wall-clock deadline + 1ms polling loop with `dt.waitIdleProbes()` which uses a `sync.WaitGroup`
- Eliminates flaky CI failures on loaded runners where the idle probe goroutine couldn't schedule within the deadline

Closes #497

## Test plan

- [x] `make check` passes (specifically `TestReconcileSessionBeads_StartsIdleDrainAfterGrace`)
- [ ] No more spurious `idle probe for gc-1 did not complete` failures in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)