### PR TITLE
fix: apply workspace.start_command when provider is resolved (#498)

### DIFF
--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -29,6 +29,8 @@ type LookPathFunc func(string) (string, error)
 //     (verify binary exists in PATH via lookPath)
 //  4. Merge agent-level overrides: non-zero agent fields replace base spec fields
 //     (env merges additively — agent env adds to/overrides base env)
+//     4b. workspace.StartCommand overrides command (preserves provider settings,
+//     clears Args/OptionsSchema/EffectiveDefaults)
 //  5. Default prompt_mode to "arg" if still empty
 func ResolveProvider(agent *Agent, ws *Workspace, cityProviders map[string]ProviderSpec, lookPath LookPathFunc) (*ResolvedProvider, error) {
 	// Step 1: agent.StartCommand is the escape hatch.
@@ -64,6 +66,21 @@ func ResolveProvider(agent *Agent, ws *Workspace, cityProviders map[string]Provi
 	resolved := specToResolved(name, spec)
 	resolved.Kind = resolveProviderKind(name, cityProviders)
 	mergeAgentOverrides(resolved, agent)
+
+	// Step 4b: workspace.start_command overrides the resolved command when
+	// the agent doesn't set its own. Unlike the escape hatch at step 2
+	// (which returns a bare provider for the no-provider case), this path
+	// preserves all provider settings (PromptMode, ProcessNames, etc.)
+	// while replacing the command. Args, OptionsSchema, and
+	// EffectiveDefaults are cleared because start_command is the complete
+	// command line — appending schema-derived flags would conflict with
+	// the user's explicit command.
+	if agent.StartCommand == "" && ws != nil && ws.StartCommand != "" {
+		resolved.Command = ws.StartCommand
+		resolved.Args = nil
+		resolved.OptionsSchema = nil
+		resolved.EffectiveDefaults = nil
+	}
 
 	// Step 5: default prompt_mode.
 	if resolved.PromptMode == "" {

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -116,6 +116,52 @@ func TestResolveProviderWorkspaceStartCommand(t *testing.T) {
 	}
 }
 
+// TestResolveProviderWorkspaceStartCommandWithProvider verifies that
+// workspace.start_command overrides the provider command when a provider
+// name is resolved (via workspace.provider or auto-detect), preserving
+// provider settings like PromptMode while clearing schema-managed flags.
+func TestResolveProviderWorkspaceStartCommandWithProvider(t *testing.T) {
+	agent := &Agent{Name: "worker"}
+	ws := &Workspace{Name: "city", Provider: "claude", StartCommand: "claude --auto"}
+	rp, err := ResolveProvider(agent, ws, nil, lookPathAll)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	if rp.Command != "claude --auto" {
+		t.Errorf("Command = %q, want %q", rp.Command, "claude --auto")
+	}
+	if rp.CommandString() != "claude --auto" {
+		t.Errorf("CommandString() = %q, want %q (Args should be nil)", rp.CommandString(), "claude --auto")
+	}
+	// Schema-managed defaults must be cleared so they aren't appended.
+	if len(rp.ResolveDefaultArgs()) != 0 {
+		t.Errorf("ResolveDefaultArgs() = %v, want nil (start_command is complete command)", rp.ResolveDefaultArgs())
+	}
+	// Provider settings should be preserved.
+	if rp.Name != "claude" {
+		t.Errorf("Name = %q, want %q (provider settings should be preserved)", rp.Name, "claude")
+	}
+	builtins := BuiltinProviders()
+	claudeSpec := builtins["claude"]
+	if rp.ReadyPromptPrefix != claudeSpec.ReadyPromptPrefix {
+		t.Errorf("ReadyPromptPrefix = %q, want %q", rp.ReadyPromptPrefix, claudeSpec.ReadyPromptPrefix)
+	}
+}
+
+// TestResolveProviderAgentStartCommandWinsOverWorkspace verifies that
+// agent.start_command takes precedence over workspace.start_command.
+func TestResolveProviderAgentStartCommandWinsOverWorkspace(t *testing.T) {
+	agent := &Agent{Name: "worker", StartCommand: "my-agent --custom"}
+	ws := &Workspace{Name: "city", Provider: "claude", StartCommand: "claude --auto"}
+	rp, err := ResolveProvider(agent, ws, nil, lookPathNone)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	if rp.Command != "my-agent --custom" {
+		t.Errorf("Command = %q, want %q (agent.StartCommand should win)", rp.Command, "my-agent --custom")
+	}
+}
+
 func TestResolveProviderAutoDetect(t *testing.T) {
 	agent := &Agent{Name: "worker"}
 	rp, err := ResolveProvider(agent, nil, nil, lookPathOnly("codex"))


### PR DESCRIPTION
## Summary

- `workspace.start_command` was silently ignored when `workspace.provider` was set — the provider name was resolved before the `start_command` escape hatch path, so the provider's default command was always used instead
- Added step 4b in `ResolveProvider`: after provider lookup and agent overrides, if `workspace.start_command` is set and the agent has no own `start_command`, override the resolved command while preserving all provider settings (PromptMode, ReadyPromptPrefix, ProcessNames, etc.)
- Args, OptionsSchema, and EffectiveDefaults are cleared because `start_command` is the complete command line — schema-derived flags would conflict with the user's explicit command

## What was tested

- `make fmt-check` — pass
- `make lint` — pass (0 issues)
- `make vet` — pass
- `go test ./internal/config/ -count=1 -short` — pass (all 28 ResolveProvider tests including 2 new ones)
- 3 pre-existing failures in `cmd/gc` BuildDesiredState tests confirmed on `main` (not caused by this change)

## Review outcome

Clean — single function change with focused scope.

## Changes

- `internal/config/resolve.go`: Added step 4b in `ResolveProvider` to apply `ws.StartCommand` after provider resolution
- `internal/config/resolve_test.go`: Added `TestResolveProviderWorkspaceStartCommandWithProvider` (command override + provider settings preserved + schema defaults cleared) and `TestResolveProviderAgentStartCommandWinsOverWorkspace` (precedence)

## Breaking changes

None. The only behavioral change is that `workspace.start_command` now takes effect when `workspace.provider` is also set, which was the documented intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #498