### PR TITLE
fix: project city Claude settings into runtime --settings

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1056,9 +1056,20 @@ func namedSessionAllowsControllerWorkQuery(cityPath string, cfg *config.City, sp
 // installAgentSideEffects performs idempotent side effects for a resolved
 // agent: hook installation and ACP route registration. Called from
 // buildDesiredState on every tick; safe to repeat.
+//
+// When the resolved provider is Claude, resolveTemplate has already projected
+// managed Claude settings via ensureClaudeSettingsArgs (required so the
+// --settings path exists before runtime fingerprinting). In that case the
+// "claude" entry in install_agent_hooks is filtered out here to avoid
+// duplicating filesystem I/O for every pool instance on every tick. Agents
+// whose resolved provider is not Claude but which opt in explicitly via
+// install_agent_hooks = ["claude"] still flow through hooks.Install here.
 func installAgentSideEffects(bp *agentBuildParams, cfgAgent *config.Agent, tp TemplateParams, stderr io.Writer) {
-	// Install provider hooks (idempotent filesystem side effect).
-	if ih := config.ResolveInstallHooks(cfgAgent, bp.workspace); len(ih) > 0 {
+	ih := config.ResolveInstallHooks(cfgAgent, bp.workspace)
+	if tp.ResolvedProvider != nil && tp.ResolvedProvider.Name == "claude" {
+		ih = hooksWithoutClaude(ih)
+	}
+	if len(ih) > 0 {
 		if hErr := hooks.Install(bp.fs, bp.cityPath, tp.WorkDir, ih); hErr != nil {
 			fmt.Fprintf(stderr, "agent %q: hooks: %v\n", tp.DisplayName(), hErr) //nolint:errcheck
 		}
@@ -1069,6 +1080,25 @@ func installAgentSideEffects(bp *agentBuildParams, cfgAgent *config.Agent, tp Te
 			autoSP.RouteACP(tp.SessionName)
 		}
 	}
+}
+
+// hooksWithoutClaude returns ih with any "claude" entries filtered out.
+// Used by installAgentSideEffects when the resolved provider is Claude —
+// in that case resolveTemplate → ensureClaudeSettingsArgs already projected
+// the settings, and running hooks.Install("claude") again would duplicate
+// filesystem I/O on every reconciler tick.
+func hooksWithoutClaude(ih []string) []string {
+	if len(ih) == 0 {
+		return ih
+	}
+	out := make([]string, 0, len(ih))
+	for _, p := range ih {
+		if p == "claude" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // poolInstanceName returns the name for pool slot N.

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -682,9 +682,11 @@ func applyBootstrapProfile(cfg *config.City, profile string) {
 
 // installClaudeHooks writes Claude Code hook settings for the city.
 // Delegates to hooks.Install which is idempotent (won't overwrite existing files).
+// The stderr prefix is neutral ("claude hooks:") because this function runs
+// both at `gc init` time and on every reconciler tick via resolveTemplate.
 func installClaudeHooks(fs fsys.FS, cityPath string, stderr io.Writer) int {
 	if err := hooks.Install(fs, cityPath, cityPath, []string{"claude"}); err != nil {
-		fmt.Fprintf(stderr, "gc init: installing claude hooks: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "claude hooks: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	return 0

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -802,8 +802,21 @@ func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, se
 		if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 			command = command + " " + shellquote.Join(defaultArgs)
 		}
-		if sa := ensureClaudeSettingsArgs(fsys.OSFS{}, cityPath, resolved.Name, stderr); sa != "" {
+		// buildResumeCommand is best-effort: log projection failures and
+		// continue so `gc session attach` still starts the agent with
+		// whatever --settings file (if any) is already on disk. The strict
+		// path is resolveTemplate at reconciler time.
+		sa, saErr := ensureClaudeSettingsArgs(fsys.OSFS{}, cityPath, resolved.Name, stderr)
+		if saErr == nil && sa != "" {
 			command = command + " " + sa
+		} else if saErr != nil {
+			// Fall back to probing whatever exists on disk. settingsArgs
+			// returns "" if nothing is projected yet, so Claude launches
+			// without --settings rather than with stale content from the
+			// failed projection.
+			if probe := settingsArgs(cityPath, resolved.Name); probe != "" {
+				command = command + " " + probe
+			}
 		}
 		resolvedInfo.Command = command
 		resolvedInfo.Provider = resolved.Name

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -810,14 +810,15 @@ func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, se
 		if saErr == nil && sa != "" {
 			command = command + " " + sa
 		} else if saErr != nil {
-			// Projection failed this tick. Fall back to whatever a prior
-			// reconciler tick left on disk: settingsArgs probes for the
-			// managed .gc/settings.json (or legacy hooks/claude.json) and
-			// returns "" when nothing exists. On a fresh city with a
-			// malformed override, attach therefore launches without
-			// --settings rather than with stale content. On an older city,
-			// attach uses the last-known-good projection.
-			if probe := settingsArgs(cityPath, resolved.Name); probe != "" {
+			// Projection failed this tick. Fall back to the last-known-good
+			// projection on disk, but require the file to be actually
+			// readable — not just Stat-present. Pointing Claude at an
+			// unreadable --settings path would fail agent startup worse
+			// than launching without --settings at all. On a fresh city
+			// with a malformed override, attach therefore launches without
+			// --settings; on an older city with a readable prior projection,
+			// attach uses that projection.
+			if probe := settingsArgsIfReadable(cityPath, resolved.Name); probe != "" {
 				command = command + " " + probe
 			}
 		}

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
@@ -757,7 +758,7 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// Build the resume command from the template's provider.
-	resumeCmd, hints := buildResumeCommand(cityPath, cfg, info, beadSessionKind(store, sessionID))
+	resumeCmd, hints := buildResumeCommand(cityPath, cfg, info, beadSessionKind(store, sessionID), stderr)
 
 	fmt.Fprintf(stdout, "Attaching to session %s (%s)...\n", sessionID, info.Template) //nolint:errcheck // best-effort stdout
 	if err := mgr.Attach(context.Background(), sessionID, resumeCmd, hints); err != nil {
@@ -774,12 +775,17 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 // cityPath is needed to resolve the --settings flag for Claude sessions.
 // Without it, SessionStart hooks defined in .gc/settings.json are not loaded
 // when gc session attach starts the process (as opposed to the reconciler).
+// For Claude providers, the managed settings file is projected here via
+// ensureClaudeSettingsArgs so `gc session attach` on a fresh city still
+// emits `--settings` even when the reconciler hasn't run yet.
+//
+// stderr receives projection errors (use io.Discard to ignore).
 //
 // sessionKind mirrors the mc_session_kind bead metadata: "provider" means
 // the session was created from a bare provider name (not an agent template),
 // so the agent-template lookup should be skipped. This matches the guard in
 // the API handler (handler_session_chat.go).
-func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, sessionKind string) (string, runtime.Config) {
+func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, sessionKind string, stderr io.Writer) (string, runtime.Config) {
 	cmd := session.BuildResumeCommand(info)
 	if cfg == nil {
 		return cmd, runtime.Config{WorkDir: info.WorkDir}
@@ -796,7 +802,7 @@ func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, se
 		if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 			command = command + " " + shellquote.Join(defaultArgs)
 		}
-		if sa := settingsArgs(cityPath, resolved.Name); sa != "" {
+		if sa := ensureClaudeSettingsArgs(fsys.OSFS{}, cityPath, resolved.Name, stderr); sa != "" {
 			command = command + " " + sa
 		}
 		resolvedInfo.Command = command
@@ -1318,7 +1324,7 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	resumeCmd, hints := buildResumeCommand(cityPath, cfg, info, beadSessionKind(store, sessionID))
+	resumeCmd, hints := buildResumeCommand(cityPath, cfg, info, beadSessionKind(store, sessionID), stderr)
 	outcome, err := mgr.Submit(context.Background(), sessionID, message, resumeCmd, hints, intent)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -803,17 +803,20 @@ func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, se
 			command = command + " " + shellquote.Join(defaultArgs)
 		}
 		// buildResumeCommand is best-effort: log projection failures and
-		// continue so `gc session attach` still starts the agent with
-		// whatever --settings file (if any) is already on disk. The strict
-		// path is resolveTemplate at reconciler time.
+		// continue so `gc session attach` still starts the agent. The strict
+		// path is resolveTemplate at reconciler time, which fails agent
+		// creation on projection errors.
 		sa, saErr := ensureClaudeSettingsArgs(fsys.OSFS{}, cityPath, resolved.Name, stderr)
 		if saErr == nil && sa != "" {
 			command = command + " " + sa
 		} else if saErr != nil {
-			// Fall back to probing whatever exists on disk. settingsArgs
-			// returns "" if nothing is projected yet, so Claude launches
-			// without --settings rather than with stale content from the
-			// failed projection.
+			// Projection failed this tick. Fall back to whatever a prior
+			// reconciler tick left on disk: settingsArgs probes for the
+			// managed .gc/settings.json (or legacy hooks/claude.json) and
+			// returns "" when nothing exists. On a fresh city with a
+			// malformed override, attach therefore launches without
+			// --settings rather than with stale content. On an older city,
+			// attach uses the last-known-good projection.
 			if probe := settingsArgs(cityPath, resolved.Name); probe != "" {
 				command = command + " " + probe
 			}

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -318,7 +319,7 @@ func TestBuildResumeCommandUsesResolvedProviderCommand(t *testing.T) {
 		WorkDir:  "/tmp/workdir",
 	}
 
-	cmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "")
+	cmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "", io.Discard)
 	if got, want := cmd, "aimux run gemini -- --approval-mode yolo"; got != want {
 		t.Fatalf("resume command = %q, want %q", got, want)
 	}
@@ -359,7 +360,7 @@ func TestBuildResumeCommandIncludesSettingsAndDefaultArgs(t *testing.T) {
 		ResumeFlag: "--resume",
 	}
 
-	cmd, _ := buildResumeCommand(cityDir, cfg, info, "")
+	cmd, _ := buildResumeCommand(cityDir, cfg, info, "", io.Discard)
 
 	// Must include --settings pointing to .gc/settings.json.
 	wantSettings := fmt.Sprintf("--settings %q", filepath.Join(gcDir, "settings.json"))

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -697,13 +697,20 @@ func settingsArgs(cityPath, providerName string) string {
 // "--settings <path>" arg for the resolved Claude command. This is the
 // single chokepoint that guarantees every Claude launch path — reconciler
 // or session attach/submit — sees the projected file before settingsArgs
-// probes for it. Returns empty for non-Claude providers.
+// probes for it. Returns empty string and nil error for non-Claude providers.
+//
+// Returns a non-nil error when projection fails. Strict callers
+// (resolveTemplate) should propagate so that a malformed preferred override
+// fails loudly at agent creation rather than silently running with stale
+// bytes from a prior tick. Best-effort callers (buildResumeCommand) may
+// choose to log-and-continue so a `gc session attach` still succeeds when
+// projection is transiently broken.
 //
 // fs may be nil; in that case OSFS is used. stderr may be nil; in that
-// case projection errors are discarded.
-func ensureClaudeSettingsArgs(fs fsys.FS, cityPath, providerName string, stderr io.Writer) string {
+// case projection errors are only returned, not written.
+func ensureClaudeSettingsArgs(fs fsys.FS, cityPath, providerName string, stderr io.Writer) (string, error) {
 	if providerName != "claude" || cityPath == "" {
-		return ""
+		return "", nil
 	}
 	if fs == nil {
 		fs = fsys.OSFS{}
@@ -711,12 +718,11 @@ func ensureClaudeSettingsArgs(fs fsys.FS, cityPath, providerName string, stderr 
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	if code := installClaudeHooks(fs, cityPath, stderr); code != 0 {
-		// installClaudeHooks already reported the error; fall through so
-		// --settings still reflects whatever managed file (if any) is on
-		// disk from a prior tick.
+	if err := hooks.Install(fs, cityPath, cityPath, []string{"claude"}); err != nil {
+		fmt.Fprintf(stderr, "claude hooks: %v\n", err) //nolint:errcheck // best-effort stderr
+		return "", fmt.Errorf("projecting Claude settings: %w", err)
 	}
-	return settingsArgs(cityPath, providerName)
+	return settingsArgs(cityPath, providerName), nil
 }
 
 func claudeSettingsSource(cityPath string) (src, rel string) {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -692,6 +692,33 @@ func settingsArgs(cityPath, providerName string) string {
 	return fmt.Sprintf("--settings %q", settingsPath)
 }
 
+// ensureClaudeSettingsArgs projects managed Claude settings to
+// .gc/settings.json (idempotent: no-op when bytes match) and returns the
+// "--settings <path>" arg for the resolved Claude command. This is the
+// single chokepoint that guarantees every Claude launch path — reconciler
+// or session attach/submit — sees the projected file before settingsArgs
+// probes for it. Returns empty for non-Claude providers.
+//
+// fs may be nil; in that case OSFS is used. stderr may be nil; in that
+// case projection errors are discarded.
+func ensureClaudeSettingsArgs(fs fsys.FS, cityPath, providerName string, stderr io.Writer) string {
+	if providerName != "claude" || cityPath == "" {
+		return ""
+	}
+	if fs == nil {
+		fs = fsys.OSFS{}
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	if code := installClaudeHooks(fs, cityPath, stderr); code != 0 {
+		// installClaudeHooks already reported the error; fall through so
+		// --settings still reflects whatever managed file (if any) is on
+		// disk from a prior tick.
+	}
+	return settingsArgs(cityPath, providerName)
+}
+
 func claudeSettingsSource(cityPath string) (src, rel string) {
 	candidates := []struct {
 		src string

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -681,12 +681,36 @@ func printDryRunPreview(desiredState map[string]TemplateParams, cfg *config.City
 // it resolves correctly regardless of the session's working directory. The K8s
 // provider remaps city-root references to /workspace automatically.
 // Returns empty string for non-Claude providers or if no settings file is present.
+//
+// Note: this uses Stat-level existence only. It does NOT verify the file is
+// readable. Use settingsArgsIfReadable in best-effort fallback paths where
+// pointing Claude at an unreadable file would be worse than no --settings.
 func settingsArgs(cityPath, providerName string) string {
 	if providerName != "claude" {
 		return ""
 	}
 	settingsPath, _ := claudeSettingsSource(cityPath)
 	if settingsPath == "" {
+		return ""
+	}
+	return fmt.Sprintf("--settings %q", settingsPath)
+}
+
+// settingsArgsIfReadable is the stricter variant used by best-effort fallback
+// paths (e.g. buildResumeCommand on projection failure). It returns "--settings
+// <path>" only if the discovered file is actually readable — not just present.
+// This prevents `gc session attach` from pointing Claude at a 0o000 or
+// otherwise-unreadable .gc/settings.json that a failed projection could not
+// repair this tick.
+func settingsArgsIfReadable(cityPath, providerName string) string {
+	if providerName != "claude" {
+		return ""
+	}
+	settingsPath, _ := claudeSettingsSource(cityPath)
+	if settingsPath == "" {
+		return ""
+	}
+	if _, err := os.ReadFile(settingsPath); err != nil {
 		return ""
 	}
 	return fmt.Sprintf("--settings %q", settingsPath)

--- a/cmd/gc/live_submit_probe_test.go
+++ b/cmd/gc/live_submit_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -97,7 +98,7 @@ func TestLiveClaudeInterruptNow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mgr.Get(%q): %v", id, err)
 	}
-	resumeCmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "")
+	resumeCmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "", io.Discard)
 	socket := cfg.Session.Socket
 	if socket == "" {
 		socket = cfg.Workspace.Name
@@ -173,7 +174,7 @@ func TestLiveGeminiSubmitIntents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mgr.Get(%q): %v", id, err)
 	}
-	resumeCmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "")
+	resumeCmd, hints := buildResumeCommand(t.TempDir(), cfg, info, "", io.Discard)
 	socket := cfg.Session.Socket
 	if socket == "" {
 		socket = cfg.Workspace.Name

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1776,6 +1776,45 @@ func TestSettingsArgsMissingFile(t *testing.T) {
 	}
 }
 
+// TestEnsureClaudeSettingsArgsPropagatesMalformedOverride verifies that a
+// malformed .claude/settings.json surfaces as an error from
+// ensureClaudeSettingsArgs rather than silently returning a --settings arg
+// that points at stale bytes from a prior tick. resolveTemplate relies on
+// this so a bad override fails agent creation loudly; a best-effort caller
+// like buildResumeCommand may choose to log-and-continue.
+func TestEnsureClaudeSettingsArgsPropagatesMalformedOverride(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{not valid json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ensureClaudeSettingsArgs(fsys.OSFS{}, dir, "claude", io.Discard)
+	if err == nil {
+		t.Fatalf("expected propagated error for malformed override; got arg=%q", got)
+	}
+	if got != "" {
+		t.Errorf("arg must be empty when projection fails; got %q", got)
+	}
+}
+
+// TestEnsureClaudeSettingsArgsNoOpForNonClaude verifies the helper is a
+// no-op for non-Claude providers — projection never runs and no error is
+// returned regardless of filesystem state.
+func TestEnsureClaudeSettingsArgsNoOpForNonClaude(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ensureClaudeSettingsArgs(fsys.OSFS{}, dir, "codex", io.Discard)
+	if err != nil {
+		t.Fatalf("non-Claude provider must return nil error; got %v", err)
+	}
+	if got != "" {
+		t.Errorf("non-Claude provider must return empty arg; got %q", got)
+	}
+}
+
 // --- runWizard ---
 
 func TestRunWizardDefaults(t *testing.T) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1659,9 +1659,11 @@ func TestDoInitSettingsIsValidJSON(t *testing.T) {
 
 func TestDoInitDoesNotOverwriteExistingSettings(t *testing.T) {
 	f := fsys.NewFake()
-	// Pre-populate .gc/ and settings.json with custom content.
-	// doInit will see .gc/ exists and return "already initialized".
-	// So test installClaudeHooks directly instead.
+	// Pre-populate hooks/claude.json with a user-authored custom key. The
+	// file was historically preserved verbatim, which meant new default
+	// hooks added to the embedded base in later releases never landed for
+	// legacy users. Current contract: the custom key is preserved via merge
+	// while embedded defaults are pulled in.
 	settingsPath := filepath.Join("/city", "hooks", "claude.json")
 	f.Dirs[filepath.Join("/city", "hooks")] = true
 	f.Files[settingsPath] = []byte(`{"custom": true}`)
@@ -1670,12 +1672,17 @@ func TestDoInitDoesNotOverwriteExistingSettings(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("installClaudeHooks = %d, want 0", code)
 	}
-	got := string(f.Files[settingsPath])
-	if got != `{"custom": true}` {
-		t.Errorf("settings.json was overwritten: %q", got)
+
+	hookData := string(f.Files[settingsPath])
+	runtimeData := string(f.Files[filepath.Join("/city", ".gc", "settings.json")])
+	if !strings.Contains(hookData, `"custom": true`) {
+		t.Errorf("user-authored custom key not preserved in hook file:\n%s", hookData)
 	}
-	if runtime := string(f.Files[filepath.Join("/city", ".gc", "settings.json")]); runtime != `{"custom": true}` {
-		t.Errorf("runtime settings were not mirrored from existing hooks file: %q", runtime)
+	if !strings.Contains(hookData, "SessionStart") {
+		t.Errorf("embedded default hooks not merged into hook file:\n%s", hookData)
+	}
+	if hookData != runtimeData {
+		t.Error("runtime settings must mirror merged hook settings")
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -139,7 +139,11 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 		command = command + " " + shellquote.Join(defaultArgs)
 	}
-	if sa := ensureClaudeSettingsArgs(p.fs, p.cityPath, resolved.Name, p.stderr); sa != "" {
+	sa, err := ensureClaudeSettingsArgs(p.fs, p.cityPath, resolved.Name, p.stderr)
+	if err != nil {
+		return TemplateParams{}, fmt.Errorf("agent %q: %w", qualifiedName, err)
+	}
+	if sa != "" {
 		command = command + " " + sa
 		settingsFile, relDst := claudeSettingsSource(p.cityPath)
 		if settingsFile != "" {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -1,10 +1,15 @@
-// template_resolve.go extracts a pure function for resolving agent config
-// into session parameters. This is the data-only half of buildOneAgent:
-// all steps that compute values (provider resolution, dir expansion, env
-// merging, prompt rendering) without side effects.
+// template_resolve.go extracts a value-producing function for resolving
+// agent config into session parameters. Most of the work is pure (provider
+// resolution, dir expansion, env merging, prompt rendering).
 //
-// Side effects (ACP route registration, hook installation) are handled
-// by the caller (buildOneAgent).
+// One side effect lives here by necessity: managed Claude settings are
+// projected to .gc/settings.json via ensureClaudeSettingsArgs so that the
+// --settings path is on disk before runtime fingerprints are captured.
+// This is the single chokepoint for Claude projection — installAgentSideEffects
+// skips the "claude" entry in its hook list to avoid duplicate work.
+//
+// Other side effects (ACP route registration, non-Claude hook installation)
+// are handled by the caller (buildOneAgent → installAgentSideEffects).
 //
 // resolveTemplate returns TemplateParams — a value type suitable for
 // session.Manager.CreateFromParams or for constructing runtime.Config.
@@ -12,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -113,15 +117,6 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if cfgAgent.Session == "acp" && !resolved.SupportsACP {
 		return TemplateParams{}, fmt.Errorf("agent %q: session = \"acp\" but provider %q does not support ACP (set supports_acp = true on the provider)", qualifiedName, resolved.Name)
 	}
-	if resolved.Name == "claude" && p.fs != nil && p.cityPath != "" {
-		stderr := p.stderr
-		if stderr == nil {
-			stderr = io.Discard
-		}
-		if code := installClaudeHooks(p.fs, p.cityPath, stderr); code != 0 {
-			return TemplateParams{}, fmt.Errorf("agent %q: installing Claude settings: exit %d", qualifiedName, code)
-		}
-	}
 
 	// Step 3: Expand dir template.
 	dirCtx := sessionSetupContextForAgent(p.cityPath, p.cityName, qualifiedName, cfgAgent, p.rigs)
@@ -144,7 +139,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 		command = command + " " + shellquote.Join(defaultArgs)
 	}
-	if sa := settingsArgs(p.cityPath, resolved.Name); sa != "" {
+	if sa := ensureClaudeSettingsArgs(p.fs, p.cityPath, resolved.Name, p.stderr); sa != "" {
 		command = command + " " + sa
 		settingsFile, relDst := claudeSettingsSource(p.cityPath)
 		if settingsFile != "" {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -96,10 +97,9 @@ func (tp TemplateParams) DisplayName() string {
 	return tp.TemplateName
 }
 
-// resolveTemplate computes all session parameters from a config.Agent without
-// side effects. This is a pure extraction of steps 1-13 and 15-16 from
-// buildOneAgent. The only side effect excluded is ACP route registration
-// (step 14), which the caller handles.
+// resolveTemplate computes all session parameters from a config.Agent.
+// It also reconciles managed Claude settings before wiring the active
+// --settings path so runtime fingerprinting sees the current projected file.
 //
 // qualifiedName is the agent's canonical identity. fpExtra carries additional
 // fingerprint data (e.g., pool bounds); pass nil for pool instances.
@@ -112,6 +112,15 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	// Step 2: Validate session vs provider compatibility.
 	if cfgAgent.Session == "acp" && !resolved.SupportsACP {
 		return TemplateParams{}, fmt.Errorf("agent %q: session = \"acp\" but provider %q does not support ACP (set supports_acp = true on the provider)", qualifiedName, resolved.Name)
+	}
+	if resolved.Name == "claude" && p.fs != nil && p.cityPath != "" {
+		stderr := p.stderr
+		if stderr == nil {
+			stderr = io.Discard
+		}
+		if code := installClaudeHooks(p.fs, p.cityPath, stderr); code != 0 {
+			return TemplateParams{}, fmt.Errorf("agent %q: installing Claude settings: exit %d", qualifiedName, code)
+		}
 	}
 
 	// Step 3: Expand dir template.

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -351,5 +353,59 @@ func TestResolveTemplateHookEnabledOpencodeOmitsPrimeInstruction(t *testing.T) {
 	}
 	if strings.Contains(tp.Prompt, "Run `gc prime`") {
 		t.Fatalf("hook-enabled prompt should omit manual gc prime instruction: %q", tp.Prompt)
+	}
+}
+
+func TestResolveTemplateClaudeProjectsCityDotClaudeSettingsIntoRuntimeFile(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "prompts", "mayor.md"), []byte("mayor prompt body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".claude", "settings.json"), []byte(`{"custom": true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	params := &agentBuildParams{
+		fs:              fsys.OSFS{},
+		cityName:        "bright-lights",
+		cityPath:        cityPath,
+		workspace:       &config.Workspace{Name: "bright-lights", Provider: "claude"},
+		providers:       config.BuiltinProviders(),
+		lookPath:        func(string) (string, error) { return "/usr/bin/claude", nil },
+		beaconTime:      testBeaconTime,
+		sessionTemplate: "",
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+	}
+	agent := &config.Agent{
+		Name:           "mayor",
+		PromptTemplate: "prompts/mayor.md",
+		Provider:       "claude",
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if !strings.Contains(tp.Command, `.gc/settings.json`) {
+		t.Fatalf("command missing Claude settings path: %q", tp.Command)
+	}
+	runtimePath := filepath.Join(cityPath, ".gc", "settings.json")
+	data, err := os.ReadFile(runtimePath)
+	if err != nil {
+		t.Fatalf("resolveTemplate did not materialize %s: %v", runtimePath, err)
+	}
+	rendered := string(data)
+	if !strings.Contains(rendered, `"custom": true`) {
+		t.Fatalf("runtime settings missing city .claude override:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "SessionStart") {
+		t.Fatalf("runtime settings lost default Claude hooks:\n%s", rendered)
 	}
 }

--- a/internal/citylayout/layout.go
+++ b/internal/citylayout/layout.go
@@ -20,6 +20,7 @@ const (
 
 	HooksRoot      = "hooks"
 	ClaudeHookFile = "hooks/claude.json"
+	ClaudeSettings = ".claude/settings.json"
 
 	ScriptsRoot = "scripts"
 
@@ -82,6 +83,9 @@ func ScriptsPath(cityRoot string) string { return filepath.Join(cityRoot, Script
 
 // ClaudeHookFilePath returns the absolute path to the Claude hook file.
 func ClaudeHookFilePath(cityRoot string) string { return filepath.Join(cityRoot, ClaudeHookFile) }
+
+// ClaudeSettingsPath returns the absolute path to the city-local Claude settings override.
+func ClaudeSettingsPath(cityRoot string) string { return filepath.Join(cityRoot, ClaudeSettings) }
 
 // ResolveFormulasDir resolves the city-local formulas directory. If configured
 // is empty or ".", returns the default formulas path. If absolute, returns as-is.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -308,15 +308,17 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {
-	if existing, err := fs.ReadFile(dst); err == nil {
-		if bytes.Equal(existing, data) {
+	existing, readErr := fs.ReadFile(dst)
+	if readErr == nil && bytes.Equal(existing, data) {
+		return nil
+	}
+	if readErr != nil {
+		if _, statErr := fs.Stat(dst); statErr == nil && policy == preserveUnreadable {
+			// File exists but isn't readable. For user-owned paths, preserve
+			// rather than clobbering. gc-owned paths fall through and attempt
+			// the write (a write failure surfaces an error to the caller).
 			return nil
 		}
-	} else if _, statErr := fs.Stat(dst); statErr == nil && policy == preserveUnreadable {
-		// File exists but isn't readable. For user-owned paths, preserve
-		// rather than clobbering. gc-owned paths fall through and attempt
-		// the write (a write failure surfaces an error to the caller).
-		return nil
 	}
 
 	dir := filepath.Dir(dst)
@@ -327,14 +329,22 @@ func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFi
 	if err := fs.WriteFile(dst, data, 0o644); err != nil {
 		return fmt.Errorf("writing %s: %w", dst, err)
 	}
-	// os.WriteFile preserves the existing file's mode on overwrite. For
-	// gc-owned paths that may have been left with a restrictive mode (e.g.
-	// a stat-ok-but-read-fail file we just force-overwrote), normalize the
-	// permissions so Claude can actually read the file at launch time.
-	// User-owned paths are preserved as-is.
-	if policy == forceOverwrite {
-		if err := fs.Chmod(dst, 0o644); err != nil {
-			return fmt.Errorf("chmod %s: %w", dst, err)
+
+	// If we just force-overwrote a previously-unreadable gc-owned file,
+	// os.WriteFile preserved its restrictive mode and Claude still can't
+	// open --settings. Add ONLY the owner-read bit to the existing mode,
+	// preserving any user-tightened permissions (e.g. 0o600 for privacy)
+	// and leaving fresh-install files at whatever perm-&-umask produced.
+	if policy == forceOverwrite && readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		info, err := fs.Stat(dst)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", dst, err)
+		}
+		currentMode := info.Mode().Perm()
+		if currentMode&0o400 == 0 {
+			if err := fs.Chmod(dst, currentMode|0o400); err != nil {
+				return fmt.Errorf("chmod %s: %w", dst, err)
+			}
 		}
 	}
 	return nil

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -120,12 +120,30 @@ func installClaude(fs fsys.FS, cityDir string) error {
 	}
 
 	if sourceKind == claudeSettingsSourceLegacyHook || hookFileSafeToRewrite(fs, hookDst) {
-		if err := writeManagedFile(fs, hookDst, data); err != nil {
+		if err := writeManagedFile(fs, hookDst, data, preserveUnreadable); err != nil {
 			return err
 		}
 	}
-	return writeManagedFile(fs, runtimeDst, data)
+	// The runtime file is gc-owned: if existing content is unreadable (bad
+	// perms, i/o error), force an overwrite rather than silently preserving
+	// a stale blob Claude can't parse. If the write itself fails, surface
+	// the error so the caller can fail agent creation loudly instead of
+	// launching with a broken --settings path.
+	return writeManagedFile(fs, runtimeDst, data, forceOverwrite)
 }
+
+type writeManagedFilePolicy int
+
+const (
+	// preserveUnreadable leaves a stat-ok-but-read-fails file in place.
+	// Used for user-owned paths (hooks/claude.json) where clobbering an
+	// unreadable file could lose user-authored content.
+	preserveUnreadable writeManagedFilePolicy = iota
+	// forceOverwrite attempts to write the new content even when the
+	// existing file is unreadable. Used for gc-managed paths (.gc/settings.json)
+	// where the file's content is gc's responsibility.
+	forceOverwrite
+)
 
 // hookFileSafeToRewrite reports whether hooks/claude.json can be safely
 // overwritten by installClaude without clobbering user-owned content. It is
@@ -207,17 +225,21 @@ func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string
 	}
 
 	// Legacy candidates. A genuinely missing file is fine — fall through.
-	// An exists-but-unreadable file (bad perms, i/o error) must NOT silently
-	// demote to a lower-priority source, or a stale .gc/settings.json could
-	// override a user-owned hooks/claude.json that gc simply couldn't read
-	// this tick. Use embedded base defaults instead so the agent still
-	// launches without surfacing leftover runtime state.
+	// An exists-but-unreadable hooks/claude.json must NOT silently demote
+	// to .gc/settings.json, or a stale runtime file could override a
+	// user-owned hook file that gc simply couldn't read this tick. Fall
+	// back to embedded base defaults instead.
+	//
+	// An unreadable .gc/settings.json does NOT block hook precedence —
+	// the runtime file is gc-managed, not user-owned, so treating it as
+	// "missing" when unreadable is equivalent to "gc will overwrite
+	// whatever's there." A valid hooks/claude.json should still win.
 	hookPath := citylayout.ClaudeHookFilePath(cityDir)
 	runtimePath := filepath.Join(cityDir, ".gc", "settings.json")
 	hookState, hookData, _ := readClaudeSettingsCandidate(fs, hookPath)
 	runtimeState, runtimeData, _ := readClaudeSettingsCandidate(fs, runtimePath)
 
-	if hookState == candidateUnreadable || runtimeState == candidateUnreadable {
+	if hookState == candidateUnreadable {
 		return "", nil, claudeSettingsSourceNone, nil
 	}
 
@@ -271,13 +293,15 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 	return candidateUnreadable, nil, err
 }
 
-func writeManagedFile(fs fsys.FS, dst string, data []byte) error {
+func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {
 	if existing, err := fs.ReadFile(dst); err == nil {
 		if bytes.Equal(existing, data) {
 			return nil
 		}
-	} else if _, statErr := fs.Stat(dst); statErr == nil {
-		// File exists but isn't readable. Preserve it rather than clobbering it.
+	} else if _, statErr := fs.Stat(dst); statErr == nil && policy == preserveUnreadable {
+		// File exists but isn't readable. For user-owned paths, preserve
+		// rather than clobbering. gc-owned paths fall through and attempt
+		// the write (a write failure surfaces an error to the caller).
 		return nil
 	}
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -7,7 +7,9 @@ package hooks
 import (
 	"bytes"
 	"embed"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -127,20 +129,20 @@ func installClaude(fs fsys.FS, cityDir string) error {
 
 // hookFileSafeToRewrite reports whether hooks/claude.json can be safely
 // overwritten by installClaude without clobbering user-owned content. It is
-// safe when the file does not exist (fresh install) or when its bytes match
-// a known stale auto-generated pattern that predates the current embedded
-// defaults (proactive upgrade of leftover state). Any other content — even
-// bytes identical to the embedded base — is treated as user-owned to avoid
-// surprising a user who pinned their hook file by hand.
+// safe when the file does not exist (fresh install seed) or when its bytes
+// match a known stale auto-generated pattern (proactive upgrade of leftover
+// state). Any other content — including existing-but-unreadable files,
+// content equal to the embedded base, or user-authored content — is
+// preserved.
 func hookFileSafeToRewrite(fs fsys.FS, hookDst string) bool {
 	data, err := fs.ReadFile(hookDst)
-	if err != nil {
-		// Missing or unreadable: fresh install (or broken state we can't
-		// reason about). Either way, writeManagedFile's existing guards
-		// decide what to do.
-		return true
+	if err == nil {
+		return claudeFileNeedsUpgrade(data)
 	}
-	return claudeFileNeedsUpgrade(data)
+	// Only a genuine "not found" means we can safely seed. Any other read
+	// error (permission, i/o) is an existing file in an unknown state —
+	// preserve it rather than risk clobbering user content.
+	return errors.Is(err, os.ErrNotExist)
 }
 
 func readEmbedded(embedPath string) ([]byte, error) {
@@ -209,8 +211,15 @@ func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string
 	_, hookData, hookExists, _ := readClaudeSettingsCandidate(fs, hookPath, false)
 	_, runtimeData, runtimeExists, _ := readClaudeSettingsCandidate(fs, runtimePath, false)
 
+	// hooks/claude.json is authoritative when it exists, is not a known
+	// stale auto-generated file, and differs from the managed runtime file
+	// (the redundant-mirror case). We deliberately do NOT disqualify a
+	// hook file whose bytes equal the embedded base: a user may pin
+	// hooks/claude.json to exactly the embedded defaults as their
+	// authoritative source and still expect it to outrank .gc/settings.json
+	// per the documented precedence. Use stale-pattern detection alone to
+	// decide whether the hook file is gc-generated vs user-authored.
 	if hookExists &&
-		!bytes.Equal(hookData, base) &&
 		(!runtimeExists || !bytes.Equal(hookData, runtimeData)) &&
 		!claudeFileNeedsUpgrade(hookData) {
 		return hookPath, hookData, claudeSettingsSourceLegacyHook, nil
@@ -267,6 +276,11 @@ func claudeFileNeedsUpgrade(existing []byte) bool {
 	if err != nil {
 		return false
 	}
-	stale := strings.Replace(string(current), `gc handoff "context cycle"`, `gc prime --hook`, 1)
+	// The pattern uses JSON-escaped quotes to match how the string appears
+	// in the embedded file bytes. Without the escapes, strings.Replace
+	// finds nothing and stale == current — which silently flags every
+	// base-equal file as "needs upgrade" and masks any precedence logic
+	// that depends on this predicate.
+	stale := strings.Replace(string(current), `gc handoff \"context cycle\"`, `gc prime --hook`, 1)
 	return string(existing) == stale
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -200,7 +200,21 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 	if err != nil {
 		return nil, claudeSettingsSourceNone, err
 	}
+
+	if sourceKind == claudeSettingsSourceNone {
+		// No override found. Return embedded base as-is.
+		return base, claudeSettingsSourceNone, nil
+	}
 	if len(overrideData) == 0 {
+		// An override source was located but its content is empty. For the
+		// preferred source (.claude/settings.json), that contradicts the
+		// strict contract — an intentionally-empty file is indistinguishable
+		// from a truncated write and must not silently degrade to defaults.
+		// For legacy sources, an empty file is unusual but not worth failing
+		// the entire agent over; fall back to embedded base.
+		if sourceKind == claudeSettingsSourceCityDotClaude {
+			return nil, claudeSettingsSourceNone, fmt.Errorf("empty Claude settings from %s (file present but zero bytes)", overridePath)
+		}
 		return base, claudeSettingsSourceNone, nil
 	}
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -163,7 +163,12 @@ func hookFileSafeToRewrite(fs fsys.FS, hookDst string) bool {
 	return errors.Is(err, os.ErrNotExist)
 }
 
-func readEmbedded(embedPath string) ([]byte, error) {
+// readEmbedded returns the embedded Claude defaults (config/claude.json).
+// The path is fixed — the embed directive only captures that one file —
+// so the parameter would be dead weight (and tripped up the unparam
+// linter). All callers read the same file.
+func readEmbedded() ([]byte, error) {
+	const embedPath = "config/claude.json"
 	data, err := configFS.ReadFile(embedPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading embedded %s: %w", embedPath, err)
@@ -191,7 +196,7 @@ const (
 // for users whose source is hooks/claude.json or .gc/settings.json, not
 // just users on .claude/settings.json.
 func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSourceKind, error) {
-	base, err := readEmbedded("config/claude.json")
+	base, err := readEmbedded()
 	if err != nil {
 		return nil, claudeSettingsSourceNone, err
 	}
@@ -351,7 +356,7 @@ func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFi
 }
 
 func claudeFileNeedsUpgrade(existing []byte) bool {
-	current, err := readEmbedded("config/claude.json")
+	current, err := readEmbedded()
 	if err != nil {
 		return false
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -93,17 +93,22 @@ func Install(fs fsys.FS, cityDir, workDir string, providers []string) error {
 	return nil
 }
 
-// installClaude writes both the legacy hook file (hooks/claude.json) and the
-// runtime settings file (.gc/settings.json) in the city directory.
+// installClaude writes the runtime settings file (.gc/settings.json) that gc
+// passes to Claude via --settings. The legacy hooks/claude.json file is
+// treated as user-owned whenever it contains content gc cannot recognize as
+// its own: present and not matching a known stale auto-generated pattern.
+// That file is rewritten only when it IS the selected source (legacy-hook
+// migration), when it doesn't exist (fresh install seed), or when it matches
+// a known stale pattern (safe auto-upgrade).
 //
 // Source precedence for user-authored Claude settings:
 //  1. <city>/.claude/settings.json
 //  2. <city>/hooks/claude.json
 //  3. <city>/.gc/settings.json
 //
-// The selected source is merged onto the embedded default Claude settings, and
-// the merged result is written to the managed outputs that Gas City points
-// Claude's --settings flag at.
+// The selected source (or embedded defaults, if no override exists) is merged
+// onto the embedded default Claude settings so new default hooks added in
+// future releases land for users on every source, not just .claude/settings.json.
 func installClaude(fs fsys.FS, cityDir string) error {
 	hookDst := filepath.Join(cityDir, citylayout.ClaudeHookFile)
 	runtimeDst := filepath.Join(cityDir, ".gc", "settings.json")
@@ -112,12 +117,30 @@ func installClaude(fs fsys.FS, cityDir string) error {
 		return err
 	}
 
-	if sourceKind != claudeSettingsSourceLegacyHook {
+	if sourceKind == claudeSettingsSourceLegacyHook || hookFileSafeToRewrite(fs, hookDst) {
 		if err := writeManagedFile(fs, hookDst, data); err != nil {
 			return err
 		}
 	}
 	return writeManagedFile(fs, runtimeDst, data)
+}
+
+// hookFileSafeToRewrite reports whether hooks/claude.json can be safely
+// overwritten by installClaude without clobbering user-owned content. It is
+// safe when the file does not exist (fresh install) or when its bytes match
+// a known stale auto-generated pattern that predates the current embedded
+// defaults (proactive upgrade of leftover state). Any other content — even
+// bytes identical to the embedded base — is treated as user-owned to avoid
+// surprising a user who pinned their hook file by hand.
+func hookFileSafeToRewrite(fs fsys.FS, hookDst string) bool {
+	data, err := fs.ReadFile(hookDst)
+	if err != nil {
+		// Missing or unreadable: fresh install (or broken state we can't
+		// reason about). Either way, writeManagedFile's existing guards
+		// decide what to do.
+		return true
+	}
+	return claudeFileNeedsUpgrade(data)
 }
 
 func readEmbedded(embedPath string) ([]byte, error) {
@@ -137,6 +160,16 @@ const (
 	claudeSettingsSourceLegacyRuntime
 )
 
+// desiredClaudeSettings returns the bytes that should land in the managed
+// runtime file (.gc/settings.json) and the source kind that was chosen.
+//
+// All override sources — including legacy ones — are merged against the
+// embedded base. The hooks array in overlay.MergeSettingsJSON uses
+// union-by-identity semantics (duplicate entries collapse), so merging is
+// safe and gives legacy users the future-base-hook-additions path back: any
+// new default hook added to config/claude.json in a future release lands
+// for users whose source is hooks/claude.json or .gc/settings.json, not
+// just users on .claude/settings.json.
 func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSourceKind, error) {
 	base, err := readEmbedded("config/claude.json")
 	if err != nil {
@@ -150,9 +183,6 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 	if len(overrideData) == 0 {
 		return base, claudeSettingsSourceNone, nil
 	}
-	if sourceKind != claudeSettingsSourceCityDotClaude {
-		return overrideData, sourceKind, nil
-	}
 
 	merged, err := overlay.MergeSettingsJSON(base, overrideData)
 	if err != nil {
@@ -162,22 +192,22 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 }
 
 func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string, []byte, claudeSettingsSourceKind, error) {
-	if path, data, ok, err := readClaudeSettingsCandidate(fs, citylayout.ClaudeSettingsPath(cityDir)); err != nil {
+	// The preferred source (.claude/settings.json) is strict: if the user
+	// placed the file and it can't be read, that's a hard error — we don't
+	// want to silently fall back to a legacy source they didn't intend.
+	if path, data, ok, err := readClaudeSettingsCandidate(fs, citylayout.ClaudeSettingsPath(cityDir), true); err != nil {
 		return "", nil, claudeSettingsSourceNone, err
 	} else if ok {
 		return path, data, claudeSettingsSourceCityDotClaude, nil
 	}
 
+	// Legacy candidates are tolerant: an unreadable leftover file (bad perms,
+	// partial write from a crashed tick) must not block source selection when
+	// a readable higher-priority source or embedded defaults can be used.
 	hookPath := citylayout.ClaudeHookFilePath(cityDir)
 	runtimePath := filepath.Join(cityDir, ".gc", "settings.json")
-	_, hookData, hookExists, err := readClaudeSettingsCandidate(fs, hookPath)
-	if err != nil {
-		return "", nil, claudeSettingsSourceNone, err
-	}
-	_, runtimeData, runtimeExists, err := readClaudeSettingsCandidate(fs, runtimePath)
-	if err != nil {
-		return "", nil, claudeSettingsSourceNone, err
-	}
+	_, hookData, hookExists, _ := readClaudeSettingsCandidate(fs, hookPath, false)
+	_, runtimeData, runtimeExists, _ := readClaudeSettingsCandidate(fs, runtimePath, false)
 
 	if hookExists &&
 		!bytes.Equal(hookData, base) &&
@@ -193,13 +223,20 @@ func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string
 	return "", nil, claudeSettingsSourceNone, nil
 }
 
-func readClaudeSettingsCandidate(fs fsys.FS, path string) (string, []byte, bool, error) {
+// readClaudeSettingsCandidate reads a candidate settings file. When strict is
+// true, a file that exists-but-can't-be-read surfaces as an error so callers
+// can fail loudly. When strict is false, unreadable files are reported as
+// "not found" so a corrupt leftover file doesn't block fallback to the next
+// source or to embedded defaults.
+func readClaudeSettingsCandidate(fs fsys.FS, path string, strict bool) (string, []byte, bool, error) {
 	data, err := fs.ReadFile(path)
 	if err == nil {
 		return path, data, true, nil
 	}
-	if _, statErr := fs.Stat(path); statErr == nil {
-		return "", nil, false, fmt.Errorf("reading %s: %w", path, err)
+	if strict {
+		if _, statErr := fs.Stat(path); statErr == nil {
+			return "", nil, false, fmt.Errorf("reading %s: %w", path, err)
+		}
 	}
 	return "", nil, false, nil
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -194,22 +194,32 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 }
 
 func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string, []byte, claudeSettingsSourceKind, error) {
-	// The preferred source (.claude/settings.json) is strict: if the user
-	// placed the file and it can't be read, that's a hard error — we don't
-	// want to silently fall back to a legacy source they didn't intend.
-	if path, data, ok, err := readClaudeSettingsCandidate(fs, citylayout.ClaudeSettingsPath(cityDir), true); err != nil {
-		return "", nil, claudeSettingsSourceNone, err
-	} else if ok {
-		return path, data, claudeSettingsSourceCityDotClaude, nil
+	// Preferred source (.claude/settings.json): a present-but-unreadable
+	// file is a hard error. Falling back silently to a legacy source the
+	// user did not intend would ship the wrong --settings.
+	preferredPath := citylayout.ClaudeSettingsPath(cityDir)
+	preferredState, preferredData, preferredErr := readClaudeSettingsCandidate(fs, preferredPath)
+	switch preferredState {
+	case candidateFound:
+		return preferredPath, preferredData, claudeSettingsSourceCityDotClaude, nil
+	case candidateUnreadable:
+		return "", nil, claudeSettingsSourceNone, fmt.Errorf("reading %s: %w", preferredPath, preferredErr)
 	}
 
-	// Legacy candidates are tolerant: an unreadable leftover file (bad perms,
-	// partial write from a crashed tick) must not block source selection when
-	// a readable higher-priority source or embedded defaults can be used.
+	// Legacy candidates. A genuinely missing file is fine — fall through.
+	// An exists-but-unreadable file (bad perms, i/o error) must NOT silently
+	// demote to a lower-priority source, or a stale .gc/settings.json could
+	// override a user-owned hooks/claude.json that gc simply couldn't read
+	// this tick. Use embedded base defaults instead so the agent still
+	// launches without surfacing leftover runtime state.
 	hookPath := citylayout.ClaudeHookFilePath(cityDir)
 	runtimePath := filepath.Join(cityDir, ".gc", "settings.json")
-	_, hookData, hookExists, _ := readClaudeSettingsCandidate(fs, hookPath, false)
-	_, runtimeData, runtimeExists, _ := readClaudeSettingsCandidate(fs, runtimePath, false)
+	hookState, hookData, _ := readClaudeSettingsCandidate(fs, hookPath)
+	runtimeState, runtimeData, _ := readClaudeSettingsCandidate(fs, runtimePath)
+
+	if hookState == candidateUnreadable || runtimeState == candidateUnreadable {
+		return "", nil, claudeSettingsSourceNone, nil
+	}
 
 	// hooks/claude.json is authoritative when it exists, is not a known
 	// stale auto-generated file, and differs from the managed runtime file
@@ -217,8 +227,10 @@ func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string
 	// hook file whose bytes equal the embedded base: a user may pin
 	// hooks/claude.json to exactly the embedded defaults as their
 	// authoritative source and still expect it to outrank .gc/settings.json
-	// per the documented precedence. Use stale-pattern detection alone to
-	// decide whether the hook file is gc-generated vs user-authored.
+	// per the documented precedence. Stale-pattern detection alone
+	// distinguishes gc-generated from user-authored.
+	hookExists := hookState == candidateFound
+	runtimeExists := runtimeState == candidateFound
 	if hookExists &&
 		(!runtimeExists || !bytes.Equal(hookData, runtimeData)) &&
 		!claudeFileNeedsUpgrade(hookData) {
@@ -232,22 +244,31 @@ func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string
 	return "", nil, claudeSettingsSourceNone, nil
 }
 
-// readClaudeSettingsCandidate reads a candidate settings file. When strict is
-// true, a file that exists-but-can't-be-read surfaces as an error so callers
-// can fail loudly. When strict is false, unreadable files are reported as
-// "not found" so a corrupt leftover file doesn't block fallback to the next
-// source or to embedded defaults.
-func readClaudeSettingsCandidate(fs fsys.FS, path string, strict bool) (string, []byte, bool, error) {
+type claudeCandidateState int
+
+const (
+	candidateMissing claudeCandidateState = iota
+	candidateFound
+	candidateUnreadable
+)
+
+// readClaudeSettingsCandidate reads a candidate settings file and reports
+// one of three states. Callers decide strictness: the preferred source
+// surfaces candidateUnreadable as a hard error; legacy sources use it to
+// block silent fallback to a lower-priority source.
+//
+// A read error that wraps os.ErrNotExist reports candidateMissing (matches
+// both real OS filesystems and the test Fake). Any other read error
+// reports candidateUnreadable with the original error returned.
+func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState, []byte, error) {
 	data, err := fs.ReadFile(path)
 	if err == nil {
-		return path, data, true, nil
+		return candidateFound, data, nil
 	}
-	if strict {
-		if _, statErr := fs.Stat(path); statErr == nil {
-			return "", nil, false, fmt.Errorf("reading %s: %w", path, err)
-		}
+	if errors.Is(err, os.ErrNotExist) {
+		return candidateMissing, nil, nil
 	}
-	return "", nil, false, nil
+	return candidateUnreadable, nil, err
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte) error {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -5,6 +5,7 @@
 package hooks
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/overlay"
 )
 
 //go:embed config/claude.json
@@ -91,37 +93,31 @@ func Install(fs fsys.FS, cityDir, workDir string, providers []string) error {
 	return nil
 }
 
-// installClaude writes both the source hook file (hooks/claude.json) and the
+// installClaude writes both the legacy hook file (hooks/claude.json) and the
 // runtime settings file (.gc/settings.json) in the city directory.
 //
-// The session command path always points at .gc/settings.json, but older code
-// and tests still treat hooks/claude.json as the canonical source file. When
-// either file already exists, use its content to seed the missing counterpart
-// so existing custom hook settings are preserved.
+// Source precedence for user-authored Claude settings:
+//  1. <city>/.claude/settings.json
+//  2. <city>/hooks/claude.json
+//  3. <city>/.gc/settings.json
+//
+// The selected source is merged onto the embedded default Claude settings, and
+// the merged result is written to the managed outputs that Gas City points
+// Claude's --settings flag at.
 func installClaude(fs fsys.FS, cityDir string) error {
 	hookDst := filepath.Join(cityDir, citylayout.ClaudeHookFile)
 	runtimeDst := filepath.Join(cityDir, ".gc", "settings.json")
-	embedded, err := readEmbedded("config/claude.json")
+	data, sourceKind, err := desiredClaudeSettings(fs, cityDir)
 	if err != nil {
 		return err
 	}
 
-	data, err := fs.ReadFile(hookDst)
-	if err != nil {
-		data, err = fs.ReadFile(runtimeDst)
-		if err != nil {
-			data = embedded
-		} else if claudeFileNeedsUpgrade(data) {
-			data = embedded
+	if sourceKind != claudeSettingsSourceLegacyHook {
+		if err := writeManagedFile(fs, hookDst, data); err != nil {
+			return err
 		}
-	} else if claudeFileNeedsUpgrade(data) {
-		data = embedded
 	}
-
-	if err := writeEmbeddedManaged(fs, hookDst, data, claudeFileNeedsUpgrade); err != nil {
-		return err
-	}
-	return writeEmbeddedManaged(fs, runtimeDst, data, claudeFileNeedsUpgrade)
+	return writeManagedFile(fs, runtimeDst, data)
 }
 
 func readEmbedded(embedPath string) ([]byte, error) {
@@ -132,9 +128,85 @@ func readEmbedded(embedPath string) ([]byte, error) {
 	return data, nil
 }
 
-func writeEmbeddedManaged(fs fsys.FS, dst string, data []byte, needsUpgrade func([]byte) bool) error {
+type claudeSettingsSourceKind int
+
+const (
+	claudeSettingsSourceNone claudeSettingsSourceKind = iota
+	claudeSettingsSourceCityDotClaude
+	claudeSettingsSourceLegacyHook
+	claudeSettingsSourceLegacyRuntime
+)
+
+func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSourceKind, error) {
+	base, err := readEmbedded("config/claude.json")
+	if err != nil {
+		return nil, claudeSettingsSourceNone, err
+	}
+
+	overridePath, overrideData, sourceKind, err := readClaudeSettingsOverride(fs, cityDir, base)
+	if err != nil {
+		return nil, claudeSettingsSourceNone, err
+	}
+	if len(overrideData) == 0 {
+		return base, claudeSettingsSourceNone, nil
+	}
+	if sourceKind != claudeSettingsSourceCityDotClaude {
+		return overrideData, sourceKind, nil
+	}
+
+	merged, err := overlay.MergeSettingsJSON(base, overrideData)
+	if err != nil {
+		return nil, claudeSettingsSourceNone, fmt.Errorf("merging Claude settings from %s: %w", overridePath, err)
+	}
+	return merged, sourceKind, nil
+}
+
+func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string, []byte, claudeSettingsSourceKind, error) {
+	if path, data, ok, err := readClaudeSettingsCandidate(fs, citylayout.ClaudeSettingsPath(cityDir)); err != nil {
+		return "", nil, claudeSettingsSourceNone, err
+	} else if ok {
+		return path, data, claudeSettingsSourceCityDotClaude, nil
+	}
+
+	hookPath := citylayout.ClaudeHookFilePath(cityDir)
+	runtimePath := filepath.Join(cityDir, ".gc", "settings.json")
+	_, hookData, hookExists, err := readClaudeSettingsCandidate(fs, hookPath)
+	if err != nil {
+		return "", nil, claudeSettingsSourceNone, err
+	}
+	_, runtimeData, runtimeExists, err := readClaudeSettingsCandidate(fs, runtimePath)
+	if err != nil {
+		return "", nil, claudeSettingsSourceNone, err
+	}
+
+	if hookExists &&
+		!bytes.Equal(hookData, base) &&
+		(!runtimeExists || !bytes.Equal(hookData, runtimeData)) &&
+		!claudeFileNeedsUpgrade(hookData) {
+		return hookPath, hookData, claudeSettingsSourceLegacyHook, nil
+	}
+	if runtimeExists &&
+		!bytes.Equal(runtimeData, base) &&
+		!claudeFileNeedsUpgrade(runtimeData) {
+		return runtimePath, runtimeData, claudeSettingsSourceLegacyRuntime, nil
+	}
+	return "", nil, claudeSettingsSourceNone, nil
+}
+
+func readClaudeSettingsCandidate(fs fsys.FS, path string) (string, []byte, bool, error) {
+	data, err := fs.ReadFile(path)
+	if err == nil {
+		return path, data, true, nil
+	}
+	if _, statErr := fs.Stat(path); statErr == nil {
+		return "", nil, false, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return "", nil, false, nil
+}
+
+func writeManagedFile(fs fsys.FS, dst string, data []byte) error {
 	if existing, err := fs.ReadFile(dst); err == nil {
-		if needsUpgrade == nil || !needsUpgrade(existing) {
+		if bytes.Equal(existing, data) {
 			return nil
 		}
 	} else if _, statErr := fs.Stat(dst); statErr == nil {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -327,6 +327,16 @@ func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFi
 	if err := fs.WriteFile(dst, data, 0o644); err != nil {
 		return fmt.Errorf("writing %s: %w", dst, err)
 	}
+	// os.WriteFile preserves the existing file's mode on overwrite. For
+	// gc-owned paths that may have been left with a restrictive mode (e.g.
+	// a stat-ok-but-read-fail file we just force-overwrote), normalize the
+	// permissions so Claude can actually read the file at launch time.
+	// User-owned paths are preserved as-is.
+	if policy == forceOverwrite {
+		if err := fs.Chmod(dst, 0o644); err != nil {
+			return fmt.Errorf("chmod %s: %w", dst, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -302,6 +302,66 @@ func TestInstallClaudeUnreadableHookBlocksRuntimeFallback(t *testing.T) {
 	}
 }
 
+// TestInstallClaudeUnreadableRuntimeDoesNotDemoteValidHook verifies that
+// when hooks/claude.json is readable and .gc/settings.json is unreadable,
+// the hook file still wins source selection — the runtime file is gc-owned,
+// not user-owned, so its unreadability must not demote a legitimate user
+// hook to "no source." A prior fixup blocked on either candidate being
+// unreadable, which inverted precedence for this case.
+func TestInstallClaudeUnreadableRuntimeDoesNotDemoteValidHook(t *testing.T) {
+	fs := fsys.NewFake()
+	// User pins hooks/claude.json with a custom key (not stale, not base).
+	fs.Files["/city/hooks/claude.json"] = []byte(`{"user_hook": true}`)
+	// The gc-managed runtime file is present but unreadable.
+	fs.Errors["/city/.gc/settings.json"] = errors.New("permission denied")
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		// Install may surface an error from the force-overwrite write if
+		// the injected error also blocks WriteFile (it does, in the Fake).
+		// That's acceptable: a failed write surfaces loudly. What must NOT
+		// happen is silent success with the stale unreadable runtime kept.
+		if !strings.Contains(err.Error(), ".gc/settings.json") {
+			t.Fatalf("unexpected error (expected a write failure surfacing the runtime path): %v", err)
+		}
+		return
+	}
+	// If Install succeeded, the runtime file must now contain the merged
+	// hook-source content (which includes the user_hook key).
+	runtime := string(fs.Files["/city/.gc/settings.json"])
+	if !strings.Contains(runtime, `"user_hook": true`) {
+		t.Errorf("runtime must reflect hook source even when prior runtime was unreadable:\n%s", runtime)
+	}
+}
+
+// TestInstallClaudeForceOverwritesUnreadableRuntime verifies that an
+// unreadable gc-managed .gc/settings.json is force-overwritten with the
+// new projection instead of silently preserved. Preserving an unreadable
+// runtime file would leave Claude pointing at content it cannot parse on
+// the next launch.
+func TestInstallClaudeForceOverwritesUnreadableRuntime(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.claude/settings.json"] = []byte(`{"custom": true}`)
+	// Simulate an unreadable runtime file by seeding Files (so stat-ok is
+	// simulated via presence) and injecting a ReadFile error. Using Dirs
+	// alone would make ReadFile succeed-as-empty in some Fake branches;
+	// this setup ensures the writeManagedFile stat-ok-read-fail branch is
+	// exercised.
+	fs.Files["/city/.gc/settings.json"] = []byte(`{"stale": true}`)
+	// No Errors injection means WriteFile will succeed and overwrite.
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	runtime := string(fs.Files["/city/.gc/settings.json"])
+	if strings.Contains(runtime, `"stale": true`) {
+		t.Errorf("runtime must be overwritten with fresh projection:\n%s", runtime)
+	}
+	if !strings.Contains(runtime, `"custom": true`) {
+		t.Errorf("runtime must reflect .claude/settings.json override:\n%s", runtime)
+	}
+}
+
 // TestInstallClaudeSurfacesMalformedOverride verifies that a syntactically
 // invalid .claude/settings.json surfaces a descriptive error rather than
 // silently falling back to a legacy source or the embedded base.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -119,7 +120,13 @@ func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}
-	stale := strings.Replace(string(current), `gc handoff "context cycle"`, `gc prime --hook`, 1)
+	// Build a realistic stale fixture: the embedded file stores the command
+	// as JSON, so the literal bytes contain escaped quotes. Matching that
+	// shape is what claudeFileNeedsUpgrade expects.
+	stale := strings.Replace(string(current), `gc handoff \"context cycle\"`, `gc prime --hook`, 1)
+	if stale == string(current) {
+		t.Fatal("stale fixture did not diverge from current embedded config — check stale pattern")
+	}
 	fs.Files["/city/hooks/claude.json"] = []byte(stale)
 	fs.Files["/city/.gc/settings.json"] = []byte(stale)
 
@@ -213,16 +220,19 @@ func TestInstallClaudePreservesUserOwnedHookFile(t *testing.T) {
 }
 
 // TestInstallClaudeTolerantToUnreadableLegacyCandidate verifies that a
-// stat-ok-but-read-fails non-chosen candidate (simulated via a directory at
-// the hook-file path) does not block installation when .claude/settings.json
-// is a valid higher-priority source. Previously readClaudeSettingsCandidate
-// returned a hard error for stat-ok-but-unreadable, aborting resolution.
+// non-chosen legacy candidate whose ReadFile fails (simulated by injecting
+// a read error) does not block installation when .claude/settings.json is
+// a valid higher-priority source. Previously readClaudeSettingsCandidate
+// returned a hard error for any existing-but-unreadable candidate,
+// aborting resolution even when the preferred source was perfectly fine.
 func TestInstallClaudeTolerantToUnreadableLegacyCandidate(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.claude/settings.json"] = []byte(`{"custom": true}`)
-	// Put a directory at the hook-file path so Stat succeeds but ReadFile
-	// errors (Fake returns ErrNotExist because the path is not in Files).
-	fs.Dirs["/city/hooks/claude.json"] = true
+	// Inject a read error on the legacy hook path so any attempt to read
+	// it fails. This models a permission-denied or i/o-error file that
+	// would otherwise have made readClaudeSettingsCandidate abort source
+	// selection.
+	fs.Errors["/city/hooks/claude.json"] = errors.New("permission denied")
 
 	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
 		t.Fatalf("Install must tolerate unreadable non-chosen legacy candidate: %v", err)
@@ -231,6 +241,37 @@ func TestInstallClaudeTolerantToUnreadableLegacyCandidate(t *testing.T) {
 	runtime := string(fs.Files["/city/.gc/settings.json"])
 	if !strings.Contains(runtime, `"custom": true`) {
 		t.Errorf("runtime settings missing .claude override:\n%s", runtime)
+	}
+}
+
+// TestInstallClaudePinnedHookFileOutranksRuntime verifies that when a user
+// pins hooks/claude.json to content that happens to match the embedded
+// defaults byte-for-byte, it still wins over .gc/settings.json per the
+// documented precedence. Earlier versions disqualified any
+// bytes-equal-base hook file, silently letting a stale .gc/settings.json
+// override the user's chosen source.
+func TestInstallClaudePinnedHookFileOutranksRuntime(t *testing.T) {
+	fs := fsys.NewFake()
+	base, err := readEmbedded("config/claude.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	// User has pinned their hook file to exactly the embedded defaults
+	// and separately has a stale .gc/settings.json with a custom key that
+	// they intended to remove when they pinned the hook file.
+	fs.Files["/city/hooks/claude.json"] = base
+	fs.Files["/city/.gc/settings.json"] = []byte(`{"stale_override": true}`)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	runtime := string(fs.Files["/city/.gc/settings.json"])
+	if strings.Contains(runtime, `"stale_override": true`) {
+		t.Errorf("runtime must reflect pinned hook source, not stale runtime override:\n%s", runtime)
+	}
+	if !strings.Contains(runtime, "SessionStart") {
+		t.Errorf("runtime must contain embedded default hooks:\n%s", runtime)
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -402,6 +402,49 @@ func TestInstallClaudeForceOverwritesUnreadableRuntimeOSFS(t *testing.T) {
 	}
 }
 
+// TestInstallClaudePreservesTightenedRuntimeMode verifies that a user who
+// intentionally tightened .gc/settings.json permissions (e.g. 0o600 for
+// privacy) keeps that mode after Install rewrites the file. The
+// force-overwrite policy must only ADD owner-read when absent, never
+// widen existing permissions.
+//
+// Skipped as root (root bypasses unix permission checks).
+func TestInstallClaudePreservesTightenedRuntimeMode(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses unix permission checks")
+	}
+	cityDir := t.TempDir()
+	claudeDir := filepath.Join(cityDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"custom": true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runtimePath := filepath.Join(gcDir, "settings.json")
+	// User-tightened: readable, but private (no group/other access).
+	if err := os.WriteFile(runtimePath, []byte(`{"stale": true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Install(fsys.OSFS{}, cityDir, cityDir, []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	info, err := os.Stat(runtimePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must preserve the user's 0o600, not widen to 0o644.
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("runtime mode widened from 0o600 to %o; force-overwrite must not override user tightening", got)
+	}
+}
+
 // TestInstallClaudeSurfacesEmptyPreferredOverride verifies that a
 // zero-byte .claude/settings.json is treated as malformed and surfaces a
 // descriptive error rather than silently degrading to embedded defaults.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -380,14 +380,18 @@ func TestInstallClaudeForceOverwritesUnreadableRuntimeOSFS(t *testing.T) {
 
 	// The file must be readable immediately after Install — no test-side
 	// chmod. force-overwrite is responsible for normalizing the mode so
-	// Claude can actually open --settings at launch time. A test that
-	// requires a manual chmod here would hide exactly that regression.
+	// Claude can actually open --settings at launch time.
+	//
+	// Asserting the EXACT mode (0o600 from 0o200) pins the "minimal repair"
+	// contract: we add ONLY the owner-read bit. A regression to a broader
+	// chmod (e.g. unconditional 0o644) would widen other bits and still
+	// pass a looser readability check — this assertion catches that.
 	info, err := os.Stat(runtimePath)
 	if err != nil {
 		t.Fatalf("stat runtime after Install: %v", err)
 	}
-	if info.Mode().Perm()&0o400 == 0 {
-		t.Errorf("runtime must be readable after force-overwrite; got mode %o", info.Mode().Perm())
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("runtime mode must be exactly 0o600 (0o200 + 0o400 owner-read); got %o", got)
 	}
 	data, err := os.ReadFile(runtimePath)
 	if err != nil {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -378,13 +378,20 @@ func TestInstallClaudeForceOverwritesUnreadableRuntimeOSFS(t *testing.T) {
 		t.Fatalf("Install with unreadable-but-writable runtime: %v", err)
 	}
 
-	// Restore read so we can verify the content was actually rewritten.
-	if err := os.Chmod(runtimePath, 0o644); err != nil {
-		t.Fatal(err)
+	// The file must be readable immediately after Install — no test-side
+	// chmod. force-overwrite is responsible for normalizing the mode so
+	// Claude can actually open --settings at launch time. A test that
+	// requires a manual chmod here would hide exactly that regression.
+	info, err := os.Stat(runtimePath)
+	if err != nil {
+		t.Fatalf("stat runtime after Install: %v", err)
+	}
+	if info.Mode().Perm()&0o400 == 0 {
+		t.Errorf("runtime must be readable after force-overwrite; got mode %o", info.Mode().Perm())
 	}
 	data, err := os.ReadFile(runtimePath)
 	if err != nil {
-		t.Fatalf("reading runtime after chmod: %v", err)
+		t.Fatalf("reading runtime immediately after Install: %v", err)
 	}
 	runtime := string(data)
 	if strings.Contains(runtime, `"stale": true`) {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -185,6 +185,71 @@ func TestInstallClaudePrefersCityDotClaudeSettingsOverLegacyHookSource(t *testin
 	}
 }
 
+// TestInstallClaudePreservesUserOwnedHookFile verifies that when both
+// .claude/settings.json and a hand-written hooks/claude.json are present,
+// Install writes only the runtime settings file and leaves the user-owned
+// hook file untouched. The old behavior silently rewrote hooks/claude.json
+// with merged bytes, violating the "hook file is user-authored" contract.
+func TestInstallClaudePreservesUserOwnedHookFile(t *testing.T) {
+	fs := fsys.NewFake()
+	userHook := []byte(`{"user_authored": true}`)
+	fs.Files["/city/hooks/claude.json"] = userHook
+	fs.Files["/city/.claude/settings.json"] = []byte(`{"custom": true}`)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if got := string(fs.Files["/city/hooks/claude.json"]); got != string(userHook) {
+		t.Errorf("user-owned hooks/claude.json was clobbered:\n  want: %q\n  got:  %q", userHook, got)
+	}
+	runtime := string(fs.Files["/city/.gc/settings.json"])
+	if !strings.Contains(runtime, `"custom": true`) {
+		t.Errorf("runtime settings missing .claude override merge:\n%s", runtime)
+	}
+	if !strings.Contains(runtime, "SessionStart") {
+		t.Errorf("runtime settings missing embedded base hooks:\n%s", runtime)
+	}
+}
+
+// TestInstallClaudeTolerantToUnreadableLegacyCandidate verifies that a
+// stat-ok-but-read-fails non-chosen candidate (simulated via a directory at
+// the hook-file path) does not block installation when .claude/settings.json
+// is a valid higher-priority source. Previously readClaudeSettingsCandidate
+// returned a hard error for stat-ok-but-unreadable, aborting resolution.
+func TestInstallClaudeTolerantToUnreadableLegacyCandidate(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.claude/settings.json"] = []byte(`{"custom": true}`)
+	// Put a directory at the hook-file path so Stat succeeds but ReadFile
+	// errors (Fake returns ErrNotExist because the path is not in Files).
+	fs.Dirs["/city/hooks/claude.json"] = true
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install must tolerate unreadable non-chosen legacy candidate: %v", err)
+	}
+
+	runtime := string(fs.Files["/city/.gc/settings.json"])
+	if !strings.Contains(runtime, `"custom": true`) {
+		t.Errorf("runtime settings missing .claude override:\n%s", runtime)
+	}
+}
+
+// TestInstallClaudeSurfacesMalformedOverride verifies that a syntactically
+// invalid .claude/settings.json surfaces a descriptive error rather than
+// silently falling back to a legacy source or the embedded base.
+func TestInstallClaudeSurfacesMalformedOverride(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.claude/settings.json"] = []byte(`{not valid json`)
+
+	err := Install(fs, "/city", "/work", []string{"claude"})
+	if err == nil {
+		t.Fatal("Install must surface malformed .claude/settings.json as an error")
+	}
+	if !strings.Contains(err.Error(), ".claude/settings.json") {
+		t.Errorf("error must name the offending path: %v", err)
+	}
+}
+
 // TestInstallOverlayManagedNoOp verifies that providers whose hooks ship via
 // the core pack overlay are accepted by Install but produce no Go-side files.
 func TestInstallOverlayManagedNoOp(t *testing.T) {
@@ -225,21 +290,38 @@ func TestInstallMultipleProviders(t *testing.T) {
 
 func TestInstallIdempotent(t *testing.T) {
 	fs := fsys.NewFake()
-	// Pre-populate with custom content.
+	// Pre-populate with a legacy hook file that carries a custom key. Under
+	// the current contract this is treated as the chosen source and merged
+	// against the embedded base so future default hooks land for users who
+	// stayed on hooks/claude.json.
 	fs.Files["/city/hooks/claude.json"] = []byte(`{"custom": true}`)
 
-	err := Install(fs, "/city", "/work", []string{"claude"})
-	if err != nil {
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
-	// Should not overwrite existing file.
-	got := string(fs.Files["/city/hooks/claude.json"])
-	if got != `{"custom": true}` {
-		t.Errorf("Install overwrote existing file: got %q", got)
+	hookData := string(fs.Files["/city/hooks/claude.json"])
+	runtimeData := string(fs.Files["/city/.gc/settings.json"])
+	if !strings.Contains(hookData, `"custom": true`) {
+		t.Errorf("merge must preserve user-authored custom key in hook file:\n%s", hookData)
 	}
-	if runtime := string(fs.Files["/city/.gc/settings.json"]); runtime != `{"custom": true}` {
-		t.Errorf("Install should mirror existing hook settings into runtime file: got %q", runtime)
+	if !strings.Contains(hookData, "SessionStart") {
+		t.Errorf("merge must pull embedded default hooks into hook file:\n%s", hookData)
+	}
+	if hookData != runtimeData {
+		t.Error("runtime settings must mirror merged hook settings")
+	}
+
+	// A second Install must be a true no-op: bytes already match the merged
+	// result, so writeManagedFile short-circuits.
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("second Install: %v", err)
+	}
+	if got := string(fs.Files["/city/hooks/claude.json"]); got != hookData {
+		t.Errorf("second Install changed hook file bytes:\n  before: %q\n  after:  %q", hookData, got)
+	}
+	if got := string(fs.Files["/city/.gc/settings.json"]); got != runtimeData {
+		t.Errorf("second Install changed runtime file bytes:\n  before: %q\n  after:  %q", runtimeData, got)
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -3,6 +3,8 @@ package hooks
 import (
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -333,32 +335,85 @@ func TestInstallClaudeUnreadableRuntimeDoesNotDemoteValidHook(t *testing.T) {
 	}
 }
 
-// TestInstallClaudeForceOverwritesUnreadableRuntime verifies that an
-// unreadable gc-managed .gc/settings.json is force-overwritten with the
-// new projection instead of silently preserved. Preserving an unreadable
-// runtime file would leave Claude pointing at content it cannot parse on
-// the next launch.
-func TestInstallClaudeForceOverwritesUnreadableRuntime(t *testing.T) {
-	fs := fsys.NewFake()
-	fs.Files["/city/.claude/settings.json"] = []byte(`{"custom": true}`)
-	// Simulate an unreadable runtime file by seeding Files (so stat-ok is
-	// simulated via presence) and injecting a ReadFile error. Using Dirs
-	// alone would make ReadFile succeed-as-empty in some Fake branches;
-	// this setup ensures the writeManagedFile stat-ok-read-fail branch is
-	// exercised.
-	fs.Files["/city/.gc/settings.json"] = []byte(`{"stale": true}`)
-	// No Errors injection means WriteFile will succeed and overwrite.
+// TestInstallClaudeForceOverwritesUnreadableRuntimeOSFS verifies the
+// force-overwrite policy against a real filesystem. The gc-managed
+// .gc/settings.json is seeded write-only (mode 0o200): stat succeeds,
+// read fails, but WriteFile still succeeds. Under the old preserve
+// policy Install would silently return without writing; under the new
+// force-overwrite policy it attempts the write and succeeds. The Fake
+// cannot express stat-ok/read-fail (its Errors map is symmetric across
+// ReadFile, Stat, and WriteFile), so real OSFS is the only way to lock
+// this branch.
+//
+// Skipped as root (root bypasses unix permission checks).
+func TestInstallClaudeForceOverwritesUnreadableRuntimeOSFS(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses unix permission checks; cannot simulate stat-ok/read-fail")
+	}
+	cityDir := t.TempDir()
+	claudeDir := filepath.Join(cityDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"custom": true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runtimePath := filepath.Join(gcDir, "settings.json")
+	if err := os.WriteFile(runtimePath, []byte(`{"stale": true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write-only mode: Stat succeeds, ReadFile fails, WriteFile succeeds.
+	// This is the only permission bitmask that can distinguish preserve-on-
+	// unreadable from force-overwrite through observable behavior.
+	if err := os.Chmod(runtimePath, 0o200); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(runtimePath, 0o644) })
 
-	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
-		t.Fatalf("Install: %v", err)
+	if err := Install(fsys.OSFS{}, cityDir, cityDir, []string{"claude"}); err != nil {
+		t.Fatalf("Install with unreadable-but-writable runtime: %v", err)
 	}
 
-	runtime := string(fs.Files["/city/.gc/settings.json"])
+	// Restore read so we can verify the content was actually rewritten.
+	if err := os.Chmod(runtimePath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(runtimePath)
+	if err != nil {
+		t.Fatalf("reading runtime after chmod: %v", err)
+	}
+	runtime := string(data)
 	if strings.Contains(runtime, `"stale": true`) {
-		t.Errorf("runtime must be overwritten with fresh projection:\n%s", runtime)
+		t.Errorf("runtime must be overwritten, not preserved:\n%s", runtime)
 	}
 	if !strings.Contains(runtime, `"custom": true`) {
 		t.Errorf("runtime must reflect .claude/settings.json override:\n%s", runtime)
+	}
+}
+
+// TestInstallClaudeSurfacesEmptyPreferredOverride verifies that a
+// zero-byte .claude/settings.json is treated as malformed and surfaces a
+// descriptive error rather than silently degrading to embedded defaults.
+// A truncated or mid-edit file that happens to be zero bytes is
+// indistinguishable from a valid "empty config" intent — strict behavior
+// is to fail loudly so the user notices the truncation.
+func TestInstallClaudeSurfacesEmptyPreferredOverride(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.claude/settings.json"] = []byte{}
+
+	err := Install(fs, "/city", "/work", []string{"claude"})
+	if err == nil {
+		t.Fatal("Install must surface empty .claude/settings.json as an error")
+	}
+	if !strings.Contains(err.Error(), ".claude/settings.json") {
+		t.Errorf("error must name the offending path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error must indicate emptiness: %v", err)
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -275,6 +275,33 @@ func TestInstallClaudePinnedHookFileOutranksRuntime(t *testing.T) {
 	}
 }
 
+// TestInstallClaudeUnreadableHookBlocksRuntimeFallback verifies that when
+// hooks/claude.json exists-but-is-unreadable and .gc/settings.json exists
+// with content, the tolerant-legacy path does NOT silently demote hook
+// precedence and let the runtime file become the source. Earlier versions
+// of the tolerant-read change skipped the unreadable hook file entirely,
+// which allowed a stale .gc/settings.json to override the user-owned but
+// currently-unreadable hook file — a precedence violation. The override
+// now resolves to "no source" (embedded base defaults) so Claude launches
+// with known-good settings instead.
+func TestInstallClaudeUnreadableHookBlocksRuntimeFallback(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Errors["/city/hooks/claude.json"] = errors.New("permission denied")
+	fs.Files["/city/.gc/settings.json"] = []byte(`{"stale_runtime_override": true}`)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	runtime := string(fs.Files["/city/.gc/settings.json"])
+	if strings.Contains(runtime, `"stale_runtime_override": true`) {
+		t.Errorf("unreadable hook must not let stale runtime override win:\n%s", runtime)
+	}
+	if !strings.Contains(runtime, "SessionStart") {
+		t.Errorf("runtime must contain embedded base defaults:\n%s", runtime)
+	}
+}
+
 // TestInstallClaudeSurfacesMalformedOverride verifies that a syntactically
 // invalid .claude/settings.json surfaces a descriptive error rather than
 // silently falling back to a legacy source or the embedded base.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -118,7 +118,7 @@ func TestInstallClaude(t *testing.T) {
 
 func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
 	fs := fsys.NewFake()
-	current, err := readEmbedded("config/claude.json")
+	current, err := readEmbedded()
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestInstallClaudeTolerantToUnreadableLegacyCandidate(t *testing.T) {
 // override the user's chosen source.
 func TestInstallClaudePinnedHookFileOutranksRuntime(t *testing.T) {
 	fs := fsys.NewFake()
-	base, err := readEmbedded("config/claude.json")
+	base, err := readEmbedded()
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -137,6 +137,54 @@ func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeMergesCityDotClaudeSettings(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.claude/settings.json"] = []byte(`{
+  "custom": true,
+  "mcpServers": {
+    "notes": {
+      "command": "notes-mcp"
+    }
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/city/.gc/settings.json"])
+	if !strings.Contains(data, `"custom": true`) {
+		t.Fatalf("runtime settings missing custom top-level key:\n%s", data)
+	}
+	if !strings.Contains(data, `"mcpServers"`) {
+		t.Fatalf("runtime settings missing merged mcpServers:\n%s", data)
+	}
+	if !strings.Contains(data, "SessionStart") {
+		t.Fatalf("runtime settings lost default hooks during merge:\n%s", data)
+	}
+	if string(fs.Files["/city/hooks/claude.json"]) != data {
+		t.Fatal("hooks/claude.json should mirror merged Claude runtime settings")
+	}
+}
+
+func TestInstallClaudePrefersCityDotClaudeSettingsOverLegacyHookSource(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.claude/settings.json"] = []byte(`{"preferred": true}`)
+	fs.Files["/city/hooks/claude.json"] = []byte(`{"legacy": true}`)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/city/.gc/settings.json"])
+	if !strings.Contains(data, `"preferred": true`) {
+		t.Fatalf("runtime settings missing preferred city .claude override:\n%s", data)
+	}
+	if strings.Contains(data, `"legacy": true`) {
+		t.Fatalf("legacy hooks source should not win over city .claude/settings.json:\n%s", data)
+	}
+}
+
 // TestInstallOverlayManagedNoOp verifies that providers whose hooks ship via
 // the core pack overlay are accepted by Install but produce no Go-side files.
 func TestInstallOverlayManagedNoOp(t *testing.T) {


### PR DESCRIPTION
## Summary
- prefer city-root `.claude/settings.json` as the user-authored Claude override source
- merge that override over the embedded default Claude settings and project the merged result into `.gc/settings.json` before wiring Claude `--settings`
- preserve legacy `hooks/claude.json` and existing runtime settings as fallback inputs while keeping legacy hook files user-owned
- clean up the pre-existing lint/test drift in this branch baseline so the PR is green under current lint rules

## Verification
- `make lint`
- `go test ./internal/hooks ./internal/citylayout`
- `go test ./cmd/gc -run 'TestResolveTemplateClaudeProjectsCityDotClaudeSettingsIntoRuntimeFile|TestPhase3StartupMaterialization|TestPhase3InitialInputDelivery|TestDoInitDoesNotOverwriteExistingSettings|TestLoadPackCommandEntries|TestCmdStopWaitsForStandaloneControllerExit' -count=1`

Closes #736.
Supersedes #768.