### PR TITLE
fix: surface real error when controller test socket wait times out

### DIFF
--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -52,7 +52,8 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 	}
 	const seededSession = "seeded-session"
 
-	var controllerStdout, controllerStderr bytes.Buffer
+	var controllerStdout bytes.Buffer
+	var controllerStderr syncBuffer
 	done := make(chan struct{})
 	go func() {
 		runController(dir, tomlPath, cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
@@ -70,7 +71,7 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 		}
 	})
 
-	waitForController(t, dir, 5*time.Second)
+	waitForController(t, dir, 5*time.Second, done, &controllerStderr)
 	if err := sp.Start(context.Background(), seededSession, runtime.Config{}); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -140,7 +141,8 @@ func TestControllerShutdown(t *testing.T) {
 	// Dolt-backed .beads/ database).
 	tomlPath := writeCityTOML(t, dir, "test", "mayor")
 
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr syncBuffer
 
 	// Run controller in a goroutine; it will block until canceled.
 	// Use a close-able channel so cleanup can detect whether the
@@ -162,7 +164,7 @@ func TestControllerShutdown(t *testing.T) {
 	})
 
 	// Poll for controller socket to become available instead of fixed sleep.
-	waitForController(t, dir, 5*time.Second)
+	waitForController(t, dir, 5*time.Second, done, &stderr)
 
 	if !tryStopController(dir, &bytes.Buffer{}) {
 		t.Fatal("tryStopController returned false, expected true")
@@ -814,7 +816,8 @@ func TestControllerPokeTriggersImmediate(t *testing.T) {
 	// operations rather than falling back to cwd.
 	tomlPath := writeCityTOML(t, dir, "test")
 
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr syncBuffer
 
 	done := make(chan struct{})
 	go func() {
@@ -832,7 +835,7 @@ func TestControllerPokeTriggersImmediate(t *testing.T) {
 	})
 
 	// Poll for controller socket to become available.
-	waitForController(t, dir, 5*time.Second)
+	waitForController(t, dir, 5*time.Second, done, &stderr)
 
 	// Wait for initial tick.
 	deadline := time.After(5 * time.Second)
@@ -875,19 +878,66 @@ func TestControllerPokeTriggersImmediate(t *testing.T) {
 	}
 }
 
+// syncBuffer is a concurrency-safe bytes.Buffer for use as an io.Writer
+// (e.g. capturing stderr from a goroutine) that can be read safely from
+// another goroutine. It implements io.Writer plus String/Len accessors.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (sb *syncBuffer) Write(p []byte) (int, error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.Write(p)
+}
+
+func (sb *syncBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.String()
+}
+
+func (sb *syncBuffer) Len() int {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.Len()
+}
+
 // waitForController polls until the controller socket at dir is responsive,
-// or fails the test after the given timeout. This replaces fixed sleeps that
-// are unreliable under load.
-func waitForController(t *testing.T, dir string, timeout time.Duration) {
+// or fails the test after the given timeout. If done is non-nil it is checked
+// on each poll iteration; a closed channel means runController exited early
+// and the real error is in stderr rather than a socket timeout.
+func waitForController(t *testing.T, dir string, timeout time.Duration, done <-chan struct{}, stderr *syncBuffer) {
 	t.Helper()
 	deadline := time.After(timeout)
 	for {
 		if controllerAlive(dir) != 0 {
 			return
 		}
+		// Detect early exit: runController returned before the socket
+		// became responsive. Report stderr so the real error surfaces
+		// instead of a misleading "timed out" message.
+		if done != nil {
+			select {
+			case <-done:
+				var diag string
+				if stderr != nil {
+					diag = stderr.String()
+				}
+				t.Fatalf("controller exited before socket became ready; stderr: %s", diag)
+			default:
+			}
+		}
 		select {
 		case <-deadline:
-			t.Fatal("timed out waiting for controller socket to become available")
+			msg := "timed out waiting for controller socket to become available"
+			if stderr != nil {
+				if s := stderr.String(); s != "" {
+					msg += "; stderr: " + s
+				}
+			}
+			t.Fatal(msg)
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -880,7 +882,7 @@ func TestControllerPokeTriggersImmediate(t *testing.T) {
 
 // syncBuffer is a concurrency-safe bytes.Buffer for use as an io.Writer
 // (e.g. capturing stderr from a goroutine) that can be read safely from
-// another goroutine. It implements io.Writer plus String/Len accessors.
+// another goroutine. It implements io.Writer plus a String accessor.
 type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
@@ -896,12 +898,6 @@ func (sb *syncBuffer) String() string {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 	return sb.buf.String()
-}
-
-func (sb *syncBuffer) Len() int {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
-	return sb.buf.Len()
 }
 
 // waitForController polls until the controller socket at dir is responsive,
@@ -941,6 +937,69 @@ func waitForController(t *testing.T, dir string, timeout time.Duration, done <-c
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}
+	}
+}
+
+// TestWaitForControllerDetectsEarlyExit verifies that waitForController
+// surfaces the real stderr content (not a generic timeout) when the
+// controller goroutine exits before the socket becomes ready.
+func TestWaitForControllerDetectsEarlyExit(t *testing.T) {
+	if os.Getenv("TEST_CONTROLLER_EARLY_EXIT") == "1" {
+		dir := t.TempDir()
+
+		var stderr syncBuffer
+		fmt.Fprint(&stderr, "gc start: injected startup failure\n") //nolint:errcheck // test setup
+
+		done := make(chan struct{})
+		close(done) // controller already exited
+
+		waitForController(t, dir, 5*time.Second, done, &stderr)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWaitForControllerDetectsEarlyExit$")
+	cmd.Env = append(os.Environ(), "TEST_CONTROLLER_EARLY_EXIT=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected subprocess to fail via t.Fatalf")
+	}
+	output := string(out)
+	if !strings.Contains(output, "controller exited before socket became ready") {
+		t.Fatalf("expected early-exit diagnostic, got:\n%s", output)
+	}
+	if !strings.Contains(output, "injected startup failure") {
+		t.Fatalf("expected stderr content in diagnostic, got:\n%s", output)
+	}
+}
+
+// TestWaitForControllerTimeoutIncludesStderr verifies that when
+// waitForController times out, it appends any buffered stderr content
+// to the failure message for diagnosis.
+func TestWaitForControllerTimeoutIncludesStderr(t *testing.T) {
+	if os.Getenv("TEST_CONTROLLER_TIMEOUT_STDERR") == "1" {
+		dir := t.TempDir()
+
+		var stderr syncBuffer
+		fmt.Fprint(&stderr, "gc start: partial startup output\n") //nolint:errcheck // test setup
+
+		done := make(chan struct{}) // never closed — simulates hung controller
+
+		waitForController(t, dir, 50*time.Millisecond, done, &stderr)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWaitForControllerTimeoutIncludesStderr$")
+	cmd.Env = append(os.Environ(), "TEST_CONTROLLER_TIMEOUT_STDERR=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected subprocess to fail via t.Fatalf")
+	}
+	output := string(out)
+	if !strings.Contains(output, "timed out waiting for controller socket") {
+		t.Fatalf("expected timeout message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "partial startup output") {
+		t.Fatalf("expected stderr appended to timeout message, got:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #562. `waitForController` now detects early `runController` exit and reports the actual startup error instead of a misleading "timed out waiting for controller socket" message.

- `waitForController` gains `done <-chan struct{}` and `stderr *bytes.Buffer` parameters
- On each poll, checks if the controller goroutine already exited (done channel closed) — reports stderr as the real error
- On timeout, appends stderr to the failure message for diagnosis
- All 3 call sites updated: `TestControllerShutdown`, `TestControllerPokeTriggersImmediateReconcile`, `TestCmdStopWaitsForStandaloneControllerExit`
- No production code modified — `controllerAlive` (10+ callers) is untouched

**Root cause analysis:** The reporter's consistent failure on `feat/migrate-doctor` was likely an early exit from `runController` (token write or bead store init failing in that branch's environment). The 5s timeout then masked the real error with a generic "timed out" message. This fix ensures the next occurrence surfaces the actual failure.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] All 3 affected tests pass with `-count=5`
- [x] Full `cmd/gc` test suite passes (175s, 0 failures beyond known baseline)
- [x] Blast radius analysis: `controllerAlive` not modified, no production impact
- [x] 21-rule codebase audit: 0 violations