### PR TITLE
fix: rename "Gas Town Control Center" to "Gas City Control Center"

### DIFF
--- a/cmd/gc/dashboard/templates/convoy.html
+++ b/cmd/gc/dashboard/templates/convoy.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="dashboard-token" content="{{.CSRFToken}}">
     {{if .SelectedCity}}<meta name="selected-city" content="{{.SelectedCity}}">{{end}}
-    <title>Gas Town Control Center</title>
+    <title>Gas City Control Center</title>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     <script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>
     <link rel="stylesheet" href="/static/dashboard.css">
@@ -13,10 +13,10 @@
 <body>
     <div class="dashboard" id="dashboard-main" hx-get="{{if .SelectedCity}}/?city={{.SelectedCity}}{{else}}/{{end}}" hx-trigger="sse:dashboard-update, every 30s [!window.pauseRefresh && !window.sseConnected]" hx-swap="morph:outerHTML" hx-ext="morph">
         <header>
-            <pre class="ascii-title">  __  __    __   _____ __  _   _  __  _    ___ __  __  _ _____ ___  __  _      ______ __  _ _____ ___ ___
- / _]/  \ /' _| |_   _/__\| | | ||  \| |  / _//__\|  \| |_   _| _ \/__\| |    / _/ __|  \| |_   _| __| _ \
-| [/\ /\ |`._`.   | || \/ | 'V' || | ' | | \_| \/ | | ' | | | | v / \/ | |_  | \_| _|| | ' | | | | _|| v /
- \__/_||_||___/   |_| \__/!_/ \_!|_|\__|  \__/\__/|_|\__| |_| |_|_\\__/|___|  \__/___|_|\__| |_| |___|_|_\</pre>
+            <pre class="ascii-title">  __  __    __    ____ _______   __   ___ __  __  _ _____ ___  __  _      ______ __  _ _____ ___ ___
+ / _]/  \ /' _|  / _/ |_   _\ `v' /  / _//__\|  \| |_   _| _ \/__\| |    / _/ __|  \| |_   _| __| _ \
+| [/\ /\ |`._`. | \_| | | |  `. .'  | \_| \/ | | ' | | | | v / \/ | |_  | \_| _|| | ' | | | | _|| v /
+ \__/_||_||___/  \__/_| |_|   !_!    \__/\__/|_|\__| |_| |_|_\\__/|___|  \__/___|_|\__| |_| |___|_|_\</pre>
             <div style="display: flex; align-items: center; gap: 12px;">
                 <button class="cmd-btn" id="open-palette-btn">
                     <span>⌘</span> Commands <kbd>⌘K</kbd>


### PR DESCRIPTION
## Why
The dashboard convoy view still says "Gas Town Control Center" but the project has been called Gas City for a while. Visible in the page title and the ASCII banner.

## What changed
Single template file edit in `cmd/gc/dashboard/templates/convoy.html` — title tag + matching ASCII banner.

## Before
```
<title>Gas Town Control Center</title>
... ASCII banner reading "Gas Town Control Center"
```

## After
```
<title>Gas City Control Center</title>
... ASCII banner reading "Gas City Control Center"
```

The banner was regenerated with the original figlet font `stforek` (via pyfiglet, width=500), preserving the one-char manual tweak on the "S" in GAS so the style matches the prior banner exactly.

## Testing
No tests pin this string (`services_test.go` is the only test rendering `convoy.html` and only asserts on service-panel content). No shipped screenshots use it. No txtar fixtures or i18n catalogs reference the old wording.

Closes #740