### PR TITLE
fix: copy cross-rig bead content into shim on gc sling (gc-tvu)

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -323,6 +323,23 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	store := beads.NewBdStore(storeDir, beads.ExecCommandRunnerWithEnv(storeEnv))
 	storeRef := workflowStoreRefForDir(storeDir, cityPath, cfg.Workspace.Name, cfg)
 
+	// Cross-rig copy: if the input is a bead ID that lives in another rig
+	// store (HQ or a sibling rig), copy its content into the local store
+	// before routing. Without this, the polecat in the target rig would see
+	// either an empty stub (auto-created from the bare ID) or fail to find
+	// the bead at all. The helper propagates title, description, type,
+	// priority, and labels so the polecat sees actionable work, and stamps
+	// gc.original_bead_id metadata so callers can trace back to the source.
+	if !isFormula && !dryRun && !beadExistsInStore(store, beadOrFormula) {
+		newID, ok, copyErr := copyCrossRigBead(beadOrFormula, store, cfg, cityPath, storeDir, stdout, stderr)
+		if copyErr != nil {
+			return 1
+		}
+		if ok {
+			beadOrFormula = newID
+		}
+	}
+
 	// Inline text mode: if the argument doesn't look like a bead ID
 	// (and we're not in formula mode), create a task bead from the text.
 	// Skip during dry-run to avoid side effects.
@@ -456,6 +473,13 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier) int {
 	if !opts.IsFormula && !opts.Force {
 		result := checkBeadState(querier, opts.BeadOrFormula, a)
 		if result.Idempotent {
+			if result.RepairMeta && deps.Store != nil {
+				if err := deps.Store.SetMetadata(opts.BeadOrFormula, "gc.routed_to", a.QualifiedName()); err != nil {
+					fmt.Fprintf(deps.Stderr, "gc sling: repairing gc.routed_to on %s: %v\n", opts.BeadOrFormula, err) //nolint:errcheck // best-effort
+				} else {
+					fmt.Fprintf(deps.Stdout, "Bead %s had pool label but missing gc.routed_to — repaired metadata\n", opts.BeadOrFormula) //nolint:errcheck // best-effort
+				}
+			}
 			if opts.DryRun {
 				return dryRunSingle(opts, deps, querier)
 			}
@@ -748,6 +772,13 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier) int 
 		if !opts.Force {
 			result := checkBeadState(querier, child.ID, a)
 			if result.Idempotent {
+				if result.RepairMeta && deps.Store != nil {
+					if err := deps.Store.SetMetadata(child.ID, "gc.routed_to", a.QualifiedName()); err != nil {
+						fmt.Fprintf(deps.Stderr, "gc sling: repairing gc.routed_to on %s: %v\n", child.ID, err) //nolint:errcheck // best-effort
+					} else {
+						fmt.Fprintf(deps.Stdout, "  Bead %s had pool label but missing gc.routed_to — repaired metadata\n", child.ID) //nolint:errcheck // best-effort
+					}
+				}
 				fmt.Fprintf(deps.Stdout, "  Skipped %s — already routed to %s\n", child.ID, a.QualifiedName()) //nolint:errcheck // best-effort
 				idempotent++
 				continue
@@ -1431,6 +1462,7 @@ func targetType(a *config.Agent) string {
 // beadCheckResult captures the outcome of a pre-flight bead state check.
 type beadCheckResult struct {
 	Idempotent bool     // bead already routed to the same target
+	RepairMeta bool     // pool label present but gc.routed_to metadata missing — caller should set it
 	Warnings   []string // warnings about existing routing to different targets
 }
 
@@ -1501,11 +1533,14 @@ func checkBeadState(q BeadQuerier, beadID string, a config.Agent) beadCheckResul
 	// Multi-session targets: pool labels are a legacy fallback only when
 	// gc.routed_to is absent. If gc.routed_to is set (even to a different
 	// target), it is authoritative — a stale pool label must not short-circuit.
+	// When the pool label matches but gc.routed_to is missing, signal the
+	// caller to repair the metadata so the controller's scale_check can
+	// discover the bead.
 	if strings.TrimSpace(b.Metadata["gc.routed_to"]) == "" {
 		poolLabel := "pool:" + target
 		for _, l := range b.Labels {
 			if l == poolLabel {
-				return beadCheckResult{Idempotent: true}
+				return beadCheckResult{Idempotent: true, RepairMeta: true}
 			}
 		}
 	}
@@ -1923,14 +1958,6 @@ func isCustomSlingQuery(a config.Agent) bool {
 	return a.SlingQuery != ""
 }
 
-// looksLikeBeadID reports whether s matches the bead ID pattern: an
-// alphabetic-led alphanumeric prefix, a dash, and a short alphanumeric
-// suffix of 1-8 chars (e.g. "BL-42", "mp-1j1", "gc-56nqn",
-// "gc-r5sr6bm"). Short suffixes (1-4 chars) are accepted
-// unconditionally. Longer suffixes (5-8 chars) must contain at least
-// one digit to distinguish base36 hashes from English words like
-// "hello-world". Strings with spaces or multiple dashes (like
-// "code-review") are treated as inline text for ad-hoc bead creation.
 // beadExistsInStore returns true if the given ID resolves to a bead in the store.
 // Used as a fallback when looksLikeBeadID returns false for valid hierarchical
 // IDs (e.g., "ProjectWrenUnity-0fze.1").
@@ -1939,6 +1966,14 @@ func beadExistsInStore(store beads.Store, id string) bool {
 	return err == nil
 }
 
+// looksLikeBeadID reports whether s matches the bead ID pattern: an
+// alphabetic-led alphanumeric prefix, a dash, and a short alphanumeric
+// suffix of 1-8 chars (e.g. "BL-42", "mp-1j1", "gc-56nqn",
+// "gc-r5sr6bm"). Short suffixes (1-4 chars) are accepted
+// unconditionally. Longer suffixes (5-8 chars) must contain at least
+// one digit to distinguish base36 hashes from English words like
+// "hello-world". Strings with spaces or multiple dashes (like
+// "code-review") are treated as inline text for ad-hoc bead creation.
 func looksLikeBeadID(s string) bool {
 	if strings.ContainsAny(s, " \t\n") {
 		return false
@@ -2037,4 +2072,119 @@ func checkCrossRig(beadID string, a config.Agent, cfg *config.City) string {
 	}
 	return fmt.Sprintf("gc sling: cross-rig routing blocked — bead %s (prefix %q) targets %s (rig prefix %q); use --force to override",
 		beadID, bp, a.QualifiedName(), rp)
+}
+
+// crossRigBeadLookup is the function used by cmdSling to find a bead in
+// non-current stores. Replaceable in tests so we can exercise the cross-rig
+// copy logic without real bd subprocesses.
+var crossRigBeadLookup = lookupBeadInOtherStores
+
+// copyCrossRigBead inspects beadID and, if it lives in another rig store,
+// copies its content into localStore. Returns the new local bead ID, a
+// boolean indicating whether a copy occurred, and an error if the copy
+// itself failed (the caller should treat this as fatal). When the bead is
+// not found in any sibling store, returns ("", false, nil) so the caller
+// can fall through to inline-text creation. The function is broken out
+// from cmdSling so it can be exercised with MemStores in unit tests.
+func copyCrossRigBead(
+	beadID string,
+	localStore beads.Store,
+	cfg *config.City,
+	cityPath, currentDir string,
+	stdout, stderr io.Writer,
+) (string, bool, error) {
+	origBead, origDir, found := crossRigBeadLookup(cfg, cityPath, currentDir, beadID)
+	if !found {
+		return "", false, nil
+	}
+	copy := beads.Bead{
+		Title:       origBead.Title,
+		Description: formatCrossRigCopyDescription(origBead.Description, beadID, origDir),
+		Type:        origBead.Type,
+		Priority:    origBead.Priority,
+		Labels:      origBead.Labels,
+	}
+	created, err := localStore.Create(copy)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc sling: copying cross-rig bead %s: %v\n", beadID, err) //nolint:errcheck // best-effort stderr
+		return "", false, err
+	}
+	// Best-effort: link back to the original. Non-fatal if it fails; the
+	// copy still has actionable content.
+	if metaErr := localStore.SetMetadata(created.ID, "gc.original_bead_id", beadID); metaErr != nil {
+		fmt.Fprintf(stderr, "gc sling: setting gc.original_bead_id on %s: %v\n", created.ID, metaErr) //nolint:errcheck // best-effort
+	}
+	fmt.Fprintf(stdout, "Copied %s → %s — %q\n", beadID, created.ID, origBead.Title) //nolint:errcheck // best-effort stdout
+	return created.ID, true, nil
+}
+
+// lookupBeadInOtherStores searches for a bead ID in stores other than
+// currentDir. It checks the rig store matching the bead's prefix and the
+// city HQ store when the prefix matches the workspace prefix. Returns the
+// bead, the directory it was found in, and true on success. Returns
+// (zero, "", false) when the bead can't be located in any sibling store.
+//
+// This powers the cross-rig sling fix: when an agent in rig A slings a
+// bead that lives in rig B (or HQ), the bead's content is copied into A
+// instead of an empty stub being auto-created.
+func lookupBeadInOtherStores(cfg *config.City, cityPath, currentDir, beadID string) (beads.Bead, string, bool) {
+	if cfg == nil {
+		return beads.Bead{}, "", false
+	}
+	bp := beadPrefix(beadID)
+	if bp == "" {
+		return beads.Bead{}, "", false
+	}
+
+	var candidates []string
+
+	// Try the rig matching the bead prefix.
+	if rig, found := findRigByPrefix(cfg, bp); found {
+		rigPath := rig.Path
+		if !filepath.IsAbs(rigPath) {
+			rigPath = filepath.Join(cityPath, rigPath)
+		}
+		if !samePath(rigPath, currentDir) {
+			candidates = append(candidates, rigPath)
+		}
+	}
+
+	// Try the city HQ store if the bead prefix matches the workspace prefix.
+	if strings.EqualFold(bp, config.EffectiveHQPrefix(cfg)) {
+		if !samePath(cityPath, currentDir) {
+			candidates = append(candidates, cityPath)
+		}
+	}
+
+	for _, dir := range candidates {
+		var env map[string]string
+		if samePath(dir, cityPath) {
+			env = bdRuntimeEnv(cityPath)
+		} else {
+			env = bdRuntimeEnvForRig(cityPath, cfg, dir)
+		}
+		store := beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(env))
+		bead, err := store.Get(beadID)
+		if err == nil {
+			return bead, dir, true
+		}
+	}
+	return beads.Bead{}, "", false
+}
+
+// formatCrossRigCopyDescription builds the description body for a cross-rig
+// copy: a "> Original: <id> (from <rig>)" header followed by the original
+// description (or just the header if the original is empty). The header
+// makes it obvious to the polecat (and to humans browsing the bead) where
+// the work originated.
+func formatCrossRigCopyDescription(originalDescription, originalID, originalDir string) string {
+	label := filepath.Base(filepath.Clean(originalDir))
+	if label == "" || label == "." || label == "/" {
+		label = originalDir
+	}
+	header := fmt.Sprintf("> **Original**: %s (from %s)", originalID, label)
+	if strings.TrimSpace(originalDescription) == "" {
+		return header
+	}
+	return header + "\n\n" + originalDescription
 }

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2917,6 +2917,63 @@ func TestCheckBeadStateDifferentPoolLabel(t *testing.T) {
 	}
 }
 
+func TestCheckBeadStatePoolLabelWithoutMetadataRepairMeta(t *testing.T) {
+	// Bug fix: pool label matching target but missing gc.routed_to metadata
+	// should be idempotent (skip re-routing) but signal RepairMeta so the
+	// caller sets gc.routed_to for the controller's scale_check.
+	q := &fakeQuerier{bead: beads.Bead{ID: "BL-42", Labels: []string{"pool:hw/polecat"}}}
+	a := config.Agent{Name: "polecat", Dir: "hw", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3)}
+
+	result := checkBeadState(q, "BL-42", a)
+	if !result.Idempotent {
+		t.Error("expected Idempotent=true when pool label matches (bead is already routed)")
+	}
+	if !result.RepairMeta {
+		t.Error("expected RepairMeta=true when pool label matches but gc.routed_to is missing")
+	}
+}
+
+func TestDoSlingPoolLabelMismatchRepairsMetadata(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "polecat", Dir: "hw", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3)}
+	// Pool label present but gc.routed_to metadata missing — the mismatch scenario.
+	q := &fakeQuerier{bead: beads.Bead{ID: "BL-42", Labels: []string{"pool:hw/polecat"}}}
+
+	deps, stdout, _ := testDeps(cfg, sp, runner.run)
+	// Seed the store with the bead so SetMetadata can find it.
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "BL-42", Title: "Work", Type: "task", Status: "open", Labels: []string{"pool:hw/polecat"}},
+	}, nil)
+	opts := testOpts(a, "BL-42")
+	code := doSling(opts, deps, q)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0", code)
+	}
+	// Should be idempotent — no routing command executed.
+	if len(runner.calls) != 0 {
+		t.Errorf("mismatch repair should not re-route; got %d calls: %v", len(runner.calls), runner.calls)
+	}
+	// Should report the repair.
+	if !strings.Contains(stdout.String(), "repaired metadata") {
+		t.Errorf("stdout = %q, want repair message", stdout.String())
+	}
+	// Should still report idempotent skip.
+	if !strings.Contains(stdout.String(), "skipping (idempotent)") {
+		t.Errorf("stdout = %q, want idempotent message", stdout.String())
+	}
+	// Verify gc.routed_to was actually set on the store.
+	repaired, err := deps.Store.Get("BL-42")
+	if err != nil {
+		t.Fatalf("store.Get after repair: %v", err)
+	}
+	if got := repaired.Metadata["gc.routed_to"]; got != "hw/polecat" {
+		t.Errorf("gc.routed_to = %q after repair, want %q", got, "hw/polecat")
+	}
+}
+
 func TestDoSlingIdempotentSkipsRouting(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
@@ -4112,6 +4169,204 @@ func TestBeadExistsInStoreFallback(t *testing.T) {
 	// Non-existent bead should return false.
 	if beadExistsInStore(store, "nonexistent-xyz") {
 		t.Error("beadExistsInStore should return false for missing bead")
+	}
+}
+
+func TestFormatCrossRigCopyDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		original string
+		id       string
+		dir      string
+		want     string
+	}{
+		{
+			name:     "with body",
+			original: "Symptom: foo\nFix: bar",
+			id:       "lx-qgn287",
+			dir:      "/home/zook/loomington",
+			want:     "> **Original**: lx-qgn287 (from loomington)\n\nSymptom: foo\nFix: bar",
+		},
+		{
+			name:     "empty body",
+			original: "",
+			id:       "lx-abc",
+			dir:      "/home/zook/loomington",
+			want:     "> **Original**: lx-abc (from loomington)",
+		},
+		{
+			name:     "whitespace-only body",
+			original: "   \n  ",
+			id:       "lx-abc",
+			dir:      "/home/zook/loomington",
+			want:     "> **Original**: lx-abc (from loomington)",
+		},
+		{
+			name:     "rig path",
+			original: "real content",
+			id:       "sl-w2h",
+			dir:      "/home/zook/loomington/rigs/signal-loom",
+			want:     "> **Original**: sl-w2h (from signal-loom)\n\nreal content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCrossRigCopyDescription(tt.original, tt.id, tt.dir)
+			if got != tt.want {
+				t.Errorf("formatCrossRigCopyDescription() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookupBeadInOtherStores(t *testing.T) {
+	t.Run("nil cfg returns false", func(t *testing.T) {
+		_, _, found := lookupBeadInOtherStores(nil, "/city", "/city/rigs/gc", "lx-abc")
+		if found {
+			t.Error("expected found=false for nil cfg")
+		}
+	})
+
+	t.Run("no prefix returns false", func(t *testing.T) {
+		cfg := &config.City{Workspace: config.Workspace{Name: "loomington", Prefix: "lx"}}
+		_, _, found := lookupBeadInOtherStores(cfg, "/city", "/city/rigs/gc", "noprefix")
+		if found {
+			t.Error("expected found=false for input with no dash prefix")
+		}
+	})
+
+	// Note: deeper coverage of the actual store lookup requires real bd; the
+	// function is otherwise exercised end-to-end via copyCrossRigBead tests
+	// that use the crossRigBeadLookup override hook.
+}
+
+func TestCopyCrossRigBeadCopiesContent(t *testing.T) {
+	// Stub the lookup to return a known cross-rig bead.
+	prio := 2
+	original := beads.Bead{
+		ID:          "lx-qgn287",
+		Title:       "Real bug needing fix",
+		Description: "Symptom and reproduction details",
+		Type:        "bug",
+		Priority:    &prio,
+		Labels:      []string{"bug", "p2"},
+	}
+	old := crossRigBeadLookup
+	crossRigBeadLookup = func(cfg *config.City, cityPath, currentDir, beadID string) (beads.Bead, string, bool) {
+		if beadID == "lx-qgn287" {
+			return original, "/home/zook/loomington", true
+		}
+		return beads.Bead{}, "", false
+	}
+	defer func() { crossRigBeadLookup = old }()
+
+	store := beads.NewMemStore()
+	cfg := &config.City{Workspace: config.Workspace{Name: "loomington", Prefix: "lx"}}
+	var stdout, stderr bytes.Buffer
+
+	newID, ok, err := copyCrossRigBead("lx-qgn287", store, cfg, "/home/zook/loomington", "/home/zook/loomington/rigs/gascity", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("copyCrossRigBead returned error: %v; stderr: %s", err, stderr.String())
+	}
+	if !ok {
+		t.Fatal("copyCrossRigBead returned ok=false, want true")
+	}
+	if newID == "" {
+		t.Fatal("copyCrossRigBead returned empty newID")
+	}
+	if newID == "lx-qgn287" {
+		t.Errorf("copyCrossRigBead returned source ID %q; expected a new local ID", newID)
+	}
+
+	// Verify the copy in the store has the propagated content.
+	got, err := store.Get(newID)
+	if err != nil {
+		t.Fatalf("getting copied bead: %v", err)
+	}
+	if got.Title != "Real bug needing fix" {
+		t.Errorf("copy.Title = %q, want %q", got.Title, original.Title)
+	}
+	if !strings.Contains(got.Description, "Symptom and reproduction details") {
+		t.Errorf("copy.Description = %q, want to contain original description", got.Description)
+	}
+	if !strings.Contains(got.Description, "**Original**: lx-qgn287") {
+		t.Errorf("copy.Description = %q, want to contain Original header", got.Description)
+	}
+	if got.Type != "bug" {
+		t.Errorf("copy.Type = %q, want bug", got.Type)
+	}
+	if got.Priority == nil || *got.Priority != 2 {
+		t.Errorf("copy.Priority = %v, want 2", got.Priority)
+	}
+	if len(got.Labels) != 2 {
+		t.Errorf("copy.Labels = %v, want [bug p2]", got.Labels)
+	}
+	// Verify the back-link metadata.
+	if got.Metadata["gc.original_bead_id"] != "lx-qgn287" {
+		t.Errorf("copy metadata gc.original_bead_id = %q, want lx-qgn287", got.Metadata["gc.original_bead_id"])
+	}
+	// Verify the user-facing message.
+	if !strings.Contains(stdout.String(), "Copied lx-qgn287") {
+		t.Errorf("stdout = %q, want to contain 'Copied lx-qgn287'", stdout.String())
+	}
+}
+
+func TestCopyCrossRigBeadNotFound(t *testing.T) {
+	// Stub returns not-found for everything.
+	old := crossRigBeadLookup
+	crossRigBeadLookup = func(cfg *config.City, cityPath, currentDir, beadID string) (beads.Bead, string, bool) {
+		return beads.Bead{}, "", false
+	}
+	defer func() { crossRigBeadLookup = old }()
+
+	store := beads.NewMemStore()
+	cfg := &config.City{Workspace: config.Workspace{Name: "loomington", Prefix: "lx"}}
+	var stdout, stderr bytes.Buffer
+
+	newID, ok, err := copyCrossRigBead("write a README", store, cfg, "/city", "/city/rigs/gc", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("copyCrossRigBead returned error: %v", err)
+	}
+	if ok {
+		t.Errorf("copyCrossRigBead ok=true for not-found, want false")
+	}
+	if newID != "" {
+		t.Errorf("copyCrossRigBead newID=%q for not-found, want empty", newID)
+	}
+	// Nothing should have been printed when no copy was made.
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty when no copy occurred", stdout.String())
+	}
+}
+
+func TestCopyCrossRigBeadEmptyDescription(t *testing.T) {
+	// Original bead has no description; copy still works and the header
+	// stands alone (no trailing blank line or stray separator).
+	original := beads.Bead{
+		ID:    "lx-qfq5r1",
+		Title: "Just a title",
+		Type:  "task",
+	}
+	old := crossRigBeadLookup
+	crossRigBeadLookup = func(cfg *config.City, cityPath, currentDir, beadID string) (beads.Bead, string, bool) {
+		return original, "/home/zook/loomington", true
+	}
+	defer func() { crossRigBeadLookup = old }()
+
+	store := beads.NewMemStore()
+	cfg := &config.City{Workspace: config.Workspace{Name: "loomington", Prefix: "lx"}}
+	var stdout, stderr bytes.Buffer
+
+	newID, ok, err := copyCrossRigBead("lx-qfq5r1", store, cfg, "/city", "/city/rigs/gc", &stdout, &stderr)
+	if err != nil || !ok {
+		t.Fatalf("copyCrossRigBead failed: ok=%v err=%v stderr=%s", ok, err, stderr.String())
+	}
+	got, err := store.Get(newID)
+	if err != nil {
+		t.Fatalf("getting copy: %v", err)
+	}
+	if got.Description != "> **Original**: lx-qfq5r1 (from loomington)" {
+		t.Errorf("description = %q, want header-only", got.Description)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes gc-tvu: cross-rig `gc sling` was creating empty shim beads (title=original-id, no description, no labels), making cross-rig dispatch effectively broken — target polecats would refuse the unworkable shims and either drain or escalate.

## Root cause

`cmdSling` had no path to copy content from the source rig's bead store into the local shim. The shim ended up with only `metadata.gc.routed_to` and the original ID as the title.

## Fix

Adds `copyCrossRigBead`, called from `cmdSling` before the inline-text fallback, that:

1. **Looks up the bead** in sibling rig stores (via the new `lookupBeadInOtherStores` helper, wired through a `crossRigBeadLookup` package var so unit tests can stub it).
2. **Creates a local copy** propagating title, description, type, priority, and labels.
3. **Prefixes the description** with `> **Original**: <id> (from <rig>)` so assignees know where the work came from. `formatCrossRigCopyDescription` keeps the header alone when the source description is empty.
4. **Stamps `metadata.gc.original_bead_id`** on the copy for backlink/traceability.
5. **Replaces the input ID** with the new local ID before continuing into the existing routing pipeline.

Also adds a small repair path on the existing idempotency check: when a bead has the matching `pool:<rig>/<role>` label but is missing `gc.routed_to` metadata, `checkBeadState` now sets `RepairMeta=true` and `doSling`/`doSlingBatch` write the metadata in place. This unblocks the controller's `scale_check`, which uses `gc.routed_to` and ignores the legacy pool labels.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] All new tests pass:
  - `TestCheckBeadStatePoolLabelWithoutMetadataRepairMeta`
  - `TestDoSlingPoolLabelMismatchRepairsMetadata`
  - `TestFormatCrossRigCopyDescription` (with body / empty / whitespace / rig path)
  - `TestLookupBeadInOtherStores` (nil cfg / no prefix)
  - `TestCopyCrossRigBeadCopiesContent`
  - `TestCopyCrossRigBeadNotFound`
  - `TestCopyCrossRigBeadEmptyDescription`

Closes gc-tvu.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>