### PR TITLE
fix: error on v2+ formula compilation when formula_v2 is disabled

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -174,10 +174,10 @@ func TestDoAgentResumePackDerivedError(t *testing.T) {
 }
 
 func TestLoadCityConfigFSAppliesFeatureFlags(t *testing.T) {
-	oldFormulaV2 := formula.FormulaV2Enabled
+	oldFormulaV2 := formula.IsFormulaV2Enabled()
 	oldGraphApply := molecule.GraphApplyEnabled
 	t.Cleanup(func() {
-		formula.FormulaV2Enabled = oldFormulaV2
+		formula.SetFormulaV2Enabled(oldFormulaV2)
 		molecule.GraphApplyEnabled = oldGraphApply
 	})
 
@@ -196,8 +196,8 @@ formula_v2 = true
 	if !cfg.Daemon.FormulaV2 {
 		t.Fatalf("cfg.Daemon.FormulaV2 = false, want true")
 	}
-	if !formula.FormulaV2Enabled {
-		t.Fatalf("formula.FormulaV2Enabled = false, want true")
+	if !formula.IsFormulaV2Enabled() {
+		t.Fatalf("formula.IsFormulaV2Enabled() = false, want true")
 	}
 	if !molecule.GraphApplyEnabled {
 		t.Fatalf("molecule.GraphApplyEnabled = false, want true")

--- a/cmd/gc/cmd_sling_routevars_test.go
+++ b/cmd/gc/cmd_sling_routevars_test.go
@@ -143,12 +143,12 @@ type = "task"
 	}
 
 	// Enable graph workflow features.
-	prevFormulaV2 := formula.FormulaV2Enabled
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
 	prevGraphApply := molecule.GraphApplyEnabled
-	formula.FormulaV2Enabled = true
+	formula.SetFormulaV2Enabled(true)
 	molecule.GraphApplyEnabled = true
 	t.Cleanup(func() {
-		formula.FormulaV2Enabled = prevFormulaV2
+		formula.SetFormulaV2Enabled(prevFormulaV2)
 		molecule.GraphApplyEnabled = prevGraphApply
 	})
 

--- a/cmd/gc/feature_flags.go
+++ b/cmd/gc/feature_flags.go
@@ -11,6 +11,6 @@ import (
 // any formula compilation or molecule instantiation.
 func applyFeatureFlags(cfg *config.City) {
 	gw := cfg.Daemon.FormulaV2
-	formula.FormulaV2Enabled = gw
+	formula.SetFormulaV2Enabled(gw)
 	molecule.GraphApplyEnabled = gw
 }

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -29,6 +29,9 @@ patrol_interval = "30s"
 max_restarts = 5
 restart_window = "1h"
 shutdown_timeout = "5s"
+# Gastown formulas declare version >= 2 (e.g. mol-deacon-patrol at v12,
+# mol-polecat-work at v7). formula_v2 must be enabled to compile them.
+formula_v2 = true
 
 # Register a rig to activate per-rig agents (witness, refinery, polecat):
 # [[rigs]]

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -549,9 +549,9 @@ func (s failPerRootChildLookupStore) List(query beads.ListQuery) ([]beads.Bead, 
 }
 
 func TestFormulaDetailReturnsCompiledPreview(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	state := newFakeState(t)
 	formulaDir := t.TempDir()

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/formula"
 )
 
 func TestFormulaListReturnsCatalogSummaries(t *testing.T) {
@@ -548,6 +549,10 @@ func (s failPerRootChildLookupStore) List(query beads.ListQuery) ([]beads.Bead, 
 }
 
 func TestFormulaDetailReturnsCompiledPreview(t *testing.T) {
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+
 	state := newFakeState(t)
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -1506,9 +1506,9 @@ func TestProcessRalphCheckRecoversRetryAttemptMissingFinalAssigneePass(t *testin
 }
 
 func TestProcessFanoutSpawnsFragmentsAndClosesOnSecondPass(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1636,9 +1636,9 @@ needs = ["{target}.review"]
 }
 
 func TestProcessFanoutResumesExistingFragmentsWithoutDuplicates(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1741,9 +1741,9 @@ needs = ["{target}.review"]
 }
 
 func TestProcessFanoutSequentialChainsFragments(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1846,9 +1846,9 @@ title = "Review {reviewer}"
 }
 
 func TestProcessFanoutSequentialResumeRestoresExternalDeps(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1965,9 +1965,9 @@ title = "Review {reviewer}"
 }
 
 func TestProcessFanoutSequentialChainSurvivesEmptyMiddleFragment(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -2087,9 +2087,9 @@ title = "Review {reviewer}"
 }
 
 func TestProcessFanoutRecoversPartialFragmentInstance(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -2188,9 +2188,9 @@ needs = ["{target}.review"]
 }
 
 func TestProcessFanoutRecoversIncompletelyWiredFragmentInstance(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `
@@ -2487,9 +2487,9 @@ func TestCanDiscardPartialFragmentBeadWaitsForDependents(t *testing.T) {
 }
 
 func TestProcessFanoutClosesScopeWhenLastMember(t *testing.T) {
-	prev := formula.FormulaV2Enabled
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	expansion := `

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -1506,7 +1506,9 @@ func TestProcessRalphCheckRecoversRetryAttemptMissingFinalAssigneePass(t *testin
 }
 
 func TestProcessFanoutSpawnsFragmentsAndClosesOnSecondPass(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1634,7 +1636,9 @@ needs = ["{target}.review"]
 }
 
 func TestProcessFanoutResumesExistingFragmentsWithoutDuplicates(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1737,7 +1741,9 @@ needs = ["{target}.review"]
 }
 
 func TestProcessFanoutSequentialChainsFragments(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1840,7 +1846,9 @@ title = "Review {reviewer}"
 }
 
 func TestProcessFanoutSequentialResumeRestoresExternalDeps(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -1957,7 +1965,9 @@ title = "Review {reviewer}"
 }
 
 func TestProcessFanoutSequentialChainSurvivesEmptyMiddleFragment(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -2077,7 +2087,9 @@ title = "Review {reviewer}"
 }
 
 func TestProcessFanoutRecoversPartialFragmentInstance(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -2176,7 +2188,9 @@ needs = ["{target}.review"]
 }
 
 func TestProcessFanoutRecoversIncompletelyWiredFragmentInstance(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `
@@ -2473,7 +2487,9 @@ func TestCanDiscardPartialFragmentBeadWaitsForDependents(t *testing.T) {
 }
 
 func TestProcessFanoutClosesScopeWhenLastMember(t *testing.T) {
-	t.Parallel()
+	prev := formula.FormulaV2Enabled
+	formula.FormulaV2Enabled = true
+	t.Cleanup(func() { formula.FormulaV2Enabled = prev })
 
 	dir := t.TempDir()
 	expansion := `

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -3,7 +3,6 @@ package formula
 import (
 	"context"
 	"fmt"
-	"log"
 	"maps"
 )
 
@@ -161,7 +160,10 @@ func toRecipe(f *Formula) (*Recipe, error) {
 		Pour:        f.Pour,
 	}
 
-	graphWorkflow := isGraphWorkflow(f)
+	graphWorkflow, err := isGraphWorkflow(f)
+	if err != nil {
+		return nil, err
+	}
 
 	// Determine root title: use {{title}} placeholder if the variable
 	// is defined, otherwise fall back to formula name.
@@ -398,25 +400,25 @@ func flattenSteps(steps []*Step, parentID string, idMapping map[string]string, o
 }
 
 // FormulaV2Enabled controls whether graph.v2 formula compilation is
-// allowed. When false, isGraphWorkflow always returns false regardless of
-// the formula's Version field, causing v2 formulas to compile as v1.
+// allowed. When false, isGraphWorkflow returns an error for formulas
+// declaring version >= 2 rather than silently downgrading to v1.
 // Set by the daemon config loader from [daemon] formula_v2.
 var FormulaV2Enabled bool
 
-func isGraphWorkflow(f *Formula) bool {
+func isGraphWorkflow(f *Formula) (bool, error) {
 	if f == nil {
-		return false
+		return false, nil
 	}
 	if !FormulaV2Enabled {
 		if f.Version >= 2 {
-			log.Printf("formula declares version %d but formula_v2 is disabled; compiling as v1", f.Version)
+			return false, fmt.Errorf("formula %q declares version %d but formula_v2 is disabled; enable [daemon] formula_v2 or use a version 1 formula", f.Formula, f.Version)
 		}
-		return false
+		return false, nil
 	}
 	if f.Version >= 2 {
-		return true
+		return true, nil
 	}
-	return hasDetachedGraphSteps(f.Steps)
+	return hasDetachedGraphSteps(f.Steps), nil
 }
 
 func isDetachedGraphStep(step *Step) bool {

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sync/atomic"
 )
 
 // Compile loads a formula by name and runs the full compilation pipeline.
@@ -160,7 +161,7 @@ func toRecipe(f *Formula) (*Recipe, error) {
 		Pour:        f.Pour,
 	}
 
-	graphWorkflow, err := isGraphWorkflow(f)
+	graphWorkflow, err := isGraphWorkflow(f, IsFormulaV2Enabled())
 	if err != nil {
 		return nil, err
 	}
@@ -399,17 +400,35 @@ func flattenSteps(steps []*Step, parentID string, idMapping map[string]string, o
 	}
 }
 
-// FormulaV2Enabled controls whether graph.v2 formula compilation is
+// formulaV2Enabled controls whether graph.v2 formula compilation is
 // allowed. When false, isGraphWorkflow returns an error for formulas
 // declaring version >= 2 rather than silently downgrading to v1.
 // Set by the daemon config loader from [daemon] formula_v2.
-var FormulaV2Enabled bool
+//
+// Stored as atomic.Bool so config reload can race safely with in-flight
+// compilation without flipping a compile into the hard formula_v2 error.
+// Each compile snapshots the value once via IsFormulaV2Enabled at the top
+// of toRecipe.
+var formulaV2Enabled atomic.Bool
 
-func isGraphWorkflow(f *Formula) (bool, error) {
+// SetFormulaV2Enabled sets the graph.v2 formula compilation flag. Safe for
+// concurrent use with IsFormulaV2Enabled; intended for the daemon config
+// loader and tests.
+func SetFormulaV2Enabled(v bool) {
+	formulaV2Enabled.Store(v)
+}
+
+// IsFormulaV2Enabled reports whether graph.v2 formula compilation is
+// allowed. Safe for concurrent use.
+func IsFormulaV2Enabled() bool {
+	return formulaV2Enabled.Load()
+}
+
+func isGraphWorkflow(f *Formula, v2Enabled bool) (bool, error) {
 	if f == nil {
 		return false, nil
 	}
-	if !FormulaV2Enabled {
+	if !v2Enabled {
 		if f.Version >= 2 {
 			return false, fmt.Errorf("formula %q declares version %d but formula_v2 is disabled; enable [daemon] formula_v2 or use a version 1 formula", f.Formula, f.Version)
 		}

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -543,6 +543,75 @@ needs = ["a"]
 	}
 }
 
+func TestCompileV2FormulaFailsWhenFormulaV2Disabled(t *testing.T) {
+	// FormulaV2Enabled defaults to false — do not set it.
+
+	dir := t.TempDir()
+
+	t.Run("version 2 formula errors", func(t *testing.T) {
+		formulaContent := `
+formula = "needs-v2"
+version = 2
+
+[[steps]]
+id = "work"
+title = "Do work"
+`
+		if err := os.WriteFile(filepath.Join(dir, "needs-v2.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := Compile(context.Background(), "needs-v2", []string{dir}, nil)
+		if err == nil {
+			t.Fatal("Compile(needs-v2) succeeded, want error for v2 formula with FormulaV2Enabled=false")
+		}
+		if !strings.Contains(err.Error(), "formula_v2") {
+			t.Fatalf("error = %v, want message mentioning formula_v2", err)
+		}
+	})
+
+	t.Run("version 8 formula errors", func(t *testing.T) {
+		formulaContent := `
+formula = "needs-v8"
+version = 8
+
+[[steps]]
+id = "work"
+title = "Do work"
+`
+		if err := os.WriteFile(filepath.Join(dir, "needs-v8.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := Compile(context.Background(), "needs-v8", []string{dir}, nil)
+		if err == nil {
+			t.Fatal("Compile(needs-v8) succeeded, want error for v8 formula with FormulaV2Enabled=false")
+		}
+		if !strings.Contains(err.Error(), "formula_v2") {
+			t.Fatalf("error = %v, want message mentioning formula_v2", err)
+		}
+	})
+
+	t.Run("version 1 formula still compiles", func(t *testing.T) {
+		formulaContent := `
+formula = "still-v1"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Do work"
+`
+		if err := os.WriteFile(filepath.Join(dir, "still-v1.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := Compile(context.Background(), "still-v1", []string{dir}, nil)
+		if err != nil {
+			t.Fatalf("Compile(still-v1) = %v, want nil for v1 formula", err)
+		}
+	})
+}
+
 func TestCompileValidatesRequiredVars(t *testing.T) {
 	dir := t.TempDir()
 	formulaContent := `

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -266,8 +266,9 @@ title = "Scan"
 }
 
 func TestCompileRalphMarksWorkflowRootAndBlocksOnTopLevelSteps(t *testing.T) {
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = false })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	formulaContent := `
@@ -336,8 +337,9 @@ timeout = "30s"
 }
 
 func TestCompileVersion2UsesGraphWorkflowRootAndNoParentChild(t *testing.T) {
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = false })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	formulaContent := `
@@ -408,8 +410,9 @@ needs = ["setup"]
 }
 
 func TestCompileScopedWorkCarriesScopeAndCleanupMetadata(t *testing.T) {
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = false })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -514,8 +517,9 @@ func TestCompileScopedWorkCarriesScopeAndCleanupMetadata(t *testing.T) {
 }
 
 func TestCompileGraphWorkflowRejectsCycles(t *testing.T) {
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = false })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	formulaText := `
@@ -544,7 +548,9 @@ needs = ["a"]
 }
 
 func TestCompileV2FormulaFailsWhenFormulaV2Disabled(t *testing.T) {
-	// FormulaV2Enabled defaults to false — do not set it.
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(false)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 

--- a/internal/formula/fragment_test.go
+++ b/internal/formula/fragment_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestCompileExpansionFragmentRunsInlineExpansionAndConditionFiltering(t *testing.T) {
-	prev := FormulaV2Enabled
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = prev })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 
@@ -120,9 +120,9 @@ func TestApplyFragmentRecipeGraphControlsAddsInheritedScopeChecks(t *testing.T) 
 }
 
 func TestCompileExpansionFragmentValidatesRequiredVars(t *testing.T) {
-	prev := FormulaV2Enabled
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = prev })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 
@@ -291,6 +291,35 @@ func TestFragmentSinkStepIDsExcludesSpecBeads(t *testing.T) {
 	}
 	if !sawWork {
 		t.Fatal("expected work step in fragment sinks")
+	}
+}
+
+func TestCompileExpansionFragmentFailsWhenFormulaV2Disabled(t *testing.T) {
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(false)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
+
+	dir := t.TempDir()
+	expansion := `
+formula = "needs-v2-fragment"
+type = "expansion"
+version = 2
+
+[[template]]
+id = "{target}.work"
+title = "Work"
+`
+	if err := os.WriteFile(filepath.Join(dir, "needs-v2-fragment.formula.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion: %v", err)
+	}
+
+	target := &Step{ID: "demo.target", Title: "Target"}
+	_, err := CompileExpansionFragment(context.Background(), "needs-v2-fragment", []string{dir}, target, nil)
+	if err == nil {
+		t.Fatal("CompileExpansionFragment succeeded, want error for v2 expansion with FormulaV2Enabled=false")
+	}
+	if !strings.Contains(err.Error(), "formula_v2") {
+		t.Fatalf("error = %v, want message mentioning formula_v2", err)
 	}
 }
 

--- a/internal/formula/fragment_test.go
+++ b/internal/formula/fragment_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestCompileExpansionFragmentRunsInlineExpansionAndConditionFiltering(t *testing.T) {
+	prev := FormulaV2Enabled
+	FormulaV2Enabled = true
+	t.Cleanup(func() { FormulaV2Enabled = prev })
+
 	dir := t.TempDir()
 
 	leaf := `
@@ -116,6 +120,10 @@ func TestApplyFragmentRecipeGraphControlsAddsInheritedScopeChecks(t *testing.T) 
 }
 
 func TestCompileExpansionFragmentValidatesRequiredVars(t *testing.T) {
+	prev := FormulaV2Enabled
+	FormulaV2Enabled = true
+	t.Cleanup(func() { FormulaV2Enabled = prev })
+
 	dir := t.TempDir()
 
 	expansion := `

--- a/internal/formula/retry_test.go
+++ b/internal/formula/retry_test.go
@@ -117,9 +117,9 @@ func TestApplyRetriesBasic(t *testing.T) {
 }
 
 func TestCompileRetryManagedStepBlocksWorkflowOnLogicalBead(t *testing.T) {
-	prev := FormulaV2Enabled
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = prev })
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	dir := t.TempDir()
 	formulaContent := `

--- a/internal/formula/retry_test.go
+++ b/internal/formula/retry_test.go
@@ -117,6 +117,10 @@ func TestApplyRetriesBasic(t *testing.T) {
 }
 
 func TestCompileRetryManagedStepBlocksWorkflowOnLogicalBead(t *testing.T) {
+	prev := FormulaV2Enabled
+	FormulaV2Enabled = true
+	t.Cleanup(func() { FormulaV2Enabled = prev })
+
 	dir := t.TempDir()
 	formulaContent := `
 formula = "retry-demo"

--- a/internal/formula/source_spec_test.go
+++ b/internal/formula/source_spec_test.go
@@ -158,9 +158,9 @@ func TestNamespaceSourceSpecStepPreservesNestedRef(t *testing.T) {
 }
 
 func TestCompileControlSpecBeadsAreNotWorkflowSinks(t *testing.T) {
-	oldFormulaV2 := FormulaV2Enabled
-	FormulaV2Enabled = true
-	t.Cleanup(func() { FormulaV2Enabled = oldFormulaV2 })
+	oldFormulaV2 := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(oldFormulaV2) })
 
 	dir := t.TempDir()
 	formulaContent := `

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1062,8 +1062,9 @@ depends_on = ["implement"]
 }
 
 func TestCookEndToEndRalph(t *testing.T) {
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = false })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 	dir := t.TempDir()
 	toml := `
 formula = "ralph-demo"
@@ -1212,8 +1213,9 @@ timeout = "2m"
 }
 
 func TestCookEndToEndScopedWorkflowStampsRootAndScopeMetadata(t *testing.T) {
-	formula.FormulaV2Enabled = true
-	t.Cleanup(func() { formula.FormulaV2Enabled = false })
+	prev := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 	dir := t.TempDir()
 	toml := `
 formula = "scoped-demo"


### PR DESCRIPTION
## Summary

Closes #717.

- `isGraphWorkflow()` now returns `(bool, error)` instead of `bool`
- When `FormulaV2Enabled=false` and formula declares `version >= 2`, returns an actionable error instead of silently downgrading to v1 compilation
- Existing tests that used v2 formulas without setting `FormulaV2Enabled=true` were silently getting v1 compilation — the exact bug this fixes; they now explicitly enable the flag

### Files changed

| File | Change |
|------|--------|
| `internal/formula/compile.go` | `isGraphWorkflow` returns `(bool, error)`, `toRecipe` propagates error, removed unused `log` import |
| `internal/formula/compile_test.go` | New `TestCompileV2FormulaFailsWhenFormulaV2Disabled` (v2 error, v8 error, v1 no-regression) |
| `internal/formula/fragment_test.go` | 2 tests: add `FormulaV2Enabled=true` |
| `internal/formula/retry_test.go` | 1 test: add `FormulaV2Enabled=true` |
| `internal/dispatch/runtime_test.go` | 8 fanout tests: add `FormulaV2Enabled=true`, remove `t.Parallel()` (global var mutation) |
| `internal/api/handler_formulas_test.go` | 1 test: add `FormulaV2Enabled=true` |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (1 pre-existing baseline failure in `TestHandleProviderReadinessReturnsNotInstalledWhenBinaryMissing`)
- [x] `go test -race ./internal/formula/ ./internal/dispatch/` clean
- [x] New test covers: v2 formula errors, v8 formula errors, v1 still compiles
- [x] Multi-model review (3x Anthropic + Codex GPT-5.4 + Copilot GPT-5.3-codex): no CRITICAL or HIGH findings
- [x] 29-rule codebase audit: PASS