### PR TITLE
fix: preserve rig-owned dolt port during city sync

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -676,6 +676,12 @@ func syncConfiguredDoltPortFiles(cityPath string, rigs []config.Rig) {
 		if rigs[i].DoltHost != "" || rigs[i].DoltPort != "" {
 			continue
 		}
+		// Skip rigs that already have a live Dolt server on a different
+		// port — their port file is authoritative and must not be
+		// overwritten with the city's managed port.
+		if rigPort := currentDoltPort(rigs[i].Path); rigPort != "" && rigPort != port {
+			continue
+		}
 		normalizeManagedDoltConfig(rigs[i].Path)
 		if port != "" {
 			writeDoltPortFile(rigs[i].Path, port)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -168,6 +168,68 @@ func TestSyncConfiguredDoltPortFilesWritesArbitraryRigPaths(t *testing.T) {
 	}
 }
 
+func TestSyncConfiguredDoltPortFilesPreservesRigOwnDolt(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "myrig")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// City dolt on one port.
+	cityLn := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = cityLn.Close() })
+	cityPort := fmt.Sprintf("%d", cityLn.Addr().(*net.TCPAddr).Port)
+
+	// Rig has its own dolt on a different port.
+	rigLn := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = rigLn.Close() })
+	rigPort := fmt.Sprintf("%d", rigLn.Addr().(*net.TCPAddr).Port)
+
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".beads", "config.yaml"), []byte("dolt.auto-start: false\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Write the rig's own port BEFORE sync.
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte(rigPort+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeDoltState(cityDir, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      cityLn.Addr().(*net.TCPAddr).Port,
+		DataDir:   filepath.Join(cityDir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	syncConfiguredDoltPortFiles(cityDir, []config.Rig{{Name: "myrig", Path: rigDir}})
+
+	// City port file should have the city's port.
+	data, err := os.ReadFile(filepath.Join(cityDir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("read city port file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != cityPort {
+		t.Fatalf("city port file = %q, want %q", got, cityPort)
+	}
+
+	// Rig port file must NOT be clobbered — should still have the rig's own port.
+	data, err = os.ReadFile(filepath.Join(rigDir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("read rig port file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != rigPort {
+		t.Fatalf("rig port file = %q, want %q (was clobbered with city port)", got, rigPort)
+	}
+}
+
 func TestCurrentDoltPortIgnoresDeadRuntimeStateAndPrunesDeadPortFile(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {


### PR DESCRIPTION
## Summary
- When a rig runs its own dolt server on a different port, `syncConfiguredDoltPortFiles` was overwriting the rig's port file with the city-managed port, breaking cross-rig `bd` commands
- Skip port sync for rigs that already have a live dolt server on a different port — their port file is authoritative
- Adds test verifying rig port is preserved when city port differs

## Test plan
- [x] `TestSyncConfiguredDoltPortFilesPreservesRigOwnDolt` passes
- [x] Existing `TestSyncConfiguredDoltPortFiles*` tests still pass
- [x] Verified cross-rig `gc sling` works end-to-end after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)