### PR TITLE
fix: eliminate dolt double-restart race in gc dolt sync (#560)

### DIFF
--- a/cmd/gc/embed_beads_bd_test.go
+++ b/cmd/gc/embed_beads_bd_test.go
@@ -127,10 +127,19 @@ func TestBeadsBdScript_EnsureReadyNotRunning(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Use a dynamically allocated port to avoid flakiness if a hardcoded
+	// port happens to be in use on the CI host.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	freePort := fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+	ln.Close()
+
 	cmd := exec.Command(scriptPath, "ensure-ready")
 	cmd.Env = []string{
 		"GC_CITY_PATH=" + dir,
-		"GC_DOLT_PORT=19999",
+		"GC_DOLT_PORT=" + freePort,
 		"PATH=" + os.Getenv("PATH"),
 		"HOME=" + t.TempDir(),
 	}
@@ -344,7 +353,10 @@ func TestBeadsBdScript_EnsureReadyNeverKills(t *testing.T) {
 	if err := sleeper.Start(); err != nil {
 		t.Fatal(err)
 	}
-	defer sleeper.Process.Kill() //nolint:errcheck
+	defer func() {
+		_ = sleeper.Process.Kill()
+		_, _ = sleeper.Process.Wait() // Reap to avoid zombie.
+	}()
 	sleeperPID := fmt.Sprintf("%d", sleeper.Process.Pid)
 
 	// Use a port nothing is listening on — this triggers the TCP failure

--- a/cmd/gc/embed_beads_bd_test.go
+++ b/cmd/gc/embed_beads_bd_test.go
@@ -134,7 +134,7 @@ func TestBeadsBdScript_EnsureReadyNotRunning(t *testing.T) {
 		t.Fatal(err)
 	}
 	freePort := fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
-	ln.Close()
+	_ = ln.Close()
 
 	cmd := exec.Command(scriptPath, "ensure-ready")
 	cmd.Env = []string{
@@ -227,7 +227,7 @@ func TestBeadsBdScript_EnsureReadyTCPUnreachable(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
+	_ = ln.Close()
 
 	packDir := filepath.Join(dir, ".gc", "runtime", "packs", "dolt")
 	if err := os.MkdirAll(packDir, 0o755); err != nil {
@@ -283,7 +283,7 @@ func TestBeadsBdScript_EnsureReadyTCPReachableQueryFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	// Accept and immediately close connections so nc -z succeeds but
@@ -294,7 +294,7 @@ func TestBeadsBdScript_EnsureReadyTCPReachableQueryFails(t *testing.T) {
 			if err != nil {
 				return
 			}
-			conn.Close()
+			_ = conn.Close()
 		}
 	}()
 
@@ -366,7 +366,7 @@ func TestBeadsBdScript_EnsureReadyNeverKills(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
+	_ = ln.Close()
 
 	packDir := filepath.Join(dir, ".gc", "runtime", "packs", "dolt")
 	if err := os.MkdirAll(packDir, 0o755); err != nil {
@@ -388,7 +388,7 @@ func TestBeadsBdScript_EnsureReadyNeverKills(t *testing.T) {
 		"PATH=" + os.Getenv("PATH"),
 		"HOME=" + t.TempDir(),
 	}
-	cmd.CombinedOutput() // Ignore exit code — we only care about the side effect.
+	_, _ = cmd.CombinedOutput() // Ignore exit code — we only care about the side effect.
 
 	// The critical assertion: the sleeper process must still be alive.
 	// Before the fix, op_ensure_ready → op_start → kill -9.

--- a/cmd/gc/embed_beads_bd_test.go
+++ b/cmd/gc/embed_beads_bd_test.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -79,6 +83,305 @@ func TestBeadsBdScript_K8sDoltEnvInheritance(t *testing.T) {
 	}
 	if exitCode != 2 {
 		t.Errorf("gc-beads-bd start with GC_K8S_DOLT_HOST: exit %d, want 2 (remote detected)\noutput: %s", exitCode, out)
+	}
+}
+
+// TestBeadsBdScript_EnsureReadyRemoteExits2 verifies that ensure-ready
+// returns exit 2 (not needed) when a remote host is configured.
+func TestBeadsBdScript_EnsureReadyRemoteExits2(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "ensure-ready")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		"GC_DOLT_HOST=dolt.example.com",
+		"GC_DOLT_PORT=3306",
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if exitCode != 2 {
+		t.Errorf("ensure-ready with remote host: exit %d, want 2\noutput: %s", exitCode, out)
+	}
+}
+
+// TestBeadsBdScript_EnsureReadyNotRunning verifies that ensure-ready exits 1
+// with "not running" when no dolt server PID exists.
+func TestBeadsBdScript_EnsureReadyNotRunning(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "ensure-ready")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		"GC_DOLT_PORT=19999",
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if exitCode != 1 {
+		t.Errorf("ensure-ready with no server: exit %d, want 1\noutput: %s", exitCode, out)
+	}
+	if !strings.Contains(string(out), "not running") {
+		t.Errorf("expected 'not running' in output, got: %s", out)
+	}
+}
+
+// TestBeadsBdScript_EnsureReadyNoPort verifies that ensure-ready exits 1
+// with "no recorded port" when the PID is alive but state has no port.
+func TestBeadsBdScript_EnsureReadyNoPort(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up pack state dir and write a PID file pointing at our own PID
+	// (which is guaranteed alive).
+	packDir := filepath.Join(dir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	selfPID := fmt.Sprintf("%d", os.Getpid())
+	if err := os.WriteFile(filepath.Join(packDir, "dolt.pid"), []byte(selfPID), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// State file with no port field.
+	if err := os.WriteFile(filepath.Join(packDir, "dolt-state.json"), []byte(`{"running":true,"pid":`+selfPID+`}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "ensure-ready")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		"GC_DOLT_PORT=19999",
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if exitCode != 1 {
+		t.Errorf("ensure-ready with no port in state: exit %d, want 1\noutput: %s", exitCode, out)
+	}
+	if !strings.Contains(string(out), "no recorded port") {
+		t.Errorf("expected 'no recorded port' in output, got: %s", out)
+	}
+}
+
+// TestBeadsBdScript_EnsureReadyTCPUnreachable verifies that ensure-ready
+// exits 1 with "not reachable" when PID is alive and port is recorded
+// but nothing is listening on that port.
+func TestBeadsBdScript_EnsureReadyTCPUnreachable(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a port that nothing is listening on. Bind and immediately close
+	// to get a known-free port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	packDir := filepath.Join(dir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	selfPID := fmt.Sprintf("%d", os.Getpid())
+	if err := os.WriteFile(filepath.Join(packDir, "dolt.pid"), []byte(selfPID), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	portStr := fmt.Sprintf("%d", port)
+	stateJSON := fmt.Sprintf(`{"running":true,"pid":%s,"port":%s}`, selfPID, portStr)
+	if err := os.WriteFile(filepath.Join(packDir, "dolt-state.json"), []byte(stateJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "ensure-ready")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		"GC_DOLT_PORT=" + portStr,
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if exitCode != 1 {
+		t.Errorf("ensure-ready with unreachable port: exit %d, want 1\noutput: %s", exitCode, out)
+	}
+	if !strings.Contains(string(out), "not reachable") {
+		t.Errorf("expected 'not reachable' in output, got: %s", out)
+	}
+}
+
+// TestBeadsBdScript_EnsureReadyTCPReachableQueryFails verifies that
+// ensure-ready exits 1 when TCP is reachable but the query probe fails
+// (server listening but not a dolt SQL server).
+func TestBeadsBdScript_EnsureReadyTCPReachableQueryFails(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a TCP listener that accepts but doesn't speak MySQL/dolt protocol.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// Accept and immediately close connections so nc -z succeeds but
+	// dolt query probe fails.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	packDir := filepath.Join(dir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	selfPID := fmt.Sprintf("%d", os.Getpid())
+	if err := os.WriteFile(filepath.Join(packDir, "dolt.pid"), []byte(selfPID), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	portStr := fmt.Sprintf("%d", port)
+	stateJSON := fmt.Sprintf(`{"running":true,"pid":%s,"port":%s}`, selfPID, portStr)
+	if err := os.WriteFile(filepath.Join(packDir, "dolt-state.json"), []byte(stateJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "ensure-ready")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		"GC_DOLT_PORT=" + portStr,
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if exitCode != 1 {
+		t.Errorf("ensure-ready with non-dolt listener: exit %d, want 1\noutput: %s", exitCode, out)
+	}
+	if !strings.Contains(string(out), "not answering queries") {
+		t.Errorf("expected 'not answering queries' in output, got: %s", out)
+	}
+}
+
+// TestBeadsBdScript_EnsureReadyNeverKills is the core regression test for #560.
+// It verifies that ensure-ready NEVER kills a running process, even when
+// TCP probes fail. Before the fix, op_ensure_ready aliased op_start which
+// had a kill-9 branch on tcp_check_port failure.
+func TestBeadsBdScript_EnsureReadyNeverKills(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath, err := MaterializeBeadsBdScript(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a long-lived subprocess to act as a fake "dolt server".
+	sleeper := exec.Command("sleep", "60")
+	if err := sleeper.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer sleeper.Process.Kill() //nolint:errcheck
+	sleeperPID := fmt.Sprintf("%d", sleeper.Process.Pid)
+
+	// Use a port nothing is listening on — this triggers the TCP failure
+	// that previously caused op_start's kill-9 path.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	packDir := filepath.Join(dir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packDir, "dolt.pid"), []byte(sleeperPID), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	portStr := fmt.Sprintf("%d", port)
+	stateJSON := fmt.Sprintf(`{"running":true,"pid":%s,"port":%s}`, sleeperPID, portStr)
+	if err := os.WriteFile(filepath.Join(packDir, "dolt-state.json"), []byte(stateJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(scriptPath, "ensure-ready")
+	cmd.Env = []string{
+		"GC_CITY_PATH=" + dir,
+		"GC_DOLT_PORT=" + portStr,
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+	cmd.CombinedOutput() // Ignore exit code — we only care about the side effect.
+
+	// The critical assertion: the sleeper process must still be alive.
+	// Before the fix, op_ensure_ready → op_start → kill -9.
+	if err := sleeper.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Errorf("regression #560: ensure-ready killed PID %s (process no longer alive)", sleeperPID)
 	}
 }
 

--- a/cmd/gc/gc-beads-bd
+++ b/cmd/gc/gc-beads-bd
@@ -818,9 +818,35 @@ op_start() {
     sync_port_files
 }
 
-# op_ensure_ready is a legacy alias for start.
+# op_ensure_ready verifies the dolt server is running and reachable.
+# Non-destructive: never kills or restarts the server. Returns 0 if the
+# server is alive, reachable via TCP, and answering queries; non-zero
+# otherwise. Callers that need start-if-not-running should use op_start.
 op_ensure_ready() {
-    op_start
+    if is_remote; then
+        exit 2
+    fi
+
+    local pid
+    pid=$(find_dolt_pid)
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        die "dolt server is not running"
+    fi
+
+    local port
+    port=$(load_state_field port)
+    if [ -z "$port" ]; then
+        die "dolt server (PID $pid) has no recorded port"
+    fi
+
+    if ! tcp_check_port "$port"; then
+        die "dolt server (PID $pid) is not reachable on port $port"
+    fi
+
+    DOLT_PORT="$port"
+    if ! do_query_probe; then
+        die "dolt server (PID $pid) is reachable on port $port but not answering queries"
+    fi
 }
 
 # ensure_config_yaml creates a minimal .beads/config.yaml with prefix settings

--- a/examples/dolt/commands/sync.sh
+++ b/examples/dolt/commands/sync.sh
@@ -121,7 +121,6 @@ fi
 # Restart server if it was running.
 if [ "$was_running" = true ] && [ "$dry_run" = false ] && [ -x "$beads_bd" ]; then
   "$beads_bd" start 2>/dev/null || true
-  "$beads_bd" ensure-ready 2>/dev/null || true
 fi
 
 exit $exit_code


### PR DESCRIPTION
## Summary

- Remove the redundant `ensure-ready` call from `sync.sh:124` — `start` already blocks on TCP + query readiness before returning, so `ensure-ready` was pure redundancy that triggered a destructive kill-and-restart path ~18% of the time
- Rewrite `op_ensure_ready` in `gc-beads-bd` from a destructive `op_start` alias to a non-destructive verify-only function (PID + TCP + query probe, never kills) as defense-in-depth
- Add 6 regression tests covering all `op_ensure_ready` branches, including the core #560 assertion: ensure-ready must never kill a running process even when TCP probes transiently fail

Fixes #560

## Review notes

**Blast radius**: Exceptionally narrow. Go production code (`ensureBeadsProvider`) sends `"start"`, never `"ensure-ready"` — the Go lifecycle is unaffected. The only production shell caller was `sync.sh:124` (now removed). Other provider scripts (`gc-beads-k8s`, `gc-beads-br`) are already non-destructive for `ensure-ready`.

**Multi-model review**: 5 reviewers (3 Anthropic + Codex GPT-5.4, Copilot skipped). Zero CRITICAL/HIGH findings. Codex verified all 5 correctness questions clean against source, including that `sync_port_files` is already called by `op_start` so removing `ensure-ready` doesn't cause port drift.

## Test plan

- [x] `TestBeadsBdScript_EnsureReadyRemoteExits2` — remote mode returns exit 2
- [x] `TestBeadsBdScript_EnsureReadyNotRunning` — no PID → exit 1 "not running"
- [x] `TestBeadsBdScript_EnsureReadyNoPort` — PID alive, no port → exit 1 "no recorded port"
- [x] `TestBeadsBdScript_EnsureReadyTCPUnreachable` — TCP fails → exit 1 "not reachable"
- [x] `TestBeadsBdScript_EnsureReadyTCPReachableQueryFails` — TCP passes, query fails → exit 1 "not answering queries"
- [x] `TestBeadsBdScript_EnsureReadyNeverKills` — **core #560 regression**: TCP fails but process NOT killed
- [x] `make build` passes
- [x] `go vet ./...` clean
- [x] `make check-docs` passes
- [x] Full test suite: only pre-existing baseline failures