### PR TITLE
fix: remove nil-vars guard on Compile Stage 8 condition filtering (#477)

### DIFF
--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -12,7 +12,7 @@ import (
 //
 // vars is used only for compile-time step condition filtering: steps whose
 // condition field evaluates to false given vars are excluded. Pass nil to
-// include all steps.
+// use formula-defined variable defaults for condition evaluation.
 //
 // The pipeline stages are:
 //  1. LoadByName — load formula TOML from search paths
@@ -95,14 +95,12 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 		}
 	}
 
-	// Stage 8: Apply step condition filtering if vars provided
-	if vars != nil {
-		filteredSteps, err := FilterStepsByCondition(resolved.Steps, compileVars)
-		if err != nil {
-			return nil, fmt.Errorf("filtering steps by condition: %w", err)
-		}
-		resolved.Steps = filteredSteps
+	// Stage 8: Apply step condition filtering
+	filteredSteps, err := FilterStepsByCondition(resolved.Steps, compileVars)
+	if err != nil {
+		return nil, fmt.Errorf("filtering steps by condition: %w", err)
 	}
+	resolved.Steps = filteredSteps
 
 	// Stage 9: Handle standalone expansion formulas
 	if resolved.Type == TypeExpansion && len(resolved.Template) > 0 {

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -121,6 +121,66 @@ condition = "{{mode}} == slow"
 	}
 }
 
+func TestCompileNilVarsAppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "nil-vars"
+version = 1
+
+[vars.env]
+description = "Target environment"
+default = "dev"
+
+[[steps]]
+id = "always"
+title = "Always runs"
+
+[[steps]]
+id = "staging-only"
+title = "Only in staging"
+condition = "{{env}} == staging"
+
+[[steps]]
+id = "dev-only"
+title = "Only in dev"
+condition = "{{env}} == dev"
+`
+	if err := os.WriteFile(filepath.Join(dir, "nil-vars.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// With nil vars, formula defaults (env=dev) should still drive condition filtering
+	recipe, err := Compile(context.Background(), "nil-vars", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile with nil vars: %v", err)
+	}
+
+	// Root + always + dev-only = 3 (staging-only filtered out by default env=dev)
+	if len(recipe.Steps) != 3 {
+		t.Errorf("len(Steps) = %d, want 3 (staging-only filtered by default vars)", len(recipe.Steps))
+	}
+
+	// Verify the right steps survived
+	foundAlways := false
+	foundDevOnly := false
+	for _, step := range recipe.Steps {
+		switch step.ID {
+		case "nil-vars.always":
+			foundAlways = true
+		case "nil-vars.dev-only":
+			foundDevOnly = true
+		case "nil-vars.staging-only":
+			t.Error("staging-only step should be filtered when env defaults to dev")
+		}
+	}
+	if !foundAlways {
+		t.Error("always step missing from result")
+	}
+	if !foundDevOnly {
+		t.Error("dev-only step missing from result")
+	}
+}
+
 func TestCompileWithChildren(t *testing.T) {
 	dir := t.TempDir()
 	formulaContent := `


### PR DESCRIPTION
## Summary

Compile's Stage 8 (FilterStepsByCondition) was gated behind `if vars != nil`,
silently skipping condition filtering when callers passed nil. The `compileVars`
map — which already contains formula defaults merged with caller vars — is always
non-nil and should always drive condition evaluation.

- Remove the `if vars != nil` guard so FilterStepsByCondition runs unconditionally
- Update doc comment: nil means "use formula defaults" not "include all steps"
- Add `TestCompileNilVarsAppliesDefaults` regression test

Fixes #477 (root cause — the API contract that call-site workarounds in c0823e14 worked around).

## What was tested

- `make fmt-check` — clean
- `make lint` — 0 issues
- `make vet` — clean
- `go test ./internal/formula/` — all pass including new regression test

## Review outcome

Design council (4 perspectives, simple complexity) and adversarial review (1 round)
both cleared. Neutral judge: CLEARED. No critical or blocking findings.

Notable satellite observations (out of scope, for follow-up):
- c0823e14 caller workarounds (molecule.go nil→empty, cmd_formula.go) are now
  redundant but harmless
- Stage 9 (MaterializeExpansion) has parallel defaults-duplication that could be
  consolidated

## Changes

| File | Change |
|------|--------|
| `internal/formula/compile.go` | Remove `if vars != nil` guard, update doc comment |
| `internal/formula/compile_test.go` | Add `TestCompileNilVarsAppliesDefaults` |

## Review Story

The bug was straightforward: Stage 8 was guarded by `if vars != nil` but should
have used `compileVars` (always non-nil, initialized on line 44). The fix removes
one if-block, updates one comment, and adds one test. The review pipeline found
real satellite concerns (Stage 9 duplication, dead caller workarounds, additional
nil-passing callers) but correctly assessed all as out of scope. The regression
test verifies both positive filtering (dev-only step included) and negative
filtering (staging-only step excluded) when vars is nil with formula defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)