### PR TITLE
fix: pass locale env to managed tmux sessions

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -970,7 +970,15 @@ func passthroughEnv() map[string]string {
 			m[key] = v
 		}
 	}
-	if m["LANG"] == "" {
+	if _, ok := m["LC_ALL"]; !ok {
+		m["LC_ALL"] = ""
+	}
+	if _, ok := m["LC_CTYPE"]; !ok {
+		m["LC_CTYPE"] = ""
+	}
+	if m["LANG"] == "" && m["LC_ALL"] == "" && m["LC_CTYPE"] == "" {
+		// This fallback targets launchd-managed macOS sessions; explicit
+		// city or agent env can still override it through later layers.
 		m["LANG"] = "en_US.UTF-8"
 	}
 	// XDG directories are needed for providers to locate config files

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -961,6 +961,18 @@ func passthroughEnv() map[string]string {
 			m[key] = v
 		}
 	}
+	// Locale vars are needed so TUI tools (e.g. Claude Code statusline)
+	// correctly render UTF-8 glyphs inside managed tmux sessions.
+	// The supervisor may run as a launchd service with no locale set,
+	// so fall back to en_US.UTF-8 when the environment is empty.
+	for _, key := range []string{"LANG", "LC_ALL", "LC_CTYPE"} {
+		if v := os.Getenv(key); v != "" {
+			m[key] = v
+		}
+	}
+	if m["LANG"] == "" {
+		m["LANG"] = "en_US.UTF-8"
+	}
 	// XDG directories are needed for providers to locate config files
 	// (e.g. ~/.config/opencode/opencode.jsonc). When not set, compute
 	// defaults from HOME so spawned sessions always find user config.

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -254,8 +254,9 @@ func TestPassthroughEnvClearsClaudeNestingUnconditionally(t *testing.T) {
 }
 
 func TestPassthroughEnvLANGFallback(t *testing.T) {
-	// When LANG is unset (e.g. launchd supervisor), fall back to en_US.UTF-8
-	// so TUI tools render UTF-8 glyphs correctly in managed sessions.
+	// When no locale is set (e.g. launchd supervisor), fall back to
+	// en_US.UTF-8 so TUI tools render UTF-8 glyphs correctly in managed
+	// sessions. Empty LC_* entries clear stale higher-precedence tmux env.
 	t.Setenv("LANG", "")
 	t.Setenv("LC_ALL", "")
 	t.Setenv("LC_CTYPE", "")
@@ -265,16 +266,66 @@ func TestPassthroughEnvLANGFallback(t *testing.T) {
 	if got["LANG"] != "en_US.UTF-8" {
 		t.Errorf("LANG = %q, want %q (fallback for launchd)", got["LANG"], "en_US.UTF-8")
 	}
+	if got["LC_ALL"] != "" {
+		t.Errorf("LC_ALL = %q, want empty string to clear stale tmux env", got["LC_ALL"])
+	}
+	if got["LC_CTYPE"] != "" {
+		t.Errorf("LC_CTYPE = %q, want empty string to clear stale tmux env", got["LC_CTYPE"])
+	}
 }
 
 func TestPassthroughEnvLANGPassthrough(t *testing.T) {
 	// When LANG is set, pass it through as-is.
 	t.Setenv("LANG", "ja_JP.UTF-8")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "")
 
 	got := passthroughEnv()
 
 	if got["LANG"] != "ja_JP.UTF-8" {
 		t.Errorf("LANG = %q, want %q", got["LANG"], "ja_JP.UTF-8")
+	}
+	if got["LC_ALL"] != "" {
+		t.Errorf("LC_ALL = %q, want empty string to clear stale tmux env", got["LC_ALL"])
+	}
+	if got["LC_CTYPE"] != "" {
+		t.Errorf("LC_CTYPE = %q, want empty string to clear stale tmux env", got["LC_CTYPE"])
+	}
+}
+
+func TestPassthroughEnvLocalePassthrough(t *testing.T) {
+	t.Setenv("LANG", "en_GB.UTF-8")
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	t.Setenv("LC_CTYPE", "ja_JP.UTF-8")
+
+	got := passthroughEnv()
+
+	for key, want := range map[string]string{
+		"LANG":     "en_GB.UTF-8",
+		"LC_ALL":   "fr_FR.UTF-8",
+		"LC_CTYPE": "ja_JP.UTF-8",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %q, want %q", key, got[key], want)
+		}
+	}
+}
+
+func TestPassthroughEnvLCTypeSuppressesLANGFallback(t *testing.T) {
+	t.Setenv("LANG", "")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "ja_JP.UTF-8")
+
+	got := passthroughEnv()
+
+	if _, ok := got["LANG"]; ok {
+		t.Errorf("LANG present as %q, want omitted when LC_CTYPE provides locale", got["LANG"])
+	}
+	if got["LC_ALL"] != "" {
+		t.Errorf("LC_ALL = %q, want empty string to clear stale tmux env", got["LC_ALL"])
+	}
+	if got["LC_CTYPE"] != "ja_JP.UTF-8" {
+		t.Errorf("LC_CTYPE = %q, want %q", got["LC_CTYPE"], "ja_JP.UTF-8")
 	}
 }
 

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -253,6 +253,31 @@ func TestPassthroughEnvClearsClaudeNestingUnconditionally(t *testing.T) {
 	}
 }
 
+func TestPassthroughEnvLANGFallback(t *testing.T) {
+	// When LANG is unset (e.g. launchd supervisor), fall back to en_US.UTF-8
+	// so TUI tools render UTF-8 glyphs correctly in managed sessions.
+	t.Setenv("LANG", "")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "")
+
+	got := passthroughEnv()
+
+	if got["LANG"] != "en_US.UTF-8" {
+		t.Errorf("LANG = %q, want %q (fallback for launchd)", got["LANG"], "en_US.UTF-8")
+	}
+}
+
+func TestPassthroughEnvLANGPassthrough(t *testing.T) {
+	// When LANG is set, pass it through as-is.
+	t.Setenv("LANG", "ja_JP.UTF-8")
+
+	got := passthroughEnv()
+
+	if got["LANG"] != "ja_JP.UTF-8" {
+		t.Errorf("LANG = %q, want %q", got["LANG"], "ja_JP.UTF-8")
+	}
+}
+
 func TestStageHookFilesIncludesCanonicalClaudeHook(t *testing.T) {
 	cityDir := filepath.Join(t.TempDir(), "city")
 	workDir := filepath.Join(cityDir, "worker")

--- a/internal/runtime/tmux/executor_test.go
+++ b/internal/runtime/tmux/executor_test.go
@@ -42,6 +42,33 @@ func (f *fakeExecutor) executeCtx(_ context.Context, args []string) (string, err
 	return f.execute(args)
 }
 
+func TestNewSessionWithCommandAndEnvClearsEmptyVars(t *testing.T) {
+	exec := &fakeExecutor{}
+	tm := NewTmux()
+	tm.exec = exec
+
+	env := map[string]string{
+		"LANG":     "en_US.UTF-8",
+		"LC_ALL":   "",
+		"LC_CTYPE": "",
+	}
+	if err := tm.NewSessionWithCommandAndEnv("gc-test-locale-clear", "", "claude", env); err != nil {
+		t.Fatalf("NewSessionWithCommandAndEnv: %v", err)
+	}
+	if len(exec.calls) == 0 {
+		t.Fatal("no tmux calls recorded")
+	}
+
+	args := exec.calls[0]
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, "\x00-e\x00LANG=en_US.UTF-8\x00") {
+		t.Fatalf("new-session args missing LANG -e flag: %v", args)
+	}
+	if got := args[len(args)-1]; got != "env -u LC_ALL -u LC_CTYPE claude" {
+		t.Fatalf("command = %q, want env -u LC_ALL -u LC_CTYPE claude", got)
+	}
+}
+
 type promptFooterExecutor struct {
 	calls [][]string
 }


### PR DESCRIPTION
## Summary

- Add `LANG`, `LC_ALL`, `LC_CTYPE` to `passthroughEnv()` whitelist
- Fall back to `en_US.UTF-8` when `LANG` is unset (launchd supervisor)

## Problem

The supervisor runs as a launchd service (`com.gascity.supervisor`) which does not inherit the user's shell environment. `LANG`/`LC_ALL` are absent from managed tmux sessions, causing TUI tools like Claude Code to misrender UTF-8 glyphs — e.g. block characters (`▓`, `░`) in the statusline appear as diamonds.

The chain: launchd → gc supervisor (no LANG) → `passthroughEnv()` skips LANG (empty) → tmux `-e` flags omit it → Claude Code starts without UTF-8 locale → ambiguous-width Unicode characters render incorrectly.

## Test plan

- [ ] `TestPassthroughEnvLANGFallback` — verifies fallback to `en_US.UTF-8` when LANG is unset
- [ ] `TestPassthroughEnvLANGPassthrough` — verifies user's LANG is preserved when set
- [ ] Manual: `gc stop && gc start`, then `gc session attach mayor` — Claude Code statusline renders `▓░` correctly