### PR TITLE
fix: route rig dolt env to scale_check regardless of city provider

### DIFF
--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -14,9 +14,14 @@ func controllerQueryEnv(cityPath string, cfg *config.City, agentCfg *config.Agen
 	if strings.TrimSpace(cityPath) == "" || cfg == nil || agentCfg == nil {
 		return nil
 	}
-	if rawBeadsProvider(cityPath) != "bd" {
-		return nil
-	}
+	// Rig agents must always get rig dolt env propagated regardless of the
+	// city's beads provider — a rig may use bd/dolt even when the city uses
+	// the file provider. The previous gate `if rawBeadsProvider(cityPath) !=
+	// "bd"` skipped this, leaving rig pool scale_check subprocesses inheriting
+	// the controller's process-level BEADS_DOLT_SERVER_PORT (set by
+	// readDoltPort to the city's dolt port) which routed bd queries to the
+	// wrong server. For city agents, fall back to the city env only when the
+	// city itself uses bd.
 	var source map[string]string
 	if rigName := configuredRigName(cityPath, agentCfg, cfg.Rigs); rigName != "" {
 		if rigRoot := rigRootForName(rigName, cfg.Rigs); rigRoot != "" {
@@ -24,8 +29,10 @@ func controllerQueryEnv(cityPath string, cfg *config.City, agentCfg *config.Agen
 		} else {
 			source = bdRuntimeEnv(cityPath)
 		}
-	} else {
+	} else if rawBeadsProvider(cityPath) == "bd" {
 		source = bdRuntimeEnv(cityPath)
+	} else {
+		return nil
 	}
 	if len(source) == 0 {
 		return nil

--- a/cmd/gc/work_query_probe_test.go
+++ b/cmd/gc/work_query_probe_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,5 +29,163 @@ func TestPrefixedWorkQueryForProbe_UsesNamedSessionRuntimeName(t *testing.T) {
 	// All agents now use metadata routing via gc.routed_to.
 	if !strings.Contains(command, "gc.routed_to=demo/witness") {
 		t.Fatalf("prefixedWorkQueryForProbe() = %q, want gc.routed_to=demo/witness", command)
+	}
+}
+
+// ── controllerQueryEnv tests ────────────────────────────────────────────
+
+func TestControllerQueryEnv_NilInputs(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{}
+	agent := &config.Agent{Name: "worker"}
+
+	if got := controllerQueryEnv("", cfg, agent); got != nil {
+		t.Errorf("empty cityPath: got %v, want nil", got)
+	}
+	if got := controllerQueryEnv("  ", cfg, agent); got != nil {
+		t.Errorf("blank cityPath: got %v, want nil", got)
+	}
+	if got := controllerQueryEnv(cityPath, nil, agent); got != nil {
+		t.Errorf("nil cfg: got %v, want nil", got)
+	}
+	if got := controllerQueryEnv(cityPath, cfg, nil); got != nil {
+		t.Errorf("nil agentCfg: got %v, want nil", got)
+	}
+}
+
+func TestControllerQueryEnv_CityAgent_BdProvider(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "city-host.example.com")
+	t.Setenv("GC_DOLT_PORT", "3306")
+
+	cityPath := t.TempDir()
+	cfg := &config.City{}
+	agent := &config.Agent{Name: "worker"}
+
+	env := controllerQueryEnv(cityPath, cfg, agent)
+	if env == nil {
+		t.Fatal("expected env for city agent with bd provider, got nil")
+	}
+	if got := env["BEADS_DOLT_SERVER_HOST"]; got != "city-host.example.com" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST = %q, want %q", got, "city-host.example.com")
+	}
+	if got := env["BEADS_DOLT_SERVER_PORT"]; got != "3306" {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want %q", got, "3306")
+	}
+}
+
+func TestControllerQueryEnv_CityAgent_FileProvider_ReturnsNil(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "city-host.example.com")
+	t.Setenv("GC_DOLT_PORT", "3306")
+
+	cityPath := t.TempDir()
+	cfg := &config.City{}
+	agent := &config.Agent{Name: "worker"}
+
+	env := controllerQueryEnv(cityPath, cfg, agent)
+	if env != nil {
+		t.Errorf("expected nil for city agent with file provider, got %v", env)
+	}
+}
+
+// Regression test: rig agents must get rig dolt env even when the city uses
+// the file provider. Before the fix, controllerQueryEnv gated on
+// rawBeadsProvider(cityPath) == "bd" and returned nil for file-provider cities,
+// leaving rig scale_check subprocesses with the wrong (or no) dolt port.
+func TestControllerQueryEnv_RigAgent_FileProvider_StillGetsDoltEnv(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "rig-repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck // test cleanup
+
+	portStr := fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte(portStr), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name: "rig-repo",
+			Path: rigDir,
+		}},
+	}
+	agent := &config.Agent{Name: "sonnet", Dir: "rig-repo"}
+
+	env := controllerQueryEnv(cityPath, cfg, agent)
+	if env == nil {
+		t.Fatal("expected env for rig agent with file city provider, got nil — this was the bug")
+	}
+	if got := env["BEADS_DOLT_SERVER_PORT"]; got != portStr {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want %q (rig's managed port)", got, portStr)
+	}
+}
+
+func TestControllerQueryEnv_RigAgent_ExplicitDoltConfig(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "city-host.example.com")
+	t.Setenv("GC_DOLT_PORT", "3306")
+
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "rig-repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name:     "rig-repo",
+			Path:     rigDir,
+			DoltHost: "rig-host.example.com",
+			DoltPort: "3307",
+		}},
+	}
+	agent := &config.Agent{Name: "sonnet", Dir: "rig-repo"}
+
+	env := controllerQueryEnv(cityPath, cfg, agent)
+	if env == nil {
+		t.Fatal("expected env for rig agent, got nil")
+	}
+	if got := env["BEADS_DOLT_SERVER_HOST"]; got != "rig-host.example.com" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST = %q, want %q (rig's host, not city)", got, "rig-host.example.com")
+	}
+	if got := env["BEADS_DOLT_SERVER_PORT"]; got != "3307" {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want %q (rig's port, not city)", got, "3307")
+	}
+}
+
+func TestControllerQueryEnv_OmitsCredentials(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "host.example.com")
+	t.Setenv("GC_DOLT_PORT", "3306")
+	t.Setenv("GC_DOLT_USER", "agent")
+	t.Setenv("GC_DOLT_PASSWORD", "s3cret")
+
+	cityPath := t.TempDir()
+	cfg := &config.City{}
+	agent := &config.Agent{Name: "worker"}
+
+	env := controllerQueryEnv(cityPath, cfg, agent)
+	if env == nil {
+		t.Fatal("expected env, got nil")
+	}
+	for _, key := range []string{"GC_DOLT_USER", "GC_DOLT_PASSWORD", "BEADS_DOLT_SERVER_USER", "BEADS_DOLT_PASSWORD"} {
+		if _, ok := env[key]; ok {
+			t.Errorf("%s should not be in controllerQueryEnv output (credentials leak risk)", key)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Rig pool `scale_check` subprocesses were inheriting the city's `BEADS_DOLT_SERVER_PORT` when the city used the file provider, routing `bd` queries to the wrong dolt server
- Moves the bd-provider gate so it only skips env setup for city agents; rig agents always get their rig's dolt env propagated

## Related
- Companion to #683 (preserve rig dolt port during city sync)
- Part of cross-rig sling fix alongside #685 (exec store CRUD passthrough)

## Test plan
- [x] Cross-rig sling test: `projectwrenunity-gra` bead dispatched and completed by `ProjectWrenUnity/sonnet`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)