### PR TITLE
fix: omit empty GC_ALIAS from RuntimeEnvWithAlias

### DIFF
--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -41,10 +41,14 @@ func RuntimeEnv(sessionID, sessionName string, generation, continuationEpoch int
 
 // RuntimeEnvWithAlias extends RuntimeEnv with the public session alias.
 // Alias-aware commands use GC_ALIAS as their canonical mailbox/target
-// identity; an explicit empty value clears stale template defaults.
+// identity. An empty alias (e.g. pool workers) is omitted so that
+// consumers fall through to GC_SESSION_ID cleanly; clearing a stale
+// alias on a live runtime is the job of SyncRuntimeAlias.
 func RuntimeEnvWithAlias(sessionID, sessionName, alias string, generation, continuationEpoch int, instanceToken string) map[string]string {
 	env := RuntimeEnv(sessionID, sessionName, generation, continuationEpoch, instanceToken)
-	env["GC_ALIAS"] = alias
+	if alias != "" {
+		env["GC_ALIAS"] = alias
+	}
 	return env
 }
 

--- a/internal/session/lifecycle_test.go
+++ b/internal/session/lifecycle_test.go
@@ -1,0 +1,17 @@
+package session
+
+import "testing"
+
+func TestRuntimeEnvWithAliasOmitsEmptyAlias(t *testing.T) {
+	env := RuntimeEnvWithAlias("sid", "sname", "", DefaultGeneration, DefaultContinuationEpoch, "tok")
+	if _, ok := env["GC_ALIAS"]; ok {
+		t.Fatalf("GC_ALIAS should be absent when alias is empty; got %q", env["GC_ALIAS"])
+	}
+}
+
+func TestRuntimeEnvWithAliasSetsNonEmptyAlias(t *testing.T) {
+	env := RuntimeEnvWithAlias("sid", "sname", "mayor", DefaultGeneration, DefaultContinuationEpoch, "tok")
+	if got := env["GC_ALIAS"]; got != "mayor" {
+		t.Fatalf("GC_ALIAS = %q, want %q", got, "mayor")
+	}
+}


### PR DESCRIPTION
## Summary

`internal/session/lifecycle.go` — `RuntimeEnvWithAlias` now omits `GC_ALIAS` when the alias is `""`. Previously it wrote `env["GC_ALIAS"] = ""` unconditionally, which broke `gc mail send` sender resolution for pool workers (ants, dogs, scout-builders) that have no registered alias.

## Symptom

Pool workers hit:
```
gc mail send: invalid sender "": session not found: "<template-or-guess>"
```

Concrete case: an ant on `bug-sherrif` in worktree `.gc/worktrees/bug-sherrif/ants/ant-1` ran `gc mail send bug-sherrif/cricket -s ...`. First attempt failed with an empty-sender error; the ant then guessed `--from bug-sherrif/ant-1` from its worktree path, which also failed because that string isn't a registered session identity.

## Root cause

`RuntimeEnvWithAlias` builds a fresh env map per call and was writing the alias unconditionally. The doc-comment justified that as *"an explicit empty value clears stale template defaults"* — but clearing stale state is the job of the update path (`SyncRuntimeAlias`), which already handles empty correctly by calling `RemoveMeta`. On the create path there is no prior state to clobber, so the empty write is pure noise that downstream `defaultMailIdentity` then has to paper over.

This PR makes the two paths symmetric: skip the write when alias is `""`.

## Testing

- [x] `make check` (exit 0)
- [x] New `internal/session/lifecycle_test.go` with two cases: empty alias omits `GC_ALIAS`; non-empty alias sets it.
- [ ] `make check-docs` — no docs/nav/link changes
- [ ] `make test-integration` — no runtime/controller/workflow behavior changes

Live acceptance (from the handoff) — spawn a pool worker, confirm `env | grep GC_ALIAS` returns nothing, confirm `gc mail send <someone> -s test -m test` succeeds without `--from`. Not run in this PR because city_hy currently has no unaliased sessions running (all named sessions have aliases; dogs scaled to 0). Static reasoning: the fix is a single conditional and the unit test asserts the map contents directly.

## Checklist

- [x] Linked context from handoff
- [x] Added tests for behavior change
- [ ] Updated docs for user-facing changes — no user-facing surface change; pool workers stop misbehaving
- [ ] Breaking changes / migration notes — none; any caller that actually wanted `GC_ALIAS=""` set as a signal was relying on a side effect that only `SyncRuntimeAlias` was supposed to produce

Note: handoff suggested filing a `bd` bug first, but `bd where` in this repo returns no active workspace — skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>