### PR TITLE
[codex] align tutorials with the 0.15 config baseline

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -214,7 +214,7 @@ Conformance tests verify the behavioral contract (create/read/update/delete,
 error handling, concurrency). They deliberately don't test lifecycle ordering
 or cross-provider coordination — that's what coordination tests are for.
 
-For the current Pack/City v2 schema surface, use
+For the new 0.15 config surface, use
 `docs/packv2/doc-conformance-matrix.md` as the release-gating ledger for
 what should block CI now, what should start blocking once warning plumbing
 lands, and what remains tracked but non-gating.

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -216,8 +216,8 @@ func newAgentAddCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Add a new agent scaffold under agents/<name>/.
 
 Creates agents/<name>/prompt.template.md and, when needed,
-agents/<name>/agent.toml. This is the Pack/City v2 path and does not
-append [[agent]] blocks to city.toml.
+agents/<name>/agent.toml. These files live in the city directory and do
+not append [[agent]] blocks to city.toml.
 
 Use --prompt-template to copy prompt content from an existing file into
 the canonical prompt.template.md location. Use --dir to record a rig or
@@ -263,7 +263,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	packPath := filepath.Join(cityPath, "pack.toml")
 	if _, err := fs.Stat(packPath); err != nil {
-		fmt.Fprintln(stderr, "gc agent add: this command requires a Pack/City v2 city with pack.toml; run \"gc doctor\" or \"gc doctor --fix\" to migrate this city first") //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "gc agent add: this command requires a city directory with pack.toml; run \"gc doctor\" or \"gc doctor --fix\" to migrate this city first") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -290,8 +290,8 @@ name = "test-city"
 		t.Fatalf("code = %d, want 1", code)
 	}
 	errMsg := stderr.String()
-	if !strings.Contains(errMsg, "Pack/City v2 city") {
-		t.Errorf("stderr = %q, want Pack/City v2 requirement", errMsg)
+	if !strings.Contains(errMsg, "city directory with pack.toml") {
+		t.Errorf("stderr = %q, want pack.toml city requirement", errMsg)
 	}
 	if !strings.Contains(errMsg, `gc doctor`) || !strings.Contains(errMsg, `gc doctor --fix`) {
 		t.Errorf("stderr = %q, want migration hint to gc doctor / gc doctor --fix", errMsg)

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -201,11 +201,10 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Create a new Gas City workspace in the given directory (or cwd).
 
 Runs an interactive wizard to choose a config template and coding agent
-provider. Creates the .gc/ runtime directory, a transitional Pack/City v2
-scaffold (pack.toml, city.toml, convention directories, and .template.md
-prompt templates), and writes the default formulas. Use --provider to create
-the default mayor city non-interactively, or --file to initialize from an
-existing TOML config file.`,
+provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
+the standard top-level directories, and .template.md prompt templates, then
+writes the default formulas. Use --provider to create the default mayor city
+non-interactively, or --file to initialize from an existing TOML config file.`,
 		Example: `  gc init
   gc init ~/my-city
   gc init --provider codex ~/my-city

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -86,7 +86,9 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 
 func resolveSessionLogPath(searchPaths []string, logCtx sessionLogContext) string {
 	if logCtx.sessionKey != "" {
-		return sessionlog.FindSessionFileByID(searchPaths, logCtx.workDir, logCtx.sessionKey)
+		if path := sessionlog.FindSessionFileByID(searchPaths, logCtx.workDir, logCtx.sessionKey); path != "" {
+			return path
+		}
 	}
 	return sessionlog.FindSessionFileForProvider(searchPaths, logCtx.provider, logCtx.workDir)
 }

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -28,6 +28,22 @@ func writeTestSession(t *testing.T, searchBase, workDir string, lines ...string)
 	}
 }
 
+func writeNamedTestSession(t *testing.T, searchBase, workDir, fileName string, lines ...string) string {
+	t.Helper()
+	slug := strings.ReplaceAll(workDir, "/", "-")
+	slug = strings.ReplaceAll(slug, ".", "-")
+	dir := filepath.Join(searchBase, slug)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, fileName)
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func TestDoSessionLogsBasic(t *testing.T) {
 	searchBase := t.TempDir()
 	workDir := t.TempDir()
@@ -181,6 +197,40 @@ func TestDoSessionLogsToolResultError(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "tool_result: error") {
 		t.Errorf("output should contain tool_result error, got: %s", out)
+	}
+}
+
+func TestResolveSessionLogPathPrefersKeyedTranscriptWhenPresent(t *testing.T) {
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+	want := writeNamedTestSession(t, searchBase, workDir, "known-session.jsonl",
+		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"hello"},"timestamp":"2025-01-01T00:00:00Z"}`,
+	)
+
+	got := resolveSessionLogPath([]string{searchBase}, sessionLogContext{
+		workDir:    workDir,
+		sessionKey: "known-session",
+		provider:   "claude",
+	})
+	if got != want {
+		t.Fatalf("resolveSessionLogPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSessionLogPathFallsBackWhenSessionKeyFileMissing(t *testing.T) {
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+	want := writeNamedTestSession(t, searchBase, workDir, "latest-session.jsonl",
+		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"hello"},"timestamp":"2025-01-01T00:00:00Z"}`,
+	)
+
+	got := resolveSessionLogPath([]string{searchBase}, sessionLogContext{
+		workDir:    workDir,
+		sessionKey: "stale-session-key",
+		provider:   "claude",
+	})
+	if got != want {
+		t.Fatalf("resolveSessionLogPath() = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -48,7 +48,7 @@ func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 		return okCheck("v2-import-format", "workspace.includes already migrated")
 	}
 	return warnCheck("v2-import-format",
-		"workspace.includes is deprecated; this city must migrate to [imports] before Pack/City v2 can load it",
+		"workspace.includes is deprecated; migrate this city to [imports] before gc can load it from pack.toml and city.toml",
 		v2MigrationHint(),
 		cfg.Workspace.Includes)
 }

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3037,8 +3037,8 @@ name = "test"
 	if code != 1 {
 		t.Errorf("doAgentAdd = %d, want 1", code)
 	}
-	if !strings.Contains(stderr.String(), "Pack/City v2 city") {
-		t.Errorf("stderr = %q, want Pack/City v2 requirement", stderr.String())
+	if !strings.Contains(stderr.String(), "city directory with pack.toml") {
+		t.Errorf("stderr = %q, want pack.toml city requirement", stderr.String())
 	}
 }
 

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -36,8 +36,19 @@ Now we're ready to create our first city.
 
 ## Creating a city
 
-A city is a directory that holds your agent configuration, prompts, and
-workflows. You create a new city with `gc init`:
+A city is a directory that holds your pack definition, deployment config, agent
+prompts, and workflows. You create a new city with `gc init`:
+
+A useful mental model is:
+
+- A **city** is the whole working folder for one Gas City environment. It
+  combines your agents, formulas, rigs, orders, and the local settings that
+  tell Gas City how to run them on this machine.
+- A **pack** is the reusable part of that city. It holds the Gas City
+  definitions that are portable and worth sharing with other cities or other
+  people.
+
+Another way to say it: a city is a pack plus deployment details.
 
 ```shell
 
@@ -92,8 +103,9 @@ same command, just providing the provider explicitly.
 $ gc init ~/my-city --provider claude
 ```
 
-Gas City created the city directory, registered it, and started it. Let's look
-at what's inside:
+Gas City created the city directory, registered it, and started it. A city
+created with `gc init` comes with `pack.toml`, `city.toml`, and the standard
+top-level directories, so let's look at what's inside:
 
 ```shell
 ~
@@ -101,13 +113,18 @@ $ cd ~/my-city
 
 ~/my-city
 $ ls
-city.toml  formulas  hooks  orders  prompts
+agents  assets  city.toml  commands  doctor  formulas  orders  overlays  pack.toml  template-fragments
 ```
 
-The main file is `city.toml` — it defines your city, using the contents of those
-directories as well as containing some definitions and local config. Assuming
-you chose the default `tutorial` config template and default provider,
-`city.toml` looks like this:
+At the top level of the city directory:
+
+- `pack.toml` — the portable pack definition layer
+- `city.toml` — city-local deployment and runtime settings
+
+This city comes with a built-in `mayor` agent. The mayor's prompt lives at
+`agents/mayor/prompt.template.md`, and `city.toml` defines the always-on mayor
+session that uses it. Assuming you chose the default `tutorial` config
+template and default provider, `city.toml` looks like this:
 
 ```shell
 ~/my-city
@@ -118,7 +135,7 @@ provider = "claude"
 
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
@@ -127,12 +144,11 @@ mode = "always"
 
 The `[workspace]` section names your city and sets the default provider.
 
-Each `[[agent]]` table you configure lets you create a named set of config
-including things like the provider, the model, the prompt you want to use to
-define its role, etc. An agent is named so that you can assign it work (aka
-"sling"). Here we've created an agent called the `mayor` with a prompt template
-(the instructions for the mayor) and a default session where you instructions
-go.
+The `[[agent]]` entry defines the built-in `mayor`, and `[[named_session]]`
+keeps a `mayor` session running so you can talk to it at any time. When you
+add more agents later, Gas City creates `agents/<name>/`, with
+`prompt.template.md` for the prompt and `agent.toml` for any per-agent
+overrides.
 
 Gas City also gives you an implicit agent for each supported provider — so
 `claude`, `codex`, and `gemini` are available as agent names even though they're
@@ -142,28 +158,17 @@ prompt.
 To check on the status of your city, use `gc status`:
 
 ```shell
-~/my-project
+~/my-city
 $ gc status
 my-city  /Users/csells/my-city
   Controller: standalone (PID 83621)
   Suspended:  no
 
 Agents:
-  dog                     pool (min=0, max=3)
-2026/04/06 21:20:22 tmux state cache: refreshed 2 sessions in 3.582ms
-    dog-1                 stopped
-    dog-2                 stopped
-    dog-3                 stopped
   mayor                   pool (min=0, max=unlimited)
   claude                  pool (min=0, max=unlimited)
-  my-project/claude       pool (min=0, max=unlimited)
 
-1/4 agents running
-
-Rigs:
-  my-project              /Users/csells/my-project
-
-Sessions: 2 active, 0 suspended
+Sessions: 1 active, 0 suspended
 ```
 
 ## Adding a rig

--- a/docs/tutorials/02-agents.md
+++ b/docs/tutorials/02-agents.md
@@ -15,22 +15,25 @@ We'll pick up where Tutorial 01 left off. You should have `my-city` running with
 
 ## Defining an agent
 
-Open `city.toml`. You already have a `mayor` agent from the tutorial template.
-Let's add a second agent that uses `codex` instead of `claude`:
+Each custom agent gets its own directory under `agents/<name>/`. Start by
+creating a rig-scoped reviewer:
 
-```toml
-[workspace]
-name = "my-city"
-provider = "claude"
+```shell
+~/my-city
+$ gc agent add --name reviewer --dir my-project
+Scaffolded agent 'reviewer'
 
-... # context elided
-
-[[agent]]
-name = "reviewer"
+~/my-city
+$ cat > agents/reviewer/agent.toml << 'EOF'
 dir = "my-project"
 provider = "codex"
-prompt_template = "prompts/reviewer.md"
+EOF
 ```
+
+This creates `agents/reviewer/prompt.template.md`. Add
+`agents/reviewer/agent.toml` when you want per-agent overrides. Here we use it
+to scope the reviewer to the `my-project` rig and switch it from the city's
+default `claude` provider to `codex`.
 
 You'll want to create a prompt for the new agent. Let's take a look at the
 default GC prompt if you don't provide one:
@@ -69,7 +72,7 @@ reviewer prompt to look like the following:
 
 ```shell
 ~/my-city
-$ cat > prompts/reviewer.md << 'EOF'
+$ cat > agents/reviewer/prompt.template.md << 'EOF'
 # Code Reviewer Agent
 You are an agent in a Gas City workspace. Check for available work and execute it.
 
@@ -100,14 +103,12 @@ your own custom agents are configured as you build out more of them over time.
 If you wanted to get fancy, you could also set the model and permission mode:
 
 ```toml
-...
-[[agent]]
-name = "reviewer"
 dir = "my-project"
-prompt_template = "prompts/reviewer.md"
+provider = "codex"
 option_defaults = { model = "sonnet", permission_mode = "plan" }
-...
 ```
+
+That file would live at `agents/reviewer/agent.toml`.
 
 Now that your agent is available, it's time to sling some work to it:
 
@@ -123,10 +124,10 @@ Slung mp-p956 → my-project/reviewer
 
 Your new reviewer agent is scoped to the `my-project` rig, so from inside that
 directory you can target it explicitly as `my-project/reviewer`. Gas City
-started a Codex session, loaded the prompt from `prompts/reviewer.md`, and
-delivered the task to the rig-scoped reviewer. You can watch progress with `bd
-show` as you already know. And when the work is done, you can check the file
-system for the review you requested:
+started a Codex session, loaded the prompt from
+`agents/reviewer/prompt.template.md`, and delivered the task to the rig-scoped
+reviewer. You can watch progress with `bd show` as you already know. And when
+the work is done, you can check the file system for the review you requested:
 
 ```shell
 ~/my-project

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -212,8 +212,9 @@ into the session's terminal:
 ~/my-city
 $ gc session nudge mayor "What's the current city status?"
 2026/04/07 22:07:28 tmux state cache: refreshed 2 sessions in 3.765375ms
-Nudged mayor
 ```
+
+Gas City confirms the nudge with either `Nudged mayor` or `Queued nudge for mayor`.
 
 ![mayor nudge screenshot](mayor-nudge.png)
 
@@ -258,8 +259,9 @@ conversation as it happens:
 ```shell
 ~/my-city
 $ gc session nudge mayor "What's the current city status?"
-Nudged mayor
 ```
+
+Again, Gas City confirms the nudge with either `Nudged mayor` or `Queued nudge for mayor`.
 
 Useful for watching what a background agent is doing without attaching and
 potentially interrupting it. Peek shows the terminal; logs show the

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -10,11 +10,17 @@ you'll see and talk with agents via sessions as well as see how agents talk to
 each other. You'll also learn the difference between "polecats" (agents spun up
 on demand to handle work) and "crew" (persistent agents with named sessions),
 
-To continue with this tutorial, you'll want to start from where the last
-tutorial left off, with a `city.toml` that looks like the following and the
-appropriate agent prompts and rig folders in place to match:
+To continue with this tutorial, start from where the last two tutorials left
+off: the city root has `pack.toml` and `city.toml`, and Tutorial 02 added the
+reviewer under `agents/reviewer/`:
 
 ```shell
+~/my-city
+$ cat pack.toml
+[pack]
+name = "my-city"
+schema = 2
+
 ~/my-city
 $ cat city.toml
 [workspace]
@@ -23,22 +29,25 @@ provider = "claude"
 
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
 mode = "always"
 
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-prompt_template = "prompts/reviewer.md"
-provider = "codex"
-
 [[rigs]]
 name = "my-project"
 path = "/Users/csells/my-project"
+
+~/my-city
+$ cat agents/reviewer/agent.toml
+dir = "my-project"
+provider = "codex"
 ```
+
+The reviewer's prompt lives at `agents/reviewer/prompt.template.md`. This is the
+standard city shape: root config files plus per-agent directories under
+`agents/`.
 
 ## Looking in on Polecats
 
@@ -121,7 +130,7 @@ often used by one-and-done agents know as "polecats". While you could talk to
 one interactively, they're configured to execute beads, go idle and have their
 sessions shutdown ASAP.
 
-If you want an agent to to talk to, you'll want one configured for chatting
+If you want an agent to talk to, you'll want one configured for chatting
 called a "crew" member.
 
 ## Chatting with Crew
@@ -160,7 +169,7 @@ look again at your `city.toml` file, you'll see why:
 ...
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
@@ -243,9 +252,18 @@ with `-f`:
 $ gc session logs mayor -f
 ```
 
+In another terminal, nudge the mayor and watch the follow stream show the
+conversation as it happens:
+
+```shell
+~/my-city
+$ gc session nudge mayor "What's the current city status?"
+Nudged mayor
+```
+
 Useful for watching what a background agent is doing without attaching and
 potentially interrupting it. Peek shows the terminal; logs show the
-conversation.
+conversation as new user and assistant messages arrive.
 
 ## What's next
 

--- a/docs/tutorials/04-communication.md
+++ b/docs/tutorials/04-communication.md
@@ -144,10 +144,11 @@ install_agent_hooks = ["claude"]
 You can also set them per agent:
 
 ```toml
-[[agent]]
-name = "mayor"
+# agents/mayor/agent.toml
 install_agent_hooks = ["claude"]
 ```
+
+Agent-local overrides like this live in `agents/<name>/agent.toml`.
 
 When a session starts, Gas City installs hook configuration files that the
 provider reads. For Claude, this means a `hooks/claude.json` file that fires Gas

--- a/docs/tutorials/05-formulas.md
+++ b/docs/tutorials/05-formulas.md
@@ -115,12 +115,21 @@ For the next few examples, keep using the `mayor` from the earlier tutorials
 and add a generic worker so you have a second execution target besides the
 reviewer:
 
-```toml
-[[agent]]
-name = "worker"
-provider = "claude"
-prompt_template = "prompts/worker.md"
+```shell
+~/my-city
+$ gc agent add --name worker
+Scaffolded agent 'worker'
+
+~/my-city
+$ cat > agents/worker/prompt.template.md << 'EOF'
+# Worker Agent
+You are a general-purpose Gas City worker. Execute assigned work carefully and report the result.
+EOF
 ```
+
+Because the city already defaults to `claude`, this city-scoped worker does not
+need an `agent.toml` yet. Add one later if you want provider, model, or
+directory overrides.
 
 ## Instantiating a formula
 

--- a/docs/tutorials/06-beads.md
+++ b/docs/tutorials/06-beads.md
@@ -25,22 +25,23 @@ provider = "claude"
 
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
 mode = "always"
 
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-prompt_template = "prompts/reviewer.md"
-provider = "codex"
-
 [[rigs]]
 name = "my-project"
 path = "/Users/csells/my-project"
+
+~/my-city
+$ cat agents/reviewer/agent.toml
+dir = "my-project"
+provider = "codex"
 ```
+
+The corresponding prompt files live under `agents/<name>/prompt.template.md`.
 
 Beads are fundamental to the system. You're going to be working with crew to
 turn plans into beads that can be executed in parallel by polecats.

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -24,13 +24,13 @@ a schedule or in response to events.
 ## A simple order
 
 Orders live in an `orders/` directory at the top level of your city, alongside
-`formulas/` and `agents/`. Each order is a flat `*.order.toml` file in that
+`formulas/` and `agents/`. Each order is a flat `*.toml` file in that
 directory.
 
 ```
 orders/
-  review-check.order.toml
-  dep-update.order.toml
+  review-check.toml
+  dep-update.toml
 formulas/
   pancakes.formula.toml
   review.formula.toml
@@ -40,7 +40,7 @@ Here's a minimal order that dispatches the `review` formula from Tutorial 04
 every five minutes:
 
 ```toml
-# orders/review-check.order.toml
+# orders/review-check.toml
 [order]
 description = "Check for PRs that need review"
 formula = "review"
@@ -58,7 +58,7 @@ up.
 The controller evaluates gate conditions on every tick. When five minutes have
 passed since the last run, it instantiates the `review` formula as a wisp and
 routes it to the `worker` pool. The order name comes from the file basename
-(`review-check.order.toml` → `review-check`), not from anything in the TOML.
+(`review-check.toml` → `review-check`), not from anything in the TOML.
 
 Orders are discovered when the city starts and whenever the controller reloads
 config. You don't need to restart anything if the city is already watching the
@@ -96,7 +96,7 @@ Formula:     review
 Gate:        cooldown
 Interval:    5m
 Target:      worker
-Source:      /Users/you/my-city/orders/review-check.order.toml
+Source:      /Users/you/my-city/orders/review-check.toml
 ```
 
 To check which orders are due right now:
@@ -374,7 +374,7 @@ Say you have a pack called `dev-ops` that includes a `test-suite` order:
 ```
 packs/dev-ops/
   orders/
-    test-suite.order.toml   # gate = "cooldown", interval = "5m", pool = "worker"
+    test-suite.toml         # gate = "cooldown", interval = "5m", pool = "worker"
   formulas/
     test-suite.formula.toml
 ```
@@ -443,7 +443,7 @@ highest-priority layer wins. The layers, from lowest to highest priority:
 
 A higher layer completely replaces a lower layer's definition for the same order
 name. So if the `dev-ops` pack defines `test-suite` with a 5-minute cooldown and
-you create your own `orders/test-suite.order.toml` with a 1-minute cooldown,
+you create your own `orders/test-suite.toml` with a 1-minute cooldown,
 yours wins — the pack version is ignored entirely.
 
 ## Putting it together
@@ -456,7 +456,7 @@ Assume you've already created a `worker` agent as in
 files and the formula they dispatch.
 
 ```toml
-# orders/lint-check.order.toml
+# orders/lint-check.toml
 [order]
 description = "Run the linter on changed files"
 gate = "cooldown"
@@ -466,7 +466,7 @@ timeout = "60s"
 ```
 
 ```toml
-# orders/release-notes.order.toml
+# orders/release-notes.toml
 [order]
 description = "Generate release notes from the week's merges"
 formula = "release-notes"

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -24,13 +24,13 @@ a schedule or in response to events.
 ## A simple order
 
 Orders live in an `orders/` directory at the top level of your city, alongside
-`formulas/` and `prompts/`. Each order gets its own subdirectory containing an
-`order.toml` file. The subdirectory name becomes the order name.
+`formulas/` and `agents/`. Each order is a flat `*.order.toml` file in that
+directory.
 
 ```
 orders/
-  review-check/order.toml
-  dep-update/order.toml
+  review-check.order.toml
+  dep-update.order.toml
 formulas/
   pancakes.formula.toml
   review.formula.toml
@@ -40,7 +40,7 @@ Here's a minimal order that dispatches the `review` formula from Tutorial 04
 every five minutes:
 
 ```toml
-# orders/review-check/order.toml
+# orders/review-check.order.toml
 [order]
 description = "Check for PRs that need review"
 formula = "review"
@@ -57,8 +57,8 @@ up.
 
 The controller evaluates gate conditions on every tick. When five minutes have
 passed since the last run, it instantiates the `review` formula as a wisp and
-routes it to the `worker` pool. The order name comes from the subdirectory name
-— `review-check` — not from anything in the TOML.
+routes it to the `worker` pool. The order name comes from the file basename
+(`review-check.order.toml` → `review-check`), not from anything in the TOML.
 
 Orders are discovered when the city starts and whenever the controller reloads
 config. You don't need to restart anything if the city is already watching the
@@ -96,7 +96,7 @@ Formula:     review
 Gate:        cooldown
 Interval:    5m
 Target:      worker
-Source:      /Users/you/my-city/orders/review-check/order.toml
+Source:      /Users/you/my-city/orders/review-check.order.toml
 ```
 
 To check which orders are due right now:
@@ -250,7 +250,7 @@ The rules:
 - Every order has either `formula` or `exec`, never both.
 - Exec orders can't have a `pool` — there's no agent pipeline to route to.
 - The script receives `ORDER_DIR` in its environment, set to the directory
-  containing the `order.toml`. Pack-sourced orders also get `PACK_DIR`.
+  containing the order file. Pack-sourced orders also get `PACK_DIR`.
 
 Default timeouts differ: 30 seconds for formula orders, 300 seconds for exec
 orders.
@@ -374,8 +374,7 @@ Say you have a pack called `dev-ops` that includes a `test-suite` order:
 ```
 packs/dev-ops/
   orders/
-    test-suite/
-      order.toml        # gate = "cooldown", interval = "5m", pool = "worker"
+    test-suite.order.toml   # gate = "cooldown", interval = "5m", pool = "worker"
   formulas/
     test-suite.formula.toml
 ```
@@ -387,12 +386,16 @@ And your city applies that pack to two rigs:
 [[rigs]]
 name = "my-api"
 path = "../my-api"
-includes = ["packs/dev-ops"]
+
+[rigs.imports.dev_ops]
+source = "./packs/dev-ops"
 
 [[rigs]]
 name = "my-frontend"
 path = "../my-frontend"
-includes = ["packs/dev-ops"]
+
+[rigs.imports.dev_ops]
+source = "./packs/dev-ops"
 ```
 
 Now the city has the same order running independently for each rig:
@@ -436,11 +439,11 @@ highest-priority layer wins. The layers, from lowest to highest priority:
    `dev-ops` pack's `test-suite`)
 2. **City local** — orders in your city's own `orders/` directory
 3. **Rig packs** — orders from packs applied to a specific rig
-4. **Rig local** — orders in a rig's own formula directories
+4. **Rig local** — orders in a rig's own `orders/` directory
 
 A higher layer completely replaces a lower layer's definition for the same order
 name. So if the `dev-ops` pack defines `test-suite` with a 5-minute cooldown and
-you create your own `orders/test-suite/order.toml` with a 1-minute cooldown,
+you create your own `orders/test-suite.order.toml` with a 1-minute cooldown,
 yours wins — the pack version is ignored entirely.
 
 ## Putting it together
@@ -448,22 +451,12 @@ yours wins — the pack version is ignored entirely.
 Here's a city with two orders: a frequent lint check (exec, no agent needed) and
 weekly release notes (formula, dispatched to an agent).
 
-```toml
-# city.toml
-[workspace]
-name = "my-city"
-provider = "claude"
-
-[formulas]
-dir = "formulas"
-
-[[agent]]
-name = "worker"
-prompt_template = "prompts/worker.md"
-```
+Assume you've already created a `worker` agent as in
+[Tutorial 05](/tutorials/05-formulas). The remaining pieces are just the order
+files and the formula they dispatch.
 
 ```toml
-# orders/lint-check/order.toml
+# orders/lint-check.order.toml
 [order]
 description = "Run the linter on changed files"
 gate = "cooldown"
@@ -473,7 +466,7 @@ timeout = "60s"
 ```
 
 ```toml
-# orders/release-notes/order.toml
+# orders/release-notes.order.toml
 [order]
 description = "Generate release notes from the week's merges"
 formula = "release-notes"

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -577,10 +577,13 @@ func TestHandleProviderReadinessReturnsNotInstalledWhenBinaryMissing(t *testing.
 	t.Setenv("HOME", homeDir)
 
 	originalPathEnv := providerProbePathEnv
+	originalGOOS := providerProbeGOOS
 	providerProbePathEnv = filepath.Join(homeDir, "bin")
 	defer func() {
 		providerProbePathEnv = originalPathEnv
+		providerProbeGOOS = originalGOOS
 	}()
+	providerProbeGOOS = "test"
 
 	srv := New(newFakeState(t))
 	req := httptest.NewRequest(http.MethodGet, "/v0/provider-readiness?providers=claude,codex,gemini", nil)

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -2786,8 +2786,6 @@ func TestResolveInheritedMetadataPrefersParentBeforeWorkflowRoot(t *testing.T) {
 }
 
 func TestRunRalphCheckResolvesRelativeWorkDirAgainstCityPath(t *testing.T) {
-	t.Parallel()
-
 	cityPath := t.TempDir()
 	workDir := filepath.Join(cityPath, "frontend")
 	checkDir := filepath.Join(workDir, "checks")
@@ -2805,8 +2803,11 @@ func TestRunRalphCheckResolvesRelativeWorkDirAgainstCityPath(t *testing.T) {
 		ID:   "check-1",
 		Type: "task",
 		Metadata: map[string]string{
-			"gc.check_path":    "checks/pass.sh",
-			"gc.check_timeout": "5s",
+			"gc.check_path": "checks/pass.sh",
+			// This test is about relative path resolution, not timeout behavior.
+			// Use a generous deadline so repo-wide test load does not turn it into
+			// a spurious timeout flake.
+			"gc.check_timeout": "30s",
 			"gc.work_dir":      "frontend",
 		},
 	}

--- a/test/acceptance/tutorial_goldens/continuity_regression_test.go
+++ b/test/acceptance/tutorial_goldens/continuity_regression_test.go
@@ -43,6 +43,8 @@ func TestTutorialContinuity_SessionLookupFlowIsExplicit(t *testing.T) {
 	page03Text := collectPageText(page03)
 
 	for _, want := range []string{
+		"cat pack.toml",
+		"cat agents/reviewer/agent.toml",
 		"gc session list --template my-project/reviewer",
 		"gc session peek mc-8sfd",
 	} {
@@ -76,7 +78,15 @@ func TestTutorialContinuity_CommunicationUsesVisibleWakeAndRigScopedReviewer(t *
 func TestTutorialContinuity_FormulasIntroducesWorkerBeforeUse(t *testing.T) {
 	page05Text := readTutorialPageText(t, "05-formulas.md")
 
-	if !strings.Contains(page05Text, `name = "worker"`) {
+	for _, want := range []string{
+		"gc agent add --name worker",
+		"agents/worker/prompt.template.md",
+	} {
+		if !strings.Contains(page05Text, want) {
+			t.Fatalf("tutorial 05 is missing the worker setup step %q", want)
+		}
+	}
+	if !strings.Contains(page05Text, `gc sling worker mp-2wx`) {
 		t.Fatal("tutorial 05 slings work to worker without first establishing that agent in the prose")
 	}
 }

--- a/test/acceptance/tutorial_goldens/harness_test.go
+++ b/test/acceptance/tutorial_goldens/harness_test.go
@@ -355,9 +355,6 @@ func (w *tutorialWorkspace) configureInitializedCities() error {
 		if err := helpers.EnsureClaudeProjectState(w.env.Env, cityDir); err != nil {
 			return err
 		}
-		if err := ensureTutorialSessionSocket(path, tutorialSocketName(w.env.Root)); err != nil {
-			return err
-		}
 		return ensureTutorialObservePaths(path, observePaths)
 	})
 }

--- a/test/acceptance/tutorial_goldens/main_test.go
+++ b/test/acceptance/tutorial_goldens/main_test.go
@@ -9,7 +9,9 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -72,6 +74,68 @@ type tutorialEnv struct {
 	supervisorLog  *os.File
 }
 
+func tutorialTmuxTmpDir(runtimeDir string) string {
+	return filepath.Join(runtimeDir, "tmux")
+}
+
+func newTutorialBaseEnv(gcBinary, home, runtimeDir string) *helpers.Env {
+	env := helpers.NewEnv(gcBinary, home, runtimeDir).
+		Without("GC_SESSION").
+		Without("GC_BEADS").
+		Without("GC_DOLT").
+		With("DOLT_ROOT_PATH", home)
+	env.With("PATH", filepath.Join(home, ".local", "bin")+":"+env.Get("PATH"))
+	// Tutorial cities all use the same workspace name (`my-city`), so without an
+	// isolated tmux socket root they can adopt stale sessions from earlier runs.
+	// That lets `peek` hit an old pane while `session logs` resolves the current
+	// run's bead/work_dir and finds no transcript at all.
+	env.With("TMUX_TMPDIR", tutorialTmuxTmpDir(runtimeDir))
+	return env
+}
+
+func linkTutorialSessionRoots(hostHome, tutorialHome string) error {
+	type sessionRoot struct {
+		host string
+		dst  string
+	}
+	roots := []sessionRoot{
+		{
+			host: filepath.Join(hostHome, ".claude", "projects"),
+			dst:  filepath.Join(tutorialHome, ".claude", "projects"),
+		},
+		{
+			host: filepath.Join(hostHome, ".codex", "sessions"),
+			dst:  filepath.Join(tutorialHome, ".codex", "sessions"),
+		},
+		{
+			host: filepath.Join(hostHome, ".gemini", "tmp"),
+			dst:  filepath.Join(tutorialHome, ".gemini", "tmp"),
+		},
+	}
+	for _, root := range roots {
+		if err := os.MkdirAll(filepath.Dir(root.dst), 0o755); err != nil {
+			return err
+		}
+		if info, err := os.Lstat(root.dst); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				target, readErr := os.Readlink(root.dst)
+				if readErr == nil && target == root.host {
+					continue
+				}
+			}
+			if removeErr := os.RemoveAll(root.dst); removeErr != nil {
+				return removeErr
+			}
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Symlink(root.host, root.dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func newTutorialEnv(t *testing.T) *tutorialEnv {
 	t.Helper()
 
@@ -79,6 +143,7 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 	if err != nil {
 		t.Fatalf("preparing tutorial temp root: %v", err)
 	}
+	cleanupStaleTutorialProcesses(t, tmpRoot)
 	root, err := os.MkdirTemp(tmpRoot, "gctutenv-*")
 	if err != nil {
 		t.Fatalf("creating tutorial temp dir: %v", err)
@@ -86,7 +151,8 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
 	home := filepath.Join(root, "home")
 	runtimeDir := filepath.Join(root, "runtime")
-	for _, dir := range []string{home, runtimeDir} {
+	tmuxTmpDir := tutorialTmuxTmpDir(runtimeDir)
+	for _, dir := range []string{home, runtimeDir, tmuxTmpDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("creating %s: %v", dir, err)
 		}
@@ -113,13 +179,11 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 	if err := stageProviderBinaries(home); err != nil {
 		t.Fatalf("staging provider binaries: %v", err)
 	}
+	if err := linkTutorialSessionRoots(hostHomeDir(), home); err != nil {
+		t.Fatalf("linking session roots: %v", err)
+	}
 
-	env := helpers.NewEnv(goldenGCBinary, home, runtimeDir).
-		Without("GC_SESSION").
-		Without("GC_BEADS").
-		Without("GC_DOLT").
-		With("DOLT_ROOT_PATH", home)
-	env.With("PATH", filepath.Join(home, ".local", "bin")+":"+env.Get("PATH"))
+	env := newTutorialBaseEnv(goldenGCBinary, home, runtimeDir)
 
 	for _, key := range []string{
 		"ANTHROPIC_AUTH_TOKEN",
@@ -152,6 +216,60 @@ func newTutorialEnv(t *testing.T) *tutorialEnv {
 		stopTutorialSupervisor(tutorial)
 	})
 	return tutorial
+}
+
+func cleanupStaleTutorialProcesses(t *testing.T, tmpRoot string) {
+	t.Helper()
+
+	out, err := exec.Command("ps", "-ax", "-o", "pid=,command=").Output()
+	if err != nil {
+		t.Fatalf("listing stale tutorial processes: %v", err)
+	}
+
+	prefixes := []string{
+		filepath.Join(tmpRoot, "gctutenv-"),
+		filepath.Join("/private", strings.TrimPrefix(tmpRoot, "/"), "gctutenv-"),
+	}
+	selfPID := os.Getpid()
+	var victims []int
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 1 || pid == selfPID {
+			continue
+		}
+		cmd := strings.Join(fields[1:], " ")
+		matched := false
+		for _, prefix := range prefixes {
+			if strings.Contains(cmd, prefix) {
+				matched = true
+				break
+			}
+		}
+		if matched {
+			victims = append(victims, pid)
+		}
+	}
+	if len(victims) == 0 {
+		return
+	}
+
+	for _, pid := range victims {
+		_ = syscall.Kill(pid, syscall.SIGTERM)
+	}
+	time.Sleep(500 * time.Millisecond)
+	for _, pid := range victims {
+		if err := syscall.Kill(pid, 0); err == nil {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	}
 }
 
 func startTutorialSupervisor(env *tutorialEnv) error {
@@ -262,6 +380,45 @@ esac
 			_ = tutorial.supervisorLog.Close()
 		}
 	}()
+}
+
+func TestNewTutorialBaseEnvSetsIsolatedTmuxTmpDir(t *testing.T) {
+	home := t.TempDir()
+	runtimeDir := filepath.Join(home, "runtime")
+	got := newTutorialBaseEnv("/tmp/fake-gc", home, runtimeDir)
+
+	wantTmux := filepath.Join(runtimeDir, "tmux")
+	if got.Get("TMUX_TMPDIR") != wantTmux {
+		t.Fatalf("TMUX_TMPDIR = %q, want %q", got.Get("TMUX_TMPDIR"), wantTmux)
+	}
+	if got.Get("DOLT_ROOT_PATH") != home {
+		t.Fatalf("DOLT_ROOT_PATH = %q, want %q", got.Get("DOLT_ROOT_PATH"), home)
+	}
+	if !strings.HasPrefix(got.Get("PATH"), filepath.Join(home, ".local", "bin")+":") {
+		t.Fatalf("PATH = %q, want tutorial bin dir prefix", got.Get("PATH"))
+	}
+}
+
+func TestLinkTutorialSessionRootsCreatesSymlinkBridge(t *testing.T) {
+	hostHome := t.TempDir()
+	tutorialHome := t.TempDir()
+
+	want := filepath.Join(hostHome, ".claude", "projects")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("MkdirAll(host projects): %v", err)
+	}
+	if err := linkTutorialSessionRoots(hostHome, tutorialHome); err != nil {
+		t.Fatalf("linkTutorialSessionRoots: %v", err)
+	}
+
+	got := filepath.Join(tutorialHome, ".claude", "projects")
+	target, err := os.Readlink(got)
+	if err != nil {
+		t.Fatalf("Readlink(%s): %v", got, err)
+	}
+	if target != want {
+		t.Fatalf("projects symlink = %q, want %q", target, want)
+	}
 }
 
 func stopTutorialSupervisor(env *tutorialEnv) {

--- a/test/acceptance/tutorial_goldens/manifests_test.go
+++ b/test/acceptance/tutorial_goldens/manifests_test.go
@@ -37,8 +37,10 @@ var tutorialPageManifests = []pageManifest{
 	{
 		path: "docs/tutorials/02-agents.md",
 		commands: []string{
+			"gc agent add --name reviewer --dir my-project",
+			"cat > agents/reviewer/agent.toml << 'EOF'",
 			"gc prime",
-			"cat > prompts/reviewer.md << 'EOF'",
+			"cat > agents/reviewer/prompt.template.md << 'EOF'",
 			"gc prime my-project/reviewer",
 			"cd ~/my-project",
 			`gc sling my-project/reviewer "Review hello.py and write review.md with feedback"`,
@@ -49,7 +51,9 @@ var tutorialPageManifests = []pageManifest{
 	{
 		path: "docs/tutorials/03-sessions.md",
 		commands: []string{
+			"cat pack.toml",
 			"cat city.toml",
+			"cat agents/reviewer/agent.toml",
 			"gc session list --template my-project/reviewer",
 			"gc session peek mc-8sfd",
 			"gc session list",
@@ -59,6 +63,7 @@ var tutorialPageManifests = []pageManifest{
 			"gc session list",
 			"gc session logs mayor --tail 1",
 			"gc session logs mayor -f",
+			`gc session nudge mayor "What's the current city status?"`,
 		},
 	},
 	{
@@ -76,6 +81,8 @@ var tutorialPageManifests = []pageManifest{
 		commands: []string{
 			"gc formula list",
 			"gc formula show pancakes",
+			"gc agent add --name worker",
+			"cat > agents/worker/prompt.template.md << 'EOF'",
 			"gc sling mayor pancakes --formula",
 			"gc formula cook pancakes",
 			"gc sling worker mp-2wx",
@@ -94,6 +101,7 @@ var tutorialPageManifests = []pageManifest{
 		path: "docs/tutorials/06-beads.md",
 		commands: []string{
 			"cat city.toml",
+			"cat agents/reviewer/agent.toml",
 			"bd list",
 			`bd create "Fix the login bug"`,
 			`bd create "Refactor auth module" --type feature`,

--- a/test/acceptance/tutorial_goldens/tutorial02_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial02_test.go
@@ -30,20 +30,31 @@ func TestTutorial02Agents(t *testing.T) {
 		t.Fatalf("seed rig add: %v\n%s", err, out)
 	}
 
-	appendFile(t, filepath.Join(myCity, "city.toml"), `
-
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-provider = "`+tutorialReviewerProvider()+`"
-prompt_template = "prompts/reviewer.md"
-`)
-
 	ws.noteWarning("tutorial 02 starts from the state tutorial 01 leaves behind, so the page driver seeds the existing hello.py artifact before exercising the reviewer flow")
 	writeFile(t, filepath.Join(myProject, "hello.py"), "print(\"Hello, World!\")\n", 0o644)
 	ws.noteWarning("TODO(issue #632): once bare agent names reliably resolve to the enclosing rig in acceptance-style paths, simplify tutorial 02 back to `gc prime reviewer` and `gc sling reviewer ...` from inside ~/my-project")
 
 	var reviewTaskID string
+
+	t.Run("gc agent add --name reviewer --dir my-project", func(t *testing.T) {
+		out, err := ws.runShell("gc agent add --name reviewer --dir my-project", "")
+		if err != nil {
+			t.Fatalf("gc agent add --name reviewer --dir my-project: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "Scaffolded agent 'reviewer'") {
+			t.Fatalf("gc agent add output mismatch:\n%s", out)
+		}
+	})
+
+	t.Run("cat > agents/reviewer/agent.toml << 'EOF'", func(t *testing.T) {
+		cmd := `cat > agents/reviewer/agent.toml << 'EOF'
+dir = "my-project"
+provider = "` + tutorialReviewerProvider() + `"
+EOF`
+		if out, err := ws.runShell(cmd, ""); err != nil {
+			t.Fatalf("writing reviewer agent.toml: %v\n%s", err, out)
+		}
+	})
 
 	t.Run("gc prime", func(t *testing.T) {
 		out, err := ws.runShell("gc prime", "")
@@ -57,8 +68,8 @@ prompt_template = "prompts/reviewer.md"
 		}
 	})
 
-	t.Run("cat > prompts/reviewer.md << 'EOF'", func(t *testing.T) {
-		cmd := `cat > prompts/reviewer.md << 'EOF'
+	t.Run("cat > agents/reviewer/prompt.template.md << 'EOF'", func(t *testing.T) {
+		cmd := `cat > agents/reviewer/prompt.template.md << 'EOF'
 # Code Reviewer Agent
 You are an agent in a Gas City workspace. Check for available work and execute it.
 
@@ -153,6 +164,9 @@ EOF`
 	}
 	if data, err := os.ReadFile(filepath.Join(myCity, "city.toml")); err == nil {
 		ws.noteDiagnostic("final city.toml:\n%s", string(data))
+	}
+	if data, err := os.ReadFile(filepath.Join(myCity, "agents", "reviewer", "agent.toml")); err == nil {
+		ws.noteDiagnostic("final agents/reviewer/agent.toml:\n%s", string(data))
 	}
 	if data, err := os.ReadFile(filepath.Join(myProject, "review.md")); err == nil {
 		ws.noteDiagnostic("review.md:\n%s", string(data))

--- a/test/acceptance/tutorial_goldens/tutorial03_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial03_test.go
@@ -31,15 +31,11 @@ func TestTutorial03Sessions(t *testing.T) {
 		}
 	}
 
-	appendFile(t, filepath.Join(myCity, "city.toml"), `
-
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-provider = "`+tutorialReviewerProvider()+`"
-prompt_template = "prompts/reviewer.md"
-`)
-	writeFile(t, filepath.Join(myCity, "prompts", "reviewer.md"), "# Reviewer\nReview code.\n", 0o644)
+	if out, err := ws.runShell("gc agent add --name reviewer --dir my-project", ""); err != nil {
+		t.Fatalf("seed reviewer scaffold: %v\n%s", err, out)
+	}
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "agent.toml"), "dir = \"my-project\"\nprovider = \""+tutorialReviewerProvider()+"\"\n", 0o644)
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "prompt.template.md"), "# Reviewer\nReview code.\n", 0o644)
 	writeFile(t, filepath.Join(myProject, "hello.py"), "print(\"Hello, World!\")\n", 0o644)
 	ws.noteWarning("TODO(issue #632): once bare agent/template names reliably resolve to the enclosing rig in acceptance-style paths, simplify tutorial 03 back to bare `reviewer` references from inside ~/my-project")
 
@@ -60,12 +56,12 @@ prompt_template = "prompts/reviewer.md"
 		return peekErr == nil && strings.TrimSpace(peekOut) != ""
 	}
 	if !waitForCondition(t, 30*time.Second, 1*time.Second, mayorReady) {
-		ws.noteWarning("tutorial 03 runtime workaround: gc init seeds a named mayor session bead with resume metadata, so the page driver clears the stale resume key before bootstrapping a fresh headless submit")
+		ws.noteWarning("tutorial 03 runtime workaround: gc init can leave the named mayor session with stale resume metadata before the transcript is ready, so the page driver clears the stale resume key and queues a normal city-status request to materialize the transcript")
 		if out, err := ws.runShell("bd update "+mayorSessionID+" --unset-metadata session_key --unset-metadata started_config_hash --set-metadata continuation_reset_pending=true", ""); err != nil {
 			t.Fatalf("clear mayor stale resume metadata: %v\n%s", err, out)
 		}
-		if out, err := ws.runShell(`gc session submit mayor "__tutorial03_bootstrap__"`, ""); err != nil {
-			t.Fatalf("seed mayor submit bootstrap: %v\n%s", err, out)
+		if out, err := ws.runShell(`gc session nudge mayor "What's the current city status?"`, ""); err != nil {
+			t.Fatalf("seed mayor nudge bootstrap: %v\n%s", err, out)
 		}
 	}
 	if !waitForCondition(t, 30*time.Second, 1*time.Second, mayorReady) {
@@ -76,8 +72,13 @@ prompt_template = "prompts/reviewer.md"
 	var reviewerSessionID string
 	var mayorPeekOut string
 	var mayorTailLogs string
-	const logsSeedProbe = "__tutorial03_logs_seed__"
-	const logsFollowProbe = "__tutorial03_logs_follow_probe__"
+	var mayorLogsFollow *runningShell
+	const cityStatusPrompt = "What's the current city status?"
+	t.Cleanup(func() {
+		if mayorLogsFollow != nil {
+			_ = mayorLogsFollow.stop()
+		}
+	})
 
 	ws.noteWarning("tutorial 03 starts from the live reviewer polecat created in tutorial 02, so the page driver seeds that prior session state by slinging the same review work before exercising the visible session lookup flow")
 	if out, err := ws.runShell(`gc sling my-project/reviewer "Review hello.py and write review.md with feedback"`, ""); err != nil {
@@ -117,17 +118,45 @@ prompt_template = "prompts/reviewer.md"
 		t.Fatalf("reviewer session %s never became peekable:\n%s", reviewerSessionID, listOut)
 	}
 	ws.noteWarning("tutorial 03 runtime workaround: the mayor session can materialize before the runtime/transcript are ready, so the page driver waits for `peek` and `logs` readiness before the visible steps")
-	if !waitForCondition(t, 60*time.Second, 2*time.Second, func() bool {
+	mayorPeekReady := func() bool {
 		out, err := ws.runShell("gc session peek mayor --lines 3", "")
 		if err != nil || strings.TrimSpace(out) == "" {
 			return false
 		}
 		mayorPeekOut = out
 		return true
-	}) {
+	}
+	if !waitForCondition(t, 60*time.Second, 2*time.Second, mayorPeekReady) {
+		ws.noteWarning("tutorial 03 runtime workaround: reviewer setup can drain the named mayor session during config reload, so the page driver re-wakes it with a normal city-status request before the visible mayor transcript steps")
+		if out, err := ws.runShell("bd update "+mayorSessionID+" --unset-metadata session_key --unset-metadata started_config_hash --set-metadata continuation_reset_pending=true", ""); err != nil {
+			t.Fatalf("clear mayor stale resume metadata after reviewer seed: %v\n%s", err, out)
+		}
+		if out, err := ws.runShell("gc session wake mayor", ""); err != nil {
+			t.Fatalf("wake mayor after reviewer seed: %v\n%s", err, out)
+		}
+		if out, err := ws.runShell(`gc session nudge mayor "`+cityStatusPrompt+`"`, ""); err != nil {
+			t.Fatalf("re-wake mayor after reviewer seed: %v\n%s", err, out)
+		}
+	}
+	if !waitForCondition(t, 60*time.Second, 2*time.Second, mayorPeekReady) {
 		out, _ := ws.runShell("gc session list", "")
 		t.Fatalf("mayor session never became peekable:\n%s", out)
 	}
+
+	t.Run("cat pack.toml", func(t *testing.T) {
+		out, err := ws.runShell("cat pack.toml", "")
+		if err != nil {
+			t.Fatalf("cat pack.toml: %v\n%s", err, out)
+		}
+		for _, want := range []string{
+			`name = "my-city"`,
+			`schema = 2`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("pack.toml missing %q:\n%s", want, out)
+			}
+		}
+	})
 
 	t.Run("cat city.toml", func(t *testing.T) {
 		out, err := ws.runShell("cat city.toml", "")
@@ -136,13 +165,27 @@ prompt_template = "prompts/reviewer.md"
 		}
 		for _, want := range []string{
 			`name = "my-city"`,
-			`name = "reviewer"`,
-			`dir = "my-project"`,
-			`provider = "` + tutorialReviewerProvider() + `"`,
+			`name = "mayor"`,
+			`prompt_template = "agents/mayor/prompt.template.md"`,
 			`name = "my-project"`,
 		} {
 			if !strings.Contains(out, want) {
 				t.Fatalf("city.toml missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("cat agents/reviewer/agent.toml", func(t *testing.T) {
+		out, err := ws.runShell("cat agents/reviewer/agent.toml", "")
+		if err != nil {
+			t.Fatalf("cat agents/reviewer/agent.toml: %v\n%s", err, out)
+		}
+		for _, want := range []string{
+			`dir = "my-project"`,
+			`provider = "` + tutorialReviewerProvider() + `"`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("agents/reviewer/agent.toml missing %q:\n%s", want, out)
 			}
 		}
 	})
@@ -203,8 +246,8 @@ prompt_template = "prompts/reviewer.md"
 		}
 	})
 
-	t.Run(`gc session nudge mayor "What's the current city status?"`, func(t *testing.T) {
-		out, err := ws.runShell(`gc session nudge mayor "What's the current city status?"`, "")
+	t.Run(`gc session nudge mayor "`+cityStatusPrompt+`"`, func(t *testing.T) {
+		out, err := ws.runShell(`gc session nudge mayor "`+cityStatusPrompt+`"`, "")
 		if err != nil {
 			t.Fatalf("gc session nudge mayor: %v\n%s", err, out)
 		}
@@ -228,33 +271,17 @@ prompt_template = "prompts/reviewer.md"
 		}
 	})
 
-	ws.noteWarning("tutorial 03 runtime workaround: after the visible mayor nudge, wait for that prompt to surface in `peek` before exercising transcript commands; the session can be active while Claude is still on its welcome screen")
-	if !waitForCondition(t, 90*time.Second, 2*time.Second, func() bool {
-		out, err := ws.runShell("gc session peek mayor --lines 12", "")
-		if err != nil || strings.TrimSpace(out) == "" {
-			return false
-		}
-		mayorPeekOut = out
-		return strings.Contains(out, "What's the current city status?")
-	}) {
-		out, _ := ws.runShell("gc session peek mayor --lines 12", "")
-		t.Fatalf("mayor did not surface the visible nudge before the log steps:\n%s", out)
-	}
-
 	ws.noteWarning("tutorial 03 runtime workaround: named mayor sessions in acceptance can carry a stale session_key even when the live Claude transcript is present for the work-dir slug, so the page driver clears keyed log lookup before exercising the documented log commands")
 	if out, err := ws.runShell("bd update "+mayorSessionID+" --unset-metadata session_key", ""); err != nil {
 		t.Fatalf("clear mayor session_key before log lookup: %v\n%s", err, out)
 	}
-	ws.noteWarning("tutorial 03 runtime workaround: seed the mayor transcript and wait for the visible alias-based `gc session logs mayor` path to surface that marker before exercising the documented log commands")
-	if out, err := ws.runShell(`gc session nudge mayor "`+logsSeedProbe+`"`, ""); err != nil {
-		t.Fatalf("hidden transcript seed nudge failed: %v\n%s", err, out)
-	}
-	if !waitForCondition(t, 2*time.Minute, 2*time.Second, func() bool {
-		out, err := ws.runShell("gc session logs mayor --tail 0", "")
+	ws.noteWarning("tutorial 03 runtime workaround: wait for the visible alias-based `gc session logs mayor` path to become readable before exercising the documented log commands")
+	if !waitForCondition(t, 30*time.Second, 1*time.Second, func() bool {
+		out, err := ws.runShell("gc session logs mayor --tail 1", "")
 		if err != nil || strings.TrimSpace(out) == "" {
 			return false
 		}
-		if !strings.Contains(out, logsSeedProbe) {
+		if !strings.Contains(out, "[ASSISTANT]") {
 			return false
 		}
 		mayorTailLogs = out
@@ -279,13 +306,32 @@ prompt_template = "prompts/reviewer.md"
 		if err != nil {
 			t.Fatalf("gc session logs mayor -f: %v", err)
 		}
-		defer func() { _ = rs.stop() }()
+		mayorLogsFollow = rs
+	})
 
-		if _, err := ws.runShell(`gc session nudge mayor "`+logsFollowProbe+`"`, ""); err != nil {
-			t.Fatalf("hidden follow stimulus failed: %v", err)
+	t.Run(`gc session nudge mayor "`+cityStatusPrompt+`" after starting log follow`, func(t *testing.T) {
+		if mayorLogsFollow == nil {
+			t.Fatal("logs follow shell was not started")
 		}
-		if err := rs.waitFor(logsFollowProbe, 45*time.Second); err != nil {
-			t.Fatalf("session logs follow did not surface new output: %v", err)
+		baseline := mayorLogsFollow.output()
+
+		out, err := ws.runShell(`gc session nudge mayor "`+cityStatusPrompt+`"`, "")
+		if err != nil {
+			t.Fatalf("gc session nudge mayor log-follow request: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "Nudged mayor") && !strings.Contains(out, "Queued nudge for mayor") {
+			t.Fatalf("log-follow nudge output mismatch:\n%s", out)
+		}
+
+		if !waitForCondition(t, 90*time.Second, 500*time.Millisecond, func() bool {
+			out := mayorLogsFollow.output()
+			if !strings.HasPrefix(out, baseline) {
+				return len(out) > len(baseline) && strings.Contains(out, "[ASSISTANT]")
+			}
+			delta := out[len(baseline):]
+			return strings.Contains(delta, "[ASSISTANT]")
+		}) {
+			t.Fatalf("session logs follow did not surface fresh mayor output after nudge:\n%s", mayorLogsFollow.output())
 		}
 	})
 

--- a/test/acceptance/tutorial_goldens/tutorial04_communication_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial04_communication_test.go
@@ -30,15 +30,11 @@ func TestTutorial04Communication(t *testing.T) {
 		}
 	}
 
-	appendFile(t, filepath.Join(myCity, "city.toml"), `
-
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-provider = "`+tutorialReviewerProvider()+`"
-prompt_template = "prompts/reviewer.md"
-`)
-	writeFile(t, filepath.Join(myCity, "prompts", "reviewer.md"), "# Reviewer\nReview code.\n", 0o644)
+	if out, err := ws.runShell("gc agent add --name reviewer --dir my-project", ""); err != nil {
+		t.Fatalf("seed reviewer scaffold: %v\n%s", err, out)
+	}
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "agent.toml"), "dir = \"my-project\"\nprovider = \""+tutorialReviewerProvider()+"\"\n", 0o644)
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "prompt.template.md"), "# Reviewer\nReview code.\n", 0o644)
 	ws.noteWarning("TODO(issue #632): once bare agent names reliably resolve to the enclosing rig in acceptance-style paths, simplify tutorial 04's rig-local reviewer references from `my-project/reviewer` to bare `reviewer` where the shell is already in the rig")
 
 	mayorSessionID, err := ws.waitForSessionByTemplateOrTarget("mayor", "mayor", 30*time.Second, time.Second)

--- a/test/acceptance/tutorial_goldens/tutorial04_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial04_test.go
@@ -30,26 +30,16 @@ func TestTutorial05Formulas(t *testing.T) {
 			t.Fatalf("seed rig add %q: %v\n%s", cmd, err, out)
 		}
 	}
-	ws.noteWarning("tutorial 05 continuity workaround: the page assumes helper/worker agents and both rigs already exist, so the page driver seeds my-project, my-api, and a helper agent explicitly before exercising the formula commands")
-
-	appendFile(t, filepath.Join(myCity, "city.toml"), `
-
-[[agent]]
-name = "helper"
-provider = "claude"
-prompt_template = "prompts/worker.md"
-
-[[agent]]
-name = "worker"
-provider = "claude"
-prompt_template = "prompts/worker.md"
-
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-provider = "`+tutorialReviewerProvider()+`"
-prompt_template = "prompts/worker.md"
-`)
+	ws.noteWarning("tutorial 05 continuity workaround: the page assumes helper/reviewer agents and both rigs already exist, so the page driver seeds my-project, my-api, and those supporting agents before exercising the visible worker + formula commands")
+	if out, err := ws.runShell("gc agent add --name helper", ""); err != nil {
+		t.Fatalf("seed helper scaffold: %v\n%s", err, out)
+	}
+	writeFile(t, filepath.Join(myCity, "agents", "helper", "prompt.template.md"), "# Helper Agent\nHandle supporting work.\n", 0o644)
+	if out, err := ws.runShell("gc agent add --name reviewer --dir my-project", ""); err != nil {
+		t.Fatalf("seed reviewer scaffold: %v\n%s", err, out)
+	}
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "agent.toml"), "dir = \"my-project\"\nprovider = \""+tutorialReviewerProvider()+"\"\n", 0o644)
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "prompt.template.md"), "# Reviewer Agent\nReview code.\n", 0o644)
 
 	writeFile(t, filepath.Join(myCity, "formulas", "greeting.toml"), `formula = "greeting"
 
@@ -112,6 +102,26 @@ title = "Try to deploy"
 `, 0o644)
 
 	var pancakesRootID string
+
+	t.Run("gc agent add --name worker", func(t *testing.T) {
+		out, err := ws.runShell("gc agent add --name worker", "")
+		if err != nil {
+			t.Fatalf("gc agent add --name worker: %v\n%s", err, out)
+		}
+		if !strings.Contains(out, "Scaffolded agent 'worker'") {
+			t.Fatalf("gc agent add output mismatch:\n%s", out)
+		}
+	})
+
+	t.Run("cat > agents/worker/prompt.template.md << 'EOF'", func(t *testing.T) {
+		cmd := `cat > agents/worker/prompt.template.md << 'EOF'
+# Worker Agent
+You are a general-purpose Gas City worker. Execute assigned work carefully and report the result.
+EOF`
+		if out, err := ws.runShell(cmd, ""); err != nil {
+			t.Fatalf("writing worker prompt: %v\n%s", err, out)
+		}
+	})
 
 	t.Run("gc formula list", func(t *testing.T) {
 		out, err := ws.runShell("gc formula list", "")

--- a/test/acceptance/tutorial_goldens/tutorial05_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial05_test.go
@@ -28,24 +28,19 @@ func TestTutorial06Beads(t *testing.T) {
 	}
 	ws.noteWarning("tutorial 06 continuity workaround: the page assumes helper/worker/reviewer agents already exist from earlier tutorials, so the page driver seeds those agent definitions explicitly before querying beads state")
 	ws.noteWarning("TODO(issue #632): tutorial 06 still documents explicit rig-qualified reviewer examples; once rig-local shorthand is reliable in acceptance-style paths, simplify those examples where the user is already operating inside the rig context")
-	appendFile(t, filepath.Join(myCity, "city.toml"), `
-
-[[agent]]
-name = "helper"
-provider = "claude"
-prompt_template = "prompts/worker.md"
-
-[[agent]]
-name = "worker"
-provider = "claude"
-prompt_template = "prompts/worker.md"
-
-[[agent]]
-name = "reviewer"
-dir = "my-project"
-provider = "`+tutorialReviewerProvider()+`"
-prompt_template = "prompts/worker.md"
-`)
+	for _, cmd := range []string{
+		"gc agent add --name helper",
+		"gc agent add --name worker",
+		"gc agent add --name reviewer --dir my-project",
+	} {
+		if out, err := ws.runShell(cmd, ""); err != nil {
+			t.Fatalf("seed agent scaffold %q: %v\n%s", cmd, err, out)
+		}
+	}
+	writeFile(t, filepath.Join(myCity, "agents", "helper", "prompt.template.md"), "# Helper Agent\nHandle supporting work.\n", 0o644)
+	writeFile(t, filepath.Join(myCity, "agents", "worker", "prompt.template.md"), "# Worker Agent\nHandle general work.\n", 0o644)
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "agent.toml"), "dir = \"my-project\"\nprovider = \""+tutorialReviewerProvider()+"\"\n", 0o644)
+	writeFile(t, filepath.Join(myCity, "agents", "reviewer", "prompt.template.md"), "# Reviewer Agent\nReview code.\n", 0o644)
 
 	updateAPIOut, err := ws.runShell(`bd create "Update API docs"`, "")
 	if err != nil {
@@ -67,6 +62,38 @@ prompt_template = "prompts/worker.md"
 	var sprintConvoyID string
 	var ownedConvoyID string
 	var deployConvoyID string
+
+	t.Run("cat city.toml", func(t *testing.T) {
+		out, err := ws.runShell("cat city.toml", "")
+		if err != nil {
+			t.Fatalf("cat city.toml: %v\n%s", err, out)
+		}
+		for _, want := range []string{
+			`name = "my-city"`,
+			`name = "mayor"`,
+			`prompt_template = "agents/mayor/prompt.template.md"`,
+			`name = "my-project"`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("city.toml missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("cat agents/reviewer/agent.toml", func(t *testing.T) {
+		out, err := ws.runShell("cat agents/reviewer/agent.toml", "")
+		if err != nil {
+			t.Fatalf("cat agents/reviewer/agent.toml: %v\n%s", err, out)
+		}
+		for _, want := range []string{
+			`dir = "my-project"`,
+			`provider = "` + tutorialReviewerProvider() + `"`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("agents/reviewer/agent.toml missing %q:\n%s", want, out)
+			}
+		}
+	})
 
 	t.Run("bd list", func(t *testing.T) {
 		out, err := ws.runShell("bd list", "")

--- a/test/acceptance/tutorial_goldens/tutorial06_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial06_test.go
@@ -93,14 +93,14 @@ pool = "worker"
 description = "Run the test suite"
 formula = "test-suite"
 gate = "cooldown"
-	interval = "5m"
-	pool = "worker"
+interval = "5m"
+pool = "worker"
 `
 
-	writeFile(t, filepath.Join(myCity, "orders", "review-check.order.toml"), reviewOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "orders", "dep-update.order.toml"), depUpdateOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "orders", "release-notes.order.toml"), releaseNotesOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "orders", "test-suite.order.toml"), testSuiteOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "orders", "review-check.toml"), reviewOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "orders", "dep-update.toml"), depUpdateOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "orders", "release-notes.toml"), releaseNotesOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "orders", "test-suite.toml"), testSuiteOrder, 0o644)
 
 	t.Run("gc order list", func(t *testing.T) {
 		out, err := ws.runShell("gc order list", "")

--- a/test/acceptance/tutorial_goldens/tutorial06_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial06_test.go
@@ -32,15 +32,8 @@ func TestTutorial07Orders(t *testing.T) {
 		t,
 		cityToml,
 		fmt.Sprintf("name = %q\npath = %q\n", "my-api", myAPI),
-		fmt.Sprintf("name = %q\npath = %q\nincludes = [\"packs/dev-ops\"]\n", "my-api", myAPI),
+		fmt.Sprintf("name = %q\npath = %q\n\n[rigs.imports.dev_ops]\nsource = \"./packs/dev-ops\"\n", "my-api", myAPI),
 	)
-	appendFile(t, cityToml, `
-
-[[agent]]
-name = "worker"
-dir = "my-api"
-prompt_template = "prompts/worker.md"
-`)
 
 	writeFile(t, filepath.Join(myCity, "formulas", "review.toml"), `formula = "review"
 
@@ -66,10 +59,7 @@ needs = ["summarize"]
 `, 0o644)
 	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "pack.toml"), `[pack]
 name = "dev-ops"
-schema = 1
-
-[formulas]
-dir = "formulas"
+schema = 2
 `, 0o644)
 	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "formulas", "test-suite.toml"), `formula = "test-suite"
 
@@ -103,22 +93,14 @@ pool = "worker"
 description = "Run the test suite"
 formula = "test-suite"
 gate = "cooldown"
-interval = "5m"
-pool = "worker"
+	interval = "5m"
+	pool = "worker"
 `
 
-	// Canonical prose uses top-level orders/. Current discovery still expects
-	// formulas/orders/, so materialize the docs path and mirror it with a logged
-	// workaround to keep the page executable until prose/product converge.
-	ws.noteWarning("tutorial 07 workaround: mirrored docs-style orders/ into current formulas/orders discovery path")
-	writeFile(t, filepath.Join(myCity, "orders", "review-check", "order.toml"), reviewOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "orders", "dep-update", "order.toml"), depUpdateOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "orders", "release-notes", "order.toml"), releaseNotesOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "formulas", "orders", "review-check", "order.toml"), reviewOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "formulas", "orders", "dep-update", "order.toml"), depUpdateOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "formulas", "orders", "release-notes", "order.toml"), releaseNotesOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "orders", "test-suite", "order.toml"), testSuiteOrder, 0o644)
-	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "formulas", "orders", "test-suite", "order.toml"), testSuiteOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "orders", "review-check.order.toml"), reviewOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "orders", "dep-update.order.toml"), depUpdateOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "orders", "release-notes.order.toml"), releaseNotesOrder, 0o644)
+	writeFile(t, filepath.Join(myCity, "packs", "dev-ops", "orders", "test-suite.order.toml"), testSuiteOrder, 0o644)
 
 	t.Run("gc order list", func(t *testing.T) {
 		out, err := ws.runShell("gc order list", "")


### PR DESCRIPTION
## What Changed

- rewrote Tutorials 01 through 07 to teach the new 0.15 config as the default city shape instead of a migration story
- aligned tutorial goldens, continuity checks, and command inventories with the updated tutorial docs
- stabilized Tutorial 03 session-log coverage with per-env tmux isolation
- added a small `gc session logs` product fix: when a stored session key points at a missing transcript file, log lookup now falls back to provider/workdir discovery instead of failing outright
- fixed host-sensitive and flaky tests that were blocking green repo-wide and tutorial runs

## Why

The tutorial docs on this branch still assumed readers had the older config layout in their heads and were migrating forward. That made the docs harder to follow on the schema-2 branch, where `pack.toml`, `city.toml`, and `agents/<name>/` are the product surface. Tutorial 03 also had a brittle follow-log check that depended on probe strings and shared session state.

## Impact

Users now learn the current config story directly. Tutorial 03 asks the mayor for the city status and verifies fresh log output, which matches the actual intent of the walkthrough. Separately, `gc session logs` is more robust when session-key metadata lags behind the live provider transcript file.

## Root Cause

- the docs had drifted behind the new 0.15 config structure
- the Tutorial 03 acceptance flow depended on probe strings and non-isolated tmux/transcript state
- one provider-readiness test assumed missing binaries even on hosts where the CLIs were installed
- log resolution trusted the stored session key too strongly, even when the keyed transcript file had disappeared

## Validation

- `go test ./test/acceptance/tutorial_goldens -tags acceptance_c -run TestTutorial03Sessions -count=1 -timeout 8m`
- `go test ./test/acceptance/tutorial_goldens -tags acceptance_c -run 'TestTutorialCommandInventoryMatchesPinnedDocs|TestTutorialContinuity_.*' -count=1`
- `go test ./test/acceptance/tutorial_goldens -tags acceptance_c -run 'TestTutorial07Orders|TestTutorialCommandInventoryMatchesPinnedDocs|TestTutorialContinuity_.*' -count=1`
