### PR TITLE
feat: add gc hooks sync command (#736)

### DIFF
--- a/cmd/gc/cmd_hooks.go
+++ b/cmd/gc/cmd_hooks.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/hooks"
+)
+
+func newHooksCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hooks",
+		Short: "Manage agent hook files",
+		Long: `Manage provider agent hook files for the current city.
+
+Providers (claude, codex, gemini, opencode, copilot, cursor, pi, omp)
+each ship a hook file embedded into the gc binary. "gc init" and
+"gc rig add" install these files; "gc hooks sync" reinstalls them so
+changes to hooks/claude.json propagate to .gc/settings.json.`,
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			return c.Help()
+		},
+	}
+	cmd.AddCommand(newHooksSyncCmd(stdout, stderr))
+	return cmd
+}
+
+func newHooksSyncCmd(stdout, stderr io.Writer) *cobra.Command {
+	var providersFlag []string
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Reinstall agent hook files for the current city",
+		Long: `Reinstall agent hook files for the current city.
+
+Resolves providers from workspace.install_agent_hooks (default
+["claude"] when unset), validates them, and calls the installer.
+Propagates hooks/claude.json changes into .gc/settings.json. The
+operation is idempotent — unchanged files are left alone, so running
+sync twice is a no-op on the second call.
+
+Use --providers to override the config list (comma-separated or
+repeated). Use --dry-run to report the resolved provider list
+without writing.`,
+		Example: `  gc hooks sync
+  gc hooks sync --providers claude,gemini
+  gc hooks sync --dry-run`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdHooksSync(providersFlag, dryRun, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVar(&providersFlag, "providers", nil,
+		"override providers to install (comma-separated; default: from workspace.install_agent_hooks)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"report the resolved providers without writing files")
+	return cmd
+}
+
+// cmdHooksSync resolves the city root and delegates to doHooksSync.
+func cmdHooksSync(providersFlag []string, dryRun bool, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc hooks sync: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return doHooksSync(fsys.OSFS{}, cityPath, providersFlag, dryRun, stdout, stderr)
+}
+
+// doHooksSync is the pure logic for "gc hooks sync". Loads city.toml to
+// discover workspace-level install_agent_hooks, validates the resolved
+// provider list, and calls hooks.Install. Accepts an injected FS so
+// tests can assert writes without touching the real filesystem.
+func doHooksSync(fs fsys.FS, cityPath string, providersFlag []string, dryRun bool, stdout, stderr io.Writer) int {
+	providers := providersFlag
+	flagOverride := len(providers) > 0
+	if !flagOverride {
+		cfg, err := loadCityConfig(cityPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc hooks sync: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		providers = cfg.Workspace.InstallAgentHooks
+		if len(providers) == 0 {
+			providers = []string{"claude"}
+		}
+	}
+
+	if err := hooks.Validate(providers); err != nil {
+		fmt.Fprintf(stderr, "gc hooks sync: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	if dryRun {
+		fmt.Fprintf(stdout, "would sync providers: %s\n", strings.Join(providers, ", ")) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+
+	if err := hooks.Install(fs, cityPath, cityPath, providers); err != nil {
+		fmt.Fprintf(stderr, "gc hooks sync: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "synced providers: %s\n", strings.Join(providers, ", "))                     //nolint:errcheck // best-effort stdout
+	fmt.Fprintln(stdout, "hint: run 'gc supervisor reload' to pick up changes in a live supervisor") //nolint:errcheck // best-effort stdout
+	return 0
+}

--- a/cmd/gc/cmd_hooks_test.go
+++ b/cmd/gc/cmd_hooks_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// writeCityTOMLForHooks writes a minimal city.toml to cityDir. When
+// installAgentHooks is non-nil, it is written as the workspace
+// install_agent_hooks list.
+func writeCityTOMLForHooks(t *testing.T, cityDir string, installAgentHooks []string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("[workspace]\nname = \"test-city\"\n")
+	if installAgentHooks != nil {
+		b.WriteString("install_agent_hooks = [")
+		for i, p := range installAgentHooks {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString("\"")
+			b.WriteString(p)
+			b.WriteString("\"")
+		}
+		b.WriteString("]\n")
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHooksSync_DefaultClaude(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityTOMLForHooks(t, cityDir, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fsys.OSFS{}, cityDir, nil, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHooksSync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	for _, rel := range []string{"hooks/claude.json", ".gc/settings.json"} {
+		path := filepath.Join(cityDir, rel)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to exist after sync: %v", rel, err)
+		}
+	}
+	if !strings.Contains(stdout.String(), "synced providers: claude") {
+		t.Errorf("stdout = %q, want to contain 'synced providers: claude'", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "gc supervisor reload") {
+		t.Errorf("stdout = %q, want reload hint", stdout.String())
+	}
+}
+
+func TestHooksSync_UsesWorkspaceProviders(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityTOMLForHooks(t, cityDir, []string{"claude", "gemini"})
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fsys.OSFS{}, cityDir, nil, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHooksSync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	claudeFile := filepath.Join(cityDir, "hooks/claude.json")
+	if _, err := os.Stat(claudeFile); err != nil {
+		t.Errorf("claude hook missing: %v", err)
+	}
+	geminiFile := filepath.Join(cityDir, ".gemini/settings.json")
+	if _, err := os.Stat(geminiFile); err != nil {
+		t.Errorf("gemini hook missing: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "synced providers: claude, gemini") {
+		t.Errorf("stdout = %q, want both providers listed", stdout.String())
+	}
+}
+
+func TestHooksSync_ProvidersFlagOverrides(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	// Config says claude, but --providers gemini should win.
+	writeCityTOMLForHooks(t, cityDir, []string{"claude"})
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fsys.OSFS{}, cityDir, []string{"gemini"}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHooksSync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(cityDir, ".gemini/settings.json")); err != nil {
+		t.Errorf("gemini hook missing (flag should have selected it): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, "hooks/claude.json")); err == nil {
+		t.Errorf("claude hook should NOT be installed when --providers=gemini overrides config")
+	}
+	if !strings.Contains(stdout.String(), "synced providers: gemini") {
+		t.Errorf("stdout = %q, want 'synced providers: gemini'", stdout.String())
+	}
+}
+
+func TestHooksSync_ValidationError(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityTOMLForHooks(t, cityDir, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fsys.OSFS{}, cityDir, []string{"bogus"}, false, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doHooksSync = 0, want nonzero for unsupported provider")
+	}
+	if !strings.Contains(stderr.String(), "bogus") {
+		t.Errorf("stderr = %q, want to mention unsupported provider name", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "supported:") {
+		t.Errorf("stderr = %q, want list of supported providers", stderr.String())
+	}
+	// Nothing should have been written.
+	if _, err := os.Stat(filepath.Join(cityDir, "hooks/claude.json")); err == nil {
+		t.Errorf("validation error must not write hook files")
+	}
+}
+
+func TestHooksSync_Idempotent(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityTOMLForHooks(t, cityDir, nil)
+
+	claudeFile := filepath.Join(cityDir, "hooks/claude.json")
+
+	var stdout, stderr bytes.Buffer
+	if code := doHooksSync(fsys.OSFS{}, cityDir, nil, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("first sync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	first, err := os.ReadFile(claudeFile)
+	if err != nil {
+		t.Fatalf("reading claude file: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doHooksSync(fsys.OSFS{}, cityDir, nil, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("second sync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	second, err := os.ReadFile(claudeFile)
+	if err != nil {
+		t.Fatalf("reading claude file after second sync: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("second sync changed file content; want idempotent no-op")
+	}
+}
+
+func TestHooksSync_DryRun(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityTOMLForHooks(t, cityDir, []string{"claude", "gemini"})
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fsys.OSFS{}, cityDir, nil, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHooksSync dry-run = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "would sync providers: claude, gemini") {
+		t.Errorf("stdout = %q, want 'would sync providers: claude, gemini'", stdout.String())
+	}
+	// Dry-run must write nothing.
+	if _, err := os.Stat(filepath.Join(cityDir, "hooks/claude.json")); err == nil {
+		t.Errorf("dry-run wrote hooks/claude.json; expected no writes")
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, ".gemini/settings.json")); err == nil {
+		t.Errorf("dry-run wrote gemini settings; expected no writes")
+	}
+	if strings.Contains(stdout.String(), "supervisor reload") {
+		t.Errorf("stdout = %q, dry-run should not print the reload hint", stdout.String())
+	}
+}
+
+func TestHooksSync_PreservesUserEdits(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityTOMLForHooks(t, cityDir, nil)
+
+	// Seed hooks/claude.json with a custom payload that doesn't match the
+	// stale-upgrade pattern — installer must preserve it.
+	hooksDir := filepath.Join(cityDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := []byte(`{"custom":"user-edit"}`)
+	claudePath := filepath.Join(hooksDir, "claude.json")
+	if err := os.WriteFile(claudePath, custom, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doHooksSync(fsys.OSFS{}, cityDir, nil, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("doHooksSync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	got, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, custom) {
+		t.Errorf("custom claude.json was overwritten:\n got=%s\nwant=%s", got, custom)
+	}
+	// The runtime file should be seeded from the user-edited source.
+	settings, err := os.ReadFile(filepath.Join(cityDir, ".gc/settings.json"))
+	if err != nil {
+		t.Fatalf("reading .gc/settings.json: %v", err)
+	}
+	if !bytes.Equal(settings, custom) {
+		t.Errorf(".gc/settings.json should have been seeded from user-edited claude.json:\n got=%s\nwant=%s", settings, custom)
+	}
+}
+
+func TestHooksSync_UsesInjectedFS(t *testing.T) {
+	// With --providers set, doHooksSync skips the config load and goes
+	// straight to hooks.Install — which must use the injected FS. Uses
+	// fsys.Fake so we can assert writes without touching disk.
+	clearGCEnv(t)
+	fs := fsys.NewFake()
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fs, "/city", []string{"claude"}, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHooksSync = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if _, ok := fs.Files["/city/hooks/claude.json"]; !ok {
+		t.Errorf("expected write to /city/hooks/claude.json; files=%v", fs.Files)
+	}
+	if _, ok := fs.Files["/city/.gc/settings.json"]; !ok {
+		t.Errorf("expected write to /city/.gc/settings.json; files=%v", fs.Files)
+	}
+}
+
+func TestHooksSync_InstallErrorSurfaces(t *testing.T) {
+	// Inject a write error via fsys.Fake and confirm the non-zero exit
+	// code plus a 'gc hooks sync:' prefixed stderr message.
+	clearGCEnv(t)
+	fs := fsys.NewFake()
+	fs.Errors["/city/hooks/claude.json"] = os.ErrPermission
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fs, "/city", []string{"claude"}, false, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doHooksSync = 0, want nonzero when installer fails")
+	}
+	if !strings.Contains(stderr.String(), "gc hooks sync:") {
+		t.Errorf("stderr = %q, want 'gc hooks sync:' prefix", stderr.String())
+	}
+}
+
+func TestHooksSync_CityResolveError(t *testing.T) {
+	clearGCEnv(t)
+	// Point at a non-existent directory — loadCityConfig should fail.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	var stdout, stderr bytes.Buffer
+	code := doHooksSync(fsys.OSFS{}, missing, nil, false, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doHooksSync = 0, want nonzero for missing city.toml")
+	}
+	if !strings.Contains(stderr.String(), "gc hooks sync:") {
+		t.Errorf("stderr = %q, want 'gc hooks sync:' prefix", stderr.String())
+	}
+}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -118,6 +118,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newPackCmd(stdout, stderr),
 		newDoctorCmd(stdout, stderr),
 		newHookCmd(stdout, stderr),
+		newHooksCmd(stdout, stderr),
 		newSlingCmd(stdout, stderr),
 		newConvoyCmd(stdout, stderr),
 		newWispCmd(stdout, stderr),

--- a/cmd/gc/testdata/hooks-sync.txtar
+++ b/cmd/gc/testdata/hooks-sync.txtar
@@ -1,0 +1,78 @@
+# gc hooks sync — propagate agent hook file changes.
+
+env GC_BEADS=file
+env GC_DOLT=skip
+env GC_SESSION=fake
+
+# `gc hooks` alone prints help (parent command, no default behavior).
+exec gc hooks
+stdout 'Manage provider agent hook files'
+stdout 'Reinstall agent hook files'
+
+# Outside a city: fails with the standard prefix.
+! exec gc hooks sync
+stderr 'gc hooks sync: not in a city directory'
+
+# Initialize a city. `gc init` already installs claude hooks, so our
+# subsequent sync is an idempotent no-op — but must still succeed.
+exec gc init $WORK/my-city
+cd $WORK/my-city
+exists hooks/claude.json
+exists .gc/settings.json
+
+# Default sync (no flags) reinstalls the configured providers —
+# defaults to ["claude"] when workspace.install_agent_hooks is unset.
+exec gc hooks sync
+stdout 'synced providers: claude'
+stdout 'gc supervisor reload'
+exists hooks/claude.json
+exists .gc/settings.json
+
+# Idempotent: running sync twice produces the same result and file
+# contents remain byte-identical.
+cp hooks/claude.json $WORK/claude-before.json
+cp .gc/settings.json $WORK/settings-before.json
+exec gc hooks sync
+stdout 'synced providers: claude'
+cmp hooks/claude.json $WORK/claude-before.json
+cmp .gc/settings.json $WORK/settings-before.json
+
+# --dry-run reports the resolved providers without writing. Seed a
+# marker value in hooks/claude.json and confirm it survives.
+cp $WORK/custom-claude.json hooks/claude.json
+exec gc hooks sync --dry-run
+stdout 'would sync providers: claude'
+! stdout 'synced providers:'
+! stdout 'supervisor reload'
+cmp hooks/claude.json $WORK/custom-claude.json
+
+# --providers overrides the resolved config list. gemini installs to
+# .gemini/settings.json in the city dir.
+exec gc hooks sync --providers gemini
+stdout 'synced providers: gemini'
+exists .gemini/settings.json
+
+# --providers accepts a comma-separated list.
+exec gc hooks sync --providers claude,gemini
+stdout 'synced providers: claude, gemini'
+
+# Validation: unknown provider fails and names the supported list.
+! exec gc hooks sync --providers bogus
+stderr 'gc hooks sync:'
+stderr 'bogus'
+stderr 'supported:'
+
+# Validation: a provider without a hook mechanism is rejected with a
+# distinct message.
+! exec gc hooks sync --providers amp
+stderr 'amp \(no hook mechanism\)'
+
+# User edits to hooks/claude.json are preserved across sync (the
+# installer's needs-upgrade gating skips managed-content that a user
+# has customized).
+cp hooks/claude.json $WORK/user-edit-before.json
+exec gc hooks sync
+cmp hooks/claude.json $WORK/user-edit-before.json
+
+-- custom-claude.json --
+{"custom": "user-edit-marker"}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,7 @@ gc [flags]
 | [gc handoff](#gc-handoff) | Send handoff mail and restart this session |
 | [gc help](#gc-help) | Help about any command |
 | [gc hook](#gc-hook) | Check for available work (use --inject for Stop hook output) |
+| [gc hooks](#gc-hooks) | Manage agent hook files |
 | [gc import](#gc-import) | Manage pack imports |
 | [gc init](#gc-init) | Initialize a new city |
 | [gc mail](#gc-mail) | Send and receive messages between agents and humans |
@@ -895,6 +896,54 @@ gc hook [agent] [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--inject` | bool |  | output &lt;system-reminder&gt; block for hook injection |
+
+## gc hooks
+
+Manage provider agent hook files for the current city.
+
+Providers (claude, codex, gemini, opencode, copilot, cursor, pi, omp)
+each ship a hook file embedded into the gc binary. "gc init" and
+"gc rig add" install these files; "gc hooks sync" reinstalls them so
+changes to hooks/claude.json propagate to .gc/settings.json.
+
+```
+gc hooks
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc hooks sync](#gc-hooks-sync) | Reinstall agent hook files for the current city |
+
+## gc hooks sync
+
+Reinstall agent hook files for the current city.
+
+Resolves providers from workspace.install_agent_hooks (default
+["claude"] when unset), validates them, and calls the installer.
+Propagates hooks/claude.json changes into .gc/settings.json. The
+operation is idempotent — unchanged files are left alone, so running
+sync twice is a no-op on the second call.
+
+Use --providers to override the config list (comma-separated or
+repeated). Use --dry-run to report the resolved provider list
+without writing.
+
+```
+gc hooks sync [flags]
+```
+
+**Example:**
+
+```
+gc hooks sync
+  gc hooks sync --providers claude,gemini
+  gc hooks sync --dry-run
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dry-run` | bool |  | report the resolved providers without writing files |
+| `--providers` | stringSlice |  | override providers to install (comma-separated; default: from workspace.install_agent_hooks) |
 
 ## gc import
 


### PR DESCRIPTION
## Why

Editing `hooks/claude.json` today has no user-facing way to propagate the change to `.gc/settings.json` without re-triggering `gc init` or `gc rig add` for their side effects. The `internal/hooks.Install` helper already does exactly what's needed — it's just not exposed as a CLI command. This wires it up.

## What changed

- New `gc hooks` parent with one subcommand, `gc hooks sync`, reinstalling provider hook files for the current city.
- Default provider list comes from `workspace.install_agent_hooks` (falls back to `["claude"]` when unset). `--providers` overrides; `--dry-run` reports the resolved list without writing.
- Thin cobra wrapper over the existing `hooks.Install`, so behavior matches `gc init` / `gc rig add` / the agent spawn path exactly. Idempotent — second run is a no-op.
- Prints a hint to run `gc supervisor reload` so a live supervisor picks up the new `.gc/settings.json`.

## Before

```
$ gc hooks sync
Error: unknown command "hooks" for "gc"
```

## After

```
$ gc hooks sync --help
Reinstall agent hook files for the current city.

Resolves providers from workspace.install_agent_hooks (default
["claude"] when unset), validates them, and calls the installer.
Propagates hooks/claude.json changes into .gc/settings.json. The
operation is idempotent — unchanged files are left alone, so running
sync twice is a no-op on the second call.

Use --providers to override the config list (comma-separated or
repeated). Use --dry-run to report the resolved provider list
without writing.

Usage:
  gc hooks sync [flags]

Examples:
  gc hooks sync
  gc hooks sync --providers claude,gemini
  gc hooks sync --dry-run

Flags:
      --dry-run             report the resolved providers without writing files
  -h, --help                help for sync
      --providers strings   override providers to install (comma-separated; default: from workspace.install_agent_hooks)
```

## Scope (intentional for v1)

- Workspace-level providers only; per-agent `install_agent_hooks` iteration deferred. Claude is city-wide and covers the stated use case.
- `--dry-run` reports intent without diffing file content. A diff-quality dry-run would require factoring the "compute desired content" step out of `installClaude` — deferred.
- No supervisor-reload trigger — printed hint only.

## Testing

- Unit tests in `cmd/gc/cmd_hooks_test.go` (10 cases): default claude, workspace providers, `--providers` override, validation error, idempotent second run, `--dry-run`, user-edit preservation, injected-FS write-through, injected install error, missing-city resolve error.
- End-to-end testscript in `cmd/gc/testdata/hooks-sync.txtar` exercising the compiled binary under the existing `TestTutorial01` harness: parent help, missing-city error, default claude after `gc init`, byte-identical idempotency, `--dry-run` no-write, `--providers` single + comma-separated, unsupported-provider + no-hook-mechanism validation, user-edit preservation.
- `go test ./cmd/gc/... -run 'TestHooksSync|TestTutorial01/hooks-sync' -count=3` clean.
- `make check` and `make check-docs` pass.

Closes #736