### PR TITLE
feat: add --strict flag to gc prime for typo detection

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -142,8 +142,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 
 	// In non-strict mode, hook side effects fire eagerly (existing behavior).
 	// In strict mode, we defer them until after strict checks pass so that a
-	// failing --strict invocation does not persist a session-id for an agent
-	// that doesn't exist.
+	// failing --strict invocation does not persist a session-id for failed
+	// agent resolution or template validation.
 	runHookSideEffects := func() {
 		if !hookMode {
 			return
@@ -219,6 +219,21 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: agent %q not found in city config\n", agentName) //nolint:errcheck
 			return 1
 		}
+		// renderPrompt returns "" both when the template file cannot be read
+		// and when a valid template legitimately renders empty. Readability is
+		// the strict precondition, so check it before hook side effects.
+		for _, a := range resolvedAgents {
+			if isAgentEffectivelySuspended(cfg, &a) {
+				continue
+			}
+			if a.PromptTemplate == "" {
+				continue
+			}
+			if _, fErr := os.ReadFile(promptTemplateSourcePath(cityPath, a.PromptTemplate)); fErr != nil {
+				fmt.Fprintf(stderr, "gc prime: prompt_template %q for agent %q: %v\n", a.PromptTemplate, agentName, fErr) //nolint:errcheck
+				return 1
+			}
+		}
 		// Strict preconditions passed; now it's safe to persist session-id.
 		runHookSideEffects()
 	}
@@ -248,22 +263,6 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, stderr)
 		}
 		if a.PromptTemplate != "" {
-			// Under strict, surface template-file-read failures specifically.
-			// renderPrompt returns "" in two cases: (1) the file cannot be
-			// read (missing, permissions, etc.), and (2) the template is valid
-			// but renders to empty output (e.g., all `{{if}}` blocks false).
-			// The caller can't tell them apart from the empty return alone,
-			// so strict needs an explicit read attempt to flag (1) without
-			// false-positiving (2). os.ReadFile (rather than os.Stat) catches
-			// permission-denied as well as not-exists. Parse/execute errors
-			// already write to stderr and return the raw template bytes
-			// (non-empty), so those surface via the normal success path.
-			if strictMode {
-				if _, fErr := os.ReadFile(filepath.Join(cityPath, a.PromptTemplate)); fErr != nil {
-					fmt.Fprintf(stderr, "gc prime: prompt_template %q for agent %q: %v\n", a.PromptTemplate, agentName, fErr) //nolint:errcheck
-					return 1
-				}
-			}
 			fragments := effectivePromptFragments(
 				cfg.Workspace.GlobalFragments,
 				a.InjectFragments,

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -54,6 +54,7 @@ type primeHookInput struct {
 func newPrimeCmd(stdout, stderr io.Writer) *cobra.Command {
 	var hookMode bool
 	var hookFormat string
+	var strictMode bool
 	cmd := &cobra.Command{
 		Use:   "prime [agent-name]",
 		Short: "Output the behavioral prompt for an agent",
@@ -67,32 +68,60 @@ Runtime hook profiles may call ` + "`gc prime --hook`" + `.
 When agent-name is omitted, ` + "`GC_ALIAS`" + ` is used (falling back to ` + "`GC_AGENT`" + `).
 
 If agent-name matches a configured agent with a prompt_template,
-that template is output. Otherwise outputs a default worker prompt.`,
+that template is output. Otherwise outputs a default worker prompt.
+
+Pass --strict to fail on debugging mistakes instead of silently falling
+back to the default prompt. Strict errors on:
+
+  - no city config found
+  - city config fails to load
+  - no agent name given (from args, GC_ALIAS, or GC_AGENT)
+  - agent name not in city config (typo detection — the main use case)
+  - agent's prompt_template points at a file that cannot be read
+
+Strict does NOT error on agents whose config intentionally lacks a
+prompt_template (a supported minimal config), on templates that render
+to empty output from valid conditional logic, or on suspended states
+(city or agent) — those are legitimate quiet states, not mistakes.`,
 		Args: cobra.MaximumNArgs(1),
 	}
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
-		if doPrimeWithHookFormat(args, stdout, stderr, hookMode, hookFormat) != 0 {
+		if doPrimeWithHookFormat(args, stdout, stderr, hookMode, hookFormat, strictMode) != 0 {
 			return errExit
 		}
 		return nil
 	}
 	cmd.Flags().BoolVar(&hookMode, "hook", false, "compatibility mode for runtime hook invocations")
 	cmd.Flags().StringVar(&hookFormat, "hook-format", "", "format hook output for a provider")
+	cmd.Flags().BoolVar(&strictMode, "strict", false, "fail on missing city, missing or unknown agent, or unreadable prompt_template instead of falling back to the default prompt")
 	return cmd
 }
 
-// doPrime is the pure logic for "gc prime". Looks up the agent name in
-// city.toml and outputs the corresponding prompt template. Falls back to
-// the default run-once prompt if no match is found or no city exists.
-func doPrime(args []string, stdout, stderr io.Writer) int { //nolint:unparam // always returns 0 by design (graceful fallback)
-	return doPrimeWithMode(args, stdout, stderr, false)
+// doPrime exists as the public non-strict entry point so callers don't
+// need to know about the strict flag; its return type stays int because
+// the caller shape matches other cmd/gc entry points.
+func doPrime(args []string, stdout, stderr io.Writer) int { //nolint:unparam // strictMode=false means always returns 0
+	return doPrimeWithMode(args, stdout, stderr, false, false)
 }
 
-func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode bool) int { //nolint:unparam // always returns 0 by design (graceful fallback)
-	return doPrimeWithHookFormat(args, stdout, stderr, hookMode, "")
+// doPrimeWithMode's strict-mode contract: only states that would indicate
+// a user mistake (missing city config, no agent name, unknown agent name,
+// unreadable prompt_template file) error out. Supported minimal configs
+// (agent with no prompt_template at all, or a template that legitimately
+// renders to empty output via conditional logic) and intentional quiet
+// states (suspended city/agent) remain silent even under --strict —
+// strict is a debugging aid, not a stricter mode for the whole command.
+//
+// Hook-mode side effects under --strict are deferred until we know the
+// invocation is not a strict failure, so a failing --strict cannot leave
+// session-id state behind for an agent that doesn't exist. Suspended
+// paths still run side effects because suspension is a legitimate quiet
+// state, not a failure.
+func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode, strictMode bool) int {
+	return doPrimeWithHookFormat(args, stdout, stderr, hookMode, "", strictMode)
 }
 
-func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode bool, hookFormat string) int { //nolint:unparam // always returns 0 by design (graceful fallback)
+func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode bool, hookFormat string, strictMode bool) int {
 	agentName := os.Getenv("GC_ALIAS")
 	if agentName == "" {
 		agentName = os.Getenv("GC_AGENT")
@@ -110,28 +139,52 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	if len(args) > 0 {
 		agentName = args[0]
 	}
-	if hookMode {
+
+	// In non-strict mode, hook side effects fire eagerly (existing behavior).
+	// In strict mode, we defer them until after strict checks pass so that a
+	// failing --strict invocation does not persist a session-id for an agent
+	// that doesn't exist.
+	runHookSideEffects := func() {
+		if !hookMode {
+			return
+		}
 		if sessionID, _ := readPrimeHookContext(); sessionID != "" {
 			persistPrimeHookSessionID(sessionID)
 		}
 		persistPrimeHookProviderSessionKey()
 	}
+	if !strictMode {
+		runHookSideEffects()
+	}
 
-	// Try to find city and load config.
 	cityPath, err := resolveCity()
 	if err != nil {
+		if strictMode {
+			fmt.Fprintf(stderr, "gc prime: no city config found: %v\n", err) //nolint:errcheck
+			return 1
+		}
 		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
+		if strictMode {
+			fmt.Fprintf(stderr, "gc prime: loading city config: %v\n", err) //nolint:errcheck
+			return 1
+		}
 		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
 
 	if citySuspended(cfg) {
-		return 0 // empty output; hooks call this
+		// Suspended is a legitimate quiet state, not a strict failure —
+		// keep hook behavior consistent with non-strict (which already
+		// ran side effects eagerly above).
+		if strictMode {
+			runHookSideEffects()
+		}
+		return 0
 	}
 
 	cityName := loadedCityName(cfg, cityPath)
@@ -143,38 +196,74 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// sessions may have GC_ALIAS set to a user-facing alias that is not an
 	// agent name, so also try GC_TEMPLATE before falling back to the generic
 	// run-once prompt.
+	var resolvedAgents []config.Agent
 	agentCandidates := primeAgentCandidates(agentName, hookMode, cityPath)
 	for _, candidate := range agentCandidates {
 		a, ok := resolveAgentIdentity(cfg, candidate, currentRigContext(cfg))
 		if !ok {
 			a, ok = findAgentByName(cfg, candidate)
 		}
-		if ok && isAgentEffectivelySuspended(cfg, &a) {
-			return 0 // suspended agent gets no prompt
-		}
 		if ok {
-			if resolved, rErr := config.ResolveProvider(&a, &cfg.Workspace, cfg.Providers, exec.LookPath); rErr == nil && hookMode {
-				sessionName := os.Getenv("GC_SESSION_NAME")
-				if sessionName == "" {
-					sessionName = cliSessionName(cityPath, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-				}
-				maybeStartNudgePoller(withNudgeTargetFence(openNudgeBeadStore(cityPath), nudgeTarget{
-					cityPath:          cityPath,
-					cityName:          cityName,
-					cfg:               cfg,
-					agent:             a,
-					resolved:          resolved,
-					sessionID:         os.Getenv("GC_SESSION_ID"),
-					continuationEpoch: os.Getenv("GC_CONTINUATION_EPOCH"),
-					sessionName:       sessionName,
-				}))
+			resolvedAgents = append(resolvedAgents, a)
+		}
+	}
+
+	// Strict preconditions: fail now, before any hook side effects or the
+	// nudge poller start, so a failing --strict leaves no partial state.
+	if strictMode {
+		switch {
+		case agentName == "":
+			fmt.Fprintf(stderr, "gc prime: --strict requires an agent name (from args, GC_ALIAS, or GC_AGENT)\n") //nolint:errcheck
+			return 1
+		case len(resolvedAgents) == 0:
+			fmt.Fprintf(stderr, "gc prime: agent %q not found in city config\n", agentName) //nolint:errcheck
+			return 1
+		}
+		// Strict preconditions passed; now it's safe to persist session-id.
+		runHookSideEffects()
+	}
+
+	for _, a := range resolvedAgents {
+		if isAgentEffectivelySuspended(cfg, &a) {
+			return 0
+		}
+		if resolved, rErr := config.ResolveProvider(&a, &cfg.Workspace, cfg.Providers, exec.LookPath); rErr == nil && hookMode {
+			sessionName := os.Getenv("GC_SESSION_NAME")
+			if sessionName == "" {
+				sessionName = cliSessionName(cityPath, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
 			}
+			maybeStartNudgePoller(withNudgeTargetFence(openNudgeBeadStore(cityPath), nudgeTarget{
+				cityPath:          cityPath,
+				cityName:          cityName,
+				cfg:               cfg,
+				agent:             a,
+				resolved:          resolved,
+				sessionID:         os.Getenv("GC_SESSION_ID"),
+				continuationEpoch: os.Getenv("GC_CONTINUATION_EPOCH"),
+				sessionName:       sessionName,
+			}))
 		}
 		var ctx PromptContext
-		if ok && (a.PromptTemplate != "" || hookMode || sessionTemplateContext) {
+		if a.PromptTemplate != "" || hookMode || sessionTemplateContext {
 			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, stderr)
 		}
-		if ok && a.PromptTemplate != "" {
+		if a.PromptTemplate != "" {
+			// Under strict, surface template-file-read failures specifically.
+			// renderPrompt returns "" in two cases: (1) the file cannot be
+			// read (missing, permissions, etc.), and (2) the template is valid
+			// but renders to empty output (e.g., all `{{if}}` blocks false).
+			// The caller can't tell them apart from the empty return alone,
+			// so strict needs an explicit read attempt to flag (1) without
+			// false-positiving (2). os.ReadFile (rather than os.Stat) catches
+			// permission-denied as well as not-exists. Parse/execute errors
+			// already write to stderr and return the raw template bytes
+			// (non-empty), so those surface via the normal success path.
+			if strictMode {
+				if _, fErr := os.ReadFile(filepath.Join(cityPath, a.PromptTemplate)); fErr != nil {
+					fmt.Fprintf(stderr, "gc prime: prompt_template %q for agent %q: %v\n", a.PromptTemplate, agentName, fErr) //nolint:errcheck
+					return 1
+				}
+			}
 			fragments := effectivePromptFragments(
 				cfg.Workspace.GlobalFragments,
 				a.InjectFragments,
@@ -187,6 +276,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat)
 				return 0
 			}
+			// File is present but rendered empty. Treat as a legitimate
+			// (if unusual) minimal config — emit the default fallback.
 		}
 		// Agents without a prompt_template: read a builtin prompt shipped by
 		// the core bootstrap pack, materialized under .gc/system/packs/core/.
@@ -194,7 +285,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		// Otherwise pool agents use pool-worker.md.
 		// Pool instances have Pool=nil after resolution, so also check the
 		// template agent via findAgentByName.
-		if ok && a.PromptTemplate == "" {
+		if a.PromptTemplate == "" {
 			promptFile := ""
 			if cfg.Daemon.FormulaV2 {
 				promptFile = citylayout.SystemPacksRoot + "/core/assets/prompts/graph-worker.md"
@@ -210,7 +301,10 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		}
 	}
 
-	// Fallback: default run-once prompt.
+	// Fallback: default run-once prompt. Under strict, this is only reached
+	// when the agent has no prompt_template and doesn't match a builtin
+	// worker prompt — a supported config shape, so the default prompt is
+	// the correct output even under --strict.
 	fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
 	return 0
 }

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -250,7 +250,7 @@ prompt_template = "prompts/polecat.template.md"
 	t.Setenv("GC_SESSION_ID", "sess-777")
 
 	var stdout, stderr bytes.Buffer
-	code := doPrimeWithMode(nil, &stdout, &stderr, true)
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode() = %d, want 0; stderr=%q", code, stderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4673,6 +4673,44 @@ prompt_template = "prompts/does-not-exist.md"
 	}
 }
 
+func TestDoPrimeStrictAbsoluteTemplatePath(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptDir := t.TempDir()
+	promptPath := filepath.Join(promptDir, "mayor.md")
+	if err := os.WriteFile(promptPath, []byte("absolute mayor prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = %q
+`, promptPath)
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, absolute template path) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stdout.String() != "absolute mayor prompt" {
+		t.Errorf("stdout = %q, want absolute template content", stdout.String())
+	}
+}
+
 // TestDoPrimeStrictTemplateRendersLegitimatelyEmpty verifies that --strict
 // does NOT error when a template file exists but produces empty output.
 // Templates with conditional blocks (e.g., `{{if .RigName}}...{{end}}`)
@@ -4767,6 +4805,50 @@ name = "mayor"
 	sessionFile := filepath.Join(dir, ".runtime", "session_id")
 	if _, err := os.Stat(sessionFile); !os.IsNotExist(err) {
 		t.Errorf("strict failure should not persist session id, but %s exists (err=%v)", sessionFile, err)
+	}
+}
+
+// TestDoPrimeStrictHookModeMissingTemplateDoesNotPersistSessionOnFailure
+// verifies that strict template validation also runs before hook-mode side
+// effects. A missing prompt_template is a strict failure, so it must not
+// leave behind a session id for the failed hook invocation.
+func TestDoPrimeStrictHookModeMissingTemplateDoesNotPersistSessionOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/does-not-exist.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_SESSION_ID", "test-session-missing-template")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, true, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, hook=true, missing template) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `prompt_template "prompts/does-not-exist.md"`) {
+		t.Errorf("stderr = %q, want to reference the missing template path", stderr.String())
+	}
+
+	sessionFile := filepath.Join(dir, ".runtime", "session_id")
+	if _, err := os.Stat(sessionFile); !os.IsNotExist(err) {
+		t.Errorf("strict template failure should not persist session id, but %s exists (err=%v)", sessionFile, err)
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4450,6 +4450,487 @@ prompt_template = "prompts/mayor.md"
 	}
 }
 
+// TestDoPrimeStrictUnknownAgent verifies --strict returns a non-zero exit
+// code and writes a descriptive error to stderr when the named agent is
+// not in the city config. Regression test for #445.
+func TestDoPrimeStrictUnknownAgent(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"nonexistent"}, &stdout, &stderr, false, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, unknown agent) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+	if stdout.String() == defaultPrimePrompt {
+		t.Errorf("strict mode should not emit default prompt, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `agent "nonexistent" not found`) {
+		t.Errorf("stderr = %q, want to contain 'agent \"nonexistent\" not found'", stderr.String())
+	}
+}
+
+// TestDoPrimeStrictKnownAgent verifies --strict does NOT error when the
+// agent exists and has a renderable prompt.
+func TestDoPrimeStrictKnownAgent(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptContent := "mayor prompt content"
+	if err := os.WriteFile(filepath.Join(promptDir, "mayor.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, known agent) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), promptContent) {
+		t.Errorf("stdout = %q, want to contain %q", stdout.String(), promptContent)
+	}
+}
+
+// TestDoPrimeStrictNoCity verifies --strict errors when no city config
+// can be resolved, rather than silently emitting the default prompt.
+func TestDoPrimeStrictNoCity(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"anyname"}, &stdout, &stderr, false, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, no city) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+	if stdout.String() == defaultPrimePrompt {
+		t.Errorf("strict mode should not emit default prompt when no city, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "no city config") {
+		t.Errorf("stderr = %q, want to contain 'no city config'", stderr.String())
+	}
+}
+
+// TestDoPrimeStrictNoAgentName verifies --strict errors when no agent name
+// is available from args, GC_ALIAS, or GC_AGENT.
+func TestDoPrimeStrictNoAgentName(t *testing.T) {
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode(nil, &stdout, &stderr, false, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, no name) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--strict requires an agent name") {
+		t.Errorf("stderr = %q, want to contain '--strict requires an agent name'", stderr.String())
+	}
+}
+
+// TestDoPrimeStrictAgentWithEmptyPromptTemplate verifies that a
+// single-session agent with no prompt_template configured — a supported
+// config shape — falls through to the default prompt even under --strict,
+// rather than being reported as an error. Strict is for debugging typos
+// and template mistakes, not for rejecting valid minimal configs.
+func TestDoPrimeStrictAgentWithEmptyPromptTemplate(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Agent is in the config but has no prompt_template and isn't a pool
+	// or formula_v2 agent. Non-strict today emits defaultPrimePrompt.
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, agent without prompt_template) = %d, want 0 (supported config); stderr: %s", code, stderr.String())
+	}
+	if stdout.String() != defaultPrimePrompt {
+		t.Errorf("stdout = %q, want defaultPrimePrompt (agent without prompt_template should fall through)", stdout.String())
+	}
+}
+
+// TestDoPrimeStrictMissingTemplateFile verifies --strict errors with a
+// distinct, diagnostic message when the agent's prompt_template points
+// at a file that doesn't exist. This is the error case renderPrompt
+// silently swallows by returning "", which strict mode needs to surface
+// with the underlying stat reason.
+func TestDoPrimeStrictMissingTemplateFile(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/does-not-exist.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, missing template file) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+	if stdout.String() == defaultPrimePrompt {
+		t.Errorf("strict mode should not emit default prompt when template file missing, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `prompt_template "prompts/does-not-exist.md"`) {
+		t.Errorf("stderr = %q, want to reference the missing template path", stderr.String())
+	}
+}
+
+// TestDoPrimeStrictTemplateRendersLegitimatelyEmpty verifies that --strict
+// does NOT error when a template file exists but produces empty output.
+// Templates with conditional blocks (e.g., `{{if .RigName}}...{{end}}`)
+// can legitimately evaluate to empty under some contexts; strict mode is
+// a typo/missing-file detector, not a check that templates produce
+// substantial content. The absence of this test would let the missing-
+// file strict check quietly regress into a broader empty-render check.
+func TestDoPrimeStrictTemplateRendersLegitimatelyEmpty(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Template file exists but renders to empty string under this context.
+	// {{if}} with a missing/empty key (RigName is empty when GC_RIG isn't set)
+	// short-circuits the whole template body.
+	emptyTemplate := `{{if .RigName}}You are in rig {{.RigName}}.{{end}}`
+	if err := os.WriteFile(filepath.Join(promptDir, "mayor.md"), []byte(emptyTemplate), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear GC_RIG so .RigName evaluates to empty and the conditional
+	// short-circuits. Without this, an ambient GC_RIG would produce output.
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_ALIAS", "")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, legitimately-empty template) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+}
+
+// TestDoPrimeStrictHookModeDoesNotPersistSessionOnFailure verifies that
+// when --strict fails because the agent isn't found, hook-mode side
+// effects (persisting the session ID to .runtime/session_id) do NOT fire.
+// A failing strict invocation must not leave partial state behind.
+func TestDoPrimeStrictHookModeDoesNotPersistSessionOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Present a session ID the way a runtime hook would.
+	t.Setenv("GC_SESSION_ID", "test-session-123")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"nonexistent"}, &stdout, &stderr, true, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, hook=true, unknown agent) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+
+	// The critical assertion: no .runtime/session_id should have been created.
+	sessionFile := filepath.Join(dir, ".runtime", "session_id")
+	if _, err := os.Stat(sessionFile); !os.IsNotExist(err) {
+		t.Errorf("strict failure should not persist session id, but %s exists (err=%v)", sessionFile, err)
+	}
+}
+
+// TestDoPrimeStrictHookModePersistsSessionOnSuccess is the contrast test:
+// when --strict + --hook succeeds (agent is found, prompt renders),
+// session-id persistence DOES fire — the deferral is not a regression of
+// hook behavior for the success path.
+func TestDoPrimeStrictHookModePersistsSessionOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "mayor.md"), []byte("mayor prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_SESSION_ID", "test-session-456")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, true, true)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, hook=true, known agent) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	sessionFile := filepath.Join(dir, ".runtime", "session_id")
+	content, err := os.ReadFile(sessionFile)
+	if err != nil {
+		t.Fatalf("expected session id persisted to %s on strict success, got err: %v", sessionFile, err)
+	}
+	if !strings.Contains(string(content), "test-session-456") {
+		t.Errorf("session id file contents = %q, want to contain 'test-session-456'", string(content))
+	}
+}
+
+// TestDoPrimeStrictUnreadableTemplateFile verifies the template-read check
+// catches permission-denied as well as not-exists. os.Stat would succeed on
+// a chmod-000 file, but renderPrompt cannot read it — strict needs to
+// surface that as an error rather than letting the empty render fall
+// through to the default prompt. Skips if running as root, since root
+// bypasses POSIX permission checks.
+func TestDoPrimeStrictUnreadableTemplateFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-denied check is bypassed when running as root")
+	}
+
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	templatePath := filepath.Join(promptDir, "mayor.md")
+	if err := os.WriteFile(templatePath, []byte("mayor prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Strip read permission so the file exists (Stat succeeds) but cannot be read.
+	if err := os.Chmod(templatePath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(templatePath, 0o644) })
+
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, false, true)
+	if code == 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, unreadable template) = 0, want non-zero; stderr: %s", stderr.String())
+	}
+	if stdout.String() == defaultPrimePrompt {
+		t.Errorf("strict mode should not emit default prompt for unreadable template, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `prompt_template "prompts/mayor.md"`) {
+		t.Errorf("stderr = %q, want to reference the unreadable template path", stderr.String())
+	}
+}
+
+// TestDoPrimeStrictHookModeOnSuspendedAgentPersistsSessionID guards a
+// behavior parity that was missed in the first pass: a suspended agent
+// is a legitimate quiet state, not a strict failure, so strict+hook on
+// a suspended agent must still persist the session-id (matching what
+// non-strict+hook does via its eager call at the top of the function).
+// Without this guard, the strict deferral silently drops session-id
+// persistence on the suspended-agent success path.
+func TestDoPrimeStrictHookModeOnSuspendedAgentPersistsSessionID(t *testing.T) {
+	dir := t.TempDir()
+	gcDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+suspended = true
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_SESSION_ID", "test-session-suspended")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"mayor"}, &stdout, &stderr, true, true)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode(strict=true, hook=true, suspended agent) = %d, want 0 (suspended is a quiet success); stderr: %s", code, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty (suspended)", stdout.String())
+	}
+	sessionFile := filepath.Join(dir, ".runtime", "session_id")
+	content, err := os.ReadFile(sessionFile)
+	if err != nil {
+		t.Fatalf("expected session id persisted to %s on strict+hook+suspended success, got err: %v", sessionFile, err)
+	}
+	if !strings.Contains(string(content), "test-session-suspended") {
+		t.Errorf("session id file contents = %q, want to contain 'test-session-suspended'", string(content))
+	}
+}
+
 func TestDoPrimeNoArgs(t *testing.T) {
 	// Outside any city — should still output default prompt.
 	dir := t.TempDir()
@@ -4616,7 +5097,7 @@ prompt_template = "prompts/mayor.md"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doPrimeWithMode(nil, &stdout, &stderr, true)
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -4697,7 +5178,7 @@ prompt_template = "prompts/probe.md"
 	t.Setenv("GEMINI_SESSION_ID", "gemini-provider-session")
 
 	var stdout, stderr bytes.Buffer
-	code := doPrimeWithMode(nil, &stdout, &stderr, true)
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -4749,7 +5230,7 @@ prompt_template = "prompts/probe.md"
 	t.Setenv("GC_TEMPLATE", "probe")
 
 	var stdout, stderr bytes.Buffer
-	code := doPrimeWithMode(nil, &stdout, &stderr, true)
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -4815,7 +5296,7 @@ prompt_template = "prompts/probe.md"
 	t.Setenv("GC_TEMPLATE", "")
 
 	var stdout, stderr bytes.Buffer
-	code := doPrimeWithMode(nil, &stdout, &stderr, true)
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -51,10 +51,7 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	if templatePath == "" {
 		return ""
 	}
-	sourcePath := templatePath
-	if !filepath.IsAbs(sourcePath) {
-		sourcePath = filepath.Join(cityPath, templatePath)
-	}
+	sourcePath := promptTemplateSourcePath(cityPath, templatePath)
 	data, err := fs.ReadFile(sourcePath)
 	if err != nil {
 		return ""
@@ -125,6 +122,13 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	}
 
 	return buf.String()
+}
+
+func promptTemplateSourcePath(cityPath, templatePath string) string {
+	if filepath.IsAbs(templatePath) {
+		return templatePath
+	}
+	return filepath.Join(cityPath, templatePath)
 }
 
 func isCanonicalPromptTemplatePath(path string) bool {


### PR DESCRIPTION
## Summary

Closes #445.

- `gc prime <name>` silently falls back to the generic default prompt when `<name>` doesn't match a configured agent. A typo is indistinguishable from a correctly-resolved agent that has no custom `prompt_template` — both produce the same generic prompt with no signal that anything went wrong. Real footgun while debugging templates.
- Add `--strict` flag. Under strict, the would-be-silent-fallback paths return exit 1 with a descriptive `gc prime: ...` stderr message. Default (non-strict) behavior is byte-identical for existing callers.
- Strict errors on: missing city config, config load failure, no agent name (from args / `GC_ALIAS` / `GC_AGENT`), agent name not in config, and `prompt_template` pointing at an unreadable file. Strict does NOT error on supported quiet states: agents intentionally configured without a `prompt_template`, templates that legitimately render to empty output (e.g., conditional blocks), or suspended cities/agents.
- Hook-mode side effects (session-id persistence) are deferred under strict so a failing `--strict` invocation cannot leave state behind for an agent that doesn't exist.

**Note on scope:** [@csells](https://github.com/csells)'s comment on #445 proposes that `buildPrimeContext` fall back to reasonable values for `{{.WorkDir}}` etc. when `GC_*` env vars aren't set — a clearly related improvement to the same debugging experience. I kept this PR narrow to make the strict-flag change easier to review, but happy to either expand this PR or follow up with a separate one — whichever you prefer.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

`make check` and `make test-integration` are both unchecked due to host-environment issues unrelated to this PR (zero diff outside `cmd/gc/`):

- `make check` fails on hosts that have a `claude` binary installed in `/usr/local/bin/` due to a pre-existing test in `internal/api` (`TestFindProbeBinaryUsesNVMInstallDir`) — that test expects no `claude` in PATH so its NVM-tempdir lookup wins.
- `make test-integration` fails because integration setup requires `bd v1.0.0+` and this host has `bd v0.63.3`.

Verified separately on this PR's diff:

- `go vet ./...` clean
- `go test ./cmd/gc/...` passes; 5 new strict-mode subtests cover agent-not-in-config, missing-template-file, legitimate-empty-render, no-agent-name, and `--strict --hook` not persisting session-id on failure (with a contrast test confirming it IS persisted on success)
- Manual smoke test: `gc prime` against a real city for each strict scenario produces the expected stderr + exit code

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes (CLI `--help` text describes the flag and its strict contract)
- [x] Called out breaking changes or migration notes (none — purely additive flag, default off, existing behavior preserved)
