### PR TITLE
fix: gate tmux state cache refresh log behind GC_LOG_TMUX_CACHE env var

### DIFF
--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -133,7 +133,11 @@ func (c *StateCache) refresh() {
 			return nil, err
 		}
 
-		log.Printf("tmux state cache: refreshed %d sessions in %v", len(sessions), elapsed)
+		// Successful refresh is noisy on the session loop; opt-in via env var
+		// keeps it available for diagnostics without polluting normal CLI use.
+		if os.Getenv("GC_LOG_TMUX_CACHE") == "true" {
+			log.Printf("tmux state cache: refreshed %d sessions in %v", len(sessions), elapsed)
+		}
 
 		c.mu.Lock()
 		c.sessions = sessions

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -1,8 +1,10 @@
 package tmux
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -267,4 +269,58 @@ func TestStateCache_ConcurrentInvalidateAndRead(_ *testing.T) {
 	wg.Wait()
 
 	// No panics, no data races — that's the assertion (run with -race).
+}
+
+// TestStateCache_RefreshLogIsOptInViaEnvVar verifies that the successful
+// refresh log line is silent by default and only emitted when
+// GC_LOG_TMUX_CACHE=true. Regression test for #644.
+func TestStateCache_RefreshLogIsOptInViaEnvVar(t *testing.T) {
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+
+	t.Run("silent by default", func(t *testing.T) {
+		buf.Reset()
+		t.Setenv("GC_LOG_TMUX_CACHE", "")
+
+		f := &mockFetcher{sessions: map[string]bool{"a": true}}
+		cache := NewStateCache(f, 50*time.Millisecond)
+		cache.IsRunning("a")
+
+		if got := buf.String(); got != "" {
+			t.Errorf("expected no log output by default, got %q", got)
+		}
+	})
+
+	t.Run("logs when opted in", func(t *testing.T) {
+		buf.Reset()
+		t.Setenv("GC_LOG_TMUX_CACHE", "true")
+
+		f := &mockFetcher{sessions: map[string]bool{"a": true}}
+		cache := NewStateCache(f, 50*time.Millisecond)
+		cache.IsRunning("a")
+
+		if got := buf.String(); got == "" {
+			t.Error("expected log output with GC_LOG_TMUX_CACHE=true, got none")
+		}
+	})
+
+	t.Run("failure log still emitted when opt-out", func(t *testing.T) {
+		buf.Reset()
+		t.Setenv("GC_LOG_TMUX_CACHE", "")
+
+		f := &mockFetcher{err: errors.New("boom")}
+		cache := NewStateCache(f, 50*time.Millisecond)
+		cache.IsRunning("a")
+
+		if got := buf.String(); got == "" {
+			t.Error("expected failure log output regardless of GC_LOG_TMUX_CACHE, got none")
+		}
+	})
 }

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -306,8 +307,12 @@ func TestStateCache_RefreshLogIsOptInViaEnvVar(t *testing.T) {
 		cache := NewStateCache(f, 50*time.Millisecond)
 		cache.IsRunning("a")
 
-		if got := buf.String(); got == "" {
-			t.Error("expected log output with GC_LOG_TMUX_CACHE=true, got none")
+		got := buf.String()
+		if !strings.Contains(got, "tmux state cache: refreshed") {
+			t.Errorf("expected refresh log with GC_LOG_TMUX_CACHE=true, got %q", got)
+		}
+		if strings.Contains(got, "refresh failed") {
+			t.Errorf("unexpected failure log in success path, got %q", got)
 		}
 	})
 
@@ -319,8 +324,9 @@ func TestStateCache_RefreshLogIsOptInViaEnvVar(t *testing.T) {
 		cache := NewStateCache(f, 50*time.Millisecond)
 		cache.IsRunning("a")
 
-		if got := buf.String(); got == "" {
-			t.Error("expected failure log output regardless of GC_LOG_TMUX_CACHE, got none")
+		got := buf.String()
+		if !strings.Contains(got, "tmux state cache: refresh failed") {
+			t.Errorf("expected refresh-failed log regardless of GC_LOG_TMUX_CACHE, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Closes #644.

The successful-refresh log line in `StateCache.refresh()` fired on every cache miss during normal CLI operation, polluting `gc session` command output:

```text
2026/04/12 02:19:37 tmux state cache: refreshed 12 sessions in 7.6ms
```

Reproducible on any `gc session list` / `gc session ...` command when the cache is cold or stale.

## Change

Gate the **successful**-refresh log behind `GC_LOG_TMUX_CACHE=true`, matching the existing `GC_LOG_BD_OUTPUT` opt-in pattern in `internal/telemetry/recorder.go`.

The **failure**-refresh log (`tmux state cache: refresh failed in ...`) and the **env-var-parse-warning** log (`invalid GC_TMUX_CACHE_TTL=...`) remain unconditional — failures and misconfigurations should always surface.

## Why opt-in rather than remove

The log line has diagnostic value when debugging cache/refresh behavior (see #644's suggested approaches: "suppressing the line during normal CLI use" or "moving it behind trace/debug logging"). Gating behind an env var preserves the capability without the noise.

## Test plan

- [x] New unit test `TestStateCache_RefreshLogIsOptInViaEnvVar` with three subtests:
  - silent by default (unset `GC_LOG_TMUX_CACHE`)
  - logs when `GC_LOG_TMUX_CACHE=true`
  - failure log still emitted when opt-out (regression guard for error path)
- [x] All 10 existing `StateCache` tests still pass
- [x] `go test ./internal/runtime/tmux/...` — all pass
- [x] `go vet ./internal/runtime/tmux/...` — clean
- [x] Smoke test: `gc session list` output is now clean (no log chatter)
