### PR TITLE
fix: poll for dolt state files to stabilize TestGcBeadsBdStartUsesRootBeadsDataDir

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -512,8 +512,13 @@ func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
 
 	runScript("start")
 
+	// `start` spawns the dolt server in the background; the state and port
+	// files it writes may not exist the instant the script exits. Poll with
+	// a bounded timeout instead of reading once. Fixes flake (#542).
 	stateFile := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
 	portFile := filepath.Join(cityPath, ".beads", "dolt-server.port")
+	waitForFile(t, stateFile, 3*time.Second)
+	waitForFile(t, portFile, 3*time.Second)
 
 	state, err := os.ReadFile(stateFile)
 	if err != nil {
@@ -522,8 +527,30 @@ func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
 	if !strings.Contains(string(state), filepath.Join(cityPath, ".beads", "dolt")) {
 		t.Fatalf("state file should point at .beads/dolt, got:\n%s", state)
 	}
-	if _, err := os.Stat(portFile); err != nil {
-		t.Fatalf("dolt-server.port missing: %v", err)
+}
+
+// waitForFile polls until path exists or timeout elapses. Used to avoid
+// racing background-spawned processes like dolt server during startup.
+// Real stat errors (permission denied, malformed path) fail immediately;
+// only not-found is retried. The last not-found error is surfaced in the
+// timeout message for easier debugging.
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		_, err := os.Stat(path)
+		if err == nil {
+			return
+		}
+		if !os.IsNotExist(err) {
+			t.Fatalf("waitForFile: stat %s: %v", path, err)
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			t.Fatalf("waitForFile: %s did not appear within %v (last error: %v)", path, timeout, lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary

Supersedes #660 by @mk-imagine (rebased cleanly onto current main, which includes #655).

Credit: Original fix by @mk-imagine (commit preserved with original authorship).

Closes #542.

`TestGcBeadsBdStartUsesRootBeadsDataDir` was intermittently failing in CI with:

```
dolt server exited during startup (check /tmp/.../001/.gc/runtime/packs/dolt/dolt.log)
```

Root cause: `runScript("start")` spawns the dolt server in the background, then the test immediately reads `dolt-state.json` and checks `dolt-server.port`. These files may not exist the instant `start` returns due to filesystem visibility delays on CI runners.

## Change

Replace the immediate file reads with a bounded poll (100 ms interval, 3 s total timeout). Factored out as a `waitForFile(t, path, timeout)` helper that:
- Polls until the file exists or timeout elapses
- Distinguishes real stat errors (permission denied) from not-found
- Fails immediately on non-transient errors, retries only not-found

Removes the redundant `os.Stat(portFile)` assertion now covered by the poll.

## Why a new PR

The original PR #660 conflicted with main after PR #655 (which also addressed #542) was merged, modifying the same test region. Rather than asking the contributor to rebase, we applied their changes cleanly on top of current main.

## Test plan

- [x] `go vet ./cmd/gc/...` — clean
- [x] Triple-model review (Claude + Codex + Gemini): approve, no blockers

---
_Adopted via `/adopt-pr` workflow. Original: #660. Contributor commits preserved._