### PR TITLE
fix(beads): create .beads dirs with 0700 perms

### DIFF
--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -414,7 +414,7 @@ func TestBdStoreForRig_DoesNotExist(t *testing.T) {
 func TestBdRuntimeEnvForRigUsesManagedRigPort(t *testing.T) {
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(t.TempDir(), "repo")
-	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -447,7 +447,7 @@ func TestBdRuntimeEnvForRigFallsBackToManagedCityPort(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -468,7 +468,7 @@ func TestBdRuntimeEnvForRigFallsBackToManagedCityPort(t *testing.T) {
 	}
 
 	rigDir := filepath.Join(t.TempDir(), "repo")
-	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -490,7 +490,7 @@ func TestBdRuntimeEnvForRigPrefersExplicitRigDoltConfigOverManagedCity(t *testin
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -511,7 +511,7 @@ func TestBdRuntimeEnvForRigPrefersExplicitRigDoltConfigOverManagedCity(t *testin
 	}
 
 	rigDir := filepath.Join(t.TempDir(), "repo")
-	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gc/beads_dir.go
+++ b/cmd/gc/beads_dir.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// beadsDirPerm is the permission bd recommends for .beads/ directories.
+// Wider permissions cause bd to emit a warning on every call, which
+// pollutes agent pod output and is mistreated as a hard List() failure
+// by the controller's stderr-as-error path.
+const beadsDirPerm os.FileMode = 0o700
+
+// ensureBeadsDir creates path with restrictive permissions, tightening
+// any pre-existing directory whose mode was set by an older gascity
+// version (or another tool) to a wider value. Idempotent — safe to
+// call on every init pass.
+func ensureBeadsDir(fs fsys.FS, path string) error {
+	if err := fs.MkdirAll(path, beadsDirPerm); err != nil {
+		return err
+	}
+	return fs.Chmod(path, beadsDirPerm)
+}

--- a/cmd/gc/beads_dir.go
+++ b/cmd/gc/beads_dir.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -8,17 +9,24 @@ import (
 
 // beadsDirPerm is the permission bd recommends for .beads/ directories.
 // Wider permissions cause bd to emit a warning on every call, which
-// pollutes agent pod output and is mistreated as a hard List() failure
-// by the controller's stderr-as-error path.
+// pollutes agent pod output.
 const beadsDirPerm os.FileMode = 0o700
 
 // ensureBeadsDir creates path with restrictive permissions, tightening
 // any pre-existing directory whose mode was set by an older gascity
 // version (or another tool) to a wider value. Idempotent — safe to
 // call on every init pass.
+//
+// Chmod failure is best-effort: the directory may live on a filesystem
+// that does not support permission changes (e.g. certain container
+// mounts). In that case we log a warning and continue — a working
+// .beads/ dir with wider permissions is better than a hard failure.
 func ensureBeadsDir(fs fsys.FS, path string) error {
 	if err := fs.MkdirAll(path, beadsDirPerm); err != nil {
 		return err
 	}
-	return fs.Chmod(path, beadsDirPerm)
+	if err := fs.Chmod(path, beadsDirPerm); err != nil {
+		log.Printf("warning: chmod %s to %o: %v (continuing with existing permissions)", path, beadsDirPerm, err)
+	}
+	return nil
 }

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -162,7 +162,7 @@ func seedDeferredManagedBeads(dir, prefix, doltDatabase string) {
 		return
 	}
 	beadsDir := filepath.Join(dir, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := ensureBeadsDir(fsys.OSFS{}, beadsDir); err != nil {
 		return
 	}
 	if strings.TrimSpace(doltDatabase) == "" {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -83,7 +83,7 @@ func TestCurrentDoltPortPrefersRuntimeState(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	ln := listenOnRandomPort(t)
@@ -126,7 +126,7 @@ func TestSyncConfiguredDoltPortFilesWritesArbitraryRigPaths(t *testing.T) {
 	t.Cleanup(func() { _ = ln.Close() })
 
 	for _, dir := range []string{cityDir, rigDir} {
-		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(dir, ".beads", "config.yaml"), []byte("dolt.port: 1234\ndolt.auto-start: true\n"), 0o644); err != nil {
@@ -173,7 +173,7 @@ func TestCurrentDoltPortIgnoresDeadRuntimeStateAndPrunesDeadPortFile(t *testing.
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -206,7 +206,7 @@ func TestCurrentDoltPortIgnoresReachablePortFileWhenManagedStateIsStopped(t *tes
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -531,7 +531,7 @@ func TestGcBeadsBdInitRetriesRootStoreVerification(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"mc"}`), 0o644); err != nil {
@@ -708,7 +708,7 @@ func TestGcBeadsBdInitRepairsWrongDoltDatabaseFromExplicitCanonicalIdentity(t *t
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"wrong-db"}`), 0o644); err != nil {
@@ -785,7 +785,7 @@ func TestGcBeadsBdInitPreservesMetadataIdentityWhenCanonicalUnknownAndDatabaseMu
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gascity"}`), 0o644); err != nil {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -972,7 +972,7 @@ func writeBeadsEnvGTRoot(fs fsys.FS, rigPath, cityPath string) error {
 		content += "\n"
 	}
 
-	if err := fs.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+	if err := ensureBeadsDir(fs, filepath.Join(rigPath, ".beads")); err != nil {
 		return fmt.Errorf("creating .beads dir: %w", err)
 	}
 	return fs.WriteFile(envPath, []byte(content), 0o644)

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -149,7 +149,7 @@ func TestDoRigAdd_WritesPortFileForExternalRig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	ln := listenOnRandomPort(t)
@@ -401,7 +401,7 @@ func TestDoRigList_WithRigs(t *testing.T) {
 
 	// Create .beads/metadata.json for HQ.
 	beadsDir := filepath.Join(cityPath, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{}`), 0o644); err != nil {
@@ -922,7 +922,7 @@ func TestDoRigAdd_ExplicitPrefixConflictsWithExistingBeads(t *testing.T) {
 	// Rig already has .beads/config.yaml with prefix "ab".
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
 	beadsDir := filepath.Join(rigPath, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
@@ -957,7 +957,7 @@ func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 	// Rig "alpha-beta" would derive prefix "ab", but .beads already has "zz".
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
 	beadsDir := filepath.Join(rigPath, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
@@ -992,7 +992,7 @@ func TestDoRigAdd_MatchingPrefixSucceeds(t *testing.T) {
 	// Rig "alpha-beta" derives prefix "ab", and .beads already has "ab".
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
 	beadsDir := filepath.Join(rigPath, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
@@ -1026,7 +1026,7 @@ func TestReadBeadsPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			beadsDir := filepath.Join(dir, ".beads")
-			if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+			if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 				t.Fatal(err)
 			}
 			if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(tt.content), 0o644); err != nil {
@@ -1049,7 +1049,7 @@ func TestReadBeadsPrefix(t *testing.T) {
 	t.Run("dash form only", func(t *testing.T) {
 		dir := t.TempDir()
 		beadsDir := filepath.Join(dir, ".beads")
-		if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue-prefix: zz\n"), 0o644); err != nil {

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -609,3 +609,4 @@ func (osFS) Stat(name string) (os.FileInfo, error)                { return os.St
 func (osFS) ReadDir(name string) ([]os.DirEntry, error)           { return os.ReadDir(name) }
 func (osFS) Rename(oldpath, newpath string) error                 { return os.Rename(oldpath, newpath) }
 func (osFS) Remove(name string) error                             { return os.Remove(name) }
+func (osFS) Chmod(name string, mode os.FileMode) error            { return os.Chmod(name, mode) }

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -367,3 +367,48 @@ func TestSeedDeferredManagedBeadsPreservesExistingDoltDatabaseWhenCanonicalUnkno
 		t.Fatalf("dolt_database = %q, want %q", got, "gascity")
 	}
 }
+
+// TestSeedDeferredManagedBeadsCreatesDirWith0700 asserts that fresh .beads
+// directories created during deferred init satisfy bd's recommended 0700
+// permission. Wider perms cause bd to emit a warning on every call, which
+// spams agent pod output and is treated as a hard failure by the
+// controller's collectAssignedWorkBeads stderr-as-error path (hl-39km).
+func TestSeedDeferredManagedBeadsCreatesDirWith0700(t *testing.T) {
+	dir := t.TempDir()
+
+	seedDeferredManagedBeads(dir, "gc", "test")
+
+	info, err := os.Stat(filepath.Join(dir, ".beads"))
+	if err != nil {
+		t.Fatalf("stat .beads: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf(".beads perm = %o, want 0700", perm)
+	}
+}
+
+// TestSeedDeferredManagedBeadsTightensExistingDir asserts that pre-existing
+// .beads directories with looser permissions are tightened on next call.
+// Required because persistent volumes carry directories created by older
+// gascity versions that used 0o755.
+func TestSeedDeferredManagedBeadsTightensExistingDir(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Force 0755 explicitly — the test process umask may have reduced it.
+	if err := os.Chmod(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	seedDeferredManagedBeads(dir, "gc", "test")
+
+	info, err := os.Stat(beadsDir)
+	if err != nil {
+		t.Fatalf("stat .beads: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf(".beads perm = %o, want 0700", perm)
+	}
+}

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -288,7 +288,7 @@ func TestLifecycleCoordination_InitDirIfReady_BdDeferredPreservesExistingDoltDat
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"gascity"}`), 0o644); err != nil {
@@ -346,7 +346,7 @@ func TestSeedDeferredManagedBeadsUsesExplicitDoltDatabase(t *testing.T) {
 
 func TestSeedDeferredManagedBeadsPreservesExistingDoltDatabaseWhenCanonicalUnknown(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"gascity"}`), 0o644); err != nil {

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -821,7 +821,7 @@ func TestRigAnywhere_RigDefault(t *testing.T) {
 
 		cityPath := setupCity(t, "env-upd")
 		rigDir := filepath.Join(t.TempDir(), "envrig")
-		if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
 			t.Fatal(err)
 		}
 		// Pre-populate .beads/.env with stale GT_ROOT.
@@ -1136,7 +1136,7 @@ func TestRigAnywhere_WriteBeadsEnvGTRoot(t *testing.T) {
 	t.Run("updates_existing_gt_root", func(t *testing.T) {
 		rigDir := t.TempDir()
 		beadsDir := filepath.Join(rigDir, ".beads")
-		if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(beadsDir, ".env"),
@@ -1165,7 +1165,7 @@ func TestRigAnywhere_WriteBeadsEnvGTRoot(t *testing.T) {
 	t.Run("preserves_other_env_entries", func(t *testing.T) {
 		rigDir := t.TempDir()
 		beadsDir := filepath.Join(rigDir, ".beads")
-		if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(beadsDir, ".env"),
@@ -1202,7 +1202,7 @@ func TestRigAnywhere_WriteBeadsEnvGTRoot(t *testing.T) {
 	t.Run("adds_gt_root_when_missing_from_existing_env", func(t *testing.T) {
 		rigDir := t.TempDir()
 		beadsDir := filepath.Join(rigDir, ".beads")
-		if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(beadsDir, ".env"),

--- a/cmd/gc/rig_beads.go
+++ b/cmd/gc/rig_beads.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // rigRoute pairs a bead prefix with the absolute directory it lives in.
@@ -61,7 +62,7 @@ func writeAllRoutes(rigs []rigRoute) error {
 // Uses temp file + rename for crash safety per CLAUDE.md conventions.
 func writeRoutesFile(dir string, routes []routeEntry) error {
 	beadsDir := filepath.Join(dir, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := ensureBeadsDir(fsys.OSFS{}, beadsDir); err != nil {
 		return fmt.Errorf("creating .beads dir: %w", err)
 	}
 

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -253,7 +253,7 @@ func TestResolveTemplateUsesCityManagedDoltPort(t *testing.T) {
 func TestResolveTemplateUsesRigManagedDoltPortAndPinsHome(t *testing.T) {
 	cityPath := t.TempDir()
 	rigRoot := filepath.Join(t.TempDir(), "repo")
-	if err := os.MkdirAll(filepath.Join(rigRoot, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(rigRoot, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -280,7 +280,7 @@ func configureBeadRouteState(t *testing.T) (*fakeState, *prefixedAliasStore, *pr
 
 	alphaPath := filepath.Join(state.cityPath, "rigs", "alpha")
 	betaPath := filepath.Join(state.cityPath, "rigs", "beta")
-	if err := os.MkdirAll(filepath.Join(alphaPath, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(alphaPath, ".beads"), 0o700); err != nil {
 		t.Fatalf("MkdirAll(alpha .beads): %v", err)
 	}
 	if err := os.MkdirAll(betaPath, 0o755); err != nil {

--- a/internal/api/handler_convoy_dispatch_test.go
+++ b/internal/api/handler_convoy_dispatch_test.go
@@ -771,7 +771,7 @@ func TestWorkflowSQLCandidatesForWorkflowIDResolveBeadPrefixViaRoutes(t *testing
 	}
 
 	alphaPath := filepath.Join(state.cityPath, "rigs/alpha")
-	if err := os.MkdirAll(filepath.Join(alphaPath, ".beads"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(alphaPath, ".beads"), 0o700); err != nil {
 		t.Fatalf("MkdirAll(alpha .beads): %v", err)
 	}
 	routes := `{"prefix":"ga","path":"."}` + "\n" + `{"prefix":"gb","path":"../beta"}`

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -18,7 +18,7 @@ func TestCustomTypesCheck_NoBeadsDir(t *testing.T) {
 func TestCustomTypesCheck_MissingTypes(t *testing.T) {
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")
-	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -20,7 +20,7 @@ type Fake struct {
 
 // Call records a single method invocation on [Fake].
 type Call struct {
-	Method string // "MkdirAll", "WriteFile", "ReadFile", "Stat", "ReadDir", "Rename", or "Remove"
+	Method string // "MkdirAll", "WriteFile", "ReadFile", "Stat", "ReadDir", "Rename", "Remove", or "Chmod"
 	Path   string // path argument
 }
 
@@ -154,6 +154,22 @@ func (f *Fake) Remove(name string) error {
 		return nil
 	}
 	return &os.PathError{Op: "remove", Path: name, Err: os.ErrNotExist}
+}
+
+// Chmod records the call. Mode is not tracked — the spy log is sufficient
+// for tests that care about which paths were chmodded.
+func (f *Fake) Chmod(name string, _ os.FileMode) error {
+	f.Calls = append(f.Calls, Call{Method: "Chmod", Path: name})
+	if err, ok := f.Errors[name]; ok {
+		return err
+	}
+	if _, ok := f.Files[name]; ok {
+		return nil
+	}
+	if f.Dirs[name] {
+		return nil
+	}
+	return &os.PathError{Op: "chmod", Path: name, Err: os.ErrNotExist}
 }
 
 // --- fake os.FileInfo ---

--- a/internal/fsys/fsys.go
+++ b/internal/fsys/fsys.go
@@ -32,6 +32,9 @@ type FS interface {
 
 	// Remove removes the named file or empty directory.
 	Remove(name string) error
+
+	// Chmod changes the mode of the named file or directory.
+	Chmod(name string, mode os.FileMode) error
 }
 
 // OSFS implements [FS] by delegating to the os package.
@@ -70,4 +73,9 @@ func (OSFS) Rename(oldpath, newpath string) error {
 // Remove delegates to [os.Remove].
 func (OSFS) Remove(name string) error {
 	return os.Remove(name)
+}
+
+// Chmod delegates to [os.Chmod].
+func (OSFS) Chmod(name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
 }


### PR DESCRIPTION
## Summary

- `.beads/` directories are created with `0o755` in three bootstrap paths (`seedDeferredManagedBeads`, `writeRoutesFile`, `writeBeadsEnvGTRoot`), causing `bd` to emit a permissions warning on every call
- The warning pollutes agent pod output and — in the controller — is mistreated as a hard `List()` failure when `collectAssignedWorkBeads` treats any stderr output as an error
- Adds `ensureBeadsDir` helper that creates dirs with `0o700` and `Chmod`s existing dirs back to `0o700` on every init pass, fixing both fresh creation and pre-existing persistent volumes
- Adds `Chmod` to `fsys.FS` interface to support the abstracted call site in `writeBeadsEnvGTRoot`