### PR TITLE
fix: sweep orphaned order-tracking beads on controller startup

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -122,6 +122,16 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 			p.Cfg.Daemon.WispTTLDuration(), bdCommandRunnerForCity(p.CityPath))
 	}
 
+	// Sweep orphaned order-tracking beads on startup only (not config reload).
+	// A previous controller instance may have left tracking beads open
+	// (goroutines killed on restart, or silent Close failures).
+	sweepStore := beads.NewBdStore(p.CityPath, bdCommandRunnerForCity(p.CityPath))
+	if n, err := sweepOrphanedOrderTracking(sweepStore); err != nil {
+		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
+	} else if n > 0 {
+		fmt.Fprintf(p.Stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
+	}
+
 	od := buildOrderDispatcher(p.CityPath, p.Cfg, bdCommandRunnerForCity(p.CityPath), p.Rec, p.Stderr)
 
 	suspendedNames := computeSuspendedNames(p.Cfg, p.CityName, p.CityPath)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -62,17 +62,7 @@ type memoryOrderDispatcher struct {
 // Scans both city-level and per-rig orders. Rig orders get their Rig
 // field stamped so they use independent scoped labels.
 func buildOrderDispatcher(cityPath string, cfg *config.City, runner beads.CommandRunner, rec events.Recorder, stderr io.Writer) orderDispatcher {
-	// Sweep orphaned order-tracking beads unconditionally on every startup.
-	// A previous controller instance may have left tracking beads open
-	// (goroutines killed on restart, or silent Close failures). This runs
-	// before order scanning so cleanup happens even if the scan errors or
-	// no auto-dispatchable orders remain.
 	store := beads.NewBdStore(cityPath, runner)
-	if n, err := sweepOrphanedOrderTracking(store); err != nil {
-		fmt.Fprintf(stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
-	} else if n > 0 {
-		fmt.Fprintf(stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
-	}
 
 	allAA, err := scanAllOrders(cityPath, cfg, stderr, "gc start: order scan")
 	if err != nil {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
+const labelOrderTracking = "order-tracking"
+
 // orderDispatcher evaluates order gate conditions and dispatches due
 // orders as wisps or exec scripts. Follows the nil-guard tracker pattern:
 // nil means no auto-dispatchable orders exist.
@@ -60,6 +62,18 @@ type memoryOrderDispatcher struct {
 // Scans both city-level and per-rig orders. Rig orders get their Rig
 // field stamped so they use independent scoped labels.
 func buildOrderDispatcher(cityPath string, cfg *config.City, runner beads.CommandRunner, rec events.Recorder, stderr io.Writer) orderDispatcher {
+	// Sweep orphaned order-tracking beads unconditionally on every startup.
+	// A previous controller instance may have left tracking beads open
+	// (goroutines killed on restart, or silent Close failures). This runs
+	// before order scanning so cleanup happens even if the scan errors or
+	// no auto-dispatchable orders remain.
+	store := beads.NewBdStore(cityPath, runner)
+	if n, err := sweepOrphanedOrderTracking(store); err != nil {
+		fmt.Fprintf(stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
+	} else if n > 0 {
+		fmt.Fprintf(stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
+	}
+
 	allAA, err := scanAllOrders(cityPath, cfg, stderr, "gc start: order scan")
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: order scan: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -81,8 +95,6 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, runner beads.Comman
 	if len(auto) == 0 {
 		return nil
 	}
-
-	store := beads.NewBdStore(cityPath, runner)
 
 	// Extract events.Provider from recorder if available.
 	// FileRecorder implements Provider; Discard does not.
@@ -135,7 +147,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// This prevents the cooldown gate from re-firing on the next tick.
 		trackingBead, err := m.store.Create(beads.Bead{
 			Title:  "order:" + scoped,
-			Labels: []string{"order-run:" + scoped, "order-tracking"},
+			Labels: []string{"order-run:" + scoped, labelOrderTracking},
 		})
 		if err != nil {
 			fmt.Fprintf(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v\n", scoped, err) //nolint:errcheck
@@ -365,6 +377,29 @@ func (m *memoryOrderDispatcher) hasOpenWork(scopedName string) bool {
 		}
 	}
 	return false
+}
+
+// sweepOrphanedOrderTracking closes any open order-tracking beads left
+// behind by a previous controller instance. Returns the count of beads
+// closed. This is non-fatal: dispatch proceeds even if the sweep fails.
+func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
+	// ListByLabel without IncludeClosed returns only open beads.
+	all, err := store.ListByLabel(labelOrderTracking, 0)
+	if err != nil {
+		return 0, fmt.Errorf("listing order-tracking beads: %w", err)
+	}
+	if len(all) == 0 {
+		return 0, nil
+	}
+	ids := make([]string, len(all))
+	for i, b := range all {
+		ids[i] = b.ID
+	}
+	n, err := store.CloseAll(ids, nil)
+	if err != nil {
+		return n, fmt.Errorf("closing orphaned order-tracking beads: %w", err)
+	}
+	return n, nil
 }
 
 // effectiveTimeout returns the timeout to use for an order dispatch.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -893,10 +893,10 @@ func TestSweepOrphanedOrderTracking_OnlyClosedBeads(t *testing.T) {
 	}
 }
 
-func TestBuildOrderDispatcher_SweepsOrphansOnStartup(t *testing.T) {
+func TestStartupSweepThenBuildDispatcher(t *testing.T) {
 	store := beads.NewMemStore()
 
-	// Pre-create an orphaned tracking bead.
+	// Pre-create an orphaned tracking bead (simulating a crashed controller).
 	_, err := store.Create(beads.Bead{
 		Title:  "order:test-order",
 		Labels: []string{"order-run:test-order", labelOrderTracking},
@@ -905,19 +905,30 @@ func TestBuildOrderDispatcher_SweepsOrphansOnStartup(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
+	// Production startup sequence: sweep first, then build dispatcher.
+	// This mirrors newCityRuntime which calls sweepOrphanedOrderTracking
+	// before buildOrderDispatcher. The sweep is intentionally NOT inside
+	// buildOrderDispatcher so config reloads don't close in-flight beads.
+	closed, err := sweepOrphanedOrderTracking(store)
+	if err != nil {
+		t.Fatalf("sweepOrphanedOrderTracking: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
 	aa := []orders.Order{{
 		Name:     "test-order",
 		Gate:     "cooldown",
 		Interval: "1m",
 		Formula:  "test-formula",
 	}}
-	var stderr bytes.Buffer
-	ad := buildOrderDispatcherFromListWithSweep(aa, store, nil, noopRunner, &stderr)
+	ad := buildOrderDispatcherFromList(aa, store, nil, noopRunner)
 	if ad == nil {
 		t.Fatal("expected non-nil dispatcher")
 	}
 
-	// The orphaned bead should have been closed during construction.
+	// The orphaned bead should have been closed before dispatcher construction.
 	all := trackingBeads(t, store, labelOrderTracking)
 	for _, b := range all {
 		if b.Status != "closed" {
@@ -936,17 +947,6 @@ var noopRunner beads.CommandRunner = func(_, _ string, _ ...string) ([]byte, err
 // buildOrderDispatcherFromList builds a dispatcher from pre-scanned orders,
 // bypassing the filesystem scan. Returns nil if no auto-dispatchable orders.
 func buildOrderDispatcherFromList(aa []orders.Order, store beads.Store, ep events.Provider, runner beads.CommandRunner) orderDispatcher { //nolint:unparam // ep is nil in current tests but needed for event-gate tests
-	return buildOrderDispatcherFromListExec(aa, store, ep, runner, nil, nil)
-}
-
-// buildOrderDispatcherFromListWithSweep builds a dispatcher that runs the
-// orphaned tracking bead sweep, mirroring the production buildOrderDispatcher.
-func buildOrderDispatcherFromListWithSweep(aa []orders.Order, store beads.Store, ep events.Provider, runner beads.CommandRunner, stderr *bytes.Buffer) orderDispatcher {
-	if n, err := sweepOrphanedOrderTracking(store); err != nil {
-		fmt.Fprintf(stderr, "sweep: %v\n", err) //nolint:errcheck
-	} else if n > 0 {
-		fmt.Fprintf(stderr, "closed %d orphaned tracking beads\n", n) //nolint:errcheck
-	}
 	return buildOrderDispatcherFromListExec(aa, store, ep, runner, nil, nil)
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -793,6 +793,139 @@ func TestOrderRigSuspended(t *testing.T) {
 	}
 }
 
+// --- orphaned tracking bead sweep tests (#520) ---
+
+func TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Create some open tracking beads (simulating goroutines killed on restart).
+	for _, name := range []string{"dolt-health", "gate-sweep", "beads-health"} {
+		_, err := store.Create(beads.Bead{
+			Title:  "order:" + name,
+			Labels: []string{"order-run:" + name, labelOrderTracking},
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+	}
+
+	// Create one that's already closed (should be left alone).
+	b, err := store.Create(beads.Bead{
+		Title:  "order:old-sweep",
+		Labels: []string{"order-run:old-sweep", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(old-sweep): %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close(old-sweep): %v", err)
+	}
+
+	// Create a non-tracking bead that happens to be open (should not be touched).
+	_, err = store.Create(beads.Bead{
+		Title:  "real work",
+		Labels: []string{"order-run:dolt-health"},
+	})
+	if err != nil {
+		t.Fatalf("Create(real work): %v", err)
+	}
+
+	closed, err := sweepOrphanedOrderTracking(store)
+	if err != nil {
+		t.Fatalf("sweepOrphanedOrderTracking: %v", err)
+	}
+	if closed != 3 {
+		t.Fatalf("closed = %d, want 3", closed)
+	}
+
+	// Verify the 3 open tracking beads are now closed.
+	all := trackingBeads(t, store, labelOrderTracking)
+	for _, b := range all {
+		if b.Status != "closed" {
+			t.Errorf("tracking bead %s (%s) still open", b.ID, b.Title)
+		}
+	}
+
+	// Verify the non-tracking work bead is still open.
+	work, err := store.ListByLabel("order-run:dolt-health", 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	for _, b := range work {
+		if b.Title == "real work" && b.Status != "open" {
+			t.Errorf("non-tracking bead %s should still be open, got %s", b.ID, b.Status)
+		}
+	}
+}
+
+func TestSweepOrphanedOrderTracking_NoOrphans(t *testing.T) {
+	store := beads.NewMemStore()
+
+	closed, err := sweepOrphanedOrderTracking(store)
+	if err != nil {
+		t.Fatalf("sweepOrphanedOrderTracking: %v", err)
+	}
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+}
+
+func TestSweepOrphanedOrderTracking_OnlyClosedBeads(t *testing.T) {
+	store := beads.NewMemStore()
+
+	b, err := store.Create(beads.Bead{
+		Title:  "order:dolt-health",
+		Labels: []string{"order-run:dolt-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	closed, err := sweepOrphanedOrderTracking(store)
+	if err != nil {
+		t.Fatalf("sweepOrphanedOrderTracking: %v", err)
+	}
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+}
+
+func TestBuildOrderDispatcher_SweepsOrphansOnStartup(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Pre-create an orphaned tracking bead.
+	_, err := store.Create(beads.Bead{
+		Title:  "order:test-order",
+		Labels: []string{"order-run:test-order", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "test-order",
+		Gate:     "cooldown",
+		Interval: "1m",
+		Formula:  "test-formula",
+	}}
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcherFromListWithSweep(aa, store, nil, noopRunner, &stderr)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	// The orphaned bead should have been closed during construction.
+	all := trackingBeads(t, store, labelOrderTracking)
+	for _, b := range all {
+		if b.Status != "closed" {
+			t.Errorf("orphaned tracking bead %s still open after startup sweep", b.ID)
+		}
+	}
+}
+
 // --- helpers ---
 
 // noopRunner is a CommandRunner that always succeeds.
@@ -803,6 +936,17 @@ var noopRunner beads.CommandRunner = func(_, _ string, _ ...string) ([]byte, err
 // buildOrderDispatcherFromList builds a dispatcher from pre-scanned orders,
 // bypassing the filesystem scan. Returns nil if no auto-dispatchable orders.
 func buildOrderDispatcherFromList(aa []orders.Order, store beads.Store, ep events.Provider, runner beads.CommandRunner) orderDispatcher { //nolint:unparam // ep is nil in current tests but needed for event-gate tests
+	return buildOrderDispatcherFromListExec(aa, store, ep, runner, nil, nil)
+}
+
+// buildOrderDispatcherFromListWithSweep builds a dispatcher that runs the
+// orphaned tracking bead sweep, mirroring the production buildOrderDispatcher.
+func buildOrderDispatcherFromListWithSweep(aa []orders.Order, store beads.Store, ep events.Provider, runner beads.CommandRunner, stderr *bytes.Buffer) orderDispatcher {
+	if n, err := sweepOrphanedOrderTracking(store); err != nil {
+		fmt.Fprintf(stderr, "sweep: %v\n", err) //nolint:errcheck
+	} else if n > 0 {
+		fmt.Fprintf(stderr, "closed %d orphaned tracking beads\n", n) //nolint:errcheck
+	}
 	return buildOrderDispatcherFromListExec(aa, store, ep, runner, nil, nil)
 }
 

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -87,7 +87,7 @@ func (m *memoryWispGC) runGC(cityPath string, now time.Time) (int, error) {
 
 	// Purge expired closed tracking beads.
 	trackOut, trackErr := m.runner(cityPath, "bd", "list", "--json",
-		"--label=order-tracking", "--all", "--limit=0")
+		"--label="+labelOrderTracking, "--all", "--limit=0")
 	if trackErr == nil {
 		var trackEntries []gcEntry
 		if err := json.Unmarshal(trackOut, &trackEntries); err == nil {


### PR DESCRIPTION
## Summary

- Add `sweepOrphanedOrderTracking` that batch-closes orphaned `order-tracking` beads via `store.CloseAll` on controller startup in `buildOrderDispatcher`
- Fixes two failure modes: goroutines killed before `defer Close` on restart, and silent `Close` failures from `//nolint:errcheck`
- Introduce `labelOrderTracking` constant replacing raw `"order-tracking"` string literals
- Log partial close count on error for diagnostics

Closes #520

## Test plan

- [x] `TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads` — closes 3 open orphans, leaves closed and non-tracking beads untouched
- [x] `TestSweepOrphanedOrderTracking_NoOrphans` — empty store returns (0, nil)
- [x] `TestSweepOrphanedOrderTracking_OnlyClosedBeads` — all-closed store returns (0, nil)
- [x] `TestBuildOrderDispatcher_SweepsOrphansOnStartup` — integration: orphan closed during dispatcher construction
- [x] All 24 existing order dispatch tests pass
- [x] `make check` passes (1 pre-existing failure in `internal/api` unrelated)
- [x] `make check-docs` passes