### PR TITLE
fix: gc handoff skips restart for named (human-attended) sessions

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -126,6 +126,15 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps,
 		Payload: mailEventPayload(nil),
 	})
 
+	// Named sessions (human-attended, e.g. mayor) cannot be restarted by the
+	// controller — only a human can reopen them. Skip the restart request so
+	// the process stays alive; the handoff mail will be delivered on the next
+	// UserPromptSubmit hook cycle.
+	if named, _ := isCurrentSessionNamed(store, sessionName); named {
+		fmt.Fprintf(stdout, "Handoff: sent mail %s, skipping restart (named session)\n", b.ID) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+
 	if err := dops.setRestartRequested(sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -196,6 +205,25 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s to %s, killed session (reconciler will restart)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+// isCurrentSessionNamed reports whether the session identified by sessionName
+// is a named (human-attended) session. Named sessions cannot be restarted by
+// the controller, so handoff should skip the restart request for them.
+func isCurrentSessionNamed(store beads.Store, sessionName string) (bool, error) {
+	all, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		return false, err
+	}
+	for _, b := range all {
+		if b.Status == "closed" {
+			continue
+		}
+		if b.Metadata["session_name"] == sessionName {
+			return isNamedSessionBead(b), nil
+		}
+	}
+	return false, nil
 }
 
 // handoffThreadID generates a unique thread ID for handoff messages.

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -123,6 +123,62 @@ func TestHandoffMissingSubject(t *testing.T) {
 	}
 }
 
+func TestHandoffNamedSessionSkipsRestart(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	// Seed a named session bead so isCurrentSessionNamed returns true.
+	_, err := store.Create(beads.Bead{
+		Title:  "mayor session",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":              "gc-city-mayor",
+			"configured_named_session":  "true",
+			"configured_named_identity": "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+
+	code := doHandoff(store, rec, dops, "mayor", "gc-city-mayor",
+		[]string{"context cycle"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	// Mail bead should be created.
+	all, _ := store.List()
+	var mailBeads []beads.Bead
+	for _, b := range all {
+		if b.Type == "message" {
+			mailBeads = append(mailBeads, b)
+		}
+	}
+	if len(mailBeads) != 1 {
+		t.Fatalf("got %d mail beads, want 1", len(mailBeads))
+	}
+
+	// Restart must NOT be requested for named sessions.
+	if dops.restartRequested["gc-city-mayor"] {
+		t.Error("restart-requested should not be set for named sessions")
+	}
+
+	// No SessionDraining event.
+	for _, e := range rec.Events {
+		if e.Type == events.SessionDraining {
+			t.Error("SessionDraining event should not be recorded for named sessions")
+		}
+	}
+
+	// Stdout should mention skipping restart.
+	if !strings.Contains(stdout.String(), "skipping restart") {
+		t.Errorf("stdout = %q, want 'skipping restart' message", stdout.String())
+	}
+}
+
 func TestHandoffNotInSessionContext(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	cmd := newHandoffCmd(&stdout, &stderr)


### PR DESCRIPTION
Fixes #744

## Problem

The default city config `PreCompact` hook runs `gc handoff "context cycle"`. `gc handoff` (self-handoff) sends a mail to itself then calls `gc runtime request-restart`, which kills the Claude Code process and blocks waiting for the controller to respawn it.

This works for headless agents (polecats, witnesses) where the controller manages the lifecycle. But for **named sessions** (human-attended, e.g. `mayor`), the controller cannot restart the process — only the user can. Result: every context compaction crashes the mayor to the user's shell, with the handoff mail going unread.

## Fix

Before requesting restart, `doHandoff()` now checks whether the current session bead is a named session (`configured_named_session == "true"`). If it is, the handoff mail is still sent (context preserved) but the restart is skipped. The mail is delivered on the next `UserPromptSubmit` hook cycle via `gc mail check --inject`.

The check reuses the existing `isNamedSessionBead()` utility in `named_sessions.go` and the `sessionBeadLabel` scan pattern already used by `setBeadRestartRequested()`.

## Test

`TestHandoffNamedSessionSkipsRestart` — seeds a named session bead, calls `doHandoff`, asserts:
- Mail bead created
- `restart-requested` flag NOT set
- No `SessionDraining` event recorded
- Stdout contains "skipping restart"

All existing handoff tests continue to pass.