### PR TITLE
fix: preserve metadata-linked workflow sessions during sweep

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -672,6 +674,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	if sessionBeads == nil {
 		sessionBeads = cr.loadSessionBeadSnapshot()
 	}
+	allBeads := loadSweepActiveBeads(store, cr.rigBeadStores())
 	// poolDesired determines how many sessions should be AWAKE. Uses the
 	// same scale_check counts that buildDesiredState already computed (no
 	// duplicate shell-outs). Resume tier from cross-referenced assigned
@@ -698,7 +701,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		store,
 		sessionBeads,
 		desiredState,
-		result.AssignedWorkBeads,
+		allBeads,
 		cr.cfg,
 		cr.sp,
 		result.StoreQueryPartial,
@@ -846,12 +849,12 @@ func sweepUndesiredPoolSessionBeads(
 	store beads.Store,
 	sessionBeads *sessionBeadSnapshot,
 	desiredState map[string]TemplateParams,
-	assignedWorkBeads []beads.Bead,
+	allBeads []beads.Bead,
 	cfg *config.City,
 	sp runtime.Provider,
 	storeQueryPartial bool,
 ) int {
-	if store == nil || sessionBeads == nil || cfg == nil || storeQueryPartial {
+	if store == nil || sessionBeads == nil || cfg == nil || storeQueryPartial || allBeads == nil {
 		return 0
 	}
 	var candidates []beads.Bead
@@ -875,7 +878,54 @@ func sweepUndesiredPoolSessionBeads(
 		}
 		candidates = append(candidates, bead)
 	}
-	return len(GCSweepSessionBeads(store, candidates, assignedWorkBeads))
+	return len(GCSweepSessionBeads(store, candidates, allBeads))
+}
+
+func loadSweepActiveBeads(cityStore beads.Store, rigStores map[string]beads.Store) []beads.Bead {
+	stores := []beads.Store{cityStore}
+	if len(rigStores) > 0 {
+		rigNames := make([]string, 0, len(rigStores))
+		for rigName := range rigStores {
+			rigNames = append(rigNames, rigName)
+		}
+		sort.Strings(rigNames)
+		for _, rigName := range rigNames {
+			stores = append(stores, rigStores[rigName])
+		}
+	}
+
+	var allBeads []beads.Bead
+	seenStores := make(map[string]struct{})
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		storeID := sweepStoreIdentity(store)
+		if _, ok := seenStores[storeID]; ok {
+			continue
+		}
+		seenStores[storeID] = struct{}{}
+		if cs, ok := store.(*beads.CachingStore); ok && !cs.IsLive() {
+			return nil
+		}
+		loaded, err := store.List(beads.ListQuery{AllowScan: true})
+		if err != nil {
+			return nil
+		}
+		allBeads = append(allBeads, loaded...)
+	}
+	return allBeads
+}
+
+func sweepStoreIdentity(store beads.Store) string {
+	value := reflect.ValueOf(store)
+	if !value.IsValid() {
+		return ""
+	}
+	if value.Kind() == reflect.Ptr {
+		return fmt.Sprintf("%T:%x", store, value.Pointer())
+	}
+	return fmt.Sprintf("%T:%v", store, store)
 }
 
 func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -119,7 +119,7 @@ func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 		store,
 		sessionBeads,
 		nil,
-		nil,
+		[]beads.Bead{},
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
 		false,
@@ -133,6 +133,48 @@ func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	}
 	if got.Status != "closed" {
 		t.Fatalf("stopped pool bead status = %q, want closed", got.Status)
+	}
+}
+
+func TestLoadSweepActiveBeads_IncludesRigStores(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	cityBead, err := cityStore.Create(beads.Bead{Title: "city bead", Status: "open"})
+	if err != nil {
+		t.Fatalf("city Create: %v", err)
+	}
+
+	rigStore := beads.NewMemStore()
+	rigBead, err := rigStore.Create(beads.Bead{Title: "rig bead", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("rig Create: %v", err)
+	}
+	closedRigBead, err := rigStore.Create(beads.Bead{Title: "closed rig bead"})
+	if err != nil {
+		t.Fatalf("closed rig Create: %v", err)
+	}
+	if err := rigStore.Close(closedRigBead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	allBeads := loadSweepActiveBeads(cityStore, map[string]beads.Store{
+		"rig-a": rigStore,
+	})
+
+	if len(allBeads) != 2 {
+		t.Fatalf("len(allBeads) = %d, want 2", len(allBeads))
+	}
+	seen := map[string]bool{}
+	for _, bead := range allBeads {
+		seen[bead.ID] = true
+	}
+	if !seen[cityBead.ID] {
+		t.Fatalf("city bead %q missing from sweep bead list", cityBead.ID)
+	}
+	if !seen[rigBead.ID] {
+		t.Fatalf("rig bead %q missing from sweep bead list", rigBead.ID)
+	}
+	if seen[closedRigBead.ID] {
+		t.Fatalf("closed bead %q should not be present in sweep bead list", closedRigBead.ID)
 	}
 }
 

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -7,6 +7,10 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
+var sessionKeepaliveMetadataKeys = []string{
+	"bugflow.main_session_name",
+}
+
 // PoolSessionName derives the tmux session name for a pool worker session.
 // Format: {basename(template)}-{beadID} (e.g., "claude-mc-xyz").
 // Named sessions with an alias use the alias instead.
@@ -18,29 +22,19 @@ func PoolSessionName(template, beadID string) string {
 }
 
 // GCSweepSessionBeads closes open session beads that have no remaining
-// assigned work beads (all assigned beads are closed). Returns the IDs
-// of session beads that were closed.
-func GCSweepSessionBeads(store beads.Store, sessionBeads []beads.Bead, allWorkBeads []beads.Bead) []string {
-	// Index work beads by assignee.
-	assigneeHasWork := make(map[string]bool)
-	for _, wb := range allWorkBeads {
-		if wb.Status == "closed" {
-			continue
-		}
-		assignee := strings.TrimSpace(wb.Assignee)
-		if assignee != "" {
-			assigneeHasWork[assignee] = true
-		}
-	}
+// active work beads, including workflow beads that explicitly retain
+// ownership via metadata. Returns the IDs of session beads that were closed.
+func GCSweepSessionBeads(store beads.Store, sessionBeads []beads.Bead, allBeads []beads.Bead) []string {
+	activeSessionRefs := indexActiveSessionRefs(allBeads)
 
 	var closed []string
 	for _, sb := range sessionBeads {
 		if sb.Status == "closed" {
 			continue
 		}
-		// Check if any non-closed work bead is assigned to this session
-		// via any identifier: bead ID, session name, or named identity (alias).
-		if sessionHasAssignedWork(sb, assigneeHasWork) {
+		// Keep sessions alive for both direct assignment edges and known
+		// metadata-based workflow ownership edges.
+		if sessionHasActiveWorkRef(sb, activeSessionRefs) {
 			continue
 		}
 		if err := store.SetMetadata(sb.ID, "state", "gc_swept"); err != nil {
@@ -54,17 +48,39 @@ func GCSweepSessionBeads(store beads.Store, sessionBeads []beads.Bead, allWorkBe
 	return closed
 }
 
-// sessionHasAssignedWork checks whether any work bead is assigned to this
+func indexActiveSessionRefs(allBeads []beads.Bead) map[string]bool {
+	activeSessionRefs := make(map[string]bool)
+	for _, bead := range allBeads {
+		if bead.Status == "closed" {
+			continue
+		}
+		addActiveSessionRef(activeSessionRefs, bead.Assignee)
+		for _, key := range sessionKeepaliveMetadataKeys {
+			addActiveSessionRef(activeSessionRefs, bead.Metadata[key])
+		}
+	}
+	return activeSessionRefs
+}
+
+func addActiveSessionRef(activeSessionRefs map[string]bool, ref string) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return
+	}
+	activeSessionRefs[ref] = true
+}
+
+// sessionHasActiveWorkRef checks whether any active bead references this
 // session bead via any of its identifiers: bead ID, session name, or
 // named identity (alias).
-func sessionHasAssignedWork(sb beads.Bead, assigneeHasWork map[string]bool) bool {
-	if assigneeHasWork[sb.ID] {
+func sessionHasActiveWorkRef(sb beads.Bead, activeSessionRefs map[string]bool) bool {
+	if activeSessionRefs[sb.ID] {
 		return true
 	}
-	if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" && assigneeHasWork[sn] {
+	if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" && activeSessionRefs[sn] {
 		return true
 	}
-	if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" && assigneeHasWork[ni] {
+	if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" && activeSessionRefs[ni] {
 		return true
 	}
 	return false

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -111,6 +111,36 @@ func TestGCSweepSessionBeads_ClosesWhenAllWorkClosed(t *testing.T) {
 	}
 }
 
+func TestGCSweepSessionBeads_KeepsMetadataLinkedWorkflow(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sess, _ := store.Create(beads.Bead{
+		Title: "session",
+		Type:  "session",
+		Metadata: map[string]string{
+			"session_name": "claude-mc-xyz",
+		},
+	})
+
+	canonical, _ := store.Create(beads.Bead{
+		Title:  "canonical bug bead",
+		Status: "open",
+		Metadata: map[string]string{
+			"bugflow.main_session_name": "claude-mc-xyz",
+		},
+	})
+	_ = canonical
+
+	sessionBeads := []beads.Bead{sess}
+	allWork := []beads.Bead{canonical}
+
+	closed := GCSweepSessionBeads(store, sessionBeads, allWork)
+
+	if len(closed) != 0 {
+		t.Errorf("closed %d beads, want 0 (metadata-linked workflow keeps session alive)", len(closed))
+	}
+}
+
 func TestGCSweepSessionBeads_SkipsAlreadyClosed(t *testing.T) {
 	store := beads.NewMemStore()
 


### PR DESCRIPTION
## Summary
- keep pool session sweep alive when an active workflow bead retains ownership via metadata such as `bugflow.main_session_name`
- load sweep visibility from active city and rig bead stores instead of only actionable assigned work beads
- skip sweep when the active-bead snapshot is incomplete, and cover the behavior with focused tests

## Testing
- go test ./cmd/gc -run 'TestGCSweepSessionBeads|TestLoadSweepActiveBeads|TestSweepUndesiredPoolSessionBeads'
- go test ./cmd/gc -run '^$'
