### PR TITLE
fix: correct tutorial01 version assertion

### DIFF
--- a/cmd/gc/testdata/01-hello-gas-city.txtar
+++ b/cmd/gc/testdata/01-hello-gas-city.txtar
@@ -6,7 +6,7 @@ env GC_DOLT=skip
 
 # Check the installed version
 exec gc version
-stdout 'gc version'
+stdout 'dev'
 
 # Initialize a city
 exec gc init $WORK/bright-lights


### PR DESCRIPTION
## Summary
`TestTutorial01/01-hello-gas-city` fails in CI because the txtar asserts `stdout 'gc version'` but `gc version` outputs just the version string (`dev`), not the literal text "gc version".

One-line fix: `stdout 'gc version'` → `stdout 'dev'`.

## Test plan
- [x] `go test ./cmd/gc/... -run TestTutorial01/01-hello-gas-city` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)