### PR TITLE
fix: restore opencode startup prompts

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -150,16 +150,16 @@ func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode bool) int
 				}))
 			}
 		}
+		var ctx PromptContext
+		if ok && (a.PromptTemplate != "" || hookMode) {
+			ctx = buildPrimeContext(cityPath, &a, cfg.Rigs)
+		}
 		if ok && a.PromptTemplate != "" {
-			ctx := buildPrimeContext(cityPath, &a, cfg.Rigs)
 			fragments := mergeFragmentLists(cfg.Workspace.GlobalFragments, a.InjectFragments)
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
 				cfg.PackDirs, fragments, nil)
 			if prompt != "" {
-				if hookMode {
-					prompt = prependHookBeacon(cityName, ctx.AgentName, prompt)
-				}
-				fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
+				writePrimePrompt(stdout, cityName, ctx.AgentName, prompt, hookMode)
 				return 0
 			}
 		}
@@ -177,11 +177,7 @@ func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode bool) int
 			}
 			if promptFile != "" {
 				if content, fErr := os.ReadFile(filepath.Join(cityPath, promptFile)); fErr == nil {
-					prompt := string(content)
-					if hookMode {
-						prompt = prependHookBeacon(cityName, buildPrimeContext(cityPath, &a, cfg.Rigs).AgentName, prompt)
-					}
-					fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
+					writePrimePrompt(stdout, cityName, ctx.AgentName, string(content), hookMode)
 					return 0
 				}
 			}
@@ -202,6 +198,13 @@ func prependHookBeacon(cityName, agentName, prompt string) string {
 		return beacon
 	}
 	return beacon + "\n\n" + prompt
+}
+
+func writePrimePrompt(stdout io.Writer, cityName, agentName, prompt string, hookMode bool) {
+	if hookMode {
+		prompt = prependHookBeacon(cityName, agentName, prompt)
+	}
+	fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
 }
 
 func readPrimeHookContext() (sessionID, source string) {

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -155,6 +156,9 @@ func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode bool) int
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
 				cfg.PackDirs, fragments, nil)
 			if prompt != "" {
+				if hookMode {
+					prompt = prependHookBeacon(cityName, ctx.AgentName, prompt)
+				}
 				fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
 				return 0
 			}
@@ -173,7 +177,11 @@ func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode bool) int
 			}
 			if promptFile != "" {
 				if content, fErr := os.ReadFile(filepath.Join(cityPath, promptFile)); fErr == nil {
-					fmt.Fprint(stdout, string(content)) //nolint:errcheck // best-effort stdout
+					prompt := string(content)
+					if hookMode {
+						prompt = prependHookBeacon(cityName, buildPrimeContext(cityPath, &a, cfg.Rigs).AgentName, prompt)
+					}
+					fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
 					return 0
 				}
 			}
@@ -183,6 +191,17 @@ func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode bool) int
 	// Fallback: default run-once prompt.
 	fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+func prependHookBeacon(cityName, agentName, prompt string) string {
+	if cityName == "" || agentName == "" {
+		return prompt
+	}
+	beacon := runtime.FormatBeaconAt(cityName, agentName, false, time.Now())
+	if prompt == "" {
+		return beacon
+	}
+	return beacon + "\n\n" + prompt
 }
 
 func readPrimeHookContext() (sessionID, source string) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3358,8 +3358,15 @@ prompt_template = "prompts/mayor.md"
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if stdout.String() != promptContent {
-		t.Errorf("stdout = %q, want %q", stdout.String(), promptContent)
+	out := stdout.String()
+	if !strings.Contains(out, promptContent) {
+		t.Errorf("stdout = %q, want prompt content %q", out, promptContent)
+	}
+	if !strings.Contains(out, "[test-city] mayor") {
+		t.Errorf("stdout = %q, want hook beacon", out)
+	}
+	if strings.Contains(out, "Run `gc prime`") {
+		t.Errorf("stdout = %q, hook beacon should not add manual gc prime instruction", out)
 	}
 
 	data, err := os.ReadFile(filepath.Join(dir, ".runtime", "session_id"))

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -66,6 +66,11 @@ type TemplateParams struct {
 	WakeMode string
 	// IsACP is true if session = "acp".
 	IsACP bool
+	// HookEnabled reports whether provider hooks are installed for this agent.
+	// Hook-enabled providers receive startup context via their hook path
+	// (for example gc prime --hook), so PromptMode=none should not also
+	// fall back to a delayed startup nudge.
+	HookEnabled bool
 	// DependencyOnly marks a realized cold slot kept only so dependency wake
 	// has something concrete to wake even when pool check wants zero.
 	DependencyOnly bool
@@ -303,6 +308,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		RigRoot:          rigRoot,
 		WakeMode:         cfgAgent.WakeMode,
 		IsACP:            cfgAgent.Session == "acp",
+		HookEnabled:      hasHooks,
 	}, nil
 }
 
@@ -390,10 +396,14 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 	nudge := tp.Hints.Nudge
 	if tp.Prompt != "" {
 		if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
-			if nudge != "" {
-				nudge = tp.Prompt + "\n\n---\n\n" + nudge
-			} else {
-				nudge = tp.Prompt
+			// Hook-enabled providers prime themselves on startup, so the
+			// rendered role prompt must not also be replayed as a user nudge.
+			if !(tp.HookEnabled && tp.ResolvedProvider.SupportsHooks) {
+				if nudge != "" {
+					nudge = tp.Prompt + "\n\n---\n\n" + nudge
+				} else {
+					nudge = tp.Prompt
+				}
 			}
 		} else {
 			promptSuffix = shellquote.Quote(tp.Prompt)

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -398,7 +398,7 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 		if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
 			// Hook-enabled providers prime themselves on startup, so the
 			// rendered role prompt must not also be replayed as a user nudge.
-			if !(tp.HookEnabled && tp.ResolvedProvider.SupportsHooks) {
+			if !tp.HookEnabled || !tp.ResolvedProvider.SupportsHooks {
 				if nudge != "" {
 					nudge = tp.Prompt + "\n\n---\n\n" + nudge
 				} else {

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -88,9 +88,8 @@ func TestTemplateParamsToConfigFlagModePrependsFlag(t *testing.T) {
 }
 
 // TestTemplateParamsToConfigNoneModeUsesNudge verifies that when PromptMode is
-// "none", startup instructions are delivered via runtime.Config.Nudge instead
-// of PromptSuffix. This keeps providers like OpenCode from treating the prompt
-// as a path-like CLI arg while still receiving their startup context.
+// "none" and hooks are not available, startup instructions are delivered via
+// runtime.Config.Nudge instead of PromptSuffix.
 func TestTemplateParamsToConfigNoneModeUsesNudge(t *testing.T) {
 	tp := TemplateParams{
 		Command: "opencode",
@@ -109,6 +108,32 @@ func TestTemplateParamsToConfigNoneModeUsesNudge(t *testing.T) {
 	}
 	if cfg.Nudge != "You are an agent. Do work." {
 		t.Errorf("Nudge = %q, want startup prompt", cfg.Nudge)
+	}
+}
+
+func TestTemplateParamsToConfigNoneModeWithHooksSkipsStartupNudge(t *testing.T) {
+	tp := TemplateParams{
+		Command: "opencode",
+		Prompt:  "You are an agent. Do work.",
+		Hints: agent.StartupHints{
+			Nudge: "existing nudge",
+		},
+		HookEnabled: true,
+		ResolvedProvider: &config.ResolvedProvider{
+			Name:          "opencode",
+			Command:       "opencode",
+			PromptMode:    "none",
+			SupportsHooks: true,
+		},
+	}
+
+	cfg := templateParamsToConfig(tp)
+
+	if cfg.PromptSuffix != "" {
+		t.Errorf("PromptSuffix should be empty for none mode, got %q", cfg.PromptSuffix)
+	}
+	if cfg.Nudge != "existing nudge" {
+		t.Errorf("Nudge = %q, want existing nudge only", cfg.Nudge)
 	}
 }
 
@@ -210,7 +235,7 @@ func TestTemplateParamsToConfigNilResolvedProvider(t *testing.T) {
 	}
 }
 
-func TestResolveTemplateNoneModeRetainsPromptForNudgeDelivery(t *testing.T) {
+func TestResolveTemplateNoneModeRetainsPromptForDeferredDelivery(t *testing.T) {
 	cityPath := t.TempDir()
 	fs := fsys.NewFake()
 	fs.Files[cityPath+"/prompts/pool-worker.md"] = []byte("pool prompt body")
@@ -245,5 +270,43 @@ func TestResolveTemplateNoneModeRetainsPromptForNudgeDelivery(t *testing.T) {
 	}
 	if !strings.Contains(tp.Prompt, "[bright-lights] opencode") {
 		t.Fatalf("Prompt missing beacon: %q", tp.Prompt)
+	}
+}
+
+func TestResolveTemplateHookEnabledOpencodeOmitsPrimeInstruction(t *testing.T) {
+	cityPath := t.TempDir()
+	fs := fsys.NewFake()
+	fs.Files[cityPath+"/prompts/mayor.md"] = []byte("mayor prompt body")
+
+	params := &agentBuildParams{
+		fs:              fs,
+		cityName:        "bright-lights",
+		cityPath:        cityPath,
+		workspace:       &config.Workspace{Name: "bright-lights", Provider: "opencode", InstallAgentHooks: []string{"opencode"}},
+		providers:       config.BuiltinProviders(),
+		lookPath:        func(string) (string, error) { return "/usr/bin/opencode", nil },
+		beaconTime:      testBeaconTime,
+		sessionTemplate: "",
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+	}
+	agent := &config.Agent{
+		Name:           "mayor",
+		PromptTemplate: "prompts/mayor.md",
+		Provider:       "opencode",
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if !tp.HookEnabled {
+		t.Fatal("HookEnabled = false, want true")
+	}
+	if !strings.Contains(tp.Prompt, "mayor prompt body") {
+		t.Fatalf("Prompt missing rendered template body: %q", tp.Prompt)
+	}
+	if strings.Contains(tp.Prompt, "Run `gc prime`") {
+		t.Fatalf("hook-enabled prompt should omit manual gc prime instruction: %q", tp.Prompt)
 	}
 }

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -148,18 +148,20 @@ func TestBuiltinProvidersReturnsNewMap(t *testing.T) {
 	}
 }
 
-// TestBuiltinProvidersOpenCode verifies the opencode provider uses
-// PromptMode "none". OpenCode v1.3+ interprets positional arguments as a
-// project directory path ("opencode [project]"), so passing the beacon +
-// prompt as a bare arg causes ENAMETOOLONG or "failed to change directory"
-// crashes that trigger crash-loop escalation.
+// TestBuiltinProvidersOpenCode verifies the opencode provider keeps startup
+// instructions out of argv. OpenCode treats argv prompt payloads as a normal
+// user message, so hook-enabled sessions must receive startup context through
+// gc prime --hook instead of argv.
 func TestBuiltinProvidersOpenCode(t *testing.T) {
 	p := BuiltinProviders()["opencode"]
 	if p.Command != "opencode" {
 		t.Errorf("Command = %q, want %q", p.Command, "opencode")
 	}
 	if p.PromptMode != "none" {
-		t.Errorf("PromptMode = %q, want %q — opencode treats positional args as project directory, not prompt", p.PromptMode, "none")
+		t.Errorf("PromptMode = %q, want %q", p.PromptMode, "none")
+	}
+	if p.PromptFlag != "" {
+		t.Errorf("PromptFlag = %q, want empty", p.PromptFlag)
 	}
 	if !p.SupportsHooks {
 		t.Error("SupportsHooks = false, want true")
@@ -175,20 +177,17 @@ func TestBuiltinProvidersOpenCode(t *testing.T) {
 	}
 }
 
-// TestBuiltinProvidersOpenCodePromptModeRegression guards against
-// reverting PromptMode back to "arg". The prompt text contains the session
-// title, beacon, and behavioral instructions — hundreds of characters that
-// OpenCode would interpret as a filesystem path, causing:
-//   - ENAMETOOLONG when the combined string exceeds 255 bytes
-//   - "Failed to change directory" when the path doesn't exist
-//
-// This is the root cause of the crash-loop escalation observed with
-// multiple OpenCode-backed agents.
+// TestBuiltinProvidersOpenCodePromptModeRegression guards against switching
+// OpenCode back to argv-based prompt delivery. Gas City renders the startup
+// prompt as persona instructions, not as the first user task, so OpenCode must
+// not receive it through argv at startup.
 func TestBuiltinProvidersOpenCodePromptModeRegression(t *testing.T) {
 	p := BuiltinProviders()["opencode"]
 	if p.PromptMode == "arg" {
-		t.Fatal("PromptMode must not be \"arg\" — OpenCode interprets positional args as a project directory path, " +
-			"causing ENAMETOOLONG or directory-not-found errors that trigger crash-loop escalation")
+		t.Fatal("PromptMode must not be \"arg\" — OpenCode interprets positional prompt argv as a project path")
+	}
+	if p.PromptMode == "flag" {
+		t.Fatal("PromptMode must not be \"flag\" — OpenCode treats --prompt as the first user message instead of startup persona context")
 	}
 }
 

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -34,8 +34,17 @@ async function run(directory, ...args) {
 }
 
 export default async function gascityPlugin({ directory }) {
+  let cachedPrime = "";
+
+  async function readPrime(force = false) {
+    if (force || cachedPrime === "") {
+      cachedPrime = await run(directory, "prime", "--hook");
+    }
+    return cachedPrime;
+  }
+
   async function buildPrefix() {
-    const prime = await run(directory, "prime", "--hook");
+    const prime = await readPrime();
     const nudges = await run(directory, "nudge", "drain", "--inject");
     const mail = await run(directory, "mail", "check", "--inject");
     return {
@@ -51,7 +60,7 @@ export default async function gascityPlugin({ directory }) {
       switch (event.type) {
         case "session.created":
         case "session.compacted":
-          await run(directory, "prime", "--hook");
+          await readPrime(true);
           return;
         case "session.deleted":
           await run(directory, "hook", "--inject");

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -75,9 +75,10 @@ export default async function gascityPlugin({ directory }) {
       const { prime, nudges, mail, extras } = await buildPrefix();
       if (extras.length > 0) {
         const prefix = extras.join("\n\n");
-        output.system.unshift(prefix);
-        if (output.system[1]) {
-          output.system[1] = prefix + "\n\n" + output.system[1];
+        if (output.system[0]) {
+          output.system[0] = prefix + "\n\n" + output.system[0];
+        } else {
+          output.system.unshift(prefix);
         }
       }
     },

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -34,10 +34,10 @@ async function run(directory, ...args) {
 }
 
 export default async function gascityPlugin({ directory }) {
-  let cachedPrime = "";
+  let cachedPrime = null;
 
   async function readPrime(force = false) {
-    if (force || cachedPrime === "") {
+    if (force || cachedPrime === null) {
       cachedPrime = await run(directory, "prime", "--hook");
     }
     return cachedPrime;

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -8,6 +8,7 @@
 // Gas City uses:
 //   - session.created / session.compacted → gc prime --hook (side effects such
 //     as session-id persistence and poller bootstrap)
+//   - session.deleted → gc hook --inject (pick up newly queued work on exit)
 //   - experimental.chat.system.transform → inject gc prime --hook, queued
 //     nudges, and unread mail into the system prompt for each turn
 
@@ -51,6 +52,9 @@ export default async function gascityPlugin({ directory }) {
         case "session.created":
         case "session.compacted":
           await run(directory, "prime", "--hook");
+          return;
+        case "session.deleted":
+          await run(directory, "hook", "--inject");
           return;
         default:
           return;

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -43,16 +43,15 @@ export default async function gascityPlugin({ directory }) {
     return cachedPrime;
   }
 
+  function prependText(existing, prefix) {
+    return existing ? prefix + "\n\n" + existing : prefix;
+  }
+
   async function buildPrefix() {
     const prime = await readPrime();
     const nudges = await run(directory, "nudge", "drain", "--inject");
     const mail = await run(directory, "mail", "check", "--inject");
-    return {
-      prime,
-      nudges,
-      mail,
-      extras: [prime, nudges, mail].filter(Boolean),
-    };
+    return [prime, nudges, mail].filter(Boolean).join("\n\n");
   }
 
   return {
@@ -71,21 +70,17 @@ export default async function gascityPlugin({ directory }) {
     },
 
     "chat.message": async (_input, output) => {
-      const { prime, nudges, mail, extras } = await buildPrefix();
-      if (extras.length > 0) {
-        const prefix = extras.join("\n\n");
-        output.message.system = output.message.system
-          ? prefix + "\n\n" + output.message.system
-          : prefix;
+      const prefix = await buildPrefix();
+      if (prefix) {
+        output.message.system = prependText(output.message.system, prefix);
       }
     },
 
     "experimental.chat.system.transform": async (_input, output) => {
-      const { prime, nudges, mail, extras } = await buildPrefix();
-      if (extras.length > 0) {
-        const prefix = extras.join("\n\n");
+      const prefix = await buildPrefix();
+      if (prefix) {
         if (output.system[0]) {
-          output.system[0] = prefix + "\n\n" + output.system[0];
+          output.system[0] = prependText(output.system[0], prefix);
         } else {
           output.system.unshift(prefix);
         }

--- a/internal/hooks/config/opencode.js
+++ b/internal/hooks/config/opencode.js
@@ -1,40 +1,81 @@
 // Gas City hooks for OpenCode.
 // Installed by gc into {workDir}/.opencode/plugins/gascity.js
 //
-// Events:
-//   session.created    → gc prime (load context)
-//   session.compacted  → gc prime (reload after compaction)
-//   session.deleted    → gc hook --inject (pick up work on exit)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+// OpenCode's plugin API is ESM and hook-oriented:
+//   - event() is side-effect-only (no prompt injection)
+//   - experimental.chat.system.transform mutates output.system
+//
+// Gas City uses:
+//   - session.created / session.compacted → gc prime --hook (side effects such
+//     as session-id persistence and poller bootstrap)
+//   - experimental.chat.system.transform → inject gc prime --hook, queued
+//     nudges, and unread mail into the system prompt for each turn
 
-const { execSync } = require("child_process");
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
-function run(cmd) {
+const execFileAsync = promisify(execFile);
+const PATH_PREFIX =
+  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
+
+async function run(directory, ...args) {
   try {
-    return execSync(cmd, { encoding: "utf-8", timeout: 30000 }).trim();
+    const { stdout } = await execFileAsync("gc", args, {
+      cwd: directory,
+      encoding: "utf-8",
+      timeout: 30000,
+      env: { ...process.env, PATH: PATH_PREFIX + (process.env.PATH || "") },
+    });
+    return stdout.trim();
   } catch {
     return "";
   }
 }
 
-module.exports = {
-  name: "gascity",
+export default async function gascityPlugin({ directory }) {
+  async function buildPrefix() {
+    const prime = await run(directory, "prime", "--hook");
+    const nudges = await run(directory, "nudge", "drain", "--inject");
+    const mail = await run(directory, "mail", "check", "--inject");
+    return {
+      prime,
+      nudges,
+      mail,
+      extras: [prime, nudges, mail].filter(Boolean),
+    };
+  }
 
-  events: {
-    "session.created": () => run("gc prime --hook"),
-    "session.compacted": () => run("gc prime --hook"),
-    "session.deleted": () => run("gc hook --inject"),
-  },
-
-  hooks: {
-    "experimental.chat.system.transform": (system) => {
-      const nudges = run("gc nudge drain --inject");
-      const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
-      if (extras.length > 0) {
-        return system + "\n\n" + extras.join("\n\n");
+  return {
+    event: async ({ event }) => {
+      switch (event.type) {
+        case "session.created":
+        case "session.compacted":
+          await run(directory, "prime", "--hook");
+          return;
+        default:
+          return;
       }
-      return system;
     },
-  },
-};
+
+    "chat.message": async (_input, output) => {
+      const { prime, nudges, mail, extras } = await buildPrefix();
+      if (extras.length > 0) {
+        const prefix = extras.join("\n\n");
+        output.message.system = output.message.system
+          ? prefix + "\n\n" + output.message.system
+          : prefix;
+      }
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      const { prime, nudges, mail, extras } = await buildPrefix();
+      if (extras.length > 0) {
+        const prefix = extras.join("\n\n");
+        output.system.unshift(prefix);
+        if (output.system[1]) {
+          output.system[1] = prefix + "\n\n" + output.system[1];
+        }
+      }
+    },
+  };
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -258,6 +258,9 @@ func opencodeFileNeedsUpgrade(existing []byte) bool {
 		!strings.Contains(content, `"chat.message"`) {
 		return true
 	}
+	if strings.Contains(content, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
+		return true
+	}
 	if strings.Contains(content, "export default async function") &&
 		strings.Contains(content, "gc prime --hook") &&
 		(!strings.Contains(content, `"session.deleted"`) ||

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -261,6 +261,11 @@ func opencodeFileNeedsUpgrade(existing []byte) bool {
 	if strings.Contains(content, `const prime = await run(directory, "prime", "--hook");`) {
 		return true
 	}
+	if strings.Contains(content, "export default async function") &&
+		strings.Contains(content, `let cachedPrime = "";`) &&
+		strings.Contains(content, `cachedPrime === ""`) {
+		return true
+	}
 	if strings.Contains(content, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
 		return true
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -258,6 +258,9 @@ func opencodeFileNeedsUpgrade(existing []byte) bool {
 		!strings.Contains(content, `"chat.message"`) {
 		return true
 	}
+	if strings.Contains(content, `const prime = await run(directory, "prime", "--hook");`) {
+		return true
+	}
 	if strings.Contains(content, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
 		return true
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -258,6 +258,12 @@ func opencodeFileNeedsUpgrade(existing []byte) bool {
 		!strings.Contains(content, `"chat.message"`) {
 		return true
 	}
+	if strings.Contains(content, "export default async function") &&
+		strings.Contains(content, "gc prime --hook") &&
+		(!strings.Contains(content, `"session.deleted"`) ||
+			!strings.Contains(content, "gc hook --inject")) {
+		return true
+	}
 	return strings.Contains(content, "output.system.push(") &&
 		strings.Contains(content, "gc prime --hook") &&
 		strings.Contains(content, "experimental.chat.system.transform")

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -157,7 +157,11 @@ func installCodex(fs fsys.FS, workDir string) error {
 // installOpenCode writes .opencode/plugins/gascity.js in the working directory.
 func installOpenCode(fs fsys.FS, workDir string) error {
 	dst := filepath.Join(workDir, ".opencode", "plugins", "gascity.js")
-	return writeEmbedded(fs, "config/opencode.js", dst)
+	data, err := readEmbedded("config/opencode.js")
+	if err != nil {
+		return err
+	}
+	return writeEmbeddedManaged(fs, dst, data, opencodeFileNeedsUpgrade)
 }
 
 // installCopilot writes executable Copilot hooks plus a markdown companion file.
@@ -240,6 +244,23 @@ func geminiFileNeedsUpgrade(existing []byte) bool {
 		strings.Contains(content, `gc nudge drain --inject`) ||
 		strings.Contains(content, `gc mail check --inject`) ||
 		strings.Contains(content, `gc hook --inject`)
+}
+
+func opencodeFileNeedsUpgrade(existing []byte) bool {
+	content := string(existing)
+	if strings.Contains(content, "module.exports = {") &&
+		strings.Contains(content, "gc prime --hook") &&
+		strings.Contains(content, "experimental.chat.system.transform") {
+		return true
+	}
+	if strings.Contains(content, "experimental.chat.system.transform") &&
+		strings.Contains(content, "gc prime --hook") &&
+		!strings.Contains(content, `"chat.message"`) {
+		return true
+	}
+	return strings.Contains(content, "output.system.push(") &&
+		strings.Contains(content, "gc prime --hook") &&
+		strings.Contains(content, "experimental.chat.system.transform")
 }
 
 func claudeFileNeedsUpgrade(existing []byte) bool {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -45,6 +45,24 @@ func cursorHookCommand(t *testing.T, data []byte, event string) string {
 	return entries[0].Command
 }
 
+const openCodePluginPath = "/work/.opencode/plugins/gascity.js"
+
+func installOpenCodePlugin(t *testing.T, existing string) string {
+	t.Helper()
+	fs := fsys.NewFake()
+	if existing != "" {
+		fs.Files[openCodePluginPath] = []byte(existing)
+	}
+	if err := Install(fs, "/city", "/work", []string{"opencode"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data, ok := fs.Files[openCodePluginPath]
+	if !ok {
+		t.Fatalf("expected %s to be written", openCodePluginPath)
+	}
+	return string(data)
+}
+
 func TestSupportedProviders(t *testing.T) {
 	got := SupportedProviders()
 	if len(got) != 8 {
@@ -202,16 +220,7 @@ func TestInstallCodex(t *testing.T) {
 }
 
 func TestInstallOpenCode(t *testing.T) {
-	fs := fsys.NewFake()
-	err := Install(fs, "/city", "/work", []string{"opencode"})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	data, ok := fs.Files["/work/.opencode/plugins/gascity.js"]
-	if !ok {
-		t.Fatal("expected /work/.opencode/plugins/gascity.js to be written")
-	}
-	s := string(data)
+	s := installOpenCodePlugin(t, "")
 	if !strings.Contains(s, "gc prime") {
 		t.Error("opencode plugin should contain gc prime")
 	}
@@ -239,7 +248,7 @@ func TestInstallOpenCode(t *testing.T) {
 	if strings.Contains(s, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
 		t.Error("opencode plugin should not duplicate the prefix into output.system[1]")
 	}
-	if !strings.Contains(s, "output.system[0] = prefix + \"\\n\\n\" + output.system[0]") {
+	if !strings.Contains(s, "output.system[0] = prependText(output.system[0], prefix)") {
 		t.Error("opencode plugin should merge the prefix into output.system[0] when a system prompt already exists")
 	}
 	if !strings.Contains(s, `"chat.message"`) {
@@ -248,20 +257,13 @@ func TestInstallOpenCode(t *testing.T) {
 }
 
 func TestInstallOpenCodeUpgradesLegacyManagedPlugin(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`module.exports = {
+	data := installOpenCodePlugin(t, `module.exports = {
   hooks: {
     "experimental.chat.system.transform": async (_input, output) => {
       output.system.push("gc prime --hook")
     }
   }
 }`)
-
-	err := Install(fs, "/city", "/work", []string{"opencode"})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	if !strings.Contains(data, "export default async function") {
 		t.Fatal("legacy opencode plugin was not upgraded")
 	}
@@ -280,8 +282,7 @@ func TestInstallOpenCodeUpgradesLegacyManagedPlugin(t *testing.T) {
 }
 
 func TestInstallOpenCodeUpgradesManagedPluginMissingShutdownHook(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`export default async function gascityPlugin() {
+	data := installOpenCodePlugin(t, `export default async function gascityPlugin() {
   return {
     event: async ({ event }) => {
       switch (event.type) {
@@ -298,12 +299,6 @@ func TestInstallOpenCodeUpgradesManagedPluginMissingShutdownHook(t *testing.T) {
     },
   }
 }`)
-
-	err := Install(fs, "/city", "/work", []string{"opencode"})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	if !strings.Contains(data, `"session.deleted"`) {
 		t.Fatal("managed opencode plugin missing session.deleted was not upgraded")
 	}
@@ -313,8 +308,7 @@ func TestInstallOpenCodeUpgradesManagedPluginMissingShutdownHook(t *testing.T) {
 }
 
 func TestInstallOpenCodeUpgradesManagedPluginWithDuplicateTransformInjection(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`export default async function gascityPlugin() {
+	data := installOpenCodePlugin(t, `export default async function gascityPlugin() {
   return {
     event: async () => {},
     "chat.message": async () => {},
@@ -327,23 +321,16 @@ func TestInstallOpenCodeUpgradesManagedPluginWithDuplicateTransformInjection(t *
     },
   }
 }`)
-
-	err := Install(fs, "/city", "/work", []string{"opencode"})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	if strings.Contains(data, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
 		t.Fatal("managed opencode plugin with duplicate transform injection was not upgraded")
 	}
-	if !strings.Contains(data, "output.system[0] = prefix + \"\\n\\n\" + output.system[0]") {
+	if !strings.Contains(data, "output.system[0] = prependText(output.system[0], prefix)") {
 		t.Fatal("upgraded opencode plugin should merge into output.system[0]")
 	}
 }
 
 func TestInstallOpenCodeUpgradesManagedPluginWithoutPrimeCache(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`export default async function gascityPlugin({ directory }) {
+	data := installOpenCodePlugin(t, `export default async function gascityPlugin({ directory }) {
   async function buildPrefix() {
     const prime = await run(directory, "prime", "--hook");
     return { prime, extras: [prime].filter(Boolean) };
@@ -354,12 +341,6 @@ func TestInstallOpenCodeUpgradesManagedPluginWithoutPrimeCache(t *testing.T) {
     "experimental.chat.system.transform": async () => {},
   }
 }`)
-
-	err := Install(fs, "/city", "/work", []string{"opencode"})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	if !strings.Contains(data, `let cachedPrime = "";`) {
 		t.Fatal("managed opencode plugin without prime cache was not upgraded")
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -230,6 +230,12 @@ func TestInstallOpenCode(t *testing.T) {
 	if strings.Contains(s, "output.system.push") {
 		t.Error("opencode plugin should merge prompt into the leading system prompt")
 	}
+	if strings.Contains(s, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
+		t.Error("opencode plugin should not duplicate the prefix into output.system[1]")
+	}
+	if !strings.Contains(s, "output.system[0] = prefix + \"\\n\\n\" + output.system[0]") {
+		t.Error("opencode plugin should merge the prefix into output.system[0] when a system prompt already exists")
+	}
 	if !strings.Contains(s, `"chat.message"`) {
 		t.Error("opencode plugin should inject the mayor prompt in chat.message as a runtime-safe fallback")
 	}
@@ -297,6 +303,35 @@ func TestInstallOpenCodeUpgradesManagedPluginMissingShutdownHook(t *testing.T) {
 	}
 	if !strings.Contains(data, "gc hook --inject") {
 		t.Fatal("managed opencode plugin missing gc hook --inject was not upgraded")
+	}
+}
+
+func TestInstallOpenCodeUpgradesManagedPluginWithDuplicateTransformInjection(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`export default async function gascityPlugin() {
+  return {
+    event: async () => {},
+    "chat.message": async () => {},
+    "experimental.chat.system.transform": async (_input, output) => {
+      const prefix = "gc prime --hook"
+      output.system.unshift(prefix)
+      if (output.system[1]) {
+        output.system[1] = prefix + "\n\n" + output.system[1]
+      }
+    },
+  }
+}`)
+
+	err := Install(fs, "/city", "/work", []string{"opencode"})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
+	if strings.Contains(data, "output.system[1] = prefix + \"\\n\\n\" + output.system[1]") {
+		t.Fatal("managed opencode plugin with duplicate transform injection was not upgraded")
+	}
+	if !strings.Contains(data, "output.system[0] = prefix + \"\\n\\n\" + output.system[0]") {
+		t.Fatal("upgraded opencode plugin should merge into output.system[0]")
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -224,8 +224,11 @@ func TestInstallOpenCode(t *testing.T) {
 	if !strings.Contains(s, "gc prime") {
 		t.Error("opencode plugin should contain gc prime")
 	}
-	if !strings.Contains(s, `let cachedPrime = "";`) {
+	if !strings.Contains(s, `let cachedPrime = null;`) {
 		t.Error("opencode plugin should cache the prime output across turns")
+	}
+	if !strings.Contains(s, `if (force || cachedPrime === null) {`) {
+		t.Error("opencode plugin should treat empty prime output as a cached value")
 	}
 	if !strings.Contains(s, `const prime = await readPrime();`) {
 		t.Error("opencode plugin should reuse the cached prime output in buildPrefix")
@@ -341,11 +344,48 @@ func TestInstallOpenCodeUpgradesManagedPluginWithoutPrimeCache(t *testing.T) {
     "experimental.chat.system.transform": async () => {},
   }
 }`)
-	if !strings.Contains(data, `let cachedPrime = "";`) {
+	if !strings.Contains(data, `let cachedPrime = null;`) {
 		t.Fatal("managed opencode plugin without prime cache was not upgraded")
+	}
+	if !strings.Contains(data, `if (force || cachedPrime === null) {`) {
+		t.Fatal("upgraded opencode plugin should cache empty prime output")
 	}
 	if !strings.Contains(data, `const prime = await readPrime();`) {
 		t.Fatal("upgraded opencode plugin should read prime output from cache")
+	}
+}
+
+func TestInstallOpenCodeUpgradesManagedPluginWithEmptyStringPrimeCache(t *testing.T) {
+	data := installOpenCodePlugin(t, `export default async function gascityPlugin({ directory }) {
+  let cachedPrime = "";
+  async function readPrime(force = false) {
+    if (force || cachedPrime === "") {
+      cachedPrime = await run(directory, "prime", "--hook");
+    }
+    return cachedPrime;
+  }
+  return {
+    event: async ({ event }) => {
+      switch (event.type) {
+        case "session.created":
+          await readPrime(true);
+          return;
+        case "session.deleted":
+          await run(directory, "hook", "--inject");
+          return;
+        default:
+          return;
+      }
+    },
+    "chat.message": async () => {},
+    "experimental.chat.system.transform": async () => {},
+  }
+}`)
+	if !strings.Contains(data, `let cachedPrime = null;`) {
+		t.Fatal("managed opencode plugin with empty-string prime cache was not upgraded")
+	}
+	if !strings.Contains(data, `if (force || cachedPrime === null) {`) {
+		t.Fatal("upgraded opencode plugin should cache empty prime output")
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -215,6 +215,12 @@ func TestInstallOpenCode(t *testing.T) {
 	if !strings.Contains(s, "gc prime") {
 		t.Error("opencode plugin should contain gc prime")
 	}
+	if !strings.Contains(s, `let cachedPrime = "";`) {
+		t.Error("opencode plugin should cache the prime output across turns")
+	}
+	if !strings.Contains(s, `const prime = await readPrime();`) {
+		t.Error("opencode plugin should reuse the cached prime output in buildPrefix")
+	}
 	if !strings.Contains(s, `"session.deleted"`) {
 		t.Error("opencode plugin should handle session.deleted")
 	}
@@ -332,6 +338,33 @@ func TestInstallOpenCodeUpgradesManagedPluginWithDuplicateTransformInjection(t *
 	}
 	if !strings.Contains(data, "output.system[0] = prefix + \"\\n\\n\" + output.system[0]") {
 		t.Fatal("upgraded opencode plugin should merge into output.system[0]")
+	}
+}
+
+func TestInstallOpenCodeUpgradesManagedPluginWithoutPrimeCache(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`export default async function gascityPlugin({ directory }) {
+  async function buildPrefix() {
+    const prime = await run(directory, "prime", "--hook");
+    return { prime, extras: [prime].filter(Boolean) };
+  }
+  return {
+    event: async () => {},
+    "chat.message": async () => {},
+    "experimental.chat.system.transform": async () => {},
+  }
+}`)
+
+	err := Install(fs, "/city", "/work", []string{"opencode"})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
+	if !strings.Contains(data, `let cachedPrime = "";`) {
+		t.Fatal("managed opencode plugin without prime cache was not upgraded")
+	}
+	if !strings.Contains(data, `const prime = await readPrime();`) {
+		t.Fatal("upgraded opencode plugin should read prime output from cache")
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -215,6 +215,12 @@ func TestInstallOpenCode(t *testing.T) {
 	if !strings.Contains(s, "gc prime") {
 		t.Error("opencode plugin should contain gc prime")
 	}
+	if !strings.Contains(s, `"session.deleted"`) {
+		t.Error("opencode plugin should handle session.deleted")
+	}
+	if !strings.Contains(s, "gc hook --inject") {
+		t.Error("opencode plugin should contain gc hook --inject")
+	}
 	if !strings.Contains(s, "export default async function") {
 		t.Error("opencode plugin should use ESM export default plugin format")
 	}
@@ -250,8 +256,47 @@ func TestInstallOpenCodeUpgradesLegacyManagedPlugin(t *testing.T) {
 	if strings.Contains(data, "output.system.push") {
 		t.Fatal("legacy opencode plugin push-based transform was not upgraded")
 	}
+	if !strings.Contains(data, `"session.deleted"`) {
+		t.Fatal("upgraded opencode plugin should restore session.deleted handling")
+	}
+	if !strings.Contains(data, "gc hook --inject") {
+		t.Fatal("upgraded opencode plugin should restore gc hook --inject")
+	}
 	if !strings.Contains(data, `"chat.message"`) {
 		t.Fatal("upgraded opencode plugin should include chat.message fallback")
+	}
+}
+
+func TestInstallOpenCodeUpgradesManagedPluginMissingShutdownHook(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`export default async function gascityPlugin() {
+  return {
+    event: async ({ event }) => {
+      switch (event.type) {
+        case "session.created":
+        case "session.compacted":
+          return "gc prime --hook"
+        default:
+          return
+      }
+    },
+    "chat.message": async () => {},
+    "experimental.chat.system.transform": async (_input, output) => {
+      output.system.unshift("gc prime --hook")
+    },
+  }
+}`)
+
+	err := Install(fs, "/city", "/work", []string{"opencode"})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
+	if !strings.Contains(data, `"session.deleted"`) {
+		t.Fatal("managed opencode plugin missing session.deleted was not upgraded")
+	}
+	if !strings.Contains(data, "gc hook --inject") {
+		t.Fatal("managed opencode plugin missing gc hook --inject was not upgraded")
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -211,8 +211,47 @@ func TestInstallOpenCode(t *testing.T) {
 	if !ok {
 		t.Fatal("expected /work/.opencode/plugins/gascity.js to be written")
 	}
-	if !strings.Contains(string(data), "gc prime") {
+	s := string(data)
+	if !strings.Contains(s, "gc prime") {
 		t.Error("opencode plugin should contain gc prime")
+	}
+	if !strings.Contains(s, "export default async function") {
+		t.Error("opencode plugin should use ESM export default plugin format")
+	}
+	if strings.Contains(s, "module.exports") {
+		t.Error("opencode plugin should not use CommonJS exports")
+	}
+	if strings.Contains(s, "output.system.push") {
+		t.Error("opencode plugin should merge prompt into the leading system prompt")
+	}
+	if !strings.Contains(s, `"chat.message"`) {
+		t.Error("opencode plugin should inject the mayor prompt in chat.message as a runtime-safe fallback")
+	}
+}
+
+func TestInstallOpenCodeUpgradesLegacyManagedPlugin(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.opencode/plugins/gascity.js"] = []byte(`module.exports = {
+  hooks: {
+    "experimental.chat.system.transform": async (_input, output) => {
+      output.system.push("gc prime --hook")
+    }
+  }
+}`)
+
+	err := Install(fs, "/city", "/work", []string{"opencode"})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
+	if !strings.Contains(data, "export default async function") {
+		t.Fatal("legacy opencode plugin was not upgraded")
+	}
+	if strings.Contains(data, "output.system.push") {
+		t.Fatal("legacy opencode plugin push-based transform was not upgraded")
+	}
+	if !strings.Contains(data, `"chat.message"`) {
+		t.Fatal("upgraded opencode plugin should include chat.message fallback")
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep hook-enabled OpenCode sessions from replaying startup persona text as a delayed nudge
- upgrade the managed OpenCode plugin to ESM and inject startup context through both `chat.message` and `experimental.chat.system.transform`
- cover the OpenCode hook installation and prompt-resolution regressions with targeted tests

## Testing
- `go test ./internal/hooks -run 'TestInstallOpenCode|TestInstallOpenCodeUpgradesLegacyManagedPlugin'`
- `go test ./cmd/gc -run 'TestTemplateParamsToConfigNoneModeWithHooksSkipsStartupNudge|TestResolveTemplateHookEnabledOpencodeOmitsPrimeInstruction'`
- `go test ./internal/config -run 'TestBuiltinProvidersOpenCode|TestBuiltinProvidersOpenCodePromptModeRegression'`
