### PR TITLE
Store retry and Ralph source specs in spec beads

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -258,7 +258,7 @@ func decorateDynamicFragmentRecipe(fragment *formula.FragmentRecipe, source bead
 	for i := range fragment.Steps {
 		step := &fragment.Steps[i]
 		switch step.Metadata["gc.kind"] {
-		case "workflow", "scope", "ralph", "retry":
+		case "workflow", "scope", "ralph", "retry", "spec":
 			continue
 		}
 		binding, err := resolveGraphStepBinding(step.ID, stepByID, stepAlias, depsByStep, bindingCache, resolving, defaultRoute, routingRigContext, store, cityName, cfg)

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1170,7 +1170,7 @@ func decorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 			continue
 		}
 		switch step.Metadata["gc.kind"] {
-		case "workflow", "scope":
+		case "workflow", "scope", "spec":
 			continue
 		}
 		binding, err := resolveGraphStepBindingWithVars(step.ID, stepByID, stepAlias, depsByStep, bindingCache, resolving, routeVars, defaultRoute, routingRigContext, store, cityName, cfg)

--- a/cmd/gc/graph_dispatch_mem_test.go
+++ b/cmd/gc/graph_dispatch_mem_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/dispatch"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -432,6 +433,70 @@ func TestGraphWorkflowInMemoryRouteUsesControlDispatcherForControlBeads(t *testi
 	}
 	if !foundControl {
 		t.Fatal("expected at least one control-dispatcher bead")
+	}
+}
+
+func TestGraphWorkflowRoutingLeavesSpecBeadsUnrouted(t *testing.T) {
+	cfg := buildMemGraphWorkflowConfig(t)
+	store := beads.NewMemStore()
+	worker, ok := resolveAgentIdentity(cfg, "worker", "")
+	if !ok {
+		t.Fatal("resolveAgentIdentity(worker) failed")
+	}
+
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{
+				ID:     "wf",
+				Title:  "Workflow",
+				Type:   "task",
+				IsRoot: true,
+				Metadata: map[string]string{
+					"gc.kind":             "workflow",
+					"gc.formula_contract": "graph.v2",
+				},
+			},
+			{ID: "wf.review", Title: "Review", Type: "task", Assignee: "worker"},
+			{
+				ID:          "wf.review.spec",
+				Title:       "Review spec",
+				Type:        "spec",
+				Description: `{"id":"review"}`,
+				Metadata: map[string]string{
+					"gc.kind":     "spec",
+					"gc.spec_for": "review",
+				},
+			},
+			{ID: "wf.workflow-finalize", Title: "Finalize", Type: "task", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.workflow-finalize", DependsOnID: "wf.review", Type: "blocks"},
+			{StepID: "wf", DependsOnID: "wf.workflow-finalize", Type: "blocks"},
+		},
+	}
+
+	if err := applyGraphRouting(recipe, &worker, worker.QualifiedName(), nil, "", "", "", "city:test-city", store, cfg.Workspace.Name, cfg); err != nil {
+		t.Fatalf("applyGraphRouting: %v", err)
+	}
+
+	var spec *formula.RecipeStep
+	for i := range recipe.Steps {
+		if recipe.Steps[i].ID == "wf.review.spec" {
+			spec = &recipe.Steps[i]
+			break
+		}
+	}
+	if spec == nil {
+		t.Fatal("missing spec step")
+	}
+	if spec.Assignee != "" {
+		t.Fatalf("spec Assignee = %q, want empty", spec.Assignee)
+	}
+	for _, key := range []string{"gc.routed_to", graphExecutionRouteMetaKey, "gc.run_target"} {
+		if spec.Metadata[key] != "" {
+			t.Fatalf("spec metadata %s = %q, want empty; full metadata: %#v", key, spec.Metadata[key], spec.Metadata)
+		}
 	}
 }
 

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -577,7 +577,7 @@ func includeFormulaPreviewStep(step formula.RecipeStep, rootID string) bool {
 		return false
 	}
 	switch strings.TrimSpace(step.Metadata["gc.kind"]) {
-	case "scope-check", "workflow-finalize":
+	case "scope-check", "workflow-finalize", "spec":
 		return false
 	default:
 		return true

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -376,19 +376,8 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 				}
 				// Emit a spec bead for the nested retry so it can spawn
 				// its own attempts without oversized metadata.
-				if specJSON, err := json.Marshal(child); err == nil {
-					specID := childID + ".spec"
-					recipe.Steps = append(recipe.Steps, formula.RecipeStep{
-						ID:          specID,
-						Title:       "Step spec for " + child.Title,
-						Type:        "spec",
-						Description: string(specJSON),
-						Metadata: map[string]string{
-							"gc.kind":         "spec",
-							"gc.spec_for":     child.ID,
-							"gc.spec_for_ref": childID,
-						},
-					})
+				if step := newSpecRecipeStep(childID, child); step != nil {
+					recipe.Steps = append(recipe.Steps, *step)
 				}
 			}
 			if child.Ralph != nil {
@@ -400,19 +389,8 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 					childMeta["gc.check_path"] = child.Ralph.Check.Path
 					childMeta["gc.check_timeout"] = child.Ralph.Check.Timeout
 				}
-				if specJSON, err := json.Marshal(child); err == nil {
-					specID := childID + ".spec"
-					recipe.Steps = append(recipe.Steps, formula.RecipeStep{
-						ID:          specID,
-						Title:       "Step spec for " + child.Title,
-						Type:        "spec",
-						Description: string(specJSON),
-						Metadata: map[string]string{
-							"gc.kind":         "spec",
-							"gc.spec_for":     child.ID,
-							"gc.spec_for_ref": childID,
-						},
-					})
+				if step := newSpecRecipeStep(childID, child); step != nil {
+					recipe.Steps = append(recipe.Steps, *step)
 				}
 			}
 			childStep := formula.RecipeStep{
@@ -569,9 +547,6 @@ func removeAttemptPoolLabels(labels []string) []string {
 	return out
 }
 
-// findLatestAttempt finds the most recent attempt/iteration child of a control bead.
-// Matches by gc.step_ref pattern: the attempt's step_ref ends with
-// .attempt.N or .iteration.N where the prefix matches the control's step_ref.
 // findSpecBead locates the spec bead for a control (retry/ralph) bead.
 // The spec bead has gc.kind=spec and gc.spec_for matching the control's
 // step ID, under the same workflow root.
@@ -609,6 +584,29 @@ func findSpecBead(store beads.Store, control beads.Bead) (beads.Bead, error) {
 	return beads.Bead{}, fmt.Errorf("no spec bead found for step %q under root %s", stepID, rootID)
 }
 
+// newSpecRecipeStep builds a spec recipe step for a nested retry/ralph child.
+// Returns nil if marshaling fails.
+func newSpecRecipeStep(childID string, child *formula.Step) *formula.RecipeStep {
+	specJSON, err := json.Marshal(child)
+	if err != nil {
+		return nil
+	}
+	return &formula.RecipeStep{
+		ID:          childID + ".spec",
+		Title:       "Step spec for " + child.Title,
+		Type:        "spec",
+		Description: string(specJSON),
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.spec_for":     child.ID,
+			"gc.spec_for_ref": childID,
+		},
+	}
+}
+
+// findLatestAttempt finds the most recent attempt/iteration child of a control bead.
+// Matches by gc.step_ref pattern: the attempt's step_ref ends with
+// .attempt.N or .iteration.N where the prefix matches the control's step_ref.
 func findLatestAttempt(store beads.Store, control beads.Bead) (beads.Bead, error) {
 	rootID := control.Metadata["gc.root_bead_id"]
 	if rootID == "" {

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -242,6 +242,9 @@ func spawnNextAttempt(ctx context.Context, store beads.Store, control beads.Bead
 	executionRoute := control.Metadata["gc.execution_routed_to"]
 	routeCfg := loadAttemptRouteConfig(opts.CityPath)
 	for i := range recipe.Steps {
+		if recipe.Steps[i].Metadata["gc.kind"] == "spec" {
+			continue
+		}
 		target := strings.TrimSpace(recipe.Steps[i].Metadata["gc.routed_to"])
 		if target == "" {
 			target = strings.TrimSpace(recipe.Steps[i].Assignee)
@@ -381,8 +384,9 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 						Type:        "spec",
 						Description: string(specJSON),
 						Metadata: map[string]string{
-							"gc.kind":     "spec",
-							"gc.spec_for": child.ID,
+							"gc.kind":         "spec",
+							"gc.spec_for":     child.ID,
+							"gc.spec_for_ref": childID,
 						},
 					})
 				}
@@ -404,8 +408,9 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 						Type:        "spec",
 						Description: string(specJSON),
 						Metadata: map[string]string{
-							"gc.kind":     "spec",
-							"gc.spec_for": child.ID,
+							"gc.kind":         "spec",
+							"gc.spec_for":     child.ID,
+							"gc.spec_for_ref": childID,
 						},
 					})
 				}
@@ -582,10 +587,19 @@ func findSpecBead(store beads.Store, control beads.Bead) (beads.Bead, error) {
 	if stepID == "" {
 		return beads.Bead{}, fmt.Errorf("missing gc.step_id")
 	}
+	stepRef := control.Metadata["gc.step_ref"]
 
 	all, err := listByWorkflowRoot(store, rootID)
 	if err != nil {
 		return beads.Bead{}, err
+	}
+	for _, b := range all {
+		if b.Metadata["gc.kind"] != "spec" {
+			continue
+		}
+		if stepRef != "" && b.Metadata["gc.spec_for_ref"] == stepRef {
+			return b, nil
+		}
 	}
 	for _, b := range all {
 		if b.Metadata["gc.kind"] == "spec" && b.Metadata["gc.spec_for"] == stepID {

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -681,6 +681,32 @@ max = -1
 	if containsString(synthesize.Labels, "pool:gascity/claude") {
 		t.Fatalf("synthesize labels = %v, should not contain legacy pool label", synthesize.Labels)
 	}
+
+	assertSpawnedSpecUnrouted(t, store, root.ID, "review-claude")
+	assertSpawnedSpecUnrouted(t, store, root.ID, "review-codex")
+}
+
+func assertSpawnedSpecUnrouted(t *testing.T, store beads.Store, rootID, specFor string) {
+	t.Helper()
+	all, err := store.ListByMetadata(map[string]string{"gc.root_bead_id": rootID}, 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("ListByMetadata(gc.root_bead_id=%q): %v", rootID, err)
+	}
+	for _, bead := range all {
+		if bead.Metadata["gc.kind"] != "spec" || bead.Metadata["gc.spec_for"] != specFor {
+			continue
+		}
+		if bead.Assignee != "" {
+			t.Fatalf("spec %s assignee = %q, want empty", bead.ID, bead.Assignee)
+		}
+		for _, key := range []string{"gc.routed_to", "gc.execution_routed_to"} {
+			if bead.Metadata[key] != "" {
+				t.Fatalf("spec %s metadata %s = %q, want empty; full metadata: %#v", bead.ID, key, bead.Metadata[key], bead.Metadata)
+			}
+		}
+		return
+	}
+	t.Fatalf("missing spec bead for %q under root %s", specFor, rootID)
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -1095,5 +1095,62 @@ func mustGet(t *testing.T, store beads.Store, id string) beads.Bead {
 	return b
 }
 
+// ---------------------------------------------------------------------------
+// findSpecBead: ref-preference disambiguation
+// ---------------------------------------------------------------------------
+
+func TestFindSpecBeadPrefersRefOverStepID(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title: "workflow root",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+
+	// Two spec beads under the same root with the same gc.spec_for (logical
+	// step ID) but different gc.spec_for_ref (namespaced). This happens when
+	// a formula is instantiated multiple times in the same workflow.
+	_ = mustCreate(t, store, beads.Bead{
+		Title: "spec-old",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.spec_for":     "work",
+			"gc.spec_for_ref": "mol.iteration.1.work",
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	wantSpec := mustCreate(t, store, beads.Bead{
+		Title: "spec-new",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.spec_for":     "work",
+			"gc.spec_for_ref": "mol.iteration.2.work",
+			"gc.root_bead_id": root.ID,
+		},
+	})
+
+	control := mustCreate(t, store, beads.Bead{
+		Title: "retry control",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.step_id":      "work",
+			"gc.step_ref":     "mol.iteration.2.work",
+			"gc.root_bead_id": root.ID,
+		},
+	})
+
+	got, err := findSpecBead(store, control)
+	if err != nil {
+		t.Fatalf("findSpecBead: %v", err)
+	}
+	if got.ID != wantSpec.ID {
+		t.Fatalf("findSpecBead returned %s (%s), want %s (%s)",
+			got.ID, got.Title, wantSpec.ID, wantSpec.Title)
+	}
+}
+
 // Unused import guard.
 var _ = strconv.Itoa

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 )
 
 // Compile loads a formula by name and runs the full compilation pipeline.
@@ -299,6 +300,16 @@ func flattenSteps(steps []*Step, parentID string, idMapping map[string]string, o
 			stepType = "epic"
 		}
 
+		metadata := step.Metadata
+		if isSourceSpecStep(step) {
+			metadata = maps.Clone(step.Metadata)
+			if specForRef := metadata["gc.spec_for_ref"]; specForRef != "" {
+				if mapped, ok := idMapping[specForRef]; ok {
+					metadata["gc.spec_for_ref"] = mapped
+				}
+			}
+		}
+
 		rs := RecipeStep{
 			ID:          issueID,
 			Title:       step.Title,
@@ -308,7 +319,7 @@ func flattenSteps(steps []*Step, parentID string, idMapping map[string]string, o
 			Priority:    step.Priority,
 			Labels:      step.Labels,
 			Assignee:    step.Assignee,
-			Metadata:    step.Metadata,
+			Metadata:    metadata,
 		}
 
 		// Add gate label for waits_for field
@@ -456,7 +467,7 @@ func isWorkflowRootBlocker(step *Step) bool {
 		return false
 	}
 	switch step.Metadata["gc.kind"] {
-	case "run", "check", "retry-run", "retry-eval":
+	case "run", "check", "retry-run", "retry-eval", "spec":
 		return false
 	default:
 		return true

--- a/internal/formula/fragment.go
+++ b/internal/formula/fragment.go
@@ -219,7 +219,7 @@ func recipeStepNeedsScopeCheck(step RecipeStep) bool {
 		return false
 	}
 	switch step.Metadata["gc.kind"] {
-	case "scope", "scope-check", "workflow-finalize", "fanout", "check":
+	case "scope", "scope-check", "workflow-finalize", "fanout", "check", "spec":
 		return false
 	default:
 		return true
@@ -269,6 +269,10 @@ func fragmentSinkStepIDs(fragment *FragmentRecipe) []string {
 	sinks := make([]string, 0)
 	for _, step := range fragment.Steps {
 		if _, ok := referenced[step.ID]; ok {
+			continue
+		}
+		switch step.Metadata["gc.kind"] {
+		case "workflow-finalize", "spec":
 			continue
 		}
 		sinks = append(sinks, step.ID)

--- a/internal/formula/fragment_test.go
+++ b/internal/formula/fragment_test.go
@@ -175,3 +175,74 @@ func TestExpandStepDoesNotMutateSharedTemplateState(t *testing.T) {
 		t.Fatalf("template loop body id mutated to %q", got)
 	}
 }
+
+func TestFragmentSinkStepIDsExcludesSpecBeads(t *testing.T) {
+	t.Parallel()
+
+	fragment := &FragmentRecipe{
+		Name: "expansion-retry",
+		Steps: []RecipeStep{
+			{
+				ID:    "expansion-retry.control",
+				Title: "Retry control",
+				Metadata: map[string]string{
+					"gc.kind": "retry",
+				},
+			},
+			{
+				ID:    "expansion-retry.control.spec",
+				Title: "Step spec for retry control",
+				Type:  "spec",
+				Metadata: map[string]string{
+					"gc.kind":         "spec",
+					"gc.spec_for":     "control",
+					"gc.spec_for_ref": "expansion-retry.control",
+				},
+			},
+			{
+				ID:    "expansion-retry.work",
+				Title: "Work step",
+				Metadata: map[string]string{
+					"gc.kind": "",
+				},
+			},
+		},
+		Deps: []RecipeDep{
+			{StepID: "expansion-retry.work", DependsOnID: "expansion-retry.control", Type: "blocks"},
+		},
+	}
+
+	sinks := fragmentSinkStepIDs(fragment)
+
+	for _, id := range sinks {
+		if id == "expansion-retry.control.spec" {
+			t.Fatal("spec bead should not appear in fragment sinks")
+		}
+	}
+
+	var sawWork bool
+	for _, id := range sinks {
+		if id == "expansion-retry.work" {
+			sawWork = true
+		}
+	}
+	if !sawWork {
+		t.Fatal("expected work step in fragment sinks")
+	}
+}
+
+func TestRecipeStepNeedsScopeCheckExcludesSpec(t *testing.T) {
+	t.Parallel()
+
+	step := RecipeStep{
+		ID:    "test.spec",
+		Title: "Step spec",
+		Metadata: map[string]string{
+			"gc.kind":      "spec",
+			"gc.scope_ref": "body",
+		},
+	}
+	if recipeStepNeedsScopeCheck(step) {
+		t.Fatal("spec step should not need scope check")
+	}
+}

--- a/internal/formula/graph.go
+++ b/internal/formula/graph.go
@@ -122,7 +122,7 @@ func needsScopeCheck(step *Step) bool {
 		return false
 	}
 	switch step.Metadata["gc.kind"] {
-	case "scope", "scope-check", "workflow-finalize", "fanout", "check":
+	case "scope", "scope-check", "workflow-finalize", "fanout", "check", "spec":
 		return false
 	default:
 		return true
@@ -165,7 +165,7 @@ func graphSinkStepIDs(steps []*Step) []string {
 			continue
 		}
 		switch step.Metadata["gc.kind"] {
-		case "workflow-finalize":
+		case "workflow-finalize", "spec":
 			continue
 		case "scope":
 			// Scope bodies are terminal latches even when referenced by teardown

--- a/internal/formula/ralph.go
+++ b/internal/formula/ralph.go
@@ -1,7 +1,6 @@
 package formula
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -55,10 +54,9 @@ func expandRalph(step *Step) ([]*Step, error) {
 	attempt := 1
 	iterationID := fmt.Sprintf("%s.iteration.%d", step.ID, attempt)
 
-	// Freeze the original step spec for runtime rehydration.
-	stepSpec, err := json.Marshal(step)
+	specStep, err := newSourceSpecStep(step)
 	if err != nil {
-		return nil, fmt.Errorf("serializing step spec for %q: %w", step.ID, err)
+		return nil, err
 	}
 
 	// Control bead — orchestrates ralph iterations.
@@ -66,20 +64,19 @@ func expandRalph(step *Step) ([]*Step, error) {
 	control.Ralph = nil
 	control.Children = nil
 	control.Metadata = withMetadata(control.Metadata, map[string]string{
-		"gc.kind":             "ralph",
-		"gc.step_id":          step.ID,
-		"gc.max_attempts":     strconv.Itoa(step.Ralph.MaxAttempts),
-		"gc.check_mode":       step.Ralph.Check.Mode,
-		"gc.check_path":       step.Ralph.Check.Path,
-		"gc.check_timeout":    step.Ralph.Check.Timeout,
-		"gc.source_step_spec": string(stepSpec),
-		"gc.control_epoch":    "1",
+		"gc.kind":          "ralph",
+		"gc.step_id":       step.ID,
+		"gc.max_attempts":  strconv.Itoa(step.Ralph.MaxAttempts),
+		"gc.check_mode":    step.Ralph.Check.Mode,
+		"gc.check_path":    step.Ralph.Check.Path,
+		"gc.check_timeout": step.Ralph.Check.Timeout,
+		"gc.control_epoch": "1",
 	})
 	control.Needs = appendUniqueCopy(control.Needs, iterationID)
 	control.WaitsFor = ""
 
 	if len(step.Children) > 0 {
-		return expandNestedRalph(step, control, iterationID, attempt)
+		return expandNestedRalph(step, control, specStep, iterationID, attempt)
 	}
 
 	// Simple ralph (no children) — iteration is a single work bead.
@@ -102,10 +99,10 @@ func expandRalph(step *Step) ([]*Step, error) {
 	}
 	iteration.SourceLocation = fmt.Sprintf("%s.ralph.iteration.%d", step.SourceLocation, attempt)
 
-	return []*Step{control, iteration}, nil
+	return []*Step{control, specStep, iteration}, nil
 }
 
-func expandNestedRalph(step, control *Step, iterationID string, attempt int) ([]*Step, error) {
+func expandNestedRalph(step, control, specStep *Step, iterationID string, attempt int) ([]*Step, error) {
 	bodySteps, err := ApplyRalph(step.Children)
 	if err != nil {
 		return nil, err
@@ -141,7 +138,7 @@ func expandNestedRalph(step, control *Step, iterationID string, attempt int) ([]
 	delete(iteration.Metadata, "gc.scope_ref")
 	delete(iteration.Metadata, "gc.on_fail")
 
-	out := []*Step{control, iteration}
+	out := []*Step{control, specStep, iteration}
 	out = append(out, flattenedBody...)
 	return out, nil
 }
@@ -167,6 +164,10 @@ func namespaceRalphBodySteps(steps []*Step, iterationID string, owner *Step, att
 	var walk func([]*Step, bool)
 	walk = func(nodes []*Step, top bool) {
 		for _, node := range nodes {
+			if isSourceSpecStep(node) {
+				out = append(out, namespaceSourceSpecStep(node, iterationID))
+				continue
+			}
 			clone := cloneStep(node)
 			clone.ID = iterationID + "." + node.ID
 			clone.Children = nil
@@ -238,7 +239,7 @@ func markRalphBodyOutputSinks(steps []*Step) {
 			continue
 		}
 		switch step.Metadata["gc.kind"] {
-		case "scope", "scope-check", "workflow-finalize", "fanout", "check", "ralph":
+		case "scope", "scope-check", "workflow-finalize", "fanout", "check", "ralph", "spec":
 			continue
 		}
 		if step.Metadata["gc.scope_role"] == "teardown" {

--- a/internal/formula/ralph_test.go
+++ b/internal/formula/ralph_test.go
@@ -1,9 +1,6 @@
 package formula
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
 func TestApplyRalph_Basic(t *testing.T) {
 	steps := []*Step{
@@ -33,12 +30,13 @@ func TestApplyRalph_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyRalph failed: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("len(got) = %d, want 2 (control + iteration)", len(got))
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3 (control + spec + iteration)", len(got))
 	}
 
 	control := got[0]
-	iteration := got[1]
+	spec := got[1]
+	iteration := got[2]
 
 	// Control bead.
 	if control.ID != "implement" {
@@ -62,9 +60,10 @@ func TestApplyRalph_Basic(t *testing.T) {
 	if control.Metadata["gc.control_epoch"] != "1" {
 		t.Errorf("control gc.control_epoch = %q, want 1", control.Metadata["gc.control_epoch"])
 	}
-	if control.Metadata["gc.source_step_spec"] == "" {
-		t.Fatal("control missing gc.source_step_spec")
+	if control.Metadata["gc.source_step_spec"] != "" {
+		t.Fatalf("control gc.source_step_spec = %q, want empty", control.Metadata["gc.source_step_spec"])
 	}
+	assertFrozenSpecStep(t, spec, "implement", nil)
 
 	// Control blocks on the iteration (not a check bead).
 	wantControlNeeds := map[string]bool{"setup": true, "implement.iteration.1": true}
@@ -122,20 +121,14 @@ func TestApplyRalph_FrozenSpecRoundTrips(t *testing.T) {
 		t.Fatalf("ApplyRalph failed: %v", err)
 	}
 
-	control := got[0]
-	var frozen Step
-	if err := json.Unmarshal([]byte(control.Metadata["gc.source_step_spec"]), &frozen); err != nil {
-		t.Fatalf("unmarshal frozen spec: %v", err)
-	}
-	if frozen.ID != "converge" {
-		t.Errorf("frozen ID = %q, want converge", frozen.ID)
-	}
-	if frozen.Ralph == nil || frozen.Ralph.MaxAttempts != 5 {
-		t.Errorf("frozen ralph = %+v, want max_attempts=5", frozen.Ralph)
-	}
-	if len(frozen.Children) != 1 || frozen.Children[0].ID != "apply" {
-		t.Errorf("frozen children = %v, want [apply]", frozen.Children)
-	}
+	assertFrozenSpecStep(t, got[1], "converge", func(frozen Step) {
+		if frozen.Ralph == nil || frozen.Ralph.MaxAttempts != 5 {
+			t.Errorf("frozen ralph = %+v, want max_attempts=5", frozen.Ralph)
+		}
+		if len(frozen.Children) != 1 || frozen.Children[0].ID != "apply" {
+			t.Errorf("frozen children = %v, want [apply]", frozen.Children)
+		}
+	})
 }
 
 func TestApplyRalph_NestedWithChildren(t *testing.T) {
@@ -160,17 +153,17 @@ func TestApplyRalph_NestedWithChildren(t *testing.T) {
 		t.Fatalf("ApplyRalph failed: %v", err)
 	}
 
-	// Expect: control + iteration scope + 2 body children = 4
-	if len(got) != 4 {
+	// Expect: control + spec + iteration scope + 2 body children = 5
+	if len(got) != 5 {
 		names := make([]string, len(got))
 		for i, s := range got {
 			names[i] = s.ID
 		}
-		t.Fatalf("len(got) = %d, want 4; steps: %v", len(got), names)
+		t.Fatalf("len(got) = %d, want 5; steps: %v", len(got), names)
 	}
 
 	control := got[0]
-	iteration := got[1]
+	iteration := got[2]
 
 	if control.Metadata["gc.kind"] != "ralph" {
 		t.Errorf("control gc.kind = %q, want ralph", control.Metadata["gc.kind"])
@@ -183,8 +176,8 @@ func TestApplyRalph_NestedWithChildren(t *testing.T) {
 	}
 
 	// Body children should be namespaced under the iteration.
-	review := got[2]
-	apply := got[3]
+	review := got[3]
+	apply := got[4]
 	if review.ID != "review-loop.iteration.1.review" {
 		t.Errorf("review.ID = %q, want review-loop.iteration.1.review", review.ID)
 	}
@@ -229,7 +222,7 @@ func TestApplyRalph_BodyStepsHaveNamespacedStepRef(t *testing.T) {
 		t.Fatalf("ApplyRalph failed: %v", err)
 	}
 
-	// Body steps (index 2+) should have gc.step_ref matching their namespaced ID.
+	// Iteration/body steps (after control + spec) should have gc.step_ref matching their namespaced ID.
 	for _, step := range got[2:] {
 		ref := step.Metadata["gc.step_ref"]
 		if ref != step.ID {
@@ -281,7 +274,7 @@ func TestApplyRalph_RetryChildrenHaveNamespacedStepRef(t *testing.T) {
 
 	// Find all body steps (skip control + iteration scope)
 	for _, step := range got {
-		if step.ID == "review-loop" || step.ID == "review-loop.iteration.1" {
+		if step.ID == "review-loop" || step.ID == "review-loop.iteration.1" || isSourceSpecStep(step) {
 			continue
 		}
 		ref := step.Metadata["gc.step_ref"]
@@ -372,6 +365,9 @@ func TestApplyRalph_ComposeExpandChildrenHaveNamespacedStepRef(t *testing.T) {
 		if step.ID == "review-loop" {
 			continue // control doesn't need this check
 		}
+		if isSourceSpecStep(step) {
+			continue
+		}
 		ref := step.Metadata["gc.step_ref"]
 		if ref != step.ID {
 			mismatches = append(mismatches, step.ID+": got "+ref)
@@ -439,17 +435,21 @@ func TestApplyRalph_NestedRetryInsideRalphStepRefChains(t *testing.T) {
 		t.Fatalf("ApplyRalph failed: %v", err)
 	}
 
-	// Check that the retry control has namespaced step_ref
+	// Check that the retry control has namespaced step_ref.
+	foundSpec := false
 	for _, step := range got {
 		if step.ID == "outer.iteration.1.work" {
 			ref := step.Metadata["gc.step_ref"]
 			if ref != "outer.iteration.1.work" {
 				t.Errorf("retry control gc.step_ref = %q, want %q", ref, "outer.iteration.1.work")
 			}
-			// Verify frozen spec still exists for runtime retry spawning
-			if step.Metadata["gc.source_step_spec"] == "" {
-				t.Error("retry control missing gc.source_step_spec")
+			if step.Metadata["gc.source_step_spec"] != "" {
+				t.Errorf("retry control gc.source_step_spec = %q, want empty", step.Metadata["gc.source_step_spec"])
 			}
+		}
+		if step.ID == "outer.iteration.1.work.spec" {
+			foundSpec = true
+			assertFrozenSpecStep(t, step, "work", nil)
 		}
 		if step.ID == "outer.iteration.1.work.attempt.1" {
 			ref := step.Metadata["gc.step_ref"]
@@ -457,6 +457,9 @@ func TestApplyRalph_NestedRetryInsideRalphStepRefChains(t *testing.T) {
 				t.Errorf("retry attempt gc.step_ref = %q, want %q", ref, "outer.iteration.1.work.attempt.1")
 			}
 		}
+	}
+	if !foundSpec {
+		t.Fatal("missing retry control spec bead")
 	}
 }
 
@@ -553,9 +556,9 @@ func TestApplyRalph_PreservesNonRalphSteps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyRalph failed: %v", err)
 	}
-	// setup + (control + iteration) + cleanup = 4
-	if len(got) != 4 {
-		t.Fatalf("len(got) = %d, want 4", len(got))
+	// setup + (control + spec + iteration) + cleanup = 5
+	if len(got) != 5 {
+		t.Fatalf("len(got) = %d, want 5", len(got))
 	}
 	if got[0].ID != "setup" {
 		t.Errorf("got[0].ID = %q, want setup", got[0].ID)
@@ -563,10 +566,13 @@ func TestApplyRalph_PreservesNonRalphSteps(t *testing.T) {
 	if got[1].ID != "work" { // control
 		t.Errorf("got[1].ID = %q, want work (control)", got[1].ID)
 	}
-	if got[2].ID != "work.iteration.1" {
-		t.Errorf("got[2].ID = %q, want work.iteration.1", got[2].ID)
+	if got[2].ID != "work.spec" {
+		t.Errorf("got[2].ID = %q, want work.spec", got[2].ID)
 	}
-	if got[3].ID != "cleanup" {
-		t.Errorf("got[3].ID = %q, want cleanup", got[3].ID)
+	if got[3].ID != "work.iteration.1" {
+		t.Errorf("got[3].ID = %q, want work.iteration.1", got[3].ID)
+	}
+	if got[4].ID != "cleanup" {
+		t.Errorf("got[4].ID = %q, want cleanup", got[4].ID)
 	}
 }

--- a/internal/formula/retry.go
+++ b/internal/formula/retry.go
@@ -1,7 +1,6 @@
 package formula
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -56,10 +55,9 @@ func expandRetry(step *Step) ([]*Step, error) {
 		onExhausted = "hard_fail"
 	}
 
-	// Freeze the original step spec for runtime rehydration.
-	stepSpec, err := json.Marshal(step)
+	specStep, err := newSourceSpecStep(step)
 	if err != nil {
-		return nil, fmt.Errorf("serializing step spec for %q: %w", step.ID, err)
+		return nil, err
 	}
 
 	// Control bead — orchestrates retry attempts.
@@ -68,12 +66,11 @@ func expandRetry(step *Step) ([]*Step, error) {
 	control.Children = nil
 	control.Assignee = ""
 	control.Metadata = withMetadata(control.Metadata, map[string]string{
-		"gc.kind":             "retry",
-		"gc.step_id":          step.ID,
-		"gc.max_attempts":     strconv.Itoa(step.Retry.MaxAttempts),
-		"gc.on_exhausted":     onExhausted,
-		"gc.source_step_spec": string(stepSpec),
-		"gc.control_epoch":    "1",
+		"gc.kind":          "retry",
+		"gc.step_id":       step.ID,
+		"gc.max_attempts":  strconv.Itoa(step.Retry.MaxAttempts),
+		"gc.on_exhausted":  onExhausted,
+		"gc.control_epoch": "1",
 	})
 	if kind := step.Metadata["gc.kind"]; kind != "" {
 		control.Metadata["gc.original_kind"] = kind
@@ -102,5 +99,5 @@ func expandRetry(step *Step) ([]*Step, error) {
 	delete(run.Metadata, "gc.on_fail")
 	run.SourceLocation = fmt.Sprintf("%s.retry.attempt.%d", step.SourceLocation, attempt)
 
-	return []*Step{control, run}, nil
+	return []*Step{control, specStep, run}, nil
 }

--- a/internal/formula/retry_test.go
+++ b/internal/formula/retry_test.go
@@ -2,7 +2,6 @@ package formula
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,12 +34,13 @@ func TestApplyRetriesBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyRetries failed: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("len(got) = %d, want 2 (control + attempt)", len(got))
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3 (control + spec + attempt)", len(got))
 	}
 
 	control := got[0]
-	attempt := got[1]
+	spec := got[1]
+	attempt := got[2]
 
 	// Control bead identity and metadata.
 	if control.ID != "review" {
@@ -77,20 +77,14 @@ func TestApplyRetriesBasic(t *testing.T) {
 		t.Fatalf("control.Assignee = %q, want empty", control.Assignee)
 	}
 
-	// Control carries frozen step spec.
-	if control.Metadata["gc.source_step_spec"] == "" {
-		t.Fatal("control missing gc.source_step_spec")
+	if control.Metadata["gc.source_step_spec"] != "" {
+		t.Fatalf("control gc.source_step_spec = %q, want empty", control.Metadata["gc.source_step_spec"])
 	}
-	var frozen Step
-	if err := json.Unmarshal([]byte(control.Metadata["gc.source_step_spec"]), &frozen); err != nil {
-		t.Fatalf("frozen step spec is not valid JSON: %v", err)
-	}
-	if frozen.ID != "review" {
-		t.Fatalf("frozen step ID = %q, want review", frozen.ID)
-	}
-	if frozen.Retry == nil || frozen.Retry.MaxAttempts != 3 {
-		t.Fatalf("frozen step retry spec = %+v, want max_attempts=3", frozen.Retry)
-	}
+	assertFrozenSpecStep(t, spec, "review", func(frozen Step) {
+		if frozen.Retry == nil || frozen.Retry.MaxAttempts != 3 {
+			t.Fatalf("frozen step retry spec = %+v, want max_attempts=3", frozen.Retry)
+		}
+	})
 
 	// Attempt bead identity and metadata.
 	if attempt.ID != "review.attempt.1" {
@@ -197,9 +191,9 @@ func TestApplyRetriesPreservesNonRetrySteps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyRetries failed: %v", err)
 	}
-	// setup + (control + attempt) + cleanup = 4
-	if len(got) != 4 {
-		t.Fatalf("len(got) = %d, want 4", len(got))
+	// setup + (control + spec + attempt) + cleanup = 5
+	if len(got) != 5 {
+		t.Fatalf("len(got) = %d, want 5", len(got))
 	}
 	if got[0].ID != "setup" {
 		t.Fatalf("got[0].ID = %q, want setup", got[0].ID)
@@ -207,11 +201,14 @@ func TestApplyRetriesPreservesNonRetrySteps(t *testing.T) {
 	if got[1].ID != "review" { // control
 		t.Fatalf("got[1].ID = %q, want review (control)", got[1].ID)
 	}
-	if got[2].ID != "review.attempt.1" {
-		t.Fatalf("got[2].ID = %q, want review.attempt.1", got[2].ID)
+	if got[2].ID != "review.spec" {
+		t.Fatalf("got[2].ID = %q, want review.spec", got[2].ID)
 	}
-	if got[3].ID != "cleanup" {
-		t.Fatalf("got[3].ID = %q, want cleanup", got[3].ID)
+	if got[3].ID != "review.attempt.1" {
+		t.Fatalf("got[3].ID = %q, want review.attempt.1", got[3].ID)
+	}
+	if got[4].ID != "cleanup" {
+		t.Fatalf("got[4].ID = %q, want cleanup", got[4].ID)
 	}
 }
 
@@ -247,22 +244,18 @@ func TestApplyRetriesFrozenSpecRoundTrips(t *testing.T) {
 		t.Fatalf("ApplyRetries failed: %v", err)
 	}
 
-	control := got[0]
-	var frozen Step
-	if err := json.Unmarshal([]byte(control.Metadata["gc.source_step_spec"]), &frozen); err != nil {
-		t.Fatalf("unmarshal frozen spec: %v", err)
-	}
-
-	if frozen.Title != "Deploy {{service}}" {
-		t.Errorf("frozen title = %q, want original", frozen.Title)
-	}
-	if frozen.Assignee != "deployer" {
-		t.Errorf("frozen assignee = %q, want deployer", frozen.Assignee)
-	}
-	if len(frozen.Labels) != 2 || frozen.Labels[0] != "pool:deploy" {
-		t.Errorf("frozen labels = %v, want [pool:deploy critical]", frozen.Labels)
-	}
-	if frozen.Retry == nil || frozen.Retry.MaxAttempts != 3 {
-		t.Errorf("frozen retry = %+v, want max_attempts=3", frozen.Retry)
-	}
+	assertFrozenSpecStep(t, got[1], "deploy", func(frozen Step) {
+		if frozen.Title != "Deploy {{service}}" {
+			t.Errorf("frozen title = %q, want original", frozen.Title)
+		}
+		if frozen.Assignee != "deployer" {
+			t.Errorf("frozen assignee = %q, want deployer", frozen.Assignee)
+		}
+		if len(frozen.Labels) != 2 || frozen.Labels[0] != "pool:deploy" {
+			t.Errorf("frozen labels = %v, want [pool:deploy critical]", frozen.Labels)
+		}
+		if frozen.Retry == nil || frozen.Retry.MaxAttempts != 3 {
+			t.Errorf("frozen retry = %+v, want max_attempts=3", frozen.Retry)
+		}
+	})
 }

--- a/internal/formula/source_spec.go
+++ b/internal/formula/source_spec.go
@@ -53,7 +53,9 @@ func namespaceSourceSpecStep(step *Step, iterationID string) *Step {
 	for _, key := range []string{"gc.scope_ref", "gc.scope_role", "gc.on_fail", "gc.step_id", "gc.ralph_step_id", "gc.attempt", "gc.step_ref"} {
 		delete(clone.Metadata, key)
 	}
-	if specFor := step.Metadata["gc.spec_for"]; specFor != "" {
+	if specForRef := step.Metadata["gc.spec_for_ref"]; specForRef != "" {
+		clone.Metadata["gc.spec_for_ref"] = iterationID + "." + specForRef
+	} else if specFor := step.Metadata["gc.spec_for"]; specFor != "" {
 		clone.Metadata["gc.spec_for_ref"] = iterationID + "." + specFor
 	}
 	return clone

--- a/internal/formula/source_spec.go
+++ b/internal/formula/source_spec.go
@@ -1,0 +1,60 @@
+package formula
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const sourceSpecKind = "spec"
+
+func newSourceSpecStep(step *Step) (*Step, error) {
+	if step == nil {
+		return nil, fmt.Errorf("serializing step spec: missing step")
+	}
+	specJSON, err := json.Marshal(step)
+	if err != nil {
+		return nil, fmt.Errorf("serializing step spec for %q: %w", step.ID, err)
+	}
+	return &Step{
+		ID:          step.ID + ".spec",
+		Title:       "Step spec for " + step.Title,
+		Type:        "spec",
+		Description: string(specJSON),
+		Metadata: map[string]string{
+			"gc.kind":         sourceSpecKind,
+			"gc.spec_for":     step.ID,
+			"gc.spec_for_ref": step.ID,
+		},
+	}, nil
+}
+
+func isSourceSpecKind(kind string) bool {
+	return kind == sourceSpecKind
+}
+
+func isSourceSpecStep(step *Step) bool {
+	if step == nil {
+		return false
+	}
+	return isSourceSpecKind(step.Metadata["gc.kind"])
+}
+
+func namespaceSourceSpecStep(step *Step, iterationID string) *Step {
+	clone := cloneStep(step)
+	clone.ID = iterationID + "." + step.ID
+	clone.Children = nil
+	clone.Ralph = nil
+	clone.Retry = nil
+	clone.DependsOn = nil
+	clone.Needs = nil
+	clone.WaitsFor = ""
+	clone.Assignee = ""
+	clone.Metadata = withMetadata(clone.Metadata, nil)
+	for _, key := range []string{"gc.scope_ref", "gc.scope_role", "gc.on_fail", "gc.step_id", "gc.ralph_step_id", "gc.attempt", "gc.step_ref"} {
+		delete(clone.Metadata, key)
+	}
+	if specFor := step.Metadata["gc.spec_for"]; specFor != "" {
+		clone.Metadata["gc.spec_for_ref"] = iterationID + "." + specFor
+	}
+	return clone
+}

--- a/internal/formula/source_spec_test.go
+++ b/internal/formula/source_spec_test.go
@@ -118,7 +118,7 @@ func TestApplyRalphNestedRetrySpecBeadsRemainMetadataOnly(t *testing.T) {
 	if containsString(iteration.Needs, spec.ID) {
 		t.Fatalf("iteration needs = %v, should not block on metadata-only spec bead %s", iteration.Needs, spec.ID)
 	}
-	assertFrozenSpecStep(t, spec, "work", func(frozen Step) {
+	assertFrozenSpecStepWithRef(t, spec, "work", "outer.iteration.1.work", func(frozen Step) {
 		if frozen.Retry == nil || frozen.Retry.MaxAttempts != 2 {
 			t.Fatalf("frozen retry = %+v, want max_attempts=2", frozen.Retry)
 		}
@@ -127,6 +127,33 @@ func TestApplyRalphNestedRetrySpecBeadsRemainMetadataOnly(t *testing.T) {
 		if spec.Metadata[key] != "" {
 			t.Fatalf("nested spec metadata %s = %q, want empty; full metadata: %#v", key, spec.Metadata[key], spec.Metadata)
 		}
+	}
+}
+
+func TestNamespaceSourceSpecStepPreservesNestedRef(t *testing.T) {
+	// Simulate a spec step that has already been namespaced once (inner ralph),
+	// then namespaced again (outer ralph). The gc.spec_for_ref should accumulate
+	// both namespace prefixes.
+	step := &Step{
+		ID:    "inner.iteration.1.work.spec",
+		Title: "Step spec for work",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.spec_for":     "work",
+			"gc.spec_for_ref": "inner.iteration.1.work",
+		},
+	}
+
+	namespaced := namespaceSourceSpecStep(step, "outer.iteration.1")
+
+	wantRef := "outer.iteration.1.inner.iteration.1.work"
+	if got := namespaced.Metadata["gc.spec_for_ref"]; got != wantRef {
+		t.Fatalf("gc.spec_for_ref = %q, want %q", got, wantRef)
+	}
+	// gc.spec_for should remain the original logical step ID
+	if got := namespaced.Metadata["gc.spec_for"]; got != "work" {
+		t.Fatalf("gc.spec_for = %q, want %q", got, "work")
 	}
 }
 
@@ -197,6 +224,11 @@ path = "check.sh"
 
 func assertFrozenSpecStep(t *testing.T, spec *Step, specFor string, assert func(Step)) {
 	t.Helper()
+	assertFrozenSpecStepWithRef(t, spec, specFor, "", assert)
+}
+
+func assertFrozenSpecStepWithRef(t *testing.T, spec *Step, specFor, specForRef string, assert func(Step)) {
+	t.Helper()
 	if spec.Type != "spec" {
 		t.Fatalf("spec Type = %q, want spec", spec.Type)
 	}
@@ -211,6 +243,9 @@ func assertFrozenSpecStep(t *testing.T, spec *Step, specFor string, assert func(
 	}
 	if spec.Metadata["gc.spec_for"] != specFor {
 		t.Fatalf("spec gc.spec_for = %q, want %q", spec.Metadata["gc.spec_for"], specFor)
+	}
+	if specForRef != "" && spec.Metadata["gc.spec_for_ref"] != specForRef {
+		t.Fatalf("spec gc.spec_for_ref = %q, want %q", spec.Metadata["gc.spec_for_ref"], specForRef)
 	}
 	if spec.Description == "" {
 		t.Fatal("spec Description is empty")

--- a/internal/formula/source_spec_test.go
+++ b/internal/formula/source_spec_test.go
@@ -1,0 +1,246 @@
+package formula
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplyRetriesEmitsSpecBeadInsteadOfInlineSourceSpec(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:       "review",
+			Title:    "Review change",
+			Type:     "task",
+			Assignee: "polecat",
+			Retry:    &RetrySpec{MaxAttempts: 3, OnExhausted: "soft_fail"},
+		},
+	}
+
+	got, err := ApplyRetries(steps)
+	if err != nil {
+		t.Fatalf("ApplyRetries failed: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3 (control + spec + attempt)", len(got))
+	}
+
+	control := findGraphStepByID(got, "review")
+	spec := findGraphStepByID(got, "review.spec")
+	attempt := findGraphStepByID(got, "review.attempt.1")
+	if control == nil || spec == nil || attempt == nil {
+		t.Fatalf("missing retry expansion steps: control=%t spec=%t attempt=%t", control != nil, spec != nil, attempt != nil)
+	}
+	if got := control.Metadata["gc.source_step_spec"]; got != "" {
+		t.Fatalf("control gc.source_step_spec = %q, want empty; source spec must live in spec bead", got)
+	}
+	assertFrozenSpecStep(t, spec, "review", func(frozen Step) {
+		if frozen.Retry == nil || frozen.Retry.MaxAttempts != 3 {
+			t.Fatalf("frozen retry = %+v, want max_attempts=3", frozen.Retry)
+		}
+	})
+	if attempt.Metadata["gc.source_step_spec"] != "" {
+		t.Fatalf("attempt gc.source_step_spec = %q, want empty", attempt.Metadata["gc.source_step_spec"])
+	}
+}
+
+func TestApplyRalphEmitsSpecBeadInsteadOfInlineSourceSpec(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "converge",
+			Title: "Converge changes",
+			Type:  "task",
+			Ralph: &RalphSpec{
+				MaxAttempts: 5,
+				Check:       &RalphCheckSpec{Mode: "exec", Path: "check.sh"},
+			},
+		},
+	}
+
+	got, err := ApplyRalph(steps)
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3 (control + spec + iteration)", len(got))
+	}
+
+	control := findGraphStepByID(got, "converge")
+	spec := findGraphStepByID(got, "converge.spec")
+	iteration := findGraphStepByID(got, "converge.iteration.1")
+	if control == nil || spec == nil || iteration == nil {
+		t.Fatalf("missing ralph expansion steps: control=%t spec=%t iteration=%t", control != nil, spec != nil, iteration != nil)
+	}
+	if got := control.Metadata["gc.source_step_spec"]; got != "" {
+		t.Fatalf("control gc.source_step_spec = %q, want empty; source spec must live in spec bead", got)
+	}
+	assertFrozenSpecStep(t, spec, "converge", func(frozen Step) {
+		if frozen.Ralph == nil || frozen.Ralph.MaxAttempts != 5 {
+			t.Fatalf("frozen ralph = %+v, want max_attempts=5", frozen.Ralph)
+		}
+	})
+}
+
+func TestApplyRalphNestedRetrySpecBeadsRemainMetadataOnly(t *testing.T) {
+	children, err := ApplyRetries([]*Step{
+		{
+			ID:    "work",
+			Title: "Do work",
+			Retry: &RetrySpec{MaxAttempts: 2, OnExhausted: "hard_fail"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRetries failed: %v", err)
+	}
+
+	got, err := ApplyRalph([]*Step{
+		{
+			ID:    "outer",
+			Title: "Outer loop",
+			Ralph: &RalphSpec{
+				MaxAttempts: 5,
+				Check:       &RalphCheckSpec{Mode: "exec", Path: "check.sh"},
+			},
+			Children: children,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+
+	iteration := findGraphStepByID(got, "outer.iteration.1")
+	spec := findGraphStepByID(got, "outer.iteration.1.work.spec")
+	if iteration == nil || spec == nil {
+		t.Fatalf("missing nested iteration/spec: iteration=%t spec=%t", iteration != nil, spec != nil)
+	}
+	if containsString(iteration.Needs, spec.ID) {
+		t.Fatalf("iteration needs = %v, should not block on metadata-only spec bead %s", iteration.Needs, spec.ID)
+	}
+	assertFrozenSpecStep(t, spec, "work", func(frozen Step) {
+		if frozen.Retry == nil || frozen.Retry.MaxAttempts != 2 {
+			t.Fatalf("frozen retry = %+v, want max_attempts=2", frozen.Retry)
+		}
+	})
+	for _, key := range []string{"gc.scope_ref", "gc.scope_role", "gc.on_fail", "gc.step_id", "gc.ralph_step_id", "gc.attempt", "gc.step_ref"} {
+		if spec.Metadata[key] != "" {
+			t.Fatalf("nested spec metadata %s = %q, want empty; full metadata: %#v", key, spec.Metadata[key], spec.Metadata)
+		}
+	}
+}
+
+func TestCompileControlSpecBeadsAreNotWorkflowSinks(t *testing.T) {
+	oldFormulaV2 := FormulaV2Enabled
+	FormulaV2Enabled = true
+	t.Cleanup(func() { FormulaV2Enabled = oldFormulaV2 })
+
+	dir := t.TempDir()
+	formulaContent := `
+formula = "control-spec-demo"
+version = 2
+
+[[steps]]
+id = "review"
+title = "Review"
+assignee = "polecat"
+type = "task"
+
+[steps.retry]
+max_attempts = 3
+on_exhausted = "soft_fail"
+
+[[steps]]
+id = "converge"
+title = "Converge"
+type = "task"
+needs = ["review"]
+
+[steps.ralph]
+max_attempts = 2
+
+[steps.ralph.check]
+mode = "exec"
+path = "check.sh"
+`
+	if err := os.WriteFile(filepath.Join(dir, "control-spec-demo.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recipe, err := Compile(context.Background(), "control-spec-demo", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	review := findRecipeStepByID(recipe.Steps, "control-spec-demo.review")
+	reviewSpec := findRecipeStepByID(recipe.Steps, "control-spec-demo.review.spec")
+	converge := findRecipeStepByID(recipe.Steps, "control-spec-demo.converge")
+	convergeSpec := findRecipeStepByID(recipe.Steps, "control-spec-demo.converge.spec")
+	finalizer := findRecipeStepByID(recipe.Steps, "control-spec-demo.workflow-finalize")
+	if review == nil || reviewSpec == nil || converge == nil || convergeSpec == nil || finalizer == nil {
+		t.Fatalf("missing compiled steps: review=%t reviewSpec=%t converge=%t convergeSpec=%t finalizer=%t",
+			review != nil, reviewSpec != nil, converge != nil, convergeSpec != nil, finalizer != nil)
+	}
+	if review.Metadata["gc.source_step_spec"] != "" {
+		t.Fatalf("retry control still has inline source spec")
+	}
+	if converge.Metadata["gc.source_step_spec"] != "" {
+		t.Fatalf("ralph control still has inline source spec")
+	}
+	if hasRecipeDep(recipe.Deps, finalizer.ID, reviewSpec.ID, "blocks") {
+		t.Fatalf("workflow finalizer should not block on retry spec bead %s", reviewSpec.ID)
+	}
+	if hasRecipeDep(recipe.Deps, finalizer.ID, convergeSpec.ID, "blocks") {
+		t.Fatalf("workflow finalizer should not block on ralph spec bead %s", convergeSpec.ID)
+	}
+}
+
+func assertFrozenSpecStep(t *testing.T, spec *Step, specFor string, assert func(Step)) {
+	t.Helper()
+	if spec.Type != "spec" {
+		t.Fatalf("spec Type = %q, want spec", spec.Type)
+	}
+	if spec.Assignee != "" {
+		t.Fatalf("spec Assignee = %q, want empty", spec.Assignee)
+	}
+	if len(spec.Needs) != 0 || len(spec.DependsOn) != 0 {
+		t.Fatalf("spec deps = depends_on %v needs %v, want none", spec.DependsOn, spec.Needs)
+	}
+	if spec.Metadata["gc.kind"] != "spec" {
+		t.Fatalf("spec gc.kind = %q, want spec", spec.Metadata["gc.kind"])
+	}
+	if spec.Metadata["gc.spec_for"] != specFor {
+		t.Fatalf("spec gc.spec_for = %q, want %q", spec.Metadata["gc.spec_for"], specFor)
+	}
+	if spec.Description == "" {
+		t.Fatal("spec Description is empty")
+	}
+	var frozen Step
+	if err := json.Unmarshal([]byte(spec.Description), &frozen); err != nil {
+		t.Fatalf("unmarshal frozen spec: %v", err)
+	}
+	if frozen.ID != specFor {
+		t.Fatalf("frozen ID = %q, want %q", frozen.ID, specFor)
+	}
+	if assert != nil {
+		assert(frozen)
+	}
+}
+
+func findRecipeStepByID(steps []RecipeStep, id string) *RecipeStep {
+	for i := range steps {
+		if steps[i].ID == id {
+			return &steps[i]
+		}
+	}
+	return nil
+}
+
+func hasRecipeDep(deps []RecipeDep, stepID, dependsOnID, depType string) bool {
+	for _, dep := range deps {
+		if dep.StepID == stepID && dep.DependsOnID == dependsOnID && dep.Type == depType {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2,6 +2,7 @@ package molecule
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1098,8 +1099,8 @@ timeout = "2m"
 		t.Fatalf("Cook: %v", err)
 	}
 
-	if result.Created != 4 {
-		t.Fatalf("Created = %d, want 4 (root + design + control + iteration)", result.Created)
+	if result.Created != 5 {
+		t.Fatalf("Created = %d, want 5 (root + design + control + spec + iteration)", result.Created)
 	}
 
 	root, err := store.Get(result.RootID)
@@ -1109,6 +1110,10 @@ timeout = "2m"
 	control, err := store.Get(result.IDMapping["ralph-demo.implement"])
 	if err != nil {
 		t.Fatalf("get control: %v", err)
+	}
+	spec, err := store.Get(result.IDMapping["ralph-demo.implement.spec"])
+	if err != nil {
+		t.Fatalf("get spec: %v", err)
 	}
 	iteration, err := store.Get(result.IDMapping["ralph-demo.implement.iteration.1"])
 	if err != nil {
@@ -1129,6 +1134,25 @@ timeout = "2m"
 	}
 	if control.Metadata["gc.check_path"] != ".gascity/checks/widget.sh" {
 		t.Fatalf("control gc.check_path = %q, want .gascity/checks/widget.sh", control.Metadata["gc.check_path"])
+	}
+	if _, ok := control.Metadata["gc.source_step_spec"]; ok {
+		t.Fatalf("control still has inline gc.source_step_spec metadata")
+	}
+	if spec.Metadata["gc.kind"] != "spec" {
+		t.Fatalf("spec gc.kind = %q, want spec", spec.Metadata["gc.kind"])
+	}
+	if spec.Metadata["gc.spec_for"] != "implement" {
+		t.Fatalf("spec gc.spec_for = %q, want implement", spec.Metadata["gc.spec_for"])
+	}
+	if spec.Metadata["gc.spec_for_ref"] != "ralph-demo.implement" {
+		t.Fatalf("spec gc.spec_for_ref = %q, want ralph-demo.implement", spec.Metadata["gc.spec_for_ref"])
+	}
+	var frozenSpec formula.Step
+	if err := json.Unmarshal([]byte(spec.Description), &frozenSpec); err != nil {
+		t.Fatalf("unmarshal spec description: %v", err)
+	}
+	if frozenSpec.ID != "implement" {
+		t.Fatalf("frozen spec id = %q, want implement", frozenSpec.ID)
 	}
 	if iteration.Metadata["gc.ralph_step_id"] != "implement" {
 		t.Fatalf("iteration gc.ralph_step_id = %q, want implement", iteration.Metadata["gc.ralph_step_id"])


### PR DESCRIPTION
## Summary
Supersedes #624 by @julianknutsen, which correctly identified and migrated frozen source specs from inline `gc.source_step_spec` metadata into sibling `gc.kind=spec` beads. This PR includes that fix and adds maintainer fixups.

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

### Original changes (contributor)
- Move top-level retry/Ralph frozen source specs out of `gc.source_step_spec` metadata into sibling `gc.kind=spec` beads
- Keep spec beads out of routing, scope checks, workflow sinks, and execution worker assignment
- Update dispatcher spec lookup to prefer `gc.spec_for_ref` and keep runtime child spec beads unrouted

### Maintainer fixups
- Exclude `gc.kind=spec` from fragment sink collection and scope-check synthesis (prevents deadlock in fragments with retry/Ralph controls)
- Exclude spec steps from formula preview API (prevents internal metadata leaking to clients)
- Extract `newSpecRecipeStep` helper to deduplicate `buildAttemptRecipe` spec-step construction
- Fix nested namespace prefix preservation in `namespaceSourceSpecStep` for doubly-nested controls
- Add `findSpecBead` ref-preference disambiguation test
- Add fragment sink exclusion tests
- Add `assertFrozenSpecStepWithRef` helper for validating `gc.spec_for_ref`

## Tests
- `go test ./internal/formula/... ./internal/dispatch/... ./internal/api/...` passes
- `go vet ./...` clean

Closes ga-4w104g