### PR TITLE
fix(pool): persist pool_instance on session bead so themed names resolve

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -848,6 +848,21 @@ func desiredHasTemplate(desired map[string]TemplateParams, template string) bool
 	return false
 }
 
+// realizePoolDesiredSessions materializes one TemplateParams entry per accepted
+// pool request, claiming a slot and (when a namepool is configured) resolving a
+// themed instance name.
+//
+// As part of realization, the qualified pool_instance identity is persisted as
+// metadata on the session bead. Pool session beads are originally created
+// identified by the pool template (see createPoolSessionBead) — the slot/themed
+// identity is only known here, after claimPoolSlot and poolInstanceName run.
+// Without pool_instance on the bead, downstream lookups that start from the
+// instance name (gc status, nudge-by-instance, cliSessionName) cannot map the
+// realized instance back to its session bead and fall back to a synthesized
+// session name that does not match the running tmux session.
+//
+// The write is idempotent: we skip SetMetadata when the existing value already
+// matches, so repeated reconcile cycles do not churn the bead store.
 func realizePoolDesiredSessions(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,
@@ -879,6 +894,19 @@ func realizePoolDesiredSessions(
 		qualifiedInstance := instanceName
 		if cfgAgent.Dir != "" {
 			qualifiedInstance = cfgAgent.Dir + "/" + instanceName
+		}
+		// Persist the pool instance identity on the session bead so lookups
+		// from the themed/numeric instance name (status display, nudge,
+		// session-name resolution) can find this bead. Without this, the pool
+		// bead stays identified only by the pool template and the realized
+		// instance looks "stopped" even while its tmux session runs.
+		if bp.beadStore != nil && sessionBead.Metadata["pool_instance"] != qualifiedInstance {
+			if err := bp.beadStore.SetMetadata(sessionBead.ID, "pool_instance", qualifiedInstance); err == nil {
+				if sessionBead.Metadata == nil {
+					sessionBead.Metadata = make(map[string]string)
+				}
+				sessionBead.Metadata["pool_instance"] = qualifiedInstance
+			}
 		}
 		instanceAgent := deepCopyAgent(cfgAgent, instanceName, cfgAgent.Dir)
 		fpExtra := buildFingerprintExtra(&instanceAgent)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1773,6 +1773,178 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) 
 	}
 }
 
+// TestBuildDesiredState_PoolInstanceMetadataPersistedForNamepool verifies the
+// fix for the pool-instance identity bug: after realizePoolDesiredSessions
+// claims a slot and resolves the themed/namepool instance name, it writes
+// pool_instance metadata onto the session bead so themed lookups (e.g.
+// "myrig/furiosa") can map back to this session's tmux session_name.
+func TestBuildDesiredState_PoolInstanceMetadataPersistedForNamepool(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "myrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "myrig", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "myrig",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3), ScaleCheck: "printf 1",
+			NamepoolNames: []string{"furiosa", "nux", "slit"},
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	poolSessions := 0
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "myrig/polecat" {
+			poolSessions++
+		}
+	}
+	if poolSessions != 1 {
+		t.Fatalf("pool sessions = %d, want 1", poolSessions)
+	}
+
+	poolBeads, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(poolBeads) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(poolBeads))
+	}
+	got := poolBeads[0].Metadata["pool_instance"]
+	if got != "myrig/furiosa" {
+		t.Fatalf("pool_instance = %q, want %q (first namepool entry with rig prefix)", got, "myrig/furiosa")
+	}
+}
+
+// TestBuildDesiredState_PoolInstanceMetadataPersistedForSlotOnly covers the
+// non-namepool branch of poolInstanceName: slot-only instances are named
+// "<template>-<slot>" and persisted with the rig qualification.
+func TestBuildDesiredState_PoolInstanceMetadataPersistedForSlotOnly(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "myrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "myrig", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "dog",
+			Dir:               "myrig",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3), ScaleCheck: "printf 1",
+		}},
+	}
+
+	buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	poolBeads, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(poolBeads) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(poolBeads))
+	}
+	got := poolBeads[0].Metadata["pool_instance"]
+	if got != "myrig/dog-1" {
+		t.Fatalf("pool_instance = %q, want %q (template-slot naming with rig prefix)", got, "myrig/dog-1")
+	}
+}
+
+// poolInstanceCountingStore wraps a Store and counts SetMetadata calls that
+// target the pool_instance key, so idempotency tests can assert the fix's
+// guard actually skips redundant writes.
+type poolInstanceCountingStore struct {
+	beads.Store
+	writes int
+}
+
+func (s *poolInstanceCountingStore) SetMetadata(id, key, value string) error {
+	if key == "pool_instance" {
+		s.writes++
+	}
+	return s.Store.SetMetadata(id, key, value)
+}
+
+// TestBuildDesiredState_PoolInstanceMetadataIdempotent verifies the fix's
+// idempotency guard: repeated buildDesiredState cycles must not rewrite
+// pool_instance once it matches the realized instance. Re-writes would
+// churn the bead store on every reconcile tick.
+func TestBuildDesiredState_PoolInstanceMetadataIdempotent(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "myrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store := &poolInstanceCountingStore{Store: beads.NewMemStore()}
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "myrig", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "myrig",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3), ScaleCheck: "printf 1",
+			NamepoolNames: []string{"furiosa"},
+		}},
+	}
+
+	buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if store.writes != 1 {
+		t.Fatalf("first cycle: pool_instance writes = %d, want 1", store.writes)
+	}
+
+	buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if store.writes != 1 {
+		t.Fatalf("second cycle: pool_instance writes = %d, want 1 (guard must skip rewrite when value unchanged)", store.writes)
+	}
+
+	poolBeads, err := store.Store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil || len(poolBeads) != 1 {
+		t.Fatalf("post-cycle: beads=%d err=%v", len(poolBeads), err)
+	}
+	if got := poolBeads[0].Metadata["pool_instance"]; got != "myrig/furiosa" {
+		t.Fatalf("pool_instance = %q, want %q", got, "myrig/furiosa")
+	}
+}
+
+// TestBuildDesiredState_PoolInstanceMetadataNotWrittenForNonPoolAgent is a
+// regression check: a non-pool (singleton) agent must never have
+// pool_instance metadata written to its session bead by realize logic.
+func TestBuildDesiredState_PoolInstanceMetadataNotWrittenForNonPoolAgent(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "myrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "myrig", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name: "mayor",
+			Dir:  "myrig",
+			// MaxActiveSessions=1 marks this as a singleton (non-pool) agent
+			// per isMultiSessionCfgAgent. Omitting MinActive/MaxActive defaults
+			// to multi-session, which is itself a pool agent and would be
+			// subject to the pool_instance write.
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+
+	buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	sessionBeads, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	for _, b := range sessionBeads {
+		if got := b.Metadata["pool_instance"]; got != "" {
+			t.Fatalf("bead %s: pool_instance = %q, want empty for non-pool agent", b.ID, got)
+		}
+	}
+}
+
 // PR #216 — skipped for now. Cross-rig pool work visibility is a new
 // feature, not a bug fix. Left as open PR for discussion about the
 // gastown experience with this flow.

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -22,6 +22,25 @@ func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
 	return newSessionBeadSnapshot(open), nil
 }
 
+// newSessionBeadSnapshot indexes a set of open session beads for template- and
+// instance-name lookups used during desired-state resolution.
+//
+// Pool-managed session beads are created identified by their pool template
+// (e.g. agent_name="gascity/polecat") and only later acquire a themed or
+// slot-numbered identity when realizePoolDesiredSessions claims a slot and
+// writes pool_instance metadata. The indexing rules below reflect that two-
+// phase identity:
+//
+//   - A pool bead whose agent_name still matches the template is substituted
+//     with its pool_instance (e.g. "gascity/furiosa" or "gascity/dog-1") so
+//     lookups by the realized instance name find the bead's session_name.
+//   - A pool bead that has not yet had pool_instance written is intentionally
+//     dropped from the agent-name index — indexing every slot under the bare
+//     template would make one arbitrary slot win the template lookup.
+//   - Canonical named-session beads (configured_named_identity set) always
+//     win over pool substitutes for the same key, preserving correct
+//     resolution when leaked pool beads coexist with canonical beads.
+//   - Non-pool beads are indexed under agent_name and template unchanged.
 func newSessionBeadSnapshot(open []beads.Bead) *sessionBeadSnapshot {
 	filtered := make([]beads.Bead, 0, len(open))
 	sessionNameByAgentName := make(map[string]string)
@@ -40,7 +59,15 @@ func newSessionBeadSnapshot(open []beads.Bead) *sessionBeadSnapshot {
 		isCanonicalNamed := strings.TrimSpace(b.Metadata["configured_named_identity"]) != ""
 		if agentName := sessionBeadAgentName(b); agentName != "" {
 			if isPoolManagedSessionBead(b) && agentName == b.Metadata["template"] {
-				agentName = ""
+				// Pool bead still identified by the pool template. Substitute
+				// the realized pool_instance (written after slot claim in
+				// realizePoolDesiredSessions) so themed/numeric instance names
+				// map back to this bead's session_name.
+				if pi := strings.TrimSpace(b.Metadata["pool_instance"]); pi != "" {
+					agentName = pi
+				} else {
+					agentName = ""
+				}
 			}
 			if agentName == "" {
 				continue

--- a/cmd/gc/session_bead_snapshot_test.go
+++ b/cmd/gc/session_bead_snapshot_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestNewSessionBeadSnapshot_PoolInstanceSubstitutesTemplate verifies that a
+// pool-managed session bead identified only by its pool template is indexed
+// under the realized pool_instance name rather than dropped. Without this
+// substitution, lookups like `gc status <instance>` cannot map the themed
+// instance back to the running session.
+func TestNewSessionBeadSnapshot_PoolInstanceSubstitutesTemplate(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "gc-1",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:gascity/polecat"},
+		Metadata: map[string]string{
+			"template":             "gascity/polecat",
+			"agent_name":           "gascity/polecat",
+			"session_name":         "polecat-gc-abc",
+			"state":                "active",
+			"pool_instance":        "gascity/furiosa",
+			poolManagedMetadataKey: "true",
+		},
+	}
+
+	snap := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	if got := snap.FindSessionNameByTemplate("gascity/furiosa"); got != "polecat-gc-abc" {
+		t.Fatalf("FindSessionNameByTemplate(themed instance) = %q, want %q", got, "polecat-gc-abc")
+	}
+}
+
+// TestNewSessionBeadSnapshot_PoolInstanceSubstitutesTemplateSlotName covers
+// the slot-only naming path where pool_instance is of the form "rig/<template>-<slot>".
+func TestNewSessionBeadSnapshot_PoolInstanceSubstitutesTemplateSlotName(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "gc-2",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:gascity/dog"},
+		Metadata: map[string]string{
+			"template":             "gascity/dog",
+			"agent_name":           "gascity/dog",
+			"session_name":         "dog-gc-def",
+			"state":                "active",
+			"pool_slot":            "1",
+			"pool_instance":        "gascity/dog-1",
+			poolManagedMetadataKey: "true",
+		},
+	}
+
+	snap := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	if got := snap.FindSessionNameByTemplate("gascity/dog-1"); got != "dog-gc-def" {
+		t.Fatalf("FindSessionNameByTemplate(slot instance) = %q, want %q", got, "dog-gc-def")
+	}
+}
+
+// TestNewSessionBeadSnapshot_PoolBeadWithoutInstanceNotMisindexed verifies
+// the legacy behavior is preserved: a pool-managed bead that has not yet had
+// pool_instance written (pre-fix bead, or bead whose slot has not been claimed
+// this cycle) must not be indexed under the bare template name. Doing so would
+// make every pool template lookup resolve to a single arbitrary slot's session.
+func TestNewSessionBeadSnapshot_PoolBeadWithoutInstanceNotMisindexed(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "gc-3",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:gascity/polecat"},
+		Metadata: map[string]string{
+			"template":             "gascity/polecat",
+			"agent_name":           "gascity/polecat",
+			"session_name":         "polecat-gc-xyz",
+			"state":                "active",
+			poolManagedMetadataKey: "true",
+		},
+	}
+
+	snap := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	if got := snap.FindSessionNameByTemplate("gascity/polecat"); got != "" {
+		t.Fatalf("FindSessionNameByTemplate(bare template) = %q, want empty (pool bead without pool_instance must not be indexed under template)", got)
+	}
+}
+
+// TestNewSessionBeadSnapshot_NonPoolBeadUnaffectedByPoolInstanceMetadata
+// ensures the pool_instance substitution does not change indexing for non-pool
+// session beads. Non-pool beads should be indexed under their agent_name and
+// (for the template hint) under their template metadata exactly as before.
+func TestNewSessionBeadSnapshot_NonPoolBeadUnaffectedByPoolInstanceMetadata(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "gc-4",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:gascity/mayor"},
+		Metadata: map[string]string{
+			"template":     "gascity/mayor",
+			"agent_name":   "gascity/mayor",
+			"session_name": "mayor-gc-aaa",
+			"state":        "active",
+			// Even if pool_instance is incidentally set on a non-pool bead,
+			// it must not redirect indexing because the bead is not pool-managed.
+			"pool_instance": "should-be-ignored",
+		},
+	}
+
+	snap := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	if got := snap.FindSessionNameByTemplate("gascity/mayor"); got != "mayor-gc-aaa" {
+		t.Fatalf("FindSessionNameByTemplate(non-pool template) = %q, want %q", got, "mayor-gc-aaa")
+	}
+	if got := snap.FindSessionNameByTemplate("should-be-ignored"); got != "" {
+		t.Fatalf("FindSessionNameByTemplate should not index non-pool bead by pool_instance, got %q", got)
+	}
+}
+
+// TestNewSessionBeadSnapshot_PoolInstanceCoexistsWithCanonicalNamedBead checks
+// that when a canonical named bead exists for the same template key, it still
+// wins the index over a pool bead that happens to have pool_instance equal to
+// the same string. This protects the existing "canonical named beads always
+// win" guarantee documented on newSessionBeadSnapshot.
+func TestNewSessionBeadSnapshot_PoolInstanceCoexistsWithCanonicalNamedBead(t *testing.T) {
+	pool := beads.Bead{
+		ID:     "gc-5a",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:gascity/polecat"},
+		Metadata: map[string]string{
+			"template":             "gascity/polecat",
+			"agent_name":           "gascity/polecat",
+			"session_name":         "polecat-pool",
+			"state":                "active",
+			"pool_instance":        "gascity/furiosa",
+			poolManagedMetadataKey: "true",
+		},
+	}
+	named := beads.Bead{
+		ID:     "gc-5b",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:gascity/furiosa"},
+		Metadata: map[string]string{
+			"template":                  "gascity/furiosa",
+			"agent_name":                "gascity/furiosa",
+			"session_name":              "furiosa-canonical",
+			"state":                     "active",
+			"configured_named_identity": "gascity/furiosa",
+		},
+	}
+
+	// Insert pool first so that, without the canonical-wins rule, it would
+	// register in the index first.
+	snap := newSessionBeadSnapshot([]beads.Bead{pool, named})
+
+	if got := snap.FindSessionNameByTemplate("gascity/furiosa"); got != "furiosa-canonical" {
+		t.Fatalf("FindSessionNameByTemplate = %q, want %q (canonical named bead must win over pool substitute)", got, "furiosa-canonical")
+	}
+}


### PR DESCRIPTION
## Summary

Pool-managed session beads are created identified by their pool template
(e.g. `gascity/polecat`) before any slot is claimed. Slot claim and
namepool resolution happen later in `realizePoolDesiredSessions`, where
the bead acquires its real themed or slot-numbered identity
(e.g. `gascity/furiosa` or `gascity/dog-1`). Previously that identity
was never written back to the bead.

As a result, lookup paths that map from the instance name
(`gc status <instance>`, `cliSessionName`, nudge-by-instance) could
not find the session bead. They fell back to a synthesized session
name (`<template>-<beadID>`) that did not match the real tmux
session, so `gc status` reported pool instances as stopped while the
underlying tmux sessions were still running.

## Fix

- **`realizePoolDesiredSessions`** (`cmd/gc/build_desired_state.go`):
  after `claimPoolSlot` and `poolInstanceName`, persist
  `pool_instance=<qualifiedInstance>` metadata onto the session bead.
  The write is idempotent — we skip `SetMetadata` when the existing
  value already matches — so repeated reconcile cycles do not churn
  the bead store.
- **`newSessionBeadSnapshot`** (`cmd/gc/session_bead_snapshot.go`):
  when a pool-managed bead's `agent_name` still matches the pool
  template, substitute `pool_instance` for `agentName` so the snapshot
  indexes `session_name` under the realized themed/numeric identity.
  Pool beads without `pool_instance` written yet are intentionally
  dropped from the agent-name index — indexing every slot under the
  bare template would make an arbitrary slot win the template lookup.
  Canonical named-session beads (`configured_named_identity` set)
  continue to win over pool substitutes for the same key.

Godoc on both functions now spells out the two-phase pool-identity
contract so future readers do not have to piece it together from the
call chain.

## Test plan

New unit tests in `cmd/gc/build_desired_state_test.go` and
`cmd/gc/session_bead_snapshot_test.go`:

- [x] `TestBuildDesiredState_PoolInstanceMetadataPersistedForNamepool` —
  pool agent with a namepool: after realize, the session bead has
  `pool_instance` = the namepool-derived qualified name
  (`myrig/furiosa`).
- [x] `TestBuildDesiredState_PoolInstanceMetadataPersistedForSlotOnly` —
  pool agent without a namepool (slot-only, e.g. `dog`):
  `pool_instance` = `<rig>/<template>-<slot>` (`myrig/dog-1`).
- [x] `TestBuildDesiredState_PoolInstanceMetadataIdempotent` — a
  counting store wrapper proves the idempotency guard skips redundant
  writes across reconcile cycles.
- [x] `TestBuildDesiredState_PoolInstanceMetadataNotWrittenForNonPoolAgent`
  — singleton (non-pool) agents do not get `pool_instance` written.
- [x] `TestNewSessionBeadSnapshot_PoolInstanceSubstitutesTemplate` —
  `FindSessionNameByTemplate("<themed instance>")` resolves the
  correct session name.
- [x] `TestNewSessionBeadSnapshot_PoolInstanceSubstitutesTemplateSlotName`
  — same, for slot-numbered instances (`dog-1`).
- [x] `TestNewSessionBeadSnapshot_PoolBeadWithoutInstanceNotMisindexed`
  — pre-fix beads (no `pool_instance` yet) must not be indexed under
  the bare template.
- [x] `TestNewSessionBeadSnapshot_NonPoolBeadUnaffectedByPoolInstanceMetadata`
  — a stray `pool_instance` on a non-pool bead does not redirect
  indexing.
- [x] `TestNewSessionBeadSnapshot_PoolInstanceCoexistsWithCanonicalNamedBead`
  — canonical named beads continue to win over pool substitutes for
  the same key.

Run:

```
go test ./cmd/gc/ -run "TestPool|TestSessionBead|TestFindSession|TestNewSession|TestBuildDesired|TestRealize"
```

All 9 new tests pass. (Three pre-existing test failures on `main` are
unrelated to this change — they fail identically on `main` and on this
branch:
`TestBuildDesiredState_DrainedPoolManagedSessionIsNotRediscovered`,
`TestBuildDesiredState_DependencyFloorDoesNotReuseRegularPoolWorkerBead`,
`TestBuildDesiredState_DoesNotCreateDuplicatePoolBeadForDiscoveredSession`.)

## Validation

Validated in a live city: with the fix applied, `gc status` correctly
reports pool instances as running instead of stopped.