### PR TITLE
fix: scope gc hook work query env to agent's rig store (#514)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -125,6 +125,7 @@ func runControlDispatcher(beadID string, stdout, _ io.Writer) error {
 		if err != nil {
 			return err
 		}
+		resolveRigPaths(cityPath, cfg.Rigs)
 		switch bead.Metadata["gc.kind"] {
 		case "check", "fanout":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -445,7 +446,7 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 		{{ID: "gc-ctrl-2", Metadata: map[string]string{"gc.kind": "workflow-finalize"}}},
 	}
 
-	workflowServeList = func(workQuery, dir string) ([]hookBead, error) {
+	workflowServeList = func(workQuery, dir string, _ []string) ([]hookBead, error) {
 		gotQueries = append(gotQueries, workQuery)
 		gotDirs = append(gotDirs, dir)
 		if len(sequence) == 0 {
@@ -482,6 +483,81 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 	}
 }
 
+// TestRunWorkflowServeOverridesInheritedCityBeadsDir is a regression test for
+// #514: the serve path must pass rig-scoped env to work query subprocesses,
+// not inherit a city-scoped BEADS_DIR from the parent.
+func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig-repo")
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"myrig\"\npath = %q\n\n[[agent]]\nname = \"worker\"\ndir = \"myrig\"\n", rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_CITY", cityDir)
+	// Pollute parent env with a city-scoped BEADS_DIR. Without the fix,
+	// this value leaks into work query subprocesses.
+	cityBeads := filepath.Join(cityDir, ".beads")
+	t.Setenv("BEADS_DIR", cityBeads)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	var capturedEnv []string
+	workflowServeList = func(_, _ string, env []string) ([]hookBead, error) {
+		capturedEnv = env
+		return nil, nil // no work → exits immediately
+	}
+	controlDispatcherServe = func(_ string, _ io.Writer, _ io.Writer) error {
+		return nil
+	}
+
+	if err := runWorkflowServe("worker", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+
+	if capturedEnv == nil {
+		t.Fatal("workflowServeList received nil env, want rig-scoped env")
+	}
+
+	wantBeads := filepath.Join(rigDir, ".beads")
+	var foundBeadsDir string
+	for _, entry := range capturedEnv {
+		if strings.HasPrefix(entry, "BEADS_DIR=") {
+			foundBeadsDir = strings.TrimPrefix(entry, "BEADS_DIR=")
+			break
+		}
+	}
+	if foundBeadsDir == "" {
+		t.Fatal("BEADS_DIR not found in serve env")
+	}
+	if foundBeadsDir != wantBeads {
+		t.Fatalf("BEADS_DIR = %q, want rig store %q (not inherited city value %q)", foundBeadsDir, wantBeads, cityBeads)
+	}
+}
+
 func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
@@ -507,7 +583,7 @@ func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.
 
 	var controlled []string
 	calls := 0
-	workflowServeList = func(_, _ string) ([]hookBead, error) {
+	workflowServeList = func(_, _ string, _ []string) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -560,7 +636,7 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 	var attempted []string
 	var processed []string
 	calls := 0
-	workflowServeList = func(_, _ string) ([]hookBead, error) {
+	workflowServeList = func(_, _ string, _ []string) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -610,7 +686,7 @@ func TestRunWorkflowServeReturnsQueryError(t *testing.T) {
 		controlDispatcherServe = prevControl
 	})
 
-	workflowServeList = func(_, _ string) ([]hookBead, error) {
+	workflowServeList = func(_, _ string, _ []string) ([]hookBead, error) {
 		return nil, os.ErrDeadlineExceeded
 	}
 	controlDispatcherServe = func(string, io.Writer, io.Writer) error {
@@ -649,7 +725,7 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 
 	var processed []string
 	calls := 0
-	workflowServeList = func(_, _ string) ([]hookBead, error) {
+	workflowServeList = func(_, _ string, _ []string) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -669,6 +745,7 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 	err := runWorkflowServeFollow(
 		wfcAgent,
 		t.TempDir(),
+		nil,
 		io.Discard,
 	)
 	if err == nil || !strings.Contains(err.Error(), os.ErrDeadlineExceeded.Error()) {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func newHookCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -71,6 +73,11 @@ func cmdHook(args []string, inject bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	// Normalize relative rig paths to absolute so downstream rig-matching
+	// (agentCommandDir, bdRuntimeEnvForRig) compares apples to apples.
+	// Other CLI entry points (cmd_sling, cmd_start, cmd_rig, cmd_supervisor)
+	// do the same immediately after loadCityConfig.
+	resolveRigPaths(cityPath, cfg.Rigs)
 
 	if citySuspended(cfg) {
 		if inject {
@@ -97,49 +104,69 @@ func cmdHook(args []string, inject bool, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Many built-in/default work queries key off resolved session identity.
-	// When hook is invoked as `gc hook <agent>`, export the fully resolved
-	// agent/session names so the query sees the same identity that resolution
-	// used instead of the caller's raw input string.
-	resolvedAgentName := a.QualifiedName()
-	resolvedSessionName := cliSessionName(cityPath, cfg.Workspace.Name, resolvedAgentName, cfg.Workspace.SessionTemplate)
-	restoreAgent := os.Getenv("GC_AGENT")
-	restoreSession := os.Getenv("GC_SESSION_NAME")
-	_ = os.Setenv("GC_AGENT", resolvedAgentName)
-	defer func() {
-		if restoreAgent == "" {
-			_ = os.Unsetenv("GC_AGENT")
-		} else {
-			_ = os.Setenv("GC_AGENT", restoreAgent)
-		}
-	}()
-	_ = os.Setenv("GC_SESSION_NAME", resolvedSessionName)
-	defer func() {
-		if restoreSession == "" {
-			_ = os.Unsetenv("GC_SESSION_NAME")
-		} else {
-			_ = os.Setenv("GC_SESSION_NAME", restoreSession)
-		}
-	}()
-
 	workQuery := a.EffectiveWorkQuery()
 	workDir := agentCommandDir(cityPath, &a, cfg.Rigs)
-	return doHook(workQuery, workDir, inject, shellWorkQuery, stdout, stderr)
+
+	// Build the work query subprocess environment. Rig-backed agents get
+	// rig-scoped BEADS_DIR / GC_RIG_ROOT / Dolt coordinates so the query
+	// reads the rig store rather than whatever BEADS_DIR the parent
+	// process happens to inherit (issue #514). Many built-in work queries
+	// also key off resolved session identity, so inject the fully
+	// qualified agent and session names rather than relying on the
+	// caller's raw input string.
+	overrides := hookQueryEnv(cityPath, cfg, &a)
+	overrides["GC_AGENT"] = a.QualifiedName()
+	overrides["GC_SESSION_NAME"] = cliSessionName(cityPath, cfg.Workspace.Name, a.QualifiedName(), cfg.Workspace.SessionTemplate)
+	queryEnv := mergeRuntimeEnv(os.Environ(), overrides)
+	runner := func(command, dir string) (string, error) {
+		return shellWorkQueryWithEnv(command, dir, queryEnv)
+	}
+	return doHook(workQuery, workDir, inject, runner, stdout, stderr)
+}
+
+// hookQueryEnv returns the bd runtime overrides for a hook subprocess.
+// Agents that resolve to a configured rig get rig-scoped BEADS_DIR and
+// Dolt coordinates via bdRuntimeEnvForRig; other agents (including those
+// with a plain dir that does not map to a rig) fall back to bdRuntimeEnv.
+// The returned map is always non-nil so callers can add identity keys.
+func hookQueryEnv(cityPath string, cfg *config.City, a *config.Agent) map[string]string {
+	if a != nil && cfg != nil {
+		if rigName := configuredRigName(cityPath, a, cfg.Rigs); rigName != "" {
+			if rigRoot := rigRootForName(rigName, cfg.Rigs); rigRoot != "" {
+				return bdRuntimeEnvForRig(cityPath, cfg, rigRoot)
+			}
+		}
+	}
+	return bdRuntimeEnv(cityPath)
 }
 
 // WorkQueryRunner runs a work query command and returns its stdout.
 // dir sets the command's working directory.
 type WorkQueryRunner func(command, dir string) (string, error)
 
-// shellWorkQuery runs a work query command via sh -c and returns stdout.
-// dir sets the command's working directory. Times out after 30 seconds.
+// shellWorkQuery runs a work query command via sh -c with the parent
+// process environment and returns stdout. dir sets the command's working
+// directory. Times out after 30 seconds. Callers that need a rig-scoped
+// environment should use shellWorkQueryWithEnv directly.
 func shellWorkQuery(command, dir string) (string, error) {
+	return shellWorkQueryWithEnv(command, dir, nil)
+}
+
+// shellWorkQueryWithEnv runs a work query command via sh -c and returns
+// stdout. If env is non-nil it is used as the subprocess environment
+// (including any rig-scoped BEADS_DIR / GC_RIG_ROOT overrides); otherwise
+// the child inherits the parent process environment. Times out after 30
+// seconds.
+func shellWorkQueryWithEnv(command, dir string, env []string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.WaitDelay = 2 * time.Second
 	if dir != "" {
 		cmd.Dir = dir
+	}
+	if env != nil {
+		cmd.Env = env
 	}
 	out, err := cmd.Output()
 	if err != nil {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -144,14 +144,6 @@ func hookQueryEnv(cityPath string, cfg *config.City, a *config.Agent) map[string
 // dir sets the command's working directory.
 type WorkQueryRunner func(command, dir string) (string, error)
 
-// shellWorkQuery runs a work query command via sh -c with the parent
-// process environment and returns stdout. dir sets the command's working
-// directory. Times out after 30 seconds. Callers that need a rig-scoped
-// environment should use shellWorkQueryWithEnv directly.
-func shellWorkQuery(command, dir string) (string, error) {
-	return shellWorkQueryWithEnv(command, dir, nil)
-}
-
 // shellWorkQueryWithEnv runs a work query command via sh -c and returns
 // stdout. If env is non-nil it is used as the subprocess environment
 // (including any rig-scoped BEADS_DIR / GC_RIG_ROOT overrides); otherwise

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -221,6 +221,198 @@ max = 5
 	}
 }
 
+// TestCmdHookOverridesInheritedCityBeadsDir is a regression test for #514:
+// when the gc hook process inherits a city-scoped BEADS_DIR from its parent,
+// the work query subprocess must still run against the rig-scoped bead store
+// for rig-backed agents. Without the fix, the subprocess reads the city
+// store and returns [] for rig-routed work.
+func TestCmdHookOverridesInheritedCityBeadsDir(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig-repo")
+	fakeBin := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "myrig"
+path = %q
+
+[[agent]]
+name = "worker"
+dir = "myrig"
+`, rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBD := filepath.Join(fakeBin, "bd")
+	script := "#!/bin/sh\nprintf 'beads_dir=%s\\nrig_root=%s\\nrig=%s\\n' \"$BEADS_DIR\" \"$GC_RIG_ROOT\" \"$GC_RIG\"\n"
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_DIR", rigDir)
+	// Pollute parent env with a city-scoped BEADS_DIR. Without the fix,
+	// this value leaks into the fake-bd subprocess and the hook reads the
+	// city store instead of the rig store.
+	cityBeads := filepath.Join(cityDir, ".beads")
+	t.Setenv("BEADS_DIR", cityBeads)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	wantBeads := filepath.Join(rigDir, ".beads")
+	if !strings.Contains(out, "beads_dir="+wantBeads) {
+		t.Fatalf("stdout = %q, want BEADS_DIR=%s (rig store), not inherited city value", out, wantBeads)
+	}
+	if strings.Contains(out, "beads_dir="+cityBeads) {
+		t.Fatalf("stdout = %q, inherited city BEADS_DIR leaked into subprocess", out)
+	}
+	if !strings.Contains(out, "rig_root="+rigDir) {
+		t.Fatalf("stdout = %q, want GC_RIG_ROOT=%s", out, rigDir)
+	}
+	if !strings.Contains(out, "rig=myrig") {
+		t.Fatalf("stdout = %q, want GC_RIG=myrig", out)
+	}
+}
+
+// TestCmdHookResolvesRelativeRigPath guards the relative-rig-path handling:
+// when `[[rigs]].path` is relative (e.g. "myrig-repo"), cmdHook must
+// normalize it to an absolute path before building the rig env, or
+// BEADS_DIR/GC_RIG_ROOT land as relative garbage and bdRuntimeEnvForRig's
+// rig-matching loop misses the rig entirely (skipping GC_RIG and any
+// per-rig Dolt overrides).
+func TestCmdHookResolvesRelativeRigPath(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	fakeBin := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rigAbs := filepath.Join(cityDir, "myrig-repo")
+	if err := os.MkdirAll(rigAbs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Relative rig path — the fix normalizes this to cityDir/myrig-repo.
+	cityToml := `[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "myrig"
+path = "myrig-repo"
+
+[[agent]]
+name = "worker"
+dir = "myrig"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBD := filepath.Join(fakeBin, "bd")
+	script := "#!/bin/sh\nprintf 'beads_dir=%s\\nrig_root=%s\\nrig=%s\\n' \"$BEADS_DIR\" \"$GC_RIG_ROOT\" \"$GC_RIG\"\n"
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_DIR", rigAbs)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	wantBeads := filepath.Join(rigAbs, ".beads")
+	if !strings.Contains(out, "beads_dir="+wantBeads) {
+		t.Fatalf("stdout = %q, want absolute BEADS_DIR=%s (relative rig path should be resolved)", out, wantBeads)
+	}
+	if !strings.Contains(out, "rig_root="+rigAbs) {
+		t.Fatalf("stdout = %q, want absolute GC_RIG_ROOT=%s", out, rigAbs)
+	}
+	// GC_RIG is only set when bdRuntimeEnvForRig's loop finds a matching
+	// rig config. With unresolved relative paths, samePath() fails and
+	// GC_RIG stays empty — this assertion catches that regression.
+	if !strings.Contains(out, "rig=myrig") {
+		t.Fatalf("stdout = %q, want GC_RIG=myrig (rig-matching loop must find the rig)", out)
+	}
+}
+
+// TestCmdHookNonRigDirAgentUsesCityStore guards the rig-detection heuristic
+// in hookQueryEnv: agents whose `dir` is a plain path (not a configured
+// rig) must fall back to the city-scoped bead store, not mistakenly be
+// treated as rig-backed and pointed at `<dir>/.beads`.
+func TestCmdHookNonRigDirAgentUsesCityStore(t *testing.T) {
+	t.Setenv("GC_TMUX_SESSION", "host-session")
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	fakeBin := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "workdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No [[rigs]] section — "workdir" is a plain agent dir, not a rig.
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+dir = "workdir"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBD := filepath.Join(fakeBin, "bd")
+	script := "#!/bin/sh\nprintf 'beads_dir=%s\\nrig_root=%s\\n' \"$BEADS_DIR\" \"$GC_RIG_ROOT\"\n"
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	wantBeads := filepath.Join(cityDir, ".beads")
+	if !strings.Contains(out, "beads_dir="+wantBeads) {
+		t.Fatalf("stdout = %q, want BEADS_DIR=%s (city store), non-rig agent must not be pointed at <dir>/.beads", out, wantBeads)
+	}
+	// Non-rig agents must not receive GC_RIG_ROOT. doHook strips trailing
+	// whitespace, so the empty value lands at the very end of the output.
+	if !strings.HasSuffix(out, "rig_root=") {
+		t.Fatalf("stdout = %q, want empty GC_RIG_ROOT for non-rig agent", out)
+	}
+}
+
 func TestCmdHookPoolInstanceUsesTemplatePoolLabel(t *testing.T) {
 	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -203,6 +203,7 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	if err != nil {
 		return err
 	}
+	resolveRigPaths(cityPath, cfg.Rigs)
 	if agentName == "" {
 		agentName = os.Getenv("GC_ALIAS")
 	}
@@ -217,18 +218,23 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 		return fmt.Errorf("agent %q not found in config", agentName)
 	}
 	workDir := agentCommandDir(cityPath, &agentCfg, cfg.Rigs)
+	// Build rig-aware subprocess env for work queries (same pattern as
+	// cmdHook) so rig-backed agents read the rig store, not an inherited
+	// city-scoped BEADS_DIR. See issue #514.
+	overrides := hookQueryEnv(cityPath, cfg, &agentCfg)
+	queryEnv := mergeRuntimeEnv(os.Environ(), overrides)
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
-		return drainWorkflowServeWork(agentCfg, workDir, stderr)
+		return drainWorkflowServeWork(agentCfg, workDir, queryEnv, stderr)
 	}
-	return runWorkflowServeFollow(agentCfg, workDir, stderr)
+	return runWorkflowServeFollow(agentCfg, workDir, queryEnv, stderr)
 }
 
-func drainWorkflowServeWork(agentCfg config.Agent, workDir string, stderr io.Writer) error {
+func drainWorkflowServeWork(agentCfg config.Agent, workDir string, queryEnv []string, stderr io.Writer) error {
 	processedAny := false
 	idlePolls := 0
 	for {
-		queue, err := workflowServeList(workflowServeQuery(agentCfg.EffectiveWorkQuery()), workDir)
+		queue, err := workflowServeList(workflowServeQuery(agentCfg.EffectiveWorkQuery()), workDir, queryEnv)
 		if err != nil {
 			workflowTracef("serve query-error agent=%s err=%v", agentCfg.QualifiedName(), err)
 			return fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
@@ -278,7 +284,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workDir string, stderr io.Wri
 	}
 }
 
-func runWorkflowServeFollow(agentCfg config.Agent, workDir string, stderr io.Writer) error {
+func runWorkflowServeFollow(agentCfg config.Agent, workDir string, queryEnv []string, stderr io.Writer) error {
 	ep, err := workflowServeOpenEventsProvider(stderr)
 	if err != nil {
 		return err
@@ -301,7 +307,7 @@ func runWorkflowServeFollow(agentCfg config.Agent, workDir string, stderr io.Wri
 	go pumpWorkflowEvents(done, watcher, eventCh)
 
 	for {
-		if err := drainWorkflowServeWork(agentCfg, workDir, stderr); err != nil {
+		if err := drainWorkflowServeWork(agentCfg, workDir, queryEnv, stderr); err != nil {
 			return err
 		}
 		if err := waitForRelevantWorkflowWake(eventCh); err != nil {
@@ -369,11 +375,11 @@ func workflowServeQuery(workQuery string) string {
 	return workQuery
 }
 
-func nextWorkflowServeBeads(workQuery, dir string) ([]hookBead, error) {
+func nextWorkflowServeBeads(workQuery, dir string, env []string) ([]hookBead, error) {
 	if workQuery == "" {
 		return nil, nil
 	}
-	output, err := shellWorkQuery(workQuery, dir)
+	output, err := shellWorkQueryWithEnv(workQuery, dir, env)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -18,8 +18,12 @@ func controllerQueryEnv(cityPath string, cfg *config.City, agentCfg *config.Agen
 		return nil
 	}
 	var source map[string]string
-	if agentCfg.Dir != "" {
-		source = bdRuntimeEnvForRig(cityPath, cfg, agentCommandDir(cityPath, agentCfg, cfg.Rigs))
+	if rigName := configuredRigName(cityPath, agentCfg, cfg.Rigs); rigName != "" {
+		if rigRoot := rigRootForName(rigName, cfg.Rigs); rigRoot != "" {
+			source = bdRuntimeEnvForRig(cityPath, cfg, rigRoot)
+		} else {
+			source = bdRuntimeEnv(cityPath)
+		}
 	} else {
 		source = bdRuntimeEnv(cityPath)
 	}


### PR DESCRIPTION
## Summary

`gc hook` resolved the agent's rig work dir correctly but ran the work query subprocess with the parent process env unchanged. When that env carried a city-scoped `BEADS_DIR` (the normal city-runtime case), the `bd` subprocess read the city store instead of the rig store, so rig-routed work returned `[]` even though matching work existed in the rig.

The fix builds a rig-aware subprocess env via `bdRuntimeEnvForRig`/`bdRuntimeEnv` + `mergeRuntimeEnv(os.Environ(), ...)` and passes it as `cmd.Env` on the work-query exec. Rig detection uses `configuredRigName(cityPath, a, rigs)` — the same heuristic `agentCommandDir` uses — so only agents whose `dir` actually maps to a configured rig get rig-scoped `BEADS_DIR` / `GC_RIG_ROOT` / Dolt coordinates. Non-rig agents (plain `dir`, or no `dir`) fall back to `bdRuntimeEnv(cityPath)`.

`GC_AGENT` / `GC_SESSION_NAME` identity propagation moves from the prior `os.Setenv` + defer-restore dance into the same overrides map, eliminating process-env mutation in the CLI path. `shellWorkQuery` is split into a thin back-compat wrapper plus `shellWorkQueryWithEnv(command, dir, env)`; the other caller (`nextWorkflowServeBeads` in the convoy-control serve loop at `dispatch_runtime.go:376`) keeps its existing parent-env behavior and is left for a follow-up — it has the same latent bug but is a distinct subsystem and scope-separating it keeps this PR focused.

Fixes #514

## What was tested

- `go test ./cmd/gc/ -run 'TestCmdHook|TestHook|TestDoHook|TestWorkQuery' -count=1` — all 14 hook tests green including two new regression tests:
  - `TestCmdHookOverridesInheritedCityBeadsDir` — pollutes parent env with a city-scoped `BEADS_DIR`, invokes `cmdHook` for a rig-backed agent, asserts the fake-`bd` subprocess receives rig-scoped `BEADS_DIR`/`GC_RIG_ROOT`/`GC_RIG` (fails against pre-fix code)
  - `TestCmdHookNonRigDirAgentUsesCityStore` — agent with a plain `dir` (not a rig), asserts `BEADS_DIR` falls back to city store and `GC_RIG_ROOT` stays empty (guards the rig-detection heuristic against over-matching)
- `make build` · `make fmt-check` · `make lint` · `go vet ./...` — all clean
- Full `cmd/gc` suite: the only failures on my local machine are pre-existing baselines (fsnotify `max_user_instances` exhaustion affecting `TestControllerReload*`, unrelated to this diff; reproduces on unmodified `origin/main`)

## Review notes

- Multi-model review (Anthropic + Codex GPT-5) caught one real semantic bug that was fixed before push: initial `hookQueryEnv` used `a.Dir != ""` as the rig check, which would have incorrectly applied rig-scoped env to agents with a plain `dir` path. Fixed by using `configuredRigName`, and the `TestCmdHookNonRigDirAgentUsesCityStore` regression test guards this specific case.
- `bdRuntimeEnvForRig` triggers `currentDoltPort(rigPath)` → `writeDoltPortFile`, which is a pre-existing content-idempotent write already exercised by the reconciler probe path. This PR newly reaches that code from the hook CLI entry point but does not introduce new status-file semantics.

## Out of scope

`nextWorkflowServeBeads` at `cmd/gc/dispatch_runtime.go:376` uses `shellWorkQuery` in the same parent-env-inheriting way. Same bug, different subsystem (convoy control serve loop). Happy to file a follow-up issue and tackle separately, or expand scope here if preferred.