### PR TITLE
fix: resolve controller stop timeout flake (#572)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -412,6 +412,9 @@ func (cr *CityRuntime) tick(
 	if dirty.Swap(false) {
 		cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace)
 	}
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
@@ -439,6 +442,9 @@ func (cr *CityRuntime) tick(
 	if cr.sessionDrains != nil {
 		cr.beadReconcileTick(ctx, result, sessionBeads, trace)
 	}
+	if ctx.Err() != nil {
+		return
+	}
 
 	// Wisp GC: purge expired closed molecules.
 	if cr.wg != nil && cr.wg.shouldRun(time.Now()) {
@@ -450,9 +456,16 @@ func (cr *CityRuntime) tick(
 		}
 	}
 
+	if ctx.Err() != nil {
+		return
+	}
+
 	// Order dispatch.
 	if cr.od != nil {
 		cr.od.dispatch(ctx, cityRoot, time.Now())
+	}
+	if ctx.Err() != nil {
+		return
 	}
 
 	if cr.svc != nil {
@@ -462,6 +475,9 @@ func (cr *CityRuntime) tick(
 	// Chat session auto-suspend: suspend detached idle sessions.
 	if idleTimeout := cr.cfg.ChatSessions.IdleTimeoutDuration(); idleTimeout > 0 {
 		autoSuspendChatSessions(cr.cityBeadStore(), cr.sp, idleTimeout, clock.Real{}, cr.stdout, cr.stderr)
+	}
+	if ctx.Err() != nil {
+		return
 	}
 
 	// Drain queued convergence requests (CLI commands) BEFORE tick so

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -69,7 +69,7 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 
 	// If a controller is running, ask it to shut down (it stops agents).
 	if tryStopController(cityPath, stdout) {
-		if err := waitForStandaloneControllerStop(cityPath, cfg.Daemon.ShutdownTimeoutDuration()+5*time.Second); err != nil {
+		if err := waitForStandaloneControllerStop(cityPath, cfg.Daemon.ShutdownTimeoutDuration()+15*time.Second); err != nil {
 			fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -186,3 +186,103 @@ func TestCmdStopUsesTargetCitySessionProviderOutsideCityDir(t *testing.T) {
 		t.Fatalf("session provider provider = %q, want %q", gotProvider, "subprocess")
 	}
 }
+
+// TestCmdStopMarginExhaustion verifies that cmdStop tolerates slow controller
+// shutdowns without timing out. With a non-zero ShutdownTimeout and a provider
+// whose Stop blocks briefly (simulating CI scheduling delays or an in-flight
+// tick), the increased wait margin must absorb the overhead.
+//
+// Regression test for gastownhall/gascity#572.
+func TestCmdStopMarginExhaustion(t *testing.T) {
+	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
+
+	dir := shortSocketTempDir(t, "gc-margin-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-margin"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "1s"},
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := newGatedStopProvider()
+	buildFn := func(_ *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	var controllerStdout, controllerStderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, filepath.Join(dir, "city.toml"), cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		running, _ := sp.ListRunning("")
+		for _, name := range running {
+			sp.release(name)
+		}
+		tryStopController(dir, &bytes.Buffer{})
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForController(t, dir, 5*time.Second)
+
+	const sess = "margin-session"
+	if err := sp.Start(context.Background(), sess, runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		sp.waitForInterrupts(t, 1)
+		sp.releaseInterrupt(sess)
+	}()
+
+	var stdout, stderr bytes.Buffer
+	stopDone := make(chan int, 1)
+	go func() {
+		stopDone <- cmdStop([]string{dir}, &stdout, &stderr)
+	}()
+
+	stopped := sp.waitForStops(t, 1)
+	if len(stopped) != 1 || stopped[0] != sess {
+		t.Fatalf("stop targets = %v, want [%s]", stopped, sess)
+	}
+
+	time.AfterFunc(500*time.Millisecond, func() {
+		sp.release(sess)
+	})
+
+	select {
+	case code := <-stopDone:
+		if code != 0 {
+			t.Fatalf("cmdStop = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("cmdStop did not finish within margin budget")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("controller did not exit after cmdStop")
+	}
+
+	if !strings.Contains(stdout.String(), "Controller stopping...") {
+		t.Fatalf("stdout missing controller stop message: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout missing city stopped message: %q", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ctx.Err()` early-exit checks between major operations in `tick()` (`city_runtime.go`) so the controller run loop exits promptly when cancelled during an in-flight tick, reducing T_tick_drain from seconds to milliseconds
- Increase standalone controller wait margin from +5s to +15s (`cmd_stop.go:70`) to absorb remaining overhead from shutdown timeout + deferred cleanup under CI load
- Add `TestCmdStopMarginExhaustion` regression test exercising the non-zero `ShutdownTimeout` margin path that was previously untested (coverage gap GAP1)

## Test plan
- [x] `TestCmdStopWaitsForStandaloneControllerExit` passes (existing test, no regression)
- [x] `TestCmdStopMarginExhaustion` passes (new regression test)
- [x] `TestTutorial01/controller` passes 5/5 runs (previously flaky at 10% failure rate)
- [x] `go vet ./...` clean
- [x] 3 pre-existing controller test failures confirmed on baseline (not caused by this change)

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)