### PR TITLE
fix: guard namedWorkReady against phantom beads in unreachable stores

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -242,9 +243,10 @@ func buildDesiredStateWithSessionBeads(
 	// named session on_demand wake. Hoisted out of the store block so
 	// the named session section can also use it.
 	var assignedWorkBeads []beads.Bead
+	var assignedBeadSources map[string]map[string]struct{}
 	var storePartial bool
 	if store != nil {
-		assignedWorkBeads, storePartial = collectAssignedWorkBeads(cfg, store, rigStores, suspendedRigPaths)
+		assignedWorkBeads, assignedBeadSources, storePartial = collectAssignedWorkBeads(cfg, store, rigStores, suspendedRigPaths)
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -324,17 +326,38 @@ func buildDesiredStateWithSessionBeads(
 	// on-demand session only materializes from that path once the work is
 	// actually actionable. This keeps blocked or merely routed work from
 	// waking/materializing the named session prematurely.
-	for identity := range namedSpecs {
+	for identity, spec := range namedSpecs {
+		// Determine which store the named session's bd context can actually
+		// reach. A session pinned to a rig can only query that rig's store;
+		// a city-scoped session queries the city store. Matching an assignee
+		// against a bead in an unreachable store (e.g. the supervisor sees
+		// it via a union query across stores) would produce a phantom match
+		// that triggers endless respawns of a session that can never find
+		// its assigned work via its own bd context.
+		reachable := configuredRigName(cityPath, spec.Agent, cfg.Rigs)
 		for _, wb := range assignedWorkBeads {
 			if wb.Status != "open" && wb.Status != "in_progress" {
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)
-			if assignee == identity {
-				fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck
-				namedWorkReady[identity] = true
-				break
+			if assignee != identity {
+				continue
 			}
+			sources := assignedBeadSources[wb.ID]
+			if _, ok := sources[reachable]; !ok {
+				// Report the observed sources so operators can see why the
+				// candidate was rejected.
+				observed := make([]string, 0, len(sources))
+				for s := range sources {
+					observed = append(observed, s)
+				}
+				sort.Strings(observed)
+				fmt.Fprintf(stderr, "namedWorkReady: %s candidate bead %s is in unreachable store %v — skipping\n", identity, wb.ID, observed) //nolint:errcheck
+				continue
+			}
+			fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck
+			namedWorkReady[identity] = true
+			break
 		}
 	}
 	if len(assignedWorkBeads) > 0 {
@@ -464,45 +487,60 @@ func buildDesiredStateWithSessionBeads(
 // intentionally excluded here; new session demand comes from scale_check
 // (and work_query as a defense-in-depth wake signal), while this helper is
 // only for preserving sessions that already own actionable work.
+//
+// The second return value maps bead ID to the set of source store keys
+// ("" for the city store, rig name for rig stores) where that bead was
+// observed. This lets callers determine whether a bead's source store is
+// reachable from a given agent's bd context — a named session pinned to a
+// rig cannot query the city store (or another rig), so matching an assignee
+// against a bead in an unreachable store is a phantom match and must be
+// skipped. The set semantics matter because bead IDs can collide across
+// independent stores (each store mints its own IDs), so the guard has to
+// treat a bead as reachable if ANY of its observed sources is reachable.
 func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
-) ([]beads.Bead, bool) {
+) ([]beads.Bead, map[string]map[string]struct{}, bool) {
 	// Use CachingStore-wrapped stores. Creating raw bdStoreForCity per rig
 	// spawns bd subprocesses on every tick, saturating dolt.
-	stores := []beads.Store{cityStore}
+	type storeSource struct {
+		store beads.Store
+		key   string // "" for city, rig name for rigs
+	}
+	sources := []storeSource{{store: cityStore, key: ""}}
 	for _, rig := range cfg.Rigs {
 		if suspendedRigPaths[filepath.Clean(rig.Path)] {
 			continue
 		}
 		if s, ok := rigStores[rig.Name]; ok {
-			stores = append(stores, s)
+			sources = append(sources, storeSource{store: s, key: rig.Name})
 		}
 	}
 
 	var result []beads.Bead
+	beadSources := make(map[string]map[string]struct{})
 	var partial bool
 	seen := make(map[string]struct{})
-	for _, s := range stores {
+	for _, src := range sources {
 		// In-progress beads with an assignee (active work).
-		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress"}); err == nil {
-			appendAssignedUnique(&result, inProgress, seen)
+		if inProgress, err := src.store.List(beads.ListQuery{Status: "in_progress"}); err == nil {
+			appendAssignedUnique(&result, inProgress, seen, beadSources, src.key)
 		} else {
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
 			partial = true
 		}
 		// Ready beads with an assignee (queued direct handoff work that is
 		// actually runnable, not merely open).
-		if ready, err := s.Ready(); err == nil {
-			appendAssignedUnique(&result, ready, seen)
+		if ready, err := src.store.Ready(); err == nil {
+			appendAssignedUnique(&result, ready, seen, beadSources, src.key)
 		} else {
 			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
 			partial = true
 		}
 	}
-	return result, partial
+	return result, beadSources, partial
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is
@@ -530,7 +568,7 @@ func mergeNamedSessionDemand(poolDesired map[string]int, namedDemand map[string]
 	}
 }
 
-func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[string]struct{}) {
+func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[string]struct{}, beadSources map[string]map[string]struct{}, sourceKey string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
@@ -542,6 +580,18 @@ func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[str
 		// separately by the mail system.
 		if b.Type == sessionBeadType {
 			continue
+		}
+		// Always record the source, even if the bead ID was already seen in
+		// a prior store — independently-minted stores can collide on IDs, and
+		// the reachability guard needs the full set of sources to avoid
+		// mislabeling a legitimate same-ID hit as phantom.
+		if beadSources != nil {
+			sources, ok := beadSources[b.ID]
+			if !ok {
+				sources = make(map[string]struct{})
+				beadSources[b.ID] = sources
+			}
+			sources[sourceKey] = struct{}{}
 		}
 		if _, ok := seen[b.ID]; ok {
 			continue

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -42,7 +42,7 @@ func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T)
 		t.Fatalf("create queued bead: %v", err)
 	}
 
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1: %#v", len(got), got)
 	}
@@ -77,7 +77,7 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 		t.Fatalf("add blocking dep: %v", err)
 	}
 
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
 	if len(got) != 0 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0: %#v", len(got), got)
 	}
@@ -101,7 +101,7 @@ func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *tes
 	}); err != nil {
 		t.Fatalf("create unrouted bead: %v", err)
 	}
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
 	if len(got) != 0 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0", len(got))
 	}
@@ -139,7 +139,7 @@ func TestCollectAssignedWorkBeads_ExcludesSessionBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create task bead: %v", err)
 	}
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1 (task only): %#v", len(got), got)
 	}
@@ -605,6 +605,140 @@ func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckNonIntegerFallsToWorkQ
 	// scale_check parse error should record 0 in ScaleCheckCounts
 	if dsResult.ScaleCheckCounts["dog"] != 0 {
 		t.Fatalf("ScaleCheckCounts[dog] = %d, want 0 (parse error should not produce demand)", dsResult.ScaleCheckCounts["dog"])
+	}
+}
+
+// TestBuildDesiredState_NamedWorkReady_PhantomBeadGuardReachability verifies
+// that the namedWorkReady loop refuses to mark a named session as having
+// demand when the matched assigned bead lives in a store the session's bd
+// context cannot reach. Without this guard, a rig-scoped named session
+// pinned to rig A would be endlessly respawned because the supervisor sees
+// a matching bead in the city store (or rig B) via its union query, but the
+// session itself — which only queries rig A via its agent's bd context —
+// can never find the work.
+func TestBuildDesiredState_NamedWorkReady_PhantomBeadGuardReachability(t *testing.T) {
+	t.Parallel()
+	cityPath := t.TempDir()
+	rigAPath := filepath.Join(cityPath, "riga")
+	rigBPath := filepath.Join(cityPath, "rigb")
+	if err := os.MkdirAll(rigAPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigBPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The named session identity is "riga/mayor" — its bd context is
+	// pinned to rig A's store via agent.Dir="riga".
+	identity := "riga/mayor"
+
+	makeCfg := func() *config.City {
+		return &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Rigs: []config.Rig{
+				{Name: "riga", Path: rigAPath},
+				{Name: "rigb", Path: rigBPath},
+			},
+			Agents: []config.Agent{{
+				Name:              "mayor",
+				Dir:               "riga",
+				StartCommand:      "true",
+				MaxActiveSessions: intPtr(1),
+				WorkQuery:         "printf ''",
+			}},
+			NamedSessions: []config.NamedSession{{
+				Template: "mayor",
+				Dir:      "riga",
+				Mode:     "on_demand",
+			}},
+		}
+	}
+
+	cases := []struct {
+		name             string
+		placeReachable   bool // put an assigned bead in riga (reachable)
+		placeUnreachable bool // put an assigned bead in the city store AND rigb (unreachable)
+		wantDemand       bool
+	}{
+		{
+			name:           "reachable_store_only",
+			placeReachable: true,
+			wantDemand:     true,
+		},
+		{
+			name:             "unreachable_store_only",
+			placeUnreachable: true,
+			wantDemand:       false,
+		},
+		{
+			name:             "both_stores",
+			placeReachable:   true,
+			placeUnreachable: true,
+			wantDemand:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cityStore := beads.NewMemStore()
+			rigAStore := beads.NewMemStore()
+			rigBStore := beads.NewMemStore()
+
+			if tc.placeReachable {
+				if _, err := rigAStore.Create(beads.Bead{
+					Title:    "assigned reachable work",
+					Type:     "task",
+					Status:   "in_progress",
+					Assignee: identity,
+				}); err != nil {
+					t.Fatalf("create reachable bead: %v", err)
+				}
+			}
+			if tc.placeUnreachable {
+				// City store — not reachable from a rig-pinned session.
+				if _, err := cityStore.Create(beads.Bead{
+					Title:    "assigned phantom (city)",
+					Type:     "task",
+					Status:   "in_progress",
+					Assignee: identity,
+				}); err != nil {
+					t.Fatalf("create phantom city bead: %v", err)
+				}
+				// Another rig's store — also not reachable.
+				if _, err := rigBStore.Create(beads.Bead{
+					Title:    "assigned phantom (rigb)",
+					Type:     "task",
+					Status:   "in_progress",
+					Assignee: identity,
+				}); err != nil {
+					t.Fatalf("create phantom rigb bead: %v", err)
+				}
+			}
+
+			cfg := makeCfg()
+			rigStores := map[string]beads.Store{
+				"riga": rigAStore,
+				"rigb": rigBStore,
+			}
+			var stderr strings.Builder
+			dsResult := buildDesiredStateWithSessionBeads(
+				"test-city", cityPath, time.Now().UTC(),
+				cfg, runtime.NewFake(), cityStore, rigStores, nil, nil, &stderr,
+			)
+			gotDemand := dsResult.NamedSessionDemand[identity]
+			if gotDemand != tc.wantDemand {
+				t.Fatalf("NamedSessionDemand[%q] = %v, want %v\nstderr: %s",
+					identity, gotDemand, tc.wantDemand, stderr.String())
+			}
+			if tc.placeUnreachable && !tc.placeReachable {
+				// Warning must be emitted for the skipped phantom.
+				if !strings.Contains(stderr.String(), "unreachable store") {
+					t.Fatalf("expected 'unreachable store' warning in stderr, got: %s", stderr.String())
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

In \`build_desired_state.go\`, the loop around lines 327-339 sets \`namedWorkReady[identity] = true\` whenever any bead in \`assignedWorkBeads\` has its \`Assignee\` matching the named session's identity. But \`assignedWorkBeads\` is aggregated from \`collectAssignedWorkBeads\`, which queries BOTH the city store AND every rig store. If the matched bead lives in a store the named session's bd context cannot reach, the match is a **phantom**: the supervisor materializes the session expecting it to work on the bead, but the session can never see the bead — and never marks progress — and gets respawned forever.

This was the trigger for the production respawn-loop incident.

## Fix

Add a reachability guard. \`collectAssignedWorkBeads\` now also returns a \`map[beadID]map[storeKey]struct{}\` tracking every source store for each bead (set semantics, not single-source — independently-minted stores can collide on bead IDs, so all sources must be tracked). The phantom guard treats a bead as reachable if **any** of its source stores matches one the named session can query.

When a candidate match is rejected, a warning log fires:
\`namedWorkReady: <identity> candidate bead <id> is in unreachable store <stores> — skipping\`

## Tests

\`TestBuildDesiredState_NamedWorkReady_PhantomBeadGuardReachability\` (table-driven):
- \`reachable_store_only\` → namedWorkReady = true
- \`unreachable_store_only\` → namedWorkReady = false (with warning)
- \`both_stores\` (same ID in both) → namedWorkReady = true (at least one reachable)

\`go test ./cmd/gc/... -run 'BuildDesiredState|NamedWorkReady|Phantom'\` passes (0.258s). Full \`cmd/gc\` suite passes (32.9s). \`go vet\` clean.

## Caveats

- **Signature change**: \`collectAssignedWorkBeads\` now returns \`([]beads.Bead, map[string]map[string]struct{}, bool)\` (added a bead-ID → source-key set). All four existing call sites in this file and its tests were updated.
- **Expected merge conflict** with the supervisor logging PR (\#N), which reworks the same \`for identity, spec := range namedSpecs\` block. Straightforward to resolve at integration.