### PR TITLE
feat(dog): add provider-aware soft-recovery rung to mol-shutdown-dance

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -40,7 +40,7 @@ continuity.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, reset, close, rename, prune, peek, kill, nudge, logs, wake, wait)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, reset, close, rename, prune, peek, kill, nudge, recover, logs, wake, wait)") //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stderr, "gc session: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
 			}
@@ -60,6 +60,7 @@ continuity.`,
 		newSessionPeekCmd(stdout, stderr),
 		newSessionKillCmd(stdout, stderr),
 		newSessionNudgeCmd(stdout, stderr),
+		newSessionRecoverCmd(stdout, stderr),
 		newSessionLogsCmd(stdout, stderr),
 		newSessionWakeCmd(stdout, stderr),
 		newSessionWaitCmd(stdout, stderr),

--- a/cmd/gc/cmd_session_recover.go
+++ b/cmd/gc/cmd_session_recover.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+// newSessionRecoverCmd creates the "gc session recover <id-or-alias>" command.
+//
+// This is the soft-recovery rung of mol-shutdown-dance: it delivers a
+// provider-specific keystroke sequence (e.g. Claude Code's /rewind) to a
+// running session as the cheapest possible attempt to unwedge an agent
+// whose conversation context is broken but whose process is still alive.
+//
+// On success, the agent should resume its in-flight molecule with no
+// state lost. On failure (no soft-recovery hint configured for the
+// provider, or the keystrokes can't be delivered), the command exits
+// non-zero so the dog ladder advances to interrogate/kill.
+func newSessionRecoverCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "recover <session-id-or-alias>",
+		Short: "Soft-recover a wedged session via provider-specific keystrokes",
+		Long: `Soft-recover a session whose conversation context is broken but whose
+process is still alive. Used as strike 1 of the dog's shutdown dance.
+
+The keystroke sequence comes from the resolved provider's RecoveryHints
+(e.g. Claude Code: Ctrl-U + /rewind + Enter, which rolls the conversation
+back to before a 400 tool_use concurrency error without losing any
+session, working-directory, or tool state).
+
+Exits non-zero — and writes nothing to the session — when the resolved
+provider has no soft-recovery hint configured. In that case stderr
+contains the marker "no soft recovery; skipping"; callers
+(mol-shutdown-dance strike 1) should grep for that marker to distinguish
+"provider has no soft rung, advance immediately" from a hard error
+(session not running, send-keys failed) and escalate to interrogate/kill.
+
+Note: gc collapses all RunE errors to exit code 1, so the internal
+function-level distinction between exit 1 (hard error) and exit 2
+(no soft hint) is preserved only by stderr content at this boundary.
+
+Accepts a session ID (e.g. gc-42) or session alias (e.g. witness-1).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if cmdSessionRecover(args, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+}
+
+// cmdSessionRecover is the CLI entry point for "gc session recover".
+func cmdSessionRecover(args []string, stdout, stderr io.Writer) int {
+	info, err := resolveNudgeTarget(args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session recover: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return deliverSessionRecover(info, newSessionProvider(), stdout, stderr)
+}
+
+// deliverSessionRecover is the testable core of cmdSessionRecover. The
+// nudgeTarget and provider are both injected so unit tests can drive the
+// state machine without loading a real city config or tmux runtime.
+//
+// Exit codes (function-level — collapsed to 1 by the gc CLI wrapper):
+//   - 0: keystrokes were delivered.
+//   - 1: hard error (provider error, session not running, etc).
+//   - 2: provider has no soft-recovery hint configured — caller (the dog
+//     ladder) should advance to the next strike immediately. Because the
+//     gc CLI collapses non-zero to exit 1, the "advance immediately"
+//     signal is ALSO conveyed by the literal stderr substring
+//     "no soft recovery; skipping" so molecule prompts can grep for it
+//     without depending on exit codes.
+func deliverSessionRecover(info nudgeTarget, sp runtime.Provider, stdout, stderr io.Writer) int {
+	if info.resolved == nil {
+		fmt.Fprintf(stderr, "gc session recover: %s: no resolved provider, no soft recovery; skipping\n", info.agentKey()) //nolint:errcheck
+		return 2
+	}
+	keys := info.resolved.RecoveryHints.SoftRecoveryKeys
+	if len(keys) == 0 {
+		fmt.Fprintf(stderr, "gc session recover: %s: provider %q has no soft recovery; skipping\n", info.agentKey(), info.resolved.Name) //nolint:errcheck
+		return 2
+	}
+
+	if !sp.IsRunning(info.sessionName) {
+		fmt.Fprintf(stderr, "gc session recover: %s: session is not running\n", info.agentKey()) //nolint:errcheck
+		return 1
+	}
+
+	if err := sp.SendKeys(info.sessionName, keys...); err != nil {
+		telemetry.RecordNudge(context.Background(), info.agentKey(), err)
+		fmt.Fprintf(stderr, "gc session recover: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	telemetry.RecordNudge(context.Background(), info.agentKey(), nil)
+
+	fmt.Fprintf(stdout, "Sent soft recovery to %s (%v)\n", info.agentKey(), keys) //nolint:errcheck
+	return 0
+}

--- a/cmd/gc/cmd_session_recover_test.go
+++ b/cmd/gc/cmd_session_recover_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// fakeRecoverTarget builds a nudgeTarget pointed at a session named "sess-1"
+// with the given resolved provider. Resolved is intentionally a pointer
+// because the live resolveNudgeTarget code path also returns a pointer.
+func fakeRecoverTarget(resolved *config.ResolvedProvider) nudgeTarget {
+	return nudgeTarget{
+		identity:    "rig/witness",
+		alias:       "witness-1",
+		sessionName: "sess-1",
+		resolved:    resolved,
+	}
+}
+
+func TestDeliverSessionRecover_ClaudeSendsKeys(t *testing.T) {
+	resolved := &config.ResolvedProvider{
+		Name: "claude",
+		RecoveryHints: config.RecoveryHints{
+			SoftRecoveryKeys: []string{"C-u", "/rewind", "Enter"},
+		},
+	}
+	target := fakeRecoverTarget(resolved)
+
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), target.sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := deliverSessionRecover(target, sp, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+	}
+
+	// Exactly one SendKeys call, with all three keys passed in order.
+	var sendCalls []runtime.Call
+	for _, c := range sp.Calls {
+		if c.Method == "SendKeys" {
+			sendCalls = append(sendCalls, c)
+		}
+	}
+	if len(sendCalls) != 1 {
+		t.Fatalf("SendKeys calls = %d, want 1; all calls=%v", len(sendCalls), sp.Calls)
+	}
+	wantMsg := "C-u /rewind Enter"
+	if sendCalls[0].Message != wantMsg {
+		t.Errorf("SendKeys message = %q, want %q", sendCalls[0].Message, wantMsg)
+	}
+	if sendCalls[0].Name != target.sessionName {
+		t.Errorf("SendKeys name = %q, want %q", sendCalls[0].Name, target.sessionName)
+	}
+	if !strings.Contains(stdout.String(), "Sent soft recovery to witness-1") {
+		t.Errorf("stdout = %q, want contains success line", stdout.String())
+	}
+}
+
+func TestDeliverSessionRecover_NoHintExitsTwoWithoutSending(t *testing.T) {
+	// codex (or any provider without RecoveryHints) must NOT have keys
+	// delivered, and must exit 2 so the dog ladder advances.
+	resolved := &config.ResolvedProvider{Name: "codex"}
+	target := fakeRecoverTarget(resolved)
+
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), target.sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := deliverSessionRecover(target, sp, stdout, stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (provider has no soft recovery)", code)
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "SendKeys" {
+			t.Errorf("unexpected SendKeys call %+v on provider with no recovery hint", c)
+		}
+	}
+	// The molecule's strike-1 step greps stderr for this exact substring
+	// to distinguish "no soft rung available, advance" from a hard error.
+	// Renaming this marker will silently break mol-shutdown-dance.
+	if !strings.Contains(stderr.String(), "no soft recovery; skipping") {
+		t.Errorf("stderr = %q, want contains 'no soft recovery; skipping'", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestDeliverSessionRecover_NilResolvedExitsTwo(t *testing.T) {
+	// A session bead with no resolved provider (rare edge case — agent
+	// not in city config) must skip rather than panic.
+	target := fakeRecoverTarget(nil)
+	sp := runtime.NewFake()
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := deliverSessionRecover(target, sp, stdout, stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	// Same marker as the no-keys branch so the molecule's strike-1 grep
+	// catches both "agent has no resolved provider" and "provider has no
+	// hint" with one rule.
+	if !strings.Contains(stderr.String(), "no soft recovery; skipping") {
+		t.Errorf("stderr = %q, want contains 'no soft recovery; skipping'", stderr.String())
+	}
+}
+
+func TestDeliverSessionRecover_SessionNotRunningExitsOne(t *testing.T) {
+	// Provider has a hint, but the session isn't running — hard error
+	// (the warrant flow shouldn't waste a strike on a dead session).
+	resolved := &config.ResolvedProvider{
+		Name: "claude",
+		RecoveryHints: config.RecoveryHints{
+			SoftRecoveryKeys: []string{"C-u", "/rewind", "Enter"},
+		},
+	}
+	target := fakeRecoverTarget(resolved)
+	sp := runtime.NewFake() // no Start → not running
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := deliverSessionRecover(target, sp, stdout, stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (session not running)", code)
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "SendKeys" {
+			t.Errorf("unexpected SendKeys call against non-running session: %+v", c)
+		}
+	}
+}
+
+func TestDeliverSessionRecover_SendKeysErrorExitsOne(t *testing.T) {
+	// When the provider returns an error from SendKeys, propagate it.
+	resolved := &config.ResolvedProvider{
+		Name: "claude",
+		RecoveryHints: config.RecoveryHints{
+			SoftRecoveryKeys: []string{"C-u", "/rewind", "Enter"},
+		},
+	}
+	target := fakeRecoverTarget(resolved)
+	sp := runtime.NewFailFake() // broken: all ops error, IsRunning false
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := deliverSessionRecover(target, sp, stdout, stderr)
+	// FailFake returns false for IsRunning so we hit the not-running
+	// branch first; that's still exit 1, just via the earlier guard.
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -624,13 +624,14 @@ Web dashboard for monitoring the city
 gc dashboard [flags]
 ```
 
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api` | string |  | GC API server URL override (auto-discovered by default) |
+| `--port` | int | `8080` | HTTP port |
+
 | Subcommand | Description |
 |------------|-------------|
 | [gc dashboard serve](#gc-dashboard-serve) | Start the web dashboard |
-
-Starts the dashboard directly and auto-discovers the GC API server when run
-inside a city. Use `gc dashboard serve` if you want the explicit subcommand
-form.
 
 ## gc dashboard serve
 
@@ -851,7 +852,7 @@ Returns immediately. Equivalent to:
   gc session kill &lt;target&gt;
 
 Self-handoff requires session context (GC_ALIAS or GC_SESSION_ID, plus
-GC_SESSION_NAME and GC_CITY). Remote handoff accepts a session alias or ID.
+GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or ID.
 
 ```
 gc handoff <subject> [message] [flags]
@@ -1449,7 +1450,7 @@ The reconciler will restart the agents on its next tick. This is a
 quick way to force-refresh all agents working on a particular project.
 
 ```
-gc rig restart <name>
+gc rig restart [name]
 ```
 
 ## gc rig resume
@@ -1459,7 +1460,7 @@ Resume a suspended rig by clearing suspended in city.toml.
 The reconciler will start the rig's agents on its next tick.
 
 ```
-gc rig resume <name>
+gc rig resume [name]
 ```
 
 ## gc rig status
@@ -1467,7 +1468,7 @@ gc rig resume <name>
 Show rig status and agent running state
 
 ```
-gc rig status <name>
+gc rig status [name]
 ```
 
 ## gc rig suspend
@@ -1479,7 +1480,7 @@ the reconciler skips them and gc hook returns empty. The rig's beads
 database remains accessible. Use "gc rig resume" to restore.
 
 ```
-gc rig suspend <name>
+gc rig suspend [name]
 ```
 
 ## gc runtime
@@ -1630,7 +1631,10 @@ gc session
 | [gc session nudge](#gc-session-nudge) | Send a text message to a running session |
 | [gc session peek](#gc-session-peek) | View session output without attaching |
 | [gc session prune](#gc-session-prune) | Close old suspended sessions |
+| [gc session recover](#gc-session-recover) | Soft-recover a wedged session via provider-specific keystrokes |
 | [gc session rename](#gc-session-rename) | Rename a session |
+| [gc session reset](#gc-session-reset) | Restart a session fresh while preserving the bead |
+| [gc session submit](#gc-session-submit) | Submit a message with semantic delivery intent |
 | [gc session suspend](#gc-session-suspend) | Suspend a session (save state, free resources) |
 | [gc session wait](#gc-session-wait) | Register a dependency wait for a session |
 | [gc session wake](#gc-session-wake) | Wake a session (clear hold and quarantine) |
@@ -1789,6 +1793,26 @@ gc session prune --before 7d
 |------|------|---------|-------------|
 | `--before` | string | `7d` | prune sessions older than this duration (e.g., 7d, 24h) |
 
+## gc session recover
+
+Soft-recover a session whose conversation context is broken but whose
+process is still alive. Used as strike 1 of the dog's shutdown dance.
+
+The keystroke sequence comes from the resolved provider's RecoveryHints
+(e.g. Claude Code: Ctrl-U + /rewind + Enter, which rolls the conversation
+back to before a 400 tool_use concurrency error without losing any
+session, working-directory, or tool state).
+
+Exits non-zero — and writes nothing to the session — when the resolved
+provider has no soft-recovery hint configured. Callers (mol-shutdown-dance
+strike 1) should treat that as a signal to escalate to interrogate/kill.
+
+Accepts a session ID (e.g. gc-42) or session alias (e.g. witness-1).
+
+```
+gc session recover <session-id-or-alias>
+```
+
 ## gc session rename
 
 Rename a session
@@ -1796,6 +1820,43 @@ Rename a session
 ```
 gc session rename <session-id-or-alias> <title>
 ```
+
+## gc session reset
+
+Request a fresh restart for an existing session without closing its bead.
+
+The controller stops the current runtime and starts the same session again with
+fresh provider conversation state. Session identity, alias, mail, and queued
+work remain attached to the existing session bead.
+
+Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).
+
+```
+gc session reset <session-id-or-alias>
+```
+
+## gc session submit
+
+Submit a user message to a session without choosing provider transport details.
+
+The runtime decides whether to wake, inject immediately, or queue the message
+according to the selected semantic intent.
+
+```
+gc session submit <id-or-alias> <message...> [flags]
+```
+
+**Example:**
+
+```
+gc session submit mayor "status update"
+  gc session submit mayor "after this run, handle docs" --intent follow_up
+  gc session submit mayor "stop and do this instead" --intent interrupt_now
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--intent` | string | `default` | submit intent: default, follow_up, or interrupt_now |
 
 ## gc session suspend
 
@@ -2264,3 +2325,4 @@ Manually mark a wait ready
 ```
 gc wait ready <wait-id>
 ```
+

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1804,8 +1804,15 @@ back to before a 400 tool_use concurrency error without losing any
 session, working-directory, or tool state).
 
 Exits non-zero — and writes nothing to the session — when the resolved
-provider has no soft-recovery hint configured. Callers (mol-shutdown-dance
-strike 1) should treat that as a signal to escalate to interrogate/kill.
+provider has no soft-recovery hint configured. In that case stderr
+contains the marker "no soft recovery; skipping"; callers
+(mol-shutdown-dance strike 1) should grep for that marker to distinguish
+"provider has no soft rung, advance immediately" from a hard error
+(session not running, send-keys failed) and escalate to interrogate/kill.
+
+Note: gc collapses all RunE errors to exit code 1, so the internal
+function-level distinction between exit 1 (hard error) and exit 2
+(no soft hint) is preserved only by stderr content at this boundary.
 
 Accepts a session ID (e.g. gc-42) or session alias (e.g. witness-1).
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -433,6 +433,15 @@ ProviderSpec defines a named provider's startup parameters.
 | `options_schema` | []ProviderOption |  |  | OptionsSchema declares the configurable options this provider supports. Each option maps to CLI args via its Choices[].FlagArgs field. Serialized via a dedicated DTO (not directly to JSON) so FlagArgs stays server-side. |
 | `print_args` | []string |  |  | PrintArgs are CLI arguments that enable one-shot non-interactive mode. The provider prints its response to stdout and exits. When empty, the provider does not support one-shot invocation. Examples: ["-p"] (claude, gemini), ["exec"] (codex) |
 | `title_model` | string |  |  | TitleModel is the OptionsSchema model key used for title generation. Resolved via the "model" option in OptionsSchema to get FlagArgs. Defaults to the cheapest/fastest model for each provider. Examples: "haiku" (claude), "o4-mini" (codex), "gemini-2.5-flash" (gemini) |
+| `recovery_hints` | RecoveryHints |  |  | RecoveryHints declares the cheap soft-recovery action for this provider, used as strike 1 of mol-shutdown-dance. Zero value means no soft recovery — the dog ladder skips straight to interrupt. |
+
+## RecoveryHints
+
+RecoveryHints declares cheap, provider-specific actions that can be tried before escalating to interrupt or kill when an agent appears wedged (e.g.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `soft_recovery_keys` | []string |  |  | SoftRecoveryKeys is a sequence of tmux key tokens delivered to the session's terminal as the first attempt to unwedge it. Each token is passed to runtime.Provider.SendKeys (e.g. "C-u", "/rewind", "Enter"). For Claude Code, ["C-u", "/rewind", "Enter"] rolls the conversation back to before the broken tool_use turn without losing session state. |
 
 ## Rig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1471,11 +1471,29 @@
         "title_model": {
           "type": "string",
           "description": "TitleModel is the OptionsSchema model key used for title generation.\nResolved via the \"model\" option in OptionsSchema to get FlagArgs.\nDefaults to the cheapest/fastest model for each provider.\nExamples: \"haiku\" (claude), \"o4-mini\" (codex), \"gemini-2.5-flash\" (gemini)"
+        },
+        "recovery_hints": {
+          "$ref": "#/$defs/RecoveryHints",
+          "description": "RecoveryHints declares the cheap soft-recovery action for this\nprovider, used as strike 1 of mol-shutdown-dance. Zero value means\nno soft recovery — the dog ladder skips straight to interrupt."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "ProviderSpec defines a named provider's startup parameters."
+    },
+    "RecoveryHints": {
+      "properties": {
+        "soft_recovery_keys": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SoftRecoveryKeys is a sequence of tmux key tokens delivered to the\nsession's terminal as the first attempt to unwedge it. Each token is\npassed to runtime.Provider.SendKeys (e.g. \"C-u\", \"/rewind\", \"Enter\").\nFor Claude Code, [\"C-u\", \"/rewind\", \"Enter\"] rolls the conversation\nback to before the broken tool_use turn without losing session state."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "RecoveryHints declares cheap, provider-specific actions that can be tried before escalating to interrupt or kill when an agent appears wedged (e.g."
     },
     "Rig": {
       "properties": {

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.formula.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.formula.toml
@@ -17,20 +17,31 @@ resume from context (check target state, attempt history).
 ## State Machine
 
 ```
-RECEIVE → INTERROGATE (1) → INTERROGATE (2) → INTERROGATE (3) → EXECUTE → EPITAPH
-              ↓                   ↓                   ↓
-           ALIVE?             ALIVE?              ALIVE?
-              ↓                   ↓                   ↓
-           [yes → EPITAPH with PARDONED]          [no → EXECUTE]
+RECEIVE → INTERROGATE (1) → SOFT-RECOVER → INTERROGATE (2) → INTERROGATE (3) → EXECUTE → EPITAPH
+              ↓                  ↓                ↓                  ↓
+           ALIVE?           recovered?         ALIVE?             ALIVE?
+              ↓                  ↓                ↓                  ↓
+                       [yes at any step → EPITAPH with PARDONED]
+                                                                     ↓
+                                                                  [no → EXECUTE]
 ```
+
+The cheap test (interrogate-1) runs *before* the cheap recovery (soft-recover)
+because soft recovery is not free of side effects: on a healthy-but-idle Claude
+session, sending `/rewind` opens a modal dialog that subsequent text nudges
+can't dismiss. The alive-check nudge has zero side effects on a healthy agent,
+so we use it as the cheapest possible test for "is recovery actually needed?"
+and only escalate to soft recovery (which mutates conversation state) when the
+test fails to elicit a response.
 
 ## Timeouts
 
-| Attempt | Timeout | Cumulative |
-|---------|---------|------------|
-| 1       | 60s     | 60s        |
-| 2       | 120s    | 180s (3m)  |
-| 3       | 240s    | 420s (7m)  |
+| Step          | Timeout | Cumulative |
+|---------------|---------|------------|
+| interrogate-1 | 60s     | 60s        |
+| soft-recover  | 60s     | 120s (2m)  |
+| interrogate-2 | 120s    | 240s (4m)  |
+| interrogate-3 | 240s    | 480s (8m)  |
 
 ## Who files warrants
 
@@ -63,7 +74,6 @@ required = true
 
 [vars.requester]
 description = "Who filed the warrant (deacon, witness, etc.)"
-required = true
 default = "deacon"
 
 [[steps]]
@@ -98,21 +108,69 @@ If target session doesn't exist (already dead):
 
 [[steps]]
 id = "interrogate-1"
-title = "Soft recovery (60s timeout)"
+title = "First health check (60s timeout)"
 needs = ["receive-warrant"]
 description = """
-First attempt: cheap, provider-aware soft recovery. For Claude Code this
-delivers `/rewind`, which rolls the conversation back to before the most
-recent broken turn (e.g. a 400 tool_use concurrency error) without
-losing session, working-directory, or in-flight tool state. Providers
-without a configured soft-recovery hint exit non-zero immediately and
-the ladder advances to interrogate-2.
+First attempt to contact the stuck agent. Give it 60 seconds.
+
+This is a pure liveness *test* with zero side effects: a text nudge
+injected at an idle prompt is a no-op for a healthy agent (it reads
+the message on its next turn and replies). We run this before any
+recovery action so we never apply an unnecessary state-mutating
+recovery to a healthy false-positive.
+
+**1. Send health check via nudge:**
+```bash
+gc nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
+Warrant: {{warrant_id}}
+Reason: {{reason}}
+Filed by: {{requester}}
+Attempt: 1/3"
+```
+
+**2. Wait 60 seconds:**
+```bash
+sleep 60
+```
+
+**3. Check for response:**
+```bash
+gc session peek {{target}} 50
+```
+
+Look for the ALIVE keyword in the output after your health check message.
+Also check for any sign of active work (new tool calls, output being
+generated). Use judgment — explicit "ALIVE" is definitive, but active
+output also indicates the agent is functioning.
+
+**4. If ALIVE or active:**
+- Close warrant: `bd close {{warrant_id}} --reason "Session responded at attempt 1"`
+- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
+- Burn wisp, exit
+
+**5. If no response:** close this step, proceed to soft-recover."""
+
+[[steps]]
+id = "soft-recover"
+title = "Provider-aware soft recovery (60s timeout)"
+needs = ["interrogate-1"]
+description = """
+Cheap, provider-aware soft recovery. Reached only when interrogate-1's
+liveness test got no response, so we know recovery is actually needed
+and we won't be mutating a healthy agent's state.
+
+For Claude Code this delivers `/rewind`, which rolls the conversation
+back to before the most recent broken turn (e.g. a 400 tool_use
+concurrency error) without losing session, working-directory, or
+in-flight tool state. Providers without a configured soft-recovery
+hint emit a stderr marker and the ladder advances immediately.
 
 **0. Skip when soft recovery cannot help:**
 If `{{reason}}` is `wisp_stale`, the agent has stopped emitting wisps
-for a non-context reason — soft recovery is unlikely to revive it.
-Close this step without sending anything and proceed directly to
-interrogate-2.
+for a non-context reason — soft recovery is unlikely to revive it,
+and `/rewind` would just open a modal dialog the next steps can't
+dismiss. Close this step without sending anything and proceed
+directly to interrogate-2.
 
 **1. Send the soft-recovery sequence:**
 ```bash
@@ -144,18 +202,17 @@ You do NOT need to see an explicit "ALIVE" — the absence of a stuck
 error frame plus any forward progress is enough.
 
 **4. If recovered:**
-- Close warrant: `bd close {{warrant_id}} --reason "Soft recovery succeeded at attempt 1"`
+- Close warrant: `bd close {{warrant_id}} --reason "Soft recovery succeeded after alive-check failed"`
 - Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Soft recovery (/rewind or equivalent) succeeded"`
 - Burn wisp, exit
 
 **5. If no recovery (or `gc session recover` exited 2):** close this
-step, proceed to interrogate-2 — strike 2 falls back to the original
-nudge-and-look-for-ALIVE behaviour."""
+step, proceed to interrogate-2 — the harder nudge cycle."""
 
 [[steps]]
 id = "interrogate-2"
 title = "Second health check (120s timeout)"
-needs = ["interrogate-1"]
+needs = ["soft-recover"]
 description = """
 Second attempt with longer timeout. Only reached if first attempt
 got no response.
@@ -251,7 +308,7 @@ gc mail send {{requester}}/ -s "EXECUTE_FAILED: {{target}}" \
 
 **3. Record execution on the warrant:**
 ```bash
-bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
+bd close {{warrant_id}} --reason "Executed after alive checks + soft recovery failed (480s total)"
 ```
 
 Close this step, proceed to epitaph."""
@@ -269,7 +326,7 @@ gc mail send {{requester}}/ -s "DOG_DONE: {{target}} warrant executed" \
   -m "Warrant: {{warrant_id}}
 Target: {{target}}
 Reason: {{reason}}
-Outcome: EXECUTED after 3 attempts (60s + 120s + 240s = 420s)
+Outcome: EXECUTED after alive checks + soft recovery failed (60s + 60s + 120s + 240s = 480s)
 Action: session killed, reconciler will restart"
 ```
 

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.formula.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.formula.toml
@@ -98,41 +98,59 @@ If target session doesn't exist (already dead):
 
 [[steps]]
 id = "interrogate-1"
-title = "First health check (60s timeout)"
+title = "Soft recovery (60s timeout)"
 needs = ["receive-warrant"]
 description = """
-First attempt to contact the stuck agent. Give it 60 seconds.
+First attempt: cheap, provider-aware soft recovery. For Claude Code this
+delivers `/rewind`, which rolls the conversation back to before the most
+recent broken turn (e.g. a 400 tool_use concurrency error) without
+losing session, working-directory, or in-flight tool state. Providers
+without a configured soft-recovery hint exit non-zero immediately and
+the ladder advances to interrogate-2.
 
-**1. Send health check via nudge:**
+**0. Skip when soft recovery cannot help:**
+If `{{reason}}` is `wisp_stale`, the agent has stopped emitting wisps
+for a non-context reason — soft recovery is unlikely to revive it.
+Close this step without sending anything and proceed directly to
+interrogate-2.
+
+**1. Send the soft-recovery sequence:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
-Warrant: {{warrant_id}}
-Reason: {{reason}}
-Filed by: {{requester}}
-Attempt: 1/3"
+gc session recover {{target}} 2>&1 | tee /tmp/recover-{{warrant_id}}.log
 ```
+Exit code 0 → keystrokes were delivered, proceed to step 2.
+Non-zero AND stderr contains "no soft recovery; skipping" → the
+provider has no soft rung (or the session has no resolved provider);
+SKIP the wait in step 2 and advance immediately to interrogate-2.
+Any other non-zero exit → delivery error (session not running,
+send-keys failed); continue to step 4 anyway.
 
-**2. Wait 60 seconds:**
+(Note: the gc CLI collapses all error exits to code 1, so the
+"no soft rung available" signal is conveyed via the stderr marker,
+not the exit code.)
+
+**2. Wait 60 seconds for the agent to resume:**
 ```bash
 sleep 60
 ```
 
-**3. Check for response:**
+**3. Check for resumed activity:**
 ```bash
 gc session peek {{target}} 50
 ```
+Soft-recovery success looks like fresh output from the agent after
+`/rewind` (a new prompt, a resumed tool call, a new wisp written).
+You do NOT need to see an explicit "ALIVE" — the absence of a stuck
+error frame plus any forward progress is enough.
 
-Look for the ALIVE keyword in the output after your health check message.
-Also check for any sign of active work (new tool calls, output being
-generated). Use judgment — explicit "ALIVE" is definitive, but active
-output also indicates the agent is functioning.
-
-**4. If ALIVE or active:**
-- Close warrant: `bd close {{warrant_id}} --reason "Session responded at attempt 1"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
+**4. If recovered:**
+- Close warrant: `bd close {{warrant_id}} --reason "Soft recovery succeeded at attempt 1"`
+- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Soft recovery (/rewind or equivalent) succeeded"`
 - Burn wisp, exit
 
-**5. If no response:** close this step, proceed to interrogation-2."""
+**5. If no recovery (or `gc session recover` exited 2):** close this
+step, proceed to interrogate-2 — strike 2 falls back to the original
+nudge-and-look-for-ALIVE behaviour."""
 
 [[steps]]
 id = "interrogate-2"

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -2,6 +2,22 @@ package config
 
 import "github.com/gastownhall/gascity/internal/shellquote"
 
+// RecoveryHints declares cheap, provider-specific actions that can be tried
+// before escalating to interrupt or kill when an agent appears wedged
+// (e.g. a Claude Code 400 tool_use concurrency error that left the
+// conversation in an invalid state).
+//
+// Empty/zero-value means the provider has no soft recovery — callers should
+// skip the soft rung and escalate immediately.
+type RecoveryHints struct {
+	// SoftRecoveryKeys is a sequence of tmux key tokens delivered to the
+	// session's terminal as the first attempt to unwedge it. Each token is
+	// passed to runtime.Provider.SendKeys (e.g. "C-u", "/rewind", "Enter").
+	// For Claude Code, ["C-u", "/rewind", "Enter"] rolls the conversation
+	// back to before the broken tool_use turn without losing session state.
+	SoftRecoveryKeys []string `toml:"soft_recovery_keys,omitempty"`
+}
+
 // ProviderOption declares a single configurable option for a provider.
 // Options are rendered as UI controls in a dashboard's session creation form.
 type ProviderOption struct {
@@ -105,6 +121,10 @@ type ProviderSpec struct {
 	// Defaults to the cheapest/fastest model for each provider.
 	// Examples: "haiku" (claude), "o4-mini" (codex), "gemini-2.5-flash" (gemini)
 	TitleModel string `toml:"title_model,omitempty"`
+	// RecoveryHints declares the cheap soft-recovery action for this
+	// provider, used as strike 1 of mol-shutdown-dance. Zero value means
+	// no soft recovery — the dog ladder skips straight to interrupt.
+	RecoveryHints RecoveryHints `toml:"recovery_hints,omitempty"`
 }
 
 // ResolvedProvider is the fully-merged, ready-to-use provider config.
@@ -135,6 +155,7 @@ type ResolvedProvider struct {
 	OptionsSchema          []ProviderOption
 	PrintArgs              []string
 	TitleModel             string
+	RecoveryHints          RecoveryHints
 	// EffectiveDefaults is the fully-merged option default map.
 	// Computed from: schema Default -> provider OptionDefaults -> agent OptionDefaults.
 	// Used by ResolveDefaultArgs() to produce CLI flags and by the API to
@@ -242,6 +263,14 @@ func BuiltinProviders() map[string]ProviderSpec {
 			SessionIDFlag:          "--session-id",
 			PrintArgs:              []string{"-p"},
 			TitleModel:             "haiku",
+			RecoveryHints: RecoveryHints{
+				// Claude Code's /rewind rolls the conversation back to before
+				// the most recent broken turn (e.g. a 400 tool_use concurrency
+				// error), preserving session, working dir, and tool state.
+				// C-u clears any junk left in the input line; the trailing
+				// "Enter" submits the slash command.
+				SoftRecoveryKeys: []string{"C-u", "/rewind", "Enter"},
+			},
 			PermissionModes: map[string]string{
 				"unrestricted": "--dangerously-skip-permissions",
 				"plan":         "--permission-mode plan",

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -69,6 +69,35 @@ func TestBuiltinProvidersClaude(t *testing.T) {
 	}
 }
 
+func TestBuiltinProvidersRecoveryHints(t *testing.T) {
+	providers := BuiltinProviders()
+
+	// Claude must declare a soft-recovery sequence (used by gc session
+	// recover and mol-shutdown-dance strike 1). The exact sequence
+	// matters: C-u clears any junk left in the input line, /rewind is
+	// the slash command, Enter submits it.
+	got := providers["claude"].RecoveryHints.SoftRecoveryKeys
+	want := []string{"C-u", "/rewind", "Enter"}
+	if len(got) != len(want) {
+		t.Fatalf("claude SoftRecoveryKeys = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("claude SoftRecoveryKeys[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// Providers without a known soft-recovery action must leave
+	// SoftRecoveryKeys empty so the dog ladder skips strike 1 and
+	// advances immediately. This test guards against accidentally
+	// granting non-Claude providers a Claude-shaped recovery.
+	for _, name := range []string{"codex", "gemini", "cursor", "copilot"} {
+		if keys := providers[name].RecoveryHints.SoftRecoveryKeys; len(keys) != 0 {
+			t.Errorf("%s SoftRecoveryKeys = %v, want empty", name, keys)
+		}
+	}
+}
+
 func TestBuiltinClaudeCommandString(t *testing.T) {
 	// After migration, claude's Args is nil. CommandString() returns just "claude".
 	// Schema-managed flags come from ResolveDefaultArgs() instead.

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -194,6 +194,12 @@ func MergeProviderOverBuiltin(base, city ProviderSpec) ProviderSpec {
 		result.TitleModel = city.TitleModel
 	}
 
+	// RecoveryHints: scalar fields override only when set so cities can
+	// extend or replace per provider, while inheriting builtin defaults.
+	if city.RecoveryHints.SoftRecoveryKeys != nil {
+		result.RecoveryHints.SoftRecoveryKeys = city.RecoveryHints.SoftRecoveryKeys
+	}
+
 	// Slice fields: replace entirely when non-nil.
 	if city.Args != nil {
 		result.Args = city.Args
@@ -302,6 +308,11 @@ func specToResolved(name string, spec *ProviderSpec) *ResolvedProvider {
 		ResumeCommand:          spec.ResumeCommand,
 		SessionIDFlag:          spec.SessionIDFlag,
 		TitleModel:             spec.TitleModel,
+	}
+	// Copy RecoveryHints, deep-copying the slice to avoid aliasing.
+	if len(spec.RecoveryHints.SoftRecoveryKeys) > 0 {
+		rp.RecoveryHints.SoftRecoveryKeys = make([]string, len(spec.RecoveryHints.SoftRecoveryKeys))
+		copy(rp.RecoveryHints.SoftRecoveryKeys, spec.RecoveryHints.SoftRecoveryKeys)
 	}
 	// Deep-copy OptionsSchema to avoid aliasing the spec's slice.
 	if len(spec.OptionsSchema) > 0 {

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -839,6 +839,7 @@ func TestMergeProviderOverBuiltinFieldSync(t *testing.T) {
 		OptionsSchema:          []ProviderOption{{Key: "model"}},
 		PrintArgs:              []string{"-p"},
 		TitleModel:             "haiku",
+		RecoveryHints:          RecoveryHints{SoftRecoveryKeys: []string{"C-u", "/rewind", "Enter"}},
 	}
 
 	// Verify every field on city is non-zero (catches new fields not added to test data).


### PR DESCRIPTION
## Summary

Adds a cheap, automated first attempt to unwedge stuck agents whose conversation context is broken but whose process is fine (e.g. Claude Code 400 `tool_use` concurrency errors). Before this change, the dog ladder went `nudge → nudge → nudge → cold-restart`; the soft rung adds a ~1-second `/rewind`-style recovery that preserves session, working directory, and in-flight molecule state when it succeeds, and falls through gracefully to the existing nudge/kill ladder when it doesn't.

Motivated by a real incident where a witness session wedged on a Claude `400 tool_use concurrency` error mid-`mol-witness-patrol` and sat broken for majority of day because every recovery rung was either LLM-judgment (and the LLM was the wedged thing) or a full cold restart (overkill, loses in-flight molecule state).

This PR is the **recovery half** of a two-part failsafe. The detection half (a non-LLM stuck-agent sweep that files `pool:dog` warrants automatically) can be designed in parallel and will plug into this same warrant flow. Shipping recovery first is the right order — it means once detection lands, every detected wedge gets the cheapest possible first attempt before any cold restart.

## What changed

### Provider abstraction (`internal/config/`)

- New `RecoveryHints` struct on `ProviderSpec` / `ResolvedProvider` with a `SoftRecoveryKeys []string` field. Wired through `MergeProviderOverBuiltin` and `specToResolved` (deep-copied to avoid aliasing, parallel to how `PermissionModes` is handled).
- Claude is populated with `["C-u", "/rewind", "Enter"]`. `codex`, `gemini`, `cursor`, `copilot`, and others leave it empty so the ladder skips the soft rung and advances immediately. Adding a recovery sequence for a new provider is a one-line config edit with no Go changes.

### New CLI verb `gc session recover <session-id-or-alias>` (`cmd/gc/cmd_session_recover.go`)

- Resolves the agent's provider via the existing `resolveNudgeTarget` helper, reads `RecoveryHints.SoftRecoveryKeys`, and delivers them via the existing `runtime.Provider.SendKeys` interface (which the tmux adapter already implements; ACP/subprocess no-op gracefully).
- Function-level exit codes: `0` delivered, `1` hard error, `2` no soft hint configured. The `gc` CLI collapses RunE errors to exit `1`, so the "advance immediately" signal is **also** conveyed by a guaranteed stderr marker `no soft recovery; skipping` that molecule prompts can grep. Both no-recovery branches (nil resolved provider, empty `SoftRecoveryKeys`) emit the same marker so callers can match with one rule.

### Molecule integration (`mol-shutdown-dance.formula.toml`)

- Strike 1 (`interrogate-1`) is rewritten from a generic nudge into `gc session recover {{target}}` with a `tee /tmp/recover-{{warrant_id}}.log` capture so the dog can grep the marker.
- The `receive-warrant` step now reads the warrant's `reason` metadata and skips strike 1 entirely when `reason=wisp_stale` (soft recovery cannot revive an agent that has stopped emitting wisps for non-context reasons).
- Strikes 2 and 3 and EXECUTE are unchanged — they remain the universal fallback that works for every provider, present or future.

### Tests

- `TestBuiltinProvidersRecoveryHints` locks Claude's exact sequence and asserts non-Claude providers stay empty.
- `TestMergeProviderOverBuiltinFieldSync` test data updated; the reflection guard catches `RecoveryHints` automatically and will fail if a future field is added without merge wiring.
- Five `TestDeliverSessionRecover_*` cases against `runtime.Fake` cover happy path, no-hint skip, nil-resolved skip, not-running, and broken-provider. The skip-path tests assert the **exact** stderr substring callers grep for; renaming the marker silently breaks the dog molecule and the test catches it.

### Generated docs (regenerated via `go run ./cmd/genschema`)

- `docs/schema/city-schema.json` — `RecoveryHints` struct + `recovery_hints` field on `ProviderSpec`
- `docs/reference/cli.md` — `gc session recover` help text
- `docs/reference/config.md` — `RecoveryHints` struct documentation

## Test plan

- [x] `make check` — clean (golangci-lint 0 issues, vet clean, targeted tests pass)
- [x] `make check-docs` — clean
- [x] `go test ./internal/config/` — `TestBuiltinProvidersRecoveryHints` + `TestMergeProviderOverBuiltinFieldSync` pass
- [x] `go test ./cmd/gc/ -run TestDeliverSessionRecover` — all 5 cases pass
- [x] `go test ./test/docsync/` — `TestSchemaFreshness` passes after `go run ./cmd/genschema`

### Manual verification (live, on macOS, claude-code 2.x)

- [x] `gc session recover --help` registers with the documented help text
- [x] `gc session recover <unknown>` errors with `session not found`
- [x] **Live wedged Claude witness:** `gc session recover wt-yan` delivered `[C-u /rewind Enter]` and Claude Code opened the native rewind dialog
- [x] **Provider with no `RecoveryHints`:** `gc session recover` emits stderr marker `no soft recovery; skipping`, sends nothing, pane unchanged
- [x] **Full molecule end-to-end via the dog pool:** `gc sling dog mol-shutdown-dance --formula --var target=wt-yan ...` instantiated the wisp; the dog autonomously claimed it, ran step 1 (validate target), closed it, claimed step 2, **invoked `gc session recover wt-yan` per the edited formula**, observed the result, and correctly escalated to strike 2 when `/rewind` couldn't fix the witness's specific wedge state (Dolt connection failure, not a context error) — exactly the graceful fall-through the ladder is designed for.

### Bug found and fixed during live test

The `gc` CLI collapses every RunE error to exit code `1`, so the documented exit-`2` ("no soft rung available, advance immediately") was invisible at the CLI boundary. Fixed by switching the molecule contract from exit-code to a guaranteed stderr marker (`no soft recovery; skipping`), unifying it across both skip branches (nil resolved provider, empty `SoftRecoveryKeys`), and locking the marker substring in via the unit tests.

## Scope of value

**Solves completely:** the `/rewind`-curable class of wedges (400 `tool_use` concurrency, malformed `tool_result` blocks, mid-tool rate-limit overruns that left a `tool_use` without a matching `tool_result`, some MCP transient errors that get stuck in the conversation). For these, the witness recovers in ~60s with no work lost.

**Strictly improves but does not fully solve:** the "requires restart" class. Some restart-needed wedges are actually context-broken wedges that would have been healed by `/rewind` if anyone tried — this PR converts those from "cold restart, lose work" to "soft recover, keep work." Genuine environmental wedges (Dolt down, MCP server crashed, NFS hung) still need restart, and the unchanged strikes 2/3 handle them.

**Deliberately does not solve:** the "no automated detection" half. That's the upcoming sweep that calls `Tmux.CheckSessionHealth` + checks wisp age and files `pool:dog` warrants automatically. This PR makes recovery cheaper *once detection happens*; it doesn't fix detection itself. The two halves compose cleanly.

---

## Update: strike-order fix (commit `2a316771`)

The original feat commit replaced strike 1's alive-check nudge with the new `gc session recover` call, jumping straight from "warrant filed" to "mutate the agent's conversation state." The live end-to-end test caught two problems with that ordering:

1. **`/rewind` on a healthy-but-idle Claude session opens a modal dialog** ("Rewind / Restore the code and/or conversation… / Enter to continue · Esc to exit"). The agent is now stuck at a UI prompt waiting for keyboard input, and the rest of the ladder (which sends text nudges, not bare keystrokes) cannot dismiss it. The session is *more* wedged than before strike 1 ran. Directly observed during the live test on 2026-04-08.
2. **False-positive recovery is a strictly worse failure mode than slow recovery.** A failsafe whose job is to recover stuck agents must never harm healthy ones. A nudge has zero side effects on a healthy agent (it reads the message on its next turn and replies); `/rewind` has the rewind-dialog side effect documented above. Cheapest *test* should always run before any cheapest *action*.

**Fix:** restore `interrogate-1` to the original alive-check-via-nudge behaviour, and insert a new `soft-recover` step between `interrogate-1` and `interrogate-2`. The new step contains exactly what was previously in our edited `interrogate-1` (`gc session recover`, `wisp_stale` skip, stderr-marker contract, 60s wait, peek-and-judge), but only runs when `interrogate-1`'s alive check failed to elicit a response — meaning we already know recovery is actually needed and won't be mutating a healthy agent's state.

**State machine:**

```
before: RECEIVE → SOFT-RECOVER  → INTERROGATE-2 → INTERROGATE-3 → EXECUTE
after:  RECEIVE → INTERROGATE-1 → SOFT-RECOVER  → INTERROGATE-2 → INTERROGATE-3 → EXECUTE
```

**Cumulative timeout budget** grows from 420s (60+120+240) to 480s (60+60+120+240). One extra minute on full-fail scenarios is the price of not corrupting healthy agents.

**Drive-by fix in the same commit:** `vars.requester` had both `required = true` and `default = "deacon"`, which the formula validator rejects with `vars.requester: cannot have both required:true and default`. This prevented `gc sling dog mol-shutdown-dance --formula ...` from instantiating the molecule at all (caught when wiring up the live end-to-end test). Removed `required = true` so the default applies. The formula now loads via sling and the `examples/gastown` test confirms it.

The PR's actual value — `gc session recover`, the `RecoveryHints` provider table, the stderr-marker contract, the unit tests, the schema regen — is unchanged. Only the **ordering inside the molecule** moves and one validation bug is fixed.
