### PR TITLE
fix: preserve slashes in DefaultBranch() (#719)

### DIFF
--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -3876,6 +3876,46 @@ func TestBuildSlingFormulaVarsUsesRigDefaultBranchWhenTargetMissing(t *testing.T
 	}
 }
 
+func TestBuildSlingFormulaVarsPreservesSlashesInRigDefaultBranch(t *testing.T) {
+	// Regression test for #719: slashes in the default branch must survive
+	// the rig → defaultBranchFor → base_branch path, not just the internal
+	// git parser. Previously LastIndex(ref, "/") truncated at the consumer
+	// boundary too.
+	repoDir := newRepoWithOriginHead(t, "team/feature/x")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "hw", Path: repoDir},
+		},
+	}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Store = &recordingStore{Store: beads.NewMemStore()}
+
+	vars := buildSlingFormulaVars("mol-polecat-work", "HW-42", nil, config.Agent{Name: "polecat", Dir: "hw"}, deps)
+
+	if got, ok := findVarValue(vars, "base_branch"); !ok || got != "team/feature/x" {
+		t.Fatalf("base_branch var = %q, %v; want team/feature/x, true", got, ok)
+	}
+}
+
+func TestBuildSlingFormulaVarsPreservesSlashesInRefineryTargetBranch(t *testing.T) {
+	// Regression test for #719 covering the refinery target_branch path.
+	repoDir := newRepoWithOriginHead(t, "boylec/develop")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "hw", Path: repoDir},
+		},
+	}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+
+	vars := buildSlingFormulaVars("mol-refinery-patrol", "", nil, config.Agent{Name: "refinery", Dir: "hw"}, deps)
+
+	if got, ok := findVarValue(vars, "target_branch"); !ok || got != "boylec/develop" {
+		t.Fatalf("target_branch var = %q, %v; want boylec/develop, true", got, ok)
+	}
+}
+
 func TestBuildSlingFormulaVarsPreservesExplicitValues(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	store := &recordingStore{

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -287,6 +287,19 @@ func TestDefaultBranchFor_NonGitDir(t *testing.T) {
 	}
 }
 
+func TestDefaultBranchFor_PreservesSlashesInBranchName(t *testing.T) {
+	// Regression test for #719: defaultBranchFor must preserve slashes in
+	// the default branch name. Previously strings.LastIndex(ref, "/") in
+	// DefaultBranch() truncated "refs/remotes/origin/team/feature/x" to "x",
+	// leaking the wrong branch name into PromptContext.DefaultBranch and
+	// the direct cmd_sling / cmd_prime consumers.
+	repoDir := newRepoWithOriginHead(t, "team/feature/x")
+	got := defaultBranchFor(repoDir)
+	if got != "team/feature/x" {
+		t.Errorf("defaultBranchFor(repo with slashy default) = %q, want %q", got, "team/feature/x")
+	}
+}
+
 func TestBuildTemplateDataDefaultBranchOverridesEnv(t *testing.T) {
 	ctx := PromptContext{
 		DefaultBranch: "develop",

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -59,12 +59,11 @@ func (g *Git) DefaultBranch() (string, error) {
 	if err != nil {
 		return "main", nil
 	}
-	// Output is like "refs/remotes/origin/main"
+	// Output is like "refs/remotes/origin/main" or
+	// "refs/remotes/origin/user/feature". Strip the full prefix so branch
+	// names containing slashes are preserved.
 	ref := strings.TrimSpace(out)
-	if i := strings.LastIndex(ref, "/"); i >= 0 {
-		return ref[i+1:], nil
-	}
-	return ref, nil
+	return strings.TrimPrefix(ref, "refs/remotes/origin/"), nil
 }
 
 // WorktreeRemove removes a worktree. If force is true, removes even with

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -80,6 +80,51 @@ func TestDefaultBranch_NoRemote(t *testing.T) {
 	}
 }
 
+// TestDefaultBranch_FromOriginHEAD exercises the symref parsing path and
+// verifies that branch names containing slashes round-trip correctly.
+// Regression test for the bug where strings.LastIndex(ref, "/") truncated
+// "refs/remotes/origin/user/feature" to "feature".
+func TestDefaultBranch_FromOriginHEAD(t *testing.T) {
+	tests := []struct {
+		name   string
+		branch string
+	}{
+		{"plain branch", "main"},
+		{"single slash", "boylec/develop"},
+		{"nested slashes", "team/feature/x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up a bare remote and a clone that tracks it, so
+			// refs/remotes/origin/HEAD can be wired to the target ref.
+			bare := t.TempDir()
+			runGit(t, bare, "init", "--bare")
+
+			clone := t.TempDir()
+			runGit(t, clone, "clone", bare, ".")
+			runGit(t, clone, "config", "user.email", "test@test.com")
+			runGit(t, clone, "config", "user.name", "Test")
+			runGit(t, clone, "commit", "--allow-empty", "-m", "init")
+
+			// Create the target ref under refs/remotes/origin/ and point
+			// origin/HEAD at it. symbolic-ref is permissive about its
+			// target so we don't need to push the branch first.
+			target := "refs/remotes/origin/" + tt.branch
+			runGit(t, clone, "update-ref", target, "HEAD")
+			runGit(t, clone, "symbolic-ref", "refs/remotes/origin/HEAD", target)
+
+			g := New(clone)
+			got, err := g.DefaultBranch()
+			if err != nil {
+				t.Fatalf("DefaultBranch: %v", err)
+			}
+			if got != tt.branch {
+				t.Errorf("DefaultBranch() = %q, want %q", got, tt.branch)
+			}
+		})
+	}
+}
+
 func TestWorktreeRemove(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)


### PR DESCRIPTION
## Summary

Fixes #719.

`DefaultBranch()` in `internal/git/git.go` used `strings.LastIndex(ref, \"/\")` to strip the `refs/remotes/origin/` prefix from the output of `git symbolic-ref refs/remotes/origin/HEAD`. This also ate every intermediate slash, so a ref like `refs/remotes/origin/user/feature` came out as `feature` instead of `user/feature`.

The value flows into `PromptContext.DefaultBranch` and is rendered as `{{ .DefaultBranch }}` in polecat, refinery, and approval-fallacy templates — so polecats and refineries targeting slash-containing default branches ended up filing PRs against the wrong base.

**Fix:** replace `LastIndex` with `strings.TrimPrefix(ref, \"refs/remotes/origin/\")`. Slashes inside the branch name are preserved. The change is consistent with the existing `TrimPrefix` pattern used for `refs/heads/` stripping in the same file at `internal/git/git.go:291`.

**Test:** new `TestDefaultBranch_FromOriginHEAD` table-driven regression test covering:
- `main` (plain)
- `boylec/develop` (single slash)
- `team/feature/x` (nested slashes)

The test sets up a bare remote plus clone, uses `git update-ref refs/remotes/origin/<branch> HEAD` then `git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/<branch>` (the pattern already established in `cmd/gc/cmd_sling_test.go:155`), and asserts the returned branch name exactly. Verified the test fails under the old code: `single_slash` returns `\"develop\"` and `nested_slashes` returns `\"x\"` — the exact bug path.

## Blast radius

Grepped the tree for sibling instances:
- The literal `\"refs/remotes/origin/\"` appears in Go only inside this function. No other parser is affected.
- The other 9 `strings.LastIndex(x, \"/\")` sites parse rig/agent/session/pack/identity names (not git refs) where last-segment semantics are intentional — not sibling bugs.
- Downstream templates (polecat/refinery/approval-fallacy) use `{{ .DefaultBranch }}` as a branch/target-ref argument. Slashy branch names are valid in those contexts.

Note: gastown has the same latent bug in `RemoteDefaultBranch()` at `internal/git/git.go:763-787` — out of scope for this gascity PR, but worth a mention for cross-repo follow-up.

## Test plan

- [x] `go test -race ./internal/git/...` passes
- [x] `go vet ./internal/git/...` clean
- [x] `go test ./cmd/gc/... -run DefaultBranch` passes (downstream `PromptContext.DefaultBranch` consumers)
- [x] `go build ./...` clean
- [x] New test fails under the original `LastIndex` code on the slash cases (verified by stash-and-rerun)