### PR TITLE
fix(git): preserve slashes in DefaultBranch parsing

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -59,10 +59,13 @@ func (g *Git) DefaultBranch() (string, error) {
 	if err != nil {
 		return "main", nil
 	}
-	// Output is like "refs/remotes/origin/main"
+	// Output is like "refs/remotes/origin/main" or "refs/remotes/origin/boylec/develop".
+	// Strip the fixed prefix rather than splitting on the last slash, which
+	// would lose a path segment for branch names containing slashes.
 	ref := strings.TrimSpace(out)
-	if i := strings.LastIndex(ref, "/"); i >= 0 {
-		return ref[i+1:], nil
+	const prefix = "refs/remotes/origin/"
+	if strings.HasPrefix(ref, prefix) {
+		return ref[len(prefix):], nil
 	}
 	return ref, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -80,6 +80,48 @@ func TestDefaultBranch_NoRemote(t *testing.T) {
 	}
 }
 
+// TestDefaultBranch_SlashInName exercises the parsing path that previously
+// used strings.LastIndex(ref, "/"), which truncated names like "boylec/develop"
+// down to "develop". The fix strips the fixed "refs/remotes/origin/" prefix.
+func TestDefaultBranch_SlashInName(t *testing.T) {
+	cases := []struct {
+		name   string
+		branch string
+	}{
+		{"simple", "main"},
+		{"with_slash", "boylec/develop"},
+		{"nested_slashes", "team/feature/rc1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Bare remote with a single commit on tc.branch, HEAD pointing at it.
+			bare := t.TempDir()
+			runGit(t, bare, "init", "--bare")
+
+			seed := t.TempDir()
+			runGit(t, seed, "init", "--initial-branch="+tc.branch)
+			runGit(t, seed, "config", "user.email", "test@test.com")
+			runGit(t, seed, "config", "user.name", "Test")
+			runGit(t, seed, "commit", "--allow-empty", "-m", "init")
+			runGit(t, seed, "remote", "add", "origin", bare)
+			runGit(t, seed, "push", "origin", tc.branch)
+			runGit(t, bare, "symbolic-ref", "HEAD", "refs/heads/"+tc.branch)
+
+			clone := t.TempDir()
+			runGit(t, clone, "clone", bare, ".")
+
+			g := New(clone)
+			got, err := g.DefaultBranch()
+			if err != nil {
+				t.Fatalf("DefaultBranch: %v", err)
+			}
+			if got != tc.branch {
+				t.Errorf("DefaultBranch() = %q, want %q", got, tc.branch)
+			}
+		})
+	}
+}
+
 func TestWorktreeRemove(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)


### PR DESCRIPTION
## Summary

`DefaultBranch()` in `internal/git/git.go` used `strings.LastIndex(ref, "/")` to strip the `refs/remotes/origin/` prefix. That broke for any branch name containing a slash: `refs/remotes/origin/boylec/develop` collapsed to `develop`, silently dropping the `boylec/` segment.

This replaces the last-slash heuristic with a fixed-prefix strip, so names with any number of slashes round-trip intact.

## Changes

- `internal/git/git.go` — replace `strings.LastIndex` split with `strings.HasPrefix("refs/remotes/origin/")` strip.
- `internal/git/git_test.go` — add `TestDefaultBranch_SlashInName` table-driven test covering `main`, `boylec/develop`, and `team/feature/rc1`.

## Test plan

- [x] `go test ./internal/git/... -run TestDefaultBranch -v` — all 4 cases pass (simple, slash, nested, no-remote fallback).
- [x] `go test ./internal/git/...` — full package green.
- [x] `go vet ./internal/git/...` and `gofmt -l internal/git/` — clean.
- [x] `go build ./...` — no downstream breakage.

Fixes #719