### PR TITLE
Reduce CI and local test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,11 @@ jobs:
   # Runs always. Keep the packages shard blocking so PRs still fail on
   # integration-tagged package regressions even though `Check` is now
   # unit-only. Set repository variable CI_PACKAGES_SHARD_SOFT_FAIL=true
-  # for an emergency rollback to best-effort without editing the workflow;
-  # the heavier end-to-end shards remain best-effort while we tighten
-  # their gating in follow-up phases.
+  # for an emergency rollback to best-effort without editing the workflow.
+  # The heavier end-to-end review-formulas shard is routed in its own
+  # workflow so label-triggered reruns do not re-fire the whole CI suite.
+  # The remaining shards stay best-effort while we tighten their routing in
+  # follow-up phases.
   integration-shards:
     name: Integration / ${{ matrix.shard_name }}
     runs-on: ubuntu-latest
@@ -140,12 +142,6 @@ jobs:
             command: make test-integration-packages-cover
             coverage_file: coverage.integration-packages.txt
             coverage_flag: integration-packages
-          - shard_name: review-formulas
-            continue_on_error: true
-            timeout_minutes: 45
-            command: make test-integration-review-formulas-cover
-            coverage_file: coverage.integration-review-formulas.txt
-            coverage_flag: integration-review-formulas
           - shard_name: bdstore
             continue_on_error: true
             timeout_minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,11 @@ jobs:
 
   # Runs always. Keep the packages shard blocking so PRs still fail on
   # integration-tagged package regressions even though `Check` is now
-  # unit-only. Set repository variable CI_PACKAGES_SHARD_SOFT_FAIL=true
-  # for an emergency rollback to best-effort without editing the workflow.
+  # unit-only. This is also the required non-fast path for the slow cmd/gc
+  # process suite, because scripts/test-integration-shard forces
+  # `GC_FAST_UNIT=0` for integration shard execution. Set repository variable
+  # CI_PACKAGES_SHARD_SOFT_FAIL=true for an emergency rollback to best-effort
+  # without editing the workflow.
   # The heavier end-to-end review-formulas shard is routed in its own
   # workflow so label-triggered reruns do not re-fire the whole CI suite.
   # The rest shard is now split: a smoke slice stays here on every PR while

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,31 +111,53 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           files: coverage.txt
+          flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-  # Runs always, but remains non-blocking while integration/provider paths are still stabilizing.
+  # Runs always. Keep the packages shard blocking so PRs still fail on
+  # integration-tagged package regressions even though `Check` is now
+  # unit-only. Set repository variable CI_PACKAGES_SHARD_SOFT_FAIL=true
+  # for an emergency rollback to best-effort without editing the workflow;
+  # the heavier end-to-end shards remain best-effort while we tighten
+  # their gating in follow-up phases.
   integration-shards:
     name: Integration / ${{ matrix.shard_name }}
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: >-
+      ${{
+        matrix.continue_on_error ||
+        (matrix.shard_name == 'packages' && vars.CI_PACKAGES_SHARD_SOFT_FAIL == 'true')
+      }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - shard_name: packages
-            timeout_minutes: 35
-            command: make test-integration-packages
-          - shard_name: review-formulas
+            continue_on_error: false
             timeout_minutes: 45
-            command: make test-integration-review-formulas
+            command: make test-integration-packages-cover
+            coverage_file: coverage.integration-packages.txt
+            coverage_flag: integration-packages
+          - shard_name: review-formulas
+            continue_on_error: true
+            timeout_minutes: 45
+            command: make test-integration-review-formulas-cover
+            coverage_file: coverage.integration-review-formulas.txt
+            coverage_flag: integration-review-formulas
           - shard_name: bdstore
+            continue_on_error: true
             timeout_minutes: 15
-            command: make test-integration-bdstore
+            command: make test-integration-bdstore-cover
+            coverage_file: coverage.integration-bdstore.txt
+            coverage_flag: integration-bdstore
           - shard_name: rest
+            continue_on_error: true
             timeout_minutes: 35
-            command: make test-integration-rest
+            command: make test-integration-rest-cover
+            coverage_file: coverage.integration-rest.txt
+            coverage_flag: integration-rest
     env:
       DOLT_VERSION: "1.86.1"
       BD_VERSION: "v1.0.0"
@@ -149,7 +171,24 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Run integration shard
+        id: shard
         run: ${{ matrix.command }}
+      - name: Inspect shard coverage profile
+        if: steps.shard.outcome == 'success'
+        run: |
+          if [[ -f "${{ matrix.coverage_file }}" ]]; then
+            ls -lh "${{ matrix.coverage_file }}"
+          else
+            echo "coverage file missing: ${{ matrix.coverage_file }}"
+          fi
+      - name: Upload shard coverage to Codecov
+        if: steps.shard.outcome == 'success' && hashFiles(matrix.coverage_file) != ''
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          files: ${{ matrix.coverage_file }}
+          flags: ${{ matrix.coverage_flag }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   # Runs when pack-related files change — full gastown integration suite.
   pack-gate:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       k8s: ${{ steps.filter.outputs.k8s }}
       beads: ${{ steps.filter.outputs.beads }}
       packs: ${{ steps.filter.outputs.packs }}
+      rest_full: ${{ steps.filter.outputs.rest_full }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
@@ -45,6 +46,20 @@ jobs:
               - 'internal/config/pack.go'
               - 'internal/config/compose.go'
               - 'cmd/gc/embed_builtin_packs.go'
+            rest_full:
+              - '.github/actions/setup-gascity-ubuntu/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/nightly.yml'
+              - '.github/workflows/rc-gate.yml'
+              - 'Makefile'
+              - 'go.mod'
+              - 'go.sum'
+              - 'cmd/gc/**'
+              - 'scripts/test-integration-shard'
+              - 'test/agents/**'
+              - 'test/integration/**'
+              - 'test/tmuxtest/**'
+              - 'internal/**'
 
   # Always runs: lint, fmt, vet, unit tests, docs, acceptance, coverage.
   check:
@@ -121,8 +136,8 @@ jobs:
   # for an emergency rollback to best-effort without editing the workflow.
   # The heavier end-to-end review-formulas shard is routed in its own
   # workflow so label-triggered reruns do not re-fire the whole CI suite.
-  # The remaining shards stay best-effort while we tighten their routing in
-  # follow-up phases.
+  # The rest shard is now split: a smoke slice stays here on every PR while
+  # the full tier runs separately on targeted runtime/workflow changes.
   integration-shards:
     name: Integration / ${{ matrix.shard_name }}
     runs-on: ubuntu-latest
@@ -148,12 +163,12 @@ jobs:
             command: make test-integration-bdstore-cover
             coverage_file: coverage.integration-bdstore.txt
             coverage_flag: integration-bdstore
-          - shard_name: rest
+          - shard_name: rest-smoke
             continue_on_error: true
-            timeout_minutes: 35
-            command: make test-integration-rest-cover
-            coverage_file: coverage.integration-rest.txt
-            coverage_flag: integration-rest
+            timeout_minutes: 30
+            command: make test-integration-rest-smoke-cover
+            coverage_file: coverage.integration-rest-smoke.txt
+            coverage_flag: integration-rest-smoke
     env:
       DOLT_VERSION: "1.86.1"
       BD_VERSION: "v1.0.0"
@@ -183,6 +198,53 @@ jobs:
         with:
           files: ${{ matrix.coverage_file }}
           flags: ${{ matrix.coverage_flag }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  # The heavier rest tier only runs on workflow/runtime changes in PRs and
+  # pushes; nightly and RC still exercise it unconditionally.
+  integration-rest-full:
+    name: Integration / rest-full
+    needs: [changes]
+    if: github.event_name == 'push' || needs.changes.outputs.rest_full == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    env:
+      DOLT_VERSION: "1.86.1"
+      BD_VERSION: "v1.0.0"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run rest-full shard
+        id: shard
+        run: make test-integration-rest-full-cover
+      - name: Inspect shard coverage profile
+        if: steps.shard.outcome == 'success'
+        run: |
+          if [[ -f "coverage.integration-rest-full.txt" ]]; then
+            ls -lh "coverage.integration-rest-full.txt"
+          else
+            echo "coverage file missing: coverage.integration-rest-full.txt"
+          fi
+      - name: Upload shard coverage to Codecov
+        if: >-
+          steps.shard.outcome == 'success' &&
+          hashFiles('coverage.integration-rest-full.txt') != '' &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          files: coverage.integration-rest-full.txt
+          flags: integration-rest-full
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -140,8 +140,8 @@ jobs:
           ACCEPTANCE_TIMEOUT: 20m
         run: make test-acceptance
 
-  # Integration-tagged coverage pass — the Linux `Check` job's equivalent
-  # of `make test-cover`. Kept best-effort while we discover Mac-specific
+  # Unit coverage pass — the Linux `Check` job's equivalent of
+  # `make test-cover`. Kept best-effort while we discover Mac-specific
   # failures; continue-on-error is on the test step (not the job) so the
   # job's result still reflects the actual outcome for the summary.
   mac-cover:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,10 +14,25 @@ env:
 
 jobs:
   linux-review-formulas:
-    name: Linux / integration review-formulas
+    # Nightly intentionally hard-fails here so a broken subshard still
+    # surfaces under the legacy summary check instead of disappearing
+    # behind best-effort matrix jobs.
+    name: Linux / integration review-formulas (${{ matrix.label }})
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: review-formulas-basic
+            label: basic
+            coverprofile: coverage.integration-review-formulas-basic.txt
+          - shard: review-formulas-retries
+            label: retries
+            coverprofile: coverage.integration-review-formulas-retries.txt
+          - shard: review-formulas-recovery
+            label: recovery
+            coverprofile: coverage.integration-review-formulas-recovery.txt
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -28,15 +43,33 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Run integration review-formulas shard
-        run: make test-integration-review-formulas-cover
+        run: GO_TEST_COVERPROFILE=${{ matrix.coverprofile }} ./scripts/test-integration-shard ${{ matrix.shard }}
       - name: Upload shard coverage to Codecov
-        if: hashFiles('coverage.integration-review-formulas.txt') != ''
+        if: hashFiles(matrix.coverprofile) != ''
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
-          files: coverage.integration-review-formulas.txt
+          files: ${{ matrix.coverprofile }}
           flags: integration-review-formulas
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+  linux-review-formulas-summary:
+    # Preserve the historical nightly check name while the real work runs
+    # in parallel review-formulas shards above.
+    name: Linux / integration review-formulas
+    needs:
+      - linux-review-formulas
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize nightly review-formulas result
+        env:
+          SHARD_RESULT: ${{ needs.linux-review-formulas.result }}
+        run: |
+          if [[ "${SHARD_RESULT}" != "success" ]]; then
+            echo "nightly review-formulas subshards failed" >&2
+            exit 1
+          fi
 
   linux-rest-smoke:
     name: Linux / integration rest-smoke

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,56 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+  linux-rest-smoke:
+    name: Linux / integration rest-smoke
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run integration rest-smoke shard
+        run: make test-integration-rest-smoke-cover
+      - name: Upload shard coverage to Codecov
+        if: hashFiles('coverage.integration-rest-smoke.txt') != ''
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          files: coverage.integration-rest-smoke.txt
+          flags: integration-rest-smoke
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  linux-rest-full:
+    name: Linux / integration rest-full
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run integration rest-full shard
+        run: make test-integration-rest-full-cover
+      - name: Upload shard coverage to Codecov
+        if: hashFiles('coverage.integration-rest-full.txt') != ''
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          files: coverage.integration-rest-full.txt
+          flags: integration-rest-full
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
   inference:
     name: Tier C inference tests
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,31 @@ env:
   BD_VERSION: "v1.0.0"
 
 jobs:
+  linux-review-formulas:
+    name: Linux / integration review-formulas
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run integration review-formulas shard
+        run: make test-integration-review-formulas-cover
+      - name: Upload shard coverage to Codecov
+        if: hashFiles('coverage.integration-review-formulas.txt') != ''
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          files: coverage.integration-review-formulas.txt
+          flags: integration-review-formulas
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
   inference:
     name: Tier C inference tests
     runs-on: ubuntu-latest

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -17,23 +17,25 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: review-formulas-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DOLT_VERSION: "1.86.1"
   BD_VERSION: "v1.0.0"
 
 jobs:
-  review-formulas:
-    name: Integration / review-formulas
+  gate:
+    name: review-formulas routing
     if: >-
       github.event_name != 'pull_request' ||
       github.event.action != 'labeled' ||
       github.event.label.name == 'needs-review-formulas'
     runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 45
-    concurrency:
-      group: review-formulas-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      run_shard: ${{ steps.gate.outputs.run_shard }}
+      reason: ${{ steps.gate.outputs.reason }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
@@ -95,39 +97,95 @@ jobs:
       - name: Report routing decision
         run: |
           echo "review-formulas shard: ${{ steps.gate.outputs.reason }}"
+
+  review-formulas-shard:
+    name: Integration / review-formulas (${{ matrix.label }})
+    needs: gate
+    if: needs.gate.outputs.run_shard == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: review-formulas-basic
+            label: basic
+            coverprofile: coverage.integration-review-formulas-basic.txt
+          - shard: review-formulas-retries
+            label: retries
+            coverprofile: coverage.integration-review-formulas-retries.txt
+          - shard: review-formulas-recovery
+            label: recovery
+            coverprofile: coverage.integration-review-formulas-recovery.txt
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
-        if: steps.gate.outputs.run_shard == 'true'
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
           bd-version: ${{ env.BD_VERSION }}
           install-claude-cli: "true"
       - name: Install tools
-        if: steps.gate.outputs.run_shard == 'true'
         run: make install-tools
       - name: Run review-formulas shard
         id: shard
-        if: steps.gate.outputs.run_shard == 'true'
-        run: make test-integration-review-formulas-cover
+        run: GO_TEST_COVERPROFILE=${{ matrix.coverprofile }} ./scripts/test-integration-shard ${{ matrix.shard }}
       - name: Inspect shard coverage profile
-        if: steps.gate.outputs.run_shard == 'true' && steps.shard.outcome == 'success'
+        if: steps.shard.outcome == 'success'
         run: |
-          if [[ -f "coverage.integration-review-formulas.txt" ]]; then
-            ls -lh "coverage.integration-review-formulas.txt"
+          if [[ -f "${{ matrix.coverprofile }}" ]]; then
+            ls -lh "${{ matrix.coverprofile }}"
           else
-            echo "coverage file missing: coverage.integration-review-formulas.txt"
+            echo "coverage file missing: ${{ matrix.coverprofile }}"
           fi
       - name: Upload shard coverage to Codecov
         if: >-
-          steps.gate.outputs.run_shard == 'true' &&
           steps.shard.outcome == 'success' &&
-          hashFiles('coverage.integration-review-formulas.txt') != '' &&
+          hashFiles(matrix.coverprofile) != '' &&
           (
             github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name == github.repository
           )
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
-          files: coverage.integration-review-formulas.txt
+          files: ${{ matrix.coverprofile }}
           flags: integration-review-formulas
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+  review-formulas:
+    # This synthesized result is the historical branch-protected gate.
+    # The old workflow carried `continue-on-error`, but PR checks still
+    # treated this name as a failing signal. Keep that effective behavior
+    # explicit while the shards run in parallel underneath it.
+    name: Integration / review-formulas
+    needs:
+      - gate
+      - review-formulas-shard
+    if: >-
+      always() &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.action != 'labeled' ||
+        github.event.label.name == 'needs-review-formulas'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize review-formulas result
+        env:
+          GATE_RESULT: ${{ needs.gate.result }}
+          RUN_SHARD: ${{ needs.gate.outputs.run_shard }}
+          REASON: ${{ needs.gate.outputs.reason }}
+          SHARD_RESULT: ${{ needs.review-formulas-shard.result }}
+        run: |
+          echo "review-formulas shard: ${REASON}"
+          if [[ "${GATE_RESULT}" != "success" ]]; then
+            echo "review-formulas routing failed" >&2
+            exit 1
+          fi
+          if [[ "${RUN_SHARD}" != "true" ]]; then
+            exit 0
+          fi
+          if [[ "${SHARD_RESULT}" != "success" ]]; then
+            echo "review-formulas subshards failed" >&2
+            exit 1
+          fi

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -1,0 +1,133 @@
+name: CI
+# Keep the historical check name `CI / Integration / review-formulas` even
+# though the shard now lives in a dedicated workflow.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOLT_VERSION: "1.86.1"
+  BD_VERSION: "v1.0.0"
+
+jobs:
+  review-formulas:
+    name: Integration / review-formulas
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'needs-review-formulas'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    concurrency:
+      group: review-formulas-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          filters: |
+            review_formulas:
+              - '.github/actions/setup-gascity-ubuntu/**'
+              - '.github/workflows/nightly.yml'
+              - '.github/workflows/review-formulas.yml'
+              - 'Makefile'
+              - 'go.mod'
+              - 'go.sum'
+              - 'cmd/gc/**'
+              - 'examples/bd/**'
+              - 'examples/dolt/**'
+              - 'examples/gastown/packs/**'
+              - 'scripts/test-integration-shard'
+              - 'test/agents/**'
+              - 'test/integration/**'
+              - 'test/tmuxtest/**'
+              - 'internal/**'
+      - name: Decide whether shard should run
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABELED_NAME: ${{ github.event.label.name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PATH_HIT: ${{ steps.filter.outputs.review_formulas }}
+          NEEDS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'needs-review-formulas') }}
+        run: |
+          run_shard=false
+          reason="skipped"
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            run_shard=true
+            reason="manual dispatch"
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            run_shard=true
+            reason="push to main safety net"
+          elif [[ "$PR_DRAFT" != "true" ]]; then
+            if [[ "$EVENT_ACTION" == "labeled" && "$LABELED_NAME" != "needs-review-formulas" ]]; then
+              reason="ignored unrelated label event"
+            elif [[ "$PATH_HIT" == "true" || "$NEEDS_LABEL" == "true" ]]; then
+              run_shard=true
+              reason="pull request path/label match"
+            else
+              reason="pull request path/label miss"
+            fi
+          else
+            reason="draft pull request"
+          fi
+
+          {
+            echo "run_shard=$run_shard"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+      - name: Report routing decision
+        run: |
+          echo "review-formulas shard: ${{ steps.gate.outputs.reason }}"
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        if: steps.gate.outputs.run_shard == 'true'
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        if: steps.gate.outputs.run_shard == 'true'
+        run: make install-tools
+      - name: Run review-formulas shard
+        id: shard
+        if: steps.gate.outputs.run_shard == 'true'
+        run: make test-integration-review-formulas-cover
+      - name: Inspect shard coverage profile
+        if: steps.gate.outputs.run_shard == 'true' && steps.shard.outcome == 'success'
+        run: |
+          if [[ -f "coverage.integration-review-formulas.txt" ]]; then
+            ls -lh "coverage.integration-review-formulas.txt"
+          else
+            echo "coverage file missing: coverage.integration-review-formulas.txt"
+          fi
+      - name: Upload shard coverage to Codecov
+        if: >-
+          steps.gate.outputs.run_shard == 'true' &&
+          steps.shard.outcome == 'success' &&
+          hashFiles('coverage.integration-review-formulas.txt') != '' &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          files: coverage.integration-review-formulas.txt
+          flags: integration-review-formulas
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 CLAUDE.local.md
 coverage.txt
 coverage.integration-*.txt
+cmd/gc/.runtime/
 /bin/
 /gc
 /genschema

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 CLAUDE.local.md
 coverage.txt
+coverage.integration-*.txt
 /bin/
 /gc
 /genschema

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-cmd-gc-process test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
 
 ## build: compile gc binary with version metadata
 build:
@@ -99,9 +99,16 @@ fmt: $(GOLANGCI_LINT)
 vet:
 	go vet ./...
 
-## test: run unit tests (skip integration tests tagged with //go:build integration)
+## test: run fast unit tests (skip integration-tagged and GC_FAST_UNIT-gated process tests)
+## The skipped cmd/gc process-backed scenarios remain covered by
+## `make test-cmd-gc-process` locally and the CI `test-integration-packages` shard.
 test:
-	go test ./...
+	GC_FAST_UNIT=1 go test ./...
+
+## test-cmd-gc-process: run the full non-short cmd/gc suite, including the
+## process-backed lifecycle coverage routed out of the default fast loop
+test-cmd-gc-process:
+	GC_FAST_UNIT=0 go test ./cmd/gc
 
 ## test-acceptance: run acceptance tests (Tier A — fast, <5 min, every PR).
 ## ACCEPTANCE_TIMEOUT overrides the go-test timeout (defaults to 5m on
@@ -133,6 +140,7 @@ test-integration-shards: test-integration-packages test-integration-review-formu
 test-integration-shards-cover: test-integration-packages-cover test-integration-review-formulas-cover test-integration-bdstore-cover test-integration-rest-smoke-cover test-integration-rest-full-cover
 
 ## test-integration-packages: run all integration-tagged packages except ./test/integration
+## This shard is also the required non-short CI path for the slow cmd/gc process suite.
 test-integration-packages:
 	./scripts/test-integration-shard packages
 
@@ -212,9 +220,11 @@ check-docs:
 #   beadstest: conformance helper, runs under internal/beads coverage
 UNIT_COVER_PKGS := $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest)
 
-## test-cover: run unit-test coverage without the integration-tagged package sweep
+## test-cover: run fast unit-test coverage without the integration-tagged package sweep
+## The skipped cmd/gc process-backed scenarios remain covered by
+## `make test-cmd-gc-process` locally and the CI `test-integration-packages` shard.
 test-cover:
-	go test -timeout 8m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
+	GC_FAST_UNIT=1 go test -timeout 8m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
 
 ## cover: run tests and show coverage report
 cover: test-cover

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-cmd-gc-process test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-cmd-gc-process test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
 
 ## build: compile gc binary with version metadata
 build:
@@ -150,11 +150,49 @@ test-integration-packages-cover:
 
 ## test-integration-review-formulas: run the long-running workflow formula integration tests
 test-integration-review-formulas:
-	./scripts/test-integration-shard review-formulas
+	@status=0; \
+	$(MAKE) test-integration-review-formulas-basic || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	$(MAKE) test-integration-review-formulas-retries || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	$(MAKE) test-integration-review-formulas-recovery || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	exit $$status
 
 ## test-integration-review-formulas-cover: run the review-formulas shard with a CI coverage profile
 test-integration-review-formulas-cover:
-	GO_TEST_COVERPROFILE=coverage.integration-review-formulas.txt ./scripts/test-integration-shard review-formulas
+	@status=0; \
+	$(MAKE) test-integration-review-formulas-basic-cover || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	$(MAKE) test-integration-review-formulas-retries-cover || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	$(MAKE) test-integration-review-formulas-recovery-cover || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	if [ $$status -eq 0 ]; then \
+		./scripts/merge-coverprofiles coverage.integration-review-formulas.txt \
+			coverage.integration-review-formulas-basic.txt \
+			coverage.integration-review-formulas-retries.txt \
+			coverage.integration-review-formulas-recovery.txt; \
+	fi; \
+	exit $$status
+
+## test-integration-review-formulas-basic: run the core happy-path review-formulas tests
+test-integration-review-formulas-basic:
+	./scripts/test-integration-shard review-formulas-basic
+
+## test-integration-review-formulas-basic-cover: run the basic review-formulas shard with coverage
+test-integration-review-formulas-basic-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-review-formulas-basic.txt ./scripts/test-integration-shard review-formulas-basic
+
+## test-integration-review-formulas-retries: run the retry-heavy review-formulas tests
+test-integration-review-formulas-retries:
+	./scripts/test-integration-shard review-formulas-retries
+
+## test-integration-review-formulas-retries-cover: run the retry-heavy review-formulas shard with coverage
+test-integration-review-formulas-retries-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-review-formulas-retries.txt ./scripts/test-integration-shard review-formulas-retries
+
+## test-integration-review-formulas-recovery: run the crash/recovery review-formulas test
+test-integration-review-formulas-recovery:
+	./scripts/test-integration-shard review-formulas-recovery
+
+## test-integration-review-formulas-recovery-cover: run the crash/recovery review-formulas shard with coverage
+test-integration-review-formulas-recovery-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-review-formulas-recovery.txt ./scripts/test-integration-shard review-formulas-recovery
 
 ## test-integration-bdstore: run the bd store conformance shard in isolation
 test-integration-bdstore:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
 
 ## build: compile gc binary with version metadata
 build:
@@ -127,10 +127,10 @@ test-integration:
 	go test -tags integration -timeout 30m ./...
 
 ## test-integration-shards: run the CI integration shards sequentially
-test-integration-shards: test-integration-packages test-integration-review-formulas test-integration-bdstore test-integration-rest
+test-integration-shards: test-integration-packages test-integration-review-formulas test-integration-bdstore test-integration-rest-smoke test-integration-rest-full
 
 ## test-integration-shards-cover: run the CI integration coverage shards sequentially
-test-integration-shards-cover: test-integration-packages-cover test-integration-review-formulas-cover test-integration-bdstore-cover test-integration-rest-cover
+test-integration-shards-cover: test-integration-packages-cover test-integration-review-formulas-cover test-integration-bdstore-cover test-integration-rest-smoke-cover test-integration-rest-full-cover
 
 ## test-integration-packages: run all integration-tagged packages except ./test/integration
 test-integration-packages:
@@ -156,13 +156,35 @@ test-integration-bdstore:
 test-integration-bdstore-cover:
 	GO_TEST_COVERPROFILE=coverage.integration-bdstore.txt ./scripts/test-integration-shard bdstore
 
-## test-integration-rest: run the remaining ./test/integration tests
-test-integration-rest:
-	./scripts/test-integration-shard rest
+## test-integration-rest-smoke: run the PR smoke subset of the remaining ./test/integration tests
+test-integration-rest-smoke:
+	./scripts/test-integration-shard rest-smoke
 
-## test-integration-rest-cover: run the rest shard with a CI coverage profile
+## test-integration-rest-smoke-cover: run the smoke rest shard with a CI coverage profile
+test-integration-rest-smoke-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-rest-smoke.txt ./scripts/test-integration-shard rest-smoke
+
+## test-integration-rest-full: run the heavier rest shard kept for nightly/RC and targeted PRs
+test-integration-rest-full:
+	./scripts/test-integration-shard rest-full
+
+## test-integration-rest-full-cover: run the full rest shard with a CI coverage profile
+test-integration-rest-full-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-rest-full.txt ./scripts/test-integration-shard rest-full
+
+## test-integration-rest: run the combined rest smoke+full suite
+test-integration-rest:
+	@status=0; \
+	$(MAKE) test-integration-rest-smoke || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	$(MAKE) test-integration-rest-full || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	exit $$status
+
+## test-integration-rest-cover: run the combined rest smoke+full coverage shards
 test-integration-rest-cover:
-	GO_TEST_COVERPROFILE=coverage.integration-rest.txt ./scripts/test-integration-shard rest
+	@status=0; \
+	$(MAKE) test-integration-rest-smoke-cover || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	$(MAKE) test-integration-rest-full-cover || { st=$$?; [ $$status -ne 0 ] || status=$$st; }; \
+	exit $$status
 
 ## test-chaos-dolt: run the opt-in managed Dolt chaos integration test
 ## Set GC_DOLT_CHAOS_DURATION and GC_DOLT_CHAOS_SEED to control runtime and replay failures.

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-packages test-integration-review-formulas test-integration-bdstore test-integration-rest test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
 
 ## build: compile gc binary with version metadata
 build:
@@ -129,21 +129,40 @@ test-integration:
 ## test-integration-shards: run the CI integration shards sequentially
 test-integration-shards: test-integration-packages test-integration-review-formulas test-integration-bdstore test-integration-rest
 
+## test-integration-shards-cover: run the CI integration coverage shards sequentially
+test-integration-shards-cover: test-integration-packages-cover test-integration-review-formulas-cover test-integration-bdstore-cover test-integration-rest-cover
+
 ## test-integration-packages: run all integration-tagged packages except ./test/integration
 test-integration-packages:
 	./scripts/test-integration-shard packages
+
+## test-integration-packages-cover: run the packages shard with a CI coverage profile
+test-integration-packages-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-packages.txt ./scripts/test-integration-shard packages
 
 ## test-integration-review-formulas: run the long-running workflow formula integration tests
 test-integration-review-formulas:
 	./scripts/test-integration-shard review-formulas
 
+## test-integration-review-formulas-cover: run the review-formulas shard with a CI coverage profile
+test-integration-review-formulas-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-review-formulas.txt ./scripts/test-integration-shard review-formulas
+
 ## test-integration-bdstore: run the bd store conformance shard in isolation
 test-integration-bdstore:
 	./scripts/test-integration-shard bdstore
 
+## test-integration-bdstore-cover: run the bdstore shard with a CI coverage profile
+test-integration-bdstore-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-bdstore.txt ./scripts/test-integration-shard bdstore
+
 ## test-integration-rest: run the remaining ./test/integration tests
 test-integration-rest:
 	./scripts/test-integration-shard rest
+
+## test-integration-rest-cover: run the rest shard with a CI coverage profile
+test-integration-rest-cover:
+	GO_TEST_COVERPROFILE=coverage.integration-rest.txt ./scripts/test-integration-shard rest
 
 ## test-chaos-dolt: run the opt-in managed Dolt chaos integration test
 ## Set GC_DOLT_CHAOS_DURATION and GC_DOLT_CHAOS_SEED to control runtime and replay failures.
@@ -169,11 +188,11 @@ check-docs:
 # Packages for coverage — exclude noise:
 #   session/tmux: integration-test-only, not meaningful for unit coverage
 #   beadstest: conformance helper, runs under internal/beads coverage
-COVER_PKGS := $(shell go list ./... | grep -v -e /session/tmux -e /beadstest)
+UNIT_COVER_PKGS := $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v -e /session/tmux -e /beadstest)
 
-## test-cover: run all tests with coverage output (excludes tmux)
+## test-cover: run unit-test coverage without the integration-tagged package sweep
 test-cover:
-	go test -tags integration -timeout 8m -coverprofile=coverage.txt $(COVER_PKGS)
+	go test -timeout 8m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
 
 ## cover: run tests and show coverage report
 cover: test-cover

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,6 +29,13 @@ func TestBeadStore_CorruptLine(t *testing.T) {
 When to use: corrupted data, concurrent writes, specific error types,
 double-claim conflicts, rollback behavior, boundary conditions.
 
+`make test-cover` now follows this boundary strictly: it runs unit-test
+coverage only. If you need the CI integration-tagged coverage sweep
+locally, use `make test-integration-shards-cover`. As a result,
+`coverage.txt` is now the unit-only baseline; the integration contribution
+comes from the shard-specific `coverage.integration-*.txt` profiles and
+their matching Codecov flags.
+
 ### 2. Testscript (`.txtar` files in `cmd/gc/testdata/`)
 
 Test what the USER sees. Run the real `gc` binary, assert on stdout/stderr.

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,12 +29,20 @@ func TestBeadStore_CorruptLine(t *testing.T) {
 When to use: corrupted data, concurrent writes, specific error types,
 double-claim conflicts, rollback behavior, boundary conditions.
 
-`make test-cover` now follows this boundary strictly: it runs unit-test
-coverage only. If you need the CI integration-tagged coverage sweep
-locally, use `make test-integration-shards-cover`. As a result,
-`coverage.txt` is now the unit-only baseline; the integration contribution
-comes from the shard-specific `coverage.integration-*.txt` profiles and
-their matching Codecov flags.
+`make test` and `make test-cover` now follow this boundary strictly: they
+run the fast unit loop only, with `GC_FAST_UNIT=1` gating slow `cmd/gc`
+process scenarios. Slow process-backed cases
+such as managed Dolt recovery, real `bd` lifecycle, tutorial regression
+scripts, and the large `gc-beads-bd` provider suite are routed out of the
+default path so local `make check` and CI `Check` stay focused on quick
+feedback. If you need that full `cmd/gc` scenario coverage locally, run
+`make test-cmd-gc-process`. In CI, the required non-short path is the
+`test-integration-packages` shard. If you need the heavier package
+coverage sweep locally, use `make test-integration-packages-cover` or
+`make test-integration-shards-cover`. As a result, `coverage.txt` is the
+fast unit-only baseline; the integration contribution comes from the
+shard-specific `coverage.integration-*.txt` profiles and their matching
+Codecov flags.
 
 ### 2. Testscript (`.txtar` files in `cmd/gc/testdata/`)
 

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2120,6 +2120,7 @@ func TestStartBeadsLifecycleDoesNotMutateProcessDoltEnv(t *testing.T) {
 }
 
 func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")
@@ -2626,6 +2627,7 @@ exit 2
 }
 
 func TestHealthBeadsProviderPublishesManagedRuntimeStateWhenHealthyButUnpublished(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath, _ := setupManagedBdWaitTestCity(t)
 
 	if err := os.Remove(managedDoltStatePath(cityPath)); err != nil && !os.IsNotExist(err) {
@@ -3777,98 +3779,6 @@ esac
 	}
 }
 
-func listenOnRandomPort(t *testing.T) net.Listener {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	return ln
-}
-
-func reserveRandomTCPPort(t *testing.T) int {
-	t.Helper()
-	ln := listenOnRandomPort(t)
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-	return port
-}
-
-func startTCPListenerProcess(t *testing.T, port int) *exec.Cmd {
-	t.Helper()
-	cmd := exec.Command("python3", "-c", `
-import signal
-import socket
-import sys
-import time
-port = int(sys.argv[1])
-sock = socket.socket()
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-sock.bind(("127.0.0.1", port))
-sock.listen(5)
-def _stop(*_args):
-    raise SystemExit(0)
-signal.signal(signal.SIGTERM, _stop)
-signal.signal(signal.SIGINT, _stop)
-while True:
-    time.sleep(1)
-`, strconv.Itoa(port))
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start listener process: %v", err)
-	}
-	t.Cleanup(func() {
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-		}
-		_ = cmd.Wait()
-	})
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return cmd
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("listener process on %d did not become ready", port)
-	return nil
-}
-
-func writeDoltState(cityPath string, state doltRuntimeState) error {
-	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		return err
-	}
-	data := fmt.Sprintf(`{"running":%t,"pid":%d,"port":%d,"data_dir":%q,"started_at":%q}`,
-		state.Running, state.PID, state.Port, state.DataDir, state.StartedAt)
-	return os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(data), 0o644)
-}
-
-// writeTestScript creates a shell script that exits with the given code.
-// If stderrMsg is non-empty, the script writes it to stderr before exiting.
-func writeTestScript(t *testing.T, _ string, exitCode int, stderrMsg string) string {
-	t.Helper()
-	dir := t.TempDir()
-	script := filepath.Join(dir, "test-beads.sh")
-
-	content := "#!/bin/sh\n"
-	if stderrMsg != "" {
-		content += "echo '" + stderrMsg + "' >&2\n"
-	}
-	content += "exit " + itoa(exitCode) + "\n"
-
-	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return script
-}
-
-// itoa is a simple int to string converter for test scripts.
-func itoa(n int) string {
-	return []string{"0", "1", "2"}[n]
-}
-
 // ── isExternalDolt tests ──────────────────────────────────────────────
 
 func TestIsExternalDoltEnvFallback(t *testing.T) {
@@ -4122,6 +4032,7 @@ dolt.port: 3307
 }
 
 func TestGcBeadsBdStartIgnoresReachableCompatPortFileInput(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -4671,6 +4582,7 @@ esac
 }
 
 func TestGcBeadsBdStartDoesNotReplaceLiveLockFileInode(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	if _, err := exec.LookPath("flock"); err != nil {
 		t.Skip("flock not installed")
 	}
@@ -4846,6 +4758,7 @@ while [ ! -f "$release_file" ]; do
 }
 
 func TestGcBeadsBdStartWaitsForConcurrentStarterSuccess(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
 		t.Fatalf("MaterializeBuiltinPacks: %v", err)
@@ -5388,6 +5301,7 @@ func readManagedDoltConfigForTest(t *testing.T, path string) managedDoltConfigFo
 }
 
 func TestGcBeadsBdStartIsIdempotentWhenAlreadyRunning(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -5516,6 +5430,7 @@ esac
 }
 
 func TestGcBeadsBdStartRestartsServerHoldingDeletedDataInodes(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -5648,6 +5563,7 @@ esac
 }
 
 func TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -6409,6 +6325,7 @@ func TestNormalizeCanonicalBdScopeFilesRepairsCityAndRigScopeFiles(t *testing.T)
 }
 
 func TestGcBeadsBdInitNormalizesScopeAndRemovesLocalServerArtifacts(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "frontend")
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1009,6 +1009,7 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 }
 
 func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
+	skipSlowCmdGCTest(t, "spawns managed dolt holder processes; run without -short or via integration packages")
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
@@ -1843,6 +1844,7 @@ func TestDoltStateStopManagedCmdDoesNotKillImposterPortHolder(t *testing.T) {
 }
 
 func TestDoltStateRecoverManagedCmdReportsReadOnlyAndRestarts(t *testing.T) {
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run without -short or via integration packages")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -2199,6 +2201,7 @@ esac
 }
 
 func TestDoltStateRecoverManagedCmdClearsPublishedStateWhenPreflightCleanupFails(t *testing.T) {
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run without -short or via integration packages")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -2273,6 +2276,7 @@ func TestDoltStateRecoverManagedCmdClearsPublishedStateWhenPreflightCleanupFails
 }
 
 func TestDoltStateRecoverManagedCmdFailsWhenPostStartHealthFails(t *testing.T) {
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run without -short or via integration packages")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1040,6 +1040,7 @@ func TestCanonicalValidationPasswordUsesCredentialsFileOverride(t *testing.T) {
 }
 
 func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run without -short or via integration packages")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")
@@ -1130,6 +1131,7 @@ func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T
 }
 
 func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run without -short or via integration packages")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")
@@ -1233,6 +1235,7 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 }
 
 func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run without -short or via integration packages")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -103,6 +103,7 @@ func TestRegisterCityWithSupervisorKeepsRegistrationWhenCityNeverBecomesReady(t 
 }
 
 func TestRegisterCityWithSupervisorKeepsRegistrationWhenReloadFails(t *testing.T) {
+	skipSlowCmdGCTest(t, "exercises supervisor registration retry behavior; run without -short for scenario coverage")
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
 

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -61,6 +61,7 @@ func waitTestEnv(overrides map[string]string) []string {
 
 func waitTestRealBDPath(t *testing.T) string {
 	t.Helper()
+	skipSlowCmdGCTest(t, "requires a managed bd lifecycle city; run without -short or via integration packages")
 	waitTestRealBDPathOnce.Do(func() {
 		for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 			if strings.TrimSpace(dir) == "" {

--- a/cmd/gc/dolt_project_id_test.go
+++ b/cmd/gc/dolt_project_id_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabaseMissing(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run without -short or via integration packages")
 	doltPath := os.Getenv("GC_DOLT_REAL_BINARY")
 	var err error
 	if doltPath == "" {
@@ -257,6 +258,7 @@ func TestManagedDoltWaitReadyWithPasswordUsesDirectQueryProbe(t *testing.T) {
 }
 
 func TestRecoverManagedDoltProcessWithPasswordUsesDirectHelpersAgainstRealServer(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run without -short or via integration packages")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -303,6 +305,7 @@ func TestRecoverManagedDoltProcessWithPasswordUsesDirectHelpersAgainstRealServer
 }
 
 func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWithPasswordedServer(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run without -short or via integration packages")
 	cityDir := t.TempDir()
 	metadataPath := filepath.Join(cityDir, ".beads", "metadata.json")
 	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o755); err != nil {

--- a/cmd/gc/fast_loop_helpers_test.go
+++ b/cmd/gc/fast_loop_helpers_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func skipSlowCmdGCTest(t *testing.T, reason string) {
+	t.Helper()
+	if os.Getenv("GC_FAST_UNIT") == "1" || testing.Short() {
+		t.Skip(reason)
+	}
+}
+
+// writeTestScript creates a shell script that exits with the given code.
+// If stderrMsg is non-empty, the script writes it to stderr before exiting.
+func writeTestScript(t *testing.T, _ string, exitCode int, stderrMsg string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "test-beads.sh")
+
+	content := "#!/bin/sh\n"
+	if stderrMsg != "" {
+		content += "echo '" + stderrMsg + "' >&2\n"
+	}
+	content += "exit " + itoa(exitCode) + "\n"
+
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func itoa(n int) string {
+	return []string{"0", "1", "2"}[n]
+}
+
+func listenOnRandomPort(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln
+}
+
+func reserveRandomTCPPort(t *testing.T) int {
+	t.Helper()
+	ln := listenOnRandomPort(t)
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+func startTCPListenerProcess(t *testing.T, port int) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("python3", "-c", `
+import signal
+import socket
+import sys
+import time
+port = int(sys.argv[1])
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", port))
+sock.listen(5)
+def _stop(*_args):
+    raise SystemExit(0)
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+while True:
+    time.sleep(1)
+`, strconv.Itoa(port))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start listener process: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return cmd
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("listener process on %d did not become ready", port)
+	return nil
+}
+
+func writeDoltState(cityPath string, state doltRuntimeState) error {
+	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	data := fmt.Sprintf(`{"running":%t,"pid":%d,"port":%d,"data_dir":%q,"started_at":%q}`,
+		state.Running, state.PID, state.Port, state.DataDir, state.StartedAt)
+	return os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(data), 0o644)
+}

--- a/cmd/gc/live_submit_probe_test.go
+++ b/cmd/gc/live_submit_probe_test.go
@@ -20,6 +20,7 @@ import (
 
 func preferRealBDOnPath(t *testing.T) {
 	t.Helper()
+	skipSlowCmdGCTest(t, "requires a live bd-managed session probe; run without -short")
 
 	currentPath := os.Getenv("PATH")
 	pathEntries := filepath.SplitList(currentPath)

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -149,6 +149,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestTutorial01(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs the end-to-end tutorial script; run without -short for scenario coverage")
 	testscript.Run(t, newTestscriptParams(t))
 }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,8 @@ coverage:
           - integration-packages
           - integration-review-formulas
           - integration-bdstore
-          - integration-rest
+          - integration-rest-smoke
+          - integration-rest-full
 
 flags:
   unit:
@@ -40,7 +41,13 @@ flags:
       - internal/
       - test/
     carryforward: true
-  integration-rest:
+  integration-rest-smoke:
+    paths:
+      - cmd/
+      - internal/
+      - test/
+    carryforward: true
+  integration-rest-full:
     paths:
       - cmd/
       - internal/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,48 @@
+coverage:
+  status:
+    default_rules:
+      flag_coverage_not_uploaded_behavior: include
+    project:
+      default:
+        target: auto
+        flags:
+          - unit
+          - integration-packages
+          - integration-review-formulas
+          - integration-bdstore
+          - integration-rest
+
+flags:
+  unit:
+    paths:
+      - cmd/
+      - internal/
+      - test/
+    carryforward: true
+  # These integration shards exercise the repo as a whole under different
+  # test partitions, so they intentionally share the same source paths and
+  # rely on flag names to distinguish the uploads.
+  integration-packages:
+    paths:
+      - cmd/
+      - internal/
+      - test/
+    carryforward: true
+  integration-review-formulas:
+    paths:
+      - cmd/
+      - internal/
+      - test/
+    carryforward: true
+  integration-bdstore:
+    paths:
+      - cmd/
+      - internal/
+      - test/
+    carryforward: true
+  integration-rest:
+    paths:
+      - cmd/
+      - internal/
+      - test/
+    carryforward: true

--- a/scripts/merge-coverprofiles
+++ b/scripts/merge-coverprofiles
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(
+            "usage: merge-coverprofiles <output> <input1> [<input2> ...]",
+            file=sys.stderr,
+        )
+        return 1
+
+    output = Path(sys.argv[1])
+    inputs = [Path(path) for path in sys.argv[2:]]
+
+    mode = None
+    merged = {}
+
+    for path in inputs:
+        lines = path.read_text().splitlines()
+        if not lines:
+            continue
+        header = lines[0].strip()
+        if not header.startswith("mode: "):
+            raise SystemExit(f"{path}: missing coverage mode header")
+        current_mode = header.split(": ", 1)[1]
+        if mode is None:
+            mode = current_mode
+        elif current_mode != mode:
+            raise SystemExit(f"{path}: mode {current_mode} != expected {mode}")
+
+        for line in lines[1:]:
+            if not line.strip():
+                continue
+            key, count_text = line.rsplit(" ", 1)
+            count = int(count_text)
+            if key not in merged:
+                merged[key] = count
+                continue
+            if mode == "set":
+                merged[key] = max(merged[key], count)
+            else:
+                merged[key] += count
+
+    if mode is None:
+        raise SystemExit("no coverage profiles supplied")
+
+    output.write_text(
+        "mode: "
+        + mode
+        + "\n"
+        + "\n".join(f"{key} {count}" for key, count in merged.items())
+        + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -58,7 +58,7 @@ run_pkg_tests() {
   if [[ -n "${GO_TEST_COVERPROFILE:-}" ]]; then
     go_test_args+=(-coverpkg=./... -coverprofile "$GO_TEST_COVERPROFILE")
   fi
-  go test "${go_test_args[@]}" "$test_pkg" -run "$regex"
+  GC_FAST_UNIT=0 go test "${go_test_args[@]}" "$test_pkg" -run "$regex"
 }
 
 list_integration_tests() {
@@ -99,7 +99,7 @@ run_packages_shard() {
   if [[ -n "${GO_TEST_COVERPROFILE:-}" ]]; then
     go_test_args+=(-coverpkg=./... -coverprofile "$GO_TEST_COVERPROFILE")
   fi
-  go test "${go_test_args[@]}" "${packages[@]}"
+  GC_FAST_UNIT=0 go test "${go_test_args[@]}" "${packages[@]}"
 }
 
 run_rest_smoke_shard() {

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
-  echo "usage: $0 <packages|review-formulas|bdstore|rest|rest-smoke|rest-full|all>" >&2
+  echo "usage: $0 <packages|review-formulas|review-formulas-basic|review-formulas-retries|review-formulas-recovery|bdstore|rest|rest-smoke|rest-full|all>" >&2
   exit 1
 fi
 
@@ -20,6 +20,21 @@ formula_tests=(
   TestAdoptPRSkipGemini
   TestAdoptPRFormulaRetriesTransientReviewerStep
   TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries
+  TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash
+)
+
+review_formulas_basic_tests=(
+  TestAdoptPRFormulaCompileAndRun
+  TestPersonalWorkFormulaCompileAndRun
+  TestAdoptPRSkipGemini
+)
+
+review_formulas_retry_tests=(
+  TestAdoptPRFormulaRetriesTransientReviewerStep
+  TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries
+)
+
+review_formulas_recovery_tests=(
   TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash
 )
 
@@ -131,12 +146,32 @@ run_rest_full_shard() {
   run_pkg_tests "$pkg" "${rest_tests[@]}"
 }
 
+run_review_formulas_all() {
+  local status=0 st=0
+  "$0" review-formulas-basic || { st=$?; [[ $status -ne 0 ]] || status=$st; }
+  "$0" review-formulas-retries || { st=$?; [[ $status -ne 0 ]] || status=$st; }
+  "$0" review-formulas-recovery || { st=$?; [[ $status -ne 0 ]] || status=$st; }
+  exit "$status"
+}
+
 case "$shard" in
   packages)
     run_packages_shard
     ;;
   review-formulas)
-    run_pkg_tests "$pkg" "${formula_tests[@]}"
+    run_review_formulas_all
+    ;;
+  review-formulas-basic)
+    validate_selected_tests "${review_formulas_basic_tests[@]}"
+    run_pkg_tests "$pkg" "${review_formulas_basic_tests[@]}"
+    ;;
+  review-formulas-retries)
+    validate_selected_tests "${review_formulas_retry_tests[@]}"
+    run_pkg_tests "$pkg" "${review_formulas_retry_tests[@]}"
+    ;;
+  review-formulas-recovery)
+    validate_selected_tests "${review_formulas_recovery_tests[@]}"
+    run_pkg_tests "$pkg" "${review_formulas_recovery_tests[@]}"
     ;;
   bdstore)
     run_pkg_tests "$pkg" TestBdStoreConformance
@@ -153,7 +188,9 @@ case "$shard" in
     ;;
   all)
     "$0" packages
-    "$0" review-formulas
+    "$0" review-formulas-basic
+    "$0" review-formulas-retries
+    "$0" review-formulas-recovery
     "$0" bdstore
     "$0" rest-smoke
     "$0" rest-full

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
-  echo "usage: $0 <packages|review-formulas|bdstore|rest|all>" >&2
+  echo "usage: $0 <packages|review-formulas|bdstore|rest|rest-smoke|rest-full|all>" >&2
   exit 1
 fi
 
@@ -21,6 +21,18 @@ formula_tests=(
   TestAdoptPRFormulaRetriesTransientReviewerStep
   TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries
   TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash
+)
+
+# Keep this list to top-level test names. Matching a parent test runs all of
+# its subtests, so additions here directly widen the every-PR smoke budget.
+rest_smoke_tests=(
+  TestE2E_WorkspaceDefaults
+  TestE2E_Hook_WithWork
+  TestE2E_MailCheck
+  TestE2E_MultiAgent_PoolAndFixed
+  TestGastown_ControllerStartStop
+  TestGastown_PipelineHumanToWorker
+  TestGraphWorkflowSuccessPath
 )
 
 join_regex() {
@@ -53,6 +65,23 @@ list_integration_tests() {
   go test -tags integration -list '^Test' "$pkg" | grep '^Test'
 }
 
+validate_selected_tests() {
+  local -a requested=("$@")
+  local available missing requested_name
+
+  available="$(list_integration_tests)"
+  missing=0
+  for requested_name in "${requested[@]}"; do
+    if ! printf '%s\n' "$available" | grep -Fxq -- "$requested_name"; then
+      echo "missing integration test for shard ${shard}: ${requested_name}" >&2
+      missing=1
+    fi
+  done
+  if [[ $missing -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_packages_shard() {
   # Avoid bash 4 `mapfile` so this runs on macOS's stock bash 3.2.
   local -a packages=()
@@ -73,14 +102,19 @@ run_packages_shard() {
   go test "${go_test_args[@]}" "${packages[@]}"
 }
 
-run_rest_shard() {
+run_rest_smoke_shard() {
+  validate_selected_tests "${rest_smoke_tests[@]}"
+  run_pkg_tests "$pkg" "${rest_smoke_tests[@]}"
+}
+
+run_rest_full_shard() {
   # bash 3.2 has no associative arrays; encode the excluded set as a
   # newline-delimited string and use grep -Fx to test membership.
   local -a all_tests=() rest_tests=()
   local excluded excluded_name test_name
 
   excluded=""
-  for excluded_name in "${formula_tests[@]}" TestBdStoreConformance; do
+  for excluded_name in "${formula_tests[@]}" "${rest_smoke_tests[@]}" TestBdStoreConformance; do
     excluded+="${excluded_name}"$'\n'
   done
 
@@ -107,14 +141,22 @@ case "$shard" in
   bdstore)
     run_pkg_tests "$pkg" TestBdStoreConformance
     ;;
+  rest-smoke)
+    run_rest_smoke_shard
+    ;;
+  rest-full)
+    run_rest_full_shard
+    ;;
   rest)
-    run_rest_shard
+    run_rest_smoke_shard
+    run_rest_full_shard
     ;;
   all)
     "$0" packages
     "$0" review-formulas
     "$0" bdstore
-    "$0" rest
+    "$0" rest-smoke
+    "$0" rest-full
     ;;
   *)
     echo "unknown shard: ${shard}" >&2

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -32,6 +32,7 @@ run_pkg_tests() {
   local test_pkg="$1"
   shift
   local -a tests=("$@")
+  local -a go_test_args=()
   local regex
 
   if [[ ${#tests[@]} -eq 0 ]]; then
@@ -41,7 +42,11 @@ run_pkg_tests() {
 
   regex="^($(join_regex "${tests[@]}"))$"
   echo "Running shard ${shard} against ${test_pkg} (${#tests[@]} tests)"
-  go test -tags integration -timeout "$timeout" "$test_pkg" -run "$regex"
+  go_test_args=(-tags integration -timeout "$timeout")
+  if [[ -n "${GO_TEST_COVERPROFILE:-}" ]]; then
+    go_test_args+=(-coverpkg=./... -coverprofile "$GO_TEST_COVERPROFILE")
+  fi
+  go test "${go_test_args[@]}" "$test_pkg" -run "$regex"
 }
 
 list_integration_tests() {
@@ -51,6 +56,7 @@ list_integration_tests() {
 run_packages_shard() {
   # Avoid bash 4 `mapfile` so this runs on macOS's stock bash 3.2.
   local -a packages=()
+  local -a go_test_args=()
   local line
   while IFS= read -r line; do
     packages+=("$line")
@@ -60,7 +66,11 @@ run_packages_shard() {
     exit 1
   fi
   echo "Running shard packages (${#packages[@]} packages)"
-  go test -tags integration -timeout "$timeout" "${packages[@]}"
+  go_test_args=(-tags integration -timeout "$timeout")
+  if [[ -n "${GO_TEST_COVERPROFILE:-}" ]]; then
+    go_test_args+=(-coverpkg=./... -coverprofile "$GO_TEST_COVERPROFILE")
+  fi
+  go test "${go_test_args[@]}" "${packages[@]}"
 }
 
 run_rest_shard() {

--- a/test/agents/graph-dispatch.sh
+++ b/test/agents/graph-dispatch.sh
@@ -168,6 +168,10 @@ show_assignee() {
     timeout 10 bd show --json "$1" | json_payload | jq_bead '.assignee'
 }
 
+refresh_bead_json() {
+    timeout 10 bd show --json "$1" 2>/dev/null
+}
+
 owned_status_ok() {
     local status="$1"
     local assignee="$2"
@@ -412,29 +416,20 @@ while true; do
             ;;
     esac
 
-    status_before=$(show_status "$bead_id" 2>/dev/null || true)
-    outcome_before=$(show_outcome "$bead_id" 2>/dev/null || true)
-    assignee_before=$(show_assignee "$bead_id" 2>/dev/null || true)
-    if [ "$outcome_before" = "skipped" ]; then
-        trace "skip-terminal bead=$bead_id ref=$ref status=$status_before outcome=$outcome_before"
+    if ! bead_json=$(refresh_bead_json "$bead_id"); then
+        trace "state-refresh-failed bead=$bead_id ref=$ref"
         sleep 0.2
         continue
     fi
-    if [ "$owns_bead" = "true" ]; then
-        if ! owned_status_ok "$status_before" "$assignee_before"; then
-            trace "skip-terminal bead=$bead_id ref=$ref status=$status_before outcome=$outcome_before assignee=$assignee_before"
-            sleep 0.2
-            continue
-        fi
-    elif [ "$status_before" != "open" ]; then
-        trace "skip-terminal bead=$bead_id ref=$ref status=$status_before outcome=$outcome_before"
+    bead_payload=$(printf '%s\n' "$bead_json" | json_payload)
+    if [ -z "$bead_payload" ] || ! printf '%s\n' "$bead_payload" | jq -e . >/dev/null 2>&1; then
+        trace "state-refresh-failed bead=$bead_id ref=$ref reason=invalid-json"
         sleep 0.2
         continue
     fi
-
-    status_before=$(show_status "$bead_id" 2>/dev/null || true)
-    outcome_before=$(show_outcome "$bead_id" 2>/dev/null || true)
-    assignee_before=$(show_assignee "$bead_id" 2>/dev/null || true)
+    status_before=$(printf '%s\n' "$bead_payload" | jq_bead '.status')
+    outcome_before=$(printf '%s\n' "$bead_payload" | jq_bead '.metadata["gc.outcome"]')
+    assignee_before=$(printf '%s\n' "$bead_payload" | jq_bead '.assignee')
     if [ "$outcome_before" = "skipped" ]; then
         trace "skip-before-action bead=$bead_id ref=$ref status=$status_before outcome=$outcome_before"
         sleep 0.2

--- a/test/integration/graph_dispatch_test.go
+++ b/test/integration/graph_dispatch_test.go
@@ -209,35 +209,26 @@ func startScopedWorkflow(t *testing.T, cityDir string) (string, string) {
 	}
 	slingOutput := out
 
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+	if _, workflowID, err := waitForBeadMetadataValue(t, cityDir, issueID, "workflow_id", 10*time.Second); err == nil {
+		return issueID, workflowID
+	} else {
 		issue := showBead(t, cityDir, issueID)
-		if workflowID := metaValue(issue, "workflow_id"); workflowID != "" {
-			return issueID, workflowID
-		}
-		time.Sleep(200 * time.Millisecond)
+		t.Fatalf("timed out waiting for workflow_id on source bead %s: %v\ngc sling output:\n%s\nsource bead:\n%+v", issueID, err, slingOutput, issue)
 	}
-
-	issue := showBead(t, cityDir, issueID)
-	t.Fatalf("timed out waiting for workflow_id on source bead %s\ngc sling output:\n%s\nsource bead:\n%+v", issueID, slingOutput, issue)
 	return "", ""
 }
 
 func waitForBeadClosed(t *testing.T, cityDir, beadID string, timeout time.Duration) graphBead {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		bead, err := tryShowBead(cityDir, beadID)
-		if err != nil {
-			t.Logf("bd show error (retrying): %v", err)
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		if bead.Status == "closed" {
-			return bead
-		}
-		time.Sleep(200 * time.Millisecond)
+	var waitErr error
+	if bead, err := waitForBeadCondition(t, cityDir, beadID, timeout, func(bead graphBead) bool {
+		return bead.Status == "closed"
+	}); err == nil {
+		return bead
+	} else {
+		waitErr = err
+		t.Logf("waitForBeadClosed(%s) ended with %v; collecting diagnostics", beadID, err)
 	}
 
 	out, err := bdDolt(cityDir, "list", "--json", "--all", "--limit=0")
@@ -262,8 +253,8 @@ func waitForBeadClosed(t *testing.T, cityDir, beadID string, timeout time.Durati
 	}
 	traceOut := readOptionalFile(filepath.Join(cityDir, "graph-workflow-trace.log"))
 	workflowTraceOut := readOptionalFile(filepath.Join(cityDir, "control-dispatcher-trace.log"))
-	t.Fatalf("timed out waiting for bead %s to close\nready:\n%s\nready worker:\n%s\nsessions:\n%s\nworker peek:\n%s\ntrace:\n%s\nworkflow trace:\n%s\nbeads:\n%s",
-		beadID, readyOut, readyAssigneeOut, sessionListOut, sessionPeekOut, traceOut, workflowTraceOut, out)
+	t.Fatalf("waiting for bead %s to close failed: %v\nready:\n%s\nready worker:\n%s\nsessions:\n%s\nworker peek:\n%s\ntrace:\n%s\nworkflow trace:\n%s\nbeads:\n%s",
+		beadID, waitErr, readyOut, readyAssigneeOut, sessionListOut, sessionPeekOut, traceOut, workflowTraceOut, out)
 	return graphBead{}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -408,12 +408,21 @@ func bdDolt(dir string, args ...string) (string, error) {
 			"GC_CITY_PATH="+dir,
 			"GC_CITY_RUNTIME_DIR="+filepath.Join(dir, ".gc", "runtime"),
 		)
-		if port, ok := currentManagedDoltPortForTest(dir); ok {
+		if port, ok := ensureManagedDoltPortForTest(dir); ok {
 			env = filterEnv(env, "GC_DOLT_PORT")
 			env = append(env, "GC_DOLT_PORT="+port)
 		}
 	}
-	return runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
+	out, err := runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
+	if err == nil || dir == "" || !managedDoltTransportRetryable(out) {
+		return out, err
+	}
+	if port, ok := ensureManagedDoltPortForTest(dir); ok {
+		env = filterEnv(env, "GC_DOLT_PORT")
+		env = append(env, "GC_DOLT_PORT="+port)
+		return runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
+	}
+	return out, err
 }
 
 func runGCWithEnv(env []string, dir string, args ...string) (string, error) {
@@ -847,6 +856,44 @@ func currentManagedDoltPortForTest(cityDir string) (string, bool) {
 		return "", false
 	}
 	return port, true
+}
+
+func ensureManagedDoltPortForTest(cityDir string) (string, bool) {
+	if port, ok := currentManagedDoltPortForTest(cityDir); ok {
+		return port, true
+	}
+	if cityDir == "" {
+		return "", false
+	}
+	startOut, startErr := runGCDoltWithEnv(commandEnvForDir(cityDir, true), "", "start", cityDir)
+	if startErr != nil && !isGCStartAlreadyRunning(startOut) {
+		return "", false
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if port, ok := currentManagedDoltPortForTest(cityDir); ok {
+			return port, true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return "", false
+}
+
+func managedDoltTransportRetryable(out string) bool {
+	msg := strings.ToLower(out)
+	for _, marker := range []string{
+		"dolt server unreachable",
+		"dial tcp",
+		"connection refused",
+		"broken pipe",
+		"unexpected eof",
+		"bad connection",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func testPortReachable(port string) bool {

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -230,7 +230,7 @@ func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {
 		"GC_CITY_PATH="+cityDir,
 		"GC_CITY_RUNTIME_DIR="+filepath.Join(cityDir, ".gc", "runtime"),
 	)
-	if port, ok := currentManagedDoltPortForTest(cityDir); ok {
+	if port, ok := ensureManagedDoltPortForTest(cityDir); ok {
 		env = append(env, "GC_DOLT_PORT="+port)
 	}
 	return env

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -896,16 +896,14 @@ func startReviewWorkflow(t *testing.T, cityDir, formula string, vars map[string]
 	if err != nil {
 		t.Fatalf("gc sling failed: %v\noutput: %s", err, out)
 	}
+	slingOutput := out
 
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+	if _, wid, err := waitForBeadMetadataValue(t, cityDir, issueID, "workflow_id", 10*time.Second); err == nil {
+		return issueID, wid
+	} else {
 		issue := showBead(t, cityDir, issueID)
-		if wid := metaValue(issue, "workflow_id"); wid != "" {
-			return issueID, wid
-		}
-		time.Sleep(200 * time.Millisecond)
+		t.Fatalf("timed out waiting for workflow_id on %s: %v\ngc sling output:\n%s\nsource bead:\n%+v", issueID, err, slingOutput, issue)
 	}
-	t.Fatalf("timed out waiting for workflow_id on %s", issueID)
 	return "", ""
 }
 

--- a/test/integration/workflow_event_wait_test.go
+++ b/test/integration/workflow_event_wait_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+const (
+	beadEventScanInterval       = 250 * time.Millisecond
+	beadFallbackRefreshInterval = 200 * time.Millisecond
+)
+
+func waitForBeadCondition(t *testing.T, cityDir, beadID string, timeout time.Duration, predicate func(graphBead) bool) (graphBead, error) {
+	t.Helper()
+
+	eventLog := filepath.Join(cityDir, ".gc", "events.jsonl")
+	offset := eventLogOffset(eventLog)
+
+	if bead, err := tryShowBead(cityDir, beadID); err == nil {
+		if predicate(bead) {
+			return bead, nil
+		}
+	} else {
+		t.Logf("bd show error before waiting for %s (retrying via events): %v", beadID, err)
+	}
+
+	eventTicker := time.NewTicker(beadEventScanInterval)
+	defer eventTicker.Stop()
+	refreshTicker := time.NewTicker(beadFallbackRefreshInterval)
+	defer refreshTicker.Stop()
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	for {
+		shouldRefresh := false
+		select {
+		case <-timeoutTimer.C:
+			return graphBead{}, context.DeadlineExceeded
+		case <-refreshTicker.C:
+			shouldRefresh = true
+		case <-eventTicker.C:
+			matched, newOffset, err := beadEventsMentionSubject(eventLog, offset, beadID)
+			if err != nil {
+				t.Logf("event log read error while waiting for %s (falling back to periodic refresh): %v", beadID, err)
+				continue
+			}
+			offset = newOffset
+			shouldRefresh = matched
+		}
+		if !shouldRefresh {
+			continue
+		}
+
+		bead, err := tryShowBead(cityDir, beadID)
+		if err != nil {
+			t.Logf("bd show error while waiting for %s (retrying): %v", beadID, err)
+			continue
+		}
+		if predicate(bead) {
+			return bead, nil
+		}
+	}
+}
+
+func waitForBeadMetadataValue(t *testing.T, cityDir, beadID, key string, timeout time.Duration) (graphBead, string, error) {
+	t.Helper()
+
+	bead, err := waitForBeadCondition(t, cityDir, beadID, timeout, func(bead graphBead) bool {
+		return metaValue(bead, key) != ""
+	})
+	if err != nil {
+		return graphBead{}, "", err
+	}
+	return bead, metaValue(bead, key), nil
+}
+
+func beadEventsMentionSubject(path string, offset int64, subject string) (bool, int64, error) {
+	evts, newOffset, err := events.ReadFrom(path, offset)
+	if err != nil {
+		return false, newOffset, err
+	}
+	for _, evt := range evts {
+		if evt.Subject != subject {
+			continue
+		}
+		switch evt.Type {
+		case events.BeadCreated, events.BeadUpdated, events.BeadClosed:
+			return true, newOffset, nil
+		}
+	}
+	return false, newOffset, nil
+}
+
+func eventLogOffset(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}


### PR DESCRIPTION
## Summary
- split unit coverage from integration shard coverage and keep Codecov coverage intact across the new shard layout
- gate the Linux review-formulas and rest-full suites so the default PR path runs the cheaper required checks first
- move the slow `cmd/gc` process-backed cases out of the fast unit loop and trim review-formula harness polling/CLI churn

## Validation
- `bash -n scripts/test-integration-shard`
- `python3 -c 'import yaml; yaml.safe_load(open("codecov.yml")); print("codecov.yml ok")'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/nightly.yml .github/workflows/rc-gate.yml`
- `env GC_FAST_UNIT=1 go test ./cmd/gc`
- `env GC_FAST_UNIT=1 make test-cover`
- `go test -tags integration ./test/integration -run '^TestGraphWorkflowSuccessPath$' -count=1`
- `go test -tags integration ./test/integration -run '^TestAdoptPRFormulaCompileAndRun$' -count=1`
- `go test -tags integration ./test/integration -run '^TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash$' -count=1`
- `go test -tags integration ./test/integration -run '^TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries$' -count=1`
- `go test -tags integration ./test/integration -run '^TestGraphWorkflowSuccessPath$|^TestAdoptPRFormulaCompileAndRun$' -count=1`
