### PR TITLE
fix(doctor): register convergence custom type + merge-preserve on --fix

### DIFF
--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -295,8 +295,9 @@ case "$op" in
     GC_STORE_ROOT="$scope_root" run_bd config set issue_prefix "$prefix" >/dev/null 2>&1 || true
     # Register custom bead types required by Gas City (mirrors gc-beads-bd
     # and doctor.RequiredCustomTypes). Without this, bd rejects creates for
-    # types like "session" that aren't in the default set.
-    custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec}"
+    # types like "session" that aren't in the default set. "convergence" is
+    # required because gc's convergence handler creates beads with that type.
+    custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
     GC_STORE_ROOT="$scope_root" run_bd config set types.custom "$custom_types" >/dev/null 2>&1 || true
     ;;
 

--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -206,7 +206,8 @@ case "$op" in
       if [ -n "$CUSTOM_TYPES" ]; then
         run_bd config set types.custom "$CUSTOM_TYPES" >/dev/null 2>&1 || true
       else
-        custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec}"
+        # Must match the init-branch default below and doctor.RequiredCustomTypes.
+        custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
         run_bd config set types.custom "$custom_types" >/dev/null 2>&1 || true
       fi
       exit 0

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1547,7 +1547,9 @@ op_init() {
 
     # Custom bead types for bd (extracted from beads core in v0.46.0).
     # GC_BEADS_CUSTOM_TYPES overrides the default SDK set.
-    local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec}"
+    # "convergence" is required because gc's convergence handler creates
+    # beads with that type — must match doctor.RequiredCustomTypes.
+    local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
 
     # If already initialized on disk, ensure the database is also registered
     # with the running server. This covers the case where bd init created the

--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -105,45 +106,68 @@ func (c *CustomTypesCheck) Fix(_ *CheckContext) error {
 		return nil
 	}
 	// Read the current list so we can preserve user-added types.
+	// If we cannot read it, return the error rather than overwriting —
+	// silently dropping user types is worse than failing loud.
 	current, err := getCustomTypes(c.Dir)
 	if err != nil {
-		// If we cannot read the current list, fall back to writing just the
-		// required list. This is a degraded but safe path.
-		return setCustomTypes(c.Dir, strings.Join(RequiredCustomTypes, ","))
+		return fmt.Errorf("reading current custom types: %w", err)
 	}
+	merged := mergeCustomTypes(current, RequiredCustomTypes)
+	return setCustomTypes(c.Dir, strings.Join(merged, ","))
+}
 
-	// Build the merged list: start with the current (preserved) types,
-	// then append any missing required types.
-	currentSet := make(map[string]bool, len(current))
-	var merged []string
+// mergeCustomTypes returns the union of current and required, in order:
+// current entries first (preserving user order), then any required entries
+// not already present. Empty/whitespace-only entries are dropped and
+// duplicates are removed.
+func mergeCustomTypes(current, required []string) []string {
+	seen := make(map[string]bool, len(current)+len(required))
+	merged := make([]string, 0, len(current)+len(required))
 	for _, t := range current {
 		trimmed := strings.TrimSpace(t)
 		if trimmed == "" {
 			continue
 		}
-		if !currentSet[trimmed] {
-			currentSet[trimmed] = true
-			merged = append(merged, trimmed)
+		if seen[trimmed] {
+			continue
 		}
+		seen[trimmed] = true
+		merged = append(merged, trimmed)
 	}
-	for _, req := range RequiredCustomTypes {
-		if !currentSet[req] {
-			currentSet[req] = true
-			merged = append(merged, req)
+	for _, req := range required {
+		if seen[req] {
+			continue
 		}
+		seen[req] = true
+		merged = append(merged, req)
 	}
-	return setCustomTypes(c.Dir, strings.Join(merged, ","))
+	return merged
 }
 
 // getCustomTypes reads the current types.custom config from a bd store.
+// Uses --json so an unset key returns an empty string value rather than
+// the human-readable "types.custom (not set)" sentinel (which would
+// otherwise be persisted as a fake custom type when Fix() merges).
 func getCustomTypes(dir string) ([]string, error) {
-	cmd := exec.Command("bd", "config", "get", "types.custom")
+	cmd := exec.Command("bd", "config", "get", "--json", "types.custom")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
-	raw := strings.TrimSpace(string(out))
+	return parseCustomTypesJSON(out)
+}
+
+// parseCustomTypesJSON decodes the output of `bd config get --json types.custom`
+// into a list of types. Empty values yield nil (not []string{""}).
+func parseCustomTypesJSON(out []byte) ([]string, error) {
+	var parsed struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing bd config get output: %w", err)
+	}
+	raw := strings.TrimSpace(parsed.Value)
 	if raw == "" {
 		return nil, nil
 	}

--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -10,9 +10,15 @@ import (
 
 // RequiredCustomTypes lists the bead types that Gas City requires
 // to be registered with every bd store (city + rigs).
+//
+// "convergence" is included because gc's convergence handler
+// (internal/convergence/create.go) creates beads with type="convergence"
+// as the root of every convergence loop. Without it registered, every
+// `gc converge create` call fails with "invalid issue type: convergence".
 var RequiredCustomTypes = []string{
 	"molecule", "convoy", "message", "event", "gate",
 	"merge-request", "agent", "role", "rig", "session", "spec",
+	"convergence",
 }
 
 // CustomTypesCheck verifies that all required Gas City custom bead
@@ -86,13 +92,47 @@ func (c *CustomTypesCheck) Run(_ *CheckContext) *CheckResult {
 // CanFix returns true — missing types can be registered.
 func (c *CustomTypesCheck) CanFix() bool { return true }
 
-// Fix registers all required custom types with the bd store.
+// Fix registers any missing required custom types with the bd store,
+// preserving any additional custom types the user has already added.
+//
+// This function MUST merge — not overwrite — because a city may have
+// additional custom types registered beyond the RequiredCustomTypes
+// baseline (e.g., pack-specific types, user-defined types). Overwriting
+// would silently delete those, causing failures the next time code tries
+// to create beads of the deleted types.
 func (c *CustomTypesCheck) Fix(_ *CheckContext) error {
 	if len(c.missing) == 0 {
 		return nil
 	}
-	fullList := strings.Join(RequiredCustomTypes, ",")
-	return setCustomTypes(c.Dir, fullList)
+	// Read the current list so we can preserve user-added types.
+	current, err := getCustomTypes(c.Dir)
+	if err != nil {
+		// If we cannot read the current list, fall back to writing just the
+		// required list. This is a degraded but safe path.
+		return setCustomTypes(c.Dir, strings.Join(RequiredCustomTypes, ","))
+	}
+
+	// Build the merged list: start with the current (preserved) types,
+	// then append any missing required types.
+	currentSet := make(map[string]bool, len(current))
+	var merged []string
+	for _, t := range current {
+		trimmed := strings.TrimSpace(t)
+		if trimmed == "" {
+			continue
+		}
+		if !currentSet[trimmed] {
+			currentSet[trimmed] = true
+			merged = append(merged, trimmed)
+		}
+	}
+	for _, req := range RequiredCustomTypes {
+		if !currentSet[req] {
+			currentSet[req] = true
+			merged = append(merged, req)
+		}
+	}
+	return setCustomTypes(c.Dir, strings.Join(merged, ","))
 }
 
 // getCustomTypes reads the current types.custom config from a bd store.

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -63,6 +64,123 @@ func TestCustomTypesCheck_RequiredTypesIncludeConvergence(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("RequiredCustomTypes must include 'convergence' — gc's convergence handler requires this type")
+	}
+}
+
+// TestMergeCustomTypes exercises the merge/dedup/preservation logic that
+// backs CustomTypesCheck.Fix(). The regression it guards against is
+// `--fix` overwriting user-defined types (which was the pre-PR behavior
+// and still the failure mode if the merge is ever reverted).
+func TestMergeCustomTypes(t *testing.T) {
+	cases := []struct {
+		name     string
+		current  []string
+		required []string
+		want     []string
+	}{
+		{
+			name:     "empty current gets required only",
+			current:  nil,
+			required: []string{"a", "b"},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "preserves extra user types and appends missing required",
+			current:  []string{"custom-foo", "molecule"},
+			required: []string{"molecule", "spec", "convergence"},
+			want:     []string{"custom-foo", "molecule", "spec", "convergence"},
+		},
+		{
+			name:     "dedupes duplicates in current",
+			current:  []string{"a", "a", "b", "a"},
+			required: []string{"c"},
+			want:     []string{"a", "b", "c"},
+		},
+		{
+			name:     "drops empty and whitespace-only entries",
+			current:  []string{"a", "", "  ", "b"},
+			required: []string{"c"},
+			want:     []string{"a", "b", "c"},
+		},
+		{
+			name:     "trims whitespace around entries",
+			current:  []string{" a ", "b\t"},
+			required: []string{"a", "c"},
+			want:     []string{"a", "b", "c"},
+		},
+		{
+			name:     "dedupes when required entry already in current",
+			current:  []string{"a", "b", "c"},
+			required: []string{"b", "c", "d"},
+			want:     []string{"a", "b", "c", "d"},
+		},
+		{
+			name:     "preserves order of current entries",
+			current:  []string{"z", "y", "x"},
+			required: []string{"a"},
+			want:     []string{"z", "y", "x", "a"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeCustomTypes(tc.current, tc.required)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergeCustomTypes(%v, %v) = %v, want %v",
+					tc.current, tc.required, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseCustomTypesJSON guards against the regression where
+// `bd config get types.custom` on a store with an unset key returns
+// "types.custom (not set)" and the old parser would persist that
+// string as a fake custom type when Fix() merges. Switching to
+// --json (+ this parser) eliminates the sentinel.
+func TestParseCustomTypesJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "unset key returns nil",
+			input: `{"key":"types.custom","value":""}`,
+			want:  nil,
+		},
+		{
+			name:  "whitespace-only value returns nil",
+			input: `{"key":"types.custom","value":"   "}`,
+			want:  nil,
+		},
+		{
+			name:  "populated value splits on comma",
+			input: `{"key":"types.custom","value":"molecule,spec,convergence"}`,
+			want:  []string{"molecule", "spec", "convergence"},
+		},
+		{
+			name:    "malformed JSON errors",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseCustomTypesJSON([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (result=%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseCustomTypesJSON(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -47,12 +47,31 @@ func TestCustomTypesCheck_RequiredTypesIncludeSpec(t *testing.T) {
 	}
 }
 
+// TestCustomTypesCheck_RequiredTypesIncludeConvergence verifies that
+// "convergence" is in the required list. gc's convergence handler
+// (internal/convergence/create.go) creates beads with Type="convergence"
+// on every `gc converge create` call; if the type isn't registered in
+// bd's types.custom, every convergence loop fails at creation with
+// "invalid issue type: convergence".
+func TestCustomTypesCheck_RequiredTypesIncludeConvergence(t *testing.T) {
+	found := false
+	for _, typ := range RequiredCustomTypes {
+		if typ == "convergence" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("RequiredCustomTypes must include 'convergence' — gc's convergence handler requires this type")
+	}
+}
+
 func TestCustomTypesCheck_RequiredTypesComplete(t *testing.T) {
 	expected := map[string]bool{
 		"molecule": true, "convoy": true, "message": true,
 		"event": true, "gate": true, "merge-request": true,
 		"agent": true, "role": true, "rig": true,
-		"session": true, "spec": true,
+		"session": true, "spec": true, "convergence": true,
 	}
 	for _, typ := range RequiredCustomTypes {
 		if !expected[typ] {


### PR DESCRIPTION
## Summary

- `internal/convergence/create.go` has always created beads with `Type="convergence"`, but `"convergence"` was missing from `doctor.RequiredCustomTypes` (and the two bd-init helper scripts' defaults). On a freshly-initialized city, every `gc converge create` call fails with `invalid issue type: convergence`.
- This PR registers `convergence` in the required list and in both shell-side init defaults.
- While doing so, `CustomTypesCheck.Fix` is rewritten to **merge** the required types with whatever the store already has, rather than overwriting. The previous `Fix` would silently drop any pack-specific or user-defined custom types a city had registered beyond the required baseline. Now that adding `convergence` to `RequiredCustomTypes` will trigger `Fix` on existing cities, this safety fix prevents a regression for anyone running `gc doctor --fix` with extra custom types.

## Motivation

Bootstrapping a city that uses convergence for a council-based deliberation loop surfaced this gap. `gc converge create` failed at the first call; tracing it back led to the missing type registration.

## Changes

| File | Change |
|------|--------|
| `internal/doctor/checks_custom_types.go` | add `\"convergence\"` to `RequiredCustomTypes`; rewrite `Fix` to preserve existing custom types by merging |
| `internal/doctor/checks_custom_types_test.go` | add `TestCustomTypesCheck_RequiredTypesIncludeConvergence`; extend `TestCustomTypesCheck_RequiredTypesComplete` with the new type |
| `cmd/gc/gc-beads-bd` | keep the shell-side custom_types default in sync with the Go list |
| `contrib/beads-scripts/gc-beads-k8s` | same, for the k8s helper |

## Test plan

- [x] `go build ./cmd/gc` — compiles clean against `v0.15.0-rc2-3`
- [x] `go test ./internal/doctor/...` — new test passes, existing tests still green
- [ ] Reviewer: confirm `gc converge create` on a freshly-inited city succeeds after this change (previously fails on the first call with the type error)
- [ ] Reviewer: confirm `gc doctor --fix` on a city with extra user-registered custom types preserves them (previously would overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)