### PR TITLE
fix: canonicalize init scaffold and retire import migrate

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -201,11 +202,11 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Create a new Gas City workspace in the given directory (or cwd).
 
 Runs an interactive wizard to choose a config template and coding agent
-provider. Creates the .gc/ runtime directory, a transitional Pack/City v2
-scaffold (pack.toml, city.toml, convention directories, and .template.md
-prompt templates), and writes the default formulas. Use --provider to create
-the default mayor city non-interactively, or --file to initialize from an
-existing TOML config file.`,
+provider. Creates the .gc/ runtime directory, a Pack/City v2 scaffold
+(pack.toml, city.toml, convention directories, and agents/<name>/
+prompt.template.md scaffolds), and writes the default formulas. Use
+--provider to create the default mayor city non-interactively, or --file
+to initialize from an existing TOML config file.`,
 		Example: `  gc init
   gc init ~/my-city
   gc init --provider codex ~/my-city
@@ -384,6 +385,32 @@ func rewriteInitPromptTemplates(cfg *config.City) {
 			cfg.Agents[i].PromptTemplate = next
 		}
 	}
+}
+
+// canonicalizeInitConfigForWrite rewrites embedded prompt references to the
+// convention-discovered scaffold paths and omits the default inline mayor
+// declaration when the scaffold alone fully defines it.
+func canonicalizeInitConfigForWrite(cfg *config.City) {
+	if cfg == nil {
+		return
+	}
+	rewriteInitPromptTemplates(cfg)
+	if shouldOmitInitInlineMayor(cfg.Agents) {
+		cfg.Agents = nil
+	}
+}
+
+func shouldOmitInitInlineMayor(agents []config.Agent) bool {
+	if len(agents) != 1 {
+		return false
+	}
+	agent := agents[0]
+	if agent.Name != "mayor" || agent.PromptTemplate != filepath.Join("agents", "mayor", "prompt.template.md") {
+		return false
+	}
+	agent.Name = ""
+	agent.PromptTemplate = ""
+	return reflect.DeepEqual(agent, config.Agent{})
 }
 
 func ensureInitConventionDirs(fs fsys.FS, cityPath string) error {
@@ -600,10 +627,10 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", err) //nolint:errcheck // best-effort stderr
 	}
 
-	// Write city.toml — wizard path gets one agent + provider/startCommand;
-	// --provider path gets the same city shape non-interactively;
-	// custom path gets one mayor + no provider (user configures manually).
-	rewriteInitPromptTemplates(&cfg)
+	// Write city.toml. The init scaffold is convention-first: we write the
+	// prompt file under agents/<name>/ and omit the redundant inline
+	// [[agent]] block when the scaffold alone defines the default mayor.
+	canonicalizeInitConfigForWrite(&cfg)
 	content, err := cfg.Marshal()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_migrate.go
+++ b/cmd/gc/cmd_migrate.go
@@ -11,22 +11,24 @@ import (
 func newImportMigrateCmd(stdout, stderr io.Writer) *cobra.Command {
 	var dryRun bool
 	cmd := &cobra.Command{
-		Use:   "migrate",
-		Short: "Migrate a V1 city layout to the V2 pack shape",
-		Long: `Rewrite a legacy city into the V2 migration shape.
+		Use:    "migrate",
+		Hidden: true,
+		Short:  "Legacy migration shim",
+		Long: `gc import migrate is no longer a public migration surface.
 
-Moves workspace.includes into pack imports, converts [[agent]] tables
-into agents/<name>/ directories, and stages prompt/overlay/namepool
-assets into their V2 locations.`,
+Use "gc doctor" to detect legacy Pack/City v1 shapes and "gc doctor --fix"
+to apply safe mechanical repairs. For the remaining manual migration steps,
+follow docs/guides/migrating-to-pack-vnext.md.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if doImportMigrate(dryRun, stdout, stderr) != 0 {
-				return errExit
-			}
-			return nil
+			fmt.Fprintln(stderr, `gc import migrate has been removed`) //nolint:errcheck // best-effort stderr
+			fmt.Fprintln(stderr, `use "gc doctor" to detect legacy Pack/City v1 shapes`) //nolint:errcheck // best-effort stderr
+			fmt.Fprintln(stderr, `use "gc doctor --fix" for safe mechanical repairs`)     //nolint:errcheck // best-effort stderr
+			fmt.Fprintln(stderr, `see docs/guides/migrating-to-pack-vnext.md for the remaining manual migration steps`) //nolint:errcheck // best-effort stderr
+			return errExit
 		},
 	}
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would change without writing")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "ignored legacy flag kept for compatibility")
 	return cmd
 }
 

--- a/cmd/gc/cmd_migrate_test.go
+++ b/cmd/gc/cmd_migrate_test.go
@@ -8,6 +8,31 @@ import (
 	"testing"
 )
 
+func TestImportMigrateCommandShowsDoctorGuidance(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newImportMigrateCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() = nil, want errExit")
+	}
+
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	out := stderr.String()
+	for _, want := range []string{
+		`gc import migrate has been removed`,
+		`gc doctor`,
+		`gc doctor --fix`,
+		`docs/guides/migrating-to-pack-vnext.md`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestDoImportMigrateDryRun(t *testing.T) {
 	cityDir := t.TempDir()
 	writeMigrateTestFile(t, cityDir, "city.toml", `

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1407,14 +1407,21 @@ func TestDoInitSuccess(t *testing.T) {
 	if cfg.Workspace.Name != "bright-lights" {
 		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	if len(cfg.Agents) != 0 {
+		t.Fatalf("len(Agents) = %d, want 0", len(cfg.Agents))
 	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
+	effective, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
+	if err != nil {
+		t.Fatalf("loadCityConfigFS: %v", err)
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if len(effective.Agents) != 1 {
+		t.Fatalf("len(effective.Agents) = %d, want 1", len(effective.Agents))
+	}
+	if effective.Agents[0].Name != "mayor" {
+		t.Errorf("effective.Agents[0].Name = %q, want %q", effective.Agents[0].Name, "mayor")
+	}
+	if effective.Agents[0].PromptTemplate != filepath.Join("/bright-lights", "agents", "mayor", "prompt.template.md") {
+		t.Errorf("effective.Agents[0].PromptTemplate = %q, want canonical agent scaffold path", effective.Agents[0].PromptTemplate)
 	}
 }
 
@@ -1430,10 +1437,6 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 	got := string(f.Files[filepath.Join("/bright-lights", "city.toml")])
 	want := `[workspace]
 name = "bright-lights"
-
-[[agent]]
-name = "mayor"
-prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
@@ -1929,14 +1932,8 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
-	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
-	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if len(cfg.Agents) != 0 {
+		t.Fatalf("len(Agents) = %d, want 0", len(cfg.Agents))
 	}
 	// Verify provider appears in TOML.
 	if !strings.Contains(string(data), `provider = "claude"`) {
@@ -1970,8 +1967,8 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 	if cfg.Workspace.Provider != "" {
 		t.Errorf("Workspace.Provider = %q, want empty", cfg.Workspace.Provider)
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	if len(cfg.Agents) != 0 {
+		t.Fatalf("len(Agents) = %d, want 0", len(cfg.Agents))
 	}
 }
 
@@ -2033,17 +2030,14 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	// Custom template → DefaultCity (one mayor, no provider).
+	// Custom template → default scaffold, no inline agents.
 	data := f.Files[filepath.Join("/my-city", "city.toml")]
 	cfg, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
-	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
+	if len(cfg.Agents) != 0 {
+		t.Fatalf("len(Agents) = %d, want 0", len(cfg.Agents))
 	}
 	if cfg.Workspace.Provider != "" {
 		t.Errorf("Workspace.Provider = %q, want empty", cfg.Workspace.Provider)

--- a/cmd/gc/testdata/migrate-v2.txtar
+++ b/cmd/gc/testdata/migrate-v2.txtar
@@ -1,4 +1,4 @@
-# gc import migrate rewrites legacy layouts via the CLI.
+# gc import migrate is no longer a public migration path.
 
 env GC_SESSION=fake
 env GC_BEADS=file
@@ -6,33 +6,15 @@ env GC_DOLT=skip
 
 cd $WORK/legacy-city
 
-# Dry-run reports changes without writing files.
-exec gc import migrate --dry-run
-stdout 'Planned changes for'
-stdout 'rewrite city.toml'
-stdout 'rewrite pack.toml'
-stdout 'No side effects executed \x28--dry-run\x29\.'
+# The legacy command hard-fails with doctor-first guidance.
+! exec gc import migrate --dry-run
+stderr 'gc import migrate has been removed'
+stderr 'gc doctor'
+stderr 'gc doctor --fix'
+stderr 'migrating-to-pack-vnext'
 ! exists $WORK/legacy-city/pack.toml
 ! exists $WORK/legacy-city/agents
 exec grep '\[\[agent\]\]' $WORK/legacy-city/city.toml
-
-# Real migration rewrites config and moves assets.
-exec gc import migrate
-stdout 'Applied changes for'
-stdout 'warning: dropped fallback field'
-exists $WORK/legacy-city/pack.toml
-exists $WORK/legacy-city/agents/mayor/agent.toml
-exists $WORK/legacy-city/agents/mayor/prompt.template.md
-exists $WORK/legacy-city/agents/mayor/overlay/CLAUDE.md
-exists $WORK/legacy-city/agents/mayor/namepool.txt
-! exists $WORK/legacy-city/prompts/mayor.md
-! exists $WORK/legacy-city/overlays/mayor
-! exists $WORK/legacy-city/namepools/mayor.txt
-exec grep '\[imports.gastown\]' $WORK/legacy-city/pack.toml
-exec grep '\[defaults.rig.imports.default-rig\]' $WORK/legacy-city/pack.toml
-! exec grep '\[\[agent\]\]' $WORK/legacy-city/city.toml
-! exec grep 'includes =' $WORK/legacy-city/city.toml
-! exec grep 'default_rig_includes' $WORK/legacy-city/city.toml
 
 -- legacy-city/city.toml --
 [workspace]

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -17,8 +17,9 @@ work, so this guide keeps the focus on `pack.toml`, `city.toml`, and the
 pack directory tree.
 
 The public migration flow is `gc doctor`, then `gc doctor --fix` for
-the safe mechanical rewrites, then `gc doctor` again to confirm the
-result. Some old cities may hard-break until migrated; that is
+the safe mechanical repairs, then `gc doctor` again to confirm the
+result. Anything doctor cannot safely rewrite stays as a manual step in
+this guide. Some old cities may hard-break until migrated; that is
 intentional in this wave.
 
 > **Scope note:** This guide describes the target Pack/City v2 migration
@@ -520,9 +521,10 @@ Use TOML when you actually need:
 
 ### "Can I still use `gc import migrate`?"
 
-No. The public migration and gating story is `gc doctor` followed by
-`gc doctor --fix`. `gc import migrate` is no longer the primary public
-path.
+No. `gc import migrate` is no longer a public command. The public
+migration and gating story is `gc doctor` followed by
+`gc doctor --fix` for the safe mechanical subset, then this guide for
+any remaining manual cleanup.
 
 ## Reference: Gas City 14.0 `city.toml` elements to Pack/City v2
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -907,7 +907,6 @@ gc import
 | [gc import add](#gc-import-add) | Add a pack import |
 | [gc import install](#gc-import-install) | Install imports from packs.lock |
 | [gc import list](#gc-import-list) | List imported packs |
-| [gc import migrate](#gc-import-migrate) | Migrate a V1 city layout to the V2 pack shape |
 | [gc import remove](#gc-import-remove) | Remove a pack import |
 | [gc import upgrade](#gc-import-upgrade) | Upgrade imported packs within their constraints |
 
@@ -944,22 +943,6 @@ gc import list [flags]
 |------|------|---------|-------------|
 | `--tree` | bool |  | Show the import dependency tree |
 
-## gc import migrate
-
-Rewrite a legacy city into the V2 migration shape.
-
-Moves workspace.includes into pack imports, converts [[agent]] tables
-into agents/&lt;name&gt;/ directories, and stages prompt/overlay/namepool
-assets into their V2 locations.
-
-```
-gc import migrate [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--dry-run` | bool |  | print what would change without writing |
-
 ## gc import remove
 
 Remove a pack import
@@ -981,11 +964,11 @@ gc import upgrade [name]
 Create a new Gas City workspace in the given directory (or cwd).
 
 Runs an interactive wizard to choose a config template and coding agent
-provider. Creates the .gc/ runtime directory, a transitional Pack/City v2
-scaffold (pack.toml, city.toml, convention directories, and .template.md
-prompt templates), and writes the default formulas. Use --provider to create
-the default mayor city non-interactively, or --file to initialize from an
-existing TOML config file.
+provider. Creates the .gc/ runtime directory, a Pack/City v2 scaffold
+(pack.toml, city.toml, convention directories, and agents/&lt;name&gt;/
+prompt.template.md scaffolds), and writes the default formulas. Use
+--provider to create the default mayor city non-interactively, or --file
+to initialize from an existing TOML config file.
 
 ```
 gc init [path] [flags]
@@ -2406,4 +2389,3 @@ Manually mark a wait ready
 ```
 gc wait ready <wait-id>
 ```
-


### PR DESCRIPTION
## Summary
- make `gc init` write a canonical Pack/City v2 scaffold instead of a hybrid inline-`[[agent]]` mayor config
- retire `gc import migrate` as a public command and replace it with a hard-fail shim that points users to `gc doctor`, `gc doctor --fix`, and the migration guide
- update the focused tests and user-facing docs that describe these two behaviors

## Validation
- `go test ./cmd/gc -run 'TestDoInit|TestImportMigrateCommandShowsDoctorGuidance|TestDoImportMigrate|TestV2DeprecationChecks|TestImportMigrateScript' -count=1`
- `go test ./test/docsync -run 'TestLocalMarkdownLinks' -count=1`
- `git diff --check`