### PR TITLE
fix(maintenance): harden scripts against bd orphans + unbounded queries

### DIFF
--- a/examples/gastown/packs/maintenance/scripts/cross-rig-deps.sh
+++ b/examples/gastown/packs/maintenance/scripts/cross-rig-deps.sh
@@ -13,7 +13,15 @@
 # Becomes unnecessary when beads supports cross-rig computeBlockedIDs.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — flock, bd_safe, trap.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 LOOKBACK="${CROSS_RIG_LOOKBACK:-15m}"
@@ -23,28 +31,37 @@ LOOKBACK="${CROSS_RIG_LOOKBACK:-15m}"
 SINCE=$(date -u -d "-${LOOKBACK%m} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
         date -u -v-"${LOOKBACK%m}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || exit 0
 
-CLOSED=$(bd list --status=closed --closed-after="$SINCE" --json 2>/dev/null) || exit 0
+CLOSED=$(bd_safe list --status=closed --closed-after="$SINCE" --json 2>/dev/null) || exit 0
 if [ -z "$CLOSED" ] || [ "$CLOSED" = "[]" ]; then
     exit 0
 fi
 
 # Step 2: For each closed issue, check for cross-rig dependents.
 RESOLVED=0
-echo "$CLOSED" | jq -r '.[].id' 2>/dev/null | while IFS= read -r closed_id; do
-    # Find beads that have a blocks dep on this closed issue.
-    DEPS=$(bd dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
-    if [ -z "$DEPS" ] || [ "$DEPS" = "[]" ]; then
-        continue
-    fi
+CLOSED_IDS=$(echo "$CLOSED" | jq -r '.[].id' 2>/dev/null) || CLOSED_IDS=""
+if [ -n "$CLOSED_IDS" ]; then
+    while IFS= read -r closed_id; do
+        [ -z "$closed_id" ] && continue
 
-    # Filter for external (cross-rig) deps.
-    echo "$DEPS" | jq -r '.[] | select(.id | startswith("external:")) | .id' 2>/dev/null | while IFS= read -r dep_id; do
-        # Convert blocks → related: remove blocking semantics, keep audit trail.
-        bd dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
-        bd dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
-        RESOLVED=$((RESOLVED + 1))
-    done
-done
+        # Find beads that have a blocks dep on this closed issue.
+        DEPS=$(bd_safe dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
+        if [ -z "$DEPS" ] || [ "$DEPS" = "[]" ]; then
+            continue
+        fi
+
+        # Filter for external (cross-rig) deps.
+        DEP_IDS=$(echo "$DEPS" | jq -r '.[] | select(.id | startswith("external:")) | .id' 2>/dev/null) || DEP_IDS=""
+        if [ -n "$DEP_IDS" ]; then
+            while IFS= read -r dep_id; do
+                [ -z "$dep_id" ] && continue
+                # Convert blocks → related: remove blocking semantics, keep audit trail.
+                bd_safe dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
+                bd_safe dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
+                RESOLVED=$((RESOLVED + 1))
+            done <<<"$DEP_IDS"
+        fi
+    done <<<"$CLOSED_IDS"
+fi
 
 if [ "$RESOLVED" -gt 0 ]; then
     echo "cross-rig-deps: resolved $RESOLVED cross-rig dependencies"

--- a/examples/gastown/packs/maintenance/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/scripts/gate-sweep.sh
@@ -6,45 +6,59 @@
 # are exit code checks, GitHub gates are API status queries.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — flock, bd_safe, trap.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 
 # Step 1: Close elapsed timer gates.
 # bd gate check evaluates all open gate beads, closes those past their
 # timeout, and prints a summary. --escalate sends mail for expired gates.
-bd gate check --type=timer --escalate 2>/dev/null || true
+bd_safe gate check --type=timer --escalate 2>/dev/null || true
 
 # Step 2: Evaluate condition gates.
 # For each open condition gate, run its check command. Close if exit 0.
-CONDITION_GATES=$(bd gate list --type=condition --status=open --json 2>/dev/null) || true
+CONDITION_GATES=$(bd_safe gate list --type=condition --status=open --json 2>/dev/null) || CONDITION_GATES=""
 if [ -n "$CONDITION_GATES" ] && [ "$CONDITION_GATES" != "[]" ]; then
-    echo "$CONDITION_GATES" | jq -r '.[] | "\(.id)\t\(.metadata.check)"' 2>/dev/null | while IFS=$'\t' read -r gate_id check_cmd; do
-        if [ -n "$check_cmd" ] && eval "$check_cmd" >/dev/null 2>&1; then
-            bd gate close "$gate_id" --reason "condition satisfied" 2>/dev/null || true
-        fi
-    done
+    COND_LINES=$(echo "$CONDITION_GATES" | jq -r '.[] | "\(.id)\t\(.metadata.check)"' 2>/dev/null) || COND_LINES=""
+    if [ -n "$COND_LINES" ]; then
+        while IFS=$'\t' read -r gate_id check_cmd; do
+            if [ -n "$check_cmd" ] && eval "$check_cmd" >/dev/null 2>&1; then
+                bd_safe gate close "$gate_id" --reason "condition satisfied" 2>/dev/null || true
+            fi
+        done <<<"$COND_LINES"
+    fi
 fi
 
 # Step 3: Evaluate GitHub gates (gh:run, gh:pr).
 # For each open GitHub gate, check the workflow/PR status and close if done.
-GH_GATES=$(bd gate list --type=gh --status=open --json 2>/dev/null) || true
+GH_GATES=$(bd_safe gate list --type=gh --status=open --json 2>/dev/null) || GH_GATES=""
 if [ -n "$GH_GATES" ] && [ "$GH_GATES" != "[]" ]; then
-    echo "$GH_GATES" | jq -r '.[] | "\(.id)\t\(.metadata.await_type)\t\(.metadata.ref)"' 2>/dev/null | while IFS=$'\t' read -r gate_id await_type ref; do
-        case "$await_type" in
-            gh:run)
-                STATUS=$(gh run view "$ref" --json status -q .status 2>/dev/null) || continue
-                if [ "$STATUS" = "completed" ]; then
-                    CONCLUSION=$(gh run view "$ref" --json conclusion -q .conclusion 2>/dev/null)
-                    bd gate close "$gate_id" --reason "workflow $CONCLUSION" 2>/dev/null || true
-                fi
-                ;;
-            gh:pr)
-                STATE=$(gh pr view "$ref" --json state -q .state 2>/dev/null) || continue
-                if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
-                    bd gate close "$gate_id" --reason "PR $STATE" 2>/dev/null || true
-                fi
-                ;;
-        esac
-    done
+    GH_LINES=$(echo "$GH_GATES" | jq -r '.[] | "\(.id)\t\(.metadata.await_type)\t\(.metadata.ref)"' 2>/dev/null) || GH_LINES=""
+    if [ -n "$GH_LINES" ]; then
+        while IFS=$'\t' read -r gate_id await_type ref; do
+            case "$await_type" in
+                gh:run)
+                    STATUS=$(gh run view "$ref" --json status -q .status 2>/dev/null) || continue
+                    if [ "$STATUS" = "completed" ]; then
+                        CONCLUSION=$(gh run view "$ref" --json conclusion -q .conclusion 2>/dev/null)
+                        bd_safe gate close "$gate_id" --reason "workflow $CONCLUSION" 2>/dev/null || true
+                    fi
+                    ;;
+                gh:pr)
+                    STATE=$(gh pr view "$ref" --json state -q .state 2>/dev/null) || continue
+                    if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
+                        bd_safe gate close "$gate_id" --reason "PR $STATE" 2>/dev/null || true
+                    fi
+                    ;;
+            esac
+        done <<<"$GH_LINES"
+    fi
 fi

--- a/examples/gastown/packs/maintenance/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/scripts/jsonl-export.sh
@@ -6,7 +6,17 @@
 # add/commit/push. No LLM judgment needed.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — flock, trap.
+# This script doesn't call bd directly (uses `dolt sql` + git), so
+# bd_safe wrapping is not needed; the trap and lock still matter.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 DOLT_PORT="${GC_DOLT_PORT:-3307}"

--- a/examples/gastown/packs/maintenance/scripts/lib-bd-safe.sh
+++ b/examples/gastown/packs/maintenance/scripts/lib-bd-safe.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# lib-bd-safe.sh — shared safety primitives for maintenance scripts.
+#
+# Sourced by scripts in packs/maintenance/scripts/ to prevent two
+# failure modes that hit the fleet during incident lx-wisp-ece:
+#
+#   * lx-qfq5r1 — unbounded `bd list` queries in spawn-storm-detect.sh
+#     and wisp-compact.sh ran longer than their cooldown, stacked up,
+#     and drove Dolt to 250% CPU.
+#   * lx-f2z2ph — a bd child inside `$(bd list ...)` command substitution
+#     kept running after its parent bash script died, reparenting to
+#     systemd and continuing to hammer Dolt.
+#
+# This library provides three primitives every maintenance script should
+# call at the top of its body:
+#
+#   install_trap  — propagate EXIT/INT/TERM to background jobs so bd
+#                   children can't outlive the parent script.
+#   acquire_lock  — non-blocking per-script flock; if another instance is
+#                   already running, exit 0 silently (cooldown dedup).
+#   bd_safe       — bd wrapper that runs every call under `timeout`
+#                   (default 30s, override with BD_SAFE_TIMEOUT). On
+#                   deadline miss, signals the parent script so the
+#                   trap tears down any pending children.
+#
+# Usage (at the top of a script, after `set -euo pipefail`):
+#
+#     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#     # shellcheck source=lib-bd-safe.sh
+#     . "$SCRIPT_DIR/lib-bd-safe.sh"
+#     install_trap
+#     acquire_lock
+#
+# Then replace every `bd ...` call with `bd_safe ...`.
+#
+# Pure bash + POSIX utilities. Scripts that also need jq require it
+# directly — this library deliberately has no jq dependency.
+
+# bd_safe: run bd under `timeout` so a hung query can't block forever.
+# Usage is identical to bd itself: `bd_safe list --status=open --json`.
+# On deadline miss (timeout returns 124) this emits a log line and
+# signals the parent script with SIGTERM, which the installed trap
+# catches to tear down any pending children. Other non-zero exits
+# (bd errors, empty results, etc.) are returned to the caller unchanged
+# so existing `|| exit 0` and `|| true` patterns keep working.
+bd_safe() {
+    local timeout_sec="${BD_SAFE_TIMEOUT:-30}"
+    local rc=0
+    timeout "$timeout_sec" bd "$@" || rc=$?
+    if [ "$rc" -eq 124 ]; then
+        printf '%s: bd_safe deadline miss after %ss: bd %s\n' \
+            "${BD_SAFE_SCRIPT_NAME:-${0##*/}}" "$timeout_sec" "$*" >&2
+        # $$ expands to the invoking shell PID even inside $(...) command
+        # substitution, so this signals the script tree even if bd_safe
+        # was called in a subshell.
+        kill -TERM "$$" 2>/dev/null || true
+        exit 124
+    fi
+    return "$rc"
+}
+
+# acquire_lock: non-blocking per-script lock. If another instance of the
+# same script is already running, exit 0 silently so stacked cooldowns
+# no-op instead of piling up.
+#
+# Lock file location:
+#   * $GC_PACK_STATE_DIR if set (per-pack/per-city state directory)
+#   * /tmp/gc-maintenance/ otherwise (machine-wide fallback)
+#
+# The lock is released automatically when the script exits — bash
+# closes FD 200 on exit. `release_lock` is provided for scripts that
+# want to release early; most don't need it.
+#
+# Uses FD 200 by convention. Scripts that also want to use FD 200 for
+# their own purposes should call release_lock first.
+acquire_lock() {
+    local script_name="${1:-${0##*/}}"
+    local lockdir="${GC_PACK_STATE_DIR:-/tmp/gc-maintenance}"
+    if ! mkdir -p "$lockdir" 2>/dev/null; then
+        # Can't create lockdir — fall through without locking rather
+        # than fail the whole run. Best-effort semantics.
+        return 0
+    fi
+    local lockfile="$lockdir/${script_name%.sh}.lock"
+    if ! exec 200>"$lockfile" 2>/dev/null; then
+        return 0
+    fi
+    if ! flock -n 200; then
+        # Another instance holds the lock. Silent cooldown dedup.
+        exit 0
+    fi
+}
+
+# release_lock: close FD 200 to release the flock early. Bash closes
+# the FD automatically on script exit, so this is only needed by
+# long-running scripts that want to yield the lock partway through.
+release_lock() {
+    exec 200>&- 2>/dev/null || true
+}
+
+# install_trap: propagate EXIT/INT/TERM to background jobs. Scripts
+# that spawn bd or other children in the background (including inside
+# `$(...)` command substitutions) rely on this trap to avoid orphaning
+# children on signal — see lx-f2z2ph.
+#
+# Two traps are installed:
+#   * EXIT captures the real exit code via `$?` and re-exits with it,
+#     so scripts under `set -euo pipefail` propagate failure cleanly.
+#   * INT/TERM forces a non-zero exit (143) regardless of `$?`. This
+#     matters because bd_safe sends SIGTERM to `$$` on deadline miss.
+#     If the signal trap captured `$?` it would grab 0 from the kill
+#     command itself, masking the failure.
+#
+# Both traps wrap `kill $(jobs -p)` in `|| true` because there are
+# usually no background jobs, so the expansion becomes bare `kill`
+# which errors out — without `|| true` that would trip `set -e`
+# inside the trap body.
+install_trap() {
+    trap '__rc=$?; kill $(jobs -p) 2>/dev/null || true; exit "$__rc"' EXIT
+    trap 'kill $(jobs -p) 2>/dev/null || true; exit 143' INT TERM
+}

--- a/examples/gastown/packs/maintenance/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/scripts/orphan-sweep.sh
@@ -9,12 +9,25 @@
 # Does NOT do worktree salvage — that's the witness's job.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — sanity limit on
+# in-progress query, flock, bd_safe, trap.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 
-# Step 1: Get all in-progress beads with assignees.
-IN_PROGRESS=$(bd list --status=in_progress --json --limit=0 2>/dev/null) || exit 0
+# Step 1: Get all in-progress beads with assignees. The in_progress set
+# is small in practice (bounded by concurrent agent count). Cap at 500
+# as a sanity limit — if more than that are in-progress something is
+# seriously wrong and the script shouldn't try to sweep them all at
+# once.
+IN_PROGRESS=$(bd_safe list --status=in_progress --json --limit=500 2>/dev/null) || exit 0
 if [ -z "$IN_PROGRESS" ] || [ "$IN_PROGRESS" = "[]" ]; then
     exit 0
 fi
@@ -45,12 +58,15 @@ is_known_agent() {
 }
 
 ORPHANED=0
-echo "$IN_PROGRESS" | jq -r '.[] | select(.assignee != null and .assignee != "") | "\(.id)\t\(.assignee)"' 2>/dev/null | while IFS=$'\t' read -r bead_id assignee; do
-    if ! is_known_agent "$assignee"; then
-        bd update "$bead_id" --status=open --assignee="" 2>/dev/null || true
-        ORPHANED=$((ORPHANED + 1))
-    fi
-done
+ORPHAN_LINES=$(echo "$IN_PROGRESS" | jq -r '.[] | select(.assignee != null and .assignee != "") | "\(.id)\t\(.assignee)"' 2>/dev/null) || ORPHAN_LINES=""
+if [ -n "$ORPHAN_LINES" ]; then
+    while IFS=$'\t' read -r bead_id assignee; do
+        if ! is_known_agent "$assignee"; then
+            bd_safe update "$bead_id" --status=open --assignee="" 2>/dev/null || true
+            ORPHANED=$((ORPHANED + 1))
+        fi
+    done <<<"$ORPHAN_LINES"
+fi
 
 if [ "$ORPHANED" -gt 0 ]; then
     echo "orphan-sweep: reset $ORPHANED orphaned beads"

--- a/examples/gastown/packs/maintenance/scripts/prune-branches.sh
+++ b/examples/gastown/packs/maintenance/scripts/prune-branches.sh
@@ -6,7 +6,18 @@
 # branches persist indefinitely. This script prunes them.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — flock, trap.
+# This script doesn't call bd directly, so no bd_safe wrapping is
+# needed; the trap and lock still matter because git operations on
+# many rigs can take a long time.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 PRUNED=0

--- a/examples/gastown/packs/maintenance/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/scripts/reaper.sh
@@ -6,7 +6,18 @@
 # comparisons against alert thresholds.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — flock, bd_safe, trap.
+# Most of the heavy lifting is via `dolt sql` directly, not bd, but
+# the trap + lock still matter: reaper walks every database on the
+# Dolt server and a hung dolt sql call stacks the same way bd does.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 DOLT_PORT="${GC_DOLT_PORT:-3307}"
@@ -121,7 +132,7 @@ for DB in $DATABASES; do
     if [ -n "$STALE_IDS" ] && [ -z "$DRY_RUN" ]; then
         while IFS= read -r issue_id; do
             [ -z "$issue_id" ] && continue
-            bd close "$issue_id" --reason "stale:auto-closed by reaper" 2>/dev/null || true
+            bd_safe close "$issue_id" --reason "stale:auto-closed by reaper" 2>/dev/null || true
             TOTAL_ISSUES_CLOSED=$((TOTAL_ISSUES_CLOSED + 1))
         done <<< "$STALE_IDS"
     fi

--- a/examples/gastown/packs/maintenance/scripts/spawn-storm-detect.sh
+++ b/examples/gastown/packs/maintenance/scripts/spawn-storm-detect.sh
@@ -5,16 +5,27 @@
 # (status=open, assignee cleared). Counts resets per bead. When any
 # bead exceeds the threshold, escalates to mayor via mail.
 #
-# State file tracks cumulative reset counts across runs. Closed beads
-# are pruned from the ledger automatically.
+# State files track cumulative reset counts and the last-run timestamp
+# across runs. Closed beads are pruned from the ledger automatically.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the incident that drove the hardening
+# pass (bounded queries, single-jq pruning, flock, bd_safe, trap).
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
 LEDGER="$PACK_STATE_DIR/spawn-storm-counts.json"
+LAST_RUN_FILE="$PACK_STATE_DIR/spawn-storm-last-run"
 THRESHOLD="${SPAWN_STORM_THRESHOLD:-2}"
+MAX_BEADS="${SPAWN_STORM_MAX_BEADS:-500}"
 
 if [ ! -e "$LEDGER" ] && [ -e "$CITY/.gc/spawn-storm-counts.json" ]; then
     LEDGER="$CITY/.gc/spawn-storm-counts.json"
@@ -26,51 +37,84 @@ if [ ! -f "$LEDGER" ]; then
     echo '{}' > "$LEDGER"
 fi
 
-# Step 1: Find beads that were recently reset to pool.
-# Look for open beads that have been updated (recovery resets them to open + unassigned).
-OPEN_BEADS=$(bd list --status=open --assignee="" --json --limit=0 2>/dev/null) || exit 0
-if [ -z "$OPEN_BEADS" ] || [ "$OPEN_BEADS" = "[]" ]; then
-    exit 0
+# Record the start time NOW so next run's --updated-after window covers
+# the full duration of this run (minor overlap is safe; missing events
+# is not).
+START_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Load last-run timestamp. Default to a 24h look-back on first run so
+# we don't flood Dolt with an unbounded scan of history.
+if [ -f "$LAST_RUN_FILE" ]; then
+    LAST_RUN_TS=$(cat "$LAST_RUN_FILE")
+fi
+if [ -z "${LAST_RUN_TS:-}" ]; then
+    LAST_RUN_TS=$(date -u -d "-24 hours" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || exit 0
+fi
+
+# Step 1: Find beads recently reset to pool.
+# Bounded by --updated-after LAST_RUN_TS so we only look at fresh reset
+# events, not every open+unassigned bead in the database (the old
+# --limit=0 scan drove Dolt to 250% CPU during incident lx-wisp-ece).
+OPEN_BEADS=$(bd_safe list --status=open --assignee="" \
+    --updated-after "$LAST_RUN_TS" --json --limit="$MAX_BEADS" 2>/dev/null) || OPEN_BEADS="[]"
+if [ -z "$OPEN_BEADS" ]; then
+    OPEN_BEADS="[]"
 fi
 
 # Step 2: Load current ledger.
 COUNTS=$(cat "$LEDGER")
 
-# Step 3: For each open unassigned bead, check if it has rejection metadata
-# (indicates it was returned from refinery or recovered by witness).
+# Step 3: For each open unassigned bead with rejection/recovery metadata,
+# increment its count and escalate if over threshold. Filter once with
+# jq; iterate in the main shell (here-string, not pipe) so COUNTS
+# updates persist across iterations.
 STORMS=0
-echo "$OPEN_BEADS" | jq -r '.[] | select(.metadata.rejection_reason != null or .metadata.recovered != null) | .id' 2>/dev/null | while IFS= read -r bead_id; do
-    [ -z "$bead_id" ] && continue
+STORM_IDS=$(echo "$OPEN_BEADS" | jq -r '.[] | select(.metadata.rejection_reason != null or .metadata.recovered != null) | .id' 2>/dev/null) || STORM_IDS=""
+if [ -n "$STORM_IDS" ]; then
+    while IFS= read -r bead_id; do
+        [ -z "$bead_id" ] && continue
 
-    # Increment count for this bead.
-    PREV=$(echo "$COUNTS" | jq -r --arg id "$bead_id" '.[$id] // 0')
-    NEW=$((PREV + 1))
-    COUNTS=$(echo "$COUNTS" | jq --arg id "$bead_id" --argjson n "$NEW" '.[$id] = $n')
+        PREV=$(echo "$COUNTS" | jq -r --arg id "$bead_id" '.[$id] // 0')
+        NEW=$((PREV + 1))
+        COUNTS=$(echo "$COUNTS" | jq --arg id "$bead_id" --argjson n "$NEW" '.[$id] = $n')
 
-    if [ "$NEW" -ge "$THRESHOLD" ]; then
-        TITLE=$(bd show "$bead_id" --json 2>/dev/null | jq -r '.title // "unknown"')
-        gc mail send mayor/ \
-            -s "SPAWN_STORM: bead $bead_id reset ${NEW}x" \
-            -m "Bead $bead_id ($TITLE) has been reset to pool $NEW times (threshold: $THRESHOLD).
+        if [ "$NEW" -ge "$THRESHOLD" ]; then
+            TITLE=$(bd_safe show "$bead_id" --json 2>/dev/null | jq -r '.title // "unknown"') || TITLE="unknown"
+            gc mail send mayor/ \
+                -s "SPAWN_STORM: bead $bead_id reset ${NEW}x" \
+                -m "Bead $bead_id ($TITLE) has been reset to pool $NEW times (threshold: $THRESHOLD).
 This likely indicates a polecat crash loop on this specific work.
 
 Recommended actions:
 - Inspect the bead: bd show $bead_id --json
 - Check rejection history: metadata.rejection_reason
 - Consider quarantining the bead or investigating the root cause." \
-            2>/dev/null || true
-        STORMS=$((STORMS + 1))
-    fi
-done
+                2>/dev/null || true
+            STORMS=$((STORMS + 1))
+        fi
+    done <<<"$STORM_IDS"
+fi
 
-# Step 4: Prune closed beads from ledger.
-CLOSED_IDS=$(bd list --status=closed --json --limit=0 2>/dev/null | jq -r '.[].id' 2>/dev/null) || true
-for cid in $CLOSED_IDS; do
-    COUNTS=$(echo "$COUNTS" | jq --arg id "$cid" 'del(.[$id])' 2>/dev/null) || true
-done
+# Step 4: Prune recently-closed beads from the ledger. Bounded by the
+# same --updated-after window so we don't scan all closed history.
+# Uses a single jq invocation instead of the prior O(n^2) shell loop.
+CLOSED_BEADS=$(bd_safe list --status=closed \
+    --updated-after "$LAST_RUN_TS" --json --limit="$MAX_BEADS" 2>/dev/null) || CLOSED_BEADS="[]"
+if [ -z "$CLOSED_BEADS" ]; then
+    CLOSED_BEADS="[]"
+fi
+if [ "$CLOSED_BEADS" != "[]" ]; then
+    COUNTS=$(jq -n --argjson counts "$COUNTS" --argjson closed "$CLOSED_BEADS" \
+        '$counts | reduce ($closed | map(.id))[] as $id (.; del(.[$id]))')
+fi
 
-# Step 5: Save updated ledger.
+# Step 5: Save updated ledger and record run timestamp. The LAST_RUN_TS
+# we record is the time we captured BEFORE running any queries, so next
+# run's window always overlaps slightly with this one (at-least-once
+# semantics — we'd rather double-count than miss a reset event).
 echo "$COUNTS" > "$LEDGER"
+echo "$START_TS" > "$LAST_RUN_FILE"
 
 if [ "$STORMS" -gt 0 ]; then
     echo "spawn-storm-detect: found $STORMS beads exceeding reset threshold"

--- a/examples/gastown/packs/maintenance/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/scripts/wisp-compact.sh
@@ -14,15 +14,43 @@
 #   default (untyped): 24h
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# See lx-qfq5r1 / lx-f2z2ph for the hardening pass — bounded query
+# via --label-pattern + --updated-before, flock, bd_safe, trap.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-bd-safe.sh
+. "$SCRIPT_DIR/lib-bd-safe.sh"
+install_trap
+acquire_lock
 
 CITY="${GC_CITY:-.}"
 
-# Get all ephemeral beads.
-ALL=$(bd list --json --all -n 0 2>/dev/null) || exit 0
-EPHEMERALS=$(echo "$ALL" | jq '[.[] | select(.ephemeral == true)]' 2>/dev/null) || exit 0
+# Candidate query cutoff: the minimum TTL in the table above (6h) so
+# the query captures every wisp that could possibly be past its TTL.
+# Per-bead logic below applies the specific TTL per wisp_type.
+# Override via env var if you want a wider/narrower candidate window.
+CUTOFF="${WISP_COMPACT_CUTOFF:-6h}"
+MAX_BEADS="${WISP_COMPACT_MAX_BEADS:-1000}"
 
-if [ -z "$EPHEMERALS" ] || [ "$EPHEMERALS" = "[]" ]; then
+# Parse the cutoff into hours (supports Nh and Nd only — keep simple).
+case "$CUTOFF" in
+    *h) CUTOFF_HOURS="${CUTOFF%h}" ;;
+    *d) CUTOFF_HOURS=$((${CUTOFF%d} * 24)) ;;
+    *)  CUTOFF_HOURS=6 ;;
+esac
+
+CUTOFF_TS=$(date -u -d "-${CUTOFF_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-"${CUTOFF_HOURS}"H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || exit 0
+
+# Query candidate wisps: label matches wisp_type:* and last-updated is
+# older than the candidate cutoff. Replaces the prior --all -n 0 scan
+# that hammered Dolt during lx-wisp-ece.
+WISPS=$(bd_safe list --label-pattern "wisp_type:*" \
+    --updated-before "$CUTOFF_TS" --json --limit="$MAX_BEADS" 2>/dev/null) || exit 0
+
+if [ -z "$WISPS" ] || [ "$WISPS" = "[]" ]; then
     exit 0
 fi
 
@@ -31,49 +59,55 @@ PROMOTED=0
 DELETED=0
 SKIPPED=0
 
-# Process each ephemeral bead.
-echo "$EPHEMERALS" | jq -c '.[]' 2>/dev/null | while IFS= read -r bead; do
-    id=$(echo "$bead" | jq -r '.id')
-    status=$(echo "$bead" | jq -r '.status')
-    updated_at=$(echo "$bead" | jq -r '.updated_at // .created_at')
-    comment_count=$(echo "$bead" | jq -r '.comment_count // 0')
-    labels=$(echo "$bead" | jq -r '.labels // [] | .[]' 2>/dev/null)
+# Process each candidate in the main shell (here-string, not pipe) so
+# the summary counters below reflect real totals.
+WISP_LINES=$(echo "$WISPS" | jq -c '.[]' 2>/dev/null) || WISP_LINES=""
+if [ -n "$WISP_LINES" ]; then
+    while IFS= read -r bead; do
+        [ -z "$bead" ] && continue
 
-    # Determine TTL from wisp_type label.
-    TTL_SECONDS=$((24 * 3600))  # default: 24h
-    for label in $labels; do
-        case "$label" in
-            wisp_type:heartbeat|wisp_type:ping) TTL_SECONDS=$((6 * 3600)) ;;
-            wisp_type:patrol|wisp_type:gc_report) TTL_SECONDS=$((24 * 3600)) ;;
-            wisp_type:recovery|wisp_type:error|wisp_type:escalation) TTL_SECONDS=$((7 * 24 * 3600)) ;;
-            keep) TTL_SECONDS=0 ;;  # force promote
-        esac
-    done
+        id=$(echo "$bead" | jq -r '.id')
+        status=$(echo "$bead" | jq -r '.status')
+        updated_at=$(echo "$bead" | jq -r '.updated_at // .created_at')
+        comment_count=$(echo "$bead" | jq -r '.comment_count // 0')
+        labels=$(echo "$bead" | jq -r '.labels // [] | .[]' 2>/dev/null)
 
-    # Calculate age.
-    BEAD_TS=$(date -d "$updated_at" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
-    AGE=$((NOW - BEAD_TS))
+        # Determine TTL from wisp_type label.
+        TTL_SECONDS=$((24 * 3600))  # default: 24h
+        for label in $labels; do
+            case "$label" in
+                wisp_type:heartbeat|wisp_type:ping) TTL_SECONDS=$((6 * 3600)) ;;
+                wisp_type:patrol|wisp_type:gc_report) TTL_SECONDS=$((24 * 3600)) ;;
+                wisp_type:recovery|wisp_type:error|wisp_type:escalation) TTL_SECONDS=$((7 * 24 * 3600)) ;;
+                keep) TTL_SECONDS=0 ;;  # force promote
+            esac
+        done
 
-    # Skip if within TTL (unless force-promote via keep label).
-    if [ "$TTL_SECONDS" -gt 0 ] && [ "$AGE" -lt "$TTL_SECONDS" ]; then
-        SKIPPED=$((SKIPPED + 1))
-        continue
-    fi
+        # Calculate age.
+        BEAD_TS=$(date -d "$updated_at" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
+        AGE=$((NOW - BEAD_TS))
 
-    # Promote if has comments, keep label, or non-closed.
-    if [ "$comment_count" -gt 0 ] || echo "$labels" | grep -q '^keep$' || [ "$status" != "closed" ]; then
-        REASON="proven value"
-        [ "$status" != "closed" ] && REASON="open past TTL (stuck detection)"
-        bd update "$id" --persistent 2>/dev/null || true
-        bd comment "$id" "Promoted from wisp: $REASON" 2>/dev/null || true
-        PROMOTED=$((PROMOTED + 1))
-        continue
-    fi
+        # Skip if within TTL (unless force-promote via keep label).
+        if [ "$TTL_SECONDS" -gt 0 ] && [ "$AGE" -lt "$TTL_SECONDS" ]; then
+            SKIPPED=$((SKIPPED + 1))
+            continue
+        fi
 
-    # Closed + past TTL + no special attributes → delete.
-    bd delete "$id" --force 2>/dev/null || true
-    DELETED=$((DELETED + 1))
-done
+        # Promote if has comments, keep label, or non-closed.
+        if [ "$comment_count" -gt 0 ] || echo "$labels" | grep -q '^keep$' || [ "$status" != "closed" ]; then
+            REASON="proven value"
+            [ "$status" != "closed" ] && REASON="open past TTL (stuck detection)"
+            bd_safe update "$id" --persistent 2>/dev/null || true
+            bd_safe comment "$id" "Promoted from wisp: $REASON" 2>/dev/null || true
+            PROMOTED=$((PROMOTED + 1))
+            continue
+        fi
+
+        # Closed + past TTL + no special attributes → delete.
+        bd_safe delete "$id" --force 2>/dev/null || true
+        DELETED=$((DELETED + 1))
+    done <<<"$WISP_LINES"
+fi
 
 TOTAL=$((PROMOTED + DELETED))
 if [ "$TOTAL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Harden 6+ maintenance scripts against `bd`-orphan and unbounded-query patterns. Fixes HQ bugs `lx-qfq5r1` (bd orphans reparenting to systemd) and `lx-f2z2ph` (Dolt CPU storm from unbounded `bd list` queries during incident lx-wisp-ece).

Tracking bead: `gc-hk6` (gascity/refinery queue)

## What changes

New shared helper `scripts/lib-bd-safe.sh` provides three primitives:

- **`bd_safe`** — wraps every `bd` call under `timeout` (default 30s, override via `BD_SAFE_TIMEOUT`). On deadline miss it signals the parent script via `kill -TERM $$` so the installed trap tears down pending children, closing the orphan window from `lx-f2z2ph`.
- **`acquire_lock`** — non-blocking per-script `flock`. Stacked cooldowns no-op silently instead of piling up — root cause of the `lx-wisp-ece` CPU storm.
- **`install_trap`** — separates `EXIT` from `INT`/`TERM`. `EXIT` propagates `$?`; `INT`/`TERM` forces `exit 143` so `bd_safe`'s SIGTERM-to-self pattern isn't masked.

All scripts now source the helper, install the trap, acquire a lock, and use `bd_safe` for every `bd` invocation. Notable query hardening:

- `spawn-storm-detect.sh`: `bd list --limit=0` → `bd_safe list --updated-after $last_run_ts --limit=500` with `LAST_RUN_FILE` state. O(n²) jq-in-shell prune loop collapsed into a single `jq` reduce.
- `wisp-compact.sh`: `bd list --all -n 0` → `bd_safe list --label-pattern 'wisp_type:*' --updated-before $cutoff --limit=1000`.

## Test plan

- [ ] Run each hardened script in dry-run/no-op mode and confirm the trap fires cleanly on timeout.
- [ ] Verify `BD_SAFE_TIMEOUT` override path.
- [ ] Confirm `flock` cooldowns no-op on concurrent invocation instead of stacking.
- [ ] Spot-check each script's `bd list` bounds (limit, label filter, updated-before/after).