### PR TITLE
fix: only log supervisor state lines on transitions

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -168,6 +168,29 @@ func buildDesiredStateWithSessionBeads(
 	trace *sessionReconcilerTraceCycle,
 	stderr io.Writer,
 ) DesiredStateResult {
+	return buildDesiredStateWithSessionBeadsCached(
+		cityName, cityPath, beaconTime, cfg, sp, store, rigStores,
+		sessionBeads, trace, nil, stderr,
+	)
+}
+
+// buildDesiredStateWithSessionBeadsCached is the full-featured entry
+// point that also accepts a log cache so the supervisor can suppress
+// repeated "assignedWorkBeads" / "namedWorkReady" lines when state has
+// not changed between ticks. A nil logCache preserves the original
+// behavior of logging on every invocation.
+func buildDesiredStateWithSessionBeadsCached(
+	cityName, cityPath string,
+	beaconTime time.Time,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	sessionBeads *sessionBeadSnapshot,
+	trace *sessionReconcilerTraceCycle,
+	logCache *buildDesiredStateLogCache,
+	stderr io.Writer,
+) DesiredStateResult {
 	if cfg.Workspace.Suspended {
 		return DesiredStateResult{}
 	}
@@ -248,13 +271,18 @@ func buildDesiredStateWithSessionBeads(
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
-		if len(assignedWorkBeads) > 0 {
-			fmt.Fprintf(stderr, "assignedWorkBeads: %d beads found\n", len(assignedWorkBeads)) //nolint:errcheck
-			for _, wb := range assignedWorkBeads {
-				fmt.Fprintf(stderr, "  %s assignee=%s routed=%s status=%s\n", wb.ID, wb.Assignee, wb.Metadata["gc.routed_to"], wb.Status) //nolint:errcheck
+		// Only emit the assignedWorkBeads summary (and per-bead detail
+		// lines) when the observed set has changed since the last tick.
+		// Repeated identical state used to dominate supervisor.log volume.
+		if logCache.shouldLogAssignedWorkBeads(assignedWorkBeads) {
+			if len(assignedWorkBeads) > 0 {
+				fmt.Fprintf(stderr, "assignedWorkBeads: %d beads found\n", len(assignedWorkBeads)) //nolint:errcheck
+				for _, wb := range assignedWorkBeads {
+					fmt.Fprintf(stderr, "  %s assignee=%s routed=%s status=%s\n", wb.ID, wb.Assignee, wb.Metadata["gc.routed_to"], wb.Status) //nolint:errcheck
+				}
+			} else {
+				fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 			}
-		} else {
-			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, assignedWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		for _, poolState := range poolDesiredStates {
@@ -331,13 +359,15 @@ func buildDesiredStateWithSessionBeads(
 			}
 			assignee := strings.TrimSpace(wb.Assignee)
 			if assignee == identity {
-				fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck
+				if logCache.shouldLogNamedMatch(identity, wb.ID) {
+					fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck
+				}
 				namedWorkReady[identity] = true
 				break
 			}
 		}
 	}
-	if len(assignedWorkBeads) > 0 {
+	if len(assignedWorkBeads) > 0 && logCache.shouldLogNamedReadySummary(namedWorkReady) {
 		fmt.Fprintf(stderr, "namedWorkReady: %d assigned beads, %d named specs, ready=%v\n", len(assignedWorkBeads), len(namedSpecs), namedWorkReady) //nolint:errcheck
 	}
 	for identity, spec := range namedSpecs {

--- a/cmd/gc/build_desired_state_log_cache.go
+++ b/cmd/gc/build_desired_state_log_cache.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// buildDesiredStateLogCache suppresses repeated supervisor.log lines that
+// describe identical state across consecutive reconciler ticks. The
+// reconciler fires roughly every 30s and most ticks observe zero churn,
+// so emitting the same "assignedWorkBeads" / "namedWorkReady" block each
+// tick was producing ~90% of supervisor.log volume. This cache records
+// the signature of the last-logged values and only allows a new emission
+// when the signature actually changes.
+//
+// A cache instance is per CityRuntime / supervisor instance, never
+// package-global: tests can construct independent caches and assert
+// logging behavior in isolation.
+type buildDesiredStateLogCache struct {
+	mu sync.Mutex
+
+	// assignedWorkBeadsSig is the last-logged signature for the
+	// "assignedWorkBeads: N beads found" summary line. Empty string
+	// means "never logged yet"; the zero-beads case uses a dedicated
+	// sentinel so we still detect transitions to/from empty.
+	assignedWorkBeadsSig   string
+	assignedWorkBeadsKnown bool
+
+	// matchedNamedPairs records identity|beadID tuples we have already
+	// logged "namedWorkReady: %s matched by bead %s" for. We only emit
+	// the first time a pair is observed.
+	matchedNamedPairs map[string]struct{}
+
+	// namedReadySig is the last-logged signature for the
+	// "namedWorkReady: ... ready=%v" summary line.
+	namedReadySig   string
+	namedReadyKnown bool
+}
+
+func newBuildDesiredStateLogCache() *buildDesiredStateLogCache {
+	return &buildDesiredStateLogCache{
+		matchedNamedPairs: make(map[string]struct{}),
+	}
+}
+
+// assignedWorkBeadsSignature derives a stable identity key from the
+// slice. Two slices with the same set of (ID, status, assignee,
+// gc.routed_to) tuples produce the same signature regardless of order.
+func assignedWorkBeadsSignature(wbs []beads.Bead) string {
+	if len(wbs) == 0 {
+		return "empty"
+	}
+	parts := make([]string, 0, len(wbs))
+	for _, wb := range wbs {
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s",
+			wb.ID, wb.Status, wb.Assignee, wb.Metadata["gc.routed_to"]))
+	}
+	// Sort so slice ordering doesn't cause spurious signature churn.
+	// Insertion is cheap for the small slices the supervisor deals
+	// with (single-digit typical).
+	for i := 1; i < len(parts); i++ {
+		j := i
+		for j > 0 && parts[j-1] > parts[j] {
+			parts[j-1], parts[j] = parts[j], parts[j-1]
+			j--
+		}
+	}
+	return strings.Join(parts, ";")
+}
+
+// shouldLogAssignedWorkBeads reports whether the "assignedWorkBeads"
+// summary (plus per-bead detail lines) should be emitted for the given
+// slice. The cache is updated on true return.
+func (c *buildDesiredStateLogCache) shouldLogAssignedWorkBeads(wbs []beads.Bead) bool {
+	if c == nil {
+		return true
+	}
+	sig := assignedWorkBeadsSignature(wbs)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.assignedWorkBeadsKnown && c.assignedWorkBeadsSig == sig {
+		return false
+	}
+	c.assignedWorkBeadsSig = sig
+	c.assignedWorkBeadsKnown = true
+	return true
+}
+
+// shouldLogNamedMatch reports whether the per-match
+// "namedWorkReady: %s matched by bead %s" line should be emitted for
+// the given identity/bead pair. Returns true only the first time the
+// pair is seen; the cache is updated on true return.
+func (c *buildDesiredStateLogCache) shouldLogNamedMatch(identity, beadID string) bool {
+	if c == nil {
+		return true
+	}
+	key := identity + "|" + beadID
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, seen := c.matchedNamedPairs[key]; seen {
+		return false
+	}
+	c.matchedNamedPairs[key] = struct{}{}
+	return true
+}
+
+// namedReadySignature derives a stable identity key from the readiness
+// map so logical equality is preserved regardless of Go map iteration
+// order.
+func namedReadySignature(ready map[string]bool) string {
+	if len(ready) == 0 {
+		return "empty"
+	}
+	keys := make([]string, 0, len(ready))
+	for k, v := range ready {
+		if v {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return "none-ready"
+	}
+	for i := 1; i < len(keys); i++ {
+		j := i
+		for j > 0 && keys[j-1] > keys[j] {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+			j--
+		}
+	}
+	return strings.Join(keys, ",")
+}
+
+// shouldLogNamedReadySummary reports whether the
+// "namedWorkReady: %d assigned beads, %d named specs, ready=%v" line
+// should be emitted. Returns true when the set of ready identities
+// changed relative to the previous call; the cache is updated on true
+// return.
+func (c *buildDesiredStateLogCache) shouldLogNamedReadySummary(ready map[string]bool) bool {
+	if c == nil {
+		return true
+	}
+	sig := namedReadySignature(ready)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.namedReadyKnown && c.namedReadySig == sig {
+		return false
+	}
+	c.namedReadySig = sig
+	c.namedReadyKnown = true
+	return true
+}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1591,3 +1591,359 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) 
 // PR #216 — skipped for now. Cross-rig pool work visibility is a new
 // feature, not a bug fix. Left as open PR for discussion about the
 // gastown experience with this flow.
+
+// --- supervisor log state-transition cache tests ---
+//
+// These tests exercise buildDesiredStateWithSessionBeadsCached's log
+// cache and assert that identical consecutive ticks do NOT re-emit the
+// repeated "assignedWorkBeads" / "namedWorkReady" lines, while real
+// state transitions DO emit fresh lines.
+
+// runBuildDesiredStateTwice invokes buildDesiredStateWithSessionBeadsCached
+// for two ticks (same cache) against the provided store factories and
+// returns the captured stderr buffers for each tick.
+func runBuildDesiredStateTwice(
+	t *testing.T,
+	cityPath string,
+	cfg *config.City,
+	tick1Store, tick2Store beads.Store,
+) (first, second *strings.Builder) {
+	t.Helper()
+	cache := newBuildDesiredStateLogCache()
+
+	first = &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), tick1Store, nil, nil, nil, cache, first,
+	)
+
+	second = &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), tick2Store, nil, nil, nil, cache, second,
+	)
+	return first, second
+}
+
+func TestBuildDesiredStateLogCache_IdenticalTicksSuppressRepeats(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			Dir:               "repo",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+
+	first, second := runBuildDesiredStateTwice(t, cityPath, cfg, store, store)
+
+	if !strings.Contains(first.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("first tick should log assignedWorkBeads summary, got:\n%s", first.String())
+	}
+	if strings.Contains(second.String(), "assignedWorkBeads:") {
+		t.Fatalf("second tick (identical state) should NOT re-emit assignedWorkBeads, got:\n%s", second.String())
+	}
+	// Per-bead detail lines ride on the summary; also suppressed.
+	if strings.Contains(second.String(), "  bead-") || strings.Contains(second.String(), "assignee=repo/refinery") {
+		t.Fatalf("second tick should NOT re-emit per-bead detail lines, got:\n%s", second.String())
+	}
+}
+
+func TestBuildDesiredStateLogCache_ChangedStateLogsAgain(t *testing.T) {
+	cityPath := t.TempDir()
+
+	tick1Store := beads.NewMemStore()
+	if _, err := tick1Store.Create(beads.Bead{
+		Title:    "tick1 work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}); err != nil {
+		t.Fatalf("create tick1 bead: %v", err)
+	}
+
+	tick2Store := beads.NewMemStore()
+	if _, err := tick2Store.Create(beads.Bead{
+		Title:    "tick2 work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/smelter",
+	}); err != nil {
+		t.Fatalf("create tick2 bead: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "refinery", Dir: "repo", StartCommand: "true", MaxActiveSessions: intPtr(1)},
+			{Name: "smelter", Dir: "repo", StartCommand: "true", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	first, second := runBuildDesiredStateTwice(t, cityPath, cfg, tick1Store, tick2Store)
+
+	if !strings.Contains(first.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("first tick should log summary, got:\n%s", first.String())
+	}
+	if !strings.Contains(second.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("second tick (different assignee) should re-log summary, got:\n%s", second.String())
+	}
+	if !strings.Contains(first.String(), "assignee=repo/refinery") {
+		t.Fatalf("first tick should describe refinery bead, got:\n%s", first.String())
+	}
+	if !strings.Contains(second.String(), "assignee=repo/smelter") {
+		t.Fatalf("second tick should describe smelter bead, got:\n%s", second.String())
+	}
+}
+
+func TestBuildDesiredStateLogCache_AddRemoveBeadLogsTransition(t *testing.T) {
+	cityPath := t.TempDir()
+	cache := newBuildDesiredStateLogCache()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "refinery", Dir: "repo", StartCommand: "true", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	// Tick 1: one bead present.
+	store1 := beads.NewMemStore()
+	if _, err := store1.Create(beads.Bead{
+		Title:    "present",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	buf1 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store1, nil, nil, nil, cache, buf1,
+	)
+	if !strings.Contains(buf1.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("tick1 should log 1-bead summary, got:\n%s", buf1.String())
+	}
+
+	// Tick 2: identical — should be silent.
+	buf2 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store1, nil, nil, nil, cache, buf2,
+	)
+	if strings.Contains(buf2.String(), "assignedWorkBeads:") {
+		t.Fatalf("tick2 (identical) should be silent, got:\n%s", buf2.String())
+	}
+
+	// Tick 3: bead removed (empty store) — should log transition to empty.
+	store3 := beads.NewMemStore()
+	buf3 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store3, nil, nil, nil, cache, buf3,
+	)
+	if !strings.Contains(buf3.String(), "assignedWorkBeads: 0 beads") {
+		t.Fatalf("tick3 (bead removed) should log 0-beads summary, got:\n%s", buf3.String())
+	}
+
+	// Tick 4: still empty — silent again.
+	buf4 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store3, nil, nil, nil, cache, buf4,
+	)
+	if strings.Contains(buf4.String(), "assignedWorkBeads:") {
+		t.Fatalf("tick4 (still empty) should be silent, got:\n%s", buf4.String())
+	}
+
+	// Tick 5: bead re-added — should log transition back to 1-bead.
+	store5 := beads.NewMemStore()
+	if _, err := store5.Create(beads.Bead{
+		Title:    "re-added",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}); err != nil {
+		t.Fatalf("create re-added bead: %v", err)
+	}
+	buf5 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store5, nil, nil, nil, cache, buf5,
+	)
+	if !strings.Contains(buf5.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("tick5 (bead re-added) should log 1-bead summary, got:\n%s", buf5.String())
+	}
+}
+
+func TestBuildDesiredStateLogCache_NamedWorkReadyMatchLoggedOnce(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:    "mayor work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "mayor",
+	})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "on_demand",
+		}},
+	}
+
+	first, second := runBuildDesiredStateTwice(t, cityPath, cfg, store, store)
+
+	matchLine := "namedWorkReady: mayor matched by bead " + bead.ID
+	if !strings.Contains(first.String(), matchLine) {
+		t.Fatalf("first tick should log match line, got:\n%s", first.String())
+	}
+	if strings.Contains(second.String(), "matched by bead") {
+		t.Fatalf("second tick should NOT re-emit match line for the same pair, got:\n%s", second.String())
+	}
+}
+
+func TestBuildDesiredStateLogCache_NamedReadySummarySuppressedWhenUnchanged(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:    "mayor work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "mayor",
+	}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "on_demand",
+		}},
+	}
+
+	first, second := runBuildDesiredStateTwice(t, cityPath, cfg, store, store)
+
+	if !strings.Contains(first.String(), "namedWorkReady: 1 assigned beads") {
+		t.Fatalf("first tick should log named-ready summary, got:\n%s", first.String())
+	}
+	if strings.Contains(second.String(), "assigned beads") {
+		t.Fatalf("second tick (identical ready map) should NOT re-emit summary, got:\n%s", second.String())
+	}
+}
+
+func TestBuildDesiredStateLogCache_NilCacheLogsEveryCall(t *testing.T) {
+	// With a nil cache, behavior must match the original: every call
+	// emits the summary lines. This guards the one-shot code paths
+	// that intentionally pass nil.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:    "work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			Dir:               "repo",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+
+	buf1 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store, nil, nil, nil, nil, buf1,
+	)
+	buf2 := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store, nil, nil, nil, nil, buf2,
+	)
+
+	if !strings.Contains(buf1.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("nil cache tick1 should log, got:\n%s", buf1.String())
+	}
+	if !strings.Contains(buf2.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("nil cache tick2 should also log (no suppression), got:\n%s", buf2.String())
+	}
+}
+
+func TestBuildDesiredStateLogCache_IndependentInstances(t *testing.T) {
+	// Two separate cache instances must not share state: a log emitted
+	// via cache A must not suppress the same log when emitted via cache
+	// B. This is what guarantees per-supervisor isolation.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:    "work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	}); err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			Dir:               "repo",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+
+	cacheA := newBuildDesiredStateLogCache()
+	cacheB := newBuildDesiredStateLogCache()
+
+	bufA := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store, nil, nil, nil, cacheA, bufA,
+	)
+	bufB := &strings.Builder{}
+	buildDesiredStateWithSessionBeadsCached(
+		"test-city", cityPath, time.Now().UTC(), cfg,
+		runtime.NewFake(), store, nil, nil, nil, cacheB, bufB,
+	)
+
+	if !strings.Contains(bufA.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("cacheA should log on first call, got:\n%s", bufA.String())
+	}
+	if !strings.Contains(bufB.String(), "assignedWorkBeads: 1 beads found") {
+		t.Fatalf("cacheB should log on first call independently, got:\n%s", bufB.String())
+	}
+}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -38,6 +38,10 @@ func standaloneBuildAgentsFnWithSessionBeads(
 	beaconTime time.Time,
 	stderr io.Writer,
 ) func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+	// Per-daemon-instance log cache: suppresses repeated
+	// assignedWorkBeads / namedWorkReady log lines when state is
+	// unchanged between reconciler ticks.
+	logCache := newBuildDesiredStateLogCache()
 	return func(
 		c *config.City,
 		currentSP runtime.Provider,
@@ -46,7 +50,7 @@ func standaloneBuildAgentsFnWithSessionBeads(
 		sessionBeads *sessionBeadSnapshot,
 		trace *sessionReconcilerTraceCycle,
 	) DesiredStateResult {
-		return buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, c, currentSP, store, rigStores, sessionBeads, trace, stderr)
+		return buildDesiredStateWithSessionBeadsCached(cityName, cityPath, beaconTime, c, currentSP, store, rigStores, sessionBeads, trace, logCache, stderr)
 	}
 }
 

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1494,8 +1494,12 @@ func supervisorBuildAgentsFn(cityPath, cityName string, stderr io.Writer) func(*
 
 func supervisorBuildAgentsFnWithSessionBeads(cityPath, cityName string, stderr io.Writer) func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
 	beaconTime := time.Now()
+	// Per-supervisor-instance log cache: suppresses repeated
+	// assignedWorkBeads / namedWorkReady log lines when state is
+	// unchanged between reconciler ticks.
+	logCache := newBuildDesiredStateLogCache()
 	return func(c *config.City, sp runtime.Provider, store beads.Store, rigStores map[string]beads.Store, sessionBeads *sessionBeadSnapshot, trace *sessionReconcilerTraceCycle) DesiredStateResult {
-		return buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, c, sp, store, rigStores, sessionBeads, trace, stderr)
+		return buildDesiredStateWithSessionBeadsCached(cityName, cityPath, beaconTime, c, sp, store, rigStores, sessionBeads, trace, logCache, stderr)
 	}
 }
 


### PR DESCRIPTION
## Problem

In \`cmd/gc/build_desired_state.go\`, the supervisor logs \`assignedWorkBeads: N beads found\` plus per-bead lines and \`namedWorkReady: ...\` lines on **every tick** (~30s), regardless of whether anything changed. This was ~90% of supervisor.log volume in field reports.

## Fix

Add a per-supervisor-instance \`buildDesiredStateLogCache\` that compares the current tick's signature against the previous tick:

1. **assignedWorkBeads**: signature is sorted \`ID|status|assignee|routed_to\` per bead. If unchanged, suppress the summary AND the per-bead detail lines.
2. **namedWorkReady summary**: signature is the ready map. If unchanged, suppress.
3. **namedWorkReady match lines** (\"matched by bead\"): only log the first time a given identity/bead pair is seen.

Cache is **nil-safe**: passing \`nil\` preserves the original always-log behavior. The wrapper \`buildDesiredStateWithSessionBeads\` forwards a nil cache, while the new \`buildDesiredStateWithSessionBeadsCached\` is the full entry point used by per-instance call sites in supervisor and standalone modes. One-shot paths in \`cmd_start.go\` intentionally still pass nil since they only log once per process.

## Tests

7 new tests, all in \`build_desired_state_test.go\`:

- \`TestBuildDesiredStateLogCache_IdenticalTicksSuppressRepeats\`
- \`TestBuildDesiredStateLogCache_ChangedStateLogsAgain\`
- \`TestBuildDesiredStateLogCache_AddRemoveBeadLogsTransition\` (5-tick add/steady/remove/steady/re-add)
- \`TestBuildDesiredStateLogCache_NamedWorkReadyMatchLoggedOnce\`
- \`TestBuildDesiredStateLogCache_NamedReadySummarySuppressedWhenUnchanged\`
- \`TestBuildDesiredStateLogCache_NilCacheLogsEveryCall\`
- \`TestBuildDesiredStateLogCache_IndependentInstances\` (per-supervisor isolation)

Targeted run: 0.27s. Full \`cmd/gc\` package: 33s. \`go vet\` clean. \`gofmt\` clean.

## Caveats

- The \"matched by bead\" pairs map grows unboundedly for the life of a supervisor process. In practice bead IDs churn slowly so this is fine, but if a bead is closed and a new bead with the same ID + same identity is later created, the line would be suppressed. Acceptable per spec.
- **Expected merge conflict** with the phantom-bead guard PR (\#N), which also touches the same logging block. Both changes are confined to the \`if store != nil\` block; conflict resolution is mechanical.