### PR TITLE
fix: propagate rig-scoped env vars for exec: provider

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -150,7 +150,7 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 			stores[rig.Name] = sharedFileStore
 		} else {
 			stores[rig.Name] = wrapWithCachingStore(
-				cs.openRigStore(provider, rig.Path, rig.EffectivePrefix(), rig.Name),
+				cs.openRigStore(provider, rig.Path, rig.EffectivePrefix(), rig.Name, cfg),
 				cs.eventProv,
 			)
 		}
@@ -171,7 +171,9 @@ func beadsProviderFor(cfg *config.City) string {
 }
 
 // openRigStore creates a bead store for a rig path using the given provider.
-func (cs *controllerState) openRigStore(provider, rigPath, prefix, rigName string) beads.Store {
+// cfg is the config snapshot that triggered this build — callers must pass it
+// explicitly so hot-reload never reads the stale cs.cfg.
+func (cs *controllerState) openRigStore(provider, rigPath, prefix, rigName string, cfg *config.City) beads.Store {
 	if strings.HasPrefix(provider, "exec:") {
 		s := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
 		env := citylayout.CityRuntimeEnvMap(cs.cityPath)
@@ -187,11 +189,11 @@ func (cs *controllerState) openRigStore(provider, rigPath, prefix, rigName strin
 	case "file":
 		store, err := beads.OpenFileStore(fsys.OSFS{}, filepath.Join(cs.cityPath, ".gc", "beads.json"))
 		if err != nil {
-			return bdStoreForRig(rigPath, cs.cityPath, cs.cfg)
+			return bdStoreForRig(rigPath, cs.cityPath, cfg)
 		}
 		return store
 	default: // "bd" or unrecognized
-		return bdStoreForRig(rigPath, cs.cityPath, cs.cfg)
+		return bdStoreForRig(rigPath, cs.cityPath, cfg)
 	}
 }
 

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -176,8 +176,10 @@ func (cs *controllerState) openRigStore(provider, rigPath, prefix string) beads.
 		s := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
 		env := citylayout.CityRuntimeEnvMap(cs.cityPath)
 		env["GC_BEADS_PREFIX"] = prefix
+		rigPath = filepath.Clean(rigPath)
 		env["BEADS_DIR"] = filepath.Join(rigPath, ".beads")
 		env["GC_RIG_ROOT"] = rigPath
+		env["GC_RIG"] = ""
 		if cs.cfg != nil {
 			for _, r := range cs.cfg.Rigs {
 				rp := r.Path

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -150,7 +150,7 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 			stores[rig.Name] = sharedFileStore
 		} else {
 			stores[rig.Name] = wrapWithCachingStore(
-				cs.openRigStore(provider, rig.Path, rig.EffectivePrefix()),
+				cs.openRigStore(provider, rig.Path, rig.EffectivePrefix(), rig.Name),
 				cs.eventProv,
 			)
 		}
@@ -171,7 +171,7 @@ func beadsProviderFor(cfg *config.City) string {
 }
 
 // openRigStore creates a bead store for a rig path using the given provider.
-func (cs *controllerState) openRigStore(provider, rigPath, prefix string) beads.Store {
+func (cs *controllerState) openRigStore(provider, rigPath, prefix, rigName string) beads.Store {
 	if strings.HasPrefix(provider, "exec:") {
 		s := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
 		env := citylayout.CityRuntimeEnvMap(cs.cityPath)
@@ -179,19 +179,7 @@ func (cs *controllerState) openRigStore(provider, rigPath, prefix string) beads.
 		rigPath = filepath.Clean(rigPath)
 		env["BEADS_DIR"] = filepath.Join(rigPath, ".beads")
 		env["GC_RIG_ROOT"] = rigPath
-		env["GC_RIG"] = ""
-		if cs.cfg != nil {
-			for _, r := range cs.cfg.Rigs {
-				rp := r.Path
-				if !filepath.IsAbs(rp) {
-					rp = filepath.Join(cs.cityPath, rp)
-				}
-				if samePath(rp, rigPath) {
-					env["GC_RIG"] = r.Name
-					break
-				}
-			}
-		}
+		env["GC_RIG"] = rigName
 		s.SetEnv(env)
 		return s
 	}

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -176,6 +176,20 @@ func (cs *controllerState) openRigStore(provider, rigPath, prefix string) beads.
 		s := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
 		env := citylayout.CityRuntimeEnvMap(cs.cityPath)
 		env["GC_BEADS_PREFIX"] = prefix
+		env["BEADS_DIR"] = filepath.Join(rigPath, ".beads")
+		env["GC_RIG_ROOT"] = rigPath
+		if cs.cfg != nil {
+			for _, r := range cs.cfg.Rigs {
+				rp := r.Path
+				if !filepath.IsAbs(rp) {
+					rp = filepath.Join(cs.cityPath, rp)
+				}
+				if samePath(rp, rigPath) {
+					env["GC_RIG"] = r.Name
+					break
+				}
+			}
+		}
 		s.SetEnv(env)
 		return s
 	}


### PR DESCRIPTION
## Summary

Fixes #473.

- `openRigStore` in `cmd/gc/api_state.go` dropped the `rigPath` parameter when the provider was `exec:` — only city-level env vars were set via `CityRuntimeEnvMap`. Non-exec providers (`bd`, `file`) correctly set rig-scoped vars via `bdStoreForRig`.
- Now sets `BEADS_DIR`, `GC_RIG_ROOT`, and `GC_RIG` for the `exec:` provider, matching the pattern from `bdRuntimeEnvForRig` in `bd_env.go`.
- Applies `filepath.Clean(rigPath)` before use, consistent with `bdRuntimeEnvForRig`.
- Initializes `GC_RIG` to `""` before the config scan loop to prevent stale inherited values from leaking into exec subprocesses.
- Intentionally does **not** mirror DoltHost/DoltPort handling — exec scripts are user-supplied and manage their own Dolt wiring.

## Test plan

- [x] `make build` passes
- [x] `make check` passes (baseline-only failures)
- [ ] Manual: configure `exec:` provider with a rig, verify `BEADS_DIR`/`GC_RIG_ROOT`/`GC_RIG` are set correctly in the exec subprocess environment