### PR TITLE
fix: skip post-unregister supervisor probes when city dir is gone (#715)

### DIFF
--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -344,6 +344,18 @@ func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer, com
 
 	fmt.Fprintf(stdout, "Unregistered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
 
+	// If the city directory is gone, there's nothing to wait on or restore.
+	// Skip the supervisor-side probes that would otherwise spew
+	// "probing standalone controller" + "restore failed" on a missing path
+	// (the unregister itself already succeeded; the supervisor's next
+	// reconcile will drop the dead city).
+	if _, statErr := os.Stat(cityPath); errors.Is(statErr, os.ErrNotExist) {
+		if supervisorAliveHook() != 0 {
+			_ = reloadSupervisorHook(stdout, stderr) // best-effort reconcile nudge; failure is benign since the city is gone
+		}
+		return true, 0
+	}
+
 	if supervisorAliveHook() != 0 {
 		if reloadSupervisorHook(stdout, stderr) != 0 {
 			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -401,6 +401,84 @@ func TestUnregisterCityFromSupervisorWaitsForControllerStop(t *testing.T) {
 	}
 }
 
+func TestUnregisterCityFromSupervisorSkipsProbesWhenCityDirMissing(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	reloads := 0
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int {
+			reloads++
+			return 0
+		},
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	// If the guard regresses, the stale waitForSupervisorControllerStopHook
+	// default would call acquireControllerLock on the missing .gc dir and
+	// surface the cascading "probing standalone controller" spew — fail
+	// the test loudly if the probe path is entered.
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error {
+		t.Fatalf("waitForSupervisorControllerStopHook called when city dir is gone")
+		return nil
+	}
+
+	if err := os.RemoveAll(cityPath); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	if !handled || code != 0 {
+		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 0)", handled, code)
+	}
+	if !strings.Contains(stdout.String(), "Unregistered city 'bright-lights'") {
+		t.Fatalf("stdout = %q, want success line for 'bright-lights'", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty (no cascading probe/restore spew)", stderr.String())
+	}
+	for _, bad := range []string{
+		"probing standalone controller",
+		"restore failed",
+		"restored registration",
+		"resolving symlinks",
+	} {
+		if strings.Contains(stderr.String(), bad) {
+			t.Fatalf("stderr = %q, must not contain %q", stderr.String(), bad)
+		}
+	}
+	if reloads != 1 {
+		t.Fatalf("reloadSupervisorHook called %d times, want 1 (nudge supervisor reconcile)", reloads)
+	}
+
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty registry after unregister, got %v", entries)
+	}
+}
+
 func TestUnregisterCityFromSupervisorRestoresRegistrationWhenControllerStopWaitFails(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)


### PR DESCRIPTION
## Why
When a city directory is deleted on disk before `gc unregister` or `gc stop` runs, the unregister succeeds but then the supervisor cleanup probes cascade-fail with confusing `probing standalone controller` and `restore failed` messages. The unregister itself worked; the spew is post-success noise on a path that can't succeed.

## What changed
In `unregisterCityFromSupervisor`, after the successful `Unregister` call, short-circuit the stale supervisor-side probe/wait path when `cityPath` no longer exists on disk. The code still nudges one supervisor reload, but now preserves reload-failure semantics by returning a non-zero exit if that reconcile step fails.

## Before
```
$ gc unregister <missing-city>
Unregistered city <name>
probing standalone controller: opening controller lock: open <path>/.gc/controller.lock: no such file or directory
restore failed: resolving symlinks: lstat <path>: no such file or directory
```

## After
```
$ gc unregister <missing-city>
Unregistered city <name>
Reconciliation triggered.
```

## Testing
- `go test ./cmd/gc/... -run TestUnregisterCityFromSupervisor -count=1`
- `go test ./cmd/gc/... -count=1` (currently fails in unrelated `TestGcBeadsBdStartUsesRootBeadsDataDir`)

Closes #715
