### PR TITLE
test(tier_b): fix TestLifecycle timeouts after PR #666 (ga-k7s)

### DIFF
--- a/test/acceptance/helpers/lifecycle.go
+++ b/test/acceptance/helpers/lifecycle.go
@@ -132,12 +132,38 @@ func (c *City) WaitForReport(name string, timeout time.Duration) map[string]stri
 	// One more try with diagnostics.
 	data, err := os.ReadFile(reportFile)
 	if err != nil {
+		c.dumpDiagnostics(name)
 		c.t.Fatalf("report for %q not found after %s: %v", name, timeout, err)
 	}
 	if !strings.Contains(string(data), "REPORT_DONE=true") {
+		c.dumpDiagnostics(name)
 		c.t.Fatalf("report for %q incomplete after %s:\n%s", name, timeout, string(data))
 	}
 	return parseEnvReport(string(data))
+}
+
+// dumpDiagnostics prints useful debugging info when a report wait fails.
+func (c *City) dumpDiagnostics(name string) {
+	c.t.Helper()
+	c.t.Logf("=== DIAGNOSTICS for %q in %s ===", name, c.Dir)
+	// Check .gc dir contents.
+	if out, err := exec.Command("bash", "-c", "find "+c.Dir+"/.gc -maxdepth 4 -type f 2>/dev/null | head -40").CombinedOutput(); err == nil {
+		c.t.Logf(".gc files:\n%s", out)
+	}
+	// Try gc status.
+	if out, err := c.GC("status", "--city", c.Dir); err == nil {
+		c.t.Logf("gc status:\n%s", out)
+	}
+	// Dump recent supervisor log.
+	if gcHome := c.Env.vars["GC_HOME"]; gcHome != "" {
+		if out, err := exec.Command("tail", "-n", "200", filepath.Join(gcHome, "supervisor.log")).CombinedOutput(); err == nil {
+			c.t.Logf("supervisor.log tail:\n%s", out)
+		}
+	}
+	// Dump any logs under .gc
+	if out, err := exec.Command("bash", "-c", "for f in "+c.Dir+"/.gc/*.log "+c.Dir+"/.gc/runtime/*.log; do echo \"--- $f ---\"; tail -n 100 \"$f\" 2>/dev/null; done").CombinedOutput(); err == nil {
+		c.t.Logf("city logs:\n%s", out)
+	}
 }
 
 func parseEnvReport(s string) map[string]string {
@@ -186,6 +212,15 @@ func (c *City) WriteE2EConfig(agents []E2EAgent) {
 			if a.Pool.ScaleCheck != "" {
 				fmt.Fprintf(&b, "check = %q\n", a.Pool.ScaleCheck)
 			}
+		}
+		// Reserve a canonical named session so the lifecycle reconciler
+		// materializes and starts the agent. Without this, post-PR-666 the
+		// template is just config and never runs until work arrives. Drain-ack
+		// still transitions the session to the sticky "drained" state, so
+		// mode=always does not prevent the drain-ack tests from observing a
+		// stopped session.
+		if !a.Suspended && a.Pool == nil {
+			fmt.Fprintf(&b, "\n[[named_session]]\ntemplate = %q\nmode = \"always\"\n", a.Name)
 		}
 	}
 

--- a/test/acceptance/helpers/lifecycle.go
+++ b/test/acceptance/helpers/lifecycle.go
@@ -1,6 +1,7 @@
 package acceptancehelpers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -143,26 +144,71 @@ func (c *City) WaitForReport(name string, timeout time.Duration) map[string]stri
 }
 
 // dumpDiagnostics prints useful debugging info when a report wait fails.
+// Each external command is bounded by diagTimeout so a wedged diagnostic
+// (e.g. an unresponsive supervisor under gc status) cannot convert a
+// ~60s report-wait failure into an indefinite CI stall.
 func (c *City) dumpDiagnostics(name string) {
 	c.t.Helper()
 	c.t.Logf("=== DIAGNOSTICS for %q in %s ===", name, c.Dir)
-	// Check .gc dir contents.
-	if out, err := exec.Command("bash", "-c", "find "+c.Dir+"/.gc -maxdepth 4 -type f 2>/dev/null | head -40").CombinedOutput(); err == nil {
-		c.t.Logf(".gc files:\n%s", out)
+
+	const diagTimeout = 10 * time.Second
+
+	// List .gc dir contents. Direct exec (no shell), so paths with spaces
+	// or glob metacharacters in TMPDIR don't break the diagnostic itself.
+	ctx, cancel := context.WithTimeout(context.Background(), diagTimeout)
+	if out, err := exec.CommandContext(ctx, "find", filepath.Join(c.Dir, ".gc"), "-maxdepth", "4", "-type", "f").CombinedOutput(); err == nil {
+		lines := strings.SplitN(string(out), "\n", 41)
+		if len(lines) > 40 {
+			lines = lines[:40]
+		}
+		c.t.Logf(".gc files:\n%s", strings.Join(lines, "\n"))
 	}
-	// Try gc status.
-	if out, err := c.GC("status", "--city", c.Dir); err == nil {
-		c.t.Logf("gc status:\n%s", out)
+	cancel()
+
+	// gc status. RunGC takes no context, so bound it via a goroutine timer.
+	statusCh := make(chan string, 1)
+	go func() {
+		out, err := c.GC("status", "--city", c.Dir)
+		if err != nil {
+			statusCh <- ""
+			return
+		}
+		statusCh <- out
+	}()
+	select {
+	case out := <-statusCh:
+		if out != "" {
+			c.t.Logf("gc status:\n%s", out)
+		}
+	case <-time.After(diagTimeout):
+		c.t.Logf("gc status: timed out after %s", diagTimeout)
 	}
-	// Dump recent supervisor log.
+
+	// Supervisor log tail.
 	if gcHome := c.Env.vars["GC_HOME"]; gcHome != "" {
-		if out, err := exec.Command("tail", "-n", "200", filepath.Join(gcHome, "supervisor.log")).CombinedOutput(); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), diagTimeout)
+		if out, err := exec.CommandContext(ctx, "tail", "-n", "200", filepath.Join(gcHome, "supervisor.log")).CombinedOutput(); err == nil {
 			c.t.Logf("supervisor.log tail:\n%s", out)
 		}
+		cancel()
 	}
-	// Dump any logs under .gc
-	if out, err := exec.Command("bash", "-c", "for f in "+c.Dir+"/.gc/*.log "+c.Dir+"/.gc/runtime/*.log; do echo \"--- $f ---\"; tail -n 100 \"$f\" 2>/dev/null; done").CombinedOutput(); err == nil {
-		c.t.Logf("city logs:\n%s", out)
+
+	// City logs: glob in Go + direct exec, to avoid shell interpolation
+	// and so each tail is individually time-bounded.
+	var logs []string
+	for _, pat := range []string{
+		filepath.Join(c.Dir, ".gc", "*.log"),
+		filepath.Join(c.Dir, ".gc", "runtime", "*.log"),
+	} {
+		matches, _ := filepath.Glob(pat)
+		logs = append(logs, matches...)
+	}
+	for _, f := range logs {
+		ctx, cancel := context.WithTimeout(context.Background(), diagTimeout)
+		if out, err := exec.CommandContext(ctx, "tail", "-n", "100", f).CombinedOutput(); err == nil {
+			c.t.Logf("--- %s ---\n%s", f, out)
+		}
+		cancel()
 	}
 }
 
@@ -218,9 +264,13 @@ func (c *City) WriteE2EConfig(agents []E2EAgent) {
 		// template is just config and never runs until work arrives. Drain-ack
 		// still transitions the session to the sticky "drained" state, so
 		// mode=always does not prevent the drain-ack tests from observing a
-		// stopped session.
+		// stopped session. Mirror a.Dir so rig-scoped agents resolve to the
+		// correct TemplateQualifiedName.
 		if !a.Suspended && a.Pool == nil {
 			fmt.Fprintf(&b, "\n[[named_session]]\ntemplate = %q\nmode = \"always\"\n", a.Name)
+			if a.Dir != "" {
+				fmt.Fprintf(&b, "dir = %q\n", a.Dir)
+			}
 		}
 	}
 

--- a/test/acceptance/tier_b/lifecycle_b_test.go
+++ b/test/acceptance/tier_b/lifecycle_b_test.go
@@ -112,14 +112,18 @@ func TestLifecycle_RigAgentGetsBeadsDir(t *testing.T) {
 
 	reportCmd := c.WriteReportScript("worker", true)
 
-	// Write config with a rig-scoped agent.
+	// Write config with a rig-scoped agent. The [[named_session]] entry
+	// reserves a canonical session so the reconciler materializes and
+	// starts the agent even without queued work — post-PR-666 templates
+	// are lazy.
 	cityName := filepath.Base(c.Dir)
 	config := "[workspace]\nname = \"" + cityName + "\"\n" +
 		"\n[beads]\nprovider = \"file\"\n" +
 		"\n[[rigs]]\nname = \"myrig\"\npath = \"" + rigDir + "\"\n" +
 		"\n[[agent]]\nname = \"worker\"\ndir = \"myrig\"\n" +
 		"max_active_sessions = 1\n" +
-		"start_command = \"" + reportCmd + "\"\n"
+		"start_command = \"" + reportCmd + "\"\n" +
+		"\n[[named_session]]\ntemplate = \"worker\"\ndir = \"myrig\"\nmode = \"always\"\n"
 	c.WriteConfig(config)
 
 	c.StartWithSupervisor()


### PR DESCRIPTION
## Summary

Three TestLifecycle_* acceptance tests in tier_b were timing out at ~63s
after PR #666 made agent templates lazy. The tests now pass.

**Root cause:** PR #666 changed the reconciler so agent templates no
longer auto-spawn a session when there is no pending work and no
`[[named_session]]` reservation. The lifecycle tests use agents that
just dump env and drain, so no work ever arrives — the template sits as
config and the report file is never written, so the test times out.

**Fix:** Reserve a canonical `[[named_session]] mode = "always"` for
each non-pool lifecycle test agent, in two places:

1. `test/acceptance/helpers/lifecycle.go` — `WriteE2EConfig` appends
   the block for each non-suspended, non-pool agent. Covers
   `TestLifecycle_AgentGetsCorrectEnv` and
   `TestLifecycle_DrainAckStopsSession`.
2. `test/acceptance/tier_b/lifecycle_b_test.go` —
   `TestLifecycle_RigAgentGetsBeadsDir` writes its config inline, so
   the named_session is added directly in the test. The rig-scoped
   agent requires matching `dir = "myrig"` on the named_session so
   `TemplateQualifiedName()` resolves correctly.

`mode = "always"` ensures the reconciler reserves and starts the
session. Drain-ack still transitions the session to the sticky
"drained" state, so DrainAckStopsSession correctly observes a stopped
session.

Also adds `dumpDiagnostics` that runs on report-wait failure and logs:
`.gc` directory contents, `gc status` output, supervisor.log tail, and
other city-local logs. Future report-wait timeouts will surface more
useful context than a bare "no such file or directory".

## Test plan

- [x] `TestLifecycle_AgentGetsCorrectEnv` passes
- [x] `TestLifecycle_RigAgentGetsBeadsDir` passes
- [x] `TestLifecycle_DrainAckStopsSession` passes
- [x] Full `go test -tags acceptance_b ./test/acceptance/tier_b` passes
- [x] `go vet ./...` clean
- [x] `go test ./internal/config/... ./test/acceptance/helpers/...` passes

---

Closes ga-k7s (polecat-pr).