### PR TITLE
feat: persist workspace name during registration (adopts #677)

### DIFF
--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -5,8 +5,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +61,60 @@ func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io
 		fmt.Fprintf(stderr, "gc register: %s is not a city directory (no city.toml found)\n", cityPath) //nolint:errcheck
 		return 1
 	}
-	return registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, "gc register", true)
+	registerName, persistName, err := resolveRegistrationName(cityPath, nameOverride)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc register: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if persistName {
+		if code := overrideCityName(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), registerName, stderr); code != 0 {
+			return code
+		}
+	}
+	return registerCityWithSupervisorNamed(cityPath, registerName, stdout, stderr, "gc register", true)
+}
+
+func resolveRegistrationName(cityPath, nameOverride string) (string, bool, error) {
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		return "", false, err
+	}
+
+	current := strings.TrimSpace(cfg.Workspace.Name)
+	if alias := strings.TrimSpace(nameOverride); alias != "" {
+		return alias, current != alias, nil
+	}
+	if current != "" {
+		return current, false, nil
+	}
+
+	packName, err := readPackName(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		return "", false, err
+	}
+	if strings.TrimSpace(packName) == "" {
+		return "", false, fmt.Errorf("%s: missing [pack].name for registration fallback", filepath.Join(cityPath, "pack.toml"))
+	}
+	return packName, true, nil
+}
+
+func readPackName(packTomlPath string) (string, error) {
+	data, err := os.ReadFile(packTomlPath)
+	if err != nil {
+		return "", fmt.Errorf("reading %q: %w", packTomlPath, err)
+	}
+	var meta struct {
+		Pack struct {
+			Name string `toml:"name"`
+		} `toml:"pack"`
+	}
+	if _, err := toml.Decode(string(data), &meta); err != nil {
+		return "", fmt.Errorf("parsing %q: %w", packTomlPath, err)
+	}
+	if strings.TrimSpace(meta.Pack.Name) == "" {
+		return "", fmt.Errorf("%s: missing [pack].name for registration fallback", packTomlPath)
+	}
+	return meta.Pack.Name, nil
 }
 
 func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -12,26 +12,34 @@ import (
 )
 
 func newRegisterCmd(stdout, stderr io.Writer) *cobra.Command {
+	var nameFlag string
 	cmd := &cobra.Command{
 		Use:   "register [path]",
 		Short: "Register a city with the machine-wide supervisor",
 		Long: `Register a city directory with the machine-wide supervisor.
 
 If no path is given, registers the current city (discovered from cwd).
+Use --name to store a machine-local alias in the supervisor registry
+without rewriting pack.toml or city.toml.
 Registration is idempotent — registering the same city twice is a no-op.
 The supervisor is started if needed and immediately reconciles the city.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if doRegister(args, stdout, stderr) != 0 {
+			if doRegisterWithOptions(args, nameFlag, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&nameFlag, "name", "", "machine-local alias for this city registration")
 	return cmd
 }
 
 func doRegister(args []string, stdout, stderr io.Writer) int {
+	return doRegisterWithOptions(args, "", stdout, stderr)
+}
+
+func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io.Writer) int {
 	var cityPath string
 	var err error
 	if len(args) > 0 {
@@ -49,7 +57,7 @@ func doRegister(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc register: %s is not a city directory (no city.toml found)\n", cityPath) //nolint:errcheck
 		return 1
 	}
-	return registerCityWithSupervisor(cityPath, stdout, stderr, "gc register", true)
+	return registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, "gc register", true)
 }
 
 func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -23,8 +23,10 @@ func newRegisterCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Register a city directory with the machine-wide supervisor.
 
 If no path is given, registers the current city (discovered from cwd).
-Use --name to store a machine-local alias in the supervisor registry
-without rewriting pack.toml or city.toml.
+Use --name to set the registration name; this also persists workspace.name
+in city.toml so later registrations stay aligned. When --name is omitted,
+workspace.name is used if present, otherwise [pack].name is used and
+backfilled into workspace.name.
 Registration is idempotent — registering the same city twice is a no-op.
 The supervisor is started if needed and immediately reconciles the city.`,
 		Args: cobra.MaximumNArgs(1),
@@ -91,9 +93,6 @@ func resolveRegistrationName(cityPath, nameOverride string) (string, bool, error
 	packName, err := readPackName(filepath.Join(cityPath, "pack.toml"))
 	if err != nil {
 		return "", false, err
-	}
-	if strings.TrimSpace(packName) == "" {
-		return "", false, fmt.Errorf("%s: missing [pack].name for registration fallback", filepath.Join(cityPath, "pack.toml"))
 	}
 	return packName, true, nil
 }

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -50,6 +50,100 @@ func TestDoRegister(t *testing.T) {
 	}
 }
 
+func TestDoRegisterWithNameOverrideUsesMachineLocalAlias(t *testing.T) {
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = nil
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"workspace-name\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	packToml := "[pack]\nname = \"pack-name\"\nschema = 2\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegisterWithOptions([]string{cityPath}, "machine-alias", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "machine-alias") {
+		t.Fatalf("stdout = %q, want machine-local alias", stdout.String())
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %v", entries)
+	}
+	if entries[0].Name != "machine-alias" {
+		t.Fatalf("registry name = %q, want %q", entries[0].Name, "machine-alias")
+	}
+
+	gotCityToml, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotCityToml) != cityToml {
+		t.Fatalf("city.toml changed during register --name:\n%s", string(gotCityToml))
+	}
+	gotPackToml, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotPackToml) != packToml {
+		t.Fatalf("pack.toml changed during register --name:\n%s", string(gotPackToml))
+	}
+}
+
+func TestDoRegisterWithoutNameStillUsesWorkspaceName(t *testing.T) {
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = nil
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"workspace-name\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte("[pack]\nname = \"pack-name\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegister([]string{cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", code, stderr.String())
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %v", entries)
+	}
+	if entries[0].Name != "workspace-name" {
+		t.Fatalf("registry name = %q, want %q", entries[0].Name, "workspace-name")
+	}
+}
+
 func TestDoRegisterNotCity(t *testing.T) {
 	dir := t.TempDir()
 	notCity := filepath.Join(dir, "not-a-city")

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -50,7 +50,7 @@ func TestDoRegister(t *testing.T) {
 	}
 }
 
-func TestDoRegisterWithNameOverrideUsesMachineLocalAlias(t *testing.T) {
+func TestDoRegisterWithNameOverrideRewritesWorkspaceName(t *testing.T) {
 	oldRegister := registerCityWithSupervisorTestHook
 	registerCityWithSupervisorTestHook = nil
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
@@ -60,8 +60,7 @@ func TestDoRegisterWithNameOverrideUsesMachineLocalAlias(t *testing.T) {
 	if err := os.MkdirAll(cityPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityToml := "[workspace]\nname = \"workspace-name\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"workspace-name\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	packToml := "[pack]\nname = \"pack-name\"\nschema = 2\n"
@@ -95,8 +94,8 @@ func TestDoRegisterWithNameOverrideUsesMachineLocalAlias(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(gotCityToml) != cityToml {
-		t.Fatalf("city.toml changed during register --name:\n%s", string(gotCityToml))
+	if !strings.Contains(string(gotCityToml), `name = "machine-alias"`) {
+		t.Fatalf("city.toml should persist the registered name, got:\n%s", string(gotCityToml))
 	}
 	gotPackToml, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
 	if err != nil {
@@ -141,6 +140,79 @@ func TestDoRegisterWithoutNameStillUsesWorkspaceName(t *testing.T) {
 	}
 	if entries[0].Name != "workspace-name" {
 		t.Fatalf("registry name = %q, want %q", entries[0].Name, "workspace-name")
+	}
+}
+
+func TestDoRegisterWithoutNameFallsBackToPackNameAndPersistsWorkspaceName(t *testing.T) {
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = nil
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte("[pack]\nname = \"pack-name\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegister([]string{cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", code, stderr.String())
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %v", entries)
+	}
+	if entries[0].Name != "pack-name" {
+		t.Fatalf("registry name = %q, want %q", entries[0].Name, "pack-name")
+	}
+
+	gotCityToml, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gotCityToml), `name = "pack-name"`) {
+		t.Fatalf("city.toml should persist pack.name fallback, got:\n%s", string(gotCityToml))
+	}
+}
+
+func TestDoRegisterWithoutNameErrorsWhenWorkspaceAndPackNameMissing(t *testing.T) {
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = nil
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte("[pack]\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegister([]string{cityPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "missing [pack].name") {
+		t.Fatalf("stderr = %q, want missing [pack].name", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -45,7 +45,7 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "List visible skills",
 		Long:  "List the current city pack's visible skills, optionally scoped to an agent or session.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if strings.TrimSpace(agentName) != "" && strings.TrimSpace(sessionID) != "" {
 				fmt.Fprintln(stderr, "gc skill list: --agent and --session are mutually exclusive") //nolint:errcheck // best-effort stderr
 				return errExit

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/api"
@@ -71,6 +72,13 @@ func effectiveCityName(cityPath string) (string, error) {
 		name = cfg.Workspace.Name
 	}
 	return name, nil
+}
+
+func registeredCityName(cityPath, nameOverride string) (string, error) {
+	if alias := strings.TrimSpace(nameOverride); alias != "" {
+		return alias, nil
+	}
+	return effectiveCityName(cityPath)
 }
 
 func normalizeRegisteredCityPath(cityPath string) (string, error) {
@@ -138,6 +146,10 @@ func ensureNoStandaloneController(cityPath string) (int, error) {
 }
 
 func registerCityWithSupervisor(cityPath string, stdout, stderr io.Writer, commandName string, showProgress bool) int {
+	return registerCityWithSupervisorNamed(cityPath, "", stdout, stderr, commandName, showProgress)
+}
+
+func registerCityWithSupervisorNamed(cityPath, nameOverride string, stdout, stderr io.Writer, commandName string, showProgress bool) int {
 	cityPath = normalizePathForCompare(cityPath)
 	if pid, err := ensureNoStandaloneController(cityPath); err != nil {
 		if errors.Is(err, errControllerAlreadyRunning) {
@@ -164,7 +176,7 @@ func registerCityWithSupervisor(cityPath string, stdout, stderr io.Writer, comma
 		fmt.Fprintf(stderr, "%s: fetching packs: %v\n", commandName, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	name, err := effectiveCityName(cityPath)
+	name, err := registeredCityName(cityPath, nameOverride)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", commandName, err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2526,6 +2526,13 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 	if cfg.Workspace.Name != "my-bare-name" {
 		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-bare-name")
 	}
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	if !strings.Contains(string(packData), `name = "my-bare-name"`) {
+		t.Errorf("pack.toml should keep init name aligned with workspace.name, got:\n%s", string(packData))
+	}
 }
 
 func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -533,7 +533,7 @@ schema, plus the qualified rows that matter most during migration.
 |---|---|---|
 | `include` | Merged extra config fragments into `city.toml` before load | Remove as part of migration. Move real composition to imports and move remaining config to `pack.toml`, `city.toml`, or discovered directories. |
 | `[workspace]` | Held city metadata and pack composition in one place | Split across the root `pack.toml`, `city.toml`, and `.gc/`. |
-| `workspace.name` | Workspace identity | Remove from city.toml. Now derived from `pack.name` at registration time and stored in `.gc/` as site binding. Use `gc register --name` for machine-local alias once [#602](https://github.com/gastownhall/gascity/issues/602) lands. |
+| `workspace.name` | Workspace identity | Transitional in this wave. Fresh `gc init` keeps it aligned with `pack.name`; `gc register --name` now provides a machine-local alias without rewriting checked-in config. Full removal from `city.toml` still waits for the broader site-binding cutover. |
 | `workspace.includes` | City-level pack composition | Move to `[imports.*]` in the root city `pack.toml`. |
 | `workspace.default_rig_includes` | Default pack composition for newly added rigs | Move to `[defaults.rig.imports]` in the root city `pack.toml`. This is the target shape, but loader-backed support is still tracked in [#360](https://github.com/gastownhall/gascity/issues/360). |
 | `[providers.*]` | Named provider presets | Usually move to `[providers.*]` in the root city `pack.toml`, unless the setting is truly deployment-only. |

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -533,7 +533,7 @@ schema, plus the qualified rows that matter most during migration.
 |---|---|---|
 | `include` | Merged extra config fragments into `city.toml` before load | Remove as part of migration. Move real composition to imports and move remaining config to `pack.toml`, `city.toml`, or discovered directories. |
 | `[workspace]` | Held city metadata and pack composition in one place | Split across the root `pack.toml`, `city.toml`, and `.gc/`. |
-| `workspace.name` | Workspace identity | Transitional in this wave. Fresh `gc init` keeps it aligned with `pack.name`; `gc register --name` now provides a machine-local alias without rewriting checked-in config. Full removal from `city.toml` still waits for the broader site-binding cutover. |
+| `workspace.name` | Workspace identity | Transitional in this wave. Fresh `gc init` keeps it aligned with `pack.name`; `gc register` keeps it aligned with the registered city name, using `workspace.name` when present and backfilling it from `pack.name` when absent. Full removal from `city.toml` still waits for the broader site-binding cutover. |
 | `workspace.includes` | City-level pack composition | Move to `[imports.*]` in the root city `pack.toml`. |
 | `workspace.default_rig_includes` | Default pack composition for newly added rigs | Move to `[defaults.rig.imports]` in the root city `pack.toml`. This is the target shape, but loader-backed support is still tracked in [#360](https://github.com/gastownhall/gascity/issues/360). |
 | `[providers.*]` | Named provider presets | Usually move to `[providers.*]` in the root city `pack.toml`, unless the setting is truly deployment-only. |

--- a/docs/packv2/doc-conformance-matrix.md
+++ b/docs/packv2/doc-conformance-matrix.md
@@ -69,7 +69,7 @@ These are settled enough, and implemented enough, to block CI now.
 | Commands discovery | The default `commands/<name>/run.sh` discovery path works; final manifest shape remains non-gating | Unit + testscript | `internal/config/command_discovery.go` |
 | Doctor discovery | The default `doctor/<name>/run.sh` discovery path works | Unit + testscript | `internal/config/doctor_discovery.go` |
 | Legacy migration rewrite | `gc doctor` inventories legacy Pack/City v1 usage and `gc doctor --fix` performs the safe mechanical rewrites for agent directories, prompt/overlay/namepool moves, and import-oriented composition. Legacy remote `workspace.includes` is a hard-break migration issue, not a runtime compatibility target. | Testscript | `cmd/gc/doctor_v2_checks.go`, migration fix path TBD |
-| Registration aliasing | `gc register --name` stores a machine-local registration alias and persists it into `workspace.name`; default no-flag registration uses `workspace.name` when present, otherwise falls back to `[pack].name` and persists that into `workspace.name` | Unit | `cmd/gc/cmd_register.go`, `cmd/gc/cmd_supervisor_city.go`, `internal/supervisor/registry.go` |
+| Registration naming | `gc register --name` persists `workspace.name` to the chosen registration name before registering; plain `gc register` uses `workspace.name` if present, otherwise `pack.name`, and backfills `workspace.name` before registering | Unit | `cmd/gc/cmd_register.go`, `cmd/gc/cmd_supervisor_city.go`, `internal/supervisor/registry.go` |
 
 ## Add To CI When Warning Plumbing Lands
 

--- a/docs/packv2/doc-conformance-matrix.md
+++ b/docs/packv2/doc-conformance-matrix.md
@@ -69,6 +69,7 @@ These are settled enough, and implemented enough, to block CI now.
 | Commands discovery | The default `commands/<name>/run.sh` discovery path works; final manifest shape remains non-gating | Unit + testscript | `internal/config/command_discovery.go` |
 | Doctor discovery | The default `doctor/<name>/run.sh` discovery path works | Unit + testscript | `internal/config/doctor_discovery.go` |
 | Legacy migration rewrite | `gc doctor` inventories legacy Pack/City v1 usage and `gc doctor --fix` performs the safe mechanical rewrites for agent directories, prompt/overlay/namepool moves, and import-oriented composition. Legacy remote `workspace.includes` is a hard-break migration issue, not a runtime compatibility target. | Testscript | `cmd/gc/doctor_v2_checks.go`, migration fix path TBD |
+| Registration aliasing | `gc register --name` stores a machine-local registration alias and persists it into `workspace.name`; default no-flag registration uses `workspace.name` when present, otherwise falls back to `[pack].name` and persists that into `workspace.name` | Unit | `cmd/gc/cmd_register.go`, `cmd/gc/cmd_supervisor_city.go`, `internal/supervisor/registry.go` |
 
 ## Add To CI When Warning Plumbing Lands
 
@@ -98,7 +99,6 @@ unsettled to be reliable release gates.
 |---|---|---|
 | `[defaults.rig.imports]` loader support | documented intent, not implemented | Migration tooling may write it, but the loader does not yet honor it |
 | `[agent_defaults] provider` driving runtime provider selection | migration target is documented, but runtime behavior is not aligned enough to gate | Current implementation still resolves runtime defaults through `workspace.provider` / `ResolveProvider`; locking in the future rule now would create false failures |
-| `gc register --name` | documented in design docs, not implemented | Release docs mention it, but `skew-analysis.md` marks it red, so the suite must not assume it exists |
 | `patches/` directory convention for imported prompt replacements | documented in v.next docs, not implemented | Current implementation still relies on explicit patch fields rather than full loader-discovered patch files |
 | Pack `skills/` discovery | documented, not implemented | First slice is current-city-pack only with list-only visibility; imported-pack catalogs are later |
 | `mcp/` TOML abstraction | documented, not implemented | Same first-slice scope as skills: current-city-pack only, list-only visibility first, provider projection later |

--- a/docs/packv2/doc-pack-v2.md
+++ b/docs/packv2/doc-pack-v2.md
@@ -135,9 +135,9 @@ Everything else — agents, named sessions, providers, formulas, prompts, script
 
 #### Names, prefixes, and generation
 
-`gc init` and `gc rig add` generate names and prefixes by default. Users can override with `--name` and `--prefix` (typically to resolve conflicts).
+`gc init` and `gc rig add` generate names and prefixes by default. Users can override with `--name` and `--prefix` (typically to resolve conflicts). In this rollout, `gc init --name` keeps definition and runtime identity aligned by writing the chosen name to both `pack.toml` and `city.toml`.
 
-`gc register` accepts `--name` to set a **machine-local alias** stored in `.gc/` (site binding). If `--name` is omitted, the fallback chain is: `pack.name` from `pack.toml`, then directory basename. `workspace.name` is not consulted. The registered name appears in `gc city list`, `gc status`, etc. — it is the human handle on this machine for this city. ([#602](https://github.com/gastownhall/gascity/issues/602))
+`gc register` accepts `--name` to set a **machine-local alias** stored in site binding. The registered name appears in `gc city list`, `gc status`, etc. — it is the human handle on this machine for this city. When `--name` is omitted, the current rollout keeps the existing runtime city identity (`workspace.name`, then directory basename) so already-managed cities do not drift unexpectedly. `gc register --name` does not rewrite `pack.toml` or `city.toml`. ([#602](https://github.com/gastownhall/gascity/issues/602))
 
 Names and prefixes are both managed by `gc`. The authoritative copy lives in `.gc/`. Names are human-facing labels; prefixes are derived from names and baked into bead IDs. Neither should be casually changed after creation.
 
@@ -149,11 +149,11 @@ If `gc` detects a mismatch between a rig name in city.toml and its managed state
 
 #### How `pack.name` and workspace identity relate
 
-`pack.name` is the identity of the definition — "this pack is called gastown." It lives in pack.toml, is portable, and travels with the pack when imported.
+`pack.name` is the identity of the definition — "this pack is called gastown." It lives in `pack.toml`, is portable, and travels with the pack when imported.
 
-There is no `workspace.name` in city.toml. The workspace identity is derived from `pack.name` at registration time and stored in `.gc/` as site binding.
+`workspace.name` is still a transitional runtime identity surface in this rollout. `gc init` keeps fresh cities stable by writing the same chosen name to both `pack.toml` and `city.toml`. `gc register --name` is a machine-local alias only; it does not rewrite either file.
 
-This means city.toml has no identity fields at all. It is purely deployment: rigs, substrates, infrastructure. All identity lives in pack.toml (`pack.name`) or in `.gc/` (workspace instance name, prefixes).
+The long-term direction remains the same: remove `workspace.name` from `city.toml`, derive portable identity from `pack.name`, and keep machine-local naming in site binding. This PR does not complete that cutover.
 
 The full field-by-field migration is in the appendix.
 

--- a/docs/packv2/doc-pack-v2.md
+++ b/docs/packv2/doc-pack-v2.md
@@ -137,7 +137,7 @@ Everything else — agents, named sessions, providers, formulas, prompts, script
 
 `gc init` and `gc rig add` generate names and prefixes by default. Users can override with `--name` and `--prefix` (typically to resolve conflicts). In this rollout, `gc init --name` keeps definition and runtime identity aligned by writing the chosen name to both `pack.toml` and `city.toml`.
 
-`gc register` accepts `--name` to set a **machine-local alias** stored in site binding. The registered name appears in `gc city list`, `gc status`, etc. — it is the human handle on this machine for this city. When `--name` is omitted, the current rollout keeps the existing runtime city identity (`workspace.name`, then directory basename) so already-managed cities do not drift unexpectedly. `gc register --name` does not rewrite `pack.toml` or `city.toml`. ([#602](https://github.com/gastownhall/gascity/issues/602))
+`gc register` accepts `--name` to set the city's registration name explicitly. In the current rollout, that name is persisted into `workspace.name` before registration so the runtime and registry stay aligned. When `--name` is omitted, `gc register` uses `workspace.name` if present; otherwise it falls back to `pack.name`, writes that into `city.toml`, and registers the city under that name. `gc register` does not rewrite `pack.toml`. ([#602](https://github.com/gastownhall/gascity/issues/602))
 
 Names and prefixes are both managed by `gc`. The authoritative copy lives in `.gc/`. Names are human-facing labels; prefixes are derived from names and baked into bead IDs. Neither should be casually changed after creation.
 
@@ -151,7 +151,7 @@ If `gc` detects a mismatch between a rig name in city.toml and its managed state
 
 `pack.name` is the identity of the definition — "this pack is called gastown." It lives in `pack.toml`, is portable, and travels with the pack when imported.
 
-`workspace.name` is still a transitional runtime identity surface in this rollout. `gc init` keeps fresh cities stable by writing the same chosen name to both `pack.toml` and `city.toml`. `gc register --name` is a machine-local alias only; it does not rewrite either file.
+`workspace.name` is still a transitional runtime identity surface in this rollout. `gc init` keeps fresh cities stable by writing the same chosen name to both `pack.toml` and `city.toml`. `gc register` keeps registration and runtime identity aligned by updating `workspace.name` to the chosen registration name, or by backfilling it from `pack.name` when needed.
 
 The long-term direction remains the same: remove `workspace.name` from `city.toml`, derive portable identity from `pack.name`, and keep machine-local naming in site binding. This PR does not complete that cutover.
 

--- a/docs/packv2/skew-analysis.md
+++ b/docs/packv2/skew-analysis.md
@@ -86,7 +86,7 @@
 
 | Status | Field | As-built | Current rollout disposition | Later destination |
 |--------|-------|----------|--------------------|-----------------------|
-| 🟡 | `name` | Required string | **Optional.** Transitional runtime identity field in this wave. Fresh `gc init` keeps it aligned with `pack.name`; runtime fallback still uses `workspace.name` → directory basename. Soft warning: "use `gc register --name` for a machine-local alias; full site-binding cutover remains later." | `.gc/` site binding (#600) |
+| 🟡 | `name` | Required string | **Optional.** Transitional runtime identity field in this wave. Fresh `gc init` keeps it aligned with `pack.name`; `gc register` keeps it aligned with the registered city name and backfills it from `pack.name` when absent. Soft warning: full site-binding cutover remains later. | `.gc/` site binding (#600) |
 | 🟡 | `prefix` | String | **Optional.** Same treatment as `name`. Soft warning. | `.gc/` site binding (#600) |
 | 🟡 | `provider` | String | **Soft warning.** "Use `[agent_defaults] provider = ...` instead." | `[agent_defaults]` in pack.toml |
 | 🟡 | `start_command` | String | **Soft warning.** "Use per-agent `start_command` in `agent.toml` instead." | Per-agent `agent.toml` |
@@ -252,7 +252,7 @@ All Import fields match spec. No changes needed.
 | 🟢 | `orders/` top-level discovery | doc-directory-conventions | `discoverFlatFiles` in orders/discovery.go |
 | 🟢 | `commands/` convention discovery | doc-commands | `DiscoverPackCommands` in command_discovery.go |
 | 🔴 | `[defaults.rig.imports]` loader support | doc-pack-v2 | Migrate tool writes it, loader ignores it |
-| 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented as a machine-local registration alias. Default no-flag registration keeps the current runtime city identity in this wave. |
+| 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented. The current rollout persists the chosen registration name into `workspace.name`; no-flag registration uses `workspace.name` first, then `pack.name` and backfills `workspace.name`. |
 | 🔴 | `patches/` directory convention | doc-agent-v2 | Not implemented |
 | 🔴 | `skills/` pack discovery | doc-agent-v2 | First slice is current-city-pack only with list-only visibility; imported-pack catalogs are later |
 | 🔴 | `mcp/` TOML abstraction | doc-agent-v2 | First slice is current-city-pack only with list-only visibility; provider projection is later |

--- a/docs/packv2/skew-analysis.md
+++ b/docs/packv2/skew-analysis.md
@@ -86,7 +86,7 @@
 
 | Status | Field | As-built | Current rollout disposition | Later destination |
 |--------|-------|----------|--------------------|-----------------------|
-| 🟡 | `name` | Required string | **Optional.** Falls back to `pack.name` → directory basename. Soft warning: "use `gc register --name` instead." | `.gc/` site binding (#600) |
+| 🟡 | `name` | Required string | **Optional.** Transitional runtime identity field in this wave. Fresh `gc init` keeps it aligned with `pack.name`; runtime fallback still uses `workspace.name` → directory basename. Soft warning: "use `gc register --name` for a machine-local alias; full site-binding cutover remains later." | `.gc/` site binding (#600) |
 | 🟡 | `prefix` | String | **Optional.** Same treatment as `name`. Soft warning. | `.gc/` site binding (#600) |
 | 🟡 | `provider` | String | **Soft warning.** "Use `[agent_defaults] provider = ...` instead." | `[agent_defaults]` in pack.toml |
 | 🟡 | `start_command` | String | **Soft warning.** "Use per-agent `start_command` in `agent.toml` instead." | Per-agent `agent.toml` |
@@ -252,7 +252,7 @@ All Import fields match spec. No changes needed.
 | 🟢 | `orders/` top-level discovery | doc-directory-conventions | `discoverFlatFiles` in orders/discovery.go |
 | 🟢 | `commands/` convention discovery | doc-commands | `DiscoverPackCommands` in command_discovery.go |
 | 🔴 | `[defaults.rig.imports]` loader support | doc-pack-v2 | Migrate tool writes it, loader ignores it |
-| 🔴 | `gc register --name` flag | doc-pack-v2 | #602 — no flag on register command |
+| 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented as a machine-local registration alias. Default no-flag registration keeps the current runtime city identity in this wave. |
 | 🔴 | `patches/` directory convention | doc-agent-v2 | Not implemented |
 | 🔴 | `skills/` pack discovery | doc-agent-v2 | First slice is current-city-pack only with list-only visibility; imported-pack catalogs are later |
 | 🔴 | `mcp/` TOML abstraction | doc-agent-v2 | First slice is current-city-pack only with list-only visibility; provider projection is later |

--- a/internal/config/agent_discovery.go
+++ b/internal/config/agent_discovery.go
@@ -14,7 +14,7 @@ import (
 // agent.toml provides optional per-agent config, prompt.template.md is
 // canonical, prompt.md.tmpl remains temporarily supported, and prompt.md is
 // the plain-markdown fallback.
-func DiscoverPackAgents(fs fsys.FS, packDir, packName string, skipNames map[string]bool) ([]Agent, error) {
+func DiscoverPackAgents(fs fsys.FS, packDir, _ string, skipNames map[string]bool) ([]Agent, error) {
 	agentsDir := filepath.Join(packDir, "agents")
 	entries, err := fs.ReadDir(agentsDir)
 	if err != nil {

--- a/internal/config/agent_discovery_test.go
+++ b/internal/config/agent_discovery_test.go
@@ -17,7 +17,9 @@ func TestAgentDiscovery_BasicDirectory(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "worker")
 
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -27,7 +29,9 @@ schema = 1
 	writeTestFile(t, agentDir, "prompt.md", `You are a worker agent.`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -60,7 +64,9 @@ func TestAgentDiscovery_CanonicalTemplateSuffix(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "worker")
 
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -70,7 +76,9 @@ schema = 1
 	writeTestFile(t, agentDir, "prompt.template.md", `You are {{ .AgentName }}.`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -99,7 +107,9 @@ func TestAgentDiscovery_LegacyTemplateSuffixStillLoads(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "worker")
 
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -109,7 +119,9 @@ schema = 1
 	writeTestFile(t, agentDir, "prompt.md.tmpl", `legacy`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -138,7 +150,9 @@ func TestAgentDiscovery_PrefersCanonicalTemplateSuffix(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "worker")
 
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -150,7 +164,9 @@ schema = 1
 	writeTestFile(t, agentDir, "prompt.md", `plain`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -180,7 +196,9 @@ func TestAgentDiscovery_WithAgentToml(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "coder")
 
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -194,7 +212,9 @@ provider = "codex"
 	writeTestFile(t, agentDir, "prompt.md", `You are a coder.`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -228,7 +248,9 @@ func TestAgentDiscovery_TomlAgentTakesPrecedence(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "mayor")
 
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -247,7 +269,9 @@ provider = "codex"
 	writeTestFile(t, agentDir, "prompt.md", `Convention prompt.`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -285,7 +309,9 @@ func TestAgentDiscovery_WithOverlay(t *testing.T) {
 	agentDir := filepath.Join(packDir, "agents", "helper")
 	overlayDir := filepath.Join(agentDir, "overlay")
 
-	os.MkdirAll(overlayDir, 0o755)
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -296,7 +322,9 @@ schema = 1
 	writeTestFile(t, overlayDir, "CLAUDE.md", `# Helper overlay`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -325,8 +353,12 @@ func TestAgentDiscovery_WithSharedCatalogRoots(t *testing.T) {
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "helper")
 
-	os.MkdirAll(filepath.Join(agentDir, "skills", "private"), 0o755)
-	os.MkdirAll(filepath.Join(agentDir, "mcp"), 0o755)
+	if err := os.MkdirAll(filepath.Join(agentDir, "skills", "private"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(agentDir, "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -340,7 +372,9 @@ command = ["helper-mcp"]
 `)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -371,7 +405,9 @@ func TestAgentDiscovery_NoAgentsDir(t *testing.T) {
 	// A pack with no agents/ directory should work fine (no agents discovered).
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "mypk")
-	os.MkdirAll(packDir, 0o755)
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -380,7 +416,9 @@ schema = 1
 `)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
@@ -404,7 +442,9 @@ func TestAgentDiscovery_WithImport(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "mypk")
 	agentDir := filepath.Join(packDir, "agents", "assist")
-	os.MkdirAll(agentDir, 0o755)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	writeTestFile(t, packDir, "pack.toml", `
 [pack]
@@ -417,7 +457,9 @@ scope = "city"
 	writeTestFile(t, agentDir, "prompt.md", `Assist agent.`)
 
 	cityDir := filepath.Join(dir, "city")
-	os.MkdirAll(cityDir, 0o755)
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -616,24 +616,6 @@ func hasOpenScopeMembers(store beads.Store, rootID, scopeRef string) (bool, erro
 	return snapshot.hasOpenScopeMembers(), nil
 }
 
-func listScopeMembers(store beads.Store, rootID, scopeRef string) ([]beads.Bead, error) {
-	all, err := listByWorkflowRoot(store, rootID)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]beads.Bead, 0)
-	for _, bead := range all {
-		if bead.Metadata["gc.root_bead_id"] != rootID {
-			continue
-		}
-		if bead.Metadata["gc.scope_ref"] != scopeRef {
-			continue
-		}
-		result = append(result, bead)
-	}
-	return result, nil
-}
-
 func listByWorkflowRoot(store beads.Store, rootID string) ([]beads.Bead, error) {
 	all, err := store.List(beads.ListQuery{
 		Metadata:      map[string]string{"gc.root_bead_id": rootID},

--- a/internal/supervisor/registry.go
+++ b/internal/supervisor/registry.go
@@ -121,14 +121,14 @@ func (r *Registry) Register(cityPath, effectiveName string) error {
 			// Name changed — check for conflicts with other entries, then update.
 			for j, other := range entries {
 				if j != i && other.EffectiveName() == effectiveName {
-					return fmt.Errorf("city name %q already registered at %s (set a unique workspace.name)", effectiveName, other.Path)
+					return fmt.Errorf("city name %q already registered at %s (choose a unique registration name, for example with gc register --name)", effectiveName, other.Path)
 				}
 			}
 			entries[i].Name = effectiveName
 			return r.saveLocked(entries)
 		}
 		if e.EffectiveName() == effectiveName {
-			return fmt.Errorf("city name %q already registered at %s (set a unique workspace.name)", effectiveName, e.Path)
+			return fmt.Errorf("city name %q already registered at %s (choose a unique registration name, for example with gc register --name)", effectiveName, e.Path)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adopts the two real work commits from #677 onto `fix/track1-gascity-example-pack-schema`, plus a maintainer review-fixup commit. The original branch had diverged ~100 files from main, so this PR re-lands just the register-name feature on the correct base.

## Commits

- `feat: add gc register --name alias` — @donbox
- `fix: persist workspace name during registration` — @donbox
- `review fixups: correct --name help text and drop dead check` — maintainer

Credit: Original feature by @donbox (commits preserved with original authorship).

## What it does

Adds `gc register --name <name>`. Resolution order for the registered name:

1. `--name` flag (persists to `workspace.name` if it differs)
2. `workspace.name` if present (used as-is)
3. `[pack].name` fallback (backfilled into `workspace.name`)
4. error if neither workspace.name nor pack.name exists

## Review fixups

1. The Long help text for `gc register --name` claimed the flag stored an alias "without rewriting pack.toml or city.toml" — but the implementation rewrites `workspace.name` in city.toml when the alias differs, and `TestDoRegisterWithNameOverrideRewritesWorkspaceName` asserts that behavior. Help text now matches the code.
2. Dropped an unreachable empty-pack-name check in `resolveRegistrationName` — `readPackName` already returns an error when `[pack].name` is missing or blank.

## Test plan

- [x] `go build ./cmd/gc`
- [x] `go vet ./cmd/gc`
- [x] `go test ./cmd/gc -run 'TestDoRegister|TestInitNameFlagWithBareInit'` — all pass
- [ ] CI green