### PR TITLE
Fix Discord-bound session delivery edge cases

### DIFF
--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -23,8 +23,100 @@ type noActivityCapabilityProvider struct {
 
 func intPtrNudge(n int) *int { return &n }
 
+type missingNudgeBeadStore struct {
+	*beads.MemStore
+	missingID string
+}
+
+func (s *missingNudgeBeadStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.missingID {
+		return fmt.Errorf("setting metadata on %q: exit status 1: Error resolving %s: no issue found matching %q", id, id, id)
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+func (s *missingNudgeBeadStore) Close(id string) error {
+	if id == s.missingID {
+		return fmt.Errorf("closing bead %q: exit status 1: Error resolving %s: no issue found matching %q", id, id, id)
+	}
+	return s.MemStore.Close(id)
+}
+
 func (p *noActivityCapabilityProvider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{}
+}
+
+func TestMarkQueuedNudgeTerminalFallsBackFromMissingStoredBeadID(t *testing.T) {
+	store := &missingNudgeBeadStore{MemStore: beads.NewMemStore(), missingID: "gc-458"}
+	item := queuedNudge{
+		ID:        "nudge-stale",
+		Agent:     "wendy.wendy",
+		SessionID: "mc-ayq6xi",
+		Source:    "session",
+		Message:   "follow up",
+		BeadID:    "gc-458",
+		CreatedAt: time.Now().Add(-time.Minute).UTC(),
+	}
+	createdID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected ensureQueuedNudgeBead to create a backing nudge bead")
+	}
+
+	now := time.Now().UTC()
+	item.LastError = "expired"
+	if err := markQueuedNudgeTerminal(store, item, "expired", "expired", "", now); err != nil {
+		t.Fatalf("markQueuedNudgeTerminal: %v", err)
+	}
+
+	bead, err := store.Get(createdID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", createdID, err)
+	}
+	if bead.Status != "closed" {
+		t.Fatalf("bead.Status = %q, want closed", bead.Status)
+	}
+	if bead.Metadata["state"] != "expired" {
+		t.Fatalf("state = %q, want expired", bead.Metadata["state"])
+	}
+	if bead.Metadata["terminal_reason"] != "expired" {
+		t.Fatalf("terminal_reason = %q, want expired", bead.Metadata["terminal_reason"])
+	}
+}
+
+func TestPruneExpiredQueuedNudgesIgnoresMissingTerminalBead(t *testing.T) {
+	store := &missingNudgeBeadStore{MemStore: beads.NewMemStore(), missingID: "gc-458"}
+	now := time.Now().UTC()
+	state := &nudgeQueueState{
+		Pending: []queuedNudge{
+			{
+				ID:           "nudge-stale",
+				BeadID:       "gc-458",
+				Agent:        "wendy.wendy",
+				SessionID:    "mc-ayq6xi",
+				Source:       "session",
+				Message:      "follow up",
+				CreatedAt:    now.Add(-2 * time.Hour),
+				DeliverAfter: now.Add(-2 * time.Hour),
+				ExpiresAt:    now.Add(-time.Hour),
+			},
+		},
+	}
+
+	if err := pruneExpiredQueuedNudges(state, store, now); err != nil {
+		t.Fatalf("pruneExpiredQueuedNudges: %v", err)
+	}
+	if len(state.Pending) != 0 {
+		t.Fatalf("pending = %d, want 0", len(state.Pending))
+	}
+	if len(state.Dead) != 1 {
+		t.Fatalf("dead = %d, want 1", len(state.Dead))
+	}
+	if state.Dead[0].LastError != "expired" {
+		t.Fatalf("dead[0].LastError = %q, want expired", state.Dead[0].LastError)
+	}
 }
 
 func TestDeliverSessionNudgeWithProviderWaitIdleQueuesForCodex(t *testing.T) {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -42,8 +42,56 @@ func (s *missingNudgeBeadStore) Close(id string) error {
 	return s.MemStore.Close(id)
 }
 
+type unrelatedNotFoundNudgeBeadStore struct {
+	*beads.MemStore
+	errorID string
+}
+
+func (s *unrelatedNotFoundNudgeBeadStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.errorID {
+		return fmt.Errorf("setting metadata on %q: backend path not found", id)
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
 func (p *noActivityCapabilityProvider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{}
+}
+
+func TestMarkQueuedNudgeTerminalFallsBackWhenStoredBeadIDEmpty(t *testing.T) {
+	store := beads.NewMemStore()
+	item := queuedNudge{
+		ID:        "nudge-empty-bead",
+		Agent:     "wendy.wendy",
+		SessionID: "mc-ayq6xi",
+		Source:    "session",
+		Message:   "follow up",
+		CreatedAt: time.Now().Add(-time.Minute).UTC(),
+	}
+	createdID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected ensureQueuedNudgeBead to create a backing nudge bead")
+	}
+
+	now := time.Now().UTC()
+	item.LastError = "expired"
+	if err := markQueuedNudgeTerminal(store, item, "expired", "expired", "", now); err != nil {
+		t.Fatalf("markQueuedNudgeTerminal: %v", err)
+	}
+
+	bead, err := store.Get(createdID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", createdID, err)
+	}
+	if bead.Status != "closed" {
+		t.Fatalf("bead.Status = %q, want closed", bead.Status)
+	}
+	if bead.Metadata["state"] != "expired" {
+		t.Fatalf("state = %q, want expired", bead.Metadata["state"])
+	}
 }
 
 func TestMarkQueuedNudgeTerminalFallsBackFromMissingStoredBeadID(t *testing.T) {
@@ -83,6 +131,32 @@ func TestMarkQueuedNudgeTerminalFallsBackFromMissingStoredBeadID(t *testing.T) {
 	}
 	if bead.Metadata["terminal_reason"] != "expired" {
 		t.Fatalf("terminal_reason = %q, want expired", bead.Metadata["terminal_reason"])
+	}
+}
+
+func TestMarkQueuedNudgeTerminalReturnsUnrelatedNotFoundErrors(t *testing.T) {
+	store := &unrelatedNotFoundNudgeBeadStore{MemStore: beads.NewMemStore()}
+	item := queuedNudge{
+		ID:        "nudge-terminal-error",
+		Agent:     "wendy.wendy",
+		SessionID: "mc-ayq6xi",
+		Source:    "session",
+		Message:   "follow up",
+		CreatedAt: time.Now().Add(-time.Minute).UTC(),
+	}
+	createdID, _, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	store.errorID = createdID
+	item.BeadID = createdID
+
+	err = markQueuedNudgeTerminal(store, item, "expired", "expired", "", time.Now().UTC())
+	if err == nil {
+		t.Fatal("markQueuedNudgeTerminal returned nil, want unrelated not found error")
+	}
+	if !strings.Contains(err.Error(), "backend path not found") {
+		t.Fatalf("markQueuedNudgeTerminal error = %v, want backend path not found", err)
 	}
 }
 

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -400,28 +400,11 @@ func resolvedSessionCommand(cityPath string, resolved *config.ResolvedProvider, 
 	if resolved == nil {
 		return "", fmt.Errorf("resolved provider is nil")
 	}
-	command := resolved.CommandString()
-	if len(resolved.OptionsSchema) > 0 {
-		fullOptions := make(map[string]string, len(resolved.EffectiveDefaults)+len(optionOverrides))
-		for k, v := range resolved.EffectiveDefaults {
-			fullOptions[k] = v
-		}
-		for k, v := range optionOverrides {
-			if k == "initial_message" {
-				continue
-			}
-			fullOptions[k] = v
-		}
-		if args, err := config.ResolveExplicitOptions(resolved.OptionsSchema, fullOptions); err != nil {
-			return "", fmt.Errorf("resolving provider defaults: %w", err)
-		} else if len(args) > 0 {
-			command = replaceSchemaFlags(command, resolved.OptionsSchema, args)
-		}
+	launchCommand, err := config.BuildProviderLaunchCommand(cityPath, resolved, optionOverrides)
+	if err != nil {
+		return "", fmt.Errorf("resolving provider launch command: %w", err)
 	}
-	if sa := settingsArgs(cityPath, resolved.Name); sa != "" {
-		command = command + " " + sa
-	}
-	return command, nil
+	return launchCommand.Command, nil
 }
 
 func resolveSessionTemplate(cfg *config.City, input, currentRigDir string) (config.Agent, bool) {

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -119,28 +121,62 @@ func markQueuedNudgeTerminal(store beads.Store, item queuedNudge, state, reason,
 	if store == nil {
 		return nil
 	}
-	beadID := item.BeadID
-	if beadID == "" {
-		b, ok, err := findQueuedNudgeBead(store, item.ID)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return nil
-		}
-		beadID = b.ID
-	}
-	if err := store.SetMetadataBatch(beadID, map[string]string{
+	update := map[string]string{
 		"state":           state,
 		"last_attempt_at": formatOptionalTime(item.LastAttemptAt),
 		"last_error":      item.LastError,
 		"terminal_reason": reason,
 		"commit_boundary": commitBoundary,
 		"terminal_at":     now.UTC().Format(time.RFC3339),
-	}); err != nil {
+	}
+
+	tryTerminalize := func(beadID string) error {
+		if beadID == "" {
+			return nil
+		}
+		if err := store.SetMetadataBatch(beadID, update); err != nil {
+			if isMissingQueuedNudgeBeadErr(err) {
+				return beads.ErrNotFound
+			}
+			return err
+		}
+		if err := store.Close(beadID); err != nil {
+			if isMissingQueuedNudgeBeadErr(err) {
+				return beads.ErrNotFound
+			}
+			return err
+		}
+		return nil
+	}
+
+	if err := tryTerminalize(item.BeadID); err == nil {
+		return nil
+	} else if !errors.Is(err, beads.ErrNotFound) {
 		return err
 	}
-	return store.Close(beadID)
+
+	b, ok, err := findAnyQueuedNudgeBead(store, item.ID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if err := tryTerminalize(b.ID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func isMissingQueuedNudgeBeadErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, beads.ErrNotFound) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "no issue found")
 }
 
 func marshalNudgeReference(ref *nudgeReference) string {

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -132,16 +133,16 @@ func markQueuedNudgeTerminal(store beads.Store, item queuedNudge, state, reason,
 
 	tryTerminalize := func(beadID string) error {
 		if beadID == "" {
-			return nil
+			return beads.ErrNotFound
 		}
 		if err := store.SetMetadataBatch(beadID, update); err != nil {
-			if isMissingQueuedNudgeBeadErr(err) {
+			if isMissingQueuedNudgeBeadErr(err, beadID) {
 				return beads.ErrNotFound
 			}
 			return err
 		}
 		if err := store.Close(beadID); err != nil {
-			if isMissingQueuedNudgeBeadErr(err) {
+			if isMissingQueuedNudgeBeadErr(err, beadID) {
 				return beads.ErrNotFound
 			}
 			return err
@@ -168,15 +169,20 @@ func markQueuedNudgeTerminal(store beads.Store, item queuedNudge, state, reason,
 	return nil
 }
 
-func isMissingQueuedNudgeBeadErr(err error) bool {
+func isMissingQueuedNudgeBeadErr(err error, beadID string) bool {
 	if err == nil {
 		return false
 	}
 	if errors.Is(err, beads.ErrNotFound) {
 		return true
 	}
+	beadID = strings.ToLower(strings.TrimSpace(beadID))
+	if beadID == "" {
+		return false
+	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "not found") || strings.Contains(msg, "no issue found")
+	return strings.Contains(msg, "no issue found matching "+strings.ToLower(strconv.Quote(beadID))) ||
+		strings.Contains(msg, "error resolving "+beadID+": no issue found")
 }
 
 func marshalNudgeReference(ref *nudgeReference) string {

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -119,6 +119,10 @@ func materializeSessionForTemplateWithOptions(
 		if err != nil {
 			return "", err
 		}
+		sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil)
+		if err != nil {
+			return "", err
+		}
 		workDirQualifiedName := workdirutil.SessionQualifiedName(cityPath, *spec.Agent, cfg.Rigs, spec.Identity, "")
 		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, workDirQualifiedName)
 		if err != nil {
@@ -153,7 +157,7 @@ func materializeSessionForTemplateWithOptions(
 			spec.SessionName,
 			templateIdentity,
 			title,
-			resolved.CommandString(),
+			sessionCommand,
 			providerName,
 			workDir,
 			spec.Agent.Session,
@@ -259,6 +263,10 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 	if err != nil {
 		return "", err
 	}
+	sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil)
+	if err != nil {
+		return "", err
+	}
 	explicitName, err := sessionExplicitNameForNewSession(agentCfg, "")
 	if err != nil {
 		return "", err
@@ -292,7 +300,7 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 		explicitName,
 		agentCfg.QualifiedName(),
 		title,
-		resolved.CommandString(),
+		sessionCommand,
 		agentCfg.Provider,
 		workDir,
 		agentCfg.Session,

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
-	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/gastownhall/gascity/internal/worker"
 )
 
@@ -323,12 +322,10 @@ func resolvedWorkerRuntimeWithConfig(cityPath string, cfg *config.City, info ses
 		return nil
 	}
 
+	launchCommand, err := config.BuildProviderLaunchCommand(cityPath, resolved, nil)
 	command := resolved.CommandString()
-	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
-		command = command + " " + shellquote.Join(defaultArgs)
-	}
-	if sa := settingsArgs(cityPath, resolved.Name); sa != "" {
-		command = command + " " + sa
+	if err == nil {
+		command = launchCommand.Command
 	}
 
 	workDir := strings.TrimSpace(info.WorkDir)

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -98,6 +100,45 @@ STUB_ENV = "present"
 	}
 	if start.Env["STUB_ENV"] != "present" {
 		t.Fatalf("Env[STUB_ENV] = %q, want present", start.Env["STUB_ENV"])
+	}
+}
+
+func TestResolvedWorkerRuntimeWithConfigUsesProviderLaunchCommand(t *testing.T) {
+	cityDir := t.TempDir()
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gcDir, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	claude := config.BuiltinProviders()["claude"]
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:     "worker",
+			Provider: "claude",
+		}},
+		Providers: map[string]config.ProviderSpec{
+			"claude": claude,
+		},
+	}
+
+	resolved := resolvedWorkerRuntimeWithConfig(cityDir, cfg, session.Info{
+		Template: "worker",
+		WorkDir:  cityDir,
+	}, "")
+	if resolved == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
+	}
+	if !strings.Contains(resolved.Command, "--dangerously-skip-permissions") {
+		t.Fatalf("Command = %q, want unrestricted default", resolved.Command)
+	}
+	if !strings.Contains(resolved.Command, "--effort max") {
+		t.Fatalf("Command = %q, want effort max default", resolved.Command)
+	}
+	if !strings.Contains(resolved.Command, "--settings") {
+		t.Fatalf("Command = %q, want settings arg", resolved.Command)
 	}
 }
 

--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -41,11 +41,58 @@ func (s *Server) extmsgEmitEvent() func(string, string, events.Payload) {
 	}
 }
 
-// extmsgNotifyMembers sends a "check transcript" message to all transcript
-// members via the session message API. This ensures delivery regardless of
-// session state: sleeping sessions are woken, idle sessions get a new prompt
-// turn that triggers the transcript check hook.
-func (s *Server) extmsgNotifyMembers(ctx context.Context, conv extmsg.ConversationRef, inboundMsg extmsg.ExternalInboundMessage) {
+func extmsgHandleLabel(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return value
+	}
+	if idx := strings.LastIndex(value, "/"); idx >= 0 && idx+1 < len(value) {
+		return value[idx+1:]
+	}
+	return value
+}
+
+func (s *Server) extmsgSessionHandleForSelector(selector string) string {
+	store := s.state.CityBeadStore()
+	if store == nil {
+		return extmsgHandleLabel(selector)
+	}
+	resolvedID, err := session.ResolveSessionIDAllowClosed(store, selector)
+	if err != nil {
+		return extmsgHandleLabel(selector)
+	}
+	return s.extmsgSessionHandleForResolvedID(resolvedID, selector)
+}
+
+func (s *Server) extmsgSessionHandleForResolvedID(resolvedID, fallback string) string {
+	store := s.state.CityBeadStore()
+	if store == nil {
+		return extmsgHandleLabel(fallback)
+	}
+	b, err := store.Get(resolvedID)
+	if err != nil {
+		return extmsgHandleLabel(fallback)
+	}
+	if alias := strings.TrimSpace(b.Metadata["alias"]); alias != "" {
+		return extmsgHandleLabel(alias)
+	}
+	if sessionName := strings.TrimSpace(b.Metadata["session_name"]); sessionName != "" {
+		return extmsgHandleLabel(sessionName)
+	}
+	return extmsgHandleLabel(fallback)
+}
+
+// extmsgNotifyMembers sends a peer-publication reminder to transcript members
+// via the session message API. This treats membership as the routing truth and
+// lets session resolution materialize or wake named sessions on first receive.
+func (s *Server) extmsgNotifyMembers(
+	ctx context.Context,
+	conv extmsg.ConversationRef,
+	actorDisplayName string,
+	actorKind string,
+	text string,
+	excludeSelector string,
+) {
 	svc := s.state.ExtMsgServices()
 	store := s.state.CityBeadStore()
 	if svc == nil || store == nil {
@@ -58,29 +105,30 @@ func (s *Server) extmsgNotifyMembers(ctx context.Context, conv extmsg.Conversati
 		return
 	}
 
-	actorKind := "agent"
-	if !inboundMsg.Actor.IsBot {
-		actorKind = "human"
+	excludedResolvedID := ""
+	if selector := strings.TrimSpace(excludeSelector); selector != "" {
+		resolvedID, err := s.resolveSessionIDMaterializingNamedWithContext(ctx, store, selector)
+		if err != nil {
+			log.Printf("extmsg: resolve sender %s failed: %v", selector, err)
+		} else {
+			excludedResolvedID = resolvedID
+		}
 	}
 
 	var wg sync.WaitGroup
 	for _, m := range members {
 		wg.Add(1)
-		go func(sessionID string) {
+		go func(sessionSelector string) {
 			defer wg.Done()
-			// Resolve the member's handle from their session bead alias.
-			// Membership stores session names (s-et-xxxx); bead IDs drop the "s-" prefix.
-			handle := sessionID
-			beadID := strings.TrimPrefix(sessionID, "s-")
-			if b, err := store.Get(beadID); err == nil {
-				if alias := b.Metadata["alias"]; alias != "" {
-					if idx := strings.LastIndex(alias, "/"); idx >= 0 {
-						handle = alias[idx+1:]
-					} else {
-						handle = alias
-					}
-				}
+			resolvedID, err := s.resolveSessionIDMaterializingNamedWithContext(ctx, store, sessionSelector)
+			if err != nil {
+				log.Printf("extmsg: resolve session %s failed: %v", sessionSelector, err)
+				return
 			}
+			if excludedResolvedID != "" && resolvedID == excludedResolvedID {
+				return
+			}
+			handle := s.extmsgSessionHandleForResolvedID(resolvedID, sessionSelector)
 			nudge := fmt.Sprintf("<system-reminder>\nNew message in shared conversation %s/%s:\n\n"+
 				"- %s (%s): %s\n\n"+
 				"To reply in Discord, write your response to a file and run:\n"+
@@ -89,20 +137,22 @@ func (s *Server) extmsgNotifyMembers(ctx context.Context, conv extmsg.Conversati
 				"Run 'gc transcript read --ack' after responding to mark as read.\n"+
 				"</system-reminder>",
 				conv.Provider, conv.ConversationID,
-				inboundMsg.Actor.DisplayName, actorKind, inboundMsg.Text,
+				actorDisplayName, actorKind, text,
 				conv.ConversationID,
 				handle,
 			)
-			// Resolve session identifier to bead ID, then send.
-			resolvedID, err := session.ResolveSessionID(store, sessionID)
-			if err != nil {
-				log.Printf("extmsg: resolve session %s failed: %v", sessionID, err)
-				return
-			}
 			if err := s.sendBackgroundMessageToSession(ctx, store, resolvedID, nudge); err != nil {
-				log.Printf("extmsg: notify %s failed: %v", sessionID, err)
+				log.Printf("extmsg: notify %s failed: %v", sessionSelector, err)
 			}
 		}(m.SessionID)
 	}
 	wg.Wait()
+}
+
+func (s *Server) extmsgNotifyInboundMembers(ctx context.Context, msg extmsg.ExternalInboundMessage) {
+	actorKind := "agent"
+	if !msg.Actor.IsBot {
+		actorKind = "human"
+	}
+	s.extmsgNotifyMembers(ctx, msg.Conversation, msg.Actor.DisplayName, actorKind, msg.Text, "")
 }

--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -106,12 +106,32 @@ func (s *Server) extmsgNotifyMembers(
 	}
 
 	excludedResolvedID := ""
+	excludedSelector := apiNormalizeSessionTarget(excludeSelector)
 	if selector := strings.TrimSpace(excludeSelector); selector != "" {
-		resolvedID, err := s.resolveSessionIDMaterializingNamedWithContext(ctx, store, selector)
+		resolvedID, err := s.resolveSessionTargetIDWithContext(ctx, store, selector, apiSessionResolveOptions{})
 		if err != nil {
 			log.Printf("extmsg: resolve sender %s failed: %v", selector, err)
 		} else {
 			excludedResolvedID = resolvedID
+		}
+	}
+
+	notifyResolved := func(sessionSelector, resolvedID string) {
+		handle := s.extmsgSessionHandleForResolvedID(resolvedID, sessionSelector)
+		nudge := fmt.Sprintf("<system-reminder>\nNew message in shared conversation %s/%s:\n\n"+
+			"- %s (%s): %s\n\n"+
+			"To reply in Discord, write your response to a file and run:\n"+
+			"  gc discord reply-current --conversation-id %s --body-file <path>\n"+
+			"Prefix your reply with your agent handle in bold (e.g., **%s:** your message).\n"+
+			"Run 'gc transcript read --ack' after responding to mark as read.\n"+
+			"</system-reminder>",
+			conv.Provider, conv.ConversationID,
+			actorDisplayName, actorKind, text,
+			conv.ConversationID,
+			handle,
+		)
+		if err := s.sendBackgroundMessageToSession(ctx, store, resolvedID, nudge); err != nil {
+			log.Printf("extmsg: notify %s failed: %v", sessionSelector, err)
 		}
 	}
 
@@ -120,30 +140,29 @@ func (s *Server) extmsgNotifyMembers(
 		wg.Add(1)
 		go func(sessionSelector string) {
 			defer wg.Done()
+			if excludedSelector != "" && apiNormalizeSessionTarget(sessionSelector) == excludedSelector {
+				return
+			}
+			preexistingID, preErr := s.resolveSessionTargetIDWithContext(ctx, store, sessionSelector, apiSessionResolveOptions{})
+			if preErr == nil && preexistingID != "" {
+				if excludedResolvedID != "" && preexistingID == excludedResolvedID {
+					return
+				}
+				notifyResolved(sessionSelector, preexistingID)
+				return
+			}
 			resolvedID, err := s.resolveSessionIDMaterializingNamedWithContext(ctx, store, sessionSelector)
 			if err != nil {
 				log.Printf("extmsg: resolve session %s failed: %v", sessionSelector, err)
 				return
 			}
+			if preErr != nil {
+				log.Printf("extmsg: materialized session %s as %s for conversation %s/%s", sessionSelector, resolvedID, conv.Provider, conv.ConversationID)
+			}
 			if excludedResolvedID != "" && resolvedID == excludedResolvedID {
 				return
 			}
-			handle := s.extmsgSessionHandleForResolvedID(resolvedID, sessionSelector)
-			nudge := fmt.Sprintf("<system-reminder>\nNew message in shared conversation %s/%s:\n\n"+
-				"- %s (%s): %s\n\n"+
-				"To reply in Discord, write your response to a file and run:\n"+
-				"  gc discord reply-current --conversation-id %s --body-file <path>\n"+
-				"Prefix your reply with your agent handle in bold (e.g., **%s:** your message).\n"+
-				"Run 'gc transcript read --ack' after responding to mark as read.\n"+
-				"</system-reminder>",
-				conv.Provider, conv.ConversationID,
-				actorDisplayName, actorKind, text,
-				conv.ConversationID,
-				handle,
-			)
-			if err := s.sendBackgroundMessageToSession(ctx, store, resolvedID, nudge); err != nil {
-				log.Printf("extmsg: notify %s failed: %v", sessionSelector, err)
-			}
+			notifyResolved(sessionSelector, resolvedID)
 		}(m.SessionID)
 	}
 	wg.Wait()

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/extmsg"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+type testExtMsgAdapter struct {
+	publishCalls []extmsg.PublishRequest
+}
+
+func (a *testExtMsgAdapter) Name() string { return "test-extmsg-adapter" }
+
+func (a *testExtMsgAdapter) Capabilities() extmsg.AdapterCapabilities {
+	return extmsg.AdapterCapabilities{}
+}
+
+func (a *testExtMsgAdapter) VerifyAndNormalizeInbound(context.Context, extmsg.InboundPayload) (*extmsg.ExternalInboundMessage, error) {
+	panic("unexpected VerifyAndNormalizeInbound call")
+}
+
+func (a *testExtMsgAdapter) Publish(_ context.Context, req extmsg.PublishRequest) (*extmsg.PublishReceipt, error) {
+	a.publishCalls = append(a.publishCalls, req)
+	return &extmsg.PublishReceipt{
+		MessageID:    "discord-msg-1",
+		Conversation: req.Conversation,
+		Delivered:    true,
+	}, nil
+}
+
+func (a *testExtMsgAdapter) EnsureChildConversation(context.Context, extmsg.ConversationRef, string) (*extmsg.ConversationRef, error) {
+	panic("unexpected EnsureChildConversation call")
+}
+
+func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	services := extmsg.NewServices(fs.cityBeadStore)
+	fs.extmsgSvc = &services
+	registry := extmsg.NewAdapterRegistry()
+	adapter := &testExtMsgAdapter{}
+	registry.Register(extmsg.AdapterKey{Provider: "discord", AccountID: "acct-1"}, adapter)
+	fs.adapterReg = registry
+
+	source := createTestSession(t, fs.cityBeadStore, fs.sp, "Publisher")
+	ref := extmsg.ConversationRef{
+		ScopeID:        "guild-1",
+		Provider:       "discord",
+		AccountID:      "acct-1",
+		ConversationID: "thread-1",
+		Kind:           extmsg.ConversationThread,
+	}
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	now := time.Now().UTC()
+	if _, err := services.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: ref,
+		SessionID:    source.ID,
+		Now:          now,
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if _, err := services.Transcript.EnsureMembership(context.Background(), extmsg.EnsureMembershipInput{
+		Caller:         caller,
+		Conversation:   ref,
+		SessionID:      "myrig/worker",
+		BackfillPolicy: extmsg.MembershipBackfillSinceJoin,
+		Owner:          extmsg.MembershipOwnerManual,
+		Now:            now,
+	}); err != nil {
+		t.Fatalf("EnsureMembership(peer): %v", err)
+	}
+	if _, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil {
+		t.Fatal("named peer should not be materialized before outbound publish")
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"session_id": source.ID,
+		"conversation": map[string]any{
+			"scope_id":        ref.ScopeID,
+			"provider":        ref.Provider,
+			"account_id":      ref.AccountID,
+			"conversation_id": ref.ConversationID,
+			"kind":            ref.Kind,
+		},
+		"text": "hello peers",
+	})
+	if err != nil {
+		t.Fatalf("Marshal(body): %v", err)
+	}
+	req := newPostRequest("/v0/extmsg/outbound", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(adapter.publishCalls) != 1 {
+		t.Fatalf("publish calls = %d, want 1", len(adapter.publishCalls))
+	}
+	if adapter.publishCalls[0].Text != "hello peers" {
+		t.Fatalf("publish text = %q, want hello peers", adapter.publishCalls[0].Text)
+	}
+
+	peerID, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
+	if err != nil {
+		t.Fatalf("ResolveSessionID(myrig/worker): %v", err)
+	}
+	peerBead, err := fs.cityBeadStore.Get(peerID)
+	if err != nil {
+		t.Fatalf("Get(peer): %v", err)
+	}
+	peerSessionName := peerBead.Metadata["session_name"]
+	if peerSessionName == "" {
+		t.Fatal("materialized peer session missing session_name")
+	}
+	if !fs.sp.IsRunning(peerSessionName) {
+		t.Fatalf("peer session %q should be running after outbound publish", peerSessionName)
+	}
+
+	peerNudges := 0
+	for _, call := range fs.sp.Calls {
+		if call.Method != "Nudge" {
+			continue
+		}
+		if call.Name == source.SessionName {
+			t.Fatalf("source session should not receive peer publish nudge; calls=%#v", fs.sp.Calls)
+		}
+		if call.Name == peerSessionName && strings.Contains(call.Message, "hello peers") {
+			peerNudges++
+		}
+	}
+	if peerNudges != 1 {
+		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, fs.sp.Calls)
+	}
+}

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 type testExtMsgAdapter struct {
-	publishCalls []extmsg.PublishRequest
+	publishCalls        []extmsg.PublishRequest
+	receiptConversation extmsg.ConversationRef
 }
 
 func (a *testExtMsgAdapter) Name() string { return "test-extmsg-adapter" }
@@ -29,9 +30,13 @@ func (a *testExtMsgAdapter) VerifyAndNormalizeInbound(context.Context, extmsg.In
 
 func (a *testExtMsgAdapter) Publish(_ context.Context, req extmsg.PublishRequest) (*extmsg.PublishReceipt, error) {
 	a.publishCalls = append(a.publishCalls, req)
+	conversation := req.Conversation
+	if a.receiptConversation != (extmsg.ConversationRef{}) {
+		conversation = a.receiptConversation
+	}
 	return &extmsg.PublishReceipt{
 		MessageID:    "discord-msg-1",
-		Conversation: req.Conversation,
+		Conversation: conversation,
 		Delivered:    true,
 	}, nil
 }
@@ -156,5 +161,149 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	}
 	if peerNudges != 1 {
 		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, fs.sp.Calls)
+	}
+}
+
+func TestExtmsgNotifyMembersDoesNotMaterializeExcludedNamedSender(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	services := extmsg.NewServices(fs.cityBeadStore)
+	fs.extmsgSvc = &services
+
+	ref := extmsg.ConversationRef{
+		ScopeID:        "guild-1",
+		Provider:       "discord",
+		AccountID:      "acct-1",
+		ConversationID: "thread-1",
+		Kind:           extmsg.ConversationThread,
+	}
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	if _, err := services.Transcript.EnsureMembership(context.Background(), extmsg.EnsureMembershipInput{
+		Caller:         caller,
+		Conversation:   ref,
+		SessionID:      "myrig/worker",
+		BackfillPolicy: extmsg.MembershipBackfillSinceJoin,
+		Owner:          extmsg.MembershipOwnerManual,
+		Now:            time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("EnsureMembership(sender): %v", err)
+	}
+	if _, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil {
+		t.Fatal("named sender should not be materialized before notify")
+	}
+
+	srv.extmsgNotifyMembers(context.Background(), ref, "worker", "agent", "self update", "myrig/worker")
+
+	if _, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err == nil {
+		t.Fatal("excluded named sender was materialized")
+	}
+	for _, call := range fs.sp.Calls {
+		if call.Method == "Nudge" {
+			t.Fatalf("excluded sender should not receive nudge; calls=%#v", fs.sp.Calls)
+		}
+	}
+}
+
+func TestHandleExtMsgOutboundNotifiesDeliveredConversationMembers(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	services := extmsg.NewServices(fs.cityBeadStore)
+	fs.extmsgSvc = &services
+	requestRef := extmsg.ConversationRef{
+		ScopeID:        "guild-1",
+		Provider:       "discord",
+		AccountID:      "acct-1",
+		ConversationID: "thread-request",
+		Kind:           extmsg.ConversationThread,
+	}
+	deliveredRef := requestRef
+	deliveredRef.ConversationID = "thread-delivered"
+	registry := extmsg.NewAdapterRegistry()
+	adapter := &testExtMsgAdapter{receiptConversation: deliveredRef}
+	registry.Register(extmsg.AdapterKey{Provider: "discord", AccountID: "acct-1"}, adapter)
+	fs.adapterReg = registry
+
+	source := createTestSession(t, fs.cityBeadStore, fs.sp, "Publisher")
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	now := time.Now().UTC()
+	if _, err := services.Bindings.Bind(context.Background(), caller, extmsg.BindInput{
+		Conversation: requestRef,
+		SessionID:    source.ID,
+		Now:          now,
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if _, err := services.Transcript.EnsureMembership(context.Background(), extmsg.EnsureMembershipInput{
+		Caller:         caller,
+		Conversation:   deliveredRef,
+		SessionID:      "myrig/worker",
+		BackfillPolicy: extmsg.MembershipBackfillSinceJoin,
+		Owner:          extmsg.MembershipOwnerManual,
+		Now:            now,
+	}); err != nil {
+		t.Fatalf("EnsureMembership(peer): %v", err)
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"session_id": source.ID,
+		"conversation": map[string]any{
+			"scope_id":        requestRef.ScopeID,
+			"provider":        requestRef.Provider,
+			"account_id":      requestRef.AccountID,
+			"conversation_id": requestRef.ConversationID,
+			"kind":            requestRef.Kind,
+		},
+		"text": "hello delivered peers",
+	})
+	if err != nil {
+		t.Fatalf("Marshal(body): %v", err)
+	}
+	req := newPostRequest(cityURL(fs, "/extmsg/outbound"), strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var peerID string
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		peerID, err = session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("ResolveSessionID(myrig/worker): %v", err)
+	}
+	peerBead, err := fs.cityBeadStore.Get(peerID)
+	if err != nil {
+		t.Fatalf("Get(peer): %v", err)
+	}
+	peerSessionName := peerBead.Metadata["session_name"]
+	if peerSessionName == "" {
+		t.Fatal("materialized peer session missing session_name")
+	}
+
+	found := false
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		for _, call := range fs.sp.Calls {
+			if call.Method == "Nudge" && call.Name == peerSessionName && strings.Contains(call.Message, "thread-delivered") {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !found {
+		t.Fatalf("delivered conversation peer nudge not found; calls=%#v", fs.sp.Calls)
 	}
 }

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -96,7 +96,7 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	if err != nil {
 		t.Fatalf("Marshal(body): %v", err)
 	}
-	req := newPostRequest("/v0/extmsg/outbound", strings.NewReader(string(body)))
+	req := newPostRequest(cityURL(fs, "/extmsg/outbound"), strings.NewReader(string(body)))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -110,7 +110,15 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 		t.Fatalf("publish text = %q, want hello peers", adapter.publishCalls[0].Text)
 	}
 
-	peerID, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
+	var peerID string
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		peerID, err = session.ResolveSessionID(fs.cityBeadStore, "myrig/worker")
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err != nil {
 		t.Fatalf("ResolveSessionID(myrig/worker): %v", err)
 	}
@@ -127,16 +135,24 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	}
 
 	peerNudges := 0
-	for _, call := range fs.sp.Calls {
-		if call.Method != "Nudge" {
-			continue
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		peerNudges = 0
+		for _, call := range fs.sp.Calls {
+			if call.Method != "Nudge" {
+				continue
+			}
+			if call.Name == source.SessionName {
+				t.Fatalf("source session should not receive peer publish nudge; calls=%#v", fs.sp.Calls)
+			}
+			if call.Name == peerSessionName && strings.Contains(call.Message, "hello peers") {
+				peerNudges++
+			}
 		}
-		if call.Name == source.SessionName {
-			t.Fatalf("source session should not receive peer publish nudge; calls=%#v", fs.sp.Calls)
+		if peerNudges == 1 {
+			break
 		}
-		if call.Name == peerSessionName && strings.Contains(call.Message, "hello peers") {
-			peerNudges++
-		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if peerNudges != 1 {
 		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, fs.sp.Calls)

--- a/internal/api/handler_session_chat_test.go
+++ b/internal/api/handler_session_chat_test.go
@@ -80,3 +80,34 @@ func TestBuildSessionResumeUsesResolvedProviderCommand(t *testing.T) {
 		t.Fatalf("hints.Env[GC_HOME] = %q, want %q", got, want)
 	}
 }
+
+func TestBuildSessionResumePreservesStoredResolvedCommand(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", Provider: "wrapped"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"wrapped": {
+				DisplayName: "Wrapped Claude",
+				Command:     "claude",
+				PathCheck:   "true",
+			},
+		},
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:       "gc-1",
+		Template: "mayor",
+		Command:  "claude --dangerously-skip-permissions --settings /tmp/settings.json",
+		Provider: "wrapped",
+		WorkDir:  "/tmp/workdir",
+	}
+
+	cmd, _ := srv.buildSessionResume(info)
+	if got, want := cmd, "claude --dangerously-skip-permissions --settings /tmp/settings.json"; got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}

--- a/internal/api/handler_session_create.go
+++ b/internal/api/handler_session_create.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
-	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/gastownhall/gascity/internal/worker"
 )
 
@@ -230,7 +229,6 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 	}
 
 	// Resolve options against the provider's schema.
-	var extraArgs []string
 	var optMeta map[string]string
 	if len(body.Options) > 0 && len(resolved.OptionsSchema) == 0 {
 		s.idem.unreserve(idemKey)
@@ -239,7 +237,7 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 	}
 	if len(resolved.OptionsSchema) > 0 {
 		var optErr error
-		extraArgs, optMeta, optErr = config.ResolveOptions(resolved.OptionsSchema, body.Options, resolved.EffectiveDefaults)
+		_, optMeta, optErr = config.ResolveOptions(resolved.OptionsSchema, body.Options, resolved.EffectiveDefaults)
 		if optErr != nil {
 			s.idem.unreserve(idemKey)
 			if errors.Is(optErr, config.ErrUnknownOption) {
@@ -276,10 +274,17 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 
-	command := firstNonEmptyString(resolved.CommandString(), resolved.Name)
-	if len(extraArgs) > 0 {
-		command = command + " " + shellquote.Join(extraArgs)
+	launchCommand, err := config.BuildProviderLaunchCommand(s.state.CityPath(), resolved, body.Options)
+	if err != nil {
+		s.idem.unreserve(idemKey)
+		if errors.Is(err, config.ErrUnknownOption) {
+			writeError(w, http.StatusBadRequest, "unknown_option", err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid_option_value", err.Error())
+		return
 	}
+	command := launchCommand.Command
 
 	resolvedCfg, err := resolvedSessionConfigForProvider(alias, "", template, title, "", map[string]string{
 		"session_origin": "manual",

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1812,6 +1812,65 @@ func TestHandleSessionMessageMaterializesNamedSessionUsingProviderDefaultNudge(t
 	}
 }
 
+func TestHandleSessionMessageMaterializesBoundNamedSessionUsingQualifiedIdentity(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents = []config.Agent{{
+		Name:         "alex",
+		BindingName:  "employees",
+		Provider:     "test-agent",
+		StartCommand: "true",
+	}}
+	fs.cfg.NamedSessions = []config.NamedSession{{
+		Name:        "corp--alex",
+		Template:    "alex",
+		BindingName: "employees",
+	}}
+	srv := New(fs)
+
+	req := newPostRequest("/v0/session/employees.corp--alex/messages", strings.NewReader(`{"message":"hello"}`))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("message status = %d, want %d; body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	id := resp["id"]
+	if id == "" {
+		t.Fatal("response missing session id")
+	}
+	b, err := fs.cityBeadStore.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", id, err)
+	}
+	if got := b.Metadata[apiNamedSessionMetadataKey]; got != "true" {
+		t.Fatalf("configured_named_session = %q, want true", got)
+	}
+	if got := b.Metadata["alias"]; got != "employees.corp--alex" {
+		t.Fatalf("alias = %q, want employees.corp--alex", got)
+	}
+	sessionName := b.Metadata["session_name"]
+	if sessionName == "" {
+		t.Fatal("materialized named session missing session_name")
+	}
+	if !fs.sp.IsRunning(sessionName) {
+		t.Fatalf("session %q should be running after POST /messages", sessionName)
+	}
+	nudgeCount := 0
+	for _, call := range fs.sp.Calls {
+		if call.Method == "Nudge" && call.Name == sessionName && call.Message == "hello" {
+			nudgeCount++
+		}
+	}
+	if nudgeCount != 1 {
+		t.Fatalf("Nudge count for %q = %d, want 1; calls=%#v", sessionName, nudgeCount, fs.sp.Calls)
+	}
+}
+
 func TestResolveSessionIDMaterializingNamedWithContext_RollsBackCanceledCreate(t *testing.T) {
 	fs := newSessionFakeState(t)
 	provider := &cancelStartProvider{Fake: runtime.NewFake()}

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1827,7 +1827,7 @@ func TestHandleSessionMessageMaterializesBoundNamedSessionUsingQualifiedIdentity
 	}}
 	srv := New(fs)
 
-	req := newPostRequest("/v0/session/employees.corp--alex/messages", strings.NewReader(`{"message":"hello"}`))
+	req := newPostRequest(cityURL(fs, "/session/employees.corp--alex/messages"), strings.NewReader(`{"message":"hello"}`))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -119,9 +119,13 @@ func (s *Server) humaHandleExtMsgOutbound(ctx context.Context, input *ExtMsgOutb
 	if err != nil {
 		return nil, huma.Error422UnprocessableEntity(err.Error())
 	}
-	if result.Receipt.Delivered {
+	if result != nil && result.Receipt.Delivered {
+		notifyConversation := input.Body.Conversation
+		if result.Receipt.Conversation != (extmsg.ConversationRef{}) {
+			notifyConversation = result.Receipt.Conversation
+		}
 		sourceDisplay := s.extmsgSessionHandleForSelector(input.Body.SessionID)
-		go s.extmsgNotifyMembers(s.backgroundCtx(), input.Body.Conversation, sourceDisplay, "agent", input.Body.Text, input.Body.SessionID)
+		go s.extmsgNotifyMembers(s.backgroundCtx(), notifyConversation, sourceDisplay, "agent", input.Body.Text, input.Body.SessionID)
 	}
 	out := &ExtMsgOutboundOutput{}
 	if result != nil {

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -58,7 +58,7 @@ func (s *Server) humaHandleExtMsgInbound(ctx context.Context, input *ExtMsgInbou
 		if handleErr != nil {
 			return nil, huma.Error422UnprocessableEntity(handleErr.Error())
 		}
-		go s.extmsgNotifyMembers(s.backgroundCtx(), input.Body.Message.Conversation, *input.Body.Message)
+		go s.extmsgNotifyInboundMembers(s.backgroundCtx(), *input.Body.Message)
 		out := &ExtMsgInboundOutput{}
 		if result != nil {
 			out.Body = *result
@@ -119,11 +119,10 @@ func (s *Server) humaHandleExtMsgOutbound(ctx context.Context, input *ExtMsgOutb
 	if err != nil {
 		return nil, huma.Error422UnprocessableEntity(err.Error())
 	}
-	go s.extmsgNotifyMembers(s.backgroundCtx(), input.Body.Conversation, extmsg.ExternalInboundMessage{
-		Conversation: input.Body.Conversation,
-		Actor:        extmsg.ExternalActor{ID: input.Body.SessionID, DisplayName: input.Body.SessionID, IsBot: true},
-		Text:         input.Body.Text,
-	})
+	if result.Receipt.Delivered {
+		sourceDisplay := s.extmsgSessionHandleForSelector(input.Body.SessionID)
+		go s.extmsgNotifyMembers(s.backgroundCtx(), input.Body.Conversation, sourceDisplay, "agent", input.Body.Text, input.Body.SessionID)
+	}
 	out := &ExtMsgOutboundOutput{}
 	if result != nil {
 		out.Body = *result

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sessionlog"
-	"github.com/gastownhall/gascity/internal/shellquote"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
@@ -195,14 +194,13 @@ func (s *Server) humaCreateProviderSession(ctx context.Context, store beads.Stor
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
-	var extraArgs []string
 	var optMeta map[string]string
 	if len(body.Options) > 0 && len(resolved.OptionsSchema) == 0 {
 		return nil, huma.Error400BadRequest("provider '" + providerName + "' does not accept options")
 	}
 	if len(resolved.OptionsSchema) > 0 {
 		var optErr error
-		extraArgs, optMeta, optErr = config.ResolveOptions(resolved.OptionsSchema, body.Options, resolved.EffectiveDefaults)
+		_, optMeta, optErr = config.ResolveOptions(resolved.OptionsSchema, body.Options, resolved.EffectiveDefaults)
 		if optErr != nil {
 			if errors.Is(optErr, config.ErrUnknownOption) {
 				return nil, huma.Error400BadRequest(optErr.Error())
@@ -236,10 +234,11 @@ func (s *Server) humaCreateProviderSession(ctx context.Context, store beads.Stor
 		return nil, humaSessionManagerError(err)
 	}
 
-	command := resolved.CommandString()
-	if len(extraArgs) > 0 {
-		command = command + " " + shellquote.Join(extraArgs)
+	launchCommand, err := config.BuildProviderLaunchCommand(s.state.CityPath(), resolved, body.Options)
+	if err != nil {
+		return nil, huma.Error400BadRequest(err.Error())
 	}
+	command := launchCommand.Command
 
 	mgr := s.sessionManager(store)
 	hints := sessionCreateHints(resolved)

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -268,6 +268,10 @@ func (s *Server) materializeNamedSessionWithContext(ctx context.Context, store b
 	if err != nil {
 		return "", err
 	}
+	launchCommand, err := config.BuildProviderLaunchCommand(s.state.CityPath(), resolved, nil)
+	if err != nil {
+		return "", err
+	}
 	var workDir string
 	workDirQualifiedName := workdirutil.SessionQualifiedName(s.state.CityPath(), *spec.Agent, s.state.Config().Rigs, spec.Identity, "")
 	workDir, err = s.resolveSessionWorkDir(*spec.Agent, workDirQualifiedName)
@@ -280,7 +284,7 @@ func (s *Server) materializeNamedSessionWithContext(ctx context.Context, store b
 		apiNamedSessionModeKey:     spec.Mode,
 		"session_origin":           "named",
 	}
-	resolvedCfg, err := resolvedSessionConfigForProvider(spec.Identity, spec.SessionName, qualifiedTemplate, spec.Identity, transport, extraMeta, resolved, "", workDir)
+	resolvedCfg, err := resolvedSessionConfigForProvider(spec.Identity, spec.SessionName, qualifiedTemplate, spec.Identity, transport, extraMeta, resolved, launchCommand.Command, workDir)
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -117,7 +118,11 @@ func (s *Server) buildSessionResume(info session.Info) (string, runtime.Config) 
 		return cmd, runtime.Config{WorkDir: info.WorkDir}
 	}
 	resolvedInfo := info
-	resolvedInfo.Command = resolved.CommandString()
+	if command, err := s.resolvedSessionRuntimeCommand(resolved, info.Command); err == nil {
+		resolvedInfo.Command = command
+	} else {
+		resolvedInfo.Command = firstNonEmptyString(info.Command, resolved.CommandString(), resolved.Name)
+	}
 	resolvedInfo.Provider = resolved.Name
 	resolvedInfo.ResumeFlag = resolved.ResumeFlag
 	resolvedInfo.ResumeStyle = resolved.ResumeStyle
@@ -125,13 +130,40 @@ func (s *Server) buildSessionResume(info session.Info) (string, runtime.Config) 
 	return session.BuildResumeCommand(resolvedInfo), sessionResumeHints(resolved, workDir)
 }
 
+func (s *Server) resolvedSessionRuntimeCommand(resolved *config.ResolvedProvider, storedCommand string) (string, error) {
+	if command := strings.TrimSpace(storedCommand); shouldPreserveStoredRuntimeCommand(command, resolved.CommandString()) {
+		return command, nil
+	}
+	launchCommand, err := config.BuildProviderLaunchCommand(s.state.CityPath(), resolved, nil)
+	if err != nil {
+		return "", fmt.Errorf("building provider launch command: %w", err)
+	}
+	return firstNonEmptyString(launchCommand.Command, resolved.CommandString(), resolved.Name), nil
+}
+
+func shouldPreserveStoredRuntimeCommand(storedCommand, resolvedCommand string) bool {
+	storedCommand = strings.TrimSpace(storedCommand)
+	if storedCommand == "" {
+		return false
+	}
+	resolvedCommand = strings.TrimSpace(resolvedCommand)
+	if resolvedCommand == "" {
+		return true
+	}
+	return storedCommand == resolvedCommand || strings.HasPrefix(storedCommand, resolvedCommand+" ")
+}
+
 func (s *Server) resolveWorkerSessionRuntime(info session.Info, _ string) (*worker.ResolvedRuntime, error) {
 	resolved, workDir := s.resolveSessionRuntime(info)
 	if resolved == nil {
 		return nil, nil
 	}
+	command, err := s.resolvedSessionRuntimeCommand(resolved, info.Command)
+	if err != nil {
+		return nil, err
+	}
 	runtimeCfg, err := worker.NormalizeResolvedRuntime(worker.ResolvedRuntime{
-		Command:    firstNonEmptyString(resolved.CommandString(), info.Command, resolved.Name),
+		Command:    command,
 		WorkDir:    firstNonEmptyString(workDir, info.WorkDir),
 		Provider:   firstNonEmptyString(resolved.Name, info.Provider),
 		SessionEnv: resolved.Env,

--- a/internal/api/worker_factory_test.go
+++ b/internal/api/worker_factory_test.go
@@ -67,6 +67,52 @@ func TestWorkerFactorySessionByIDUsesResolvedTemplateRuntime(t *testing.T) {
 	}
 }
 
+func TestWorkerFactorySessionByIDPreservesStoredResolvedCommand(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents[0].Provider = "resolved-worker"
+	fs.cfg.Providers["resolved-worker"] = config.ProviderSpec{
+		DisplayName:   "Resolved Worker",
+		Command:       "/bin/echo",
+		SessionIDFlag: "--session-id-resolved",
+	}
+
+	srv := New(fs)
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	info, err := mgr.CreateBeadOnly(
+		"myrig/worker",
+		"Chat",
+		"/bin/echo --composed",
+		t.TempDir(),
+		"resolved-worker",
+		"",
+		nil,
+		session.ProviderResume{SessionIDFlag: "--stale-session-id"},
+	)
+	if err != nil {
+		t.Fatalf("CreateBeadOnly: %v", err)
+	}
+
+	factory, err := srv.workerFactory(fs.cityBeadStore)
+	if err != nil {
+		t.Fatalf("workerFactory: %v", err)
+	}
+	handle, err := factory.SessionByID(info.ID)
+	if err != nil {
+		t.Fatalf("SessionByID(%q): %v", info.ID, err)
+	}
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	start := fs.sp.LastStartConfig(info.SessionName)
+	if start == nil {
+		t.Fatal("LastStartConfig() = nil")
+	}
+	if got, want := start.Command, "/bin/echo --composed --session-id-resolved "+info.SessionKey; got != want {
+		t.Fatalf("start command = %q, want %q", got, want)
+	}
+}
+
 func TestWorkerFactoryHandleForTargetUsesResolvedTemplateRuntimeForSessionMeta(t *testing.T) {
 	fs := newSessionFakeState(t)
 	fs.cfg.Agents[0].Provider = "resolved-worker"

--- a/internal/config/launch_command.go
+++ b/internal/config/launch_command.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+)
+
+// ProviderLaunchCommand is the fully composed provider command plus any
+// provider-owned settings file discovered for that launch.
+type ProviderLaunchCommand struct {
+	Command      string
+	SettingsPath string
+	SettingsRel  string
+}
+
+// BuildProviderLaunchCommand composes the final provider launch command used
+// for session startup. It starts from the raw provider command, applies
+// schema-managed defaults plus any explicit option overrides, and appends a
+// provider-owned settings file when present.
+func BuildProviderLaunchCommand(cityPath string, resolved *ResolvedProvider, optionOverrides map[string]string) (ProviderLaunchCommand, error) {
+	if resolved == nil {
+		return ProviderLaunchCommand{}, fmt.Errorf("resolved provider is nil")
+	}
+
+	command := resolved.CommandString()
+	if len(resolved.OptionsSchema) > 0 {
+		mergedOptions := make(map[string]string, len(resolved.EffectiveDefaults)+len(optionOverrides))
+		for key, value := range resolved.EffectiveDefaults {
+			mergedOptions[key] = value
+		}
+		for key, value := range optionOverrides {
+			mergedOptions[key] = value
+		}
+		if len(mergedOptions) > 0 {
+			mergedArgs, err := ResolveExplicitOptions(resolved.OptionsSchema, mergedOptions)
+			if err != nil {
+				return ProviderLaunchCommand{}, err
+			}
+			command = ReplaceSchemaFlags(command, resolved.OptionsSchema, mergedArgs)
+		}
+	}
+
+	settingsPath, settingsRel := ProviderSettingsSource(cityPath, resolved.Name)
+	if settingsPath != "" {
+		command = command + " " + fmt.Sprintf("--settings %q", settingsPath)
+	}
+
+	return ProviderLaunchCommand{
+		Command:      command,
+		SettingsPath: settingsPath,
+		SettingsRel:  settingsRel,
+	}, nil
+}
+
+// ProviderSettingsSource returns the provider-owned settings file that should
+// be passed to the launched process, plus the relative destination used when
+// staging that file into remote runtimes.
+func ProviderSettingsSource(cityPath, providerName string) (src, rel string) {
+	if providerName != "claude" {
+		return "", ""
+	}
+	candidates := []struct {
+		src string
+		rel string
+	}{
+		{src: filepath.Join(cityPath, ".gc", "settings.json"), rel: path.Join(".gc", "settings.json")},
+		{src: citylayout.ClaudeHookFilePath(cityPath), rel: path.Clean(strings.ReplaceAll(citylayout.ClaudeHookFile, string(filepath.Separator), "/"))},
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate.src); err == nil {
+			return candidate.src, candidate.rel
+		}
+	}
+	return "", ""
+}

--- a/internal/config/launch_command.go
+++ b/internal/config/launch_command.go
@@ -34,6 +34,9 @@ func BuildProviderLaunchCommand(cityPath string, resolved *ResolvedProvider, opt
 			mergedOptions[key] = value
 		}
 		for key, value := range optionOverrides {
+			if key == "initial_message" {
+				continue
+			}
 			mergedOptions[key] = value
 		}
 		if len(mergedOptions) > 0 {

--- a/internal/config/launch_command_test.go
+++ b/internal/config/launch_command_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildProviderLaunchCommandAddsDefaultsAndSettings(t *testing.T) {
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runtimeDir, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	spec := BuiltinProviders()["claude"]
+	rp := specToResolved("claude", &spec)
+
+	got, err := BuildProviderLaunchCommand(dir, rp, nil)
+	if err != nil {
+		t.Fatalf("BuildProviderLaunchCommand: %v", err)
+	}
+
+	wantCommand := fmt.Sprintf("claude --dangerously-skip-permissions --effort max --settings %q", filepath.Join(dir, ".gc", "settings.json"))
+	if got.Command != wantCommand {
+		t.Fatalf("Command = %q, want %q", got.Command, wantCommand)
+	}
+	if got.SettingsPath != filepath.Join(dir, ".gc", "settings.json") {
+		t.Fatalf("SettingsPath = %q, want %q", got.SettingsPath, filepath.Join(dir, ".gc", "settings.json"))
+	}
+	if got.SettingsRel != filepath.Join(".gc", "settings.json") {
+		t.Fatalf("SettingsRel = %q, want %q", got.SettingsRel, filepath.Join(".gc", "settings.json"))
+	}
+}
+
+func TestBuildProviderLaunchCommandAppliesOptionOverrides(t *testing.T) {
+	spec := BuiltinProviders()["claude"]
+	rp := specToResolved("claude", &spec)
+
+	got, err := BuildProviderLaunchCommand("", rp, map[string]string{
+		"permission_mode": "plan",
+		"effort":          "low",
+	})
+	if err != nil {
+		t.Fatalf("BuildProviderLaunchCommand: %v", err)
+	}
+
+	want := "claude --permission-mode plan --effort low"
+	if got.Command != want {
+		t.Fatalf("Command = %q, want %q", got.Command, want)
+	}
+	if got.SettingsPath != "" || got.SettingsRel != "" {
+		t.Fatalf("unexpected settings source: %#v", got)
+	}
+}

--- a/internal/config/launch_command_test.go
+++ b/internal/config/launch_command_test.go
@@ -57,3 +57,21 @@ func TestBuildProviderLaunchCommandAppliesOptionOverrides(t *testing.T) {
 		t.Fatalf("unexpected settings source: %#v", got)
 	}
 }
+
+func TestBuildProviderLaunchCommandIgnoresInitialMessageOverride(t *testing.T) {
+	spec := BuiltinProviders()["claude"]
+	rp := specToResolved("claude", &spec)
+
+	got, err := BuildProviderLaunchCommand("", rp, map[string]string{
+		"initial_message": "hello",
+		"effort":          "low",
+	})
+	if err != nil {
+		t.Fatalf("BuildProviderLaunchCommand: %v", err)
+	}
+
+	want := "claude --dangerously-skip-permissions --effort low"
+	if got.Command != want {
+		t.Fatalf("Command = %q, want %q", got.Command, want)
+	}
+}

--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -42,8 +42,7 @@ type OutboundDeps struct {
 //  4. Call adapter.Publish.
 //  5. Record delivery context.
 //  6. Append outbound entry to transcript.
-//  7. Notify peer conversation members (best-effort nudge).
-//  8. Emit event.
+//  7. Emit event for the caller to fan out peer notifications.
 func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req OutboundRequest) (*OutboundResult, error) {
 	if deps.Registry == nil {
 		return nil, errors.New("adapter registry is nil")
@@ -128,8 +127,7 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 	}
 
 	// Step 7: Emit event.
-	// Wake is handled by the caller (HTTP handler calls state.Poke()).
-	// Peer sessions discover new entries via gc transcript check --inject.
+	// Wake and peer fanout are handled by the caller.
 	if deps.EmitEvent != nil {
 		deps.EmitEvent(events.ExtMsgOutbound, binding.SessionID, OutboundEventPayload{
 			Provider:       req.Conversation.Provider,

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -61,6 +61,7 @@ func TestValidateAlias(t *testing.T) {
 	}{
 		{name: "empty allowed", input: "", want: ""},
 		{name: "trimmed qualified", input: "  myrig/worker  ", want: "myrig/worker"},
+		{name: "binding qualified", input: "employees.corp--alex", want: "employees.corp--alex"},
 		{name: "reserved prefix", input: "s-gc-123", wantErr: ErrInvalidSessionAlias},
 		{name: "human reserved", input: "human", wantErr: ErrInvalidSessionAlias},
 		{name: "session id syntax reserved", input: "gc-42", wantErr: ErrInvalidSessionAlias},

--- a/internal/session/submit.go
+++ b/internal/session/submit.go
@@ -92,14 +92,14 @@ func (m *Manager) submit(ctx context.Context, id, message, resumeCommand string,
 		}
 		switch intent {
 		case SubmitIntentFollowUp:
-			if err := m.pendingInteractionLocked(sessName); err != nil {
-				return err
-			}
 			if !m.supportsFollowUpLocked(b) {
 				return ErrInteractionUnsupported
 			}
 			if State(b.Metadata["state"]) == StateSuspended || !m.sp.IsRunning(sessName) {
 				return m.sendLocked(ctx, id, b, sessName, message, resumeCommand, hints, true)
+			}
+			if err := m.pendingInteractionLocked(sessName); err != nil {
+				return err
 			}
 			if err := m.enqueueDeferredSubmitLocked(b, sessName, message); err != nil {
 				return err

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -396,6 +396,52 @@ func TestSubmitFollowUpOnSuspendedSessionFallsBackToImmediateSend(t *testing.T) 
 	}
 }
 
+func TestSubmitFollowUpOnAsleepSessionFallsBackToImmediateSend(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	cityPath := t.TempDir()
+	mgr := NewManagerWithCityPath(store, sp, cityPath)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", t.TempDir(), "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := sp.Stop(info.SessionName); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := store.SetMetadata(info.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatalf("SetMetadata(state): %v", err)
+	}
+
+	outcome, err := mgr.Submit(context.Background(), info.ID, "wake and send", BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir}, SubmitIntentFollowUp)
+	if err != nil {
+		t.Fatalf("Submit(follow_up): %v", err)
+	}
+	if outcome.Queued {
+		t.Fatal("Submit(follow_up) unexpectedly queued for asleep session")
+	}
+	if !sp.IsRunning(info.SessionName) {
+		t.Fatal("session should be running after follow_up on asleep session")
+	}
+	state, err := nudgequeue.LoadState(cityPath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(state.Pending) != 0 {
+		t.Fatalf("pending queued submits = %d, want 0", len(state.Pending))
+	}
+	found := false
+	for _, call := range sp.Calls {
+		if call.Method == "NudgeNow" && call.Name == info.SessionName && call.Message == "wake and send" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("calls = %#v, want NudgeNow(wake and send)", sp.Calls)
+	}
+}
+
 func TestSubmissionCapabilitiesFollowUpUnsupportedForACP(t *testing.T) {
 	caps := SubmissionCapabilitiesForMetadata(
 		map[string]string{


### PR DESCRIPTION
## Summary
- wake transcript peers on extmsg outbound publish instead of relying on already-live sessions
- accept binding-qualified named session selectors such as `employees.corp--alex`
- share final provider launch command assembly across template startup and API materialization paths
- tolerate missing historical nudge beads when terminalizing queued reminders so stale queue state no longer blocks delivery

## Testing
- `go test ./internal/api ./internal/config ./internal/extmsg ./internal/session -count=1`
- `go test ./cmd/gc -run 'TestMarkQueuedNudgeTerminalFallsBackFromMissingStoredBeadID|TestPruneExpiredQueuedNudgesIgnoresMissingTerminalBead' -count=1`

## Context
These fixes were exercised locally against Discord-bound named sessions in city workflows, including the Alex/Wendy wake-and-deliver path.
