### PR TITLE
fix: always evaluate step conditions with formula defaults (#477)

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -81,8 +81,8 @@ func newFormulaShowCmd(stdout, _ io.Writer) *cobra.Command {
 		Short: "Show a compiled formula recipe",
 		Long: `Compile and display a formula recipe.
 
-By default, shows the recipe with {{variable}} placeholders intact.
-Use --var to substitute variables and preview the resolved output.
+Steps with conditions are filtered using formula-declared variable defaults.
+Use --var to override defaults and preview with different values.
 
 Examples:
   gc formula show mol-feature
@@ -100,12 +100,7 @@ Examples:
 				}
 			}
 
-			var compileVars map[string]string
-			if len(vars) > 0 {
-				compileVars = vars
-			}
-
-			recipe, err := formula.Compile(cmd.Context(), name, cityFormulaSearchPaths(), compileVars)
+			recipe, err := formula.Compile(cmd.Context(), name, cityFormulaSearchPaths(), vars)
 			if err != nil {
 				return err
 			}

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -10,9 +10,9 @@ import (
 // The returned Recipe contains {{variable}} placeholders — substitution
 // happens at instantiation time, not compilation time.
 //
-// vars is used only for compile-time step condition filtering: steps whose
-// condition field evaluates to false given vars are excluded. Pass nil to
-// include all steps.
+// vars provides caller overrides for compile-time step condition filtering.
+// Formula [vars] defaults are always applied to condition evaluation.
+// Pass nil to evaluate conditions using only formula defaults.
 //
 // The pipeline stages are:
 //  1. LoadByName — load formula TOML from search paths
@@ -95,14 +95,12 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 		}
 	}
 
-	// Stage 8: Apply step condition filtering if vars provided
-	if vars != nil {
-		filteredSteps, err := FilterStepsByCondition(resolved.Steps, compileVars)
-		if err != nil {
-			return nil, fmt.Errorf("filtering steps by condition: %w", err)
-		}
-		resolved.Steps = filteredSteps
+	// Stage 8: Apply step condition filtering (always uses defaults + caller vars)
+	filteredSteps, err := FilterStepsByCondition(resolved.Steps, compileVars)
+	if err != nil {
+		return nil, fmt.Errorf("filtering steps by condition: %w", err)
 	}
+	resolved.Steps = filteredSteps
 
 	// Stage 9: Handle standalone expansion formulas
 	if resolved.Type == TypeExpansion && len(resolved.Template) > 0 {

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -121,6 +121,50 @@ condition = "{{mode}} == slow"
 	}
 }
 
+func TestCompileNilVarsAppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "conditional"
+version = 1
+
+[vars.mode]
+description = "Execution mode"
+default = "fast"
+
+[[steps]]
+id = "always"
+title = "Always runs"
+
+[[steps]]
+id = "slow-only"
+title = "Only in slow mode"
+condition = "{{mode}} == slow"
+`
+	if err := os.WriteFile(filepath.Join(dir, "conditional.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Passing nil vars should still evaluate conditions using [vars] defaults.
+	// This is the regression test for #477: cook and show ignored conditions
+	// when no --var flags were provided.
+	recipe, err := Compile(context.Background(), "conditional", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile with nil vars: %v", err)
+	}
+
+	// Root + always = 2 (slow-only filtered by default mode=fast)
+	if len(recipe.Steps) != 2 {
+		t.Errorf("len(Steps) = %d, want 2 (slow-only should be filtered by default mode=fast)", len(recipe.Steps))
+	}
+
+	if recipe.Steps[0].ID != "conditional" || !recipe.Steps[0].IsRoot {
+		t.Errorf("Steps[0] = %q (root=%v), want root step 'conditional'", recipe.Steps[0].ID, recipe.Steps[0].IsRoot)
+	}
+	if recipe.Steps[1].ID != "conditional.always" {
+		t.Errorf("Steps[1] = %q, want 'conditional.always'", recipe.Steps[1].ID)
+	}
+}
+
 func TestCompileWithChildren(t *testing.T) {
 	dir := t.TempDir()
 	formulaContent := `


### PR DESCRIPTION
## Summary

Fixes two related bugs in formula condition evaluation (Fixes #477):

1. **`gc formula cook`** materialized steps regardless of their `condition` field — conditional steps ended up as live beads in the store
2. **`gc formula show`** without `--var` didn't apply `[vars]` defaults to conditions

**Root cause:** The `if vars != nil` guard on Stage 8 (`FilterStepsByCondition`) in `Compile` skipped condition evaluation entirely when no caller-supplied vars were provided. The `compileVars` map (which merges formula defaults with caller overrides) was already constructed unconditionally — only the filtering call was gated.

## Changes

- **`internal/formula/compile.go`**: Remove `if vars != nil` guard so `FilterStepsByCondition` always runs with formula defaults merged with any caller overrides. Updated doc comment to reflect new contract: nil vars means "evaluate with defaults only."
- **`cmd/gc/cmd_formula.go`**: Simplify `show` command to pass `vars` directly to `Compile` instead of wrapping in a nil-conditional. Updated help text.
- **`internal/formula/compile_test.go`**: Added `TestCompileNilVarsAppliesDefaults` regression test confirming nil vars still evaluates conditions using `[vars]` defaults.

## What was tested

- `make fmt-check` — clean
- `make lint` — 0 issues
- `make vet` — clean
- `go test ./internal/formula/... -run TestCompile` — pass

## Review outcome

Clean, focused fix. No scope creep. Edge cases covered by existing `FilterStepsByCondition` tests plus the new nil-vars regression test.

## Breaking changes

Semantic change to `Compile` contract: nil `vars` now means "evaluate conditions with defaults" instead of "skip condition filtering." All known callers (show, cook, molecule.Cook, molecule.Attach) benefit from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)