### PR TITLE
fix: off-by-one step count in gc formula show

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -152,7 +152,8 @@ Examples:
 				}
 			}
 
-			_, _ = fmt.Fprintf(stdout, "\nSteps (%d):\n", len(recipe.Steps)-1)
+			stepCount := max(0, len(recipe.Steps)-1)
+			_, _ = fmt.Fprintf(stdout, "\nSteps (%d):\n", stepCount)
 			for i, step := range recipe.Steps {
 				if step.IsRoot {
 					continue

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -152,7 +152,7 @@ Examples:
 				}
 			}
 
-			_, _ = fmt.Fprintf(stdout, "\nSteps (%d):\n", len(recipe.Steps))
+			_, _ = fmt.Fprintf(stdout, "\nSteps (%d):\n", len(recipe.Steps)-1)
 			for i, step := range recipe.Steps {
 				if step.IsRoot {
 					continue

--- a/test/integration/gastown_formula_test.go
+++ b/test/integration/gastown_formula_test.go
@@ -89,6 +89,9 @@ needs = ["combine"]
 	if err != nil {
 		t.Fatalf("gc formula show failed: %v\noutput: %s", err, out)
 	}
+	if !strings.Contains(out, "Steps (4):") {
+		t.Errorf("expected 'Steps (4):' in formula show output (got %q)", out)
+	}
 	for _, step := range []string{"dry", "wet", "combine", "cook"} {
 		if !strings.Contains(out, step) {
 			t.Errorf("expected step %q in formula show output:\n%s", step, out)


### PR DESCRIPTION
## Summary

Fixes #476.

- `gc formula show` displayed `Steps (N):` where N included the synthetic root step, but the display loop skips root steps — so the count was always one too high.
- Changed `len(recipe.Steps)` to `max(0, len(recipe.Steps)-1)` to match the number of steps actually rendered. The `max` clamp guards against a hypothetical empty-steps edge case.
- Added a step count assertion (`Steps (4):`) to the existing integration test in `test/integration/gastown_formula_test.go`.

## Test plan

- [x] `make build` passes
- [x] `make check` passes (baseline-only failures)
- [x] Integration test asserts correct step count
- [ ] Manual: `gc formula show <formula>` displays correct count