### PR TITLE
Fix imported session naming and builtin maintenance dedupe

### DIFF
--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -399,8 +399,7 @@ func discoverPoolInstances(agentName, agentDir string, sp0 scaleParams, a *confi
 			if templatePrefix != "" && strings.HasPrefix(qnSanitized, templatePrefix) {
 				qnSanitized = qnSanitized[len(templatePrefix):]
 			}
-			// Unsanitize: "--" → "/"
-			qn := strings.ReplaceAll(qnSanitized, "--", "/")
+			qn := agent.UnsanitizeQualifiedNameFromSession(qnSanitized)
 			names = append(names, qn)
 		}
 	}

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -4,6 +4,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -13,9 +14,7 @@ import (
 // Named sessions with an alias use the alias instead.
 func PoolSessionName(template, beadID string) string {
 	base := path.Base(template)
-	// Sanitize: replace "/" with "--" for tmux compatibility.
-	base = strings.ReplaceAll(base, "/", "--")
-	return base + "-" + beadID
+	return agent.SanitizeQualifiedNameForSession(base) + "-" + beadID
 }
 
 // GCSweepSessionBeads closes open session beads that have no remaining

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -17,6 +17,8 @@ func TestPoolSessionName(t *testing.T) {
 		{"claude", "mc-abc", "claude-mc-abc"},
 		{"myrig/codex", "mc-123", "codex-mc-123"},
 		{"control-dispatcher", "mc-wfc", "control-dispatcher-mc-wfc"},
+		{"gs.polecat", "mc-dot", "gs__polecat-mc-dot"},
+		{"myrig/gs.polecat", "mc-rigdot", "gs__polecat-mc-rigdot"},
 	}
 	for _, tt := range tests {
 		got := PoolSessionName(tt.template, tt.beadID)

--- a/internal/agent/session_name.go
+++ b/internal/agent/session_name.go
@@ -8,12 +8,34 @@ import (
 	"text/template"
 )
 
+var sessionNameQualifiedReplacer = strings.NewReplacer(
+	"/", "--",
+	".", "__",
+)
+
+var sessionNameQualifiedReverseReplacer = strings.NewReplacer(
+	"--", "/",
+	"__", ".",
+)
+
 // sessionData holds template variables for custom session naming.
 type sessionData struct {
 	City  string // workspace name
-	Agent string // tmux-safe qualified name (/ → --)
+	Agent string // tmux-safe qualified name (/ -> --, . -> __)
 	Dir   string // rig/dir component (empty for singletons)
 	Name  string // bare agent name
+}
+
+// SanitizeQualifiedNameForSession converts a qualified identity into the
+// deterministic tmux-safe form used by runtime session_name values.
+func SanitizeQualifiedNameForSession(agentName string) string {
+	return sessionNameQualifiedReplacer.Replace(agentName)
+}
+
+// UnsanitizeQualifiedNameFromSession best-effort decodes a tmux-safe runtime
+// session name fragment back to the corresponding qualified identity.
+func UnsanitizeQualifiedNameFromSession(name string) string {
+	return sessionNameQualifiedReverseReplacer.Replace(name)
 }
 
 // SessionNameFor returns the session name for a city agent.
@@ -22,14 +44,14 @@ type sessionData struct {
 // default pattern "{agent}" (the sanitized agent name). With per-city
 // tmux socket isolation as the default, the city prefix is unnecessary.
 //
-// For rig-scoped agents (name contains "/"), the dir and name
-// components are joined with "--" to avoid tmux naming issues:
+// For qualified identities, structural separators are encoded to avoid tmux
+// naming issues while preserving slash-vs-dot distinction:
 //
 //	"mayor"               → "mayor"
 //	"hello-world/polecat" → "hello-world--polecat"
+//	"gastown.mayor"       → "gastown__mayor"
 func SessionNameFor(cityName, agentName, sessionTemplate string) string {
-	// Pre-sanitize: replace "/" with "--" for tmux safety.
-	sanitized := strings.ReplaceAll(agentName, "/", "--")
+	sanitized := SanitizeQualifiedNameForSession(agentName)
 
 	if sessionTemplate == "" {
 		// Default: just the sanitized agent name. Per-city tmux socket

--- a/internal/agent/session_name_test.go
+++ b/internal/agent/session_name_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import "testing"
+
+func TestSanitizeQualifiedNameForSession(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain", input: "mayor", want: "mayor"},
+		{name: "rig scoped", input: "repo/polecat", want: "repo--polecat"},
+		{name: "imported city scoped", input: "wendy.wendy", want: "wendy__wendy"},
+		{name: "imported rig scoped", input: "repo/wendy.wendy", want: "repo--wendy__wendy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeQualifiedNameForSession(tt.input); got != tt.want {
+				t.Fatalf("SanitizeQualifiedNameForSession(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if got := SessionNameFor("city", tt.input, ""); got != tt.want {
+				t.Fatalf("SessionNameFor(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnsanitizeQualifiedNameFromSession(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "mayor", want: "mayor"},
+		{input: "repo--polecat", want: "repo/polecat"},
+		{input: "wendy__wendy", want: "wendy.wendy"},
+		{input: "repo--wendy__wendy", want: "repo/wendy.wendy"},
+	}
+
+	for _, tt := range tests {
+		if got := UnsanitizeQualifiedNameFromSession(tt.input); got != tt.want {
+			t.Fatalf("UnsanitizeQualifiedNameFromSession(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -415,7 +415,7 @@ func discoverUnlimitedPool(a config.Agent, poolName, cityName, sessTmpl string, 
 		if templatePrefix != "" && strings.HasPrefix(qnSanitized, templatePrefix) {
 			qnSanitized = qnSanitized[len(templatePrefix):]
 		}
-		qn := strings.ReplaceAll(qnSanitized, "--", "/")
+		qn := agent.UnsanitizeQualifiedNameFromSession(qnSanitized)
 		result = append(result, expandedAgent{
 			qualifiedName: qn,
 			rig:           a.Dir,

--- a/internal/api/handler_agents_test.go
+++ b/internal/api/handler_agents_test.go
@@ -125,6 +125,53 @@ func TestAgentListUnlimitedPoolDiscovery(t *testing.T) {
 	}
 }
 
+func TestAgentListUnlimitedImportedPoolDiscovery(t *testing.T) {
+	state := newFakeState(t)
+	state.cfg.Agents = []config.Agent{
+		{
+			Name:              "polecat",
+			Dir:               "myrig",
+			BindingName:       "gs",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(-1),
+		},
+	}
+	state.sp.Start(context.Background(), "myrig--gs__polecat-1", runtime.Config{}) //nolint:errcheck
+	state.sp.Start(context.Background(), "myrig--gs__polecat-2", runtime.Config{}) //nolint:errcheck
+	srv := New(state)
+
+	req := httptest.NewRequest("GET", "/v0/agents", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Items []agentResponse `json:"items"`
+		Total int             `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Fatalf("Total = %d, want 2", resp.Total)
+	}
+
+	for i, item := range resp.Items {
+		if item.Name != "myrig/gs.polecat-1" && item.Name != "myrig/gs.polecat-2" {
+			t.Errorf("Items[%d].Name = %q, want imported pool member name", i, item.Name)
+		}
+		if item.Pool != "myrig/gs.polecat" {
+			t.Errorf("Items[%d].Pool = %q, want %q", i, item.Pool, "myrig/gs.polecat")
+		}
+		if !item.Running {
+			t.Errorf("Items[%d].Running = false, want true", i)
+		}
+	}
+}
+
 func TestFindAgentUnlimitedPoolMember(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -237,9 +237,10 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	// Inject system pack includes into Workspace.Includes. These are
 	// appended AFTER user includes so user packs override system pack
 	// fallbacks via the normal dedup/fallback resolution.
-	// Skip packs already reachable from user includes (avoids duplicate
-	// agent errors when a user pack transitively includes a system pack).
-	existingPacks := resolvedPackNames(root.Workspace.Includes, fs, cityRoot)
+	// Skip packs already reachable from user includes or top-level imports
+	// (avoids duplicate agent errors when a user pack transitively includes
+	// a system pack).
+	existingPacks := resolvedPackNames(root.Workspace.Includes, root.Imports, fs, cityRoot)
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
 		if name != "" && existingPacks[name] {
@@ -831,23 +832,30 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 }
 
 // resolvedPackNames collects pack names that are reachable from a set of
-// include paths (including transitive includes in pack.toml). Used to
-// skip system pack injection when a pack is already included by the user.
-func resolvedPackNames(includes []string, sysFS fsys.FS, cityRoot string) map[string]bool {
-	names := make(map[string]bool, len(includes))
-	var visit func(ref string)
-	visit = func(ref string) {
-		dir := resolveConfigPath(ref, cityRoot, cityRoot)
-		// Try resolving as a pack directory.
-		packPath := filepath.Join(dir, packFile)
-		data, err := sysFS.ReadFile(packPath)
+// top-level include paths and imports. It walks both legacy [pack].includes
+// and V2 [imports] transitively so builtin system-pack injection can be
+// skipped when a user pack already brings the same pack into the city
+// closure.
+func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
+	names := make(map[string]bool, len(includes)+len(imports))
+	seenDirs := make(map[string]bool)
+
+	var visit func(ref, declDir string)
+	visit = func(ref, declDir string) {
+		dir, err := resolvePackRef(ref, declDir, cityRoot)
 		if err != nil {
-			// Maybe it's a remote ref.
-			if resolved, rErr := resolvePackRef(ref, cityRoot, cityRoot); rErr == nil {
-				dir = resolved
-				data, err = sysFS.ReadFile(filepath.Join(dir, packFile))
-			}
+			return
 		}
+		absDir, absErr := filepath.Abs(dir)
+		if absErr != nil {
+			absDir = dir
+		}
+		if seenDirs[absDir] {
+			return
+		}
+		seenDirs[absDir] = true
+
+		data, err := sysFS.ReadFile(filepath.Join(dir, packFile))
 		if err != nil {
 			return
 		}
@@ -856,20 +864,26 @@ func resolvedPackNames(includes []string, sysFS fsys.FS, cityRoot string) map[st
 				Name     string   `toml:"name"`
 				Includes []string `toml:"includes"`
 			} `toml:"pack"`
+			Imports map[string]Import `toml:"imports"`
 		}
 		if _, decErr := toml.Decode(string(data), &pc); decErr != nil || pc.Pack.Name == "" {
 			return
 		}
-		if names[pc.Pack.Name] {
-			return
-		}
+
 		names[pc.Pack.Name] = true
 		for _, sub := range pc.Pack.Includes {
-			visit(resolveConfigPath(sub, dir, cityRoot))
+			visit(sub, dir)
+		}
+		for _, imp := range pc.Imports {
+			visit(imp.Source, dir)
 		}
 	}
+
 	for _, inc := range includes {
-		visit(inc)
+		visit(inc, cityRoot)
+	}
+	for _, imp := range imports {
+		visit(imp.Source, cityRoot)
 	}
 	return names
 }

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -45,6 +45,79 @@ name = "mayor"
 	}
 }
 
+func TestLoadWithIncludes_SkipsSystemPackWhenReachableFromRootImport(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	write("city.toml", `
+[workspace]
+name = "test"
+`)
+	write("pack.toml", `
+[pack]
+name = "test"
+schema = 2
+
+[imports.gs]
+source = "./packs/gastown"
+`)
+	write("packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+includes = ["../maintenance"]
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+	write("packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+
+[[agent]]
+name = "dog"
+scope = "city"
+`)
+	write("system/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+
+[[agent]]
+name = "dog"
+scope = "city"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"), filepath.Join(dir, "system", "maintenance"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, a := range explicitAgents(cfg.Agents) {
+		found[a.QualifiedName()] = true
+	}
+	if !found["gs.mayor"] {
+		t.Fatalf("missing gs.mayor: %v", found)
+	}
+	if !found["gs.dog"] {
+		t.Fatalf("missing gs.dog from imported maintenance closure: %v", found)
+	}
+	if found["dog"] {
+		t.Fatalf("system maintenance should have been skipped when root import already reaches maintenance: %v", found)
+	}
+}
+
 func TestLoadWithIncludes_CityPackSchema2(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`

--- a/test/acceptance/import_named_sessions_regression_test.go
+++ b/test/acceptance/import_named_sessions_regression_test.go
@@ -1,0 +1,113 @@
+//go:build acceptance_a
+
+package acceptance_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+type namedSessionListEntry struct {
+	Template    string `json:"Template"`
+	SessionName string `json:"SessionName"`
+}
+
+func TestImportedNamedSessionsUseSafeRuntimeNames(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	rigDir := filepath.Join(c.Dir, "repo")
+	mustWriteTestFile(t, filepath.Join(c.Dir, "pack.toml"), `
+[pack]
+name = "import-regression"
+schema = 2
+
+[imports.gs]
+source = "./assets/sidecar"
+`)
+	mustWriteTestFile(t, filepath.Join(c.Dir, "city.toml"), `
+[workspace]
+name = "import-regression"
+start_command = "sleep 300"
+
+[[rigs]]
+name = "repo"
+path = "./repo"
+
+[rigs.imports.gs]
+source = "./assets/sidecar"
+`)
+	mustWriteTestFile(t, filepath.Join(c.Dir, "assets", "sidecar", "pack.toml"), `
+[pack]
+name = "sidecar"
+schema = 2
+
+[[named_session]]
+template = "captain"
+scope = "city"
+mode = "always"
+
+[[named_session]]
+template = "watcher"
+scope = "rig"
+mode = "always"
+`)
+	mustWriteTestFile(t, filepath.Join(c.Dir, "assets", "sidecar", "agents", "captain", "agent.toml"), "scope = \"city\"\n")
+	mustWriteTestFile(t, filepath.Join(c.Dir, "assets", "sidecar", "agents", "captain", "prompt.md"), "You are the imported captain.\n")
+	mustWriteTestFile(t, filepath.Join(c.Dir, "assets", "sidecar", "agents", "watcher", "agent.toml"), "scope = \"rig\"\n")
+	mustWriteTestFile(t, filepath.Join(c.Dir, "assets", "sidecar", "agents", "watcher", "prompt.md"), "You are the imported watcher.\n")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("creating rig dir: %v", err)
+	}
+
+	if out, err := c.GC("unregister", c.Dir); err != nil {
+		t.Fatalf("gc unregister: %v\n%s", err, out)
+	}
+
+	c.StartForeground()
+
+	var sessions []namedSessionListEntry
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := c.GC("session", "list", "--json")
+		if err == nil {
+			if unmarshalErr := json.Unmarshal([]byte(out), &sessions); unmarshalErr == nil {
+				if hasNamedSession(sessions, "gs.captain", "gs__captain") &&
+					hasNamedSession(sessions, "repo/gs.watcher", "repo--gs__watcher") {
+					return
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	out, err := c.GC("session", "list", "--json")
+	if err != nil {
+		t.Fatalf("gc session list --json: %v\n%s", err, out)
+	}
+	t.Fatalf("imported named sessions never reached safe runtime names:\n%s", out)
+}
+
+func hasNamedSession(sessions []namedSessionListEntry, template, sessionName string) bool {
+	for _, s := range sessions {
+		if s.Template == template && s.SessionName == sessionName {
+			return true
+		}
+	}
+	return false
+}
+
+func mustWriteTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("creating %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

- fix imported named-session runtime names so namespaced templates like `gt.mayor` and `repo/gt.witness` are sanitized into tmux-safe session names instead of failing on `.`
- add acceptance and unit coverage for import-native named session startup
- skip injecting builtin maintenance when it is already reachable from the root import graph, which avoids duplicate `dog` composition in import-native gastown setups

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test -tags acceptance_a ./test/acceptance -run TestImportedNamedSessionsUseSafeRuntimeNames -count=1`
- [x] `go test ./internal/agent ./internal/config ./cmd/gc -run 'TestSanitizeQualifiedNameForSession|TestUnsanitizeQualifiedNameFromSession|TestPoolSessionName|TestLoadWithIncludes_SkipsSystemPackWhenReachableFromRootImport|TestImport_DiamondDAGNoCycle|TestLoadWithIncludes_DoesNotOverrideExplicitImport' -count=1`

## Checklist

- [x] Linked an issue, or explained why one is not needed
- No separate issue: this is a focused follow-up carved out of the PackV2 rollout branch to unblock import-native validation.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
- No breaking change intended. This restores expected behavior for import-native cities by making imported named sessions startable and by avoiding duplicate builtin maintenance injection when a root import already brings maintenance into the composed graph.
