### PR TITLE
fix: race in ACP Nudge after Interrupt_RunningSession (#716)

### DIFF
--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -491,7 +491,20 @@ func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
 			sc.activePromptID = 0
 		}
 		sc.mu.Unlock()
-		return fmt.Errorf("sending prompt to %q: %w", name, err)
+		// Pipe write failed — the agent process is exiting (e.g., a prior
+		// Interrupt delivered SIGINT and the agent died, or Stop closed
+		// our stdin end between the alive() check and the write).
+		// Sync on the existing lifecycle event: cmd.Wait() → drainPending →
+		// close(sc.done). Once that fires, this is identical to the
+		// !sc.alive() case above, so honor the best-effort contract by
+		// returning nil. The 2s bound is defensive in case the monitor
+		// goroutine is wedged; the common path returns in microseconds.
+		select {
+		case <-sc.done:
+			return nil
+		case <-time.After(2 * time.Second):
+			return fmt.Errorf("sending prompt to %q: %w", name, err)
+		}
 	}
 
 	// Drain the response channel in the background. If the agent

--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -21,6 +22,12 @@ import (
 	"github.com/gastownhall/gascity/internal/overlay"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+// nudgePostWriteDrainTimeout caps the wait for sc.done after a Nudge stdin
+// write fails. Sized to match terminateProcess's SIGTERM grace period so a
+// Nudge racing with Stop still converges to the best-effort nil contract
+// rather than surfacing a spurious error before SIGKILL lands.
+const nudgePostWriteDrainTimeout = 5 * time.Second
 
 // Config holds ACP provider settings.
 type Config struct {
@@ -446,8 +453,8 @@ func (p *Provider) ProcessAlive(name string, processNames []string) bool {
 }
 
 // Nudge sends a session/prompt to the named session. Waits for the agent to
-// become idle before sending. Returns nil if the session doesn't exist
-// (best-effort).
+// become idle before sending. Returns nil if the session doesn't exist or
+// the agent process exits during the send (best-effort).
 func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
 	p.mu.Lock()
 	sc, ok := p.conns[name]
@@ -463,6 +470,13 @@ func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
 	// sendRequest is atomic with respect to other concurrent Nudge calls.
 	sc.nudgeMu.Lock()
 	defer sc.nudgeMu.Unlock()
+
+	// Re-check liveness under the lock. If an earlier Nudge observed the
+	// process exit and returned nil while we were queued on nudgeMu, skip
+	// the marshal+write work instead of tripping through the recovery path.
+	if !sc.alive() {
+		return nil
+	}
 
 	// Wait for agent to become idle.
 	if !sc.waitIdle(p.cfg.nudgeBusyTimeout()) {
@@ -491,18 +505,28 @@ func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
 			sc.activePromptID = 0
 		}
 		sc.mu.Unlock()
+		// Non-pipe failures (e.g., marshal errors) have nothing to do with
+		// the agent lifecycle, so surface them immediately rather than
+		// stalling the caller on sc.done.
+		if !isPipeWriteError(err) {
+			return fmt.Errorf("sending prompt to %q: %w", name, err)
+		}
 		// Pipe write failed — the agent process is exiting (e.g., a prior
 		// Interrupt delivered SIGINT and the agent died, or Stop closed
 		// our stdin end between the alive() check and the write).
 		// Sync on the existing lifecycle event: cmd.Wait() → drainPending →
 		// close(sc.done). Once that fires, this is identical to the
 		// !sc.alive() case above, so honor the best-effort contract by
-		// returning nil. The 2s bound is defensive in case the monitor
-		// goroutine is wedged; the common path returns in microseconds.
+		// returning nil. The bound matches terminateProcess's SIGTERM grace
+		// period; the common path returns in microseconds.
 		select {
 		case <-sc.done:
+			// A chronically flapping agent would otherwise be silent here;
+			// a single stderr line lets ops distinguish "nothing happened"
+			// from "agent died mid-write."
+			fmt.Fprintf(os.Stderr, "acp: nudge to %q skipped (agent exiting): %v\n", name, err)
 			return nil
-		case <-time.After(2 * time.Second):
+		case <-time.After(nudgePostWriteDrainTimeout):
 			return fmt.Errorf("sending prompt to %q: %w", name, err)
 		}
 	}
@@ -834,6 +858,14 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 // SleepCapability reports that ACP sessions support timed-only idle sleep.
 func (p *Provider) SleepCapability(string) runtime.SessionSleepCapability {
 	return runtime.SessionSleepCapabilityTimedOnly
+}
+
+// isPipeWriteError reports whether err originated from writing to a closed
+// stdin pipe — the signal that the agent process exited between our alive()
+// check and the write. Other sendRequest failures (marshal errors, etc.) are
+// unrelated to lifecycle and should surface immediately.
+func isPipeWriteError(err error) bool {
+	return errors.Is(err, io.ErrClosedPipe) || errors.Is(err, syscall.EPIPE)
 }
 
 // terminateProcess sends SIGTERM then SIGKILL to a tracked process group.

--- a/internal/runtime/acp/acp_test.go
+++ b/internal/runtime/acp/acp_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -764,5 +766,105 @@ func TestStderrCaptured_InHandshakeError(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "fatal: bad config") {
 		t.Errorf("error should contain stderr output, got: %v", err)
+	}
+}
+
+// closedPipeStdin models a stdin pipe whose agent end has exited: the first
+// Write signals that the recovery path is about to run, then returns
+// io.ErrClosedPipe. Subsequent writes are idempotent.
+type closedPipeStdin struct {
+	writeCalled chan struct{}
+	once        sync.Once
+}
+
+func (c *closedPipeStdin) Write(_ []byte) (int, error) {
+	c.once.Do(func() { close(c.writeCalled) })
+	return 0, io.ErrClosedPipe
+}
+
+func (*closedPipeStdin) Close() error { return nil }
+
+// erroringStdin returns a fixed error on every Write — used to model a
+// non-lifecycle failure (e.g. the equivalent of a marshal error) that must
+// bypass the sc.done drain path.
+type erroringStdin struct{ err error }
+
+func (e *erroringStdin) Write(_ []byte) (int, error) { return 0, e.err }
+func (*erroringStdin) Close() error                  { return nil }
+
+// TestNudge_ReturnsNilWhenAgentExitsDuringSend pins the recovery branch in
+// Provider.Nudge: when sendRequest fails with a pipe-write error and the
+// monitor goroutine closes sc.done shortly after, Nudge honors its
+// best-effort nil contract instead of surfacing a spurious error. This is
+// independent of fakeacp's SIGINT handling, so a future refactor of either
+// cannot silently undo the fix.
+func TestNudge_ReturnsNilWhenAgentExitsDuringSend(t *testing.T) {
+	p := NewProviderWithDir(shortTempDir(t), Config{NudgeBusyTimeout: 2 * time.Second})
+	name := testName()
+
+	stdin := &closedPipeStdin{writeCalled: make(chan struct{})}
+	sc := newSessionConn(nil, stdin, nil, 100)
+	sc.sessionID = "session-1"
+
+	p.mu.Lock()
+	p.conns[name] = sc
+	p.mu.Unlock()
+
+	// Mimic the monitor goroutine converging lifecycle state after the
+	// child exits: close sc.done as soon as the failing write is observed.
+	go func() {
+		<-stdin.writeCalled
+		close(sc.done)
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Nudge(name, []runtime.ContentBlock{{Type: "text", Text: "hi"}})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error when agent exits during send, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Nudge did not return within 3s — recovery select likely timed out")
+	}
+}
+
+// TestNudge_NonPipeErrorSurfacesImmediately verifies that sendRequest
+// failures unrelated to the agent lifecycle (modeled here by a writer
+// returning a non-pipe error) do NOT stall on sc.done and instead surface
+// immediately — the pipe-origin gate is doing its job.
+func TestNudge_NonPipeErrorSurfacesImmediately(t *testing.T) {
+	p := NewProviderWithDir(shortTempDir(t), Config{NudgeBusyTimeout: 2 * time.Second})
+	name := testName()
+
+	stubErr := errors.New("disk quota exceeded")
+	sc := newSessionConn(nil, &erroringStdin{err: stubErr}, nil, 100)
+	sc.sessionID = "session-1"
+
+	p.mu.Lock()
+	p.conns[name] = sc
+	p.mu.Unlock()
+
+	// sc.done is intentionally left open: if the new branch mis-routes
+	// non-pipe errors through the select, the call will hang until
+	// nudgePostWriteDrainTimeout and the test will fail.
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Nudge(name, []runtime.ContentBlock{{Type: "text", Text: "hi"}})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected non-pipe error to surface, got nil")
+		}
+		if !errors.Is(err, stubErr) {
+			t.Fatalf("expected wrapped %v, got %v", stubErr, err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Nudge stalled on non-pipe error — origin gate should have bypassed sc.done wait")
 	}
 }

--- a/internal/runtime/acp/testdata/fakeacp/main.go
+++ b/internal/runtime/acp/testdata/fakeacp/main.go
@@ -1,7 +1,9 @@
 // Command fakeacp is a minimal ACP server for integration tests.
 // It reads JSON-RPC from stdin and responds to the ACP handshake.
 // On session/prompt it echoes the text as a session/update notification
-// then sends the response. Stays alive until SIGTERM.
+// then sends the response. Stays alive until SIGTERM (SIGINT is ignored,
+// mirroring real ACP agents for which Interrupt is a soft prompt cancel,
+// not session teardown).
 package main
 
 import (
@@ -53,9 +55,15 @@ func notify(method string, params any) {
 func main() {
 	const sessionID = "fakeacp-session-1"
 
-	// Handle SIGTERM gracefully.
+	// Ignore SIGINT — ACP Interrupt is a soft prompt-cancel signal, not a
+	// teardown signal. Real agents keep running through Ctrl-C; the fake
+	// must too, otherwise the test-side SIGINT from Interrupt races with
+	// our lifecycle cleanup (see Provider.Nudge for the SDK-side fix).
+	signal.Ignore(syscall.SIGINT)
+
+	// Exit on SIGTERM.
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(sigCh, syscall.SIGTERM)
 	go func() {
 		<-sigCh
 		os.Exit(0)


### PR DESCRIPTION
## Summary

Supersedes #766 by @skullbloc. The original PR's branch lives on an organization-owned fork, so the adopt-pr flow couldn't push maintainer review fixups back to it despite `maintainerCanModify: true`. This PR carries the original fix unchanged (authorship preserved) plus the review fixups identified during adoption review.

Credit: original fix by @skullbloc (`gascity/crew/flaky_acp_test <hcstebbins@gmail.com>`) — commit preserved with original authorship.

### Original fix (unchanged)

`TestACPConformance/SharedSession/Nudge_RunningSession` flaked because `Provider.Nudge` could write to a stdin pipe the agent had just closed. `Interrupt_RunningSession` delivers SIGINT → `fakeacp` exits → but `sc.done` is only closed later by the monitor goroutine. In that gap, `sc.alive()` is still true, so `Nudge` sails past the liveness gate and writes to a dead pipe. Any pre-write probe is TOCTOU. The fix converges state _after_ the failed write on the lifecycle channel the rest of the SDK already trusts (`sc.done`). `fakeacp` now ignores SIGINT to match real ACP agents (Interrupt is a soft prompt-cancel, not teardown).

Before branch: `-count=50 -race` → 17/50 FAIL on `Nudge_RunningSession` (write |1: broken pipe).
After branch: `-count=100 -race` → 100/100 ok.

### Adoption review fixups

Six follow-ups from multi-model review (Claude + Codex + Gemini):

1. **(major)** Pin the new recovery branch with two unit tests. After `fakeacp` stopped exiting on SIGINT, nothing in CI drove `sendRequest` into the post-exit failure mode. The new tests use `newSessionConn` directly with a stubbed stdin — they don't depend on `fakeacp`'s signal handling and fail deterministically if the recovery `select` is ever collapsed.
2. **(minor)** Raise the post-write drain timeout from 2s → 5s and extract as `nudgePostWriteDrainTimeout`. Matches `terminateProcess`'s SIGTERM grace period so a `Nudge` racing with `Stop` still converges to the best-effort `nil` contract instead of firing first.
3. **(nit)** Re-check `sc.alive()` after acquiring `sc.nudgeMu`. Short-circuits queued `Nudge` calls behind a shutdown-observing `Nudge` instead of re-marshaling and tripping back through the recovery path.
4. **(nit)** Gate the `sc.done` wait on `isPipeWriteError()`. Non-lifecycle failures (marshal errors, etc.) now surface immediately; they stalled the caller for the full drain timeout before.
5. **(nit)** Update the `Nudge` doc comment to describe the broader best-effort surface.
6. **(nit)** Emit a single stderr line before returning `nil` from the recovery path — a chronically flapping agent isn't invisible to operators anymore.

Closes #716

## Testing

- [x] `go test -race ./internal/runtime/acp/` — ok
- [x] `go test -race -count=25 -tags=integration -run 'TestACPConformance/SharedSession/Nudge_RunningSession' ./internal/runtime/acp/` — 25/25 ok
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./internal/runtime/acp/...` — 0 issues

## Checklist

- [x] Linked issue (#716)
- [x] Added tests for behavior changes (`TestNudge_ReturnsNilWhenAgentExitsDuringSend`, `TestNudge_NonPipeErrorSurfacesImmediately`)
- [x] No user-facing docs affected
- [x] No breaking changes