### PR TITLE
fix: add PID-port coherence check and clean up stale dolt state (#525)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -131,6 +132,8 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 		if port := currentDoltPort(cityPath); port != "" {
 			env["GC_DOLT_PORT"] = port
 		}
+	} else {
+		log.Printf("beads provider health check failed for %s: %v", cityPath, err)
 	}
 	// When dolt.auto-start is disabled and no live port was found, propagate
 	// the stale port from the port file so bd will attempt to connect to it

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -443,6 +443,7 @@ func TestBdRuntimeEnvForRigUsesManagedRigPort(t *testing.T) {
 }
 
 func TestBdRuntimeEnvForRigFallsBackToManagedCityPort(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
@@ -486,6 +487,7 @@ func TestBdRuntimeEnvForRigFallsBackToManagedCityPort(t *testing.T) {
 }
 
 func TestBdRuntimeEnvForRigPrefersExplicitRigDoltConfigOverManagedCity(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -585,6 +586,13 @@ func currentManagedDoltPort(cityPath string) string {
 			continue
 		}
 		if !validDoltRuntimeState(state, cityPath) {
+			// Clean up state files where Running is true but the PID is dead.
+			// These are stale orphans from crashed processes. Don't remove
+			// intentional stop markers (Running: false) — those signal that
+			// gc-beads-bd op_stop ran and hasManagedDoltState relies on them.
+			if state.Running && state.PID > 0 && !pidAlive(state.PID) {
+				_ = os.Remove(statePath)
+			}
 			continue
 		}
 		candidates = append(candidates, candidate{path: statePath, state: state})
@@ -626,6 +634,9 @@ func validDoltRuntimeState(state doltRuntimeState, cityPath string) bool {
 	if !pidAlive(state.PID) {
 		return false
 	}
+	if !pidIsDoltCheck(state.PID) {
+		return false
+	}
 	if !doltPortReachable(strconv.Itoa(state.Port)) {
 		return false
 	}
@@ -638,6 +649,31 @@ func pidAlive(pid int) bool {
 	}
 	err := syscall.Kill(pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+// pidIsDoltCheck is the live coherence check used by validDoltRuntimeState.
+// Tests override this to bypass /proc inspection (the test process is not dolt).
+var pidIsDoltCheck = pidIsDolt
+
+// pidIsDolt verifies that the given PID belongs to a dolt process by reading
+// /proc/<pid>/cmdline on Linux. On other platforms or when /proc is unavailable,
+// it returns true (graceful degradation to the pre-existing behavior).
+func pidIsDolt(pid int) bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		// /proc unavailable or process already gone — degrade gracefully.
+		return true
+	}
+	// cmdline is null-delimited; the first field is the binary path/name.
+	fields := bytes.Split(data, []byte{0})
+	if len(fields) == 0 {
+		return true
+	}
+	bin := string(fields[0])
+	return strings.Contains(filepath.Base(bin), "dolt")
 }
 
 func doltPortReachable(port string) bool {
@@ -660,7 +696,10 @@ func writeDoltPortFile(dir, port string) {
 	if data, err := os.ReadFile(portFile); err == nil && strings.TrimSpace(string(data)) == port {
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(portFile), 0o755); err != nil {
+	// Only write if the parent directory already exists. Do not create
+	// .beads/ as a side effect of reading the current port — directory
+	// creation belongs in explicit initialization paths.
+	if _, err := os.Stat(filepath.Dir(portFile)); err != nil {
 		return
 	}
 	_ = os.WriteFile(portFile, []byte(port+"\n"), 0o644)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -170,6 +170,7 @@ func TestShutdownBeadsProvider_bd_skip(t *testing.T) {
 }
 
 func TestCurrentDoltPortPrefersRuntimeState(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
@@ -208,6 +209,7 @@ func TestCurrentDoltPortPrefersRuntimeState(t *testing.T) {
 }
 
 func TestSyncConfiguredDoltPortFilesWritesArbitraryRigPaths(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(t.TempDir(), "foobar")
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
@@ -260,6 +262,7 @@ func TestSyncConfiguredDoltPortFilesWritesArbitraryRigPaths(t *testing.T) {
 }
 
 func TestCurrentDoltPortIgnoresDeadRuntimeStateAndPrunesDeadPortFile(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
@@ -326,6 +329,7 @@ func TestCurrentDoltPortIgnoresReachablePortFileWhenManagedStateIsStopped(t *tes
 }
 
 func TestReadDoltPortOverwritesInheritedValue(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	ln := listenOnRandomPort(t)
 	t.Cleanup(func() { _ = ln.Close() })
@@ -977,6 +981,17 @@ esac
 	}
 }
 
+// skipPidIsDoltCheck overrides the pidIsDoltCheck function to always return
+// true for the duration of the test. Existing tests use os.Getpid() as the
+// PID in dolt state files; the test process is not dolt, so the coherence
+// check must be bypassed for these tests to exercise port-resolution logic.
+func skipPidIsDoltCheck(t *testing.T) {
+	t.Helper()
+	old := pidIsDoltCheck
+	pidIsDoltCheck = func(int) bool { return true }
+	t.Cleanup(func() { pidIsDoltCheck = old })
+}
+
 func listenOnRandomPort(t *testing.T) net.Listener {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -1164,6 +1179,7 @@ func TestStartBeadsLifecycleRegistersDoltConfig(t *testing.T) {
 // ── readDoltPort with external host ───────────────────────────────────
 
 func TestReadDoltPortPreservesExternalHostPort(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityDir := t.TempDir()
 	// Register per-city config (simulates startBeadsLifecycle having run).
 	cityDoltConfigs.Store(cityDir, config.DoltConfig{Host: "mini2.hippo-tilapia.ts.net", Port: 3307})
@@ -1229,5 +1245,101 @@ func TestStartBeadsLifecycleSkipsProviderForExternalHost(t *testing.T) {
 		if strings.TrimSpace(line) == "start" {
 			t.Errorf("ensureBeadsProvider('start') was called — should be skipped for external host with bd provider")
 		}
+	}
+}
+
+// ── PID-port coherence tests ────────────────────────────────────────────
+
+// TestValidDoltRuntimeStateRejectsNonDoltPID verifies that
+// validDoltRuntimeState rejects a state entry where the PID is alive
+// but belongs to a non-dolt process (e.g., the test binary itself).
+func TestValidDoltRuntimeStateRejectsNonDoltPID(t *testing.T) {
+	// Do NOT call skipPidIsDoltCheck — we want the real check.
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	ln := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	state := doltRuntimeState{
+		Running: true,
+		PID:     os.Getpid(), // alive but not dolt
+		Port:    ln.Addr().(*net.TCPAddr).Port,
+		DataDir: filepath.Join(cityDir, ".beads", "dolt"),
+	}
+	if validDoltRuntimeState(state, cityDir) {
+		t.Fatal("validDoltRuntimeState should reject state where PID is alive but not a dolt process")
+	}
+}
+
+// TestCurrentManagedDoltPortCleansUpDeadPIDState verifies that
+// currentManagedDoltPort removes stale state files for dead PIDs.
+func TestCurrentManagedDoltPortCleansUpDeadPIDState(t *testing.T) {
+	skipPidIsDoltCheck(t)
+	cityDir := t.TempDir()
+	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a PID that is very unlikely to be alive. PID 2 is kthreadd on Linux
+	// and only accessible by root; for non-root test processes, pidAlive
+	// returns true (EPERM). Use a very large PID that won't exist.
+	deadPID := 4194300 // near pid_max, very unlikely to be alive
+	if err := writeDoltState(cityDir, doltRuntimeState{
+		Running: true,
+		PID:     deadPID,
+		Port:    39999,
+		DataDir: filepath.Join(cityDir, ".beads", "dolt"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	statePath := filepath.Join(stateDir, "dolt-state.json")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file should exist before test: %v", err)
+	}
+
+	got := currentManagedDoltPort(cityDir)
+	if got != "" {
+		t.Fatalf("currentManagedDoltPort = %q, want empty for dead PID state", got)
+	}
+
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("stale state file for dead PID should be removed, stat err = %v", err)
+	}
+}
+
+// TestWriteDoltPortFileSkipsMkdirWhenBeadsDirMissing verifies that
+// writeDoltPortFile does not create .beads/ as a side effect.
+func TestWriteDoltPortFileSkipsMkdirWhenBeadsDirMissing(t *testing.T) {
+	dir := t.TempDir()
+	// Do NOT create .beads/ directory.
+	writeDoltPortFile(dir, "12345")
+
+	beadsDir := filepath.Join(dir, ".beads")
+	if _, err := os.Stat(beadsDir); !os.IsNotExist(err) {
+		t.Fatalf(".beads/ should not be created by writeDoltPortFile, stat err = %v", err)
+	}
+}
+
+// TestWriteDoltPortFileWritesWhenBeadsDirExists verifies that
+// writeDoltPortFile writes the port file when .beads/ already exists.
+func TestWriteDoltPortFileWritesWhenBeadsDirExists(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	writeDoltPortFile(dir, "12345")
+
+	data, err := os.ReadFile(filepath.Join(dir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("port file should exist: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "12345" {
+		t.Fatalf("port file = %q, want %q", got, "12345")
 	}
 }

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1525,6 +1525,7 @@ func TestBuildDesiredState_PoolCheckOmitsDoltPortForCityScopedAgent(t *testing.T
 }
 
 func TestBuildDesiredState_PoolCheckUsesManagedCityDoltPortWhenRigHasNoOverride(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	t.Setenv("GC_BEADS", "bd")
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "myrig")

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -142,6 +142,7 @@ func TestDoRigAdd_IdempotentSameNameSamePath(t *testing.T) {
 }
 
 func TestDoRigAdd_WritesPortFileForExternalRig(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -214,6 +214,7 @@ func TestResolveTemplateRigScopedEnvCarriesRigRoots(t *testing.T) {
 }
 
 func TestResolveTemplateUsesCityManagedDoltPort(t *testing.T) {
+	skipPidIsDoltCheck(t)
 	cityPath := t.TempDir()
 	writeTemplateResolveCityConfig(t, cityPath, "")
 	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")


### PR DESCRIPTION
## Summary

Fixes three related defects that cause `bd` connection failures after dolt restarts (gastownhall/gascity#525):

Fixes #525 

1. **PID-port coherence**: `validDoltRuntimeState()` checked PID alive and port reachable independently — now verifies the PID is actually a dolt process via `/proc/<pid>/cmdline` on Linux (graceful degradation on other platforms)
2. **Stale state cleanup**: `currentManagedDoltPort()` now removes dolt-state.json files where `Running: true` but the PID is dead
3. **Side-effect guard**: `writeDoltPortFile()` no longer creates `.beads/` via `MkdirAll` — replaced with `Stat` guard so directory creation only happens in explicit initialization paths
4. **Error observability**: `bdRuntimeEnv()` recovery path now logs `healthBeadsProvider` errors instead of silently dropping them

## What was tested

- `make fmt-check` — clean
- `make lint` — 0 issues
- `make vet` — clean
- New unit tests:
  - `TestValidDoltRuntimeStateRejectsNonDoltPID` — coherence check rejects non-dolt PID
  - `TestCurrentManagedDoltPortCleansUpDeadPIDState` — dead PID state files are removed
  - `TestWriteDoltPortFileSkipsMkdirWhenBeadsDirMissing` — no `.beads/` side effect
  - `TestWriteDoltPortFileWritesWhenBeadsDirExists` — write succeeds when dir exists
- Existing tests updated with `skipPidIsDoltCheck` to bypass `/proc` inspection where test process isn't dolt

## Review outcome

Single clean commit on top of main. Branch was cleaned up from a prior session that had accumulated unrelated commits.

## Changes

- `cmd/gc/beads_provider_lifecycle.go` — `pidIsDolt()` coherence check, stale state cleanup, `writeDoltPortFile` guard
- `cmd/gc/beads_provider_lifecycle_test.go` — 4 new tests, `skipPidIsDoltCheck` helper
- `cmd/gc/bd_env.go` — error logging in `bdRuntimeEnv`
- `cmd/gc/bd_env_test.go`, `cmd/gc/build_desired_state_test.go`, `cmd/gc/cmd_rig_test.go`, `cmd/gc/template_resolve_workdir_test.go` — `skipPidIsDoltCheck` where needed