### PR TITLE
fix(searchpath): sort glob'd Node version dirs numerically

### DIFF
--- a/internal/searchpath/searchpath.go
+++ b/internal/searchpath/searchpath.go
@@ -9,6 +9,80 @@ import (
 	"strings"
 )
 
+// compareNatural compares two strings using a natural ordering that treats
+// runs of decimal digits as numbers. This lets version-like strings such as
+// "v8.17.0" and "v22.14.0" sort numerically (v8 < v22) instead of
+// lexicographically (v22 < v8 because '2' < '8'). Returns -1 if a < b,
+// 0 if a == b, and 1 if a > b.
+func compareNatural(a, b string) int {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		ai, bi := a[i], b[j]
+		aDigit := ai >= '0' && ai <= '9'
+		bDigit := bi >= '0' && bi <= '9'
+		if aDigit && bDigit {
+			// Skip leading zeros so "007" and "7" compare equal on value.
+			aStart := i
+			for aStart < len(a) && a[aStart] == '0' {
+				aStart++
+			}
+			bStart := j
+			for bStart < len(b) && b[bStart] == '0' {
+				bStart++
+			}
+			// Advance i/j to the end of each digit run.
+			aEnd := i
+			for aEnd < len(a) && a[aEnd] >= '0' && a[aEnd] <= '9' {
+				aEnd++
+			}
+			bEnd := j
+			for bEnd < len(b) && b[bEnd] >= '0' && b[bEnd] <= '9' {
+				bEnd++
+			}
+			aNum := a[aStart:aEnd]
+			bNum := b[bStart:bEnd]
+			switch {
+			case len(aNum) < len(bNum):
+				return -1
+			case len(aNum) > len(bNum):
+				return 1
+			case aNum != bNum:
+				if aNum < bNum {
+					return -1
+				}
+				return 1
+			}
+			// Numbers equal; tie-break on leading-zero count so "07" > "7".
+			aZeros := aStart - i
+			bZeros := bStart - j
+			if aZeros != bZeros {
+				if aZeros < bZeros {
+					return -1
+				}
+				return 1
+			}
+			i, j = aEnd, bEnd
+			continue
+		}
+		if ai != bi {
+			if ai < bi {
+				return -1
+			}
+			return 1
+		}
+		i++
+		j++
+	}
+	switch {
+	case i < len(a):
+		return 1
+	case j < len(b):
+		return -1
+	default:
+		return 0
+	}
+}
+
 // Expand returns a deterministic PATH search order that preserves the caller's
 // base PATH while adding common user-managed install locations.
 func Expand(homeDir, goos, basePath string) []string {
@@ -109,10 +183,12 @@ func existingDirs(paths ...string) []string {
 }
 
 // globExistingDirs expands each glob pattern, filters to directories that
-// exist, and returns them in reverse-lexicographic order so that newer
-// versions (e.g. v22.x) sort before older ones (e.g. v18.x). These entries
-// are fallbacks — stable "current" or shim paths checked earlier in
-// userManagedDirs take priority when they exist.
+// exist, and returns them in descending natural (version-aware) order so
+// that newer versions (e.g. v22.x) sort before older ones (e.g. v8.x).
+// Plain lexicographic sort is wrong here — "v8" > "v22" lex because '8' > '2'
+// — so we treat digit runs numerically. These entries are fallbacks —
+// stable "current" or shim paths checked earlier in userManagedDirs take
+// priority when they exist.
 func globExistingDirs(patterns ...string) []string {
 	var out []string
 	for _, pattern := range patterns {
@@ -120,7 +196,9 @@ func globExistingDirs(patterns ...string) []string {
 		if err != nil {
 			continue
 		}
-		sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+		sort.SliceStable(matches, func(i, j int) bool {
+			return compareNatural(matches[i], matches[j]) > 0
+		})
 		out = append(out, existingDirs(matches...)...)
 	}
 	return out

--- a/internal/searchpath/searchpath_test.go
+++ b/internal/searchpath/searchpath_test.go
@@ -214,7 +214,7 @@ func TestExpandFnmMixedMajorsSortedNumerically(t *testing.T) {
 	if idx2 == -1 || idx10 == -1 || idx20 == -1 {
 		t.Fatalf("expected all three fnm versions in dirs: %v", dirs)
 	}
-	if !(idx20 < idx10 && idx10 < idx2) {
+	if idx20 >= idx10 || idx10 >= idx2 {
 		t.Fatalf("expected v20 < v10 < v2 ordering, got v20=%d v10=%d v2=%d: %v", idx20, idx10, idx2, dirs)
 	}
 }

--- a/internal/searchpath/searchpath_test.go
+++ b/internal/searchpath/searchpath_test.go
@@ -167,6 +167,113 @@ func TestExpandCurrentSymlinkBeforeGlobVersions(t *testing.T) {
 	}
 }
 
+func TestExpandNVMSingleDigitMajorSortedNumerically(t *testing.T) {
+	home := t.TempDir()
+	// v8 is lexicographically greater than v22 ('8' > '2'), so a plain
+	// reverse-lexicographic sort would incorrectly place v8 before v22.
+	// Natural sort must place v22 first because it is a newer version.
+	v8 := filepath.Join(home, ".nvm", "versions", "node", "v8.17.0", "bin")
+	v22 := filepath.Join(home, ".nvm", "versions", "node", "v22.14.0", "bin")
+	for _, d := range []string{v8, v22} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dirs := Expand(home, "linux", "/usr/bin")
+
+	idx8 := slices.Index(dirs, v8)
+	idx22 := slices.Index(dirs, v22)
+	if idx8 == -1 || idx22 == -1 {
+		t.Fatalf("expected both nvm versions in dirs: %v", dirs)
+	}
+	if idx22 > idx8 {
+		t.Fatalf("v22 (%d) should appear before v8 (%d) in dirs: %v", idx22, idx8, dirs)
+	}
+}
+
+func TestExpandFnmMixedMajorsSortedNumerically(t *testing.T) {
+	home := t.TempDir()
+	// Exercise fnm layout with three majors that would break under
+	// lexicographic sort: v2 < v10 < v20 numerically, but lex puts v2
+	// between v20 and v10.
+	v2 := filepath.Join(home, ".fnm", "node-versions", "v2.5.0", "installation", "bin")
+	v10 := filepath.Join(home, ".fnm", "node-versions", "v10.24.1", "installation", "bin")
+	v20 := filepath.Join(home, ".fnm", "node-versions", "v20.11.1", "installation", "bin")
+	for _, d := range []string{v2, v10, v20} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dirs := Expand(home, "linux", "/usr/bin")
+
+	idx2 := slices.Index(dirs, v2)
+	idx10 := slices.Index(dirs, v10)
+	idx20 := slices.Index(dirs, v20)
+	if idx2 == -1 || idx10 == -1 || idx20 == -1 {
+		t.Fatalf("expected all three fnm versions in dirs: %v", dirs)
+	}
+	if !(idx20 < idx10 && idx10 < idx2) {
+		t.Fatalf("expected v20 < v10 < v2 ordering, got v20=%d v10=%d v2=%d: %v", idx20, idx10, idx2, dirs)
+	}
+}
+
+func TestExpandNVMPatchAndMinorSortedNumerically(t *testing.T) {
+	home := t.TempDir()
+	// Same major, mixed minor/patch widths: v20.9.0 vs v20.11.0 — lex
+	// sort would place v20.9.0 before v20.11.0 because '9' > '1'.
+	v20_9 := filepath.Join(home, ".nvm", "versions", "node", "v20.9.0", "bin")
+	v20_11 := filepath.Join(home, ".nvm", "versions", "node", "v20.11.0", "bin")
+	for _, d := range []string{v20_9, v20_11} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dirs := Expand(home, "linux", "/usr/bin")
+
+	idx9 := slices.Index(dirs, v20_9)
+	idx11 := slices.Index(dirs, v20_11)
+	if idx9 == -1 || idx11 == -1 {
+		t.Fatalf("expected both versions in dirs: %v", dirs)
+	}
+	if idx11 > idx9 {
+		t.Fatalf("v20.11.0 (%d) should appear before v20.9.0 (%d): %v", idx11, idx9, dirs)
+	}
+}
+
+func TestCompareNatural(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{name: "equal strings", a: "foo", b: "foo", want: 0},
+		{name: "pure lex less", a: "abc", b: "abd", want: -1},
+		{name: "pure lex greater", a: "abd", b: "abc", want: 1},
+		{name: "single digit vs two digit", a: "v8", b: "v22", want: -1},
+		{name: "two digit vs single digit", a: "v22", b: "v8", want: 1},
+		{name: "same width numeric", a: "v18", b: "v22", want: -1},
+		{name: "multi-segment version less", a: "v20.9.0", b: "v20.11.0", want: -1},
+		{name: "multi-segment version greater", a: "v20.11.0", b: "v20.9.0", want: 1},
+		{name: "three majors", a: "v2.5.0", b: "v10.0.0", want: -1},
+		{name: "leading zeros equal value", a: "v007", b: "v7", want: 1},
+		{name: "numeric prefix equal suffix differs", a: "node-22-lts", b: "node-22-alpha", want: 1},
+		{name: "empty a", a: "", b: "foo", want: -1},
+		{name: "empty b", a: "foo", b: "", want: 1},
+		{name: "both empty", a: "", b: "", want: 0},
+		{name: "prefix is less", a: "v22", b: "v22.1", want: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compareNatural(tt.a, tt.b); got != tt.want {
+				t.Fatalf("compareNatural(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExpandUserManagedDirsOnlyExisting(t *testing.T) {
 	home := t.TempDir()
 	// Create only cargo bin, not go bin.


### PR DESCRIPTION
## Summary

`globExistingDirs` used reverse-lexicographic sort to order Node version directories discovered via glob (nvm, fnm, nodebrew patterns). Lex order misranks majors with different digit widths:

- `v8.17.0` > `v22.14.0` lex (because `'8' > '2'`), so a user with both Node 8 and Node 22 installed had Node 8 picked as "newest".
- Same class of bug for `v2` vs `v10`, and for `v20.9.0` vs `v20.11.0` within a single major.

The existing test (`TestExpandNVMVersionsReverseSorted`) only compared `v18` vs `v22` — same-width majors — so it did not catch the bug. A recent commit (`d84fb44` "fix: add searchpath unit tests and document glob ordering") touched this area but preserved the lex sort.

## Fix

- Introduce a small byte-wise `compareNatural` that treats runs of decimal digits as numbers and handles leading-zero tie-breaks and shared prefixes.
- Switch `globExistingDirs` to `sort.SliceStable` with descending natural order. No new imports.

## Tests

- `TestExpandNVMSingleDigitMajorSortedNumerically` — `v8.17.0` vs `v22.14.0` (fails under the old sort).
- `TestExpandFnmMixedMajorsSortedNumerically` — `v2 / v10 / v20` ordering across the fnm layout.
- `TestExpandNVMPatchAndMinorSortedNumerically` — `v20.9.0` vs `v20.11.0` within one major.
- `TestCompareNatural` — table-driven coverage of leading zeros, shared prefixes, and empty operands.

## Test plan

- [ ] `go test ./internal/searchpath/...`
- [ ] Verify no other callers rely on the old (lex) ordering — `globExistingDirs` is unexported and only used by `userManagedDirs`.