### PR TITLE
fix: race in ACP Nudge after Interrupt_RunningSession (#716)

### DIFF
--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -491,7 +491,20 @@ func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
 			sc.activePromptID = 0
 		}
 		sc.mu.Unlock()
-		return fmt.Errorf("sending prompt to %q: %w", name, err)
+		// Pipe write failed — the agent process is exiting (e.g., a prior
+		// Interrupt delivered SIGINT and the agent died, or Stop closed
+		// our stdin end between the alive() check and the write).
+		// Sync on the existing lifecycle event: cmd.Wait() → drainPending →
+		// close(sc.done). Once that fires, this is identical to the
+		// !sc.alive() case above, so honor the best-effort contract by
+		// returning nil. The 2s bound is defensive in case the monitor
+		// goroutine is wedged; the common path returns in microseconds.
+		select {
+		case <-sc.done:
+			return nil
+		case <-time.After(2 * time.Second):
+			return fmt.Errorf("sending prompt to %q: %w", name, err)
+		}
 	}
 
 	// Drain the response channel in the background. If the agent

--- a/internal/runtime/acp/testdata/fakeacp/main.go
+++ b/internal/runtime/acp/testdata/fakeacp/main.go
@@ -1,7 +1,9 @@
 // Command fakeacp is a minimal ACP server for integration tests.
 // It reads JSON-RPC from stdin and responds to the ACP handshake.
 // On session/prompt it echoes the text as a session/update notification
-// then sends the response. Stays alive until SIGTERM.
+// then sends the response. Stays alive until SIGTERM (SIGINT is ignored,
+// mirroring real ACP agents for which Interrupt is a soft prompt cancel,
+// not session teardown).
 package main
 
 import (
@@ -53,9 +55,15 @@ func notify(method string, params any) {
 func main() {
 	const sessionID = "fakeacp-session-1"
 
-	// Handle SIGTERM gracefully.
+	// Ignore SIGINT — ACP Interrupt is a soft prompt-cancel signal, not a
+	// teardown signal. Real agents keep running through Ctrl-C; the fake
+	// must too, otherwise the test-side SIGINT from Interrupt races with
+	// our lifecycle cleanup (see Provider.Nudge for the SDK-side fix).
+	signal.Ignore(syscall.SIGINT)
+
+	// Exit on SIGTERM.
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(sigCh, syscall.SIGTERM)
 	go func() {
 		<-sigCh
 		os.Exit(0)


### PR DESCRIPTION
## Why
`TestACPConformance/SharedSession/Nudge_RunningSession` flakes because `Provider.Nudge` writes to a stdin pipe that the agent process has just closed. The `Interrupt_RunningSession` subtest immediately before it sends SIGINT; `fakeacp` exits on SIGINT; but `sc.done` is only closed later by the monitor goroutine (`cmd.Wait` → `drainPending` → `close(done)`). In that microsecond gap, `sc.alive()` is still `true`, so `Nudge` sails past the liveness gate and writes to a dead pipe: `write |1: broken pipe`.

Any pre-write probe is TOCTOU. The right fix converges state *after* the failed write, on the lifecycle channel the rest of the SDK already trusts.

## What changed
- `internal/runtime/acp/acp.go` — in `Provider.Nudge`, on `sendRequest` error, wait on `sc.done` and return `nil` (matches the existing `!sc.alive()` best-effort branch).
- `internal/runtime/acp/testdata/fakeacp/main.go` — `signal.Ignore(SIGINT)` so the fake models real ACP agents (Interrupt is a soft prompt-cancel, not teardown). Removes the test-side amplifier; the SDK fix stands on its own.

No `time.Sleep`. `sc.done` is the same channel `Stop`/`terminateProcess` already wait on.

## Before
```go
ch, err := sc.sendRequest(msg)
if err != nil {
    sc.mu.Lock()
    if sc.activePromptID == id {
        sc.activePromptID = 0
    }
    sc.mu.Unlock()
    return fmt.Errorf("sending prompt to %q: %w", name, err)
}
```

## After
```go
ch, err := sc.sendRequest(msg)
if err != nil {
    sc.mu.Lock()
    if sc.activePromptID == id {
        sc.activePromptID = 0
    }
    sc.mu.Unlock()
    // Pipe write failed — the agent process is exiting. Sync on the
    // lifecycle event (cmd.Wait → drainPending → close(sc.done)); once
    // it fires we're in the !sc.alive() state and honor the best-effort
    // contract. 2s cap for a wedged monitor; common path is microseconds.
    select {
    case <-sc.done:
        return nil
    case <-time.After(2 * time.Second):
        return fmt.Errorf("sending prompt to %q: %w", name, err)
    }
}
```

## Testing
Loop test on this branch's base (`upstream/main`):
```
-count=50 -race ./internal/runtime/acp/  →  17/50 FAIL (write |1: broken pipe)
```

Same loop on this branch:
```
-count=100 -race ./internal/runtime/acp/  →  100/100 ok  (26.6s)
```

No mocks — uses the existing hand-written `fakeacp` double (`TESTING.md`-compliant).

Closes #716
