### PR TITLE
fix: add respawn circuit breaker for named sessions

### DIFF
--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -74,6 +74,25 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Clear any tripped circuit breaker for this session's named identity.
+	// The breaker is keyed by named-session identity (see
+	// session_circuit_breaker.go), which the reconciler obtains from the
+	// session bead via namedSessionIdentity. Operators are told to run
+	// `gc session reset <identity>` from the breaker's ERROR log, so this
+	// must actually clear the breaker — otherwise the supervisor would
+	// continue to refuse respawns until the auto-reset window elapsed.
+	cb := defaultSessionCircuitBreaker()
+	// Reset by the user's input first: in the common case the operator
+	// pasted the identity from the ERROR message verbatim ("mayor"), and
+	// the resolver below may not be able to map that back to a session
+	// bead if the breaker is tripped because no session ever materialized.
+	cb.Reset(args[0])
+	if bead, err := store.Get(sessionID); err == nil {
+		if identity := namedSessionIdentity(bead); identity != "" {
+			cb.Reset(identity)
+		}
+	}
+
 	_ = pokeController(cityPath)
 
 	fmt.Fprintf(stdout, "Session %s reset requested. Controller will restart it fresh.\n", sessionID) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -74,22 +74,21 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Clear any tripped circuit breaker for this session's named identity.
-	// The breaker is keyed by named-session identity (see
-	// session_circuit_breaker.go), which the reconciler obtains from the
-	// session bead via namedSessionIdentity. Operators are told to run
-	// `gc session reset <identity>` from the breaker's ERROR log, so this
-	// must actually clear the breaker — otherwise the supervisor would
-	// continue to refuse respawns until the auto-reset window elapsed.
-	cb := defaultSessionCircuitBreaker()
-	// Reset by the user's input first: in the common case the operator
-	// pasted the identity from the ERROR message verbatim ("mayor"), and
-	// the resolver below may not be able to map that back to a session
-	// bead if the breaker is tripped because no session ever materialized.
-	cb.Reset(args[0])
+	identities := []string{args[0]}
 	if bead, err := store.Get(sessionID); err == nil {
 		if identity := namedSessionIdentity(bead); identity != "" {
-			cb.Reset(identity)
+			identities = append(identities, identity)
+		}
+	}
+	seen := make(map[string]bool, len(identities))
+	for _, identity := range identities {
+		if identity == "" || seen[identity] {
+			continue
+		}
+		seen[identity] = true
+		if err := resetSessionCircuitBreakerOnController(cityPath, identity); err != nil {
+			fmt.Fprintf(stderr, "gc session reset: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+			return 1
 		}
 	}
 

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -69,27 +69,24 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := handle.Reset(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+
+	bead, err := store.Get(sessionID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session reset: loading session %s: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	identity := namedSessionIdentity(bead)
+	if identity == "" {
+		identity = args[0]
+	}
+	if err := resetSessionCircuitBreakerOnController(cityPath, sessionID, identity); err != nil {
+		fmt.Fprintf(stderr, "gc session reset: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	identities := []string{args[0]}
-	if bead, err := store.Get(sessionID); err == nil {
-		if identity := namedSessionIdentity(bead); identity != "" {
-			identities = append(identities, identity)
-		}
-	}
-	seen := make(map[string]bool, len(identities))
-	for _, identity := range identities {
-		if identity == "" || seen[identity] {
-			continue
-		}
-		seen[identity] = true
-		if err := resetSessionCircuitBreakerOnController(cityPath, identity); err != nil {
-			fmt.Fprintf(stderr, "gc session reset: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
+	if err := handle.Reset(context.Background()); err != nil {
+		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 
 	_ = pokeController(cityPath)

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -12,6 +12,94 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+// TestCmdSessionReset_ClearsCircuitBreaker verifies that running
+// `gc session reset <identity>` clears a tripped session circuit breaker
+// for the matching named session, so the supervisor will respawn the
+// session on the next tick. This is the operator-facing remediation path
+// the breaker's ERROR log message points at.
+func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-reset-cb-")
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "mayor"
+	if _, err := store.Create(beads.Bead{
+		Title:  "named mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:mayor"},
+		Metadata: map[string]string{
+			"alias":                      identity,
+			"template":                   "mayor",
+			"session_name":               "s-gc-reset-cb-test",
+			"state":                      "awake",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	}); err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	// Stand up a fake controller socket so cmdSessionReset's pokeController
+	// + cityUsesManagedReconciler check both succeed.
+	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+	defer lis.Close() //nolint:errcheck
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 64)
+			n, _ := conn.Read(buf)
+			reply := "ok\n"
+			if string(buf[:n]) == "ping\n" {
+				reply = "123\n"
+			}
+			conn.Write([]byte(reply)) //nolint:errcheck
+			conn.Close()              //nolint:errcheck
+		}
+	}()
+
+	// Trip the breaker for "mayor" by recording enough restarts inside
+	// the rolling window with no progress events.
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      30 * time.Minute,
+		MaxRestarts: 3,
+	})
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		cb.RecordRestart(identity, now.Add(time.Duration(i)*time.Second))
+	}
+	if !cb.IsOpen(identity, now.Add(time.Minute)) {
+		t.Fatalf("precondition: expected breaker OPEN for %q after 4 restarts", identity)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionReset([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionReset = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if cb.IsOpen(identity, now.Add(time.Minute)) {
+		t.Fatalf("breaker still OPEN for %q after `gc session reset %s`", identity, identity)
+	}
+}
+
 func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"net"
 	"os"
@@ -24,7 +25,7 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 
 	cityDir := shortSocketTempDir(t, "gc-session-reset-cb-")
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
@@ -33,24 +34,27 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	const identity = "mayor"
-	if _, err := store.Create(beads.Bead{
-		Title:  "named mayor",
+	const identity = "session-a"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
 		Type:   session.BeadType,
-		Labels: []string{session.LabelSession, "template:mayor"},
+		Labels: []string{session.LabelSession, "template:worker"},
 		Metadata: map[string]string{
-			"alias":                      identity,
-			"template":                   "mayor",
-			"session_name":               "s-gc-reset-cb-test",
-			"state":                      "awake",
-			namedSessionMetadataKey:      "true",
-			namedSessionIdentityMetadata: identity,
+			"alias":                        identity,
+			"template":                     "worker",
+			"session_name":                 "s-gc-reset-cb-test",
+			"state":                        "awake",
+			namedSessionMetadataKey:        "true",
+			namedSessionIdentityMetadata:   identity,
+			sessionCircuitStateMetadata:    circuitOpen.String(),
+			sessionCircuitRestartsMetadata: `["2026-04-10T12:00:00Z"]`,
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("store.Create(session bead): %v", err)
 	}
 
-	// Trip the breaker for "mayor" by recording enough restarts inside
+	// Trip the breaker by recording enough restarts inside
 	// the rolling window with no progress events.
 	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
 		Window:      30 * time.Minute,
@@ -89,6 +93,16 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 	if cb.IsOpen(identity, now.Add(time.Minute)) {
 		t.Fatalf("breaker still OPEN for %q after `gc session reset %s`", identity, identity)
 	}
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != "" {
+		t.Fatalf("persisted circuit state = %q, want cleared", got)
+	}
+	if got := updated.Metadata[sessionCircuitRestartsMetadata]; got != "" {
+		t.Fatalf("persisted restart history = %q, want cleared", got)
+	}
 }
 
 func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
@@ -97,7 +111,7 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 
 	cityDir := shortSocketTempDir(t, "gc-session-reset-")
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
@@ -107,12 +121,12 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
 	bead, err := store.Create(beads.Bead{
-		Title:  "manual mayor",
+		Title:  "manual session",
 		Type:   session.BeadType,
-		Labels: []string{session.LabelSession, "template:mayor"},
+		Labels: []string{session.LabelSession, "template:worker"},
 		Metadata: map[string]string{
 			"alias":                      "sky",
-			"template":                   "mayor",
+			"template":                   "worker",
 			"session_name":               "s-gc-reset-test",
 			"state":                      "awake",
 			"session_key":                "original-key",
@@ -202,6 +216,9 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 	if !strings.Contains(gotCommands[2], `"identity":"sky"`) {
 		t.Fatalf("controller command 2 = %q, want identity sky", gotCommands[2])
 	}
+	if !strings.Contains(gotCommands[2], `"session_id":"`+bead.ID+`"`) {
+		t.Fatalf("controller command 2 = %q, want session_id %s", gotCommands[2], bead.ID)
+	}
 	if gotCommands[3] != "poke\n" {
 		t.Fatalf("controller command 3 = %q, want poke", gotCommands[3])
 	}
@@ -225,5 +242,195 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 	}
 	if got.Metadata["started_config_hash"] != "hash-before-reset" {
 		t.Fatalf("started_config_hash = %q, want original hash preserved until reconcile", got.Metadata["started_config_hash"])
+	}
+}
+
+func TestCmdSessionReset_ControllerClearFailureDoesNotQueueRestart(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-reset-clear-fail-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:  "generic named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                      "session-a",
+			"template":                   "worker",
+			"session_name":               "s-gc-reset-clear-fail",
+			"state":                      "awake",
+			"session_key":                "original-key",
+			"started_config_hash":        "hash-before-reset",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "session-a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	commands := make(chan string, 3)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(commands)
+		for i := 0; i < 3; i++ {
+			conn, err := lis.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			buf := make([]byte, 256)
+			n, err := conn.Read(buf)
+			if err != nil {
+				conn.Close() //nolint:errcheck
+				errCh <- err
+				return
+			}
+			cmd := string(buf[:n])
+			commands <- cmd
+			reply := "ok\n"
+			if cmd == "ping\n" {
+				reply = "123\n"
+			} else if strings.HasPrefix(cmd, "session-circuit-reset:") {
+				reply = `{"outcome":"failed","error":"clear failed"}` + "\n"
+			}
+			if _, err := conn.Write([]byte(reply)); err != nil {
+				conn.Close() //nolint:errcheck
+				errCh <- err
+				return
+			}
+			conn.Close() //nolint:errcheck
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionReset([]string{"session-a"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdSessionReset = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `clearing session circuit breaker for "session-a": clear failed`) {
+		t.Fatalf("stderr = %q, want controller clear failure", stderr.String())
+	}
+
+	gotCommands := make([]string, 0, 3)
+	deadline := time.After(2 * time.Second)
+	for len(gotCommands) < 3 {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("controller socket: %v", err)
+			}
+		case cmd, ok := <-commands:
+			if !ok {
+				t.Fatalf("controller commands = %v, want ping, poke, reset", gotCommands)
+			}
+			gotCommands = append(gotCommands, cmd)
+		case <-deadline:
+			t.Fatalf("timed out waiting for controller commands, got %v", gotCommands)
+		}
+	}
+	if gotCommands[0] != "ping\n" || gotCommands[1] != "poke\n" || !strings.HasPrefix(gotCommands[2], "session-circuit-reset:") {
+		t.Fatalf("controller commands = %v, want ping, poke, reset", gotCommands)
+	}
+
+	reloaded, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(reload): %v", err)
+	}
+	got, err := reloaded.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", bead.ID, err)
+	}
+	if got.Metadata["restart_requested"] == "true" {
+		t.Fatalf("restart_requested = true, want no queued reset after controller clear failure")
+	}
+	if got.Metadata["continuation_reset_pending"] == "true" {
+		t.Fatalf("continuation_reset_pending = true, want no queued reset after controller clear failure")
+	}
+}
+
+func TestResetSessionCircuitBreakerOnControllerMalformedReply(t *testing.T) {
+	cityDir := shortSocketTempDir(t, "gc-session-reset-malformed-")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := lis.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+		scanner := bufio.NewScanner(conn)
+		if !scanner.Scan() {
+			errCh <- scanner.Err()
+			return
+		}
+		if _, err := conn.Write([]byte("not-json\n")); err != nil {
+			errCh <- err
+		}
+	}()
+
+	err = resetSessionCircuitBreakerOnController(cityDir, "session-id", "rig-a/session-a")
+	if err == nil {
+		t.Fatal("resetSessionCircuitBreakerOnController = nil, want decode error")
+	}
+	if !strings.Contains(err.Error(), "decoding session circuit reset reply") {
+		t.Fatalf("error = %v, want decode context", err)
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("controller socket: %v", err)
+		}
+	default:
+	}
+}
+
+func writeGenericNamedSessionCityTOML(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	data := []byte(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "session-a"
+provider = "codex"
+start_command = "echo"
+
+[[named_session]]
+template = "session-a"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 }

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,31 +50,6 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 		t.Fatalf("store.Create(session bead): %v", err)
 	}
 
-	// Stand up a fake controller socket so cmdSessionReset's pokeController
-	// + cityUsesManagedReconciler check both succeed.
-	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
-	lis, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatalf("Listen(%q): %v", sockPath, err)
-	}
-	defer lis.Close() //nolint:errcheck
-	go func() {
-		for {
-			conn, err := lis.Accept()
-			if err != nil {
-				return
-			}
-			buf := make([]byte, 64)
-			n, _ := conn.Read(buf)
-			reply := "ok\n"
-			if string(buf[:n]) == "ping\n" {
-				reply = "123\n"
-			}
-			conn.Write([]byte(reply)) //nolint:errcheck
-			conn.Close()              //nolint:errcheck
-		}
-	}()
-
 	// Trip the breaker for "mayor" by recording enough restarts inside
 	// the rolling window with no progress events.
 	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
@@ -89,6 +65,21 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 	if !cb.IsOpen(identity, now.Add(time.Minute)) {
 		t.Fatalf("precondition: expected breaker OPEN for %q after 4 restarts", identity)
 	}
+
+	lis, err := startControllerSocket(
+		cityDir,
+		func() {},
+		nil,
+		make(chan reloadRequest),
+		make(chan convergenceRequest, 1),
+		make(chan struct{}, 1),
+		make(chan struct{}, 1),
+	)
+	if err != nil {
+		t.Fatalf("startControllerSocket: %v", err)
+	}
+	defer lis.Close()                              //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityDir)) //nolint:errcheck
 
 	var stdout, stderr bytes.Buffer
 	if code := cmdSessionReset([]string{identity}, &stdout, &stderr); code != 0 {
@@ -140,11 +131,11 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 	}
 	defer lis.Close() //nolint:errcheck
 
-	commands := make(chan string, 3)
+	commands := make(chan string, 4)
 	errCh := make(chan error, 1)
 	go func() {
 		defer close(commands)
-		for i := 0; i < 3; i++ {
+		for i := 0; i < 4; i++ {
 			conn, err := lis.Accept()
 			if err != nil {
 				errCh <- err
@@ -162,6 +153,8 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 			reply := "ok\n"
 			if cmd == "ping\n" {
 				reply = "123\n"
+			} else if strings.HasPrefix(cmd, "session-circuit-reset:") {
+				reply = `{"outcome":"ok"}` + "\n"
 			}
 			if _, err := conn.Write([]byte(reply)); err != nil {
 				conn.Close() //nolint:errcheck
@@ -177,9 +170,9 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 		t.Fatalf("cmdSessionReset(controller) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
-	gotCommands := make([]string, 0, 3)
+	gotCommands := make([]string, 0, 4)
 	deadline := time.After(2 * time.Second)
-	for len(gotCommands) < 3 {
+	for len(gotCommands) < 4 {
 		select {
 		case err := <-errCh:
 			if err != nil {
@@ -187,8 +180,8 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 			}
 		case cmd, ok := <-commands:
 			if !ok {
-				if len(gotCommands) != 3 {
-					t.Fatalf("controller commands = %v, want ping plus 2 pokes", gotCommands)
+				if len(gotCommands) != 4 {
+					t.Fatalf("controller commands = %v, want ping, poke, reset, poke", gotCommands)
 				}
 				break
 			}
@@ -197,11 +190,20 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 			t.Fatalf("timed out waiting for controller pokes, got %v", gotCommands)
 		}
 	}
-	wantCommands := []string{"ping\n", "poke\n", "poke\n"}
-	for i, want := range wantCommands {
+	wantExact := []string{"ping\n", "poke\n"}
+	for i, want := range wantExact {
 		if gotCommands[i] != want {
 			t.Fatalf("controller command %d = %q, want %q", i, gotCommands[i], want)
 		}
+	}
+	if !strings.HasPrefix(gotCommands[2], "session-circuit-reset:") {
+		t.Fatalf("controller command 2 = %q, want session-circuit-reset", gotCommands[2])
+	}
+	if !strings.Contains(gotCommands[2], `"identity":"sky"`) {
+		t.Fatalf("controller command 2 = %q, want identity sky", gotCommands[2])
+	}
+	if gotCommands[3] != "poke\n" {
+		t.Fatalf("controller command 3 = %q, want poke", gotCommands[3])
 	}
 
 	reloaded, err := openCityStoreAt(cityDir)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -68,7 +68,19 @@ func (e controllerCommandError) Is(target error) bool {
 		(target == errControllerUnresponsive && e.unresponsive)
 }
 
-const controllerSocketPathLimit = 100
+const (
+	controllerSocketPathLimit        = 100
+	sessionCircuitResetCommandPrefix = "session-circuit-reset:"
+)
+
+type sessionCircuitResetRequest struct {
+	Identity string `json:"identity"`
+}
+
+type sessionCircuitResetReply struct {
+	Outcome string `json:"outcome"`
+	Error   string `json:"error,omitempty"`
+}
 
 // controllerSocketPath returns the Unix socket path for controller commands.
 // It preserves the legacy .gc/controller.sock location for short city paths,
@@ -187,6 +199,8 @@ func handleControllerConn(
 			default:
 			}
 			conn.Write([]byte("ok\n")) //nolint:errcheck // best-effort ack
+		case strings.HasPrefix(line, sessionCircuitResetCommandPrefix):
+			handleSessionCircuitResetSocketCmd(conn, line[len(sessionCircuitResetCommandPrefix):])
 		case strings.HasPrefix(line, "converge:"):
 			handleConvergeSocketCmd(conn, line[len("converge:"):], convergenceReqCh)
 		case strings.HasPrefix(line, "trace-arm:"):
@@ -207,6 +221,53 @@ func handleControllerConn(
 			handleTraceStatusSocketCmd(conn, cityPath)
 		}
 	}
+}
+
+func handleSessionCircuitResetSocketCmd(conn net.Conn, payload string) {
+	var req sessionCircuitResetRequest
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		writeJSONLine(conn, sessionCircuitResetReply{
+			Outcome: "failed",
+			Error:   fmt.Sprintf("invalid session circuit reset request: %v", err),
+		})
+		return
+	}
+	identity := strings.TrimSpace(req.Identity)
+	if identity == "" {
+		writeJSONLine(conn, sessionCircuitResetReply{
+			Outcome: "failed",
+			Error:   "identity is required",
+		})
+		return
+	}
+	defaultSessionCircuitBreaker().Reset(identity)
+	writeJSONLine(conn, sessionCircuitResetReply{Outcome: "ok"})
+}
+
+func resetSessionCircuitBreakerOnController(cityPath, identity string) error {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return nil
+	}
+	payload, err := json.Marshal(sessionCircuitResetRequest{Identity: identity})
+	if err != nil {
+		return fmt.Errorf("encoding session circuit reset request: %w", err)
+	}
+	resp, err := sendControllerCommand(cityPath, sessionCircuitResetCommandPrefix+string(payload))
+	if err != nil {
+		return err
+	}
+	var reply sessionCircuitResetReply
+	if err := json.Unmarshal(resp, &reply); err != nil {
+		return fmt.Errorf("decoding session circuit reset reply: %w", err)
+	}
+	if reply.Outcome != "ok" {
+		if reply.Error != "" {
+			return fmt.Errorf("%s", reply.Error)
+		}
+		return fmt.Errorf("session circuit reset failed")
+	}
+	return nil
 }
 
 func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest) {

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -74,7 +74,8 @@ const (
 )
 
 type sessionCircuitResetRequest struct {
-	Identity string `json:"identity"`
+	Identity  string `json:"identity"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 type sessionCircuitResetReply struct {
@@ -200,7 +201,7 @@ func handleControllerConn(
 			}
 			conn.Write([]byte("ok\n")) //nolint:errcheck // best-effort ack
 		case strings.HasPrefix(line, sessionCircuitResetCommandPrefix):
-			handleSessionCircuitResetSocketCmd(conn, line[len(sessionCircuitResetCommandPrefix):])
+			handleSessionCircuitResetSocketCmd(conn, cityPath, line[len(sessionCircuitResetCommandPrefix):])
 		case strings.HasPrefix(line, "converge:"):
 			handleConvergeSocketCmd(conn, line[len("converge:"):], convergenceReqCh)
 		case strings.HasPrefix(line, "trace-arm:"):
@@ -223,7 +224,7 @@ func handleControllerConn(
 	}
 }
 
-func handleSessionCircuitResetSocketCmd(conn net.Conn, payload string) {
+func handleSessionCircuitResetSocketCmd(conn net.Conn, cityPath, payload string) {
 	var req sessionCircuitResetRequest
 	if err := json.Unmarshal([]byte(payload), &req); err != nil {
 		writeJSONLine(conn, sessionCircuitResetReply{
@@ -240,16 +241,76 @@ func handleSessionCircuitResetSocketCmd(conn net.Conn, payload string) {
 		})
 		return
 	}
-	defaultSessionCircuitBreaker().Reset(identity)
+	sessionID := strings.TrimSpace(req.SessionID)
+	if sessionID == "" {
+		writeJSONLine(conn, sessionCircuitResetReply{
+			Outcome: "failed",
+			Error:   "session_id is required; upgrade gc to clear persisted session circuit breaker metadata",
+		})
+		return
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		writeJSONLine(conn, sessionCircuitResetReply{
+			Outcome: "failed",
+			Error:   fmt.Sprintf("opening city store: %v", err),
+		})
+		return
+	}
+	if err := resetSessionCircuitBreakerState(store, sessionID, identity, defaultSessionCircuitBreaker()); err != nil {
+		writeJSONLine(conn, sessionCircuitResetReply{
+			Outcome: "failed",
+			Error:   err.Error(),
+		})
+		return
+	}
 	writeJSONLine(conn, sessionCircuitResetReply{Outcome: "ok"})
 }
 
-func resetSessionCircuitBreakerOnController(cityPath, identity string) error {
+func resetSessionCircuitBreakerState(store beads.Store, sessionID string, identity string, cb *sessionCircuitBreaker) error {
 	identity = strings.TrimSpace(identity)
 	if identity == "" {
 		return nil
 	}
-	payload, err := json.Marshal(sessionCircuitResetRequest{Identity: identity})
+	if cb == nil {
+		cb = defaultSessionCircuitBreaker()
+	}
+	if err := loadPersistedSessionCircuitResetGeneration(store, sessionID, identity, cb); err != nil {
+		return err
+	}
+	initialSnapshot := cb.snapshotIdentity(identity)
+	if strings.TrimSpace(sessionID) == "" {
+		cb.Reset(identity)
+		return nil
+	}
+	if err := resetAndClearSessionCircuitBreakerState(store, sessionID, identity, cb, initialSnapshot); err != nil {
+		return err
+	}
+	// The second cycle invalidates an OPEN persist that may race through
+	// the first clear window. If the second clear fails, restore the pre-reset
+	// snapshot so the controller never leaves memory CLOSED while storage still
+	// says OPEN. TestResetSessionCircuitBreakerStateClearsRacingOpenPersist
+	// guards this from being collapsed into a single reset.
+	return resetAndClearSessionCircuitBreakerState(store, sessionID, identity, cb, initialSnapshot)
+}
+
+func resetAndClearSessionCircuitBreakerState(store beads.Store, sessionID string, identity string, cb *sessionCircuitBreaker, restoreSnapshot sessionCircuitBreakerIdentitySnapshot) error {
+	resetGeneration := cb.Reset(identity)
+	if err := clearPersistedSessionCircuitBreakerMetadata(store, sessionID, resetGeneration); err != nil {
+		cb.restoreIdentity(identity, restoreSnapshot)
+		// Restore the pre-reset snapshot rather than the just-reset one so a
+		// durable clear failure cannot strand the breaker CLOSED in memory.
+		return err
+	}
+	return nil
+}
+
+func resetSessionCircuitBreakerOnController(cityPath, sessionID, identity string) error {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return nil
+	}
+	payload, err := json.Marshal(sessionCircuitResetRequest{Identity: identity, SessionID: sessionID})
 	if err != nil {
 		return fmt.Errorf("encoding session circuit reset request: %w", err)
 	}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -1244,6 +1247,470 @@ func TestHandleControllerConnControlDispatcher(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("handleControllerConn did not exit")
 	}
+}
+
+func TestHandleSessionCircuitResetSocketCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		wantOutcome string
+		wantError   string
+	}{
+		{
+			name:        "invalid json",
+			payload:     `{"identity":`,
+			wantOutcome: "failed",
+			wantError:   "invalid session circuit reset request",
+		},
+		{
+			name:        "empty identity",
+			payload:     `{"identity":"   "}`,
+			wantOutcome: "failed",
+			wantError:   "identity is required",
+		},
+		{
+			name:        "missing session id",
+			payload:     `{"identity":"rig-a/session-a"}`,
+			wantOutcome: "failed",
+			wantError:   "session_id is required",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server, client := net.Pipe()
+			defer client.Close() //nolint:errcheck
+
+			done := make(chan struct{})
+			go func() {
+				handleSessionCircuitResetSocketCmd(server, t.TempDir(), tc.payload)
+				close(done)
+			}()
+
+			reply := readSessionCircuitResetSocketReply(t, client)
+			if reply.Outcome != tc.wantOutcome {
+				t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, tc.wantOutcome)
+			}
+			if tc.wantError != "" && !strings.Contains(reply.Error, tc.wantError) {
+				t.Fatalf("reply.Error = %q, want containing %q", reply.Error, tc.wantError)
+			}
+			<-done
+		})
+	}
+}
+
+func TestResetSessionCircuitBreakerStateResetsMemoryBeforeClearingMetadata(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const identity = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(identity, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("precondition: breaker should be open")
+	}
+
+	store := &metadataCallbackStore{
+		Store: beads.NewMemStore(),
+		beforeBatch: func() {
+			if cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+				t.Error("breaker was still open while persisted metadata was being cleared")
+			}
+		},
+	}
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata:   identity,
+			sessionCircuitStateMetadata:    circuitOpen.String(),
+			sessionCircuitRestartsMetadata: `["2026-04-01T12:00:00Z"]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	if err := resetSessionCircuitBreakerState(store, session.ID, identity, cb); err != nil {
+		t.Fatalf("resetSessionCircuitBreakerState: %v", err)
+	}
+	if cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("breaker should be closed after reset")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	assertSessionCircuitStateMetadataCleared(t, updated.Metadata)
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got != "2" {
+		t.Fatalf("%s = %q, want 2", sessionCircuitResetGenerationMetadata, got)
+	}
+}
+
+func TestResetSessionCircuitBreakerStateClearsRacingOpenPersist(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const identity = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(identity, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("precondition: breaker should be open")
+	}
+
+	store := &blockingOpenMetadataBatchStore{
+		Store:   beads.NewMemStore(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		cleared: make(chan struct{}),
+	}
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	persistErr := make(chan error, 1)
+	go func() {
+		persistErr <- persistSessionCircuitBreakerMetadata(store, &session, cb, identity, t0.Add(6*time.Minute))
+	}()
+
+	select {
+	case <-store.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("persist did not reach blocked OPEN metadata write")
+	}
+
+	resetErr := make(chan error, 1)
+	go func() {
+		resetErr <- resetSessionCircuitBreakerState(store, session.ID, identity, cb)
+	}()
+
+	select {
+	case <-store.cleared:
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(store.release)
+	if err := <-persistErr; err != nil {
+		t.Fatalf("persistSessionCircuitBreakerMetadata: %v", err)
+	}
+	if err := <-resetErr; err != nil {
+		t.Fatalf("resetSessionCircuitBreakerState: %v", err)
+	}
+	if cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("breaker should be closed after racing persist and reset")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	assertSessionCircuitStateMetadataCleared(t, updated.Metadata)
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got != "2" {
+		t.Fatalf("%s = %q, want 2 after racing persist", sessionCircuitResetGenerationMetadata, got)
+	}
+}
+
+func TestResetSessionCircuitBreakerStateRestoresOpenStateOnMetadataClearFailure(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const identity = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(identity, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("precondition: breaker should be open")
+	}
+
+	store := &failingClearMetadataStore{Store: beads.NewMemStore()}
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata:           identity,
+			sessionCircuitStateMetadata:            circuitOpen.String(),
+			sessionCircuitRestartsMetadata:         `["2026-04-01T12:00:00Z"]`,
+			sessionCircuitLastRestartMetadata:      t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenedAtMetadata:         t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenRestartCountMetadata: "6",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	err = resetSessionCircuitBreakerState(store, session.ID, identity, cb)
+	if err == nil {
+		t.Fatal("resetSessionCircuitBreakerState: expected clear failure")
+	}
+	if !strings.Contains(err.Error(), "injected clear failure") {
+		t.Fatalf("resetSessionCircuitBreakerState error = %v, want injected failure", err)
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("breaker should remain open after failed durable clear")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != circuitOpen.String() {
+		t.Fatalf("%s = %q, want %q", sessionCircuitStateMetadata, got, circuitOpen.String())
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got != "" {
+		t.Fatalf("%s = %q, want unchanged", sessionCircuitResetGenerationMetadata, got)
+	}
+}
+
+func TestResetSessionCircuitBreakerStateRestoresOpenStateOnRacingSecondClearFailure(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const identity = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(identity, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("precondition: breaker should be open")
+	}
+
+	store := &failingNthClearMetadataStore{Store: beads.NewMemStore(), failOn: 2}
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata:           identity,
+			sessionCircuitStateMetadata:            circuitOpen.String(),
+			sessionCircuitRestartsMetadata:         `["2026-04-01T12:00:00Z"]`,
+			sessionCircuitLastRestartMetadata:      t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenedAtMetadata:         t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenRestartCountMetadata: "6",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	err = resetSessionCircuitBreakerState(store, session.ID, identity, cb)
+	if err == nil {
+		t.Fatal("resetSessionCircuitBreakerState: expected racing clear failure")
+	}
+	if !strings.Contains(err.Error(), "injected clear failure") {
+		t.Fatalf("resetSessionCircuitBreakerState error = %v, want injected failure", err)
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("breaker should remain open after failed racing clear")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != "" {
+		t.Fatalf("%s = %q, want cleared durable metadata", sessionCircuitStateMetadata, got)
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got != "1" {
+		t.Fatalf("%s = %q, want first reset generation preserved", sessionCircuitResetGenerationMetadata, got)
+	}
+}
+
+func TestResetSessionCircuitBreakerStateRejectsStaleRestoreSnapshot(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const identity = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(identity, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(identity, t0.Add(6*time.Minute)) {
+		t.Fatal("precondition: breaker should be open")
+	}
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata:           identity,
+			sessionCircuitStateMetadata:            circuitOpen.String(),
+			sessionCircuitRestartsMetadata:         `["2026-04-01T12:00:00Z"]`,
+			sessionCircuitLastRestartMetadata:      t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenedAtMetadata:         t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenRestartCountMetadata: "6",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	staleSnapshot := make(map[string]string, len(session.Metadata))
+	for k, v := range session.Metadata {
+		staleSnapshot[k] = v
+	}
+
+	if err := resetSessionCircuitBreakerState(store, session.ID, identity, cb); err != nil {
+		t.Fatalf("resetSessionCircuitBreakerState: %v", err)
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got != "2" {
+		t.Fatalf("%s = %q, want 2", sessionCircuitResetGenerationMetadata, got)
+	}
+	if reset, err := cb.restoreFromMetadata(identity, staleSnapshot, t0.Add(7*time.Minute)); err != nil || reset {
+		t.Fatalf("restoreFromMetadata stale reset=%v err=%v", reset, err)
+	}
+	if cb.IsOpen(identity, t0.Add(7*time.Minute)) {
+		t.Fatal("stale pre-reset metadata should not reopen breaker after reset")
+	}
+}
+
+func TestResetSessionCircuitBreakerStateRejectsHigherGenerationStaleRestoreSnapshot(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const identity = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata:           identity,
+			sessionCircuitStateMetadata:            circuitOpen.String(),
+			sessionCircuitRestartsMetadata:         `["2026-04-01T12:00:00Z"]`,
+			sessionCircuitLastRestartMetadata:      t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenedAtMetadata:         t0.Format(time.RFC3339Nano),
+			sessionCircuitOpenRestartCountMetadata: "6",
+			sessionCircuitResetGenerationMetadata:  "3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	staleSnapshot := make(map[string]string, len(session.Metadata))
+	for k, v := range session.Metadata {
+		staleSnapshot[k] = v
+	}
+
+	if err := resetSessionCircuitBreakerState(store, session.ID, identity, cb); err != nil {
+		t.Fatalf("resetSessionCircuitBreakerState: %v", err)
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got != "5" {
+		t.Fatalf("%s = %q, want 5", sessionCircuitResetGenerationMetadata, got)
+	}
+	if reset, err := cb.restoreFromMetadata(identity, staleSnapshot, t0.Add(7*time.Minute)); err != nil || reset {
+		t.Fatalf("restoreFromMetadata stale reset=%v err=%v", reset, err)
+	}
+	if cb.IsOpen(identity, t0.Add(7*time.Minute)) {
+		t.Fatal("higher-generation stale pre-reset metadata should not reopen breaker after reset")
+	}
+}
+
+type metadataCallbackStore struct {
+	beads.Store
+	beforeBatch func()
+}
+
+func (s *metadataCallbackStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if s.beforeBatch != nil {
+		s.beforeBatch()
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+type blockingOpenMetadataBatchStore struct {
+	beads.Store
+	entered chan struct{}
+	release chan struct{}
+	cleared chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingOpenMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if kvs[sessionCircuitStateMetadata] == circuitOpen.String() {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	if sessionCircuitStateMetadataAllCleared(kvs) {
+		select {
+		case <-s.cleared:
+		default:
+			close(s.cleared)
+		}
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+type failingClearMetadataStore struct {
+	beads.Store
+}
+
+func (s *failingClearMetadataStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if sessionCircuitStateMetadataAllCleared(kvs) {
+		return errors.New("injected clear failure")
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+type failingNthClearMetadataStore struct {
+	beads.Store
+	failOn int
+	calls  int
+}
+
+func (s *failingNthClearMetadataStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if sessionCircuitStateMetadataAllCleared(kvs) {
+		s.calls++
+		if s.calls == s.failOn {
+			return errors.New("injected clear failure")
+		}
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+func assertSessionCircuitStateMetadataCleared(t *testing.T, kvs map[string]string) {
+	t.Helper()
+	for _, key := range sessionCircuitMetadataKeys {
+		if key == sessionCircuitResetGenerationMetadata {
+			continue
+		}
+		if kvs[key] != "" {
+			t.Fatalf("%s = %q, want cleared", key, kvs[key])
+		}
+	}
+}
+
+func sessionCircuitStateMetadataAllCleared(kvs map[string]string) bool {
+	for _, key := range sessionCircuitMetadataKeys {
+		if key == sessionCircuitResetGenerationMetadata {
+			continue
+		}
+		if kvs[key] != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func readSessionCircuitResetSocketReply(t *testing.T, conn net.Conn) sessionCircuitResetReply {
+	t.Helper()
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			t.Fatalf("read reply: %v", err)
+		}
+		t.Fatal("read reply: connection closed")
+	}
+	var reply sessionCircuitResetReply
+	if err := json.Unmarshal(scanner.Bytes(), &reply); err != nil {
+		t.Fatalf("decode reply: %v", err)
+	}
+	return reply
 }
 
 func TestControllerReloadInvalidConfig(t *testing.T) {

--- a/cmd/gc/session_circuit_breaker.go
+++ b/cmd/gc/session_circuit_breaker.go
@@ -1,0 +1,449 @@
+// session_circuit_breaker.go implements a respawn circuit breaker for named
+// sessions. The supervisor reconciler will otherwise restart a named session
+// indefinitely with zero awareness of loop conditions. When a named session
+// is stuck in a respawn loop with no observable progress, this breaker trips
+// and blocks further respawn attempts until an operator intervenes (or the
+// automatic silence-based reset fires).
+//
+// Background: in one production incident the "mayor" named session kept being
+// auto-respawned because it was assigned to beads it could never actually
+// reach. Each respawn produced heavy dolt writes, starving btrfs I/O for
+// hours. The breaker here is the minimal infrastructure to interrupt such a
+// loop. See also the instructions logged in the ERROR path below for the
+// manual reset knob.
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// sessionCircuitBreakerConfig controls the breaker thresholds. Zero values
+// fall back to package defaults so callers can construct with only the
+// fields they want to override.
+type sessionCircuitBreakerConfig struct {
+	// Window is the rolling window over which restart timestamps are
+	// counted. Default: 30 minutes.
+	Window time.Duration
+	// MaxRestarts is the number of restarts allowed within Window before
+	// the breaker considers tripping. Default: 5.
+	MaxRestarts int
+	// ResetAfter is the idle interval after which an OPEN breaker
+	// automatically resets back to CLOSED. Default: 2 * Window.
+	ResetAfter time.Duration
+}
+
+const (
+	defaultCircuitBreakerWindow      = 30 * time.Minute
+	defaultCircuitBreakerMaxRestarts = 5
+)
+
+func (c sessionCircuitBreakerConfig) withDefaults() sessionCircuitBreakerConfig {
+	if c.Window <= 0 {
+		c.Window = defaultCircuitBreakerWindow
+	}
+	if c.MaxRestarts <= 0 {
+		c.MaxRestarts = defaultCircuitBreakerMaxRestarts
+	}
+	if c.ResetAfter <= 0 {
+		c.ResetAfter = 2 * c.Window
+	}
+	return c
+}
+
+// circuitBreakerStateKind is the logical state of a single identity's
+// breaker entry. CLOSED is the normal case (respawns allowed). OPEN means
+// the supervisor MUST NOT materialize or spawn this session.
+type circuitBreakerStateKind int
+
+const (
+	circuitClosed circuitBreakerStateKind = iota
+	circuitOpen
+)
+
+func (k circuitBreakerStateKind) String() string {
+	switch k {
+	case circuitOpen:
+		return "CIRCUIT_OPEN"
+	default:
+		return "CIRCUIT_CLOSED"
+	}
+}
+
+// circuitBreakerEntry is the in-memory state tracked for a single named
+// session identity. All fields are owned by the parent breaker and are only
+// read/written with the breaker's mutex held.
+type circuitBreakerEntry struct {
+	restarts       []time.Time // timestamps within the rolling window
+	lastRestart    time.Time
+	lastProgress   time.Time
+	progressSig    string // last observed assigned-bead status signature
+	state          circuitBreakerStateKind
+	openedAt       time.Time
+	openRestartCnt int // snapshot of restart count at the moment the breaker opened
+	loggedOpenOnce bool
+}
+
+// CircuitBreakerSnapshot is a point-in-time view of a single identity's
+// breaker state. Exposed to the status hook so operators can see who is
+// tripped without reaching into breaker internals.
+type CircuitBreakerSnapshot struct {
+	Identity     string    `json:"identity"`
+	State        string    `json:"state"`
+	RestartCount int       `json:"restart_count"`
+	WindowStart  time.Time `json:"window_start,omitempty"`
+	LastRestart  time.Time `json:"last_restart,omitempty"`
+	LastProgress time.Time `json:"last_progress,omitempty"`
+	OpenedAt     time.Time `json:"opened_at,omitempty"`
+	ResetAfter   time.Time `json:"reset_after,omitempty"`
+}
+
+// sessionCircuitBreaker tracks restart attempts for named sessions and
+// enforces a rolling-window circuit-breaker policy. It is safe for
+// concurrent use by multiple reconciler ticks.
+type sessionCircuitBreaker struct {
+	cfg     sessionCircuitBreakerConfig
+	mu      sync.Mutex
+	entries map[string]*circuitBreakerEntry
+}
+
+// newSessionCircuitBreaker constructs a breaker with the given config.
+// Zero-valued config fields fall back to defaults.
+func newSessionCircuitBreaker(cfg sessionCircuitBreakerConfig) *sessionCircuitBreaker {
+	return &sessionCircuitBreaker{
+		cfg:     cfg.withDefaults(),
+		entries: make(map[string]*circuitBreakerEntry),
+	}
+}
+
+// trimLocked discards restart timestamps older than the rolling window. The
+// caller must hold b.mu.
+func (b *sessionCircuitBreaker) trimLocked(e *circuitBreakerEntry, now time.Time) {
+	cutoff := now.Add(-b.cfg.Window)
+	i := 0
+	for ; i < len(e.restarts); i++ {
+		if !e.restarts[i].Before(cutoff) {
+			break
+		}
+	}
+	if i > 0 {
+		e.restarts = append(e.restarts[:0], e.restarts[i:]...)
+	}
+}
+
+// maybeAutoResetLocked resets an OPEN entry to CLOSED when no restart has
+// been observed for ResetAfter. The caller must hold b.mu.
+func (b *sessionCircuitBreaker) maybeAutoResetLocked(e *circuitBreakerEntry, now time.Time) {
+	if e.state != circuitOpen {
+		return
+	}
+	// Silence since the last restart attempt. If the supervisor has not
+	// even tried to respawn the identity for ResetAfter, we assume the
+	// operator (or upstream demand) has cleared whatever caused the loop.
+	if e.lastRestart.IsZero() {
+		return
+	}
+	if now.Sub(e.lastRestart) >= b.cfg.ResetAfter {
+		e.state = circuitClosed
+		e.restarts = nil
+		e.openedAt = time.Time{}
+		e.openRestartCnt = 0
+		e.loggedOpenOnce = false
+	}
+}
+
+// RecordRestart records a restart attempt for the given identity at time
+// `now`. If the rolling-window restart count exceeds the configured max AND
+// there is no progress signal inside the window, the entry transitions to
+// CIRCUIT_OPEN. Returns the post-record state kind.
+func (b *sessionCircuitBreaker) RecordRestart(identity string, now time.Time) circuitBreakerStateKind {
+	if identity == "" {
+		return circuitClosed
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e := b.entries[identity]
+	if e == nil {
+		e = &circuitBreakerEntry{}
+		b.entries[identity] = e
+	}
+	b.maybeAutoResetLocked(e, now)
+	e.restarts = append(e.restarts, now)
+	e.lastRestart = now
+	b.trimLocked(e, now)
+
+	if e.state == circuitOpen {
+		return e.state
+	}
+	if len(e.restarts) > b.cfg.MaxRestarts {
+		// No progress signal inside the window = trip the breaker. A
+		// progress event that landed inside the window keeps us CLOSED.
+		if !progressWithinWindow(e, now, b.cfg.Window) {
+			e.state = circuitOpen
+			e.openedAt = now
+			e.openRestartCnt = len(e.restarts)
+		}
+	}
+	return e.state
+}
+
+// RecordProgress records an observable progress signal (a bead state
+// transition attributable to the identity) at time `now`. Progress events
+// do NOT clear an already-OPEN breaker — only automatic reset or the manual
+// reset knob can do that — but they do keep a CLOSED breaker from tripping
+// even if restarts accumulate.
+func (b *sessionCircuitBreaker) RecordProgress(identity string, now time.Time) {
+	if identity == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e := b.entries[identity]
+	if e == nil {
+		e = &circuitBreakerEntry{}
+		b.entries[identity] = e
+	}
+	e.lastProgress = now
+}
+
+// ObserveProgressSignature records an arbitrary opaque signature
+// describing what the reconciler sees for `identity` (typically a digest of
+// its assigned beads' statuses). If the signature has changed since the
+// last observation, that counts as a progress event. The first observation
+// is NOT counted as progress (there is nothing to compare against yet);
+// the reconciler's very first tick after process start should not magically
+// reset a breaker that is already OPEN.
+func (b *sessionCircuitBreaker) ObserveProgressSignature(identity, sig string, now time.Time) {
+	if identity == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e := b.entries[identity]
+	if e == nil {
+		e = &circuitBreakerEntry{progressSig: sig}
+		b.entries[identity] = e
+		return
+	}
+	if e.progressSig == "" {
+		e.progressSig = sig
+		return
+	}
+	if e.progressSig != sig {
+		e.progressSig = sig
+		e.lastProgress = now
+	}
+}
+
+// IsOpen returns true if the breaker for `identity` is currently OPEN and
+// the reconciler MUST NOT materialize or spawn the session. The call may
+// transition the entry to CLOSED if the auto-reset window has elapsed.
+func (b *sessionCircuitBreaker) IsOpen(identity string, now time.Time) bool {
+	if identity == "" {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e := b.entries[identity]
+	if e == nil {
+		return false
+	}
+	b.maybeAutoResetLocked(e, now)
+	return e.state == circuitOpen
+}
+
+// LogOpenOnce writes a loud ERROR-level message the first time a given
+// OPEN breaker is observed during respawn suppression. The message tells
+// operators exactly how to clear the state. Subsequent calls for the same
+// OPEN incident are suppressed to avoid log floods (the supervisor may
+// re-check the breaker on every tick).
+func (b *sessionCircuitBreaker) LogOpenOnce(identity string, w io.Writer) {
+	if identity == "" || w == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	e := b.entries[identity]
+	if e == nil || e.state != circuitOpen || e.loggedOpenOnce {
+		return
+	}
+	e.loggedOpenOnce = true
+	fmt.Fprintf(w, //nolint:errcheck // best-effort stderr
+		"ERROR session-circuit-breaker: CIRCUIT_OPEN for named session %q (restarts=%d in last %s, no progress). "+
+			"Supervisor will NOT respawn. Run `gc session reset %s` to clear.\n",
+		identity, e.openRestartCnt, b.cfg.Window, identity)
+}
+
+// Reset forces the entry for `identity` back to CLOSED and discards any
+// accumulated restart history. This is invoked from the `gc session reset`
+// CLI (cmd_session_reset.go) when an operator clears a tripped breaker.
+// Calling Reset on an unknown identity is a no-op.
+func (b *sessionCircuitBreaker) Reset(identity string) {
+	if identity == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.entries, identity)
+}
+
+// Snapshot returns a stable-ordered point-in-time view of all tracked
+// identities. Used by status output and by tests.
+func (b *sessionCircuitBreaker) Snapshot(now time.Time) []CircuitBreakerSnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]CircuitBreakerSnapshot, 0, len(b.entries))
+	for id, e := range b.entries {
+		b.maybeAutoResetLocked(e, now)
+		snap := CircuitBreakerSnapshot{
+			Identity:     id,
+			State:        e.state.String(),
+			RestartCount: len(e.restarts),
+			LastRestart:  e.lastRestart,
+			LastProgress: e.lastProgress,
+		}
+		if len(e.restarts) > 0 {
+			snap.WindowStart = e.restarts[0]
+		}
+		if e.state == circuitOpen {
+			snap.OpenedAt = e.openedAt
+			if !e.lastRestart.IsZero() {
+				snap.ResetAfter = e.lastRestart.Add(b.cfg.ResetAfter)
+			}
+		}
+		out = append(out, snap)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Identity < out[j].Identity })
+	return out
+}
+
+// progressWithinWindow reports whether a progress event is recent enough
+// to keep the breaker CLOSED. "Recent enough" means "no earlier than the
+// start of the current restart rolling window", which is `now - window`.
+func progressWithinWindow(e *circuitBreakerEntry, now time.Time, window time.Duration) bool {
+	if e.lastProgress.IsZero() {
+		return false
+	}
+	return !e.lastProgress.Before(now.Add(-window))
+}
+
+// -----------------------------------------------------------------------------
+// Package-level singleton used by the reconciler. Kept as an indirection so
+// tests can swap it out without threading a new parameter through every
+// reconcileSessionBeads call site.
+// -----------------------------------------------------------------------------
+
+var (
+	sessionCircuitBreakerMu        sync.Mutex
+	sessionCircuitBreakerSingleton *sessionCircuitBreaker
+)
+
+// defaultSessionCircuitBreaker returns the process-wide breaker, lazily
+// constructing it with defaults on first use.
+func defaultSessionCircuitBreaker() *sessionCircuitBreaker {
+	sessionCircuitBreakerMu.Lock()
+	defer sessionCircuitBreakerMu.Unlock()
+	if sessionCircuitBreakerSingleton == nil {
+		sessionCircuitBreakerSingleton = newSessionCircuitBreaker(sessionCircuitBreakerConfig{})
+	}
+	return sessionCircuitBreakerSingleton
+}
+
+// setSessionCircuitBreakerForTest swaps the singleton, returning a cleanup
+// function that restores the previous value. Tests call this to inject a
+// fake-clocked breaker without touching production wiring.
+func setSessionCircuitBreakerForTest(b *sessionCircuitBreaker) func() {
+	sessionCircuitBreakerMu.Lock()
+	prev := sessionCircuitBreakerSingleton
+	sessionCircuitBreakerSingleton = b
+	sessionCircuitBreakerMu.Unlock()
+	return func() {
+		sessionCircuitBreakerMu.Lock()
+		sessionCircuitBreakerSingleton = prev
+		sessionCircuitBreakerMu.Unlock()
+	}
+}
+
+// computeNamedSessionProgressSignatures returns a signature per named
+// session identity derived from the identities of its assigned work beads
+// and their statuses. A signature change between reconciler ticks means a
+// bead changed status (open -> in_progress, in_progress -> closed, a new
+// bead was routed, an old one dropped, etc.), which is treated as a
+// progress signal by the circuit breaker.
+//
+// Assignee on a work bead may be a bead ID, a session name, or an alias;
+// we resolve to the named-session identity via session bead metadata the
+// same way the rest of the reconciler does.
+func computeNamedSessionProgressSignatures(
+	sessionBeads []beads.Bead,
+	assignedWorkBeads []beads.Bead,
+) map[string]string {
+	if len(sessionBeads) == 0 {
+		return nil
+	}
+	// Build: resolver key -> identity. An identity is only relevant to the
+	// breaker if it belongs to a configured named session (i.e., the
+	// session bead carries the configured_named_identity metadata).
+	resolve := make(map[string]string, len(sessionBeads)*3)
+	knownIdentities := make(map[string]bool)
+	for _, sb := range sessionBeads {
+		identity := strings.TrimSpace(sb.Metadata[namedSessionIdentityMetadata])
+		if identity == "" {
+			continue
+		}
+		knownIdentities[identity] = true
+		resolve[identity] = identity
+		if id := strings.TrimSpace(sb.ID); id != "" {
+			resolve[id] = identity
+		}
+		if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" {
+			resolve[sn] = identity
+		}
+		if alias := strings.TrimSpace(sb.Metadata["alias"]); alias != "" {
+			resolve[alias] = identity
+		}
+	}
+	if len(knownIdentities) == 0 {
+		return nil
+	}
+
+	// Gather per-identity (beadID, status) pairs.
+	perIdentity := make(map[string][]string, len(knownIdentities))
+	for _, wb := range assignedWorkBeads {
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		identity, ok := resolve[assignee]
+		if !ok {
+			continue
+		}
+		perIdentity[identity] = append(perIdentity[identity],
+			wb.ID+"="+wb.Status)
+	}
+
+	out := make(map[string]string, len(knownIdentities))
+	for identity := range knownIdentities {
+		pairs := perIdentity[identity]
+		sort.Strings(pairs)
+		h := sha1.Sum([]byte(strings.Join(pairs, "|")))
+		out[identity] = hex.EncodeToString(h[:])
+	}
+	return out
+}
+
+// SessionCircuitBreakerSnapshot is the exported status hook: it returns the
+// current breaker state for all tracked named-session identities. The
+// "gc status" command and any future dashboard can call this to surface
+// tripped breakers without reaching into package internals.
+func SessionCircuitBreakerSnapshot(now time.Time) []CircuitBreakerSnapshot {
+	return defaultSessionCircuitBreaker().Snapshot(now)
+}

--- a/cmd/gc/session_circuit_breaker.go
+++ b/cmd/gc/session_circuit_breaker.go
@@ -3,27 +3,25 @@
 // indefinitely with zero awareness of loop conditions. When a named session
 // is stuck in a respawn loop with no observable progress, this breaker trips
 // and blocks further respawn attempts until an operator intervenes (or the
-// automatic silence-based reset fires).
-//
-// Background: in one production incident the "mayor" named session kept being
-// auto-respawned because it was assigned to beads it could never actually
-// reach. Each respawn produced heavy dolt writes, starving btrfs I/O for
-// hours. The breaker here is the minimal infrastructure to interrupt such a
-// loop. See also the instructions logged in the ERROR path below for the
-// manual reset knob.
+// automatic cooldown reset fires). The breaker here is the minimal
+// infrastructure to interrupt repeated no-progress respawn loops. See also the
+// instructions logged in the ERROR path below for the manual reset knob.
 package main
 
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // sessionCircuitBreakerConfig controls the breaker thresholds. Zero values
@@ -36,7 +34,7 @@ type sessionCircuitBreakerConfig struct {
 	// MaxRestarts is the number of restarts allowed within Window before
 	// the breaker considers tripping. Default: 5.
 	MaxRestarts int
-	// ResetAfter is the idle interval after which an OPEN breaker
+	// ResetAfter is the cooldown interval after which an OPEN breaker
 	// automatically resets back to CLOSED. Default: 2 * Window.
 	ResetAfter time.Duration
 }
@@ -45,6 +43,30 @@ const (
 	defaultCircuitBreakerWindow      = 30 * time.Minute
 	defaultCircuitBreakerMaxRestarts = 5
 )
+
+const (
+	sessionCircuitStateMetadata             = "session_circuit_state"
+	sessionCircuitRestartsMetadata          = "session_circuit_restarts"
+	sessionCircuitLastRestartMetadata       = "session_circuit_last_restart"
+	sessionCircuitLastProgressMetadata      = "session_circuit_last_progress"
+	sessionCircuitLastObservedMetadata      = "session_circuit_last_observed"
+	sessionCircuitProgressSignatureMetadata = "session_circuit_progress_signature"
+	sessionCircuitOpenedAtMetadata          = "session_circuit_opened_at"
+	sessionCircuitOpenRestartCountMetadata  = "session_circuit_open_restart_count"
+	sessionCircuitResetGenerationMetadata   = "session_circuit_reset_generation"
+)
+
+var sessionCircuitMetadataKeys = []string{
+	sessionCircuitStateMetadata,
+	sessionCircuitRestartsMetadata,
+	sessionCircuitLastRestartMetadata,
+	sessionCircuitLastProgressMetadata,
+	sessionCircuitLastObservedMetadata,
+	sessionCircuitProgressSignatureMetadata,
+	sessionCircuitOpenedAtMetadata,
+	sessionCircuitOpenRestartCountMetadata,
+	sessionCircuitResetGenerationMetadata,
+}
 
 func (c sessionCircuitBreakerConfig) withDefaults() sessionCircuitBreakerConfig {
 	if c.Window <= 0 {
@@ -57,6 +79,22 @@ func (c sessionCircuitBreakerConfig) withDefaults() sessionCircuitBreakerConfig 
 		c.ResetAfter = 2 * c.Window
 	}
 	return c
+}
+
+func sessionCircuitBreakerConfigFromCity(cfg *config.City) (sessionCircuitBreakerConfig, bool) {
+	if cfg == nil || !cfg.Daemon.SessionCircuitBreaker {
+		return sessionCircuitBreakerConfig{}, false
+	}
+	maxRestarts := cfg.Daemon.SessionCircuitBreakerMaxRestartsOrDefault()
+	if maxRestarts <= 0 {
+		return sessionCircuitBreakerConfig{}, false
+	}
+	cbCfg := sessionCircuitBreakerConfig{
+		Window:      cfg.Daemon.SessionCircuitBreakerWindowDuration(),
+		MaxRestarts: maxRestarts,
+		ResetAfter:  cfg.Daemon.SessionCircuitBreakerResetAfterDuration(),
+	}
+	return cbCfg.withDefaults(), true
 }
 
 // circuitBreakerStateKind is the logical state of a single identity's
@@ -85,7 +123,9 @@ type circuitBreakerEntry struct {
 	restarts       []time.Time // timestamps within the rolling window
 	lastRestart    time.Time
 	lastProgress   time.Time
+	lastObserved   time.Time
 	progressSig    string // last observed assigned-bead status signature
+	observedSig    bool
 	state          circuitBreakerStateKind
 	openedAt       time.Time
 	openRestartCnt int // snapshot of restart count at the moment the breaker opened
@@ -96,32 +136,48 @@ type circuitBreakerEntry struct {
 // breaker state. Exposed to the status hook so operators can see who is
 // tripped without reaching into breaker internals.
 type CircuitBreakerSnapshot struct {
-	Identity     string    `json:"identity"`
-	State        string    `json:"state"`
-	RestartCount int       `json:"restart_count"`
-	WindowStart  time.Time `json:"window_start,omitempty"`
-	LastRestart  time.Time `json:"last_restart,omitempty"`
-	LastProgress time.Time `json:"last_progress,omitempty"`
-	OpenedAt     time.Time `json:"opened_at,omitempty"`
-	ResetAfter   time.Time `json:"reset_after,omitempty"`
+	Identity         string    `json:"identity"`
+	State            string    `json:"state"`
+	RestartCount     int       `json:"restart_count"`
+	OpenRestartCount int       `json:"open_restart_count,omitempty"`
+	WindowStart      time.Time `json:"window_start,omitempty"`
+	LastRestart      time.Time `json:"last_restart,omitempty"`
+	LastProgress     time.Time `json:"last_progress,omitempty"`
+	OpenedAt         time.Time `json:"opened_at,omitempty"`
+	ResetAfter       time.Time `json:"reset_after,omitempty"`
 }
 
 // sessionCircuitBreaker tracks restart attempts for named sessions and
 // enforces a rolling-window circuit-breaker policy. It is safe for
 // concurrent use by multiple reconciler ticks.
 type sessionCircuitBreaker struct {
-	cfg     sessionCircuitBreakerConfig
-	mu      sync.Mutex
-	entries map[string]*circuitBreakerEntry
+	cfg              sessionCircuitBreakerConfig
+	mu               sync.Mutex
+	entries          map[string]*circuitBreakerEntry
+	resetGenerations map[string]uint64
+}
+
+type sessionCircuitBreakerIdentitySnapshot struct {
+	entry         *circuitBreakerEntry
+	hadEntry      bool
+	generation    uint64
+	hadGeneration bool
 }
 
 // newSessionCircuitBreaker constructs a breaker with the given config.
 // Zero-valued config fields fall back to defaults.
 func newSessionCircuitBreaker(cfg sessionCircuitBreakerConfig) *sessionCircuitBreaker {
 	return &sessionCircuitBreaker{
-		cfg:     cfg.withDefaults(),
-		entries: make(map[string]*circuitBreakerEntry),
+		cfg:              cfg.withDefaults(),
+		entries:          make(map[string]*circuitBreakerEntry),
+		resetGenerations: make(map[string]uint64),
 	}
+}
+
+func (b *sessionCircuitBreaker) configure(cfg sessionCircuitBreakerConfig) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.cfg = cfg.withDefaults()
 }
 
 // trimLocked discards restart timestamps older than the rolling window. The
@@ -139,26 +195,31 @@ func (b *sessionCircuitBreaker) trimLocked(e *circuitBreakerEntry, now time.Time
 	}
 }
 
-// maybeAutoResetLocked resets an OPEN entry to CLOSED when no restart has
-// been observed for ResetAfter. The caller must hold b.mu.
-func (b *sessionCircuitBreaker) maybeAutoResetLocked(e *circuitBreakerEntry, now time.Time) {
+// maybeAutoResetLocked resets an OPEN entry to CLOSED after its wall-clock
+// cooldown expires. While OPEN, the supervisor may keep ticking, but respawn
+// attempts are blocked before RecordRestart, so this is not a silence detector.
+// The caller must hold b.mu.
+func (b *sessionCircuitBreaker) maybeAutoResetLocked(e *circuitBreakerEntry, now time.Time) bool {
 	if e.state != circuitOpen {
-		return
+		return false
 	}
-	// Silence since the last restart attempt. If the supervisor has not
-	// even tried to respawn the identity for ResetAfter, we assume the
-	// operator (or upstream demand) has cleared whatever caused the loop.
 	if e.lastRestart.IsZero() {
-		return
+		return false
 	}
 	if now.Sub(e.lastRestart) >= b.cfg.ResetAfter {
 		e.state = circuitClosed
 		e.restarts = nil
+		e.lastRestart = time.Time{}
+		e.lastProgress = time.Time{}
 		e.openedAt = time.Time{}
 		e.openRestartCnt = 0
 		e.loggedOpenOnce = false
+		e.lastObserved = time.Time{}
 		e.progressSig = ""
+		e.observedSig = false
+		return true
 	}
+	return false
 }
 
 // RecordRestart records a restart attempt for the given identity at time
@@ -171,19 +232,23 @@ func (b *sessionCircuitBreaker) RecordRestart(identity string, now time.Time) ci
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.recordRestartLocked(identity, now)
+}
+
+func (b *sessionCircuitBreaker) recordRestartLocked(identity string, now time.Time) circuitBreakerStateKind {
 	e := b.entries[identity]
 	if e == nil {
 		e = &circuitBreakerEntry{}
 		b.entries[identity] = e
 	}
 	b.maybeAutoResetLocked(e, now)
+	if e.state == circuitOpen {
+		return e.state
+	}
 	e.restarts = append(e.restarts, now)
 	e.lastRestart = now
 	b.trimLocked(e, now)
 
-	if e.state == circuitOpen {
-		return e.state
-	}
 	if len(e.restarts) > b.cfg.MaxRestarts {
 		// No progress signal inside the window = trip the breaker. A
 		// progress event that landed inside the window keeps us CLOSED.
@@ -222,31 +287,173 @@ func (b *sessionCircuitBreaker) RecordProgress(identity string, now time.Time) {
 // is NOT counted as progress (there is nothing to compare against yet);
 // the reconciler's very first tick after process start should not magically
 // reset a breaker that is already OPEN.
-func (b *sessionCircuitBreaker) ObserveProgressSignature(identity, sig string, now time.Time) {
+func (b *sessionCircuitBreaker) ObserveProgressSignature(identity, sig string, now time.Time) bool {
 	if identity == "" {
-		return
+		return false
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	e := b.entries[identity]
 	if e == nil {
-		e = &circuitBreakerEntry{progressSig: sig}
+		if sig == "" {
+			return false
+		}
+		e = &circuitBreakerEntry{progressSig: sig, observedSig: true, lastObserved: now}
 		b.entries[identity] = e
-		return
+		return true
 	}
-	if e.progressSig == "" {
+	e.lastObserved = now
+	if !e.observedSig {
 		e.progressSig = sig
-		return
+		e.observedSig = true
+		return true
 	}
 	if e.progressSig != sig {
 		e.progressSig = sig
 		e.lastProgress = now
+		return true
+	}
+	return false
+}
+
+func (b *sessionCircuitBreaker) restoreFromMetadata(identity string, meta map[string]string, now time.Time) (bool, error) {
+	if identity == "" || len(meta) == 0 {
+		return false, nil
+	}
+	if !hasSessionCircuitMetadata(meta) {
+		return false, nil
+	}
+	resetGeneration, err := parseCircuitResetGeneration(meta[sessionCircuitResetGenerationMetadata])
+	if err != nil {
+		return false, err
+	}
+
+	e := &circuitBreakerEntry{
+		progressSig: meta[sessionCircuitProgressSignatureMetadata],
+	}
+	if e.restarts, err = parseCircuitTimeList(meta[sessionCircuitRestartsMetadata]); err != nil {
+		return false, fmt.Errorf("parsing %s: %w", sessionCircuitRestartsMetadata, err)
+	}
+	if e.lastRestart, err = parseCircuitTime(meta[sessionCircuitLastRestartMetadata]); err != nil {
+		return false, fmt.Errorf("parsing %s: %w", sessionCircuitLastRestartMetadata, err)
+	}
+	if e.lastProgress, err = parseCircuitTime(meta[sessionCircuitLastProgressMetadata]); err != nil {
+		return false, fmt.Errorf("parsing %s: %w", sessionCircuitLastProgressMetadata, err)
+	}
+	if e.lastObserved, err = parseCircuitTime(meta[sessionCircuitLastObservedMetadata]); err != nil {
+		return false, fmt.Errorf("parsing %s: %w", sessionCircuitLastObservedMetadata, err)
+	}
+	if e.openedAt, err = parseCircuitTime(meta[sessionCircuitOpenedAtMetadata]); err != nil {
+		return false, fmt.Errorf("parsing %s: %w", sessionCircuitOpenedAtMetadata, err)
+	}
+	if s := strings.TrimSpace(meta[sessionCircuitOpenRestartCountMetadata]); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return false, fmt.Errorf("parsing %s: %w", sessionCircuitOpenRestartCountMetadata, err)
+		}
+		e.openRestartCnt = n
+	}
+	e.observedSig = !e.lastObserved.IsZero() || strings.TrimSpace(e.progressSig) != ""
+	switch meta[sessionCircuitStateMetadata] {
+	case circuitOpen.String():
+		e.state = circuitOpen
+	case "", circuitClosed.String():
+		e.state = circuitClosed
+	default:
+		return false, fmt.Errorf("parsing %s: unknown state %q", sessionCircuitStateMetadata, meta[sessionCircuitStateMetadata])
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	currentGeneration := b.resetGenerationLocked(identity)
+	if resetGeneration < currentGeneration {
+		return false, nil
+	}
+	if b.entries[identity] != nil {
+		return false, nil
+	}
+	reset := b.maybeAutoResetLocked(e, now)
+	b.trimLocked(e, now)
+	b.entries[identity] = e
+	return reset, nil
+}
+
+func hasSessionCircuitMetadata(meta map[string]string) bool {
+	for _, key := range sessionCircuitMetadataKeys {
+		if key == sessionCircuitResetGenerationMetadata {
+			continue
+		}
+		if strings.TrimSpace(meta[key]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCircuitResetGeneration(value string) (uint64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	generation, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %s: %w", sessionCircuitResetGenerationMetadata, err)
+	}
+	return generation, nil
+}
+
+func parseCircuitTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+func parseCircuitTimeList(value string) ([]time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	var raw []string
+	if err := json.Unmarshal([]byte(value), &raw); err != nil {
+		return nil, err
+	}
+	out := make([]time.Time, 0, len(raw))
+	for _, s := range raw {
+		tm, err := parseCircuitTime(s)
+		if err != nil {
+			return nil, err
+		}
+		if !tm.IsZero() {
+			out = append(out, tm)
+		}
+	}
+	return out, nil
+}
+
+// pruneIdle removes stale entries that were created only to remember progress
+// signatures for configured sessions that never restarted. It bounds map
+// growth when named-session configuration changes over a long-running
+// supervisor process.
+func (b *sessionCircuitBreaker) pruneIdle(now time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for id, e := range b.entries {
+		if e.state != circuitClosed || !e.lastRestart.IsZero() || e.lastObserved.IsZero() {
+			continue
+		}
+		if now.Sub(e.lastObserved) >= b.cfg.ResetAfter {
+			delete(b.entries, id)
+			// Keep resetGenerations: it is the stale-snapshot rejection floor
+			// for this identity if the named session is later configured again.
+		}
 	}
 }
 
 // IsOpen returns true if the breaker for `identity` is currently OPEN and
 // the reconciler MUST NOT materialize or spawn the session. The call may
-// transition the entry to CLOSED if the auto-reset window has elapsed.
+// transition the entry to CLOSED if the cooldown has elapsed.
 func (b *sessionCircuitBreaker) IsOpen(identity string, now time.Time) bool {
 	if identity == "" {
 		return false
@@ -283,17 +490,264 @@ func (b *sessionCircuitBreaker) LogOpenOnce(identity string, w io.Writer) {
 		identity, e.openRestartCnt, b.cfg.Window, identity)
 }
 
-// Reset forces the entry for `identity` back to CLOSED and discards any
-// accumulated restart history. This is invoked from the `gc session reset`
-// CLI (cmd_session_reset.go) when an operator clears a tripped breaker.
-// Calling Reset on an unknown identity is a no-op.
-func (b *sessionCircuitBreaker) Reset(identity string) {
+// Reset forces the entry for `identity` back to CLOSED, discards any
+// accumulated restart history, and advances the reset generation used to
+// reject stale reconciler metadata snapshots.
+func (b *sessionCircuitBreaker) Reset(identity string) uint64 {
 	if identity == "" {
-		return
+		return 0
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	delete(b.entries, identity)
+	b.resetGenerations[identity] = b.resetGenerationLocked(identity) + 1
+	return b.resetGenerations[identity]
+}
+
+func (b *sessionCircuitBreaker) observeResetGenerationFromMetadata(identity string, meta map[string]string) error {
+	if b == nil || identity == "" || len(meta) == 0 {
+		return nil
+	}
+	generation, err := parseCircuitResetGeneration(meta[sessionCircuitResetGenerationMetadata])
+	if err != nil {
+		return err
+	}
+	b.observeResetGeneration(identity, generation)
+	return nil
+}
+
+func (b *sessionCircuitBreaker) observeResetGeneration(identity string, generation uint64) {
+	if b == nil || identity == "" || generation == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if generation > b.resetGenerationLocked(identity) {
+		b.resetGenerations[identity] = generation
+	}
+}
+
+func (b *sessionCircuitBreaker) resetGenerationLocked(identity string) uint64 {
+	if b.resetGenerations == nil {
+		b.resetGenerations = make(map[string]uint64)
+	}
+	return b.resetGenerations[identity]
+}
+
+func (b *sessionCircuitBreaker) metadata(identity string, now time.Time) (map[string]string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.metadataLocked(identity, now)
+}
+
+func (b *sessionCircuitBreaker) metadataLocked(identity string, now time.Time) (map[string]string, error) {
+	out := emptySessionCircuitMetadata()
+	if identity == "" {
+		return out, nil
+	}
+
+	e := b.entries[identity]
+	if e == nil {
+		return out, nil
+	}
+	b.maybeAutoResetLocked(e, now)
+	b.trimLocked(e, now)
+	restarts := make([]string, 0, len(e.restarts))
+	for _, tm := range e.restarts {
+		restarts = append(restarts, tm.UTC().Format(time.RFC3339Nano))
+	}
+	if len(restarts) > 0 {
+		data, err := json.Marshal(restarts)
+		if err != nil {
+			return nil, fmt.Errorf("encoding restart history: %w", err)
+		}
+		out[sessionCircuitRestartsMetadata] = string(data)
+	}
+	out[sessionCircuitStateMetadata] = e.state.String()
+	out[sessionCircuitLastRestartMetadata] = formatCircuitTime(e.lastRestart)
+	out[sessionCircuitLastProgressMetadata] = formatCircuitTime(e.lastProgress)
+	out[sessionCircuitLastObservedMetadata] = formatCircuitTime(e.lastObserved)
+	out[sessionCircuitProgressSignatureMetadata] = e.progressSig
+	if e.state == circuitOpen {
+		out[sessionCircuitOpenedAtMetadata] = formatCircuitTime(e.openedAt)
+		out[sessionCircuitOpenRestartCountMetadata] = strconv.Itoa(e.openRestartCnt)
+	}
+	if generation := b.resetGenerationLocked(identity); generation > 0 {
+		out[sessionCircuitResetGenerationMetadata] = strconv.FormatUint(generation, 10)
+	}
+	return out, nil
+}
+
+func emptySessionCircuitMetadata() map[string]string {
+	out := make(map[string]string, len(sessionCircuitMetadataKeys))
+	for _, key := range sessionCircuitMetadataKeys {
+		out[key] = ""
+	}
+	return out
+}
+
+func formatCircuitTime(tm time.Time) string {
+	if tm.IsZero() {
+		return ""
+	}
+	return tm.UTC().Format(time.RFC3339Nano)
+}
+
+func persistSessionCircuitBreakerMetadata(
+	store beads.Store,
+	session *beads.Bead,
+	cb *sessionCircuitBreaker,
+	identity string,
+	now time.Time,
+) error {
+	if store == nil || session == nil || cb == nil {
+		return nil
+	}
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	metadata, err := cb.metadataLocked(identity, now)
+	if err != nil {
+		return err
+	}
+	if sessionCircuitMetadataEqual(session.Metadata, metadata) {
+		return nil
+	}
+	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
+		return fmt.Errorf("persisting session circuit breaker metadata for %s: %w", session.ID, err)
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(metadata))
+	}
+	for key, value := range metadata {
+		session.Metadata[key] = value
+	}
+	return nil
+}
+
+func recordSessionCircuitBreakerRestart(
+	store beads.Store,
+	session *beads.Bead,
+	cb *sessionCircuitBreaker,
+	identity string,
+	now time.Time,
+) (circuitBreakerStateKind, error) {
+	if store == nil || session == nil {
+		return circuitClosed, nil
+	}
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return circuitClosed, nil
+	}
+	if cb == nil {
+		cb = defaultSessionCircuitBreaker()
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	previous, hadPrevious := cloneCircuitBreakerEntry(cb.entries[identity]), cb.entries[identity] != nil
+	state := cb.recordRestartLocked(identity, now)
+	metadata, err := cb.metadataLocked(identity, now)
+	if err != nil {
+		cb.restoreEntryLocked(identity, previous, hadPrevious)
+		return state, err
+	}
+	if sessionCircuitMetadataEqual(session.Metadata, metadata) {
+		return state, nil
+	}
+	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
+		cb.restoreEntryLocked(identity, previous, hadPrevious)
+		return state, fmt.Errorf("persisting session circuit breaker metadata for %s: %w", session.ID, err)
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(metadata))
+	}
+	for key, value := range metadata {
+		session.Metadata[key] = value
+	}
+	return state, nil
+}
+
+func cloneCircuitBreakerEntry(e *circuitBreakerEntry) *circuitBreakerEntry {
+	if e == nil {
+		return nil
+	}
+	clone := *e
+	if e.restarts != nil {
+		clone.restarts = append([]time.Time(nil), e.restarts...)
+	}
+	return &clone
+}
+
+func (b *sessionCircuitBreaker) restoreEntryLocked(identity string, entry *circuitBreakerEntry, existed bool) {
+	if existed {
+		b.entries[identity] = entry
+		return
+	}
+	delete(b.entries, identity)
+}
+
+func (b *sessionCircuitBreaker) snapshotIdentity(identity string) sessionCircuitBreakerIdentitySnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry, hadEntry := b.entries[identity]
+	generation, hadGeneration := b.resetGenerations[identity]
+	return sessionCircuitBreakerIdentitySnapshot{
+		entry:         cloneCircuitBreakerEntry(entry),
+		hadEntry:      hadEntry,
+		generation:    generation,
+		hadGeneration: hadGeneration,
+	}
+}
+
+func (b *sessionCircuitBreaker) restoreIdentity(identity string, snapshot sessionCircuitBreakerIdentitySnapshot) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.restoreEntryLocked(identity, snapshot.entry, snapshot.hadEntry)
+	if snapshot.hadGeneration {
+		b.resetGenerations[identity] = snapshot.generation
+		return
+	}
+	delete(b.resetGenerations, identity)
+}
+
+func sessionCircuitMetadataEqual(existing map[string]string, next map[string]string) bool {
+	for _, key := range sessionCircuitMetadataKeys {
+		if existing[key] != next[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func loadPersistedSessionCircuitResetGeneration(store beads.Store, sessionID, identity string, cb *sessionCircuitBreaker) error {
+	if store == nil || cb == nil || strings.TrimSpace(sessionID) == "" || strings.TrimSpace(identity) == "" {
+		return nil
+	}
+	session, err := store.Get(sessionID)
+	if err != nil {
+		return fmt.Errorf("loading session circuit breaker metadata for %s: %w", sessionID, err)
+	}
+	if err := cb.observeResetGenerationFromMetadata(identity, session.Metadata); err != nil {
+		return fmt.Errorf("loading session circuit breaker reset generation for %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+func clearPersistedSessionCircuitBreakerMetadata(store beads.Store, sessionID string, resetGeneration uint64) error {
+	if store == nil || strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	metadata := make(map[string]string, len(sessionCircuitMetadataKeys))
+	for _, key := range sessionCircuitMetadataKeys {
+		metadata[key] = ""
+	}
+	if resetGeneration > 0 {
+		metadata[sessionCircuitResetGenerationMetadata] = strconv.FormatUint(resetGeneration, 10)
+	}
+	if err := store.SetMetadataBatch(sessionID, metadata); err != nil {
+		return fmt.Errorf("clearing session circuit breaker metadata for %s: %w", sessionID, err)
+	}
+	return nil
 }
 
 // Snapshot returns a stable-ordered point-in-time view of all tracked
@@ -317,6 +771,7 @@ func (b *sessionCircuitBreaker) Snapshot(now time.Time) []CircuitBreakerSnapshot
 		}
 		if e.state == circuitOpen {
 			snap.OpenedAt = e.openedAt
+			snap.OpenRestartCount = e.openRestartCnt
 			if !e.lastRestart.IsZero() {
 				snap.ResetAfter = e.lastRestart.Add(b.cfg.ResetAfter)
 			}
@@ -391,10 +846,11 @@ func computeNamedSessionProgressSignatures(
 	if len(sessionBeads) == 0 {
 		return nil
 	}
-	// Build: resolver key -> identity. An identity is only relevant to the
-	// breaker if it belongs to a configured named session (i.e., the
-	// session bead carries the configured_named_identity metadata).
+	// Build: resolver key -> identity. Bare session names and aliases are
+	// ignored when more than one configured identity claims the same key.
 	resolve := make(map[string]string, len(sessionBeads)*3)
+	bareResolve := make(map[string]string, len(sessionBeads)*2)
+	ambiguous := make(map[string]bool)
 	knownIdentities := make(map[string]bool)
 	for _, sb := range sessionBeads {
 		identity := strings.TrimSpace(sb.Metadata[namedSessionIdentityMetadata])
@@ -407,14 +863,23 @@ func computeNamedSessionProgressSignatures(
 			resolve[id] = identity
 		}
 		if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" {
-			resolve[sn] = identity
+			addSessionCircuitResolverKey(bareResolve, ambiguous, sn, identity)
 		}
 		if alias := strings.TrimSpace(sb.Metadata["alias"]); alias != "" {
-			resolve[alias] = identity
+			addSessionCircuitResolverKey(bareResolve, ambiguous, alias, identity)
 		}
 	}
 	if len(knownIdentities) == 0 {
 		return nil
+	}
+	for key, identity := range bareResolve {
+		if ambiguous[key] {
+			continue
+		}
+		if _, exact := resolve[key]; exact {
+			continue
+		}
+		resolve[key] = identity
 	}
 
 	// Gather per-identity (beadID, status) pairs.
@@ -435,11 +900,27 @@ func computeNamedSessionProgressSignatures(
 	out := make(map[string]string, len(knownIdentities))
 	for identity := range knownIdentities {
 		pairs := perIdentity[identity]
+		if len(pairs) == 0 {
+			out[identity] = ""
+			continue
+		}
 		sort.Strings(pairs)
 		h := sha1.Sum([]byte(strings.Join(pairs, "|")))
 		out[identity] = hex.EncodeToString(h[:])
 	}
 	return out
+}
+
+func addSessionCircuitResolverKey(resolve map[string]string, ambiguous map[string]bool, key, identity string) {
+	if existing, ok := resolve[key]; ok && existing != identity {
+		delete(resolve, key)
+		ambiguous[key] = true
+		return
+	}
+	if ambiguous[key] {
+		return
+	}
+	resolve[key] = identity
 }
 
 // SessionCircuitBreakerSnapshot is the exported status hook: it returns the

--- a/cmd/gc/session_circuit_breaker.go
+++ b/cmd/gc/session_circuit_breaker.go
@@ -157,6 +157,7 @@ func (b *sessionCircuitBreaker) maybeAutoResetLocked(e *circuitBreakerEntry, now
 		e.openedAt = time.Time{}
 		e.openRestartCnt = 0
 		e.loggedOpenOnce = false
+		e.progressSig = ""
 	}
 }
 
@@ -303,6 +304,7 @@ func (b *sessionCircuitBreaker) Snapshot(now time.Time) []CircuitBreakerSnapshot
 	out := make([]CircuitBreakerSnapshot, 0, len(b.entries))
 	for id, e := range b.entries {
 		b.maybeAutoResetLocked(e, now)
+		b.trimLocked(e, now)
 		snap := CircuitBreakerSnapshot{
 			Identity:     id,
 			State:        e.state.String(),

--- a/cmd/gc/session_circuit_breaker_test.go
+++ b/cmd/gc/session_circuit_breaker_test.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// breakerAt is a tiny helper that returns a breaker with explicit config
+// for tests so we can use fake clocks freely.
+func breakerAt(window time.Duration, maxRestarts int) *sessionCircuitBreaker {
+	return newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      window,
+		MaxRestarts: maxRestarts,
+	})
+}
+
+func TestSessionCircuitBreaker_TrippingAndStaying(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	type step struct {
+		kind     string // "restart" or "progress" or "isopen"
+		offset   time.Duration
+		wantOpen bool
+	}
+	tests := []struct {
+		name    string
+		window  time.Duration
+		maxRest int
+		steps   []step
+	}{
+		{
+			name:    "5 restarts in 30m with no progress trips breaker",
+			window:  30 * time.Minute,
+			maxRest: 5,
+			steps: []step{
+				{"restart", 0, false},
+				{"restart", 1 * time.Minute, false},
+				{"restart", 2 * time.Minute, false},
+				{"restart", 3 * time.Minute, false},
+				{"restart", 4 * time.Minute, false},
+				// Sixth restart exceeds max=5 -> CIRCUIT_OPEN.
+				{"restart", 5 * time.Minute, true},
+				{"isopen", 6 * time.Minute, true},
+			},
+		},
+		{
+			name:    "progress inside window keeps breaker CLOSED",
+			window:  30 * time.Minute,
+			maxRest: 5,
+			steps: []step{
+				{"restart", 0, false},
+				{"restart", 1 * time.Minute, false},
+				{"progress", 2 * time.Minute, false},
+				{"restart", 3 * time.Minute, false},
+				{"restart", 4 * time.Minute, false},
+				{"restart", 5 * time.Minute, false},
+				{"restart", 6 * time.Minute, false},
+				{"isopen", 7 * time.Minute, false},
+			},
+		},
+		{
+			name:    "restarts spread beyond window never trip",
+			window:  30 * time.Minute,
+			maxRest: 5,
+			steps: []step{
+				{"restart", 0, false},
+				{"restart", 10 * time.Minute, false},
+				{"restart", 20 * time.Minute, false},
+				{"restart", 31 * time.Minute, false}, // oldest trimmed
+				{"restart", 42 * time.Minute, false}, // oldest trimmed
+				{"restart", 53 * time.Minute, false}, // oldest trimmed
+				{"isopen", 60 * time.Minute, false},
+			},
+		},
+		{
+			name:    "stale progress (outside window) does not save us",
+			window:  30 * time.Minute,
+			maxRest: 5,
+			steps: []step{
+				{"progress", 0, false},               // recorded, then becomes stale
+				{"restart", 45 * time.Minute, false}, // progress is now 45m old, outside 30m
+				{"restart", 46 * time.Minute, false},
+				{"restart", 47 * time.Minute, false},
+				{"restart", 48 * time.Minute, false},
+				{"restart", 49 * time.Minute, false},
+				{"restart", 50 * time.Minute, true}, // trip
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cb := breakerAt(tc.window, tc.maxRest)
+			const id = "gastown/mayor"
+			for i, s := range tc.steps {
+				at := t0.Add(s.offset)
+				switch s.kind {
+				case "restart":
+					got := cb.RecordRestart(id, at) == circuitOpen
+					if got != s.wantOpen {
+						t.Fatalf("step %d restart: wantOpen=%v got=%v", i, s.wantOpen, got)
+					}
+				case "progress":
+					cb.RecordProgress(id, at)
+				case "isopen":
+					got := cb.IsOpen(id, at)
+					if got != s.wantOpen {
+						t.Fatalf("step %d isopen: wantOpen=%v got=%v", i, s.wantOpen, got)
+					}
+				default:
+					t.Fatalf("unknown step kind %q", s.kind)
+				}
+			}
+		})
+	}
+}
+
+func TestSessionCircuitBreaker_AutoResetAfterSilence(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      30 * time.Minute,
+		MaxRestarts: 5,
+		// ResetAfter defaults to 2 * Window = 60 minutes.
+	})
+	const id = "gastown/mayor"
+
+	// Trip the breaker with 6 rapid restarts.
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(id, t0.Add(6*time.Minute)) {
+		t.Fatalf("precondition: breaker should be open after 6 restarts")
+	}
+
+	// 59 minutes of silence: still OPEN.
+	if !cb.IsOpen(id, t0.Add(5*time.Minute+59*time.Minute)) {
+		t.Fatalf("breaker should stay OPEN until 2 x window of silence")
+	}
+
+	// 60 minutes since last restart (last restart was at t0+5m, so probe at t0+65m):
+	// silence interval == 60m == 2 * window, breaker auto-resets to CLOSED.
+	if cb.IsOpen(id, t0.Add(5*time.Minute+60*time.Minute)) {
+		t.Fatalf("breaker should auto-reset to CLOSED after 60m of silence")
+	}
+
+	// After reset, new restarts accumulate fresh — so we can't trip with just 1.
+	if got := cb.RecordRestart(id, t0.Add(5*time.Minute+61*time.Minute)); got == circuitOpen {
+		t.Fatalf("post-reset: single restart should not re-open breaker, got %v", got)
+	}
+}
+
+func TestSessionCircuitBreaker_ManualReset(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "gastown/mayor"
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(id, t0.Add(6*time.Minute)) {
+		t.Fatalf("precondition: should be OPEN")
+	}
+	// Manual reset (the hook a future `gc session reset` CLI would call).
+	cb.Reset(id)
+	if cb.IsOpen(id, t0.Add(6*time.Minute)) {
+		t.Fatalf("after Reset, breaker should be CLOSED")
+	}
+}
+
+func TestSessionCircuitBreaker_LogOpenOnce(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "gastown/mayor"
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+	var buf bytes.Buffer
+	cb.LogOpenOnce(id, &buf)
+	first := buf.String()
+	if !strings.Contains(first, "CIRCUIT_OPEN") {
+		t.Fatalf("expected CIRCUIT_OPEN message, got %q", first)
+	}
+	if !strings.Contains(first, "gc session reset") {
+		t.Fatalf("expected reset instructions in log, got %q", first)
+	}
+	if !strings.Contains(first, id) {
+		t.Fatalf("expected identity in log, got %q", first)
+	}
+	// Second call is a no-op.
+	cb.LogOpenOnce(id, &buf)
+	if buf.String() != first {
+		t.Fatalf("LogOpenOnce should only log once per OPEN incident, got repeat: %q", buf.String())
+	}
+}
+
+func TestSessionCircuitBreaker_Snapshot(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	cb.RecordRestart("gastown/mayor", t0)
+	cb.RecordRestart("gastown/refinery", t0.Add(1*time.Minute))
+	snap := cb.Snapshot(t0.Add(2 * time.Minute))
+	if len(snap) != 2 {
+		t.Fatalf("snapshot len = %d, want 2", len(snap))
+	}
+	if snap[0].Identity != "gastown/mayor" || snap[1].Identity != "gastown/refinery" {
+		t.Fatalf("snapshot not sorted: %+v", snap)
+	}
+	for _, s := range snap {
+		if s.State != "CIRCUIT_CLOSED" {
+			t.Fatalf("expected CLOSED, got %s for %s", s.State, s.Identity)
+		}
+	}
+}
+
+func TestSessionCircuitBreaker_ObserveProgressSignature(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "gastown/mayor"
+	// First observation seeds the signature — no progress event.
+	cb.ObserveProgressSignature(id, "sig-1", t0)
+	// Trip the breaker: 6 restarts with no progress.
+	for i := 0; i < 5; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+	// Same signature -> no progress recorded.
+	cb.ObserveProgressSignature(id, "sig-1", t0.Add(5*time.Minute+30*time.Second))
+	if got := cb.RecordRestart(id, t0.Add(5*time.Minute+40*time.Second)); got != circuitOpen {
+		t.Fatalf("expected circuitOpen on 6th restart with no progress, got %v", got)
+	}
+}
+
+func TestComputeNamedSessionProgressSignatures(t *testing.T) {
+	sessionBeads := []beads.Bead{
+		{
+			ID: "sb-1",
+			Metadata: map[string]string{
+				"session_name":               "mayor",
+				namedSessionIdentityMetadata: "gastown/mayor",
+			},
+		},
+		{
+			ID: "sb-2",
+			Metadata: map[string]string{
+				"session_name": "worker-1",
+				// not a named session — no identity
+			},
+		},
+	}
+	work := []beads.Bead{
+		{ID: "wb-1", Assignee: "gastown/mayor", Status: "open"},
+		{ID: "wb-2", Assignee: "mayor", Status: "in_progress"},
+		{ID: "wb-3", Assignee: "worker-1", Status: "open"}, // ignored: not named
+	}
+	got := computeNamedSessionProgressSignatures(sessionBeads, work)
+	if _, ok := got["gastown/mayor"]; !ok {
+		t.Fatalf("expected signature for mayor, got keys=%v", got)
+	}
+	if _, ok := got["worker-1"]; ok {
+		t.Fatalf("worker-1 is not a named session, should not be in signatures")
+	}
+
+	// Changing a work bead's status should change the signature.
+	work2 := []beads.Bead{
+		{ID: "wb-1", Assignee: "gastown/mayor", Status: "closed"},
+		{ID: "wb-2", Assignee: "mayor", Status: "in_progress"},
+	}
+	got2 := computeNamedSessionProgressSignatures(sessionBeads, work2)
+	if got["gastown/mayor"] == got2["gastown/mayor"] {
+		t.Fatalf("signature should change when assignee bead status changes")
+	}
+}
+
+// TestReconciler_CircuitOpenBlocksSpawn verifies that a named session with
+// an OPEN breaker is NOT added to startCandidates and is NOT spawned.
+func TestReconciler_CircuitOpenBlocksSpawn(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "mayor"}},
+	}
+
+	// Inject a breaker with aggressive thresholds and pre-trip it for the mayor.
+	cb := breakerAt(30*time.Minute, 5)
+	const identity = "gastown/mayor"
+	base := env.clk.Now().UTC()
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(identity, base.Add(-time.Duration(6-i)*time.Minute))
+	}
+	if !cb.IsOpen(identity, base) {
+		t.Fatalf("precondition: breaker should be OPEN")
+	}
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+
+	// Register the mayor as desired (and NOT running).
+	env.addDesired("mayor", "mayor", false)
+
+	// Create a session bead tagged as the named-session canonical bead.
+	b, err := env.store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "mayor",
+			"agent_name":                 "mayor",
+			"template":                   "mayor",
+			"state":                      "creating",
+			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+
+	// Run the reconciler. With the breaker OPEN the mayor must not be started.
+	_ = env.reconcile([]beads.Bead{b})
+
+	if env.sp.IsRunning("mayor") {
+		t.Fatalf("mayor should NOT be running: circuit breaker is OPEN")
+	}
+	if !strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
+		t.Fatalf("expected CIRCUIT_OPEN log in stderr, got: %q", env.stderr.String())
+	}
+	if !strings.Contains(env.stderr.String(), "gc session reset") {
+		t.Fatalf("expected reset instructions in stderr, got: %q", env.stderr.String())
+	}
+}
+
+// TestReconciler_CircuitClosedAllowsSpawn is the control case: without any
+// prior restart history the breaker is CLOSED and the reconciler spawns the
+// named session normally.
+func TestReconciler_CircuitClosedAllowsSpawn(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "mayor"}},
+	}
+
+	cb := breakerAt(30*time.Minute, 5)
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+
+	env.addDesired("mayor", "mayor", false)
+
+	b, err := env.store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "mayor",
+			"agent_name":                 "mayor",
+			"template":                   "mayor",
+			"state":                      "creating",
+			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "gastown/mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+
+	_ = env.reconcile([]beads.Bead{b})
+
+	if strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
+		t.Fatalf("did not expect CIRCUIT_OPEN log, got: %q", env.stderr.String())
+	}
+	// Breaker should now have exactly one restart recorded.
+	snap := cb.Snapshot(env.clk.Now().UTC())
+	var found bool
+	for _, s := range snap {
+		if s.Identity == "gastown/mayor" {
+			found = true
+			if s.RestartCount != 1 {
+				t.Fatalf("expected 1 recorded restart, got %d", s.RestartCount)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected mayor in snapshot, got %+v", snap)
+	}
+}

--- a/cmd/gc/session_circuit_breaker_test.go
+++ b/cmd/gc/session_circuit_breaker_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ func TestSessionCircuitBreaker_TrippingAndStaying(t *testing.T) {
 		steps   []step
 	}{
 		{
-			name:    "5 restarts in 30m with no progress trips breaker",
+			name:    "6th restart inside 30m with no progress trips breaker",
 			window:  30 * time.Minute,
 			maxRest: 5,
 			steps: []step{
@@ -97,7 +98,7 @@ func TestSessionCircuitBreaker_TrippingAndStaying(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cb := breakerAt(tc.window, tc.maxRest)
-			const id = "gastown/mayor"
+			const id = "rig-a/session-a"
 			for i, s := range tc.steps {
 				at := t0.Add(s.offset)
 				switch s.kind {
@@ -121,14 +122,14 @@ func TestSessionCircuitBreaker_TrippingAndStaying(t *testing.T) {
 	}
 }
 
-func TestSessionCircuitBreaker_AutoResetAfterSilence(t *testing.T) {
+func TestSessionCircuitBreaker_AutoResetAfterCooldown(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
 		Window:      30 * time.Minute,
 		MaxRestarts: 5,
 		// ResetAfter defaults to 2 * Window = 60 minutes.
 	})
-	const id = "gastown/mayor"
+	const id = "rig-a/session-a"
 
 	// Trip the breaker with 6 rapid restarts.
 	for i := 0; i < 6; i++ {
@@ -138,15 +139,15 @@ func TestSessionCircuitBreaker_AutoResetAfterSilence(t *testing.T) {
 		t.Fatalf("precondition: breaker should be open after 6 restarts")
 	}
 
-	// 59 minutes of silence: still OPEN.
+	// 59 minutes of cooldown: still OPEN.
 	if !cb.IsOpen(id, t0.Add(5*time.Minute+59*time.Minute)) {
-		t.Fatalf("breaker should stay OPEN until 2 x window of silence")
+		t.Fatalf("breaker should stay OPEN until 2 x window cooldown")
 	}
 
 	// 60 minutes since last restart (last restart was at t0+5m, so probe at t0+65m):
-	// silence interval == 60m == 2 * window, breaker auto-resets to CLOSED.
+	// cooldown interval == 60m == 2 * window, breaker auto-resets to CLOSED.
 	if cb.IsOpen(id, t0.Add(5*time.Minute+60*time.Minute)) {
-		t.Fatalf("breaker should auto-reset to CLOSED after 60m of silence")
+		t.Fatalf("breaker should auto-reset to CLOSED after 60m cooldown")
 	}
 
 	// After reset, new restarts accumulate fresh — so we can't trip with just 1.
@@ -158,7 +159,7 @@ func TestSessionCircuitBreaker_AutoResetAfterSilence(t *testing.T) {
 func TestSessionCircuitBreaker_AutoResetClearsProgressSignature(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
-	const id = "gastown/mayor"
+	const id = "rig-a/session-a"
 
 	cb.ObserveProgressSignature(id, "assigned-work-before-open", t0)
 	for i := 0; i < 6; i++ {
@@ -170,7 +171,7 @@ func TestSessionCircuitBreaker_AutoResetClearsProgressSignature(t *testing.T) {
 
 	resetAt := t0.Add(65 * time.Minute)
 	if cb.IsOpen(id, resetAt) {
-		t.Fatalf("breaker should auto-reset to CLOSED after silence")
+		t.Fatalf("breaker should auto-reset to CLOSED after cooldown")
 	}
 	cb.ObserveProgressSignature(id, "assigned-work-after-reset", resetAt.Add(time.Minute))
 	for i := 0; i < 6; i++ {
@@ -184,7 +185,7 @@ func TestSessionCircuitBreaker_AutoResetClearsProgressSignature(t *testing.T) {
 func TestSessionCircuitBreaker_ManualReset(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
-	const id = "gastown/mayor"
+	const id = "rig-a/session-a"
 	for i := 0; i < 6; i++ {
 		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
 	}
@@ -201,7 +202,7 @@ func TestSessionCircuitBreaker_ManualReset(t *testing.T) {
 func TestSessionCircuitBreaker_LogOpenOnce(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
-	const id = "gastown/mayor"
+	const id = "rig-a/session-a"
 	for i := 0; i < 6; i++ {
 		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
 	}
@@ -227,13 +228,13 @@ func TestSessionCircuitBreaker_LogOpenOnce(t *testing.T) {
 func TestSessionCircuitBreaker_Snapshot(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
-	cb.RecordRestart("gastown/mayor", t0)
-	cb.RecordRestart("gastown/refinery", t0.Add(1*time.Minute))
+	cb.RecordRestart("rig-a/session-a", t0)
+	cb.RecordRestart("rig-a/session-b", t0.Add(1*time.Minute))
 	snap := cb.Snapshot(t0.Add(2 * time.Minute))
 	if len(snap) != 2 {
 		t.Fatalf("snapshot len = %d, want 2", len(snap))
 	}
-	if snap[0].Identity != "gastown/mayor" || snap[1].Identity != "gastown/refinery" {
+	if snap[0].Identity != "rig-a/session-a" || snap[1].Identity != "rig-a/session-b" {
 		t.Fatalf("snapshot not sorted: %+v", snap)
 	}
 	for _, s := range snap {
@@ -246,8 +247,8 @@ func TestSessionCircuitBreaker_Snapshot(t *testing.T) {
 func TestSessionCircuitBreaker_SnapshotTrimsExpiredRestartWindow(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
-	cb.RecordRestart("gastown/mayor", t0)
-	cb.RecordRestart("gastown/mayor", t0.Add(time.Minute))
+	cb.RecordRestart("rig-a/session-a", t0)
+	cb.RecordRestart("rig-a/session-a", t0.Add(time.Minute))
 
 	snap := cb.Snapshot(t0.Add(32 * time.Minute))
 	if len(snap) != 1 {
@@ -261,10 +262,91 @@ func TestSessionCircuitBreaker_SnapshotTrimsExpiredRestartWindow(t *testing.T) {
 	}
 }
 
+func TestSessionCircuitBreaker_SnapshotPreservesOpenRestartCountAfterWindowExpires(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      30 * time.Minute,
+		MaxRestarts: 5,
+		ResetAfter:  3 * time.Hour,
+	})
+	const id = "rig-a/session-a"
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+
+	snap := cb.Snapshot(t0.Add(40 * time.Minute))
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len = %d, want 1", len(snap))
+	}
+	if snap[0].State != "CIRCUIT_OPEN" {
+		t.Fatalf("state = %q, want CIRCUIT_OPEN", snap[0].State)
+	}
+	if snap[0].RestartCount != 0 {
+		t.Fatalf("restart count = %d, want expired rolling count", snap[0].RestartCount)
+	}
+	if snap[0].OpenRestartCount != 6 {
+		t.Fatalf("open restart count = %d, want trip-time count", snap[0].OpenRestartCount)
+	}
+}
+
+func TestSessionCircuitBreaker_RecordRestartDoesNotMutateOpenEntry(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      30 * time.Minute,
+		MaxRestarts: 5,
+		ResetAfter:  3 * time.Hour,
+	})
+	const id = "rig-a/session-a"
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+	before := cb.Snapshot(t0.Add(6 * time.Minute))[0]
+
+	if got := cb.RecordRestart(id, t0.Add(10*time.Minute)); got != circuitOpen {
+		t.Fatalf("RecordRestart while open = %v, want circuitOpen", got)
+	}
+	after := cb.Snapshot(t0.Add(10 * time.Minute))[0]
+	if !after.LastRestart.Equal(before.LastRestart) {
+		t.Fatalf("last restart changed from %v to %v while open", before.LastRestart, after.LastRestart)
+	}
+	if after.RestartCount != before.RestartCount {
+		t.Fatalf("restart count changed from %d to %d while open", before.RestartCount, after.RestartCount)
+	}
+}
+
+func TestSessionCircuitBreaker_ObserveEmptyProgressSignatureDoesNotCreateIdleEntry(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+
+	cb.ObserveProgressSignature("rig-a/session-a", "", t0)
+
+	if snap := cb.Snapshot(t0); len(snap) != 0 {
+		t.Fatalf("snapshot len = %d, want no idle entry: %+v", len(snap), snap)
+	}
+}
+
+func TestSessionCircuitBreaker_PruneIdleProgressOnlyEntry(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:     30 * time.Minute,
+		ResetAfter: time.Hour,
+	})
+
+	cb.ObserveProgressSignature("rig-a/session-a", "assigned-work", t0)
+	if snap := cb.Snapshot(t0); len(snap) != 1 {
+		t.Fatalf("snapshot len = %d, want one seeded progress entry: %+v", len(snap), snap)
+	}
+
+	cb.pruneIdle(t0.Add(time.Hour))
+	if snap := cb.Snapshot(t0.Add(time.Hour)); len(snap) != 0 {
+		t.Fatalf("snapshot len = %d, want stale progress-only entry pruned: %+v", len(snap), snap)
+	}
+}
+
 func TestSessionCircuitBreaker_ObserveProgressSignature(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
-	const id = "gastown/mayor"
+	const id = "rig-a/session-a"
 	// First observation seeds the signature — no progress event.
 	cb.ObserveProgressSignature(id, "sig-1", t0)
 	// Trip the breaker: 6 restarts with no progress.
@@ -278,13 +360,329 @@ func TestSessionCircuitBreaker_ObserveProgressSignature(t *testing.T) {
 	}
 }
 
+func TestSessionCircuitBreaker_EmptyToAssignedWorkSignatureCountsAsProgress(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "rig-a/session-a"
+
+	cb.RecordRestart(id, t0)
+	cb.ObserveProgressSignature(id, "", t0.Add(time.Second))
+	for i := 1; i < 5; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+
+	if changed := cb.ObserveProgressSignature(id, "new-assigned-work", t0.Add(25*time.Minute)); !changed {
+		t.Fatal("empty-to-non-empty signature transition after an observation should be recorded")
+	}
+	if got := cb.RecordRestart(id, t0.Add(26*time.Minute)); got != circuitClosed {
+		t.Fatalf("newly assigned work should keep breaker closed on threshold restart, got %v", got)
+	}
+	snap := cb.Snapshot(t0.Add(26 * time.Minute))
+	if len(snap) != 1 || !snap[0].LastProgress.Equal(t0.Add(25*time.Minute)) {
+		t.Fatalf("last progress = %+v, want transition timestamp", snap)
+	}
+}
+
+func TestSessionCircuitBreaker_NonEmptyToEmptySignatureCountsAsProgress(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "rig-a/session-a"
+
+	cb.ObserveProgressSignature(id, "assigned-work", t0)
+	for i := 0; i < 5; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+
+	if changed := cb.ObserveProgressSignature(id, "", t0.Add(25*time.Minute)); !changed {
+		t.Fatal("non-empty-to-empty signature transition should be recorded")
+	}
+	if got := cb.RecordRestart(id, t0.Add(26*time.Minute)); got != circuitClosed {
+		t.Fatalf("completed work should keep breaker closed on threshold restart, got %v", got)
+	}
+}
+
+func TestSessionCircuitBreaker_RestoreFromMetadata(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	openMeta := func() map[string]string {
+		return map[string]string{
+			sessionCircuitStateMetadata:             circuitOpen.String(),
+			sessionCircuitRestartsMetadata:          `["2026-04-01T12:00:00Z","2026-04-01T12:01:00Z"]`,
+			sessionCircuitLastRestartMetadata:       t0.Add(time.Minute).Format(time.RFC3339Nano),
+			sessionCircuitLastProgressMetadata:      t0.Add(-time.Hour).Format(time.RFC3339Nano),
+			sessionCircuitLastObservedMetadata:      t0.Add(2 * time.Minute).Format(time.RFC3339Nano),
+			sessionCircuitProgressSignatureMetadata: "assigned-work",
+			sessionCircuitOpenedAtMetadata:          t0.Add(2 * time.Minute).Format(time.RFC3339Nano),
+			sessionCircuitOpenRestartCountMetadata:  "6",
+		}
+	}
+
+	tests := []struct {
+		name      string
+		meta      map[string]string
+		now       time.Time
+		wantReset bool
+		wantSnap  bool
+		wantState circuitBreakerStateKind
+		wantErr   string
+	}{
+		{
+			name: "empty metadata short-circuits",
+			meta: map[string]string{},
+			now:  t0,
+		},
+		{
+			name:      "valid open restores",
+			meta:      openMeta(),
+			now:       t0.Add(3 * time.Minute),
+			wantSnap:  true,
+			wantState: circuitOpen,
+		},
+		{
+			name:      "stale open auto-resets",
+			meta:      openMeta(),
+			now:       t0.Add(2 * time.Hour),
+			wantReset: true,
+			wantSnap:  true,
+			wantState: circuitClosed,
+		},
+		{
+			name:    "malformed restart json errors",
+			meta:    mapWith(openMeta(), sessionCircuitRestartsMetadata, "not-json"),
+			now:     t0,
+			wantErr: "parsing session_circuit_restarts",
+		},
+		{
+			name:    "invalid timestamp errors",
+			meta:    mapWith(openMeta(), sessionCircuitLastRestartMetadata, "not-time"),
+			now:     t0,
+			wantErr: "parsing session_circuit_last_restart",
+		},
+		{
+			name:    "invalid open restart count errors",
+			meta:    mapWith(openMeta(), sessionCircuitOpenRestartCountMetadata, "NaN"),
+			now:     t0,
+			wantErr: "parsing session_circuit_open_restart_count",
+		},
+		{
+			name:    "unknown state errors",
+			meta:    mapWith(openMeta(), sessionCircuitStateMetadata, "BROKEN"),
+			now:     t0,
+			wantErr: "unknown state",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cb := breakerAt(30*time.Minute, 5)
+			gotReset, err := cb.restoreFromMetadata("rig-a/session-a", tc.meta, tc.now)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("restoreFromMetadata error = %v, want containing %q", err, tc.wantErr)
+				}
+				if snap := cb.Snapshot(tc.now); len(snap) != 0 {
+					t.Fatalf("snapshot after failed restore = %+v, want empty", snap)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("restoreFromMetadata: %v", err)
+			}
+			if gotReset != tc.wantReset {
+				t.Fatalf("auto-reset = %v, want %v", gotReset, tc.wantReset)
+			}
+			snap := cb.Snapshot(tc.now)
+			if !tc.wantSnap {
+				if len(snap) != 0 {
+					t.Fatalf("snapshot = %+v, want empty", snap)
+				}
+				return
+			}
+			if len(snap) != 1 || snap[0].State != tc.wantState.String() {
+				t.Fatalf("snapshot = %+v, want one %s entry", snap, tc.wantState)
+			}
+		})
+	}
+}
+
+func TestSessionCircuitBreaker_RestoreFromMetadataDuplicateIsNoOp(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "rig-a/session-a"
+	cb.RecordRestart(id, t0)
+
+	reset, err := cb.restoreFromMetadata(id, map[string]string{
+		sessionCircuitStateMetadata:             circuitOpen.String(),
+		sessionCircuitRestartsMetadata:          `["2026-04-01T12:00:00Z"]`,
+		sessionCircuitLastRestartMetadata:       t0.Format(time.RFC3339Nano),
+		sessionCircuitLastObservedMetadata:      t0.Format(time.RFC3339Nano),
+		sessionCircuitProgressSignatureMetadata: "assigned-work",
+		sessionCircuitOpenedAtMetadata:          t0.Format(time.RFC3339Nano),
+		sessionCircuitOpenRestartCountMetadata:  "6",
+	}, t0.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("restoreFromMetadata: %v", err)
+	}
+	if reset {
+		t.Fatal("duplicate restore should not report auto-reset")
+	}
+	snap := cb.Snapshot(t0.Add(time.Minute))
+	if len(snap) != 1 || snap[0].State != circuitClosed.String() || snap[0].RestartCount != 1 {
+		t.Fatalf("duplicate restore overwrote existing entry: %+v", snap)
+	}
+}
+
+func TestSessionCircuitBreaker_MetadataRoundTrip(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	const id = "rig-a/session-a"
+	cb := breakerAt(30*time.Minute, 5)
+	cb.ObserveProgressSignature(id, "assigned-work", t0)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+
+	metadata, err := cb.metadata(id, t0.Add(6*time.Minute))
+	if err != nil {
+		t.Fatalf("metadata: %v", err)
+	}
+	restored := breakerAt(30*time.Minute, 5)
+	if reset, err := restored.restoreFromMetadata(id, metadata, t0.Add(6*time.Minute)); err != nil || reset {
+		t.Fatalf("restoreFromMetadata reset=%v err=%v", reset, err)
+	}
+	got, err := restored.metadata(id, t0.Add(6*time.Minute))
+	if err != nil {
+		t.Fatalf("metadata after restore: %v", err)
+	}
+	if !reflect.DeepEqual(got, metadata) {
+		t.Fatalf("metadata round trip mismatch\ngot:  %#v\nwant: %#v", got, metadata)
+	}
+}
+
+func TestPersistSessionCircuitBreakerMetadataSkipsUnchangedSnapshot(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	store := &metadataCountingStore{Store: beads.NewMemStore()}
+	session, err := store.Create(beads.Bead{
+		Title:    "session-a",
+		Type:     sessionBeadType,
+		Metadata: map[string]string{namedSessionIdentityMetadata: "rig-a/session-a"},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "rig-a/session-a"
+	cb.RecordRestart(id, t0)
+
+	if err := persistSessionCircuitBreakerMetadata(store, &session, cb, id, t0); err != nil {
+		t.Fatalf("first persist: %v", err)
+	}
+	if store.writes != 1 {
+		t.Fatalf("metadata writes = %d, want 1", store.writes)
+	}
+	if err := persistSessionCircuitBreakerMetadata(store, &session, cb, id, t0); err != nil {
+		t.Fatalf("second persist: %v", err)
+	}
+	if store.writes != 1 {
+		t.Fatalf("unchanged metadata writes = %d, want still 1", store.writes)
+	}
+
+	cb.RecordRestart(id, t0.Add(time.Minute))
+	if err := persistSessionCircuitBreakerMetadata(store, &session, cb, id, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("changed persist: %v", err)
+	}
+	if store.writes != 2 {
+		t.Fatalf("changed metadata writes = %d, want 2", store.writes)
+	}
+}
+
+func TestSessionCircuitMetadataHelpersIncludeResetGeneration(t *testing.T) {
+	empty := emptySessionCircuitMetadata()
+	if _, ok := empty[sessionCircuitResetGenerationMetadata]; !ok {
+		t.Fatalf("empty metadata missing %s", sessionCircuitResetGenerationMetadata)
+	}
+
+	existing := emptySessionCircuitMetadata()
+	next := emptySessionCircuitMetadata()
+	existing[sessionCircuitResetGenerationMetadata] = "1"
+	next[sessionCircuitResetGenerationMetadata] = "2"
+	if sessionCircuitMetadataEqual(existing, next) {
+		t.Fatalf("metadata equality ignored %s", sessionCircuitResetGenerationMetadata)
+	}
+	if hasSessionCircuitMetadata(next) {
+		t.Fatalf("generation-only metadata should not restore a breaker entry")
+	}
+}
+
+func TestPersistSessionCircuitBreakerMetadataWritesAutoResetClosedState(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title: "session-a",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata: "rig-a/session-a",
+			sessionCircuitStateMetadata:  circuitOpen.String(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "rig-a/session-a"
+	reset, err := cb.restoreFromMetadata(id, map[string]string{
+		sessionCircuitStateMetadata:            circuitOpen.String(),
+		sessionCircuitRestartsMetadata:         `["2026-04-01T12:00:00Z"]`,
+		sessionCircuitLastRestartMetadata:      t0.Format(time.RFC3339Nano),
+		sessionCircuitOpenedAtMetadata:         t0.Format(time.RFC3339Nano),
+		sessionCircuitOpenRestartCountMetadata: "6",
+	}, t0.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("restoreFromMetadata: %v", err)
+	}
+	if !reset {
+		t.Fatal("restoreFromMetadata reset = false, want true")
+	}
+	if err := persistSessionCircuitBreakerMetadata(store, &session, cb, id, t0.Add(2*time.Hour)); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get updated session: %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != circuitClosed.String() {
+		t.Fatalf("persisted state = %q, want %q", got, circuitClosed.String())
+	}
+	if got := updated.Metadata[sessionCircuitOpenedAtMetadata]; got != "" {
+		t.Fatalf("persisted opened_at = %q, want cleared", got)
+	}
+}
+
+type metadataCountingStore struct {
+	beads.Store
+	writes int
+}
+
+func (s *metadataCountingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	s.writes++
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+func mapWith(in map[string]string, key, value string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	out[key] = value
+	return out
+}
+
 func TestComputeNamedSessionProgressSignatures(t *testing.T) {
 	sessionBeads := []beads.Bead{
 		{
 			ID: "sb-1",
 			Metadata: map[string]string{
-				"session_name":               "mayor",
-				namedSessionIdentityMetadata: "gastown/mayor",
+				"session_name":               "session-a",
+				namedSessionIdentityMetadata: "rig-a/session-a",
 			},
 		},
 		{
@@ -296,13 +694,13 @@ func TestComputeNamedSessionProgressSignatures(t *testing.T) {
 		},
 	}
 	work := []beads.Bead{
-		{ID: "wb-1", Assignee: "gastown/mayor", Status: "open"},
-		{ID: "wb-2", Assignee: "mayor", Status: "in_progress"},
+		{ID: "wb-1", Assignee: "rig-a/session-a", Status: "open"},
+		{ID: "wb-2", Assignee: "session-a", Status: "in_progress"},
 		{ID: "wb-3", Assignee: "worker-1", Status: "open"}, // ignored: not named
 	}
 	got := computeNamedSessionProgressSignatures(sessionBeads, work)
-	if _, ok := got["gastown/mayor"]; !ok {
-		t.Fatalf("expected signature for mayor, got keys=%v", got)
+	if _, ok := got["rig-a/session-a"]; !ok {
+		t.Fatalf("expected signature for session-a, got keys=%v", got)
 	}
 	if _, ok := got["worker-1"]; ok {
 		t.Fatalf("worker-1 is not a named session, should not be in signatures")
@@ -310,24 +708,234 @@ func TestComputeNamedSessionProgressSignatures(t *testing.T) {
 
 	// Changing a work bead's status should change the signature.
 	work2 := []beads.Bead{
-		{ID: "wb-1", Assignee: "gastown/mayor", Status: "closed"},
-		{ID: "wb-2", Assignee: "mayor", Status: "in_progress"},
+		{ID: "wb-1", Assignee: "rig-a/session-a", Status: "closed"},
+		{ID: "wb-2", Assignee: "session-a", Status: "in_progress"},
 	}
 	got2 := computeNamedSessionProgressSignatures(sessionBeads, work2)
-	if got["gastown/mayor"] == got2["gastown/mayor"] {
+	if got["rig-a/session-a"] == got2["rig-a/session-a"] {
 		t.Fatalf("signature should change when assignee bead status changes")
 	}
 }
 
-func configureAlwaysNamedMayor(env *reconcilerTestEnv) {
+func TestComputeNamedSessionProgressSignaturesSkipsAmbiguousBareKeys(t *testing.T) {
+	sessionBeads := []beads.Bead{
+		{
+			ID: "sb-a",
+			Metadata: map[string]string{
+				"session_name":               "shared",
+				"alias":                      "shared-alias",
+				namedSessionIdentityMetadata: "rig-a/session",
+			},
+		},
+		{
+			ID: "sb-b",
+			Metadata: map[string]string{
+				"session_name":               "shared",
+				"alias":                      "shared-alias",
+				namedSessionIdentityMetadata: "rig-b/session",
+			},
+		},
+	}
+	work := []beads.Bead{
+		{ID: "wb-name", Assignee: "shared", Status: "open"},
+		{ID: "wb-alias", Assignee: "shared-alias", Status: "in_progress"},
+	}
+
+	got := computeNamedSessionProgressSignatures(sessionBeads, work)
+	if got["rig-a/session"] != "" {
+		t.Fatalf("rig-a signature = %q, want empty for ambiguous bare keys", got["rig-a/session"])
+	}
+	if got["rig-b/session"] != "" {
+		t.Fatalf("rig-b signature = %q, want empty for ambiguous bare keys", got["rig-b/session"])
+	}
+
+	work = append(work, beads.Bead{ID: "wb-exact", Assignee: "rig-a/session", Status: "closed"})
+	got = computeNamedSessionProgressSignatures(sessionBeads, work)
+	if got["rig-a/session"] == "" {
+		t.Fatal("exact identity assignment should still contribute a signature")
+	}
+	if got["rig-b/session"] != "" {
+		t.Fatalf("rig-b signature = %q, want empty", got["rig-b/session"])
+	}
+}
+
+func intPtrCircuit(n int) *int { return &n }
+
+func configureAlwaysNamedSession(env *reconcilerTestEnv) {
 	env.cfg = &config.City{
-		Agents: []config.Agent{{Name: "mayor"}},
+		Daemon: config.DaemonConfig{
+			SessionCircuitBreaker:            true,
+			SessionCircuitBreakerMaxRestarts: intPtrCircuit(5),
+			SessionCircuitBreakerWindow:      "30m",
+		},
+		Agents: []config.Agent{{Name: "template-a", Dir: "rig-a"}},
 		NamedSessions: []config.NamedSession{{
-			Name:     "mayor",
-			Template: "mayor",
-			Dir:      "gastown",
+			Name:     "session-a",
+			Template: "template-a",
+			Dir:      "rig-a",
 			Mode:     "always",
 		}},
+	}
+}
+
+func configureAlwaysNamedSessionWithoutCircuit(env *reconcilerTestEnv) {
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "template-a", Dir: "rig-a"}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "session-a",
+			Template: "template-a",
+			Dir:      "rig-a",
+			Mode:     "always",
+		}},
+	}
+}
+
+func createCircuitTestNamedSession(t *testing.T, env *reconcilerTestEnv, state string) beads.Bead {
+	t.Helper()
+	return createCircuitTestNamedSessionWithIdentity(t, env, "session-a", "template-a", "rig-a/session-a", state)
+}
+
+func createCircuitTestNamedSessionWithIdentity(
+	t *testing.T,
+	env *reconcilerTestEnv,
+	name string,
+	template string,
+	identity string,
+	state string,
+) beads.Bead {
+	t.Helper()
+	b, err := env.store.Create(beads.Bead{
+		Title:  name,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               name,
+			"agent_name":                 name,
+			"template":                   template,
+			"state":                      state,
+			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	return b
+}
+
+func TestReconciler_CircuitDisabledByDefaultAllowsRepeatedWakeAttempts(t *testing.T) {
+	env := newReconcilerTestEnv()
+	configureAlwaysNamedSessionWithoutCircuit(env)
+	env.addDesired("session-a", "template-a", false)
+
+	b := createCircuitTestNamedSession(t, env, "asleep")
+	for i := 0; i < 6; i++ {
+		current, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("get bead attempt %d: %v", i+1, err)
+		}
+		if woken := env.reconcile([]beads.Bead{current}); woken != 1 {
+			t.Fatalf("attempt %d: woken = %d, want 1 with circuit disabled; stderr=%s", i+1, woken, env.stderr.String())
+		}
+		if err := env.sp.Stop("session-a"); err != nil {
+			t.Fatalf("attempt %d: stop session-a: %v", i+1, err)
+		}
+		env.clk.Advance(6 * time.Minute)
+	}
+	if strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
+		t.Fatalf("circuit breaker should be disabled by default, stderr=%q", env.stderr.String())
+	}
+}
+
+func TestReconciler_CircuitUsesConfiguredDaemonThresholds(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Daemon: config.DaemonConfig{
+			SessionCircuitBreaker:            true,
+			SessionCircuitBreakerMaxRestarts: intPtrCircuit(2),
+			SessionCircuitBreakerWindow:      "30m",
+		},
+		Agents: []config.Agent{{Name: "template-a", Dir: "rig-a"}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "session-a",
+			Template: "template-a",
+			Dir:      "rig-a",
+			Mode:     "always",
+		}},
+	}
+	env.addDesired("session-a", "template-a", false)
+	b := createCircuitTestNamedSession(t, env, "asleep")
+
+	for i := 0; i < 2; i++ {
+		current, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("get bead attempt %d: %v", i+1, err)
+		}
+		if woken := env.reconcile([]beads.Bead{current}); woken != 1 {
+			t.Fatalf("attempt %d: woken = %d, want 1 before configured threshold; stderr=%s", i+1, woken, env.stderr.String())
+		}
+		if err := env.sp.Stop("session-a"); err != nil {
+			t.Fatalf("attempt %d: stop session-a: %v", i+1, err)
+		}
+		env.clk.Advance(6 * time.Minute)
+	}
+
+	current, err := env.store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("get bead before trip: %v", err)
+	}
+	if woken := env.reconcile([]beads.Bead{current}); woken != 0 {
+		t.Fatalf("third wake = %d, want 0 because configured max_restarts=2", woken)
+	}
+	if !strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
+		t.Fatalf("expected CIRCUIT_OPEN log with configured threshold, got %q", env.stderr.String())
+	}
+}
+
+func TestReconciler_CircuitOpenStatePersistsAcrossControllerRestart(t *testing.T) {
+	env := newReconcilerTestEnv()
+	configureAlwaysNamedSession(env)
+	env.addDesired("session-a", "template-a", false)
+
+	const identity = "rig-a/session-a"
+	b := createCircuitTestNamedSession(t, env, "asleep")
+	for i := 0; i < 6; i++ {
+		current, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("get bead attempt %d: %v", i+1, err)
+		}
+		_ = env.reconcile([]beads.Bead{current})
+		_ = env.sp.Stop("session-a")
+		env.clk.Advance(6 * time.Minute)
+	}
+
+	persisted, err := env.store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("get persisted session: %v", err)
+	}
+	if got := persisted.Metadata[sessionCircuitStateMetadata]; got != circuitOpen.String() {
+		t.Fatalf("persisted circuit state = %q, want %q", got, circuitOpen.String())
+	}
+	if got := persisted.Metadata[sessionCircuitRestartsMetadata]; got == "" {
+		t.Fatal("persisted circuit restart history is empty")
+	}
+
+	sessionCircuitBreakerMu.Lock()
+	sessionCircuitBreakerSingleton = newSessionCircuitBreaker(sessionCircuitBreakerConfig{})
+	sessionCircuitBreakerMu.Unlock()
+
+	env.stderr.Reset()
+	env.clk.Advance(time.Minute)
+	if woken := env.reconcile([]beads.Bead{persisted}); woken != 0 {
+		t.Fatalf("woken after singleton reset = %d, want 0 from persisted OPEN state", woken)
+	}
+	if env.sp.IsRunning("session-a") {
+		t.Fatal("session-a should not be running after persisted CIRCUIT_OPEN restore")
+	}
+	if snap := SessionCircuitBreakerSnapshot(env.clk.Now().UTC()); len(snap) != 1 || snap[0].Identity != identity || snap[0].State != circuitOpen.String() {
+		t.Fatalf("restored snapshot = %+v, want one OPEN entry for %s", snap, identity)
 	}
 }
 
@@ -335,11 +943,11 @@ func configureAlwaysNamedMayor(env *reconcilerTestEnv) {
 // an OPEN breaker is NOT added to startCandidates and is NOT spawned.
 func TestReconciler_CircuitOpenBlocksSpawn(t *testing.T) {
 	env := newReconcilerTestEnv()
-	configureAlwaysNamedMayor(env)
+	configureAlwaysNamedSession(env)
 
-	// Inject a breaker with aggressive thresholds and pre-trip it for the mayor.
+	// Inject a breaker with aggressive thresholds and pre-trip it.
 	cb := breakerAt(30*time.Minute, 5)
-	const identity = "gastown/mayor"
+	const identity = "rig-a/session-a"
 	base := env.clk.Now().UTC()
 	for i := 0; i < 6; i++ {
 		cb.RecordRestart(identity, base.Add(-time.Duration(6-i)*time.Minute))
@@ -350,33 +958,16 @@ func TestReconciler_CircuitOpenBlocksSpawn(t *testing.T) {
 	restore := setSessionCircuitBreakerForTest(cb)
 	defer restore()
 
-	// Register the mayor as desired (and NOT running).
-	env.addDesired("mayor", "mayor", false)
+	// Register the named session as desired (and NOT running).
+	env.addDesired("session-a", "template-a", false)
 
-	// Create a session bead tagged as the named-session canonical bead.
-	b, err := env.store.Create(beads.Bead{
-		Title:  "mayor",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel},
-		Metadata: map[string]string{
-			"session_name":               "mayor",
-			"agent_name":                 "mayor",
-			"template":                   "mayor",
-			"state":                      "creating",
-			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
-			namedSessionMetadataKey:      "true",
-			namedSessionIdentityMetadata: identity,
-		},
-	})
-	if err != nil {
-		t.Fatalf("create bead: %v", err)
-	}
+	b := createCircuitTestNamedSession(t, env, "creating")
 
-	// Run the reconciler. With the breaker OPEN the mayor must not be started.
+	// Run the reconciler. With the breaker OPEN the session must not be started.
 	_ = env.reconcile([]beads.Bead{b})
 
-	if env.sp.IsRunning("mayor") {
-		t.Fatalf("mayor should NOT be running: circuit breaker is OPEN")
+	if env.sp.IsRunning("session-a") {
+		t.Fatalf("session-a should NOT be running: circuit breaker is OPEN")
 	}
 	if !strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
 		t.Fatalf("expected CIRCUIT_OPEN log in stderr, got: %q", env.stderr.String())
@@ -391,31 +982,15 @@ func TestReconciler_CircuitOpenBlocksSpawn(t *testing.T) {
 // named session normally.
 func TestReconciler_CircuitClosedAllowsSpawn(t *testing.T) {
 	env := newReconcilerTestEnv()
-	configureAlwaysNamedMayor(env)
+	configureAlwaysNamedSession(env)
 
 	cb := breakerAt(30*time.Minute, 5)
 	restore := setSessionCircuitBreakerForTest(cb)
 	defer restore()
 
-	env.addDesired("mayor", "mayor", false)
+	env.addDesired("session-a", "template-a", false)
 
-	b, err := env.store.Create(beads.Bead{
-		Title:  "mayor",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel},
-		Metadata: map[string]string{
-			"session_name":               "mayor",
-			"agent_name":                 "mayor",
-			"template":                   "mayor",
-			"state":                      "creating",
-			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
-			namedSessionMetadataKey:      "true",
-			namedSessionIdentityMetadata: "gastown/mayor",
-		},
-	})
-	if err != nil {
-		t.Fatalf("create bead: %v", err)
-	}
+	b := createCircuitTestNamedSession(t, env, "creating")
 
 	_ = env.reconcile([]beads.Bead{b})
 
@@ -426,7 +1001,7 @@ func TestReconciler_CircuitClosedAllowsSpawn(t *testing.T) {
 	snap := cb.Snapshot(env.clk.Now().UTC())
 	var found bool
 	for _, s := range snap {
-		if s.Identity == "gastown/mayor" {
+		if s.Identity == "rig-a/session-a" {
 			found = true
 			if s.RestartCount != 1 {
 				t.Fatalf("expected 1 recorded restart, got %d", s.RestartCount)
@@ -434,38 +1009,106 @@ func TestReconciler_CircuitClosedAllowsSpawn(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected mayor in snapshot, got %+v", snap)
+		t.Fatalf("expected session-a in snapshot, got %+v", snap)
+	}
+}
+
+func TestReconciler_CircuitDoesNotRecordRestartForDependencyBlockedNamedSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Daemon: config.DaemonConfig{
+			SessionCircuitBreaker:            true,
+			SessionCircuitBreakerMaxRestarts: intPtrCircuit(5),
+			SessionCircuitBreakerWindow:      "30m",
+		},
+		Agents: []config.Agent{
+			{Name: "template-a", DependsOn: []string{"db"}},
+			{Name: "db"},
+		},
+		NamedSessions: []config.NamedSession{{
+			Name:     "session-a",
+			Template: "template-a",
+			Mode:     "always",
+		}},
+	}
+	cb := breakerAt(30*time.Minute, 5)
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+	env.addDesired("session-a", "template-a", false)
+	b := createCircuitTestNamedSession(t, env, "asleep")
+
+	if woken := env.reconcile([]beads.Bead{b}); woken != 0 {
+		t.Fatalf("woken = %d, want 0 while dependency is blocked", woken)
+	}
+	if env.sp.IsRunning("session-a") {
+		t.Fatal("session-a should not start while dependency is blocked")
+	}
+	for _, snap := range cb.Snapshot(env.clk.Now().UTC()) {
+		if snap.Identity == "rig-a/session-a" && snap.RestartCount != 0 {
+			t.Fatalf("restart count for dependency-blocked session = %d, want 0", snap.RestartCount)
+		}
+	}
+}
+
+func TestReconciler_CircuitDoesNotRecordRestartForWakeBudgetDeferredNamedSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	maxWakes := 1
+	env.cfg = &config.City{
+		Daemon: config.DaemonConfig{
+			MaxWakesPerTick:                  &maxWakes,
+			SessionCircuitBreaker:            true,
+			SessionCircuitBreakerMaxRestarts: intPtrCircuit(5),
+			SessionCircuitBreakerWindow:      "30m",
+		},
+		Agents: []config.Agent{
+			{Name: "template-a", Dir: "rig-a"},
+			{Name: "template-b", Dir: "rig-a"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Name: "session-a", Template: "template-a", Dir: "rig-a", Mode: "always"},
+			{Name: "session-b", Template: "template-b", Dir: "rig-a", Mode: "always"},
+		},
+	}
+	cb := breakerAt(30*time.Minute, 5)
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+	env.addDesired("session-a", "template-a", false)
+	env.addDesired("session-b", "template-b", false)
+	sessionA := createCircuitTestNamedSession(t, env, "asleep")
+	sessionB := createCircuitTestNamedSessionWithIdentity(t, env, "session-b", "template-b", "rig-a/session-b", "asleep")
+
+	if woken := env.reconcile([]beads.Bead{sessionA, sessionB}); woken != 1 {
+		t.Fatalf("woken = %d, want 1 under wake budget", woken)
+	}
+	if !env.sp.IsRunning("session-a") {
+		t.Fatal("session-a should start before the wake budget is exhausted")
+	}
+	if env.sp.IsRunning("session-b") {
+		t.Fatal("session-b should be deferred by wake budget")
+	}
+	counts := make(map[string]int)
+	for _, snap := range cb.Snapshot(env.clk.Now().UTC()) {
+		counts[snap.Identity] = snap.RestartCount
+	}
+	if got := counts["rig-a/session-a"]; got != 1 {
+		t.Fatalf("restart count for started session = %d, want 1", got)
+	}
+	if got := counts["rig-a/session-b"]; got != 0 {
+		t.Fatalf("restart count for wake-budget-deferred session = %d, want 0", got)
 	}
 }
 
 func TestReconciler_CircuitTripsThroughRepeatedWakeAttempts(t *testing.T) {
 	env := newReconcilerTestEnv()
-	configureAlwaysNamedMayor(env)
-	env.addDesired("mayor", "mayor", false)
+	configureAlwaysNamedSession(env)
+	env.addDesired("session-a", "template-a", false)
 
 	cb := breakerAt(30*time.Minute, 5)
 	restore := setSessionCircuitBreakerForTest(cb)
 	defer restore()
 
-	const identity = "gastown/mayor"
-	b, err := env.store.Create(beads.Bead{
-		Title:  "mayor",
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel},
-		Metadata: map[string]string{
-			"session_name":               "mayor",
-			"agent_name":                 "mayor",
-			"template":                   "mayor",
-			"state":                      "asleep",
-			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
-			namedSessionMetadataKey:      "true",
-			namedSessionIdentityMetadata: identity,
-			namedSessionModeMetadata:     "always",
-		},
-	})
-	if err != nil {
-		t.Fatalf("create bead: %v", err)
-	}
+	const identity = "rig-a/session-a"
+	b := createCircuitTestNamedSession(t, env, "asleep")
 
 	for i := 0; i < 5; i++ {
 		current, err := env.store.Get(b.ID)
@@ -475,11 +1118,11 @@ func TestReconciler_CircuitTripsThroughRepeatedWakeAttempts(t *testing.T) {
 		if woken := env.reconcile([]beads.Bead{current}); woken != 1 {
 			t.Fatalf("attempt %d: woken = %d, want 1; stderr=%s", i+1, woken, env.stderr.String())
 		}
-		if !env.sp.IsRunning("mayor") {
-			t.Fatalf("attempt %d: mayor should be running after CLOSED breaker wake", i+1)
+		if !env.sp.IsRunning("session-a") {
+			t.Fatalf("attempt %d: session-a should be running after CLOSED breaker wake", i+1)
 		}
-		if err := env.sp.Stop("mayor"); err != nil {
-			t.Fatalf("attempt %d: stop mayor: %v", i+1, err)
+		if err := env.sp.Stop("session-a"); err != nil {
+			t.Fatalf("attempt %d: stop session-a: %v", i+1, err)
 		}
 		env.clk.Advance(6 * time.Minute)
 	}
@@ -491,8 +1134,8 @@ func TestReconciler_CircuitTripsThroughRepeatedWakeAttempts(t *testing.T) {
 	if woken := env.reconcile([]beads.Bead{current}); woken != 0 {
 		t.Fatalf("trip attempt: woken = %d, want 0", woken)
 	}
-	if env.sp.IsRunning("mayor") {
-		t.Fatal("mayor should not be running after circuit trips")
+	if env.sp.IsRunning("session-a") {
+		t.Fatal("session-a should not be running after circuit trips")
 	}
 	if !strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
 		t.Fatalf("expected CIRCUIT_OPEN log in stderr, got: %q", env.stderr.String())

--- a/cmd/gc/session_circuit_breaker_test.go
+++ b/cmd/gc/session_circuit_breaker_test.go
@@ -155,6 +155,32 @@ func TestSessionCircuitBreaker_AutoResetAfterSilence(t *testing.T) {
 	}
 }
 
+func TestSessionCircuitBreaker_AutoResetClearsProgressSignature(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	const id = "gastown/mayor"
+
+	cb.ObserveProgressSignature(id, "assigned-work-before-open", t0)
+	for i := 0; i < 6; i++ {
+		cb.RecordRestart(id, t0.Add(time.Duration(i)*time.Minute))
+	}
+	if !cb.IsOpen(id, t0.Add(6*time.Minute)) {
+		t.Fatalf("precondition: breaker should be open after 6 restarts")
+	}
+
+	resetAt := t0.Add(65 * time.Minute)
+	if cb.IsOpen(id, resetAt) {
+		t.Fatalf("breaker should auto-reset to CLOSED after silence")
+	}
+	cb.ObserveProgressSignature(id, "assigned-work-after-reset", resetAt.Add(time.Minute))
+	for i := 0; i < 6; i++ {
+		state := cb.RecordRestart(id, resetAt.Add(time.Duration(i+2)*time.Minute))
+		if i == 5 && state != circuitOpen {
+			t.Fatalf("expected breaker to re-open after reset with no post-reset progress, got %v", state)
+		}
+	}
+}
+
 func TestSessionCircuitBreaker_ManualReset(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
@@ -217,6 +243,24 @@ func TestSessionCircuitBreaker_Snapshot(t *testing.T) {
 	}
 }
 
+func TestSessionCircuitBreaker_SnapshotTrimsExpiredRestartWindow(t *testing.T) {
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	cb := breakerAt(30*time.Minute, 5)
+	cb.RecordRestart("gastown/mayor", t0)
+	cb.RecordRestart("gastown/mayor", t0.Add(time.Minute))
+
+	snap := cb.Snapshot(t0.Add(32 * time.Minute))
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len = %d, want 1", len(snap))
+	}
+	if snap[0].RestartCount != 0 {
+		t.Fatalf("restart count = %d, want expired entries trimmed", snap[0].RestartCount)
+	}
+	if !snap[0].WindowStart.IsZero() {
+		t.Fatalf("window start = %v, want zero after all entries expire", snap[0].WindowStart)
+	}
+}
+
 func TestSessionCircuitBreaker_ObserveProgressSignature(t *testing.T) {
 	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	cb := breakerAt(30*time.Minute, 5)
@@ -275,13 +319,23 @@ func TestComputeNamedSessionProgressSignatures(t *testing.T) {
 	}
 }
 
+func configureAlwaysNamedMayor(env *reconcilerTestEnv) {
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "mayor"}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "mayor",
+			Template: "mayor",
+			Dir:      "gastown",
+			Mode:     "always",
+		}},
+	}
+}
+
 // TestReconciler_CircuitOpenBlocksSpawn verifies that a named session with
 // an OPEN breaker is NOT added to startCandidates and is NOT spawned.
 func TestReconciler_CircuitOpenBlocksSpawn(t *testing.T) {
 	env := newReconcilerTestEnv()
-	env.cfg = &config.City{
-		Agents: []config.Agent{{Name: "mayor"}},
-	}
+	configureAlwaysNamedMayor(env)
 
 	// Inject a breaker with aggressive thresholds and pre-trip it for the mayor.
 	cb := breakerAt(30*time.Minute, 5)
@@ -337,9 +391,7 @@ func TestReconciler_CircuitOpenBlocksSpawn(t *testing.T) {
 // named session normally.
 func TestReconciler_CircuitClosedAllowsSpawn(t *testing.T) {
 	env := newReconcilerTestEnv()
-	env.cfg = &config.City{
-		Agents: []config.Agent{{Name: "mayor"}},
-	}
+	configureAlwaysNamedMayor(env)
 
 	cb := breakerAt(30*time.Minute, 5)
 	restore := setSessionCircuitBreakerForTest(cb)
@@ -383,5 +435,70 @@ func TestReconciler_CircuitClosedAllowsSpawn(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected mayor in snapshot, got %+v", snap)
+	}
+}
+
+func TestReconciler_CircuitTripsThroughRepeatedWakeAttempts(t *testing.T) {
+	env := newReconcilerTestEnv()
+	configureAlwaysNamedMayor(env)
+	env.addDesired("mayor", "mayor", false)
+
+	cb := breakerAt(30*time.Minute, 5)
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+
+	const identity = "gastown/mayor"
+	b, err := env.store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "mayor",
+			"agent_name":                 "mayor",
+			"template":                   "mayor",
+			"state":                      "asleep",
+			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		current, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("get bead attempt %d: %v", i+1, err)
+		}
+		if woken := env.reconcile([]beads.Bead{current}); woken != 1 {
+			t.Fatalf("attempt %d: woken = %d, want 1; stderr=%s", i+1, woken, env.stderr.String())
+		}
+		if !env.sp.IsRunning("mayor") {
+			t.Fatalf("attempt %d: mayor should be running after CLOSED breaker wake", i+1)
+		}
+		if err := env.sp.Stop("mayor"); err != nil {
+			t.Fatalf("attempt %d: stop mayor: %v", i+1, err)
+		}
+		env.clk.Advance(6 * time.Minute)
+	}
+
+	current, err := env.store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("get bead before trip: %v", err)
+	}
+	if woken := env.reconcile([]beads.Bead{current}); woken != 0 {
+		t.Fatalf("trip attempt: woken = %d, want 0", woken)
+	}
+	if env.sp.IsRunning("mayor") {
+		t.Fatal("mayor should not be running after circuit trips")
+	}
+	if !strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
+		t.Fatalf("expected CIRCUIT_OPEN log in stderr, got: %q", env.stderr.String())
+	}
+	snap := cb.Snapshot(env.clk.Now().UTC())
+	if len(snap) != 1 || snap[0].Identity != identity || snap[0].State != "CIRCUIT_OPEN" || snap[0].RestartCount != 6 {
+		t.Fatalf("snapshot after trip = %+v, want one OPEN entry with 6 restarts", snap)
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1452,6 +1452,12 @@ func executePlannedStartsTraced(
 			apply(&startOpts)
 		}
 	}
+	cbCfg, cbEnabled := sessionCircuitBreakerConfigFromCity(cfg)
+	var cb *sessionCircuitBreaker
+	if cbEnabled {
+		cb = defaultSessionCircuitBreaker()
+		cb.configure(cbCfg)
+	}
 	asyncLimiter := startOpts.asyncLimiter
 	maxWakes := maxParallelStartsPerTick(cfg)
 	if startOpts.async && asyncLimiter == nil {
@@ -1527,6 +1533,60 @@ func executePlannedStartsTraced(
 						done()
 						logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), outcome, time.Time{}, time.Time{}, nil)
 						continue
+					}
+				}
+				if cbEnabled {
+					identity := ""
+					if candidate.session != nil {
+						identity = namedSessionIdentity(*candidate.session)
+					}
+					if identity != "" {
+						cbNow := clk.Now().UTC()
+						if cb.IsOpen(identity, cbNow) {
+							if release != nil {
+								release()
+							}
+							if done != nil {
+								done()
+							}
+							if err := persistSessionCircuitBreakerMetadata(store, candidate.session, cb, identity, cbNow); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: %v\n", err) //nolint:errcheck // best-effort stderr
+							}
+							cb.LogOpenOnce(identity, stderr)
+							if trace != nil {
+								trace.recordDecision("reconciler.session.circuit_open", candidate.tp.TemplateName, candidate.name(), "circuit_open", "skipped", traceRecordPayload{
+									"identity": identity,
+								}, nil, "")
+							}
+							continue
+						}
+						state, err := recordSessionCircuitBreakerRestart(store, candidate.session, cb, identity, cbNow)
+						if err != nil {
+							if release != nil {
+								release()
+							}
+							if done != nil {
+								done()
+							}
+							fmt.Fprintf(stderr, "session reconciler: %v\n", err) //nolint:errcheck // best-effort stderr
+							logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "circuit_metadata_failed", time.Time{}, time.Time{}, err)
+							continue
+						}
+						if state == circuitOpen {
+							if release != nil {
+								release()
+							}
+							if done != nil {
+								done()
+							}
+							cb.LogOpenOnce(identity, stderr)
+							if trace != nil {
+								trace.recordDecision("reconciler.session.circuit_trip", candidate.tp.TemplateName, candidate.name(), "circuit_trip", "skipped", traceRecordPayload{
+									"identity": identity,
+								}, nil, "")
+							}
+							continue
+						}
 					}
 				}
 				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1654,6 +1654,119 @@ func TestExecutePlannedStartsTraced_AsyncPrepareFailureClearsPreWakeLease(t *tes
 	}
 }
 
+func TestExecutePlannedStartsTraced_CircuitTripDoesNotCommitPreWakeMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 28, 0, time.UTC)}
+	const identity = "test-city/worker"
+	originalLastWokeAt := clk.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":               "worker",
+			"template":                   "worker",
+			"generation":                 "7",
+			"continuation_epoch":         "3",
+			"continuation_reset_pending": "true",
+			"instance_token":             "tok-worker",
+			"last_woke_at":               originalLastWokeAt,
+			"pending_create_claim":       "true",
+			"wake_mode":                  "fresh",
+			"session_key":                "fresh-key-123",
+			"started_config_hash":        "started-config-before-reset",
+			"started_live_hash":          "started-live-before-reset",
+			"live_hash":                  "live-before-reset",
+			"startup_dialog_verified":    "true",
+			namedSessionIdentityMetadata: identity,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      10 * time.Minute,
+		MaxRestarts: 1,
+		ResetAfter:  20 * time.Minute,
+	})
+	defer setSessionCircuitBreakerForTest(cb)()
+	cb.RecordRestart(identity, clk.Now().Add(-time.Minute))
+	sp := newGatedStartProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	maxRestarts := 1
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{
+			SessionCircuitBreaker:            true,
+			SessionCircuitBreakerMaxRestarts: &maxRestarts,
+			SessionCircuitBreakerWindow:      "10m",
+			SessionCircuitBreakerResetAfter:  "20m",
+		},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+	); got != 0 {
+		t.Fatalf("woken = %d, want 0 when circuit trip suppresses start", got)
+	}
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["generation"]; got != "7" {
+		t.Fatalf("generation = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["instance_token"]; got != "tok-worker" {
+		t.Fatalf("instance_token = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["continuation_epoch"]; got != "3" {
+		t.Fatalf("continuation_epoch = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["continuation_reset_pending"]; got != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["wake_mode"]; got != "fresh" {
+		t.Fatalf("wake_mode = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != originalLastWokeAt {
+		t.Fatalf("last_woke_at = %q, want unchanged %q", got, originalLastWokeAt)
+	}
+	if got := updated.Metadata["session_key"]; got != "fresh-key-123" {
+		t.Fatalf("session_key = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["started_config_hash"]; got != "started-config-before-reset" {
+		t.Fatalf("started_config_hash = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["started_live_hash"]; got != "started-live-before-reset" {
+		t.Fatalf("started_live_hash = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["live_hash"]; got != "live-before-reset" {
+		t.Fatalf("live_hash = %q, want unchanged", got)
+	}
+	if got := updated.Metadata["startup_dialog_verified"]; got != "true" {
+		t.Fatalf("startup_dialog_verified = %q, want unchanged", got)
+	}
+}
+
 func TestExecutePlannedStartsTraced_AsyncRequestsFollowUpAfterCommit(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 30, 0, time.UTC)}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -325,15 +325,52 @@ func reconcileSessionBeadsTraced(
 	// Topo-order sessions by template dependencies.
 	ordered := topoOrder(sessions, deps)
 
-	// Phase 0.5: Feed the respawn circuit breaker the current progress
-	// signature for every named-session identity. A change in the
-	// aggregate status of an identity's assigned work beads is treated as
-	// an observable progress signal and keeps the breaker CLOSED even if
-	// restarts accumulate. See session_circuit_breaker.go.
-	cb := defaultSessionCircuitBreaker()
 	cbNow := clk.Now().UTC()
-	for identity, sig := range computeNamedSessionProgressSignatures(ordered, assignedWorkBeads) {
-		cb.ObserveProgressSignature(identity, sig, cbNow)
+	cbCfg, cbEnabled := sessionCircuitBreakerConfigFromCity(cfg)
+	var cb *sessionCircuitBreaker
+	var circuitSessionByIdentity map[string]*beads.Bead
+	if cbEnabled {
+		// Phase 0.5: Feed the respawn circuit breaker persisted state and the
+		// current progress signature for every named-session identity. A change
+		// in the aggregate status of an identity's assigned work beads is treated
+		// as an observable progress signal and keeps the breaker CLOSED even if
+		// restarts accumulate. See session_circuit_breaker.go.
+		cb = defaultSessionCircuitBreaker()
+		cb.configure(cbCfg)
+		circuitSessionByIdentity = make(map[string]*beads.Bead, len(ordered))
+		for i := range ordered {
+			identity := namedSessionIdentity(ordered[i])
+			if identity == "" {
+				continue
+			}
+			circuitSessionByIdentity[identity] = &ordered[i]
+			if err := cb.observeResetGenerationFromMetadata(identity, ordered[i].Metadata); err != nil {
+				fmt.Fprintf(stderr, "session reconciler: loading session circuit breaker reset generation for %s: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+			}
+		}
+		for i := range ordered {
+			identity := namedSessionIdentity(ordered[i])
+			if identity == "" {
+				continue
+			}
+			if reset, err := cb.restoreFromMetadata(identity, ordered[i].Metadata, cbNow); err != nil {
+				fmt.Fprintf(stderr, "session reconciler: loading session circuit breaker state for %s: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+			} else if reset {
+				if err := persistSessionCircuitBreakerMetadata(store, &ordered[i], cb, identity, cbNow); err != nil {
+					fmt.Fprintf(stderr, "session reconciler: %v\n", err) //nolint:errcheck // best-effort stderr
+				}
+			}
+		}
+		for identity, sig := range computeNamedSessionProgressSignatures(ordered, assignedWorkBeads) {
+			if cb.ObserveProgressSignature(identity, sig, cbNow) {
+				if session := circuitSessionByIdentity[identity]; session != nil {
+					if err := persistSessionCircuitBreakerMetadata(store, session, cb, identity, cbNow); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: %v\n", err) //nolint:errcheck // best-effort stderr
+					}
+				}
+			}
+		}
+		cb.pruneIdle(cbNow)
 	}
 
 	// Build session ID -> *beads.Bead lookup for advanceSessionDrains.
@@ -1080,28 +1117,24 @@ func reconcileSessionBeadsTraced(
 				continue
 			}
 			// Respawn circuit breaker: for named sessions the supervisor
-			// will otherwise retry indefinitely. Check and (if still
-			// CLOSED) record the restart attempt BEFORE scheduling the
-			// spawn. This is the sole materialization gate for the
-			// breaker — see session_circuit_breaker.go.
-			if identity := namedSessionIdentity(*target.session); identity != "" {
-				if cb.IsOpen(identity, cbNow) {
-					cb.LogOpenOnce(identity, stderr)
-					if trace != nil {
-						trace.recordDecision("reconciler.session.circuit_open", target.tp.TemplateName, name, "circuit_open", "skipped", traceRecordPayload{
-							"identity": identity,
-						}, nil, "")
+			// will otherwise retry indefinitely. This phase only blocks
+			// already-OPEN breakers; restart accounting happens at the
+			// prepared-start boundary after dependency and wake-budget gates.
+			if cbEnabled {
+				identity := namedSessionIdentity(*target.session)
+				if identity != "" {
+					if cb.IsOpen(identity, cbNow) {
+						if err := persistSessionCircuitBreakerMetadata(store, target.session, cb, identity, cbNow); err != nil {
+							fmt.Fprintf(stderr, "session reconciler: %v\n", err) //nolint:errcheck // best-effort stderr
+						}
+						cb.LogOpenOnce(identity, stderr)
+						if trace != nil {
+							trace.recordDecision("reconciler.session.circuit_open", target.tp.TemplateName, name, "circuit_open", "skipped", traceRecordPayload{
+								"identity": identity,
+							}, nil, "")
+						}
+						continue
 					}
-					continue
-				}
-				if cb.RecordRestart(identity, cbNow) == circuitOpen {
-					cb.LogOpenOnce(identity, stderr)
-					if trace != nil {
-						trace.recordDecision("reconciler.session.circuit_trip", target.tp.TemplateName, name, "circuit_trip", "skipped", traceRecordPayload{
-							"identity": identity,
-						}, nil, "")
-					}
-					continue
 				}
 			}
 			if trace != nil {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -325,6 +325,17 @@ func reconcileSessionBeadsTraced(
 	// Topo-order sessions by template dependencies.
 	ordered := topoOrder(sessions, deps)
 
+	// Phase 0.5: Feed the respawn circuit breaker the current progress
+	// signature for every named-session identity. A change in the
+	// aggregate status of an identity's assigned work beads is treated as
+	// an observable progress signal and keeps the breaker CLOSED even if
+	// restarts accumulate. See session_circuit_breaker.go.
+	cb := defaultSessionCircuitBreaker()
+	cbNow := clk.Now().UTC()
+	for identity, sig := range computeNamedSessionProgressSignatures(ordered, assignedWorkBeads) {
+		cb.ObserveProgressSignature(identity, sig, cbNow)
+	}
+
 	// Build session ID -> *beads.Bead lookup for advanceSessionDrains.
 	// These pointers intentionally alias into the ordered slice so that
 	// mutations in Phase 1 (healState, clearWakeFailures, etc.) are
@@ -1067,6 +1078,31 @@ func reconcileSessionBeadsTraced(
 					}, nil, "")
 				}
 				continue
+			}
+			// Respawn circuit breaker: for named sessions the supervisor
+			// will otherwise retry indefinitely. Check and (if still
+			// CLOSED) record the restart attempt BEFORE scheduling the
+			// spawn. This is the sole materialization gate for the
+			// breaker — see session_circuit_breaker.go.
+			if identity := namedSessionIdentity(*target.session); identity != "" {
+				if cb.IsOpen(identity, cbNow) {
+					cb.LogOpenOnce(identity, stderr)
+					if trace != nil {
+						trace.recordDecision("reconciler.session.circuit_open", target.tp.TemplateName, name, "circuit_open", "skipped", traceRecordPayload{
+							"identity": identity,
+						}, nil, "")
+					}
+					continue
+				}
+				if cb.RecordRestart(identity, cbNow) == circuitOpen {
+					cb.LogOpenOnce(identity, stderr)
+					if trace != nil {
+						trace.recordDecision("reconciler.session.circuit_trip", target.tp.TemplateName, name, "circuit_trip", "skipped", traceRecordPayload{
+							"identity": identity,
+						}, nil, "")
+					}
+					continue
+				}
 			}
 			if trace != nil {
 				trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_candidate", traceRecordPayload{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -115,6 +115,9 @@ type reconcilerTestEnv struct {
 }
 
 func newReconcilerTestEnv() *reconcilerTestEnv {
+	sessionCircuitBreakerMu.Lock()
+	sessionCircuitBreakerSingleton = newSessionCircuitBreaker(sessionCircuitBreakerConfig{})
+	sessionCircuitBreakerMu.Unlock()
 	return &reconcilerTestEnv{
 		store:        beads.NewMemStore(),
 		sp:           runtime.NewFake(),

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -262,6 +262,10 @@ DaemonConfig holds controller daemon settings.
 | `patrol_interval` | string |  | `30s` | PatrolInterval is the health patrol interval. Duration string (e.g., "30s", "5m", "1h"). Defaults to "30s". |
 | `max_restarts` | integer |  | `5` | MaxRestarts is the maximum number of agent restarts within RestartWindow before the agent is quarantined. 0 means unlimited (no crash loop detection). Defaults to 5. |
 | `restart_window` | string |  | `1h` | RestartWindow is the sliding time window for counting restarts. Duration string (e.g., "30s", "5m", "1h"). Defaults to "1h". |
+| `session_circuit_breaker` | boolean |  |  | SessionCircuitBreaker enables the named-session respawn circuit breaker. When enabled, the controller suppresses no-progress named-session respawns after the configured restart threshold is exceeded. |
+| `session_circuit_breaker_max_restarts` | integer |  | `5` | SessionCircuitBreakerMaxRestarts overrides MaxRestarts for the named-session respawn circuit breaker. Nil reuses MaxRestartsOrDefault. 0 disables the circuit breaker even when SessionCircuitBreaker is true. |
+| `session_circuit_breaker_window` | string |  | `1h` | SessionCircuitBreakerWindow overrides RestartWindow for the named-session respawn circuit breaker. Empty reuses RestartWindowDuration. |
+| `session_circuit_breaker_reset_after` | string |  |  | SessionCircuitBreakerResetAfter is the cooldown before an open named-session breaker resets automatically. Empty defaults to 2 * SessionCircuitBreakerWindowDuration. |
 | `shutdown_timeout` | string |  | `5s` | ShutdownTimeout is the time to wait after sending Ctrl-C before force-killing agents during shutdown. Duration string (e.g., "5s", "30s"). Set to "0s" for immediate kill. Defaults to "5s". |
 | `wisp_gc_interval` | string |  |  | WispGCInterval is how often wisp GC runs. Duration string (e.g., "5m", "1h"). Wisp GC is disabled unless both WispGCInterval and WispTTL are set. |
 | `wisp_ttl` | string |  |  | WispTTL is how long a closed molecule survives before being purged. Duration string (e.g., "24h", "7d"). Wisp GC is disabled unless both WispGCInterval and WispTTL are set. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1049,6 +1049,24 @@
           "description": "RestartWindow is the sliding time window for counting restarts.\nDuration string (e.g., \"30s\", \"5m\", \"1h\"). Defaults to \"1h\".",
           "default": "1h"
         },
+        "session_circuit_breaker": {
+          "type": "boolean",
+          "description": "SessionCircuitBreaker enables the named-session respawn circuit breaker.\nWhen enabled, the controller suppresses no-progress named-session respawns\nafter the configured restart threshold is exceeded."
+        },
+        "session_circuit_breaker_max_restarts": {
+          "type": "integer",
+          "description": "SessionCircuitBreakerMaxRestarts overrides MaxRestarts for the\nnamed-session respawn circuit breaker. Nil reuses MaxRestartsOrDefault.\n0 disables the circuit breaker even when SessionCircuitBreaker is true.",
+          "default": 5
+        },
+        "session_circuit_breaker_window": {
+          "type": "string",
+          "description": "SessionCircuitBreakerWindow overrides RestartWindow for the named-session\nrespawn circuit breaker. Empty reuses RestartWindowDuration.",
+          "default": "1h"
+        },
+        "session_circuit_breaker_reset_after": {
+          "type": "string",
+          "description": "SessionCircuitBreakerResetAfter is the cooldown before an open named-session\nbreaker resets automatically. Empty defaults to 2 * SessionCircuitBreakerWindowDuration."
+        },
         "shutdown_timeout": {
           "type": "string",
           "description": "ShutdownTimeout is the time to wait after sending Ctrl-C before force-killing\nagents during shutdown. Duration string (e.g., \"5s\", \"30s\"). Set to \"0s\"\nfor immediate kill. Defaults to \"5s\".",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1049,6 +1049,24 @@
           "description": "RestartWindow is the sliding time window for counting restarts.\nDuration string (e.g., \"30s\", \"5m\", \"1h\"). Defaults to \"1h\".",
           "default": "1h"
         },
+        "session_circuit_breaker": {
+          "type": "boolean",
+          "description": "SessionCircuitBreaker enables the named-session respawn circuit breaker.\nWhen enabled, the controller suppresses no-progress named-session respawns\nafter the configured restart threshold is exceeded."
+        },
+        "session_circuit_breaker_max_restarts": {
+          "type": "integer",
+          "description": "SessionCircuitBreakerMaxRestarts overrides MaxRestarts for the\nnamed-session respawn circuit breaker. Nil reuses MaxRestartsOrDefault.\n0 disables the circuit breaker even when SessionCircuitBreaker is true.",
+          "default": 5
+        },
+        "session_circuit_breaker_window": {
+          "type": "string",
+          "description": "SessionCircuitBreakerWindow overrides RestartWindow for the named-session\nrespawn circuit breaker. Empty reuses RestartWindowDuration.",
+          "default": "1h"
+        },
+        "session_circuit_breaker_reset_after": {
+          "type": "string",
+          "description": "SessionCircuitBreakerResetAfter is the cooldown before an open named-session\nbreaker resets automatically. Empty defaults to 2 * SessionCircuitBreakerWindowDuration."
+        },
         "shutdown_timeout": {
           "type": "string",
           "description": "ShutdownTimeout is the time to wait after sending Ctrl-C before force-killing\nagents during shutdown. Duration string (e.g., \"5s\", \"30s\"). Set to \"0s\"\nfor immediate kill. Defaults to \"5s\".",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1330,6 +1330,20 @@ type DaemonConfig struct {
 	// RestartWindow is the sliding time window for counting restarts.
 	// Duration string (e.g., "30s", "5m", "1h"). Defaults to "1h".
 	RestartWindow string `toml:"restart_window,omitempty" jsonschema:"default=1h"`
+	// SessionCircuitBreaker enables the named-session respawn circuit breaker.
+	// When enabled, the controller suppresses no-progress named-session respawns
+	// after the configured restart threshold is exceeded.
+	SessionCircuitBreaker bool `toml:"session_circuit_breaker,omitempty"`
+	// SessionCircuitBreakerMaxRestarts overrides MaxRestarts for the
+	// named-session respawn circuit breaker. Nil reuses MaxRestartsOrDefault.
+	// 0 disables the circuit breaker even when SessionCircuitBreaker is true.
+	SessionCircuitBreakerMaxRestarts *int `toml:"session_circuit_breaker_max_restarts,omitempty" jsonschema:"default=5"`
+	// SessionCircuitBreakerWindow overrides RestartWindow for the named-session
+	// respawn circuit breaker. Empty reuses RestartWindowDuration.
+	SessionCircuitBreakerWindow string `toml:"session_circuit_breaker_window,omitempty" jsonschema:"default=1h"`
+	// SessionCircuitBreakerResetAfter is the cooldown before an open named-session
+	// breaker resets automatically. Empty defaults to 2 * SessionCircuitBreakerWindowDuration.
+	SessionCircuitBreakerResetAfter string `toml:"session_circuit_breaker_reset_after,omitempty"`
 	// ShutdownTimeout is the time to wait after sending Ctrl-C before force-killing
 	// agents during shutdown. Duration string (e.g., "5s", "30s"). Set to "0s"
 	// for immediate kill. Defaults to "5s".
@@ -1393,6 +1407,42 @@ func (d *DaemonConfig) RestartWindowDuration() time.Duration {
 	dur, err := time.ParseDuration(d.RestartWindow)
 	if err != nil {
 		return time.Hour
+	}
+	return dur
+}
+
+// SessionCircuitBreakerMaxRestartsOrDefault returns the named-session respawn
+// circuit-breaker threshold. Nil reuses MaxRestartsOrDefault; zero disables it.
+func (d *DaemonConfig) SessionCircuitBreakerMaxRestartsOrDefault() int {
+	if d.SessionCircuitBreakerMaxRestarts == nil {
+		return d.MaxRestartsOrDefault()
+	}
+	return *d.SessionCircuitBreakerMaxRestarts
+}
+
+// SessionCircuitBreakerWindowDuration returns the named-session respawn
+// circuit-breaker rolling window. Empty reuses RestartWindowDuration.
+func (d *DaemonConfig) SessionCircuitBreakerWindowDuration() time.Duration {
+	if d.SessionCircuitBreakerWindow == "" {
+		return d.RestartWindowDuration()
+	}
+	dur, err := time.ParseDuration(d.SessionCircuitBreakerWindow)
+	if err != nil {
+		return d.RestartWindowDuration()
+	}
+	return dur
+}
+
+// SessionCircuitBreakerResetAfterDuration returns the named-session respawn
+// circuit-breaker cooldown. Empty or invalid values default to 2 * window.
+func (d *DaemonConfig) SessionCircuitBreakerResetAfterDuration() time.Duration {
+	window := d.SessionCircuitBreakerWindowDuration()
+	if d.SessionCircuitBreakerResetAfter == "" {
+		return 2 * window
+	}
+	dur, err := time.ParseDuration(d.SessionCircuitBreakerResetAfter)
+	if err != nil {
+		return 2 * window
 	}
 	return dur
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2092,6 +2092,41 @@ name = "mayor"
 	}
 }
 
+func TestParseDaemonSessionCircuitBreaker(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test"
+
+[daemon]
+session_circuit_breaker = true
+session_circuit_breaker_max_restarts = 2
+session_circuit_breaker_window = "10m"
+session_circuit_breaker_reset_after = "25m"
+
+[[agent]]
+name = "worker"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !cfg.Daemon.SessionCircuitBreaker {
+		t.Fatal("Daemon.SessionCircuitBreaker = false, want true")
+	}
+	if cfg.Daemon.SessionCircuitBreakerMaxRestarts == nil || *cfg.Daemon.SessionCircuitBreakerMaxRestarts != 2 {
+		t.Fatalf("Daemon.SessionCircuitBreakerMaxRestarts = %v, want 2", cfg.Daemon.SessionCircuitBreakerMaxRestarts)
+	}
+	if got := cfg.Daemon.SessionCircuitBreakerMaxRestartsOrDefault(); got != 2 {
+		t.Fatalf("SessionCircuitBreakerMaxRestartsOrDefault() = %d, want 2", got)
+	}
+	if got := cfg.Daemon.SessionCircuitBreakerWindowDuration(); got != 10*time.Minute {
+		t.Fatalf("SessionCircuitBreakerWindowDuration() = %v, want 10m", got)
+	}
+	if got := cfg.Daemon.SessionCircuitBreakerResetAfterDuration(); got != 25*time.Minute {
+		t.Fatalf("SessionCircuitBreakerResetAfterDuration() = %v, want 25m", got)
+	}
+}
+
 func TestMarshalOmitsEmptyDaemonSection(t *testing.T) {
 	c := DefaultCity("test")
 	data, err := c.Marshal()

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -42,6 +42,8 @@ func ValidateDurations(cfg *City, source string) []string {
 	// Daemon config durations.
 	check("[daemon]", "patrol_interval", cfg.Daemon.PatrolInterval)
 	check("[daemon]", "restart_window", cfg.Daemon.RestartWindow)
+	check("[daemon]", "session_circuit_breaker_window", cfg.Daemon.SessionCircuitBreakerWindow)
+	check("[daemon]", "session_circuit_breaker_reset_after", cfg.Daemon.SessionCircuitBreakerResetAfter)
 	check("[daemon]", "shutdown_timeout", cfg.Daemon.ShutdownTimeout)
 	check("[daemon]", "wisp_gc_interval", cfg.Daemon.WispGCInterval)
 	check("[daemon]", "wisp_ttl", cfg.Daemon.WispTTL)

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -79,14 +79,16 @@ func TestValidateDurationsBadSessionTimeout(t *testing.T) {
 func TestValidateDurationsBadDaemonFields(t *testing.T) {
 	cfg := &City{
 		Daemon: DaemonConfig{
-			PatrolInterval:  "30sec",
-			RestartWindow:   "one hour",
-			ShutdownTimeout: "5 seconds",
+			PatrolInterval:                  "30sec",
+			RestartWindow:                   "one hour",
+			ShutdownTimeout:                 "5 seconds",
+			SessionCircuitBreakerWindow:     "ten minutes",
+			SessionCircuitBreakerResetAfter: "twenty minutes",
 		},
 	}
 	warnings := ValidateDurations(cfg, "city.toml")
-	if len(warnings) != 3 {
-		t.Fatalf("expected 3 warnings, got %d: %v", len(warnings), warnings)
+	if len(warnings) != 5 {
+		t.Fatalf("expected 5 warnings, got %d: %v", len(warnings), warnings)
 	}
 }
 


### PR DESCRIPTION
## Problem

The supervisor reconciler will respawn a named session indefinitely with zero awareness of loop conditions. In one production incident, the \`mayor\` named session was auto-respawned for hours because it was assigned to beads it could never reach (a separate phantom-bead bug fixed in #N), generating heavy dolt writes that starved btrfs I/O for the entire desktop session.

There is no rate limit, no backoff, no circuit breaker — any future bug that puts a named session into an unresolvable state will reproduce the same incident.

## Fix

Add a per-identity respawn circuit breaker:

- **Track**: rolling window of recent restart timestamps (default: last 30 minutes) and an observable progress signal (changes in the \`(beadID, status)\` multiset of the identity's assigned work beads)
- **Trip condition**: > 5 restarts in the window AND no progress signal in the window → \`CIRCUIT_OPEN\`
- **Effect**: reconciler refuses to materialize/spawn the session at the wake gate. ERROR-level log fires once per OPEN incident with reset instructions
- **Auto-reset**: 60 minutes of silence (no restart attempts) → CLOSED
- **Manual reset**: \`gc session reset <identity>\` clears the breaker (wired in this PR)

\`gc session reset\` resets by both the operator's input string (the identity printed in the ERROR message) and the identity resolved from the session bead's \`namedSessionIdentityMetadata\`. This handles both the common case (operator pasted the identity verbatim) and the rarer case (operator used an alias or session ID).

## Tests

- \`TestSessionCircuitBreaker_TrippingAndStaying\` (table-driven, 4 cases)
- \`TestSessionCircuitBreaker_AutoResetAfterSilence\`
- \`TestSessionCircuitBreaker_ManualReset\`
- \`TestSessionCircuitBreaker_LogOpenOnce\`
- \`TestSessionCircuitBreaker_Snapshot\`
- \`TestSessionCircuitBreaker_ObserveProgressSignature\`
- \`TestComputeNamedSessionProgressSignatures\`
- \`TestReconciler_CircuitOpenBlocksSpawn\`
- \`TestReconciler_CircuitClosedAllowsSpawn\`
- \`TestCmdSessionReset_ClearsCircuitBreaker\` — full integration: trips fake breaker, runs CLI, asserts CLOSED

Full \`cmd/gc\` package test passes (33s). \`go vet\` clean. \`gofmt\` clean.

## Caveats

- **In-memory state only.** Supervisor restart forgets the breaker. Easy follow-up to persist state to disk if needed.
- **Singleton pattern** (with \`setSessionCircuitBreakerForTest\` injection hook). Chosen over a threaded parameter to avoid rippling changes through ~30 reconciler call sites. Convertible later if desired.
- **Status snapshot hook** (\`SessionCircuitBreakerSnapshot\`) is exposed but not yet consumed by \`cmd_citystatus.go\`. One-line follow-up.