### PR TITLE
fix: apply formula step tags as bead labels during cook/wisp

### DIFF
--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -373,6 +373,9 @@ func ExtractVariables(formula *Formula) []string {
 		extract(step.Description)
 		extract(step.Assignee)
 		extract(step.Condition)
+		for _, l := range step.Labels {
+			extract(l)
+		}
 		for _, child := range step.Children {
 			extractFromStep(child)
 		}

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1359,6 +1359,76 @@ waits_for = "all-children"
 	}
 }
 
+func TestParseTOML_StepTags(t *testing.T) {
+	tomlData := `
+formula = "mol-tags-test"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "alpha"
+title = "Alpha step"
+tags = ["my-tag", "{{epic}}"]
+
+[[steps]]
+id = "beta"
+title = "Beta step"
+needs = ["alpha"]
+tags = ["my-tag", "review"]
+`
+	p := NewParser()
+	f, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+
+	if len(f.Steps) != 2 {
+		t.Fatalf("len(Steps) = %d, want 2", len(f.Steps))
+	}
+
+	alpha := f.Steps[0]
+	if len(alpha.Labels) != 2 {
+		t.Fatalf("Steps[0].Labels = %v, want [my-tag {{epic}}]", alpha.Labels)
+	}
+	if alpha.Labels[0] != "my-tag" || alpha.Labels[1] != "{{epic}}" {
+		t.Errorf("Steps[0].Labels = %v, want [my-tag {{epic}}]", alpha.Labels)
+	}
+
+	beta := f.Steps[1]
+	if len(beta.Labels) != 2 {
+		t.Fatalf("Steps[1].Labels = %v, want [my-tag review]", beta.Labels)
+	}
+	if beta.Labels[0] != "my-tag" || beta.Labels[1] != "review" {
+		t.Errorf("Steps[1].Labels = %v, want [my-tag review]", beta.Labels)
+	}
+}
+
+func TestExtractVariables_IncludesLabels(t *testing.T) {
+	f := &Formula{
+		Formula:     "mol-label-vars",
+		Description: "Test {{project}}",
+		Steps: []*Step{
+			{ID: "s1", Title: "Step", Labels: []string{"{{epic}}", "fixed"}},
+		},
+	}
+
+	vars := ExtractVariables(f)
+	found := make(map[string]bool)
+	for _, v := range vars {
+		found[v] = true
+	}
+
+	if !found["project"] {
+		t.Error("ExtractVariables missed 'project' from description")
+	}
+	if !found["epic"] {
+		t.Error("ExtractVariables missed 'epic' from step labels")
+	}
+	if found["fixed"] {
+		t.Error("ExtractVariables should not extract non-variable 'fixed'")
+	}
+}
+
 // Tests for simple string vars in TOML [vars] section
 
 func TestParseTOML_SimpleStringVars(t *testing.T) {

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -212,7 +212,8 @@ type Step struct {
 	Priority *int `json:"priority,omitempty"`
 
 	// Labels are applied to the created issue.
-	Labels []string `json:"labels,omitempty"`
+	// TOML key is "tags" (formula author facing); JSON/Go name is "labels" (bead facing).
+	Labels []string `json:"labels,omitempty" toml:"tags,omitempty"`
 
 	// Metadata is copied to the cooked issue metadata as string key/value pairs.
 	// Reserved runtime keys under the gc.* namespace may be added by transforms.

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -654,7 +654,7 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 		Description: formula.Substitute(step.Description, vars),
 		Type:        stepType,
 		Priority:    resolveStepPriority(step, priorityOverride),
-		Labels:      step.Labels,
+		Labels:      substituteLabels(step.Labels, vars),
 		Assignee:    formula.Substitute(step.Assignee, vars),
 	}
 
@@ -670,6 +670,18 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 	}
 
 	return b
+}
+
+// substituteLabels applies variable substitution to each label.
+func substituteLabels(labels []string, vars map[string]string) []string {
+	if len(labels) == 0 {
+		return labels
+	}
+	out := make([]string, len(labels))
+	for i, l := range labels {
+		out[i] = formula.Substitute(l, vars)
+	}
+	return out
 }
 
 func resolveStepPriority(step formula.RecipeStep, priorityOverride *int) *int {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -839,6 +839,43 @@ func TestInstantiateSubstitutesAssigneeVars(t *testing.T) {
 	}
 }
 
+func TestInstantiateSubstitutesLabelVars(t *testing.T) {
+	store := beads.NewMemStore()
+	epicDefault := "CLOUD-100"
+	recipe := &formula.Recipe{
+		Name: "label-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "label-vars", Title: "Root", Type: "molecule", IsRoot: true},
+			{ID: "label-vars.step", Title: "Tagged", Type: "task", Labels: []string{"{{epic}}", "review"}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "label-vars.step", DependsOnID: "label-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"epic": {Description: "Epic label", Default: &epicDefault},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	step, err := store.Get(result.IDMapping["label-vars.step"])
+	if err != nil {
+		t.Fatalf("get step: %v", err)
+	}
+	if len(step.Labels) != 2 {
+		t.Fatalf("step.Labels = %v, want [CLOUD-100 review]", step.Labels)
+	}
+	if step.Labels[0] != "CLOUD-100" {
+		t.Errorf("step.Labels[0] = %q, want CLOUD-100 (substituted)", step.Labels[0])
+	}
+	if step.Labels[1] != "review" {
+		t.Errorf("step.Labels[1] = %q, want review", step.Labels[1])
+	}
+}
+
 func TestInstantiateNilRecipe(t *testing.T) {
 	store := beads.NewMemStore()
 	_, err := Instantiate(context.Background(), store, nil, Options{})


### PR DESCRIPTION
## Summary

- Adds `toml:"tags"` struct tag to `Step.Labels` so formula `tags = [...]` are parsed into the Labels field
- `ExtractVariables` now includes labels, so template variables in tags (e.g. `{{epic}}`) are discovered
- `stepToBead` applies variable substitution to labels instead of passing them through raw

Closes #530

## Test plan

- [x] `TestParseTOML_StepTags` — tags parsed from TOML into Labels
- [x] `TestExtractVariables_IncludesLabels` — template vars in labels are extracted
- [x] `TestInstantiateSubstitutesLabelVars` — labels on cooked beads have vars substituted (including defaults)
- [x] `go test ./internal/formula/... ./internal/molecule/...` passes
- [x] `go vet` clean