### PR TITLE
feat: headless Docker session provider for worker agents

### DIFF
--- a/scripts/gc-session-docker-headless
+++ b/scripts/gc-session-docker-headless
@@ -1,0 +1,572 @@
+#!/usr/bin/env bash
+# gc-session-docker-headless — Docker session provider for headless agents
+#
+# Usage:
+#   GC_SESSION=exec:scripts/gc-session-docker-headless gc start
+#
+# Implements the Gas City exec session provider protocol (see
+# internal/runtime/exec/exec.go). Each agent runs in its own Docker
+# container WITHOUT tmux. Nudge triggers `claude -p ... --output-format
+# json --resume <id>` inside the container; peek reads the output log.
+#
+# Architecture:
+#   docker run -d --init $image sleep infinity     # container stays alive
+#   docker exec claude -p "..." --output-format json --resume <id>
+#
+# Process tree: tini → sleep infinity (PID 1) + claude (per nudge)
+# No tmux, no TUI, no ncurses. Suitable for worker agents that receive
+# prompts and produce structured output.
+#
+# Why: Claude Code's TUI hangs in Docker containers (Docker's PTY
+# multiplexing bridge deadlocks Ink's React renderer). Headless mode
+# via `claude -p` bypasses this entirely. Workers don't need interactive
+# sessions — they receive a prompt, produce output, and wait for the
+# next nudge. Eliminating tmux reduces container image size (~15MB)
+# and attack surface.
+#
+# Requirements: docker, jq
+# Container requirement: claude CLI on PATH (no tmux needed)
+#
+# Configuration via agent env vars (set in city.toml [[agent]] env):
+#   GC_DOCKER_IMAGE      — container image (default: gc-agent:latest)
+#   GC_DOCKER_NETWORK    — Docker network name (optional)
+#   GC_DOCKER_EXTRA      — extra docker-run flags (optional, space-separated)
+#   GC_DOCKER_HOME_MOUNT — mount $HOME read-only (default: true)
+#   GC_DOCKER_USER       — container user (e.g. "1000:1000") (optional)
+
+set -euo pipefail
+
+# Default image if not specified in agent env.
+DEFAULT_IMAGE="gc-agent:latest"
+
+# Directory inside the container for output logs and metadata.
+# Using /run ensures container-local tmpfs, isolated from host mounts.
+GC_HEADLESS_DIR="/run/gc-headless"
+
+# Controller-only env vars stripped from containers. These reference
+# controller-side resources (Unix sockets, localhost ports) that aren't
+# reachable from inside a container. Matches the K8s provider's skip list
+# in internal/session/k8s/pod.go buildPodEnv().
+ENV_JQ='.env // {} | del(.GC_BEADS, .GC_SESSION, .GC_EVENTS, .GC_DOLT_HOST, .GC_DOLT_PORT)'
+
+# --- Helpers ---
+
+die() { echo "$*" >&2; exit 1; }
+
+# Parse a JSON field from config.
+# Usage: field <json> <path> [default]
+field() {
+    local val
+    val=$(echo "$1" | jq -r "$2 // empty" 2>/dev/null) || true
+    if [ -z "$val" ]; then
+        echo "${3:-}"
+    else
+        echo "$val"
+    fi
+}
+
+# Parse a JSON array field as newline-separated values.
+# Usage: field_array <json> <path>
+field_array() {
+    echo "$1" | jq -r "$2 // [] | .[]" 2>/dev/null || true
+}
+
+# Sanitize container name: Docker allows [a-zA-Z0-9][a-zA-Z0-9_.-] only.
+sanitize_name() {
+    local name
+    name=$(echo "$1" | tr -c 'a-zA-Z0-9_.-' '-')
+    # Strip leading non-alphanumeric chars (Docker requirement).
+    name="${name#"${name%%[a-zA-Z0-9]*}"}"
+    # Strip trailing dashes for cleanliness.
+    name="${name%"${name##*[a-zA-Z0-9_.]}"}"
+    echo "${name:-gc-unnamed}"
+}
+
+# Check if path A is the same as or under path B.
+# Usage: is_under <path> <parent>
+is_under() {
+    case "$1" in
+        "$2"|"$2/"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# --- Operations ---
+
+do_start() {
+    local name="$1"
+    local config
+    config=$(cat)
+
+    local cname
+    cname=$(sanitize_name "$name")
+
+    # Parse config fields from JSON on stdin.
+    local command work_dir image network extra home_mount
+    command=$(field "$config" '.command' 'claude')
+    work_dir=$(field "$config" '.work_dir' '/workspace')
+    image=$(field "$config" '.env.GC_DOCKER_IMAGE' "$DEFAULT_IMAGE")
+    network=$(field "$config" '.env.GC_DOCKER_NETWORK' '')
+    extra=$(field "$config" '.env.GC_DOCKER_EXTRA' '')
+    home_mount=$(field "$config" '.env.GC_DOCKER_HOME_MOUNT' 'true')
+    docker_user=$(field "$config" '.env.GC_DOCKER_USER' '')
+
+    # Parse readiness hints.
+    local ready_delay_ms
+    ready_delay_ms=$(field "$config" '.ready_delay_ms' '0')
+
+    # Pre-pull check: fail fast if image not local.
+    docker image inspect "$image" >/dev/null 2>&1 ||
+        die "image '$image' not found locally. Run: docker pull $image"
+
+    # --- Start idempotency ---
+    # If container is already running, leave it alone.
+    if docker inspect -f '{{.State.Running}}' "$cname" 2>/dev/null | grep -q true; then
+        return 0  # healthy — idempotent no-op
+    fi
+
+    # Remove stale container.
+    docker rm -f "$cname" >/dev/null 2>&1 || true
+
+    # --- Null-delimited env parsing (handles values with newlines) ---
+    local env_args=()
+    while IFS= read -r -d '' entry; do
+        [ -n "$entry" ] && env_args+=(-e "$entry")
+    done < <(echo "$config" | jq -j "$ENV_JQ | to_entries[] | \"\\(.key)=\\(.value)\\u0000\"")
+
+    # Build volume mounts — same host path inside the container.
+    local vol_args=()
+    if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+        vol_args+=(-v "$work_dir:$work_dir")
+    fi
+
+    local city_path
+    city_path=$(field "$config" '.env.GC_CITY' '')
+    if [ -n "$city_path" ] && [ -d "$city_path" ]; then
+        if ! is_under "$city_path" "$work_dir"; then
+            vol_args+=(-v "$city_path:$city_path")
+        fi
+    fi
+
+    # Mount $HOME read-only for API keys, git config, SSH keys.
+    if [ "$home_mount" = "true" ] && [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+        local skip_home=false
+        if [ "$HOME" = "$work_dir" ]; then
+            skip_home=true
+        elif [ -n "$city_path" ] && [ "$HOME" = "$city_path" ]; then
+            skip_home=true
+        fi
+        if [ "$skip_home" = "false" ]; then
+            vol_args+=(-v "$HOME:$HOME:ro")
+            # Overlay $HOME/.claude as writable so Claude can persist
+            # session data across invocations within the container.
+            if [ -d "$HOME/.claude" ]; then
+                vol_args+=(-v "$HOME/.claude:$HOME/.claude")
+            fi
+        fi
+    fi
+
+    # Network flag.
+    local net_args=()
+    if [ -n "$network" ]; then
+        net_args+=(--network "$network")
+    fi
+
+    # Extra flags (space-separated, unquoted expansion is intentional).
+    local extra_args=()
+    if [ -n "$extra" ]; then
+        # shellcheck disable=SC2206
+        extra_args=($extra)
+    fi
+
+    # Start container with sleep infinity (PID 1 keepalive).
+    # HOME must be set explicitly: Docker defaults HOME=/ for numeric
+    # --user UIDs, which breaks credential discovery for Claude and git.
+    docker run -d \
+        --name "$cname" \
+        --init \
+        ${docker_user:+--user "$docker_user"} \
+        --label gc.managed=true \
+        --label "gc.agent=$name" \
+        --label gc.headless=true \
+        -e "HOME=${HOME:-/root}" \
+        -e "TERM=${TERM:-xterm-256color}" \
+        "${vol_args[@]+"${vol_args[@]}"}" \
+        "${env_args[@]+"${env_args[@]}"}" \
+        "${net_args[@]+"${net_args[@]}"}" \
+        "${extra_args[@]+"${extra_args[@]}"}" \
+        -w "$work_dir" \
+        "$image" \
+        sleep infinity \
+        >/dev/null
+
+    # Create headless runtime directory inside the container.
+    docker exec --user 0 "$cname" sh -c \
+        "mkdir -p '$GC_HEADLESS_DIR/meta' '$GC_HEADLESS_DIR/log' && chmod -R 1777 '$GC_HEADLESS_DIR'"
+
+    # --- File staging (overlay + copy_files) ---
+    overlay_dir=$(field "$config" '.overlay_dir' '')
+    if [ -n "$overlay_dir" ] && [ -d "$overlay_dir" ]; then
+        if ! cp -r "$overlay_dir/." "$work_dir/"; then
+            echo "gc: warning: overlay staging failed: $overlay_dir → $work_dir" >&2
+        fi
+    fi
+
+    echo "$config" | jq -c '.copy_files // [] | .[]' 2>/dev/null | while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        src=$(echo "$entry" | jq -r '.src')
+        rel_dst=$(echo "$entry" | jq -r '.rel_dst // ""')
+        dst="$work_dir"
+        [ -n "$rel_dst" ] && dst="$work_dir/$rel_dst"
+        if [ -d "$src" ]; then
+            mkdir -p "$dst"
+            if ! cp -r "$src/." "$dst/"; then
+                echo "gc: warning: copy_files staging failed: $src → $dst" >&2
+            fi
+        elif [ -f "$src" ]; then
+            mkdir -p "$(dirname "$dst")"
+            if ! cp "$src" "$dst"; then
+                echo "gc: warning: copy_files staging failed: $src → $dst" >&2
+            fi
+        fi
+    done
+
+    # --- Pre-start commands ---
+    local pre_start_cmds
+    pre_start_cmds=$(field_array "$config" '.pre_start')
+    if [ -n "$pre_start_cmds" ]; then
+        local pre_exec_env=(-w "$work_dir")
+        while IFS= read -r -d '' entry; do
+            [ -n "$entry" ] && pre_exec_env+=(-e "$entry")
+        done < <(echo "$config" | jq -j "$ENV_JQ | to_entries[] | \"\\(.key)=\\(.value)\\u0000\"")
+        while IFS= read -r cmd; do
+            [ -n "$cmd" ] || continue
+            docker exec "${pre_exec_env[@]}" "$cname" \
+                timeout 10 sh -c "$cmd" 2>/dev/null || true
+        done <<< "$pre_start_cmds"
+    fi
+
+    # --- Readiness ---
+    if [ "$ready_delay_ms" -gt 0 ] 2>/dev/null; then
+        local delay_sec
+        delay_sec=$(awk "BEGIN {printf \"%.3f\", $ready_delay_ms / 1000}")
+        sleep "$delay_sec"
+    fi
+
+    # Verify container survived startup.
+    local running
+    running=$(docker inspect -f '{{.State.Running}}' "$cname" 2>/dev/null) || running="false"
+    if [ "$running" != "true" ]; then
+        local logs
+        logs=$(docker logs --tail 5 "$cname" 2>&1 || true)
+        die "container '$cname' died during startup. Logs: $logs"
+    fi
+
+    # --- Initial command (if not default sleep) ---
+    # For headless agents, the command field typically specifies the
+    # claude invocation pattern. Run it as the first nudge if present
+    # and it's not a bare shell.
+    local nudge
+    nudge=$(field "$config" '.nudge' '')
+    if [ -n "$nudge" ]; then
+        # Fire the initial nudge asynchronously.
+        _do_headless_invoke "$cname" "$nudge" &
+    fi
+}
+
+do_stop() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    # Graceful stop (SIGTERM → 10s grace → SIGKILL) then remove.
+    docker stop -t 10 "$cname" >/dev/null 2>&1 || true
+    docker rm -f "$cname" >/dev/null 2>&1 || true
+}
+
+do_interrupt() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    # Send SIGINT to any running claude process inside the container.
+    docker exec "$cname" pkill -INT -x claude 2>/dev/null || true
+    docker exec "$cname" pkill -INT -x node 2>/dev/null || true
+}
+
+do_is_running() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    local running
+    running=$(docker inspect -f '{{.State.Running}}' "$cname" 2>/dev/null) || running="false"
+    printf '%s' "$running" | tr -d '[:space:]'
+}
+
+do_process_alive() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    # Read process names from stdin (one per line).
+    local names
+    names=$(cat)
+
+    # Empty names → true (per protocol: no check possible).
+    if [ -z "$names" ]; then
+        echo "true"
+        return
+    fi
+
+    while IFS= read -r pname || [ -n "$pname" ]; do
+        [ -z "$pname" ] && continue
+        if docker exec "$cname" pgrep -x "$pname" >/dev/null 2>&1; then
+            echo "true"
+            return
+        fi
+    done <<< "$names"
+
+    echo "false"
+}
+
+# _do_headless_invoke runs claude -p inside the container and logs output.
+# Called asynchronously by nudge. Manages session ID persistence.
+#
+# The session ID is stored in $GC_HEADLESS_DIR/session_id so that
+# subsequent nudges resume the same conversation. Output (JSON) is
+# appended to the log file for peek to read.
+_do_headless_invoke() {
+    local cname="$1" message="$2"
+
+    local sid_file="$GC_HEADLESS_DIR/session_id"
+    local log_file="$GC_HEADLESS_DIR/log/output.log"
+    local lock_file="$GC_HEADLESS_DIR/lock"
+
+    # Build claude command.
+    local claude_args="-p"
+    local resume_id
+    resume_id=$(docker exec "$cname" cat "$sid_file" 2>/dev/null) || resume_id=""
+
+    # Write a separator and timestamp to the log.
+    docker exec "$cname" sh -c \
+        "echo '--- nudge $(date -u +%Y-%m-%dT%H:%M:%SZ) ---' >> '$log_file'"
+
+    # Run claude inside the container. Capture output to parse session ID
+    # and append to log. The lock file prevents concurrent nudges from
+    # interleaving (the controller generally serializes, but be safe).
+    #
+    # We use flock if available, otherwise proceed without locking.
+    local flock_prefix=""
+    if docker exec "$cname" which flock >/dev/null 2>&1; then
+        flock_prefix="flock '$lock_file'"
+    fi
+
+    local result
+    if [ -n "$resume_id" ]; then
+        result=$(docker exec -w "$(docker inspect -f '{{.Config.WorkingDir}}' "$cname")" \
+            "$cname" sh -c \
+            "$flock_prefix claude -p \"\$1\" --output-format json --resume \"\$2\" 2>/dev/null" \
+            -- "$message" "$resume_id" 2>/dev/null) || result=""
+    else
+        result=$(docker exec -w "$(docker inspect -f '{{.Config.WorkingDir}}' "$cname")" \
+            "$cname" sh -c \
+            "$flock_prefix claude -p \"\$1\" --output-format json 2>/dev/null" \
+            -- "$message" 2>/dev/null) || result=""
+    fi
+
+    if [ -n "$result" ]; then
+        # Append result to log.
+        docker exec "$cname" sh -c "cat >> '$log_file'" <<< "$result"
+
+        # Extract and persist session ID for next resume.
+        local new_sid
+        new_sid=$(echo "$result" | jq -r '.session_id // empty' 2>/dev/null) || new_sid=""
+        if [ -n "$new_sid" ]; then
+            printf '%s' "$new_sid" | docker exec -i "$cname" sh -c "cat > '$sid_file'"
+        fi
+
+        # Extract the text result for human-readable log.
+        local text_result
+        text_result=$(echo "$result" | jq -r '.result // empty' 2>/dev/null) || text_result=""
+        if [ -n "$text_result" ]; then
+            docker exec "$cname" sh -c "echo \"\$1\" >> '$log_file'" -- "$text_result"
+        fi
+    else
+        docker exec "$cname" sh -c \
+            "echo 'ERROR: claude invocation failed' >> '$log_file'"
+    fi
+}
+
+do_nudge() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    local message
+    message=$(cat)
+
+    # Fire-and-forget: run the claude invocation in the background.
+    # The exec protocol expects nudge to return quickly.
+    _do_headless_invoke "$cname" "$message" &
+}
+
+do_peek() {
+    local cname lines
+    cname=$(sanitize_name "$1")
+    lines="${2:-50}"
+
+    local log_file="$GC_HEADLESS_DIR/log/output.log"
+
+    if [ "$lines" -le 0 ] 2>/dev/null; then
+        docker exec "$cname" cat "$log_file" 2>/dev/null || true
+    else
+        docker exec "$cname" tail -n "$lines" "$log_file" 2>/dev/null || true
+    fi
+}
+
+do_attach() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    # Headless agents don't have an interactive session to attach to.
+    # Provide a shell for debugging.
+    docker exec -it "$cname" bash 2>/dev/null ||
+        docker exec -it "$cname" sh
+}
+
+do_set_meta() {
+    local cname key value
+    cname=$(sanitize_name "$1")
+    key="$2"
+    value=$(cat)
+
+    # File-based metadata: one file per key in the meta directory.
+    # Sanitize key to prevent path traversal.
+    local safe_key
+    safe_key=$(echo "$key" | tr -c 'a-zA-Z0-9_.-' '_')
+    printf '%s' "$value" | docker exec -i "$cname" sh -c "cat > '$GC_HEADLESS_DIR/meta/$safe_key'" \
+        2>/dev/null || true
+}
+
+do_get_meta() {
+    local cname key
+    cname=$(sanitize_name "$1")
+    key="$2"
+
+    local safe_key
+    safe_key=$(echo "$key" | tr -c 'a-zA-Z0-9_.-' '_')
+    docker exec "$cname" cat "$GC_HEADLESS_DIR/meta/$safe_key" 2>/dev/null || true
+}
+
+do_remove_meta() {
+    local cname key
+    cname=$(sanitize_name "$1")
+    key="$2"
+
+    local safe_key
+    safe_key=$(echo "$key" | tr -c 'a-zA-Z0-9_.-' '_')
+    docker exec "$cname" rm -f "$GC_HEADLESS_DIR/meta/$safe_key" 2>/dev/null || true
+}
+
+do_list_running() {
+    local prefix="$1"
+
+    docker ps --filter "status=running" \
+              --filter "label=gc.managed=true" \
+              --filter "label=gc.headless=true" \
+              --format '{{.Names}}' 2>/dev/null \
+        | grep "^${prefix}" \
+        | sort \
+        || true
+}
+
+do_get_last_activity() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    local log_file="$GC_HEADLESS_DIR/log/output.log"
+
+    # Get mtime of the output log as last activity indicator.
+    local epoch
+    epoch=$(docker exec "$cname" stat -c '%Y' "$log_file" 2>/dev/null) || epoch=""
+
+    # stat -c is GNU coreutils; try BusyBox format if it fails.
+    if [ -z "$epoch" ]; then
+        epoch=$(docker exec "$cname" stat -f '%m' "$log_file" 2>/dev/null) || epoch=""
+    fi
+
+    if [ -n "$epoch" ] && [ "$epoch" -gt 0 ] 2>/dev/null; then
+        # Convert epoch to RFC3339. Try GNU date first, then BSD/BusyBox.
+        docker exec "$cname" date -u -d "@$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
+            docker exec "$cname" date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
+            true
+    fi
+}
+
+do_clear_scrollback() {
+    local cname
+    cname=$(sanitize_name "$1")
+
+    local log_file="$GC_HEADLESS_DIR/log/output.log"
+    docker exec "$cname" sh -c "> '$log_file'" 2>/dev/null || true
+}
+
+# --- Dispatch ---
+
+op="${1:-}"
+shift || true
+
+case "$op" in
+    start)              do_start "$@" ;;
+    stop)               do_stop "$@" ;;
+    interrupt)          do_interrupt "$@" ;;
+    is-running)         do_is_running "$@" ;;
+    process-alive)      do_process_alive "$@" ;;
+    nudge)              do_nudge "$@" ;;
+    peek)               do_peek "$@" ;;
+    attach)             do_attach "$@" ;;
+    set-meta)           do_set_meta "$@" ;;
+    get-meta)           do_get_meta "$@" ;;
+    remove-meta)        do_remove_meta "$@" ;;
+    list-running)       do_list_running "$@" ;;
+    get-last-activity)  do_get_last_activity "$@" ;;
+    clear-scrollback)   do_clear_scrollback "$@" ;;
+    check-image)
+        image="${1:-$DEFAULT_IMAGE}"
+        docker image inspect "$image" >/dev/null 2>&1 ||
+            die "image '$image' not found locally. Run: docker pull $image"
+        ;;
+    copy-to)
+        cname=$(sanitize_name "$1")
+        src="$2"
+        rel_dst="${3:-}"
+        if [ -z "$src" ]; then exit 0; fi
+        work_dir=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$cname" 2>/dev/null \
+            | grep '^GC_DIR=' | head -1 | cut -d= -f2-)
+        if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+            dst="$work_dir"
+            [ -n "$rel_dst" ] && dst="$work_dir/$rel_dst"
+            if [ -d "$src" ]; then
+                mkdir -p "$dst"
+                cp -r "$src/." "$dst/" 2>/dev/null || true
+            elif [ -f "$src" ]; then
+                mkdir -p "$(dirname "$dst")"
+                cp "$src" "$dst" 2>/dev/null || true
+            fi
+        else
+            dst="/workspace"
+            [ -n "$rel_dst" ] && dst="/workspace/$rel_dst"
+            docker exec "$cname" mkdir -p "$dst" 2>/dev/null || true
+            if [ -d "$src" ]; then
+                docker cp "$src/." "$cname:$dst/" 2>/dev/null || true
+            elif [ -f "$src" ]; then
+                docker cp "$src" "$cname:$dst" 2>/dev/null || true
+            fi
+        fi
+        ;;
+    send-keys)
+        # Headless agents don't have a terminal to send keys to.
+        # Exit 2 (unknown operation) for forward compatibility.
+        exit 2
+        ;;
+    *)
+        # Unknown operation — exit 2 for forward compatibility.
+        exit 2
+        ;;
+esac

--- a/scripts/gc-session-docker-headless
+++ b/scripts/gc-session-docker-headless
@@ -47,7 +47,7 @@ GC_HEADLESS_DIR="/run/gc-headless"
 # controller-side resources (Unix sockets, localhost ports) that aren't
 # reachable from inside a container. Matches the K8s provider's skip list
 # in internal/session/k8s/pod.go buildPodEnv().
-ENV_JQ='.env // {} | del(.GC_BEADS, .GC_SESSION, .GC_EVENTS, .GC_DOLT_HOST, .GC_DOLT_PORT)'
+ENV_JQ='.env // {} | del(.GC_BEADS, .GC_SESSION, .GC_EVENTS, .GC_DOLT_HOST, .GC_DOLT_PORT, .BEADS_DOLT_SERVER_HOST, .BEADS_DOLT_SERVER_PORT)'
 
 # --- Helpers ---
 
@@ -182,6 +182,13 @@ do_start() {
     # Start container with sleep infinity (PID 1 keepalive).
     # HOME must be set explicitly: Docker defaults HOME=/ for numeric
     # --user UIDs, which breaks credential discovery for Claude and git.
+    # When home_mount=true, use the controller's HOME (it's bind-mounted).
+    # When false, fall back to /root (the path doesn't exist in-container).
+    local container_home="/root"
+    if [ "$home_mount" = "true" ] && [ -n "${HOME:-}" ]; then
+        container_home="$HOME"
+    fi
+
     docker run -d \
         --name "$cname" \
         --init \
@@ -189,7 +196,7 @@ do_start() {
         --label gc.managed=true \
         --label "gc.agent=$name" \
         --label gc.headless=true \
-        -e "HOME=${HOME:-/root}" \
+        -e "HOME=$container_home" \
         -e "TERM=${TERM:-xterm-256color}" \
         "${vol_args[@]+"${vol_args[@]}"}" \
         "${env_args[@]+"${env_args[@]}"}" \
@@ -204,11 +211,29 @@ do_start() {
     docker exec --user 0 "$cname" sh -c \
         "mkdir -p '$GC_HEADLESS_DIR/meta' '$GC_HEADLESS_DIR/log' && chmod -R 1777 '$GC_HEADLESS_DIR'"
 
+    # Persist the resolved command so nudge can use it (carries provider
+    # flags like permission mode, model, effort, etc.).
+    printf '%s' "$command" | docker exec -i "$cname" sh -c "cat > '$GC_HEADLESS_DIR/command'"
+
     # --- File staging (overlay + copy_files) ---
+    # When work_dir is bind-mounted (exists on host), host-side cp works.
+    # When it's container-only, use docker cp to reach the container filesystem.
+    local work_dir_mounted=false
+    if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+        work_dir_mounted=true
+    fi
+
     overlay_dir=$(field "$config" '.overlay_dir' '')
     if [ -n "$overlay_dir" ] && [ -d "$overlay_dir" ]; then
-        if ! cp -r "$overlay_dir/." "$work_dir/"; then
-            echo "gc: warning: overlay staging failed: $overlay_dir → $work_dir" >&2
+        if [ "$work_dir_mounted" = "true" ]; then
+            if ! cp -r "$overlay_dir/." "$work_dir/"; then
+                echo "gc: warning: overlay staging failed: $overlay_dir → $work_dir" >&2
+            fi
+        else
+            docker exec "$cname" mkdir -p "$work_dir" 2>/dev/null || true
+            if ! docker cp "$overlay_dir/." "$cname:$work_dir/"; then
+                echo "gc: warning: overlay staging failed: $overlay_dir → $cname:$work_dir" >&2
+            fi
         fi
     fi
 
@@ -218,15 +243,29 @@ do_start() {
         rel_dst=$(echo "$entry" | jq -r '.rel_dst // ""')
         dst="$work_dir"
         [ -n "$rel_dst" ] && dst="$work_dir/$rel_dst"
-        if [ -d "$src" ]; then
-            mkdir -p "$dst"
-            if ! cp -r "$src/." "$dst/"; then
-                echo "gc: warning: copy_files staging failed: $src → $dst" >&2
+        if [ "$work_dir_mounted" = "true" ]; then
+            if [ -d "$src" ]; then
+                mkdir -p "$dst"
+                if ! cp -r "$src/." "$dst/"; then
+                    echo "gc: warning: copy_files staging failed: $src → $dst" >&2
+                fi
+            elif [ -f "$src" ]; then
+                mkdir -p "$(dirname "$dst")"
+                if ! cp "$src" "$dst"; then
+                    echo "gc: warning: copy_files staging failed: $src → $dst" >&2
+                fi
             fi
-        elif [ -f "$src" ]; then
-            mkdir -p "$(dirname "$dst")"
-            if ! cp "$src" "$dst"; then
-                echo "gc: warning: copy_files staging failed: $src → $dst" >&2
+        else
+            if [ -d "$src" ]; then
+                docker exec "$cname" mkdir -p "$dst" 2>/dev/null || true
+                if ! docker cp "$src/." "$cname:$dst/"; then
+                    echo "gc: warning: copy_files staging failed: $src → $cname:$dst" >&2
+                fi
+            elif [ -f "$src" ]; then
+                docker exec "$cname" mkdir -p "$(dirname "$dst")" 2>/dev/null || true
+                if ! docker cp "$src" "$cname:$dst"; then
+                    echo "gc: warning: copy_files staging failed: $src → $cname:$dst" >&2
+                fi
             fi
         fi
     done
@@ -262,14 +301,45 @@ do_start() {
         die "container '$cname' died during startup. Logs: $logs"
     fi
 
-    # --- Initial command (if not default sleep) ---
-    # For headless agents, the command field typically specifies the
-    # claude invocation pattern. Run it as the first nudge if present
-    # and it's not a bare shell.
+    # --- Session setup ---
+    # Run session_setup commands inside the container via docker exec,
+    # matching the tmux provider's behavior (gc-session-docker).
+    local setup_cmds
+    setup_cmds=$(field_array "$config" '.session_setup')
+    if [ -n "$setup_cmds" ]; then
+        local setup_exec_env=(-w "$work_dir")
+        while IFS= read -r -d '' entry; do
+            [ -n "$entry" ] && setup_exec_env+=(-e "$entry")
+        done < <(echo "$config" | jq -j "$ENV_JQ | to_entries[] | \"\\(.key)=\\(.value)\\u0000\"")
+        while IFS= read -r cmd; do
+            [ -n "$cmd" ] || continue
+            docker exec "${setup_exec_env[@]}" "$cname" \
+                timeout 10 sh -c "$cmd" 2>/dev/null || true
+        done <<< "$setup_cmds"
+    fi
+
+    # Run session_setup_script: a host-side file piped into the container.
+    local setup_script
+    setup_script=$(field "$config" '.session_setup_script' '')
+    if [ -n "$setup_script" ]; then
+        if [ -f "$setup_script" ]; then
+            local setup_exec_env=(-i -w "$work_dir")
+            while IFS= read -r -d '' entry; do
+                [ -n "$entry" ] && setup_exec_env+=(-e "$entry")
+            done < <(echo "$config" | jq -j "$ENV_JQ | to_entries[] | \"\\(.key)=\\(.value)\\u0000\"")
+            docker exec "${setup_exec_env[@]}" "$cname" \
+                timeout 10 sh < "$setup_script" 2>/dev/null || true
+        else
+            echo "gc: session_setup_script warning: $setup_script not found on controller" >&2
+        fi
+    fi
+
+    # --- Initial nudge ---
+    # If a nudge message was provided in the start config, fire it
+    # asynchronously as the first prompt to the agent.
     local nudge
     nudge=$(field "$config" '.nudge' '')
     if [ -n "$nudge" ]; then
-        # Fire the initial nudge asynchronously.
         _do_headless_invoke "$cname" "$nudge" &
     fi
 }
@@ -305,93 +375,97 @@ do_process_alive() {
     local cname
     cname=$(sanitize_name "$1")
 
-    # Read process names from stdin (one per line).
-    local names
-    names=$(cat)
+    # Consume process names from stdin to preserve the command protocol, but
+    # for headless containers liveness is defined by the container itself.
+    # The steady-state process is PID 1 (typically `sleep infinity`), while
+    # claude/node only run briefly during nudges, so pgrep-based checks would
+    # incorrectly report healthy sessions as dead.
+    cat >/dev/null || true
 
-    # Empty names → true (per protocol: no check possible).
-    if [ -z "$names" ]; then
+    if [ "$(do_is_running "$1")" = "true" ]; then
         echo "true"
-        return
+    else
+        echo "false"
     fi
-
-    while IFS= read -r pname || [ -n "$pname" ]; do
-        [ -z "$pname" ] && continue
-        if docker exec "$cname" pgrep -x "$pname" >/dev/null 2>&1; then
-            echo "true"
-            return
-        fi
-    done <<< "$names"
-
-    echo "false"
 }
 
-# _do_headless_invoke runs claude -p inside the container and logs output.
-# Called asynchronously by nudge. Manages session ID persistence.
+# _do_headless_invoke runs the configured command inside the container and
+# logs output. Called asynchronously by nudge. Manages session ID persistence.
 #
 # The session ID is stored in $GC_HEADLESS_DIR/session_id so that
 # subsequent nudges resume the same conversation. Output (JSON) is
 # appended to the log file for peek to read.
+#
+# The entire sequence (read sid → run command → append log → update sid)
+# runs in a single docker exec under flock to prevent concurrent nudges
+# from interleaving or corrupting session state.
 _do_headless_invoke() {
     local cname="$1" message="$2"
 
-    local sid_file="$GC_HEADLESS_DIR/session_id"
-    local log_file="$GC_HEADLESS_DIR/log/output.log"
-    local lock_file="$GC_HEADLESS_DIR/lock"
+    local workdir
+    workdir="$(docker inspect -f '{{.Config.WorkingDir}}' "$cname")"
 
-    # Build claude command.
-    local claude_args="-p"
-    local resume_id
-    resume_id=$(docker exec "$cname" cat "$sid_file" 2>/dev/null) || resume_id=""
+    # Run the full nudge sequence inside a single docker exec so that
+    # all state reads/writes happen atomically within one critical section.
+    docker exec -i -w "$workdir" "$cname" sh -s -- \
+        "$GC_HEADLESS_DIR/session_id" \
+        "$GC_HEADLESS_DIR/log/output.log" \
+        "$GC_HEADLESS_DIR/lock" \
+        "$message" \
+        "$GC_HEADLESS_DIR/command" \
+        <<'NUDGE_EOF'
+sid_file="$1"
+log_file="$2"
+lock_file="$3"
+message="$4"
+cmd_file="$5"
 
-    # Write a separator and timestamp to the log.
-    docker exec "$cname" sh -c \
-        "echo '--- nudge $(date -u +%Y-%m-%dT%H:%M:%SZ) ---' >> '$log_file'"
+run_nudge() {
+    local resume_id="" result="" new_sid="" text_result=""
 
-    # Run claude inside the container. Capture output to parse session ID
-    # and append to log. The lock file prevents concurrent nudges from
-    # interleaving (the controller generally serializes, but be safe).
-    #
-    # We use flock if available, otherwise proceed without locking.
-    local flock_prefix=""
-    if docker exec "$cname" which flock >/dev/null 2>&1; then
-        flock_prefix="flock '$lock_file'"
+    # Read the persisted command (set during start from config .command).
+    local cmd="claude"
+    if [ -f "$cmd_file" ]; then
+        cmd=$(cat "$cmd_file" 2>/dev/null) || cmd="claude"
     fi
 
-    local result
+    if [ -f "$sid_file" ]; then
+        resume_id=$(cat "$sid_file" 2>/dev/null) || resume_id=""
+    fi
+
+    echo "--- nudge $(date -u +%Y-%m-%dT%H:%M:%SZ) ---" >> "$log_file"
+
     if [ -n "$resume_id" ]; then
-        result=$(docker exec -w "$(docker inspect -f '{{.Config.WorkingDir}}' "$cname")" \
-            "$cname" sh -c \
-            "$flock_prefix claude -p \"\$1\" --output-format json --resume \"\$2\" 2>/dev/null" \
-            -- "$message" "$resume_id" 2>/dev/null) || result=""
+        result=$($cmd -p "$message" --output-format json --resume "$resume_id" 2>/dev/null) || result=""
     else
-        result=$(docker exec -w "$(docker inspect -f '{{.Config.WorkingDir}}' "$cname")" \
-            "$cname" sh -c \
-            "$flock_prefix claude -p \"\$1\" --output-format json 2>/dev/null" \
-            -- "$message" 2>/dev/null) || result=""
+        result=$($cmd -p "$message" --output-format json 2>/dev/null) || result=""
     fi
 
     if [ -n "$result" ]; then
-        # Append result to log.
-        docker exec "$cname" sh -c "cat >> '$log_file'" <<< "$result"
+        printf '%s\n' "$result" >> "$log_file"
 
-        # Extract and persist session ID for next resume.
-        local new_sid
-        new_sid=$(echo "$result" | jq -r '.session_id // empty' 2>/dev/null) || new_sid=""
+        new_sid=$(printf '%s' "$result" | jq -r '.session_id // empty' 2>/dev/null) || new_sid=""
         if [ -n "$new_sid" ]; then
-            printf '%s' "$new_sid" | docker exec -i "$cname" sh -c "cat > '$sid_file'"
+            printf '%s' "$new_sid" > "$sid_file"
         fi
 
-        # Extract the text result for human-readable log.
-        local text_result
-        text_result=$(echo "$result" | jq -r '.result // empty' 2>/dev/null) || text_result=""
+        text_result=$(printf '%s' "$result" | jq -r '.result // empty' 2>/dev/null) || text_result=""
         if [ -n "$text_result" ]; then
-            docker exec "$cname" sh -c "echo \"\$1\" >> '$log_file'" -- "$text_result"
+            printf '%s\n' "$text_result" >> "$log_file"
         fi
     else
-        docker exec "$cname" sh -c \
-            "echo 'ERROR: claude invocation failed' >> '$log_file'"
+        echo 'ERROR: claude invocation failed' >> "$log_file"
     fi
+}
+
+if command -v flock >/dev/null 2>&1; then
+    exec 9>>"$lock_file"
+    flock 9
+    run_nudge
+else
+    run_nudge
+fi
+NUDGE_EOF
 }
 
 do_nudge() {
@@ -471,7 +545,7 @@ do_list_running() {
               --filter "label=gc.managed=true" \
               --filter "label=gc.headless=true" \
               --format '{{.Names}}' 2>/dev/null \
-        | grep "^${prefix}" \
+        | awk -v p="$prefix" 'index($0, p) == 1' \
         | sort \
         || true
 }

--- a/scripts/test-docker-session-headless
+++ b/scripts/test-docker-session-headless
@@ -67,6 +67,7 @@ cleanup() {
     "$SCRIPT" stop "${SESSION}-clear" 2>/dev/null || true
     "$SCRIPT" stop "${SESSION}-interrupt" 2>/dev/null || true
     "$SCRIPT" stop "${SESSION}-setup" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-list" 2>/dev/null || true
     [ -n "$BUILD_CTX" ] && rm -rf "$BUILD_CTX"
 }
 trap cleanup EXIT
@@ -209,16 +210,18 @@ check "start idempotency (same container)" "$cid1" "$cid2"
 "$SCRIPT" stop "${SESSION}-idem" 2>/dev/null || true
 
 # =====================================================================
-# Test: process-alive
+# Test: process-alive (container-based, ignores process names)
 # =====================================================================
 echo "--- process-alive ---"
+# Headless process-alive checks container liveness, not specific processes.
+# Any process name input is consumed but ignored.
 alive=$(echo "sleep" | "$SCRIPT" process-alive "$SESSION")
-check "process-alive (sleep)" "true" "$alive"
+check "process-alive (running container)" "true" "$alive"
 
 alive=$(echo "nonexistent-xyz" | "$SCRIPT" process-alive "$SESSION")
-check "process-alive (nonexistent)" "false" "$alive"
+check "process-alive (ignores process names)" "true" "$alive"
 
-# Empty names → true.
+# Empty names → true (container is running).
 alive=$(echo "" | "$SCRIPT" process-alive "$SESSION")
 check "process-alive (empty → true)" "true" "$alive"
 
@@ -417,7 +420,6 @@ echo "  PASS: interrupt (no error)"
 # =====================================================================
 echo "--- session setup (inside container) ---"
 setup_marker="/tmp/gc-headless-setup-marker-$$"
-rm -f "$setup_marker" 2>/dev/null || true
 config=$(cat <<EOF
 {
     "command": "sleep 300",
@@ -430,9 +432,16 @@ config=$(cat <<EOF
 }
 EOF
 )
-# Note: session_setup for exec providers runs on the host via sh -c,
-# not inside the container. The headless provider inherits this behavior
-# from the exec protocol. For in-container setup, use pre_start.
+echo "$config" | "$SCRIPT" start "${SESSION}-setup"
+# Verify the marker file was created inside the container.
+if docker exec "${SESSION}-setup" test -f "$setup_marker" 2>/dev/null; then
+    echo "  PASS: session_setup marker exists in container"
+    ((pass++)) || true
+else
+    echo "  FAIL: session_setup marker not found in container"
+    ((fail++)) || true
+fi
+"$SCRIPT" stop "${SESSION}-setup" 2>/dev/null || true
 
 # =====================================================================
 # Test: list-running
@@ -449,10 +458,10 @@ config=$(cat <<EOF
 }
 EOF
 )
-echo "$config" | "$SCRIPT" start "${SESSION}-setup"
+echo "$config" | "$SCRIPT" start "${SESSION}-list"
 listed=$("$SCRIPT" list-running "gc-headless-test")
-check_contains "list-running finds session" "${SESSION}-setup" "$listed"
-"$SCRIPT" stop "${SESSION}-setup" 2>/dev/null || true
+check_contains "list-running finds session" "${SESSION}-list" "$listed"
+"$SCRIPT" stop "${SESSION}-list" 2>/dev/null || true
 
 # =====================================================================
 # Test: send-keys returns exit 2 (unsupported)

--- a/scripts/test-docker-session-headless
+++ b/scripts/test-docker-session-headless
@@ -1,0 +1,520 @@
+#!/usr/bin/env bash
+# test-docker-session-headless — integration tests for gc-session-docker-headless
+#
+# Usage: ./scripts/test-docker-session-headless
+#
+# Exercises the exec provider protocol against the headless Docker session
+# script. Uses a mock claude CLI (shell script that echoes JSON) to avoid
+# requiring real API credentials.
+#
+# Requires: docker, jq
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/gc-session-docker-headless"
+SESSION="gc-headless-test"
+TEST_IMAGE="gc-test-headless"
+
+pass=0
+fail=0
+
+check() {
+    local desc="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+        echo "  PASS: $desc"
+        ((pass++)) || true
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$got')"
+        ((fail++)) || true
+    fi
+}
+
+check_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF -- "$needle"; then
+        echo "  PASS: $desc"
+        ((pass++)) || true
+    else
+        echo "  FAIL: $desc (expected to contain '$needle', got '$haystack')"
+        ((fail++)) || true
+    fi
+}
+
+check_not_empty() {
+    local desc="$1" got="$2"
+    if [ -n "$got" ]; then
+        echo "  PASS: $desc (got '$got')"
+        ((pass++)) || true
+    else
+        echo "  FAIL: $desc (expected non-empty, got empty)"
+        ((fail++)) || true
+    fi
+}
+
+BUILD_CTX=""
+
+cleanup() {
+    echo ""
+    echo "--- Cleanup ---"
+    "$SCRIPT" stop "$SESSION" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-idem" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-nudge" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-resume" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-meta" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-delay" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-prepull" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-activity" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-clear" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-interrupt" 2>/dev/null || true
+    "$SCRIPT" stop "${SESSION}-setup" 2>/dev/null || true
+    [ -n "$BUILD_CTX" ] && rm -rf "$BUILD_CTX"
+}
+trap cleanup EXIT
+
+echo "=== gc-session-docker-headless integration tests ==="
+echo "Script: $SCRIPT"
+echo ""
+
+# --- Build test image ---
+# The test image contains a mock `claude` CLI that returns JSON output
+# matching the real claude -p --output-format json schema. This lets us
+# test the full exec protocol without real API credentials.
+echo "--- Building test image ---"
+BUILD_CTX=$(mktemp -d)
+
+# Mock claude CLI: echoes a JSON result with the prompt embedded.
+# Supports --resume by reading session ID from args.
+# Supports --output-format json (ignored, always outputs JSON).
+cat > "$BUILD_CTX/claude" <<'MOCK'
+#!/bin/sh
+# Mock claude CLI for testing gc-session-docker-headless.
+# Parses -p <prompt> and --resume <id> from args.
+
+prompt=""
+session_id="mock-session-$(date +%s)-$$"
+resume_id=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -p) prompt="$2"; shift 2 ;;
+        --resume) resume_id="$2"; session_id="$2"; shift 2 ;;
+        --output-format) shift 2 ;;  # ignore, always JSON
+        *) shift ;;
+    esac
+done
+
+# Simulate processing time.
+sleep 0.5
+
+cat <<EOF
+{"type":"result","subtype":"success","is_error":false,"result":"Mock response to: ${prompt}","session_id":"${session_id}","total_cost_usd":0.001,"duration_ms":500,"num_turns":1,"stop_reason":"end_turn"}
+EOF
+MOCK
+chmod +x "$BUILD_CTX/claude"
+
+# Mock claude that sleeps forever (for interrupt testing).
+cat > "$BUILD_CTX/claude-slow" <<'MOCK'
+#!/bin/sh
+sleep 300
+MOCK
+chmod +x "$BUILD_CTX/claude-slow"
+
+cat > "$BUILD_CTX/Dockerfile" <<'DOCKERFILE'
+FROM alpine:latest
+RUN apk add --no-cache procps bash coreutils
+COPY claude /usr/local/bin/claude
+COPY claude-slow /usr/local/bin/claude-slow
+CMD ["sleep", "300"]
+DOCKERFILE
+
+docker build -t "$TEST_IMAGE" "$BUILD_CTX"
+echo "  OK: built $TEST_IMAGE (headless, no tmux)"
+echo ""
+
+# =====================================================================
+# Test: pre-pull check (missing image)
+# =====================================================================
+echo "--- pre-pull check (missing image) ---"
+config=$(cat <<EOF
+{
+    "command": "echo hi",
+    "work_dir": "/tmp",
+    "env": { "GC_DOCKER_IMAGE": "gc-nonexistent-image-42:latest" }
+}
+EOF
+)
+rc=0
+echo "$config" | "$SCRIPT" start "${SESSION}-prepull" 2>/dev/null || rc=$?
+check "pre-pull fails on missing image" "1" "$rc"
+"$SCRIPT" stop "${SESSION}-prepull" 2>/dev/null || true
+
+# =====================================================================
+# Test: start (no tmux required)
+# =====================================================================
+echo "--- start (headless, no tmux) ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "$SESSION"
+echo "  PASS: start (no error, no tmux)"
+((pass++)) || true
+
+running=$("$SCRIPT" is-running "$SESSION")
+check "container is running" "true" "$running"
+
+# Verify no tmux inside the container.
+rc=0
+docker exec "$SESSION" which tmux 2>/dev/null || rc=$?
+check "no tmux in container" "1" "$rc"
+
+# =====================================================================
+# Test: container labels
+# =====================================================================
+echo "--- container labels ---"
+label_managed=$(docker inspect -f '{{index .Config.Labels "gc.managed"}}' "$SESSION" 2>/dev/null || echo "MISSING")
+label_agent=$(docker inspect -f '{{index .Config.Labels "gc.agent"}}' "$SESSION" 2>/dev/null || echo "MISSING")
+label_headless=$(docker inspect -f '{{index .Config.Labels "gc.headless"}}' "$SESSION" 2>/dev/null || echo "MISSING")
+check "gc.managed label" "true" "$label_managed"
+check "gc.agent label" "$SESSION" "$label_agent"
+check "gc.headless label" "true" "$label_headless"
+
+# =====================================================================
+# Test: start idempotency
+# =====================================================================
+echo "--- start idempotency ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-idem"
+cid1=$(docker inspect -f '{{.Id}}' "${SESSION}-idem" 2>/dev/null || echo "")
+echo "$config" | "$SCRIPT" start "${SESSION}-idem"
+cid2=$(docker inspect -f '{{.Id}}' "${SESSION}-idem" 2>/dev/null || echo "")
+check "start idempotency (same container)" "$cid1" "$cid2"
+"$SCRIPT" stop "${SESSION}-idem" 2>/dev/null || true
+
+# =====================================================================
+# Test: process-alive
+# =====================================================================
+echo "--- process-alive ---"
+alive=$(echo "sleep" | "$SCRIPT" process-alive "$SESSION")
+check "process-alive (sleep)" "true" "$alive"
+
+alive=$(echo "nonexistent-xyz" | "$SCRIPT" process-alive "$SESSION")
+check "process-alive (nonexistent)" "false" "$alive"
+
+# Empty names → true.
+alive=$(echo "" | "$SCRIPT" process-alive "$SESSION")
+check "process-alive (empty → true)" "true" "$alive"
+
+# =====================================================================
+# Test: set-meta / get-meta
+# =====================================================================
+echo "--- set-meta / get-meta ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-meta"
+
+echo -n "test-value-42" | "$SCRIPT" set-meta "${SESSION}-meta" "my-key"
+got=$("$SCRIPT" get-meta "${SESSION}-meta" "my-key")
+check "meta round-trip" "test-value-42" "$got"
+
+# =====================================================================
+# Test: get-meta (missing key)
+# =====================================================================
+echo "--- get-meta (missing key) ---"
+got=$("$SCRIPT" get-meta "${SESSION}-meta" "no-such-key")
+check "missing meta is empty" "" "$got"
+
+# =====================================================================
+# Test: remove-meta
+# =====================================================================
+echo "--- remove-meta ---"
+"$SCRIPT" remove-meta "${SESSION}-meta" "my-key"
+got=$("$SCRIPT" get-meta "${SESSION}-meta" "my-key")
+check "removed meta is empty" "" "$got"
+"$SCRIPT" stop "${SESSION}-meta" 2>/dev/null || true
+
+# =====================================================================
+# Test: nudge + peek (core headless workflow)
+# =====================================================================
+echo "--- nudge + peek (headless invoke) ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-nudge"
+
+# Send a nudge and wait for the mock claude to complete.
+echo -n "Hello from test" | "$SCRIPT" nudge "${SESSION}-nudge"
+sleep 3  # mock claude takes 0.5s + overhead
+
+output=$("$SCRIPT" peek "${SESSION}-nudge" 20)
+check_contains "nudge output contains response" "Mock response to: Hello from test" "$output"
+check_contains "peek shows nudge separator" "--- nudge" "$output"
+
+# Verify session ID was persisted.
+sid=$(docker exec "${SESSION}-nudge" cat /run/gc-headless/session_id 2>/dev/null || echo "")
+check_not_empty "session ID persisted" "$sid"
+
+"$SCRIPT" stop "${SESSION}-nudge" 2>/dev/null || true
+
+# =====================================================================
+# Test: nudge with resume (multi-turn)
+# =====================================================================
+echo "--- nudge with resume (multi-turn) ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-resume"
+
+# First nudge — establishes session.
+echo -n "First message" | "$SCRIPT" nudge "${SESSION}-resume"
+sleep 3
+
+sid1=$(docker exec "${SESSION}-resume" cat /run/gc-headless/session_id 2>/dev/null || echo "")
+check_not_empty "first session ID" "$sid1"
+
+# Second nudge — should resume same session.
+echo -n "Second message" | "$SCRIPT" nudge "${SESSION}-resume"
+sleep 3
+
+output=$("$SCRIPT" peek "${SESSION}-resume" 30)
+check_contains "first response in log" "Mock response to: First message" "$output"
+check_contains "second response in log" "Mock response to: Second message" "$output"
+
+"$SCRIPT" stop "${SESSION}-resume" 2>/dev/null || true
+
+# =====================================================================
+# Test: peek with lines=0 (capture all)
+# =====================================================================
+echo "--- peek lines=0 ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-activity"
+echo -n "Peek test" | "$SCRIPT" nudge "${SESSION}-activity"
+sleep 3
+
+output=$("$SCRIPT" peek "${SESSION}-activity" 0)
+check_contains "peek lines=0 captures all" "Mock response to: Peek test" "$output"
+
+# =====================================================================
+# Test: get-last-activity
+# =====================================================================
+echo "--- get-last-activity ---"
+activity=$("$SCRIPT" get-last-activity "${SESSION}-activity")
+if echo "$activity" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'; then
+    echo "  PASS: get-last-activity returns RFC3339 ($activity)"
+    ((pass++)) || true
+else
+    echo "  FAIL: get-last-activity expected RFC3339, got '$activity'"
+    ((fail++)) || true
+fi
+"$SCRIPT" stop "${SESSION}-activity" 2>/dev/null || true
+
+# =====================================================================
+# Test: clear-scrollback
+# =====================================================================
+echo "--- clear-scrollback ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-clear"
+echo -n "Before clear" | "$SCRIPT" nudge "${SESSION}-clear"
+sleep 3
+
+before=$("$SCRIPT" peek "${SESSION}-clear" 0)
+check_contains "log has content before clear" "Before clear" "$before"
+
+"$SCRIPT" clear-scrollback "${SESSION}-clear"
+after=$("$SCRIPT" peek "${SESSION}-clear" 0)
+check "log empty after clear" "" "$after"
+"$SCRIPT" stop "${SESSION}-clear" 2>/dev/null || true
+
+# =====================================================================
+# Test: interrupt
+# =====================================================================
+echo "--- interrupt ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-interrupt"
+# Start a long-running claude process to interrupt.
+docker exec -d "${SESSION}-interrupt" claude-slow
+sleep 0.5
+"$SCRIPT" interrupt "${SESSION}-interrupt"
+sleep 0.5
+echo "  PASS: interrupt (no error)"
+((pass++)) || true
+"$SCRIPT" stop "${SESSION}-interrupt" 2>/dev/null || true
+
+# =====================================================================
+# Test: session_setup runs inside container
+# =====================================================================
+echo "--- session setup (inside container) ---"
+setup_marker="/tmp/gc-headless-setup-marker-$$"
+rm -f "$setup_marker" 2>/dev/null || true
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "session_setup": ["touch $setup_marker"],
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+# Note: session_setup for exec providers runs on the host via sh -c,
+# not inside the container. The headless provider inherits this behavior
+# from the exec protocol. For in-container setup, use pre_start.
+
+# =====================================================================
+# Test: list-running
+# =====================================================================
+echo "--- list-running ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+echo "$config" | "$SCRIPT" start "${SESSION}-setup"
+listed=$("$SCRIPT" list-running "gc-headless-test")
+check_contains "list-running finds session" "${SESSION}-setup" "$listed"
+"$SCRIPT" stop "${SESSION}-setup" 2>/dev/null || true
+
+# =====================================================================
+# Test: send-keys returns exit 2 (unsupported)
+# =====================================================================
+echo "--- send-keys (unsupported) ---"
+rc=0
+"$SCRIPT" send-keys "$SESSION" "Enter" 2>/dev/null || rc=$?
+check "send-keys exits 2 (unsupported)" "2" "$rc"
+
+# =====================================================================
+# Test: unknown operation
+# =====================================================================
+echo "--- unknown operation ---"
+rc=0
+"$SCRIPT" future-op "$SESSION" 2>/dev/null || rc=$?
+check "unknown op exits 2" "2" "$rc"
+
+# =====================================================================
+# Test: ready_delay_ms
+# =====================================================================
+echo "--- ready_delay_ms ---"
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "ready_delay_ms": 1000,
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+start_time=$SECONDS
+echo "$config" | "$SCRIPT" start "${SESSION}-delay"
+elapsed=$((SECONDS - start_time))
+if [ "$elapsed" -ge 1 ]; then
+    echo "  PASS: ready_delay_ms waited ~${elapsed}s"
+    ((pass++)) || true
+else
+    echo "  FAIL: ready_delay_ms waited only ${elapsed}s (expected >= 1)"
+    ((fail++)) || true
+fi
+"$SCRIPT" stop "${SESSION}-delay" 2>/dev/null || true
+
+# =====================================================================
+# Test: stop
+# =====================================================================
+echo "--- stop ---"
+"$SCRIPT" stop "$SESSION"
+sleep 0.5
+running=$("$SCRIPT" is-running "$SESSION")
+check "stopped container is not running" "false" "$running"
+
+# =====================================================================
+# Test: stop idempotent
+# =====================================================================
+echo "--- stop (idempotent) ---"
+"$SCRIPT" stop "$SESSION"
+echo "  PASS: double stop (no error)"
+((pass++)) || true
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]

--- a/scripts/test-docker-session-headless-multi
+++ b/scripts/test-docker-session-headless-multi
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# test-docker-session-headless-multi — multi-agent tests for gc-session-docker-headless
+#
+# Usage: ./scripts/test-docker-session-headless-multi
+#
+# Verifies that multiple headless containers run independently:
+# isolated output, independent sessions, independent metadata,
+# and that stopping one doesn't affect others.
+#
+# Requires: docker, jq
+# Prerequisite: run test-docker-session-headless first (builds test image).
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/gc-session-docker-headless"
+WORKER1="gc-multi-worker1"
+WORKER2="gc-multi-worker2"
+TEST_IMAGE="gc-test-headless"
+
+pass=0
+fail=0
+
+check() {
+    local desc="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+        echo "  PASS: $desc"
+        ((pass++)) || true
+    else
+        echo "  FAIL: $desc (expected '$expected', got '$got')"
+        ((fail++)) || true
+    fi
+}
+
+check_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF -- "$needle"; then
+        echo "  PASS: $desc"
+        ((pass++)) || true
+    else
+        echo "  FAIL: $desc (expected to contain '$needle')"
+        ((fail++)) || true
+    fi
+}
+
+cleanup() {
+    echo ""
+    echo "--- Cleanup ---"
+    "$SCRIPT" stop "$WORKER1" 2>/dev/null || true
+    "$SCRIPT" stop "$WORKER2" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== gc-session-docker-headless multi-agent tests ==="
+echo "Script: $SCRIPT"
+echo ""
+
+# Verify test image exists (built by test-docker-session-headless).
+docker image inspect "$TEST_IMAGE" >/dev/null 2>&1 ||
+    { echo "ERROR: $TEST_IMAGE not found. Run test-docker-session-headless first."; exit 1; }
+
+config=$(cat <<EOF
+{
+    "command": "sleep 300",
+    "work_dir": "/tmp",
+    "env": {
+        "GC_DOCKER_IMAGE": "$TEST_IMAGE",
+        "GC_DOCKER_HOME_MOUNT": "false"
+    }
+}
+EOF
+)
+
+# =====================================================================
+# Test: start both workers
+# =====================================================================
+echo "--- Starting two headless workers ---"
+echo "$config" | "$SCRIPT" start "$WORKER1"
+echo "$config" | "$SCRIPT" start "$WORKER2"
+
+r1=$("$SCRIPT" is-running "$WORKER1")
+r2=$("$SCRIPT" is-running "$WORKER2")
+check "worker1 running" "true" "$r1"
+check "worker2 running" "true" "$r2"
+
+# =====================================================================
+# Test: nudge both with different prompts
+# =====================================================================
+echo "--- Nudging both workers ---"
+echo -n "Task for worker ONE" | "$SCRIPT" nudge "$WORKER1"
+echo -n "Task for worker TWO" | "$SCRIPT" nudge "$WORKER2"
+sleep 4  # mock claude takes 0.5s each + overhead
+
+# =====================================================================
+# Test: output isolation
+# =====================================================================
+echo "--- Verifying output isolation ---"
+out1=$("$SCRIPT" peek "$WORKER1" 20)
+out2=$("$SCRIPT" peek "$WORKER2" 20)
+check_contains "worker1 got its prompt" "Mock response to: Task for worker ONE" "$out1"
+check_contains "worker2 got its prompt" "Mock response to: Task for worker TWO" "$out2"
+
+# Verify NO cross-contamination.
+if echo "$out1" | grep -qF "worker TWO"; then
+    echo "  FAIL: worker1 contains worker2 output (cross-contamination)"
+    ((fail++)) || true
+else
+    echo "  PASS: worker1 output is isolated"
+    ((pass++)) || true
+fi
+
+if echo "$out2" | grep -qF "worker ONE"; then
+    echo "  FAIL: worker2 contains worker1 output (cross-contamination)"
+    ((fail++)) || true
+else
+    echo "  PASS: worker2 output is isolated"
+    ((pass++)) || true
+fi
+
+# =====================================================================
+# Test: independent session IDs
+# =====================================================================
+echo "--- Verifying independent sessions ---"
+sid1=$(docker exec "$WORKER1" cat /run/gc-headless/session_id 2>/dev/null || echo "")
+sid2=$(docker exec "$WORKER2" cat /run/gc-headless/session_id 2>/dev/null || echo "")
+
+if [ -n "$sid1" ] && [ -n "$sid2" ] && [ "$sid1" != "$sid2" ]; then
+    echo "  PASS: session IDs are independent ($sid1 vs $sid2)"
+    ((pass++)) || true
+else
+    echo "  FAIL: session IDs not independent (sid1=$sid1, sid2=$sid2)"
+    ((fail++)) || true
+fi
+
+# =====================================================================
+# Test: independent metadata
+# =====================================================================
+echo "--- Verifying independent metadata ---"
+echo -n "drain-requested" | "$SCRIPT" set-meta "$WORKER1" "gc-drain"
+echo -n "active" | "$SCRIPT" set-meta "$WORKER2" "gc-drain"
+
+m1=$("$SCRIPT" get-meta "$WORKER1" "gc-drain")
+m2=$("$SCRIPT" get-meta "$WORKER2" "gc-drain")
+check "worker1 drain meta" "drain-requested" "$m1"
+check "worker2 drain meta" "active" "$m2"
+
+# =====================================================================
+# Test: list-running shows both
+# =====================================================================
+echo "--- list-running ---"
+listed=$("$SCRIPT" list-running "gc-multi-")
+check_contains "list-running shows worker1" "$WORKER1" "$listed"
+check_contains "list-running shows worker2" "$WORKER2" "$listed"
+
+# =====================================================================
+# Test: multi-turn on worker1
+# =====================================================================
+echo "--- Multi-turn on worker1 ---"
+echo -n "Follow-up for worker ONE" | "$SCRIPT" nudge "$WORKER1"
+sleep 4
+
+out1=$("$SCRIPT" peek "$WORKER1" 30)
+check_contains "worker1 has follow-up" "Mock response to: Follow-up for worker ONE" "$out1"
+
+# =====================================================================
+# Test: stop worker1, verify worker2 unaffected
+# =====================================================================
+echo "--- Stop worker1, verify worker2 survives ---"
+"$SCRIPT" stop "$WORKER1"
+sleep 0.5
+
+r1=$("$SCRIPT" is-running "$WORKER1")
+r2=$("$SCRIPT" is-running "$WORKER2")
+check "worker1 stopped" "false" "$r1"
+check "worker2 still running" "true" "$r2"
+
+# Worker2 can still be nudged after worker1 is stopped.
+echo -n "Worker2 still alive" | "$SCRIPT" nudge "$WORKER2"
+sleep 4
+out2=$("$SCRIPT" peek "$WORKER2" 30)
+check_contains "worker2 responds after worker1 stopped" "Mock response to: Worker2 still alive" "$out2"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds `gc-session-docker-headless`, a variant of `gc-session-docker` that runs worker agents **without tmux**. Workers communicate via `claude -p <prompt> --output-format json --resume <id>` through `docker exec` — no TUI, no tmux, no PTY.

- **Eliminates tmux dependency** for worker containers (~15MB image reduction, smaller attack surface)
- **Implements full exec provider protocol**: start, stop, nudge, peek, interrupt, metadata, list-running, get-last-activity, clear-scrollback, copy-to, check-image
- **Multi-turn support** via `--resume` with persisted session ID
- **File-based metadata** (replaces tmux environment for set-meta/get-meta)
- **Pluggable frontend architecture**: because the headless provider exposes a container with Claude + transport but no UI coupling, any frontend can attach via `docker exec` — Ink terminal UI, Telegram bot, Slack integration, web dashboard, REST API, or any custom client

## Research & Findings

### Why headless?

Claude Code's TUI hangs in **all** Docker containers. Root cause: Docker's PTY multiplexing bridge creates backpressure that deadlocks Ink's React renderer ([documented in `docs/namurim/gc-session-docker-acp/docker-tui-findings.md`](docs/namurim/gc-session-docker-acp/docker-tui-findings.md)). Headless `-p` mode bypasses this entirely.

Workers don't need interactive sessions. They receive a prompt, produce structured output, and wait. The headless provider matches this pattern exactly.

### Decoupled transport and UI

Testing revealed that the mayor's SDK transport layer works perfectly headless inside Docker — it's only the Ink terminal UI that requires a TTY. This means the headless provider isn't just for workers: it can host any agent whose transport runs inside the container, with the presentation layer attached externally:

```
Gas City controller
  └── gc-session-docker-headless
       └── docker exec → transport layer  ← runs inside container, no UI
            └── claude (subprocess)
                 └── Anthropic API

Human operator (optional)
  └── docker exec -it → Ink UI / Telegram bot / Slack / web  ← attached on demand
       └── same transport layer
```

### HOME bug (affects gc-session-docker too)

Docker defaults `HOME=/` for numeric `--user` UIDs (e.g. `--user 1001:1001`). This breaks credential discovery for Claude, git, and SSH. The headless provider fixes this with explicit `-e HOME=...` in `docker run`. The tmux-based provider masks this because `tmux new-session` inherits environment differently, but direct `docker exec` exposes it.

### Protocol mapping

| Operation | tmux provider | Headless provider |
|-----------|--------------|-------------------|
| start | `docker run` + `tmux new-session` | `docker run` + `sleep infinity` |
| nudge | `tmux send-keys` + Enter + wake | `docker exec claude -p` (async, log output) |
| peek | `tmux capture-pane` | `tail` output log |
| metadata | `tmux set-environment` | File-based (`/run/gc-headless/meta/`) |
| interrupt | `tmux send-keys C-c` | `pkill -INT claude` |
| attach | `tmux attach-session` | `docker exec -it bash` (debug shell) |
| send-keys | Supported | Exit 2 (unsupported, forward-compat) |

## Test plan

- [x] Integration test suite (`scripts/test-docker-session-headless`): **31/31 passing** — exercises all exec protocol operations with mock claude CLI
- [x] Multi-agent isolation tests (`scripts/test-docker-session-headless-multi`): **15/15 passing** — output isolation, independent sessions/metadata, stop-one-survives-other
- [x] E2E validated on ARM64 Linux (Ubuntu 24.04) with real Claude CLI, OAuth credentials, and `gc-agent:latest` image
- [x] Multi-turn conversation via `--resume` verified
- [x] Credential discovery with `--user 1001:1001` verified (HOME fix)
- [x] Mixed provider E2E: headless worker + tmux mayor running side by side with independent lifecycle, isolated metadata
- [x] Mayor SDK transport running headless in the same container architecture, real Claude invocation returning correct response

### Note on mixed providers

The session provider is city-level (all agents share one provider). Per-agent session provider override is proposed in #555. The headless provider works standalone for all-headless cities, and alongside `gc-session-docker` when invoked directly.