### PR TITLE
fix: honor gc mail reply --notify

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1078,9 +1078,11 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	rec := openCityRecorder(stderr)
 
 	sender := defaultMailIdentity()
+	var hasStore bool
 	if sender != "human" {
 		v := mailProviderName()
 		if !strings.HasPrefix(v, "exec:") && v != "fake" && v != "fail" {
+			hasStore = true
 			store, storeCode := openCityStore(stderr, "gc mail reply")
 			if store == nil {
 				return storeCode
@@ -1107,7 +1109,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	}
 
 	var nf nudgeFunc
-	if notify {
+	if notify && hasStore {
 		nf = newMailNudgeFunc(sender)
 	}
 

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -21,9 +21,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// nudgeFunc is an optional callback for nudging an agent after sending mail.
-// When non-nil, it is called with the recipient name. Errors are non-fatal.
+// nudgeFunc is an optional callback for nudging an agent after sending or
+// replying to mail. When non-nil, it is called with the recipient name.
+// Errors are non-fatal.
 type nudgeFunc func(recipient string) error
+
+func newMailNudgeFunc(sender string) nudgeFunc {
+	return func(recipient string) error {
+		target, err := resolveNudgeTarget(recipient)
+		if err != nil {
+			return err
+		}
+		return sendMailNotify(target, sender)
+	}
+}
 
 func newMailCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -799,13 +810,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 
 	var nf nudgeFunc
 	if notify && store != nil {
-		nf = func(recipient string) error {
-			target, err := resolveNudgeTarget(recipient)
-			if err != nil {
-				return err
-			}
-			return sendMailNotify(target, sender)
-		}
+		nf = newMailNudgeFunc(sender)
 	}
 
 	// When --to is set, prepend it to args so doMailSend sees [to, body].
@@ -1101,11 +1106,16 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 		body = strings.Join(args[1:], " ")
 	}
 
-	return doMailReply(mp, rec, args[0], sender, subject, body, notify, stdout, stderr)
+	var nf nudgeFunc
+	if notify {
+		nf = newMailNudgeFunc(sender)
+	}
+
+	return doMailReply(mp, rec, args[0], sender, subject, body, nf, stdout, stderr)
 }
 
 // doMailReply creates a reply to an existing message.
-func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, body string, _ bool, stdout, stderr io.Writer) int {
+func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, body string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
 	reply, err := mp.Reply(id, sender, subject, body)
 	telemetry.RecordMailOp(context.Background(), "reply", err)
 	if err != nil {
@@ -1120,6 +1130,12 @@ func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, bod
 		Payload: mailEventPayload(&reply),
 	})
 	fmt.Fprintf(stdout, "Replied to %s — sent message %s to %s\n", id, reply.ID, reply.To) //nolint:errcheck // best-effort stdout
+
+	if nudgeFn != nil && reply.To != "human" {
+		if err := nudgeFn(reply.To); err != nil {
+			fmt.Fprintf(stderr, "gc mail reply: nudge failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		}
+	}
 	return 0
 }
 

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -647,7 +647,7 @@ func TestMailReplySuccess(t *testing.T) {
 	mp.Send("alice", "bob", "Hello", "first") //nolint:errcheck
 
 	var stdout, stderr bytes.Buffer
-	code := doMailReply(mp, events.Discard, "gc-1", "bob", "RE: Hello", "reply body", false, &stdout, &stderr)
+	code := doMailReply(mp, events.Discard, "gc-1", "bob", "RE: Hello", "reply body", nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doMailReply = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -656,6 +656,52 @@ func TestMailReplySuccess(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "to alice") {
 		t.Errorf("stdout = %q, want reply addressed to alice", stdout.String())
+	}
+}
+
+func TestMailReplyNotifySuccess(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	mp.Send("alice", "bob", "Hello", "first") //nolint:errcheck
+
+	var nudged string
+	nf := func(recipient string) error {
+		nudged = recipient
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailReply(mp, events.Discard, "gc-1", "bob", "RE: Hello", "reply body", nf, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailReply = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Replied to gc-1") {
+		t.Errorf("stdout = %q, want reply confirmation", stdout.String())
+	}
+	if nudged != "alice" {
+		t.Errorf("nudgeFn called with %q, want %q", nudged, "alice")
+	}
+}
+
+func TestMailReplyNotifyNudgeError(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	mp.Send("alice", "bob", "Hello", "first") //nolint:errcheck
+
+	nf := func(_ string) error {
+		return fmt.Errorf("session not found")
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailReply(mp, events.Discard, "gc-1", "bob", "RE: Hello", "reply body", nf, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailReply = %d, want 0 (nudge failure is non-fatal); stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Replied to gc-1") {
+		t.Errorf("stdout = %q, want reply confirmation", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "nudge failed") {
+		t.Errorf("stderr = %q, want nudge failure warning", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
Supersedes #623 by @julianknutsen.

- honor `gc mail reply --notify` by reusing the existing mail nudge path
- nudge the reply recipient after a successful reply while keeping nudge failures non-fatal
- add regression tests covering successful reply notification and nudge warning behavior
- gate reply nudge behind store availability to match `cmdMailSend` behavior (maintainer fixup)

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

Closes #619.

## Verification
- `go vet ./cmd/gc/`
- `go test ./cmd/gc/ -run TestMailReply -v`