### PR TITLE
fix(api): honor rig context when dispatching sling via HTTP API

### DIFF
--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -111,6 +111,21 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject contradictory rig inputs. When the caller sends a
+	// qualified target ("otherrig/worker") alongside scope_kind=rig
+	// with a different scope_ref, the downstream store selection (via
+	// agentCfg.Dir) and the formula's ScopeRef disagree, producing a
+	// split-brain dispatch where beads land in one rig and formula
+	// scope metadata references another. Surface the ambiguity loud.
+	if body.ScopeKind == "rig" && body.ScopeRef != "" && strings.Contains(body.Target, "/") {
+		targetDir := strings.SplitN(body.Target, "/", 2)[0]
+		if targetDir != body.ScopeRef {
+			writeError(w, http.StatusBadRequest, "invalid",
+				"scope_ref "+body.ScopeRef+" conflicts with qualified target rig "+targetDir)
+			return
+		}
+	}
+
 	resp, status, code, message := s.execSlingDirect(r.Context(), body, agentCfg)
 	if code != "" {
 		writeError(w, status, code, message)

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -59,11 +59,12 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 	cfg := s.state.Config()
 
 	// UI dispatches carry scope_kind/scope_ref but not the CLI's ambient
-	// rig directory. Apply the same rig-prefixing convention so a bare
-	// target resolves to the rig-scoped agent when scope_kind=rig. Keeps
-	// formulas generic (bare assignees) while routing to the correct
-	// rig-local beads/worktree context.
-	body.Target = qualifySlingTarget(cfg, body.Target, body.ScopeKind, body.ScopeRef)
+	// rig directory. Dashboard dispatches use body.Rig (from --rig=X).
+	// Apply the same rig-prefixing convention for either so a bare
+	// target resolves to the rig-scoped agent. Keeps formulas generic
+	// (bare assignees) while routing to the correct rig-local beads
+	// and worktree context.
+	body.Target = qualifySlingTarget(cfg, body.Target, slingRigContext(body))
 
 	agentCfg, ok := findAgent(cfg, body.Target)
 	if !ok {
@@ -346,25 +347,36 @@ func (apiAgentResolver) ResolveAgent(cfg *config.City, name, rigContext string) 
 	return findAgent(cfg, name)
 }
 
-// qualifySlingTarget prepends a rig directory to a bare-name target when
-// the caller passes scope_kind=rig and a scope_ref that names a real
-// rig-scoped agent. Returns the target unchanged in all other cases
-// (already-qualified, city scope, no rig-scoped match). This lets the
-// UI carry scope via scope_kind/scope_ref without every caller having
-// to compose the "<rig>/<name>" string manually, matching the CLI's
-// ambient-rig-directory behavior.
-func qualifySlingTarget(cfg *config.City, target, scopeKind, scopeRef string) string {
-	if scopeKind != "rig" || scopeRef == "" {
+// qualifySlingTarget prepends a rig directory to a bare-name target
+// when the caller supplies a non-empty rigContext. Returns the target
+// unchanged if already qualified or if the qualified form does not
+// resolve (the caller's final findAgent call will then surface a clean
+// 404). This lets the API carry rig intent via scope_ref (UI path) or
+// body.Rig (dashboard/--rig CLI path) without every caller composing
+// the "<rig>/<name>" string manually.
+func qualifySlingTarget(cfg *config.City, target, rigContext string) string {
+	if rigContext == "" || strings.Contains(target, "/") {
 		return target
 	}
-	if strings.Contains(target, "/") {
-		return target
-	}
-	qualified := scopeRef + "/" + target
+	qualified := rigContext + "/" + target
 	if _, ok := findAgent(cfg, qualified); ok {
 		return qualified
 	}
 	return target
+}
+
+// slingRigContext derives the effective rig context for target
+// qualification. scope_ref takes precedence (explicit UI intent); when
+// absent, body.Rig is used as the implicit rig for legacy dashboard
+// dispatches that pass --rig= without scope_kind/scope_ref.
+func slingRigContext(body slingBody) string {
+	if body.ScopeKind == "rig" && body.ScopeRef != "" {
+		return body.ScopeRef
+	}
+	if body.ScopeKind == "" && body.Rig != "" {
+		return body.Rig
+	}
+	return ""
 }
 
 // apiBranchResolver implements sling.BranchResolver for the API context.

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -50,7 +50,21 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Scope fields are consulted for target qualification before the other
+	// validation below, so trim them eagerly. The semantic checks happen
+	// further down once all other fields are known.
+	body.ScopeKind = strings.TrimSpace(body.ScopeKind)
+	body.ScopeRef = strings.TrimSpace(body.ScopeRef)
+
 	cfg := s.state.Config()
+
+	// UI dispatches carry scope_kind/scope_ref but not the CLI's ambient
+	// rig directory. Apply the same rig-prefixing convention so a bare
+	// target resolves to the rig-scoped agent when scope_kind=rig. Keeps
+	// formulas generic (bare assignees) while routing to the correct
+	// rig-local beads/worktree context.
+	body.Target = qualifySlingTarget(cfg, body.Target, body.ScopeKind, body.ScopeRef)
+
 	agentCfg, ok := findAgent(cfg, body.Target)
 	if !ok {
 		writeError(w, http.StatusNotFound, "not_found", "target "+body.Target+" not found")
@@ -70,8 +84,6 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body.ScopeKind = strings.TrimSpace(body.ScopeKind)
-	body.ScopeRef = strings.TrimSpace(body.ScopeRef)
 	workflowLaunchOptions := body.AttachedBeadID != "" ||
 		len(body.Vars) > 0 ||
 		body.Title != "" ||
@@ -269,11 +281,42 @@ func mergeEnvForSling(extra map[string]string) []string {
 }
 
 // apiAgentResolver implements sling.AgentResolver for the API context.
-// Uses exact qualified name matching (no ambient rig context).
+// Mirrors the CLI's resolveAgentIdentity rig-context behavior so formula
+// child steps with bare assignees route to the same rig as the top-level
+// target when dispatched through the API (e.g. gasworks-gui UI).
 type apiAgentResolver struct{}
 
-func (apiAgentResolver) ResolveAgent(cfg *config.City, name, _ string) (config.Agent, bool) {
+func (apiAgentResolver) ResolveAgent(cfg *config.City, name, rigContext string) (config.Agent, bool) {
+	// Step 1: ambient rig match — if the caller supplied a rig context and
+	// the name is bare, prefer the rig-scoped agent.
+	if rigContext != "" && !strings.Contains(name, "/") {
+		if a, ok := findAgent(cfg, rigContext+"/"+name); ok {
+			return a, true
+		}
+	}
+	// Step 2: literal lookup (qualified or city-scoped).
 	return findAgent(cfg, name)
+}
+
+// qualifySlingTarget prepends a rig directory to a bare-name target when
+// the caller passes scope_kind=rig and a scope_ref that names a real
+// rig-scoped agent. Returns the target unchanged in all other cases
+// (already-qualified, city scope, no rig-scoped match). This lets the
+// UI carry scope via scope_kind/scope_ref without every caller having
+// to compose the "<rig>/<name>" string manually, matching the CLI's
+// ambient-rig-directory behavior.
+func qualifySlingTarget(cfg *config.City, target, scopeKind, scopeRef string) string {
+	if scopeKind != "rig" || scopeRef == "" {
+		return target
+	}
+	if strings.Contains(target, "/") {
+		return target
+	}
+	qualified := scopeRef + "/" + target
+	if _, ok := findAgent(cfg, qualified); ok {
+		return qualified
+	}
+	return target
 }
 
 // apiBranchResolver implements sling.BranchResolver for the API context.

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -111,17 +111,32 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject contradictory rig inputs. When the caller sends a
-	// qualified target ("otherrig/worker") alongside scope_kind=rig
-	// with a different scope_ref, the downstream store selection (via
-	// agentCfg.Dir) and the formula's ScopeRef disagree, producing a
-	// split-brain dispatch where beads land in one rig and formula
-	// scope metadata references another. Surface the ambiguity loud.
-	if body.ScopeKind == "rig" && body.ScopeRef != "" && strings.Contains(body.Target, "/") {
-		targetDir := strings.SplitN(body.Target, "/", 2)[0]
-		if targetDir != body.ScopeRef {
+	// Reject contradictory rig inputs. When scope_kind=rig, the
+	// sling operation's effective rig must agree across every input
+	// that drives routing or storage, because downstream:
+	//   - findSlingStore picks the store from body.Rig → agentCfg.Dir → city
+	//   - FormulaOpts.ScopeRef flows from body.ScopeRef
+	// Silently accepting disagreement produces split-brain dispatches
+	// (beads land in one rig, formula scope metadata references
+	// another). This single guard covers three concrete classes:
+	//   (a) qualified target in a different rig than scope_ref
+	//       ("otherrig/worker" + scope_ref="myrig"): agentCfg.Dir="otherrig"
+	//   (b) bare name fell through to a city-scoped agent while the
+	//       caller requested rig scope ("mayor" + scope_ref="myrig"):
+	//       agentCfg.Dir=""
+	//   (c) body.Rig override disagreeing with scope_ref.
+	if body.ScopeKind == "rig" && body.ScopeRef != "" {
+		if agentCfg.Dir != body.ScopeRef {
+			msg := "scope_ref " + body.ScopeRef + " conflicts with resolved target rig " + agentCfg.Dir
+			if agentCfg.Dir == "" {
+				msg = "scope_ref " + body.ScopeRef + " requires a rig-scoped target; resolved target " + body.Target + " is city-scoped"
+			}
+			writeError(w, http.StatusBadRequest, "invalid", msg)
+			return
+		}
+		if body.Rig != "" && body.Rig != body.ScopeRef {
 			writeError(w, http.StatusBadRequest, "invalid",
-				"scope_ref "+body.ScopeRef+" conflicts with qualified target rig "+targetDir)
+				"rig "+body.Rig+" conflicts with scope_ref "+body.ScopeRef)
 			return
 		}
 	}

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -281,9 +281,26 @@ func mergeEnvForSling(extra map[string]string) []string {
 }
 
 // apiAgentResolver implements sling.AgentResolver for the API context.
-// Mirrors the CLI's resolveAgentIdentity rig-context behavior so formula
-// child steps with bare assignees route to the same rig as the top-level
-// target when dispatched through the API (e.g. gasworks-gui UI).
+// Mirrors the CLI's resolveAgentIdentity rig-context behavior (step 1)
+// so formula child steps with bare assignees route to the same rig as
+// the top-level target when dispatched through the API (e.g. gasworks-gui
+// UI).
+//
+// Intentional divergence from cmd/gc/cmd_agent.go:resolveAgentIdentity:
+//
+//   - Step 3 (unambiguous bare-name fallback across all rigs) is
+//     deliberately not implemented here. UI/API dispatches always carry
+//     scope_kind+scope_ref when they want rig routing; without that
+//     context, routing to a single rig-scoped agent by bare name would
+//     be ambiguous in any multi-rig city. A bare name with no rig
+//     context falls through to findAgent's qualified-or-city-scoped
+//     lookup, which also retains findAgent's V2 BindingName pool-prefix
+//     handling that agentutil.ResolveAgent does not currently implement.
+//
+//   - Unifying CLI and API onto agentutil.ResolveAgent is a follow-up;
+//     doing it safely requires porting findAgent's V2 BindingName logic
+//     into agentutil first. TestApiVsAgentutilResolverParity below
+//     captures the current behavioral contract this resolver guarantees.
 type apiAgentResolver struct{}
 
 func (apiAgentResolver) ResolveAgent(cfg *config.City, name, rigContext string) (config.Agent, bool) {
@@ -294,7 +311,8 @@ func (apiAgentResolver) ResolveAgent(cfg *config.City, name, rigContext string) 
 			return a, true
 		}
 	}
-	// Step 2: literal lookup (qualified or city-scoped).
+	// Step 2: literal lookup (qualified or city-scoped, plus V2
+	// BindingName pool-member synthesis inside findAgent).
 	return findAgent(cfg, name)
 }
 

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -250,5 +251,101 @@ func TestSlingRigScopeRejectsUnknownBareTarget(t *testing.T) {
 	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSlingRigScopeE2EReachesFormulaValidation is the end-to-end
+// regression guard for the target rewrite. A bare target with
+// scope_kind=rig + a matching rig-scoped agent must make it past
+// handleSling's agent lookup and hit the downstream "formula required
+// when scope is set" validation — any regression in qualifySlingTarget
+// or its invocation would 404 here instead of 400.
+//
+// This is the single observable boundary where we can prove the
+// end-to-end /v0/sling → target rewrite wiring still works without
+// dragging in real formula instantiation machinery.
+func TestSlingRigScopeE2EReachesFormulaValidation(t *testing.T) {
+	srv, _ := newSlingTestServer(t)
+	// Bare "worker" must be qualified to "myrig/worker" by handleSling
+	// before findAgent is called. If the rewrite is broken, findAgent
+	// returns 404 for bare "worker". If it's working, the handler moves
+	// on and trips the "formula required when scope is set" rule (400).
+	body := `{"target":"worker","bead":"BD-42","scope_kind":"rig","scope_ref":"myrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("got 404 — qualifySlingTarget did not rewrite bare target; body = %s", rec.Body.String())
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (formula-required); body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "formula") {
+		t.Errorf("body = %s; expected formula-required error (proves we got past agent lookup)", rec.Body.String())
+	}
+}
+
+// TestApiVsAgentutilResolverParity locks in the current behavioral
+// contract between apiAgentResolver and agentutil.ResolveAgent so that
+// future drift between CLI and API resolution surfaces as a test
+// failure rather than a silent regression (the exact class of bug
+// that motivated this PR). Any case where the two resolvers disagree
+// is either an intentional divergence (document it here) or a bug.
+func TestApiVsAgentutilResolverParity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "myrig", MaxActiveSessions: intPtr(1)},
+			{Name: "worker", Dir: "otherrig", MaxActiveSessions: intPtr(1)},
+			{Name: "mayor", MaxActiveSessions: intPtr(1)}, // city-scoped, unique
+		},
+	}
+	apiRes := apiAgentResolver{}
+
+	cases := []struct {
+		name       string
+		input      string
+		rigContext string
+		wantFound  bool
+		wantQName  string
+		// mustAgree: both resolvers must give the same answer.
+		// When false, this is an intentional divergence documented below.
+		mustAgree bool
+	}{
+		{"qualified_name", "myrig/worker", "", true, "myrig/worker", true},
+		{"qualified_name_with_rig_context", "myrig/worker", "otherrig", true, "myrig/worker", true},
+		{"bare_name_with_rig_context", "worker", "myrig", true, "myrig/worker", true},
+		{"bare_name_with_other_rig_context", "worker", "otherrig", true, "otherrig/worker", true},
+		{"city_scoped_bare_name", "mayor", "", true, "mayor", true},
+		{"city_scoped_bare_name_with_rig_context", "mayor", "myrig", true, "mayor", true},
+		// Intentional divergence: API resolver deliberately omits
+		// step-3 unambiguous-bare-name fallback, so a bare rig-scoped
+		// name with no rig context does NOT resolve through the API.
+		// agentutil.ResolveAgent with UseAmbientRig=false also skips
+		// it; enabling it would require AllowPoolMembers=true and
+		// would expose BindingName gaps. See apiAgentResolver doc.
+		{"bare_name_no_context_ambiguous_rig_scoped", "worker", "", false, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apiAgent, apiOK := apiRes.ResolveAgent(cfg, tc.input, tc.rigContext)
+			if apiOK != tc.wantFound {
+				t.Fatalf("apiAgentResolver found=%v, want %v", apiOK, tc.wantFound)
+			}
+			if apiOK && apiAgent.QualifiedName() != tc.wantQName {
+				t.Fatalf("apiAgentResolver QualifiedName = %q, want %q", apiAgent.QualifiedName(), tc.wantQName)
+			}
+			if !tc.mustAgree {
+				return
+			}
+			utilAgent, utilOK := agentutil.ResolveAgent(cfg, tc.input, agentutil.ResolveOpts{
+				UseAmbientRig: tc.rigContext != "",
+				RigContext:    tc.rigContext,
+			})
+			if apiOK != utilOK {
+				t.Errorf("resolver disagreement: apiAgentResolver found=%v, agentutil.ResolveAgent found=%v", apiOK, utilOK)
+			}
+			if apiOK && utilOK && apiAgent.QualifiedName() != utilAgent.QualifiedName() {
+				t.Errorf("resolver disagreement: api=%q, util=%q", apiAgent.QualifiedName(), utilAgent.QualifiedName())
+			}
+		})
 	}
 }

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -380,62 +380,98 @@ func TestSlingRigScopeE2EReachesFormulaValidation(t *testing.T) {
 // future drift between CLI and API resolution surfaces as a test
 // failure rather than a silent regression (the exact class of bug
 // that motivated this PR). Any case where the two resolvers disagree
-// is either an intentional divergence (document it here) or a bug.
+// is either an intentional divergence (documented below) or a bug.
+//
+// Coverage dimensions:
+//   - simple agents (rig-scoped + city-scoped)
+//   - pool members (bare "polecat-N", qualified "rig/polecat-N")
+//   - V2 BindingName pool prefixes ("pack.name-N")
+//
+// Intentional divergences:
+//
+//   - Bare rig-scoped name with no rig context: apiAgentResolver
+//     deliberately omits the CLI's step-3 unambiguous-bare-name scan
+//     to avoid ambiguity in multi-rig cities. agentutil with
+//     UseAmbientRig=false also declines, so both agree — but the CLI
+//     path (resolveAgentIdentity) would succeed; that's expected.
+//
+//   - Pool-instance shape: findAgent resolves "rig/polecat-N" to the
+//     pool TEMPLATE agent, leaving synthesis to the caller, while
+//     agentutil with AllowPoolMembers=true returns the synthesized
+//     INSTANCE directly. Same shape difference applies to V2
+//     BindingName pool members ("rig/binding.name-N"). Both shapes
+//     are valid; a future unification will need to pick one.
 func TestApiVsAgentutilResolverParity(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{
 			{Name: "worker", Dir: "myrig", MaxActiveSessions: intPtr(1)},
 			{Name: "worker", Dir: "otherrig", MaxActiveSessions: intPtr(1)},
 			{Name: "mayor", MaxActiveSessions: intPtr(1)}, // city-scoped, unique
+			// Pool agent (multi-session, unlimited)
+			{Name: "polecat", Dir: "myrig", MaxActiveSessions: intPtr(-1)},
+			// V2 bound pool (BindingName prefix)
+			{Name: "witness", Dir: "myrig", BindingName: "gastown", MaxActiveSessions: intPtr(-1)},
 		},
 	}
 	apiRes := apiAgentResolver{}
 
+	// Each case locks in the expected behavior of BOTH resolvers for
+	// the same input. Where apiWantQName != utilWantQName (or found
+	// values differ), that is an intentional divergence — documented
+	// in the function comment above. Changing either without a
+	// matching update to the other means the parity guarantee has
+	// shifted and the test call site should be audited.
 	cases := []struct {
-		name       string
-		input      string
-		rigContext string
-		wantFound  bool
-		wantQName  string
-		// mustAgree: both resolvers must give the same answer.
-		// When false, this is an intentional divergence documented below.
-		mustAgree bool
+		name          string
+		input         string
+		rigContext    string
+		apiWantFound  bool
+		apiWantQName  string
+		utilWantFound bool
+		utilWantQName string
 	}{
-		{"qualified_name", "myrig/worker", "", true, "myrig/worker", true},
-		{"qualified_name_with_rig_context", "myrig/worker", "otherrig", true, "myrig/worker", true},
-		{"bare_name_with_rig_context", "worker", "myrig", true, "myrig/worker", true},
-		{"bare_name_with_other_rig_context", "worker", "otherrig", true, "otherrig/worker", true},
-		{"city_scoped_bare_name", "mayor", "", true, "mayor", true},
-		{"city_scoped_bare_name_with_rig_context", "mayor", "myrig", true, "mayor", true},
-		// Intentional divergence: API resolver deliberately omits
-		// step-3 unambiguous-bare-name fallback, so a bare rig-scoped
-		// name with no rig context does NOT resolve through the API.
-		// agentutil.ResolveAgent with UseAmbientRig=false also skips
-		// it; enabling it would require AllowPoolMembers=true and
-		// would expose BindingName gaps. See apiAgentResolver doc.
-		{"bare_name_no_context_ambiguous_rig_scoped", "worker", "", false, "", true},
+		// Shared behavior: simple agents, rig context, city-scoped.
+		{"qualified_name", "myrig/worker", "", true, "myrig/worker", true, "myrig/worker"},
+		{"qualified_name_with_rig_context", "myrig/worker", "otherrig", true, "myrig/worker", true, "myrig/worker"},
+		{"bare_name_with_rig_context", "worker", "myrig", true, "myrig/worker", true, "myrig/worker"},
+		{"bare_name_with_other_rig_context", "worker", "otherrig", true, "otherrig/worker", true, "otherrig/worker"},
+		{"city_scoped_bare_name", "mayor", "", true, "mayor", true, "mayor"},
+		{"city_scoped_bare_name_with_rig_context", "mayor", "myrig", true, "mayor", true, "mayor"},
+		{"bare_name_no_context_ambiguous_rig_scoped", "worker", "", false, "", false, ""},
+
+		// Pool-member divergence: findAgent resolves a pool instance
+		// request to the POOL TEMPLATE (caller then synthesizes).
+		// agentutil with AllowPoolMembers=true synthesizes the
+		// INSTANCE directly. Both are valid shapes, but the contract
+		// must not shift silently.
+		{"qualified_pool_member", "myrig/polecat-2", "", true, "myrig/polecat", true, "myrig/polecat-2"},
+
+		// V2 BindingName divergence: both resolvers recognize the
+		// "<binding>.<name>-N" prefix, but with the same template
+		// vs instance shape as the polecat case — findAgent returns
+		// the pool template (binding-qualified), agentutil returns
+		// the synthesized instance.
+		{"v2_binding_pool_member", "myrig/gastown.witness-1", "", true, "myrig/gastown.witness", true, "myrig/gastown.witness-1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			apiAgent, apiOK := apiRes.ResolveAgent(cfg, tc.input, tc.rigContext)
-			if apiOK != tc.wantFound {
-				t.Fatalf("apiAgentResolver found=%v, want %v", apiOK, tc.wantFound)
+			if apiOK != tc.apiWantFound {
+				t.Fatalf("apiAgentResolver found=%v, want %v", apiOK, tc.apiWantFound)
 			}
-			if apiOK && apiAgent.QualifiedName() != tc.wantQName {
-				t.Fatalf("apiAgentResolver QualifiedName = %q, want %q", apiAgent.QualifiedName(), tc.wantQName)
-			}
-			if !tc.mustAgree {
-				return
+			if apiOK && apiAgent.QualifiedName() != tc.apiWantQName {
+				t.Fatalf("apiAgentResolver QualifiedName = %q, want %q", apiAgent.QualifiedName(), tc.apiWantQName)
 			}
 			utilAgent, utilOK := agentutil.ResolveAgent(cfg, tc.input, agentutil.ResolveOpts{
-				UseAmbientRig: tc.rigContext != "",
-				RigContext:    tc.rigContext,
+				UseAmbientRig:    tc.rigContext != "",
+				RigContext:       tc.rigContext,
+				AllowPoolMembers: true,
 			})
-			if apiOK != utilOK {
-				t.Errorf("resolver disagreement: apiAgentResolver found=%v, agentutil.ResolveAgent found=%v", apiOK, utilOK)
+			if utilOK != tc.utilWantFound {
+				t.Fatalf("agentutil.ResolveAgent found=%v, want %v", utilOK, tc.utilWantFound)
 			}
-			if apiOK && utilOK && apiAgent.QualifiedName() != utilAgent.QualifiedName() {
-				t.Errorf("resolver disagreement: api=%q, util=%q", apiAgent.QualifiedName(), utilAgent.QualifiedName())
+			if utilOK && utilAgent.QualifiedName() != tc.utilWantQName {
+				t.Fatalf("agentutil.ResolveAgent QualifiedName = %q, want %q", utilAgent.QualifiedName(), tc.utilWantQName)
 			}
 		})
 	}

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -155,11 +155,12 @@ func TestSlingPoolTarget(t *testing.T) {
 	}
 }
 
-// TestQualifySlingTarget covers the scope-aware target qualification logic:
-// when a UI dispatch arrives with scope_kind=rig and a bare-name target,
-// the helper rewrites the target to "<scope_ref>/<name>" — but only when
-// the rig-scoped agent actually exists, so city-scoped fallbacks keep
-// working.
+// TestQualifySlingTarget covers the rig-aware target qualification
+// helper. Given a rigContext (derived from scope_ref for UI dispatches
+// or body.Rig for dashboard dispatches), the helper rewrites a bare
+// target to "<rigContext>/<name>" when that qualified form resolves.
+// In all other cases (empty context, already-qualified target, no
+// matching agent) the target passes through unchanged.
 func TestQualifySlingTarget(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{
@@ -169,27 +170,65 @@ func TestQualifySlingTarget(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		target    string
-		scopeKind string
-		scopeRef  string
-		want      string
+		name       string
+		target     string
+		rigContext string
+		want       string
 	}{
-		{"rig_bare_qualifies", "worker", "rig", "myrig", "myrig/worker"},
-		{"rig_bare_no_match_unchanged", "worker", "rig", "otherrig", "worker"},
-		{"rig_qualified_unchanged", "myrig/worker", "rig", "myrig", "myrig/worker"},
-		{"city_bare_unchanged", "worker", "city", "test-city", "worker"},
-		{"no_scope_unchanged", "worker", "", "", "worker"},
-		{"rig_but_no_ref_unchanged", "worker", "rig", "", "worker"},
-		{"rig_city_scoped_fallthrough", "mayor", "rig", "myrig", "mayor"},
+		{"rig_bare_qualifies", "worker", "myrig", "myrig/worker"},
+		{"rig_bare_no_match_unchanged", "worker", "otherrig", "worker"},
+		{"already_qualified_unchanged", "myrig/worker", "myrig", "myrig/worker"},
+		{"empty_context_unchanged", "worker", "", "worker"},
+		{"rig_city_scoped_fallthrough", "mayor", "myrig", "mayor"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := qualifySlingTarget(cfg, tc.target, tc.scopeKind, tc.scopeRef)
+			got := qualifySlingTarget(cfg, tc.target, tc.rigContext)
 			if got != tc.want {
-				t.Errorf("qualifySlingTarget(%q, %q, %q) = %q, want %q", tc.target, tc.scopeKind, tc.scopeRef, got, tc.want)
+				t.Errorf("qualifySlingTarget(%q, %q) = %q, want %q", tc.target, tc.rigContext, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSlingRigContext locks in the rigContext derivation rules used
+// by handleSling to pick between scope_ref (UI intent) and body.Rig
+// (dashboard/--rig CLI intent).
+func TestSlingRigContext(t *testing.T) {
+	cases := []struct {
+		name string
+		body slingBody
+		want string
+	}{
+		{"scope_ref_wins", slingBody{ScopeKind: "rig", ScopeRef: "myrig", Rig: "otherrig"}, "myrig"},
+		{"body_rig_when_no_scope", slingBody{Rig: "myrig"}, "myrig"},
+		{"empty_when_city_scope", slingBody{ScopeKind: "city", ScopeRef: "test-city", Rig: "myrig"}, ""},
+		{"empty_when_nothing_set", slingBody{}, ""},
+		{"rig_scope_without_ref_is_empty", slingBody{ScopeKind: "rig"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := slingRigContext(tc.body); got != tc.want {
+				t.Errorf("slingRigContext(%+v) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSlingDashboardRigQualifiesBareTarget is the E2E complement:
+// the dashboard's sling command passes --rig=X as body.Rig (no
+// scope_kind/scope_ref), and bare targets must still be qualified
+// to the matching rig-scoped agent rather than 404ing.
+func TestSlingDashboardRigQualifiesBareTarget(t *testing.T) {
+	srv, _ := newSlingTestServer(t)
+	// Bare "worker" with body.Rig="myrig" (no scope_kind) — mirrors
+	// `sling <bead> worker --rig=myrig` via cmd/gc/dashboard/api.go.
+	// Must resolve to myrig/worker and hit the happy direct-bead path.
+	body := `{"target":"worker","bead":"abc","rig":"myrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("got 404 — body.Rig qualification did not apply; body = %s", rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -240,6 +240,50 @@ func TestApiAgentResolverHonorsRigContext(t *testing.T) {
 	}
 }
 
+// TestSlingRejectsScopeRefQualifiedTargetMismatch covers the split-brain
+// case: a qualified target pointing at one rig while scope_ref names a
+// different rig. Store selection follows agentCfg.Dir while the formula's
+// ScopeRef flows from body.ScopeRef, so silently accepting this would
+// route beads and formula scope to different rigs. Must reject upfront.
+func TestSlingRejectsScopeRefQualifiedTargetMismatch(t *testing.T) {
+	srv, state := newSlingTestServer(t)
+	// Add a second rig + agent so both "myrig/worker" and "otherrig/worker" exist.
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "otherrig", Path: "/tmp/otherrig", Prefix: "gc"})
+	state.cfg.Agents = append(state.cfg.Agents, config.Agent{
+		Name: "worker", Dir: "otherrig", Provider: "test-agent", MaxActiveSessions: intPtr(1),
+	})
+	state.stores["otherrig"] = beads.NewMemStore()
+
+	// Qualified target says otherrig; scope_ref says myrig — reject.
+	body := `{"target":"otherrig/worker","formula":"mol-review","scope_kind":"rig","scope_ref":"myrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "conflicts with qualified target rig") {
+		t.Errorf("error message = %s; expected mismatch diagnostic", rec.Body.String())
+	}
+}
+
+// TestSlingAllowsScopeRefQualifiedTargetMatch verifies that when the
+// qualified target's rig matches scope_ref, the handler does NOT reject.
+// Belt-and-suspenders — ensures the mismatch guard doesn't fire on
+// consistent inputs.
+func TestSlingAllowsScopeRefQualifiedTargetMatch(t *testing.T) {
+	srv, _ := newSlingTestServer(t)
+	// Matching scope: target=myrig/worker, scope_ref=myrig — should pass
+	// the mismatch guard and then trip the formula-required validation
+	// (the next validation downstream). Either result is fine as long
+	// as it is NOT the mismatch error.
+	body := `{"target":"myrig/worker","bead":"BD-42","scope_kind":"rig","scope_ref":"myrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if strings.Contains(rec.Body.String(), "conflicts with qualified target rig") {
+		t.Errorf("should not reject matching scope_ref/target; body = %s", rec.Body.String())
+	}
+}
+
 // TestSlingRigScopeRejectsUnknownBareTarget is the end-to-end sibling:
 // a bare target that can't be rig-qualified must still 404 (not silently
 // route to a wrong agent).

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -261,7 +261,7 @@ func TestSlingRejectsScopeRefQualifiedTargetMismatch(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "conflicts with qualified target rig") {
+	if !strings.Contains(rec.Body.String(), "conflicts with resolved target rig") {
 		t.Errorf("error message = %s; expected mismatch diagnostic", rec.Body.String())
 	}
 }
@@ -279,8 +279,55 @@ func TestSlingAllowsScopeRefQualifiedTargetMatch(t *testing.T) {
 	body := `{"target":"myrig/worker","bead":"BD-42","scope_kind":"rig","scope_ref":"myrig"}`
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
-	if strings.Contains(rec.Body.String(), "conflicts with qualified target rig") {
+	if strings.Contains(rec.Body.String(), "conflicts") {
 		t.Errorf("should not reject matching scope_ref/target; body = %s", rec.Body.String())
+	}
+}
+
+// TestSlingRejectsCityScopedAgentWithRigScope catches the bare-name
+// fall-through that iter2's original guard missed: a caller asks for
+// rig scope but the bare target resolves to a city-scoped agent
+// (agentCfg.Dir == ""). findSlingStore would select the city bead
+// store while FormulaOpts.ScopeRef would claim rig scope — split-brain.
+func TestSlingRejectsCityScopedAgentWithRigScope(t *testing.T) {
+	srv, state := newSlingTestServer(t)
+	// Add a city-scoped agent.
+	state.cfg.Agents = append(state.cfg.Agents, config.Agent{
+		Name:              "mayor",
+		Provider:          "test-agent",
+		MaxActiveSessions: intPtr(1),
+	})
+
+	// Bare "mayor" + scope_kind=rig — qualifySlingTarget will not find
+	// "myrig/mayor", falls through to city-scoped mayor, guard must reject.
+	body := `{"target":"mayor","formula":"mol-review","scope_kind":"rig","scope_ref":"myrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "city-scoped") {
+		t.Errorf("error = %s; expected city-scoped diagnostic", rec.Body.String())
+	}
+}
+
+// TestSlingRejectsBodyRigMismatch catches the case where the caller
+// explicitly sets body.Rig to something different from scope_ref.
+// body.Rig wins store selection in findSlingStore, so disagreement
+// produces split-brain dispatch.
+func TestSlingRejectsBodyRigMismatch(t *testing.T) {
+	srv, state := newSlingTestServer(t)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "otherrig", Path: "/tmp/otherrig", Prefix: "gc"})
+	state.stores["otherrig"] = beads.NewMemStore()
+
+	body := `{"target":"myrig/worker","formula":"mol-review","scope_kind":"rig","scope_ref":"myrig","rig":"otherrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "rig otherrig") {
+		t.Errorf("error = %s; expected body-rig mismatch diagnostic", rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -153,3 +153,102 @@ func TestSlingPoolTarget(t *testing.T) {
 		t.Fatalf("status = %q, want slung", resp["status"])
 	}
 }
+
+// TestQualifySlingTarget covers the scope-aware target qualification logic:
+// when a UI dispatch arrives with scope_kind=rig and a bare-name target,
+// the helper rewrites the target to "<scope_ref>/<name>" — but only when
+// the rig-scoped agent actually exists, so city-scoped fallbacks keep
+// working.
+func TestQualifySlingTarget(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "myrig", MaxActiveSessions: intPtr(1)},
+			{Name: "mayor", MaxActiveSessions: intPtr(1)}, // city-scoped
+		},
+	}
+
+	cases := []struct {
+		name      string
+		target    string
+		scopeKind string
+		scopeRef  string
+		want      string
+	}{
+		{"rig_bare_qualifies", "worker", "rig", "myrig", "myrig/worker"},
+		{"rig_bare_no_match_unchanged", "worker", "rig", "otherrig", "worker"},
+		{"rig_qualified_unchanged", "myrig/worker", "rig", "myrig", "myrig/worker"},
+		{"city_bare_unchanged", "worker", "city", "test-city", "worker"},
+		{"no_scope_unchanged", "worker", "", "", "worker"},
+		{"rig_but_no_ref_unchanged", "worker", "rig", "", "worker"},
+		{"rig_city_scoped_fallthrough", "mayor", "rig", "myrig", "mayor"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := qualifySlingTarget(cfg, tc.target, tc.scopeKind, tc.scopeRef)
+			if got != tc.want {
+				t.Errorf("qualifySlingTarget(%q, %q, %q) = %q, want %q", tc.target, tc.scopeKind, tc.scopeRef, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApiAgentResolverHonorsRigContext verifies that the API-side agent
+// resolver does the same rig-contextual bare-name match the CLI does —
+// required so formula child steps with bare assignees resolve to the
+// correct rig when the top-level target is rig-qualified.
+func TestApiAgentResolverHonorsRigContext(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "myrig", MaxActiveSessions: intPtr(1)},
+			{Name: "worker", Dir: "otherrig", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	resolver := apiAgentResolver{}
+
+	// Bare name + rig context prefers the rig-scoped agent.
+	a, ok := resolver.ResolveAgent(cfg, "worker", "myrig")
+	if !ok {
+		t.Fatal("expected to resolve worker with rig context")
+	}
+	if a.QualifiedName() != "myrig/worker" {
+		t.Errorf("got %q, want myrig/worker", a.QualifiedName())
+	}
+
+	// Bare name + different rig context resolves to that rig.
+	a, ok = resolver.ResolveAgent(cfg, "worker", "otherrig")
+	if !ok {
+		t.Fatal("expected to resolve worker with otherrig context")
+	}
+	if a.QualifiedName() != "otherrig/worker" {
+		t.Errorf("got %q, want otherrig/worker", a.QualifiedName())
+	}
+
+	// Qualified name is never re-qualified.
+	a, ok = resolver.ResolveAgent(cfg, "myrig/worker", "otherrig")
+	if !ok {
+		t.Fatal("expected to resolve qualified name")
+	}
+	if a.QualifiedName() != "myrig/worker" {
+		t.Errorf("got %q, want myrig/worker (rigContext must not override qualified name)", a.QualifiedName())
+	}
+
+	// No rig context: fall back to plain findAgent behavior (bare name
+	// without context and no city-scoped match → not found).
+	if _, ok := resolver.ResolveAgent(cfg, "worker", ""); ok {
+		t.Error("expected bare name with no rig context + no city-scoped agent to fail")
+	}
+}
+
+// TestSlingRigScopeRejectsUnknownBareTarget is the end-to-end sibling:
+// a bare target that can't be rig-qualified must still 404 (not silently
+// route to a wrong agent).
+func TestSlingRigScopeRejectsUnknownBareTarget(t *testing.T) {
+	srv, _ := newSlingTestServer(t)
+	// No agent named "ghost" in any scope.
+	body := `{"target":"ghost","bead":"abc","scope_kind":"rig","scope_ref":"myrig"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- `/v0/sling` now qualifies bare-name targets using rig context (from `scope_ref` for UI dispatches or `body.Rig` for dashboard `--rig=X` dispatches), matching the CLI's ambient-rig behavior. Formulas using generic bare-name assignees (e.g. `codex-max`) finally route to the correct rig when launched from gasworks-gui or `gc dashboard`.
- `apiAgentResolver.ResolveAgent` honors the `rigContext` parameter it was previously discarding, so formula child steps route to the top-level target's rig instead of falling through to city-scoped sessions.
- New consistency guard rejects split-brain dispatches where the agent's home rig, `body.Rig`, and `scope_ref` disagree — surfaces UI bugs loudly instead of letting beads land in one rig while formula scope references another.

## Root cause

`handleSling` called `findAgent(cfg, body.Target)` without any rig context, and `apiAgentResolver.ResolveAgent` explicitly ignored its `rigContext` argument (`func (apiAgentResolver) ResolveAgent(cfg *config.City, name, _ string)`). The CLI path (`cmd/gc/cmd_agent.go:resolveAgentIdentity`) gets rig context from the cwd; the API path had no equivalent.

Consequence: when gasworks-gui dispatched an adopt-pr formula for a specific rig with a generic bare-name target, both the top-level target and every bare-assignee child step resolved city-scoped, which then queried the city beads store for rig-local beads and failed.

## Test plan

- [x] `go test ./internal/api/...` — all green, including 8 new tests covering qualification, resolver parity (with pool + V2 BindingName cases), split-brain rejection (3 classes), and dashboard body.Rig path
- [x] `make lint` — 0 issues
- [x] `go vet ./internal/...` — clean
- [ ] CI green
- [ ] Manual: launch an adopt-pr-like formula from gasworks-gui UI with `scope_kind=rig` and confirm bare-name assignees route to the correct rig
- [ ] Manual: `gc dashboard` → `sling <bead> worker --rig=myrig` with bare target now resolves to `myrig/worker`

## Review

Reviewed across 6 iterations via multi-model review pipeline (Claude + Codex, Gemini rate-limited from iter2). Each iteration surfaced a genuine concrete gap that was then addressed:

1. Initial fix + unit tests
2. E2E coverage + resolver parity test
3. Reject qualified-target vs scope_ref mismatch
4. Tighten guard to cover city-scope fall-through + body.Rig mismatch
5. Expand parity coverage to pool + V2 BindingName cases
6. Honor body.Rig as ambient context for dashboard dispatches

Final iteration (#6): both reviewers report fix validations correct, no blockers or majors, only minors/nit.

## Follow-ups (not in this PR)

- Unify CLI and API resolvers onto `internal/agentutil/ResolveAgent` — requires first porting `findAgent`'s V2 BindingName pool-prefix handling into `agentutil`. `TestApiVsAgentutilResolverParity` locks in current divergence so the refactor is trackable.
- `cmd/gc/dashboard/api.go` could optionally also send `scope_kind=rig` + `scope_ref=X` when `--rig=X` is present alongside `--formula=...`, to get the consistency guard protection for formula launches too. This PR handles the routing correctly without that change; upgrading the dashboard is a narrow quality-of-life win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)