### PR TITLE
fix(mail): wrap gc-mail-mcp-agent-mail in main() so wrappers can source it

### DIFF
--- a/contrib/mail-scripts/gc-mail-mcp-agent-mail
+++ b/contrib/mail-scripts/gc-mail-mcp-agent-mail
@@ -14,13 +14,15 @@
 #   GC_MCP_MAIL_PROJECT — project human_key for mcp_agent_mail (default: pwd)
 #
 # Dependencies: curl, jq, bash
-set -euo pipefail
 
 # --- Configuration ---
-
-MCP_URL="${GC_MCP_MAIL_URL:-http://127.0.0.1:8765}"
-MCP_TOKEN="${GC_MCP_MAIL_TOKEN:-}"
-PROJECT="${GC_MCP_MAIL_PROJECT:-$(pwd)}"
+#
+# _init_config reads environment variables and creates cache directories.
+# Deferred to a function so wrappers that source this script can set env
+# vars (GC_CITY, GC_MCP_MAIL_PROJECT, etc.) *after* sourcing and before
+# calling main(). Top-level execution calls _init_config at the start of
+# main(); wrappers may call it explicitly if they need cache paths before
+# invoking main().
 
 # Cache directories for name mappings and message state.
 #
@@ -53,14 +55,19 @@ PROJECT="${GC_MCP_MAIL_PROJECT:-$(pwd)}"
 # they reference different mcp_agent_mail projects. The controller is
 # responsible for setting both env vars consistently on every pod it
 # spawns (see contrib/session-scripts/gc-session-k8s).
-PROJECT_HASH="$(printf '%s' "$PROJECT" | md5sum | cut -d' ' -f1)"
-CACHE_DIR="/tmp/gc-mcp-mail-cache/${PROJECT_HASH}"
-if [ -n "${GC_CITY:-}" ]; then
-  NAME_MAP_DIR="${GC_CITY}/.gc/mail-cache/${PROJECT_HASH}/name-map"
-else
-  NAME_MAP_DIR="${CACHE_DIR}/name-map"
-fi
-mkdir -p "$NAME_MAP_DIR" "$CACHE_DIR/msg-agent" "$CACHE_DIR/msg-read" "$CACHE_DIR/msg-thread"
+_init_config() {
+  MCP_URL="${GC_MCP_MAIL_URL:-http://127.0.0.1:8765}"
+  MCP_TOKEN="${GC_MCP_MAIL_TOKEN:-}"
+  PROJECT="${GC_MCP_MAIL_PROJECT:-$(pwd)}"
+  PROJECT_HASH="$(printf '%s' "$PROJECT" | md5sum | cut -d' ' -f1)"
+  CACHE_DIR="/tmp/gc-mcp-mail-cache/${PROJECT_HASH}"
+  if [ -n "${GC_CITY:-}" ]; then
+    NAME_MAP_DIR="${GC_CITY}/.gc/mail-cache/${PROJECT_HASH}/name-map"
+  else
+    NAME_MAP_DIR="${CACHE_DIR}/name-map"
+  fi
+  mkdir -p "$NAME_MAP_DIR" "$CACHE_DIR/msg-agent" "$CACHE_DIR/msg-read" "$CACHE_DIR/msg-thread"
+}
 
 # --- Name mapping ---
 
@@ -240,6 +247,8 @@ get_cached_thread_id() {
 # override name-mapping functions before operations run. The BASH_SOURCE
 # guard at the bottom keeps sourcing from executing any case branches.
 main() {
+set -euo pipefail
+_init_config
 op="${1:?usage: gc-mail-mcp-agent-mail <operation> [args...]}"
 shift
 

--- a/contrib/mail-scripts/gc-mail-mcp-agent-mail
+++ b/contrib/mail-scripts/gc-mail-mcp-agent-mail
@@ -16,9 +16,6 @@
 # Dependencies: curl, jq, bash
 set -euo pipefail
 
-op="${1:?usage: gc-mail-mcp-agent-mail <operation> [args...]}"
-shift
-
 # --- Configuration ---
 
 MCP_URL="${GC_MCP_MAIL_URL:-http://127.0.0.1:8765}"
@@ -238,6 +235,13 @@ get_cached_thread_id() {
 }
 
 # --- Operations ---
+
+# main wraps the case statement so wrappers can source this script and
+# override name-mapping functions before operations run. The BASH_SOURCE
+# guard at the bottom keeps sourcing from executing any case branches.
+main() {
+op="${1:?usage: gc-mail-mcp-agent-mail <operation> [args...]}"
+shift
 
 case "$op" in
   ensure-running)
@@ -779,3 +783,9 @@ case "$op" in
     exit 2  # Unknown operation — forward compatible
     ;;
 esac
+}
+
+# Run main only when executed directly, not when sourced by a wrapper.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/internal/mail/exec/mcp_conformance_test.go
+++ b/internal/mail/exec/mcp_conformance_test.go
@@ -87,6 +87,9 @@ func TestMCPMailBridgeSourceable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sourcing script failed: %v\noutput: %s", err, out)
 	}
+	if len(out) > 0 {
+		t.Errorf("sourcing script produced unexpected output: %s", out)
+	}
 }
 
 // TestMCPMailCrossPodNameResolution verifies that when GC_CITY is set,

--- a/internal/mail/exec/mcp_conformance_test.go
+++ b/internal/mail/exec/mcp_conformance_test.go
@@ -58,6 +58,37 @@ func TestMCPMailConformance(t *testing.T) {
 	})
 }
 
+// TestMCPMailBridgeSourceable verifies the bridge script is safely
+// sourceable without errors and exposes main() plus the name-mapping
+// functions that wrappers rely on. Wrappers like the cross-project
+// contacts wrapper source the bridge to override specific functions
+// before main() runs; this test is a regression guard against the
+// bridge reverting to top-level operation parsing that would break
+// sourcing.
+func TestMCPMailBridgeSourceable(t *testing.T) {
+	if _, err := osexec.LookPath("bash"); err != nil {
+		t.Skip("bash not on PATH")
+	}
+	scriptPath, err := findMCPScript()
+	if err != nil {
+		t.Skipf("MCP mail script not found: %v", err)
+	}
+	// Source the script with no positional parameters, then assert the
+	// expected functions exist. A sourced bridge must NOT execute any
+	// case branches at source time.
+	check := `source "$1" && ` +
+		`declare -f main >/dev/null && ` +
+		`declare -f gc_to_mcp_name >/dev/null && ` +
+		`declare -f mcp_to_gc_name >/dev/null && ` +
+		`declare -f ensure_agent >/dev/null && ` +
+		`declare -f build_name_map_json >/dev/null`
+	cmd := osexec.Command("bash", "-c", check, "bash", scriptPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sourcing script failed: %v\noutput: %s", err, out)
+	}
+}
+
 // TestMCPMailCrossPodNameResolution verifies that when GC_CITY is set,
 // two independent provider instances (simulating separate K8s pods) share
 // the name cache via the city directory, allowing the receiver to resolve


### PR DESCRIPTION
## Summary

`contrib/mail-scripts/gc-mail-mcp-agent-mail` parses its operation arg
and runs its `case "$op"` block at top level. Wrappers that decorate
the bridge — for example a cross-project contacts wrapper that
overrides `gc_to_mcp_name` / `mcp_to_gc_name` / `ensure_agent` /
`build_name_map_json` — have to source the bridge so the overrides
become visible. Today sourcing the bridge fires the unset-param check
on line 19 and exits the caller with status 1, so:

- The wrapper's overrides never get installed.
- Operations that would otherwise produce output (`inbox`,
  `mark-read`) silently fail when invoked through the wrapper.
- Cross-project contact routing via `GC_MCP_MAIL_CONTACTS` is
  silently ignored.

Wrap the operation parsing and case statement in a `main()` function
and add a `BASH_SOURCE` guard so the script only runs work when
invoked directly. Direct invocation (the `exec:` provider contract)
is unchanged — same usage error on no args, same exit-2 on unknown
ops. Sourcing now defines `main()` plus the overridable name-mapping
functions without executing any case branches, which is what the
wrappers have always assumed.

A regression test in `internal/mail/exec/mcp_conformance_test.go`
sources the script in a fresh shell and asserts the expected
functions exist. The existing `TestMCPMailConformance` Go suite (32
subtests) and the cross-pod / project isolation tests still pass
unchanged because the exec provider executes the script as a
subprocess rather than sourcing it.

## Test plan

- `go test ./internal/mail/exec/` — all green, including the new
  `TestMCPMailBridgeSourceable`.
- Direct invocation: `gc-mail-mcp-agent-mail` (no args) still exits
  with the usage error; `gc-mail-mcp-agent-mail bogus-op` still
  exits 2.
- Verified on a homelab pod running the deployed image: sourcing
  `/bin/gc-mail-mcp-agent-mail` no longer errors, and a downstream
  cross-project contacts wrapper that sources the bridge installs
  its `gc_to_mcp_name` override successfully (`testalias` →
  `CoralPond@/homelab` instead of falling back to the hashed local
  name).