### PR TITLE
fix: close ACP socket before signaling done to prevent IsRunning race (#532)

### DIFF
--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -246,13 +246,19 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 	go sc.readLoop(stdoutPipe)
 
 	// Monitor process exit — clean up pending state, socket, and listener.
+	// Socket cleanup happens BEFORE close(done) so that callers waiting
+	// on sc.done (e.g., terminateProcess) can rely on the socket being
+	// gone when done fires. Without this ordering, IsRunning can race:
+	// Stop deletes the conn from the map, terminateProcess waits on done,
+	// done closes, Stop returns — but the socket is still alive, so
+	// IsRunning falls through to socketAlive and returns true.
 	go func() {
 		_ = cmd.Wait()
 		sc.drainPending()
-		close(sc.done)
 		lis.Close()                 //nolint:errcheck
 		os.Remove(p.sockPath(name)) //nolint:errcheck
 		_ = os.Remove(p.sockNamePath(name))
+		close(sc.done)
 	}()
 
 	// Perform ACP handshake with a deadline. hsCtx (created above with


### PR DESCRIPTION
## Summary
- Fixes flaky `TestACPConformance/Stop_ConcurrentDistinctSessions` caused by a race between `Stop` returning and socket cleanup in the monitor goroutine
- Root cause: `close(sc.done)` happened before `lis.Close()` and `os.Remove(sockPath)`, so `terminateProcess` would return while the socket was still alive, causing `IsRunning` to fall through to `socketAlive()` and return `true`
- Fix: reorder the monitor goroutine to clean up the socket BEFORE signaling `done`

## What was tested
- `make fmt-check` — pass
- `make lint` — pass (0 issues)
- `make vet` — pass

## Review outcome
Single-line reorder with clear causal chain. All `sc.done` consumers checked — none depend on the socket being alive after `done` fires.

## Breaking changes
None. Internal ordering change only.

Closes #532