### PR TITLE
fix: scope deps.env to docker-base recipe via inline sourcing (#474)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,9 @@ docs-dev:
 
 ## docker-base: build base image with system dependencies (~2.5 min, rebuild rarely)
 docker-base: check-docker
-	docker build -f contrib/k8s/Dockerfile.base -t gc-agent-base:latest .
+	. ./deps.env && docker build -f contrib/k8s/Dockerfile.base \
+		--build-arg DOLT_VERSION=$$DOLT_VERSION \
+		-t gc-agent-base:latest .
 
 ## docker-agent: build base agent image (~5s on top of base). For prebaked images use: gc build-image
 docker-agent: check-docker


### PR DESCRIPTION
## Summary

Source `deps.env` inline in the `docker-base` recipe (`. ./deps.env && docker build --build-arg DOLT_VERSION=$$DOLT_VERSION ...`) instead of using a top-level `include deps.env` + `export` that would leak Docker build variables (`DOLT_VERSION`, `BD_COMMIT`, `BD_REPO`, `BR_VERSION`) into every Make target.

Only `docker-base` is modified — `docker-agent` and `docker-controller` copy pre-built binaries and have no version `ARG`s to wire.

Fixes #474. Surfaced during #418 review.

## What was tested

- `make fmt-check` — clean
- `make lint` — 0 issues
- `make vet` — clean

## Review outcome

- **Design council** (simple): Both architecture and Make-expert perspectives converged on inline sourcing (Approach 1). Approach 2 (target-specific vars with `$(shell ...)`) has a critical flaw — evaluated at parse time regardless of target. Approach 3 (sub-make) is disproportionate.
- **Adversarial review**: 2 critical findings dismissed (out-of-scope CI/K8s sync, intentional docker-agent omission), 2 important findings acknowledged as consistent with codebase conventions (relative paths, empty-value edge case). No code changes required.
- **UAT**: SKIPPED — build-system change, no UX impact.
- **Docs**: PASS — no docs updates needed.
- **Neutral judge**: CLEARED.

## Review story

The fix prevents a future top-level `include deps.env` + `export` from leaking Dolt version and other vars into unrelated Make targets (flagged during PR #418 review). Solution: single-recipe sourcing in the only target that needs it. The `Dockerfile.base` `ARG DOLT_VERSION=1.85.0` default is intentionally preserved — it enables the documented direct `docker build` path without Make.

## Notes

- Pre-existing debt: CI YAML and Dockerfile.base still hardcode `DOLT_VERSION=1.85.0` separately. This PR reduces the manual-sync surface from 5 files to 4 but doesn't eliminate it. Worth a separate follow-up issue.
- No breaking changes.