### PR TITLE
fix: forward DOLT_VERSION from deps.env to docker-base build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,8 +191,8 @@ docs-dev:
 
 ## docker-base: build base image with system dependencies (~2.5 min, rebuild rarely)
 docker-base: check-docker
-	. $(CURDIR)/deps.env && docker build -f contrib/k8s/Dockerfile.base \
-		--build-arg DOLT_VERSION=$$DOLT_VERSION \
+	. "$(CURDIR)/deps.env" && docker build -f contrib/k8s/Dockerfile.base \
+		--build-arg "DOLT_VERSION=$$DOLT_VERSION" \
 		-t gc-agent-base:latest .
 
 ## docker-agent: build base agent image (~5s on top of base). For prebaked images use: gc build-image

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,9 @@ docs-dev:
 
 ## docker-base: build base image with system dependencies (~2.5 min, rebuild rarely)
 docker-base: check-docker
-	docker build -f contrib/k8s/Dockerfile.base -t gc-agent-base:latest .
+	. $(CURDIR)/deps.env && docker build -f contrib/k8s/Dockerfile.base \
+		--build-arg DOLT_VERSION=$$DOLT_VERSION \
+		-t gc-agent-base:latest .
 
 ## docker-agent: build base agent image (~5s on top of base). For prebaked images use: gc build-image
 docker-agent: check-docker


### PR DESCRIPTION
## Summary

Fixes #474.

- `make docker-base` never passed `DOLT_VERSION` as a `--build-arg`, so the Dockerfile's hardcoded `ARG DOLT_VERSION=1.85.0` default was silently authoritative and could drift from `deps.env`.
- Sources `deps.env` inline in the `docker-base` recipe (`. $(CURDIR)/deps.env &&`) and passes `--build-arg DOLT_VERSION`. This keeps the variable scoped to the single recipe shell invocation — no leakage to other targets.
- Uses `$(CURDIR)` for path safety with `make -C` invocations.
- Other docker targets (`docker-agent`, `docker-controller`) build on `gc-agent-base:latest` and don't install Dolt independently, so no changes needed there.

## Test plan

- [x] `make build` passes
- [x] `make check` passes (baseline-only failures)
- [x] `make -n docker-base` shows correct sourcing and `--build-arg` in dry run
- [ ] Manual: `make docker-base` builds with version from `deps.env`