### PR TITLE
fix: include V2 binding name in /v0/config agent response

### DIFF
--- a/internal/api/handler_config.go
+++ b/internal/api/handler_config.go
@@ -58,13 +58,25 @@ type configPatchesResponse struct {
 	ProviderCount int `json:"provider_count"`
 }
 
+// agentResponseName returns the name an API client should use as the agent's
+// identity within a (optional) rig scope. For V2 imported agents this prefixes
+// the bare Name with BindingName so callers can reconstruct the same qualified
+// identity that appears in session.template (e.g. "gastown.mayor"). Keeping
+// Dir separate preserves the existing `dir/name` reconstruction contract.
+func agentResponseName(a config.Agent) string {
+	if a.BindingName == "" {
+		return a.Name
+	}
+	return a.BindingName + "." + a.Name
+}
+
 func (s *Server) handleConfigGet(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.state.Config()
 
 	agents := make([]configAgentResponse, 0, len(cfg.Agents))
 	for _, a := range cfg.Agents {
 		agents = append(agents, configAgentResponse{
-			Name:      a.Name,
+			Name:      agentResponseName(a),
 			Dir:       a.Dir,
 			Provider:  a.Provider,
 			IsPool:    isMultiSessionAgent(a),
@@ -146,7 +158,7 @@ func (s *Server) handleConfigExplain(w http.ResponseWriter, _ *http.Request) {
 		origin := agentOrigin(a, rawCfg, cfg)
 		agents = append(agents, annotatedAgent{
 			configAgentResponse: configAgentResponse{
-				Name:      a.Name,
+				Name:      agentResponseName(a),
 				Dir:       a.Dir,
 				Provider:  a.Provider,
 				IsPool:    isMultiSessionAgent(a),

--- a/internal/api/handler_config.go
+++ b/internal/api/handler_config.go
@@ -58,25 +58,13 @@ type configPatchesResponse struct {
 	ProviderCount int `json:"provider_count"`
 }
 
-// agentResponseName returns the name an API client should use as the agent's
-// identity within a (optional) rig scope. For V2 imported agents this prefixes
-// the bare Name with BindingName so callers can reconstruct the same qualified
-// identity that appears in session.template (e.g. "gastown.mayor"). Keeping
-// Dir separate preserves the existing `dir/name` reconstruction contract.
-func agentResponseName(a config.Agent) string {
-	if a.BindingName == "" {
-		return a.Name
-	}
-	return a.BindingName + "." + a.Name
-}
-
 func (s *Server) handleConfigGet(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.state.Config()
 
 	agents := make([]configAgentResponse, 0, len(cfg.Agents))
 	for _, a := range cfg.Agents {
 		agents = append(agents, configAgentResponse{
-			Name:      agentResponseName(a),
+			Name:      a.BindingQualifiedName(),
 			Dir:       a.Dir,
 			Provider:  a.Provider,
 			IsPool:    isMultiSessionAgent(a),
@@ -158,7 +146,7 @@ func (s *Server) handleConfigExplain(w http.ResponseWriter, _ *http.Request) {
 		origin := agentOrigin(a, rawCfg, cfg)
 		agents = append(agents, annotatedAgent{
 			configAgentResponse: configAgentResponse{
-				Name:      agentResponseName(a),
+				Name:      a.BindingQualifiedName(),
 				Dir:       a.Dir,
 				Provider:  a.Provider,
 				IsPool:    isMultiSessionAgent(a),

--- a/internal/api/handler_config_test.go
+++ b/internal/api/handler_config_test.go
@@ -226,6 +226,93 @@ func TestHandleConfigValidate_InvalidServiceRuntimeSupport(t *testing.T) {
 	}
 }
 
+func TestHandleConfigGet_V2BindingNameIncludedInAgentName(t *testing.T) {
+	// V2 imported agents carry a BindingName that's runtime-only (json:"-").
+	// The config response still needs to expose it so clients can
+	// reconstruct the same qualified identity that appears in
+	// session.template — otherwise downstream filters (e.g. gasworks-gui's
+	// CityInfo session bucket) compare "mayor" against "gastown.mayor" and
+	// drop the session.
+	fs := newFakeState(t)
+	fs.cfg.Agents = []config.Agent{
+		// City-scoped V2 agent: Dir="", BindingName set.
+		{Name: "mayor", BindingName: "gastown", Provider: "claude"},
+		// Rig-scoped V2 agent: Dir="myrig", BindingName set.
+		{Name: "polecat", Dir: "myrig", BindingName: "gastown", Provider: "claude"},
+		// V1 agent (no binding): Name must pass through unchanged.
+		{Name: "worker", Dir: "myrig", Provider: "claude"},
+	}
+	srv := New(fs)
+
+	req := httptest.NewRequest("GET", "/v0/config", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp configResponse
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+
+	if len(resp.Agents) != 3 {
+		t.Fatalf("agents count = %d, want 3", len(resp.Agents))
+	}
+
+	// City-scoped V2: name should include binding, dir stays empty so
+	// qualified identity reconstructs as "gastown.mayor".
+	if got, want := resp.Agents[0].Name, "gastown.mayor"; got != want {
+		t.Errorf("city V2 agent name = %q, want %q", got, want)
+	}
+	if got := resp.Agents[0].Dir; got != "" {
+		t.Errorf("city V2 agent dir = %q, want empty", got)
+	}
+
+	// Rig-scoped V2: name includes binding, dir stays on Dir so
+	// qualified identity reconstructs as "myrig/gastown.polecat".
+	if got, want := resp.Agents[1].Name, "gastown.polecat"; got != want {
+		t.Errorf("rig V2 agent name = %q, want %q", got, want)
+	}
+	if got, want := resp.Agents[1].Dir, "myrig"; got != want {
+		t.Errorf("rig V2 agent dir = %q, want %q", got, want)
+	}
+
+	// V1 agent: no binding → name passes through unchanged.
+	if got, want := resp.Agents[2].Name, "worker"; got != want {
+		t.Errorf("V1 agent name = %q, want %q", got, want)
+	}
+	if got, want := resp.Agents[2].Dir, "myrig"; got != want {
+		t.Errorf("V1 agent dir = %q, want %q", got, want)
+	}
+}
+
+func TestHandleConfigExplain_V2BindingNameIncludedInAgentName(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cfg.Agents = []config.Agent{
+		{Name: "mayor", BindingName: "gastown", Provider: "claude"},
+	}
+	srv := New(fs)
+
+	req := httptest.NewRequest("GET", "/v0/config/explain", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+	agents := resp["agents"].([]any)
+	if len(agents) != 1 {
+		t.Fatalf("agents count = %d, want 1", len(agents))
+	}
+	agent0 := agents[0].(map[string]any)
+	if got, want := agent0["name"], "gastown.mayor"; got != want {
+		t.Errorf("explain agent name = %q, want %q", got, want)
+	}
+}
+
 func TestHandleConfigExplain_PackDerivedAgent(t *testing.T) {
 	fs := newFakeState(t)
 	// Simulate pack-derived agent: present in expanded config (cfg) but

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,14 +38,24 @@ func ControlDispatcherStartCommandFor(qualifiedName string) string {
 	return `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
 }
 
+// BindingQualifiedName returns the agent's identity within its (optional)
+// rig scope: "binding.name" for V2 imported agents, bare "name" for V1.
+// This is the leaf half of QualifiedName — Dir is not included. Use this
+// when rendering the agent into surfaces that already carry Dir separately
+// (e.g. the /v0/config response, where Dir and Name are emitted as distinct
+// JSON fields and clients reassemble "dir/name").
+func (a *Agent) BindingQualifiedName() string {
+	if a.BindingName == "" {
+		return a.Name
+	}
+	return a.BindingName + "." + a.Name
+}
+
 // QualifiedName returns the agent's canonical identity.
 // V1: "hello-world/polecat" (rig-scoped) or "mayor" (city-wide).
 // V2 with binding: "hello-world/gastown.polecat" or "gastown.mayor".
 func (a *Agent) QualifiedName() string {
-	name := a.Name
-	if a.BindingName != "" {
-		name = a.BindingName + "." + a.Name
-	}
+	name := a.BindingQualifiedName()
 	if a.Dir == "" {
 		return name
 	}

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -1777,37 +1777,44 @@ func TestAgentMatchesIdentity(t *testing.T) {
 
 func TestQualifiedName_WithBindingName(t *testing.T) {
 	tests := []struct {
-		name   string
-		agent  Agent
-		wantQN string
+		name    string
+		agent   Agent
+		wantQN  string
+		wantBQN string
 	}{
 		{
-			name:   "bare name, no binding, no dir",
-			agent:  Agent{Name: "mayor"},
-			wantQN: "mayor",
+			name:    "bare name, no binding, no dir",
+			agent:   Agent{Name: "mayor"},
+			wantQN:  "mayor",
+			wantBQN: "mayor",
 		},
 		{
-			name:   "with dir, no binding",
-			agent:  Agent{Name: "mayor", Dir: "proj"},
-			wantQN: "proj/mayor",
+			name:    "with dir, no binding",
+			agent:   Agent{Name: "mayor", Dir: "proj"},
+			wantQN:  "proj/mayor",
+			wantBQN: "mayor",
 		},
 		{
-			name:   "with binding, no dir",
-			agent:  Agent{Name: "mayor", BindingName: "gastown"},
-			wantQN: "gastown.mayor",
+			name:    "with binding, no dir",
+			agent:   Agent{Name: "mayor", BindingName: "gastown"},
+			wantQN:  "gastown.mayor",
+			wantBQN: "gastown.mayor",
 		},
 		{
-			name:   "with binding and dir",
-			agent:  Agent{Name: "polecat", BindingName: "gastown", Dir: "proj"},
-			wantQN: "proj/gastown.polecat",
+			name:    "with binding and dir",
+			agent:   Agent{Name: "polecat", BindingName: "gastown", Dir: "proj"},
+			wantQN:  "proj/gastown.polecat",
+			wantBQN: "gastown.polecat",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.agent.QualifiedName()
-			if got != tt.wantQN {
+			if got := tt.agent.QualifiedName(); got != tt.wantQN {
 				t.Errorf("QualifiedName() = %q, want %q", got, tt.wantQN)
+			}
+			if got := tt.agent.BindingQualifiedName(); got != tt.wantBQN {
+				t.Errorf("BindingQualifiedName() = %q, want %q", got, tt.wantBQN)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

PackV2 imported agents carry a runtime-only `BindingName` field (`json:"-"`) that never reached API consumers. `/v0/config` was emitting `{name:"mayor", dir:""}` while the sibling `/v0/sessions` was emitting `template:"gastown.mayor"`. Any consumer that cross-checks the two — notably **gasworks-gui's CityInfo session bucket** (`server/src/services/gc.rs::build_city_info`) — dropped imported-agent sessions from its sidebar because `template_names.contains(&"gastown.mayor")` is false when the config only advertises `"mayor"`.

- **Fix:** `/v0/config` and `/v0/config/explain` now emit `name: "gastown.mayor"` (and `"myrig/gastown.polecat"` via `dir + "/" + name`) for V2 imported agents. V1 agents with no binding are unchanged.
- **Refactor:** hoist the binding-prefix step from a local handler helper into a new exported method `Agent.BindingQualifiedName()` on `config.Agent`, and route `QualifiedName()` through it so the two can't drift. Addresses codex review finding (avoid a second hand-coded identity formatter).

The downstream gasworks-gui bug ("imported-pack sessions don't show up in the sidebar") is resolved by this change alone — no gasworks-gui changes required. A sibling PR at gascity/gasworks-gui#38 fixes a separate PackV2-adjacent bug in that repo (`agentDefaults.<agent>.<field>` key parser misparsing dotted agent names).

## Review

Ran `/review-pr` (dual-model: Claude + Codex; Gemini hit rate limits). No blockers, no majors. Minor findings addressed:
- Codex: don't duplicate identity-formatting logic → addressed in the second commit via `BindingQualifiedName()`.
- Codex: patch surface docs still describe `name` as the raw field → tracked separately; out of scope.
- Codex: missing cross-endpoint regression test → noted; needs integration test infra.

## Test plan

- [x] `go vet ./internal/api/ ./internal/config/` clean
- [x] `go test ./internal/api/ ./internal/config/` passes (full package suites, including new `TestHandleConfigGet_V2BindingNameIncludedInAgentName`, `TestHandleConfigExplain_V2BindingNameIncludedInAgentName`, and extended `TestQualifiedName_WithBindingName` asserting `BindingQualifiedName()` for V1/V2 × city/rig combinations)
- [ ] Manual: confirm imported-pack sessions reappear in gasworks-gui sidebar after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)