### PR TITLE
fix: strip all BEADS_* vars by prefix in mergeRuntimeEnv and gc bd

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -213,12 +213,9 @@ func cityForStoreDir(dir string) string {
 }
 
 func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
+	// GC_* keys to strip by exact name. BEADS_* keys are stripped by
+	// prefix below, so they do not need to appear here.
 	keys := []string{
-		"BEADS_DIR",
-		"BEADS_DOLT_PASSWORD",
-		"BEADS_DOLT_SERVER_HOST",
-		"BEADS_DOLT_SERVER_PORT",
-		"BEADS_DOLT_SERVER_USER",
 		"GC_CITY",
 		"GC_CITY_ROOT", // kept for stripping: no code emits this anymore, but inherited values must be cleaned
 		"GC_CITY_PATH",
@@ -243,6 +240,11 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 	for _, key := range keys {
 		out = removeEnvKey(out, key)
 	}
+	// Strip all BEADS_* vars by prefix so unknown/future vars from the
+	// parent environment cannot leak into bd subprocesses. Only vars
+	// explicitly set via overrides are re-added below. This makes the
+	// boundary fail-closed: new bd vars are stripped by default.
+	out = removeEnvPrefix(out, "BEADS_")
 	overrideKeys := make([]string, 0, len(overrides))
 	for key := range overrides {
 		overrideKeys = append(overrideKeys, key)
@@ -255,7 +257,10 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 }
 
 func removeEnvKey(environ []string, key string) []string {
-	prefix := key + "="
+	return removeEnvPrefix(environ, key+"=")
+}
+
+func removeEnvPrefix(environ []string, prefix string) []string {
 	out := make([]string, 0, len(environ))
 	for _, entry := range environ {
 		if !strings.HasPrefix(entry, prefix) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -273,6 +274,76 @@ func TestMergeRuntimeEnvReplacesInheritedRuntimeKeys(t *testing.T) {
 	}
 	if _, ok := got["GC_RIG_ROOT"]; ok {
 		t.Fatalf("GC_RIG_ROOT should be removed, env = %#v", got)
+	}
+}
+
+func TestMergeRuntimeEnvStripsUnknownBeadsVars(t *testing.T) {
+	parent := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"BEADS_CREDENTIALS_FILE=/tmp/evil-creds.json",
+		"BEADS_SKIP_IDENTITY_CHECK=1",
+		"BEADS_DOLT_SERVER_TLS=false",
+		"BEADS_TEST_MODE=1",
+		"BEADS_DOLT_DATA_DIR=/wrong/path",
+		"BEADS_DB=/wrong/db",
+		"BEADS_ACTOR=wrong-actor",
+		"BEADS_HOOK_TIMEOUT=999",
+		"BEADS_IDENTITY=wrong",
+		"BEADS_DOLT_SERVER_MODE=wrong",
+		"BEADS_DOLT_SHARED_SERVER=1",
+		"BEADS_DOLT_REMOTESAPI_PORT=9999",
+		"BEADS_DOLT_PORT=9999",
+		"BEADS_MAIL_DELEGATE=wrong",
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_TIP_SEED=wrong",
+		// This one is set explicitly via overrides — must survive.
+		"BEADS_DOLT_SERVER_PORT=old-port",
+	}
+	overrides := map[string]string{
+		"BEADS_DOLT_SERVER_PORT": "31364",
+		"GC_CITY_PATH":           "/city",
+	}
+	result := mergeRuntimeEnv(parent, overrides)
+
+	got := make(map[string]string)
+	for _, entry := range result {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			got[key] = value
+		}
+	}
+
+	// Non-BEADS vars must survive.
+	if got["PATH"] != "/usr/bin" {
+		t.Fatalf("PATH = %q, want %q", got["PATH"], "/usr/bin")
+	}
+	if got["HOME"] != "/home/user" {
+		t.Fatalf("HOME = %q, want %q", got["HOME"], "/home/user")
+	}
+
+	// Override BEADS var must survive with the override value.
+	if got["BEADS_DOLT_SERVER_PORT"] != "31364" {
+		t.Fatalf("BEADS_DOLT_SERVER_PORT = %q, want %q", got["BEADS_DOLT_SERVER_PORT"], "31364")
+	}
+
+	// All foreign BEADS_* vars must be stripped. Only BEADS_* keys
+	// present in overrides are allowed through.
+	allowed := make(map[string]bool)
+	for k := range overrides {
+		if strings.HasPrefix(k, "BEADS_") {
+			allowed[k] = true
+		}
+	}
+	leaked := []string{}
+	for key := range got {
+		if strings.HasPrefix(key, "BEADS_") && !allowed[key] {
+			leaked = append(leaked, key)
+		}
+	}
+	sort.Strings(leaked)
+	if len(leaked) > 0 {
+		t.Fatalf("foreign BEADS_* vars leaked through: %v", leaked)
 	}
 }
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -71,9 +71,9 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	// Build env: pin BEADS_DIR to the selected store so rig-scoped calls don't
-	// fall back to the city store via gc-beads-bd's GC_CITY_PATH handling.
-	env := removeEnvKey(os.Environ(), "BEADS_DIR")
+	// Build env: strip all BEADS_* vars from the parent so foreign values
+	// cannot leak into the bd subprocess, then set only the vars gc controls.
+	env := removeEnvPrefix(os.Environ(), "BEADS_")
 	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
 	if dir != cityPath {
 		for _, r := range cfg.Rigs {

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -71,9 +71,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	// Build env: strip all BEADS_* vars from the parent so foreign values
-	// cannot leak into the bd subprocess, then set only the vars gc controls.
+	// Build env: strip all BEADS_* vars and GC runtime keys that doBd
+	// controls so inherited duplicates cannot shadow the values appended
+	// below. Without this, a parent GC_RIG=X causes the subprocess to
+	// see X instead of the value gc bd intends.
 	env := removeEnvPrefix(os.Environ(), "BEADS_")
+	env = removeEnvKey(env, "GC_RIG")
+	env = removeEnvKey(env, "GC_RIG_ROOT")
 	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
 	if dir != cityPath {
 		for _, r := range cfg.Rigs {


### PR DESCRIPTION
## Summary

Fixes #541.

- `mergeRuntimeEnv` used a static blocklist of 5 `BEADS_*` keys, allowing 16 others (including `BEADS_CREDENTIALS_FILE`, `BEADS_SKIP_IDENTITY_CHECK`, `BEADS_DOLT_SERVER_TLS`) to leak from the parent environment into `bd` subprocesses
- Switched to prefix-based stripping: all `BEADS_*` vars are stripped first, then only vars explicitly set via overrides are re-added — making the boundary **fail-closed**
- Applied the same fix to `cmd_bd.go` which constructed subprocess env independently with the same leak class
- Refactored `removeEnvKey` to delegate to new `removeEnvPrefix` helper, eliminating duplicated loop body
- Removed 5 now-redundant `BEADS_*` entries from the static key list (covered by prefix strip)

## Security impact

Without this fix, a parent shell with hostile `BEADS_*` vars can:
- Point bd to wrong credentials (`BEADS_CREDENTIALS_FILE`)
- Disable TLS (`BEADS_DOLT_SERVER_TLS`)
- Bypass identity checks (`BEADS_SKIP_IDENTITY_CHECK`)
- Enable test mode in production (`BEADS_TEST_MODE`)

## Test plan

- [x] `TestMergeRuntimeEnvStripsUnknownBeadsVars` — 16 foreign BEADS_* vars in parent, verifies all stripped while overrides and non-BEADS vars survive
- [x] All existing bd_env tests pass unchanged
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make check` passes (1 known baseline failure in `internal/api` unrelated)

## Review notes

- **Codex (gpt-5.4)** verified: `cityRuntimeProcessEnv` and `cmd_sling.go` set all BEADS_* vars explicitly — no caller relies on inherited passthrough
- **Copilot (gpt-5.3-codex)** independently confirmed the same
- `removeEnvKey`'s `key+"="` suffix prevents false prefix matches (e.g., `GC_CITY` won't match `GC_CITY_PATH=`)
- `cmd_bd.go` was identified during review as a third env construction path with the same leak — fixed in this PR