### PR TITLE
fix: normalize rig context across symlink aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.env
 CLAUDE.local.md
 coverage.txt
 /bin/

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -165,10 +165,8 @@ func findAgentByQualified(cfg *config.City, identity string) (config.Agent, bool
 // name resolution. Checks GC_DIR env var first, then cwd.
 func currentRigContext(cfg *config.City) string {
 	if gcDir := os.Getenv("GC_DIR"); gcDir != "" {
-		for _, r := range cfg.Rigs {
-			if filepath.Clean(gcDir) == filepath.Clean(r.Path) {
-				return r.Name
-			}
+		if name, _, found := findEnclosingRig(gcDir, cfg.Rigs); found {
+			return name
 		}
 	}
 	if cwd, err := os.Getwd(); err == nil {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -404,13 +404,15 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 func findEnclosingRig(dir string, rigs []config.Rig) (name, rigPath string, found bool) {
 	cleanDir := normalizePathForCompare(dir)
 	bestName, bestPath := "", ""
+	bestMatchLen := -1
 	for _, r := range rigs {
 		cleanRig := normalizePathForCompare(r.Path)
 		if cleanDir == cleanRig ||
 			strings.HasPrefix(cleanDir, cleanRig+string(filepath.Separator)) {
-			if len(cleanRig) > len(bestPath) {
+			if len(cleanRig) > bestMatchLen {
 				bestName = r.Name
 				bestPath = filepath.Clean(r.Path)
+				bestMatchLen = len(cleanRig)
 				found = true
 			}
 		}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -402,15 +402,15 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 // findEnclosingRig returns the rig whose path is a prefix of dir. It does
 // prefix matching so that subdirectories of a rig are recognized.
 func findEnclosingRig(dir string, rigs []config.Rig) (name, rigPath string, found bool) {
-	cleanDir := filepath.Clean(dir)
+	cleanDir := normalizePathForCompare(dir)
 	bestName, bestPath := "", ""
 	for _, r := range rigs {
-		cleanRig := filepath.Clean(r.Path)
+		cleanRig := normalizePathForCompare(r.Path)
 		if cleanDir == cleanRig ||
 			strings.HasPrefix(cleanDir, cleanRig+string(filepath.Separator)) {
 			if len(cleanRig) > len(bestPath) {
 				bestName = r.Name
-				bestPath = cleanRig
+				bestPath = filepath.Clean(r.Path)
 				found = true
 			}
 		}

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -176,9 +176,7 @@ func TestCmdStopUsesTargetCitySessionProviderOutsideCityDir(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if canonicalTestPath(gotPath) != canonicalTestPath(cityDir) {
-		t.Fatalf("session provider cityPath = %q, want %q", gotPath, cityDir)
-	}
+	assertSameTestPath(t, gotPath, cityDir)
 	if gotName != "bright-lights" {
 		t.Fatalf("session provider cityName = %q, want %q", gotName, "bright-lights")
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3486,6 +3486,31 @@ func TestFindEnclosingRigResolvesSymlinkAlias(t *testing.T) {
 	}
 }
 
+func TestFindEnclosingRigPrefersDeepestNormalizedMatch(t *testing.T) {
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real")
+	parentRigPath := filepath.Join(realRoot, "my-project")
+	nestedRigPath := filepath.Join(parentRigPath, "nested")
+	if err := os.MkdirAll(filepath.Join(nestedRigPath, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(root, "extremely-long-alias-name")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink setup unavailable: %v", err)
+	}
+
+	rigs := []config.Rig{
+		{Name: "parent", Path: filepath.Join(aliasRoot, "my-project")},
+		{Name: "nested", Path: nestedRigPath},
+	}
+	dirViaAlias := filepath.Join(aliasRoot, "my-project", "nested", "src")
+
+	name, rp, found := findEnclosingRig(dirViaAlias, rigs)
+	if !found || name != "nested" || rp != nestedRigPath {
+		t.Fatalf("deepest normalized match: name=%q path=%q found=%v, want name=%q path=%q found=true", name, rp, found, "nested", nestedRigPath)
+	}
+}
+
 func TestCurrentRigContextUsesGCDirThroughSymlinkAlias(t *testing.T) {
 	rigPath, aliasRigPath := makeRigSymlinkAliasFixture(t)
 	cfg := &config.City{

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3459,6 +3459,68 @@ func TestFindEnclosingRig(t *testing.T) {
 	}
 }
 
+func makeRigSymlinkAliasFixture(t *testing.T) (rigPath, aliasRigPath string) {
+	t.Helper()
+
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real")
+	rigPath = filepath.Join(realRoot, "my-project")
+	if err := os.MkdirAll(filepath.Join(rigPath, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(root, "alias")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink setup unavailable: %v", err)
+	}
+	return rigPath, filepath.Join(aliasRoot, "my-project")
+}
+
+func TestFindEnclosingRigResolvesSymlinkAlias(t *testing.T) {
+	rigPath, aliasRigPath := makeRigSymlinkAliasFixture(t)
+	rigs := []config.Rig{{Name: "my-project", Path: rigPath}}
+	dirViaAlias := filepath.Join(aliasRigPath, "src")
+
+	name, rp, found := findEnclosingRig(dirViaAlias, rigs)
+	if !found || name != "my-project" || rp != rigPath {
+		t.Fatalf("symlink alias match: name=%q path=%q found=%v, want name=%q path=%q found=true", name, rp, found, "my-project", rigPath)
+	}
+}
+
+func TestCurrentRigContextUsesGCDirThroughSymlinkAlias(t *testing.T) {
+	rigPath, aliasRigPath := makeRigSymlinkAliasFixture(t)
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "my-project", Path: rigPath}},
+	}
+
+	t.Setenv("GC_DIR", aliasRigPath)
+	if got := currentRigContext(cfg); got != "my-project" {
+		t.Fatalf("currentRigContext() = %q, want %q", got, "my-project")
+	}
+}
+
+func TestCurrentRigContextUsesWorkingDirThroughSymlinkAlias(t *testing.T) {
+	rigPath, aliasRigPath := makeRigSymlinkAliasFixture(t)
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "my-project", Path: rigPath}},
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(aliasRigPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	t.Setenv("GC_DIR", "")
+	if got := currentRigContext(cfg); got != "my-project" {
+		t.Fatalf("currentRigContext() = %q, want %q", got, "my-project")
+	}
+}
+
 // --- doAgentAdd with --dir and --suspended ---
 
 func TestDoAgentAddWithDir(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #632 by resolving rig context through canonicalized filesystem paths instead of raw cleaned path strings.

## What changed
- normalize `findEnclosingRig` path comparisons with symlink-aware path canonicalization
- make `currentRigContext` use `findEnclosingRig` for both `GC_DIR` and cwd lookup
- add regressions for rig detection through symlink aliases for both `GC_DIR` and the working directory
- ignore repo-local `.env` files
- keep the stop-path test on shared path helpers instead of raw path string comparison

## Validation
- `go test ./cmd/gc -run 'TestFindEnclosingRig|TestCurrentRigContextUsesGCDirThroughSymlinkAlias|TestCurrentRigContextUsesWorkingDirThroughSymlinkAlias|TestCmdStopUsesTargetCitySessionProviderOutsideCityDir|TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout' -count=1`
- `go test ./cmd/gc -count=1`
