### PR TITLE
test: isolate review-check-script subtests in their own managed-Dolt cities

### DIFF
--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -62,11 +62,20 @@ func (c reviewCheckCase) checkStepRef(attempt int) string {
 	return fmt.Sprintf("%s.%s.check.%d", c.formula, c.ralphStepID, attempt)
 }
 
+// Each subtest below calls setupReviewCheckScriptCity inside t.Run so
+// every case gets its own managed-Dolt instance with a fresh state
+// file. Sharing one city across the three cases caused intermittent
+// "Dolt server unreachable at 127.0.0.1:0" failures in `Integration /
+// rest` on main: when the parent city's managed Dolt raced between
+// subtests (crash, auto-stop, or a state-file write that left port 0
+// or an unreachable port), the test helper silently dropped
+// GC_DOLT_PORT and bd's own discovery fell through to port 0. See the
+// failure analysis on PR that introduced this test isolation.
 func TestReviewCheckScriptsDetectVerdictAcrossRalphStep(t *testing.T) {
-	cityDir := setupReviewCheckScriptCity(t)
-
 	for _, tc := range reviewCheckCases() {
 		t.Run(tc.name, func(t *testing.T) {
+			cityDir := setupReviewCheckScriptCity(t)
+
 			rootID := createJSONBead(t, cityDir, "workflow-root")
 			verdictID := createJSONBead(t, cityDir, "apply")
 			checkID := createJSONBead(t, cityDir, "check")
@@ -98,10 +107,10 @@ func TestReviewCheckScriptsDetectVerdictAcrossRalphStep(t *testing.T) {
 }
 
 func TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep(t *testing.T) {
-	cityDir := setupReviewCheckScriptCity(t)
-
 	for _, tc := range reviewCheckCases() {
 		t.Run(tc.name, func(t *testing.T) {
+			cityDir := setupReviewCheckScriptCity(t)
+
 			rootID := createJSONBead(t, cityDir, "workflow-root")
 			oldVerdictID := createJSONBead(t, cityDir, "apply-old")
 			updateBeadMetadata(t, cityDir, oldVerdictID,


### PR DESCRIPTION
## Summary

`Integration / rest` on `main` has been failing consistently for the past two runs (24598630361 → 21942e42, 24601312757 → c1a4ff42) on `TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep/{code_review,adopt_pr_review}` with:

```
bd create failed: exit status 1
  "error": "failed to open database: Dolt server unreachable at
    127.0.0.1:0: dial tcp 127.0.0.1:0: connect: connection refused"
```

## Root cause

The failing tests set up one managed-Dolt city via `setupReviewCheckScriptCity(t)` at the parent level, then ran three subtests sequentially against that shared city. Three things compound to produce the port-0 dial target:

1. **Managed Dolt's auto-lifecycle can race across subtests.** When the city's Dolt dies, auto-stops, or lands mid state-file update, the on-disk state file can report port 0 or an unreachable port.
2. **`bdDolt` silently drops `GC_DOLT_PORT`** when `currentManagedDoltPortForTest` can't return a valid reachable port — it assumes bd's native discovery will take over.
3. **bd's native Dolt discovery falls through to port 0** rather than erroring, producing the literal `127.0.0.1:0` dial target.

`design_review` runs first and passes. `code_review` fails on its second `bd create`. `adopt_pr_review` fails on its first `bd create` immediately afterwards — the state file stays poisoned across the 0.08s gap.

## Fix

Move `setupReviewCheckScriptCity(t)` inside `t.Run`. Each subtest gets its own city, its own managed-Dolt instance, and its own state file. Cross-subtest contamination can no longer produce the port-0 race, and a real Dolt startup failure only fails the affected subtest rather than poisoning the two that follow.

## Cost

Three full `gc init` + managed-Dolt startup cycles per parent test instead of one. Roughly triples wall time for these two parents — still well under the integration-test budget, straight trade for determinism.

## Testing

- [x] `make check`
- [ ] `make check-docs` — no docs touched
- [ ] `make test-integration` — gated on CI since it requires managed Dolt; the local subset runs the same path the CI job will re-exercise

## Checklist

- [x] Linked the failure analysis (see commit body)
- [x] Minimal diff — two `t.Run` bodies, no helper changes
- [x] No behavioral change for passing tests (same assertions, same setup semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)