### PR TITLE
fix: gc doctor config-refs false positives for schema=2 packs (#759)

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -166,23 +166,23 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 	for _, a := range c.cfg.Agents {
 		qn := a.QualifiedName()
 		if a.PromptTemplate != "" {
-			path := filepath.Join(c.cityPath, a.PromptTemplate)
+			path := resolveConfigRefPath(c.cityPath, a.PromptTemplate)
 			if _, err := os.Stat(path); err != nil {
-				issues = append(issues, fmt.Sprintf("agent %q: prompt_template %q not found", qn, a.PromptTemplate))
+				issues = append(issues, fmt.Sprintf("agent %q: prompt_template %q not found", qn, path))
 			}
 		}
 		if a.SessionSetupScript != "" {
-			path := filepath.Join(c.cityPath, a.SessionSetupScript)
+			path := resolveConfigRefPath(c.cityPath, a.SessionSetupScript)
 			if _, err := os.Stat(path); err != nil {
-				issues = append(issues, fmt.Sprintf("agent %q: session_setup_script %q not found", qn, a.SessionSetupScript))
+				issues = append(issues, fmt.Sprintf("agent %q: session_setup_script %q not found", qn, path))
 			}
 		}
 		if a.OverlayDir != "" {
-			path := filepath.Join(c.cityPath, a.OverlayDir)
+			path := resolveConfigRefPath(c.cityPath, a.OverlayDir)
 			if fi, err := os.Stat(path); err != nil {
-				issues = append(issues, fmt.Sprintf("agent %q: overlay_dir %q not found", qn, a.OverlayDir))
+				issues = append(issues, fmt.Sprintf("agent %q: overlay_dir %q not found", qn, path))
 			} else if !fi.IsDir() {
-				issues = append(issues, fmt.Sprintf("agent %q: overlay_dir %q is not a directory", qn, a.OverlayDir))
+				issues = append(issues, fmt.Sprintf("agent %q: overlay_dir %q is not a directory", qn, path))
 			}
 		}
 		if a.Provider != "" && len(c.cfg.Providers) > 0 {
@@ -208,6 +208,16 @@ func (c *ConfigRefsCheck) CanFix() bool { return false }
 
 // Fix is a no-op.
 func (c *ConfigRefsCheck) Fix(_ *CheckContext) error { return nil }
+
+// resolveConfigRefPath resolves an agent config path reference against the
+// city root. Schema=2 packs emit absolute paths; legacy [[agent]] tables
+// use city-relative paths, so guard against double-rooting before joining.
+func resolveConfigRefPath(cityPath, p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(cityPath, p)
+}
 
 // BuiltinPackFamilyCheck fails when a city overrides only one member of the
 // builtin bd/dolt pack family. Mixed system/user families are unsupported.

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -272,6 +272,71 @@ func TestConfigRefsCheck_MultipleIssues(t *testing.T) {
 	}
 }
 
+// Regression for schema=2 packs: convention-discovered agents store
+// prompt_template / session_setup_script / overlay_dir as absolute paths.
+// The check must stat them directly instead of joining against cityPath,
+// which doubles the root prefix and makes every file "not found".
+func TestConfigRefsCheck_AbsolutePaths(t *testing.T) {
+	cases := []struct {
+		name         string
+		createFiles  bool
+		overlayIsDir bool // only applies when createFiles=true
+		wantStatus   CheckStatus
+		wantIssues   int
+	}{
+		{"existing_files", true, true, StatusOK, 0},
+		{"missing_files", false, false, StatusWarning, 3},
+		{"overlay_is_file_not_dir", true, false, StatusWarning, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			packDir := t.TempDir()
+			absPrompt := filepath.Join(packDir, "agents", "mayor", "prompt.template.md")
+			absScript := filepath.Join(packDir, "agents", "mayor", "setup.sh")
+			absOverlay := filepath.Join(packDir, "agents", "mayor", "overlay")
+			if tc.createFiles {
+				if err := os.MkdirAll(filepath.Dir(absPrompt), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(absPrompt, []byte("hi"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(absScript, []byte("#!/bin/sh"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if tc.overlayIsDir {
+					if err := os.MkdirAll(absOverlay, 0o755); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					if err := os.WriteFile(absOverlay, []byte("file-not-dir"), 0o644); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			cfg := &config.City{
+				Agents: []config.Agent{{
+					Name:               "mayor",
+					PromptTemplate:     absPrompt,
+					SessionSetupScript: absScript,
+					OverlayDir:         absOverlay,
+				}},
+			}
+			c := NewConfigRefsCheck(cfg, cityDir)
+			r := c.Run(&CheckContext{})
+			if r.Status != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; msg = %s; details = %v",
+					r.Status, tc.wantStatus, r.Message, r.Details)
+			}
+			if len(r.Details) != tc.wantIssues {
+				t.Errorf("got %d issues, want %d: %v", len(r.Details), tc.wantIssues, r.Details)
+			}
+		})
+	}
+}
+
 // --- BuiltinPackFamilyCheck ---
 
 func TestBuiltinPackFamilyCheck_Unmodified(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #759. `gc doctor config-refs` reported `prompt_template not found` and `overlay_dir not found` warnings for schema=2 packs whose files exist on disk (2×N spurious warnings per pack).

## Root cause

Schema=2 packs discovered via `DiscoverPackAgents` (`internal/config/agent_discovery.go:51,58`) store `PromptTemplate` and `OverlayDir` as **absolute** paths — discovery calls `filepath.Join(agentDir, name)` where `agentDir` is already absolute. The doctor check was then unconditionally doing `filepath.Join(cityPath, absPath)`, which produces a double-rooted path (`/home/user/gcity/home/user/gcity/...`) that `os.Stat` can never find. The error message printed the raw field, not the path that was stat'd, so rileywhite's 0.15.1 reproduction showed a well-formed absolute path in the warning but the file "not found."

## Fix

Adds an `IsAbs`-guard helper `resolveConfigRefPath` in `internal/doctor/checks.go` and uses it at the three affected call sites (`PromptTemplate`, `SessionSetupScript`, `OverlayDir`). Error messages now print the resolved path so users can paste it into `ls`/`stat` to reproduce. Regression test is table-driven with rows for `existing_files`, `missing_files`, and `overlay_is_file_not_dir`.

## Why at the check layer, not storage

The abs-path storage convention is load-bearing elsewhere — `internal/migrate/migrate.go:459`, `internal/runtime/tmux/adapter.go:91`, `internal/runtime/subprocess/subprocess.go:102`, and `internal/runtime/k8s/staging.go:46` all consume these fields and already handle absolute paths via their own `IsAbs` guards or via `os.Stat` (which accepts absolute input directly). Changing storage would ripple through runtime fingerprinting, migrate's resolver, and three runtime adapters — the surgical fix belongs at the single buggy call site.

## Test plan

- [x] `go test ./internal/doctor/ -run ConfigRefsCheck -v` — 10 subtests pass (7 preexisting relative-path tests + 3 new abs-path rows)
- [x] Verified the fix is load-bearing: with the fix reverted, `TestConfigRefsCheck_AbsolutePaths/existing_files` fails with the exact `prompt_template "/...abs-path..." not found` symptom rileywhite reported on 0.15.1
- [x] `go vet ./internal/doctor/...` clean, `gofmt` clean
- [x] Grepped the rest of the repo for parallel sibling call sites of the `Join(cityPath, agent.<field>)` anti-pattern — none found

## Follow-up (not in this PR)

Five near-identical `IsAbs`-guarded path resolvers now exist across `internal/migrate`, `cmd/gc/pool.go`, `cmd/gc/cmd_start.go`, `cmd/gc/doctor_v2_checks.go`, and `internal/doctor`. Worth consolidating into a shared helper in a separate refactor PR; three of the four existing ones also apply `filepath.Clean` while this new one deliberately does not (Clean can change `os.Stat` semantics on symlink-sensitive `..` paths).