### PR TITLE
fix: restore bare-name attach for V2-bound named sessions (#800)

### DIFF
--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -405,6 +405,109 @@ func TestResolveSessionIDMaterializingNamed_MaterializesConfiguredNamedSession(t
 	}
 }
 
+// TestResolveSessionIDMaterializingNamed_BareNameResolvesV2BoundNamedSession
+// guards against the regression reported in #800: after packs V2, imported
+// named sessions carry a BindingName (e.g. "gastown.mayor"). Users who
+// previously typed `gc session attach mayor` must still resolve to the
+// binding-qualified identity so they don't have to type the full
+// "gastown.mayor" form.
+func TestResolveSessionIDMaterializingNamed_BareNameResolvesV2BoundNamedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			BindingName:  "gastown",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "mayor",
+			BindingName: "gastown",
+		}},
+	}
+	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	spec, ok := findNamedSessionSpec(cfg, cityName, "gastown.mayor")
+	if !ok {
+		t.Fatal("findNamedSessionSpec(gastown.mayor) = false")
+	}
+	existing, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":               spec.SessionName,
+			"template":                   "gastown.mayor",
+			"agent_name":                 "gastown.mayor",
+			"state":                      "asleep",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "gastown.mayor",
+			namedSessionModeMetadata:     spec.Mode,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(): %v", err)
+	}
+
+	id, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, "mayor")
+	if err != nil {
+		t.Fatalf("resolveSessionIDMaterializingNamed(mayor): %v", err)
+	}
+	if id != existing.ID {
+		t.Fatalf("resolveSessionIDMaterializingNamed(mayor) = %q, want %q", id, existing.ID)
+	}
+}
+
+// TestResolveSessionIDMaterializingNamed_FullyQualifiedStillResolvesV2BoundNamedSession
+// confirms that the qualified form keeps working alongside the bare-name
+// convenience path.
+func TestResolveSessionIDMaterializingNamed_FullyQualifiedStillResolvesV2BoundNamedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			BindingName:  "gastown",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "mayor",
+			BindingName: "gastown",
+		}},
+	}
+	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	spec, ok := findNamedSessionSpec(cfg, cityName, "gastown.mayor")
+	if !ok {
+		t.Fatal("findNamedSessionSpec(gastown.mayor) = false")
+	}
+	existing, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":               spec.SessionName,
+			"template":                   "gastown.mayor",
+			"agent_name":                 "gastown.mayor",
+			"state":                      "asleep",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "gastown.mayor",
+			namedSessionModeMetadata:     spec.Mode,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(): %v", err)
+	}
+
+	id, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, "gastown.mayor")
+	if err != nil {
+		t.Fatalf("resolveSessionIDMaterializingNamed(gastown.mayor): %v", err)
+	}
+	if id != existing.ID {
+		t.Fatalf("resolveSessionIDMaterializingNamed(gastown.mayor) = %q, want %q", id, existing.ID)
+	}
+}
+
 func TestResolveSessionIDMaterializingNamed_AdoptsCanonicalRuntimeSessionNameBead(t *testing.T) {
 	store := beads.NewMemStore()
 	cityPath := t.TempDir()

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -130,7 +130,73 @@ func ResolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, 
 	if found {
 		return matched, true, nil
 	}
+
+	// Bare-name fallback for V2 imports. When target is unqualified (no
+	// "/") but no direct match succeeded, accept a short name that maps
+	// unambiguously to a single in-scope configured named session. This
+	// preserves the pre-packs-V2 UX where `gc session attach mayor`
+	// resolves to the sole configured `gastown.mayor` named session.
+	// A rig-scoped named session is only in scope when the caller is
+	// inside that rig, matching the rig-scoping rules the agent-template
+	// resolver used before the session-model refactor.
+	if !strings.Contains(target, "/") {
+		var rigMatch, cityMatch NamedSessionSpec
+		rigFound, rigAmbiguous := false, false
+		cityFound, cityAmbiguous := false, false
+		for i := range cfg.NamedSessions {
+			ns := &cfg.NamedSessions[i]
+			if namedSessionBareName(ns) != target {
+				continue
+			}
+			spec, ok := FindNamedSessionSpec(cfg, cityName, ns.QualifiedName())
+			if !ok {
+				continue
+			}
+			switch {
+			case ns.Dir == "":
+				if cityFound && cityMatch.Identity != spec.Identity {
+					cityAmbiguous = true
+				}
+				cityMatch = spec
+				cityFound = true
+			case rigContext != "" && ns.Dir == rigContext:
+				if rigFound && rigMatch.Identity != spec.Identity {
+					rigAmbiguous = true
+				}
+				rigMatch = spec
+				rigFound = true
+			}
+		}
+		if rigFound {
+			if rigAmbiguous {
+				return NamedSessionSpec{}, false, fmt.Errorf("%w: %q matches multiple configured named sessions", ErrAmbiguous, target)
+			}
+			return rigMatch, true, nil
+		}
+		if cityFound {
+			if cityAmbiguous {
+				return NamedSessionSpec{}, false, fmt.Errorf("%w: %q matches multiple configured named sessions", ErrAmbiguous, target)
+			}
+			return cityMatch, true, nil
+		}
+	}
+
 	return NamedSessionSpec{}, false, nil
+}
+
+// namedSessionBareName returns the unqualified public leaf name for a
+// configured named session — the part a user would type without binding
+// or rig prefixes. For `{BindingName: "gastown", Template: "mayor"}` it
+// returns "mayor"; for `{Name: "boot", BindingName: "gastown"}` it
+// returns "boot".
+func namedSessionBareName(ns *config.NamedSession) string {
+	if ns == nil {
+		return ""
+	}
+	if ns.Name != "" {
+		return ns.Name
+	}
+	return ns.Template
 }
 
 // FindNamedSessionSpecForTarget resolves a session-facing token to a named session spec.

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -137,47 +137,31 @@ func ResolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, 
 	// preserves the pre-packs-V2 UX where `gc session attach mayor`
 	// resolves to the sole configured `gastown.mayor` named session.
 	// A rig-scoped named session is only in scope when the caller is
-	// inside that rig, matching the rig-scoping rules the agent-template
-	// resolver used before the session-model refactor.
+	// inside that rig. A collision between a city-scoped and rig-scoped
+	// match is surfaced as ErrAmbiguous, matching the direct-identity
+	// loop above — we never let rig scope silently shadow city scope.
 	if !strings.Contains(target, "/") {
-		var rigMatch, cityMatch NamedSessionSpec
-		rigFound, rigAmbiguous := false, false
-		cityFound, cityAmbiguous := false, false
+		matched, found := NamedSessionSpec{}, false
 		for i := range cfg.NamedSessions {
 			ns := &cfg.NamedSessions[i]
 			if namedSessionBareName(ns) != target {
+				continue
+			}
+			if ns.Dir != "" && (rigContext == "" || ns.Dir != rigContext) {
 				continue
 			}
 			spec, ok := FindNamedSessionSpec(cfg, cityName, ns.QualifiedName())
 			if !ok {
 				continue
 			}
-			switch {
-			case ns.Dir == "":
-				if cityFound && cityMatch.Identity != spec.Identity {
-					cityAmbiguous = true
-				}
-				cityMatch = spec
-				cityFound = true
-			case rigContext != "" && ns.Dir == rigContext:
-				if rigFound && rigMatch.Identity != spec.Identity {
-					rigAmbiguous = true
-				}
-				rigMatch = spec
-				rigFound = true
-			}
-		}
-		if rigFound {
-			if rigAmbiguous {
+			if found && matched.Identity != spec.Identity {
 				return NamedSessionSpec{}, false, fmt.Errorf("%w: %q matches multiple configured named sessions", ErrAmbiguous, target)
 			}
-			return rigMatch, true, nil
+			matched = spec
+			found = true
 		}
-		if cityFound {
-			if cityAmbiguous {
-				return NamedSessionSpec{}, false, fmt.Errorf("%w: %q matches multiple configured named sessions", ErrAmbiguous, target)
-			}
-			return cityMatch, true, nil
+		if found {
+			return matched, true, nil
 		}
 	}
 

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -83,42 +83,42 @@ func ResolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, 
 		return NamedSessionSpec{}, false, nil
 	}
 
-	var identities []string
-	if strings.Contains(target, "/") {
-		identities = append(identities, target)
-	} else {
-		identities = append(identities, target)
-		if rigContext != "" {
-			identities = append(identities, rigContext+"/"+target)
-		}
-	}
-	var matched NamedSessionSpec
-	found := false
-	seen := make(map[string]bool, len(identities))
-	for _, identity := range identities {
-		if identity == "" || seen[identity] {
-			continue
-		}
-		seen[identity] = true
-		if spec, ok := FindNamedSessionSpec(cfg, cityName, identity); ok {
-			if found && matched.Identity != spec.Identity {
-				return NamedSessionSpec{}, false, fmt.Errorf("%w: %q matches multiple configured named sessions", ErrAmbiguous, target)
-			}
-			matched = spec
-			found = true
-		}
-	}
-	if found {
-		return matched, true, nil
+	qualified := strings.Contains(target, "/")
+	identities := map[string]bool{target: true}
+	if !qualified && rigContext != "" {
+		identities[rigContext+"/"+target] = true
 	}
 
+	// Collect every configured named session whose identity, runtime
+	// session_name, or in-scope bare leaf matches the target. Bare leaf
+	// matches are how packs-V2 imports like `gastown.mayor` accept a
+	// user typing `mayor`. We fold every match shape into one candidate
+	// set so rig/city and direct/fallback collisions surface as
+	// ErrAmbiguous uniformly instead of the direct-match loop silently
+	// winning.
+	matched := NamedSessionSpec{}
+	found := false
 	for i := range cfg.NamedSessions {
-		identity := cfg.NamedSessions[i].QualifiedName()
+		ns := &cfg.NamedSessions[i]
+		identity := ns.QualifiedName()
 		spec, ok := FindNamedSessionSpec(cfg, cityName, identity)
 		if !ok {
 			continue
 		}
-		if spec.SessionName != target {
+		match := false
+		if identities[identity] {
+			match = true
+		} else if spec.SessionName == target {
+			match = true
+		} else if !qualified && namedSessionBareName(ns) == target {
+			// Rig-scoped named sessions are only reachable by bare
+			// name from inside the rig, matching the pre-refactor
+			// agent-template resolver.
+			if ns.Dir == "" || (rigContext != "" && ns.Dir == rigContext) {
+				match = true
+			}
+		}
+		if !match {
 			continue
 		}
 		if found && matched.Identity != spec.Identity {
@@ -130,41 +130,6 @@ func ResolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, 
 	if found {
 		return matched, true, nil
 	}
-
-	// Bare-name fallback for V2 imports. When target is unqualified (no
-	// "/") but no direct match succeeded, accept a short name that maps
-	// unambiguously to a single in-scope configured named session. This
-	// preserves the pre-packs-V2 UX where `gc session attach mayor`
-	// resolves to the sole configured `gastown.mayor` named session.
-	// A rig-scoped named session is only in scope when the caller is
-	// inside that rig. A collision between a city-scoped and rig-scoped
-	// match is surfaced as ErrAmbiguous, matching the direct-identity
-	// loop above — we never let rig scope silently shadow city scope.
-	if !strings.Contains(target, "/") {
-		matched, found := NamedSessionSpec{}, false
-		for i := range cfg.NamedSessions {
-			ns := &cfg.NamedSessions[i]
-			if namedSessionBareName(ns) != target {
-				continue
-			}
-			if ns.Dir != "" && (rigContext == "" || ns.Dir != rigContext) {
-				continue
-			}
-			spec, ok := FindNamedSessionSpec(cfg, cityName, ns.QualifiedName())
-			if !ok {
-				continue
-			}
-			if found && matched.Identity != spec.Identity {
-				return NamedSessionSpec{}, false, fmt.Errorf("%w: %q matches multiple configured named sessions", ErrAmbiguous, target)
-			}
-			matched = spec
-			found = true
-		}
-		if found {
-			return matched, true, nil
-		}
-	}
-
 	return NamedSessionSpec{}, false, nil
 }
 

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -106,11 +106,12 @@ func ResolveNamedSessionSpecForConfigTarget(cfg *config.City, cityName, target, 
 			continue
 		}
 		match := false
-		if identities[identity] {
+		switch {
+		case identities[identity]:
 			match = true
-		} else if spec.SessionName == target {
+		case spec.SessionName == target:
 			match = true
-		} else if !qualified && namedSessionBareName(ns) == target {
+		case !qualified && namedSessionBareName(ns) == target:
 			// Rig-scoped named sessions are only reachable by bare
 			// name from inside the rig, matching the pre-refactor
 			// agent-template resolver.

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -209,6 +209,78 @@ func TestFindClosedNamedSessionBead_PrefersNewestClosedCanonical(t *testing.T) {
 	}
 }
 
+func TestResolveNamedSessionSpecForConfigTarget_BareNameResolvesV2BoundSession(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:        "mayor",
+			BindingName: "gastown",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "mayor",
+			BindingName: "gastown",
+		}},
+	}
+	spec, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "mayor", "")
+	if err != nil {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(mayor): %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolveNamedSessionSpecForConfigTarget(mayor) = false, want true")
+	}
+	if spec.Identity != "gastown.mayor" {
+		t.Fatalf("spec.Identity = %q, want gastown.mayor", spec.Identity)
+	}
+}
+
+func TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousAcrossBindings(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", BindingName: "gastown"},
+			{Name: "mayor", BindingName: "otherpack"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", BindingName: "gastown"},
+			{Template: "mayor", BindingName: "otherpack"},
+		},
+	}
+	_, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "mayor", "")
+	if err == nil {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(mayor) ok=%v, want ambiguous error", ok)
+	}
+	if ok {
+		t.Fatal("ResolveNamedSessionSpecForConfigTarget(mayor) = true, want false on ambiguity")
+	}
+}
+
+func TestResolveNamedSessionSpecForConfigTarget_BareNameIgnoresRigScopedOutsideRig(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name: "witness",
+			Dir:  "demo",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "witness",
+			Dir:      "demo",
+		}},
+	}
+	if _, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "witness", ""); err != nil || ok {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(witness) ok=%v err=%v, want not found outside rig context", ok, err)
+	}
+	spec, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "witness", "demo")
+	if err != nil {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(witness, demo): %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolveNamedSessionSpecForConfigTarget(witness, demo) = false, want true")
+	}
+	if spec.Identity != "demo/witness" {
+		t.Fatalf("spec.Identity = %q, want demo/witness", spec.Identity)
+	}
+}
+
 func TestFindClosedNamedSessionBead_AcceptsLegacySessionType(t *testing.T) {
 	store := beads.NewMemStore()
 	legacy, err := store.Create(beads.Bead{

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -273,6 +273,28 @@ func TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousAcrossRigAndCit
 	}
 }
 
+func TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousMixesDirectAndBareMatches(t *testing.T) {
+	// A V1 rig-scoped entry (direct identity == "demo/mayor") plus a V2
+	// city import (bare leaf == "mayor") must surface as ErrAmbiguous
+	// when the user types bare "mayor" inside rig "demo". Otherwise the
+	// direct-identity loop would silently shadow the V2 import.
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", Dir: "demo"},
+			{Name: "mayor", BindingName: "citypack"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Dir: "demo"},
+			{Template: "mayor", BindingName: "citypack"},
+		},
+	}
+	_, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "mayor", "demo")
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(mayor, demo) ok=%v err=%v, want ErrAmbiguous across direct+bare matches", ok, err)
+	}
+}
+
 func TestResolveNamedSessionSpecForConfigTarget_BareNameIgnoresRigScopedOutsideRig(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -246,11 +247,29 @@ func TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousAcrossBindings(
 		},
 	}
 	_, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "mayor", "")
-	if err == nil {
-		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(mayor) ok=%v, want ambiguous error", ok)
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(mayor) ok=%v err=%v, want ErrAmbiguous", ok, err)
 	}
 	if ok {
 		t.Fatal("ResolveNamedSessionSpecForConfigTarget(mayor) = true, want false on ambiguity")
+	}
+}
+
+func TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousAcrossRigAndCity(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", BindingName: "citypack"},
+			{Name: "mayor", BindingName: "rigpack", Dir: "demo"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", BindingName: "citypack"},
+			{Template: "mayor", BindingName: "rigpack", Dir: "demo"},
+		},
+	}
+	_, ok, err := ResolveNamedSessionSpecForConfigTarget(cfg, "test-city", "mayor", "demo")
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("ResolveNamedSessionSpecForConfigTarget(mayor, demo) ok=%v err=%v, want ErrAmbiguous across rig+city scopes", ok, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #800: after packs V2 stamps a `BindingName` on imported named sessions, users had to type `gc session attach gastown.mayor` instead of the short-name `gc session attach mayor` they'd been using pre-upgrade.
- The session-model unification in #666 removed the short-name fallback from `resolveNamedSessionSpecForConfigTarget`; this PR reinstates it inside the centralized `internal/session.ResolveNamedSessionSpecForConfigTarget` so every downstream caller (CLI attach, `session new`, mail, `session logs`, API `findNamedSessionSpecForTarget`, doctor) benefits.
- The new resolver folds identity, runtime session-name, and in-scope bare-leaf matches into a single candidate pass so collisions (rig vs. city, V1 direct vs. V2 imported bare leaf, multiple bindings) uniformly surface as `session.ErrAmbiguous` instead of silently letting one shape shadow another.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed — _N/A, no docs touched._
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — _N/A, change is pure resolver logic; unit-tested at both `internal/session` and `cmd/gc` layers._

New tests:
- `TestResolveNamedSessionSpecForConfigTarget_BareNameResolvesV2BoundSession`
- `TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousAcrossBindings`
- `TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousAcrossRigAndCity`
- `TestResolveNamedSessionSpecForConfigTarget_BareNameAmbiguousMixesDirectAndBareMatches`
- `TestResolveNamedSessionSpecForConfigTarget_BareNameIgnoresRigScopedOutsideRig`
- `TestResolveSessionIDMaterializingNamed_BareNameResolvesV2BoundNamedSession`
- `TestResolveSessionIDMaterializingNamed_FullyQualifiedStillResolvesV2BoundNamedSession`

The existing `TestResolveConfiguredSessionLogContext_RejectsBareRigScopedNamedSession` still passes, confirming rig-scoped named sessions remain unreachable by bare name outside the rig.

## Checklist

- [x] Linked an issue (#800)
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — _N/A; this restores the UX docs already describe (`docs/tutorials/03-sessions.md:191` and `docs/getting-started/coming-from-gastown.md:418` already show `gc session attach mayor`)._
- [ ] Called out breaking changes or migration notes — _no breaking changes; the ambiguity surface is strictly a diagnostic improvement over the previous silent-shadow behavior._

## Review Notes

The branch was run through `/review-pr` (Claude + Codex + Gemini) three times. Pass 1 and pass 2 fixed Codex majors about rig-vs-city shadowing and mixed V1-direct + V2-bare collisions respectively; pass 3 returned no blockers or majors.