### PR TITLE
feat: controller-level stuck-agent sweep (#571)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -42,6 +42,7 @@ type CityRuntime struct {
 	dops  drainOps
 	ct    crashTracker
 	it    idleTracker
+	st    stuckTracker
 	wg    wispGC
 	od    orderDispatcher
 	trace *sessionReconcilerTraceManager
@@ -120,6 +121,8 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 
 	it := buildIdleTracker(p.Cfg, p.CityName, p.CityPath, p.SP)
 
+	st := newStuckTracker(p.Cfg.Daemon.StuckTimeoutDuration())
+
 	var wg wispGC
 	if p.Cfg.Daemon.WispGCEnabled() {
 		wg = newWispGC(p.Cfg.Daemon.WispGCIntervalDuration(),
@@ -170,6 +173,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		dops:                    p.Dops,
 		ct:                      ct,
 		it:                      it,
+		st:                      st,
 		wg:                      wg,
 		od:                      od,
 		trace:                   newSessionReconcilerTraceManager(p.CityPath, p.CityName, p.Stderr),
@@ -654,6 +658,20 @@ func (cr *CityRuntime) reloadConfigTraced(
 
 	cr.it = buildIdleTracker(nextCfg, cr.cityName, cr.cityPath, nextSp)
 
+	// Rebuild stuck tracker only if stuck_timeout value changed.
+	// Preserves accumulated state for unrelated config edits.
+	newStuckTimeout := nextCfg.Daemon.StuckTimeoutDuration()
+	switch {
+	case newStuckTimeout <= 0:
+		cr.st = nil
+	case cr.st == nil:
+		cr.st = newStuckTracker(newStuckTimeout)
+	default:
+		if cr.st.timeout() != newStuckTimeout {
+			cr.st = newStuckTracker(newStuckTimeout)
+		}
+	}
+
 	if nextCfg.Daemon.WispGCEnabled() {
 		cr.wg = newWispGC(nextCfg.Daemon.WispGCIntervalDuration(),
 			nextCfg.Daemon.WispTTLDuration(), bdCommandRunnerForCity(cityRoot))
@@ -856,7 +874,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		result.AssignedWorkBeads, readyWaitSet, cr.sessionDrains, poolDesired,
 		result.StoreQueryPartial,
 		workSet, cityName,
-		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
+		cr.it, cr.st, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
 		cr.cfg.Daemon.DriftDrainTimeoutDuration(),
 		cr.stdout, cr.stderr, trace,
 	)
@@ -997,6 +1015,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		nil,   // workSet: not computed for config-change reconcile
 		cr.cityName,
 		cr.it,
+		cr.st,
 		clock.Real{},
 		cr.rec,
 		cr.cfg.Session.StartupTimeoutDuration(),

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -76,6 +76,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewBuiltinPackFamilyCheck(cfg, cityPath))
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		d.Register(doctor.NewDurationRangeCheck(cfg))
+		d.Register(doctor.NewStuckTimeoutCheck(cfg))
 	}
 
 	// System formulas check.

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -632,7 +632,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		nil, nil, nil, dt, poolDesired,
 		dsResult.StoreQueryPartial,
 		nil, cityName,
-		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
+		nil, nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
 		stdout, stderr,
 	)
 

--- a/cmd/gc/dashboard/helpers.go
+++ b/cmd/gc/dashboard/helpers.go
@@ -160,7 +160,7 @@ func eventCategory(eventType string) string {
 	switch eventType {
 	case "session.woke", "session.stopped", "session.crashed",
 		"session.draining", "session.undrained", "session.quarantined",
-		"session.idle_killed", "session.suspended", "session.updated":
+		"session.idle_killed", "session.stuck_killed", "session.suspended", "session.updated":
 		return "session"
 	case "bead.created", "bead.closed", "bead.updated":
 		return "work"
@@ -197,7 +197,8 @@ func eventIcon(eventType string) string {
 		"session.draining":    "\u23f3",       // hourglass
 		"session.undrained":   "\u25b6\ufe0f", // play (resumed)
 		"session.quarantined": "\U0001f6ab",   // no entry
-		"session.idle_killed": "\U0001f480",   // skull
+		"session.idle_killed":  "\U0001f480",   // skull
+		"session.stuck_killed": "\U0001f9ca",   // ice (frozen)
 		"session.suspended":   "\u23f8\ufe0f", // pause
 		"session.updated":     "\U0001f504",   // counterclockwise arrows
 		"bead.created":        "\U0001fa9d",   // hook
@@ -243,6 +244,11 @@ func eventSummary(eventType, actor, subject, message string) string {
 		return fmt.Sprintf("%s quarantined", formatAgentAddress(subject))
 	case "session.idle_killed":
 		return fmt.Sprintf("%s idle-killed", formatAgentAddress(subject))
+	case "session.stuck_killed":
+		if message != "" {
+			return fmt.Sprintf("%s stuck-killed: %s", formatAgentAddress(subject), message)
+		}
+		return fmt.Sprintf("%s stuck-killed", formatAgentAddress(subject))
 	case "session.suspended":
 		return fmt.Sprintf("%s suspended", formatAgentAddress(subject))
 	case "session.updated":

--- a/cmd/gc/dashboard/helpers.go
+++ b/cmd/gc/dashboard/helpers.go
@@ -191,32 +191,32 @@ func extractRig(actor string) string {
 // eventIcon returns an emoji for an event type.
 func eventIcon(eventType string) string {
 	icons := map[string]string{
-		"session.woke":        "\u25b6\ufe0f", // play
-		"session.stopped":     "\u23f9\ufe0f", // stop
-		"session.crashed":     "\u2620\ufe0f", // skull and crossbones
-		"session.draining":    "\u23f3",       // hourglass
-		"session.undrained":   "\u25b6\ufe0f", // play (resumed)
-		"session.quarantined": "\U0001f6ab",   // no entry
+		"session.woke":         "\u25b6\ufe0f", // play
+		"session.stopped":      "\u23f9\ufe0f", // stop
+		"session.crashed":      "\u2620\ufe0f", // skull and crossbones
+		"session.draining":     "\u23f3",       // hourglass
+		"session.undrained":    "\u25b6\ufe0f", // play (resumed)
+		"session.quarantined":  "\U0001f6ab",   // no entry
 		"session.idle_killed":  "\U0001f480",   // skull
 		"session.stuck_killed": "\U0001f9ca",   // ice (frozen)
-		"session.suspended":   "\u23f8\ufe0f", // pause
-		"session.updated":     "\U0001f504",   // counterclockwise arrows
-		"bead.created":        "\U0001fa9d",   // hook
-		"bead.closed":         "\u2705",       // check mark
-		"bead.updated":        "\U0001f4dd",   // memo
-		"mail.sent":           "\U0001f4ec",   // mailbox
-		"mail.read":           "\U0001f4e8",   // incoming envelope
-		"mail.archived":       "\U0001f4e6",   // package
-		"controller.started":  "\U0001f680",   // rocket
-		"controller.stopped":  "\U0001f6d1",   // stop sign
-		"city.suspended":      "\u23f8\ufe0f", // pause
-		"city.resumed":        "\u25b6\ufe0f", // play
-		"convoy.created":      "\U0001f69a",   // delivery truck
-		"convoy.closed":       "\u2705",       // check mark
-		"order.fired":         "\u26a1",       // lightning
-		"order.completed":     "\u2714\ufe0f", // check
-		"order.failed":        "\u274c",       // cross mark
-		"provider.swapped":    "\U0001f500",   // shuffle
+		"session.suspended":    "\u23f8\ufe0f", // pause
+		"session.updated":      "\U0001f504",   // counterclockwise arrows
+		"bead.created":         "\U0001fa9d",   // hook
+		"bead.closed":          "\u2705",       // check mark
+		"bead.updated":         "\U0001f4dd",   // memo
+		"mail.sent":            "\U0001f4ec",   // mailbox
+		"mail.read":            "\U0001f4e8",   // incoming envelope
+		"mail.archived":        "\U0001f4e6",   // package
+		"controller.started":   "\U0001f680",   // rocket
+		"controller.stopped":   "\U0001f6d1",   // stop sign
+		"city.suspended":       "\u23f8\ufe0f", // pause
+		"city.resumed":         "\u25b6\ufe0f", // play
+		"convoy.created":       "\U0001f69a",   // delivery truck
+		"convoy.closed":        "\u2705",       // check mark
+		"order.fired":          "\u26a1",       // lightning
+		"order.completed":      "\u2714\ufe0f", // check
+		"order.failed":         "\u274c",       // cross mark
+		"provider.swapped":     "\U0001f500",   // shuffle
 	}
 	if icon, ok := icons[eventType]; ok {
 		return icon

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -376,7 +376,7 @@ func TestReconcileSessionBeads_StartsIndependentWaveInParallelBeforeDependentWav
 		done <- reconcileSessionBeads(
 			context.Background(), sessions, desired, configuredSessionNames(cfg, "", store),
 			cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"db": 1, "cache": 1, "worker": 1}, false, nil, "",
-			nil, clk, rec, 5*time.Second, 0, ioDiscard{}, ioDiscard{},
+			nil, nil, clk, rec, 5*time.Second, 0, ioDiscard{}, ioDiscard{},
 		)
 	}()
 
@@ -810,7 +810,7 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 	woken := reconcileSessionBeads(
 		context.Background(), sessions, desired, configuredSessionNames(cfg, "", store),
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), poolDesired, false, nil, "",
-		nil, clk, events.Discard, 5*time.Second, 0, ioDiscard{}, ioDiscard{},
+		nil, nil, clk, events.Discard, 5*time.Second, 0, ioDiscard{}, ioDiscard{},
 	)
 
 	if woken != defaultMaxParallelStartsPerWave {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -128,6 +128,7 @@ func reconcileSessionBeads(
 	workSet map[string]bool,
 	cityName string,
 	it idleTracker,
+	st stuckTracker,
 	clk clock.Clock,
 	rec events.Recorder,
 	startupTimeout time.Duration,
@@ -136,7 +137,7 @@ func reconcileSessionBeads(
 ) int {
 	return reconcileSessionBeadsAtPath(
 		ctx, "", sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, readyWaitSet, dt,
-		poolDesired, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
+		poolDesired, storeQueryPartial, workSet, cityName, it, st, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
 	)
 }
 
@@ -158,6 +159,7 @@ func reconcileSessionBeadsAtPath(
 	workSet map[string]bool,
 	cityName string,
 	it idleTracker,
+	st stuckTracker,
 	clk clock.Clock,
 	rec events.Recorder,
 	startupTimeout time.Duration,
@@ -166,7 +168,7 @@ func reconcileSessionBeadsAtPath(
 ) int {
 	return reconcileSessionBeadsTraced(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, readyWaitSet, dt,
-		poolDesired, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
+		poolDesired, storeQueryPartial, workSet, cityName, it, st, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
 	)
 }
 
@@ -188,6 +190,7 @@ func reconcileSessionBeadsTraced(
 	workSet map[string]bool,
 	cityName string,
 	it idleTracker,
+	st stuckTracker,
 	clk clock.Clock,
 	rec events.Recorder,
 	startupTimeout time.Duration,
@@ -614,6 +617,60 @@ func reconcileSessionBeadsTraced(
 				alive = false
 			}
 			// Fall through to wakeReasons — it will re-wake immediately if config present
+		}
+
+		// Stuck detection: kill sessions whose terminal output hasn't changed.
+		if st != nil && alive && sp.Capabilities().CanPeek {
+			if dt == nil || dt.get(session.ID) == nil { // skip sessions already draining
+				output, peekErr := sp.Peek(name, stuckPeekLines)
+				if peekErr == nil && st.checkStuck(name, output, clk.Now()) {
+					fmt.Fprintf(stderr, "session reconciler: stuck timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
+					if trace != nil {
+						trace.recordDecision("reconciler.session.stuck_timeout", tp.TemplateName, name, "stuck_timeout", "stop", nil, nil, "")
+					}
+					if err := sp.Stop(name); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: stopping stuck %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+					} else {
+						_ = sp.ClearScrollback(name)
+						snippet := truncatePeekSnippet(output, 120)
+						rec.Record(events.Event{
+							Type:    events.SessionStuckKilled,
+							Actor:   "gc",
+							Subject: tp.DisplayName(),
+							Message: fmt.Sprintf("output unchanged for >%s: %s", st.timeout(), snippet),
+						})
+						if st.recordKill(name, clk.Now()) {
+							// Quarantine: too many stuck-kills in the window.
+							fmt.Fprintf(stderr, "session reconciler: stuck quarantine for %s (exceeded %d kills)\n", tp.DisplayName(), stuckKillsMax) //nolint:errcheck // best-effort stderr
+							qUntil := clk.Now().Add(defaultQuarantineDuration).UTC().Format(time.RFC3339)
+							rec.Record(events.Event{
+								Type:    events.SessionQuarantined,
+								Actor:   "gc",
+								Subject: tp.DisplayName(),
+								Message: "stuck-kill circuit breaker: exceeded kill limit",
+							})
+							_ = store.SetMetadataBatch(session.ID, map[string]string{
+								"state": "asleep", "last_woke_at": "", "sleep_reason": "quarantine",
+								"quarantined_until": qUntil,
+							})
+							session.Metadata["state"] = "asleep"
+							session.Metadata["last_woke_at"] = ""
+							session.Metadata["sleep_reason"] = "quarantine"
+							session.Metadata["quarantined_until"] = qUntil
+						} else {
+							// Normal stuck-kill: asleep for immediate re-wake.
+							_ = store.SetMetadataBatch(session.ID, map[string]string{
+								"state": "asleep", "last_woke_at": "", "sleep_reason": "stuck-timeout",
+							})
+							session.Metadata["state"] = "asleep"
+							session.Metadata["last_woke_at"] = ""
+							session.Metadata["sleep_reason"] = "stuck-timeout"
+						}
+						st.clearSession(name)
+						alive = false
+					}
+				}
+			}
 		}
 
 		wakeTargets = append(wakeTargets, wakeTarget{session: session, tp: tp, alive: alive})

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -639,6 +639,7 @@ func reconcileSessionBeadsTraced(
 							Subject: tp.DisplayName(),
 							Message: fmt.Sprintf("output unchanged for >%s: %s", st.timeout(), snippet),
 						})
+						telemetry.RecordAgentStuckKill(context.Background(), tp.DisplayName())
 						if st.recordKill(name, clk.Now()) {
 							// Quarantine: too many stuck-kills in the window.
 							fmt.Fprintf(stderr, "session reconciler: stuck quarantine for %s (exceeded %d kills)\n", tp.DisplayName(), stuckKillsMax) //nolint:errcheck // best-effort stderr
@@ -666,7 +667,7 @@ func reconcileSessionBeadsTraced(
 							session.Metadata["last_woke_at"] = ""
 							session.Metadata["sleep_reason"] = "stuck-timeout"
 						}
-						st.clearSession(name)
+						st.resetDetection(name)
 						alive = false
 					}
 				}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3004,10 +3004,12 @@ func TestReconcileSessionBeads_StuckKill_OwnCircuitBreaker(t *testing.T) {
 
 	st := newStuckTracker(5 * time.Minute)
 
-	// Simulate stuckKillsMax-1 prior kills.
+	// Simulate stuckKillsMax-1 prior kills within the quarantine window.
+	// Quarantine window = 2 * 5m = 10m. Place kills at t+5m and t+6m so
+	// they survive pruning when the reconciler runs at t+11m (cutoff = t+1m).
 	st.checkStuck("worker", "frozen output", env.clk.Now())
 	for i := 0; i < stuckKillsMax-1; i++ {
-		st.recordKill("worker", env.clk.Now().Add(time.Duration(i)*time.Minute))
+		st.recordKill("worker", env.clk.Now().Add(time.Duration(5+i)*time.Minute))
 	}
 
 	// Now trigger the final stuck-kill via reconciler.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2922,7 +2922,7 @@ func TestReconcileSessionBeads_StuckCheck_SkippedWhenDraining(t *testing.T) {
 	st.checkStuck("worker", "frozen output", env.clk.Now())
 
 	// Mark session as draining.
-	env.dt.start(session.ID, drainInfo{reason: "test"})
+	env.dt.set(session.ID, &drainState{reason: "test"})
 
 	env.clk.Time = env.clk.Time.Add(11 * time.Minute)
 
@@ -3041,5 +3041,48 @@ func TestReconcileSessionBeads_StuckKill_OwnCircuitBreaker(t *testing.T) {
 	}
 	if b.Metadata["quarantined_until"] == "" {
 		t.Error("quarantined_until should be set")
+	}
+}
+
+func TestReconcileSessionBeads_IdleFires_BeforeStuck(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.SetPeekOutput("worker", "frozen output")
+
+	// Set up both trackers: idle fires, stuck would also fire.
+	it := newFakeIdleTracker()
+	it.idle["worker"] = true
+
+	st := newStuckTracker(5 * time.Minute)
+	st.checkStuck("worker", "frozen output", env.clk.Now())
+	env.clk.Time = env.clk.Time.Add(11 * time.Minute)
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, st, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Idle should fire (it comes first in the reconciler).
+	var foundIdle, foundStuck bool
+	for _, e := range rec.Events {
+		if e.Type == events.SessionIdleKilled {
+			foundIdle = true
+		}
+		if e.Type == events.SessionStuckKilled {
+			foundStuck = true
+		}
+	}
+	if !foundIdle {
+		t.Error("expected SessionIdleKilled event — idle check should fire first")
+	}
+	if foundStuck {
+		t.Error("unexpected SessionStuckKilled event — stuck check should be skipped when idle already killed")
 	}
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -216,7 +216,7 @@ func (e *reconcilerTestEnv) reconcileWithPoolDesired(sessions []beads.Bead, pool
 	return reconcileSessionBeads(
 		context.Background(), sessions, e.desiredState, cfgNames, e.cfg, e.sp,
 		e.store, nil, nil, nil, e.dt, poolDesired, false, nil, "",
-		nil, e.clk, e.rec, 0, 0, &e.stdout, &e.stderr,
+		nil, nil, e.clk, e.rec, 0, 0, &e.stdout, &e.stderr,
 	)
 }
 
@@ -250,6 +250,7 @@ func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,
@@ -312,6 +313,7 @@ func TestReconcileSessionBeads_DrainAckResumeModePreservesSessionIdentity(t *tes
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,
@@ -377,6 +379,7 @@ func TestReconcileSessionBeads_DrainAckFreshModeClearsSessionIdentity(t *testing
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,
@@ -457,6 +460,7 @@ func TestReconcileSessionBeads_DrainAckStopFailurePreservesMetadata(t *testing.T
 		nil,
 		"",
 		nil,
+		nil,
 		env.clk,
 		env.rec,
 		0,
@@ -520,6 +524,7 @@ func TestReconcileSessionBeads_DrainAckResumeModeNotClassifiedAsCrashNextTick(t 
 		nil,
 		"",
 		nil,
+		nil,
 		env.clk,
 		env.rec,
 		0,
@@ -555,6 +560,7 @@ func TestReconcileSessionBeads_DrainAckResumeModeNotClassifiedAsCrashNextTick(t 
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,
@@ -612,6 +618,7 @@ func TestReconcileSessionBeads_DrainAckHonoredAfterSessionExit(t *testing.T) {
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,
@@ -1402,6 +1409,7 @@ func TestReconcileSessionBeads_OnDemandNamedSessionRecoversAfterClosedCanonicalB
 		map[string]bool{"refinery": true},
 		cfg.EffectiveCityName(),
 		newFakeIdleTracker(),
+		nil,
 		clk,
 		events.Discard,
 		0,
@@ -1616,7 +1624,7 @@ func TestReconcileSessionBeads_RollsBackAdHocCreateOnRuntimeCollision(t *testing
 	woken := reconcileSessionBeads(
 		context.Background(), []beads.Bead{bead}, desired, cfgNames,
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"helper": 1}, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
@@ -1682,7 +1690,7 @@ func TestReconcileSessionBeads_ConvergesPendingCreateWhenRuntimeMatchesBead(t *t
 	woken := reconcileSessionBeads(
 		context.Background(), []beads.Bead{bead}, desired, cfgNames,
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"helper": 1}, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	if woken != 1 {
 		t.Fatalf("woken = %d, want 1", woken)
@@ -1755,7 +1763,7 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenConflictingRuntimeAlrea
 	woken := reconcileSessionBeads(
 		context.Background(), []beads.Bead{bead}, desired, cfgNames,
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{}, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
@@ -1816,7 +1824,7 @@ func TestReconcileSessionBeads_ConvergesPendingCreateOnLateSuccessStartError(t *
 	woken := reconcileSessionBeads(
 		context.Background(), []beads.Bead{bead}, desired, cfgNames,
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"helper": 1}, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	if woken != 1 {
 		t.Fatalf("woken = %d, want 1", woken)
@@ -1870,7 +1878,7 @@ func TestReconcileSessionBeads_DoesNotRollbackExistingSessionWithoutPendingClaim
 	woken := reconcileSessionBeads(
 		context.Background(), []beads.Bead{bead}, desired, cfgNames,
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{}, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
@@ -1932,7 +1940,7 @@ func TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError(t *testing.
 	woken := reconcileSessionBeads(
 		context.Background(), []beads.Bead{bead}, desired, cfgNames,
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"helper": 1}, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
@@ -1979,7 +1987,7 @@ func TestReconcileSessionBeads_PoolScaleDownOrphansExcess(t *testing.T) {
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{s1, s2}, env.desiredState, cfgNames,
 		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, poolDesired, false, nil, "",
-		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		nil, nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
 	)
 
 	d2 := env.dt.get(s2.ID)
@@ -2125,7 +2133,7 @@ func TestReconcileSessionBeads_DriftDrainUsesConfigTimeout(t *testing.T) {
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
 		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
-		nil, env.clk, env.rec, 0, env.cfg.Daemon.DriftDrainTimeoutDuration(),
+		nil, nil, env.clk, env.rec, 0, env.cfg.Daemon.DriftDrainTimeoutDuration(),
 		&env.stdout, &env.stderr,
 	)
 
@@ -2156,7 +2164,7 @@ func TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep(t *testing.T) {
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
 		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
-		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		it, nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
 	)
 
 	// Session should have been stopped and left asleep until a real wake reason appears.
@@ -2188,7 +2196,7 @@ func TestReconcileSessionBeads_IdleTimeoutNilTrackerSkipped(t *testing.T) {
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
 		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
-		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		nil, nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
 	)
 
 	if !env.sp.IsRunning("worker") {
@@ -2224,7 +2232,7 @@ func TestReconcileSessionBeads_ZombieCapturesScrollback(t *testing.T) {
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
 		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
-		nil, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
+		nil, nil, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
 	)
 
 	// Should have recorded a crash event with scrollback.
@@ -2440,7 +2448,7 @@ func TestReconcileSessionBeads_ClosedOnDemandBeadReopensWhenInDesiredState(t *te
 	woken := reconcileSessionBeads(
 		context.Background(), sessions, ds, cfgNames, cfg, sp,
 		store, nil, nil, nil, newDrainTracker(), poolDesired, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &bytes.Buffer{}, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &bytes.Buffer{}, &stderr,
 	)
 
 	// Bead should still be open after reconciliation.
@@ -2561,7 +2569,7 @@ func TestReconcileSessionBeads_PoolRecoveryAfterClosedBead(t *testing.T) {
 	woken := reconcileSessionBeads(
 		context.Background(), sessions, ds, cfgNames, cfg, sp,
 		store, nil, nil, nil, newDrainTracker(), poolDesired, false, nil, "",
-		nil, clk, events.Discard, 0, 0, &bytes.Buffer{}, &stderr,
+		nil, nil, clk, events.Discard, 0, 0, &bytes.Buffer{}, &stderr,
 	)
 
 	// Fresh bead should still be open after reconciliation.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2847,3 +2847,199 @@ func TestPoolDesiredLimitsWakeWork(t *testing.T) {
 // Regression: poolDesired derived from desiredState counts ALL session beads
 // (including discovered ones), inflating the desired count. This test verifies
 // that derivePoolDesired only counts pool sessions, not all discovered beads.
+
+// --- Stuck detection integration tests ---
+
+func TestReconcileSessionBeads_StuckKill_StopsAndRewakes(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.SetPeekOutput("worker", "frozen output")
+
+	st := newStuckTracker(5 * time.Minute)
+
+	// First call establishes baseline.
+	st.checkStuck("worker", "frozen output", env.clk.Now())
+
+	// Advance past grace period + timeout.
+	env.clk.Time = env.clk.Time.Add(11 * time.Minute)
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		nil, st, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Session should have been stopped.
+	if env.sp.IsRunning("worker") {
+		t.Error("worker should be stopped after stuck timeout")
+	}
+
+	// Verify event was recorded.
+	var foundStuck bool
+	for _, e := range rec.Events {
+		if e.Type == events.SessionStuckKilled {
+			foundStuck = true
+			if e.Subject == "" {
+				t.Error("stuck_killed event should have a subject")
+			}
+		}
+	}
+	if !foundStuck {
+		t.Error("expected SessionStuckKilled event")
+	}
+
+	// Verify bead metadata: asleep with stuck-timeout reason (eligible for re-wake).
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["state"] != "asleep" {
+		t.Errorf("state = %q, want asleep", b.Metadata["state"])
+	}
+	if b.Metadata["sleep_reason"] != "stuck-timeout" {
+		t.Errorf("sleep_reason = %q, want stuck-timeout", b.Metadata["sleep_reason"])
+	}
+	if b.Metadata["last_woke_at"] != "" {
+		t.Error("last_woke_at should be cleared for immediate re-wake")
+	}
+}
+
+func TestReconcileSessionBeads_StuckCheck_SkippedWhenDraining(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.SetPeekOutput("worker", "frozen output")
+
+	st := newStuckTracker(5 * time.Minute)
+	st.checkStuck("worker", "frozen output", env.clk.Now())
+
+	// Mark session as draining.
+	env.dt.start(session.ID, drainInfo{reason: "test"})
+
+	env.clk.Time = env.clk.Time.Add(11 * time.Minute)
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		nil, st, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Session should still be running — stuck check skipped for draining sessions.
+	if !env.sp.IsRunning("worker") {
+		t.Error("draining session should not be stuck-killed")
+	}
+}
+
+func TestReconcileSessionBeads_StuckCheck_SkippedWhenNilTracker(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.SetPeekOutput("worker", "frozen output")
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		nil, nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Session should still be running — nil tracker means disabled.
+	if !env.sp.IsRunning("worker") {
+		t.Error("session should not be stopped when stuck tracker is nil")
+	}
+}
+
+func TestReconcileSessionBeads_StuckKill_EventMessageHasPeekSnippet(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.SetPeekOutput("worker", "some diagnostic output here")
+
+	st := newStuckTracker(5 * time.Minute)
+	st.checkStuck("worker", "some diagnostic output here", env.clk.Now())
+	env.clk.Time = env.clk.Time.Add(11 * time.Minute)
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		nil, st, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	for _, e := range rec.Events {
+		if e.Type == events.SessionStuckKilled {
+			if e.Message == "" {
+				t.Error("stuck_killed event should contain a message with peek snippet")
+			}
+			return
+		}
+	}
+	t.Error("expected SessionStuckKilled event")
+}
+
+func TestReconcileSessionBeads_StuckKill_OwnCircuitBreaker(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.sp.SetPeekOutput("worker", "frozen output")
+
+	st := newStuckTracker(5 * time.Minute)
+
+	// Simulate stuckKillsMax-1 prior kills.
+	st.checkStuck("worker", "frozen output", env.clk.Now())
+	for i := 0; i < stuckKillsMax-1; i++ {
+		st.recordKill("worker", env.clk.Now().Add(time.Duration(i)*time.Minute))
+	}
+
+	// Now trigger the final stuck-kill via reconciler.
+	env.clk.Time = env.clk.Time.Add(11 * time.Minute)
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		nil, st, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	// Verify quarantine event was recorded.
+	var foundQuarantine bool
+	for _, e := range rec.Events {
+		if e.Type == events.SessionQuarantined {
+			foundQuarantine = true
+		}
+	}
+	if !foundQuarantine {
+		t.Error("expected SessionQuarantined event after circuit breaker")
+	}
+
+	// Verify bead metadata reflects quarantine.
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["sleep_reason"] != "quarantine" {
+		t.Errorf("sleep_reason = %q, want quarantine", b.Metadata["sleep_reason"])
+	}
+	if b.Metadata["quarantined_until"] == "" {
+		t.Error("quarantined_until should be set")
+	}
+}

--- a/cmd/gc/session_sleep.go
+++ b/cmd/gc/session_sleep.go
@@ -177,6 +177,9 @@ func configWakeSuppressed(
 	if session.Metadata["sleep_reason"] == "idle-timeout" {
 		return false
 	}
+	if session.Metadata["sleep_reason"] == "stuck-timeout" {
+		return false
+	}
 	if session.Metadata["sleep_reason"] == "idle" &&
 		session.Metadata["sleep_policy_fingerprint"] != "" &&
 		session.Metadata["sleep_policy_fingerprint"] == policy.Fingerprint {

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -228,14 +228,14 @@ func TestReconcileSessionBeads_StartsIdleDrainAfterGrace(t *testing.T) {
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
 		env.store, nil, nil, nil, env.dt, poolDesired, false, nil, "",
-		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		nil, nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
 	)
 	close(idleGate)
 	waitForIdleProbeReady(t, env.dt, session.ID)
 	reconcileSessionBeads(
 		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
 		env.store, nil, nil, nil, env.dt, poolDesired, false, nil, "",
-		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		nil, nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
 	)
 
 	ds := env.dt.get(session.ID)
@@ -495,6 +495,7 @@ func TestReconcileSessionBeads_IdleTimeoutLeavesImmediateSleepPolicyAsleep(t *te
 		nil,
 		"",
 		it,
+		nil,
 		env.clk,
 		env.rec,
 		0,
@@ -557,6 +558,7 @@ func TestReconcileSessionBeads_IdleTimeoutDoesNotRetryWithoutExplicitWakeReason(
 		nil,
 		"",
 		it,
+		nil,
 		env.clk,
 		env.rec,
 		0,
@@ -598,6 +600,7 @@ func TestReconcileSessionBeads_IdleTimeoutDoesNotRetryWithoutExplicitWakeReason(
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,
@@ -820,6 +823,7 @@ func TestReconcileSessionBeads_AsleepSingletonsDoNotWakeViaScaleCheck(t *testing
 		false,
 		nil,
 		"",
+		nil,
 		nil,
 		env.clk,
 		env.rec,

--- a/cmd/gc/stuck_tracker.go
+++ b/cmd/gc/stuck_tracker.go
@@ -53,9 +53,9 @@ type stuckEntry struct {
 // State is in-memory only — intentionally lost on controller restart
 // (same as crashTracker, Erlang/OTP model).
 type memoryStuckTracker struct {
-	mu         sync.Mutex
-	stuckTime  time.Duration
-	sessions   map[string]*stuckEntry
+	mu        sync.Mutex
+	stuckTime time.Duration
+	sessions  map[string]*stuckEntry
 }
 
 // newStuckTracker creates a stuck tracker with the given timeout.

--- a/cmd/gc/stuck_tracker.go
+++ b/cmd/gc/stuck_tracker.go
@@ -160,6 +160,13 @@ func (m *memoryStuckTracker) resetDetection(sessionName string) {
 // This function is independently testable without any Provider mock.
 func doCheckStuck(entry stuckEntry, output string, now time.Time, timeout time.Duration) (stuck bool, updated stuckEntry) {
 	updated = entry
+
+	// After resetDetection, firstSeen is zero — re-initialize so the
+	// restarted session gets a real grace period from this tick.
+	if updated.firstSeen.IsZero() {
+		updated.firstSeen = now
+	}
+
 	h := sha256.Sum256([]byte(output))
 
 	if h != entry.hash {

--- a/cmd/gc/stuck_tracker.go
+++ b/cmd/gc/stuck_tracker.go
@@ -32,10 +32,17 @@ type stuckTracker interface {
 	// stuckKillsMax kills within the quarantine window).
 	recordKill(sessionName string, now time.Time) bool
 
-	// clearSession removes all tracking for a session. Called when a
-	// session is stopped so the restarted session gets a fresh grace
-	// period and kill window.
+	// clearSession removes all tracking for a session, including kill
+	// history. Use when the session is permanently removed (e.g., config
+	// change, manual stop). For stuck-kill restarts, use resetDetection
+	// to preserve kill history for the circuit breaker.
 	clearSession(sessionName string)
+
+	// resetDetection resets the detection state (hash, changedAt,
+	// firstSeen) for a session while preserving the kill history. Called
+	// after a stuck-kill so the restarted session gets a fresh grace
+	// period but the circuit breaker can still accumulate kills.
+	resetDetection(sessionName string)
 
 	// timeout returns the configured stuck timeout duration.
 	timeout() time.Duration
@@ -131,6 +138,19 @@ func (m *memoryStuckTracker) clearSession(sessionName string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.sessions, sessionName)
+}
+
+func (m *memoryStuckTracker) resetDetection(sessionName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry, ok := m.sessions[sessionName]
+	if !ok {
+		return
+	}
+	// Preserve kills for circuit breaker, reset detection state.
+	entry.hash = [32]byte{}
+	entry.changedAt = time.Time{}
+	entry.firstSeen = time.Time{}
 }
 
 // doCheckStuck is the pure detection function. It compares the SHA-256

--- a/cmd/gc/stuck_tracker.go
+++ b/cmd/gc/stuck_tracker.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"crypto/sha256"
+	"sync"
+	"time"
+)
+
+// stuckPeekLines is the number of terminal lines captured for stuck
+// detection. Not configurable — 50 lines is sufficient for hash
+// differentiation without excessive capture overhead.
+const stuckPeekLines = 50
+
+// stuckKillsMax is the maximum number of stuck-kills within the
+// quarantine window before the session is quarantined. Prevents
+// infinite kill-restart loops when the underlying cause persists.
+const stuckKillsMax = 3
+
+// stuckTracker detects sessions whose terminal output has not changed
+// for longer than a configured timeout. Nil means stuck detection is
+// disabled (backward compatible). Follows the same nil-guard pattern
+// as crashTracker and idleTracker.
+type stuckTracker interface {
+	// checkStuck returns true if the session's output hash has been
+	// unchanged for longer than the timeout. The output parameter is
+	// the result of sp.Peek(name, stuckPeekLines). Empty output with
+	// no error means the session is not peekable (skip).
+	checkStuck(sessionName string, output string, now time.Time) bool
+
+	// recordKill notes that a session was killed for being stuck.
+	// Returns true if the session should be quarantined (exceeded
+	// stuckKillsMax kills within the quarantine window).
+	recordKill(sessionName string, now time.Time) bool
+
+	// clearSession removes all tracking for a session. Called when a
+	// session is stopped so the restarted session gets a fresh grace
+	// period and kill window.
+	clearSession(sessionName string)
+
+	// timeout returns the configured stuck timeout duration.
+	timeout() time.Duration
+}
+
+// stuckEntry holds per-session state for stuck detection.
+type stuckEntry struct {
+	hash      [32]byte
+	changedAt time.Time
+	firstSeen time.Time
+	kills     []time.Time // recent stuck-kills for own circuit breaker
+}
+
+// memoryStuckTracker is the production implementation of stuckTracker.
+// State is in-memory only — intentionally lost on controller restart
+// (same as crashTracker, Erlang/OTP model).
+type memoryStuckTracker struct {
+	mu         sync.Mutex
+	stuckTime  time.Duration
+	sessions   map[string]*stuckEntry
+}
+
+// newStuckTracker creates a stuck tracker with the given timeout.
+// Returns nil if timeout <= 0 (disabled). Callers check for nil
+// before using, same pattern as crashTracker and idleTracker.
+func newStuckTracker(timeout time.Duration) stuckTracker {
+	if timeout <= 0 {
+		return nil
+	}
+	return &memoryStuckTracker{
+		stuckTime: timeout,
+		sessions:  make(map[string]*stuckEntry),
+	}
+}
+
+func (m *memoryStuckTracker) timeout() time.Duration {
+	return m.stuckTime
+}
+
+func (m *memoryStuckTracker) checkStuck(sessionName string, output string, now time.Time) bool {
+	// Empty output means this session is not peekable (per-session
+	// fallback for hybrid/auto providers). Skip without updating state.
+	if output == "" {
+		return false
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.sessions[sessionName]
+	if !ok {
+		// First observation — initialize with current hash and time.
+		// The grace period starts from now.
+		h := sha256.Sum256([]byte(output))
+		m.sessions[sessionName] = &stuckEntry{
+			hash:      h,
+			changedAt: now,
+			firstSeen: now,
+		}
+		return false
+	}
+
+	stuck, updated := doCheckStuck(*entry, output, now, m.stuckTime)
+	*entry = updated
+	return stuck
+}
+
+func (m *memoryStuckTracker) recordKill(sessionName string, now time.Time) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.sessions[sessionName]
+	if !ok {
+		return false
+	}
+
+	// Prune kills outside the quarantine window (2 * timeout).
+	window := 2 * m.stuckTime
+	cutoff := now.Add(-window)
+	pruned := entry.kills[:0]
+	for _, t := range entry.kills {
+		if !t.Before(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	pruned = append(pruned, now)
+	entry.kills = pruned
+
+	return len(entry.kills) >= stuckKillsMax
+}
+
+func (m *memoryStuckTracker) clearSession(sessionName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, sessionName)
+}
+
+// doCheckStuck is the pure detection function. It compares the SHA-256
+// hash of the current output against the stored hash. If the hash has
+// not changed for longer than the timeout, the session is stuck.
+//
+// This function is independently testable without any Provider mock.
+func doCheckStuck(entry stuckEntry, output string, now time.Time, timeout time.Duration) (stuck bool, updated stuckEntry) {
+	updated = entry
+	h := sha256.Sum256([]byte(output))
+
+	if h != entry.hash {
+		// Output changed — reset the staleness timer.
+		updated.hash = h
+		updated.changedAt = now
+		return false, updated
+	}
+
+	// Hash unchanged. Check if we're still in the startup grace period.
+	if now.Sub(entry.firstSeen) < timeout {
+		return false, updated
+	}
+
+	// Hash has been unchanged long enough — session is stuck.
+	return now.Sub(entry.changedAt) > timeout, updated
+}
+
+// truncatePeekSnippet clips output to the first line or maxLen chars,
+// whichever comes first. Used for the event Message field.
+func truncatePeekSnippet(output string, maxLen int) string {
+	for i, ch := range output {
+		if ch == '\n' || i >= maxLen {
+			return output[:i]
+		}
+	}
+	if len(output) > maxLen {
+		return output[:maxLen]
+	}
+	return output
+}

--- a/cmd/gc/stuck_tracker_test.go
+++ b/cmd/gc/stuck_tracker_test.go
@@ -103,6 +103,28 @@ func TestStuckTracker_ClearSession_ResetsState(t *testing.T) {
 	}
 }
 
+func TestStuckTracker_ResetDetection_PreservesKills(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "output", now)
+	st.recordKill("sess1", now)
+	st.recordKill("sess1", now.Add(1*time.Minute))
+
+	// resetDetection should preserve kill history.
+	st.resetDetection("sess1")
+
+	// Detection state reset: next call is a fresh first observation.
+	if st.checkStuck("sess1", "output", now.Add(1*time.Hour)) {
+		t.Fatal("expected false: resetDetection should reset detection state")
+	}
+
+	// Kill history preserved: third kill should trigger quarantine.
+	if !st.recordKill("sess1", now.Add(2*time.Minute)) {
+		t.Fatal("expected quarantine: resetDetection should preserve kill history")
+	}
+}
+
 func TestStuckTracker_MultipleSessionsIndependent(t *testing.T) {
 	st := newStuckTracker(5 * time.Minute)
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/cmd/gc/stuck_tracker_test.go
+++ b/cmd/gc/stuck_tracker_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"crypto/sha256"
+	"testing"
+	"time"
+)
+
+func TestStuckTracker_NilSafe(t *testing.T) {
+	var st stuckTracker // nil interface
+	if st != nil {
+		t.Fatal("nil stuckTracker should be nil")
+	}
+}
+
+func TestStuckTracker_DisabledWhenTimeoutZero(t *testing.T) {
+	st := newStuckTracker(0)
+	if st != nil {
+		t.Fatal("expected nil tracker for zero timeout")
+	}
+	st = newStuckTracker(-1 * time.Minute)
+	if st != nil {
+		t.Fatal("expected nil tracker for negative timeout")
+	}
+}
+
+func TestStuckTracker_FirstSeen_GracePeriod(t *testing.T) {
+	st := newStuckTracker(10 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// First call: establishes firstSeen, always returns false.
+	if st.checkStuck("sess1", "some output", now) {
+		t.Fatal("expected false on first observation")
+	}
+
+	// Same hash within grace period — still false.
+	if st.checkStuck("sess1", "some output", now.Add(5*time.Minute)) {
+		t.Fatal("expected false within grace period")
+	}
+}
+
+func TestStuckTracker_HashChanges_ResetsTimer(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "output1", now)
+	// Wait past grace period, hash changes.
+	st.checkStuck("sess1", "output2", now.Add(6*time.Minute))
+
+	// Now same hash for < timeout — not stuck.
+	if st.checkStuck("sess1", "output2", now.Add(10*time.Minute)) {
+		t.Fatal("expected false: hash changed 4 minutes ago")
+	}
+}
+
+func TestStuckTracker_HashStale_ReturnsTrue(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "frozen output", now)
+
+	// Past grace period + past timeout with unchanged hash.
+	if !st.checkStuck("sess1", "frozen output", now.Add(11*time.Minute)) {
+		t.Fatal("expected true: hash stale for > timeout past grace period")
+	}
+}
+
+func TestStuckTracker_HashStale_JustUnder_ReturnsFalse(t *testing.T) {
+	st := newStuckTracker(10 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "frozen output", now)
+
+	// Exactly at timeout (not past) — should NOT fire.
+	if st.checkStuck("sess1", "frozen output", now.Add(10*time.Minute)) {
+		t.Fatal("expected false: exactly at timeout, not past it")
+	}
+}
+
+func TestStuckTracker_EmptyOutput_SkipsSession(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Empty output is skipped (per-session not-peekable signal).
+	if st.checkStuck("sess1", "", now) {
+		t.Fatal("expected false for empty output")
+	}
+	if st.checkStuck("sess1", "", now.Add(1*time.Hour)) {
+		t.Fatal("expected false for empty output even after long time")
+	}
+}
+
+func TestStuckTracker_ClearSession_ResetsState(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "output", now)
+	st.clearSession("sess1")
+
+	// After clear, next call is a fresh first observation.
+	if st.checkStuck("sess1", "output", now.Add(1*time.Hour)) {
+		t.Fatal("expected false: clearSession should reset state")
+	}
+}
+
+func TestStuckTracker_MultipleSessionsIndependent(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "output A", now)
+	st.checkStuck("sess2", "output B", now)
+
+	// sess1 stays frozen, sess2 changes.
+	st.checkStuck("sess1", "output A", now.Add(11*time.Minute))
+	st.checkStuck("sess2", "output C", now.Add(11*time.Minute))
+
+	if !st.checkStuck("sess1", "output A", now.Add(12*time.Minute)) {
+		t.Fatal("expected sess1 stuck")
+	}
+	if st.checkStuck("sess2", "output C", now.Add(12*time.Minute)) {
+		t.Fatal("expected sess2 not stuck — hash changed recently")
+	}
+}
+
+func TestStuckTracker_OwnCircuitBreaker_Quarantines(t *testing.T) {
+	st := newStuckTracker(10 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Initialize session.
+	st.checkStuck("sess1", "output", now)
+
+	// Record kills within the window (2 * timeout = 20 minutes).
+	if st.recordKill("sess1", now.Add(1*time.Minute)) {
+		t.Fatal("expected no quarantine after 1 kill")
+	}
+	if st.recordKill("sess1", now.Add(5*time.Minute)) {
+		t.Fatal("expected no quarantine after 2 kills")
+	}
+	if !st.recordKill("sess1", now.Add(10*time.Minute)) {
+		t.Fatal("expected quarantine after 3 kills within window")
+	}
+}
+
+func TestStuckTracker_OwnCircuitBreaker_WindowExpiry(t *testing.T) {
+	st := newStuckTracker(10 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	st.checkStuck("sess1", "output", now)
+
+	// Two kills at t=0.
+	st.recordKill("sess1", now)
+	st.recordKill("sess1", now.Add(1*time.Minute))
+
+	// Third kill well outside the window (2*10m = 20m). Old kills pruned.
+	if st.recordKill("sess1", now.Add(30*time.Minute)) {
+		t.Fatal("expected no quarantine: old kills outside window")
+	}
+}
+
+func TestDoCheckStuck_PureFunction(t *testing.T) {
+	timeout := 5 * time.Minute
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("hash_changes", func(t *testing.T) {
+		entry := stuckEntry{
+			hash:      sha256.Sum256([]byte("old output")),
+			changedAt: now,
+			firstSeen: now.Add(-10 * time.Minute),
+		}
+		stuck, updated := doCheckStuck(entry, "new output", now.Add(6*time.Minute), timeout)
+		if stuck {
+			t.Fatal("expected false when hash changes")
+		}
+		if updated.hash == entry.hash {
+			t.Fatal("expected hash to be updated")
+		}
+	})
+
+	t.Run("stale_hash_triggers", func(t *testing.T) {
+		entry := stuckEntry{
+			hash:      sha256.Sum256([]byte("frozen")),
+			changedAt: now,
+			firstSeen: now.Add(-10 * time.Minute),
+		}
+		stuck, _ := doCheckStuck(entry, "frozen", now.Add(6*time.Minute), timeout)
+		if !stuck {
+			t.Fatal("expected true: hash stale for > timeout")
+		}
+	})
+
+	t.Run("grace_period_suppresses", func(t *testing.T) {
+		entry := stuckEntry{
+			hash:      sha256.Sum256([]byte("frozen")),
+			changedAt: now,
+			firstSeen: now,
+		}
+		stuck, _ := doCheckStuck(entry, "frozen", now.Add(3*time.Minute), timeout)
+		if stuck {
+			t.Fatal("expected false: within grace period")
+		}
+	})
+}
+
+func TestTruncatePeekSnippet(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"empty", "", 120, ""},
+		{"short", "hello", 120, "hello"},
+		{"newline", "line1\nline2", 120, "line1"},
+		{"long", "abcdefghij", 5, "abcde"},
+		{"newline_before_max", "ab\ncd", 10, "ab"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncatePeekSnippet(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncatePeekSnippet(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/stuck_tracker_test.go
+++ b/cmd/gc/stuck_tracker_test.go
@@ -125,6 +125,33 @@ func TestStuckTracker_ResetDetection_PreservesKills(t *testing.T) {
 	}
 }
 
+func TestStuckTracker_ResetDetection_GracePeriod(t *testing.T) {
+	st := newStuckTracker(5 * time.Minute)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Establish session.
+	st.checkStuck("sess1", "frozen", now)
+
+	// Simulate stuck-kill: reset detection state.
+	st.resetDetection("sess1")
+
+	// After reset, first observation with new output — hash change, not stuck.
+	restartTime := now.Add(1 * time.Hour)
+	if st.checkStuck("sess1", "new output", restartTime) {
+		t.Fatal("expected false on first observation after reset")
+	}
+
+	// Same output within grace period (timeout/2 < timeout) — must NOT fire.
+	if st.checkStuck("sess1", "new output", restartTime.Add(3*time.Minute)) {
+		t.Fatal("expected false: should be within grace period after reset")
+	}
+
+	// Same output past grace period AND past timeout — should fire.
+	if !st.checkStuck("sess1", "new output", restartTime.Add(11*time.Minute)) {
+		t.Fatal("expected true: past grace period and timeout after reset")
+	}
+}
+
 func TestStuckTracker_MultipleSessionsIndependent(t *testing.T) {
 	st := newStuckTracker(5 * time.Minute)
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1364,6 +1364,10 @@ Use --prefix to set the bead ID prefix explicitly (default: derived from name).
 Use --start-suspended to add the rig in a suspended state (dormant-by-default).
 The rig's agents won't spawn until explicitly resumed with "gc rig resume".
 
+Use --adopt to register a directory that already has a fully initialized
+.beads/ directory (must include both metadata.json and config.yaml).
+Skips beads init; the git repo check remains informational.
+
 ```
 gc rig add <path> [flags]
 ```
@@ -1376,10 +1380,12 @@ gc rig add /path/to/project
   gc rig add /path/to/project --prefix r1
   gc rig add ./my-project --include packs/gastown
   gc rig add ./my-project --include packs/gastown --start-suspended
+  gc rig add /path/to/existing --adopt
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--adopt` | bool |  | adopt existing .beads/ directory (skip init) |
 | `--include` | string |  | pack directory for rig agents |
 | `--name` | string |  | rig name (default: directory basename) |
 | `--prefix` | string |  | bead ID prefix (default: derived from name) |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -247,6 +247,7 @@ DaemonConfig holds controller daemon settings.
 | `drift_drain_timeout` | string |  | `2m` | DriftDrainTimeout is the maximum time to wait for an agent to acknowledge a drain signal during a config-drift restart. If the agent doesn't ack within this window, the controller force-kills and restarts it. Duration string (e.g., "2m", "5m"). Defaults to "2m". |
 | `observe_paths` | []string |  |  | ObservePaths lists extra directories to search for Claude JSONL session files (e.g., aimux session paths). The default search path (~/.claude/projects/) is always included. |
 | `probe_concurrency` | integer |  | `8` | ProbeConcurrency bounds the number of concurrent bd subprocess probes issued by the pool scale_check and work_query paths. bd serializes on a shared dolt sql-server, so unbounded parallelism causes contention. Nil (unset) defaults to 8. Set higher for workspaces with a fast dedicated dolt server, or lower to reduce contention on slow storage. |
+| `stuck_timeout` | string |  |  | StuckTimeout is the maximum time a session's terminal output can remain unchanged before the controller kills and restarts it. Duration string (e.g., "30m", "1h"). Empty (default) disables stuck detection. Requires a runtime provider that supports Peek (e.g., tmux). |
 
 ## DoltConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -943,6 +943,10 @@
           "type": "integer",
           "description": "ProbeConcurrency bounds the number of concurrent bd subprocess probes\nissued by the pool scale_check and work_query paths. bd serializes on\na shared dolt sql-server, so unbounded parallelism causes contention.\nNil (unset) defaults to 8. Set higher for workspaces with a fast\ndedicated dolt server, or lower to reduce contention on slow storage.",
           "default": 8
+        },
+        "stuck_timeout": {
+          "type": "string",
+          "description": "StuckTimeout is the maximum time a session's terminal output can remain\nunchanged before the controller kills and restarts it. Duration string\n(e.g., \"30m\", \"1h\"). Empty (default) disables stuck detection.\nRequires a runtime provider that supports Peek (e.g., tmux)."
         }
       },
       "additionalProperties": false,

--- a/engdocs/architecture/controller.md
+++ b/engdocs/architecture/controller.md
@@ -45,7 +45,7 @@ automations, and garbage-collects expired wisps.
   parallel via goroutines.
 
 - **Nil-Guard Tracker Pattern**: Optional subsystems (crash tracker, idle
-  tracker, wisp GC, order dispatcher) follow a nil-means-disabled
+  tracker, stuck tracker, wisp GC, order dispatcher) follow a nil-means-disabled
   convention. Callers check `if tracker != nil` before use. This avoids
   conditional plumbing and keeps the loop body clean.
 
@@ -128,7 +128,7 @@ Each tick of `controllerLoop()` (`cmd/gc/controller.go:268-320`) performs:
 
 - **`controllerLoop()`** (`cmd/gc/controller.go:226`): The main loop
   function. Accepts all dependencies as parameters for testability:
-  config, build function, session provider, reconcile/drain ops, all four
+  config, build function, session provider, reconcile/drain ops, all five
   trackers, event recorder, and I/O writers.
 
 - **`runController()`** (`cmd/gc/controller.go:335`): The top-level
@@ -145,8 +145,8 @@ Each tick of `controllerLoop()` (`cmd/gc/controller.go:268-320`) performs:
 
 - **`DaemonConfig`** (`internal/config/config.go:377`): Configuration
   struct holding `patrol_interval`, `max_restarts`, `restart_window`,
-  `shutdown_timeout`, `wisp_gc_interval`, `wisp_ttl`. All durations
-  have `*Duration()` accessor methods with sensible defaults.
+  `shutdown_timeout`, `stuck_timeout`, `wisp_gc_interval`, `wisp_ttl`.
+  All durations have `*Duration()` accessor methods with sensible defaults.
 
 ## Invariants
 

--- a/engdocs/architecture/controller.md
+++ b/engdocs/architecture/controller.md
@@ -164,9 +164,11 @@ indicate bugs.
   startup; changing it requires a controller restart.
 
 - **Tracker rebuild is atomic per tick**: When config reloads, all five
-  trackers (crash, idle, stuck, wisp GC, order) are rebuilt in the same
-  tick before reconciliation runs. No tick ever uses a mix of old and new
-  tracker state.
+  trackers (crash, idle, stuck, wisp GC, order) are updated in the same
+  tick before reconciliation runs. Most trackers are rebuilt unconditionally;
+  the stuck tracker preserves accumulated state when its timeout value is
+  unchanged (only rebuilt when `stuck_timeout` changes or is removed).
+  No tick ever uses a mix of old and new tracker config.
 
 - **Dirty flag is edge-triggered, not level-triggered**: The `atomic.Bool`
   is set by the fsnotify goroutine and cleared by `dirty.Swap(false)` at

--- a/engdocs/architecture/controller.md
+++ b/engdocs/architecture/controller.md
@@ -76,7 +76,7 @@ gc start --foreground
   ├─11. runController()
   │     ├─ acquireControllerLock()   →  flock LOCK_EX|LOCK_NB
   │     ├─ startControllerSocket()   →  Unix socket for IPC
-  │     ├─ build trackers (crash, idle, wisp GC, order)
+  │     ├─ build trackers (crash, idle, stuck, wisp GC, order)
   │     └─ controllerLoop()
   │           ├─ watchConfigDirs()   →  fsnotify on config + pack dirs
   │           ├─ initial reconciliation
@@ -99,7 +99,7 @@ Each tick of `controllerLoop()` (`cmd/gc/controller.go:268-320`) performs:
 
 1. **Dirty check** (`dirty.Swap(false)`): If config files changed since
    the last tick, `tryReloadConfig()` re-parses `city.toml` with includes
-   and patches. On success, all four trackers are rebuilt from the new
+   and patches. On success, all five trackers are rebuilt from the new
    config. On failure (parse error, validation error, name change), the
    old config is kept and an error is logged.
 
@@ -163,9 +163,9 @@ indicate bugs.
   any reload where `workspace.name` changes. The city name is locked at
   startup; changing it requires a controller restart.
 
-- **Tracker rebuild is atomic per tick**: When config reloads, all four
-  trackers (crash, idle, wisp GC, order) are rebuilt in the same tick
-  before reconciliation runs. No tick ever uses a mix of old and new
+- **Tracker rebuild is atomic per tick**: When config reloads, all five
+  trackers (crash, idle, stuck, wisp GC, order) are rebuilt in the same
+  tick before reconciliation runs. No tick ever uses a mix of old and new
   tracker state.
 
 - **Dirty flag is edge-triggered, not level-triggered**: The `atomic.Bool`
@@ -264,6 +264,7 @@ patrol_interval = "30s"     # reconciliation tick frequency (default: 30s)
 max_restarts = 5            # crash loop threshold (default: 5, 0 = unlimited)
 restart_window = "1h"       # sliding window for restart counting (default: 1h)
 shutdown_timeout = "5s"     # grace period before force-kill (default: 5s)
+stuck_timeout = "30m"       # kill+restart if terminal output unchanged (disabled if unset)
 wisp_gc_interval = "5m"     # wisp GC run frequency (disabled if unset)
 wisp_ttl = "24h"            # how long closed wisps survive (disabled if unset)
 ```

--- a/engdocs/architecture/event-bus.md
+++ b/engdocs/architecture/event-bus.md
@@ -223,7 +223,8 @@ are enforced by the conformance suite in
 | Depended on by | How |
 |---|---|
 | `cmd/gc/controller.go` | Records `controller.started` and `controller.stopped` events at lifecycle boundaries; passes `Recorder` to reconciliation and shutdown |
-| `cmd/gc/reconcile.go` | Records `agent.started`, `agent.stopped`, `agent.crashed`, `agent.idle_killed`, `agent.quarantined`, `agent.suspended` events during reconciliation |
+| `cmd/gc/reconcile.go` | Records `session.woke`, `session.stopped`, `session.crashed`, `session.idle_killed`, `session.quarantined`, `session.suspended` events during reconciliation |
+| `cmd/gc/session_reconciler.go` | Records `session.stuck_killed`, `session.quarantined` (stuck circuit breaker), and `session.idle_killed` events during bead-driven session reconciliation |
 | `cmd/gc/order_dispatch.go` | Records `order.fired`, `order.completed`, `order.failed` events during order dispatch |
 | `cmd/gc/cmd_events.go` | CLI `gc events` command: reads and displays events with filtering (`--type`, `--since`), watch mode (`--watch`), and sequence query (`--seq`) |
 | `cmd/gc/cmd_event_emit.go` | CLI `gc event emit` command: records custom events from scripts and bd hooks (best-effort, always exits 0) |
@@ -316,7 +317,7 @@ is a complete, self-contained JSON object:
 
 ```json
 {"seq":1,"type":"controller.started","ts":"2026-03-01T10:00:00Z","actor":"gc"}
-{"seq":2,"type":"agent.started","ts":"2026-03-01T10:00:01Z","actor":"gc","subject":"worker-1","message":"agent started successfully"}
+{"seq":2,"type":"session.woke","ts":"2026-03-01T10:00:01Z","actor":"gc","subject":"worker-1","message":"session started successfully"}
 {"seq":3,"type":"bead.created","ts":"2026-03-01T10:00:05Z","actor":"human","subject":"gc-42","payload":{"title":"Fix bug","labels":["urgent"]}}
 ```
 

--- a/engdocs/architecture/event-bus.md
+++ b/engdocs/architecture/event-bus.md
@@ -256,28 +256,41 @@ All event type constants are defined in `internal/events/events.go`:
 
 | Constant | Value | Emitted by |
 |---|---|---|
-| `AgentStarted` | `agent.started` | Controller reconciliation on agent start |
-| `AgentStopped` | `agent.stopped` | Controller reconciliation on agent stop, shutdown, or drain completion |
-| `AgentCrashed` | `agent.crashed` | Controller reconciliation when a running agent's process is gone |
-| `AgentDraining` | `agent.draining` | Agent drain command |
-| `AgentUndrained` | `agent.undrained` | Agent undrain command |
-| `AgentQuarantined` | `agent.quarantined` | Controller when crash loop threshold exceeded |
-| `AgentIdleKilled` | `agent.idle_killed` | Controller when idle timeout exceeded |
-| `AgentSuspended` | `agent.suspended` | Controller when agent is suspended via config |
+| `SessionWoke` | `session.woke` | Controller reconciliation on session start |
+| `SessionStopped` | `session.stopped` | Controller reconciliation on session stop, shutdown, or drain completion |
+| `SessionCrashed` | `session.crashed` | Controller reconciliation when a running session's process is gone |
+| `SessionDraining` | `session.draining` | Session drain command |
+| `SessionUndrained` | `session.undrained` | Session undrain command |
+| `SessionQuarantined` | `session.quarantined` | Controller when crash loop or stuck-kill threshold exceeded |
+| `SessionIdleKilled` | `session.idle_killed` | Controller when idle timeout exceeded |
+| `SessionStuckKilled` | `session.stuck_killed` | Controller when terminal output unchanged for stuck_timeout |
+| `SessionSuspended` | `session.suspended` | Controller when session is suspended via config |
+| `SessionUpdated` | `session.updated` | Controller when session metadata is updated |
 | `BeadCreated` | `bead.created` | Bead creation hooks |
 | `BeadClosed` | `bead.closed` | Bead close hooks |
 | `BeadUpdated` | `bead.updated` | Bead update hooks |
 | `MailSent` | `mail.sent` | Mail send command |
 | `MailRead` | `mail.read` | Mail read command |
+| `MailArchived` | `mail.archived` | Mail archive command |
+| `MailMarkedRead` | `mail.marked_read` | Mail mark-read command |
+| `MailMarkedUnread` | `mail.marked_unread` | Mail mark-unread command |
+| `MailReplied` | `mail.replied` | Mail reply command |
+| `MailDeleted` | `mail.deleted` | Mail delete command |
 | `ConvoyCreated` | `convoy.created` | Convoy creation |
 | `ConvoyClosed` | `convoy.closed` | Convoy close |
 | `ControllerStarted` | `controller.started` | Controller startup |
 | `ControllerStopped` | `controller.stopped` | Controller shutdown |
 | `CitySuspended` | `city.suspended` | City suspend command |
 | `CityResumed` | `city.resumed` | City resume command |
-| `AutomationFired` | `order.fired` | Order dispatch when gate is due |
-| `AutomationCompleted` | `order.completed` | Order dispatch on successful completion |
-| `AutomationFailed` | `order.failed` | Order dispatch on failure |
+| `OrderFired` | `order.fired` | Order dispatch when gate is due |
+| `OrderCompleted` | `order.completed` | Order dispatch on successful completion |
+| `OrderFailed` | `order.failed` | Order dispatch on failure |
+| `ProviderSwapped` | `provider.swapped` | Controller when runtime provider changes |
+| `ExtMsgBound` | `extmsg.bound` | External messaging binding |
+| `ExtMsgUnbound` | `extmsg.unbound` | External messaging unbinding |
+| `ExtMsgGroupCreated` | `extmsg.group_created` | External messaging group creation |
+| `ExtMsgAdapterAdded` | `extmsg.adapter_added` | External messaging adapter registration |
+| `ExtMsgAdapterRemoved` | `extmsg.adapter_removed` | External messaging adapter removal |
 
 ## Configuration
 

--- a/engdocs/architecture/health-patrol.md
+++ b/engdocs/architecture/health-patrol.md
@@ -112,8 +112,8 @@ A single controller tick proceeds as follows:
 1. **Config reload** (conditional). If the `dirty` atomic flag is set
    (via fsnotify debounce on config directory changes),
    `tryReloadConfig()` re-parses `city.toml` with includes and patches.
-   If the reload succeeds, the crash tracker, idle tracker, wisp GC, and
-   order dispatcher are all rebuilt from the new config.
+   If the reload succeeds, the crash tracker, idle tracker, stuck tracker,
+   wisp GC, and order dispatcher are all rebuilt from the new config.
 
 2. **Agent list build**. `buildFn(cfg)` re-evaluates the desired agent
    set, including pool `check` commands for elastic scaling.
@@ -165,7 +165,7 @@ hit).
 **Orphan cleanup** (Phase 2) handles sessions with the city prefix that
 are not in the desired set:
 - Pool excess members are drained gracefully via `drainOps`.
-- Suspended agents are stopped with an `agent.suspended` event.
+- Suspended agents are stopped with a `session.suspended` event.
 - True orphans are killed immediately.
 
 **Dependency-aware bounded parallel starts** (Phase 1b): The bead-driven
@@ -286,7 +286,7 @@ Health Patrol follows Erlang/OTP patterns mapped to Gas City:
 |---|---|
 | `internal/config` | Parses `DaemonConfig` for patrol interval, max restarts, restart window, shutdown timeout. Provides `Revision()` for config reload detection. |
 | `internal/runtime` | `Provider` interface for Start/Stop/IsRunning/ListRunning/GetLastActivity/SetMeta/GetMeta. `ConfigFingerprint()` for drift detection. |
-| `internal/events` | `Recorder` interface for emitting lifecycle events (`agent.started`, `agent.stopped`, `agent.crashed`, `agent.quarantined`, `agent.idle_killed`, `agent.suspended`, `controller.started`, `controller.stopped`, `order.fired`, `order.completed`, `order.failed`). `Provider` interface for event gate queries. |
+| `internal/events` | `Recorder` interface for emitting lifecycle events (`session.woke`, `session.stopped`, `session.crashed`, `session.quarantined`, `session.idle_killed`, `session.stuck_killed`, `session.suspended`, `controller.started`, `controller.stopped`, `order.fired`, `order.completed`, `order.failed`). `Provider` interface for event gate queries. |
 | `internal/beads` | `Store` interface for order tracking beads (create, update, list by label). `CommandRunner` for bd CLI invocation. |
 | `internal/orders` | `Scan()` to discover orders from formula layers. `CheckGate()` to evaluate gate conditions. `Order` struct for dispatch metadata. |
 | `internal/agent` | `Agent` interface wrapping config + session provider for `Start()`/`Stop()`/`IsRunning()`/`SessionName()` operations. |
@@ -354,6 +354,8 @@ Each Health Patrol component has dedicated unit tests:
 | `cmd/gc/reconcile_test.go` | All four reconciliation states (not running/healthy/orphan/drifted), parallel starts, zombie capture, crash loop quarantine integration, idle restart, pool drain, suspended agent handling |
 | `cmd/gc/crash_tracker_test.go` | Sliding window pruning, quarantine threshold, clear history, nil-guard (disabled tracker) |
 | `cmd/gc/idle_tracker_test.go` | Timeout detection, zero time handling, per-agent timeout configuration, nil-guard |
+| `cmd/gc/stuck_tracker_test.go` | Hash comparison, grace period, stale hash detection, boundary conditions, empty output skip, clear session, multi-session independence, circuit breaker quarantine, window expiry, pure function tests, truncate snippet |
+| `cmd/gc/session_reconciler_test.go` | Stuck-kill stops and re-wakes, skipped when draining, skipped when nil tracker, idle fires before stuck, event message contains peek snippet, circuit breaker triggers quarantine |
 | `cmd/gc/order_dispatch_test.go` | Gate evaluation (cooldown, cron, condition, event, manual), exec dispatch, wisp dispatch, tracking bead creation, timeout capping, rig-scoped orders |
 
 All tests use in-memory fakes (`runtime.Fake`, `events.Discard`,

--- a/engdocs/architecture/health-patrol.md
+++ b/engdocs/architecture/health-patrol.md
@@ -38,6 +38,15 @@ are child specs, and "let it crash" is realized through GUPP + beads
   with no session I/O activity is killed and restarted. Queries
   `runtime.Provider.GetLastActivity()` on each tick.
 
+- **Stuck Detection**: An opt-in city-wide duration after which a
+  session whose terminal output hash has not changed is killed and
+  restarted. Uses `runtime.Provider.Peek()` to capture terminal output
+  and SHA-256 hashing for change detection. Requires a provider with
+  `CanPeek` capability (tmux, k8s). Configured via
+  `[daemon] stuck_timeout`. Includes an own circuit breaker that
+  quarantines sessions exceeding `stuckKillsMax` kills within
+  `2 * stuck_timeout`.
+
 - **Order Dispatch**: The controller evaluates gate conditions
   (cooldown, cron, condition, event, manual) on every tick and fires
   due orders. Exec orders run shell scripts directly. Formula
@@ -55,7 +64,7 @@ are child specs, and "let it crash" is realized through GUPP + beads
 The Health Patrol is not a standalone subsystem with its own package. It
 is composed from several collaborating components wired together inside
 the controller loop in `cmd/gc/controller.go`. The controller
-instantiates and holds instances of four tracker interfaces, each
+instantiates and holds instances of five tracker interfaces, each
 following a nil-guard pattern (nil means disabled, callers check before
 use):
 
@@ -80,6 +89,7 @@ use):
                      │  │ (reconcile.go)               │   │
                      │  │   ├─ crashTracker            │   │
                      │  │   ├─ idleTracker             │   │
+                     │  │   ├─ stuckTracker            │   │
                      │  │   ├─ reconcileOps (drift)    │   │
                      │  │   └─ drainOps (pool scaling) │   │
                      │  └──────────────┬──────────────┘   │
@@ -141,8 +151,11 @@ Additional sub-states within "running" are checked in order:
 1. **Restart requested**: Agent self-requested restart (context
    exhaustion). Stop + start.
 2. **Idle timeout exceeded**: `idleTracker.checkIdle()` returns true.
-   Stop + start, emit `agent.idle_killed` event.
-3. **Config drift**: Stored hash differs from current. Stop + start.
+   Stop + start, emit `session.idle_killed` event.
+3. **Stuck timeout exceeded**: `stuckTracker.checkStuck()` returns true.
+   Stop, emit `session.stuck_killed` event, mark asleep for re-wake.
+   Own circuit breaker quarantines after repeated kills.
+4. **Config drift**: Stored hash differs from current. Stop + start.
 
 Agents not running are subject to **crash loop quarantine**: if
 `crashTracker.isQuarantined()` returns true, the agent is skipped
@@ -177,6 +190,12 @@ waves with bounded parallelism.
   `runtime.Provider.GetLastActivity()` and compares against per-agent
   timeout durations.
 
+- **`stuckTracker`** (`cmd/gc/stuck_tracker.go`): Interface for
+  terminal output staleness detection. Production impl
+  `memoryStuckTracker` hashes Peek output (SHA-256) and compares
+  across ticks. Per-session `stuckEntry` tracks hash, changedAt,
+  firstSeen (grace period), and kills (circuit breaker window).
+
 - **`reconcileOps`** (`cmd/gc/reconcile.go`): Interface for
   session-level operations needed by reconciliation: `listRunning()`,
   `storeConfigHash()`, `configHash()`. Backed by
@@ -190,7 +209,7 @@ waves with bounded parallelism.
 
 - **`DaemonConfig`** (`internal/config/config.go`): Configuration struct
   holding patrol interval, max restarts, restart window, shutdown timeout,
-  wisp GC settings.
+  stuck timeout, wisp GC settings.
 
 ## Invariants
 
@@ -288,6 +307,8 @@ All Health Patrol implementation lives in `cmd/gc/`:
 | `cmd/gc/reconcile.go` | `reconcileOps` interface, `doReconcileAgents()` (4-state reconciliation + parallel starts + orphan cleanup), `doStopOrphans()` |
 | `cmd/gc/crash_tracker.go` | `crashTracker` interface, `memoryCrashTracker` (in-memory restart history with sliding window pruning) |
 | `cmd/gc/idle_tracker.go` | `idleTracker` interface, `memoryIdleTracker` (per-agent timeout + GetLastActivity query) |
+| `cmd/gc/stuck_tracker.go` | `stuckTracker` interface, `memoryStuckTracker` (SHA-256 hash comparison of Peek output, grace period, own circuit breaker) |
+| `cmd/gc/session_reconciler.go` | Bead-driven session reconciliation with stuck detection integration (stuck check after idle check, drain guard) |
 | `cmd/gc/order_dispatch.go` | `orderDispatcher` interface, `memoryOrderDispatcher` (gate evaluation, exec dispatch, wisp dispatch, tracking bead lifecycle) |
 | `internal/config/config.go` | `DaemonConfig` struct with `PatrolIntervalDuration()`, `MaxRestartsOrDefault()`, `RestartWindowDuration()`, `ShutdownTimeoutDuration()` |
 | `internal/config/revision.go` | `Revision()` (SHA-256 bundle hash of all config sources + pack dirs), `WatchDirs()` |
@@ -306,6 +327,7 @@ patrol_interval = "30s"     # reconciliation tick frequency (default: 30s)
 max_restarts = 5            # crash loop threshold (default: 5, 0 = unlimited)
 restart_window = "1h"       # sliding window for restart counting (default: 1h)
 shutdown_timeout = "5s"     # grace period before force-kill on shutdown (default: 5s)
+stuck_timeout = "30m"       # kill+restart if terminal output unchanged (disabled if unset)
 wisp_gc_interval = "5m"     # how often to purge expired wisps (disabled if unset)
 wisp_ttl = "24h"            # how long closed wisps survive (disabled if unset)
 
@@ -363,6 +385,12 @@ stubbed `ExecRunner`) with no external infrastructure dependencies. See
 - **No hot-reload for structural changes**: Changing `workspace.name`
   requires a full controller restart. `tryReloadConfig()` rejects name
   changes and keeps the old config.
+
+- **Stuck detection is city-wide**: `stuck_timeout` applies to all
+  sessions. Set it to accommodate the slowest-running agent with
+  legitimately stable output. Per-agent override is not yet supported.
+  Subprocess and ACP sessions cannot be monitored for stuckness
+  (CanPeek is false for those providers).
 
 ## See Also
 

--- a/engdocs/contributors/primitive-test.md
+++ b/engdocs/contributors/primitive-test.md
@@ -69,6 +69,12 @@ decision belongs in the prompt, not the code.
 - "Detect stale hooks and decide what to do" → cognition → consumer
 - "Send SIGTERM to a process" → transport → primitive
 
+**Note:** Comparing byte hashes of terminal output (as in stuckTracker)
+is transport, not cognition. The controller observes that output has not
+changed; it does not classify or interpret the output content. Contrast
+with error pattern matching, which WOULD be cognition — it requires the
+framework to understand what an error means.
+
 ## Applying the framework
 
 ### Decision table template

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -988,6 +988,11 @@ type DaemonConfig struct {
 	// Nil (unset) defaults to 8. Set higher for workspaces with a fast
 	// dedicated dolt server, or lower to reduce contention on slow storage.
 	ProbeConcurrency *int `toml:"probe_concurrency,omitempty" jsonschema:"default=8"`
+	// StuckTimeout is the maximum time a session's terminal output can remain
+	// unchanged before the controller kills and restarts it. Duration string
+	// (e.g., "30m", "1h"). Empty (default) disables stuck detection.
+	// Requires a runtime provider that supports Peek (e.g., tmux).
+	StuckTimeout string `toml:"stuck_timeout,omitempty"`
 }
 
 // PatrolIntervalDuration returns the patrol interval as a time.Duration.
@@ -1099,6 +1104,19 @@ func (d *DaemonConfig) WispTTLDuration() time.Duration {
 // and wisp_ttl must be set to non-zero durations.
 func (d *DaemonConfig) WispGCEnabled() bool {
 	return d.WispGCIntervalDuration() > 0 && d.WispTTLDuration() > 0
+}
+
+// StuckTimeoutDuration returns the stuck timeout as a time.Duration.
+// Returns 0 if empty or unparseable (disabled).
+func (d *DaemonConfig) StuckTimeoutDuration() time.Duration {
+	if d.StuckTimeout == "" {
+		return 0
+	}
+	dur, err := time.ParseDuration(d.StuckTimeout)
+	if err != nil {
+		return 0
+	}
+	return dur
 }
 
 // FormulasDir returns the formulas directory, defaulting to "formulas".

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -46,6 +46,7 @@ func ValidateDurations(cfg *City, source string) []string {
 	check("[daemon]", "wisp_gc_interval", cfg.Daemon.WispGCInterval)
 	check("[daemon]", "wisp_ttl", cfg.Daemon.WispTTL)
 	check("[daemon]", "drift_drain_timeout", cfg.Daemon.DriftDrainTimeout)
+	check("[daemon]", "stuck_timeout", cfg.Daemon.StuckTimeout)
 
 	// Orders config durations.
 	check("[orders]", "max_timeout", cfg.Orders.MaxTimeout)

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -19,6 +19,7 @@ func TestValidateDurationsAllValid(t *testing.T) {
 			RestartWindow:     "1h",
 			ShutdownTimeout:   "5s",
 			DriftDrainTimeout: "2m",
+			StuckTimeout:      "30m",
 		},
 		Agents: []Agent{
 			{Name: "mayor", IdleTimeout: "15m"},

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -235,3 +235,42 @@ func (c *ConfigSemanticsCheck) CanFix() bool { return false }
 
 // Fix is a no-op.
 func (c *ConfigSemanticsCheck) Fix(_ *CheckContext) error { return nil }
+
+// --- Stuck timeout info check ---
+
+// StuckTimeoutCheck reports whether stuck detection is configured.
+// StatusInfo when stuck_timeout is empty (feature available but unused).
+type StuckTimeoutCheck struct {
+	cfg *config.City
+}
+
+// NewStuckTimeoutCheck creates an informational check for stuck detection.
+func NewStuckTimeoutCheck(cfg *config.City) *StuckTimeoutCheck {
+	return &StuckTimeoutCheck{cfg: cfg}
+}
+
+// Name returns the check identifier.
+func (c *StuckTimeoutCheck) Name() string { return "daemon-stuck-timeout" }
+
+// Run checks whether stuck_timeout is configured.
+func (c *StuckTimeoutCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg.Daemon.StuckTimeout != "" {
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("stuck_timeout = %q", c.cfg.Daemon.StuckTimeout)
+		return r
+	}
+	r.Status = StatusOK
+	r.Message = "stuck_timeout not set (disabled)"
+	r.Details = []string{
+		"stuck detection is available: add stuck_timeout to [daemon] to enable",
+		"note: stuck_timeout applies city-wide; set it to accommodate your slowest-running agent",
+	}
+	return r
+}
+
+// CanFix returns false — this is informational only.
+func (c *StuckTimeoutCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *StuckTimeoutCheck) Fix(_ *CheckContext) error { return nil }

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -239,7 +239,7 @@ func (c *ConfigSemanticsCheck) Fix(_ *CheckContext) error { return nil }
 // --- Stuck timeout info check ---
 
 // StuckTimeoutCheck reports whether stuck detection is configured.
-// StatusInfo when stuck_timeout is empty (feature available but unused).
+// StatusOK in both cases (informational only, never warns).
 type StuckTimeoutCheck struct {
 	cfg *config.City
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -34,6 +34,7 @@ const (
 	SessionUndrained   = "session.undrained"
 	SessionQuarantined = "session.quarantined"
 	SessionIdleKilled  = "session.idle_killed"
+	SessionStuckKilled = "session.stuck_killed"
 	SessionSuspended   = "session.suspended"
 	SessionUpdated     = "session.updated"
 	ConvoyCreated      = "convoy.created"

--- a/internal/runtime/auto/auto.go
+++ b/internal/runtime/auto/auto.go
@@ -266,6 +266,7 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{
 		CanReportAttachment: dc.CanReportAttachment && ac.CanReportAttachment,
 		CanReportActivity:   dc.CanReportActivity && ac.CanReportActivity,
+		CanPeek:             dc.CanPeek,
 	}
 }
 

--- a/internal/runtime/fake.go
+++ b/internal/runtime/fake.go
@@ -465,6 +465,7 @@ func (f *Fake) Capabilities() ProviderCapabilities {
 	return ProviderCapabilities{
 		CanReportAttachment: true,
 		CanReportActivity:   true,
+		CanPeek:             true,
 	}
 }
 

--- a/internal/runtime/hybrid/hybrid.go
+++ b/internal/runtime/hybrid/hybrid.go
@@ -175,6 +175,7 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{
 		CanReportAttachment: lc.CanReportAttachment && rc.CanReportAttachment,
 		CanReportActivity:   lc.CanReportActivity && rc.CanReportActivity,
+		CanPeek:             lc.CanPeek,
 	}
 }
 

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -539,6 +539,7 @@ func (p *Provider) ClearScrollback(name string) error {
 func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{
 		CanReportActivity: true,
+		CanPeek:           true,
 	}
 }
 

--- a/internal/runtime/probe.go
+++ b/internal/runtime/probe.go
@@ -20,6 +20,10 @@ type ProviderCapabilities struct {
 	CanReportAttachment bool
 	// CanReportActivity is true if GetLastActivity returns meaningful results.
 	CanReportActivity bool
+	// CanPeek is true if Peek returns meaningful terminal output suitable
+	// for hash-based stuck detection. False for providers where Peek returns
+	// empty strings or protocol-level output (e.g., subprocess, ACP).
+	CanPeek bool
 }
 
 // SessionSleepCapability describes how safely a runtime can participate in

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -231,6 +231,7 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{
 		CanReportAttachment: true,
 		CanReportActivity:   true,
+		CanPeek:             true,
 	}
 }
 

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -31,6 +31,7 @@ type recorderInstruments struct {
 	agentCrashTotal      metric.Int64Counter
 	agentQuarantineTotal metric.Int64Counter
 	agentIdleKillTotal   metric.Int64Counter
+	agentStuckKillTotal  metric.Int64Counter
 	reconcileCycleTotal  metric.Int64Counter
 	nudgeTotal           metric.Int64Counter
 	configReloadTotal    metric.Int64Counter
@@ -85,6 +86,9 @@ func initInstruments() {
 		)
 		inst.agentIdleKillTotal, _ = m.Int64Counter("gc.agent.idle_kills.total",
 			metric.WithDescription("Total agent idle timeout restarts"),
+		)
+		inst.agentStuckKillTotal, _ = m.Int64Counter("gc.agent.stuck_kills.total",
+			metric.WithDescription("Total agent stuck timeout restarts"),
 		)
 		inst.reconcileCycleTotal, _ = m.Int64Counter("gc.reconcile.cycles.total",
 			metric.WithDescription("Total reconciliation cycles"),
@@ -269,6 +273,17 @@ func RecordAgentIdleKill(ctx context.Context, agentName string) {
 		metric.WithAttributes(attribute.String("agent", agentName)),
 	)
 	emit(ctx, "agent.idle_kill", otellog.SeverityInfo,
+		otellog.String("agent", agentName),
+	)
+}
+
+// RecordAgentStuckKill records a stuck timeout restart (metrics + log event).
+func RecordAgentStuckKill(ctx context.Context, agentName string) {
+	initInstruments()
+	inst.agentStuckKillTotal.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("agent", agentName)),
+	)
+	emit(ctx, "agent.stuck_kill", otellog.SeverityInfo,
 		otellog.String("agent", agentName),
 	)
 }


### PR DESCRIPTION
## Summary

Adds a fifth health-patrol tracker — `stuckTracker` — to the controller reconciler. It detects sessions whose terminal output (SHA-256 hash of Peek output) has not changed for longer than a configurable `stuck_timeout`, kills them, and marks them for immediate re-wake. A built-in circuit breaker quarantines sessions that repeatedly get stuck.

### Key changes
- **Core tracker** (`cmd/gc/stuck_tracker.go`): `stuckTracker` interface + `memoryStuckTracker` with `doCheckStuck` pure function, grace period, and own circuit breaker (quarantine after 3 kills in `2 * timeout` window)
- **Reconciler integration** (`cmd/gc/session_reconciler.go`): Stuck check after idle check with drain-in-progress guard and CanPeek gating
- **Config** (`internal/config/config.go`): `stuck_timeout` field on `DaemonConfig` with duration accessor and validation
- **Runtime** (`internal/runtime/probe.go`): `CanPeek` capability flag (true for tmux/k8s/fake, false for subprocess/exec/acp)
- **Wake bypass** (`cmd/gc/session_sleep.go`): `configWakeSuppressed` exception for `stuck-timeout` (matches idle-timeout behavior)
- **Telemetry** (`internal/telemetry/recorder.go`): `RecordAgentStuckKill` counter + log event
- **Dashboard** (`cmd/gc/dashboard/helpers.go`): 🧊 ice icon, category, summary for `session.stuck_killed`
- **Doctor** (`internal/doctor/checks_semantic.go`): Informational `daemon-stuck-timeout` check
- **Docs**: Updated event-bus.md (full table replacement with correct session.* names), health-patrol.md (fifth tracker), controller.md, primitive-test.md (ZFC clarification)

### Design decisions
- **Hash comparison is transport, not cognition (ZFC clean)**: The controller observes that output has not changed; it does not classify or interpret content
- **Opt-in, city-wide**: `stuck_timeout` disabled by default. Set to accommodate the slowest-running agent
- **resetDetection vs clearSession**: After a stuck-kill, detection state resets but kill history is preserved for the circuit breaker

## What was tested

- `make fmt-check` — pass
- `make lint` — 0 issues
- `make vet` — pass
- 19 targeted tests pass (stuck_tracker_test.go + session_reconciler_test.go stuck integration tests)

## Review outcome

Five parallel reviews (adversarial, what-about, UAT, docs, alignment) + neutral judge.

**Critical finding (fixed):** `clearSession` wiped kill history after every stuck-kill, making the circuit breaker unreachable in production. Fixed by adding `resetDetection()` that preserves kills while resetting detection state.

**Judge verdict: CLEARED.** The implementation matches the design brief, adversarial findings were handled appropriately, and the change is aligned with Gas City's principles (ZFC, Bitter Lesson, Primitive Test all pass).

### Review Story

The stuck-agent sweep adds the third leg of the controller's health triad (crash, idle, stuck). The design brief laid out a clear architecture; the implementation followed it faithfully. Five independent reviews converged on one critical bug — the circuit breaker was unreachable because clearSession wiped the kill history it depended on — and the fix was structurally correct. Secondary findings (CanPeek granularity, test coverage gaps, cosmetic truncation) are real but non-blocking. The implementation is aligned with Gas City's core principles: hash comparison is pure transport observation (ZFC clean), stuck detection remains necessary regardless of model capability (Bitter Lesson pass), and no role names appear in the code (zero hardcoded roles).

## Residual risks (non-blocking)

1. **CanPeek granularity**: Provider-level, not per-session. Hybrid/auto with ACP backend could theoretically false-positive. Mitigated by empty-output guard and idle-fires-first ordering.
2. **City-wide timeout**: No per-agent override yet. Documented limitation.

Closes #571