### PR TITLE
fix: cover .gc/, .beads/, hooks/ in generated gitignore (#301)

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -427,6 +427,10 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if err := ensureGitignoreEntries(fs, cityPath, cityGitignoreEntries); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	fmt.Fprintf(stdout, "Welcome to Gas City!\n")                                           //nolint:errcheck // best-effort stdout
 	fmt.Fprintf(stdout, "Initialized city %q from %s.\n", cityName, filepath.Base(tomlSrc)) //nolint:errcheck // best-effort stdout
@@ -524,6 +528,10 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	}
 	logInitProgress(stdout, 5, "Writing city configuration")
 	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := ensureGitignoreEntries(fs, cityPath, cityGitignoreEntries); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -743,6 +751,10 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 		if rsErr := ResolveScripts(cityPath, expandedCfg.ScriptLayers.City); rsErr != nil {
 			fmt.Fprintf(stderr, "gc init: resolving scripts: %v\n", rsErr) //nolint:errcheck // best-effort stderr
 		}
+	}
+	if err := ensureGitignoreEntries(fs, cityPath, cityGitignoreEntries); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 
 	fmt.Fprintln(stdout, "Welcome to Gas City!")                                           //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -288,6 +288,11 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 		}
 	}
 
+	if err := ensureGitignoreEntries(fs, rigPath, rigGitignoreEntries); err != nil {
+		fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
 	// --- Phase 2: Commit config (only after infrastructure succeeds) ---
 	// Skipped for re-adds (config already has this rig).
 

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -59,6 +59,47 @@ func TestDoRigAdd_Basic(t *testing.T) {
 	}
 }
 
+func TestDoRigAdd_WritesGitignore(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "my-rig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, "", "", "", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	gitignore, err := os.ReadFile(filepath.Join(rigPath, ".gitignore"))
+	if err != nil {
+		t.Fatalf("reading rig .gitignore: %v", err)
+	}
+	got := string(gitignore)
+	if !strings.Contains(got, ".beads/") {
+		t.Errorf("rig gitignore missing .beads/:\n%s", got)
+	}
+	// Rigs do not own .gc/ or hooks/ — those are city-level state.
+	if strings.Contains(got, ".gc/") {
+		t.Errorf("rig gitignore should not contain .gc/:\n%s", got)
+	}
+	if strings.Contains(got, "hooks/") {
+		t.Errorf("rig gitignore should not contain hooks/:\n%s", got)
+	}
+}
+
 func TestDoRigAdd_DuplicateNameDifferentPath(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/cmd/gc/gitignore.go
+++ b/cmd/gc/gitignore.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// gcManagedGitignoreHeader marks the section of .gitignore that gc init
+// and gc rig add append to. Operators can delete the whole block by
+// removing from this header to the next blank line.
+const gcManagedGitignoreHeader = "# Gas City managed state"
+
+// cityGitignoreEntries covers state that the city root generates and
+// that must not be committed: the .gc/ runtime, the .beads/ database,
+// and the hooks/ directory where per-provider agent hook files are
+// materialized. The beads backend (bd init) writes its own entries for
+// .dolt/, *.db, and .beads-credential-key; ensureGitignoreEntries
+// complements that set rather than replacing it.
+var cityGitignoreEntries = []string{".gc/", ".beads/", "hooks/"}
+
+// rigGitignoreEntries covers state that a rig root generates. Unlike
+// cities, rigs do not own .gc/ or hooks/ — only the .beads/ database.
+var rigGitignoreEntries = []string{".beads/"}
+
+// ensureGitignoreEntries appends any entries that are not already
+// present to dir/.gitignore. A missing file is created; an existing
+// file keeps its prior content and receives only the missing entries
+// under a [gcManagedGitignoreHeader] block. The function is idempotent:
+// once every entry is present, subsequent calls with the same set leave
+// the file untouched.
+func ensureGitignoreEntries(fs fsys.FS, dir string, entries []string) error {
+	path := filepath.Join(dir, ".gitignore")
+
+	existing, err := fs.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	present := make(map[string]bool)
+	for _, line := range bytes.Split(existing, []byte("\n")) {
+		trimmed := string(bytes.TrimSpace(line))
+		if trimmed == "" || trimmed[0] == '#' {
+			continue
+		}
+		present[trimmed] = true
+	}
+
+	var missing []string
+	for _, e := range entries {
+		if !present[e] {
+			missing = append(missing, e)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	buf.Write(existing)
+	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+		buf.WriteByte('\n')
+	}
+	if len(existing) > 0 {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(gcManagedGitignoreHeader)
+	buf.WriteByte('\n')
+	for _, e := range missing {
+		buf.WriteString(e)
+		buf.WriteByte('\n')
+	}
+
+	if err := fs.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/gc/gitignore_test.go
+++ b/cmd/gc/gitignore_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestEnsureGitignoreEntries_CreatesFileWhenMissing(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+
+	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/", "hooks/"}); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	got := string(f.Files["/city/.gitignore"])
+	want := "# Gas City managed state\n.gc/\n.beads/\nhooks/\n"
+	if got != want {
+		t.Errorf("gitignore =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestEnsureGitignoreEntries_AppendsToBdInitFile(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+	// Mirrors the content bd init writes today.
+	f.Files["/city/.gitignore"] = []byte("# Beads / Dolt files (added by bd init)\n.dolt/\n*.db\n.beads-credential-key\n")
+
+	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/", "hooks/"}); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	got := string(f.Files["/city/.gitignore"])
+	want := "# Beads / Dolt files (added by bd init)\n.dolt/\n*.db\n.beads-credential-key\n\n# Gas City managed state\n.gc/\n.beads/\nhooks/\n"
+	if got != want {
+		t.Errorf("gitignore =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestEnsureGitignoreEntries_NoOpWhenAllPresent(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+	f.Files["/city/.gitignore"] = []byte(".gc/\n.beads/\nhooks/\n")
+
+	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/", "hooks/"}); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	for _, c := range f.Calls {
+		if c.Method == "WriteFile" && c.Path == "/city/.gitignore" {
+			t.Errorf("unexpected WriteFile when entries already present")
+		}
+	}
+}
+
+func TestEnsureGitignoreEntries_PartialOverlap(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+	f.Files["/city/.gitignore"] = []byte(".gc/\n")
+
+	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/", "hooks/"}); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	got := string(f.Files["/city/.gitignore"])
+	want := ".gc/\n\n# Gas City managed state\n.beads/\nhooks/\n"
+	if got != want {
+		t.Errorf("gitignore =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestEnsureGitignoreEntries_PreservesUserEntriesAndComments(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+	f.Files["/city/.gitignore"] = []byte("# user comment\nnode_modules/\n\n# another comment\n.gc/\n")
+
+	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/"}); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	got := string(f.Files["/city/.gitignore"])
+	if !strings.Contains(got, "# user comment") {
+		t.Errorf("lost user comment:\n%s", got)
+	}
+	if !strings.Contains(got, "node_modules/") {
+		t.Errorf("lost user entry:\n%s", got)
+	}
+	if strings.Count(got, ".gc/") != 1 {
+		t.Errorf(".gc/ should appear exactly once:\n%s", got)
+	}
+	if !strings.Contains(got, "\n.beads/\n") {
+		t.Errorf(".beads/ not appended:\n%s", got)
+	}
+}
+
+func TestEnsureGitignoreEntries_HandlesMissingTrailingNewline(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+	f.Files["/city/.gitignore"] = []byte(".dolt/")
+
+	if err := ensureGitignoreEntries(f, "/city", []string{".gc/"}); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	got := string(f.Files["/city/.gitignore"])
+	want := ".dolt/\n\n# Gas City managed state\n.gc/\n"
+	if got != want {
+		t.Errorf("gitignore =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestEnsureGitignoreEntries_Idempotent(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+
+	for i := 0; i < 3; i++ {
+		if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/", "hooks/"}); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+
+	got := string(f.Files["/city/.gitignore"])
+	want := "# Gas City managed state\n.gc/\n.beads/\nhooks/\n"
+	if got != want {
+		t.Errorf("gitignore after 3 calls =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestEnsureGitignoreEntries_RigSet(t *testing.T) {
+	f := fsys.NewFake()
+	f.Dirs["/rig"] = true
+	f.Files["/rig/.gitignore"] = []byte("# Beads / Dolt files (added by bd init)\n.dolt/\n*.db\n.beads-credential-key\n")
+
+	if err := ensureGitignoreEntries(f, "/rig", rigGitignoreEntries); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+
+	got := string(f.Files["/rig/.gitignore"])
+	if !strings.Contains(got, ".beads/") {
+		t.Errorf(".beads/ not appended to rig gitignore:\n%s", got)
+	}
+	if strings.Contains(got, ".gc/") {
+		t.Errorf("rig gitignore unexpectedly contains .gc/:\n%s", got)
+	}
+	if strings.Contains(got, "hooks/") {
+		t.Errorf("rig gitignore unexpectedly contains hooks/:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

`gc init` and `gc rig add` now ensure the city- and rig-level `.gitignore`
files list gas city managed state in addition to the entries `bd init`
already writes (`.dolt/`, `*.db`, `.beads-credential-key`). Cities get
`.gc/`, `.beads/`, and `hooks/`; rigs get `.beads/` only. Fixes #301.

Introduces a new `ensureGitignoreEntries` helper in `cmd/gc/gitignore.go`.
The helper is idempotent: it reads any existing `.gitignore`, computes the
missing entries, and appends them under a `# Gas City managed state`
header. User-authored content, comments, and the bead backend's entries
are preserved.

## Changes

- `cmd/gc/gitignore.go` (new) — `ensureGitignoreEntries` helper plus
  `cityGitignoreEntries` and `rigGitignoreEntries` sets.
- `cmd/gc/cmd_init.go` — call the helper in all three city init
  entry points (`cmdInitFromTOMLFileWithOptions`, `doInit`,
  `doInitFromDirWithOptions`).
- `cmd/gc/cmd_rig.go` — call the helper in `doRigAdd` after phase 1
  infrastructure lands, before phase 2 config commit.
- `cmd/gc/gitignore_test.go` (new) — 8 unit tests covering create,
  append-to-bd-init output, no-op when present, partial overlap, user
  content preservation, missing trailing newline, idempotency, rig set.
- `cmd/gc/cmd_rig_test.go` — end-to-end test that `doRigAdd` writes a
  rig `.gitignore` containing `.beads/` but not `.gc/` or `hooks/`.

## Testing

- `make fmt-check` — clean
- `make vet` — clean
- `make lint` — 0 issues
- `go test -run '^TestEnsureGitignore|^TestDoRigAdd_WritesGitignore' ./cmd/gc` — passes

## Review

This is a re-run of the prior attempt in #615, which was closed by the
maintainer to re-dispatch through the fixed wasteland-integrated scoping
flow. The code is identical to the earlier attempt, cherry-picked cleanly
onto current `upstream/main` (one intervening commit — `.github/bugflow.toml`
chore — does not conflict).

## Notes

Idempotent by design: the helper reads the existing file, computes
entries that are not already present (skipping blank and comment lines),
and only writes when there are missing entries. Safe to invoke on
restart or re-init.

No breaking changes. No docs updates required — the behavior is an
extension of existing init output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)