### PR TITLE
fix(k8s): strip stale project_id from staged beads metadata in pod

### DIFF
--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -749,16 +749,24 @@ func initBeadsInPod(ctx context.Context, ops k8sOps, podName string, cfg runtime
 
 	// The shell command decodes the base64 values, so no user-controlled
 	// content is ever interpreted as shell syntax.
+	//
+	// project_id is dropped from the staged metadata because the controller's
+	// project_id is wrong for the agent pod — the staged copy carries the
+	// controller's identity but the pod talks to the in-cluster Dolt server,
+	// where bd will rediscover the correct project_id. Leaving it in place
+	// causes bd to fail with PROJECT IDENTITY MISMATCH on first use.
 	patchCmd := fmt.Sprintf(
 		`WD=$(echo '%s' | base64 -d) && cd "$WD" && PATCH=$(echo '%s' | base64 -d) && `+
 			`if [ -f .beads/metadata.json ]; then `+
 			`python3 -c "import json,sys; `+
 			`m=json.load(open('.beads/metadata.json')); `+
 			`p=json.loads(sys.argv[1]); m.update(p); `+
+			`m.pop('project_id', None); `+
 			`json.dump(m,open('.beads/metadata.json','w'),indent=2)" "$PATCH" 2>/dev/null || `+
 			`python3 -c "import json,sys; `+
 			`m=json.load(open('.beads/metadata.json')); `+
 			`p=json.loads(sys.stdin.read()); m.update(p); `+
+			`m.pop('project_id', None); `+
 			`json.dump(m,open('.beads/metadata.json','w'),indent=2)" <<< "$PATCH"; `+
 			`else PREFIX=$(echo '%s' | base64 -d) && `+
 			`DOLT_HOST=$(echo '%s' | base64 -d) && `+

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -1012,6 +1012,44 @@ func TestInitBeadsInPodPrefixDerivation(t *testing.T) {
 	}
 }
 
+// TestInitBeadsInPodStripsProjectIDFromMetadata verifies that the metadata
+// patch removes the controller's project_id so the agent pod's bd does not
+// fail with PROJECT IDENTITY MISMATCH against the in-cluster Dolt server.
+// The staged .beads/metadata.json carries the controller's project_id, which
+// is wrong for the pod and must be dropped so bd rediscovers it.
+func TestInitBeadsInPodStripsProjectIDFromMetadata(t *testing.T) {
+	fake := newFakeK8sOps()
+	cfg := runtime.Config{
+		Env: map[string]string{
+			"GC_K8S_DOLT_HOST": "dolt.gc.svc.cluster.local",
+			"GC_K8S_DOLT_PORT": "3307",
+		},
+	}
+
+	if err := initBeadsInPod(context.Background(), fake, "gc-test-pod", cfg, "/workspace/demo-repo"); err != nil {
+		t.Fatalf("initBeadsInPod: %v", err)
+	}
+
+	var script string
+	for _, c := range fake.calls {
+		if c.method == "execInPod" && len(c.cmd) >= 3 && c.cmd[0] == "sh" && c.cmd[1] == "-c" {
+			script = c.cmd[2]
+			break
+		}
+	}
+	if script == "" {
+		t.Fatal("no sh -c exec call found")
+	}
+
+	// Both the argv and stdin python3 fallback paths must drop project_id
+	// after merging the patch into the staged metadata.
+	want := "m.pop('project_id', None)"
+	count := strings.Count(script, want)
+	if count < 2 {
+		t.Errorf("expected %q to appear in both python3 patch invocations (>=2 times), got %d\nscript:\n%s", want, count, script)
+	}
+}
+
 func TestStartSkipsStagingWhenPrebaked(t *testing.T) {
 	fake := newFakeK8sOps()
 	p := newProviderWithOps(fake)


### PR DESCRIPTION
## Summary

When the controller stages `.beads/metadata.json` into agent pods, the
controller's own `project_id` gets copied in. That ID is wrong for the
pod's view of the in-cluster Dolt server, causing `bd` to fail with
`PROJECT IDENTITY MISMATCH` on first use.

- Strip `project_id` from the metadata JSON patch so `bd` rediscovers
  the correct identity from the shared Dolt server
- Add regression test asserting `project_id` is absent from staged metadata