### PR TITLE
fix: exec beads provider CRUD passthrough to bd

### DIFF
--- a/cmd/gc/embed_beads_bd_test.go
+++ b/cmd/gc/embed_beads_bd_test.go
@@ -82,6 +82,73 @@ func TestBeadsBdScript_K8sDoltEnvInheritance(t *testing.T) {
 	}
 }
 
+// TestBeadsBdScript_CRUDGetForwardsToBd verifies that the "get" CRUD
+// operation forwards to "bd show --json" and transforms the output.
+func TestBeadsBdScript_CRUDGetForwardsToBd(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "get" with a non-existent ID should exit 1 (bd show fails),
+	// not exit 2 (unknown operation).
+	cmd := exec.Command(scriptPath, "get", "nonexistent-id-12345")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		// GC_DOLT intentionally NOT set — CRUD ops need to reach bd.
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+	}
+	// Should be exit 1 (bd show returns error for missing bead), NOT exit 2
+	// (which would mean "get" is unrecognized). Exit 0 is also acceptable if
+	// bd is not installed (the test validates the script dispatches correctly).
+	if exitCode == 2 {
+		t.Errorf("gc-beads-bd get: exit 2 means 'get' was not recognized as a CRUD operation\noutput: %s", out)
+	}
+}
+
+// TestBeadsBdScript_CRUDListForwardsToBd verifies that the "list" CRUD
+// operation forwards to bd and doesn't exit 2.
+func TestBeadsBdScript_CRUDListForwardsToBd(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "list")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		// GC_DOLT intentionally NOT set — CRUD ops need to reach bd.
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+	}
+	if exitCode == 2 {
+		t.Errorf("gc-beads-bd list: exit 2 means 'list' was not recognized as a CRUD operation\noutput: %s", out)
+	}
+}
+
 func TestMaterializeBeadsBdScript_idempotent(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -1293,6 +1293,16 @@ case "$op" in
         from_field=$(printf '%s' "$input" | jq -r '.from // ""')
         metadata_json=$(printf '%s' "$input" | jq -c '.metadata // empty')
 
+        # bd doesn't have a --from flag; store "from" in metadata (matches
+        # BdStore.Create behaviour in the Go code).
+        if [ -n "$from_field" ]; then
+            if [ -n "$metadata_json" ]; then
+                metadata_json=$(printf '%s' "$metadata_json" | jq -c --arg f "$from_field" '. + {from: $f}')
+            else
+                metadata_json=$(jq -nc --arg f "$from_field" '{from: $f}')
+            fi
+        fi
+
         # Collect labels.
         labels=""
         for label in $(printf '%s' "$input" | jq -r '.labels // [] | .[]'); do
@@ -1306,7 +1316,6 @@ case "$op" in
         set -- create --json --type="$bead_type"
         [ -n "$description" ] && set -- "$@" --description "$description"
         [ -n "$assignee" ] && set -- "$@" --assignee "$assignee"
-        [ -n "$from_field" ] && set -- "$@" --from "$from_field"
         [ -n "$labels" ] && set -- "$@" --labels "$labels"
         [ -n "$metadata_json" ] && set -- "$@" --metadata "$metadata_json"
         set -- "$@" "$title"

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -1,10 +1,11 @@
 #!/bin/sh
 # gc-beads-bd — exec: beads provider for Dolt-backed beads (bd).
 #
-# Implements the exec beads lifecycle protocol:
+# Implements the full exec beads provider protocol:
 #   gc-beads-bd <operation> [args...]
 #
-# Operations: start, ensure-ready, stop, shutdown, init, health, recover, probe
+# Lifecycle operations: start, ensure-ready, stop, shutdown, init, health, recover, probe
+# CRUD operations: get, list, list-by-label, children, create, update, close, delete, set-metadata
 # Exit codes: 0 = success, 1 = error, 2 = not needed / not running
 #
 # Environment:
@@ -1196,7 +1197,62 @@ CONFIG_FILE="$PACK_STATE_DIR/dolt-config.yaml"
 # Resolve DOLT_PORT now that STATE_FILE is set.
 DOLT_PORT=$(allocate_port)
 
+# --- CRUD helpers ---
+# bd_to_gc converts a single bd JSON object to the exec beads wire format.
+# bd uses "issue_type" where the exec protocol uses "type"; status values
+# like blocked/review/testing map to "open".
+bd_to_gc() {
+    jq '{
+      id: .id,
+      title: .title,
+      status: (if .status == "blocked" or .status == "review" or .status == "testing" then "open" else .status end),
+      type: (.issue_type // .type // "task"),
+      created_at: .created_at,
+      assignee: (.assignee // ""),
+      from: (.from // ""),
+      parent_id: ([.labels // [] | .[] | select(startswith("parent:")) | ltrimstr("parent:")] | first // ""),
+      ref: (.ref // ""),
+      needs: [.labels // [] | .[] | select(startswith("needs:")) | ltrimstr("needs:")],
+      description: (.description // .notes // ""),
+      labels: [.labels // [] | .[] | select((startswith("parent:") or startswith("meta:") or startswith("needs:")) | not)],
+      metadata: (([.labels // [] | .[] | select(startswith("meta:")) | ltrimstr("meta:") | split("=") | {(.[0]): (.[1:] | join("="))}] | add // {}) + (.metadata // {}) | map_values(tostring))
+    }'
+}
+
+# bd_list_to_gc converts a bd JSON array to exec beads wire format.
+bd_list_to_gc() {
+    jq '[.[] | {
+      id: .id,
+      title: .title,
+      status: (if .status == "blocked" or .status == "review" or .status == "testing" then "open" else .status end),
+      type: (.issue_type // .type // "task"),
+      created_at: .created_at,
+      assignee: (.assignee // ""),
+      from: (.from // ""),
+      parent_id: ([.labels // [] | .[] | select(startswith("parent:")) | ltrimstr("parent:")] | first // ""),
+      ref: (.ref // ""),
+      needs: [.labels // [] | .[] | select(startswith("needs:")) | ltrimstr("needs:")],
+      description: (.description // .notes // ""),
+      labels: [.labels // [] | .[] | select((startswith("parent:") or startswith("meta:") or startswith("needs:")) | not)],
+      metadata: (([.labels // [] | .[] | select(startswith("meta:")) | ltrimstr("meta:") | split("=") | {(.[0]): (.[1:] | join("="))}] | add // {}) + (.metadata // {}) | map_values(tostring))
+    }]'
+}
+
+# join_labels joins arguments with commas for bd --labels flag.
+join_labels() {
+    local result=""
+    for label in "$@"; do
+        if [ -n "$result" ]; then
+            result="$result,$label"
+        else
+            result="$label"
+        fi
+    done
+    printf '%s' "$result"
+}
+
 case "$op" in
+    # --- Lifecycle operations ---
     start)        op_start ;;
     ensure-ready) op_ensure_ready ;;
     init)         op_init "$@" ;;
@@ -1205,5 +1261,92 @@ case "$op" in
     recover)      op_recover ;;
     stop)         op_stop ;;
     shutdown)     op_shutdown ;;
-    *)            exit 2 ;;  # Unknown operation — forward compatible.
+
+    # --- CRUD operations (forwarded to bd) ---
+    get)
+        id="${1:?get: missing id}"
+        bd show --json "$id" | jq '.[0]' | bd_to_gc
+        ;;
+    list)
+        bd list --json --limit 0 --all "$@" | bd_list_to_gc
+        ;;
+    list-by-label)
+        label="${1:?list-by-label: missing label}"
+        limit="${2:-0}"
+        if [ "$limit" -gt 0 ] 2>/dev/null; then
+            bd list --json --all --label "$label" --limit "$limit" | bd_list_to_gc
+        else
+            bd list --json --all --label "$label" | bd_list_to_gc
+        fi
+        ;;
+    children)
+        parent_id="${1:?children: missing parent_id}"
+        bd list --json --all --label "parent:$parent_id" | bd_list_to_gc | jq 'sort_by(.created_at)'
+        ;;
+    create)
+        input=$(cat)
+        title=$(printf '%s' "$input" | jq -r '.title')
+        bead_type=$(printf '%s' "$input" | jq -r '.type // "task"')
+        parent_id=$(printf '%s' "$input" | jq -r '.parent_id // ""')
+        description=$(printf '%s' "$input" | jq -r '.description // ""')
+        assignee=$(printf '%s' "$input" | jq -r '.assignee // ""')
+        from_field=$(printf '%s' "$input" | jq -r '.from // ""')
+        metadata_json=$(printf '%s' "$input" | jq -c '.metadata // empty')
+
+        # Collect labels.
+        labels=""
+        for label in $(printf '%s' "$input" | jq -r '.labels // [] | .[]'); do
+            [ -n "$label" ] && labels="${labels:+$labels,}$label"
+        done
+        [ -n "$parent_id" ] && labels="${labels:+$labels,}parent:$parent_id"
+        for need in $(printf '%s' "$input" | jq -r '.needs // [] | .[]'); do
+            [ -n "$need" ] && labels="${labels:+$labels,}needs:$need"
+        done
+
+        set -- create --json --type="$bead_type"
+        [ -n "$description" ] && set -- "$@" --description "$description"
+        [ -n "$assignee" ] && set -- "$@" --assignee "$assignee"
+        [ -n "$from_field" ] && set -- "$@" --from "$from_field"
+        [ -n "$labels" ] && set -- "$@" --labels "$labels"
+        [ -n "$metadata_json" ] && set -- "$@" --metadata "$metadata_json"
+        set -- "$@" "$title"
+
+        bd "$@" | bd_to_gc
+        ;;
+    update)
+        id="${1:?update: missing id}"
+        input=$(cat)
+        set -- update --json "$id"
+
+        description=$(printf '%s' "$input" | jq -r '.description // empty')
+        [ -n "$description" ] && set -- "$@" --description "$description"
+
+        for label in $(printf '%s' "$input" | jq -r '.labels // [] | .[]'); do
+            [ -n "$label" ] && set -- "$@" --add-label "$label"
+        done
+
+        parent_id=$(printf '%s' "$input" | jq -r '.parent_id // empty')
+        [ -n "$parent_id" ] && set -- "$@" --add-label "parent:$parent_id"
+
+        metadata_json=$(printf '%s' "$input" | jq -c '.metadata // empty')
+        [ -n "$metadata_json" ] && set -- "$@" --metadata "$metadata_json"
+
+        bd "$@" > /dev/null
+        ;;
+    close)
+        id="${1:?close: missing id}"
+        bd close --json "$id" > /dev/null
+        ;;
+    delete)
+        id="${1:?delete: missing id}"
+        bd delete --force "$id" > /dev/null 2>&1 || true
+        ;;
+    set-metadata)
+        id="${1:?set-metadata: missing id}"
+        key="${2:?set-metadata: missing key}"
+        value=$(cat)
+        bd update --json "$id" --set-metadata "${key}=${value}" > /dev/null
+        ;;
+
+    *)  exit 2 ;;  # Unknown operation — forward compatible.
 esac

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -195,6 +195,13 @@ func (s *Store) Get(id string) (beads.Bead, error) {
 		}
 		return beads.Bead{}, fmt.Errorf("getting bead %q: %w", id, err)
 	}
+	// Empty output means the script didn't implement the operation (exit
+	// code 2, treated as success by run()) or returned nothing. Treat as
+	// not-found so callers fall through to alias/session-name resolution
+	// instead of failing on a JSON parse error.
+	if strings.TrimSpace(out) == "" {
+		return beads.Bead{}, fmt.Errorf("getting bead %q: %w", id, beads.ErrNotFound)
+	}
 	result, err := parseBead(out)
 	if err != nil {
 		return beads.Bead{}, fmt.Errorf("exec beads get: %w", err)
@@ -263,6 +270,16 @@ func (s *Store) List(query beads.ListQuery) ([]beads.Bead, error) {
 		args := []string{"list"}
 		if query.Status != "" {
 			args = append(args, "--status="+query.Status)
+		}
+		// Pass type and assignee filters to the script so backends
+		// that partition by type (e.g. bd with wisp beads) return
+		// the correct subset. Client-side ApplyListQuery still runs
+		// for any remaining filters.
+		if query.Type != "" {
+			args = append(args, "--type="+query.Type)
+		}
+		if query.Assignee != "" {
+			args = append(args, "--assignee="+query.Assignee)
 		}
 		out, err = s.run(nil, args...)
 	}

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -498,6 +498,27 @@ esac
 	}
 }
 
+func TestGet_emptyOutputTreatedAsNotFound(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate a script that doesn't implement "get" (exits 2, which
+	// run() treats as success with empty output).
+	script := writeScript(t, dir, `
+case "$1" in
+  get) exit 2 ;;
+  *) exit 2 ;;
+esac
+`)
+	s := NewStore(script)
+
+	_, err := s.Get("mayor")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	dir := t.TempDir()
 	outFile := filepath.Join(dir, "stdin.json")

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -82,6 +82,101 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+// TestCreate_fromFieldRoundTrips verifies that the "from" field set during
+// Create survives a round-trip through the exec beads provider. This
+// validates the protocol contract: providers that lack a native --from
+// flag must store it in metadata and expose it on read.
+func TestCreate_fromFieldRoundTrips(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available")
+	}
+	scriptPath, err := filepath.Abs(filepath.Join("testdata", "conformance.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(scriptPath)
+	s.SetEnv(map[string]string{"BEADS_DIR": t.TempDir()})
+
+	created, err := s.Create(beads.Bead{
+		Title:       "HANDOFF: session 3",
+		Type:        "message",
+		Description: "Detailed handoff context goes here.",
+		Assignee:    "mayor",
+		From:        "mayor",
+		Labels:      []string{"gc:message", "thread:abc123"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.From != "mayor" {
+		t.Errorf("created.From = %q, want %q", created.From, "mayor")
+	}
+
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.From != "mayor" {
+		t.Errorf("Get.From = %q, want %q", got.From, "mayor")
+	}
+	if got.Assignee != "mayor" {
+		t.Errorf("Get.Assignee = %q, want %q", got.Assignee, "mayor")
+	}
+	if got.Description != "Detailed handoff context goes here." {
+		t.Errorf("Get.Description = %q, want handoff context", got.Description)
+	}
+}
+
+// TestCreate_multilineDescriptionRoundTrips verifies that descriptions
+// containing newlines, markdown formatting, and special characters survive
+// the exec provider round-trip. This is the scenario that causes the
+// "JSON parse error on long messages" bug when the provider script doesn't
+// properly handle multi-line descriptions.
+func TestCreate_multilineDescriptionRoundTrips(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available")
+	}
+	scriptPath, err := filepath.Abs(filepath.Join("testdata", "conformance.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(scriptPath)
+	s.SetEnv(map[string]string{"BEADS_DIR": t.TempDir()})
+
+	longDesc := "# Handoff — Session 3\n\n" +
+		"## What was done\n\n" +
+		"### MCDClient PR review\n" +
+		"- Approved 7 PRs (#934, 935, 939, 940, 942, 943, 944)\n" +
+		"- Commented on #941 (CardArtID vs VariantID question)\n\n" +
+		"### Special characters\n" +
+		"- Quotes: \"double\" and 'single'\n" +
+		"- Backslashes: C:\\Users\\test\n" +
+		"- Unicode: café, naïve, 日本語\n" +
+		"- Tabs:\there\tand\there"
+
+	created, err := s.Create(beads.Bead{
+		Title:       "HANDOFF: multiline test",
+		Type:        "message",
+		Description: longDesc,
+		Assignee:    "mayor",
+		From:        "mayor",
+		Labels:      []string{"gc:message"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Description != longDesc {
+		t.Errorf("Description mismatch.\ngot:  %q\nwant: %q", got.Description, longDesc)
+	}
+}
+
 func TestCreate_stdinReachesScript(t *testing.T) {
 	dir := t.TempDir()
 	outFile := filepath.Join(dir, "stdin.json")


### PR DESCRIPTION
## Summary
- `gc-beads-bd` (exec beads provider script) only implemented lifecycle ops (start/stop/health/probe)
- CRUD ops (get/list/create/update) exited code 2, which the exec store treated as success with empty output
- This broke session resolution and mail delivery in all managed sessions using the exec provider

## Changes
1. `gc-beads-bd` — Added CRUD handlers that forward to `bd` with JSON transforms
2. `exec.go` Get — Returns `ErrNotFound` on empty output (safety net)
3. `exec.go` List — Passes `--type`/`--assignee` filters to script

## Nightly CI impact
The Tier C nightly (`TestGastown_MayorDispatchPipeline`) fails intermittently with:
```
beads get: parsing JSON: unexpected end of JSON input
gc mail inbox: looking up session "repo/witness": exec beads get: parsing JSON: unexpected end of JSON input
```
These are the exec store CRUD returning empty output for Get operations — exactly what this PR fixes.

## Test plan
- [x] Mail delivery works in managed sessions
- [x] Cross-rig sling test: `projectwrenunity-gra` dispatched and completed
- [ ] CI
- [ ] Nightly Tier C should stop seeing JSON parsing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)