### PR TITLE
fix: break SSE proxy 404 loop on per-city events stream (#287)

### DIFF
--- a/cmd/gc/dashboard/api.go
+++ b/cmd/gc/dashboard/api.go
@@ -1801,6 +1801,19 @@ func (h *APIHandler) handleSSEProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close() //nolint:errcheck // best-effort close
 
+	// On upstream error, forward the error response as-is so the browser's
+	// EventSource sees a non-200 status and backs off properly. Without this
+	// check, the proxy writes 200 + "event: connected" unconditionally,
+	// which resets the browser's reconnect backoff to 1s and creates a tight
+	// 404 retry loop when the city is not yet running.
+	if resp.StatusCode != http.StatusOK {
+		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+		w.WriteHeader(resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		_, _ = w.Write(body)
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")

--- a/cmd/gc/dashboard/sse_proxy_test.go
+++ b/cmd/gc/dashboard/sse_proxy_test.go
@@ -1,0 +1,74 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSSEProxyForwardsUpstreamError verifies that handleSSEProxy forwards
+// non-200 upstream responses as-is instead of wrapping them in SSE headers.
+// Without this check, a 404 from the supervisor would be masked as a
+// successful SSE connection, causing the browser to reconnect in a tight
+// loop (resetting backoff each time via the "connected" event).
+func TestSSEProxyForwardsUpstreamError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":"not_found","message":"city not found or not running: gc-work"}`))
+	}))
+	defer upstream.Close()
+
+	h := NewAPIHandler("/tmp/city", "gc-work", upstream.URL, "gc-work",
+		10*time.Second, 30*time.Second, "test-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	rec := httptest.NewRecorder()
+	h.handleSSEProxy(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if strings.Contains(rec.Body.String(), "event: connected") {
+		t.Error("response must NOT contain SSE connected event on upstream error")
+	}
+}
+
+// TestSSEProxySuccessWritesConnectedEvent verifies that a 200 upstream
+// response produces the expected SSE "connected" event and headers.
+func TestSSEProxySuccessWritesConnectedEvent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if ok {
+			flusher.Flush()
+		}
+		// Close immediately to let the proxy return.
+	}))
+	defer upstream.Close()
+
+	h := NewAPIHandler("/tmp/city", "gc-work", upstream.URL, "gc-work",
+		10*time.Second, 30*time.Second, "test-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	rec := httptest.NewRecorder()
+	h.handleSSEProxy(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "event: connected") {
+		t.Error("response should contain SSE connected event")
+	}
+}

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -567,6 +567,43 @@ func TestSupervisorEmptyCityName(t *testing.T) {
 	}
 }
 
+// TestSupervisorPerCityEventStream verifies that per-city event stream
+// requests (/v0/city/{name}/events/stream) are correctly routed to the
+// city's event handler. This is a regression test for #287 where the
+// supervisor returned 404 for valid per-city event stream requests.
+func TestSupervisorPerCityEventStream(t *testing.T) {
+	s := newFakeState(t)
+	s.cityName = "gc-work"
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"gc-work": s,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/v0/city/gc-work/events/stream", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sm.ServeHTTP(rec, req)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+}
+
 func TestSupervisorGlobalEventList(t *testing.T) {
 	s1 := newFakeState(t)
 	s1.cityName = "alpha"


### PR DESCRIPTION
## Summary

- Dashboard SSE proxy (`handleSSEProxy`) now checks `resp.StatusCode` before writing SSE headers and the `event: connected` message
- Non-200 upstream responses are forwarded as-is, matching the pattern already used by the session stream proxy
- Adds regression test for per-city event stream routing through the supervisor mux

## Root cause

The SSE proxy unconditionally wrote `200 OK` + `Content-Type: text/event-stream` + `event: connected` before reading the upstream body. When the supervisor returned 404 (e.g., city not yet running), the browser saw a successful SSE connection that immediately closed. The `connected` event reset the browser's reconnect backoff to 1s, creating a tight retry loop that flooded supervisor logs with 404s.

The session stream proxy at the same file already had the correct pattern (`if resp.StatusCode != http.StatusOK { forward error }`), but the events stream proxy was missing it.

## What was tested

- `make fmt-check` — pass
- `make lint` — pass (0 issues)
- `make vet` — pass
- `TestSSEProxyForwardsUpstreamError` — verifies 404 is forwarded, no SSE `connected` event
- `TestSSEProxySuccessWritesConnectedEvent` — verifies 200 path still works
- `TestSupervisorPerCityEventStream` — regression test confirming per-city event stream routing works

## Changes

- `cmd/gc/dashboard/api.go` — add upstream status check in `handleSSEProxy`
- `cmd/gc/dashboard/sse_proxy_test.go` — new: SSE proxy error handling tests
- `internal/api/supervisor_test.go` — new: per-city event stream routing regression test

Closes #287 

🤖 Generated with [Claude Code](https://claude.com/claude-code)