### PR TITLE
feat: add --debounce flag to gc events --watch

### DIFF
--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -388,14 +388,14 @@ func doEventsWatchDebounce(ep events.Provider, typeFilter string, payloadMatch m
 	}
 
 	for {
-		remaining := time.Until(debounceDeadline)
-		if remaining <= 0 {
+		untilDebounce := time.Until(debounceDeadline)
+		if untilDebounce <= 0 {
 			return printEventsJSON(accumulated, stdout, stderr)
 		}
 
 		sleep := pollInterval
-		if remaining < sleep {
-			sleep = remaining
+		if untilDebounce < sleep {
+			sleep = untilDebounce
 		}
 		time.Sleep(sleep)
 

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -274,6 +274,10 @@ func cmdEventsWatch(typeFilter string, payloadMatch []string, afterSeq uint64, t
 			fmt.Fprintf(stderr, "gc events: invalid --debounce %q: %v\n", debounceFlag, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
+		if debounce < 0 {
+			fmt.Fprintf(stderr, "gc events: --debounce must not be negative\n") //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		if debounce >= timeout {
 			fmt.Fprintf(stderr, "gc events: --debounce (%s) must be less than --timeout (%s)\n", debounce, timeout) //nolint:errcheck // best-effort stderr
 			return 1
@@ -384,11 +388,16 @@ func doEventsWatchDebounce(ep events.Provider, typeFilter string, payloadMatch m
 	}
 
 	for {
-		if time.Now().After(debounceDeadline) {
+		remaining := time.Until(debounceDeadline)
+		if remaining <= 0 {
 			return printEventsJSON(accumulated, stdout, stderr)
 		}
 
-		time.Sleep(pollInterval)
+		sleep := pollInterval
+		if remaining < sleep {
+			sleep = remaining
+		}
+		time.Sleep(sleep)
 
 		evts, err := ep.List(events.Filter{AfterSeq: lastSeq})
 		if err != nil {

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -20,6 +20,7 @@ func newEventsCmd(stdout, stderr io.Writer) *cobra.Command {
 	var seqFlag bool
 	var jsonFlag bool
 	var timeoutFlag string
+	var debounceFlag string
 	var afterFlag uint64
 	var payloadMatch []string
 
@@ -35,6 +36,7 @@ scripting and automation).`,
 		Example: `  gc events
   gc events --type bead.created --since 1h
   gc events --watch --type convoy.closed --timeout 5m
+  gc events --watch --type bead.updated --timeout 5m --debounce 60s
   gc events --follow
   gc events --seq`,
 		Args: cobra.NoArgs,
@@ -52,7 +54,7 @@ scripting and automation).`,
 				return nil
 			}
 			if watchFlag {
-				if cmdEventsWatch(typeFilter, payloadMatch, afterFlag, timeoutFlag, stdout, stderr) != 0 {
+				if cmdEventsWatch(typeFilter, payloadMatch, afterFlag, timeoutFlag, debounceFlag, stdout, stderr) != 0 {
 					return errExit
 				}
 				return nil
@@ -71,6 +73,7 @@ scripting and automation).`,
 	cmd.Flags().StringVar(&timeoutFlag, "timeout", "30s", "Max wait duration for --watch (e.g. 30s, 5m)")
 	cmd.Flags().Uint64Var(&afterFlag, "after", 0, "Resume watching from this sequence number (0 = current head)")
 	cmd.Flags().StringArrayVar(&payloadMatch, "payload-match", nil, "Filter by payload field (key=value, repeatable)")
+	cmd.Flags().StringVar(&debounceFlag, "debounce", "", "Minimum collection window before returning matches in --watch mode (e.g. 60s). Prevents rapid-fire wakes from high-frequency event streams")
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output in JSON format (list mode only)")
 	return cmd
 }
@@ -243,10 +246,8 @@ func doEventsFollow(ep events.Provider, typeFilter string, payloadMatch map[stri
 			return 1
 		}
 
-		for _, e := range evts {
-			if e.Seq > lastSeq {
-				lastSeq = e.Seq
-			}
+		if s := lastSeqOf(evts); s > lastSeq {
+			lastSeq = s
 		}
 
 		if matches := filterEvents(evts, afterSeq, typeFilter, payloadMatch); len(matches) > 0 {
@@ -259,11 +260,24 @@ func doEventsFollow(ep events.Provider, typeFilter string, payloadMatch map[stri
 }
 
 // cmdEventsWatch is the CLI entry point for watch mode.
-func cmdEventsWatch(typeFilter string, payloadMatch []string, afterSeq uint64, timeoutFlag string, stdout, stderr io.Writer) int {
+func cmdEventsWatch(typeFilter string, payloadMatch []string, afterSeq uint64, timeoutFlag, debounceFlag string, stdout, stderr io.Writer) int {
 	timeout, err := time.ParseDuration(timeoutFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc events: invalid --timeout %q: %v\n", timeoutFlag, err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+
+	var debounce time.Duration
+	if debounceFlag != "" {
+		debounce, err = time.ParseDuration(debounceFlag)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc events: invalid --debounce %q: %v\n", debounceFlag, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if debounce >= timeout {
+			fmt.Fprintf(stderr, "gc events: --debounce (%s) must be less than --timeout (%s)\n", debounce, timeout) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	pm, err := parsePayloadMatch(payloadMatch)
@@ -277,14 +291,19 @@ func cmdEventsWatch(typeFilter string, payloadMatch []string, afterSeq uint64, t
 		return code
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doEventsWatch(ep, typeFilter, pm, afterSeq, timeout, 250*time.Millisecond, stdout, stderr)
+	return doEventsWatch(ep, typeFilter, pm, afterSeq, timeout, debounce, 250*time.Millisecond, stdout, stderr)
 }
 
 // doEventsWatch polls the event provider for new events matching the filter.
 // It blocks until matching events arrive or the timeout expires. Outputs
 // matching events as JSON lines (one per line). Returns 0 always — empty
 // stdout means timeout, non-empty means events found.
-func doEventsWatch(ep events.Provider, typeFilter string, payloadMatch map[string][]string, afterSeq uint64, timeout, pollInterval time.Duration, stdout, stderr io.Writer) int {
+//
+// When debounce > 0, the first matching event starts a debounce window.
+// Events continue accumulating until the window closes, then all matches
+// are returned at once. This prevents high-frequency event streams from
+// causing rapid-fire wakes in patrol loops (see issue #458).
+func doEventsWatch(ep events.Provider, typeFilter string, payloadMatch map[string][]string, afterSeq uint64, timeout, debounce, pollInterval time.Duration, stdout, stderr io.Writer) int {
 	explicitAfterSeq := afterSeq > 0
 
 	// Determine starting point.
@@ -306,7 +325,12 @@ func doEventsWatch(ep events.Provider, typeFilter string, payloadMatch map[strin
 			return 1
 		}
 		if matches := filterEvents(evts, afterSeq, typeFilter, payloadMatch); len(matches) > 0 {
-			return printEventsJSON(matches, stdout, stderr)
+			if debounce <= 0 {
+				return printEventsJSON(matches, stdout, stderr)
+			}
+			// Debounce: accumulate more events before returning.
+			// Full timeout as remaining — no deadline created yet in this early path.
+			return doEventsWatchDebounce(ep, typeFilter, payloadMatch, matches, lastSeqOf(evts), timeout, debounce, pollInterval, stdout, stderr)
 		}
 	}
 
@@ -320,15 +344,17 @@ func doEventsWatch(ep events.Provider, typeFilter string, payloadMatch map[strin
 			return 1
 		}
 
-		// Track the highest seq we've seen.
-		for _, e := range evts {
-			if e.Seq > lastSeq {
-				lastSeq = e.Seq
-			}
+		if s := lastSeqOf(evts); s > lastSeq {
+			lastSeq = s
 		}
 
 		if matches := filterEvents(evts, afterSeq, typeFilter, payloadMatch); len(matches) > 0 {
-			return printEventsJSON(matches, stdout, stderr)
+			if debounce <= 0 {
+				return printEventsJSON(matches, stdout, stderr)
+			}
+			// Debounce: accumulate more events before returning.
+			remaining := time.Until(deadline)
+			return doEventsWatchDebounce(ep, typeFilter, payloadMatch, matches, lastSeq, remaining, debounce, pollInterval, stdout, stderr)
 		}
 
 		if time.Now().After(deadline) {
@@ -337,6 +363,59 @@ func doEventsWatch(ep events.Provider, typeFilter string, payloadMatch map[strin
 
 		time.Sleep(pollInterval)
 	}
+}
+
+// doEventsWatchDebounce accumulates events within a debounce window after the
+// first match. Returns all accumulated matches when the window closes. If the
+// overall timeout expires first, returns whatever has been accumulated so far.
+func doEventsWatchDebounce(ep events.Provider, typeFilter string, payloadMatch map[string][]string, initial []events.Event, lastSeq uint64, remaining, debounce, pollInterval time.Duration, stdout, stderr io.Writer) int {
+	accumulated := append([]events.Event(nil), initial...)
+	// highWater tracks the debounce-internal filter cursor. filterEvents
+	// returns events with Seq > highWater, so initializing to the caller's
+	// lastSeq excludes the initial batch already in accumulated.
+	highWater := lastSeq
+
+	debounceDeadline := time.Now().Add(debounce)
+	overallDeadline := time.Now().Add(remaining)
+
+	// Cap debounce at overall deadline.
+	if debounceDeadline.After(overallDeadline) {
+		debounceDeadline = overallDeadline
+	}
+
+	for {
+		if time.Now().After(debounceDeadline) {
+			return printEventsJSON(accumulated, stdout, stderr)
+		}
+
+		time.Sleep(pollInterval)
+
+		evts, err := ep.List(events.Filter{AfterSeq: lastSeq})
+		if err != nil {
+			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck // best-effort stderr
+			return printEventsJSON(accumulated, stdout, stderr)
+		}
+
+		if s := lastSeqOf(evts); s > lastSeq {
+			lastSeq = s
+		}
+
+		if matches := filterEvents(evts, highWater, typeFilter, payloadMatch); len(matches) > 0 {
+			accumulated = append(accumulated, matches...)
+			highWater = lastSeq
+		}
+	}
+}
+
+// lastSeqOf returns the highest sequence number in a slice of events.
+func lastSeqOf(evts []events.Event) uint64 {
+	var highest uint64
+	for _, e := range evts {
+		if e.Seq > highest {
+			highest = e.Seq
+		}
+	}
+	return highest
 }
 
 // filterEvents returns events with Seq > afterSeq that match typeFilter

--- a/cmd/gc/cmd_events_test.go
+++ b/cmd/gc/cmd_events_test.go
@@ -271,7 +271,7 @@ func TestDoEventsWatchImmediate(t *testing.T) {
 
 	// afterSeq=1 → seq 2 is already there, should return immediately.
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, "", nil, 1, 100*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, "", nil, 1, 100*time.Millisecond, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -299,7 +299,7 @@ func TestDoEventsWatchTimeout(t *testing.T) {
 	ep := newTestProvider(t, dir)
 
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, "", nil, 0, 50*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, "", nil, 0, 50*time.Millisecond, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -328,7 +328,7 @@ func TestDoEventsWatchTypeFilter(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, events.BeadClosed, nil, 0, 2*time.Second, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, events.BeadClosed, nil, 0, 2*time.Second, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -351,7 +351,7 @@ func TestDoEventsWatchAfterSeq(t *testing.T) {
 
 	// Watch with explicit afterSeq=3 — should return seq 4 and 5.
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, "", nil, 3, 100*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, "", nil, 3, 100*time.Millisecond, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -395,7 +395,7 @@ func TestDoEventsWatchDefaultAfterSeq(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, "", nil, 0, 2*time.Second, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, "", nil, 0, 2*time.Second, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -435,7 +435,7 @@ func TestDoEventsWatchNoTypeFilter(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, "", nil, 0, 2*time.Second, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, "", nil, 0, 2*time.Second, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -484,7 +484,7 @@ func TestDoEventsWatchPayloadMatch(t *testing.T) {
 
 	pm := map[string][]string{"type": {"merge-request"}}
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, events.BeadCreated, pm, 0, 2*time.Second, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, events.BeadCreated, pm, 0, 2*time.Second, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -510,12 +510,162 @@ func TestDoEventsWatchPayloadMatchTimeout(t *testing.T) {
 
 	pm := map[string][]string{"type": {"merge-request"}}
 	var stdout, stderr bytes.Buffer
-	code := doEventsWatch(ep, events.BeadCreated, pm, 1, 50*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	code := doEventsWatch(ep, events.BeadCreated, pm, 1, 50*time.Millisecond, 0, 10*time.Millisecond, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
 	}
 	if stdout.String() != "" {
 		t.Errorf("expected empty stdout on timeout, got %q", stdout.String())
+	}
+}
+
+// --- Debounce tests ---
+
+func TestDoEventsWatchDebounceAccumulates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	ep := newTestProvider(t, dir)
+	ep.Record(events.Event{Type: events.BeadCreated, Actor: "human"}) // seq 1
+
+	// Append events in batches during the debounce window.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		var stderrBuf bytes.Buffer
+		rec2, err := events.NewFileRecorder(path, &stderrBuf)
+		if err != nil {
+			return
+		}
+		rec2.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-1"}) // seq 2
+		rec2.Close()                                                                           //nolint:errcheck // test cleanup
+
+		time.Sleep(30 * time.Millisecond)
+		rec3, err := events.NewFileRecorder(path, &stderrBuf)
+		if err != nil {
+			return
+		}
+		rec3.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-2"}) // seq 3
+		rec3.Close()                                                                           //nolint:errcheck // test cleanup
+	}()
+
+	var stdout, stderr bytes.Buffer
+	// debounce=150ms — should accumulate both events before returning.
+	code := doEventsWatch(ep, events.BeadUpdated, nil, 0, 2*time.Second, 150*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("got %d lines, want >= 2 (debounce should accumulate); output: %q", len(lines), stdout.String())
+	}
+
+	// Both bead.updated events should be present.
+	out := stdout.String()
+	if !strings.Contains(out, "gc-1") {
+		t.Errorf("output missing gc-1: %q", out)
+	}
+	if !strings.Contains(out, "gc-2") {
+		t.Errorf("output missing gc-2: %q", out)
+	}
+}
+
+func TestDoEventsWatchDebounceZeroIsImmediate(t *testing.T) {
+	// With debounce=0, behavior is identical to pre-debounce: returns on first match.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	ep := newTestProvider(t, dir)
+	ep.Record(events.Event{Type: events.BeadCreated, Actor: "human"}) // seq 1
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		var stderrBuf bytes.Buffer
+		rec2, err := events.NewFileRecorder(path, &stderrBuf)
+		if err != nil {
+			return
+		}
+		rec2.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-1"}) // seq 2
+		rec2.Close()                                                                           //nolint:errcheck // test cleanup
+
+		time.Sleep(30 * time.Millisecond)
+		rec3, err := events.NewFileRecorder(path, &stderrBuf)
+		if err != nil {
+			return
+		}
+		rec3.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-2"}) // seq 3
+		rec3.Close()                                                                           //nolint:errcheck // test cleanup
+	}()
+
+	var stdout, stderr bytes.Buffer
+	// debounce=0 — should return immediately on first match.
+	code := doEventsWatch(ep, events.BeadUpdated, nil, 0, 2*time.Second, 0, 10*time.Millisecond, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	// Should return only the first batch (seq 2), not wait for seq 3.
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1 (no debounce = immediate return); output: %q", len(lines), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "gc-1") {
+		t.Errorf("output missing gc-1: %q", stdout.String())
+	}
+}
+
+func TestDoEventsWatchDebounceTimeoutBeforeMatch(t *testing.T) {
+	// Timeout expires before any events arrive — debounce doesn't change this.
+	dir := t.TempDir()
+	ep := newTestProvider(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doEventsWatch(ep, events.BeadUpdated, nil, 0, 80*time.Millisecond, 40*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("expected empty stdout on timeout, got %q", stdout.String())
+	}
+}
+
+func TestDoEventsWatchDebounceWithExplicitAfterSeq(t *testing.T) {
+	// Debounce should work when events already exist past afterSeq.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	ep := newTestProvider(t, dir)
+	ep.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-1"}) // seq 1
+	ep.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-2"}) // seq 2
+
+	// Append a third event during the debounce window.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		var stderrBuf bytes.Buffer
+		rec2, err := events.NewFileRecorder(path, &stderrBuf)
+		if err != nil {
+			return
+		}
+		rec2.Record(events.Event{Type: events.BeadUpdated, Actor: "polecat", Subject: "gc-3"}) // seq 3
+		rec2.Close()                                                                           //nolint:errcheck // test cleanup
+	}()
+
+	var stdout, stderr bytes.Buffer
+	// afterSeq=0 means "current head" (seq 2). Only seq 3 should appear.
+	// But with afterSeq=1, seqs 2 and 3 should appear after debounce.
+	code := doEventsWatch(ep, events.BeadUpdated, nil, 1, 2*time.Second, 100*time.Millisecond, 10*time.Millisecond, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doEventsWatch = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	// Should have at least 2 events: gc-2 (already past afterSeq=1) and gc-3 (appended during debounce).
+	if len(lines) < 2 {
+		t.Fatalf("got %d lines, want >= 2; output: %q", len(lines), out)
+	}
+	if !strings.Contains(out, "gc-2") {
+		t.Errorf("output missing gc-2: %q", out)
+	}
+	if !strings.Contains(out, "gc-3") {
+		t.Errorf("output missing gc-3: %q", out)
 	}
 }
 

--- a/cmd/gc/testdata/events.txtar
+++ b/cmd/gc/testdata/events.txtar
@@ -95,6 +95,11 @@ stderr 'invalid --timeout'
 ! exec gc events --watch --debounce=notaduration
 stderr 'invalid --debounce'
 
+# --- Watch mode: negative --debounce ---
+
+! exec gc events --watch --debounce=-1s
+stderr 'must not be negative'
+
 # --- Watch mode: debounce >= timeout ---
 
 ! exec gc events --watch --timeout=30s --debounce=30s

--- a/cmd/gc/testdata/events.txtar
+++ b/cmd/gc/testdata/events.txtar
@@ -89,3 +89,21 @@ exec gc events --watch --type=agent.crashed --timeout=100ms
 
 ! exec gc events --watch --timeout=notaduration
 stderr 'invalid --timeout'
+
+# --- Watch mode: invalid --debounce ---
+
+! exec gc events --watch --debounce=notaduration
+stderr 'invalid --debounce'
+
+# --- Watch mode: debounce >= timeout ---
+
+! exec gc events --watch --timeout=30s --debounce=30s
+stderr 'must be less than'
+
+! exec gc events --watch --timeout=30s --debounce=60s
+stderr 'must be less than'
+
+# --- Watch mode: debounce with timeout, no matching events ---
+
+exec gc events --watch --type=agent.crashed --timeout=100ms --debounce=30ms
+! stdout '.'


### PR DESCRIPTION
## Summary

- Adds `--debounce` flag to `gc events --watch` that enforces a minimum collection window before returning matches
- Directly addresses the event-storm root cause from #458: with ~45 bead.updated events/minute, the witness patrol formula's backoff is defeated because events always arrive before the timeout. With `--debounce=60s`, the first match starts a 60s window; events accumulate until the window closes, then all are returned at once
- Extracts `lastSeqOf` helper and applies it to all 3 existing inline max-seq loops (doEventsWatch, doEventsFollow, doEventsWatchDebounce)

## Details

The witness patrol loop runs `gc events --watch --type=bead.updated --timeout=Ns`. Without debounce, events arrive every ~14s and the watch returns immediately, causing 120-240 API turns/hour at ~100K tokens each. With `--debounce=60s`, the patrol cycle drops to ~60 turns/hour — a 2-4x reduction in API cost for the dominant cost driver (69% of city API spend).

**Validation:**
- `--debounce` defaults to empty (off) — zero behavior change for existing formulas
- `--debounce >= --timeout` rejected at parse time
- Debounce window capped at overall timeout deadline
- Error during debounce logs to stderr and returns accumulated events

## Test plan

- [x] 4 new unit tests: accumulation, zero-is-immediate, timeout-before-match, explicit-afterSeq+debounce
- [x] 3 new txtar tests: invalid duration, debounce >= timeout, debounce with no matching events
- [x] All 8 existing watch tests pass with debounce=0 (backward compat)
- [x] `make build` passes
- [x] `make check` passes (1 baseline failure in internal/api unrelated — `TestHandleProviderReadinessReturnsNotInstalledWhenBinaryMissing`)
- [x] `go vet ./...` clean
- [x] Contributor audit: all 29 codebase rules (B1-B29) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)