### PR TITLE
fix: reconciler reaps session beads whose tmux session is dead (#742)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -386,6 +386,11 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			}
 		}()
 
+		// Reap stale session beads from a previous run before building desired
+		// state, so desired state does not reference already-closed beads (#742).
+		if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
+			sessionBeads = cr.loadSessionBeadSnapshot()
+		}
 		result := cr.buildDesiredState(sessionBeads, startupTrace)
 		sessionBeads = cr.loadSessionBeadSnapshot()
 		result = refreshDesiredStateWithSessionBeads(
@@ -650,6 +655,11 @@ func (cr *CityRuntime) tick(
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
 	// corrects bead state, and the pre-reconcile sync is sufficient for
 	// the reconciler to read/write hashes during reconciliation.
+	// Reap open session beads whose tmux session is dead before loading demand
+	// so stale names cannot block desired-state computation (#742).
+	if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
+		sessionBeads = cr.loadSessionBeadSnapshot()
+	}
 	demand := cr.loadDemandSnapshot(sessionBeads, trace, trigger, configChanged)
 	result := demand.result
 	sessionBeads = cr.loadSessionBeadSnapshot()

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1199,6 +1199,64 @@ func setMetaBatch(store beads.Store, id string, batch map[string]string, stderr 
 	return nil
 }
 
+// reapStaleSessionBeads cross-references open session beads against live
+// tmux sessions. If a bead claims a session_name but no matching tmux
+// session exists, and the bead has been in that state past the startup
+// grace period, the bead is closed.
+//
+// This prevents infinite retry loops where a dead tmux session's bead
+// blocks name availability for new sessions (see #742).
+//
+// Returns the number of beads reaped.
+func reapStaleSessionBeads(
+	store beads.Store,
+	sp runtime.Provider,
+	dt *drainTracker,
+	clk clock.Clock,
+	stderr io.Writer,
+) int {
+	if store == nil || sp == nil {
+		return 0
+	}
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		fmt.Fprintf(stderr, "reapStaleSessionBeads: %v\n", err) //nolint:errcheck
+		return 0
+	}
+	now := clk.Now()
+	reaped := 0
+	for _, b := range open {
+		sn := b.Metadata["session_name"]
+		if sn == "" {
+			continue
+		}
+		// Don't reap beads whose tmux session hasn't been started yet.
+		if b.Metadata["state"] == "creating" || strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true" {
+			continue
+		}
+		// Don't reap beads with an active drain — the drainTracker is
+		// managing their lifecycle and the tmux session may have just died
+		// as part of the drain sequence.
+		if dt != nil && dt.get(b.ID) != nil {
+			continue
+		}
+		// Session is alive — nothing to reap.
+		if sp.IsRunning(sn) {
+			continue
+		}
+		// Startup grace: don't reap beads younger than the creating-state
+		// timeout. Zero CreatedAt means unknown age — skip conservatively.
+		if b.CreatedAt.IsZero() || now.Sub(b.CreatedAt) < staleCreatingStateTimeout {
+			continue
+		}
+		if closeBead(store, b.ID, "stale-session", now.UTC(), stderr) {
+			fmt.Fprintf(stderr, "WARN: reconciler: reaped stale session bead %s — tmux session %q not found\n", b.ID, sn) //nolint:errcheck
+			reaped++
+		}
+	}
+	return reaped
+}
+
 // closeBead sets final metadata on a session bead and closes it.
 // This completes the bead's lifecycle record. The close_reason distinguishes
 // why the bead was closed (e.g., "orphaned", "suspended").

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2767,3 +2767,272 @@ func TestFindClosedNamedSessionBead_PrefersNewestClosedCanonical(t *testing.T) {
 		t.Fatalf("found bead ID = %q, want newest canonical %q", found.ID, newer.ID)
 	}
 }
+
+func TestReapStaleSessionBeads(t *testing.T) {
+	// MemStore.Create sets CreatedAt = time.Now(). Each subtest computes
+	// its fake clock relative to the created bead's CreatedAt so the test
+	// is deterministic regardless of wall-clock latency.
+	type clockMode int
+	const (
+		clockPastGrace   clockMode = iota // 2 min past bead creation
+		clockWithinGrace                  // 30s past bead creation
+	)
+
+	tests := []struct {
+		name       string
+		beads      []beads.Bead
+		running    []string // session names that are alive in the provider
+		draining   []string // bead IDs with active drains
+		clock      clockMode
+		wantReaped int
+		wantOpen   int // expected number of open beads after reap
+	}{
+		{
+			name: "dead_session_reaped",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "active",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 1,
+			wantOpen:   0,
+		},
+		{
+			name: "live_session_kept",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "active",
+				},
+			}},
+			running:    []string{"worker-1"},
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "creating_state_skipped",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "creating",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "pending_create_skipped",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":         "worker-1",
+					"state":                "stopped",
+					"pending_create_claim": "true",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "grace_period_honored",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "active",
+				},
+			}},
+			running:    nil,
+			clock:      clockWithinGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "no_session_name_skipped",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"state": "active",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "draining_session_skipped",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "active",
+				},
+			}},
+			running:    nil,
+			draining:   []string{""}, // uses createdIDs[0] as bead ID
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "multiple_stale_reaped",
+			beads: []beads.Bead{
+				{
+					Title:  "worker",
+					Type:   sessionBeadType,
+					Labels: []string{sessionBeadLabel},
+					Metadata: map[string]string{
+						"session_name": "worker-1",
+						"state":        "active",
+					},
+				},
+				{
+					Title:  "mayor",
+					Type:   sessionBeadType,
+					Labels: []string{sessionBeadLabel},
+					Metadata: map[string]string{
+						"session_name": "mayor",
+						"state":        "awake",
+					},
+				},
+				{
+					Title:  "polecat",
+					Type:   sessionBeadType,
+					Labels: []string{sessionBeadLabel},
+					Metadata: map[string]string{
+						"session_name": "polecat-1",
+						"state":        "active",
+					},
+				},
+			},
+			running:    []string{"polecat-1"}, // only polecat is alive
+			clock:      clockPastGrace,
+			wantReaped: 2,
+			wantOpen:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			sp := runtime.NewFake()
+
+			// Clock is set after bead creation, relative to CreatedAt.
+			var clk *clock.Fake
+
+			// Start running sessions in the provider.
+			for _, name := range tt.running {
+				if err := sp.Start(context.TODO(), name, runtime.Config{Command: "test"}); err != nil {
+					t.Fatalf("Start(%s): %v", name, err)
+				}
+			}
+
+			// Create beads in the store. MemStore sets CreatedAt = time.Now().
+			var createdIDs []string
+			var firstCreatedAt time.Time
+			for _, b := range tt.beads {
+				created, err := store.Create(b)
+				if err != nil {
+					t.Fatalf("Create: %v", err)
+				}
+				createdIDs = append(createdIDs, created.ID)
+				if firstCreatedAt.IsZero() {
+					firstCreatedAt = created.CreatedAt
+				}
+			}
+
+			// Set the fake clock relative to bead creation time.
+			switch tt.clock {
+			case clockPastGrace:
+				clk = &clock.Fake{Time: firstCreatedAt.Add(2 * time.Minute)}
+			case clockWithinGrace:
+				clk = &clock.Fake{Time: firstCreatedAt.Add(30 * time.Second)}
+			}
+
+			// Set up drain tracker with draining beads.
+			var dt *drainTracker
+			if len(tt.draining) > 0 {
+				dt = newDrainTracker()
+				for i, id := range tt.draining {
+					beadID := id
+					if beadID == "" && i < len(createdIDs) {
+						beadID = createdIDs[i]
+					}
+					dt.mu.Lock()
+					dt.drains[beadID] = &drainState{reason: "test"}
+					dt.mu.Unlock()
+				}
+			}
+
+			var stderr bytes.Buffer
+			got := reapStaleSessionBeads(store, sp, dt, clk, &stderr)
+			if got != tt.wantReaped {
+				t.Errorf("reapStaleSessionBeads() = %d, want %d\nstderr: %s", got, tt.wantReaped, stderr.String())
+			}
+
+			// Verify open bead count.
+			open, err := loadSessionBeads(store)
+			if err != nil {
+				t.Fatalf("loadSessionBeads: %v", err)
+			}
+			if len(open) != tt.wantOpen {
+				t.Errorf("open beads = %d, want %d", len(open), tt.wantOpen)
+			}
+
+			// For reaped beads, verify close_reason.
+			if tt.wantReaped > 0 {
+				all := allSessionBeads(t, store)
+				for _, b := range all {
+					if b.Status == "closed" && b.Metadata["close_reason"] != "stale-session" {
+						t.Errorf("closed bead %s has close_reason=%q, want %q",
+							b.ID, b.Metadata["close_reason"], "stale-session")
+					}
+				}
+				if !strings.Contains(stderr.String(), "WARN: reconciler: reaped stale session bead") {
+					t.Error("expected WARN log line for reaped bead")
+				}
+			}
+		})
+	}
+}
+
+func TestReapStaleSessionBeads_NilStoreAndProvider(t *testing.T) {
+	clk := &clock.Fake{Time: time.Now()}
+	var stderr bytes.Buffer
+
+	if got := reapStaleSessionBeads(nil, nil, nil, clk, &stderr); got != 0 {
+		t.Errorf("nil store+provider: got %d, want 0", got)
+	}
+	if got := reapStaleSessionBeads(beads.NewMemStore(), nil, nil, clk, &stderr); got != 0 {
+		t.Errorf("nil provider: got %d, want 0", got)
+	}
+	if got := reapStaleSessionBeads(nil, runtime.NewFake(), nil, clk, &stderr); got != 0 {
+		t.Errorf("nil store: got %d, want 0", got)
+	}
+}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2904,34 +2904,34 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			name: "multiple_stale_reaped",
 			beads: []beads.Bead{
 				{
-					Title:  "worker",
+					Title:  "session alpha",
 					Type:   sessionBeadType,
 					Labels: []string{sessionBeadLabel},
 					Metadata: map[string]string{
-						"session_name": "worker-1",
+						"session_name": "session-alpha",
 						"state":        "active",
 					},
 				},
 				{
-					Title:  "mayor",
+					Title:  "session beta",
 					Type:   sessionBeadType,
 					Labels: []string{sessionBeadLabel},
 					Metadata: map[string]string{
-						"session_name": "mayor",
+						"session_name": "session-beta",
 						"state":        "awake",
 					},
 				},
 				{
-					Title:  "polecat",
+					Title:  "session gamma",
 					Type:   sessionBeadType,
 					Labels: []string{sessionBeadLabel},
 					Metadata: map[string]string{
-						"session_name": "polecat-1",
+						"session_name": "session-gamma",
 						"state":        "active",
 					},
 				},
 			},
-			running:    []string{"polecat-1"}, // only polecat is alive
+			running:    []string{"session-gamma"}, // only gamma is alive
 			clock:      clockPastGrace,
 			wantReaped: 2,
 			wantOpen:   1,


### PR DESCRIPTION
## Summary

- Adds `reapStaleSessionBeads` which cross-references open session beads against live tmux sessions (`sp.IsRunning`). Beads claiming a `session_name` with no matching tmux session past the 60s startup grace period are closed with reason `stale-session`.
- Called before `buildDesiredState` at both startup (`run()`) and every reconciler tick (`tick()`), preventing stale beads from blocking session name availability.
- Guards: skips beads in `creating` state, with `pending_create_claim`, with active drains, or with zero `CreatedAt`. Checks `closeBead` return value before counting. Reloads session bead snapshot only when beads were actually reaped.

Closes #742

## Test plan

- [x] `TestReapStaleSessionBeads` — 8 table-driven cases: dead session reaped, live session kept, creating state skipped, pending_create skipped, grace period honored, no session_name skipped, draining session skipped, multiple stale reaped
- [x] `TestReapStaleSessionBeads_NilStoreAndProvider` — nil guard coverage
- [x] `go test ./cmd/gc/...` — full suite passes (44s)
- [x] `go vet ./...` — clean
- [ ] Manual: start a city with `mode="always"` named session, kill the tmux session, observe reconciler reaps the stale bead and creates a fresh one on the next tick

## Review notes

- Reuses existing `staleCreatingStateTimeout` (60s) from `session_reconcile.go` rather than defining a duplicate constant
- Does NOT remove `.lock` files — they are `flock`-based coordination files, not presence-based locks (blast radius finding)
- Does NOT skip named session beads — they are the primary target of this fix; the reconciler creates a fresh canonical bead on the next tick after reap
- `strings.TrimSpace` applied to `pending_create_claim` check for consistency with `session_reconcile.go:167`

🤖 Generated with [Claude Code](https://claude.com/claude-code)