### PR TITLE
fix: skip orders targeting suspended rigs (#478)

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -115,6 +115,11 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			continue
 		}
 
+		// Skip orders targeting suspended rigs.
+		if m.orderRigSuspended(a) {
+			continue
+		}
+
 		// Skip dispatch if previous work hasn't been processed yet.
 		scoped := a.ScopedName()
 		if m.hasOpenWork(scoped) {
@@ -310,6 +315,30 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, a orders.Order
 
 	// Label tracking bead with outcome.
 	m.store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp"}}) //nolint:errcheck // best-effort
+}
+
+// orderRigSuspended reports whether the order targets a suspended rig.
+// Rig-scoped orders check their rig directly. City-level orders with a
+// qualified pool ("rig/pool") check the pool's rig prefix.
+func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
+	if m.cfg == nil {
+		return false
+	}
+	rigName := a.Rig
+	if rigName == "" && a.Pool != "" {
+		if i := strings.Index(a.Pool, "/"); i > 0 {
+			rigName = a.Pool[:i]
+		}
+	}
+	if rigName == "" {
+		return false
+	}
+	for _, r := range m.cfg.Rigs {
+		if r.Name == rigName {
+			return r.Suspended
+		}
+	}
+	return false
 }
 
 // hasOpenWork reports whether any non-closed work bead exists for this

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -599,6 +599,139 @@ func TestEffectiveTimeout(t *testing.T) {
 	}
 }
 
+// --- suspended rig tests ---
+
+func TestOrderDispatchSkipsSuspendedRig(t *testing.T) {
+	store := beads.NewMemStore()
+
+	aa := []orders.Order{{
+		Name:         "rig-order",
+		Gate:         "cooldown",
+		Interval:     "1m",
+		Formula:      "test-formula",
+		Rig:          "demo",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil, noopRunner)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	// Mark the rig as suspended.
+	mad := ad.(*memoryOrderDispatcher)
+	mad.cfg = &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: "/tmp/demo", Suspended: true}},
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	// No tracking bead should be created for a suspended rig.
+	all := trackingBeads(t, store, "order-run:rig-order:rig:demo")
+	if len(all) != 0 {
+		t.Errorf("expected 0 tracking beads for suspended rig, got %d", len(all))
+	}
+}
+
+func TestOrderDispatchSkipsSuspendedRigQualifiedPool(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// City-level order with a qualified pool targeting a suspended rig.
+	aa := []orders.Order{{
+		Name:         "city-order",
+		Gate:         "cooldown",
+		Interval:     "1m",
+		Formula:      "test-formula",
+		Pool:         "demo/polecat",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil, noopRunner)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	mad := ad.(*memoryOrderDispatcher)
+	mad.cfg = &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: "/tmp/demo", Suspended: true}},
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	all := trackingBeads(t, store, "order-run:city-order")
+	if len(all) != 0 {
+		t.Errorf("expected 0 tracking beads for suspended rig pool, got %d", len(all))
+	}
+}
+
+func TestOrderDispatchAllowsNonSuspendedRig(t *testing.T) {
+	store := beads.NewMemStore()
+
+	aa := []orders.Order{{
+		Name:         "rig-order",
+		Gate:         "cooldown",
+		Interval:     "1m",
+		Formula:      "test-formula",
+		Rig:          "demo",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil, noopRunner)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	// Rig exists but is NOT suspended.
+	mad := ad.(*memoryOrderDispatcher)
+	mad.cfg = &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: "/tmp/demo", Suspended: false}},
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	all := trackingBeads(t, store, "order-run:rig-order:rig:demo")
+	if len(all) == 0 {
+		t.Error("expected tracking bead for non-suspended rig")
+	}
+}
+
+func TestOrderRigSuspended(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "active", Path: "/tmp/active", Suspended: false},
+			{Name: "frozen", Path: "/tmp/frozen", Suspended: true},
+		},
+	}
+	m := &memoryOrderDispatcher{cfg: cfg}
+
+	tests := []struct {
+		name string
+		a    orders.Order
+		want bool
+	}{
+		{"rig-scoped suspended", orders.Order{Rig: "frozen"}, true},
+		{"rig-scoped active", orders.Order{Rig: "active"}, false},
+		{"rig-scoped unknown", orders.Order{Rig: "unknown"}, false},
+		{"qualified pool suspended", orders.Order{Pool: "frozen/polecat"}, true},
+		{"qualified pool active", orders.Order{Pool: "active/polecat"}, false},
+		{"unqualified pool", orders.Order{Pool: "polecat"}, false},
+		{"no rig no pool", orders.Order{}, false},
+		{"nil cfg", orders.Order{Rig: "frozen"}, false}, // handled separately
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := m
+			if tt.name == "nil cfg" {
+				target = &memoryOrderDispatcher{}
+			}
+			if got := target.orderRigSuspended(tt.a); got != tt.want {
+				t.Errorf("orderRigSuspended() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // --- helpers ---
 
 // noopRunner is a CommandRunner that always succeeds.


### PR DESCRIPTION
## Summary

- Add `orderRigSuspended()` check to order dispatch loop — skips rig-scoped orders and city-level orders with qualified pools (e.g. `demo/polecat`) when the target rig is suspended
- Ensures the suspend/resume contract is respected by background maintenance automation, not just interactive work

Closes #478

## Test plan

- [x] `TestOrderDispatchSkipsSuspendedRig` — rig-scoped order skipped
- [x] `TestOrderDispatchSkipsSuspendedRigQualifiedPool` — qualified pool order skipped
- [x] `TestOrderDispatchAllowsNonSuspendedRig` — non-suspended rig proceeds
- [x] `TestOrderRigSuspended` — table-driven unit tests (8 cases)
- [x] CI `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)