### PR TITLE
fix: resolve cross-rig beads in gc session wait

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -738,7 +738,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cityName, sessionBeads)
 
-	readyWaitSet, err := prepareWaitWakeState(store, time.Now())
+	readyWaitSet, err := prepareWaitWakeState(store, cr.rigBeadStores(), time.Now())
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: preparing waits: %v\n", cr.logPrefix, err) //nolint:errcheck
 		readyWaitSet = nil
@@ -1041,6 +1041,12 @@ func (cr *CityRuntime) buildDesiredState(sessionBeads *sessionBeadSnapshot, trac
 }
 
 func buildStandaloneRigStores(cfg *config.City, cityPath string, stderr io.Writer) map[string]beads.Store {
+	return buildRigStores(cfg, cityPath, "gc supervisor", stderr)
+}
+
+// buildRigStores opens bead stores for all rigs attached to the city.
+// Errors on individual rigs are logged with logPrefix and skipped.
+func buildRigStores(cfg *config.City, cityPath, logPrefix string, stderr io.Writer) map[string]beads.Store {
 	if cfg == nil || len(cfg.Rigs) == 0 {
 		return nil
 	}
@@ -1048,7 +1054,7 @@ func buildStandaloneRigStores(cfg *config.City, cityPath string, stderr io.Write
 	for _, rig := range cfg.Rigs {
 		store, err := openStoreAtForCity(rig.Path, cityPath)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc supervisor: rig bead store %q: %v\n", rig.Name, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rig bead store %q: %v\n", logPrefix, rig.Name, err) //nolint:errcheck // best-effort stderr
 			continue
 		}
 		stores[rig.Name] = store

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -179,8 +179,12 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		fmt.Fprintf(stderr, "gc session wait: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	// Build a cross-rig getter so dependency beads in any attached rig store
+	// can be resolved (not just the city's own store).
+	rigStores := buildRigStores(cfg, cityPath, "gc session wait", stderr)
+	get := multiStoreGetter(store, rigStores)
 	for _, depID := range depIDs {
-		if _, err := store.Get(depID); err != nil {
+		if _, err := get(depID); err != nil {
 			fmt.Fprintf(stderr, "gc session wait: dependency %s: %v\n", depID, err) //nolint:errcheck
 			return 1
 		}
@@ -216,7 +220,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		fmt.Fprintf(stderr, "gc session wait: creating wait: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	ready, depErr := depsWaitReadyDetailed(store, waitBead)
+	ready, depErr := depsWaitReadyDetailed(get, waitBead)
 	if depErr != nil {
 		_ = setWaitTerminalState(store, waitBead.ID, map[string]string{
 			"state":      waitStateFailed,
@@ -422,12 +426,42 @@ func loadWaitBeadsByLabel(store beads.Store, label string) ([]beads.Bead, error)
 	return result, nil
 }
 
+// beadGetter abstracts bead lookup so dependency resolution can span multiple
+// stores (city + rig stores) without coupling to a single beads.Store.
+type beadGetter func(id string) (beads.Bead, error)
+
+// multiStoreGetter returns a beadGetter that tries the city store first, then
+// each rig store until a match is found. This matches the findBeadAcrossStores
+// pattern used by convoy dispatch. Non-ErrNotFound errors (connectivity,
+// permissions) are propagated immediately rather than masked as "not found".
+func multiStoreGetter(cityStore beads.Store, rigStores map[string]beads.Store) beadGetter {
+	return func(id string) (beads.Bead, error) {
+		b, err := cityStore.Get(id)
+		if err == nil {
+			return b, nil
+		}
+		if !errors.Is(err, beads.ErrNotFound) {
+			return beads.Bead{}, fmt.Errorf("getting bead %q from city store: %w", id, err)
+		}
+		for _, rs := range rigStores {
+			b, err = rs.Get(id)
+			if err == nil {
+				return b, nil
+			}
+			if !errors.Is(err, beads.ErrNotFound) {
+				return beads.Bead{}, fmt.Errorf("getting bead %q from rig store: %w", id, err)
+			}
+		}
+		return beads.Bead{}, fmt.Errorf("getting bead %q: %w", id, beads.ErrNotFound)
+	}
+}
+
 func depsWaitReady(store beads.Store, wait beads.Bead) bool {
-	ready, err := depsWaitReadyDetailed(store, wait)
+	ready, err := depsWaitReadyDetailed(store.Get, wait)
 	return err == nil && ready
 }
 
-func depsWaitReadyDetailed(store beads.Store, wait beads.Bead) (bool, error) {
+func depsWaitReadyDetailed(get beadGetter, wait beads.Bead) (bool, error) {
 	rawDepIDs := strings.Split(wait.Metadata["dep_ids"], ",")
 	depIDs := make([]string, 0, len(rawDepIDs))
 	for _, depID := range rawDepIDs {
@@ -444,7 +478,7 @@ func depsWaitReadyDetailed(store beads.Store, wait beads.Bead) (bool, error) {
 	foundAny := false
 	var missingErr error
 	for _, depID := range depIDs {
-		dep, err := store.Get(depID)
+		dep, err := get(depID)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				if mode != "any" {
@@ -504,11 +538,12 @@ func retryableWaitMetadata(src map[string]string) map[string]string {
 	return meta
 }
 
-func prepareWaitWakeState(store beads.Store, now time.Time) (map[string]bool, error) {
+func prepareWaitWakeState(store beads.Store, rigStores map[string]beads.Store, now time.Time) (map[string]bool, error) {
 	waits, err := loadWaitBeads(store)
 	if err != nil {
 		return nil, err
 	}
+	get := multiStoreGetter(store, rigStores)
 	readyWaitSet := make(map[string]bool)
 	for _, wait := range waits {
 		state := wait.Metadata["state"]
@@ -567,7 +602,7 @@ func prepareWaitWakeState(store beads.Store, now time.Time) (map[string]bool, er
 		if wait.Metadata["kind"] != "deps" {
 			continue
 		}
-		ready, depErr := depsWaitReadyDetailed(store, wait)
+		ready, depErr := depsWaitReadyDetailed(get, wait)
 		if depErr != nil {
 			if errors.Is(depErr, beads.ErrNotFound) {
 				if err := setWaitTerminalState(store, wait.ID, map[string]string{

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,7 +73,7 @@ func TestPrepareWaitWakeState_MarksDepsReady(t *testing.T) {
 		t.Fatalf("create wait bead: %v", err)
 	}
 
-	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	readyWaitSet, err := prepareWaitWakeState(store, nil, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("prepareWaitWakeState: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestPrepareWaitWakeState_FailsMissingDependencyWait(t *testing.T) {
 		t.Fatalf("create wait bead: %v", err)
 	}
 
-	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	readyWaitSet, err := prepareWaitWakeState(store, nil, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("prepareWaitWakeState: %v", err)
 	}
@@ -213,7 +214,7 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 		t.Fatalf("close nudge bead: %v", err)
 	}
 
-	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	readyWaitSet, err := prepareWaitWakeState(store, nil, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("prepareWaitWakeState: %v", err)
 	}
@@ -250,6 +251,195 @@ func TestDepsWaitReady_IgnoresEmptyDependencyEntries(t *testing.T) {
 	})
 	if !ready {
 		t.Fatal("depsWaitReady = false, want true with only one real closed dependency")
+	}
+}
+
+func TestDepsWaitReadyDetailed_ResolvesRigBeads(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// Create a dep bead in the rig store (not the city store).
+	dep, err := rigStore.Create(beads.Bead{Title: "rig-task"})
+	if err != nil {
+		t.Fatalf("create dep bead in rig store: %v", err)
+	}
+	if err := rigStore.Close(dep.ID); err != nil {
+		t.Fatalf("close dep bead: %v", err)
+	}
+
+	get := multiStoreGetter(cityStore, map[string]beads.Store{"my-rig": rigStore})
+
+	ready, err := depsWaitReadyDetailed(get, beads.Bead{
+		Metadata: map[string]string{
+			"dep_ids":  dep.ID,
+			"dep_mode": "all",
+		},
+	})
+	if err != nil {
+		t.Fatalf("depsWaitReadyDetailed: %v", err)
+	}
+	if !ready {
+		t.Fatal("depsWaitReadyDetailed = false, want true for closed rig bead")
+	}
+}
+
+func TestDepsWaitReadyDetailed_RigBeadNotClosedStaysPending(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// Create a dep bead in the rig store but do NOT close it.
+	dep, err := rigStore.Create(beads.Bead{Title: "rig-task-pending"})
+	if err != nil {
+		t.Fatalf("create dep bead in rig store: %v", err)
+	}
+
+	get := multiStoreGetter(cityStore, map[string]beads.Store{"my-rig": rigStore})
+
+	ready, err := depsWaitReadyDetailed(get, beads.Bead{
+		Metadata: map[string]string{
+			"dep_ids":  dep.ID,
+			"dep_mode": "all",
+		},
+	})
+	if err != nil {
+		t.Fatalf("depsWaitReadyDetailed: %v", err)
+	}
+	if ready {
+		t.Fatal("depsWaitReadyDetailed = true, want false for open rig bead")
+	}
+}
+
+func TestDepsWaitReadyDetailed_MissingFromAllStores(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	get := multiStoreGetter(cityStore, map[string]beads.Store{"my-rig": rigStore})
+
+	ready, err := depsWaitReadyDetailed(get, beads.Bead{
+		Metadata: map[string]string{
+			"dep_ids":  "gc-nonexistent",
+			"dep_mode": "all",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for bead missing from all stores")
+	}
+	if ready {
+		t.Fatal("depsWaitReadyDetailed = true, want false for missing bead")
+	}
+}
+
+func TestPrepareWaitWakeState_ResolvesCrossRigDeps(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	// Offset rig store sequence to avoid ID collisions with the city store.
+	rigStore := beads.NewMemStoreFrom(100, nil, nil)
+
+	// Create session bead in city store.
+	sessionBead, err := cityStore.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// Create dependency bead in rig store and close it.
+	dep, err := rigStore.Create(beads.Bead{Title: "rig-work"})
+	if err != nil {
+		t.Fatalf("create dep bead in rig store: %v", err)
+	}
+	if err := rigStore.Close(dep.ID); err != nil {
+		t.Fatalf("close dep bead: %v", err)
+	}
+
+	// Create wait bead in city store referencing the rig dep.
+	_, err = cityStore.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStatePending,
+			"dep_ids":          dep.ID,
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	rigStores := map[string]beads.Store{"my-rig": rigStore}
+	readyWaitSet, err := prepareWaitWakeState(cityStore, rigStores, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if !readyWaitSet[sessionBead.ID] {
+		t.Fatalf("readyWaitSet does not contain session %s — cross-rig dep not resolved", sessionBead.ID)
+	}
+}
+
+func TestMultiStoreGetter_CityStoreFirst(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	// Create bead in city store.
+	cityBead, err := cityStore.Create(beads.Bead{Title: "city-bead"})
+	if err != nil {
+		t.Fatalf("create city bead: %v", err)
+	}
+
+	get := multiStoreGetter(cityStore, map[string]beads.Store{"my-rig": rigStore})
+	b, err := get(cityBead.ID)
+	if err != nil {
+		t.Fatalf("multiStoreGetter: %v", err)
+	}
+	if b.Title != "city-bead" {
+		t.Fatalf("got title %q, want %q", b.Title, "city-bead")
+	}
+}
+
+// brokenStore wraps a MemStore but returns a non-ErrNotFound error on Get.
+type brokenStore struct {
+	*beads.MemStore
+}
+
+func (s brokenStore) Get(id string) (beads.Bead, error) {
+	return beads.Bead{}, errors.New("store unavailable")
+}
+
+func TestMultiStoreGetter_PropagatesCityStoreError(t *testing.T) {
+	city := brokenStore{beads.NewMemStore()}
+	rig := beads.NewMemStore()
+
+	get := multiStoreGetter(city, map[string]beads.Store{"r": rig})
+	_, err := get("gc-1")
+	if err == nil {
+		t.Fatal("expected error from broken city store")
+	}
+	if !strings.Contains(err.Error(), "city store") {
+		t.Fatalf("error should mention city store, got: %v", err)
+	}
+}
+
+func TestMultiStoreGetter_PropagatesRigStoreError(t *testing.T) {
+	city := beads.NewMemStore()
+	rig := brokenStore{beads.NewMemStore()}
+
+	get := multiStoreGetter(city, map[string]beads.Store{"r": rig})
+	_, err := get("gc-nonexistent")
+	if err == nil {
+		t.Fatal("expected error from broken rig store")
+	}
+	if !strings.Contains(err.Error(), "rig store") {
+		t.Fatalf("error should mention rig store, got: %v", err)
 	}
 }
 

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -411,7 +411,7 @@ type brokenStore struct {
 	*beads.MemStore
 }
 
-func (s brokenStore) Get(id string) (beads.Bead, error) {
+func (s brokenStore) Get(_ string) (beads.Bead, error) {
 	return beads.Bead{}, errors.New("store unavailable")
 }
 


### PR DESCRIPTION
## Summary

- `gc session wait --on-beads <id>` failed with "bead not found" when the target bead lived in a rig store. This blocked bugflow human gates (approve-classification, approve-implementation, etc.) where pool workers park on work beads in rig stores.
- Root cause: `cmdSessionWait` and `prepareWaitWakeState` resolved dependency beads through the city store only. Rig stores were never consulted.
- Fix introduces a `beadGetter` function type and `multiStoreGetter` that tries city store first, then rig stores — matching the `findBeadAcrossStores` pattern from convoy dispatch. CLI path opens rig stores via shared `buildRigStores` helper; controller tick reuses pre-opened `cr.rigBeadStores()`.

Closes #620

## Changes

| File | Change |
|------|--------|
| `cmd/gc/cmd_wait.go` | Add `beadGetter` type, `multiStoreGetter`; change `depsWaitReadyDetailed` to accept `beadGetter`; update `cmdSessionWait` and `prepareWaitWakeState` for cross-rig lookup |
| `cmd/gc/city_runtime.go` | Extract shared `buildRigStores` helper with log prefix param; pass `cr.rigBeadStores()` to `prepareWaitWakeState` in controller tick |
| `cmd/gc/cmd_wait_test.go` | 7 new tests covering cross-rig resolution, pending rig bead, missing-from-all-stores, city-store-first priority, error propagation from city/rig stores; update 3 existing call sites |

## Test plan

- [x] `TestDepsWaitReadyDetailed_ResolvesRigBeads` — closed dep in rig store resolves to ready
- [x] `TestDepsWaitReadyDetailed_RigBeadNotClosedStaysPending` — open dep in rig store stays pending (not ErrNotFound)
- [x] `TestDepsWaitReadyDetailed_MissingFromAllStores` — dep missing from all stores returns error
- [x] `TestPrepareWaitWakeState_ResolvesCrossRigDeps` — controller tick resolves cross-rig deps and marks wait ready
- [x] `TestMultiStoreGetter_CityStoreFirst` — city store is checked before rig stores
- [x] `TestMultiStoreGetter_PropagatesCityStoreError` — non-ErrNotFound from city store propagates immediately
- [x] `TestMultiStoreGetter_PropagatesRigStoreError` — non-ErrNotFound from rig store propagates immediately
- [x] All existing wait tests pass unchanged
- [x] Full `cmd/gc` test suite passes
- [x] `go vet ./...` clean
- [x] Race detector clean on wait tests