### PR TITLE
fix(molecule): convert GraphApplyEnabled to atomic.Bool to close config-reload race

### DIFF
--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -131,8 +131,9 @@ func TestAttachBasic(t *testing.T) {
 }
 
 func TestAttachBasicGraphApplyPreservesWorkflowRootID(t *testing.T) {
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 
 	store := beads.NewMemStore()
 	root := setupWorkflow(t, store)

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -17,15 +17,21 @@ import (
 // graphApplyEnabled controls whether Instantiate uses the GraphApplyStore
 // batch path. When false, falls back to sequential bead creation.
 // Set by the daemon config loader from [daemon] formula_v2.
+//
+// Stored as atomic.Bool so config reload can race safely with in-flight
+// instantiation. Each instantiate call snapshots the value once via
+// IsGraphApplyEnabled.
 var graphApplyEnabled atomic.Bool
 
-// SetGraphApplyEnabled toggles the graph-batch apply path. Called from the
-// daemon config loader when [daemon] formula_v2 changes.
-func SetGraphApplyEnabled(enabled bool) {
-	graphApplyEnabled.Store(enabled)
+// SetGraphApplyEnabled sets the graph-apply batch instantiation flag. Safe
+// for concurrent use with IsGraphApplyEnabled; intended for the daemon
+// config loader and tests.
+func SetGraphApplyEnabled(v bool) {
+	graphApplyEnabled.Store(v)
 }
 
-// IsGraphApplyEnabled reports whether graph-batch apply is currently active.
+// IsGraphApplyEnabled reports whether graph-apply batch instantiation is
+// allowed. Safe for concurrent use.
 func IsGraphApplyEnabled() bool {
 	return graphApplyEnabled.Load()
 }

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -102,8 +102,9 @@ func TestInstantiateSimple(t *testing.T) {
 
 func TestInstantiateUsesGraphApplyStoreWhenAvailable(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -201,8 +202,9 @@ func TestBuildRecipeApplyPlan_GraphWorkflowOwnershipUsesTracks(t *testing.T) {
 
 func TestInstantiateGraphApplyPreservesStepMetadata(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -239,8 +241,9 @@ func TestInstantiateGraphApplyPreservesStepMetadata(t *testing.T) {
 func TestInstantiateSequentialPathPreservesStepMetadata(t *testing.T) {
 	// Verify the NON-graph-apply (sequential) path also preserves step metadata.
 	store := beads.NewMemStore() // MemStore does NOT implement GraphApplyStore
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(false)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -279,8 +282,9 @@ func TestInstantiateSequentialPathPreservesStepMetadata(t *testing.T) {
 
 func TestInstantiateUsesGraphApplyStoreForRetryLogicalRefs(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -355,8 +359,9 @@ func TestInstantiatePriorityOverrideCopiesToAllBeads(t *testing.T) {
 
 func TestInstantiateUsesGraphApplyPriorityOverride(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 
 	recipe := &formula.Recipe{
 		Name: "wf",
@@ -459,8 +464,9 @@ func TestInstantiateRejectsPartialGraphApplyResult(t *testing.T) {
 			},
 		},
 	}
+	prev := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
-	t.Cleanup(func() { SetGraphApplyEnabled(false) })
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -1405,8 +1411,9 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 
 	t.Run("graph-apply path rejects unresolved vars", func(t *testing.T) {
 		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+		prev := IsGraphApplyEnabled()
 		SetGraphApplyEnabled(true)
-		t.Cleanup(func() { SetGraphApplyEnabled(false) })
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 
 		_, err := Instantiate(context.Background(), gaStore, recipe, Options{
 			Title: "My Feature",
@@ -1443,8 +1450,9 @@ func TestInstantiateFragmentRejectsResidualTitleVars(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		prev := IsGraphApplyEnabled()
 		SetGraphApplyEnabled(false)
-		t.Cleanup(func() { SetGraphApplyEnabled(false) })
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 
 		_, err = InstantiateFragment(context.Background(), store, fragment, FragmentOptions{
 			RootID: root.ID,
@@ -1465,8 +1473,9 @@ func TestInstantiateFragmentRejectsResidualTitleVars(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		prev := IsGraphApplyEnabled()
 		SetGraphApplyEnabled(true)
-		t.Cleanup(func() { SetGraphApplyEnabled(false) })
+		t.Cleanup(func() { SetGraphApplyEnabled(prev) })
 
 		_, err = InstantiateFragment(context.Background(), gaStore, fragment, FragmentOptions{
 			RootID: root.ID,


### PR DESCRIPTION
Closes #827.

## Summary

`molecule.GraphApplyEnabled` was reported as a package-level feature flag that could be written by config reload while molecule instantiation and Ralph retry paths read it. Current `main` now already contains the production fix: the flag is an unexported `atomic.Bool` behind `SetGraphApplyEnabled` / `IsGraphApplyEnabled`, and production readers/writers use those accessors.

After rebasing this PR on current `main`, the remaining branch keeps the useful follow-up pieces from the original fix:

- save and restore the previous graph-apply flag value in molecule tests instead of always resetting it to `false`
- expand the graph-apply accessor documentation to state the concurrent reload/instantiation safety contract

## Changes

**Tests**

Converted molecule-package test cleanup from hardcoded-false reset:

```go
SetGraphApplyEnabled(true)
t.Cleanup(func() { SetGraphApplyEnabled(false) })
```

to save/restore:

```go
prev := IsGraphApplyEnabled()
SetGraphApplyEnabled(true)
t.Cleanup(func() { SetGraphApplyEnabled(prev) })
```

This preserves any ambient flag state a higher-level test may have set and avoids corrupting later tests if the default ever changes.

**Docs**

`internal/molecule/graph_apply.go` now documents that the accessors are safe for config reload racing with in-flight instantiation, matching the intent of the `formulaV2Enabled` atomic flag.

## Verification

Adoption review ran against the rebased branch and found no code issues:

- Claude reviewer: approve, no new findings
- Codex reviewer: approve, no new findings
- Gemini reviewer: approve, no new findings
- Synthesis: approve

Local verification is run by the maintainer before merge, and GitHub CI must pass before this PR is merged.

## Not included

- Decoupling `[daemon] graph_apply` from `formula_v2` as a standalone config entry
- Adding a generic `testutil.WithFlag(t, Get, Set, v)` helper
- Cross-flag write atomicity if `formula_v2` and graph apply ever need to flip as an observable pair
