### PR TITLE
feat: per-agent drain policy in session templates (#504)

### DIFF
--- a/cmd/gc/lifecycle_drain_test.go
+++ b/cmd/gc/lifecycle_drain_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestSessionHasActiveBeads(t *testing.T) {
+	session := beads.Bead{
+		ID: "sess-1",
+		Metadata: map[string]string{
+			"session_name":              "rig/mayor",
+			"configured_named_identity": "rig/mayor-alias",
+		},
+	}
+
+	t.Run("no beads", func(t *testing.T) {
+		if sessionHasActiveBeads(session, nil) {
+			t.Error("expected false with no beads")
+		}
+	})
+
+	t.Run("in_progress bead assigned by session name", func(t *testing.T) {
+		wbs := []beads.Bead{
+			{ID: "wb-1", Status: "in_progress", Assignee: "rig/mayor"},
+		}
+		if !sessionHasActiveBeads(session, wbs) {
+			t.Error("expected true for in_progress bead assigned by session name")
+		}
+	})
+
+	t.Run("in_progress bead assigned by bead ID", func(t *testing.T) {
+		wbs := []beads.Bead{
+			{ID: "wb-1", Status: "in_progress", Assignee: "sess-1"},
+		}
+		if !sessionHasActiveBeads(session, wbs) {
+			t.Error("expected true for in_progress bead assigned by bead ID")
+		}
+	})
+
+	t.Run("in_progress bead assigned by named identity", func(t *testing.T) {
+		wbs := []beads.Bead{
+			{ID: "wb-1", Status: "in_progress", Assignee: "rig/mayor-alias"},
+		}
+		if !sessionHasActiveBeads(session, wbs) {
+			t.Error("expected true for in_progress bead assigned by named identity")
+		}
+	})
+
+	t.Run("open bead not counted", func(t *testing.T) {
+		wbs := []beads.Bead{
+			{ID: "wb-1", Status: "open", Assignee: "rig/mayor"},
+		}
+		if sessionHasActiveBeads(session, wbs) {
+			t.Error("expected false for open (not in_progress) bead")
+		}
+	})
+
+	t.Run("in_progress bead assigned to different session", func(t *testing.T) {
+		wbs := []beads.Bead{
+			{ID: "wb-1", Status: "in_progress", Assignee: "rig/polecat"},
+		}
+		if sessionHasActiveBeads(session, wbs) {
+			t.Error("expected false for bead assigned to different session")
+		}
+	})
+
+	t.Run("empty assignee ignored", func(t *testing.T) {
+		wbs := []beads.Bead{
+			{ID: "wb-1", Status: "in_progress", Assignee: ""},
+		}
+		if sessionHasActiveBeads(session, wbs) {
+			t.Error("expected false for empty assignee")
+		}
+	})
+}
+
+func TestDrainTrackerLifecycleDeferral(t *testing.T) {
+	dt := newDrainTracker()
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	t.Run("no deferral returns zero time", func(t *testing.T) {
+		if got := dt.lifecycleDeferredSince("sess-1"); !got.IsZero() {
+			t.Errorf("expected zero time, got %v", got)
+		}
+	})
+
+	t.Run("first deferral records timestamp", func(t *testing.T) {
+		dt.deferLifecycle("sess-1", now)
+		if got := dt.lifecycleDeferredSince("sess-1"); got != now {
+			t.Errorf("expected %v, got %v", now, got)
+		}
+	})
+
+	t.Run("subsequent deferral preserves original timestamp", func(t *testing.T) {
+		later := now.Add(30 * time.Second)
+		dt.deferLifecycle("sess-1", later)
+		if got := dt.lifecycleDeferredSince("sess-1"); got != now {
+			t.Errorf("expected %v (original), got %v", now, got)
+		}
+	})
+
+	t.Run("clear removes deferral", func(t *testing.T) {
+		dt.clearLifecycleDeferral("sess-1")
+		if got := dt.lifecycleDeferredSince("sess-1"); !got.IsZero() {
+			t.Errorf("expected zero time after clear, got %v", got)
+		}
+	})
+
+	t.Run("independent sessions", func(t *testing.T) {
+		dt.deferLifecycle("sess-a", now)
+		dt.deferLifecycle("sess-b", now.Add(time.Minute))
+		if got := dt.lifecycleDeferredSince("sess-a"); got != now {
+			t.Errorf("sess-a: expected %v, got %v", now, got)
+		}
+		if got := dt.lifecycleDeferredSince("sess-b"); got != now.Add(time.Minute) {
+			t.Errorf("sess-b: expected %v, got %v", now.Add(time.Minute), got)
+		}
+	})
+}

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -273,6 +273,7 @@ func deepCopyAgent(src *config.Agent, name, dir string) config.Agent {
 	dst.OnBoot = src.OnBoot
 	dst.OnDeath = src.OnDeath
 	dst.Namepool = src.Namepool
+	dst.Lifecycle = src.Lifecycle
 	if src.ReadyDelayMs != nil {
 		v := *src.ReadyDelayMs
 		dst.ReadyDelayMs = &v

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -595,6 +595,11 @@ func TestDeepCopyAgentCoversAllFields(t *testing.T) {
 		Namepool:               "names.txt",
 		NamepoolNames:          []string{"alpha", "bravo"},
 		OptionDefaults:         map[string]string{"effort": "max"},
+		Lifecycle: config.Lifecycle{
+			DrainPolicy:  "defer_until_idle",
+			IdleSignal:   "bead_activity",
+			GraceTimeout: "5m",
+		},
 	}
 
 	// Verify every Agent field is set (non-zero) in the test data.

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -377,6 +377,31 @@ func hasDependencyWakeRoot(reasons []WakeReason) bool {
 
 // computeWorkSet runs each agent's work_query command and returns the set
 // of template names that have pending work. Called once per reconciler tick.
+// sessionHasActiveBeads reports whether the session owns any in-progress work
+// beads. Checks all identity variants (bead ID, session name, configured named
+// identity) to match regardless of which identifier was used when assigning.
+// Uses the pre-collected assignedWorkBeads slice — no I/O.
+func sessionHasActiveBeads(session beads.Bead, assignedWorkBeads []beads.Bead) bool {
+	sessionID := session.ID
+	sessionName := strings.TrimSpace(session.Metadata["session_name"])
+	namedIdentity := strings.TrimSpace(session.Metadata["configured_named_identity"])
+
+	for i := range assignedWorkBeads {
+		wb := &assignedWorkBeads[i]
+		if wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if assignee == sessionID || assignee == sessionName || (namedIdentity != "" && assignee == namedIdentity) {
+			return true
+		}
+	}
+	return false
+}
+
 // Controller-side queries run from the canonical city/rig root so pack
 // commands continue to operate on the real repo even when agent sessions use
 // isolated work_dir sandboxes. Non-empty output means work exists. Agents

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -530,6 +530,30 @@ func reconcileSessionBeadsTraced(
 							}
 							continue
 						}
+						// Defer config-drift drain based on lifecycle policy.
+						// When drain_policy is defer_until_idle, skip drain
+						// while the session has in-progress beads, up to grace_timeout.
+						if cfgAgent.EffectiveDrainPolicy() == config.DrainPolicyDeferUntilIdle {
+							graceDur := cfgAgent.GraceTimeoutDuration()
+							deferredSince := dt.lifecycleDeferredSince(session.ID)
+							graceExpired := !deferredSince.IsZero() && graceDur > 0 && clk.Now().Sub(deferredSince) >= graceDur
+							if !graceExpired && sessionHasActiveBeads(*session, assignedWorkBeads) {
+								dt.deferLifecycle(session.ID, clk.Now())
+								fmt.Fprintf(stderr, "config-drift %s: deferred by lifecycle policy (active beads)\n", name) //nolint:errcheck
+								if trace != nil {
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "deferred_lifecycle", traceRecordPayload{
+										"stored_hash":    storedHash,
+										"current_hash":   currentHash,
+										"drain_policy":   cfgAgent.Lifecycle.DrainPolicy,
+										"grace_timeout":  cfgAgent.Lifecycle.GraceTimeout,
+										"deferred_since": deferredSince.Format(time.RFC3339),
+									}, nil, "")
+								}
+								continue
+							}
+							// Grace expired or no active beads — clear deferral and proceed.
+							dt.clearLifecycleDeferral(session.ID)
+						}
 						ddt := driftDrainTimeout
 						if ddt <= 0 {
 							ddt = defaultDrainTimeout
@@ -588,30 +612,53 @@ func reconcileSessionBeadsTraced(
 
 		// Idle timeout: restart sessions idle longer than configured threshold.
 		if it != nil && alive && it.checkIdle(name, sp, clk.Now()) {
-			fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
-			if trace != nil {
-				trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "idle_timeout", "stop", nil, nil, "")
+			// Check lifecycle policy before killing.
+			idleDeferred := false
+			if idleAgent := findAgentByTemplate(cfg, tp.TemplateName); idleAgent != nil && idleAgent.EffectiveDrainPolicy() == config.DrainPolicyDeferUntilIdle {
+				graceDur := idleAgent.GraceTimeoutDuration()
+				deferredSince := dt.lifecycleDeferredSince(session.ID)
+				graceExpired := !deferredSince.IsZero() && graceDur > 0 && clk.Now().Sub(deferredSince) >= graceDur
+				if !graceExpired && sessionHasActiveBeads(*session, assignedWorkBeads) {
+					dt.deferLifecycle(session.ID, clk.Now())
+					fmt.Fprintf(stderr, "session reconciler: idle timeout for %s deferred by lifecycle policy\n", tp.DisplayName()) //nolint:errcheck
+					if trace != nil {
+						trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "idle_timeout", "deferred_lifecycle", traceRecordPayload{
+							"drain_policy":   idleAgent.Lifecycle.DrainPolicy,
+							"grace_timeout":  idleAgent.Lifecycle.GraceTimeout,
+							"deferred_since": deferredSince.Format(time.RFC3339),
+						}, nil, "")
+					}
+					idleDeferred = true
+				} else {
+					dt.clearLifecycleDeferral(session.ID)
+				}
 			}
-			if err := sp.Stop(name); err != nil {
-				fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
-			} else {
-				_ = sp.ClearScrollback(name)
-				rec.Record(events.Event{
-					Type:    events.SessionIdleKilled,
-					Actor:   "gc",
-					Subject: tp.DisplayName(),
-				})
-				telemetry.RecordAgentIdleKill(context.Background(), tp.DisplayName())
-				// Mark for immediate re-wake on this same tick by clearing
-				// last_woke_at and setting state to asleep. The wake logic
-				// below will pick it up.
-				_ = store.SetMetadataBatch(session.ID, map[string]string{
-					"state": "asleep", "last_woke_at": "", "sleep_reason": "idle-timeout",
-				})
-				session.Metadata["state"] = "asleep"
-				session.Metadata["last_woke_at"] = ""
-				session.Metadata["sleep_reason"] = "idle-timeout"
-				alive = false
+			if !idleDeferred {
+				fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
+				if trace != nil {
+					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "idle_timeout", "stop", nil, nil, "")
+				}
+				if err := sp.Stop(name); err != nil {
+					fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+				} else {
+					_ = sp.ClearScrollback(name)
+					rec.Record(events.Event{
+						Type:    events.SessionIdleKilled,
+						Actor:   "gc",
+						Subject: tp.DisplayName(),
+					})
+					telemetry.RecordAgentIdleKill(context.Background(), tp.DisplayName())
+					// Mark for immediate re-wake on this same tick by clearing
+					// last_woke_at and setting state to asleep. The wake logic
+					// below will pick it up.
+					_ = store.SetMetadataBatch(session.ID, map[string]string{
+						"state": "asleep", "last_woke_at": "", "sleep_reason": "idle-timeout",
+					})
+					session.Metadata["state"] = "asleep"
+					session.Metadata["last_woke_at"] = ""
+					session.Metadata["sleep_reason"] = "idle-timeout"
+					alive = false
+				}
 			}
 			// Fall through to wakeReasons — it will re-wake immediately if config present
 		}

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -66,17 +66,19 @@ type idleProbeState struct {
 
 // drainTracker manages in-memory drain states for all sessions.
 type drainTracker struct {
-	mu              sync.Mutex
-	drains          map[string]*drainState     // session bead ID -> drain state
-	idleProbes      map[string]*idleProbeState // session bead ID -> async idle probe
-	idleProbeCursor int
-	idleProbeWG     sync.WaitGroup
+	mu                 sync.Mutex
+	drains             map[string]*drainState     // session bead ID -> drain state
+	idleProbes         map[string]*idleProbeState // session bead ID -> async idle probe
+	lifecycleDeferrals map[string]time.Time       // session bead ID -> first deferred at
+	idleProbeCursor    int
+	idleProbeWG        sync.WaitGroup
 }
 
 func newDrainTracker() *drainTracker {
 	return &drainTracker{
-		drains:     make(map[string]*drainState),
-		idleProbes: make(map[string]*idleProbeState),
+		drains:             make(map[string]*drainState),
+		idleProbes:         make(map[string]*idleProbeState),
+		lifecycleDeferrals: make(map[string]time.Time),
 	}
 }
 
@@ -106,6 +108,32 @@ func (dt *drainTracker) all() map[string]*drainState {
 		cp[k] = v
 	}
 	return cp
+}
+
+// deferLifecycle records or preserves the first time a drain was deferred
+// for a session due to lifecycle policy. Idempotent — only writes the
+// timestamp on the first call for a given beadID.
+func (dt *drainTracker) deferLifecycle(beadID string, now time.Time) {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	if _, ok := dt.lifecycleDeferrals[beadID]; !ok {
+		dt.lifecycleDeferrals[beadID] = now
+	}
+}
+
+// lifecycleDeferredSince returns when a lifecycle deferral was first recorded.
+// Returns zero time if no deferral exists.
+func (dt *drainTracker) lifecycleDeferredSince(beadID string) time.Time {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	return dt.lifecycleDeferrals[beadID]
+}
+
+// clearLifecycleDeferral removes the lifecycle deferral record for a session.
+func (dt *drainTracker) clearLifecycleDeferral(beadID string) {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	delete(dt.lifecycleDeferrals, beadID)
 }
 
 func (dt *drainTracker) idleProbe(beadID string) (idleProbeState, bool) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,10 +4,10 @@
 
 ## Global Flags
 
-| Flag     | Type   | Default | Description                                            |
-| -------- | ------ | ------- | ------------------------------------------------------ |
-| `--city` | string |         | path to the city directory (default: walk up from cwd) |
-| `--rig`  | string |         | rig name or path (default: discover from cwd)          |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--city` | string |  | path to the city directory (default: walk up from cwd) |
+| `--rig` | string |  | rig name or path (default: discover from cwd) |
 
 ## gc
 
@@ -17,49 +17,50 @@ Gas City CLI — orchestration-builder for multi-agent workflows
 gc [flags]
 ```
 
-| Subcommand                        | Description                                                  |
-| --------------------------------- | ------------------------------------------------------------ |
-| [gc agent](#gc-agent)             | Manage agent configuration                                   |
-| [gc bd](#gc-bd)                   | Run bd in the correct rig directory                          |
-| [gc beads](#gc-beads)             | Manage the beads provider                                    |
-| [gc build-image](#gc-build-image) | Build a prebaked agent container image                       |
-| [gc cities](#gc-cities)           | List registered cities                                       |
-| [gc config](#gc-config)           | Inspect and validate city configuration                      |
-| [gc converge](#gc-converge)       | Manage convergence loops (bounded iterative refinement)      |
-| [gc convoy](#gc-convoy)           | Manage convoys — graphs of related work                      |
-| [gc dashboard](#gc-dashboard)     | Web dashboard for monitoring the city                        |
-| [gc doctor](#gc-doctor)           | Check workspace health                                       |
-| [gc event](#gc-event)             | Event operations                                             |
-| [gc events](#gc-events)           | Show the event log                                           |
-| [gc formula](#gc-formula)         | Manage and inspect formulas                                  |
-| [gc graph](#gc-graph)             | Show dependency graph for beads                              |
-| [gc handoff](#gc-handoff)         | Send handoff mail and restart this session                   |
-| [gc help](#gc-help)               | Help about any command                                       |
-| [gc hook](#gc-hook)               | Check for available work (use --inject for Stop hook output) |
-| [gc init](#gc-init)               | Initialize a new city                                        |
-| [gc mail](#gc-mail)               | Send and receive messages between agents and humans          |
-| [gc nudge](#gc-nudge)             | Inspect and deliver deferred nudges                          |
-| [gc order](#gc-order)             | Manage orders (periodic formula dispatch)                    |
-| [gc pack](#gc-pack)               | Manage remote pack sources                                   |
-| [gc prime](#gc-prime)             | Output the behavioral prompt for an agent                    |
-| [gc register](#gc-register)       | Register a city with the machine-wide supervisor             |
-| [gc restart](#gc-restart)         | Restart all agent sessions in the city                       |
-| [gc resume](#gc-resume)           | Resume a suspended city                                      |
-| [gc rig](#gc-rig)                 | Manage rigs (projects)                                       |
-| [gc runtime](#gc-runtime)         | Process-intrinsic runtime operations                         |
-| [gc service](#gc-service)         | Inspect workspace services                                   |
-| [gc session](#gc-session)         | Manage interactive chat sessions                             |
-| [gc skill](#gc-skill)             | Show command reference for a topic                           |
-| [gc sling](#gc-sling)             | Route work to an agent or pool                               |
-| [gc start](#gc-start)             | Start the city under the machine-wide supervisor             |
-| [gc status](#gc-status)           | Show city-wide status overview                               |
-| [gc stop](#gc-stop)               | Stop all agent sessions in the city                          |
-| [gc supervisor](#gc-supervisor)   | Manage the machine-wide supervisor                           |
-| [gc suspend](#gc-suspend)         | Suspend the city (all agents effectively suspended)          |
-| [gc trace](#gc-trace)             | Inspect and control session reconciler tracing               |
-| [gc unregister](#gc-unregister)   | Remove a city from the machine-wide supervisor               |
-| [gc version](#gc-version)         | Print gc version                                             |
-| [gc wait](#gc-wait)               | Inspect and manage durable session waits                     |
+| Subcommand | Description |
+|------------|-------------|
+| [gc agent](#gc-agent) | Manage agent configuration |
+| [gc bd](#gc-bd) | Run bd in the correct rig directory |
+| [gc beads](#gc-beads) | Manage the beads provider |
+| [gc build-image](#gc-build-image) | Build a prebaked agent container image |
+| [gc cities](#gc-cities) | List registered cities |
+| [gc config](#gc-config) | Inspect and validate city configuration |
+| [gc converge](#gc-converge) | Manage convergence loops (bounded iterative refinement) |
+| [gc convoy](#gc-convoy) | Manage convoys — graphs of related work |
+| [gc dashboard](#gc-dashboard) | Web dashboard for monitoring the city |
+| [gc doctor](#gc-doctor) | Check workspace health |
+| [gc dolt](#gc-dolt) | Commands from the dolt pack |
+| [gc event](#gc-event) | Event operations |
+| [gc events](#gc-events) | Show the event log |
+| [gc formula](#gc-formula) | Manage and inspect formulas |
+| [gc graph](#gc-graph) | Show dependency graph for beads |
+| [gc handoff](#gc-handoff) | Send handoff mail and restart this session |
+| [gc help](#gc-help) | Help about any command |
+| [gc hook](#gc-hook) | Check for available work (use --inject for Stop hook output) |
+| [gc init](#gc-init) | Initialize a new city |
+| [gc mail](#gc-mail) | Send and receive messages between agents and humans |
+| [gc nudge](#gc-nudge) | Inspect and deliver deferred nudges |
+| [gc order](#gc-order) | Manage orders (periodic formula dispatch) |
+| [gc pack](#gc-pack) | Manage remote pack sources |
+| [gc prime](#gc-prime) | Output the behavioral prompt for an agent |
+| [gc register](#gc-register) | Register a city with the machine-wide supervisor |
+| [gc restart](#gc-restart) | Restart all agent sessions in the city |
+| [gc resume](#gc-resume) | Resume a suspended city |
+| [gc rig](#gc-rig) | Manage rigs (projects) |
+| [gc runtime](#gc-runtime) | Process-intrinsic runtime operations |
+| [gc service](#gc-service) | Inspect workspace services |
+| [gc session](#gc-session) | Manage interactive chat sessions |
+| [gc skill](#gc-skill) | Show command reference for a topic |
+| [gc sling](#gc-sling) | Route work to an agent or pool |
+| [gc start](#gc-start) | Start the city under the machine-wide supervisor |
+| [gc status](#gc-status) | Show city-wide status overview |
+| [gc stop](#gc-stop) | Stop all agent sessions in the city |
+| [gc supervisor](#gc-supervisor) | Manage the machine-wide supervisor |
+| [gc suspend](#gc-suspend) | Suspend the city (all agents effectively suspended) |
+| [gc trace](#gc-trace) | Inspect and control session reconciler tracing |
+| [gc unregister](#gc-unregister) | Remove a city from the machine-wide supervisor |
+| [gc version](#gc-version) | Print gc version |
+| [gc wait](#gc-wait) | Inspect and manage durable session waits |
 
 ## gc agent
 
@@ -72,10 +73,10 @@ have moved to "gc session" and "gc runtime".
 gc agent
 ```
 
-| Subcommand                            | Description                                |
-| ------------------------------------- | ------------------------------------------ |
-| [gc agent add](#gc-agent-add)         | Add an agent to the workspace              |
-| [gc agent resume](#gc-agent-resume)   | Resume a suspended agent                   |
+| Subcommand | Description |
+|------------|-------------|
+| [gc agent add](#gc-agent-add) | Add an agent to the workspace |
+| [gc agent resume](#gc-agent-resume) | Resume a suspended agent |
 | [gc agent suspend](#gc-agent-suspend) | Suspend an agent (reconciler will skip it) |
 
 ## gc agent add
@@ -98,12 +99,12 @@ gc agent add --name mayor
   gc agent add --name worker --prompt-template prompts/worker.md --suspended
 ```
 
-| Flag                | Type   | Default | Description                                             |
-| ------------------- | ------ | ------- | ------------------------------------------------------- |
-| `--dir`             | string |         | Working directory for the agent (relative to city root) |
-| `--name`            | string |         | Name of the agent                                       |
-| `--prompt-template` | string |         | Path to prompt template file (relative to city root)    |
-| `--suspended`       | bool   |         | Register the agent in suspended state                   |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dir` | string |  | Working directory for the agent (relative to city root) |
+| `--name` | string |  | Name of the agent |
+| `--prompt-template` | string |  | Path to prompt template file (relative to city root) |
+| `--suspended` | bool |  | Register the agent in suspended state |
 
 ## gc agent resume
 
@@ -162,8 +163,8 @@ Subcommands for health checking and diagnostics.
 gc beads
 ```
 
-| Subcommand                          | Description                 |
-| ----------------------------------- | --------------------------- |
+| Subcommand | Description |
+|------------|-------------|
 | [gc beads health](#gc-beads-health) | Check beads provider health |
 
 ## gc beads health
@@ -187,9 +188,9 @@ gc beads health
   gc beads health --quiet
 ```
 
-| Flag      | Type | Default | Description                          |
-| --------- | ---- | ------- | ------------------------------------ |
-| `--quiet` | bool |         | silent on success, stderr on failure |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--quiet` | bool |  | silent on success, stderr on failure |
 
 ## gc build-image
 
@@ -223,13 +224,13 @@ gc build-image [city-path] [flags]
   gc build-image ~/bright-lights --tag registry.io/my-city:latest --push
 ```
 
-| Flag             | Type        | Default           | Description                                      |
-| ---------------- | ----------- | ----------------- | ------------------------------------------------ |
-| `--base-image`   | string      | `gc-agent:latest` | base Docker image                                |
-| `--context-only` | bool        |                   | write build context without running docker build |
-| `--push`         | bool        |                   | push image after building                        |
-| `--rig-path`     | stringSlice |                   | rig name:path pairs (repeatable)                 |
-| `--tag`          | string      |                   | image tag (required unless --context-only)       |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--base-image` | string | `gc-agent:latest` | base Docker image |
+| `--context-only` | bool |  | write build context without running docker build |
+| `--push` | bool |  | push image after building |
+| `--rig-path` | stringSlice |  | rig name:path pairs (repeatable) |
+| `--tag` | string |  | image tag (required unless --context-only) |
 
 ## gc cities
 
@@ -251,10 +252,10 @@ config and "explain" to see where each value originated.
 gc config
 ```
 
-| Subcommand                              | Description                                            |
-| --------------------------------------- | ------------------------------------------------------ |
+| Subcommand | Description |
+|------------|-------------|
 | [gc config explain](#gc-config-explain) | Show resolved agent config with provenance annotations |
-| [gc config show](#gc-config-show)       | Dump the resolved city configuration as TOML           |
+| [gc config show](#gc-config-show) | Dump the resolved city configuration as TOML |
 
 ## gc config explain
 
@@ -278,11 +279,11 @@ gc config explain
   gc config explain -f overlay.toml --agent polecat
 ```
 
-| Flag           | Type        | Default | Description                                        |
-| -------------- | ----------- | ------- | -------------------------------------------------- |
-| `--agent`      | string      |         | filter to a specific agent name                    |
-| `-f`, `--file` | stringArray |         | additional config files to layer (can be repeated) |
-| `--rig`        | string      |         | filter to agents in this rig                       |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--agent` | string |  | filter to a specific agent name |
+| `-f`, `--file` | stringArray |  | additional config files to layer (can be repeated) |
+| `--rig` | string |  | filter to agents in this rig |
 
 ## gc config show
 
@@ -306,11 +307,11 @@ gc config show
   gc config show -f overlay.toml
 ```
 
-| Flag           | Type        | Default | Description                                        |
-| -------------- | ----------- | ------- | -------------------------------------------------- |
-| `-f`, `--file` | stringArray |         | additional config files to layer (can be repeated) |
-| `--provenance` | bool        |         | show where each config element originated          |
-| `--validate`   | bool        |         | validate config and exit (0 = valid, 1 = errors)   |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-f`, `--file` | stringArray |  | additional config files to layer (can be repeated) |
+| `--provenance` | bool |  | show where each config element originated |
+| `--validate` | bool |  | validate config and exit (0 = valid, 1 = errors) |
 
 ## gc converge
 
@@ -324,16 +325,16 @@ and drives the loop automatically.
 gc converge
 ```
 
-| Subcommand                                      | Description                                        |
-| ----------------------------------------------- | -------------------------------------------------- |
-| [gc converge approve](#gc-converge-approve)     | Approve and close a convergence loop (manual gate) |
-| [gc converge create](#gc-converge-create)       | Create a convergence loop                          |
-| [gc converge iterate](#gc-converge-iterate)     | Force next iteration (manual gate)                 |
-| [gc converge list](#gc-converge-list)           | List convergence loops                             |
-| [gc converge retry](#gc-converge-retry)         | Retry a terminated convergence loop                |
-| [gc converge status](#gc-converge-status)       | Show convergence loop status                       |
-| [gc converge stop](#gc-converge-stop)           | Stop a convergence loop                            |
-| [gc converge test-gate](#gc-converge-test-gate) | Dry-run the gate condition (no state changes)      |
+| Subcommand | Description |
+|------------|-------------|
+| [gc converge approve](#gc-converge-approve) | Approve and close a convergence loop (manual gate) |
+| [gc converge create](#gc-converge-create) | Create a convergence loop |
+| [gc converge iterate](#gc-converge-iterate) | Force next iteration (manual gate) |
+| [gc converge list](#gc-converge-list) | List convergence loops |
+| [gc converge retry](#gc-converge-retry) | Retry a terminated convergence loop |
+| [gc converge status](#gc-converge-status) | Show convergence loop status |
+| [gc converge stop](#gc-converge-stop) | Stop a convergence loop |
+| [gc converge test-gate](#gc-converge-test-gate) | Dry-run the gate condition (no state changes) |
 
 ## gc converge approve
 
@@ -351,18 +352,18 @@ Create a convergence loop
 gc converge create [flags]
 ```
 
-| Flag                    | Type        | Default   | Description                                               |
-| ----------------------- | ----------- | --------- | --------------------------------------------------------- |
-| `--evaluate-prompt`     | string      |           | Custom evaluate prompt (overrides formula default)        |
-| `--formula`             | string      |           | Formula to use (required)                                 |
-| `--gate`                | string      | `manual`  | Gate mode: manual, condition, hybrid                      |
-| `--gate-condition`      | string      |           | Path to gate condition script                             |
-| `--gate-timeout`        | string      | `30s`     | Gate execution timeout                                    |
-| `--gate-timeout-action` | string      | `iterate` | Action on gate timeout: iterate, retry, manual, terminate |
-| `--max-iterations`      | int         | `5`       | Maximum iterations                                        |
-| `--target`              | string      |           | Target agent (required)                                   |
-| `--title`               | string      |           | Convergence loop title                                    |
-| `--var`                 | stringArray |           | Template variable (key=value, repeatable)                 |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--evaluate-prompt` | string |  | Custom evaluate prompt (overrides formula default) |
+| `--formula` | string |  | Formula to use (required) |
+| `--gate` | string | `manual` | Gate mode: manual, condition, hybrid |
+| `--gate-condition` | string |  | Path to gate condition script |
+| `--gate-timeout` | string | `30s` | Gate execution timeout |
+| `--gate-timeout-action` | string | `iterate` | Action on gate timeout: iterate, retry, manual, terminate |
+| `--max-iterations` | int | `5` | Maximum iterations |
+| `--target` | string |  | Target agent (required) |
+| `--title` | string |  | Convergence loop title |
+| `--var` | stringArray |  | Template variable (key=value, repeatable) |
 
 ## gc converge iterate
 
@@ -380,11 +381,11 @@ List convergence loops
 gc converge list [flags]
 ```
 
-| Flag      | Type   | Default | Description                                          |
-| --------- | ------ | ------- | ---------------------------------------------------- |
-| `--all`   | bool   |         | Include closed/terminated loops                      |
-| `--json`  | bool   |         | Output as JSON                                       |
-| `--state` | string |         | Filter by state (active, waiting_manual, terminated) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all` | bool |  | Include closed/terminated loops |
+| `--json` | bool |  | Output as JSON |
+| `--state` | string |  | Filter by state (active, waiting_manual, terminated) |
 
 ## gc converge retry
 
@@ -394,9 +395,9 @@ Retry a terminated convergence loop
 gc converge retry <bead-id> [flags]
 ```
 
-| Flag               | Type | Default | Description                                            |
-| ------------------ | ---- | ------- | ------------------------------------------------------ |
-| `--max-iterations` | int  |         | Override max iterations (default: inherit from source) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--max-iterations` | int |  | Override max iterations (default: inherit from source) |
 
 ## gc converge status
 
@@ -406,9 +407,9 @@ Show convergence loop status
 gc converge status <bead-id> [flags]
 ```
 
-| Flag     | Type | Default | Description    |
-| -------- | ---- | ------- | -------------- |
-| `--json` | bool |         | Output as JSON |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output as JSON |
 
 ## gc converge stop
 
@@ -438,19 +439,19 @@ use formula-compiled DAGs with control beads for orchestration.
 gc convoy
 ```
 
-| Subcommand                                | Description                                              |
-| ----------------------------------------- | -------------------------------------------------------- |
-| [gc convoy add](#gc-convoy-add)           | Add an issue to a convoy                                 |
-| [gc convoy check](#gc-convoy-check)       | Auto-close convoys where all issues are closed           |
-| [gc convoy close](#gc-convoy-close)       | Close a convoy                                           |
-| [gc convoy control](#gc-convoy-control)   | Execute control beads or run the control-dispatcher loop |
-| [gc convoy create](#gc-convoy-create)     | Create a convoy and optionally track issues              |
-| [gc convoy delete](#gc-convoy-delete)     | Close and optionally delete a convoy and all its beads   |
-| [gc convoy land](#gc-convoy-land)         | Land an owned convoy (terminate + cleanup)               |
-| [gc convoy list](#gc-convoy-list)         | List open convoys with progress                          |
-| [gc convoy status](#gc-convoy-status)     | Show detailed convoy status                              |
-| [gc convoy stranded](#gc-convoy-stranded) | Find convoys with ready work but no workers              |
-| [gc convoy target](#gc-convoy-target)     | Set the target branch on a convoy                        |
+| Subcommand | Description |
+|------------|-------------|
+| [gc convoy add](#gc-convoy-add) | Add an issue to a convoy |
+| [gc convoy check](#gc-convoy-check) | Auto-close convoys where all issues are closed |
+| [gc convoy close](#gc-convoy-close) | Close a convoy |
+| [gc convoy control](#gc-convoy-control) | Execute control beads or run the control-dispatcher loop |
+| [gc convoy create](#gc-convoy-create) | Create a convoy and optionally track issues |
+| [gc convoy delete](#gc-convoy-delete) | Close and optionally delete a convoy and all its beads |
+| [gc convoy land](#gc-convoy-land) | Land an owned convoy (terminate + cleanup) |
+| [gc convoy list](#gc-convoy-list) | List open convoys with progress |
+| [gc convoy status](#gc-convoy-status) | Show detailed convoy status |
+| [gc convoy stranded](#gc-convoy-stranded) | Find convoys with ready work but no workers |
+| [gc convoy target](#gc-convoy-target) | Set the target branch on a convoy |
 
 ## gc convoy add
 
@@ -495,10 +496,10 @@ Use --follow &lt;agent&gt; to filter the serve loop to a specific agent template
 gc convoy control [bead-id] [flags]
 ```
 
-| Flag       | Type   | Default | Description                                          |
-| ---------- | ------ | ------- | ---------------------------------------------------- |
-| `--follow` | string |         | Run serve loop filtered to a specific agent template |
-| `--serve`  | bool   |         | Run the control-dispatcher loop (continuous)         |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--follow` | string |  | Run serve loop filtered to a specific agent template |
+| `--serve` | bool |  | Run the control-dispatcher loop (continuous) |
 
 ## gc convoy create
 
@@ -520,13 +521,13 @@ gc convoy create sprint-42
   gc convoy create auth-rewrite --owned --target integration/auth-rewrite
 ```
 
-| Flag       | Type   | Default | Description                                            |
-| ---------- | ------ | ------- | ------------------------------------------------------ |
-| `--merge`  | string |         | merge strategy: direct, mr, local                      |
-| `--notify` | string |         | notification target on completion                      |
-| `--owned`  | bool   |         | mark convoy as owned (manual lifecycle, no auto-close) |
-| `--owner`  | string |         | convoy owner (who manages it)                          |
-| `--target` | string |         | target branch inherited by child work beads            |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--merge` | string |  | merge strategy: direct, mr, local |
+| `--notify` | string |  | notification target on completion |
+| `--owned` | bool |  | mark convoy as owned (manual lifecycle, no auto-close) |
+| `--owner` | string |  | convoy owner (who manages it) |
+| `--target` | string |  | target branch inherited by child work beads |
 
 ## gc convoy delete
 
@@ -542,10 +543,10 @@ also remove them from the store via bd delete --force.
 gc convoy delete <convoy-id> [flags]
 ```
 
-| Flag            | Type | Default | Description                                         |
-| --------------- | ---- | ------- | --------------------------------------------------- |
-| `--delete`      | bool |         | Also delete beads from the store after closing      |
-| `-f`, `--force` | bool |         | Actually close/delete (without this, shows preview) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--delete` | bool |  | Also delete beads from the store after closing |
+| `-f`, `--force` | bool |  | Actually close/delete (without this, shows preview) |
 
 ## gc convoy land
 
@@ -567,10 +568,10 @@ gc convoy land gc-42
   gc convoy land gc-42 --dry-run
 ```
 
-| Flag        | Type | Default | Description                  |
-| ----------- | ---- | ------- | ---------------------------- |
-| `--dry-run` | bool |         | preview what would happen    |
-| `--force`   | bool |         | land even with open children |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dry-run` | bool |  | preview what would happen |
+| `--force` | bool |  | land even with open children |
 
 ## gc convoy list
 
@@ -624,13 +625,13 @@ Web dashboard for monitoring the city
 gc dashboard [flags]
 ```
 
-| Flag     | Type   | Default | Description                                             |
-| -------- | ------ | ------- | ------------------------------------------------------- |
-| `--api`  | string |         | GC API server URL override (auto-discovered by default) |
-| `--port` | int    | `8080`  | HTTP port                                               |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api` | string |  | GC API server URL override (auto-discovered by default) |
+| `--port` | int | `8080` | HTTP port |
 
-| Subcommand                                | Description             |
-| ----------------------------------------- | ----------------------- |
+| Subcommand | Description |
+|------------|-------------|
 | [gc dashboard serve](#gc-dashboard-serve) | Start the web dashboard |
 
 ## gc dashboard serve
@@ -641,10 +642,10 @@ Start the web dashboard
 gc dashboard serve [flags]
 ```
 
-| Flag     | Type   | Default | Description                                             |
-| -------- | ------ | ------- | ------------------------------------------------------- |
-| `--api`  | string |         | GC API server URL override (auto-discovered by default) |
-| `--port` | int    | `8080`  | HTTP port                                               |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api` | string |  | GC API server URL override (auto-discovered by default) |
+| `--port` | int | `8080` | HTTP port |
 
 ## gc doctor
 
@@ -667,10 +668,111 @@ gc doctor
   gc doctor --verbose
 ```
 
-| Flag              | Type | Default | Description                         |
-| ----------------- | ---- | ------- | ----------------------------------- |
-| `--fix`           | bool |         | attempt to fix issues automatically |
-| `-v`, `--verbose` | bool |         | show extra diagnostic details       |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--fix` | bool |  | attempt to fix issues automatically |
+| `-v`, `--verbose` | bool |  | show extra diagnostic details |
+
+## gc dolt
+
+Commands from the dolt pack
+
+```
+gc dolt
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc dolt cleanup](#gc-dolt-cleanup) | Find and remove orphaned Dolt databases |
+| [gc dolt health](#gc-dolt-health) | Check Dolt data-plane health |
+| [gc dolt list](#gc-dolt-list) | List Dolt databases |
+| [gc dolt logs](#gc-dolt-logs) | Tail the Dolt server log file |
+| [gc dolt recover](#gc-dolt-recover) | Recover Dolt from read-only state |
+| [gc dolt rollback](#gc-dolt-rollback) | List or restore from migration backups |
+| [gc dolt sql](#gc-dolt-sql) | Open an interactive Dolt SQL shell |
+| [gc dolt start](#gc-dolt-start) | Start the Dolt server if not already running |
+| [gc dolt status](#gc-dolt-status) | Check if the Dolt server is running |
+| [gc dolt sync](#gc-dolt-sync) | Push databases to configured remotes |
+
+## gc dolt cleanup
+
+Find and remove orphaned Dolt databases
+
+```
+gc dolt cleanup
+```
+
+## gc dolt health
+
+Check Dolt data-plane health
+
+```
+gc dolt health
+```
+
+## gc dolt list
+
+List Dolt databases
+
+```
+gc dolt list
+```
+
+## gc dolt logs
+
+Tail the Dolt server log file
+
+```
+gc dolt logs
+```
+
+## gc dolt recover
+
+Recover Dolt from read-only state
+
+```
+gc dolt recover
+```
+
+## gc dolt rollback
+
+List or restore from migration backups
+
+```
+gc dolt rollback
+```
+
+## gc dolt sql
+
+Open an interactive Dolt SQL shell
+
+```
+gc dolt sql
+```
+
+## gc dolt start
+
+Start the Dolt server if not already running
+
+```
+gc dolt start
+```
+
+## gc dolt status
+
+Check if the Dolt server is running
+
+```
+gc dolt status
+```
+
+## gc dolt sync
+
+Push databases to configured remotes
+
+```
+gc dolt sync
+```
 
 ## gc event
 
@@ -680,8 +782,8 @@ Event operations
 gc event
 ```
 
-| Subcommand                      | Description                         |
-| ------------------------------- | ----------------------------------- |
+| Subcommand | Description |
+|------------|-------------|
 | [gc event emit](#gc-event-emit) | Emit an event to the city event log |
 
 ## gc event emit
@@ -695,12 +797,12 @@ attaching arbitrary JSON payloads.
 gc event emit <type> [flags]
 ```
 
-| Flag        | Type   | Default | Description                                                                        |
-| ----------- | ------ | ------- | ---------------------------------------------------------------------------------- |
-| `--actor`   | string |         | Actor name (default: $GC_ALIAS, else $GC_AGENT, else $GC_SESSION_ID, else "human") |
-| `--message` | string |         | Event message                                                                      |
-| `--payload` | string |         | JSON payload to attach to the event                                                |
-| `--subject` | string |         | Event subject (e.g. bead ID)                                                       |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--actor` | string |  | Actor name (default: $GC_ALIAS, else $GC_AGENT, else $GC_SESSION_ID, else "human") |
+| `--message` | string |  | Event message |
+| `--payload` | string |  | JSON payload to attach to the event |
+| `--subject` | string |  | Event subject (e.g. bead ID) |
 
 ## gc events
 
@@ -725,17 +827,17 @@ gc events
   gc events --seq
 ```
 
-| Flag              | Type        | Default | Description                                                  |
-| ----------------- | ----------- | ------- | ------------------------------------------------------------ |
-| `--after`         | uint64      |         | Resume watching from this sequence number (0 = current head) |
-| `--follow`        | bool        |         | Continuously stream events as they arrive                    |
-| `--json`          | bool        |         | Output in JSON format (list mode only)                       |
-| `--payload-match` | stringArray |         | Filter by payload field (key=value, repeatable)              |
-| `--seq`           | bool        |         | Print the current head sequence number and exit              |
-| `--since`         | string      |         | Show events since duration ago (e.g. 1h, 30m)                |
-| `--timeout`       | string      | `30s`   | Max wait duration for --watch (e.g. 30s, 5m)                 |
-| `--type`          | string      |         | Filter by event type (e.g. bead.created)                     |
-| `--watch`         | bool        |         | Block until matching events arrive (exits after first match) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--after` | uint64 |  | Resume watching from this sequence number (0 = current head) |
+| `--follow` | bool |  | Continuously stream events as they arrive |
+| `--json` | bool |  | Output in JSON format (list mode only) |
+| `--payload-match` | stringArray |  | Filter by payload field (key=value, repeatable) |
+| `--seq` | bool |  | Print the current head sequence number and exit |
+| `--since` | string |  | Show events since duration ago (e.g. 1h, 30m) |
+| `--timeout` | string | `30s` | Max wait duration for --watch (e.g. 30s, 5m) |
+| `--type` | string |  | Filter by event type (e.g. bead.created) |
+| `--watch` | bool |  | Block until matching events arrive (exits after first match) |
 
 ## gc formula
 
@@ -745,11 +847,11 @@ Manage and inspect formulas
 gc formula
 ```
 
-| Subcommand                          | Description                                       |
-| ----------------------------------- | ------------------------------------------------- |
+| Subcommand | Description |
+|------------|-------------|
 | [gc formula cook](#gc-formula-cook) | Instantiate a formula into the current bead store |
-| [gc formula list](#gc-formula-list) | List available formulas                           |
-| [gc formula show](#gc-formula-show) | Show a compiled formula recipe                    |
+| [gc formula list](#gc-formula-list) | List available formulas |
+| [gc formula show](#gc-formula-show) | Show a compiled formula recipe |
 
 ## gc formula cook
 
@@ -768,12 +870,12 @@ bead into a sub-workflow at runtime.
 gc formula cook <formula-name> [flags]
 ```
 
-| Flag            | Type        | Default | Description                                                               |
-| --------------- | ----------- | ------- | ------------------------------------------------------------------------- |
-| `--attach`      | string      |         | attach sub-DAG to existing bead (bead gains blocking dep on sub-DAG root) |
-| `--meta`        | stringArray |         | set root bead metadata after cook (key=value, repeatable)                 |
-| `-t`, `--title` | string      |         | override root bead title                                                  |
-| `--var`         | stringArray |         | variable substitution for formula (key=value, repeatable)                 |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--attach` | string |  | attach sub-DAG to existing bead (bead gains blocking dep on sub-DAG root) |
+| `--meta` | stringArray |  | set root bead metadata after cook (key=value, repeatable) |
+| `-t`, `--title` | string |  | override root bead title |
+| `--var` | stringArray |  | variable substitution for formula (key=value, repeatable) |
 
 ## gc formula list
 
@@ -794,16 +896,16 @@ By default, shows the recipe with &#123;&#123;variable&#125;&#125; placeholders 
 Use --var to substitute variables and preview the resolved output.
 
 Examples:
-gc formula show mol-feature
-gc formula show mol-feature --var title="Auth system" --var branch=main
+  gc formula show mol-feature
+  gc formula show mol-feature --var title="Auth system" --var branch=main
 
 ```
 gc formula show <formula-name> [flags]
 ```
 
-| Flag    | Type        | Default | Description                                   |
-| ------- | ----------- | ------- | --------------------------------------------- |
-| `--var` | stringArray |         | variable substitution for preview (key=value) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--var` | stringArray |  | variable substitution for preview (key=value) |
 
 ## gc graph
 
@@ -829,10 +931,10 @@ gc graph gc-42               # expand convoy children
   gc graph gc-42 --mermaid     # Mermaid.js diagram
 ```
 
-| Flag        | Type | Default | Description                    |
-| ----------- | ---- | ------- | ------------------------------ |
-| `--mermaid` | bool |         | output Mermaid.js flowchart    |
-| `--tree`    | bool |         | output Unicode dependency tree |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--mermaid` | bool |  | output Mermaid.js flowchart |
+| `--tree` | bool |  | output Unicode dependency tree |
 
 ## gc handoff
 
@@ -841,15 +943,15 @@ Convenience command for context handoff.
 Self-handoff (default): sends mail to self and blocks until controller
 restarts the session. Equivalent to:
 
-gc mail send $GC_ALIAS &lt;subject&gt; [message]
-gc runtime request-restart
+  gc mail send $GC_ALIAS &lt;subject&gt; [message]
+  gc runtime request-restart
 
 Remote handoff (--target): sends mail to a target session and kills its
 session. The reconciler restarts it with the handoff mail waiting.
 Returns immediately. Equivalent to:
 
-gc mail send &lt;target&gt; &lt;subject&gt; [message]
-gc session kill &lt;target&gt;
+  gc mail send &lt;target&gt; &lt;subject&gt; [message]
+  gc session kill &lt;target&gt;
 
 Self-handoff requires session context (GC_ALIAS or GC_SESSION_ID, plus
 GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or ID.
@@ -858,9 +960,9 @@ GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or
 gc handoff <subject> [message] [flags]
 ```
 
-| Flag       | Type   | Default | Description                                                        |
-| ---------- | ------ | ------- | ------------------------------------------------------------------ |
-| `--target` | string |         | Remote session alias or ID to handoff (sends mail + kills session) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--target` | string |  | Remote session alias or ID to handoff (sends mail + kills session) |
 
 ## gc help
 
@@ -884,9 +986,9 @@ The agent is determined from $GC_AGENT or a positional argument.
 gc hook [agent] [flags]
 ```
 
-| Flag       | Type | Default | Description                                             |
-| ---------- | ---- | ------- | ------------------------------------------------------- |
-| `--inject` | bool |         | output &lt;system-reminder&gt; block for hook injection |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--inject` | bool |  | output &lt;system-reminder&gt; block for hook injection |
 
 ## gc init
 
@@ -914,14 +1016,14 @@ gc init
   gc init --file examples/gastown.toml ~/bright-lights
 ```
 
-| Flag                        | Type   | Default | Description                                                           |
-| --------------------------- | ------ | ------- | --------------------------------------------------------------------- |
-| `--bootstrap-profile`       | string |         | bootstrap profile to apply for hosted/container defaults              |
-| `--file`                    | string |         | path to a TOML file to use as city.toml                               |
-| `--from`                    | string |         | path to an example city directory to copy                             |
-| `--name`                    | string |         | workspace name (default: target directory basename)                   |
-| `--provider`                | string |         | built-in workspace provider to use for the default mayor config       |
-| `--skip-provider-readiness` | bool   |         | skip provider login/readiness checks during init and continue startup |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--bootstrap-profile` | string |  | bootstrap profile to apply for hosted/container defaults |
+| `--file` | string |  | path to a TOML file to use as city.toml |
+| `--from` | string |  | path to an example city directory to copy |
+| `--name` | string |  | workspace name (default: target directory basename) |
+| `--provider` | string |  | built-in workspace provider to use for the default mayor config |
+| `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
 
 ## gc mail
 
@@ -935,20 +1037,20 @@ hooks to deliver mail notifications into agent prompts.
 gc mail
 ```
 
-| Subcommand                                  | Description                                          |
-| ------------------------------------------- | ---------------------------------------------------- |
-| [gc mail archive](#gc-mail-archive)         | Archive a message without reading it                 |
-| [gc mail check](#gc-mail-check)             | Check for unread mail (use --inject for hook output) |
-| [gc mail count](#gc-mail-count)             | Show total/unread message count                      |
-| [gc mail delete](#gc-mail-delete)           | Delete a message (closes the bead)                   |
-| [gc mail inbox](#gc-mail-inbox)             | List unread messages (defaults to your inbox)        |
-| [gc mail mark-read](#gc-mail-mark-read)     | Mark a message as read                               |
-| [gc mail mark-unread](#gc-mail-mark-unread) | Mark a message as unread                             |
-| [gc mail peek](#gc-mail-peek)               | Show a message without marking it as read            |
-| [gc mail read](#gc-mail-read)               | Read a message and mark it as read                   |
-| [gc mail reply](#gc-mail-reply)             | Reply to a message                                   |
-| [gc mail send](#gc-mail-send)               | Send a message to a session alias or human           |
-| [gc mail thread](#gc-mail-thread)           | List all messages in a thread                        |
+| Subcommand | Description |
+|------------|-------------|
+| [gc mail archive](#gc-mail-archive) | Archive a message without reading it |
+| [gc mail check](#gc-mail-check) | Check for unread mail (use --inject for hook output) |
+| [gc mail count](#gc-mail-count) | Show total/unread message count |
+| [gc mail delete](#gc-mail-delete) | Delete a message (closes the bead) |
+| [gc mail inbox](#gc-mail-inbox) | List unread messages (defaults to your inbox) |
+| [gc mail mark-read](#gc-mail-mark-read) | Mark a message as read |
+| [gc mail mark-unread](#gc-mail-mark-unread) | Mark a message as unread |
+| [gc mail peek](#gc-mail-peek) | Show a message without marking it as read |
+| [gc mail read](#gc-mail-read) | Read a message and mark it as read |
+| [gc mail reply](#gc-mail-reply) | Reply to a message |
+| [gc mail send](#gc-mail-send) | Send a message to a session alias or human |
+| [gc mail thread](#gc-mail-thread) | List all messages in a thread |
 
 ## gc mail archive
 
@@ -982,9 +1084,9 @@ gc mail check
   gc mail check mayor
 ```
 
-| Flag       | Type | Default | Description                                             |
-| ---------- | ---- | ------- | ------------------------------------------------------- |
-| `--inject` | bool |         | output &lt;system-reminder&gt; block for hook injection |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--inject` | bool |  | output &lt;system-reminder&gt; block for hook injection |
 
 ## gc mail count
 
@@ -1063,11 +1165,11 @@ Use -s/--subject for the reply subject and -m/--message for the reply body.
 gc mail reply <id> [-s subject] [-m body] [flags]
 ```
 
-| Flag              | Type   | Default | Description                        |
-| ----------------- | ------ | ------- | ---------------------------------- |
-| `-m`, `--message` | string |         | reply body text                    |
-| `--notify`        | bool   |         | nudge the recipient after replying |
-| `-s`, `--subject` | string |         | reply subject line                 |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-m`, `--message` | string |  | reply body text |
+| `--notify` | bool |  | nudge the recipient after replying |
+| `-s`, `--subject` | string |  | reply subject line |
 
 ## gc mail send
 
@@ -1096,14 +1198,14 @@ gc mail send mayor "Build is green"
   gc mail send --all "Status update: tests passing"
 ```
 
-| Flag              | Type   | Default | Description                                                      |
-| ----------------- | ------ | ------- | ---------------------------------------------------------------- |
-| `--all`           | bool   |         | broadcast to all live sessions (excludes sender and human)       |
-| `--from`          | string |         | sender identity (default: $GC_ALIAS, $GC_SESSION_ID, or "human") |
-| `-m`, `--message` | string |         | message body text                                                |
-| `--notify`        | bool   |         | nudge the recipient after sending                                |
-| `-s`, `--subject` | string |         | message subject line                                             |
-| `--to`            | string |         | recipient address (alternative to positional argument)           |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all` | bool |  | broadcast to all live sessions (excludes sender and human) |
+| `--from` | string |  | sender identity (default: $GC_ALIAS, $GC_SESSION_ID, or "human") |
+| `-m`, `--message` | string |  | message body text |
+| `--notify` | bool |  | nudge the recipient after sending |
+| `-s`, `--subject` | string |  | message subject line |
+| `--to` | string |  | recipient address (alternative to positional argument) |
 
 ## gc mail thread
 
@@ -1124,8 +1226,8 @@ was asleep or was not at a safe interactive boundary yet.
 gc nudge
 ```
 
-| Subcommand                          | Description                                      |
-| ----------------------------------- | ------------------------------------------------ |
+| Subcommand | Description |
+|------------|-------------|
 | [gc nudge status](#gc-nudge-status) | Show queued and dead-letter nudges for a session |
 
 ## gc nudge status
@@ -1150,13 +1252,13 @@ periodically and dispatches order formulas when they are due.
 gc order
 ```
 
-| Subcommand                            | Description                       |
-| ------------------------------------- | --------------------------------- |
-| [gc order check](#gc-order-check)     | Check which orders are due to run |
-| [gc order history](#gc-order-history) | Show order execution history      |
-| [gc order list](#gc-order-list)       | List available orders             |
-| [gc order run](#gc-order-run)         | Execute an order manually         |
-| [gc order show](#gc-order-show)       | Show details of an order          |
+| Subcommand | Description |
+|------------|-------------|
+| [gc order check](#gc-order-check) | Check which orders are due to run |
+| [gc order history](#gc-order-history) | Show order execution history |
+| [gc order list](#gc-order-list) | List available orders |
+| [gc order run](#gc-order-run) | Execute an order manually |
+| [gc order show](#gc-order-show) | Show details of an order |
 
 ## gc order check
 
@@ -1180,9 +1282,9 @@ name. Use --rig to filter by rig.
 gc order history [name] [flags]
 ```
 
-| Flag    | Type   | Default | Description                      |
-| ------- | ------ | ------- | -------------------------------- |
-| `--rig` | string |         | rig name to filter order history |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--rig` | string |  | rig name to filter order history |
 
 ## gc order list
 
@@ -1208,9 +1310,9 @@ Use --rig to disambiguate same-name orders in different rigs.
 gc order run <name> [flags]
 ```
 
-| Flag    | Type   | Default | Description                               |
-| ------- | ------ | ------- | ----------------------------------------- |
-| `--rig` | string |         | rig name to disambiguate same-name orders |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--rig` | string |  | rig name to disambiguate same-name orders |
 
 ## gc order show
 
@@ -1224,9 +1326,9 @@ Use --rig to disambiguate same-name orders in different rigs.
 gc order show <name> [flags]
 ```
 
-| Flag    | Type   | Default | Description                               |
-| ------- | ------ | ------- | ----------------------------------------- |
-| `--rig` | string |         | rig name to disambiguate same-name orders |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--rig` | string |  | rig name to disambiguate same-name orders |
 
 ## gc pack
 
@@ -1240,10 +1342,10 @@ can be pinned to specific git refs.
 gc pack
 ```
 
-| Subcommand                      | Description                                    |
-| ------------------------------- | ---------------------------------------------- |
+| Subcommand | Description |
+|------------|-------------|
 | [gc pack fetch](#gc-pack-fetch) | Clone missing and update existing remote packs |
-| [gc pack list](#gc-pack-list)   | Show remote pack sources and cache status      |
+| [gc pack list](#gc-pack-list) | Show remote pack sources and cache status |
 
 ## gc pack fetch
 
@@ -1273,7 +1375,7 @@ gc pack list
 Outputs the behavioral prompt for an agent.
 
 Use it to prime any CLI coding agent with city-aware instructions:
-claude "$(gc prime mayor)"
+  claude "$(gc prime mayor)"
   codex --prompt "$(gc prime worker)"
 
 Runtime hook profiles may call `gc prime --hook`.
@@ -1286,9 +1388,9 @@ that template is output. Otherwise outputs a default worker prompt.
 gc prime [agent-name] [flags]
 ```
 
-| Flag     | Type | Default | Description                                     |
-| -------- | ---- | ------- | ----------------------------------------------- |
-| `--hook` | bool |         | compatibility mode for runtime hook invocations |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--hook` | bool |  | compatibility mode for runtime hook invocations |
 
 ## gc register
 
@@ -1338,15 +1440,15 @@ are scoped to rigs via their "dir" field.
 gc rig
 ```
 
-| Subcommand                        | Description                                     |
-| --------------------------------- | ----------------------------------------------- |
-| [gc rig add](#gc-rig-add)         | Register a project as a rig                     |
-| [gc rig default](#gc-rig-default) | Set the default city for a rig                  |
-| [gc rig list](#gc-rig-list)       | List registered rigs                            |
-| [gc rig remove](#gc-rig-remove)   | Remove a rig from the city                      |
-| [gc rig restart](#gc-rig-restart) | Restart all agents in a rig                     |
-| [gc rig resume](#gc-rig-resume)   | Resume a suspended rig                          |
-| [gc rig status](#gc-rig-status)   | Show rig status and agent running state         |
+| Subcommand | Description |
+|------------|-------------|
+| [gc rig add](#gc-rig-add) | Register a project as a rig |
+| [gc rig default](#gc-rig-default) | Set the default city for a rig |
+| [gc rig list](#gc-rig-list) | List registered rigs |
+| [gc rig remove](#gc-rig-remove) | Remove a rig from the city |
+| [gc rig restart](#gc-rig-restart) | Restart all agents in a rig |
+| [gc rig resume](#gc-rig-resume) | Resume a suspended rig |
+| [gc rig status](#gc-rig-status) | Show rig status and agent running state |
 | [gc rig suspend](#gc-rig-suspend) | Suspend a rig (reconciler will skip its agents) |
 
 ## gc rig add
@@ -1377,12 +1479,12 @@ gc rig add /path/to/project
   gc rig add ./my-project --include packs/gastown --start-suspended
 ```
 
-| Flag                | Type   | Default | Description                                     |
-| ------------------- | ------ | ------- | ----------------------------------------------- |
-| `--include`         | string |         | pack directory for rig agents                   |
-| `--name`            | string |         | rig name (default: directory basename)          |
-| `--prefix`          | string |         | bead ID prefix (default: derived from name)     |
-| `--start-suspended` | bool   |         | add rig in suspended state (dormant-by-default) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--include` | string |  | pack directory for rig agents |
+| `--name` | string |  | rig name (default: directory basename) |
+| `--prefix` | string |  | bead ID prefix (default: derived from name) |
+| `--start-suspended` | bool |  | add rig in suspended state (dormant-by-default) |
 
 ## gc rig default
 
@@ -1404,9 +1506,9 @@ gc rig default myrig --city alpha
   gc rig default /path/to/myrig --city beta
 ```
 
-| Flag     | Type   | Default | Description                                    |
-| -------- | ------ | ------- | ---------------------------------------------- |
-| `--city` | string |         | city name or path to set as default (required) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--city` | string |  | city name or path to set as default (required) |
 
 ## gc rig list
 
@@ -1419,9 +1521,9 @@ displays its bead ID prefix and whether its beads database is initialized.
 gc rig list [flags]
 ```
 
-| Flag     | Type | Default | Description           |
-| -------- | ---- | ------- | --------------------- |
-| `--json` | bool |         | Output in JSON format |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSON format |
 
 ## gc rig remove
 
@@ -1495,13 +1597,13 @@ designed to be called from within running agent sessions, not by humans.
 gc runtime
 ```
 
-| Subcommand                                                | Description                                                    |
-| --------------------------------------------------------- | -------------------------------------------------------------- |
-| [gc runtime drain](#gc-runtime-drain)                     | Signal a session to drain (wind down gracefully)               |
-| [gc runtime drain-ack](#gc-runtime-drain-ack)             | Acknowledge drain — signal the controller to stop this session |
-| [gc runtime drain-check](#gc-runtime-drain-check)         | Check if a session is draining (exit 0 = draining)             |
-| [gc runtime request-restart](#gc-runtime-request-restart) | Request controller restart this session (blocks until killed)  |
-| [gc runtime undrain](#gc-runtime-undrain)                 | Cancel drain on a session                                      |
+| Subcommand | Description |
+|------------|-------------|
+| [gc runtime drain](#gc-runtime-drain) | Signal a session to drain (wind down gracefully) |
+| [gc runtime drain-ack](#gc-runtime-drain-ack) | Acknowledge drain — signal the controller to stop this session |
+| [gc runtime drain-check](#gc-runtime-drain-check) | Check if a session is draining (exit 0 = draining) |
+| [gc runtime request-restart](#gc-runtime-request-restart) | Request controller restart this session (blocks until killed) |
+| [gc runtime undrain](#gc-runtime-undrain) | Cancel drain on a session |
 
 ## gc runtime drain
 
@@ -1575,11 +1677,11 @@ Inspect workspace services
 gc service
 ```
 
-| Subcommand                                | Description                            |
-| ----------------------------------------- | -------------------------------------- |
-| [gc service doctor](#gc-service-doctor)   | Show detailed workspace service status |
-| [gc service list](#gc-service-list)       | List workspace services                |
-| [gc service restart](#gc-service-restart) | Restart a workspace service            |
+| Subcommand | Description |
+|------------|-------------|
+| [gc service doctor](#gc-service-doctor) | Show detailed workspace service status |
+| [gc service list](#gc-service-list) | List workspace services |
+| [gc service restart](#gc-service-restart) | Restart a workspace service |
 
 ## gc service doctor
 
@@ -1620,23 +1722,23 @@ continuity.
 gc session
 ```
 
-| Subcommand                                | Description                                       |
-| ----------------------------------------- | ------------------------------------------------- |
-| [gc session attach](#gc-session-attach)   | Attach to (or resume) a chat session              |
-| [gc session close](#gc-session-close)     | Close a session permanently                       |
-| [gc session kill](#gc-session-kill)       | Force-kill session runtime (reconciler restarts)  |
-| [gc session list](#gc-session-list)       | List chat sessions                                |
-| [gc session logs](#gc-session-logs)       | Show session logs for a session                   |
-| [gc session new](#gc-session-new)         | Create a new chat session from an agent template  |
-| [gc session nudge](#gc-session-nudge)     | Send a text message to a running session          |
-| [gc session peek](#gc-session-peek)       | View session output without attaching             |
-| [gc session prune](#gc-session-prune)     | Close old suspended sessions                      |
-| [gc session rename](#gc-session-rename)   | Rename a session                                  |
-| [gc session reset](#gc-session-reset)     | Restart a session fresh while preserving the bead |
-| [gc session submit](#gc-session-submit)   | Submit a message with semantic delivery intent    |
-| [gc session suspend](#gc-session-suspend) | Suspend a session (save state, free resources)    |
-| [gc session wait](#gc-session-wait)       | Register a dependency wait for a session          |
-| [gc session wake](#gc-session-wake)       | Wake a session (clear hold and quarantine)        |
+| Subcommand | Description |
+|------------|-------------|
+| [gc session attach](#gc-session-attach) | Attach to (or resume) a chat session |
+| [gc session close](#gc-session-close) | Close a session permanently |
+| [gc session kill](#gc-session-kill) | Force-kill session runtime (reconciler restarts) |
+| [gc session list](#gc-session-list) | List chat sessions |
+| [gc session logs](#gc-session-logs) | Show session logs for a session |
+| [gc session new](#gc-session-new) | Create a new chat session from an agent template |
+| [gc session nudge](#gc-session-nudge) | Send a text message to a running session |
+| [gc session peek](#gc-session-peek) | View session output without attaching |
+| [gc session prune](#gc-session-prune) | Close old suspended sessions |
+| [gc session rename](#gc-session-rename) | Rename a session |
+| [gc session reset](#gc-session-reset) | Restart a session fresh while preserving the bead |
+| [gc session submit](#gc-session-submit) | Submit a message with semantic delivery intent |
+| [gc session suspend](#gc-session-suspend) | Suspend a session (save state, free resources) |
+| [gc session wait](#gc-session-wait) | Register a dependency wait for a session |
+| [gc session wake](#gc-session-wake) | Wake a session (clear hold and quarantine) |
 
 ## gc session attach
 
@@ -1684,11 +1786,11 @@ List all chat sessions. By default shows active and suspended sessions.
 gc session list [flags]
 ```
 
-| Flag         | Type   | Default | Description                                             |
-| ------------ | ------ | ------- | ------------------------------------------------------- |
-| `--json`     | bool   |         | JSON output                                             |
-| `--state`    | string |         | filter by state: "active", "suspended", "closed", "all" |
-| `--template` | string |         | filter by template name                                 |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | JSON output |
+| `--state` | string |  | filter by state: "active", "suspended", "closed", "all" |
+| `--template` | string |  | filter by template name |
 
 ## gc session logs
 
@@ -1713,10 +1815,10 @@ gc session logs mayor
   gc session logs s-gc-123 -f
 ```
 
-| Flag             | Type | Default | Description                                     |
-| ---------------- | ---- | ------- | ----------------------------------------------- |
-| `-f`, `--follow` | bool |         | Follow new messages as they arrive              |
-| `--tail`         | int  | `1`     | Number of compaction segments to show (0 = all) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-f`, `--follow` | bool |  | Follow new messages as they arrive |
+| `--tail` | int | `1` | Number of compaction segments to show (0 = all) |
 
 ## gc session new
 
@@ -1741,12 +1843,12 @@ gc session new helper
   gc session new helper --no-attach
 ```
 
-| Flag           | Type   | Default | Description                                             |
-| -------------- | ------ | ------- | ------------------------------------------------------- |
-| `--alias`      | string |         | human-friendly session identifier for commands and mail |
-| `--no-attach`  | bool   |         | create session without attaching                        |
-| `--title`      | string |         | human-readable session title                            |
-| `--title-hint` | string |         | text to auto-generate a session title from              |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--alias` | string |  | human-friendly session identifier for commands and mail |
+| `--no-attach` | bool |  | create session without attaching |
+| `--title` | string |  | human-readable session title |
+| `--title-hint` | string |  | text to auto-generate a session title from |
 
 ## gc session nudge
 
@@ -1762,8 +1864,8 @@ joined automatically.
 gc session nudge <id-or-alias> <message...> [flags]
 ```
 
-| Flag         | Type   | Default     | Description                                   |
-| ------------ | ------ | ----------- | --------------------------------------------- |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
 | `--delivery` | string | `wait-idle` | delivery mode: immediate, wait-idle, or queue |
 
 ## gc session peek
@@ -1774,9 +1876,9 @@ View session output without attaching
 gc session peek <session-id-or-alias> [flags]
 ```
 
-| Flag      | Type | Default | Description                |
-| --------- | ---- | ------- | -------------------------- |
-| `--lines` | int  | `50`    | number of lines to capture |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--lines` | int | `50` | number of lines to capture |
 
 ## gc session prune
 
@@ -1794,9 +1896,9 @@ gc session prune --before 7d
   gc session prune --before 24h
 ```
 
-| Flag       | Type   | Default | Description                                             |
-| ---------- | ------ | ------- | ------------------------------------------------------- |
-| `--before` | string | `7d`    | prune sessions older than this duration (e.g., 7d, 24h) |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--before` | string | `7d` | prune sessions older than this duration (e.g., 7d, 24h) |
 
 ## gc session rename
 
@@ -1839,8 +1941,8 @@ gc session submit mayor "status update"
   gc session submit mayor "stop and do this instead" --intent interrupt_now
 ```
 
-| Flag       | Type   | Default   | Description                                         |
-| ---------- | ------ | --------- | --------------------------------------------------- |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
 | `--intent` | string | `default` | submit intent: default, follow_up, or interrupt_now |
 
 ## gc session suspend
@@ -1862,12 +1964,12 @@ Register a dependency wait for a session
 gc session wait [session-id-or-alias] [flags]
 ```
 
-| Flag         | Type        | Default | Description                                        |
-| ------------ | ----------- | ------- | -------------------------------------------------- |
-| `--any`      | bool        |         | wake when any watched bead closes (default: all)   |
-| `--note`     | string      |         | reminder text delivered when the wait is satisfied |
-| `--on-beads` | stringSlice |         | bead IDs to watch                                  |
-| `--sleep`    | bool        |         | set wait hold so the session can drain to sleep    |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--any` | bool |  | wake when any watched bead closes (default: all) |
+| `--note` | string |  | reminder text delivered when the wait is satisfied |
+| `--on-beads` | stringSlice |  | bead IDs to watch |
+| `--sleep` | bool |  | set wait hold so the session can drain to sleep |
 
 ## gc session wake
 
@@ -1925,31 +2027,31 @@ With --formula, a wisp (ephemeral molecule) is instantiated from the formula
 and its root bead is routed to the target.
 
 Examples:
-gc sling my-rig/claude BL-42 # route existing bead
-gc sling my-rig/claude "write a README" # create bead from text, then route
-gc sling mayor code-review --formula # instantiate formula, route wisp
-echo "fix login" | gc sling mayor --stdin # read bead text from stdin
+  gc sling my-rig/claude BL-42              # route existing bead
+  gc sling my-rig/claude "write a README"   # create bead from text, then route
+  gc sling mayor code-review --formula      # instantiate formula, route wisp
+  echo "fix login" | gc sling mayor --stdin # read bead text from stdin
 
 ```
 gc sling [target] <bead-or-formula-or-text> [flags]
 ```
 
-| Flag              | Type        | Default | Description                                                        |
-| ----------------- | ----------- | ------- | ------------------------------------------------------------------ |
-| `-n`, `--dry-run` | bool        |         | show what would be done without executing                          |
-| `--force`         | bool        |         | suppress warnings and allow cross-rig routing                      |
-| `-f`, `--formula` | bool        |         | treat argument as formula name                                     |
-| `--merge`         | string      |         | merge strategy: direct, mr, or local                               |
-| `--no-convoy`     | bool        |         | skip auto-convoy creation                                          |
-| `--no-formula`    | bool        |         | suppress default formula (route raw bead)                          |
-| `--nudge`         | bool        |         | nudge target after routing                                         |
-| `--on`            | string      |         | attach wisp from formula to bead before routing                    |
-| `--owned`         | bool        |         | mark auto-convoy as owned (skip auto-close)                        |
-| `--scope-kind`    | string      |         | logical workflow scope kind for graph.v2 launches                  |
-| `--scope-ref`     | string      |         | logical workflow scope ref for graph.v2 launches                   |
-| `--stdin`         | bool        |         | read bead text from stdin (first line = title, rest = description) |
-| `-t`, `--title`   | string      |         | wisp root bead title (with --formula or --on)                      |
-| `--var`           | stringArray |         | variable substitution for formula (key=value, repeatable)          |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-n`, `--dry-run` | bool |  | show what would be done without executing |
+| `--force` | bool |  | suppress warnings and allow cross-rig routing |
+| `-f`, `--formula` | bool |  | treat argument as formula name |
+| `--merge` | string |  | merge strategy: direct, mr, or local |
+| `--no-convoy` | bool |  | skip auto-convoy creation |
+| `--no-formula` | bool |  | suppress default formula (route raw bead) |
+| `--nudge` | bool |  | nudge target after routing |
+| `--on` | string |  | attach wisp from formula to bead before routing |
+| `--owned` | bool |  | mark auto-convoy as owned (skip auto-close) |
+| `--scope-kind` | string |  | logical workflow scope kind for graph.v2 launches |
+| `--scope-ref` | string |  | logical workflow scope ref for graph.v2 launches |
+| `--stdin` | bool |  | read bead text from stdin (first line = title, rest = description) |
+| `-t`, `--title` | string |  | wisp root bead title (with --formula or --on) |
+| `--var` | stringArray |  | variable substitution for formula (key=value, repeatable) |
 
 ## gc start
 
@@ -1973,9 +2075,9 @@ gc start
   gc supervisor run
 ```
 
-| Flag              | Type | Default | Description                                           |
-| ----------------- | ---- | ------- | ----------------------------------------------------- |
-| `-n`, `--dry-run` | bool |         | preview what agents would start without starting them |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-n`, `--dry-run` | bool |  | preview what agents would start without starting them |
 
 ## gc status
 
@@ -1986,9 +2088,9 @@ all agents with running status, rigs, and a summary count.
 gc status [path] [flags]
 ```
 
-| Flag     | Type | Default | Description           |
-| -------- | ---- | ------- | --------------------- |
-| `--json` | bool |         | Output in JSON format |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSON format |
 
 ## gc stop
 
@@ -2015,16 +2117,16 @@ to add cities.
 gc supervisor
 ```
 
-| Subcommand                                          | Description                                         |
-| --------------------------------------------------- | --------------------------------------------------- |
-| [gc supervisor install](#gc-supervisor-install)     | Install the supervisor as a platform service        |
-| [gc supervisor logs](#gc-supervisor-logs)           | Tail the supervisor log file                        |
-| [gc supervisor reload](#gc-supervisor-reload)       | Trigger immediate reconciliation of all cities      |
-| [gc supervisor run](#gc-supervisor-run)             | Run the machine-wide supervisor in the foreground   |
-| [gc supervisor start](#gc-supervisor-start)         | Start the machine-wide supervisor in the background |
-| [gc supervisor status](#gc-supervisor-status)       | Check if the supervisor is running                  |
-| [gc supervisor stop](#gc-supervisor-stop)           | Stop the machine-wide supervisor                    |
-| [gc supervisor uninstall](#gc-supervisor-uninstall) | Remove the platform service                         |
+| Subcommand | Description |
+|------------|-------------|
+| [gc supervisor install](#gc-supervisor-install) | Install the supervisor as a platform service |
+| [gc supervisor logs](#gc-supervisor-logs) | Tail the supervisor log file |
+| [gc supervisor reload](#gc-supervisor-reload) | Trigger immediate reconciliation of all cities |
+| [gc supervisor run](#gc-supervisor-run) | Run the machine-wide supervisor in the foreground |
+| [gc supervisor start](#gc-supervisor-start) | Start the machine-wide supervisor in the background |
+| [gc supervisor status](#gc-supervisor-status) | Check if the supervisor is running |
+| [gc supervisor stop](#gc-supervisor-stop) | Stop the machine-wide supervisor |
+| [gc supervisor uninstall](#gc-supervisor-uninstall) | Remove the platform service |
 
 ## gc supervisor install
 
@@ -2045,10 +2147,10 @@ Shows recent log output from background and service-managed supervisor runs.
 gc supervisor logs [flags]
 ```
 
-| Flag             | Type | Default | Description             |
-| ---------------- | ---- | ------- | ----------------------- |
-| `-f`, `--follow` | bool |         | follow log output       |
-| `-n`, `--lines`  | int  | `50`    | number of lines to show |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-f`, `--follow` | bool |  | follow log output |
+| `-n`, `--lines` | int | `50` | number of lines to show |
 
 ## gc supervisor reload
 
@@ -2132,15 +2234,15 @@ and can be managed even when the controller is offline.
 gc trace
 ```
 
-| Subcommand                            | Description                                 |
-| ------------------------------------- | ------------------------------------------- |
-| [gc trace cycle](#gc-trace-cycle)     | Show a cycle by tick id                     |
+| Subcommand | Description |
+|------------|-------------|
+| [gc trace cycle](#gc-trace-cycle) | Show a cycle by tick id |
 | [gc trace reasons](#gc-trace-reasons) | Show reason codes observed in trace records |
-| [gc trace show](#gc-trace-show)       | Show trace records                          |
-| [gc trace start](#gc-trace-start)     | Start or extend tracing for a template      |
-| [gc trace status](#gc-trace-status)   | Show trace arms and stream state            |
-| [gc trace stop](#gc-trace-stop)       | Stop tracing for a template                 |
-| [gc trace tail](#gc-trace-tail)       | Follow trace records                        |
+| [gc trace show](#gc-trace-show) | Show trace records |
+| [gc trace start](#gc-trace-start) | Start or extend tracing for a template |
+| [gc trace status](#gc-trace-status) | Show trace arms and stream state |
+| [gc trace stop](#gc-trace-stop) | Stop tracing for a template |
+| [gc trace tail](#gc-trace-tail) | Follow trace records |
 
 ## gc trace cycle
 
@@ -2150,9 +2252,9 @@ Show a cycle by tick id
 gc trace cycle [flags]
 ```
 
-| Flag     | Type   | Default | Description        |
-| -------- | ------ | ------- | ------------------ |
-| `--tick` | string |         | tick id to display |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--tick` | string |  | tick id to display |
 
 ## gc trace reasons
 
@@ -2162,10 +2264,10 @@ Show reason codes observed in trace records
 gc trace reasons [flags]
 ```
 
-| Flag         | Type   | Default | Description                        |
-| ------------ | ------ | ------- | ---------------------------------- |
-| `--since`    | string |         | show reasons since duration ago    |
-| `--template` | string |         | exact normalized template selector |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--since` | string |  | show reasons since duration ago |
+| `--template` | string |  | exact normalized template selector |
 
 ## gc trace show
 
@@ -2175,15 +2277,15 @@ Show trace records
 gc trace show [flags]
 ```
 
-| Flag         | Type   | Default | Description                        |
-| ------------ | ------ | ------- | ---------------------------------- |
-| `--json`     | bool   | `true`  | emit JSON array                    |
-| `--reason`   | string |         | filter by reason code              |
-| `--since`    | string |         | show records since duration ago    |
-| `--template` | string |         | exact normalized template selector |
-| `--tick`     | string |         | filter by tick id                  |
-| `--trace-id` | string |         | filter by trace id                 |
-| `--type`     | string |         | filter by record type              |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool | `true` | emit JSON array |
+| `--reason` | string |  | filter by reason code |
+| `--since` | string |  | show records since duration ago |
+| `--template` | string |  | exact normalized template selector |
+| `--tick` | string |  | filter by tick id |
+| `--trace-id` | string |  | filter by trace id |
+| `--type` | string |  | filter by record type |
 
 ## gc trace start
 
@@ -2193,12 +2295,12 @@ Start or extend tracing for a template
 gc trace start [flags]
 ```
 
-| Flag         | Type   | Default  | Description                        |
-| ------------ | ------ | -------- | ---------------------------------- |
-| `--auto`     | bool   |          | mark the arm as auto-triggered     |
-| `--for`      | string | `15m`    | trace arm duration (e.g. 15m)      |
-| `--level`    | string | `detail` | trace level: baseline or detail    |
-| `--template` | string |          | exact normalized template selector |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--auto` | bool |  | mark the arm as auto-triggered |
+| `--for` | string | `15m` | trace arm duration (e.g. 15m) |
+| `--level` | string | `detail` | trace level: baseline or detail |
+| `--template` | string |  | exact normalized template selector |
 
 ## gc trace status
 
@@ -2216,10 +2318,10 @@ Stop tracing for a template
 gc trace stop [flags]
 ```
 
-| Flag         | Type   | Default | Description                        |
-| ------------ | ------ | ------- | ---------------------------------- |
-| `--all`      | bool   |         | remove both manual and auto arms   |
-| `--template` | string |         | exact normalized template selector |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all` | bool |  | remove both manual and auto arms |
+| `--template` | string |  | exact normalized template selector |
 
 ## gc trace tail
 
@@ -2229,10 +2331,10 @@ Follow trace records
 gc trace tail [flags]
 ```
 
-| Flag         | Type   | Default | Description                        |
-| ------------ | ------ | ------- | ---------------------------------- |
-| `--since`    | string |         | follow from duration ago           |
-| `--template` | string |         | exact normalized template selector |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--since` | string |  | follow from duration ago |
+| `--template` | string |  | exact normalized template selector |
 
 ## gc unregister
 
@@ -2255,9 +2357,9 @@ Use --long to include git commit and build date metadata.
 gc version [flags]
 ```
 
-| Flag           | Type | Default | Description                                |
-| -------------- | ---- | ------- | ------------------------------------------ |
-| `-l`, `--long` | bool |         | Include git commit and build date metadata |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-l`, `--long` | bool |  | Include git commit and build date metadata |
 
 ## gc wait
 
@@ -2267,12 +2369,12 @@ Inspect and manage durable session waits
 gc wait
 ```
 
-| Subcommand                          | Description                |
-| ----------------------------------- | -------------------------- |
-| [gc wait cancel](#gc-wait-cancel)   | Cancel a wait              |
-| [gc wait inspect](#gc-wait-inspect) | Show details for a wait    |
-| [gc wait list](#gc-wait-list)       | List durable waits         |
-| [gc wait ready](#gc-wait-ready)     | Manually mark a wait ready |
+| Subcommand | Description |
+|------------|-------------|
+| [gc wait cancel](#gc-wait-cancel) | Cancel a wait |
+| [gc wait inspect](#gc-wait-inspect) | Show details for a wait |
+| [gc wait list](#gc-wait-list) | List durable waits |
+| [gc wait ready](#gc-wait-ready) | Manually mark a wait ready |
 
 ## gc wait cancel
 
@@ -2298,10 +2400,10 @@ List durable waits
 gc wait list [flags]
 ```
 
-| Flag        | Type   | Default | Description          |
-| ----------- | ------ | ------- | -------------------- |
-| `--session` | string |         | filter by session ID |
-| `--state`   | string |         | filter by wait state |
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--session` | string |  | filter by session ID |
+| `--state` | string |  | filter by wait state |
 
 ## gc wait ready
 
@@ -2310,3 +2412,4 @@ Manually mark a wait ready
 ```
 gc wait ready <wait-id>
 ```
+

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -104,6 +104,7 @@ Agent defines a configured agent in the city.
 | `depends_on` | []string |  |  | DependsOn lists agent names that must be awake before this agent wakes. Used for dependency-ordered startup and shutdown. Validated for cycles at config load time. |
 | `resume_command` | string |  |  | ResumeCommand is the full shell command to run when resuming this agent. Supports &#123;&#123;.SessionKey&#125;&#125; template variable. When set, takes precedence over the provider's ResumeFlag/ResumeStyle. Example:   "claude --resume &#123;&#123;.SessionKey&#125;&#125; --dangerously-skip-permissions" |
 | `wake_mode` | string |  |  | WakeMode controls context freshness across sleep/wake cycles. "resume" (default): reuse provider session key for conversation continuity. "fresh": start a new provider session on every wake (polecat pattern). Enum: `resume`, `fresh` |
+| `lifecycle` | Lifecycle |  |  | Lifecycle configures per-agent drain behavior. Controls how the reconciler handles drain decisions (config-drift, idle-timeout) for this agent's sessions. |
 
 ## AgentDefaults
 
@@ -160,6 +161,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `min_active_sessions` | integer |  |  | MinActiveSessions overrides the minimum number of sessions to keep alive. |
 | `scale_check` | string |  |  | ScaleCheck overrides the shell command whose output determines desired session count. |
 | `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (override keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
+| `lifecycle` | LifecyclePatch |  |  | Lifecycle overrides drain policy fields. |
 
 ## AgentPatch
 
@@ -204,6 +206,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `min_active_sessions` | integer |  |  | MinActiveSessions overrides the minimum number of sessions to keep alive. |
 | `scale_check` | string |  |  | ScaleCheck overrides the shell command whose output determines desired session count. |
 | `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (patch keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
+| `lifecycle` | LifecyclePatch |  |  | Lifecycle overrides drain policy fields. |
 
 ## BeadsConfig
 
@@ -287,6 +290,26 @@ K8sConfig holds native K8s session provider settings.
 | `cpu_limit` | string |  | `2` | CPULimit is the pod CPU limit. Default: "2". |
 | `mem_limit` | string |  | `4Gi` | MemLimit is the pod memory limit. Default: "4Gi". |
 | `prebaked` | boolean |  |  | Prebaked skips init container staging and EmptyDir volumes when true. Use with images built by `gc build-image` that have city content baked in. |
+
+## Lifecycle
+
+Lifecycle configures per-agent drain behavior.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `drain_policy` | string |  |  | DrainPolicy controls when the reconciler may drain this agent's sessions. "immediate" (default): drain proceeds as soon as the trigger fires. "defer_until_idle": defer drain while the session has active work, up to GraceTimeout. Enum: `immediate`, `defer_until_idle` |
+| `idle_signal` | string |  |  | IdleSignal selects what counts as "active" when DrainPolicy is defer_until_idle. "bead_activity" (default): in-progress beads assigned to the session. Enum: `bead_activity` |
+| `grace_timeout` | string |  |  | GraceTimeout caps how long a drain can be deferred. After this duration, the drain proceeds regardless of activity. Duration string (e.g., "5m"). Zero or empty means no cap (defer indefinitely while active). |
+
+## LifecyclePatch
+
+LifecyclePatch modifies lifecycle drain policy fields.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `drain_policy` | string |  |  | DrainPolicy overrides the drain policy. |
+| `idle_signal` | string |  |  | IdleSignal overrides the idle signal. |
+| `grace_timeout` | string |  |  | GraceTimeout overrides the grace timeout. |
 
 ## MailConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -274,6 +274,10 @@
             "fresh"
           ],
           "description": "WakeMode controls context freshness across sleep/wake cycles.\n\"resume\" (default): reuse provider session key for conversation continuity.\n\"fresh\": start a new provider session on every wake (polecat pattern)."
+        },
+        "lifecycle": {
+          "$ref": "#/$defs/Lifecycle",
+          "description": "Lifecycle configures per-agent drain behavior. Controls how the\nreconciler handles drain decisions (config-drift, idle-timeout)\nfor this agent's sessions."
         }
       },
       "additionalProperties": false,
@@ -515,6 +519,10 @@
           },
           "type": "object",
           "description": "OptionDefaults adds or overrides provider option defaults for this agent.\nKeys are option keys, values are choice values. Merges additively\n(override keys win over existing agent keys).\nExample: option_defaults = { model = \"sonnet\" }"
+        },
+        "lifecycle": {
+          "$ref": "#/$defs/LifecyclePatch",
+          "description": "Lifecycle overrides drain policy fields."
         }
       },
       "additionalProperties": false,
@@ -719,6 +727,10 @@
           },
           "type": "object",
           "description": "OptionDefaults adds or overrides provider option defaults for this agent.\nKeys are option keys, values are choice values. Merges additively\n(patch keys win over existing agent keys).\nExample: option_defaults = { model = \"sonnet\" }"
+        },
+        "lifecycle": {
+          "$ref": "#/$defs/LifecyclePatch",
+          "description": "Lifecycle overrides drain policy fields."
         }
       },
       "additionalProperties": false,
@@ -1032,6 +1044,51 @@
       "additionalProperties": false,
       "type": "object",
       "description": "K8sConfig holds native K8s session provider settings."
+    },
+    "Lifecycle": {
+      "properties": {
+        "drain_policy": {
+          "type": "string",
+          "enum": [
+            "immediate",
+            "defer_until_idle"
+          ],
+          "description": "DrainPolicy controls when the reconciler may drain this agent's sessions.\n\"immediate\" (default): drain proceeds as soon as the trigger fires.\n\"defer_until_idle\": defer drain while the session has active work,\nup to GraceTimeout."
+        },
+        "idle_signal": {
+          "type": "string",
+          "enum": [
+            "bead_activity"
+          ],
+          "description": "IdleSignal selects what counts as \"active\" when DrainPolicy is defer_until_idle.\n\"bead_activity\" (default): in-progress beads assigned to the session."
+        },
+        "grace_timeout": {
+          "type": "string",
+          "description": "GraceTimeout caps how long a drain can be deferred. After this duration,\nthe drain proceeds regardless of activity. Duration string (e.g., \"5m\").\nZero or empty means no cap (defer indefinitely while active)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Lifecycle configures per-agent drain behavior."
+    },
+    "LifecyclePatch": {
+      "properties": {
+        "drain_policy": {
+          "type": "string",
+          "description": "DrainPolicy overrides the drain policy."
+        },
+        "idle_signal": {
+          "type": "string",
+          "description": "IdleSignal overrides the idle signal."
+        },
+        "grace_timeout": {
+          "type": "string",
+          "description": "GraceTimeout overrides the grace timeout."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "LifecyclePatch modifies lifecycle drain policy fields."
     },
     "MailConfig": {
       "properties": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -357,6 +357,8 @@ type AgentOverride struct {
 	// (override keys win over existing agent keys).
 	// Example: option_defaults = { model = "sonnet" }
 	OptionDefaults map[string]string `toml:"option_defaults,omitempty"`
+	// Lifecycle overrides drain policy fields.
+	Lifecycle *LifecyclePatch `toml:"lifecycle,omitempty"`
 }
 
 // PackSource defines a remote pack repository.
@@ -1135,6 +1137,47 @@ type AgentDefaults struct {
 	AllowEnvOverride []string `toml:"allow_env_override,omitempty"`
 }
 
+// Drain policy constants for Lifecycle.DrainPolicy.
+const (
+	// DrainPolicyImmediate drains the session immediately (default behavior).
+	DrainPolicyImmediate = "immediate"
+	// DrainPolicyDeferUntilIdle defers drain while the session has active work,
+	// up to the grace timeout.
+	DrainPolicyDeferUntilIdle = "defer_until_idle"
+)
+
+// Idle signal constants for Lifecycle.IdleSignal.
+const (
+	// IdleSignalBeadActivity uses in-progress bead assignments as the activity signal.
+	IdleSignalBeadActivity = "bead_activity"
+)
+
+// Lifecycle configures per-agent drain behavior. The reconciler consults
+// these fields before draining a session (config-drift, idle-timeout).
+// Zero value means immediate drain (current default behavior).
+type Lifecycle struct {
+	// DrainPolicy controls when the reconciler may drain this agent's sessions.
+	// "immediate" (default): drain proceeds as soon as the trigger fires.
+	// "defer_until_idle": defer drain while the session has active work,
+	// up to GraceTimeout.
+	DrainPolicy string `toml:"drain_policy,omitempty" jsonschema:"enum=immediate,enum=defer_until_idle"`
+	// IdleSignal selects what counts as "active" when DrainPolicy is defer_until_idle.
+	// "bead_activity" (default): in-progress beads assigned to the session.
+	IdleSignal string `toml:"idle_signal,omitempty" jsonschema:"enum=bead_activity"`
+	// GraceTimeout caps how long a drain can be deferred. After this duration,
+	// the drain proceeds regardless of activity. Duration string (e.g., "5m").
+	// Zero or empty means no cap (defer indefinitely while active).
+	GraceTimeout string `toml:"grace_timeout,omitempty"`
+}
+
+// EffectiveIdleSignal returns the configured idle signal, defaulting to IdleSignalBeadActivity.
+func (l Lifecycle) EffectiveIdleSignal() string {
+	if l.IdleSignal != "" {
+		return l.IdleSignal
+	}
+	return IdleSignalBeadActivity
+}
+
 // Agent defines a configured agent in the city.
 type Agent struct {
 	// Name is the unique identifier for this agent.
@@ -1315,6 +1358,10 @@ type Agent struct {
 	// expansion. Pool instances use this for gc.routed_to-based work discovery
 	// (e.g., dog) rather than their concrete instance name (e.g., dog-1).
 	PoolName string `toml:"-"`
+	// Lifecycle configures per-agent drain behavior. Controls how the
+	// reconciler handles drain decisions (config-drift, idle-timeout)
+	// for this agent's sessions.
+	Lifecycle Lifecycle `toml:"lifecycle,omitempty"`
 }
 
 // IdleTimeoutDuration returns the idle timeout as a time.Duration.
@@ -1341,6 +1388,27 @@ func (a *Agent) EffectiveWakeMode() string {
 // AttachEnabled reports whether the agent supports interactive attachment.
 func (a *Agent) AttachEnabled() bool {
 	return a.Attach == nil || *a.Attach
+}
+
+// EffectiveDrainPolicy returns the configured drain policy, defaulting to DrainPolicyImmediate.
+func (a *Agent) EffectiveDrainPolicy() string {
+	if a.Lifecycle.DrainPolicy == DrainPolicyDeferUntilIdle {
+		return DrainPolicyDeferUntilIdle
+	}
+	return DrainPolicyImmediate
+}
+
+// GraceTimeoutDuration returns the lifecycle grace timeout as a time.Duration.
+// Returns 0 if empty or unparseable.
+func (a *Agent) GraceTimeoutDuration() time.Duration {
+	if a.Lifecycle.GraceTimeout == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(a.Lifecycle.GraceTimeout)
+	if err != nil {
+		return 0
+	}
+	return d
 }
 
 // EffectiveWorkQuery returns the work query command for this agent.

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -191,6 +191,7 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		MinActiveSessions:       intVal(1),
 		ScaleCheck:              strVal("echo 3"),
 		OptionDefaults:          map[string]string{"model": "sonnet"},
+		Lifecycle:               &LifecyclePatch{DrainPolicy: strVal("defer_until_idle"), IdleSignal: strVal("bead_activity"), GraceTimeout: strVal("5m")},
 	}
 
 	// Verify every AgentPatch field is set (non-zero).
@@ -233,8 +234,8 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		if targeting[fname] || modifiers[fname] {
 			continue
 		}
-		// Env, OptionDefaults, and Pool are handled specially (not a direct field copy).
-		if fname == "Env" || fname == "OptionDefaults" || fname == "Pool" {
+		// Env, OptionDefaults, Pool, and Lifecycle are handled specially (not a direct field copy).
+		if fname == "Env" || fname == "OptionDefaults" || fname == "Pool" || fname == "Lifecycle" {
 			continue
 		}
 		idx, ok := agentFieldByName[fname]
@@ -246,6 +247,16 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		}
 	}
 
+	// Verify Lifecycle was merged.
+	if agent.Lifecycle.DrainPolicy != "defer_until_idle" {
+		t.Errorf("Lifecycle.DrainPolicy = %q, want %q", agent.Lifecycle.DrainPolicy, "defer_until_idle")
+	}
+	if agent.Lifecycle.IdleSignal != "bead_activity" {
+		t.Errorf("Lifecycle.IdleSignal = %q, want %q", agent.Lifecycle.IdleSignal, "bead_activity")
+	}
+	if agent.Lifecycle.GraceTimeout != "5m" {
+		t.Errorf("Lifecycle.GraceTimeout = %q, want %q", agent.Lifecycle.GraceTimeout, "5m")
+	}
 	// Verify Env was merged.
 	if agent.Env["KEY"] != "val" {
 		t.Errorf("Env[KEY] = %q, want %q", agent.Env["KEY"], "val")
@@ -326,6 +337,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		MinActiveSessions:       intVal(1),
 		ScaleCheck:              strVal("echo 3"),
 		OptionDefaults:          map[string]string{"model": "sonnet"},
+		Lifecycle:               &LifecyclePatch{DrainPolicy: strVal("defer_until_idle"), IdleSignal: strVal("bead_activity"), GraceTimeout: strVal("5m")},
 	}
 
 	// Verify every AgentOverride field is set (non-zero).
@@ -365,7 +377,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		if targeting[fname] || modifiers[fname] {
 			continue
 		}
-		if fname == "Env" || fname == "OptionDefaults" || fname == "Pool" {
+		if fname == "Env" || fname == "OptionDefaults" || fname == "Pool" || fname == "Lifecycle" {
 			continue
 		}
 		idx, ok := agentFieldByName[fname]
@@ -377,6 +389,10 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		}
 	}
 
+	// Verify Lifecycle was merged.
+	if agent.Lifecycle.DrainPolicy != "defer_until_idle" {
+		t.Errorf("Lifecycle.DrainPolicy = %q, want %q", agent.Lifecycle.DrainPolicy, "defer_until_idle")
+	}
 	// Verify Env was merged.
 	if agent.Env["KEY"] != "val" {
 		t.Errorf("Env[KEY] = %q, want %q", agent.Env["KEY"], "val")

--- a/internal/config/lifecycle_test.go
+++ b/internal/config/lifecycle_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLifecycleDefaults(t *testing.T) {
+	var lc Lifecycle
+
+	// Zero-value Lifecycle should default to immediate drain.
+	agent := Agent{Lifecycle: lc}
+	if got := agent.EffectiveDrainPolicy(); got != DrainPolicyImmediate {
+		t.Errorf("EffectiveDrainPolicy() = %q, want %q", got, DrainPolicyImmediate)
+	}
+	if got := agent.GraceTimeoutDuration(); got != 0 {
+		t.Errorf("GraceTimeoutDuration() = %v, want 0", got)
+	}
+	if got := lc.EffectiveIdleSignal(); got != IdleSignalBeadActivity {
+		t.Errorf("EffectiveIdleSignal() = %q, want %q", got, IdleSignalBeadActivity)
+	}
+}
+
+func TestEffectiveDrainPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{"empty defaults to immediate", "", DrainPolicyImmediate},
+		{"explicit immediate", DrainPolicyImmediate, DrainPolicyImmediate},
+		{"defer_until_idle", DrainPolicyDeferUntilIdle, DrainPolicyDeferUntilIdle},
+		{"unknown defaults to immediate", "bogus", DrainPolicyImmediate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := Agent{Lifecycle: Lifecycle{DrainPolicy: tt.policy}}
+			if got := agent.EffectiveDrainPolicy(); got != tt.want {
+				t.Errorf("EffectiveDrainPolicy() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGraceTimeoutDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{"empty", "", 0},
+		{"5m", "5m", 5 * time.Minute},
+		{"30s", "30s", 30 * time.Second},
+		{"1h", "1h", time.Hour},
+		{"invalid", "bogus", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := Agent{Lifecycle: Lifecycle{GraceTimeout: tt.timeout}}
+			if got := agent.GraceTimeoutDuration(); got != tt.want {
+				t.Errorf("GraceTimeoutDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveIdleSignal(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal string
+		want   string
+	}{
+		{"empty defaults to bead_activity", "", IdleSignalBeadActivity},
+		{"explicit bead_activity", IdleSignalBeadActivity, IdleSignalBeadActivity},
+		{"custom value preserved", "custom_signal", "custom_signal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := Lifecycle{IdleSignal: tt.signal}
+			if got := lc.EffectiveIdleSignal(); got != tt.want {
+				t.Errorf("EffectiveIdleSignal() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyLifecyclePatch(t *testing.T) {
+	strVal := func(s string) *string { return &s }
+
+	t.Run("full patch", func(t *testing.T) {
+		dst := Lifecycle{}
+		src := &LifecyclePatch{
+			DrainPolicy:  strVal("defer_until_idle"),
+			IdleSignal:   strVal("bead_activity"),
+			GraceTimeout: strVal("10m"),
+		}
+		applyLifecyclePatch(&dst, src)
+		if dst.DrainPolicy != "defer_until_idle" {
+			t.Errorf("DrainPolicy = %q, want %q", dst.DrainPolicy, "defer_until_idle")
+		}
+		if dst.IdleSignal != "bead_activity" {
+			t.Errorf("IdleSignal = %q, want %q", dst.IdleSignal, "bead_activity")
+		}
+		if dst.GraceTimeout != "10m" {
+			t.Errorf("GraceTimeout = %q, want %q", dst.GraceTimeout, "10m")
+		}
+	})
+
+	t.Run("partial patch preserves existing", func(t *testing.T) {
+		dst := Lifecycle{
+			DrainPolicy:  "defer_until_idle",
+			IdleSignal:   "bead_activity",
+			GraceTimeout: "5m",
+		}
+		src := &LifecyclePatch{
+			GraceTimeout: strVal("10m"),
+		}
+		applyLifecyclePatch(&dst, src)
+		if dst.DrainPolicy != "defer_until_idle" {
+			t.Errorf("DrainPolicy = %q, want %q (should be preserved)", dst.DrainPolicy, "defer_until_idle")
+		}
+		if dst.GraceTimeout != "10m" {
+			t.Errorf("GraceTimeout = %q, want %q", dst.GraceTimeout, "10m")
+		}
+	})
+
+	t.Run("nil fields are no-ops", func(t *testing.T) {
+		dst := Lifecycle{DrainPolicy: "immediate"}
+		src := &LifecyclePatch{}
+		applyLifecyclePatch(&dst, src)
+		if dst.DrainPolicy != "immediate" {
+			t.Errorf("DrainPolicy = %q, want %q", dst.DrainPolicy, "immediate")
+		}
+	})
+}
+
+func TestLifecycleTOMLParsing(t *testing.T) {
+	input := `
+[[agent]]
+name = "mayor"
+[agent.lifecycle]
+drain_policy = "defer_until_idle"
+idle_signal = "bead_activity"
+grace_timeout = "5m"
+`
+	cfg, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(cfg.Agents))
+	}
+	a := cfg.Agents[0]
+	if a.Lifecycle.DrainPolicy != "defer_until_idle" {
+		t.Errorf("DrainPolicy = %q, want %q", a.Lifecycle.DrainPolicy, "defer_until_idle")
+	}
+	if a.Lifecycle.IdleSignal != "bead_activity" {
+		t.Errorf("IdleSignal = %q, want %q", a.Lifecycle.IdleSignal, "bead_activity")
+	}
+	if a.Lifecycle.GraceTimeout != "5m" {
+		t.Errorf("GraceTimeout = %q, want %q", a.Lifecycle.GraceTimeout, "5m")
+	}
+}
+
+func TestLifecycleTOMLOmitted(t *testing.T) {
+	input := `
+[[agent]]
+name = "worker"
+`
+	cfg, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	a := cfg.Agents[0]
+	if a.Lifecycle.DrainPolicy != "" {
+		t.Errorf("DrainPolicy = %q, want empty", a.Lifecycle.DrainPolicy)
+	}
+	if a.EffectiveDrainPolicy() != DrainPolicyImmediate {
+		t.Errorf("EffectiveDrainPolicy() = %q, want %q", a.EffectiveDrainPolicy(), DrainPolicyImmediate)
+	}
+}

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -997,6 +997,10 @@ func applyAgentOverride(a *Agent, ov *AgentOverride) {
 	if ov.Pool != nil {
 		applyPoolOverride(a, ov.Pool)
 	}
+	// Lifecycle: sub-field patching.
+	if ov.Lifecycle != nil {
+		applyLifecyclePatch(&a.Lifecycle, ov.Lifecycle)
+	}
 }
 
 // PackContentHash computes a SHA-256 hash of all files in a pack

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -101,6 +101,19 @@ type AgentPatch struct {
 	// (patch keys win over existing agent keys).
 	// Example: option_defaults = { model = "sonnet" }
 	OptionDefaults map[string]string `toml:"option_defaults,omitempty"`
+	// Lifecycle overrides drain policy fields.
+	Lifecycle *LifecyclePatch `toml:"lifecycle,omitempty"`
+}
+
+// LifecyclePatch modifies lifecycle drain policy fields. Pointer fields
+// distinguish "not set" from "set to zero value."
+type LifecyclePatch struct {
+	// DrainPolicy overrides the drain policy.
+	DrainPolicy *string `toml:"drain_policy,omitempty"`
+	// IdleSignal overrides the idle signal.
+	IdleSignal *string `toml:"idle_signal,omitempty"`
+	// GraceTimeout overrides the grace timeout.
+	GraceTimeout *string `toml:"grace_timeout,omitempty"`
 }
 
 // PoolOverride modifies pool configuration fields. Nil fields are not changed.
@@ -321,6 +334,23 @@ func applyAgentPatchFields(a *Agent, p *AgentPatch) {
 	// Pool: sub-field patching.
 	if p.Pool != nil {
 		applyPoolOverride(a, p.Pool)
+	}
+	// Lifecycle: sub-field patching.
+	if p.Lifecycle != nil {
+		applyLifecyclePatch(&a.Lifecycle, p.Lifecycle)
+	}
+}
+
+// applyLifecyclePatch merges non-nil fields from a LifecyclePatch into a Lifecycle.
+func applyLifecyclePatch(dst *Lifecycle, src *LifecyclePatch) {
+	if src.DrainPolicy != nil {
+		dst.DrainPolicy = *src.DrainPolicy
+	}
+	if src.IdleSignal != nil {
+		dst.IdleSignal = *src.IdleSignal
+	}
+	if src.GraceTimeout != nil {
+		dst.GraceTimeout = *src.GraceTimeout
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `[agent.lifecycle]` block to agent templates with `drain_policy` (immediate/defer_until_idle), `idle_signal` (bead_activity), and `grace_timeout` fields
- Reconciler consults lifecycle policy before config-drift and idle-timeout drains — defers drain while session has in-progress beads, up to grace timeout
- Activity detection uses pre-collected `assignedWorkBeads` (zero I/O cost), grace timeout tracked in drainTracker (in-memory, NDI-safe)
- Default behavior is `immediate` — zero migration burden for existing configs

## What was tested

- `make fmt-check` — pass
- `make lint` — pass (0 issues)
- `make vet` — pass
- Unit tests: `TestAgentFieldSync`, `TestApplyAgentPatchCoversAllFields`, `TestApplyAgentOverrideCoversAllFields` — all pass (struct parity enforced)
- Unit tests: `TestLifecycleDefaults`, `TestEffectiveDrainPolicy`, `TestGraceTimeoutDuration`, `TestEffectiveIdleSignal`, `TestApplyLifecyclePatch`, `TestLifecycleTOMLParsing`, `TestLifecycleTOMLOmitted` — all pass
- Unit tests: `TestSessionHasActiveBeads` (7 subtests), `TestDrainTrackerLifecycleDeferral` (5 subtests) — all pass

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `Lifecycle` struct, constants, `Agent.Lifecycle` field, `AgentOverride.Lifecycle` field, helper methods |
| `internal/config/patch.go` | Add `LifecyclePatch` struct, `AgentPatch.Lifecycle` field, `applyLifecyclePatch()` |
| `internal/config/pack.go` | Wire lifecycle patch into `applyAgentOverride()` |
| `cmd/gc/pool.go` | Deep-copy `Lifecycle` in `deepCopyAgent()` |
| `cmd/gc/session_types.go` | Add `lifecycleDeferrals` map to `drainTracker` with deferral tracking methods |
| `cmd/gc/session_reconcile.go` | Add `sessionHasActiveBeads()` helper |
| `cmd/gc/session_reconciler.go` | Config-drift + idle-timeout drain paths consult lifecycle policy |
| Tests | `lifecycle_test.go` (config), `lifecycle_drain_test.go` (reconciler), `field_sync_test.go` updates |

## Scope

This PR implements the first phase scoped in #504:
- `drain_policy`: `immediate` (default) and `defer_until_idle`
- `idle_signal`: `bead_activity` only
- `grace_timeout`: duration cap on deferral

Follow-up work (not in scope):
- `handoff` drain policy
- Additional idle signals (`sync_recency`, `process_activity`)

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)