### PR TITLE
test: tighten tutorial harness isolation checks

### DIFF
--- a/.claude/skills/isolated-tutorial-harness/SKILL.md
+++ b/.claude/skills/isolated-tutorial-harness/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: isolated-tutorial-harness
+description: Run or debug the Gas City tutorial acceptance harness in this repo when you need the coding-agent CLIs, supervisor, and city state isolated in temp homes while still authenticating Claude and Codex correctly.
+---
+
+# Isolated Tutorial Harness
+
+Use this skill when working in `gascity` on:
+- `test/acceptance/tutorial_goldens`
+- `test/acceptance/helpers`
+- provider-readiness or auth/isolation regressions that affect tutorial tests
+
+Do not use this skill for generic `go test ./...` work. It is specifically for the tutorial acceptance harness and its provider/auth boundary.
+
+## Invariants
+
+- Keep `gc` runtime isolated:
+  - temp `HOME`
+  - temp `GC_HOME`
+  - temp `XDG_RUNTIME_DIR`
+  - temp supervisor and tmux state
+- Do not borrow the host `HOME` just to make `claude` work.
+- Use a real `CLAUDE_CODE_OAUTH_TOKEN` loaded from repo-local `.env`.
+- Keep `.env` local only. It is gitignored and must never be printed into chat, logs, patches, or commits.
+
+The relevant implementation points are:
+- `test/acceptance/tutorial_goldens/main_test.go`
+- `internal/api/handler_provider_readiness.go`
+- `.gitignore`
+
+## Required Local Setup
+
+The harness expects a repo-local `.env` with:
+
+```bash
+CLAUDE_CODE_OAUTH_TOKEN=...
+```
+
+Optional:
+
+```bash
+OPENAI_API_KEY=...
+```
+
+`main_test.go` loads `.env` at package startup. If the token is missing or invalid, the tutorial harness will either skip or fail in ways that look like provider/auth problems.
+
+## Workflow
+
+1. Confirm branch state and local diffs:
+
+```bash
+git status --short --branch
+```
+
+2. Verify the isolated auth plumbing and readiness probes first:
+
+```bash
+go test ./test/acceptance/helpers -run 'TestProviderShim|TestEnsureClaude' -count=1
+go test ./internal/api -run 'TestProbeCommandEnv(PreservesXDGOverridesWhenGHConfigDirIsSet|PassesClaudeOAuthToken)$|TestHandleProviderReadinessAcceptsClaudeOAuthTokenAuth' -count=1
+```
+
+3. Run targeted tutorial tests before the full package:
+
+```bash
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run '^TestTutorial01Cities$' -count=1 -v
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run '^TestTutorial04Communication$' -count=1 -v
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run '^TestTutorial03Sessions$' -count=1 -v
+```
+
+Why these first:
+- Tutorial 01 proves isolated Claude init plus real rig-local work.
+- Tutorial 04 proves the mayor can do useful Claude work in the isolated environment.
+- Tutorial 03 is the suite-level timing canary for session/log behavior.
+
+4. If those pass, run the full package:
+
+```bash
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -count=1
+```
+
+## How To Interpret Failures
+
+### `claude auth status --json` says `loggedIn: false`
+
+This is still an isolation/auth problem, not a tutorial-content problem.
+
+Check:
+- `.env` exists at repo root
+- `CLAUDE_CODE_OAUTH_TOKEN` is present and valid
+- `main_test.go` is still passing `CLAUDE_CODE_OAUTH_TOKEN` into the temp env
+- readiness probe env still includes the token in `probeCommandEnv(...)`
+
+### Tutorial 01 fails in `gc init --provider claude`
+
+This usually means readiness rejected Claude auth, not that tutorial prose is wrong.
+
+Check:
+- `probeClaude(...)` still accepts first-party `oauth_token`
+- `probeCommandEnv(...)` still passes the OAuth token through
+
+### Tutorial 03 passes alone but fails in the full package
+
+Treat that as suite-level timing/state coupling, not an auth regression.
+
+Check:
+- `gc session list`
+- `gc session peek mayor`
+- `gc session logs mayor`
+- the diagnostics dumped by the tutorial harness
+
+If individual Tutorial 03 is green but the full package fails, the next target is session timing or page-driver assumptions, not Claude auth.
+
+## What Not To Do
+
+- Do not wrap `claude` so it runs against the host `HOME`.
+- Do not add host transcript roots or host observe paths to make the tests pass.
+- Do not trust `claude auth status --json` alone for token validation; a bogus non-empty token can look logged-in but still fail real requests.
+- Do not print or commit the token.
+
+## Files To Inspect When Updating This Flow
+
+- `test/acceptance/tutorial_goldens/main_test.go`
+- `internal/api/handler_provider_readiness.go`
+- `internal/api/handler_provider_readiness_test.go`
+- `test/acceptance/helpers`
+- `.gitignore`
+
+## Exit Criteria
+
+The harness is in good shape when all of these are true:
+- helper/auth probe tests pass
+- Tutorial 01 passes in isolation
+- Tutorial 04 passes in isolation
+- Tutorial 03 passes in isolation
+- the full `tutorial_goldens` package passes without borrowing host Claude state

--- a/.claude/skills/isolated-tutorial-harness/agents/openai.yaml
+++ b/.claude/skills/isolated-tutorial-harness/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Isolated Tutorial Harness"
+  short_description: "Run isolated tutorial harness"
+  default_prompt: "Use $isolated-tutorial-harness to run or debug the Gas City tutorial acceptance harness in full isolation."

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 CLAUDE.local.md
+.env
 coverage.txt
 /bin/
 /gc
@@ -9,7 +10,6 @@ coverage.txt
 /br
 *.test
 .beads/
-.claude/
 !examples/gastown/packs/gastown/overlays/default/.claude/
 !examples/gastown/packs/gastown/overlays/default/.claude/settings.json
 !examples/gastown/packs/maintenance/overlays/default/.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage.txt
 /br
 *.test
 .beads/
+.claude/*
+!.claude/skills/
 !examples/gastown/packs/gastown/overlays/default/.claude/
 !examples/gastown/packs/gastown/overlays/default/.claude/settings.json
 !examples/gastown/packs/maintenance/overlays/default/.claude/

--- a/README.md
+++ b/README.md
@@ -120,6 +120,45 @@ Useful commands:
 - `make check-docs`
 - `make test-integration`
 
+### Tutorial Harness
+
+This repo includes a project-scoped coding-agent skill for the tutorial
+acceptance harness at
+[`/.claude/skills/isolated-tutorial-harness`](.claude/skills/isolated-tutorial-harness/SKILL.md).
+Use it when running or debugging the tutorial tests through Codex or Claude:
+
+- invoke `$isolated-tutorial-harness`
+- follow the workflow in the skill
+
+The harness is designed to keep `gc` state isolated in temp homes, temp
+supervisors, and temp runtime dirs while still authenticating provider CLIs
+correctly. It expects a repo-local `.env` file with:
+
+```bash
+CLAUDE_CODE_OAUTH_TOKEN=...
+```
+
+Optional:
+
+```bash
+OPENAI_API_KEY=...
+```
+
+The main validation flow is:
+
+```bash
+go test ./test/acceptance/helpers -run 'TestProviderShim|TestEnsureClaude' -count=1
+go test ./internal/api -run 'TestProbeCommandEnv(PreservesXDGOverridesWhenGHConfigDirIsSet|PassesClaudeOAuthToken)$|TestHandleProviderReadinessAcceptsClaudeOAuthTokenAuth' -count=1
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run '^TestTutorial01Cities$' -count=1 -v
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run '^TestTutorial04Communication$' -count=1 -v
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run '^TestTutorial03Sessions$' -count=1 -v
+go test -tags acceptance_c ./test/acceptance/tutorial_goldens -count=1
+```
+
+If the isolated Claude path regresses, start with the skill before changing the
+tutorials. The common failure mode is provider auth/readiness, not tutorial
+content.
+
 ## License
 
 MIT

--- a/docs/tutorials/02-agents.md
+++ b/docs/tutorials/02-agents.md
@@ -141,6 +141,10 @@ No findings.
 `hello.py` is a single `print("Hello, World!")` statement and does not present a meaningful bug, security, or style issue in its current form.
 ```
 
+The exact review text will vary by provider and model. The important part is
+that the reviewer creates `review.md` in the rig and fills it with review
+feedback.
+
 This is handy for fire-and-forget kind of work. However, if you'd like to see
 the agent in action or even talk to one directly, you're going to need a
 session. And for that, you'll want to check in on [the next

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -407,7 +407,16 @@ func probeClaude(ctx context.Context, homeDir string) providerProbeResult {
 		return providerProbeResult{status: probeStatusNotInstalled}
 	}
 
-	stdout, _, err := runProbeCommand(ctx, homeDir, 5*time.Second, path, "auth", "status", "--json")
+	// Claude-specific env: OAuth token and config dir are only relevant
+	// for the Claude probe — keep them out of the shared probeCommandEnv
+	// to avoid leaking credentials to unrelated subprocesses (e.g., gh).
+	var claudeEnv []string
+	for _, key := range []string{"CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR"} {
+		if value := os.Getenv(key); value != "" {
+			claudeEnv = append(claudeEnv, key+"="+value)
+		}
+	}
+	stdout, _, err := runProbeCommand(ctx, homeDir, 5*time.Second, claudeEnv, path, "auth", "status", "--json")
 	if err != nil && strings.TrimSpace(stdout) == "" {
 		return providerProbeResult{status: probeStatusProbeError}
 	}
@@ -557,6 +566,7 @@ func probeGitHubCLIAuthStatus(ctx context.Context, homeDir, ghPath string) provi
 		ctx,
 		homeDir,
 		2*time.Second,
+		nil,
 		ghPath,
 		"auth",
 		"status",
@@ -607,6 +617,7 @@ func runProbeCommand(
 	ctx context.Context,
 	homeDir string,
 	timeout time.Duration,
+	extraEnv []string,
 	path string,
 	args ...string,
 ) (string, string, error) {
@@ -615,7 +626,7 @@ func runProbeCommand(
 
 	cmd := providerProbeCommandContext(ctx, path, args...)
 	cmd.Dir = homeDir
-	cmd.Env = probeCommandEnv(homeDir)
+	cmd.Env = append(probeCommandEnv(homeDir), extraEnv...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -636,7 +647,7 @@ func probeCommandEnv(homeDir string) []string {
 	// USER/LOGNAME are required on macOS for Keychain access — without them
 	// Claude Code cannot read its stored OAuth credentials and reports
 	// loggedIn: false even when the user is authenticated.
-	for _, key := range []string{"USER", "LOGNAME", "CLAUDE_CODE_OAUTH_TOKEN"} {
+	for _, key := range []string{"USER", "LOGNAME"} {
 		if value := os.Getenv(key); value != "" {
 			env = append(env, key+"="+value)
 		}

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -419,9 +419,10 @@ func probeClaude(ctx context.Context, homeDir string) providerProbeResult {
 	if !status.LoggedIn {
 		return providerProbeResult{status: probeStatusNeedsAuth}
 	}
-	// Onboarding only supports the first-party claude.ai OAuth flow. API-key
-	// or alternate providers are intentionally treated as unsupported.
-	if status.AuthMethod == "claude.ai" && status.APIProvider == "firstParty" {
+	// Gas City supports Claude's first-party login flows. That includes the
+	// interactive claude.ai login and long-lived oauth_token auth used for
+	// isolated acceptance environments.
+	if (status.AuthMethod == "claude.ai" || status.AuthMethod == "oauth_token") && status.APIProvider == "firstParty" {
 		return providerProbeResult{status: probeStatusConfigured}
 	}
 	return providerProbeResult{status: probeStatusInvalidConfiguration}
@@ -635,7 +636,7 @@ func probeCommandEnv(homeDir string) []string {
 	// USER/LOGNAME are required on macOS for Keychain access — without them
 	// Claude Code cannot read its stored OAuth credentials and reports
 	// loggedIn: false even when the user is authenticated.
-	for _, key := range []string{"USER", "LOGNAME"} {
+	for _, key := range []string{"USER", "LOGNAME", "CLAUDE_CODE_OAUTH_TOKEN"} {
 		if value := os.Getenv(key); value != "" {
 			env = append(env, key+"="+value)
 		}

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -72,6 +72,16 @@ func TestProbeCommandEnvPreservesXDGOverridesWhenGHConfigDirIsSet(t *testing.T) 
 	}
 }
 
+func TestProbeCommandEnvPassesClaudeOAuthToken(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "token-value")
+
+	env := probeCommandEnv(homeDir)
+	if !slices.Contains(env, "CLAUDE_CODE_OAUTH_TOKEN=token-value") {
+		t.Fatalf("probeCommandEnv missing CLAUDE_CODE_OAUTH_TOKEN: %v", env)
+	}
+}
+
 func TestProviderProbeSearchDirsIncludesUserLocalAndLinuxDefaults(t *testing.T) {
 	homeDir := t.TempDir()
 	got := providerProbeSearchDirs(homeDir, "linux", "/usr/local/bin:/usr/bin:/bin")
@@ -298,6 +308,30 @@ printf '%s\n' '{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstPar
 	if got := resp.Providers["gemini"].Status; got != probeStatusConfigured {
 		t.Errorf("gemini status = %q, want %q", got, probeStatusConfigured)
 	}
+}
+
+func TestHandleProviderReadinessAcceptsClaudeOAuthTokenAuth(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	writeExecutable(t, binDir, "claude", `#!/bin/sh
+printf '%s\n' '{"loggedIn":true,"authMethod":"oauth_token","apiProvider":"firstParty"}'
+`)
+
+	t.Setenv("HOME", homeDir)
+	originalPathEnv := providerProbePathEnv
+	originalCommandContext := providerProbeCommandContext
+	providerProbePathEnv = binDir
+	providerProbeCommandContext = exec.CommandContext
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+		providerProbeCommandContext = originalCommandContext
+	}()
+
+	srv := New(newFakeState(t))
+	assertProviderStatus(t, srv, "/v0/provider-readiness?providers=claude", "claude", probeStatusConfigured)
 }
 
 func TestHandleReadinessReturnsConfiguredStatuses(t *testing.T) {

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -72,13 +72,16 @@ func TestProbeCommandEnvPreservesXDGOverridesWhenGHConfigDirIsSet(t *testing.T) 
 	}
 }
 
-func TestProbeCommandEnvPassesClaudeOAuthToken(t *testing.T) {
+func TestProbeCommandEnvExcludesClaudeOAuthToken(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "token-value")
 
 	env := probeCommandEnv(homeDir)
-	if !slices.Contains(env, "CLAUDE_CODE_OAUTH_TOKEN=token-value") {
-		t.Fatalf("probeCommandEnv missing CLAUDE_CODE_OAUTH_TOKEN: %v", env)
+	// CLAUDE_CODE_OAUTH_TOKEN must NOT be in the shared env — it is
+	// appended only in probeClaude to avoid leaking credentials to
+	// unrelated probe subprocesses (e.g., gh auth status).
+	if slices.Contains(env, "CLAUDE_CODE_OAUTH_TOKEN=token-value") {
+		t.Fatalf("probeCommandEnv should not contain CLAUDE_CODE_OAUTH_TOKEN: %v", env)
 	}
 }
 

--- a/test/acceptance/helpers/claude_state.go
+++ b/test/acceptance/helpers/claude_state.go
@@ -14,13 +14,17 @@ func EnsureClaudeStateFile(home string) error {
 	if home == "" {
 		return nil
 	}
-	statePath := filepath.Join(home, ".claude.json")
-	root, err := loadClaudeState(statePath)
-	if err != nil {
-		return err
+	for _, statePath := range claudeStatePaths(home, filepath.Join(home, ".claude")) {
+		root, err := loadClaudeState(statePath)
+		if err != nil {
+			return err
+		}
+		root["hasCompletedOnboarding"] = true
+		if err := saveClaudeState(statePath, root); err != nil {
+			return err
+		}
 	}
-	root["hasCompletedOnboarding"] = true
-	return saveClaudeState(statePath, root)
+	return nil
 }
 
 // EnsureClaudeProjectState marks a project path as trusted/onboarded in the
@@ -47,30 +51,56 @@ func EnsureClaudeProjectState(env *Env, projectPath string) error {
 	if err := EnsureClaudeStateFile(home); err != nil {
 		return err
 	}
+	configDir := filepath.Join(home, ".claude")
+	if env != nil {
+		if v := strings.TrimSpace(env.Get("CLAUDE_CONFIG_DIR")); v != "" {
+			configDir = v
+		}
+	}
+	for _, statePath := range claudeStatePaths(home, configDir) {
+		root, err := loadClaudeState(statePath)
+		if err != nil {
+			return err
+		}
+		projects, _ := root["projects"].(map[string]any)
+		if projects == nil {
+			projects = map[string]any{}
+			root["projects"] = projects
+		}
+		entry, _ := projects[projectPath].(map[string]any)
+		if entry == nil {
+			entry = map[string]any{}
+		}
+		entry["hasCompletedProjectOnboarding"] = true
+		entry["hasTrustDialogAccepted"] = true
+		if _, ok := entry["projectOnboardingSeenCount"]; !ok {
+			entry["projectOnboardingSeenCount"] = 1
+		}
+		projects[projectPath] = entry
+		if err := saveClaudeState(statePath, root); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-	statePath := filepath.Join(home, ".claude.json")
-	root, err := loadClaudeState(statePath)
-	if err != nil {
-		return err
+func claudeStatePaths(home, configDir string) []string {
+	seen := make(map[string]struct{}, 2)
+	var paths []string
+	add := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
 	}
-
-	projects, _ := root["projects"].(map[string]any)
-	if projects == nil {
-		projects = map[string]any{}
-		root["projects"] = projects
-	}
-	entry, _ := projects[projectPath].(map[string]any)
-	if entry == nil {
-		entry = map[string]any{}
-	}
-	entry["hasCompletedProjectOnboarding"] = true
-	entry["hasTrustDialogAccepted"] = true
-	if _, ok := entry["projectOnboardingSeenCount"]; !ok {
-		entry["projectOnboardingSeenCount"] = 1
-	}
-	projects[projectPath] = entry
-
-	return saveClaudeState(statePath, root)
+	add(filepath.Join(home, ".claude.json"))
+	add(filepath.Join(configDir, ".claude.json"))
+	return paths
 }
 
 func loadClaudeState(path string) (map[string]any, error) {

--- a/test/acceptance/helpers/claude_state.go
+++ b/test/acceptance/helpers/claude_state.go
@@ -9,12 +9,20 @@ import (
 
 // EnsureClaudeStateFile creates or updates HOME/.claude.json with the minimum
 // global onboarding state Claude Code needs to avoid first-run onboarding UI.
-func EnsureClaudeStateFile(home string) error {
+// If configDir is non-empty it is used as the Claude config directory;
+// otherwise it defaults to HOME/.claude.
+func EnsureClaudeStateFile(home string, configDir ...string) error {
 	home = strings.TrimSpace(home)
 	if home == "" {
 		return nil
 	}
-	for _, statePath := range claudeStatePaths(home, filepath.Join(home, ".claude")) {
+	cd := filepath.Join(home, ".claude")
+	if len(configDir) > 0 {
+		if v := strings.TrimSpace(configDir[0]); v != "" {
+			cd = v
+		}
+	}
+	for _, statePath := range claudeStatePaths(home, cd) {
 		root, err := loadClaudeState(statePath)
 		if err != nil {
 			return err

--- a/test/acceptance/helpers/env.go
+++ b/test/acceptance/helpers/env.go
@@ -27,7 +27,7 @@ func NewEnv(gcBinary, gcHome, runtimeDir string) *Env {
 	// a test-specific directory to prevent gc from reading ~/.gc/,
 	// ~/.gitconfig, or other real user state.
 	for _, key := range []string{
-		"PATH", "TMPDIR", "LANG", "LC_ALL", "USER",
+		"PATH", "TMPDIR", "LANG", "LC_ALL", "USER", "LOGNAME",
 		"SHELL", "SSH_AUTH_SOCK", "TERM",
 		"CLAUDE_CONFIG_DIR", // Claude Code reads OAuth credentials from here
 	} {

--- a/test/acceptance/tutorial_goldens/auth_status_test.go
+++ b/test/acceptance/tutorial_goldens/auth_status_test.go
@@ -2,7 +2,13 @@
 
 package tutorialgoldens
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
 
 func TestClaudeStatusOutputLoggedIn(t *testing.T) {
 	t.Parallel()
@@ -27,4 +33,84 @@ func TestCodexStatusOutputLoggedIn(t *testing.T) {
 	if codexStatusOutputLoggedIn([]byte("Not logged in\n")) {
 		t.Fatal("expected unauthenticated output to be rejected")
 	}
+}
+
+func TestLoadEnvFileAppliesSupportedAssignments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := writeEnvFixture(path, "# comment\nexport CLAUDE_CODE_OAUTH_TOKEN=token-value\nOPENAI_API_KEY='openai-value'\nEMPTY=\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("EMPTY", "")
+	if err := loadEnvFile(path); err != nil {
+		t.Fatalf("loadEnvFile() error = %v", err)
+	}
+
+	if got := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); got != "token-value" {
+		t.Fatalf("CLAUDE_CODE_OAUTH_TOKEN = %q, want %q", got, "token-value")
+	}
+	if got := os.Getenv("OPENAI_API_KEY"); got != "openai-value" {
+		t.Fatalf("OPENAI_API_KEY = %q, want %q", got, "openai-value")
+	}
+	if got := os.Getenv("EMPTY"); got != "" {
+		t.Fatalf("EMPTY = %q, want empty string", got)
+	}
+}
+
+func TestLoadEnvFilePreservesExistingValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := writeEnvFixture(path, "CLAUDE_CODE_OAUTH_TOKEN=token-value\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "existing-token")
+	if err := loadEnvFile(path); err != nil {
+		t.Fatalf("loadEnvFile() error = %v", err)
+	}
+	if got := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); got != "existing-token" {
+		t.Fatalf("CLAUDE_CODE_OAUTH_TOKEN = %q, want existing value", got)
+	}
+}
+
+func TestLoadEnvFileRejectsMalformedAssignments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := writeEnvFixture(path, "NOT_AN_ASSIGNMENT\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := loadEnvFile(path); err == nil {
+		t.Fatal("loadEnvFile() error = nil, want malformed assignment error")
+	}
+}
+
+func TestEnsureTutorialUserEnvBackfillsLogname(t *testing.T) {
+	env := helpers.NewEnv("", t.TempDir(), t.TempDir())
+	env.With("USER", "csells")
+	env.With("LOGNAME", "")
+	ensureTutorialUserEnv(env)
+
+	if got := env.Get("USER"); got != "csells" {
+		t.Fatalf("USER = %q, want %q", got, "csells")
+	}
+	if got := env.Get("LOGNAME"); got != "csells" {
+		t.Fatalf("LOGNAME = %q, want %q", got, "csells")
+	}
+}
+
+func TestResolveTutorialUserIdentityPrefersProvidedValues(t *testing.T) {
+	t.Parallel()
+
+	userName, login := resolveTutorialUserIdentity("user-a", "login-b")
+	if userName != "user-a" || login != "login-b" {
+		t.Fatalf("resolveTutorialUserIdentity() = (%q, %q), want (%q, %q)", userName, login, "user-a", "login-b")
+	}
+}
+
+func writeEnvFixture(path, body string) error {
+	return os.WriteFile(path, []byte(body), 0o644)
 }

--- a/test/acceptance/tutorial_goldens/harness_test.go
+++ b/test/acceptance/tutorial_goldens/harness_test.go
@@ -98,6 +98,10 @@ func (w *tutorialWorkspace) attachDiagnostics(t *testing.T, pageName string) {
 			t.Logf("diagnostic notes:\n%s", strings.Join(w.diagNotes, "\n"))
 		}
 		for _, cmd := range []string{
+			"printf 'HOME=%s\\nGC_HOME=%s\\nCLAUDE_CONFIG_DIR=%s\\nTMUX_TMPDIR=%s\\nXDG_RUNTIME_DIR=%s\\n' \"$HOME\" \"$GC_HOME\" \"$CLAUDE_CONFIG_DIR\" \"$TMUX_TMPDIR\" \"$XDG_RUNTIME_DIR\"",
+			"pwd",
+			"pwd -P",
+			"claude auth status --json",
 			"gc status",
 			"gc session list",
 			"bd list --json --limit=20",
@@ -242,6 +246,26 @@ func (w *tutorialWorkspace) waitForSessionByTemplateOrTarget(template, target st
 	return "", fmt.Errorf("no session found for template=%q target=%q in `gc session list`\n%s", template, target, out)
 }
 
+func (w *tutorialWorkspace) waitForPeekableSession(template, target string, timeout, interval time.Duration) error {
+	w.t.Helper()
+
+	if _, err := w.waitForSessionByTemplateOrTarget(template, target, timeout, interval); err != nil {
+		return err
+	}
+
+	ok := waitForCondition(w.t, timeout, interval, func() bool {
+		peekOut, peekErr := w.runShell("gc session peek "+target+" --lines 1", "")
+		return peekErr == nil && strings.TrimSpace(peekOut) != ""
+	})
+	if ok {
+		return nil
+	}
+
+	statusOut, _ := w.runShell("gc status", "")
+	listOut, _ := w.runShell("gc session list", "")
+	return fmt.Errorf("session target %q did not become peekable\n\ngc status:\n%s\n\ngc session list:\n%s", target, statusOut, listOut)
+}
+
 type runningShell struct {
 	cmd    *exec.Cmd
 	cancel context.CancelFunc
@@ -314,6 +338,7 @@ func (r *runningShell) stop() error {
 	r.cancel()
 	if r.cmd.Process != nil {
 		_ = syscall.Kill(-r.cmd.Process.Pid, syscall.SIGTERM)
+		_ = r.cmd.Process.Signal(syscall.SIGTERM)
 	}
 	select {
 	case err := <-r.done:
@@ -324,9 +349,17 @@ func (r *runningShell) stop() error {
 	case <-time.After(5 * time.Second):
 		if r.cmd.Process != nil {
 			_ = syscall.Kill(-r.cmd.Process.Pid, syscall.SIGKILL)
+			_ = r.cmd.Process.Kill()
 		}
-		<-r.done
-		return nil
+		select {
+		case err := <-r.done:
+			if err == nil || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		case <-time.After(5 * time.Second):
+			return fmt.Errorf("timed out stopping running shell\n%s", r.output())
+		}
 	}
 }
 
@@ -338,15 +371,6 @@ func expandHome(home, path string) string {
 }
 
 func (w *tutorialWorkspace) configureInitializedCities() error {
-	hostHome, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	observePaths := []string{
-		filepath.Join(hostHome, ".claude", "projects"),
-		filepath.Join(hostHome, ".codex", "sessions"),
-		filepath.Join(hostHome, ".gemini", "tmp"),
-	}
 	return filepath.WalkDir(w.env.Home, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() || d.Name() != "city.toml" {
 			return nil
@@ -355,76 +379,8 @@ func (w *tutorialWorkspace) configureInitializedCities() error {
 		if err := helpers.EnsureClaudeProjectState(w.env.Env, cityDir); err != nil {
 			return err
 		}
-		if err := ensureTutorialSessionSocket(path, tutorialSocketName(w.env.Root)); err != nil {
-			return err
-		}
-		return ensureTutorialObservePaths(path, observePaths)
+		return nil
 	})
-}
-
-func tutorialSocketName(root string) string {
-	base := filepath.Base(root)
-	if len(base) > 20 {
-		base = base[len(base)-20:]
-	}
-	base = strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z':
-			return r
-		case r >= 'A' && r <= 'Z':
-			return r + ('a' - 'A')
-		case r >= '0' && r <= '9':
-			return r
-		case r == '-' || r == '_':
-			return r
-		default:
-			return '-'
-		}
-	}, base)
-	return "tg-" + base
-}
-
-func ensureTutorialSessionSocket(cityTomlPath, socket string) error {
-	data, err := os.ReadFile(cityTomlPath)
-	if err != nil {
-		return err
-	}
-	body := string(data)
-	if strings.Contains(body, "socket = ") {
-		return nil
-	}
-	if !strings.HasSuffix(body, "\n") {
-		body += "\n"
-	}
-	body += "\n[session]\n"
-	body += fmt.Sprintf("socket = %q\n", socket)
-	return os.WriteFile(cityTomlPath, []byte(body), 0o644)
-}
-
-func ensureTutorialObservePaths(cityTomlPath string, observePaths []string) error {
-	if len(observePaths) == 0 {
-		return nil
-	}
-	data, err := os.ReadFile(cityTomlPath)
-	if err != nil {
-		return err
-	}
-	body := string(data)
-	if strings.Contains(body, "observe_paths = ") {
-		return nil
-	}
-	if !strings.HasSuffix(body, "\n") {
-		body += "\n"
-	}
-	if !strings.Contains(body, "\n[daemon]\n") && !strings.HasPrefix(body, "[daemon]\n") {
-		body += "\n[daemon]\n"
-	}
-	quoted := make([]string, 0, len(observePaths))
-	for _, path := range observePaths {
-		quoted = append(quoted, fmt.Sprintf("%q", path))
-	}
-	body += fmt.Sprintf("observe_paths = [%s]\n", strings.Join(quoted, ", "))
-	return os.WriteFile(cityTomlPath, []byte(body), 0o644)
 }
 
 var beadIDPattern = regexp.MustCompile(`\b[a-z]{2}-[a-z0-9.]+\b`)

--- a/test/acceptance/tutorial_goldens/main_test.go
+++ b/test/acceptance/tutorial_goldens/main_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+	"github.com/joho/godotenv"
 )
 
 const canonicalTutorialRoot = "docs/tutorials"
@@ -24,6 +25,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	if err := loadTutorialEnvFile(); err != nil {
+		panic("tutorial-goldens: loading .env: " + err.Error())
+	}
 	if !hasClaudeAuth() || (!useClaudeForCodex() && !hasCodexAuth()) {
 		if useClaudeForCodex() {
 			fmt.Fprintln(os.Stderr, "tutorial-goldens: skipping package (requires Claude auth)")
@@ -86,7 +90,8 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
 	home := filepath.Join(root, "home")
 	runtimeDir := filepath.Join(root, "runtime")
-	for _, dir := range []string{home, runtimeDir} {
+	tmuxDir := filepath.Join(runtimeDir, "tmux")
+	for _, dir := range []string{home, runtimeDir, tmuxDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("creating %s: %v", dir, err)
 		}
@@ -100,9 +105,6 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 	doltCfg := `{"user.name":"gc-test","user.email":"gc-test@test.local"}`
 	if err := os.WriteFile(filepath.Join(home, ".dolt", "config_global.json"), []byte(doltCfg), 0o644); err != nil {
 		t.Fatalf("writing dolt config: %v", err)
-	}
-	if err := stageClaudeAuth(home); err != nil {
-		t.Fatalf("staging Claude auth: %v", err)
 	}
 	if err := helpers.EnsureClaudeStateFile(home); err != nil {
 		t.Fatalf("seeding Claude state: %v", err)
@@ -119,6 +121,11 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 		Without("GC_BEADS").
 		Without("GC_DOLT").
 		With("DOLT_ROOT_PATH", home)
+	ensureTutorialUserEnv(env)
+	env.With("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
+	env.With("TMUX_TMPDIR", tmuxDir)
+	env.With("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	env.With("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	env.With("PATH", filepath.Join(home, ".local", "bin")+":"+env.Get("PATH"))
 
 	for _, key := range []string{
@@ -130,6 +137,7 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 		"ANTHROPIC_DEFAULT_SONNET_MODEL",
 		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
 		"CLAUDE_CODE_EFFORT_LEVEL",
+		"CLAUDE_CODE_OAUTH_TOKEN",
 		"CLAUDE_CODE_SUBAGENT_MODEL",
 		"OPENAI_API_KEY",
 	} {
@@ -301,6 +309,9 @@ func hasClaudeAuth() bool {
 	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" || strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN")) != "" {
 		return true
 	}
+	if hasValidClaudeOAuthToken() {
+		return true
+	}
 	cmd := exec.Command("claude", "auth", "status")
 	out, err := cmd.Output()
 	if err != nil {
@@ -321,15 +332,21 @@ func hasCodexAuth() bool {
 	return codexStatusOutputLoggedIn(out)
 }
 
-func stageClaudeAuth(_ string) error {
-	// Tutorial acceptance uses wrapped provider binaries that delegate to the
-	// authenticated host CLI, so there is no isolated Claude auth state to copy.
-	return nil
-}
-
-func stageCodexAuth(_ string) error {
-	// Tutorial acceptance uses wrapped provider binaries that delegate to the
-	// authenticated host CLI, so there is no isolated Codex auth state to copy.
+func stageCodexAuth(dstHome string) error {
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
+		return nil
+	}
+	realHome := hostHomeDir()
+	srcCodexDir := filepath.Join(realHome, ".codex")
+	dstCodexDir := filepath.Join(dstHome, ".codex")
+	if err := os.MkdirAll(dstCodexDir, 0o755); err != nil {
+		return err
+	}
+	for _, name := range []string{"auth.json", "config.json", "config.toml"} {
+		if err := copyFileIfExists(filepath.Join(srcCodexDir, name), filepath.Join(dstCodexDir, name), 0o600); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -338,19 +355,11 @@ func stageProviderBinaries(dstHome string) error {
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return err
 	}
-	claudeShim, err := providerBinaryShim("claude")
-	if err != nil {
-		return err
-	}
-	if err := helpers.StageProviderBinary(binDir, "claude", claudeShim); err != nil {
+	if err := helpers.StageProviderBinary(binDir, "claude", ""); err != nil {
 		return err
 	}
 	if !useClaudeForCodex() {
-		codexShim, err := providerBinaryShim("codex")
-		if err != nil {
-			return err
-		}
-		if err := helpers.StageProviderBinary(binDir, "codex", codexShim); err != nil {
+		if err := helpers.StageProviderBinary(binDir, "codex", ""); err != nil {
 			return err
 		}
 	}
@@ -364,32 +373,78 @@ func stageProviderBinaries(dstHome string) error {
 	return nil
 }
 
-func providerBinaryShim(name string) (string, error) {
-	switch name {
-	case "claude":
-		if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" || strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN")) != "" {
-			return "", nil
+func loadTutorialEnvFile() error {
+	return loadEnvFile(filepath.Join(helpers.FindModuleRoot(), ".env"))
+}
+
+func loadEnvFile(path string) error {
+	values, err := godotenv.Read(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
 		}
-		return hostProviderShim(name, []string{"CLAUDE_CONFIG_DIR", "XDG_CONFIG_HOME", "XDG_STATE_HOME"})
-	case "codex":
-		if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
-			return "", nil
+		return err
+	}
+	for key, value := range values {
+		if os.Getenv(key) != "" {
+			continue
 		}
-		return hostProviderShim(name, []string{"XDG_CONFIG_HOME", "XDG_STATE_HOME"})
-	default:
-		return "", nil
+		_ = os.Setenv(key, value)
+	}
+	return nil
+}
+
+func hasValidClaudeOAuthToken() bool {
+	token := strings.TrimSpace(os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"))
+	if token == "" {
+		return false
+	}
+	tmpHome, err := os.MkdirTemp("", "claude-oauth-check-*")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(tmpHome)
+
+	cmd := exec.Command("claude", "--print", "ok")
+	cmd.Env = []string{
+		"HOME=" + tmpHome,
+		"PATH=" + os.Getenv("PATH"),
+		"CLAUDE_CODE_OAUTH_TOKEN=" + token,
+	}
+	appendNonEmptyEnv := func(key, value string) {
+		if strings.TrimSpace(value) == "" {
+			return
+		}
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	userName, login := resolveTutorialUserIdentity(os.Getenv("USER"), os.Getenv("LOGNAME"))
+	appendNonEmptyEnv("USER", userName)
+	appendNonEmptyEnv("LOGNAME", login)
+	appendNonEmptyEnv("SHELL", os.Getenv("SHELL"))
+	appendNonEmptyEnv("LANG", os.Getenv("LANG"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(out)), "ok")
+}
+
+func ensureTutorialUserEnv(env *helpers.Env) {
+	if env == nil {
+		return
+	}
+	userName, login := resolveTutorialUserIdentity(env.Get("USER"), env.Get("LOGNAME"))
+	if userName != "" {
+		env.With("USER", userName)
+	}
+	if login != "" {
+		env.With("LOGNAME", login)
 	}
 }
 
-func hostProviderShim(name string, unsetVars []string) (string, error) {
-	path, err := exec.LookPath(name)
-	if err != nil {
-		return "", err
-	}
-
-	realHome := hostHomeDir()
-	userName := strings.TrimSpace(os.Getenv("USER"))
-	login := strings.TrimSpace(os.Getenv("LOGNAME"))
+func resolveTutorialUserIdentity(userName, login string) (string, string) {
+	userName = strings.TrimSpace(userName)
+	login = strings.TrimSpace(login)
 	if current, err := user.Current(); err == nil {
 		if userName == "" {
 			userName = strings.TrimSpace(current.Username)
@@ -398,28 +453,13 @@ func hostProviderShim(name string, unsetVars []string) (string, error) {
 			login = strings.TrimSpace(current.Username)
 		}
 	}
-	if login == "" {
-		login = filepath.Base(realHome)
-	}
 	if userName == "" {
 		userName = login
 	}
-
-	parts := []string{"env"}
-	for _, key := range unsetVars {
-		parts = append(parts, "-u", key)
+	if login == "" {
+		login = userName
 	}
-	parts = append(parts,
-		"HOME="+shellQuote(realHome),
-		"USER="+shellQuote(userName),
-		"LOGNAME="+shellQuote(login),
-		shellQuote(path),
-	)
-	return strings.Join(parts, " "), nil
-}
-
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+	return userName, login
 }
 
 func acceptanceTempRoot() (string, error) {
@@ -434,6 +474,17 @@ func acceptanceTempRoot() (string, error) {
 		return "", err
 	}
 	return root, nil
+}
+
+func copyFileIfExists(src, dst string, perm os.FileMode) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return os.WriteFile(dst, data, perm)
 }
 
 func useClaudeForCodex() bool {

--- a/test/acceptance/tutorial_goldens/main_test.go
+++ b/test/acceptance/tutorial_goldens/main_test.go
@@ -3,6 +3,7 @@
 package tutorialgoldens
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -106,7 +107,8 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 	if err := os.WriteFile(filepath.Join(home, ".dolt", "config_global.json"), []byte(doltCfg), 0o644); err != nil {
 		t.Fatalf("writing dolt config: %v", err)
 	}
-	if err := helpers.EnsureClaudeStateFile(home); err != nil {
+	claudeConfigDir := filepath.Join(home, ".claude")
+	if err := helpers.EnsureClaudeStateFile(home, claudeConfigDir); err != nil {
 		t.Fatalf("seeding Claude state: %v", err)
 	}
 	if err := stageCodexAuth(home); err != nil {
@@ -306,18 +308,13 @@ func hostHomeDir() string {
 }
 
 func hasClaudeAuth() bool {
+	// Only accept auth forms that are portable to the isolated temp-home
+	// environment. Host-level `claude auth status` logins are NOT portable
+	// because the harness no longer stages host HOME into the isolated env.
 	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" || strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN")) != "" {
 		return true
 	}
-	if hasValidClaudeOAuthToken() {
-		return true
-	}
-	cmd := exec.Command("claude", "auth", "status")
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return claudeStatusOutputLoggedIn(out)
+	return hasValidClaudeOAuthToken()
 }
 
 func hasCodexAuth() bool {
@@ -405,7 +402,9 @@ func hasValidClaudeOAuthToken() bool {
 	}
 	defer os.RemoveAll(tmpHome)
 
-	cmd := exec.Command("claude", "--print", "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "claude", "--print", "ok")
 	cmd.Env = []string{
 		"HOME=" + tmpHome,
 		"PATH=" + os.Getenv("PATH"),

--- a/test/acceptance/tutorial_goldens/tutorial02_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial02_test.go
@@ -143,9 +143,6 @@ EOF`
 		if strings.TrimSpace(out) == "" {
 			t.Fatal("review.md is empty")
 		}
-		if !strings.Contains(strings.ToLower(out), "review") && !strings.Contains(strings.ToLower(out), "finding") {
-			t.Fatalf("review.md should contain review content:\n%s", out)
-		}
 	})
 
 	if reviewTaskID != "" {

--- a/test/acceptance/tutorial_goldens/tutorial03_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial03_test.go
@@ -50,33 +50,14 @@ prompt_template = "prompts/reviewer.md"
 		}
 	})
 
-	mayorSessionID, err := ws.waitForSessionByTemplateOrTarget("mayor", "mayor", 30*time.Second, time.Second)
-	if err != nil {
-		t.Fatalf("resolve mayor session bead: %v", err)
-	}
-
-	mayorReady := func() bool {
-		peekOut, peekErr := ws.runShell("gc session peek mayor --lines 1", "")
-		return peekErr == nil && strings.TrimSpace(peekOut) != ""
-	}
-	if !waitForCondition(t, 30*time.Second, 1*time.Second, mayorReady) {
-		ws.noteWarning("tutorial 03 runtime workaround: gc init seeds a named mayor session bead with resume metadata, so the page driver clears the stale resume key before bootstrapping a fresh headless submit")
-		if out, err := ws.runShell("bd update "+mayorSessionID+" --unset-metadata session_key --unset-metadata started_config_hash --set-metadata continuation_reset_pending=true", ""); err != nil {
-			t.Fatalf("clear mayor stale resume metadata: %v\n%s", err, out)
-		}
-		if out, err := ws.runShell(`gc session submit mayor "__tutorial03_bootstrap__"`, ""); err != nil {
-			t.Fatalf("seed mayor submit bootstrap: %v\n%s", err, out)
-		}
-	}
-	if !waitForCondition(t, 30*time.Second, 1*time.Second, mayorReady) {
-		out, _ := ws.runShell("gc session list", "")
-		t.Fatalf("mayor session did not become peekable during tutorial 03 seed bootstrap:\n%s", out)
+	if err := ws.waitForPeekableSession("mayor", "mayor", 30*time.Second, time.Second); err != nil {
+		t.Fatalf("mayor should be an always-on named session immediately after init: %v", err)
 	}
 
 	var reviewerSessionID string
 	var mayorPeekOut string
+	var mayorPeekBaseline string
 	var mayorTailLogs string
-	const logsSeedProbe = "__tutorial03_logs_seed__"
 	const logsFollowProbe = "__tutorial03_logs_follow_probe__"
 
 	ws.noteWarning("tutorial 03 starts from the live reviewer polecat created in tutorial 02, so the page driver seeds that prior session state by slinging the same review work before exercising the visible session lookup flow")
@@ -126,7 +107,10 @@ prompt_template = "prompts/reviewer.md"
 		return true
 	}) {
 		out, _ := ws.runShell("gc session list", "")
-		t.Fatalf("mayor session never became peekable:\n%s", out)
+			t.Fatalf("mayor session never became peekable:\n%s", out)
+	}
+	if out, err := ws.runShell("gc session peek mayor --lines 12", ""); err == nil && strings.TrimSpace(out) != "" {
+		mayorPeekBaseline = out
 	}
 
 	t.Run("cat city.toml", func(t *testing.T) {
@@ -228,33 +212,23 @@ prompt_template = "prompts/reviewer.md"
 		}
 	})
 
-	ws.noteWarning("tutorial 03 runtime workaround: after the visible mayor nudge, wait for that prompt to surface in `peek` before exercising transcript commands; the session can be active while Claude is still on its welcome screen")
+	ws.noteWarning("tutorial 03 runtime workaround: after the visible mayor nudge, wait for `peek` to return updated, non-empty output before exercising transcript commands; the session can be active while Claude is still on its welcome screen")
 	if !waitForCondition(t, 90*time.Second, 2*time.Second, func() bool {
 		out, err := ws.runShell("gc session peek mayor --lines 12", "")
 		if err != nil || strings.TrimSpace(out) == "" {
 			return false
 		}
 		mayorPeekOut = out
-		return strings.Contains(out, "What's the current city status?")
+		return strings.TrimSpace(out) != strings.TrimSpace(mayorPeekBaseline)
 	}) {
 		out, _ := ws.runShell("gc session peek mayor --lines 12", "")
-		t.Fatalf("mayor did not surface the visible nudge before the log steps:\n%s", out)
+		t.Fatalf("mayor did not return updated peek output after the visible nudge before the log steps:\n%s", out)
 	}
 
-	ws.noteWarning("tutorial 03 runtime workaround: named mayor sessions in acceptance can carry a stale session_key even when the live Claude transcript is present for the work-dir slug, so the page driver clears keyed log lookup before exercising the documented log commands")
-	if out, err := ws.runShell("bd update "+mayorSessionID+" --unset-metadata session_key", ""); err != nil {
-		t.Fatalf("clear mayor session_key before log lookup: %v\n%s", err, out)
-	}
-	ws.noteWarning("tutorial 03 runtime workaround: seed the mayor transcript and wait for the visible alias-based `gc session logs mayor` path to surface that marker before exercising the documented log commands")
-	if out, err := ws.runShell(`gc session nudge mayor "`+logsSeedProbe+`"`, ""); err != nil {
-		t.Fatalf("hidden transcript seed nudge failed: %v\n%s", err, out)
-	}
+	ws.noteWarning("tutorial 03 runtime workaround: after the visible mayor nudge, wait for the alias-based `gc session logs mayor` path itself to become readable before exercising the documented log commands")
 	if !waitForCondition(t, 2*time.Minute, 2*time.Second, func() bool {
-		out, err := ws.runShell("gc session logs mayor --tail 0", "")
+		out, err := ws.runShell("gc session logs mayor --tail 1", "")
 		if err != nil || strings.TrimSpace(out) == "" {
-			return false
-		}
-		if !strings.Contains(out, logsSeedProbe) {
 			return false
 		}
 		mayorTailLogs = out
@@ -281,10 +255,10 @@ prompt_template = "prompts/reviewer.md"
 		}
 		defer func() { _ = rs.stop() }()
 
-		if _, err := ws.runShell(`gc session nudge mayor "`+logsFollowProbe+`"`, ""); err != nil {
+		if _, err := ws.runShell(`gc session nudge mayor "Reply with `+logsFollowProbe+` and nothing else."`, ""); err != nil {
 			t.Fatalf("hidden follow stimulus failed: %v", err)
 		}
-		if err := rs.waitFor(logsFollowProbe, 45*time.Second); err != nil {
+		if err := rs.waitFor(logsFollowProbe, 90*time.Second); err != nil {
 			t.Fatalf("session logs follow did not surface new output: %v", err)
 		}
 	})

--- a/test/acceptance/tutorial_goldens/tutorial03_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial03_test.go
@@ -107,7 +107,7 @@ prompt_template = "prompts/reviewer.md"
 		return true
 	}) {
 		out, _ := ws.runShell("gc session list", "")
-			t.Fatalf("mayor session never became peekable:\n%s", out)
+		t.Fatalf("mayor session never became peekable:\n%s", out)
 	}
 	if out, err := ws.runShell("gc session peek mayor --lines 12", ""); err == nil && strings.TrimSpace(out) != "" {
 		mayorPeekBaseline = out

--- a/test/acceptance/tutorial_goldens/tutorial04_communication_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial04_communication_test.go
@@ -41,27 +41,8 @@ prompt_template = "prompts/reviewer.md"
 	writeFile(t, filepath.Join(myCity, "prompts", "reviewer.md"), "# Reviewer\nReview code.\n", 0o644)
 	ws.noteWarning("TODO(issue #632): once bare agent names reliably resolve to the enclosing rig in acceptance-style paths, simplify tutorial 04's rig-local reviewer references from `my-project/reviewer` to bare `reviewer` where the shell is already in the rig")
 
-	mayorSessionID, err := ws.waitForSessionByTemplateOrTarget("mayor", "mayor", 30*time.Second, time.Second)
-	if err != nil {
-		t.Fatalf("resolve mayor session bead: %v", err)
-	}
-
-	mayorReady := func() bool {
-		peekOut, peekErr := ws.runShell("gc session peek mayor --lines 1", "")
-		return peekErr == nil && strings.TrimSpace(peekOut) != ""
-	}
-	if !waitForCondition(t, 30*time.Second, 1*time.Second, mayorReady) {
-		ws.noteWarning("tutorial 04 runtime workaround: gc init seeds a named mayor session bead with resume metadata, so the page driver clears the stale resume key before bootstrapping a fresh headless submit")
-		if out, err := ws.runShell("bd update "+mayorSessionID+" --unset-metadata session_key --unset-metadata started_config_hash --set-metadata continuation_reset_pending=true", ""); err != nil {
-			t.Fatalf("clear mayor stale resume metadata: %v\n%s", err, out)
-		}
-		if out, err := ws.runShell(`gc session submit mayor "__tutorial04_bootstrap__"`, ""); err != nil {
-			t.Fatalf("seed mayor submit bootstrap: %v\n%s", err, out)
-		}
-	}
-	if !waitForCondition(t, 30*time.Second, 1*time.Second, mayorReady) {
-		out, _ := ws.runShell("gc session list", "")
-		t.Fatalf("mayor session did not become peekable during tutorial 04 seed bootstrap:\n%s", out)
+	if err := ws.waitForPeekableSession("mayor", "mayor", 30*time.Second, time.Second); err != nil {
+		t.Fatalf("mayor should be an always-on named session immediately after init: %v", err)
 	}
 
 	t.Run(`gc mail send mayor -s "Review needed" -m "Please look at the auth module changes in my-project"`, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Supersedes #641 by @csells, which correctly tightens the tutorial acceptance harness to behave like a real isolated environment instead of patching over failures.

Credit: Original fix by @csells (commit preserved with original authorship).

This PR includes that work plus maintainer fixups from the adoption review:

**Original changes (@csells):**
- Removes mayor bootstrap workarounds from Tutorials 03 and 04
- Adds isolated-environment diagnostics for HOME, GC_HOME, CLAUDE_CONFIG_DIR, etc.
- Replaces host-HOME provider shims with OAuth token auth via symlinked binaries
- Extends Claude state seeding across both known state file locations
- Adds `godotenv` for `.env` file loading in tutorial harness

**Maintainer fixups (review findings):**
1. `.gitignore`: use `.claude/*` with `!.claude/skills/` exception to prevent accidental commits of user-specific Claude Code state files
2. `hasClaudeAuth()`: only accept auth forms portable to the isolated temp-home env (API keys, OAuth tokens) — host `claude auth status` is no longer usable
3. Thread `CLAUDE_CONFIG_DIR` through `EnsureClaudeStateFile` (variadic configDir param) for consistent non-default config roots
4. Move `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CONFIG_DIR` out of shared `probeCommandEnv` into Claude-specific env in `probeClaude` — prevents credential leakage to unrelated subprocesses
5. Add `context.WithTimeout` (10s) to `hasValidClaudeOAuthToken` to prevent TestMain deadlock

## Validation

- `go vet ./...` clean
- `go test ./internal/api/ ./test/acceptance/helpers/` pass
- 3 review passes (Claude + Codex; Gemini rate-limited) — 0 blockers, 0 majors remaining

## Test plan

- [ ] `go test ./internal/api/ -run TestProbe` — verifies OAuth token excluded from shared probe env
- [ ] `go test ./test/acceptance/helpers/` — verifies Claude state file seeding
- [ ] `go vet ./...` — no warnings
- [ ] CI passes

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)