### PR TITLE
fix: wrap wait-idle nudges as system reminders

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -478,7 +478,7 @@ func deliverSessionNudgeWithProvider(target nudgeTarget, sp runtime.Provider, me
 			fmt.Fprintf(stdout, "Queued nudge for %s\n", target.agentKey()) //nolint:errcheck
 			return 0
 		}
-		if tryDeliverWaitIdleNudge(target, sp, message) {
+		if tryDeliverWaitIdleNudge(target, sp, "session", message) {
 			telemetry.RecordNudge(context.Background(), target.agentKey(), nil)
 			fmt.Fprintf(stdout, "Nudged %s\n", target.agentKey()) //nolint:errcheck
 			return 0
@@ -504,7 +504,7 @@ func sendMailNotifyWithProvider(target nudgeTarget, sp runtime.Provider, sender 
 	msg := fmt.Sprintf("You have mail from %s", sender)
 	now := time.Now()
 	running := sp.IsRunning(target.sessionName)
-	if !running || !tryDeliverWaitIdleNudge(target, sp, msg) {
+	if !running || !tryDeliverWaitIdleNudge(target, sp, "mail", msg) {
 		if err := enqueueQueuedNudge(target.cityPath, newQueuedNudgeWithOptions(target.agentKey(), msg, "mail", now, queuedNudgeOptionsFromTarget(target))); err != nil {
 			return err
 		}
@@ -633,7 +633,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func tryDeliverWaitIdleNudge(target nudgeTarget, sp runtime.Provider, message string) bool {
+func tryDeliverWaitIdleNudge(target nudgeTarget, sp runtime.Provider, source, message string) bool {
 	if target.sessionTransport() == "acp" {
 		err := sp.Nudge(target.sessionName, runtime.TextContent(message))
 		return err == nil
@@ -648,7 +648,7 @@ func tryDeliverWaitIdleNudge(target nudgeTarget, sp runtime.Provider, message st
 	if err := wp.WaitForIdle(context.Background(), target.sessionName, defaultNudgeWaitIdleTimeout); err != nil {
 		return false
 	}
-	if err := deliverImmediateNudge(sp, target.sessionName, runtime.TextContent(message)); err != nil {
+	if err := deliverImmediateNudge(sp, target.sessionName, runtime.TextContent(formatDirectReminderOutput(source, message))); err != nil {
 		return false
 	}
 	return true
@@ -697,7 +697,7 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, sp runtime.Provider, qui
 	if len(items) == 0 {
 		return false, nil
 	}
-	msg := formatNudgeRuntimeMessage(items)
+	msg := formatNudgeInjectOutput(items)
 	// Queued nudges are background delivery, not user-initiated sends. Keep
 	// them on the provider's regular nudge path instead of the immediate path.
 	if err := sp.Nudge(target.sessionName, runtime.TextContent(msg)); err != nil {
@@ -862,6 +862,13 @@ func ensureNudgePoller(cityPath, agentName, sessionName string) error {
 		}
 		return cmd.Process.Release()
 	})
+}
+
+func formatDirectReminderOutput(source, message string) string {
+	return formatNudgeInjectOutput([]queuedNudge{{
+		Source:  source,
+		Message: message,
+	}})
 }
 
 func formatNudgeInjectOutput(items []queuedNudge) string {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -697,7 +697,12 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, sp runtime.Provider, qui
 	if len(items) == 0 {
 		return false, nil
 	}
-	msg := formatNudgeInjectOutput(items)
+	var msg string
+	if target.sessionTransport() == "acp" {
+		msg = formatNudgeRuntimeMessage(items)
+	} else {
+		msg = formatNudgeInjectOutput(items)
+	}
 	// Queued nudges are background delivery, not user-initiated sends. Keep
 	// them on the provider's regular nudge path instead of the immediate path.
 	if err := sp.Nudge(target.sessionName, runtime.TextContent(msg)); err != nil {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -524,6 +524,92 @@ func TestTryDeliverQueuedNudgesByPollerDeliversAndAcks(t *testing.T) {
 	}
 }
 
+func TestTryDeliverQueuedNudgesByPollerLeavesACPDeliveryUnwrapped(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "check hook output", "session", now)); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.Activity = map[string]time.Time{"sess-worker": time.Now().Add(-10 * time.Second)}
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		transport:   "acp",
+		agent:       config.Agent{Name: "worker", Session: "acp"},
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: "sess-worker",
+	}
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, fake, 3*time.Second)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if !delivered {
+		t.Fatal("delivered = false, want true")
+	}
+
+	var nudgeCalls []runtime.Call
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" {
+			nudgeCalls = append(nudgeCalls, call)
+		}
+	}
+	if len(nudgeCalls) != 1 {
+		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
+	}
+	if strings.Contains(nudgeCalls[0].Message, "<system-reminder>") {
+		t.Fatalf("ACP nudge message = %q, want plain text without system-reminder wrapper", nudgeCalls[0].Message)
+	}
+	if !strings.Contains(nudgeCalls[0].Message, "check hook output") {
+		t.Fatalf("nudge message = %q, want original reminder", nudgeCalls[0].Message)
+	}
+}
+
+func TestDeliverSlingNudgeWaitIdleWrapsInSystemReminder(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.WaitForIdleErrors["sess-worker"] = nil
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		resolved:    &config.ResolvedProvider{Name: "claude"},
+		sessionName: "sess-worker",
+	}
+
+	store := openNudgeBeadStore(dir)
+	var stdout, stderr bytes.Buffer
+	deliverSlingNudge(target, fake, store, dir, &stdout, &stderr)
+
+	var nudgeNowCalls int
+	var delivered string
+	for _, call := range fake.Calls {
+		if call.Method == "NudgeNow" {
+			nudgeNowCalls++
+			delivered = call.Message
+		}
+	}
+	if nudgeNowCalls != 1 {
+		t.Fatalf("immediate nudge calls = %d, want 1", nudgeNowCalls)
+	}
+	if !strings.Contains(delivered, "<system-reminder>") {
+		t.Fatalf("delivered message = %q, want system-reminder wrapper", delivered)
+	}
+	if !strings.Contains(delivered, "[sling] Work slung. Check your hook.") {
+		t.Fatalf("delivered message = %q, want sling reminder content", delivered)
+	}
+}
+
 func TestClaimDueQueuedNudgesClaimsOnceUntilAck(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -187,6 +187,96 @@ func TestDeliverSessionNudgeWithProviderImmediateUsesImmediateNudge(t *testing.T
 	}
 }
 
+func TestDeliverSessionNudgeWithProviderWaitIdleWrapsDirectDeliveryInSystemReminder(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.WaitForIdleErrors["sess-worker"] = nil
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "worker"},
+		resolved:    &config.ResolvedProvider{Name: "claude"},
+		sessionName: "sess-worker",
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := deliverSessionNudgeWithProvider(target, fake, "check deploy status", nudgeDeliveryWaitIdle, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("deliverSessionNudgeWithProvider = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var waitCalls, nudgeNowCalls int
+	var delivered string
+	for _, call := range fake.Calls {
+		switch call.Method {
+		case "WaitForIdle":
+			waitCalls++
+		case "NudgeNow":
+			nudgeNowCalls++
+			delivered = call.Message
+		}
+	}
+	if waitCalls != 1 {
+		t.Fatalf("wait-idle calls = %d, want 1", waitCalls)
+	}
+	if nudgeNowCalls != 1 {
+		t.Fatalf("immediate nudge calls = %d, want 1", nudgeNowCalls)
+	}
+	if !strings.Contains(delivered, "<system-reminder>") {
+		t.Fatalf("delivered message = %q, want system-reminder wrapper", delivered)
+	}
+	if !strings.Contains(delivered, "[session] check deploy status") {
+		t.Fatalf("delivered message = %q, want session reminder content", delivered)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending=%d inFlight=%d dead=%d, want all zero", len(pending), len(inFlight), len(dead))
+	}
+}
+
+func TestDeliverSessionNudgeWithProviderWaitIdleLeavesACPDeliveryUnwrapped(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		transport:   "acp",
+		agent:       config.Agent{Name: "worker", Session: "acp"},
+		sessionName: "sess-worker",
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := deliverSessionNudgeWithProvider(target, fake, "check deploy status", nudgeDeliveryWaitIdle, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("deliverSessionNudgeWithProvider = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var delivered string
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" {
+			delivered = call.Message
+		}
+		if call.Method == "WaitForIdle" {
+			t.Fatalf("unexpected wait-idle call for acp target: %+v", call)
+		}
+	}
+	if delivered != "check deploy status" {
+		t.Fatalf("delivered message = %q, want raw ACP nudge", delivered)
+	}
+}
+
 func TestSendMailNotifyWithProviderQueuesWhenSessionSleeping(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
@@ -252,6 +342,59 @@ func TestSendMailNotifyWithProviderStartsCodexPollerWhenQueueingRunningSession(t
 	}
 	if !called {
 		t.Fatal("startNudgePoller was not called")
+	}
+}
+
+func TestSendMailNotifyWithProviderWaitIdleWrapsDirectDeliveryInSystemReminder(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-mayor", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.WaitForIdleErrors["sess-mayor"] = nil
+
+	target := nudgeTarget{
+		cityPath:    dir,
+		agent:       config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		resolved:    &config.ResolvedProvider{Name: "claude"},
+		sessionName: "sess-mayor",
+	}
+
+	if err := sendMailNotifyWithProvider(target, fake, "human"); err != nil {
+		t.Fatalf("sendMailNotifyWithProvider: %v", err)
+	}
+
+	var waitCalls, nudgeNowCalls int
+	var delivered string
+	for _, call := range fake.Calls {
+		switch call.Method {
+		case "WaitForIdle":
+			waitCalls++
+		case "NudgeNow":
+			nudgeNowCalls++
+			delivered = call.Message
+		}
+	}
+	if waitCalls != 1 {
+		t.Fatalf("wait-idle calls = %d, want 1", waitCalls)
+	}
+	if nudgeNowCalls != 1 {
+		t.Fatalf("immediate nudge calls = %d, want 1", nudgeNowCalls)
+	}
+	if !strings.Contains(delivered, "<system-reminder>") {
+		t.Fatalf("delivered message = %q, want system-reminder wrapper", delivered)
+	}
+	if !strings.Contains(delivered, "[mail] You have mail from human") {
+		t.Fatalf("delivered message = %q, want mail reminder content", delivered)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "mayor", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending=%d inFlight=%d dead=%d, want all zero", len(pending), len(inFlight), len(dead))
 	}
 }
 
@@ -359,8 +502,8 @@ func TestTryDeliverQueuedNudgesByPollerDeliversAndAcks(t *testing.T) {
 	if len(nudgeCalls) != 1 {
 		t.Fatalf("nudge calls = %d, want 1", len(nudgeCalls))
 	}
-	if !strings.Contains(nudgeCalls[0].Message, "Deferred reminders:") {
-		t.Fatalf("nudge message = %q, want deferred reminder wrapper", nudgeCalls[0].Message)
+	if !strings.Contains(nudgeCalls[0].Message, "<system-reminder>") {
+		t.Fatalf("nudge message = %q, want system-reminder wrapper", nudgeCalls[0].Message)
 	}
 	if !strings.Contains(nudgeCalls[0].Message, "review the deploy logs") {
 		t.Fatalf("nudge message = %q, want original reminder", nudgeCalls[0].Message)

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1619,7 +1619,7 @@ func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Stor
 	const msg = "Work slung. Check your hook."
 	running := sp.IsRunning(target.sessionName)
 	now := time.Now()
-	if running && tryDeliverWaitIdleNudge(target, sp, msg) {
+	if running && tryDeliverWaitIdleNudge(target, sp, "sling", msg) {
 		telemetry.RecordNudge(context.Background(), target.agent.QualifiedName(), nil)
 		fmt.Fprintf(stdout, "Nudged %s\n", target.agent.QualifiedName()) //nolint:errcheck // best-effort
 		return


### PR DESCRIPTION
## Summary

- Wrap successful wait-idle reminder delivery at the `gc nudge` layer so session nudges, sling nudges, and mail reminders arrive as `<system-reminder>` blocks instead of plain chat text.
- Keep ACP direct delivery semantics unchanged; only the Claude/tmux reminder paths get the wrapper.
- Send poller-delivered queued reminders through the same `<system-reminder>` envelope, with ACP transport bypass to preserve plain-text delivery for ACP targets.
- Add regression coverage for session, mail, sling, queued poller, and ACP paths.

Supersedes #665. Credit: Original fix by @julianknutsen (commit preserved with original authorship).

Linked bead: `ga-tfo6d1`

## Testing

- [x] `make check`
- [x] Added focused regression tests in `cmd/gc/cmd_nudge_test.go` covering direct wait-idle delivery, ACP preservation, mail reminder delivery, queued poller delivery, ACP queued poller bypass, and sling delivery.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
  No docs update needed; this is internal reminder-delivery behavior.
- [x] Called out breaking changes or migration notes
  None.