### PR TITLE
chore: pin beads v1.0.0 and dolt v1.86.1

### DIFF
--- a/.github/actions/setup-gascity-ubuntu/action.yml
+++ b/.github/actions/setup-gascity-ubuntu/action.yml
@@ -13,8 +13,8 @@ inputs:
   dolt-version:
     description: Dolt version to install
     required: true
-  bd-commit:
-    description: beads commit to build bd from
+  bd-version:
+    description: Beads release version to install
     required: true
   install-claude-cli:
     description: Whether to install the Claude CLI
@@ -32,12 +32,6 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        repository: gastownhall/beads
-        ref: ${{ inputs.bd-commit }}
-        path: .beads-src
-
     - name: Install system dependencies
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y tmux jq
@@ -48,13 +42,24 @@ runs:
         curl -fsSL "https://github.com/dolthub/dolt/releases/download/v${{ inputs.dolt-version }}/install.sh" | sudo bash
         dolt version
 
-    - name: Build pinned bd
+    - name: Install released bd v${{ inputs.bd-version }}
       shell: bash
-      working-directory: ${{ github.workspace }}/.beads-src
       run: |
-        mkdir -p "$GITHUB_WORKSPACE/.bd-release"
-        GOBIN="$GITHUB_WORKSPACE/.bd-release" go install ./cmd/bd
-        sudo install -m 0755 "$GITHUB_WORKSPACE/.bd-release/bd" /usr/local/bin/bd
+        version="${{ inputs.bd-version }}"
+        case "$(uname -m)" in
+          x86_64|amd64) bd_arch=amd64 ;;
+          aarch64|arm64) bd_arch=arm64 ;;
+          *)
+            echo "Unsupported runner architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+        archive="beads_${version#v}_linux_${bd_arch}.tar.gz"
+        mkdir -p "$RUNNER_TEMP/beads"
+        curl -fsSL -o "$RUNNER_TEMP/$archive" \
+          "https://github.com/gastownhall/beads/releases/download/${version}/${archive}"
+        tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/beads" bd
+        sudo install -m 0755 "$RUNNER_TEMP/beads/bd" /usr/local/bin/bd
         bd version
 
     - name: Install Claude CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,20 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Pinned dependency versions — keep in sync with deps.env.
-      DOLT_VERSION: "1.85.0"
-      BD_COMMIT: "9d9d0e53c2330bd081bef350883f56c2557eb78b"
+      DOLT_VERSION: "1.86.1"
+      BD_VERSION: "v1.0.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: gastownhall/beads
-          ref: ${{ env.BD_COMMIT }}
-          path: .beads-src
-
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          # The pinned beads fork commit requires Go 1.25.8.
           go-version: "1.25.8"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -80,12 +73,14 @@ jobs:
           curl -fsSL https://github.com/dolthub/dolt/releases/download/v${{ env.DOLT_VERSION }}/install.sh | sudo bash
           dolt version
 
-      - name: Build pinned beads (bd) from gastownhall/beads@${{ env.BD_COMMIT }}
-        working-directory: .beads-src
+      - name: Install released bd v${{ env.BD_VERSION }}
         run: |
-          mkdir -p "$GITHUB_WORKSPACE/.bd-release"
-          GOBIN="$GITHUB_WORKSPACE/.bd-release" go install ./cmd/bd
-          sudo install -m 0755 "$GITHUB_WORKSPACE/.bd-release/bd" /usr/local/bin/bd
+          archive="beads_${BD_VERSION#v}_linux_amd64.tar.gz"
+          mkdir -p "$RUNNER_TEMP/beads"
+          curl -fsSL -o "$RUNNER_TEMP/$archive" \
+            "https://github.com/gastownhall/beads/releases/download/${BD_VERSION}/${archive}"
+          tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/beads" bd
+          sudo install -m 0755 "$RUNNER_TEMP/beads/bd" /usr/local/bin/bd
           bd version
 
       - name: Install Claude CLI
@@ -132,11 +127,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: gastownhall/beads
-          ref: ${{ env.BD_COMMIT }}
-          path: .beads-src
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.25.8"
@@ -148,12 +138,14 @@ jobs:
       - name: Install dolt
         run: |
           curl -fsSL https://github.com/dolthub/dolt/releases/download/v${{ env.DOLT_VERSION }}/install.sh | sudo bash
-      - name: Build bd
-        working-directory: .beads-src
+      - name: Install released bd v${{ env.BD_VERSION }}
         run: |
-          mkdir -p "$GITHUB_WORKSPACE/.bd-release"
-          GOBIN="$GITHUB_WORKSPACE/.bd-release" go install ./cmd/bd
-          sudo install -m 0755 "$GITHUB_WORKSPACE/.bd-release/bd" /usr/local/bin/bd
+          archive="beads_${BD_VERSION#v}_linux_amd64.tar.gz"
+          mkdir -p "$RUNNER_TEMP/beads"
+          curl -fsSL -o "$RUNNER_TEMP/$archive" \
+            "https://github.com/gastownhall/beads/releases/download/${BD_VERSION}/${archive}"
+          tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/beads" bd
+          sudo install -m 0755 "$RUNNER_TEMP/beads/bd" /usr/local/bin/bd
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code
       - name: Install tools
@@ -161,8 +153,8 @@ jobs:
       - name: Pack compatibility tests
         run: make test-acceptance
     env:
-      DOLT_VERSION: "1.85.0"
-      BD_COMMIT: "9d9d0e53c2330bd081bef350883f56c2557eb78b"
+      DOLT_VERSION: "1.86.1"
+      BD_VERSION: "v1.0.0"
 
   # Runs when mail-related source paths change.
   mcp-mail:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,8 +13,8 @@ jobs:
     name: Tier C inference tests
     runs-on: ubuntu-latest
     env:
-      DOLT_VERSION: "1.85.0"
-      BD_COMMIT: "9d9d0e53c2330bd081bef350883f56c2557eb78b"
+      DOLT_VERSION: "1.86.1"
+      BD_VERSION: "v1.0.0"
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_API_KEY: ${{ secrets.SYNTHETIC_API_KEY }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -26,12 +26,6 @@ jobs:
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: gastownhall/beads
-          ref: ${{ env.BD_COMMIT }}
-          path: .beads-src
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
@@ -48,12 +42,14 @@ jobs:
         run: |
           curl -fsSL https://github.com/dolthub/dolt/releases/download/v${{ env.DOLT_VERSION }}/install.sh | sudo bash
 
-      - name: Build bd
-        working-directory: .beads-src
+      - name: Install released bd v${{ env.BD_VERSION }}
         run: |
-          mkdir -p "$GITHUB_WORKSPACE/.bd-release"
-          GOBIN="$GITHUB_WORKSPACE/.bd-release" go install ./cmd/bd
-          sudo install -m 0755 "$GITHUB_WORKSPACE/.bd-release/bd" /usr/local/bin/bd
+          archive="beads_${BD_VERSION#v}_linux_amd64.tar.gz"
+          mkdir -p "$RUNNER_TEMP/beads"
+          curl -fsSL -o "$RUNNER_TEMP/$archive" \
+            "https://github.com/gastownhall/beads/releases/download/${BD_VERSION}/${archive}"
+          tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/beads" bd
+          sudo install -m 0755 "$RUNNER_TEMP/beads/bd" /usr/local/bin/bd
 
       - name: Validate Synthetic Claude configuration
         run: |

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -7,10 +7,8 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "1.85.0"
-  BD_COMMIT: "9d9d0e53c2330bd081bef350883f56c2557eb78b"
-  BD_MAC_RELEASE_TAG: "v1.0.0"
-  BD_MAC_RELEASE_TARBALL: "beads_1.0.0_darwin_arm64.tar.gz"
+  DOLT_VERSION: "1.86.1"
+  BD_VERSION: "v1.0.0"
 
 jobs:
   ubuntu_make_test:
@@ -22,7 +20,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "false"
       - name: Run make test
         run: make test
@@ -36,7 +34,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "false"
       - name: Run make check-docs
         run: make check-docs
@@ -59,7 +57,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "true"
       - name: Validate synthetic Claude configuration
         run: |
@@ -80,7 +78,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "false"
       - name: Run make test-acceptance-b
         run: make test-acceptance-b
@@ -103,7 +101,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
       - name: Validate synthetic Claude configuration
         run: |
           test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "Missing SYNTHETIC_API_KEY GitHub secret" >&2; exit 1; }
@@ -132,7 +130,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "true"
       - name: Validate synthetic Claude configuration
         run: |
@@ -163,7 +161,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
       - name: Validate synthetic Claude configuration
         run: |
           test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "Missing SYNTHETIC_API_KEY GitHub secret" >&2; exit 1; }
@@ -185,7 +183,7 @@ jobs:
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
-          bd-commit: ${{ env.BD_COMMIT }}
+          bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "false"
       - name: Run GoReleaser snapshot
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
@@ -216,10 +214,11 @@ jobs:
           go-version: "1.25.8"
       - name: Install released bd
         run: |
+          BD_MAC_RELEASE_TARBALL="beads_${BD_VERSION#v}_darwin_arm64.tar.gz"
           mkdir -p "$HOME/.local/bin"
           mkdir -p "$RUNNER_TEMP/beads"
           curl -fsSL -o "$RUNNER_TEMP/$BD_MAC_RELEASE_TARBALL" \
-            "https://github.com/gastownhall/beads/releases/download/${BD_MAC_RELEASE_TAG}/${BD_MAC_RELEASE_TARBALL}"
+            "https://github.com/gastownhall/beads/releases/download/${BD_VERSION}/${BD_MAC_RELEASE_TARBALL}"
           tar -xzf "$RUNNER_TEMP/$BD_MAC_RELEASE_TARBALL" -C "$RUNNER_TEMP/beads" --strip-components=1
           install -m 0755 "$RUNNER_TEMP/beads/bd" "$HOME/.local/bin/bd"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Gas City requires the following tools on your system. `gc init` and
 | jq | Always | — | `brew install jq` | `apt install jq` |
 | pgrep | Always | — | (included in macOS) | `apt install procps` |
 | lsof | Always | — | (included in macOS) | `apt install lsof` |
-| dolt | Beads provider `bd` | 1.80.0 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
-| bd | Beads provider `bd` | 0.61.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
+| dolt | Beads provider `bd` | 1.86.1 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
+| bd | Beads provider `bd` | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | Beads provider `bd` | — | `brew install flock` | `apt install util-linux` |
 | claude / codex / gemini | Per provider | — | See provider docs | See provider docs |
 

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -432,8 +432,8 @@ var initRunVersion = func(binary string) (string, error) {
 
 // Minimum versions for beads-provider binaries.
 const (
-	doltMinVersion = "1.80.0" // sql-server features used by gc-beads-bd
-	bdMinVersion   = "0.61.0" // BdStore shell-out interface
+	doltMinVersion = "1.86.1" // sql-server features used by gc-beads-bd
+	bdMinVersion   = "1.0.0"  // BdStore shell-out interface
 )
 
 // checkHardDependencies verifies that all required binaries are available
@@ -525,7 +525,7 @@ func parseDepVersion(binary string) string {
 	if err != nil {
 		return ""
 	}
-	// Patterns: "dolt version 1.83.1", "bd version 0.61.0 (3ac028bf: ...)"
+	// Patterns: "dolt version 1.86.1", "bd version 1.0.0 (3ac028bf: ...)"
 	for _, field := range strings.Fields(line) {
 		if len(field) > 0 && field[0] >= '0' && field[0] <= '9' && strings.Contains(field, ".") {
 			return field

--- a/deps.env
+++ b/deps.env
@@ -4,7 +4,7 @@
 # Update these when bumping minimum versions. The internal/deps package
 # defines the minimum compatible versions (may lag behind these pins).
 
-DOLT_VERSION=1.85.0
+DOLT_VERSION=1.86.1
 BD_REPO=gastownhall/beads
-BD_COMMIT=9d9d0e53c2330bd081bef350883f56c2557eb78b
+BD_VERSION=v1.0.0
 BR_VERSION=0.1.20

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,16 +21,16 @@ managers). Choose source when you need unreleased changes or plan to contribute.
 Gas City requires a small set of runtime tools. Homebrew installs all of them
 for you; the other methods require manual installation.
 
-| Tool | Required | macOS | Linux | Notes |
-|------|----------|-------|-------|-------|
-| tmux | Yes | `brew install tmux` | `apt install tmux` | Session management |
-| jq | Yes | `brew install jq` | `apt install jq` | JSON processing |
-| git | Yes | (built-in) | (built-in) | Version control |
-| dolt | Yes | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
-| bd (Beads CLI) | Yes | `brew install beads` | [releases](https://github.com/gastownhall/beads/releases) | Issue tracking |
-| flock | Yes | `brew install flock` | (built-in via util-linux) | File locking |
-| Go 1.25+ | Source only | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
-| make | Source only | (built-in) | `apt install make` (or `build-essential`) | Drives `make install` |
+| Tool | Required | Min version | macOS | Linux | Notes |
+|------|----------|-------------|-------|-------|-------|
+| tmux | Yes | — | `brew install tmux` | `apt install tmux` | Session management |
+| jq | Yes | — | `brew install jq` | `apt install jq` | JSON processing |
+| git | Yes | — | (built-in) | (built-in) | Version control |
+| dolt | Yes | 1.86.1 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
+| bd (Beads CLI) | Yes | 1.0.0 | `brew install beads` | [releases](https://github.com/gastownhall/beads/releases) | Issue tracking |
+| flock | Yes | — | `brew install flock` | (built-in via util-linux) | File locking |
+| Go 1.25+ | Source only | 1.25 | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
+| make | Source only | — | (built-in) | `apt install make` (or `build-essential`) | Drives `make install` |
 
 The exact versions CI pins are in [`deps.env`](https://github.com/gastownhall/gascity/blob/main/deps.env).
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -60,8 +60,8 @@ check.
 
 | Tool | Min version | macOS | Linux |
 |------|-------------|-------|-------|
-| dolt | 1.80.0 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
-| bd | 0.61.0 | [releases](https://github.com/steveyegge/beads/releases) | [releases](https://github.com/steveyegge/beads/releases) |
+| dolt | 1.86.1 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
+| bd | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | -- | `brew install flock` | `apt install util-linux` |
 
 If you do not want to install dolt, bd, and flock, switch to the file-based
@@ -83,7 +83,7 @@ durable versioned storage and is recommended for real work.
 
 ## Dolt Version Too Old
 
-Gas City requires dolt 1.80.0 or newer. Check your version:
+Gas City requires dolt 1.86.1 or newer. Check your version:
 
 ```bash
 dolt version
@@ -91,6 +91,17 @@ dolt version
 
 Upgrade via Homebrew (`brew upgrade dolt`) or download a newer release from
 [dolthub/dolt/releases](https://github.com/dolthub/dolt/releases).
+
+## `bd` Version Too Old
+
+Gas City requires `bd` 1.0.0 or newer. Check your version:
+
+```bash
+bd version
+```
+
+Upgrade via Homebrew (`brew upgrade beads`) or download a newer release from
+[gastownhall/beads/releases](https://github.com/gastownhall/beads/releases).
 
 ## flock Not Found (macOS)
 


### PR DESCRIPTION
## Summary
- pin the shared dependency baseline to beads `v1.0.0` and dolt `1.86.1`
- switch CI bd installs from source builds to the released beads tarball where supported
- update README/install/troubleshooting docs and the runtime dependency version check

## Validation
- `python3` YAML parse for edited GitHub workflow/action files
- `go test ./cmd/gc -run TestCheckHardDependencies -count=1`
- `git diff --check`