### PR TITLE
fix: handle legacy pool bead names in resolvePoolSlot

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -977,12 +977,20 @@ func setBeadRestartRequested(store beads.Store, sessionName string) error {
 }
 
 // resolvePoolSlot extracts the pool slot number from a pool instance name.
+// Handles both current "<template>-<n>" and legacy "<template>-gc-<n>" naming.
 // Returns 0 for non-pool agents or if template doesn't match.
 func resolvePoolSlot(agentName, template string) int {
 	if !strings.HasPrefix(agentName, template+"-") {
 		return 0
 	}
 	suffix := agentName[len(template)+1:]
-	slot, _ := strconv.Atoi(suffix)
-	return slot
+	if slot, err := strconv.Atoi(suffix); err == nil {
+		return slot
+	}
+	// Legacy pool naming: <template>-gc-<n>
+	if strings.HasPrefix(suffix, "gc-") {
+		slot, _ := strconv.Atoi(suffix[3:])
+		return slot
+	}
+	return 0
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2633,6 +2633,19 @@ func TestResolvePoolSlot_NonNumericSuffix(t *testing.T) {
 	}
 }
 
+func TestResolvePoolSlot_LegacyGCNaming(t *testing.T) {
+	if got := resolvePoolSlot("worker-gc-1", "worker"); got != 1 {
+		t.Errorf("resolvePoolSlot(worker-gc-1, worker) = %d, want 1", got)
+	}
+	if got := resolvePoolSlot("worker-gc-5", "worker"); got != 5 {
+		t.Errorf("resolvePoolSlot(worker-gc-5, worker) = %d, want 5", got)
+	}
+	// Non-numeric after gc- still returns 0.
+	if got := resolvePoolSlot("worker-gc-abc", "worker"); got != 0 {
+		t.Errorf("resolvePoolSlot(worker-gc-abc, worker) = %d, want 0", got)
+	}
+}
+
 // BUG: PR #208 — this test fails on current code because resolvePoolSlot()
 // only recognizes pool instances that use the "<template>-<N>" naming
 // convention. Namepool-themed names like "fenrir" for a "worker" pool


### PR DESCRIPTION
## Summary

Follow-up to #636. During adoption review, we identified that `resolvePoolSlot` only handles the current `<template>-<n>` naming convention but not the legacy `<template>-gc-<n>` format. Legacy pool beads (e.g., `worker-gc-2`) fail slot recovery because `strconv.Atoi("gc-2")` returns 0, causing session churn on upgrade.

- Add fallback parsing for legacy `-gc-<n>` suffix in `resolvePoolSlot`
- Add test coverage for legacy naming, including non-numeric edge case

## Test plan
- [x] `go test ./cmd/gc/... -run TestResolvePoolSlot` — all 5 cases pass
- [x] `go test ./cmd/gc/...` — full suite passes
- [x] `go vet ./cmd/gc/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)