### PR TITLE
fix: register city Dolt config in doctor and ensure port override (#506)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -142,6 +142,12 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 		}
 	}
 	mirrorBeadsDoltEnv(env)
+	// Ensure BEADS_DOLT_SERVER_PORT is always present in the overrides
+	// map (even empty) so mergeEnv overrides any inherited value from
+	// coexisting products that share the same Dolt env vars.
+	if _, ok := env["BEADS_DOLT_SERVER_PORT"]; !ok {
+		env["BEADS_DOLT_SERVER_PORT"] = ""
+	}
 	return env
 }
 

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -548,6 +548,26 @@ func TestBdRuntimeEnvForRigPrefersExplicitRigDoltConfigOverManagedCity(t *testin
 	}
 }
 
+func TestBdRuntimeEnvAlwaysIncludesBeadsDoltServerPort(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	// No host/port configured — BEADS_DOLT_SERVER_PORT should still be
+	// present (empty) as defense-in-depth against inherited env leakage.
+	_ = os.Unsetenv("GC_DOLT_HOST")
+	_ = os.Unsetenv("GC_DOLT_PORT")
+
+	cityPath := t.TempDir()
+	env := bdRuntimeEnv(cityPath)
+
+	val, ok := env["BEADS_DOLT_SERVER_PORT"]
+	if !ok {
+		t.Fatal("BEADS_DOLT_SERVER_PORT must always be present in bdRuntimeEnv output")
+	}
+	if val != "" {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want empty (no port configured)", val)
+	}
+}
+
 func TestDoltAutoStartSuppressedInAllEnvPaths(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -65,6 +65,12 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	// checks above (which will report the parse error).
 	cfg, cfgErr := loadCityConfig(cityPath)
 	if cfgErr == nil {
+		// Register city Dolt config so bdRuntimeEnv can resolve the
+		// correct port for bead store checks (mirrors startBeadsLifecycle).
+		if cfg.Dolt.Host != "" || cfg.Dolt.Port != 0 {
+			cityDoltConfigs.Store(cityPath, cfg.Dolt)
+			defer cityDoltConfigs.Delete(cityPath)
+		}
 		d.Register(doctor.NewConfigValidCheck(cfg))
 		d.Register(doctor.NewConfigRefsCheck(cfg, cityPath))
 		d.Register(doctor.NewBuiltinPackFamilyCheck(cfg, cityPath))


### PR DESCRIPTION
## Summary

Pares back the original broad fix to the two changes identified in the maintainer's fix plan:

1. **cmd/gc/cmd_doctor.go** — Register `cityDoltConfigs.Store()` in `doDoctor()` so `bdRuntimeEnv` can resolve the correct port for bead store health checks (mirrors `startBeadsLifecycle`).

2. **cmd/gc/bd_env.go** — Always include `BEADS_DOLT_SERVER_PORT` in the overrides map (even empty) so `mergeEnv` overrides any inherited value from coexisting products.

3. **cmd/gc/bd_env_test.go** — Test verifying `BEADS_DOLT_SERVER_PORT` is always present in `bdRuntimeEnv` output.

The broader `mergeEnv` BEADS_* stripping and `gc-beads-bd` shell changes are deferred to follow-up.

Fixes #506

## What was tested

- `make fmt-check` — pass
- `make vet` — pass
- `make lint` — pass

## Changes

- No breaking changes
- No doc updates needed (internal fix)