### PR TITLE
docs: add 'How do I get to my mayor?' to coming-from-gastown guide

### DIFF
--- a/docs/getting-started/coming-from-gastown.md
+++ b/docs/getting-started/coming-from-gastown.md
@@ -232,6 +232,21 @@ Use an exec order before inventing a plugin, helper role, or hidden session.
 
 That is the direct Gas City answer to many old Town automation tasks.
 
+### "How do I get to my mayor?"
+
+```bash
+gc session attach mayor
+```
+
+The Mayor session is the primary Gas Town experience — an interactive Claude
+session with full city context that coordinates everything. The CLI is
+plumbing; this is the product.
+
+City-scoped agents from the Gastown pack — `mayor`, `deacon`, `boot` — are all
+accessible the same way. Use `gc session list` to see what is running.
+
+This replaces `gt session at mayor/` or `tmux attach -t gt-mayor` from Gas Town.
+
 ## Common Gastown Overrides In PackV2
 
 If you are using the Gastown pack, these are the most common local changes.


### PR DESCRIPTION
## Summary

The coming-from-gastown migration guide maps Gas Town concepts to Gas City primitives, but doesn't answer one of the first practical questions a Gas Town user will ask: how do I get to my mayor?

- Adds a `"How do I get to my mayor?"` entry to the Common Translation Patterns section
- Shows `gc session attach mayor` and explains it applies to all city-scoped Gastown agents
- Explicitly maps from the Gas Town equivalents (`gt session at mayor/`, `tmux attach -t gt-mayor`) that users will instinctively try first

This gap was also noted in gastownhall/gastown#21 ("Default quickstart should guide users to the Mayor tmux session") and the [DoltHub "A Day in Gas Town" post](https://www.dolthub.com/blog/2026-01-15-a-day-in-gas-town/), which describes the mayor session as the primary experience.

## Test plan

- [ ] Verify the new section renders correctly in the docs preview (`cd docs && npx --yes mint@latest dev`)
- [ ] Confirm `gc session attach mayor` works against a city running the Gastown pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)