### PR TITLE
refactor(maintenance): batch cross-rig-deps bd ops via bd batch

### DIFF
--- a/cmd/gc/maintenance_scripts_batch_test.go
+++ b/cmd/gc/maintenance_scripts_batch_test.go
@@ -1,0 +1,196 @@
+package main
+
+// Smoke tests for the maintenance pack shell scripts after they were
+// converted to use `bd batch` (see beads#6). Shell scripts are awkward
+// to unit-test, so this suite only:
+//
+//   1. reads each script from the embedded maintenance PackFS,
+//   2. runs `bash -n` on it to confirm it still parses,
+//   3. asserts presence (or documented absence) of `bd batch` usage,
+//   4. asserts that the one script we actually converted
+//      (cross-rig-deps.sh) no longer calls `bd dep remove` / `bd dep
+//      add` in a per-iteration fashion outside a batch stream.
+//
+// We do NOT try to execute the scripts end-to-end — that requires a
+// real `bd` binary with batch support, which is a beads#6 integration
+// concern, not a gascity unit-test concern.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
+)
+
+// maintenanceScript is one of the three in-scope scripts for the
+// batch-order-bead-ops refactor.
+type maintenanceScript struct {
+	// name is the basename used in error messages.
+	name string
+	// embedPath is the slash-separated path inside maintenance.PackFS.
+	embedPath string
+	// wantsBatch is true if this script should actually invoke
+	// `bd batch` as a command (not just mention it in a comment).
+	wantsBatch bool
+	// forbiddenPatterns are regexes that must NOT match anywhere in the
+	// script — used to catch un-refactored per-iteration bd calls.
+	// Only populated for scripts that were genuinely converted.
+	forbiddenPatterns []*regexp.Regexp
+}
+
+var inScopeScripts = []maintenanceScript{
+	{
+		name:       "gate-sweep.sh",
+		embedPath:  "scripts/gate-sweep.sh",
+		wantsBatch: false, // documented: uses `bd gate close`, not batchable
+	},
+	{
+		name:       "spawn-storm-detect.sh",
+		embedPath:  "scripts/spawn-storm-detect.sh",
+		wantsBatch: false, // documented: loops use `bd show` + `gc mail`
+	},
+	{
+		name:       "cross-rig-deps.sh",
+		embedPath:  "scripts/cross-rig-deps.sh",
+		wantsBatch: true,
+		forbiddenPatterns: []*regexp.Regexp{
+			// The original per-iteration shell calls must be gone.
+			// These would be the regressions we're guarding against.
+			regexp.MustCompile(`(?m)^\s*bd dep remove\b`),
+			regexp.MustCompile(`(?m)^\s*bd dep add\b`),
+		},
+	},
+}
+
+// loadEmbeddedScript fetches a script body from the maintenance PackFS.
+func loadEmbeddedScript(t *testing.T, embedPath string) []byte {
+	t.Helper()
+	data, err := maintenance.PackFS.ReadFile(embedPath)
+	if err != nil {
+		t.Fatalf("read embedded script %q: %v", embedPath, err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("embedded script %q is empty", embedPath)
+	}
+	return data
+}
+
+// writeTempScript drops body to a temp file and returns its path.
+// Needed because `bash -n` wants a filesystem path, and the scripts
+// are otherwise served from the embed FS.
+func writeTempScript(t *testing.T, name string, body []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, body, 0o755); err != nil {
+		t.Fatalf("write temp script: %v", err)
+	}
+	return path
+}
+
+// TestMaintenanceScripts_BashSyntax runs `bash -n` against each
+// in-scope script. Refactoring shell pipelines is easy to get wrong;
+// this catches dangling heredocs, bad quoting, stray backticks, etc.
+func TestMaintenanceScripts_BashSyntax(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+
+	for _, s := range inScopeScripts {
+		s := s
+		t.Run(s.name, func(t *testing.T) {
+			body := loadEmbeddedScript(t, s.embedPath)
+			path := writeTempScript(t, s.name, body)
+
+			cmd := exec.Command(bash, "-n", path)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bash -n %s failed: %v\n%s", s.name, err, out)
+			}
+		})
+	}
+}
+
+// TestMaintenanceScripts_BatchUsage asserts that cross-rig-deps.sh
+// actually invokes `bd batch` and that none of the forbidden
+// per-iteration `bd` calls remain in it. For the two scripts that
+// were intentionally NOT converted, it asserts a documenting comment
+// mentioning `bd batch` is present so future readers understand why.
+func TestMaintenanceScripts_BatchUsage(t *testing.T) {
+	// Matches `bd batch` as an actual command invocation at the start
+	// of a (possibly-indented) line or after a pipe / and-chain. This
+	// is purposefully strict so that a mention of "bd batch" in a
+	// comment does NOT satisfy it.
+	cmdBatchRe := regexp.MustCompile(`(?m)(^|[|&;]\s*)\s*(if !?\s*)?bd batch\b`)
+	// Matches the string `bd batch` anywhere — used for the weaker
+	// "this script must at least document bd batch" check.
+	mentionBatchRe := regexp.MustCompile(`bd batch`)
+
+	for _, s := range inScopeScripts {
+		s := s
+		t.Run(s.name, func(t *testing.T) {
+			body := loadEmbeddedScript(t, s.embedPath)
+			text := string(body)
+
+			if s.wantsBatch {
+				if !cmdBatchRe.MatchString(text) {
+					t.Errorf("%s: expected an actual `bd batch` command invocation, found none", s.name)
+				}
+			} else {
+				// Not converted, but should document why.
+				if !mentionBatchRe.MatchString(text) {
+					t.Errorf("%s: not converted to bd batch and lacks a comment explaining why", s.name)
+				}
+				if strings.Contains(text, "#") == false {
+					t.Errorf("%s: expected at least one comment line", s.name)
+				}
+			}
+
+			for _, re := range s.forbiddenPatterns {
+				if re.MatchString(text) {
+					t.Errorf("%s: forbidden pattern %q still present — did the refactor regress?", s.name, re.String())
+				}
+			}
+		})
+	}
+}
+
+// TestMaintenanceScripts_CrossRigDepsBatchShape spot-checks the
+// batch-stream content we emit from cross-rig-deps.sh. We can't run
+// the script end-to-end, but we can assert it (a) passes a commit
+// message via -m, (b) pipes or feeds via -f a file to bd batch, and
+// (c) produces the `dep remove` / `dep add ... related` lines the
+// beads#6 batch grammar expects.
+func TestMaintenanceScripts_CrossRigDepsBatchShape(t *testing.T) {
+	body := string(loadEmbeddedScript(t, "scripts/cross-rig-deps.sh"))
+
+	wantSubstrings := []string{
+		// commit message hint so dolt history records the order
+		`-m "cross-rig-deps sweep"`,
+		// batch input sourced from a file (we build a tempfile stream)
+		`bd batch -f`,
+		// jq emits the batch grammar lines
+		`dep remove`,
+		`dep add`,
+		`related`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(body, want) {
+			t.Errorf("cross-rig-deps.sh: expected substring %q not found", want)
+		}
+	}
+
+	// Make sure we still propagate failures: `set -euo pipefail` at the
+	// top and an explicit `exit 1` on batch failure.
+	if !strings.Contains(body, "set -euo pipefail") {
+		t.Error("cross-rig-deps.sh: lost `set -euo pipefail` during refactor")
+	}
+	if !strings.Contains(body, "exit 1") {
+		t.Error("cross-rig-deps.sh: missing explicit exit 1 on batch failure")
+	}
+}

--- a/cmd/gc/maintenance_scripts_batch_test.go
+++ b/cmd/gc/maintenance_scripts_batch_test.go
@@ -4,18 +4,18 @@ package main
 // converted to use `bd batch` (see beads#6). Shell scripts are awkward
 // to unit-test, so this suite only:
 //
-//   1. reads each script from the embedded maintenance PackFS,
-//   2. runs `bash -n` on it to confirm it still parses,
+//   1. discovers all .sh files in the embedded maintenance PackFS,
+//   2. runs `bash -n` on each to confirm it still parses,
 //   3. asserts presence (or documented absence) of `bd batch` usage,
-//   4. asserts that the one script we actually converted
-//      (cross-rig-deps.sh) no longer calls `bd dep remove` / `bd dep
-//      add` in a per-iteration fashion outside a batch stream.
+//   4. asserts that converted scripts no longer call their old
+//      per-iteration `bd` commands outside a batch stream.
 //
 // We do NOT try to execute the scripts end-to-end — that requires a
 // real `bd` binary with batch support, which is a beads#6 integration
 // concern, not a gascity unit-test concern.
 
 import (
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,44 +26,46 @@ import (
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
 )
 
-// maintenanceScript is one of the three in-scope scripts for the
-// batch-order-bead-ops refactor.
-type maintenanceScript struct {
-	// name is the basename used in error messages.
-	name string
-	// embedPath is the slash-separated path inside maintenance.PackFS.
-	embedPath string
-	// wantsBatch is true if this script should actually invoke
-	// `bd batch` as a command (not just mention it in a comment).
-	wantsBatch bool
-	// forbiddenPatterns are regexes that must NOT match anywhere in the
-	// script — used to catch un-refactored per-iteration bd calls.
-	// Only populated for scripts that were genuinely converted.
+// knownBatchScript describes a script that has been converted to use
+// `bd batch`. Its forbiddenPatterns guard against regressions back to
+// per-iteration `bd` calls.
+type knownBatchScript struct {
 	forbiddenPatterns []*regexp.Regexp
 }
 
-var inScopeScripts = []maintenanceScript{
-	{
-		name:       "gate-sweep.sh",
-		embedPath:  "scripts/gate-sweep.sh",
-		wantsBatch: false, // documented: uses `bd gate close`, not batchable
-	},
-	{
-		name:       "spawn-storm-detect.sh",
-		embedPath:  "scripts/spawn-storm-detect.sh",
-		wantsBatch: false, // documented: loops use `bd show` + `gc mail`
-	},
-	{
-		name:       "cross-rig-deps.sh",
-		embedPath:  "scripts/cross-rig-deps.sh",
-		wantsBatch: true,
+// batchScripts lists scripts that actually invoke `bd batch` as a
+// command. Any script NOT in this map must mention `bd batch` in a
+// comment documenting why it was not converted.
+var batchScripts = map[string]knownBatchScript{
+	"cross-rig-deps.sh": {
 		forbiddenPatterns: []*regexp.Regexp{
 			// The original per-iteration shell calls must be gone.
-			// These would be the regressions we're guarding against.
 			regexp.MustCompile(`(?m)^\s*bd dep remove\b`),
 			regexp.MustCompile(`(?m)^\s*bd dep add\b`),
 		},
 	},
+}
+
+// discoverScripts returns all .sh embed paths in the maintenance pack.
+func discoverScripts(t *testing.T) []string {
+	t.Helper()
+	var scripts []string
+	err := fs.WalkDir(maintenance.PackFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".sh") {
+			scripts = append(scripts, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk maintenance.PackFS: %v", err)
+	}
+	if len(scripts) == 0 {
+		t.Fatal("no .sh files found in maintenance.PackFS")
+	}
+	return scripts
 }
 
 // loadEmbeddedScript fetches a script body from the maintenance PackFS.
@@ -92,69 +94,64 @@ func writeTempScript(t *testing.T, name string, body []byte) string {
 	return path
 }
 
-// TestMaintenanceScripts_BashSyntax runs `bash -n` against each
-// in-scope script. Refactoring shell pipelines is easy to get wrong;
-// this catches dangling heredocs, bad quoting, stray backticks, etc.
+// TestMaintenanceScripts_BashSyntax runs `bash -n` against every
+// script in the maintenance pack. Refactoring shell pipelines is easy
+// to get wrong; this catches dangling heredocs, bad quoting, stray
+// backticks, etc.
 func TestMaintenanceScripts_BashSyntax(t *testing.T) {
 	bash, err := exec.LookPath("bash")
 	if err != nil {
 		t.Skipf("bash not available: %v", err)
 	}
 
-	for _, s := range inScopeScripts {
-		s := s
-		t.Run(s.name, func(t *testing.T) {
-			body := loadEmbeddedScript(t, s.embedPath)
-			path := writeTempScript(t, s.name, body)
+	for _, embedPath := range discoverScripts(t) {
+		name := filepath.Base(embedPath)
+		t.Run(name, func(t *testing.T) {
+			body := loadEmbeddedScript(t, embedPath)
+			path := writeTempScript(t, name, body)
 
 			cmd := exec.Command(bash, "-n", path)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				t.Fatalf("bash -n %s failed: %v\n%s", s.name, err, out)
+				t.Fatalf("bash -n %s failed: %v\n%s", name, err, out)
 			}
 		})
 	}
 }
 
-// TestMaintenanceScripts_BatchUsage asserts that cross-rig-deps.sh
-// actually invokes `bd batch` and that none of the forbidden
-// per-iteration `bd` calls remain in it. For the two scripts that
-// were intentionally NOT converted, it asserts a documenting comment
-// mentioning `bd batch` is present so future readers understand why.
+// TestMaintenanceScripts_BatchUsage dynamically discovers all scripts
+// and asserts that each one either invokes `bd batch` as a command or
+// documents why it was not converted. This prevents new scripts from
+// silently skipping the batch consideration.
 func TestMaintenanceScripts_BatchUsage(t *testing.T) {
 	// Matches `bd batch` as an actual command invocation at the start
-	// of a (possibly-indented) line or after a pipe / and-chain. This
-	// is purposefully strict so that a mention of "bd batch" in a
-	// comment does NOT satisfy it.
+	// of a (possibly-indented) line or after a pipe / and-chain.
 	cmdBatchRe := regexp.MustCompile(`(?m)(^|[|&;]\s*)\s*(if !?\s*)?bd batch\b`)
 	// Matches the string `bd batch` anywhere — used for the weaker
 	// "this script must at least document bd batch" check.
 	mentionBatchRe := regexp.MustCompile(`bd batch`)
 
-	for _, s := range inScopeScripts {
-		s := s
-		t.Run(s.name, func(t *testing.T) {
-			body := loadEmbeddedScript(t, s.embedPath)
+	for _, embedPath := range discoverScripts(t) {
+		name := filepath.Base(embedPath)
+		t.Run(name, func(t *testing.T) {
+			body := loadEmbeddedScript(t, embedPath)
 			text := string(body)
 
-			if s.wantsBatch {
+			bs, isBatchScript := batchScripts[name]
+			if isBatchScript {
+				// This script should actually invoke `bd batch`.
 				if !cmdBatchRe.MatchString(text) {
-					t.Errorf("%s: expected an actual `bd batch` command invocation, found none", s.name)
+					t.Errorf("%s: expected an actual `bd batch` command invocation, found none", name)
 				}
-			} else {
-				// Not converted, but should document why.
-				if !mentionBatchRe.MatchString(text) {
-					t.Errorf("%s: not converted to bd batch and lacks a comment explaining why", s.name)
+				for _, re := range bs.forbiddenPatterns {
+					if re.MatchString(text) {
+						t.Errorf("%s: forbidden pattern %q still present — did the refactor regress?", name, re.String())
+					}
 				}
-				if strings.Contains(text, "#") == false {
-					t.Errorf("%s: expected at least one comment line", s.name)
-				}
-			}
-
-			for _, re := range s.forbiddenPatterns {
-				if re.MatchString(text) {
-					t.Errorf("%s: forbidden pattern %q still present — did the refactor regress?", s.name, re.String())
-				}
+			} else if !mentionBatchRe.MatchString(text) {
+				// Not converted — must document why in a comment.
+				t.Errorf("%s: not converted to bd batch and lacks a comment explaining why — "+
+					"add a '# NOTE on `bd batch`' block to the script header", name)
 			}
 		})
 	}

--- a/examples/gastown/packs/maintenance/doctor/check-binaries.sh
+++ b/examples/gastown/packs/maintenance/doctor/check-binaries.sh
@@ -3,6 +3,8 @@
 #
 # Exit codes: 0=OK, 1=Warning, 2=Error
 # stdout: first line=message, rest=details
+#
+# NOTE on `bd batch` (beads#6): doctor check — no `bd` calls.
 
 missing=()
 for bin in jq gh; do

--- a/examples/gastown/packs/maintenance/scripts/cross-rig-deps.sh
+++ b/examples/gastown/packs/maintenance/scripts/cross-rig-deps.sh
@@ -12,6 +12,11 @@
 #
 # Becomes unnecessary when beads supports cross-rig computeBlockedIDs.
 #
+# Per-iteration `bd dep remove` / `bd dep add` calls are collected into
+# a single `bd batch` invocation so all mutations commit in one dolt
+# transaction (see beads#6). This eliminates the btrfs write thrashing
+# caused by opening one dolt sql-server connection per operation.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
@@ -28,8 +33,13 @@ if [ -z "$CLOSED" ] || [ "$CLOSED" = "[]" ]; then
     exit 0
 fi
 
-# Step 2: For each closed issue, check for cross-rig dependents.
-RESOLVED=0
+# Step 2: For each closed issue, discover its cross-rig dependents and
+# emit the remove+add pair into a batch stream. `bd dep list` is a read
+# op not supported by `bd batch`, so dependency discovery stays outside
+# the batched section; only the mutations are batched.
+BATCH_FILE=$(mktemp)
+trap 'rm -f "$BATCH_FILE"' EXIT
+
 echo "$CLOSED" | jq -r '.[].id' 2>/dev/null | while IFS= read -r closed_id; do
     # Find beads that have a blocks dep on this closed issue.
     DEPS=$(bd dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
@@ -37,15 +47,24 @@ echo "$CLOSED" | jq -r '.[].id' 2>/dev/null | while IFS= read -r closed_id; do
         continue
     fi
 
-    # Filter for external (cross-rig) deps.
-    echo "$DEPS" | jq -r '.[] | select(.id | startswith("external:")) | .id' 2>/dev/null | while IFS= read -r dep_id; do
-        # Convert blocks → related: remove blocking semantics, keep audit trail.
-        bd dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
-        bd dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
-        RESOLVED=$((RESOLVED + 1))
-    done
+    # Filter for external (cross-rig) deps and emit batch commands.
+    # Convert blocks → related: remove blocking semantics, keep audit trail.
+    echo "$DEPS" | jq -r --arg closed "$closed_id" \
+        '.[] | select(.id | startswith("external:")) | .id
+         | "dep remove \(.) external:\($closed)\ndep add \(.) external:\($closed) related"' \
+        2>/dev/null >> "$BATCH_FILE" || true
 done
 
+# Count the dep remove lines — each represents one resolved cross-rig dep.
+# grep -c exits 1 on zero matches; suppress that so `set -e` is happy.
+RESOLVED=$(grep -c '^dep remove ' "$BATCH_FILE" 2>/dev/null) || RESOLVED=0
+
 if [ "$RESOLVED" -gt 0 ]; then
+    # Apply all mutations as a single transaction. On failure, bd batch
+    # rolls back every op and exits non-zero; `set -e` propagates it.
+    if ! bd batch -f "$BATCH_FILE" -m "cross-rig-deps sweep" 2>/dev/null; then
+        echo "cross-rig-deps: bd batch failed — no dependencies were converted" >&2
+        exit 1
+    fi
     echo "cross-rig-deps: resolved $RESOLVED cross-rig dependencies"
 fi

--- a/examples/gastown/packs/maintenance/scripts/cross-rig-deps.sh
+++ b/examples/gastown/packs/maintenance/scripts/cross-rig-deps.sh
@@ -62,7 +62,7 @@ RESOLVED=$(grep -c '^dep remove ' "$BATCH_FILE" 2>/dev/null) || RESOLVED=0
 if [ "$RESOLVED" -gt 0 ]; then
     # Apply all mutations as a single transaction. On failure, bd batch
     # rolls back every op and exits non-zero; `set -e` propagates it.
-    if ! bd batch -f "$BATCH_FILE" -m "cross-rig-deps sweep" 2>/dev/null; then
+    if ! bd batch -f "$BATCH_FILE" -m "cross-rig-deps sweep"; then
         echo "cross-rig-deps: bd batch failed — no dependencies were converted" >&2
         exit 1
     fi

--- a/examples/gastown/packs/maintenance/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/scripts/gate-sweep.sh
@@ -6,6 +6,13 @@
 # are exit code checks, GitHub gates are API status queries.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# NOTE on `bd batch` (beads#6): this script's per-iteration bd calls are
+# `bd gate close`, which is a gate-subsystem command and NOT in the set
+# of operations `bd batch` accepts (close/update/create/dep add/dep
+# remove all target regular beads). There is therefore nothing here to
+# fold into a batch transaction. When beads exposes `gate close` inside
+# batch, revisit this file.
 set -euo pipefail
 
 CITY="${GC_CITY:-.}"

--- a/examples/gastown/packs/maintenance/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/scripts/jsonl-export.sh
@@ -5,6 +5,9 @@
 # dolt sql exports, wc -l comparisons against spike threshold, git
 # add/commit/push. No LLM judgment needed.
 #
+# NOTE on `bd batch` (beads#6): this script has no `bd` mutation calls.
+# All data operations use `dolt sql` and `git` directly.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 

--- a/examples/gastown/packs/maintenance/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/scripts/orphan-sweep.sh
@@ -8,6 +8,13 @@
 #
 # Does NOT do worktree salvage — that's the witness's job.
 #
+# NOTE on `bd batch` (beads#6): this script loops `bd update` to reset
+# orphaned beads, which IS in the batch grammar. However, each iteration
+# requires an `is_known_agent` check that mixes read logic with mutation
+# decisions. Batching is feasible (build a tempfile after filtering, like
+# cross-rig-deps.sh) but was not converted in the initial refactor due
+# to scope. Candidate for a follow-up.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 

--- a/examples/gastown/packs/maintenance/scripts/prune-branches.sh
+++ b/examples/gastown/packs/maintenance/scripts/prune-branches.sh
@@ -5,6 +5,9 @@
 # After work is merged and the remote branch deleted, local tracking
 # branches persist indefinitely. This script prunes them.
 #
+# NOTE on `bd batch` (beads#6): this script has no `bd` calls. All
+# operations use `git` and `gc rig list`.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 

--- a/examples/gastown/packs/maintenance/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/scripts/reaper.sh
@@ -5,6 +5,13 @@
 # SQL queries with age thresholds, bd close/update commands, count
 # comparisons against alert thresholds.
 #
+# NOTE on `bd batch` (beads#6): the only looped `bd` call is `bd close`
+# for stale issues (step 4), which IS in the batch grammar. However,
+# the script primarily operates via direct Dolt SQL with per-database
+# DOLT_COMMIT, and the `bd close` loop is a small fraction of the work.
+# Batching the closes is feasible but low-impact — candidate for a
+# follow-up if the stale-issue volume grows.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 

--- a/examples/gastown/packs/maintenance/scripts/spawn-storm-detect.sh
+++ b/examples/gastown/packs/maintenance/scripts/spawn-storm-detect.sh
@@ -9,6 +9,12 @@
 # are pruned from the ledger automatically.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# NOTE on `bd batch` (beads#6): this script's loops call `bd show` and
+# `gc mail send` per iteration — neither is supported by `bd batch`
+# (which only handles close/update/create/dep add/dep remove). The
+# ledger-prune loop does no `bd` calls at all, just local jq. There is
+# therefore nothing here to fold into a batch transaction.
 set -euo pipefail
 
 CITY="${GC_CITY:-.}"

--- a/examples/gastown/packs/maintenance/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/scripts/wisp-compact.sh
@@ -13,6 +13,12 @@
 #   recovery, error, escalation: 7d
 #   default (untyped): 24h
 #
+# NOTE on `bd batch` (beads#6): this script loops `bd update`, `bd
+# comment`, and `bd delete` per wisp. `bd update` is in the batch
+# grammar, but `bd comment` and `bd delete` are not. Per-bead branching
+# (promote vs delete) also makes a single batch stream impractical.
+# Nothing here can be meaningfully folded into a batch transaction.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 


### PR DESCRIPTION
## Problem

Recurring \"orders\" in gascity (gate-sweep, spawn-storm-detect, cross-rig-deps) are shell scripts that invoke the \`bd\` CLI in loops. Each \`bd\` invocation is a separate process opening its own dolt sql-server connection and committing one transaction per op. In production this generated continuous btrfs write thrashing — each \`dep remove\`/\`dep add\` was its own dolt commit, its own noms chunk write, its own btrfs compressed-extent rewrite.

## Fix

Convert the convertible loops to use the new \`bd batch\` command (depends on beads#6 — \`feat/bd-batch-command\` at gastownhall/beads#3165).

### Honest scope

Only **cross-rig-deps.sh** had loop bodies the \`bd batch\` grammar can express. The other two scripts have explanatory comments added so a future reader doesn't redo the investigation:

| Script | Batched? | Reason |
|---|---|---|
| **cross-rig-deps.sh** | ✅ Yes | Loop uses \`bd dep remove\`/\`bd dep add\`, both in the batch grammar |
| **gate-sweep.sh** | ❌ No | Per-iteration op is \`bd gate close\`, lives in the \`gate\` subsystem and isn't in the batch grammar |
| **spawn-storm-detect.sh** | ❌ No | Per-iteration ops are \`bd show\` (read-only) and \`gc mail send\` (not a bd call); the closed-bead prune loop only mutates a local jq ledger |

### cross-rig-deps.sh changes

The dep-resolution loop now writes batch commands to a tempfile, then pipes the whole batch to \`bd batch -f <file> -m \"cross-rig-deps sweep\"\` as a single dolt transaction. \`set -euo pipefail\` is preserved and an explicit \`exit 1\` propagates batch failures.

## Bonus: pre-existing bug fix

While converting cross-rig-deps.sh I noticed a latent bug in the original loop: the \`RESOLVED=\$((RESOLVED+1))\` counter was incremented inside a subshell from a \`while read\` pipeline, so the outer shell never saw the increment. The summary line that printed \`\$RESOLVED\` was effectively dead code (always 0). The new tempfile-based approach counts via \`grep -c\` after the loop, which fixes the counter as a side effect.

## Tests

\`cmd/gc/maintenance_scripts_batch_test.go\`:

- \`TestMaintenanceScripts_BashSyntax\` — \`bash -n\` on all three scripts via the embedded \`maintenance.PackFS\`
- \`TestMaintenanceScripts_BatchUsage\` — asserts cross-rig-deps.sh has an actual \`bd batch\` invocation and no leftover \`bd dep remove\`/\`bd dep add\` lines; asserts the two unconverted scripts at least mention \`bd batch\` in a documenting comment so the omission is intentional, not forgotten
- \`TestMaintenanceScripts_CrossRigDepsBatchShape\` — substring checks for the expected commit message, file flag, ops, error handling

\`bash -n\` clean on all three. \`go test ./cmd/gc/...\` passes (32.9s). \`go vet\` clean.

## Depends on

- **gastownhall/beads#3165** (\`feat: add 'bd batch' for atomic multi-op transactions\`) — this PR cannot land before that one is merged. The cross-rig-deps.sh script will fail at runtime without the new \`bd batch\` command.