### PR TITLE
fix: evaluate scale_check for named_session agents (#508)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -184,6 +184,11 @@ func buildDesiredStateWithSessionBeads(
 
 	desired := make(map[string]TemplateParams)
 	var pendingPools []poolEvalWork
+	// namedSessionScaleChecks collects scale_check evaluations for agents
+	// that back named sessions. These agents are materialized by the
+	// named-session pass (not the pool path), but their scale_check must
+	// still be evaluated so on_demand sessions detect work.
+	var namedSessionScaleChecks []poolEvalWork
 
 	for i := range cfg.Agents {
 		if cfg.Agents[i].Suspended {
@@ -191,7 +196,14 @@ func buildDesiredStateWithSessionBeads(
 		}
 		// Agents that back configured named sessions are materialized by the
 		// named-session pass below so on-demand/always semantics stay centralized.
+		// However, we still evaluate their scale_check so that on_demand named
+		// sessions can use it as a demand signal.
 		if _, ok := findNamedSessionSpec(cfg, cityName, cfg.Agents[i].QualifiedName()); ok {
+			sp := scaleParamsFor(&cfg.Agents[i])
+			if sp.Check != "" {
+				poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+				namedSessionScaleChecks = append(namedSessionScaleChecks, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir})
+			}
 			continue
 		}
 
@@ -232,7 +244,10 @@ func buildDesiredStateWithSessionBeads(
 
 	// scale_check runs in parallel for all pool agents — the authoritative
 	// demand signal for new sessions. Computed once, returned in result.
-	scaleCheckCounts := evaluatePendingPoolsMap(cityPath, cfg, pendingPools, stderr, trace)
+	// Named-session agents with custom scale_check are evaluated alongside
+	// pool agents so their results feed the named-session demand pass.
+	allScaleChecks := append(pendingPools, namedSessionScaleChecks...)
+	scaleCheckCounts := evaluatePendingPoolsMap(cityPath, cfg, allScaleChecks, stderr, trace)
 
 	// Collect work beads with assignees — used for both pool demand and
 	// named session on_demand wake. Hoisted out of the store block so
@@ -350,6 +365,19 @@ func buildDesiredStateWithSessionBeads(
 			continue
 		}
 		if workQueryHasReadyWork(strings.TrimSpace(out)) {
+			namedWorkReady[identity] = true
+		}
+	}
+	// scale_check demand: if a named-session agent's scale_check returned > 0,
+	// treat that as demand — the scale_check is the operator's explicit signal
+	// that work exists, independent of the work_query path.
+	for identity, spec := range namedSpecs {
+		if spec.Mode == "always" || namedWorkReady[identity] {
+			continue
+		}
+		template := spec.Agent.QualifiedName()
+		if count, ok := scaleCheckCounts[template]; ok && count > 0 {
+			fmt.Fprintf(stderr, "namedWorkReady: %s matched by scale_check (count=%d)\n", identity, count) //nolint:errcheck
 			namedWorkReady[identity] = true
 		}
 	}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -255,6 +255,18 @@ func buildDesiredStateWithSessionBeads(
 	allScaleChecks = append(allScaleChecks, namedSessionScaleChecks...)
 	scaleCheckCounts := evaluatePendingPoolsMap(cityPath, cfg, allScaleChecks, stderr, trace)
 
+	// Derive a pool-only view for ComputePoolDesiredStatesTraced so that
+	// named-session counts are NOT interpreted as pool scaling demand
+	// (which would double-materialize: once via the pool path, once via
+	// the named-session pass below).
+	poolScaleCheckCounts := make(map[string]int, len(pendingPools))
+	for _, pw := range pendingPools {
+		template := cfg.Agents[pw.agentIdx].QualifiedName()
+		if count, ok := scaleCheckCounts[template]; ok {
+			poolScaleCheckCounts[template] = count
+		}
+	}
+
 	// Collect work beads with assignees — used for both pool demand and
 	// named session on_demand wake. Hoisted out of the store block so
 	// the named session section can also use it.
@@ -273,7 +285,7 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
-		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, assignedWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
+		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, assignedWorkBeads, sessionBeads.Open(), poolScaleCheckCounts, trace)
 		for _, poolState := range poolDesiredStates {
 			cfgAgent := findAgentByTemplate(cfg, poolState.Template)
 			if cfgAgent == nil {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -196,7 +196,7 @@ func buildDesiredStateWithSessionBeads(
 		// Agents that back configured named sessions are materialized by the
 		// named-session pass below so on-demand/always semantics stay centralized.
 		if _, ok := findNamedSessionSpec(cfg, cityName, cfg.Agents[i].QualifiedName()); ok {
-			if cfg.Agents[i].ScaleCheck != "" {
+			if cfg.Agents[i].ScaleCheck != "" && !agentInSuspendedRig(cityPath, &cfg.Agents[i], cfg.Rigs, suspendedRigPaths) {
 				sp := scaleParamsFor(&cfg.Agents[i])
 				poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 				namedSessionScaleChecks = append(namedSessionScaleChecks, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir})

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -184,10 +184,9 @@ func buildDesiredStateWithSessionBeads(
 
 	desired := make(map[string]TemplateParams)
 	var pendingPools []poolEvalWork
-	// namedSessionScaleChecks collects scale_check evaluations for agents
-	// that back named sessions. These agents are materialized by the
-	// named-session pass (not the pool path), but their scale_check must
-	// still be evaluated so on_demand sessions detect work.
+	// Named-session agents with an explicit scale_check are evaluated here
+	// too — the named-session pass below uses the result as a demand signal
+	// for on_demand materialization (#508).
 	var namedSessionScaleChecks []poolEvalWork
 
 	for i := range cfg.Agents {
@@ -196,11 +195,9 @@ func buildDesiredStateWithSessionBeads(
 		}
 		// Agents that back configured named sessions are materialized by the
 		// named-session pass below so on-demand/always semantics stay centralized.
-		// However, we still evaluate their scale_check so that on_demand named
-		// sessions can use it as a demand signal.
 		if _, ok := findNamedSessionSpec(cfg, cityName, cfg.Agents[i].QualifiedName()); ok {
-			sp := scaleParamsFor(&cfg.Agents[i])
-			if sp.Check != "" {
+			if cfg.Agents[i].ScaleCheck != "" {
+				sp := scaleParamsFor(&cfg.Agents[i])
 				poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 				namedSessionScaleChecks = append(namedSessionScaleChecks, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir})
 			}
@@ -246,7 +243,11 @@ func buildDesiredStateWithSessionBeads(
 	// demand signal for new sessions. Computed once, returned in result.
 	// Named-session agents with custom scale_check are evaluated alongside
 	// pool agents so their results feed the named-session demand pass.
-	allScaleChecks := append(pendingPools, namedSessionScaleChecks...)
+	// Allocate a fresh slice to avoid aliasing pendingPools' backing array,
+	// which is still consumed below in the no-store branch.
+	allScaleChecks := make([]poolEvalWork, 0, len(pendingPools)+len(namedSessionScaleChecks))
+	allScaleChecks = append(allScaleChecks, pendingPools...)
+	allScaleChecks = append(allScaleChecks, namedSessionScaleChecks...)
 	scaleCheckCounts := evaluatePendingPoolsMap(cityPath, cfg, allScaleChecks, stderr, trace)
 
 	// Collect work beads with assignees — used for both pool demand and
@@ -351,8 +352,17 @@ func buildDesiredStateWithSessionBeads(
 	if len(assignedWorkBeads) > 0 {
 		fmt.Fprintf(stderr, "namedWorkReady: %d assigned beads, %d named specs, ready=%v\n", len(assignedWorkBeads), len(namedSpecs), namedWorkReady) //nolint:errcheck
 	}
+	// Determine demand for each on_demand named session. An explicit
+	// scale_check (evaluated above alongside pool agents) takes precedence
+	// over work_query, since it's the operator's direct signal and avoids
+	// a second subprocess spawn for the same agent.
 	for identity, spec := range namedSpecs {
 		if spec.Mode == "always" || namedWorkReady[identity] {
+			continue
+		}
+		if count := scaleCheckCounts[spec.Agent.QualifiedName()]; count > 0 {
+			fmt.Fprintf(stderr, "namedWorkReady: %s matched by scale_check (count=%d)\n", identity, count) //nolint:errcheck
+			namedWorkReady[identity] = true
 			continue
 		}
 		wq := spec.Agent.EffectiveWorkQuery()
@@ -365,19 +375,6 @@ func buildDesiredStateWithSessionBeads(
 			continue
 		}
 		if workQueryHasReadyWork(strings.TrimSpace(out)) {
-			namedWorkReady[identity] = true
-		}
-	}
-	// scale_check demand: if a named-session agent's scale_check returned > 0,
-	// treat that as demand — the scale_check is the operator's explicit signal
-	// that work exists, independent of the work_query path.
-	for identity, spec := range namedSpecs {
-		if spec.Mode == "always" || namedWorkReady[identity] {
-			continue
-		}
-		template := spec.Agent.QualifiedName()
-		if count, ok := scaleCheckCounts[template]; ok && count > 0 {
-			fmt.Fprintf(stderr, "namedWorkReady: %s matched by scale_check (count=%d)\n", identity, count) //nolint:errcheck
 			namedWorkReady[identity] = true
 		}
 	}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -184,9 +184,14 @@ func buildDesiredStateWithSessionBeads(
 
 	desired := make(map[string]TemplateParams)
 	var pendingPools []poolEvalWork
-	// Named-session agents with an explicit scale_check are evaluated here
+	// Named-session agents with an *explicit* scale_check are evaluated here
 	// too — the named-session pass below uses the result as a demand signal
-	// for on_demand materialization (#508).
+	// for on_demand materialization (#508). The default EffectiveScaleCheck()
+	// is intentionally skipped: named-session demand has historically been
+	// driven by work_query + assignee detection, and evaluating the default
+	// scale_check for every named agent would change wake semantics beyond
+	// the scope of this fix. Operators who want scale_check-based demand
+	// must opt in by configuring ScaleCheck explicitly.
 	var namedSessionScaleChecks []poolEvalWork
 
 	for i := range cfg.Agents {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1375,6 +1375,88 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) 
 	}
 }
 
+// TestBuildDesiredState_NamedSessionScaleCheckDemand verifies that a
+// named_session agent with a custom scale_check has that check evaluated
+// and used as a demand signal for on_demand materialization. Regression
+// test for #508 where the named-session code path skipped scale_check
+// entirely.
+func TestBuildDesiredState_NamedSessionScaleCheckDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 5", // simulates 5 queued molecules
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	// The scale_check should have been evaluated.
+	if dsResult.ScaleCheckCounts == nil {
+		t.Fatal("ScaleCheckCounts is nil, want scale_check to be evaluated for named-session agent")
+	}
+	// scale_check output (5) is clamped to max_active_sessions (3).
+	if got := dsResult.ScaleCheckCounts["dog"]; got != 3 {
+		t.Fatalf("ScaleCheckCounts[dog] = %d, want 3 (clamped from echo 5)", got)
+	}
+
+	// The on_demand named session should have been materialized via
+	// scale_check demand.
+	if !dsResult.NamedSessionDemand["dog"] {
+		t.Fatal("NamedSessionDemand[dog] = false, want true when scale_check returns > 0")
+	}
+
+	// Verify a session was actually desired.
+	found := false
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("no desired session for dog template, want one from scale_check demand")
+	}
+}
+
+// TestBuildDesiredState_NamedSessionScaleCheckZeroNoDemand verifies that a
+// named_session agent with scale_check returning 0 does NOT get demand.
+func TestBuildDesiredState_NamedSessionScaleCheckZeroNoDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 0",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "dog",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	if dsResult.NamedSessionDemand["dog"] {
+		t.Fatal("NamedSessionDemand[dog] = true, want false when scale_check returns 0")
+	}
+}
+
 // PR #216 — skipped for now. Cross-rig pool work visibility is a new
 // feature, not a bug fix. Left as open PR for discussion about the
 // gastown experience with this flow.

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1416,16 +1416,23 @@ func TestBuildDesiredState_NamedSessionScaleCheckDemand(t *testing.T) {
 		t.Fatal("NamedSessionDemand[dog] = false, want true when scale_check returns > 0")
 	}
 
-	// Verify a session was actually desired.
-	found := false
+	// Verify exactly one session was desired for dog, and that it came
+	// from the named-session materialization path (ConfiguredNamedIdentity
+	// is set) — NOT from a pool-managed path that would double-materialize
+	// if scaleCheckCounts were passed unfiltered to ComputePoolDesiredStates.
+	dogCount := 0
+	var dogSession TemplateParams
 	for _, tp := range dsResult.State {
 		if tp.TemplateName == "dog" {
-			found = true
-			break
+			dogCount++
+			dogSession = tp
 		}
 	}
-	if !found {
-		t.Fatal("no desired session for dog template, want one from scale_check demand")
+	if dogCount != 1 {
+		t.Fatalf("desired dog sessions = %d, want exactly 1 named-session materialization", dogCount)
+	}
+	if dogSession.ConfiguredNamedIdentity != "dog" {
+		t.Fatalf("ConfiguredNamedIdentity = %q, want \"dog\" — session was not materialized via named-session path", dogSession.ConfiguredNamedIdentity)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1455,6 +1455,11 @@ func TestBuildDesiredState_NamedSessionScaleCheckZeroNoDemand(t *testing.T) {
 	if dsResult.NamedSessionDemand["dog"] {
 		t.Fatal("NamedSessionDemand[dog] = true, want false when scale_check returns 0")
 	}
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "dog" {
+			t.Fatalf("dog session materialized with scale_check=0, should be absent")
+		}
+	}
 }
 
 // PR #216 — skipped for now. Cross-rig pool work visibility is a new


### PR DESCRIPTION
## Summary

Fixes #508. Named-session agents with a custom \`scale_check\` were completely skipped from pool scale_check evaluation — the \`findNamedSessionSpec\` early-continue in \`buildDesiredStateWithSessionBeads\` bypassed \`pendingPools\` collection entirely, so operators using \`[[named_session]] mode = \"on_demand\"\` with a custom \`scale_check\` (e.g., as a workaround for #505) saw their scale_check never execute.

### Changes

- Collect explicit \`scale_check\` for named-session agents into a separate \`namedSessionScaleChecks\` slice, merged with \`pendingPools\` for parallel evaluation via the existing \`evaluatePendingPoolsMap\` path — inherits the same concurrency bound (\`Daemon.ProbeConcurrencyOrDefault()\`).
- Fuse the scale_check and work_query demand loops into one pass over \`namedSpecs\`. Scale_check takes precedence and short-circuits the work_query subprocess when it already yields demand.
- Pre-filter \`agentInSuspendedRig\` at collection time so suspended-rig agents don't spawn wasted subprocesses.
- Explicit-only gate (\`cfg.Agents[i].ScaleCheck != \"\"\`): default \`EffectiveScaleCheck()\` is intentionally skipped — expanding to the default would change wake semantics beyond the scope of this fix. Operators opt in by configuring \`ScaleCheck\` explicitly.
- Explicit \`make\`+\`append\` (not \`append(pendingPools, ...)\`) avoids backing-array aliasing with \`pendingPools\`, which is still consumed by the no-store branch.

### Tests

- \`TestBuildDesiredState_NamedSessionScaleCheckDemand\` — verifies scale_check is evaluated and drives on_demand materialization (\`echo 5\` → clamped to max=3 → session materialized).
- \`TestBuildDesiredState_NamedSessionScaleCheckZeroNoDemand\` — verifies scale_check=0 does not produce demand and no session materialized.

### Review

Ran \`/simplify\` + 5-reviewer parallel pass (3 Anthropic specialists, Codex, Copilot). Both codex and copilot independently flagged the suspended-rig subprocess waste and the default-vs-explicit asymmetry — the first was fixed, the second was documented as intentional scope control.

## Test plan

- [x] \`go test -race ./cmd/gc/...\` — all cmd/gc tests pass deterministically
- [x] \`make build\` clean
- [x] \`make check\` — fmt/lint/vet clean; test failures in this environment are pre-existing baseline flakes (confirmed by running the same tests on \`main\`)
- [x] Manual verification: named session with explicit \`scale_check\` now appears in \`scale_check_counts\` trace