### PR TITLE
feat: add gc shell command for tab-completion integration

### DIFF
--- a/cmd/gc/cmd_shell.go
+++ b/cmd/gc/cmd_shell.go
@@ -96,25 +96,60 @@ func detectShell(shellEnv string) (string, error) {
 
 // shellRCFile returns the canonical RC file path for a shell.
 func shellRCFile(sh string) (string, error) {
-	home, err := os.UserHomeDir()
+	rcFiles, err := shellRCFiles(sh)
 	if err != nil {
-		return "", fmt.Errorf("determining home directory: %w", err)
+		return "", err
 	}
 	switch sh {
 	case "bash":
 		// Prefer .bashrc; fall back to .bash_profile if .bashrc doesn't exist.
-		rc := filepath.Join(home, ".bashrc")
+		rc := rcFiles[0]
 		if _, err := os.Stat(rc); err == nil {
 			return rc, nil
 		}
-		return filepath.Join(home, ".bash_profile"), nil
-	case "zsh":
-		return filepath.Join(home, ".zshrc"), nil
-	case "fish":
-		return filepath.Join(home, ".config", "fish", "config.fish"), nil
+		return rcFiles[1], nil
+	case "zsh", "fish":
+		return rcFiles[0], nil
 	default:
 		return "", fmt.Errorf("unsupported shell %q", sh)
 	}
+}
+
+// shellRCFiles returns all RC files relevant to a shell.
+func shellRCFiles(sh string) ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determining home directory: %w", err)
+	}
+	switch sh {
+	case "bash":
+		return []string{
+			filepath.Join(home, ".bashrc"),
+			filepath.Join(home, ".bash_profile"),
+		}, nil
+	case "zsh":
+		return []string{filepath.Join(home, ".zshrc")}, nil
+	case "fish":
+		return []string{filepath.Join(home, ".config", "fish", "config.fish")}, nil
+	default:
+		return nil, fmt.Errorf("unsupported shell %q", sh)
+	}
+}
+
+// installedShellRCFile returns the RC file that currently contains the hook.
+func installedShellRCFile(sh string) (string, error) {
+	rcFiles, err := shellRCFiles(sh)
+	if err != nil {
+		return "", err
+	}
+	for _, rcFile := range rcFiles {
+		hasHook, err := rcFileHasHook(rcFile)
+		if err != nil || !hasHook {
+			continue
+		}
+		return rcFile, nil
+	}
+	return "", os.ErrNotExist
 }
 
 // completionDir returns ~/.gc/completions.
@@ -215,6 +250,13 @@ func cmdShellInstall(root *cobra.Command, args []string, stdout, stderr io.Write
 		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if existingRC, err := installedShellRCFile(sh); err == nil {
+		rcFile = existingRC
+	}
+	if err := os.MkdirAll(filepath.Dir(rcFile), 0o755); err != nil {
+		fmt.Fprintf(stderr, "gc shell install: creating directory: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	installed, err := rcFileHasHook(rcFile)
 	if err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(stderr, "gc shell install: reading %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
@@ -256,19 +298,21 @@ func cmdShellRemove(stdout, stderr io.Writer) int {
 			}
 		}
 
-		rcFile, err := shellRCFile(sh)
+		rcFiles, err := shellRCFiles(sh)
 		if err != nil {
 			continue
 		}
-		has, err := rcFileHasHook(rcFile)
-		if err != nil || !has {
-			continue
-		}
-		if err := rcFileRemoveHook(rcFile); err != nil {
-			fmt.Fprintf(stderr, "gc shell remove: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
-		} else {
-			fmt.Fprintf(stdout, "Removed hook from %s\n", rcFile) //nolint:errcheck // best-effort stdout
-			removed = true
+		for _, rcFile := range rcFiles {
+			has, err := rcFileHasHook(rcFile)
+			if err != nil || !has {
+				continue
+			}
+			if err := rcFileRemoveHook(rcFile); err != nil {
+				fmt.Fprintf(stderr, "gc shell remove: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+			} else {
+				fmt.Fprintf(stdout, "Removed hook from %s\n", rcFile) //nolint:errcheck // best-effort stdout
+				removed = true
+			}
 		}
 	}
 	if !removed {
@@ -284,7 +328,7 @@ func cmdShellStatus(stdout, _ io.Writer) int {
 		if err != nil {
 			continue
 		}
-		rcFile, err := shellRCFile(sh)
+		rcFiles, err := shellRCFiles(sh)
 		if err != nil {
 			continue
 		}
@@ -292,7 +336,20 @@ func cmdShellStatus(stdout, _ io.Writer) int {
 		if _, err := os.Stat(compFile); err == nil {
 			hasScript = true
 		}
-		hasHook, _ := rcFileHasHook(rcFile)
+		hasHook := false
+		rcFile, err := shellRCFile(sh)
+		if err != nil {
+			continue
+		}
+		for _, candidate := range rcFiles {
+			candidateHasHook, err := rcFileHasHook(candidate)
+			if err != nil || !candidateHasHook {
+				continue
+			}
+			hasHook = true
+			rcFile = candidate
+			break
+		}
 
 		if hasScript || hasHook {
 			found = true
@@ -388,11 +445,36 @@ func replaceHookBlock(content, replacement string) string {
 
 // atomicWriteFile writes data to a temp file then renames into place.
 func atomicWriteFile(path string, data []byte) error {
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 func resolveShellArg(args []string) (string, error) {

--- a/cmd/gc/cmd_shell.go
+++ b/cmd/gc/cmd_shell.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	shellHookMarkerBegin = "# >>> gc shell integration >>>"
+	shellHookMarkerEnd   = "# <<< gc shell integration <<<"
+)
+
+func newShellCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "shell",
+		Short: "Manage the Gas City shell integration hook",
+		Long: `The shell integration adds a completion hook to your shell RC file that
+provides tab-completion for gc commands and flags.
+
+Subcommands: install, remove, status.`,
+	}
+	cmd.AddCommand(
+		newShellInstallCmd(stdout, stderr),
+		newShellRemoveCmd(stdout, stderr),
+		newShellStatusCmd(stdout, stderr),
+	)
+	return cmd
+}
+
+func newShellInstallCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "install [bash|zsh|fish]",
+		Short: "Install or update shell integration",
+		Long: `Install or update the gc shell completion hook.
+
+If no shell is specified, the shell is detected from $SHELL.
+The completion script is written to ~/.gc/completions/ and a source line
+is added to your shell RC file.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmdShellInstall(cmd.Root(), args, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+}
+
+func newShellRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove",
+		Short: "Remove shell integration",
+		Long:  `Remove the gc shell completion hook from your shell RC file and delete the completion script.`,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdShellRemove(stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+}
+
+func newShellStatusCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show shell integration status",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdShellStatus(stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+}
+
+// detectShell returns "bash", "zsh", or "fish" from the SHELL env var.
+func detectShell(shellEnv string) (string, error) {
+	parts := strings.Split(shellEnv, "/")
+	base := strings.ToLower(parts[len(parts)-1])
+	switch base {
+	case "bash", "zsh", "fish":
+		return base, nil
+	default:
+		return "", fmt.Errorf("unsupported shell %q (expected bash, zsh, or fish)", base)
+	}
+}
+
+// shellRCFile returns the canonical RC file path for a shell.
+func shellRCFile(sh string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	switch sh {
+	case "bash":
+		// Prefer .bashrc; fall back to .bash_profile if .bashrc doesn't exist.
+		rc := filepath.Join(home, ".bashrc")
+		if _, err := os.Stat(rc); err == nil {
+			return rc, nil
+		}
+		return filepath.Join(home, ".bash_profile"), nil
+	case "zsh":
+		return filepath.Join(home, ".zshrc"), nil
+	case "fish":
+		return filepath.Join(home, ".config", "fish", "config.fish"), nil
+	default:
+		return "", fmt.Errorf("unsupported shell %q", sh)
+	}
+}
+
+// completionDir returns ~/.gc/completions.
+func completionDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".gc", "completions"), nil
+}
+
+// completionFile returns the path to the completion script for a shell.
+func completionFile(sh string) (string, error) {
+	dir, err := completionDir()
+	if err != nil {
+		return "", err
+	}
+	switch sh {
+	case "bash":
+		return filepath.Join(dir, "gc.bash"), nil
+	case "zsh":
+		return filepath.Join(dir, "_gc"), nil
+	case "fish":
+		return filepath.Join(dir, "gc.fish"), nil
+	default:
+		return "", fmt.Errorf("unsupported shell %q", sh)
+	}
+}
+
+// generateCompletion generates the completion script for the given shell
+// using cobra's built-in generators.
+func generateCompletion(root *cobra.Command, sh string) ([]byte, error) {
+	var buf bytes.Buffer
+	switch sh {
+	case "bash":
+		if err := root.GenBashCompletionV2(&buf, true); err != nil {
+			return nil, err
+		}
+	case "zsh":
+		if err := root.GenZshCompletion(&buf); err != nil {
+			return nil, err
+		}
+	case "fish":
+		if err := root.GenFishCompletion(&buf, true); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported shell %q", sh)
+	}
+	return buf.Bytes(), nil
+}
+
+// hookBlock returns the lines to insert into the RC file.
+func hookBlock(sh, compFile string) string {
+	var source string
+	switch sh {
+	case "fish":
+		source = fmt.Sprintf("test -f %q && source %q", compFile, compFile)
+	default: // bash, zsh
+		source = fmt.Sprintf("[[ -f %q ]] && source %q", compFile, compFile)
+	}
+	return shellHookMarkerBegin + "\n" + source + "\n" + shellHookMarkerEnd + "\n"
+}
+
+func cmdShellInstall(root *cobra.Command, args []string, stdout, stderr io.Writer) int {
+	sh, err := resolveShellArg(args)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	// Generate completion script.
+	script, err := generateCompletion(root, sh)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc shell install: generating completion: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	// Write completion script to file.
+	compFile, err := completionFile(sh)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := os.MkdirAll(filepath.Dir(compFile), 0o755); err != nil {
+		fmt.Fprintf(stderr, "gc shell install: creating directory: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := atomicWriteFile(compFile, script); err != nil {
+		fmt.Fprintf(stderr, "gc shell install: writing completion script: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	fmt.Fprintf(stdout, "Wrote completion script to %s\n", compFile) //nolint:errcheck // best-effort stdout
+
+	// Add source line to RC file.
+	rcFile, err := shellRCFile(sh)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	installed, err := rcFileHasHook(rcFile)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(stderr, "gc shell install: reading %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if installed {
+		// Update in place — the completion script is already refreshed on disk.
+		if err := rcFileReplaceHook(rcFile, hookBlock(sh, compFile)); err != nil {
+			fmt.Fprintf(stderr, "gc shell install: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintf(stdout, "Updated hook in %s\n", rcFile) //nolint:errcheck // best-effort stdout
+	} else {
+		if err := rcFileAppendHook(rcFile, hookBlock(sh, compFile)); err != nil {
+			fmt.Fprintf(stderr, "gc shell install: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintf(stdout, "Added hook to %s\n", rcFile) //nolint:errcheck // best-effort stdout
+	}
+
+	fmt.Fprintf(stdout, "Restart your shell or run: source %s\n", rcFile) //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+func cmdShellRemove(stdout, stderr io.Writer) int {
+	// Try all shells — remove whatever we find.
+	removed := false
+	for _, sh := range []string{"bash", "zsh", "fish"} {
+		compFile, err := completionFile(sh)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(compFile); err == nil {
+			if err := os.Remove(compFile); err != nil {
+				fmt.Fprintf(stderr, "gc shell remove: removing %s: %v\n", compFile, err) //nolint:errcheck // best-effort stderr
+			} else {
+				fmt.Fprintf(stdout, "Removed %s\n", compFile) //nolint:errcheck // best-effort stdout
+				removed = true
+			}
+		}
+
+		rcFile, err := shellRCFile(sh)
+		if err != nil {
+			continue
+		}
+		has, err := rcFileHasHook(rcFile)
+		if err != nil || !has {
+			continue
+		}
+		if err := rcFileRemoveHook(rcFile); err != nil {
+			fmt.Fprintf(stderr, "gc shell remove: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+		} else {
+			fmt.Fprintf(stdout, "Removed hook from %s\n", rcFile) //nolint:errcheck // best-effort stdout
+			removed = true
+		}
+	}
+	if !removed {
+		fmt.Fprintln(stdout, "No shell integration found to remove.") //nolint:errcheck // best-effort stdout
+	}
+	return 0
+}
+
+func cmdShellStatus(stdout, _ io.Writer) int {
+	found := false
+	for _, sh := range []string{"bash", "zsh", "fish"} {
+		compFile, err := completionFile(sh)
+		if err != nil {
+			continue
+		}
+		rcFile, err := shellRCFile(sh)
+		if err != nil {
+			continue
+		}
+		hasScript := false
+		if _, err := os.Stat(compFile); err == nil {
+			hasScript = true
+		}
+		hasHook, _ := rcFileHasHook(rcFile)
+
+		if hasScript || hasHook {
+			found = true
+			status := "installed"
+			if hasScript && !hasHook {
+				status = "completion script exists but RC hook missing"
+			} else if !hasScript && hasHook {
+				status = "RC hook present but completion script missing"
+			}
+			fmt.Fprintf(stdout, "%s: %s\n", sh, status)     //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "  script: %s\n", compFile) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "  rc:     %s\n", rcFile)   //nolint:errcheck // best-effort stdout
+		}
+	}
+	if !found {
+		fmt.Fprintln(stdout, "Shell integration is not installed.") //nolint:errcheck // best-effort stdout
+		fmt.Fprintln(stdout, "Run: gc shell install")               //nolint:errcheck // best-effort stdout
+	}
+	return 0
+}
+
+// ── RC file manipulation ────────────────────────────────────────────────
+
+// rcFileHasHook reports whether the RC file contains our marker block.
+func rcFileHasHook(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Contains(data, []byte(shellHookMarkerBegin)), nil
+}
+
+// rcFileAppendHook appends the hook block to the RC file.
+func rcFileAppendHook(path, block string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	// Ensure we start on a new line.
+	_, err = f.WriteString("\n" + block)
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+// rcFileReplaceHook replaces the existing hook block in the RC file.
+func rcFileReplaceHook(path, block string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	result := replaceHookBlock(string(data), block)
+	return atomicWriteFile(path, []byte(result))
+}
+
+// rcFileRemoveHook removes the hook block from the RC file.
+func rcFileRemoveHook(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	result := replaceHookBlock(string(data), "")
+	return atomicWriteFile(path, []byte(result))
+}
+
+// replaceHookBlock replaces or removes the marker block in content.
+func replaceHookBlock(content, replacement string) string {
+	var out strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	inBlock := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == shellHookMarkerBegin {
+			inBlock = true
+			if replacement != "" {
+				out.WriteString(replacement)
+			}
+			continue
+		}
+		if inBlock {
+			if strings.TrimSpace(line) == shellHookMarkerEnd {
+				inBlock = false
+			}
+			continue
+		}
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+// atomicWriteFile writes data to a temp file then renames into place.
+func atomicWriteFile(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func resolveShellArg(args []string) (string, error) {
+	if len(args) > 0 {
+		sh := strings.ToLower(strings.TrimSpace(args[0]))
+		switch sh {
+		case "bash", "zsh", "fish":
+			return sh, nil
+		default:
+			return "", fmt.Errorf("unsupported shell %q (expected bash, zsh, or fish)", args[0])
+		}
+	}
+	return detectShell(os.Getenv("SHELL"))
+}

--- a/cmd/gc/cmd_shell_test.go
+++ b/cmd/gc/cmd_shell_test.go
@@ -259,6 +259,202 @@ func TestShellRemove(t *testing.T) {
 	}
 }
 
+func TestShellInstallFishCreatesConfigDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var stdout, stderr bytes.Buffer
+	code := cmdShellInstall(root, []string{"fish"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+
+	rc := filepath.Join(home, ".config", "fish", "config.fish")
+	data, err := os.ReadFile(rc)
+	if err != nil {
+		t.Fatalf("expected fish rc file to be created: %v", err)
+	}
+	if !strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Fatalf("fish rc file missing hook marker:\n%s", string(data))
+	}
+}
+
+func TestShellStatusTracksBashProfileInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var installOut, installErr bytes.Buffer
+	code := cmdShellInstall(root, []string{"bash"}, &installOut, &installErr)
+	if code != 0 {
+		t.Fatalf("install exit %d: %s", code, installErr.String())
+	}
+
+	bashProfile := filepath.Join(home, ".bash_profile")
+	data, err := os.ReadFile(bashProfile)
+	if err != nil {
+		t.Fatalf("expected bash profile to be created: %v", err)
+	}
+	if !strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Fatalf("bash profile missing hook marker:\n%s", string(data))
+	}
+
+	// Simulate a later shell session creating .bashrc after install.
+	shellTestWriteFile(t, filepath.Join(home, ".bashrc"), "# created later\n")
+
+	var stdout, stderr bytes.Buffer
+	code = cmdShellStatus(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("status exit %d: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "bash: installed") {
+		t.Fatalf("expected bash to still be reported installed, got:\n%s", out)
+	}
+	if !strings.Contains(out, bashProfile) {
+		t.Fatalf("expected status to point at .bash_profile, got:\n%s", out)
+	}
+}
+
+func TestShellRemoveRemovesBashProfileHookAfterBashrcAppears(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var installOut, installErr bytes.Buffer
+	code := cmdShellInstall(root, []string{"bash"}, &installOut, &installErr)
+	if code != 0 {
+		t.Fatalf("install exit %d: %s", code, installErr.String())
+	}
+
+	bashProfile := filepath.Join(home, ".bash_profile")
+	shellTestWriteFile(t, filepath.Join(home, ".bashrc"), "# created later\n")
+
+	var stdout, stderr bytes.Buffer
+	code = cmdShellRemove(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("remove exit %d: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(bashProfile)
+	if err != nil {
+		t.Fatalf("reading bash profile: %v", err)
+	}
+	if strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Fatalf("expected hook to be removed from bash profile, got:\n%s", string(data))
+	}
+	if !strings.Contains(stdout.String(), "Removed hook from "+bashProfile) {
+		t.Fatalf("expected remove output to mention bash profile, got:\n%s", stdout.String())
+	}
+}
+
+func TestShellReinstallUpdatesExistingBashProfileHookAfterBashrcAppears(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var stdout, stderr bytes.Buffer
+	code := cmdShellInstall(root, []string{"bash"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first install exit %d: %s", code, stderr.String())
+	}
+
+	bashProfile := filepath.Join(home, ".bash_profile")
+	bashRC := filepath.Join(home, ".bashrc")
+	shellTestWriteFile(t, bashRC, "# created later\n")
+
+	stdout.Reset()
+	stderr.Reset()
+	code = cmdShellInstall(root, []string{"bash"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("reinstall exit %d: %s", code, stderr.String())
+	}
+
+	profileData, err := os.ReadFile(bashProfile)
+	if err != nil {
+		t.Fatalf("reading bash profile: %v", err)
+	}
+	if strings.Count(string(profileData), shellHookMarkerBegin) != 1 {
+		t.Fatalf("expected exactly one hook block in bash profile, got:\n%s", string(profileData))
+	}
+
+	rcData, err := os.ReadFile(bashRC)
+	if err != nil {
+		t.Fatalf("reading bashrc: %v", err)
+	}
+	if strings.Contains(string(rcData), shellHookMarkerBegin) {
+		t.Fatalf("expected reinstall to keep hook in original bash profile, got bashrc:\n%s", string(rcData))
+	}
+}
+
+func TestShellReinstallPreservesRCFileMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rc := filepath.Join(home, ".zshrc")
+	shellTestWriteFile(t, rc, "# zshrc\n")
+	if err := os.Chmod(rc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var stdout, stderr bytes.Buffer
+	code := cmdShellInstall(root, []string{"zsh"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first install exit %d: %s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = cmdShellInstall(root, []string{"zsh"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("reinstall exit %d: %s", code, stderr.String())
+	}
+
+	info, err := os.Stat(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected rc mode 0600 after reinstall, got %03o", info.Mode().Perm())
+	}
+}
+
+func TestShellRemovePreservesRCFileMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rc := filepath.Join(home, ".zshrc")
+	shellTestWriteFile(t, rc, "# zshrc\n")
+	if err := os.Chmod(rc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var stdout, stderr bytes.Buffer
+	code := cmdShellInstall(root, []string{"zsh"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("install exit %d: %s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = cmdShellRemove(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("remove exit %d: %s", code, stderr.String())
+	}
+
+	info, err := os.Stat(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected rc mode 0600 after remove, got %03o", info.Mode().Perm())
+	}
+}
+
 func TestShellStatus_NotInstalled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/gc/cmd_shell_test.go
+++ b/cmd/gc/cmd_shell_test.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectShell(t *testing.T) {
+	tests := []struct {
+		env  string
+		want string
+		ok   bool
+	}{
+		{"/bin/bash", "bash", true},
+		{"/bin/zsh", "zsh", true},
+		{"/usr/local/bin/fish", "fish", true},
+		{"bash", "bash", true},
+		{"/bin/ksh", "", false},
+	}
+	for _, tt := range tests {
+		got, err := detectShell(tt.env)
+		if tt.ok && err != nil {
+			t.Errorf("detectShell(%q): unexpected error: %v", tt.env, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("detectShell(%q): expected error, got %q", tt.env, got)
+		}
+		if got != tt.want {
+			t.Errorf("detectShell(%q) = %q, want %q", tt.env, got, tt.want)
+		}
+	}
+}
+
+func TestReplaceHookBlock(t *testing.T) {
+	content := "before\n" + shellHookMarkerBegin + "\nold stuff\n" + shellHookMarkerEnd + "\nafter\n"
+
+	// Replace.
+	got := replaceHookBlock(content, shellHookMarkerBegin+"\nnew stuff\n"+shellHookMarkerEnd+"\n")
+	if !strings.Contains(got, "new stuff") {
+		t.Errorf("replace: expected 'new stuff', got:\n%s", got)
+	}
+	if strings.Contains(got, "old stuff") {
+		t.Errorf("replace: should not contain 'old stuff', got:\n%s", got)
+	}
+	if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+		t.Errorf("replace: should preserve surrounding content, got:\n%s", got)
+	}
+
+	// Remove.
+	got = replaceHookBlock(content, "")
+	if strings.Contains(got, shellHookMarkerBegin) {
+		t.Errorf("remove: should not contain marker, got:\n%s", got)
+	}
+	if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+		t.Errorf("remove: should preserve surrounding content, got:\n%s", got)
+	}
+}
+
+func TestReplaceHookBlock_NoMarker(t *testing.T) {
+	content := "line1\nline2\n"
+	got := replaceHookBlock(content, "replacement\n")
+	if got != content {
+		t.Errorf("no marker: content should be unchanged, got:\n%s", got)
+	}
+}
+
+func TestRCFileHasHook(t *testing.T) {
+	dir := t.TempDir()
+	rc := filepath.Join(dir, ".zshrc")
+
+	// File doesn't exist.
+	has, err := rcFileHasHook(rc)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if has {
+		t.Fatal("expected false for missing file")
+	}
+
+	// File without marker.
+	shellTestWriteFile(t, rc, "export PATH=/usr/bin\n")
+	has, err = rcFileHasHook(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if has {
+		t.Fatal("expected false when no marker present")
+	}
+
+	// File with marker.
+	shellTestWriteFile(t, rc, "stuff\n"+shellHookMarkerBegin+"\nsource foo\n"+shellHookMarkerEnd+"\n")
+	has, err = rcFileHasHook(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Fatal("expected true when marker present")
+	}
+}
+
+func TestRCFileAppendAndRemove(t *testing.T) {
+	dir := t.TempDir()
+	rc := filepath.Join(dir, ".bashrc")
+	shellTestWriteFile(t, rc, "# my bashrc\n")
+
+	block := hookBlock("bash", "/home/user/.gc/completions/gc.bash")
+
+	// Append.
+	if err := rcFileAppendHook(rc, block); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(rc)
+	if !strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Fatal("append: marker not found")
+	}
+	if !strings.Contains(string(data), "]] && source") {
+		t.Fatal("append: guarded source line not found")
+	}
+
+	// Remove.
+	if err := rcFileRemoveHook(rc); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = os.ReadFile(rc)
+	if strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Fatal("remove: marker still present")
+	}
+	if !strings.Contains(string(data), "# my bashrc") {
+		t.Fatal("remove: original content lost")
+	}
+}
+
+func TestRCFileReplaceHook(t *testing.T) {
+	dir := t.TempDir()
+	rc := filepath.Join(dir, ".zshrc")
+	shellTestWriteFile(t, rc, "before\n"+shellHookMarkerBegin+"\nsource old\n"+shellHookMarkerEnd+"\nafter\n")
+
+	newBlock := hookBlock("zsh", "/new/path/_gc")
+	if err := rcFileReplaceHook(rc, newBlock); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(rc)
+	content := string(data)
+	if strings.Contains(content, "source old") {
+		t.Error("old source line still present")
+	}
+	if !strings.Contains(content, "/new/path/_gc") {
+		t.Errorf("new source line not found, got:\n%s", content)
+	}
+	if !strings.Contains(content, "before") || !strings.Contains(content, "after") {
+		t.Errorf("surrounding content lost, got:\n%s", content)
+	}
+}
+
+func TestGenerateCompletion(t *testing.T) {
+	root := newRootCmd(os.Stdout, os.Stderr)
+	for _, sh := range []string{"bash", "zsh", "fish"} {
+		data, err := generateCompletion(root, sh)
+		if err != nil {
+			t.Errorf("generateCompletion(%s): %v", sh, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("generateCompletion(%s): empty output", sh)
+		}
+		// All completion scripts should mention "gc" somewhere.
+		if !strings.Contains(string(data), "gc") {
+			t.Errorf("generateCompletion(%s): output doesn't reference gc", sh)
+		}
+	}
+}
+
+func TestGenerateCompletion_Unsupported(t *testing.T) {
+	root := newRootCmd(os.Stdout, os.Stderr)
+	_, err := generateCompletion(root, "ksh")
+	if err == nil {
+		t.Fatal("expected error for unsupported shell")
+	}
+}
+
+func TestShellInstall(t *testing.T) {
+	// Override HOME so we don't touch real RC files.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a .zshrc to install into.
+	rc := filepath.Join(home, ".zshrc")
+	shellTestWriteFile(t, rc, "# zshrc\n")
+
+	root := newRootCmd(os.Stdout, os.Stderr)
+	var stdout, stderr bytes.Buffer
+	code := cmdShellInstall(root, []string{"zsh"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+
+	// Completion script should exist.
+	compFile := filepath.Join(home, ".gc", "completions", "_gc")
+	if _, err := os.Stat(compFile); err != nil {
+		t.Fatalf("completion script not created: %v", err)
+	}
+
+	// RC file should have the hook.
+	data, _ := os.ReadFile(rc)
+	if !strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Error("RC file missing hook marker")
+	}
+
+	// Installing again should update (not duplicate).
+	stdout.Reset()
+	stderr.Reset()
+	code = cmdShellInstall(root, []string{"zsh"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("re-install exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Updated") {
+		t.Error("expected 'Updated' message on re-install")
+	}
+	data, _ = os.ReadFile(rc)
+	if strings.Count(string(data), shellHookMarkerBegin) != 1 {
+		t.Error("duplicate hook markers after re-install")
+	}
+}
+
+func TestShellRemove(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Set up installed state.
+	compDir := filepath.Join(home, ".gc", "completions")
+	shellTestMkdirAll(t, compDir)
+	compFile := filepath.Join(compDir, "gc.bash")
+	shellTestWriteFile(t, compFile, "# completion")
+
+	rc := filepath.Join(home, ".bashrc")
+	shellTestWriteFile(t, rc, "before\n"+hookBlock("bash", compFile)+"after\n")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdShellRemove(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Removed") {
+		t.Error("expected 'Removed' in output")
+	}
+
+	// Completion file should be gone.
+	if _, err := os.Stat(compFile); !os.IsNotExist(err) {
+		t.Error("completion file not removed")
+	}
+
+	// RC hook should be gone.
+	data, _ := os.ReadFile(rc)
+	if strings.Contains(string(data), shellHookMarkerBegin) {
+		t.Error("hook marker still in RC file")
+	}
+}
+
+func TestShellStatus_NotInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Create RC files so shellRCFile doesn't fall through.
+	shellTestWriteFile(t, filepath.Join(home, ".bashrc"), "")
+	shellTestWriteFile(t, filepath.Join(home, ".zshrc"), "")
+	shellTestMkdirAll(t, filepath.Join(home, ".config", "fish"))
+	shellTestWriteFile(t, filepath.Join(home, ".config", "fish", "config.fish"), "")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdShellStatus(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not installed") {
+		t.Errorf("expected 'not installed', got: %s", stdout.String())
+	}
+}
+
+func TestShellStatus_Installed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create installed state for zsh.
+	compDir := filepath.Join(home, ".gc", "completions")
+	shellTestMkdirAll(t, compDir)
+	shellTestWriteFile(t, filepath.Join(compDir, "_gc"), "# zsh completion")
+	rc := filepath.Join(home, ".zshrc")
+	shellTestWriteFile(t, rc, shellHookMarkerBegin+"\nsource foo\n"+shellHookMarkerEnd+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdShellStatus(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "zsh: installed") {
+		t.Errorf("expected 'zsh: installed', got: %s", out)
+	}
+}
+
+func TestShellCmd_ViaCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	shellTestWriteFile(t, filepath.Join(home, ".zshrc"), "")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"shell", "install", "zsh"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Wrote completion script") {
+		t.Errorf("expected success message, got:\n%s", stdout.String())
+	}
+}
+
+func TestResolveShellArg(t *testing.T) {
+	tests := []struct {
+		args []string
+		env  string
+		want string
+		ok   bool
+	}{
+		{[]string{"bash"}, "", "bash", true},
+		{[]string{"ZSH"}, "", "zsh", true},
+		{[]string{"fish"}, "", "fish", true},
+		{[]string{"ksh"}, "", "", false},
+		{nil, "/bin/zsh", "zsh", true},
+		{nil, "/bin/ksh", "", false},
+	}
+	for _, tt := range tests {
+		if tt.env != "" {
+			t.Setenv("SHELL", tt.env)
+		}
+		got, err := resolveShellArg(tt.args)
+		if tt.ok && err != nil {
+			t.Errorf("resolveShellArg(%v): %v", tt.args, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("resolveShellArg(%v): expected error", tt.args)
+		}
+		if got != tt.want {
+			t.Errorf("resolveShellArg(%v) = %q, want %q", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestAtomicWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := atomicWriteFile(path, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("got %q, want %q", data, "hello")
+	}
+	// Temp file should not exist.
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("temp file still exists")
+	}
+}
+
+// shellTestWriteFile is a test helper that writes content to path, failing the test on error.
+func shellTestWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// shellTestMkdirAll is a test helper that creates a directory tree, failing the test on error.
+func shellTestMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -193,6 +193,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newBdStoreBridgeCmd(stdout, stderr),
 		newDoltConfigCmd(stdout, stderr),
 		newDoltStateCmd(stdout, stderr),
+		newShellCmd(stdout, stderr),
 	)
 	// gen-doc needs the root command to walk the tree; add after construction.
 	root.AddCommand(newGenDocCmd(stdout, stderr, root))


### PR DESCRIPTION
## Summary

- Add `gc shell install [bash|zsh|fish]` — generates cobra completion script to `~/.gc/completions/`, adds guarded source line to shell RC file
- Add `gc shell remove` — removes completion script and RC hook across all shells
- Add `gc shell status` — reports installation state per shell
- Mirrors Gas Town's `gt shell` subcommand structure (install, remove, status)

RC file hook uses existence guard matching Gas Town's pattern:
```
# >>> gc shell integration >>>
[[ -f "/path/to/completion" ]] && source "/path/to/completion"
# <<< gc shell integration <<<
```

## Test plan

- [x] `make check` passes (only pre-existing `nocompress_other.go` misspell lint)
- [x] Unit tests cover: install, re-install idempotency, remove, status, RC file append/replace/remove, hook block generation, shell detection, atomic writes
- [x] Tested `gc shell install zsh` and `gc shell status` against real RC file
- [ ] Manual: verify tab-completion works in bash, zsh, and fish after install