### PR TITLE
fix: route agent-session GC_BEADS to raw provider (#647)

### DIFF
--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -261,6 +261,13 @@ func rawBeadsProvider(cityPath string) string {
 // Maps "bd" → "exec:<cityPath>/.gc/system/bin/gc-beads-bd" so all lifecycle operations
 // route through the exec: protocol. Other providers pass through unchanged.
 //
+// This is for lifecycle operations ONLY (start/stop/health/ensure-ready/init).
+// gc-beads-bd exits 2 for data operations (get/list/create/update/close); it
+// is not a full exec-beads protocol implementation. Data-path callers — in
+// particular agent-session environments (see template_resolve.go) — must use
+// rawBeadsProvider() so they route through BdStore directly. See #647 for the
+// crash that surfaced when this invariant was violated.
+//
 // Related env vars:
 //   - GC_DOLT=skip — the gc-beads-bd script checks this and exits 2 for all
 //     operations. Used by testscript and integration tests.

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -245,8 +245,17 @@ func displayProviderName(name string) string {
 // Priority: GC_BEADS env var → city.toml [beads].provider → "bd" default.
 // This is the unmodified config value; use beadsProvider() for lifecycle
 // routing which remaps "bd" → exec:.
+//
+// If the ambient GC_BEADS points at the city-managed gc-beads-bd lifecycle
+// wrapper, we normalize it back to "bd". The wrapper exits 2 for data ops
+// (see #647), so inheriting it from a contaminated parent would reintroduce
+// the crash in nested agent sessions. Genuine user exec: overrides are
+// preserved — only the well-known lifecycle wrapper path is stripped.
 func rawBeadsProvider(cityPath string) string {
 	if v := os.Getenv("GC_BEADS"); v != "" {
+		if isLifecycleWrapperPath(v) {
+			return "bd"
+		}
 		return v
 	}
 	// Try to read provider from city.toml.
@@ -255,6 +264,15 @@ func rawBeadsProvider(cityPath string) string {
 		return cfg.Beads.Provider
 	}
 	return "bd"
+}
+
+// isLifecycleWrapperPath reports whether v is the city-managed gc-beads-bd
+// lifecycle wrapper (i.e., `exec:<anything>/.gc/system/bin/gc-beads-bd`).
+func isLifecycleWrapperPath(v string) bool {
+	if !strings.HasPrefix(v, "exec:") {
+		return false
+	}
+	return strings.HasSuffix(v, string(filepath.Separator)+citylayout.SystemBinRoot+string(filepath.Separator)+"gc-beads-bd")
 }
 
 // beadsProvider returns the bead store provider name for lifecycle operations.

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -212,7 +212,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	for key, value := range citylayout.CityRuntimeEnvMap(p.cityPath) {
 		agentEnv[key] = value
 	}
-	agentEnv["GC_BEADS"] = beadsProvider(p.cityPath)
+	// Agent-session data ops must bypass the lifecycle wrapper. See
+	// beadsProvider() docs and #647.
+	agentEnv["GC_BEADS"] = rawBeadsProvider(p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe
 	}

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -214,6 +214,8 @@ func TestResolveTemplateRigScopedEnvCarriesRigRoots(t *testing.T) {
 }
 
 func TestResolveTemplateUsesCityManagedDoltPort(t *testing.T) {
+	// Hermetic: ambient GC_BEADS would poison the "bd" assertion below.
+	t.Setenv("GC_BEADS", "")
 	cityPath := t.TempDir()
 	writeTemplateResolveCityConfig(t, cityPath, "")
 	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
@@ -269,8 +271,56 @@ func TestResolveTemplateUsesCityManagedDoltPort(t *testing.T) {
 	if got := tp.Env["GC_BIN"]; got == "" {
 		t.Fatalf("GC_BIN = %q, want non-empty", got)
 	}
-	if got := tp.Env["GC_BEADS"]; got != "exec:"+filepath.Join(cityPath, ".gc", "system", "bin", "gc-beads-bd") {
-		t.Fatalf("GC_BEADS = %q, want exec gc-beads-bd provider", got)
+	// Agent sessions route data ops to raw bd, not the lifecycle wrapper.
+	// See #647.
+	if got := tp.Env["GC_BEADS"]; got != "bd" {
+		t.Fatalf("GC_BEADS = %q, want %q", got, "bd")
+	}
+}
+
+// Regression for #647: agent-session data ops must not route through the
+// lifecycle-only gc-beads-bd wrapper.
+func TestResolveTemplateRoutesAgentSessionDataOpsToRawBd(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{name: "default bd", provider: "", want: "bd"},
+		{name: "explicit bd", provider: "bd", want: "bd"},
+		{name: "file passthrough", provider: "file", want: "file"},
+		{name: "custom exec passthrough", provider: "exec:/custom/gc-beads-br", want: "exec:/custom/gc-beads-br"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Hermetic: the city.toml value is authoritative for this test,
+			// regardless of what the developer has exported in their shell.
+			t.Setenv("GC_BEADS", "")
+			cityPath := t.TempDir()
+			writeTemplateResolveCityConfig(t, cityPath, tc.provider)
+
+			params := &agentBuildParams{
+				cityName:   "city",
+				cityPath:   cityPath,
+				workspace:  &config.Workspace{Provider: "test"},
+				providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+				lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+				fs:         fsys.OSFS{},
+				beaconTime: time.Unix(0, 0),
+				beadNames:  make(map[string]string),
+				stderr:     io.Discard,
+			}
+
+			agent := &config.Agent{Name: "worker"}
+			tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+			if err != nil {
+				t.Fatalf("resolveTemplate: %v", err)
+			}
+
+			if got := tp.Env["GC_BEADS"]; got != tc.want {
+				t.Fatalf("GC_BEADS = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -324,6 +324,70 @@ func TestResolveTemplateRoutesAgentSessionDataOpsToRawBd(t *testing.T) {
 	}
 }
 
+// Regression for #647: if a parent process leaked GC_BEADS pointing at the
+// city-managed lifecycle wrapper, nested agent sessions would re-inherit it
+// and recreate the exit-2/empty-JSON crash on data ops. The raw provider
+// normalizes that well-known wrapper path back to "bd".
+func TestResolveTemplateRawBeadsProviderStripsLifecycleWrapper(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "")
+	contaminated := "exec:" + filepath.Join(cityPath, ".gc", "system", "bin", "gc-beads-bd")
+	t.Setenv("GC_BEADS", contaminated)
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	agent := &config.Agent{Name: "worker"}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_BEADS"]; got != "bd" {
+		t.Fatalf("GC_BEADS = %q, want %q (ambient wrapper must be normalized)", got, "bd")
+	}
+}
+
+// Genuine user exec: overrides must pass through untouched — only the
+// well-known lifecycle wrapper path is stripped.
+func TestResolveTemplateRawBeadsProviderPreservesCustomExec(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "")
+	custom := "exec:/usr/local/bin/my-beads-backend"
+	t.Setenv("GC_BEADS", custom)
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	agent := &config.Agent{Name: "worker"}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_BEADS"]; got != custom {
+		t.Fatalf("GC_BEADS = %q, want %q (custom exec: must pass through)", got, custom)
+	}
+}
+
 func TestResolveTemplatePreservesLogicalAgentNameWhenSessionBeadExists(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()


### PR DESCRIPTION
## Summary

Fixes #647. Agent sessions were crashing on `gc mail inbox` with `exec beads get: parsing JSON: unexpected end of JSON input` because `template_resolve.go` was passing the lifecycle-only `gc-beads-bd` wrapper as their `GC_BEADS` env var.

## Root cause

`cmd/gc/providers.go` exposes two helpers:

- `beadsProvider()` — maps `"bd"` → `"exec:<cityPath>/.gc/system/bin/gc-beads-bd"`, the **lifecycle wrapper** that handles `start/stop/health/ensure-ready/init/probe/recover/shutdown`. It exits 2 for everything else (data ops: `get/list/create/update/close/...`).
- `rawBeadsProvider()` — returns the unmodified provider value (`"bd"`, `"file"`, or a user-set `exec:` path).

`cmd/gc/template_resolve.go:215` was calling `beadsProvider()` to populate the agent-session `GC_BEADS` env. Agent sessions perform **data** operations, not lifecycle operations. When `gc mail inbox` ran inside a session:

1. `rawBeadsProvider()` read `GC_BEADS` and saw the `exec:` prefix
2. `internal/beads/exec.Store` invoked `gc-beads-bd get <id>`
3. Wrapper exited 2 (unknown op)
4. `exec.Store.run()` treats exit 2 as "success with empty output"
5. `parseBead("")` crashed with `unexpected end of JSON input`

## Fix

Route the agent-session env var through `rawBeadsProvider()` so data ops hit `BdStore` directly via the `bd` CLI. `template_resolve.go` was the sole data-path caller of `beadsProvider()`; the other five callers are all legitimate lifecycle sites in `cmd/gc/beads_provider_lifecycle.go`.

Also:

- Expanded the `beadsProvider()` doc comment to make the lifecycle-only contract explicit and cite #647
- Flipped the assertion in `TestResolveTemplateUsesCityManagedDoltPort` (which previously encoded the bug)
- Added a table-driven regression test `TestResolveTemplateRoutesAgentSessionDataOpsToRawBd` covering default bd / explicit bd / file passthrough / custom `exec:` passthrough, hermetic under polluted `GC_BEADS` env

## Verification

- Blast-radius audit: the only non-lifecycle caller of `beadsProvider()` in the tree is `template_resolve.go:215`
- Testscripts under `cmd/gc/testdata/script/` that set `GC_DOLT=skip` also set `GC_BEADS=file` (verified via `main_test.go:32`), so no test inherits the default-bd + skip combination the wrapper's exit-2-everything was masking
- Rig-scoped agents: raw `bd` honors `BEADS_DIR=<rigRoot>/.beads` via `internal/beads/bdstore.go:58` + `cmd/gc/bd_env.go:18,39`
- Env precedence preserved: `rawBeadsProvider()` reads `$GC_BEADS` first, so `exec:custom-script` from the parent shell still passes through unchanged

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -run 'TestResolveTemplate' ./cmd/gc/...` — PASS (including 4 new subtests)
- [x] `GC_BEADS=something-weird go test -race -run 'TestResolveTemplateRoutesAgentSessionDataOpsToRawBd' ./cmd/gc/...` — PASS (hermetic)
- [x] `make build` / `make check` — PASS (pre-existing environmental baseline noise in `TestControllerReload*` due to `inotify/max_user_instances` limit, verified identical on clean `main`)