### PR TITLE
fix: evaluate scale_check for named-session on-demand agents (#508)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -363,16 +363,28 @@ func buildDesiredStateWithSessionBeads(
 			out, err := shellScaleCheck(scCmd, dir)
 			n := 0
 			outcome := "success"
+			var parseErr error
 			if err != nil {
 				outcome = "failed"
 			} else if trimmed := strings.TrimSpace(out); trimmed != "" {
-				n, _ = strconv.Atoi(trimmed)
+				n, parseErr = strconv.Atoi(trimmed)
+				if parseErr != nil {
+					outcome = "parse_error"
+					n = 0
+				}
 			}
 			if trace != nil {
+				var errStr string
+				if err != nil {
+					errStr = err.Error()
+				}
+				if parseErr != nil {
+					errStr = fmt.Sprintf("parse error: %v (raw output: %q)", parseErr, strings.TrimSpace(out))
+				}
 				trace.recordOperation("trace.scale_check_exec", template, "", "", "scale_check", outcome, traceRecordPayload{
 					"command":        sc,
 					"desired":        n,
-					"error":          fmt.Sprint(err),
+					"error":          errStr,
 					"duration_ms":    time.Since(started).Milliseconds(),
 					"agent_template": template,
 					"named_session":  identity,
@@ -382,11 +394,12 @@ func buildDesiredStateWithSessionBeads(
 			// scaleCheckCounts here — ComputePoolDesiredStatesTraced has
 			// already consumed it above.
 			scaleCheckCounts[template] = n
-			if n > 0 {
+			if parseErr == nil && err == nil && n > 0 {
 				fmt.Fprintf(stderr, "namedWorkReady: %s matched by scale_check (count=%d)\n", identity, n) //nolint:errcheck
 				namedWorkReady[identity] = true
 				continue
 			}
+			// Parse error, execution error, or zero demand — fall through to work_query.
 		}
 		// Fall back to work_query for demand detection.
 		wq := spec.Agent.EffectiveWorkQuery()

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -191,6 +192,9 @@ func buildDesiredStateWithSessionBeads(
 		}
 		// Agents that back configured named sessions are materialized by the
 		// named-session pass below so on-demand/always semantics stay centralized.
+		// Their scale_check (when explicitly configured) is evaluated in that
+		// pass too — not here — to keep demand detection within the named-session
+		// section and avoid feeding named-session agents into the pool pipeline.
 		if _, ok := findNamedSessionSpec(cfg, cityName, cfg.Agents[i].QualifiedName()); ok {
 			continue
 		}
@@ -340,6 +344,51 @@ func buildDesiredStateWithSessionBeads(
 		if spec.Mode == "always" || namedWorkReady[identity] {
 			continue
 		}
+		// Check explicit scale_check first — it is the primary demand signal
+		// when the operator has configured one on the backing agent.
+		// Named-session agents are skipped from the pool evaluation loop
+		// (pendingPools), so their scale_check must be evaluated here.
+		//
+		// We check spec.Agent.ScaleCheck (the raw config field), NOT
+		// EffectiveScaleCheck(), because the default EffectiveScaleCheck
+		// generates a bd-ready query that overlaps with the work_query
+		// fallback below. Only an operator-configured scale_check warrants
+		// this path. On scale_check error or zero, we fall through to
+		// work_query as defense-in-depth — the two signals are complementary.
+		if sc := spec.Agent.ScaleCheck; sc != "" {
+			template := spec.Agent.QualifiedName()
+			dir := agentCommandDir(cityPath, spec.Agent, cfg.Rigs)
+			scCmd := prefixControllerQueryEnv(cityPath, cfg, spec.Agent, sc)
+			started := time.Now()
+			out, err := shellScaleCheck(scCmd, dir)
+			n := 0
+			outcome := "success"
+			if err != nil {
+				outcome = "failed"
+			} else if trimmed := strings.TrimSpace(out); trimmed != "" {
+				n, _ = strconv.Atoi(trimmed)
+			}
+			if trace != nil {
+				trace.recordOperation("trace.scale_check_exec", template, "", "", "scale_check", outcome, traceRecordPayload{
+					"command":        sc,
+					"desired":        n,
+					"error":          fmt.Sprint(err),
+					"duration_ms":    time.Since(started).Milliseconds(),
+					"agent_template": template,
+					"named_session":  identity,
+				}, "")
+			}
+			// Record the count for trace visibility. Safe to mutate
+			// scaleCheckCounts here — ComputePoolDesiredStatesTraced has
+			// already consumed it above.
+			scaleCheckCounts[template] = n
+			if n > 0 {
+				fmt.Fprintf(stderr, "namedWorkReady: %s matched by scale_check (count=%d)\n", identity, n) //nolint:errcheck
+				namedWorkReady[identity] = true
+				continue
+			}
+		}
+		// Fall back to work_query for demand detection.
 		wq := spec.Agent.EffectiveWorkQuery()
 		if wq == "" {
 			continue

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -567,6 +567,48 @@ func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckErrorFallsToWorkQuery(
 	}
 }
 
+func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckNonIntegerFallsToWorkQuery(t *testing.T) {
+	// When scale_check outputs a non-integer string (e.g. "ready"), the
+	// parse error should be recorded and the path should fall through to
+	// work_query for demand detection — not silently treat it as zero.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        `echo "ready"`,
+			WorkQuery:         `echo '["ready"]'`,
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	found := false
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("on-demand named session should materialize via work_query when scale_check outputs non-integer")
+	}
+	if !dsResult.NamedSessionDemand["dog"] {
+		t.Fatal("NamedSessionDemand should include 'dog' via work_query fallback after parse error")
+	}
+	// scale_check parse error should record 0 in ScaleCheckCounts
+	if dsResult.ScaleCheckCounts["dog"] != 0 {
+		t.Fatalf("ScaleCheckCounts[dog] = %d, want 0 (parse error should not produce demand)", dsResult.ScaleCheckCounts["dog"])
+	}
+}
+
 func TestBuildDesiredState_SingletonTemplateDoesNotRealizeDependencyPoolFloorWithoutSession(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -395,6 +395,178 @@ func TestMergeNamedSessionDemand_NilPoolDesiredNoPanic(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckMaterializes(t *testing.T) {
+	// When a named-session agent has an explicit scale_check that returns
+	// demand > 0, the session should materialize even without assigned work
+	// or work_query results. This tests the fix for #508.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 2",
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	found := false
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("on-demand named session with scale_check > 0 should materialize")
+	}
+	if !dsResult.NamedSessionDemand["dog"] {
+		t.Fatal("NamedSessionDemand should include 'dog' when scale_check returns demand")
+	}
+	if dsResult.ScaleCheckCounts["dog"] != 2 {
+		t.Fatalf("ScaleCheckCounts[dog] = %d, want 2", dsResult.ScaleCheckCounts["dog"])
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckZeroDoesNotMaterialize(t *testing.T) {
+	// When scale_check returns 0 and work_query returns nothing, the
+	// on-demand named session should NOT materialize.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 0",
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			t.Fatalf("scale_check=0 should not materialize on-demand named session: %+v", tp)
+		}
+	}
+	if dsResult.ScaleCheckCounts["dog"] != 0 {
+		t.Fatalf("ScaleCheckCounts[dog] = %d, want 0", dsResult.ScaleCheckCounts["dog"])
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_NoExplicitScaleCheckUsesWorkQuery(t *testing.T) {
+	// Without an explicit ScaleCheck, the named-session path should fall
+	// back to EffectiveWorkQuery() as before. Regression guard.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "mayor" {
+			t.Fatalf("empty work_query should not materialize on-demand named session: %+v", tp)
+		}
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckDoesNotCreatePoolSessions(t *testing.T) {
+	// A named-session agent with scale_check should only create a named
+	// session, not pool-managed sessions. Verifies no pool contamination.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 3",
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	// Should have exactly one session (the named session), not 3 pool instances.
+	dogCount := 0
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			dogCount++
+		}
+	}
+	if dogCount != 1 {
+		t.Fatalf("expected 1 named session for dog, got %d (pool contamination?)", dogCount)
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckErrorFallsToWorkQuery(t *testing.T) {
+	// When scale_check fails (non-zero exit) but work_query returns ready
+	// work, the session should still materialize via the work_query fallback.
+	// This tests the defense-in-depth path.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "exit 1",
+			WorkQuery:         `echo '["ready"]'`,
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	found := false
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("on-demand named session should materialize via work_query when scale_check fails")
+	}
+	if !dsResult.NamedSessionDemand["dog"] {
+		t.Fatal("NamedSessionDemand should include 'dog' via work_query fallback")
+	}
+}
+
 func TestBuildDesiredState_SingletonTemplateDoesNotRealizeDependencyPoolFloorWithoutSession(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -147,8 +147,17 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			// Check scale_check demand for named sessions whose backing
 			// agent has an explicit scale_check. The ScaleCheckCounts map
 			// includes named-session counts added by buildDesiredState.
+			//
+			// Skip if the session is already running — the later
+			// "on-demand:running" override (step 5) will pick it up with
+			// the correct reason. Setting "named-on-demand:scale-check"
+			// here would preempt that override and lose the running-state
+			// signal.
 			if input.ScaleCheckCounts[ns.Template] > 0 {
 				if sn := findNamedSessionName(input.SessionBeads, ns.Identity); sn != "" {
+					if input.RunningSessions[sn] {
+						continue
+					}
 					bead := findBeadBySessionName(input.SessionBeads, sn)
 					if bead != nil && !bead.Drained && !bead.DependencyOnly {
 						desired[sn] = "named-on-demand:scale-check"

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -142,6 +142,20 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 				} else {
 					desired[ns.Identity] = "named-on-demand:work-query"
 				}
+				continue
+			}
+			// Check scale_check demand for named sessions whose backing
+			// agent has an explicit scale_check. The ScaleCheckCounts map
+			// includes named-session counts added by buildDesiredState.
+			if input.ScaleCheckCounts[ns.Template] > 0 {
+				if sn := findNamedSessionName(input.SessionBeads, ns.Identity); sn != "" {
+					bead := findBeadBySessionName(input.SessionBeads, sn)
+					if bead != nil && !bead.Drained && !bead.DependencyOnly {
+						desired[sn] = "named-on-demand:scale-check"
+					}
+				} else {
+					desired[ns.Identity] = "named-on-demand:scale-check"
+				}
 			}
 		}
 	}
@@ -155,7 +169,9 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		if !ok || agent.Suspended {
 			continue
 		}
-		// Skip named session templates — they wake via assignee, not scale
+		// Skip named session templates from the scaled-agent loop — they
+		// are handled in the named-session pass above (via assignee,
+		// work_query, or explicit scale_check).
 		if isNamedSessionTemplate(input.NamedSessions, template) {
 			continue
 		}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -224,12 +224,28 @@ func TestNamedOnDemand_Attached_StaysAwake(t *testing.T) {
 	assertAwake(t, result, "hello-world--refinery")
 }
 
-func TestNamedOnDemand_ScaleCheckIrrelevant(t *testing.T) {
+func TestNamedOnDemand_ScaleCheckWakes(t *testing.T) {
+	// On-demand named sessions should wake when ScaleCheckCounts > 0 for
+	// their backing template. This tests the fix for #508: named-session
+	// agents with an explicit scale_check should have it evaluated.
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:           []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
 		NamedSessions:    []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:     []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
 		ScaleCheckCounts: map[string]int{"hello-world/refinery": 1},
+		Now:              now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "named-on-demand:scale-check")
+}
+
+func TestNamedOnDemand_ScaleCheckZeroStaysAsleep(t *testing.T) {
+	// ScaleCheckCounts of 0 should not wake the session.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:           []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions:    []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads:     []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
+		ScaleCheckCounts: map[string]int{"hello-world/refinery": 0},
 		Now:              now,
 	})
 	assertAsleep(t, result, "hello-world--refinery")

--- a/engdocs/design/named-configured-sessions.md
+++ b/engdocs/design/named-configured-sessions.md
@@ -233,6 +233,9 @@ Creation triggers are:
 - controller work detection for the qualified named-session identity
   (`work_query` is evaluated in that identity's stamped runtime context
   and attributed only to that identity)
+- explicit `scale_check` on the backing agent returning demand > 0
+  (evaluated in the named-session pass, not the pool pipeline; falls
+  through to `work_query` on error or zero)
 - dependency wake when another realized session needs this template awake
 
 Once created, the bead persists as the canonical session history record.


### PR DESCRIPTION
## Summary

- Named-session agents with an explicit `scale_check` were skipped from pool evaluation entirely (`continue` at `build_desired_state.go:198`), so their `scale_check` was never executed
- Moves scale_check evaluation into the named-session demand-detection pass, before the `work_query` fallback
- Updates `ComputeAwakeSet` to recognize `named-on-demand:scale-check` as a wake reason with correct priority (assignee > work_query > scale_check)
- Uses raw `ScaleCheck` config field (not `EffectiveScaleCheck()`) to avoid overlap with the default bd-ready query that `work_query` provides

Closes #508

## What was tested

- `make fmt-check` — pass
- `make vet` — pass
- `make lint` — 0 issues

Six new tests:
- `TestBuildDesiredState_OnDemandNamedSession_ScaleCheckMaterializes` — scale_check > 0 materializes
- `TestBuildDesiredState_OnDemandNamedSession_ScaleCheckZeroDoesNotMaterialize` — scale_check = 0 does not
- `TestBuildDesiredState_OnDemandNamedSession_NoExplicitScaleCheckUsesWorkQuery` — fallback to work_query
- `TestBuildDesiredState_OnDemandNamedSession_ScaleCheckDoesNotCreatePoolSessions` — no pool contamination
- `TestBuildDesiredState_OnDemandNamedSession_ScaleCheckErrorFallsToWorkQuery` — error fallthrough
- `TestNamedOnDemand_ScaleCheckWakes` + `TestNamedOnDemand_ScaleCheckZeroStaysAsleep` — ComputeAwakeSet integration

## Review outcome

Adversarial review: no critical findings. Important items addressed:
- Added error-fallthrough test for defense-in-depth path
- Updated `engdocs/design/named-configured-sessions.md` creation triggers list

UAT: skipped (no UX-facing changes — all internal reconciler logic).

Docs: findings addressed — design doc creation triggers updated to include scale_check.

Neutral judge: **CLEARED**. No blocking issues.

## Residual notes for reviewer

- **Behavioral inversion**: `TestNamedOnDemand_ScaleCheckIrrelevant` → `TestNamedOnDemand_ScaleCheckWakes` — the old test asserted scale_check had no effect on named sessions. The fix intentionally reverses this.
- **Sequential execution**: Named-session scale_checks run sequentially (not behind the probe concurrency semaphore). Not a correctness issue; parallelization can follow if needed.
- **`continue` at `compute_awake_set.go:145`**: Prevents work_query reason from being overwritten by scale_check. Without it, both paths would execute.

## Changes

- `cmd/gc/build_desired_state.go` — scale_check evaluation in named-session demand pass
- `cmd/gc/build_desired_state_test.go` — 5 new tests
- `cmd/gc/compute_awake_set.go` — scale_check wake reason + priority ordering
- `cmd/gc/compute_awake_set_test.go` — 2 new tests (wake + zero-stays-asleep)
- `engdocs/design/named-configured-sessions.md` — creation triggers updated