### PR TITLE
fix: include --settings and default args in session attach resume

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/spf13/cobra"
 )
 
@@ -695,7 +696,7 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// Build the resume command from the template's provider.
-	resumeCmd, hints := buildResumeCommand(cfg, info, beadSessionKind(store, sessionID))
+	resumeCmd, hints := buildResumeCommand(cityPath, cfg, info, beadSessionKind(store, sessionID))
 
 	fmt.Fprintf(stdout, "Attaching to session %s (%s)...\n", sessionID, info.Template) //nolint:errcheck // best-effort stdout
 	if err := mgr.Attach(context.Background(), sessionID, resumeCmd, hints); err != nil {
@@ -709,11 +710,15 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 // a session. Uses provider resume if the session has a session key and the
 // provider supports resume; otherwise falls back to the stored command.
 //
+// cityPath is needed to resolve the --settings flag for Claude sessions.
+// Without it, SessionStart hooks defined in .gc/settings.json are not loaded
+// when gc session attach starts the process (as opposed to the reconciler).
+//
 // sessionKind mirrors the mc_session_kind bead metadata: "provider" means
 // the session was created from a bare provider name (not an agent template),
 // so the agent-template lookup should be skipped. This matches the guard in
 // the API handler (handler_session_chat.go).
-func buildResumeCommand(cfg *config.City, info session.Info, sessionKind string) (string, runtime.Config) {
+func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, sessionKind string) (string, runtime.Config) {
 	cmd := session.BuildResumeCommand(info)
 	if cfg == nil {
 		return cmd, runtime.Config{WorkDir: info.WorkDir}
@@ -724,7 +729,16 @@ func buildResumeCommand(cfg *config.City, info session.Info, sessionKind string)
 			return cmd, runtime.Config{WorkDir: info.WorkDir}
 		}
 		resolvedInfo := info
-		resolvedInfo.Command = resolved.CommandString()
+		// Build command with default args and settings, matching the
+		// reconciler's template_resolve.go command construction.
+		command := resolved.CommandString()
+		if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
+			command = command + " " + shellquote.Join(defaultArgs)
+		}
+		if sa := settingsArgs(cityPath, resolved.Name); sa != "" {
+			command = command + " " + sa
+		}
+		resolvedInfo.Command = command
 		resolvedInfo.Provider = resolved.Name
 		resolvedInfo.ResumeFlag = resolved.ResumeFlag
 		resolvedInfo.ResumeStyle = resolved.ResumeStyle
@@ -1247,7 +1261,7 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	resumeCmd, hints := buildResumeCommand(cfg, info, beadSessionKind(store, sessionID))
+	resumeCmd, hints := buildResumeCommand(cityPath, cfg, info, beadSessionKind(store, sessionID))
 	outcome, err := mgr.Submit(context.Background(), sessionID, message, resumeCmd, hints, intent)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -283,7 +284,7 @@ func TestBuildResumeCommandUsesResolvedProviderCommand(t *testing.T) {
 		WorkDir:  "/tmp/workdir",
 	}
 
-	cmd, hints := buildResumeCommand(cfg, info, "")
+	cmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "")
 	if got, want := cmd, "aimux run gemini -- --approval-mode yolo"; got != want {
 		t.Fatalf("resume command = %q, want %q", got, want)
 	}
@@ -295,6 +296,54 @@ func TestBuildResumeCommandUsesResolvedProviderCommand(t *testing.T) {
 	}
 	if got, want := hints.Env["GC_HOME"], "/tmp/gc-accept-home"; got != want {
 		t.Fatalf("hints.Env[GC_HOME] = %q, want %q", got, want)
+	}
+}
+
+func TestBuildResumeCommandIncludesSettingsAndDefaultArgs(t *testing.T) {
+	cityDir := t.TempDir()
+	// Write a .gc/settings.json so settingsArgs finds it.
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gcDir, "settings.json"), []byte(`{"hooks":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor"},
+		},
+	}
+	info := session.Info{
+		Template:   "mayor",
+		Command:    "claude",
+		Provider:   "claude",
+		WorkDir:    "/tmp/workdir",
+		SessionKey: "abc-123",
+		ResumeFlag: "--resume",
+	}
+
+	cmd, _ := buildResumeCommand(cityDir, cfg, info, "")
+
+	// Must include --settings pointing to .gc/settings.json.
+	wantSettings := fmt.Sprintf("--settings %q", filepath.Join(gcDir, "settings.json"))
+	if !strings.Contains(cmd, "--settings") {
+		t.Fatalf("resume command missing --settings:\n  got: %s", cmd)
+	}
+	if !strings.Contains(cmd, wantSettings) {
+		t.Fatalf("resume command has wrong --settings path:\n  got:  %s\n  want: ...%s...", cmd, wantSettings)
+	}
+
+	// Must include --resume flag.
+	if !strings.Contains(cmd, "--resume abc-123") {
+		t.Fatalf("resume command missing --resume flag:\n  got: %s", cmd)
+	}
+
+	// Must include default args (--dangerously-skip-permissions for claude).
+	if !strings.Contains(cmd, "--dangerously-skip-permissions") {
+		t.Fatalf("resume command missing default args:\n  got: %s", cmd)
 	}
 }
 

--- a/cmd/gc/live_submit_probe_test.go
+++ b/cmd/gc/live_submit_probe_test.go
@@ -97,7 +97,7 @@ func TestLiveClaudeInterruptNow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mgr.Get(%q): %v", id, err)
 	}
-	resumeCmd, hints := buildResumeCommand(cfg, info, "")
+	resumeCmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "")
 	socket := cfg.Session.Socket
 	if socket == "" {
 		socket = cfg.Workspace.Name
@@ -174,7 +174,7 @@ func TestLiveGeminiSubmitIntents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mgr.Get(%q): %v", id, err)
 	}
-	resumeCmd, hints := buildResumeCommand(cfg, info, "")
+	resumeCmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "")
 	socket := cfg.Session.Socket
 	if socket == "" {
 		socket = cfg.Workspace.Name


### PR DESCRIPTION
## Summary
- `buildResumeCommand` (used by `gc session attach` and `gc session submit`) re-resolved the provider via `CommandString()` but did not append `--settings` or `ResolveDefaultArgs()`
- The reconciler's `template_resolve.go` path added both, so sessions started by the reconciler had hooks; sessions started by `gc session attach` (when it won the race) did not
- This caused intermittent missing SessionStart hook output — the "every-other startup text" bug

## Root cause
The timing race: after `gc-cycle`, sometimes the reconciler started the session (with `--settings` → hooks worked), sometimes the user's `gc session attach` won (without `--settings` → hooks from `.gc/settings.json` not loaded).

## Changes
- `buildResumeCommand` now appends `ResolveDefaultArgs()` and `settingsArgs()` to match `template_resolve.go`
- Added `cityPath` parameter to `buildResumeCommand` (needed by `settingsArgs`)
- Regression test: `TestBuildResumeCommandIncludesSettingsAndDefaultArgs`

## Note
The API handler (`handler_session_chat.go`) has the same pattern but `settingsArgs` lives in `cmd/gc` — that's a separate fix if needed.

## Test plan
- [x] `TestBuildResumeCommandUsesResolvedProviderCommand` — existing test still passes
- [x] `TestBuildResumeCommandIncludesSettingsAndDefaultArgs` — new regression test
- [ ] Manual: `gc-cycle && gc session attach mayor` no longer intermittently missing startup text
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)