### PR TITLE
fix(refinery): preserve branch on all rejection paths (lx-87x7ix)

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml
@@ -227,10 +227,13 @@ TARGET=$(bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
    - Put the work bead back in the pool with rejection metadata:
      ```bash
      bd update $WORK --status=open --assignee="" \
-       --set-metadata rejection_reason="<failure summary>"
+       --set-metadata rejection_reason="<failure summary>" \
+       --set-metadata gc.routed_to=<rig>/polecat
      ```
-   - Delete branch: `git push origin --delete $BRANCH`
-   - Clean up: `git checkout "$TARGET" && git branch -D temp`
+   - Do NOT delete the branch — the new polecat will iterate on it
+     (fix failing tests, rebase, retry). This matches the rebase-conflict
+     rejection path: rejections always preserve the source branch.
+   - Clean up temp: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
      NEXT=$(bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')

--- a/examples/gastown/packs/gastown/prompts/refinery.md.tmpl
+++ b/examples/gastown/packs/gastown/prompts/refinery.md.tmpl
@@ -21,6 +21,14 @@
   (`git merge`, `git push`). Integration branches are landed by assigning the
   convoy bead to you with the correct metadata — you merge it like any other work bead.
 
+**Mechanical rejections are pre-authorized.** When the formula directs you
+to reject a bead (conflict, test failure, category mismatch), execute the
+rejection immediately — you do NOT need to pause for human confirmation.
+The formula's decision IS the authorization. Asking stalls the merge queue
+and defeats the purpose of having a refinery agent. The only exception:
+the `local` merge strategy escalation path, which is an explicit human
+handoff by design.
+
 Work beads flow directly to you: polecats push a branch, set metadata
 on the work bead (`branch`, `target`), and assign it to you. You merge
 the branch or publish a PR based on `metadata.merge_strategy`, then close
@@ -105,13 +113,11 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 On rebase conflict or test failure:
 1. Put work bead back in pool:
    `bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
-2. Branch handling depends on failure type:
-   - Conflict: leave branch intact (polecat needs it for rebase)
-   - Test failure: delete branch (polecat redoes work)
+2. **Branch is always preserved on rejection.** The new polecat picks up
+   the bead, sees `metadata.branch` and `metadata.rejection_reason`, and
+   iterates on the existing branch (fix failing tests, rebase, retry).
+   Rejections are NEVER destructive — no branch deletion, no forced redo.
 3. Pour next wisp, burn current one
-
-A new polecat picks up the bead, sees `metadata.branch` and
-`metadata.rejection_reason`, rebases or redoes work, reassigns to refinery.
 
 ## Merge Strategy
 


### PR DESCRIPTION
## Summary

Remove the destructive `git push origin --delete $BRANCH` step from the `mol-refinery-patrol` handle-failures rejection path. Rejections now always preserve the source branch — matching the rebase-conflict rejection path and making rejection recovery retry-friendly.

Tracking bead: `gc-p56` (gascity/refinery queue). Fixes HQ bug `lx-87x7ix`.

## Why

The asymmetric branch handling was the root cause of `lx-87x7ix`: the signal-loom refinery stalled ~14 minutes on a prettier-format rejection for `sl-22t` because Claude paused to confirm the destructive branch-deletion step. Witness had to manually unblock with `gc session submit --intent interrupt_now`. Non-mechanical refinery work shouldn't trip human-confirmation prompts — preserving branches unconditionally eliminates the whole class of pause.

## Changes

- **`mol-refinery-patrol.formula.toml`** — `handle-failures` step no longer deletes the branch on test/lint failure; adds `gc.routed_to` metadata for consistency with the rebase step.
- **`refinery.md.tmpl`** — Rejection Flow section documents unconditional branch preservation; adds a "Mechanical rejections are pre-authorized" clause under the role header as belt-and-suspenders against any future destructive steps triggering human-confirmation pauses.

## Out of scope

Mirror to signal-loom rig-local override at `.gc/formulas/signal-loom/mol-refinery-patrol.formula.toml` — mechanik will mirror manually (separate repo checkout).

## Test plan

- [ ] Trigger a mock refinery rejection on a test branch; confirm branch stays intact on both remotes.
- [ ] Confirm both rebase-conflict and test-failure rejection paths write the same metadata set (`rejection_reason`, `gc.routed_to`).
- [ ] Verify rendered refinery prompt includes the "mechanical rejections are pre-authorized" clause.

Refs: `lx-87x7ix` (HQ bug), `lx-wisp-514` (witness pattern report), `lx-wisp-eel` (deacon forward), `sl-22t` (stall trigger)