### PR TITLE
fix: exclude root node from formula show step count (#476)

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -152,7 +152,13 @@ Examples:
 				}
 			}
 
-			_, _ = fmt.Fprintf(stdout, "\nSteps (%d):\n", len(recipe.Steps))
+			displayCount := len(recipe.Steps)
+			for _, s := range recipe.Steps {
+				if s.IsRoot {
+					displayCount--
+				}
+			}
+			_, _ = fmt.Fprintf(stdout, "\nSteps (%d):\n", displayCount)
 			for i, step := range recipe.Steps {
 				if step.IsRoot {
 					continue

--- a/cmd/gc/testdata/formula-show.txtar
+++ b/cmd/gc/testdata/formula-show.txtar
@@ -1,0 +1,52 @@
+# gc formula show — step count excludes implicit root node.
+#
+# Regression test for gastownhall/gascity#476: the step count header
+# included the implicit root wrapper node but the listing skipped it,
+# producing "Steps (4):" followed by only 3 lines.
+
+env GC_BEADS=file
+env GC_DOLT=skip
+env GC_SESSION=fake
+
+exec gc init --file $WORK/city.toml $WORK/my-city
+cd $WORK/my-city
+
+# Formula with 3 user-defined steps should show "Steps (3):"
+exec gc formula show pancakes
+stdout 'Steps \(3\):'
+stdout 'dry'
+stdout 'wet'
+stdout 'cook'
+! stdout 'Steps \(4\)'
+
+-- city.toml --
+[workspace]
+name = "my-city"
+provider = "claude"
+
+[formulas]
+dir = "formulas"
+
+[[agent]]
+name = "chef"
+start_command = "echo hello"
+
+-- my-city/formulas/pancakes.formula.toml --
+formula = "pancakes"
+description = "Make pancakes"
+version = 1
+
+[[steps]]
+id = "dry"
+title = "Mix dry ingredients"
+type = "task"
+
+[[steps]]
+id = "wet"
+title = "Mix wet ingredients"
+type = "task"
+
+[[steps]]
+id = "cook"
+title = "Cook pancakes"
+needs = ["dry", "wet"]


### PR DESCRIPTION
## Summary

`gc formula show` counted the implicit root wrapper node in the step count header but skipped it in the listing. A formula with 3 user-defined steps displayed "Steps (4):" followed by only 3 lines. Now the count excludes root nodes so the header matches.

## What changed

- `cmd/gc/cmd_formula.go`: Count only non-root steps for the `Steps (N):` header
- `cmd/gc/testdata/formula-show.txtar`: Regression test verifying header matches listing

## What was tested

- `make fmt-check` — pass
- `make lint` — pass (0 issues)
- `make vet` — pass

## Review outcome

Simple one-line logic fix with a testscript regression test. No architectural changes.

Closes #476