### PR TITLE
ci: make Mac a first-class CI deploy target

### DIFF
--- a/.github/actions/setup-gascity-macos/action.yml
+++ b/.github/actions/setup-gascity-macos/action.yml
@@ -3,9 +3,9 @@ description: Install the shared macOS dependencies for Gas City CI jobs on the s
 
 inputs:
   go-version:
-    description: Go version to install
+    description: Explicit Go version to install. Leave empty to inherit from repo go.mod.
     required: false
-    default: "1.25.8"
+    default: ""
   node-version:
     description: Node.js version to install
     required: false
@@ -43,7 +43,11 @@ runs:
 
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
+        # Default to the repo's go.mod so a Go bump propagates to Mac CI
+        # without a separate composite-action edit. Callers can still pass
+        # an explicit `go-version` to pin a specific version.
         go-version: ${{ inputs.go-version }}
+        go-version-file: ${{ inputs.go-version == '' && 'go.mod' || '' }}
         # self-hosted macstadium runners reuse the same GOPATH across jobs;
         # actions/setup-go's cache layer is flaky on reused runners, so skip it.
         cache: false

--- a/.github/actions/setup-gascity-macos/action.yml
+++ b/.github/actions/setup-gascity-macos/action.yml
@@ -3,9 +3,9 @@ description: Install the shared macOS dependencies for Gas City CI jobs on the s
 
 inputs:
   go-version:
-    description: Explicit Go version to install. Leave empty to inherit from repo go.mod.
+    description: Go version to install. Default matches setup-gascity-ubuntu; bump both together.
     required: false
-    default: ""
+    default: "1.25.8"
   node-version:
     description: Node.js version to install
     required: false
@@ -43,11 +43,11 @@ runs:
 
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        # Default to the repo's go.mod so a Go bump propagates to Mac CI
-        # without a separate composite-action edit. Callers can still pass
-        # an explicit `go-version` to pin a specific version.
+        # Keep this default in lock-step with setup-gascity-ubuntu —
+        # a split between Mac and Linux toolchains would surface as
+        # false "Mac-only" regressions. Track the same pin both
+        # actions use today; bump them together.
         go-version: ${{ inputs.go-version }}
-        go-version-file: ${{ inputs.go-version == '' && 'go.mod' || '' }}
         # self-hosted macstadium runners reuse the same GOPATH across jobs;
         # actions/setup-go's cache layer is flaky on reused runners, so skip it.
         cache: false
@@ -65,9 +65,21 @@ runs:
           echo "Homebrew is required on the macOS runner but was not found on PATH" >&2
           exit 1
         fi
-        # flock is needed by the dolt pack doctor check and by the
-        # controller for concurrent-start prevention. macOS does not ship
-        # with util-linux flock; the flock formula provides it.
+        # Bootstrap flock first (relying on Homebrew's internal lock to
+        # serialize any concurrent brew runs). We need flock installed
+        # *before* we take our own lock, otherwise concurrent matrix jobs
+        # on a fresh runner would all race past the missing-flock branch
+        # unguarded — the exact failure Homebrew's "Another active
+        # process" error surfaces as.
+        if ! command -v flock >/dev/null 2>&1; then
+          echo "Bootstrapping flock..."
+          brew install flock
+        fi
+        # Now we can safely lock-guard the remaining installs so parallel
+        # matrix jobs don't interleave brew's output (or worse, corrupt
+        # its caches on an exotic failure).
+        lock_file="${RUNNER_TOOL_CACHE:-$HOME/.local}/gascity-brew.lock"
+        mkdir -p "$(dirname "$lock_file")"
         pkgs=(tmux jq flock)
         install_missing() {
           local missing=()
@@ -83,22 +95,10 @@ runs:
             echo "All required formulae already installed: ${pkgs[*]}"
           fi
         }
-        # Serialize brew install across concurrent Mac jobs on the same
-        # runner. When the matrix jobs kick off together (quality + unit
-        # + acceptance + ...) they all race on Homebrew's global lock and
-        # sometimes fail with "Another active Homebrew process...". A
-        # shared flock avoids the race; if flock itself is missing, the
-        # fallback runs unguarded — which is the current behavior.
-        lock_dir="${RUNNER_TOOL_CACHE:-$HOME/.local}/gascity-brew.lock"
-        mkdir -p "$(dirname "$lock_dir")"
-        if command -v flock >/dev/null 2>&1; then
-          (
-            flock -w 300 9 || { echo "timed out waiting for brew lock" >&2; exit 1; }
-            install_missing
-          ) 9>"$lock_dir"
-        else
+        (
+          flock -w 300 9 || { echo "timed out waiting for brew lock" >&2; exit 1; }
           install_missing
-        fi
+        ) 9>"$lock_file"
         for cmd in tmux jq flock lsof; do
           command -v "$cmd" >/dev/null 2>&1 || {
             echo "Required command '$cmd' missing after install" >&2

--- a/.github/actions/setup-gascity-macos/action.yml
+++ b/.github/actions/setup-gascity-macos/action.yml
@@ -1,0 +1,170 @@
+name: Setup Gas City macOS CI
+description: Install the shared macOS dependencies for Gas City CI jobs on the self-hosted ARM64 runner
+
+inputs:
+  go-version:
+    description: Go version to install
+    required: false
+    default: "1.25.8"
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: "22"
+  dolt-version:
+    description: Dolt version to install (without leading v)
+    required: true
+  bd-version:
+    description: Beads release version to install (with leading v)
+    required: true
+  install-claude-cli:
+    description: Whether to install the Claude CLI
+    required: false
+    default: "true"
+  install-system-deps:
+    description: Whether to run brew to install tmux, jq, and flock (set to false when the self-hosted runner already has them)
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Verify macOS
+      shell: bash
+      run: |
+        if [[ "$(uname)" != "Darwin" ]]; then
+          echo "setup-gascity-macos must run on macOS; uname=$(uname)" >&2
+          exit 1
+        fi
+        arch="$(uname -m)"
+        if [[ "$arch" != "arm64" ]]; then
+          echo "setup-gascity-macos currently targets arm64; got $arch" >&2
+          exit 1
+        fi
+
+    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      with:
+        go-version: ${{ inputs.go-version }}
+        # self-hosted macstadium runners reuse the same GOPATH across jobs;
+        # actions/setup-go's cache layer is flaky on reused runners, so skip it.
+        cache: false
+
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install system dependencies (brew)
+      if: ${{ inputs.install-system-deps == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v brew >/dev/null 2>&1; then
+          echo "Homebrew is required on the macOS runner but was not found on PATH" >&2
+          exit 1
+        fi
+        # flock is needed by the dolt pack doctor check and by the
+        # controller for concurrent-start prevention. macOS does not ship
+        # with util-linux flock; the flock formula provides it.
+        pkgs=(tmux jq flock)
+        missing=()
+        for pkg in "${pkgs[@]}"; do
+          if ! brew list --formula "$pkg" >/dev/null 2>&1; then
+            missing+=("$pkg")
+          fi
+        done
+        if (( ${#missing[@]} > 0 )); then
+          echo "Installing missing formulae: ${missing[*]}"
+          brew install "${missing[@]}"
+        else
+          echo "All required formulae already installed: ${pkgs[*]}"
+        fi
+        for cmd in tmux jq flock lsof; do
+          command -v "$cmd" >/dev/null 2>&1 || {
+            echo "Required command '$cmd' missing after install" >&2
+            exit 1
+          }
+        done
+
+    - name: Install dolt v${{ inputs.dolt-version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${{ inputs.dolt-version }}"
+        arch="$(uname -m)"
+        case "$arch" in
+          arm64) platform_tuple=darwin-arm64 ;;
+          x86_64) platform_tuple=darwin-amd64 ;;
+          *)
+            echo "Unsupported macOS arch: $arch" >&2
+            exit 1
+            ;;
+        esac
+        # Pin an install prefix we can write without sudo on a self-hosted
+        # runner. Prefer $RUNNER_TOOL_CACHE when present (persistent across
+        # GitHub Actions jobs) and fall back to $HOME/.local.
+        cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+        install_root="$cache_root/gascity-dolt/$version/$platform_tuple"
+        bin_dir="$install_root/bin"
+        if [[ ! -x "$bin_dir/dolt" ]]; then
+          echo "Installing dolt $version for $platform_tuple into $install_root"
+          mkdir -p "$install_root"
+          archive="dolt-${platform_tuple}.tar.gz"
+          tmp="$RUNNER_TEMP/dolt-${version}-${platform_tuple}"
+          rm -rf "$tmp"
+          mkdir -p "$tmp"
+          curl -fsSL -o "$tmp/$archive" \
+            "https://github.com/dolthub/dolt/releases/download/v${version}/${archive}"
+          tar -xzf "$tmp/$archive" -C "$tmp"
+          # The tarball root is "dolt-${platform_tuple}" with a bin/ subdir.
+          cp -R "$tmp/dolt-${platform_tuple}/." "$install_root/"
+          rm -rf "$tmp"
+        else
+          echo "Reusing cached dolt $version at $install_root"
+        fi
+        echo "$bin_dir" >> "$GITHUB_PATH"
+        "$bin_dir/dolt" version
+
+    - name: Install released bd v${{ inputs.bd-version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${{ inputs.bd-version }}"
+        arch="$(uname -m)"
+        case "$arch" in
+          arm64) bd_arch=arm64 ;;
+          x86_64) bd_arch=amd64 ;;
+          *)
+            echo "Unsupported runner architecture: $arch" >&2
+            exit 1
+            ;;
+        esac
+        cache_root="${RUNNER_TOOL_CACHE:-$HOME/.local}"
+        install_root="$cache_root/gascity-bd/${version}/darwin_${bd_arch}"
+        bin_dir="$install_root/bin"
+        if [[ ! -x "$bin_dir/bd" ]]; then
+          echo "Installing bd $version for darwin_${bd_arch} into $install_root"
+          mkdir -p "$bin_dir"
+          archive="beads_${version#v}_darwin_${bd_arch}.tar.gz"
+          tmp="$RUNNER_TEMP/bd-${version}-darwin_${bd_arch}"
+          rm -rf "$tmp"
+          mkdir -p "$tmp"
+          curl -fsSL -o "$tmp/$archive" \
+            "https://github.com/gastownhall/beads/releases/download/${version}/${archive}"
+          # Strip the top-level directory (beads_<version>_darwin_<arch>/)
+          # so `bd` lands directly in $tmp.
+          tar -xzf "$tmp/$archive" -C "$tmp" --strip-components=1
+          install -m 0755 "$tmp/bd" "$bin_dir/bd"
+          rm -rf "$tmp"
+        else
+          echo "Reusing cached bd $version at $install_root"
+        fi
+        echo "$bin_dir" >> "$GITHUB_PATH"
+        "$bin_dir/bd" version
+
+    - name: Install Claude CLI
+      if: ${{ inputs.install-claude-cli == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        # setup-node configures an npm prefix that's writable without sudo,
+        # so a plain `npm install -g` works on the self-hosted runner.
+        npm install -g @anthropic-ai/claude-code

--- a/.github/actions/setup-gascity-macos/action.yml
+++ b/.github/actions/setup-gascity-macos/action.yml
@@ -65,17 +65,35 @@ runs:
         # controller for concurrent-start prevention. macOS does not ship
         # with util-linux flock; the flock formula provides it.
         pkgs=(tmux jq flock)
-        missing=()
-        for pkg in "${pkgs[@]}"; do
-          if ! brew list --formula "$pkg" >/dev/null 2>&1; then
-            missing+=("$pkg")
+        install_missing() {
+          local missing=()
+          for pkg in "${pkgs[@]}"; do
+            if ! brew list --formula "$pkg" >/dev/null 2>&1; then
+              missing+=("$pkg")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Installing missing formulae: ${missing[*]}"
+            brew install "${missing[@]}"
+          else
+            echo "All required formulae already installed: ${pkgs[*]}"
           fi
-        done
-        if (( ${#missing[@]} > 0 )); then
-          echo "Installing missing formulae: ${missing[*]}"
-          brew install "${missing[@]}"
+        }
+        # Serialize brew install across concurrent Mac jobs on the same
+        # runner. When the matrix jobs kick off together (quality + unit
+        # + acceptance + ...) they all race on Homebrew's global lock and
+        # sometimes fail with "Another active Homebrew process...". A
+        # shared flock avoids the race; if flock itself is missing, the
+        # fallback runs unguarded — which is the current behavior.
+        lock_dir="${RUNNER_TOOL_CACHE:-$HOME/.local}/gascity-brew.lock"
+        mkdir -p "$(dirname "$lock_dir")"
+        if command -v flock >/dev/null 2>&1; then
+          (
+            flock -w 300 9 || { echo "timed out waiting for brew lock" >&2; exit 1; }
+            install_missing
+          ) 9>"$lock_dir"
         else
-          echo "All required formulae already installed: ${pkgs[*]}"
+          install_missing
         fi
         for cmd in tmux jq flock lsof; do
           command -v "$cmd" >/dev/null 2>&1 || {
@@ -169,20 +187,20 @@ runs:
         # so a plain `npm install -g` works on the self-hosted runner.
         npm install -g @anthropic-ai/claude-code
 
-    - name: Ensure global git identity
+    - name: Pin CI git identity
       shell: bash
       run: |
         set -euo pipefail
         # Dolt inherits its commit identity from the user's global git config
         # (see cmd/gc/gc-beads-bd ensure_dolt_identity). The ubuntu-latest
         # hosted runner ships with user.name/user.email baked in; the
-        # self-hosted macstadium runner does not. Seed a deterministic CI
-        # identity so `gc init` can bring up the per-city dolt server.
-        if ! git config --global --get user.name >/dev/null 2>&1; then
-          git config --global user.name "Gas City CI"
-        fi
-        if ! git config --global --get user.email >/dev/null 2>&1; then
-          git config --global user.email "ci@gascity.local"
-        fi
-        printf 'git user.name=%s\n' "$(git config --global --get user.name)"
-        printf 'git user.email=%s\n' "$(git config --global --get user.email)"
+        # self-hosted macstadium runner does not.
+        #
+        # Force-set a deterministic CI identity unconditionally. Don't log
+        # the resolved value — on a reused runner any preexisting identity
+        # from a prior maintenance session would otherwise leak into the
+        # job log (real maintainer name/email), and a shared writable
+        # `~/.gitconfig` would leave Dolt commit metadata nondeterministic
+        # between runs.
+        git config --global user.name "Gas City CI"
+        git config --global user.email "ci@gascity.local"

--- a/.github/actions/setup-gascity-macos/action.yml
+++ b/.github/actions/setup-gascity-macos/action.yml
@@ -168,3 +168,21 @@ runs:
         # setup-node configures an npm prefix that's writable without sudo,
         # so a plain `npm install -g` works on the self-hosted runner.
         npm install -g @anthropic-ai/claude-code
+
+    - name: Ensure global git identity
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Dolt inherits its commit identity from the user's global git config
+        # (see cmd/gc/gc-beads-bd ensure_dolt_identity). The ubuntu-latest
+        # hosted runner ships with user.name/user.email baked in; the
+        # self-hosted macstadium runner does not. Seed a deterministic CI
+        # identity so `gc init` can bring up the per-city dolt server.
+        if ! git config --global --get user.name >/dev/null 2>&1; then
+          git config --global user.name "Gas City CI"
+        fi
+        if ! git config --global --get user.email >/dev/null 2>&1; then
+          git config --global user.email "ci@gascity.local"
+        fi
+        printf 'git user.name=%s\n' "$(git config --global --get user.name)"
+        printf 'git user.email=%s\n' "$(git config --global --get user.email)"

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -29,11 +29,26 @@ concurrency:
   group: mac-regression-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
+env:
+  DOLT_VERSION: "1.86.1"
+  BD_VERSION: "v1.0.0"
+
+# Trigger gate re-used by every job below via `if:`.
+# We want each job to run when EITHER:
+#   - a same-repo, non-draft PR carries the `needs-mac` label
+#   - the nightly schedule fires
+#   - the user dispatches manually (smoke/full input decides reach)
+# YAML anchors do not work inside GitHub `if:` so each job copies the
+# expression; keep them in sync.
+
 jobs:
-  mac-smoke:
-    name: Mac smoke
+  # Fast quality gates that Linux runs on every PR. Keep these cheap so a
+  # Mac-parity loop stays interactive.
+  mac-quality:
+    name: Mac / quality (lint, fmt, vet, docs)
     if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.suite == 'smoke') ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -48,14 +63,175 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: ./.github/actions/setup-gascity-macos
         with:
-          go-version-file: go.mod
-      - name: Run macOS smoke suite
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "false"
+      - name: Install tools
+        run: make install-tools
+      - name: Lint
+        run: make lint
+      - name: Format
+        run: make fmt-check
+      - name: Vet
+        run: make vet
+      - name: Docs
+        run: make check-docs
+
+  # Unit tests — the suite Mac already ran as "smoke".
+  mac-unit:
+    name: Mac / make test
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "false"
+      - name: Run make test
         run: make test
 
-  mac-full:
-    name: Mac full
+  # Tier A acceptance — smoke-level gate on every PR.
+  mac-acceptance:
+    name: Mac / acceptance (Tier A)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Run acceptance tests (Tier A)
+        run: make test-acceptance
+
+  # Integration-tagged coverage pass — the Linux `Check` job's equivalent
+  # of `make test-cover`. Starts as continue-on-error while we discover
+  # Mac-specific failures; once the suite is green we can flip it strict.
+  mac-cover:
+    name: Mac / test-cover
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    timeout-minutes: 25
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run test-cover
+        run: make test-cover
+      - name: Upload coverage artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mac-coverage-${{ github.run_id }}
+          path: coverage.txt
+          if-no-files-found: ignore
+
+  # Integration shards. Linux runs these with continue-on-error today while
+  # stabilizing; we mirror that until Mac parity is proven. These three
+  # shards run on `needs-mac` label, nightly, or manual dispatch. The
+  # long-running review-formulas shard lives in a separate job below so
+  # it can gate on nightly / full-dispatch only.
+  mac-integration:
+    name: Mac / integration (${{ matrix.shard_name }})
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    continue-on-error: true
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_name: packages
+            command: make test-integration-packages
+          - shard_name: bdstore
+            command: make test-integration-bdstore
+          - shard_name: rest
+            command: make test-integration-rest
+    env:
+      ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_HAIKU_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_OPUS_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SUBAGENT_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_EFFORT_LEVEL: auto
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run integration shard
+        run: ${{ matrix.command }}
+
+  # Long-running review-formulas shard — nightly / full dispatch only.
+  mac-integration-review-formulas:
+    name: Mac / integration (review-formulas)
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.suite == 'full')
@@ -64,11 +240,72 @@ jobs:
       - macOS
       - ARM64
       - macstadium
-    timeout-minutes: 45
+    continue-on-error: true
+    timeout-minutes: 90
+    env:
+      ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_HAIKU_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_OPUS_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SUBAGENT_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_EFFORT_LEVEL: auto
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - uses: ./.github/actions/setup-gascity-macos
         with:
-          go-version-file: go.mod
-      - name: Run macOS full suite
-        run: make test
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run review-formulas shard
+        run: make test-integration-review-formulas
+
+  # Aggregate summary so a single check can report Mac parity status to
+  # the PR. Kept non-blocking (exit 0) while continue-on-error jobs are
+  # still stabilizing; flip to strict once Mac is green.
+  mac-regression-summary:
+    name: Mac regression summary
+    if: ${{ always() }}
+    needs:
+      - mac-quality
+      - mac-unit
+      - mac-acceptance
+      - mac-cover
+      - mac-integration
+      - mac-integration-review-formulas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize
+        env:
+          QUALITY: ${{ needs.mac-quality.result }}
+          UNIT: ${{ needs.mac-unit.result }}
+          ACCEPTANCE: ${{ needs.mac-acceptance.result }}
+          COVER: ${{ needs.mac-cover.result }}
+          INTEGRATION: ${{ needs.mac-integration.result }}
+          REVIEW_FORMULAS: ${{ needs.mac-integration-review-formulas.result }}
+        run: |
+          cat >>"$GITHUB_STEP_SUMMARY" <<EOF
+          ## Mac Regression
+
+          | Job | Result |
+          | --- | --- |
+          | Mac / quality | ${QUALITY} |
+          | Mac / make test | ${UNIT} |
+          | Mac / acceptance (Tier A) | ${ACCEPTANCE} |
+          | Mac / test-cover (best-effort) | ${COVER} |
+          | Mac / integration matrix (best-effort) | ${INTEGRATION} |
+          | Mac / integration review-formulas (best-effort) | ${REVIEW_FORMULAS} |
+          EOF
+
+          fail=0
+          for result in "$QUALITY" "$UNIT" "$ACCEPTANCE"; do
+            # Skipped is acceptable (e.g. when run outside the needs-mac trigger set)
+            case "$result" in
+              success|skipped|"") ;;
+              *) fail=1 ;;
+            esac
+          done
+          exit "$fail"

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -190,9 +190,13 @@ jobs:
   # shards run on `needs-mac` label, nightly, or manual dispatch. The
   # long-running review-formulas shard lives in a separate job below so
   # it can gate on nightly / full-dispatch only.
-  mac-integration:
-    name: Mac / integration (${{ matrix.shard_name }})
-    # Heavy job: schedule/full-dispatch/PR(needs-mac). Smoke dispatch skips.
+  # Integration shards. Linux runs these with continue-on-error today
+  # while stabilizing; we mirror that until Mac parity is proven. Split
+  # into discrete jobs (rather than a matrix) so each shard publishes
+  # its own `outputs.outcome` — matrix-job outputs are last-writer-wins
+  # and would mask a per-shard failure in the summary row.
+  mac-integration-packages:
+    name: Mac / integration (packages)
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
@@ -210,16 +214,6 @@ jobs:
     timeout-minutes: 60
     outputs:
       outcome: ${{ steps.shard.outcome }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - shard_name: packages
-            command: make test-integration-packages
-          - shard_name: bdstore
-            command: make test-integration-bdstore
-          - shard_name: rest
-            command: make test-integration-rest
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -241,7 +235,91 @@ jobs:
       - name: Run integration shard
         id: shard
         continue-on-error: true
-        run: ${{ matrix.command }}
+        run: make test-integration-packages
+
+  mac-integration-bdstore:
+    name: Mac / integration (bdstore)
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    timeout-minutes: 60
+    outputs:
+      outcome: ${{ steps.shard.outcome }}
+    env:
+      ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_HAIKU_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_OPUS_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SUBAGENT_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_EFFORT_LEVEL: auto
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run integration shard
+        id: shard
+        continue-on-error: true
+        run: make test-integration-bdstore
+
+  mac-integration-rest:
+    name: Mac / integration (rest)
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'needs-mac')
+      )
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    timeout-minutes: 60
+    outputs:
+      outcome: ${{ steps.shard.outcome }}
+    env:
+      ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_HAIKU_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_OPUS_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SUBAGENT_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL || vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_MODEL }}
+      CLAUDE_CODE_EFFORT_LEVEL: auto
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run integration shard
+        id: shard
+        continue-on-error: true
+        run: make test-integration-rest
 
   # Long-running review-formulas shard — nightly / full dispatch only.
   mac-integration-review-formulas:
@@ -305,7 +383,9 @@ jobs:
       - mac-unit
       - mac-acceptance
       - mac-cover
-      - mac-integration
+      - mac-integration-packages
+      - mac-integration-bdstore
+      - mac-integration-rest
       - mac-integration-review-formulas
     runs-on: ubuntu-latest
     steps:
@@ -314,11 +394,13 @@ jobs:
           QUALITY: ${{ needs.mac-quality.result }}
           UNIT: ${{ needs.mac-unit.result }}
           ACCEPTANCE: ${{ needs.mac-acceptance.result }}
-          # Best-effort jobs: use steps.*.outcome (not needs.*.result)
+          # Best-effort jobs: use outputs.outcome (not needs.*.result)
           # because their test step is continue-on-error, which forces
           # needs.*.result to "success" even on failure.
           COVER: ${{ needs.mac-cover.outputs.outcome || needs.mac-cover.result }}
-          INTEGRATION: ${{ needs.mac-integration.outputs.outcome || needs.mac-integration.result }}
+          INT_PACKAGES: ${{ needs.mac-integration-packages.outputs.outcome || needs.mac-integration-packages.result }}
+          INT_BDSTORE: ${{ needs.mac-integration-bdstore.outputs.outcome || needs.mac-integration-bdstore.result }}
+          INT_REST: ${{ needs.mac-integration-rest.outputs.outcome || needs.mac-integration-rest.result }}
           REVIEW_FORMULAS: ${{ needs.mac-integration-review-formulas.outputs.outcome || needs.mac-integration-review-formulas.result }}
         run: |
           cat >>"$GITHUB_STEP_SUMMARY" <<EOF
@@ -330,7 +412,9 @@ jobs:
           | Mac / make test | ${UNIT} |
           | Mac / acceptance (Tier A) | ${ACCEPTANCE} |
           | Mac / test-cover (best-effort) | ${COVER} |
-          | Mac / integration matrix (best-effort) | ${INTEGRATION} |
+          | Mac / integration packages (best-effort) | ${INT_PACKAGES} |
+          | Mac / integration bdstore (best-effort) | ${INT_BDSTORE} |
+          | Mac / integration rest (best-effort) | ${INT_REST} |
           | Mac / integration review-formulas (best-effort) | ${REVIEW_FORMULAS} |
           EOF
 

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -141,13 +141,15 @@ jobs:
         run: make test-acceptance
 
   # Integration-tagged coverage pass — the Linux `Check` job's equivalent
-  # of `make test-cover`. Starts as continue-on-error while we discover
-  # Mac-specific failures; once the suite is green we can flip it strict.
+  # of `make test-cover`. Kept best-effort while we discover Mac-specific
+  # failures; continue-on-error is on the test step (not the job) so the
+  # job's result still reflects the actual outcome for the summary.
   mac-cover:
     name: Mac / test-cover
+    # Heavy job: schedule/full-dispatch/PR(needs-mac). Smoke dispatch skips.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -160,7 +162,8 @@ jobs:
       - ARM64
       - macstadium
     timeout-minutes: 25
-    continue-on-error: true
+    outputs:
+      outcome: ${{ steps.cover.outcome }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-macos
@@ -171,6 +174,8 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Run test-cover
+        id: cover
+        continue-on-error: true
         run: make test-cover
       - name: Upload coverage artifact
         if: ${{ always() }}
@@ -187,9 +192,10 @@ jobs:
   # it can gate on nightly / full-dispatch only.
   mac-integration:
     name: Mac / integration (${{ matrix.shard_name }})
+    # Heavy job: schedule/full-dispatch/PR(needs-mac). Smoke dispatch skips.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -201,8 +207,9 @@ jobs:
       - macOS
       - ARM64
       - macstadium
-    continue-on-error: true
     timeout-minutes: 60
+    outputs:
+      outcome: ${{ steps.shard.outcome }}
     strategy:
       fail-fast: false
       matrix:
@@ -232,6 +239,8 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Run integration shard
+        id: shard
+        continue-on-error: true
         run: ${{ matrix.command }}
 
   # Long-running review-formulas shard — nightly / full dispatch only.
@@ -245,8 +254,9 @@ jobs:
       - macOS
       - ARM64
       - macstadium
-    continue-on-error: true
     timeout-minutes: 90
+    outputs:
+      outcome: ${{ steps.shard.outcome }}
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -266,14 +276,30 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Run review-formulas shard
+        id: shard
+        continue-on-error: true
         run: make test-integration-review-formulas
 
-  # Aggregate summary so a single check can report Mac parity status to
-  # the PR. Kept non-blocking (exit 0) while continue-on-error jobs are
-  # still stabilizing; flip to strict once Mac is green.
+  # Aggregate summary so a single check reports Mac parity status on the
+  # PR. Gated on the same trigger set as the parity jobs so it doesn't
+  # post a misleading green check on PRs that never ran Mac at all. The
+  # best-effort jobs (cover, integration, review-formulas) keep their
+  # failures visible here via job outputs that capture the real
+  # step outcome — needs.<job>.result masks it as success because the
+  # failing steps are continue-on-error.
   mac-regression-summary:
     name: Mac regression summary
-    if: ${{ always() }}
+    if: >-
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          !github.event.pull_request.draft &&
+          contains(github.event.pull_request.labels.*.name, 'needs-mac')
+        )
+      )
     needs:
       - mac-quality
       - mac-unit
@@ -288,9 +314,12 @@ jobs:
           QUALITY: ${{ needs.mac-quality.result }}
           UNIT: ${{ needs.mac-unit.result }}
           ACCEPTANCE: ${{ needs.mac-acceptance.result }}
-          COVER: ${{ needs.mac-cover.result }}
-          INTEGRATION: ${{ needs.mac-integration.result }}
-          REVIEW_FORMULAS: ${{ needs.mac-integration-review-formulas.result }}
+          # Best-effort jobs: use steps.*.outcome (not needs.*.result)
+          # because their test step is continue-on-error, which forces
+          # needs.*.result to "success" even on failure.
+          COVER: ${{ needs.mac-cover.outputs.outcome || needs.mac-cover.result }}
+          INTEGRATION: ${{ needs.mac-integration.outputs.outcome || needs.mac-integration.result }}
+          REVIEW_FORMULAS: ${{ needs.mac-integration-review-formulas.outputs.outcome || needs.mac-integration-review-formulas.result }}
         run: |
           cat >>"$GITHUB_STEP_SUMMARY" <<EOF
           ## Mac Regression

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -133,6 +133,11 @@ jobs:
           bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "true"
       - name: Run acceptance tests (Tier A)
+        env:
+          # Mac runs acceptance ~3-4x slower than Linux because launchd
+          # mediates the supervisor lifecycle; bump the go-test timeout
+          # so the whole binary doesn't panic mid-test.
+          ACCEPTANCE_TIMEOUT: 20m
         run: make test-acceptance
 
   # Integration-tagged coverage pass — the Linux `Check` job's equivalent

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,13 +8,15 @@ on:
 permissions:
   contents: read
 
+env:
+  DOLT_VERSION: "1.86.1"
+  BD_VERSION: "v1.0.0"
+
 jobs:
   inference:
     name: Tier C inference tests
     runs-on: ubuntu-latest
     env:
-      DOLT_VERSION: "1.86.1"
-      BD_VERSION: "v1.0.0"
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_API_KEY: ${{ secrets.SYNTHETIC_API_KEY }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -67,6 +69,48 @@ jobs:
 
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code
+
+      - name: Tier B acceptance tests
+        run: make test-acceptance-b
+
+      - name: Tier C inference tests
+        run: make test-acceptance-c
+
+  mac-inference:
+    name: Mac / Tier B+C inference tests
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - macstadium
+    timeout-minutes: 180
+    env:
+      ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
+      ANTHROPIC_API_KEY: ${{ secrets.SYNTHETIC_API_KEY }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_HAIKU_MODEL }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SONNET_MODEL }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_OPUS_MODEL }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.GC_WORKER_INFERENCE_CLAUDE_SYNTHETIC_SUBAGENT_MODEL }}
+      CLAUDE_CODE_EFFORT_LEVEL: auto
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-gascity-macos
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+
+      - name: Validate Synthetic Claude configuration
+        run: |
+          test -n "$ANTHROPIC_API_KEY" || { echo "Missing SYNTHETIC_API_KEY GitHub secret" >&2; exit 1; }
+          test -n "$ANTHROPIC_AUTH_TOKEN" || { echo "Missing SYNTHETIC_API_KEY GitHub secret" >&2; exit 1; }
+          test -n "$ANTHROPIC_DEFAULT_HAIKU_MODEL" || { echo "ANTHROPIC_DEFAULT_HAIKU_MODEL resolved empty" >&2; exit 1; }
+          test -n "$ANTHROPIC_DEFAULT_SONNET_MODEL" || { echo "ANTHROPIC_DEFAULT_SONNET_MODEL resolved empty" >&2; exit 1; }
+          test -n "$ANTHROPIC_DEFAULT_OPUS_MODEL" || { echo "ANTHROPIC_DEFAULT_OPUS_MODEL resolved empty" >&2; exit 1; }
+          test -n "$CLAUDE_CODE_SUBAGENT_MODEL" || { echo "CLAUDE_CODE_SUBAGENT_MODEL resolved empty" >&2; exit 1; }
 
       - name: Tier B acceptance tests
         run: make test-acceptance-b

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,13 @@ vet:
 test:
 	go test ./...
 
-## test-acceptance: run acceptance tests (Tier A — fast, <5 min, every PR)
+## test-acceptance: run acceptance tests (Tier A — fast, <5 min, every PR).
+## ACCEPTANCE_TIMEOUT overrides the go-test timeout (defaults to 5m on
+## Linux; Mac CI bumps it because launchd-mediated supervisor start is
+## noticeably slower than systemd).
+ACCEPTANCE_TIMEOUT ?= 5m
 test-acceptance:
-	go test -tags acceptance_a -timeout 5m ./test/acceptance/...
+	go test -tags acceptance_a -timeout $(ACCEPTANCE_TIMEOUT) ./test/acceptance/...
 
 ## test-acceptance-b: run Tier B acceptance tests (lifecycle, ~5 min, nightly)
 test-acceptance-b:

--- a/internal/runtime/acp/conformance_test.go
+++ b/internal/runtime/acp/conformance_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/runtime/runtimetest"
+	"github.com/gastownhall/gascity/internal/testutil"
 )
 
 func TestACPConformance(t *testing.T) {
@@ -25,7 +26,16 @@ func TestACPConformance(t *testing.T) {
 		t.Fatalf("building fakeacp: %v", err)
 	}
 
-	dir := filepath.Join(t.TempDir(), "acp-conform")
+	// Unix socket paths are capped at 104 bytes on macOS (vs 108 on
+	// Linux). The default t.TempDir() on Darwin lives under
+	// /var/folders/.../T/ which already eats ~60 chars — a few more
+	// directory levels plus the hashed "s<8hex>.sock" filename puts
+	// us over the limit. testutil.ShortTempDir roots the directory
+	// under /tmp on Darwin to keep the socket path small.
+	dir := filepath.Join(testutil.ShortTempDir(t, "acp-conform"), "acp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", dir, err)
+	}
 	p := NewProviderWithDir(dir, Config{})
 	var counter int64
 

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -49,8 +49,12 @@ list_integration_tests() {
 }
 
 run_packages_shard() {
-  local -a packages
-  mapfile -t packages < <(go list ./... | grep -v '^github.com/gastownhall/gascity/test/integration$')
+  # Avoid bash 4 `mapfile` so this runs on macOS's stock bash 3.2.
+  local -a packages=()
+  local line
+  while IFS= read -r line; do
+    packages+=("$line")
+  done < <(go list ./... | grep -v '^github.com/gastownhall/gascity/test/integration$')
   if [[ ${#packages[@]} -eq 0 ]]; then
     echo "no non-integration packages found" >&2
     exit 1
@@ -60,16 +64,22 @@ run_packages_shard() {
 }
 
 run_rest_shard() {
-  local -a all_tests rest_tests
-  local -A excluded
-  local test_name
+  # bash 3.2 has no associative arrays; encode the excluded set as a
+  # newline-delimited string and use grep -Fx to test membership.
+  local -a all_tests=() rest_tests=()
+  local excluded excluded_name test_name
 
-  mapfile -t all_tests < <(list_integration_tests)
-  for test_name in "${formula_tests[@]}" TestBdStoreConformance; do
-    excluded["$test_name"]=1
+  excluded=""
+  for excluded_name in "${formula_tests[@]}" TestBdStoreConformance; do
+    excluded+="${excluded_name}"$'\n'
   done
+
+  while IFS= read -r test_name; do
+    all_tests+=("$test_name")
+  done < <(list_integration_tests)
+
   for test_name in "${all_tests[@]}"; do
-    if [[ -z ${excluded["$test_name"]+x} ]]; then
+    if ! printf '%s' "$excluded" | grep -Fxq -- "$test_name"; then
       rest_tests+=("$test_name")
     fi
   done

--- a/test/acceptance/helpers/env.go
+++ b/test/acceptance/helpers/env.go
@@ -42,6 +42,17 @@ func NewEnv(gcBinary, gcHome, runtimeDir string) *Env {
 		e.vars["PATH"] = filepath.Dir(gcBinary) + ":" + e.vars["PATH"]
 	}
 
+	// Prepend shims for the platform service managers so `gc init` never
+	// hands the supervisor off to the real host launchd/systemd. The
+	// shims exit non-zero, which causes ensureSupervisorRunning to fall
+	// through to doSupervisorStart (bare fork). Without this on Mac,
+	// launchctl load succeeds and launchd starts a supervisor that
+	// doesn't inherit the test's isolation env vars, so the K8s session
+	// provider fires for hyperscale and fails on missing kubeconfig.
+	if shimDir, err := installServiceManagerShims(gcHome); err == nil {
+		e.vars["PATH"] = shimDir + ":" + e.vars["PATH"]
+	}
+
 	// Test isolation: HOME points to gcHome so gc never reads real user state.
 	e.vars["HOME"] = gcHome
 	e.vars["GC_HOME"] = gcHome
@@ -51,6 +62,26 @@ func NewEnv(gcBinary, gcHome, runtimeDir string) *Env {
 	e.vars["GC_SESSION"] = "subprocess"
 
 	return e
+}
+
+// installServiceManagerShims writes no-op launchctl/systemctl stubs under
+// gcHome/bin and returns that directory so the acceptance env can prepend
+// it to PATH. The stubs exit 1 so gc's supervisor-install logic falls
+// back to an in-process supervisor start instead of delegating to the
+// host's real service manager (which would also inherit the wrong env).
+func installServiceManagerShims(gcHome string) (string, error) {
+	shimDir := filepath.Join(gcHome, "bin")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		return "", err
+	}
+	const body = "#!/bin/sh\n# acceptance-test shim: force gc to bare-start the supervisor.\nexit 1\n"
+	for _, name := range []string{"launchctl", "systemctl"} {
+		p := filepath.Join(shimDir, name)
+		if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+			return "", err
+		}
+	}
+	return shimDir, nil
 }
 
 // With sets a variable, returning the Env for chaining.

--- a/test/acceptance/helpers/env.go
+++ b/test/acceptance/helpers/env.go
@@ -49,9 +49,14 @@ func NewEnv(gcBinary, gcHome, runtimeDir string) *Env {
 	// launchctl load succeeds and launchd starts a supervisor that
 	// doesn't inherit the test's isolation env vars, so the K8s session
 	// provider fires for hyperscale and fails on missing kubeconfig.
-	if shimDir, err := installServiceManagerShims(gcHome); err == nil {
-		e.vars["PATH"] = shimDir + ":" + e.vars["PATH"]
+	//
+	// Panic on failure: silently dropping the shim would look like a
+	// random hyperscale infra regression on Mac with no breadcrumb.
+	shimDir, err := installServiceManagerShims(gcHome)
+	if err != nil {
+		panic(fmt.Sprintf("acceptance: installing service-manager shims under %s: %v", gcHome, err))
 	}
+	e.vars["PATH"] = shimDir + ":" + e.vars["PATH"]
 
 	// Test isolation: HOME points to gcHome so gc never reads real user state.
 	e.vars["HOME"] = gcHome

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -16,6 +16,21 @@ import (
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
+// canonicalTempDir returns a per-test temp directory with its path
+// symlink-resolved, so agent-reported CWDs (which Go's os.Getwd already
+// canonicalizes) compare equal on macOS. Without this, every E2E
+// string-equality check between cityDir and an agent-reported path
+// fails because macOS's /var is a symlink to /private/var.
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
 // e2eAgent describes an agent for E2E tests with full config control.
 type e2eAgent struct {
 	Name              string
@@ -236,7 +251,7 @@ func setupE2ECity(t *testing.T, guard *tmuxtest.Guard, city e2eCity) string {
 		}
 	}
 
-	cityDir := filepath.Join(t.TempDir(), city.Workspace.Name)
+	cityDir := filepath.Join(canonicalTempDir(t), city.Workspace.Name)
 	configPath := filepath.Join(t.TempDir(), city.Workspace.Name+".toml")
 	if err := os.WriteFile(configPath, []byte(renderE2EToml(city)), 0o644); err != nil {
 		t.Fatalf("writing init config: %v", err)
@@ -288,7 +303,7 @@ func setupE2ECityNoStart(t *testing.T, city e2eCity) string {
 		city.Workspace.Name = uniqueCityName()
 	}
 
-	cityDir := filepath.Join(t.TempDir(), city.Workspace.Name)
+	cityDir := filepath.Join(canonicalTempDir(t), city.Workspace.Name)
 	configPath := filepath.Join(t.TempDir(), city.Workspace.Name+".toml")
 	if err := os.WriteFile(configPath, []byte(renderE2EToml(city)), 0o644); err != nil {
 		t.Fatalf("writing init config: %v", err)

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -252,7 +252,10 @@ func setupE2ECity(t *testing.T, guard *tmuxtest.Guard, city e2eCity) string {
 	}
 
 	cityDir := filepath.Join(canonicalTempDir(t), city.Workspace.Name)
-	configPath := filepath.Join(t.TempDir(), city.Workspace.Name+".toml")
+	// configPath doesn't need canonicalization today (no test compares it
+	// to agent output), but keep it symmetric so future assertions don't
+	// regress on macOS's /var→/private/var symlink.
+	configPath := filepath.Join(canonicalTempDir(t), city.Workspace.Name+".toml")
 	if err := os.WriteFile(configPath, []byte(renderE2EToml(city)), 0o644); err != nil {
 		t.Fatalf("writing init config: %v", err)
 	}
@@ -304,7 +307,7 @@ func setupE2ECityNoStart(t *testing.T, city e2eCity) string {
 	}
 
 	cityDir := filepath.Join(canonicalTempDir(t), city.Workspace.Name)
-	configPath := filepath.Join(t.TempDir(), city.Workspace.Name+".toml")
+	configPath := filepath.Join(canonicalTempDir(t), city.Workspace.Name+".toml")
 	if err := os.WriteFile(configPath, []byte(renderE2EToml(city)), 0o644); err != nil {
 		t.Fatalf("writing init config: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Expand `mac-regression.yml` so the self-hosted macOS/ARM64 runner runs the same gates Linux runs: `make lint`, `make fmt-check`, `make vet`, `make check-docs`, `make test`, `make test-acceptance`, `make test-cover`, and the integration shards (packages / bdstore / rest, with review-formulas on the nightly schedule only).
- Add `.github/actions/setup-gascity-macos` composite action — the Darwin analogue of `setup-gascity-ubuntu`. Installs pinned Go / Node / dolt / bd, uses `brew` for `tmux`, `jq`, and `flock`, and drops the binaries under `$RUNNER_TOOL_CACHE` so nothing needs sudo on the self-hosted runner.
- Triggers unchanged: Mac jobs only run when a PR carries the `needs-mac` label, the nightly schedule fires, or a maintainer manually dispatches the workflow.

Before this PR, Mac CI ran just `make test` and platform-specific regressions showed up at release time; Linux ran every gate. The expanded matrix is deliberately gated on `needs-mac`/nightly so regular PRs don't pay the Mac-runner cost, but any contributor who opts in gets full coverage across both platforms.

The `mac-cover` and `mac-integration` shards start as `continue-on-error: true` while we shake out Mac-specific failures — the aggregate `mac-regression-summary` job still enforces the quality / unit / acceptance gates strictly. Once the shards go green on Mac we can flip them to required.

## Test plan

- [ ] `mac-quality` passes — `make lint`, `make fmt-check`, `make vet`, `make check-docs` on the self-hosted runner
- [ ] `mac-unit` passes — `make test`
- [ ] `mac-acceptance` passes — `make test-acceptance` (Tier A)
- [ ] `mac-cover` runs (continue-on-error) — `make test-cover` ; triage any new Mac-only failures
- [ ] `mac-integration` shards (packages / bdstore / rest) run — triage any platform-specific failures
- [ ] `mac-regression-summary` reports the overall status on the PR
- [ ] Nightly schedule also runs the `full-only` shards (review-formulas) without the `needs-mac` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)