### PR TITLE
fix: use bd provider for managed sessions instead of lifecycle-only exec shim

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -212,7 +212,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	for key, value := range citylayout.CityRuntimeEnvMap(p.cityPath) {
 		agentEnv[key] = value
 	}
-	agentEnv["GC_BEADS"] = beadsProvider(p.cityPath)
+	agentEnv["GC_BEADS"] = "bd"
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe
 	}


### PR DESCRIPTION
## Summary

- Sets `GC_BEADS=bd` for managed sessions instead of `GC_BEADS=exec:gc-beads-bd`
- The exec provider is lifecycle-only (start/stop/health/probe) and exits 2 for data operations, which the exec store silently treats as empty success
- This broke `gc session list`, `gc session nudge`, `gc mail`, and sling pickup inside all managed sessions

One-line change in `template_resolve.go:215`. `CityRuntimeEnvMap` already provides `GC_DOLT_PORT` and runtime context that `bd` needs.

Introduced in 8d317cd0 (#636).

## Test plan

- [ ] `go build ./cmd/gc && go vet ./cmd/gc/...` — pass
- [ ] Start city, verify `gc session list` returns sessions from inside a managed session
- [ ] Verify `gc sling` dispatch → agent wakes and picks up the routed bead
- [ ] Verify `gc session nudge` delivers between managed sessions
- [ ] Check rig-scoped dolt scenarios if applicable

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)