### PR TITLE
test: suppress bd CLI Dolt auto-start in integration env

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -628,6 +628,7 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env = filterEnv(env, "DOLT_ROOT_PATH")
 	env = filterEnv(env, integrationGCBinaryEnv)
 	env = filterEnv(env, integrationDoltBinaryEnv)
+	env = filterEnv(env, "BEADS_DOLT_AUTO_START")
 	if !useDolt {
 		env = append(env, "GC_DOLT=skip")
 	}
@@ -636,6 +637,13 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env = append(env, integrationRealBDBinaryEnv+"="+realBDBinary)
 	env = append(env, "DOLT_ROOT_PATH="+gcHome)
 	env = append(env, "PATH="+prependPath(integrationToolBinDir, os.Getenv("PATH")))
+	// Match production: suppress bd's CLI Dolt auto-start so integration
+	// tests can't spawn rogue servers when the managed Dolt port file is
+	// stale between subtests. bd's auto-start logic ignores the
+	// dolt.auto-start:false config written into .beads/config.yaml
+	// (resolveAutoStart priority bug), so the env var is the only
+	// reliable kill-switch. Mirrors bdRuntimeEnv in cmd/gc/bd_env.go.
+	env = append(env, "BEADS_DOLT_AUTO_START=0")
 	return env
 }
 
@@ -974,6 +982,9 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	}
 	if path := got["PATH"]; !strings.HasPrefix(path, integrationToolBinDir+string(os.PathListSeparator)) && path != integrationToolBinDir {
 		t.Fatalf("PATH = %q, want prefix %q", path, integrationToolBinDir)
+	}
+	if got["BEADS_DOLT_AUTO_START"] != "0" {
+		t.Fatalf("BEADS_DOLT_AUTO_START = %q, want %q; tests must match bdRuntimeEnv and suppress bd's rogue auto-start", got["BEADS_DOLT_AUTO_START"], "0")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `integrationEnvFor` in `test/integration/integration_test.go` now sets `BEADS_DOLT_AUTO_START=0`, matching `bdRuntimeEnv`/`cityRuntimeProcessEnv` in `cmd/gc/bd_env.go`.
- Fixes flaky `auto-start failed` errors in `Integration / rest` and `Integration / review-formulas` when the managed Dolt port file goes stale between subtests. Most recent example: [run 24587831118, job 71901780476](https://github.com/gastownhall/gascity/actions/runs/24587831118/job/71901780476) where `TestReviewCheckScriptsDetectVerdictAcrossRalphStep/adopt_pr_review` failed with ``bd create`` spawning a rogue Dolt server that timed out binding port 40893.
- Adds a regression assertion in `TestIntegrationEnvForUsesIsolatedHome` to pin the invariant.

## Background

Production code has a kill-switch env var for a documented bd priority bug (`cmd/gc/bd_env.go:413-417`):

> Suppress bd's built-in Dolt auto-start. The gc controller manages the Dolt server lifecycle via gc-beads-bd; bd's CLI auto-start ignores the dolt.auto-start:false config (beads resolveAutoStart priority bug) and starts rogue servers from the agent's cwd with the wrong data_dir.

Integration tests did not mirror that, so any `bd` invocation via `bdDolt` — when `GC_DOLT_PORT` happened to fall out of env because `currentManagedDoltPortForTest` couldn't reach the managed server — fell through to bd's broken auto-start path.

## Testing

- [x] `make check` — lint + unit + docs gates
- [ ] `make check-docs` if docs, navigation, or links changed — _N/A, no docs touched._
- [x] `make test-integration` for the affected package — _Ran `TestIntegrationEnvForUsesIsolatedHome` locally; will exercise on CI alongside the full `Integration / rest` + `Integration / review-formulas` shards._

## Checklist

- [x] Linked the failing CI run and explained the root cause
- [x] Added a regression assertion pinning `BEADS_DOLT_AUTO_START=0`
- [ ] Updated docs for user-facing changes — _N/A; test-only change, no user-visible behavior._
- [ ] Called out breaking changes or migration notes — _no breaking changes._