### PR TITLE
fix: unblock stalled workflow control reconciliation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1527,11 +1527,9 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --assignee="$id" --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
-			// Tier 3: ready unassigned routed to this config (shared routed queue)
-			`case "$GC_SESSION_ORIGIN" in ` +
-			`ephemeral|"") ;; ` +
-			`*) exit 0 ;; ` +
-			`esac; ` +
+			// Tier 3: ready unassigned routed to this config (shared routed queue).
+			// No GC_SESSION_ORIGIN gate here — only control-dispatchers restrict
+			// demand detection to ephemeral/controller probes (see legacy branch below).
 			`bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --json --limit=1 2>/dev/null'`
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1512,22 +1512,76 @@ func (a *Agent) EffectiveWorkQuery() string {
 	if a.PoolName != "" {
 		target = a.PoolName
 	}
+	legacyTarget := legacyWorkflowControlQualifiedName(target)
+	if legacyTarget == "" {
+		return `sh -c '` +
+			// Tier 1: in_progress assigned to any of my identifiers (crash recovery)
+			`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
+			`[ -z "$id" ] && continue; ` +
+			`r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			`done; ` +
+			// Tier 2: ready assigned to any of my identifiers (pre-assigned)
+			`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
+			`[ -z "$id" ] && continue; ` +
+			`r=$(bd ready --assignee="$id" --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			`done; ` +
+			// Tier 3: ready unassigned routed to this config (shared routed queue)
+			`case "$GC_SESSION_ORIGIN" in ` +
+			`ephemeral|"") ;; ` +
+			`*) exit 0 ;; ` +
+			`esac; ` +
+			`bd ready --metadata-field gc.routed_to=` + target +
+			` --unassigned --json --limit=1 2>/dev/null'`
+	}
 	return `sh -c '` +
-		// Tier 1: in_progress assigned to any of my identifiers (crash recovery)
+		// Tier 1: in_progress assigned to any of my identifiers (crash recovery).
+		// Built-in control-dispatchers also claim legacy workflow-control names so
+		// pre-rename workflows keep moving without live metadata rewrites.
 		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
-		`r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
+		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
+		`for cand in "$id" "$legacy"; do ` +
+		`[ -z "$cand" ] && continue; ` +
+		`r=$(bd list --status in_progress --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`done; ` +
 		`done; ` +
 		// Tier 2: ready assigned to any of my identifiers (pre-assigned)
 		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
-		`r=$(bd ready --assignee="$id" --json --limit=1 2>/dev/null); ` +
+		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
+		`for cand in "$id" "$legacy"; do ` +
+		`[ -z "$cand" ] && continue; ` +
+		`r=$(bd ready --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
-		// Tier 3: ready unassigned routed to this agent (pool queue)
-		`bd ready --metadata-field gc.routed_to=` + target +
+		`done; ` +
+		// Tier 3: ready unassigned routed to this config (shared routed queue),
+		// then the legacy workflow-control route for pre-rename graphs.
+		// Demand detection only runs for ephemeral sessions or controller probes.
+		`case "$GC_SESSION_ORIGIN" in ` +
+		`ephemeral|"") ;; ` +
+		`*) exit 0 ;; ` +
+		`esac; ` +
+		`r=$(bd ready --metadata-field gc.routed_to=` + target +
+		` --unassigned --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`bd ready --metadata-field gc.routed_to=` + legacyTarget +
 		` --unassigned --json --limit=1 2>/dev/null'`
+}
+
+func legacyWorkflowControlQualifiedName(target string) string {
+	target = strings.TrimSpace(target)
+	if target == ControlDispatcherAgentName {
+		return "workflow-control"
+	}
+	const suffix = "/" + ControlDispatcherAgentName
+	if strings.HasSuffix(target, suffix) {
+		return strings.TrimSuffix(target, suffix) + "/workflow-control"
+	}
+	return ""
 }
 
 // EffectiveSlingQuery returns the sling query command template for this agent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -1338,6 +1339,69 @@ func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+}
+
+func TestEffectiveWorkQueryControlDispatcherIncludesLegacyWorkflowControlRoute(t *testing.T) {
+	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
+	got := a.EffectiveWorkQuery()
+	if !strings.Contains(got, "gc.routed_to=gascity/control-dispatcher") {
+		t.Fatalf("EffectiveWorkQuery() missing current control-dispatcher route: %q", got)
+	}
+	if !strings.Contains(got, "gc.routed_to=gascity/workflow-control") {
+		t.Fatalf("EffectiveWorkQuery() missing legacy workflow-control route: %q", got)
+	}
+	if !strings.Contains(got, `workflow-control`) {
+		t.Fatalf("EffectiveWorkQuery() missing legacy assignee alias handling: %q", got)
+	}
+}
+
+func TestEffectiveWorkQueryControlDispatcherClaimsLegacyAssignedWork(t *testing.T) {
+	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_NAME": "gascity--control-dispatcher",
+		"GC_ALIAS":        "gascity/control-dispatcher",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=1"|\
+  "list --status in_progress --assignee=gascity/control-dispatcher --json --limit=1"|\
+  "list --status in_progress --assignee=gascity--workflow-control --json --limit=1"|\
+  "list --status in_progress --assignee=gascity/workflow-control --json --limit=1")
+    printf '[]'
+    ;;
+  "ready --assignee=gascity--workflow-control --json --limit=1"|\
+  "ready --assignee=gascity/workflow-control --json --limit=1")
+    printf '[{"id":"ga-legacy-ready"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-legacy-ready"}]`; got != want {
+		t.Fatalf("legacy assigned work query output = %q, want %q", got, want)
+	}
+}
+
+func TestEffectiveWorkQueryControlDispatcherClaimsLegacyUnassignedRoute(t *testing.T) {
+	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
+	out := runEffectiveWorkQuery(t, a, nil, `#!/bin/sh
+set -eu
+case "$*" in
+  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=1")
+    printf '[]'
+    ;;
+  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=1")
+    printf '[{"id":"ga-legacy-route"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-legacy-route"}]`; got != want {
+		t.Fatalf("legacy routed work query output = %q, want %q", got, want)
 	}
 }
 
@@ -3048,6 +3112,27 @@ func TestEffectiveMethodsQualifyConsistently(t *testing.T) {
 			_ = dirPrefix // used conceptually above
 		})
 	}
+}
+
+func runEffectiveWorkQuery(t *testing.T, a Agent, env map[string]string, bdScript string) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	cmd := exec.Command("sh", "-c", a.EffectiveWorkQuery())
+	cmd.Env = []string{"PATH=" + tmp + ":" + os.Getenv("PATH")}
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run work query: %v", err)
+	}
+	return string(out)
 }
 
 // TestEffectiveMethodsAgentRouting verifies that all agents use

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -109,6 +109,9 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 				"gc.final_disposition": "controller_error",
 			})
 			_ = setOutcomeAndClose(store, bead.ID, "fail")
+			// Reconcile any enclosing scope so a controller_error terminal
+			// closure does not leave the scope body stalled.
+			_, _ = reconcileClosedScopeMember(store, bead.ID)
 			return ControlResult{}, fmt.Errorf("%s: spawning attempt %d: %w", bead.ID, nextAttempt, err)
 		}
 
@@ -205,6 +208,9 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 			"gc.final_disposition": "controller_error",
 		})
 		_ = setOutcomeAndClose(store, bead.ID, "fail")
+		// Reconcile any enclosing scope so a controller_error terminal
+		// closure does not leave the scope body stalled.
+		_, _ = reconcileClosedScopeMember(store, bead.ID)
 		return ControlResult{}, fmt.Errorf("%s: spawning iteration %d: %w", bead.ID, nextIteration, err)
 	}
 

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -62,7 +62,11 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
-		return ControlResult{Processed: true, Action: "pass"}, nil
+		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
+		}
+		return ControlResult{Processed: true, Action: "pass", Skipped: scopeResult.Skipped}, nil
 
 	case "hard":
 		if err := store.SetMetadataBatch(bead.ID, map[string]string{
@@ -76,11 +80,24 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := setOutcomeAndClose(store, bead.ID, "fail"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing hard-failed: %w", bead.ID, err)
 		}
-		return ControlResult{Processed: true, Action: "hard-fail"}, nil
+		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
+		}
+		return ControlResult{Processed: true, Action: "hard-fail", Skipped: scopeResult.Skipped}, nil
 
 	case "transient":
 		if attemptNum >= maxAttempts {
-			return handleRetryExhaustion(store, bead.ID, attemptNum, result.Reason, onExhausted)
+			exhaustedResult, err := handleRetryExhaustion(store, bead.ID, attemptNum, result.Reason, onExhausted)
+			if err != nil {
+				return ControlResult{}, err
+			}
+			scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+			if err != nil {
+				return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
+			}
+			exhaustedResult.Skipped += scopeResult.Skipped
+			return exhaustedResult, nil
 		}
 
 		// Spawn next attempt.
@@ -156,7 +173,11 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
-		return ControlResult{Processed: true, Action: "pass"}, nil
+		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
+		}
+		return ControlResult{Processed: true, Action: "pass", Skipped: scopeResult.Skipped}, nil
 	}
 
 	if iterationNum >= maxAttempts {
@@ -169,7 +190,11 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := setOutcomeAndClose(store, bead.ID, "fail"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", bead.ID, err)
 		}
-		return ControlResult{Processed: true, Action: "fail"}, nil
+		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
+		}
+		return ControlResult{Processed: true, Action: "fail", Skipped: scopeResult.Skipped}, nil
 	}
 
 	// Spawn next iteration.

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -246,6 +246,167 @@ func TestProcessRetryControlSoftFailOnExhaustion(t *testing.T) {
 	}
 }
 
+func TestProcessRetryControlClosesEnclosingScopeOnFailure(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	scopeBody := mustCreate(t, store, beads.Bead{
+		Title: "review iteration",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.2",
+			"gc.scope_role":   "body",
+		},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "apply fixes",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.review-loop.iteration.2.apply-fixes",
+			"gc.step_id":          "apply-fixes",
+			"gc.scope_ref":        "mol-test.review-loop.iteration.2",
+			"gc.scope_role":       "member",
+			"gc.max_attempts":     "3",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"apply-fixes","title":"Apply fixes","type":"task","retry":{"max_attempts":3}}`,
+			"gc.control_epoch":    "1",
+		},
+	})
+	sibling := mustCreate(t, store, beads.Bead{
+		Title: "cleanup note",
+		Metadata: map[string]string{
+			"gc.kind":         "task",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.2.cleanup-note",
+			"gc.scope_ref":    "mol-test.review-loop.iteration.2",
+			"gc.scope_role":   "member",
+		},
+	})
+	attempt1 := mustCreate(t, store, beads.Bead{
+		Title: "apply fixes attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id":   root.ID,
+			"gc.step_ref":       "mol-test.review-loop.iteration.2.apply-fixes.attempt.1",
+			"gc.attempt":        "1",
+			"gc.outcome":        "fail",
+			"gc.failure_class":  "hard",
+			"gc.failure_reason": "missing_review_artifact",
+		},
+	})
+	mustClose(t, store, attempt1.ID)
+	mustDep(t, store, control.ID, attempt1.ID, "blocks")
+	mustDep(t, store, scopeBody.ID, control.ID, "blocks")
+	mustDep(t, store, scopeBody.ID, sibling.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if !result.Processed || result.Action != "hard-fail" {
+		t.Fatalf("result = %+v, want processed hard-fail", result)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("result.Skipped = %d, want 1", result.Skipped)
+	}
+
+	controlAfter := mustGet(t, store, control.ID)
+	if controlAfter.Status != "closed" || controlAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("control = status %q outcome %q, want closed/fail", controlAfter.Status, controlAfter.Metadata["gc.outcome"])
+	}
+
+	scopeAfter := mustGet(t, store, scopeBody.ID)
+	if scopeAfter.Status != "closed" || scopeAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("scope body = status %q outcome %q, want closed/fail", scopeAfter.Status, scopeAfter.Metadata["gc.outcome"])
+	}
+
+	siblingAfter := mustGet(t, store, sibling.ID)
+	if siblingAfter.Status != "closed" || siblingAfter.Metadata["gc.outcome"] != "skipped" {
+		t.Fatalf("sibling = status %q outcome %q, want closed/skipped", siblingAfter.Status, siblingAfter.Metadata["gc.outcome"])
+	}
+}
+
+func TestProcessRetryControlClosesEnclosingScopeOnPassAndPropagatesMetadata(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	scopeBody := mustCreate(t, store, beads.Bead{
+		Title: "review iteration",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.2",
+			"gc.scope_role":   "body",
+		},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "apply fixes",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.review-loop.iteration.2.apply-fixes",
+			"gc.step_id":          "apply-fixes",
+			"gc.scope_ref":        "mol-test.review-loop.iteration.2",
+			"gc.scope_role":       "member",
+			"gc.max_attempts":     "3",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"apply-fixes","title":"Apply fixes","type":"task","retry":{"max_attempts":3}}`,
+			"gc.control_epoch":    "1",
+		},
+	})
+	attempt1 := mustCreate(t, store, beads.Bead{
+		Title: "apply fixes attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.2.apply-fixes.attempt.1",
+			"gc.attempt":      "1",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"verdict":"done"}`,
+			"review.verdict":  "done",
+			"review.summary":  "artifact restored",
+		},
+	})
+	mustClose(t, store, attempt1.ID)
+	mustDep(t, store, control.ID, attempt1.ID, "blocks")
+	mustDep(t, store, scopeBody.ID, control.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if !result.Processed || result.Action != "pass" {
+		t.Fatalf("result = %+v, want processed pass", result)
+	}
+
+	controlAfter := mustGet(t, store, control.ID)
+	if controlAfter.Status != "closed" || controlAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("control = status %q outcome %q, want closed/pass", controlAfter.Status, controlAfter.Metadata["gc.outcome"])
+	}
+
+	scopeAfter := mustGet(t, store, scopeBody.ID)
+	if scopeAfter.Status != "closed" || scopeAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("scope body = status %q outcome %q, want closed/pass", scopeAfter.Status, scopeAfter.Metadata["gc.outcome"])
+	}
+	if scopeAfter.Metadata["gc.output_json"] != `{"verdict":"done"}` {
+		t.Fatalf("scope body gc.output_json = %q, want propagated output", scopeAfter.Metadata["gc.output_json"])
+	}
+	if scopeAfter.Metadata["review.verdict"] != "done" {
+		t.Fatalf("scope body review.verdict = %q, want done", scopeAfter.Metadata["review.verdict"])
+	}
+	if scopeAfter.Metadata["review.summary"] != "artifact restored" {
+		t.Fatalf("scope body review.summary = %q, want artifact restored", scopeAfter.Metadata["review.summary"])
+	}
+}
+
 func TestProcessRetryControlInvariantViolation(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
@@ -620,6 +781,69 @@ func TestFindLatestAttemptScopeCheckNotMatched(t *testing.T) {
 	}
 	if found.ID != realAttempt.ID {
 		t.Fatalf("findLatestAttempt returned %q, want %q (scope-check should be skipped)", found.ID, realAttempt.ID)
+	}
+}
+
+func TestProcessRalphControlClosesEnclosingScopeOnIterationFailure(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	scopeBody := mustCreate(t, store, beads.Bead{
+		Title: "outer scope",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.outer-scope",
+			"gc.scope_role":   "body",
+		},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop",
+			"gc.step_id":      "review-loop",
+			"gc.scope_ref":    "mol-test.outer-scope",
+			"gc.scope_role":   "member",
+			"gc.max_attempts": "1",
+		},
+	})
+	iteration := mustCreate(t, store, beads.Bead{
+		Title: "review loop iteration 1",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.1",
+			"gc.scope_role":   "body",
+			"gc.attempt":      "1",
+			"gc.outcome":      "fail",
+		},
+	})
+	mustClose(t, store, iteration.ID)
+	mustDep(t, store, control.ID, iteration.ID, "blocks")
+	mustDep(t, store, scopeBody.ID, control.ID, "blocks")
+
+	result, err := processRalphControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRalphControl: %v", err)
+	}
+	if !result.Processed || result.Action != "fail" {
+		t.Fatalf("result = %+v, want processed fail", result)
+	}
+
+	controlAfter := mustGet(t, store, control.ID)
+	if controlAfter.Status != "closed" || controlAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("control = status %q outcome %q, want closed/fail", controlAfter.Status, controlAfter.Metadata["gc.outcome"])
+	}
+
+	scopeAfter := mustGet(t, store, scopeBody.ID)
+	if scopeAfter.Status != "closed" || scopeAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("scope body = status %q outcome %q, want closed/fail", scopeAfter.Status, scopeAfter.Metadata["gc.outcome"])
 	}
 }
 

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -847,6 +847,59 @@ func TestProcessRalphControlClosesEnclosingScopeOnIterationFailure(t *testing.T)
 	}
 }
 
+// TestReconcileClosedScopeMemberRalphPass covers the pass-side symmetry of
+// TestProcessRalphControlClosesEnclosingScopeOnIterationFailure: when a scoped
+// ralph control closes with gc.outcome=pass, reconcileClosedScopeMember must
+// auto-close the enclosing scope body with outcome=pass. Exercises the wiring
+// on control.go:176-183 without running the full check pipeline (which would
+// require an executable check script).
+func TestReconcileClosedScopeMemberRalphPass(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	scopeBody := mustCreate(t, store, beads.Bead{
+		Title: "outer scope",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.outer-scope",
+			"gc.scope_role":   "body",
+		},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop",
+			"gc.step_id":      "review-loop",
+			"gc.scope_ref":    "mol-test.outer-scope",
+			"gc.scope_role":   "member",
+			"gc.max_attempts": "3",
+		},
+	})
+	mustDep(t, store, scopeBody.ID, control.ID, "blocks")
+
+	// Simulate the terminal-pass close that processRalphControl performs
+	// at control.go:176 after a check returns GatePass.
+	if err := setOutcomeAndClose(store, control.ID, "pass"); err != nil {
+		t.Fatalf("setOutcomeAndClose: %v", err)
+	}
+
+	if _, err := reconcileClosedScopeMember(store, control.ID); err != nil {
+		t.Fatalf("reconcileClosedScopeMember: %v", err)
+	}
+
+	scopeAfter := mustGet(t, store, scopeBody.ID)
+	if scopeAfter.Status != "closed" || scopeAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("scope body = status %q outcome %q, want closed/pass", scopeAfter.Status, scopeAfter.Metadata["gc.outcome"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // buildAttemptRecipe tests
 // ---------------------------------------------------------------------------

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -287,6 +287,11 @@ func reconcileTerminalScopedMember(store beads.Store, bead beads.Bead) (ControlR
 			return ControlResult{}, fmt.Errorf("%s: aborting scope: %w", bead.ID, err)
 		}
 		if body.Status != "closed" {
+			// Propagate non-gc.* member metadata (e.g., review.verdict) onto the
+			// scope body before closing, so diagnostics survive failure auto-close.
+			if err := propagateScopeMemberMetadata(store, rootID, scopeRef, body.ID); err != nil {
+				return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
+			}
 			if err := setOutcomeAndClose(store, body.ID, "fail"); err != nil {
 				return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
 			}
@@ -568,6 +573,11 @@ func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 	})
 }
 
+// reconcileClosedScopeMember re-reads the just-closed bead and delegates to
+// reconcileTerminalScopedMember. Callers invoke it immediately after
+// setOutcomeAndClose, so this relies on the store being read-after-write
+// consistent (true for MemStore today). If a future store becomes eventually
+// consistent, pass the in-memory closed bead directly instead of re-reading.
 func reconcileClosedScopeMember(store beads.Store, beadID string) (ControlResult, error) {
 	closedBead, err := store.Get(beadID)
 	if err != nil {

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -309,6 +309,9 @@ func reconcileTerminalScopedMember(store beads.Store, bead beads.Bead) (ControlR
 	if bodyAfter.Status == "closed" {
 		return ControlResult{}, nil
 	}
+	if err := propagateScopeMemberMetadata(store, rootID, scopeRef, body.ID); err != nil {
+		return ControlResult{}, fmt.Errorf("%s: propagating scope metadata: %w", bead.ID, err)
+	}
 	outputJSON, err := resolveScopeOutputJSON(store, rootID, scopeRef, bead)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: resolving scope output: %w", bead.ID, err)
@@ -563,6 +566,17 @@ func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 		Status:   &status,
 		Metadata: map[string]string{"gc.outcome": outcome},
 	})
+}
+
+func reconcileClosedScopeMember(store beads.Store, beadID string) (ControlResult, error) {
+	closedBead, err := store.Get(beadID)
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: reloading closed scoped member: %w", beadID, err)
+	}
+	if closedBead.Status != "closed" {
+		return ControlResult{}, nil
+	}
+	return reconcileTerminalScopedMember(store, closedBead)
 }
 
 func matchesScopeRef(bead beads.Bead, scopeRef string) bool {


### PR DESCRIPTION
## Summary

- close enclosing scope bodies when retry / ralph control beads finish terminally, not just from fanout paths
- propagate non-`gc.*` member metadata when a scope auto-closes through terminal-member reconciliation
- let built-in `control-dispatcher` workers claim legacy `workflow-control` routes / assignees so pre-rename workflows keep moving

This was driven by live workflow stalls in the `ga` store:
- old review loops could leave a `gc.kind=scope` body open forever after terminal retry / ralph members closed
- older graphs still routed control work to `workflow-control` / `gascity/workflow-control`, while the runtime only woke `control-dispatcher`

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Additional validation:
- focused regressions in `internal/dispatch` for retry / ralph terminal scope reconciliation
- executable `internal/config` tests proving `control-dispatcher` work queries claim legacy `workflow-control` assignees and routes
- live verification against the shared `ga` store:
  - repaired stale scope `ga-qljmkm`, then `gc convoy control ga-vc6558` resumed the loop (`action=retry created=1`)
  - legacy rig control bead `ga-rwpb6` processed under the new path
  - legacy city-scoped control bead `ga-4ujz` processed to `gc.outcome=pass`

## Checklist

- [x] Linked an issue, or explained why one is not needed
  - No single repo issue existed; this came from live workflow incident triage.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
  - No breaking API change. This adds backward compatibility for legacy `workflow-control` metadata.
