### PR TITLE
Propose Pack/Registry CLI surface

### DIFF
--- a/engdocs/design/index.md
+++ b/engdocs/design/index.md
@@ -25,3 +25,4 @@ lives in the [Architecture](../architecture/index.md) section.
 | `named-configured-sessions` | Accepted | Explicit canonical named sessions backed by reusable templates |
 | `external-messaging-fabric` | Implemented | Provider-neutral external conversation bindings, delivery context, and group sessions |
 | `external-messaging-shared-threads` | Implemented | Transcript-backed shared-thread model with membership replay and speaker-only group routing |
+| `pack-cli-unification` | Proposed | Aligns `gc pack` and `gc registry` around imports, caches, fetch, outdated, and machine-known registry catalogs |

--- a/engdocs/design/index.md
+++ b/engdocs/design/index.md
@@ -25,4 +25,4 @@ lives in the [Architecture](../architecture/index.md) section.
 | `named-configured-sessions` | Accepted | Explicit canonical named sessions backed by reusable templates |
 | `external-messaging-fabric` | Implemented | Provider-neutral external conversation bindings, delivery context, and group sessions |
 | `external-messaging-shared-threads` | Implemented | Transcript-backed shared-thread model with membership replay and speaker-only group routing |
-| `pack-cli-unification` | Proposed | Aligns `gc pack` and `gc registry` around imports, caches, fetch, outdated, and machine-known registry catalogs |
+| `pack-cli-unification` | Proposed | Proposes a coherent `gc pack` / `gc registry` surface around imports, caches, fetch, outdated, registry catalogs, and machine-known registry configuration |

--- a/engdocs/design/pack-cli-unification.md
+++ b/engdocs/design/pack-cli-unification.md
@@ -1,0 +1,447 @@
+---
+title: "Pack And Registry CLI Surface"
+---
+
+| Field | Value |
+|---|---|
+| Status | Proposed |
+| Date | 2026-04-16 |
+| Author(s) | Donna Box, Ag Nora, Ag Noreen |
+| Issue | — |
+| Supersedes | earlier `gc pack`-only and `pack`/`store` explorations |
+
+This document builds on the **PackV2** work from the 15.0 release and makes no change to the semantics of package format or loading semantics. 
+
+It does however do two things:
+1. Introduce the notion of a *registry* where Gas City packs can be published and discovered.
+2. Propose a coherent CLI interface across all package operations (discovery, import, upgrade, et al) 
+
+## Registries
+A Gas City registry is simply a `registry.toml` file that is typically fetched over HTTP.
+
+A `registry.toml` file is simply a list of packages with a name, version info, description, and the URL of the source.  Registries don't store packs, they simply are an directory of packs. Once the source URL is read from registry.toml, the registry is out of the loop.
+
+A minimal `registry.toml` should have at least a couple of entries so search and
+catalog behavior are concrete:
+
+```toml
+schema = 1
+
+[[pack]]
+name = "maintenance"
+description = "Health checks and baseline operational tooling."
+source = "https://github.com/gastownhall/maintenance"
+
+  [[pack.release]]
+  version = "1.2.0"
+  commit = "abc123"
+  hash = "sha256:..."
+  description = "Adds doctor checks and improves stale-db handling."
+
+[[pack]]
+name = "observatory"
+description = "Metrics and telemetry helpers."
+source = "https://github.com/gastownhall/observatory"
+
+  [[pack.release]]
+  version = "0.4.0"
+  commit = "def456"
+  hash = "sha256:..."
+  description = "First public release."
+```
+
+A registry can advertise multiple versions of the same pack, with distinct notes on each version:
+
+```toml
+[[pack]]
+name = "maintenance"
+description = "Health checks and baseline operational tooling."
+source = "https://github.com/gastownhall/maintenance"
+
+  [[pack.release]]
+  version = "1.2.0"
+  commit = "abc123"
+  hash = "sha256:..."
+  description = "Adds doctor checks and improves stale-db handling."
+
+  [[pack.release]]
+  version = "1.1.0"
+  commit = "def456"
+  hash = "sha256:..."
+  description = "Stabilizes patrol behavior and stale-db handling."
+```
+
+To faciliate east dicovery,  Gas City implementation maintains a list of registries that are consulted when searching for or enumerating available packs. That list of registries is a system managed file ()`~/.gc/registries.toml`) and has the standard `add`/`list`/`remove` operations. A fresh Gas City installation will have one entry in `registries.toml` pointing to the Gac City-managed registry:
+
+```toml
+schema = 1
+
+[[registry]]
+name = "main"
+source = "https://github.com/gastownhall/gascity-packs"
+```
+
+
+
+
+
+
+## Command Trees
+
+The operations one wants to do wrt managing imports from one package to another have *some* overlap with the operations wants to do on a registry. To that end,  this design relies on two command trees:
+* `gc pack` which is focused exclusively on managign package-to-package import graphs
+* `gc registry` which is focused on discovery of pacakages based on name, description or version. 
+
+The two work in tandem: the result of a registry search is a qualified name that can be passed directly to the add command that creates the import.
+
+Note that `gc pack` subsumes the functionality of `gc pack` and `gc import` in the 0.15.0 release.
+
+### `gc registry`
+
+```text
+gc registry list
+gc registry add <registry-name> <source>
+gc registry remove <registry-name>
+gc registry search [query] [--registry <name>]
+gc registry show <qualified-pack-name>
+```
+
+### `gc pack`
+
+```text
+gc pack add <source-or-name> [--name <import-name>] [--pack <path>] [--rig <name-or-path>]
+gc pack remove <import-name> [--pack <path>] [--rig <name-or-path>]
+gc pack list [--transitive] [--pack <path>] [--rig <name-or-path>]
+gc pack show <import-name> [--pack <path>] [--rig <name-or-path>]
+gc pack fetch [<import-name>] [--pack <path>] [--rig <name-or-path>]
+gc pack outdated [<import-name>] [--pack <path>] [--rig <name-or-path>]
+gc pack upgrade [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+## Current Proposal
+
+This is the cohesive model the mock and the rest of this note now reflect.
+
+- `gc pack` is the local workflow noun
+- `gc registry` is the machine-known registry config and catalog-browsing noun
+- registries are index only
+- caches are fetched content only
+- imports declare intent
+- full materialization is optional and demand-driven
+
+The overall design should follow npm/pub-like user expectations for pack
+workflow, while keeping registry configuration and discovery as a separate
+supporting surface.
+
+## `gc pack`
+
+`gc pack` owns imports, fetched state, and upgrade flow for the selected pack.
+
+### Scope model
+
+The baseline target is always the ambient pack discovered from the current
+working directory.
+
+Working rules:
+
+- ambient behavior always targets the current pack
+- `--pack <path>` targets another pack explicitly
+- `--rig <name-or-path>` opts into rig-scoped import behavior
+- rig-scoped imports only happen when `--rig` is passed
+- `--rig` refines pack behavior; it is never ambient
+
+### Verb set
+
+| Verb | Meaning |
+|---|---|
+| `add` | Add an import to the selected scope and fetch it by default. |
+| `remove` | Remove an import from the selected scope. |
+| `list` | List imports in the selected scope. |
+| `show` | Show one imported pack in the selected scope. |
+| `fetch` | Fetch resolved pack content into cache for the selected scope. |
+| `outdated` | Show which imported packs could be upgraded. |
+| `upgrade` | Upgrade imported packs in scope and fetch the new resolved result. |
+
+### Signatures and semantics
+
+#### `gc pack add`
+
+```text
+gc pack add <source-or-name> [--name <import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+- adds an import to the selected scope
+- fetches the resolved content into cache by default
+- accepts:
+  - qualified registry names like `main:maintenance`
+  - unqualified registry names when resolution is unambiguous
+  - direct source URLs
+  - local paths
+- `--name` gives an explicit local import name when needed
+
+#### `gc pack remove`
+
+```text
+gc pack remove <import-name> [--pack <path>] [--rig <name-or-path>]
+```
+
+- removes an import from the selected scope
+- does not imply eager cache deletion
+- remains strict about inbound reference blockers
+
+#### `gc pack list`
+
+```text
+gc pack list [--transitive] [--pack <path>] [--rig <name-or-path>]
+```
+
+- with no flags, lists direct imports in scope
+- with `--transitive`, lists the full resolved transitive set
+
+#### `gc pack show`
+
+```text
+gc pack show <import-name> [--pack <path>] [--rig <name-or-path>]
+```
+
+- shows one imported pack in the selected scope
+- local inspection only
+- does not reach out to registry catalog views
+
+Expected output shape:
+
+- imported name
+- source
+- resolved version or release
+- fetched status
+- scope
+
+#### `gc pack fetch`
+
+```text
+gc pack fetch [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+- with no target, fetches all imports in scope
+- with a target, fetches one imported pack in scope
+- does not edit imports
+- is the explicit warm-cache and reconcile command
+
+#### `gc pack outdated`
+
+```text
+gc pack outdated [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+- shows what `upgrade` could move
+- does not mutate imports or cache
+- with no target, reports all outdated imports in scope
+- with a target, reports one imported pack
+
+#### `gc pack upgrade`
+
+```text
+gc pack upgrade [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+- with no target, upgrades all imports in scope
+- with a target, upgrades one imported pack
+- is transitive as needed for coherent re-resolution
+- fetches the new resolved result into cache
+
+## `gc registry`
+
+`gc registry` owns machine-known registry configuration and catalog browsing.
+
+### Surface area
+
+| Command | Meaning |
+|---|---|
+| `gc registry list` | List configured registries from `~/.gc/registries.toml`. |
+| `gc registry add <registry-name> <source>` | Add one configured registry entry. |
+| `gc registry remove <registry-name>` | Remove one configured registry entry. |
+| `gc registry search [query] [--registry <name>]` | Search pack entries across all registries by default; with no query, return everything. |
+| `gc registry show <qualified-pack-name>` | Show one exact pack catalog entry from a registry. |
+
+### Signatures and semantics
+
+#### `gc registry list`
+
+```text
+gc registry list
+```
+
+- lists configured registries from `~/.gc/registries.toml`
+- this is the full configured-registry view for POR
+
+Expected output:
+
+```text
+Name   Source
+main   https://github.com/gastownhall/gascity-packs
+acme   https://github.com/acme/gascity-packs
+```
+
+#### `gc registry add`
+
+```text
+gc registry add <registry-name> <source>
+```
+
+- adds one configured registry entry
+- edits `~/.gc/registries.toml`
+
+#### `gc registry remove`
+
+```text
+gc registry remove <registry-name>
+```
+
+- removes one configured registry entry
+- edits `~/.gc/registries.toml`
+
+#### `gc registry search`
+
+```text
+gc registry search [query] [--registry <name>]
+```
+
+- uses a plain text query, not regex
+- with no query, returns all available pack entries
+- searches across all configured registries by default
+- `--registry <name>` narrows the search to one registry
+- returns multiple results
+
+Expected output:
+
+```text
+Registry  Name         Latest  Description
+main      maintenance  1.2.0   Health checks and baseline operational tooling.
+acme      maintenance  2.0.1   Acme-flavored maintenance tasks and patrol tooling.
+```
+
+#### `gc registry show`
+
+```text
+gc registry show <qualified-pack-name>
+```
+
+- exact-address lookup for one pack catalog entry
+- requires a qualified name like `main:maintenance`
+- unqualified names are intentionally not accepted here
+
+Expected output:
+
+```text
+Pack:         acme:maintenance
+Registry:     acme
+Name:         maintenance
+Latest:       2.0.1
+Description:  Acme-flavored maintenance tasks and patrol tooling.
+Source:       https://github.com/acme/maintenance
+
+Releases:
+- 2.0.1  abc123  Adds patrol upgrades and doctor fixes.
+- 1.9.0  def456  Stabilizes maintenance workflows.
+```
+
+### Registry resolution rules
+
+- there is no `default` registry
+- first-party registry name is `main`
+- unqualified names only resolve when exactly one registry matches in contexts
+  that allow unqualified resolution
+- collisions require qualified names like `acme:maintenance`
+
+## File Formats
+
+These are the POR file-format rules.
+
+### `registries.toml`
+
+This is the machine-known registry config.
+
+- lives under `~/.gc/registries.toml`
+- is edited by `gc registry add` / `gc registry remove`
+- does not carry pack descriptions
+- does not define a default registry
+
+POR example:
+
+```toml
+schema = 1
+
+[[registry]]
+name = "main"
+source = "https://github.com/gastownhall/gascity-packs"
+
+[[registry]]
+name = "acme"
+source = "https://github.com/acme/gascity-packs"
+```
+
+### `registry.toml`
+
+This is the published registry catalog file.
+
+- each `[[pack]]` entry has a required `description`
+- each `[[pack.release]]` entry has a required `description`
+- `pack.toml` does not need a required description field for POR
+
+POR example:
+
+```toml
+schema = 1
+
+[[pack]]
+name = "maintenance"
+description = "Health checks and baseline operational tooling."
+source = "https://github.com/gastownhall/maintenance"
+
+  [[pack.release]]
+  version = "1.2.0"
+  commit = "abc123"
+  hash = "sha256:..."
+  description = "Adds doctor checks and improves stale-db handling."
+```
+
+
+## Cache And Materialization
+
+The storage model is intentionally light:
+
+| Thing | Role |
+|---|---|
+| registry | what exists |
+| import | what this scope wants |
+| cache | fetched bytes already available |
+| materialization | optional realized local tree when runtime behavior needs it |
+
+Working rules:
+
+- keep a machine-global cache under `~/.gc`
+- do not introduce a first-class machine-wide store
+- do not assume `.gc` should be kept wholesale in source control
+- treat `fetch` as cache-oriented, not as full materialization
+
+If materialization happens:
+
+- it is a runtime concern rather than the primary pack CLI story
+- rig behavior is still explicit through `--rig`
+
+## Parked Questions
+
+These are intentionally parked to the side for now. The current design pass is
+primarily trying to settle command names, signatures, and output shapes.
+
+1. This design has two top-level command trees corresponding to the two nouns
+   in play (packages and registries). If desired, we could embed the registry
+   commands under pack, but it's unclear whether creating a secondary/scoped
+   noun is better than having two peer nouns.
+2. The current design relies on implicit caching of a lowered or processed form
+   of a package, all stored under `.gc`. We lack an explicit mechanism for
+   embedding any form of the imported packages into package content (a.k.a.
+   vendoring), making the transitive closure of imported packages into a single
+   deployable unit. Our import mechanism supports the scenario by embedding
+   pack content under `assets/` and using path references in the `import`
+   directive in `pack.toml`.

--- a/engdocs/design/pack-cli-unification.md
+++ b/engdocs/design/pack-cli-unification.md
@@ -6,42 +6,55 @@ title: "Pack And Registry CLI Surface"
 |---|---|
 | Status | Proposed |
 | Date | 2026-04-16 |
-| Author(s) | Donna Box, Ag Nora, Ag Noreen |
+| Author(s) | D. Box |
 | Issue | — |
-| Supersedes | earlier `gc pack`-only and `pack`/`store` explorations |
+| Supersedes | The `gc pack`/`gc export` split introduced in 0.15.0 |
 
-This document builds on the **PackV2** work from the 15.0 release and makes no change to the semantics of package format or loading semantics. 
+This document builds on the **PackV2** work from the 0.15.0 release and makes no change to package format or loader semantics.
 
 It does however do two things:
 1. Introduce the notion of a *registry* where Gas City packs can be published and discovered.
-2. Propose a coherent CLI interface across all package operations (discovery, import, upgrade, et al) 
+2. Propose a coherent CLI interface across all package operations (discovery, import, upgrade, et al.)
+
+The proposed `gc pack` CLI rationalizes the import-facing surface introduced as
+`gc import` in 0.15.0. The primary difference is more precise targeting of
+which entity's imports are being impacted (in-scope pack vs. city pack vs.
+targeted rig). A secondary difference is that `add` accepts the result of a
+registry lookup, so you can add an import without having to paste a full URL or
+path.
+
+This proposal would also subsume the two legacy `gc pack` commands, `fetch` and
+`list`, to land on a single coherent surface area.
+
+All of this said, the main new concept in this proposal is a registry, so let's begin there.
 
 ## Registries
-A Gas City registry is simply a `registry.toml` file that is typically fetched over HTTP.
+A Gas City registry is simply a `registry.toml` file that is typically fetched
+over HTTP.
 
-A `registry.toml` file is simply a list of packages with a name, version info, description, and the URL of the source.  Registries don't store packs, they simply are an directory of packs. Once the source URL is read from registry.toml, the registry is out of the loop.
+A `registry.toml` file is a list of packages with a name, version info, description, and the URL of the source. Registries do not store packs; they are an index of packs. Once the source URL is read from `registry.toml`, the registry is out of the loop.
 
-A minimal `registry.toml` should have at least a couple of entries so search and
-catalog behavior are concrete:
+The registry entry for a pack lists one or more versioned releases of the pack. Here is an example `registry.toml` file.
+
 
 ```toml
 schema = 1
 
 [[pack]]
-name = "maintenance"
-description = "Health checks and baseline operational tooling."
-source = "https://github.com/gastownhall/maintenance"
+name = "lighthouse"
+description = "Harbor-watch checks and incident response workflows."
+source = "https://packages.example/main/lighthouse"
 
   [[pack.release]]
   version = "1.2.0"
   commit = "abc123"
   hash = "sha256:..."
-  description = "Adds doctor checks and improves stale-db handling."
+  description = "Adds dock patrol checks and improves incident triage."
 
 [[pack]]
-name = "observatory"
-description = "Metrics and telemetry helpers."
-source = "https://github.com/gastownhall/observatory"
+name = "weatherglass"
+description = "Forecasting and telemetry helpers for harbor operations."
+source = "https://packages.example/main/weatherglass"
 
   [[pack.release]]
   version = "0.4.0"
@@ -54,47 +67,64 @@ A registry can advertise multiple versions of the same pack, with distinct notes
 
 ```toml
 [[pack]]
-name = "maintenance"
-description = "Health checks and baseline operational tooling."
-source = "https://github.com/gastownhall/maintenance"
+name = "lighthouse"
+description = "Harbor-watch checks and incident response workflows."
+source = "https://packages.example/main/lighthouse"
 
   [[pack.release]]
   version = "1.2.0"
   commit = "abc123"
   hash = "sha256:..."
-  description = "Adds doctor checks and improves stale-db handling."
+  description = "Adds dock patrol checks and improves incident triage."
 
   [[pack.release]]
   version = "1.1.0"
   commit = "def456"
   hash = "sha256:..."
-  description = "Stabilizes patrol behavior and stale-db handling."
+  description = "Stabilizes patrol behavior and wakeup handling."
 ```
 
-To faciliate east dicovery,  Gas City implementation maintains a list of registries that are consulted when searching for or enumerating available packs. That list of registries is a system managed file ()`~/.gc/registries.toml`) and has the standard `add`/`list`/`remove` operations. A fresh Gas City installation will have one entry in `registries.toml` pointing to the Gac City-managed registry:
+To facilitate discovery, a Gas City installation maintains a list of registries that are consulted when searching for or enumerating available packs. That list is a system-managed file, `~/.gc/registries.toml`, and has the standard `add` / `list` / `remove` CLI operations. A fresh Gas City installation would normally include a `main` entry pointing at the Gas City-managed registry. The examples below use plain catalog URLs rather than repository URLs so the fetch semantics stay clear. A fuller example with two configured registries looks like this:
 
 ```toml
 schema = 1
 
 [[registry]]
 name = "main"
-source = "https://github.com/gastownhall/gascity-packs"
+source = "https://registries.gascity.example/main/registry.toml"
+
+[[registry]]
+name = "acme"
+source = "https://registries.acme.example/catalog/registry.toml"
 ```
 
+The `registries.toml` file can point to multiple registries. Each configured registry name must be unique locally; those local names are what disambiguate packs when two or more registries publish the same pack name.
+
+For this proposal, a registry `source` is a locator for the registry catalog,
+not a git-specific concept. A source may be:
+
+- a direct HTTP(S) URL to `registry.toml`
+- an HTTP(S) base URL where `registry.toml` is implied
+- a local filesystem path to `registry.toml`
+- a local directory containing `registry.toml`
+
+This proposal does not otherwise tie registries to GitHub or git semantics.
 
 
+## CLI Command Trees
 
-
-
-## Command Trees
-
-The operations one wants to do wrt managing imports from one package to another have *some* overlap with the operations wants to do on a registry. To that end,  this design relies on two command trees:
-* `gc pack` which is focused exclusively on managign package-to-package import graphs
-* `gc registry` which is focused on discovery of pacakages based on name, description or version. 
+The operations one wants to do when managing imports from one package to another have *some* overlap with the operations one wants to do on a registry; however, there are enough differences to warrant two command trees:
+* `gc pack` which is focused exclusively on managing package-to-package import graphs
+* `gc registry` which is focused on discovery of packages based on name, description, or version.
 
 The two work in tandem: the result of a registry search is a qualified name that can be passed directly to the add command that creates the import.
 
-Note that `gc pack` subsumes the functionality of `gc pack` and `gc import` in the 0.15.0 release.
+This design is silent with respect to *where* packages are stored:
+- Registries are index only
+- Caches are largely opaque and contain fetched content only based on a pack's `[import]` declarations.
+- `gc pack show` inspects local imports; `gc registry show` inspects exact
+  catalog entries
+
 
 ### `gc registry`
 
@@ -106,10 +136,11 @@ gc registry search [query] [--registry <name>]
 gc registry show <qualified-pack-name>
 ```
 
+
 ### `gc pack`
 
 ```text
-gc pack add <source-or-name> [--name <import-name>] [--pack <path>] [--rig <name-or-path>]
+gc pack add <source-or-name> [--name <import-name>] [--version <constraint>] [--pack <path>] [--rig <name-or-path>]
 gc pack remove <import-name> [--pack <path>] [--rig <name-or-path>]
 gc pack list [--transitive] [--pack <path>] [--rig <name-or-path>]
 gc pack show <import-name> [--pack <path>] [--rig <name-or-path>]
@@ -118,37 +149,38 @@ gc pack outdated [<import-name>] [--pack <path>] [--rig <name-or-path>]
 gc pack upgrade [<import-name>] [--pack <path>] [--rig <name-or-path>]
 ```
 
-## Current Proposal
-
-This is the cohesive model the mock and the rest of this note now reflect.
-
-- `gc pack` is the local workflow noun
-- `gc registry` is the machine-known registry config and catalog-browsing noun
-- registries are index only
-- caches are fetched content only
-- imports declare intent
-- full materialization is optional and demand-driven
-
-The overall design should follow npm/pub-like user expectations for pack
-workflow, while keeping registry configuration and discovery as a separate
-supporting surface.
-
 ## `gc pack`
 
 `gc pack` owns imports, fetched state, and upgrade flow for the selected pack.
 
 ### Scope model
 
-The baseline target is always the ambient pack discovered from the current
+The baseline target is the ambient pack, when one can be discovered from the
 working directory.
 
 Working rules:
 
-- ambient behavior always targets the current pack
-- `--pack <path>` targets another pack explicitly
-- `--rig <name-or-path>` opts into rig-scoped import behavior
-- rig-scoped imports only happen when `--rig` is passed
-- `--rig` refines pack behavior; it is never ambient
+- if the current directory is inside a pack definition, the ambient pack is
+  that surrounding pack
+- if the current directory is inside a rigged directory but not inside a
+  different pack definition, the ambient pack is the pack that defines the
+  owning city
+- if the current directory is in neither a pack directory nor a rigged
+  directory, there is no ambient pack and the user must pass `--pack` or
+  `--rig`
+
+  
+The two scope-shaping flags on most `gc pack` commands are:
+
+- `--pack <path>` explicitly targets the pack the import will be added to
+- `--rig <name-or-path>` opts into rig-scoped import behavior within the city
+  associated with the ambient or explicitly targeted pack
+- rig-scoped imports only happen when `--rig` is explicitly passed
+- `--rig` never creates an ambient rig scope on its own; it is always an
+  explicit refinement
+
+When both `--pack` and `--rig` are passed, `--rig` is resolved relative to the
+city associated with `--pack`.
 
 ### Verb set
 
@@ -167,17 +199,41 @@ Working rules:
 #### `gc pack add`
 
 ```text
-gc pack add <source-or-name> [--name <import-name>] [--pack <path>] [--rig <name-or-path>]
+gc pack add <source-or-name> [--name <import-name>] [--version <constraint>] [--pack <path>] [--rig <name-or-path>]
 ```
 
 - adds an import to the selected scope
 - fetches the resolved content into cache by default
 - accepts:
-  - qualified registry names like `main:maintenance`
+  - qualified registry names like `main:lighthouse`
   - unqualified registry names when resolution is unambiguous
   - direct source URLs
   - local paths
+- input is interpreted in this order:
+  - contains `:` and is not a URL scheme: qualified registry name
+  - has a URL scheme: direct source URL
+  - resolves on disk: local path
+  - otherwise: unqualified registry name
 - `--name` gives an explicit local import name when needed
+- without `--name`, registry-backed adds use the pack name and URL/path adds
+  use the final path segment
+- if the derived name collides with an unrelated existing import, `add` fails
+  and asks the user to pass `--name`
+- re-adding the same import name is allowed; it updates that import rather than
+  forcing the user through a separate edit command
+- `--version` records a version constraint in the import when the add is
+  registry-backed
+- `--version` is also allowed for URL and local-path adds; it is still
+  recorded in the import
+- if `--version` is omitted, registry-backed adds follow the registry's default
+  resolution behavior
+- this proposal does not freeze the resolver's default selection policy; it
+  only requires that an explicit `--version` constraint, when present, be
+  recorded in the import
+- a qualified registry name is just a convenience handle; when `add` succeeds,
+  the resulting import resolves to the underlying source or path rather than
+  retaining the registry label as a separate identity
+
 
 #### `gc pack remove`
 
@@ -187,7 +243,8 @@ gc pack remove <import-name> [--pack <path>] [--rig <name-or-path>]
 
 - removes an import from the selected scope
 - does not imply eager cache deletion
-- remains strict about inbound reference blockers
+- remains strict about inbound reference blockers, meaning other local config
+  still depends on that import and would be left invalid by removing it
 
 #### `gc pack list`
 
@@ -197,6 +254,14 @@ gc pack list [--transitive] [--pack <path>] [--rig <name-or-path>]
 
 - with no flags, lists direct imports in scope
 - with `--transitive`, lists the full resolved transitive set
+
+Expected output:
+
+```text
+Name         Version  Source
+lighthouse   ^1.2     main:lighthouse
+weatherglass 0.4      ../packs/weatherglass
+```
 
 #### `gc pack show`
 
@@ -215,6 +280,17 @@ Expected output shape:
 - resolved version or release
 - fetched status
 - scope
+
+Expected output:
+
+```text
+Import:         lighthouse
+Source:         https://packages.example/main/lighthouse
+Version:        ^1.2
+Resolved:       1.2.0
+Fetched:        yes
+Scope:          ambient pack
+```
 
 #### `gc pack fetch`
 
@@ -237,6 +313,14 @@ gc pack outdated [<import-name>] [--pack <path>] [--rig <name-or-path>]
 - does not mutate imports or cache
 - with no target, reports all outdated imports in scope
 - with a target, reports one imported pack
+- respects version constraints already recorded on imports
+
+Expected output:
+
+```text
+Name         Current  Latest allowed  Latest available  Status
+lighthouse   1.1.0    1.2.0           2.0.1             upgrade available
+```
 
 #### `gc pack upgrade`
 
@@ -248,6 +332,19 @@ gc pack upgrade [<import-name>] [--pack <path>] [--rig <name-or-path>]
 - with a target, upgrades one imported pack
 - is transitive as needed for coherent re-resolution
 - fetches the new resolved result into cache
+- respects version constraints already recorded on imports
+
+### Network and offline behavior
+
+- `gc pack outdated` should succeed against the locally available import state
+  and cached metadata
+- `gc pack upgrade` may fail if the needed pack content is not already cached
+  and cannot be fetched
+- `gc pack fetch` may fall back to cached content when the source is
+  unreachable, but it should warn that network refresh failed
+- registry-backed operations depend on registry reachability or cached catalog
+  data; the exact caching policy for `registry.toml` itself remains a parked
+  question
 
 ## `gc registry`
 
@@ -272,14 +369,14 @@ gc registry list
 ```
 
 - lists configured registries from `~/.gc/registries.toml`
-- this is the full configured-registry view for POR
+- this is the full configured-registry view for this proposal
 
 Expected output:
 
 ```text
 Name   Source
-main   https://github.com/gastownhall/gascity-packs
-acme   https://github.com/acme/gascity-packs
+main   https://registries.gascity.example/main/registry.toml
+acme   https://registries.acme.example/catalog/registry.toml
 ```
 
 #### `gc registry add`
@@ -290,6 +387,9 @@ gc registry add <registry-name> <source>
 
 - adds one configured registry entry
 - edits `~/.gc/registries.toml`
+- there are intentionally no commands here for adding or removing packs from a
+  registry itself; each registry owns and manages its own published
+  `registry.toml`
 
 #### `gc registry remove`
 
@@ -311,13 +411,14 @@ gc registry search [query] [--registry <name>]
 - searches across all configured registries by default
 - `--registry <name>` narrows the search to one registry
 - returns multiple results
+- pagination and limiting are intentionally out of scope for this proposal
 
 Expected output:
 
 ```text
 Registry  Name         Latest  Description
-main      maintenance  1.2.0   Health checks and baseline operational tooling.
-acme      maintenance  2.0.1   Acme-flavored maintenance tasks and patrol tooling.
+main      lighthouse   1.2.0   Harbor-watch checks and incident response workflows.
+acme      lighthouse   2.0.1   Acme-flavored harbor patrol and response tooling.
 ```
 
 #### `gc registry show`
@@ -327,18 +428,20 @@ gc registry show <qualified-pack-name>
 ```
 
 - exact-address lookup for one pack catalog entry
-- requires a qualified name like `main:maintenance`
+- requires a qualified name like `main:lighthouse`
 - unqualified names are intentionally not accepted here
+- cross-registry "show me every registry carrying this pack" behavior is not
+  part of this proposal
 
 Expected output:
 
 ```text
-Pack:         acme:maintenance
+Pack:         acme:lighthouse
 Registry:     acme
-Name:         maintenance
+Name:         lighthouse
 Latest:       2.0.1
-Description:  Acme-flavored maintenance tasks and patrol tooling.
-Source:       https://github.com/acme/maintenance
+Description:  Acme-flavored harbor patrol and response tooling.
+Source:       https://packages.example/acme/lighthouse
 
 Releases:
 - 2.0.1  abc123  Adds patrol upgrades and doctor fixes.
@@ -349,13 +452,15 @@ Releases:
 
 - there is no `default` registry
 - first-party registry name is `main`
+- `main` is simply the conventional name seeded at installation time; no CLI
+  behavior depends on its continued presence
 - unqualified names only resolve when exactly one registry matches in contexts
   that allow unqualified resolution
-- collisions require qualified names like `acme:maintenance`
+- collisions require qualified names like `acme:lighthouse`
 
 ## File Formats
 
-These are the POR file-format rules.
+These are the file-format rules.
 
 ### `registries.toml`
 
@@ -366,18 +471,18 @@ This is the machine-known registry config.
 - does not carry pack descriptions
 - does not define a default registry
 
-POR example:
+Example:
 
 ```toml
 schema = 1
 
 [[registry]]
 name = "main"
-source = "https://github.com/gastownhall/gascity-packs"
+source = "https://registries.gascity.example/main/registry.toml"
 
 [[registry]]
 name = "acme"
-source = "https://github.com/acme/gascity-packs"
+source = "https://registries.acme.example/catalog/registry.toml"
 ```
 
 ### `registry.toml`
@@ -386,27 +491,36 @@ This is the published registry catalog file.
 
 - each `[[pack]]` entry has a required `description`
 - each `[[pack.release]]` entry has a required `description`
-- `pack.toml` does not need a required description field for POR
+- `source` identifies the canonical fetch origin for the pack
+- `commit` records the source revision identifier for the release; for
+  git-backed sources this is naturally a git SHA, while other source kinds may
+  need a more general rule in a later revision of the format
+- `hash` is the integrity check for the fetched release payload or canonical
+  unpacked contents
 
-POR example:
+Example:
 
 ```toml
 schema = 1
 
 [[pack]]
-name = "maintenance"
-description = "Health checks and baseline operational tooling."
-source = "https://github.com/gastownhall/maintenance"
+name = "lighthouse"
+description = "Harbor-watch checks and incident response workflows."
+source = "https://packages.example/main/lighthouse"
 
   [[pack.release]]
   version = "1.2.0"
   commit = "abc123"
   hash = "sha256:..."
-  description = "Adds doctor checks and improves stale-db handling."
+  description = "Adds dock patrol checks and improves incident triage."
 ```
 
+### `pack.toml`
 
-## Cache And Materialization
+- `pack.toml` does not need a required description field for this proposal
+
+
+## Cache
 
 The storage model is intentionally light:
 
@@ -415,19 +529,15 @@ The storage model is intentionally light:
 | registry | what exists |
 | import | what this scope wants |
 | cache | fetched bytes already available |
-| materialization | optional realized local tree when runtime behavior needs it |
 
 Working rules:
 
-- keep a machine-global cache under `~/.gc`
+- keep a machine-local, per-user cache under `~/.gc`
 - do not introduce a first-class machine-wide store
 - do not assume `.gc` should be kept wholesale in source control
 - treat `fetch` as cache-oriented, not as full materialization
-
-If materialization happens:
-
-- it is a runtime concern rather than the primary pack CLI story
-- rig behavior is still explicit through `--rig`
+- any later runtime materialization is explicitly outside the scope of this CLI
+  proposal
 
 ## Parked Questions
 
@@ -444,4 +554,16 @@ primarily trying to settle command names, signatures, and output shapes.
    vendoring), making the transitive closure of imported packages into a single
    deployable unit. Our import mechanism supports the scenario by embedding
    pack content under `assets/` and using path references in the `import`
-   directive in `pack.toml`.
+   directive in `pack.toml`. But we don't provide CLI surface area to manage it.
+3. Registry catalog caching and offline behavior are not fully specified yet:
+   when registry lookups fail, the proposal does not yet say whether the CLI
+   uses a cached `registry.toml`, fails hard, or does something in between.
+4. Cache pruning is not specified. `remove` intentionally does not imply eager
+   cache deletion, but this proposal does not yet define a `clean`/`prune`
+   command or an automatic reclamation policy.
+5. Nested pack edge cases are not fully specified. In particular, if a pack is
+   nested under another pack through an `assets/`-style workflow, the expected
+   ambient behavior is likely "innermost wins," but this should be frozen
+   explicitly in a later revision.
+6. Authentication for registries and source fetches is out of scope for this
+   proposal.

--- a/examples/cli2/.gitignore
+++ b/examples/cli2/.gitignore
@@ -1,0 +1,11 @@
+# Keep this mock pack reviewable while ignoring local runtime/test state.
+*
+!.gitignore
+!README.md
+!city.toml
+!pack.toml
+!commands/
+!commands/pack/
+!commands/pack/**
+!commands/registry/
+!commands/registry/**

--- a/examples/cli2/README.md
+++ b/examples/cli2/README.md
@@ -1,0 +1,20 @@
+# cli2
+
+Mock pack used to flesh out the current `gc pack` and `gc registry` proposal.
+
+Intended command shape:
+
+- `gc cli2 pack add`
+- `gc cli2 pack remove`
+- `gc cli2 pack list`
+- `gc cli2 pack show`
+- `gc cli2 pack fetch`
+- `gc cli2 pack outdated`
+- `gc cli2 pack upgrade`
+- `gc cli2 registry list`
+- `gc cli2 registry add`
+- `gc cli2 registry remove`
+- `gc cli2 registry search`
+- `gc cli2 registry show`
+
+The command bodies are placeholders. The help text is the important part.

--- a/examples/cli2/city.toml
+++ b/examples/cli2/city.toml
@@ -1,0 +1,3 @@
+[workspace]
+name = "cli2"
+provider = "codex"

--- a/examples/cli2/commands/pack/add/command.toml
+++ b/examples/cli2/commands/pack/add/command.toml
@@ -1,0 +1,1 @@
+description = "Add an imported pack"

--- a/examples/cli2/commands/pack/add/help.md
+++ b/examples/cli2/commands/pack/add/help.md
@@ -1,0 +1,15 @@
+# `gc cli2 pack add`
+
+Add an import to the selected scope and fetch it by default.
+
+## Usage
+
+```sh
+gc cli2 pack add <source-or-name> [--name <import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+## Notes
+
+- accepts qualified registry names, unqualified names when unambiguous, URLs, and local paths
+- fetches resolved content into cache by default
+- `--rig` is the only way to do rig-scoped imports

--- a/examples/cli2/commands/pack/add/run.sh
+++ b/examples/cli2/commands/pack/add/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack add"

--- a/examples/cli2/commands/pack/command.toml
+++ b/examples/cli2/commands/pack/command.toml
@@ -1,0 +1,1 @@
+description = "Import-first pack commands"

--- a/examples/cli2/commands/pack/fetch/command.toml
+++ b/examples/cli2/commands/pack/fetch/command.toml
@@ -1,0 +1,1 @@
+description = "Fetch resolved pack content into cache"

--- a/examples/cli2/commands/pack/fetch/help.md
+++ b/examples/cli2/commands/pack/fetch/help.md
@@ -1,0 +1,15 @@
+# `gc cli2 pack fetch`
+
+Fetch resolved pack content into cache for the selected scope.
+
+## Usage
+
+```sh
+gc cli2 pack fetch [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+## Notes
+
+- with no target, fetches all imports in scope
+- with a target, fetches one imported pack in scope
+- does not edit imports

--- a/examples/cli2/commands/pack/fetch/run.sh
+++ b/examples/cli2/commands/pack/fetch/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack fetch"

--- a/examples/cli2/commands/pack/help.md
+++ b/examples/cli2/commands/pack/help.md
@@ -1,0 +1,20 @@
+# `gc cli2 pack`
+
+Local import and cache-oriented pack commands.
+
+## Subcommands
+
+- `add`
+- `remove`
+- `list`
+- `show`
+- `fetch`
+- `outdated`
+- `upgrade`
+
+## Notes
+
+- `add` manages imports and fetches by default
+- `list --transitive` is the first-release transitive view
+- `fetch` is the explicit warm-cache and reconcile command
+- registry browsing lives under `gc cli2 registry`

--- a/examples/cli2/commands/pack/list/command.toml
+++ b/examples/cli2/commands/pack/list/command.toml
@@ -1,0 +1,1 @@
+description = "List imported packs"

--- a/examples/cli2/commands/pack/list/help.md
+++ b/examples/cli2/commands/pack/list/help.md
@@ -1,0 +1,15 @@
+# `gc cli2 pack list`
+
+List imports in the selected scope.
+
+## Usage
+
+```sh
+gc cli2 pack list [--transitive] [--pack <path>] [--rig <name-or-path>]
+```
+
+## Notes
+
+- default output is the direct import set
+- `--transitive` includes the full resolved transitive set
+- `--rig` is the only way to do rig-scoped imports

--- a/examples/cli2/commands/pack/list/run.sh
+++ b/examples/cli2/commands/pack/list/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack list"

--- a/examples/cli2/commands/pack/outdated/command.toml
+++ b/examples/cli2/commands/pack/outdated/command.toml
@@ -1,0 +1,1 @@
+description = "Show which imports could be upgraded"

--- a/examples/cli2/commands/pack/outdated/help.md
+++ b/examples/cli2/commands/pack/outdated/help.md
@@ -1,0 +1,14 @@
+# `gc cli2 pack outdated`
+
+Show which imported packs could be upgraded.
+
+## Usage
+
+```sh
+gc cli2 pack outdated [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+## Notes
+
+- with no target, reports all outdated imports in scope
+- does not mutate imports or cache

--- a/examples/cli2/commands/pack/outdated/run.sh
+++ b/examples/cli2/commands/pack/outdated/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack outdated"

--- a/examples/cli2/commands/pack/remove/command.toml
+++ b/examples/cli2/commands/pack/remove/command.toml
@@ -1,0 +1,1 @@
+description = "Remove an imported pack"

--- a/examples/cli2/commands/pack/remove/help.md
+++ b/examples/cli2/commands/pack/remove/help.md
@@ -1,0 +1,15 @@
+# `gc cli2 pack remove`
+
+Remove an import from the selected scope.
+
+## Usage
+
+```sh
+gc cli2 pack remove <import-name> [--pack <path>] [--rig <name-or-path>]
+```
+
+## Notes
+
+- manages imports only
+- does not imply eager cache deletion
+- `--rig` is the only way to do rig-scoped imports

--- a/examples/cli2/commands/pack/remove/run.sh
+++ b/examples/cli2/commands/pack/remove/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack remove"

--- a/examples/cli2/commands/pack/show/command.toml
+++ b/examples/cli2/commands/pack/show/command.toml
@@ -1,0 +1,1 @@
+description = "Show one imported pack"

--- a/examples/cli2/commands/pack/show/help.md
+++ b/examples/cli2/commands/pack/show/help.md
@@ -1,0 +1,17 @@
+# `gc cli2 pack show`
+
+Show one imported pack in the selected scope.
+
+## Usage
+
+```sh
+gc cli2 pack show <import-name> [--pack <path>] [--rig <name-or-path>]
+```
+
+## Output intent
+
+- imported name
+- source
+- resolved version or release
+- fetched status
+- scope

--- a/examples/cli2/commands/pack/show/run.sh
+++ b/examples/cli2/commands/pack/show/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack show"

--- a/examples/cli2/commands/pack/upgrade/command.toml
+++ b/examples/cli2/commands/pack/upgrade/command.toml
@@ -1,0 +1,1 @@
+description = "Upgrade imported packs"

--- a/examples/cli2/commands/pack/upgrade/help.md
+++ b/examples/cli2/commands/pack/upgrade/help.md
@@ -1,0 +1,15 @@
+# `gc cli2 pack upgrade`
+
+Upgrade imported packs in scope and fetch the new resolved result.
+
+## Usage
+
+```sh
+gc cli2 pack upgrade [<import-name>] [--pack <path>] [--rig <name-or-path>]
+```
+
+## Notes
+
+- with no target, upgrades all imports in scope
+- with a target, upgrades one imported pack
+- fetches the new resolved result into cache

--- a/examples/cli2/commands/pack/upgrade/run.sh
+++ b/examples/cli2/commands/pack/upgrade/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 pack upgrade"

--- a/examples/cli2/commands/registry/add/command.toml
+++ b/examples/cli2/commands/registry/add/command.toml
@@ -1,0 +1,1 @@
+description = "Add a configured registry"

--- a/examples/cli2/commands/registry/add/help.md
+++ b/examples/cli2/commands/registry/add/help.md
@@ -1,0 +1,14 @@
+# `gc cli2 registry add`
+
+Add one configured registry entry.
+
+## Usage
+
+```sh
+gc cli2 registry add <registry-name> <source>
+```
+
+## Notes
+
+- edits `~/.gc/registries.toml`
+- first-party registry name is `main`

--- a/examples/cli2/commands/registry/add/run.sh
+++ b/examples/cli2/commands/registry/add/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 registry add"

--- a/examples/cli2/commands/registry/command.toml
+++ b/examples/cli2/commands/registry/command.toml
@@ -1,0 +1,1 @@
+description = "Machine-known registry config and catalog commands"

--- a/examples/cli2/commands/registry/help.md
+++ b/examples/cli2/commands/registry/help.md
@@ -1,0 +1,17 @@
+# `gc cli2 registry`
+
+Machine-known registry config and catalog commands.
+
+## Subcommands
+
+- `list`
+- `add`
+- `remove`
+- `search`
+- `show`
+
+## Notes
+
+- `add` and `remove` manage `~/.gc/registries.toml`
+- `search` browses pack entries across registries
+- `show` requires an exact qualified pack name

--- a/examples/cli2/commands/registry/list/command.toml
+++ b/examples/cli2/commands/registry/list/command.toml
@@ -1,0 +1,1 @@
+description = "List configured registries"

--- a/examples/cli2/commands/registry/list/help.md
+++ b/examples/cli2/commands/registry/list/help.md
@@ -1,0 +1,14 @@
+# `gc cli2 registry list`
+
+List configured registries from `~/.gc/registries.toml`.
+
+## Usage
+
+```sh
+gc cli2 registry list
+```
+
+## Output intent
+
+- `Name`
+- `Source`

--- a/examples/cli2/commands/registry/list/run.sh
+++ b/examples/cli2/commands/registry/list/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 registry list"

--- a/examples/cli2/commands/registry/remove/command.toml
+++ b/examples/cli2/commands/registry/remove/command.toml
@@ -1,0 +1,1 @@
+description = "Remove a configured registry"

--- a/examples/cli2/commands/registry/remove/help.md
+++ b/examples/cli2/commands/registry/remove/help.md
@@ -1,0 +1,13 @@
+# `gc cli2 registry remove`
+
+Remove one configured registry entry.
+
+## Usage
+
+```sh
+gc cli2 registry remove <registry-name>
+```
+
+## Notes
+
+- edits `~/.gc/registries.toml`

--- a/examples/cli2/commands/registry/remove/run.sh
+++ b/examples/cli2/commands/registry/remove/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 registry remove"

--- a/examples/cli2/commands/registry/search/command.toml
+++ b/examples/cli2/commands/registry/search/command.toml
@@ -1,0 +1,1 @@
+description = "Search pack entries across registries"

--- a/examples/cli2/commands/registry/search/help.md
+++ b/examples/cli2/commands/registry/search/help.md
@@ -1,0 +1,15 @@
+# `gc cli2 registry search`
+
+Search pack entries across all registries by default.
+
+## Usage
+
+```sh
+gc cli2 registry search [query] [--registry <name>]
+```
+
+## Notes
+
+- plain text query, not regex
+- with no query, returns all pack entries
+- default columns: `Registry`, `Name`, `Latest`, `Description`

--- a/examples/cli2/commands/registry/search/run.sh
+++ b/examples/cli2/commands/registry/search/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 registry search"

--- a/examples/cli2/commands/registry/show/command.toml
+++ b/examples/cli2/commands/registry/show/command.toml
@@ -1,0 +1,1 @@
+description = "Show one exact pack catalog entry"

--- a/examples/cli2/commands/registry/show/help.md
+++ b/examples/cli2/commands/registry/show/help.md
@@ -1,0 +1,14 @@
+# `gc cli2 registry show`
+
+Show one exact pack catalog entry from a registry.
+
+## Usage
+
+```sh
+gc cli2 registry show <qualified-pack-name>
+```
+
+## Notes
+
+- requires a qualified name like `main:maintenance`
+- exact-address lookup only

--- a/examples/cli2/commands/registry/show/run.sh
+++ b/examples/cli2/commands/registry/show/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+case "${1:-}" in
+  -h|--help)
+    exec cat "$(dirname "$0")/help.md"
+    ;;
+esac
+printf '%s\n' "mock: gc cli2 registry show"

--- a/examples/cli2/pack.toml
+++ b/examples/cli2/pack.toml
@@ -1,0 +1,3 @@
+[pack]
+name = "cli2"
+schema = 2


### PR DESCRIPTION
## Summary
- add the current Pack/Registry CLI proposal under `engdocs/design/pack-cli-unification.md`
- refresh the design index entry so the proposal is discoverable in the official design set
- carry forward the latest design refinements from the public snapshot and review round

## Review focus
- `gc pack` signatures and scope rules
- `gc registry` signatures and outputs
- proposed `registries.toml` / `registry.toml` shapes
- parked questions that should stay parked vs. be resolved before implementation

## Notes
- this is a design-doc PR only
- no implementation is included
- the current proposal intentionally leaves auth, registry catalog caching policy, and cache pruning as open follow-on questions