### PR TITLE
fix: sweep skips pool session beads in creating state

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -960,23 +960,31 @@ func sweepUndesiredPoolSessionBeads(
 		// we observed pool sessions with state=active, last_woke=empty
 		// getting closed before wake ever landed.
 		//
+		// The guard matches both "active" and "awake" because the
+		// reconciler's healStatePatch (session_reconcile.go) rewrites a
+		// live bead from "active" to "awake" whenever the runtime is
+		// alive, and the reconciler treats both values as equivalent
+		// live states. Limiting the guard to "active" alone would leave
+		// the same spin-loop open on the "awake" alias path.
+		//
 		// The guard must only match the post-create window, not crash/
 		// churn/start-failure paths that ALSO clear last_woke_at
 		// (checkStability, checkChurn, and the start-failure branch in
 		// session_lifecycle_parallel.go all clear last_woke_at on beads
 		// that may already be state=active). We distinguish by the
 		// per-start marker creation_complete_at, written atomically with
-		// the state transition by CommitStartedPatch / ConfirmStartedPatch.
-		// A bead is protected while creation_complete_at is recent
-		// (within staleCreatingStateTimeout) AND last_woke_at is still
-		// empty — crash/churn paths do not touch creation_complete_at,
-		// so a post-crash bead whose last successful start was longer
-		// than the timeout ago is sweepable even when wake_attempts or
+		// the state transition by CommitStartedPatch / ConfirmStartedPatch
+		// and restamped by recoverRunningPendingCreate on heal. A bead
+		// is protected while creation_complete_at is recent (within
+		// staleCreatingStateTimeout) AND last_woke_at is still empty —
+		// crash/churn paths do not touch creation_complete_at, so a
+		// post-crash bead whose last successful start was longer than
+		// the timeout ago is sweepable even when wake_attempts or
 		// churn_count are non-zero. The age bound mirrors
 		// staleCreatingState: a missing or zero creation_complete_at is
 		// treated as stale (sweepable) so beads without the per-start
 		// marker (older builds, manually repaired) stay recoverable.
-		if strings.TrimSpace(bead.Metadata["state"]) == "active" &&
+		if state := strings.TrimSpace(bead.Metadata["state"]); (state == "active" || state == "awake") &&
 			strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" &&
 			strings.TrimSpace(bead.Metadata["state_reason"]) == "creation_complete" {
 			if creationCompleteAt, ok := parseRFC3339Metadata(bead.Metadata["creation_complete_at"]); ok &&

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -933,13 +933,19 @@ func sweepUndesiredPoolSessionBeads(
 			continue
 		}
 		// Don't sweep beads that haven't had their tmux started yet — their
-		// work assignment window hasn't opened. Mirrors the same guard in
-		// reapStaleSessionBeads. Without this, a pool's freshly-created
+		// work assignment window hasn't opened. Mirrors the reconciler's
+		// sessionStartRequested signals (`state=creating` +
+		// `pending_create_claim`). Without this, a pool's freshly-created
 		// session bead gets swept on the same tick it's created (no work
 		// assigned → GCSweepSessionBeads closes it), spinning the pool in a
-		// rapid create→sweep→recreate loop.
+		// rapid create→sweep→recreate loop. The `staleCreatingStateTimeout`
+		// bound matches sessionStartRequested's symmetric age guard: a bead
+		// genuinely wedged in `creating` past the timeout must remain
+		// sweepable so other reconcilers can recover or replace it.
 		if bead.Metadata["state"] == "creating" || strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
-			continue
+			if bead.CreatedAt.IsZero() || time.Since(bead.CreatedAt) < staleCreatingStateTimeout {
+				continue
+			}
 		}
 		// Age grace period for the post-creating, pre-wake window. After
 		// session_lifecycle_parallel flips state from "creating" to
@@ -947,13 +953,28 @@ func sweepUndesiredPoolSessionBeads(
 		// before the wake pipeline records last_woke_at. Sweeping that
 		// window produces the same spin as sweeping during creation —
 		// we observed pool sessions with state=active, last_woke=empty
-		// getting closed with close_reason=stale-session before wake ever
-		// landed. Beads that actually drained/stopped keep state values
-		// like "drained"/"asleep"/"failed-create" and are still eligible
-		// for sweep; only pin the active-but-never-woke transient window.
-		// staleCreatingStateTimeout (1m) matches reapStaleSessionBeads'
+		// getting closed before wake ever landed.
+		//
+		// The guard must only match the post-create window, not crash/
+		// churn/start-failure paths that ALSO clear last_woke_at
+		// (checkStability in session_reconcile.go, checkChurn, and the
+		// start-failure branch in session_lifecycle_parallel.go all clear
+		// last_woke_at on a bead that may already be state=active). We
+		// distinguish the post-create window by requiring:
+		//   - state_reason=="creation_complete" (last state transition came
+		//     from the wake commit, not a crash clear)
+		//   - wake_attempts=="0" and churn_count=="0" (no prior crash/churn
+		//     cleared last_woke_at — recordWakeFailure/recordChurn both
+		//     increment these before clearing last_woke_at)
+		// Beads that actually drained/stopped keep state values like
+		// "drained"/"asleep"/"failed-create" and remain sweepable.
+		// staleCreatingStateTimeout (1m) mirrors sessionStartRequested's
 		// symmetric age guard.
-		if bead.Metadata["state"] == "active" && strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" {
+		if bead.Metadata["state"] == "active" &&
+			strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" &&
+			bead.Metadata["state_reason"] == "creation_complete" &&
+			isZeroOrEmpty(bead.Metadata["wake_attempts"]) &&
+			isZeroOrEmpty(bead.Metadata["churn_count"]) {
 			if !bead.CreatedAt.IsZero() && time.Since(bead.CreatedAt) < staleCreatingStateTimeout {
 				continue
 			}
@@ -966,6 +987,15 @@ func sweepUndesiredPoolSessionBeads(
 		candidates = append(candidates, bead)
 	}
 	return len(GCSweepSessionBeads(store, candidates, assignedWorkBeads))
+}
+
+// isZeroOrEmpty reports whether a metadata counter is absent or explicitly "0".
+// Non-numeric values return false so unexpected content fails closed (the
+// post-create protection is only granted when we're certain no prior
+// crash/churn cycle cleared last_woke_at).
+func isZeroOrEmpty(v string) bool {
+	v = strings.TrimSpace(v)
+	return v == "" || v == "0"
 }
 
 func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -962,26 +962,27 @@ func sweepUndesiredPoolSessionBeads(
 		//
 		// The guard must only match the post-create window, not crash/
 		// churn/start-failure paths that ALSO clear last_woke_at
-		// (checkStability in session_reconcile.go, checkChurn, and the
-		// start-failure branch in session_lifecycle_parallel.go all clear
-		// last_woke_at on a bead that may already be state=active). We
-		// distinguish the post-create window by requiring:
-		//   - state_reason=="creation_complete" (last state transition came
-		//     from the wake commit, not a crash clear)
-		//   - wake_attempts=="0" and churn_count=="0" (no prior crash/churn
-		//     cleared last_woke_at — recordWakeFailure/recordChurn both
-		//     increment these before clearing last_woke_at)
-		// Beads that actually drained/stopped keep state values like
-		// "drained"/"asleep"/"failed-create" and remain sweepable.
-		// The age bound mirrors staleCreatingState: a zero CreatedAt is
-		// treated as stale (sweepable) so malformed beads can be recovered.
+		// (checkStability, checkChurn, and the start-failure branch in
+		// session_lifecycle_parallel.go all clear last_woke_at on beads
+		// that may already be state=active). We distinguish by the
+		// per-start marker creation_complete_at, written atomically with
+		// the state transition by CommitStartedPatch / ConfirmStartedPatch.
+		// A bead is protected while creation_complete_at is recent
+		// (within staleCreatingStateTimeout) AND last_woke_at is still
+		// empty — crash/churn paths do not touch creation_complete_at,
+		// so a post-crash bead whose last successful start was longer
+		// than the timeout ago is sweepable even when wake_attempts or
+		// churn_count are non-zero. The age bound mirrors
+		// staleCreatingState: a missing or zero creation_complete_at is
+		// treated as stale (sweepable) so beads without the per-start
+		// marker (older builds, manually repaired) stay recoverable.
 		if strings.TrimSpace(bead.Metadata["state"]) == "active" &&
 			strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" &&
-			strings.TrimSpace(bead.Metadata["state_reason"]) == "creation_complete" &&
-			isZeroOrEmpty(bead.Metadata["wake_attempts"]) &&
-			isZeroOrEmpty(bead.Metadata["churn_count"]) &&
-			!isStaleCreating(bead.CreatedAt) {
-			continue
+			strings.TrimSpace(bead.Metadata["state_reason"]) == "creation_complete" {
+			if creationCompleteAt, ok := parseRFC3339Metadata(bead.Metadata["creation_complete_at"]); ok &&
+				time.Since(creationCompleteAt) < staleCreatingStateTimeout {
+				continue
+			}
 		}
 		template := normalizedSessionTemplate(bead, cfg)
 		agentCfg := findAgentByTemplate(cfg, template)
@@ -991,16 +992,6 @@ func sweepUndesiredPoolSessionBeads(
 		candidates = append(candidates, bead)
 	}
 	return len(GCSweepSessionBeads(store, candidates, assignedWorkBeads))
-}
-
-// isZeroOrEmpty reports whether a metadata counter is absent or explicitly "0".
-// Unexpected (non-zero, non-empty) content returns false, so the protective
-// post-create guard declines to apply and the bead remains sweepable — the
-// guard is only granted when we're certain no prior crash/churn cycle cleared
-// last_woke_at.
-func isZeroOrEmpty(v string) bool {
-	v = strings.TrimSpace(v)
-	return v == "" || v == "0"
 }
 
 // isStaleCreating mirrors staleCreatingState in session_reconcile.go without
@@ -1013,6 +1004,23 @@ func isStaleCreating(createdAt time.Time) bool {
 		return true
 	}
 	return time.Since(createdAt) >= staleCreatingStateTimeout
+}
+
+// parseRFC3339Metadata parses an RFC3339 timestamp metadata value. A missing
+// or unparseable value returns ok=false; the caller treats that as "no per-
+// start marker present" so older beads (pre-creation_complete_at rollout)
+// fall through to the default sweepable path rather than being protected
+// indefinitely.
+func parseRFC3339Metadata(v string) (time.Time, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -930,6 +931,32 @@ func sweepUndesiredPoolSessionBeads(
 		}
 		if sp != nil && sp.IsRunning(bead.Metadata["session_name"]) {
 			continue
+		}
+		// Don't sweep beads that haven't had their tmux started yet — their
+		// work assignment window hasn't opened. Mirrors the same guard in
+		// reapStaleSessionBeads. Without this, a pool's freshly-created
+		// session bead gets swept on the same tick it's created (no work
+		// assigned → GCSweepSessionBeads closes it), spinning the pool in a
+		// rapid create→sweep→recreate loop.
+		if bead.Metadata["state"] == "creating" || strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
+			continue
+		}
+		// Age grace period for the post-creating, pre-wake window. After
+		// session_lifecycle_parallel flips state from "creating" to
+		// "active" + state_reason=creation_complete, there's still a gap
+		// before the wake pipeline records last_woke_at. Sweeping that
+		// window produces the same spin as sweeping during creation —
+		// we observed pool sessions with state=active, last_woke=empty
+		// getting closed with close_reason=stale-session before wake ever
+		// landed. Beads that actually drained/stopped keep state values
+		// like "drained"/"asleep"/"failed-create" and are still eligible
+		// for sweep; only pin the active-but-never-woke transient window.
+		// staleCreatingStateTimeout (1m) matches reapStaleSessionBeads'
+		// symmetric age guard.
+		if bead.Metadata["state"] == "active" && strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" {
+			if !bead.CreatedAt.IsZero() && time.Since(bead.CreatedAt) < staleCreatingStateTimeout {
+				continue
+			}
 		}
 		template := normalizedSessionTemplate(bead, cfg)
 		agentCfg := findAgentByTemplate(cfg, template)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -984,6 +984,16 @@ func sweepUndesiredPoolSessionBeads(
 		// staleCreatingState: a missing or zero creation_complete_at is
 		// treated as stale (sweepable) so beads without the per-start
 		// marker (older builds, manually repaired) stay recoverable.
+		//
+		// Upgrade contract: older binaries did not write
+		// creation_complete_at, so any bead persisted before upgrade
+		// fails the age check and becomes sweepable. That matches the
+		// semantics a crashed bead would get under the current binary
+		// and is the intended behavior — a bead that survived a binary
+		// restart without completing its wake is not in the protected
+		// "mid-start" window. The atomicity requirement therefore only
+		// binds within a single binary (writers and sweep are the same
+		// process); the rollout needs no cross-version coordination.
 		if state := strings.TrimSpace(bead.Metadata["state"]); (state == "active" || state == "awake") &&
 			strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" &&
 			strings.TrimSpace(bead.Metadata["state_reason"]) == "creation_complete" {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -932,20 +932,25 @@ func sweepUndesiredPoolSessionBeads(
 		if sp != nil && sp.IsRunning(bead.Metadata["session_name"]) {
 			continue
 		}
-		// Don't sweep beads that haven't had their tmux started yet — their
-		// work assignment window hasn't opened. Mirrors the reconciler's
-		// sessionStartRequested signals (`state=creating` +
-		// `pending_create_claim`). Without this, a pool's freshly-created
-		// session bead gets swept on the same tick it's created (no work
-		// assigned → GCSweepSessionBeads closes it), spinning the pool in a
-		// rapid create→sweep→recreate loop. The `staleCreatingStateTimeout`
-		// bound matches sessionStartRequested's symmetric age guard: a bead
-		// genuinely wedged in `creating` past the timeout must remain
-		// sweepable so other reconcilers can recover or replace it.
-		if bead.Metadata["state"] == "creating" || strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
-			if bead.CreatedAt.IsZero() || time.Since(bead.CreatedAt) < staleCreatingStateTimeout {
-				continue
-			}
+		// Don't sweep beads that the reconciler still considers "start
+		// requested" — their work assignment window hasn't opened. Mirrors
+		// sessionStartRequested (session_reconcile.go) exactly so the two
+		// loops agree about ownership:
+		//   - pending_create_claim=true: in-flight create claim, protected
+		//     regardless of age until the lifecycle clears it.
+		//   - state=creating: protected until staleCreatingState would
+		//     return true (i.e., until staleCreatingStateTimeout has
+		//     elapsed; zero CreatedAt is treated as stale, matching
+		//     staleCreatingState in session_reconcile.go).
+		// Without this, a pool's freshly-created session bead gets swept
+		// on the same tick it's created (no work assigned →
+		// GCSweepSessionBeads closes it), spinning the pool in a rapid
+		// create→sweep→recreate loop.
+		if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
+			continue
+		}
+		if strings.TrimSpace(bead.Metadata["state"]) == "creating" && !isStaleCreating(bead.CreatedAt) {
+			continue
 		}
 		// Age grace period for the post-creating, pre-wake window. After
 		// session_lifecycle_parallel flips state from "creating" to
@@ -968,16 +973,15 @@ func sweepUndesiredPoolSessionBeads(
 		//     increment these before clearing last_woke_at)
 		// Beads that actually drained/stopped keep state values like
 		// "drained"/"asleep"/"failed-create" and remain sweepable.
-		// staleCreatingStateTimeout (1m) mirrors sessionStartRequested's
-		// symmetric age guard.
-		if bead.Metadata["state"] == "active" &&
+		// The age bound mirrors staleCreatingState: a zero CreatedAt is
+		// treated as stale (sweepable) so malformed beads can be recovered.
+		if strings.TrimSpace(bead.Metadata["state"]) == "active" &&
 			strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" &&
-			bead.Metadata["state_reason"] == "creation_complete" &&
+			strings.TrimSpace(bead.Metadata["state_reason"]) == "creation_complete" &&
 			isZeroOrEmpty(bead.Metadata["wake_attempts"]) &&
-			isZeroOrEmpty(bead.Metadata["churn_count"]) {
-			if !bead.CreatedAt.IsZero() && time.Since(bead.CreatedAt) < staleCreatingStateTimeout {
-				continue
-			}
+			isZeroOrEmpty(bead.Metadata["churn_count"]) &&
+			!isStaleCreating(bead.CreatedAt) {
+			continue
 		}
 		template := normalizedSessionTemplate(bead, cfg)
 		agentCfg := findAgentByTemplate(cfg, template)
@@ -990,12 +994,25 @@ func sweepUndesiredPoolSessionBeads(
 }
 
 // isZeroOrEmpty reports whether a metadata counter is absent or explicitly "0".
-// Non-numeric values return false so unexpected content fails closed (the
-// post-create protection is only granted when we're certain no prior
-// crash/churn cycle cleared last_woke_at).
+// Unexpected (non-zero, non-empty) content returns false, so the protective
+// post-create guard declines to apply and the bead remains sweepable — the
+// guard is only granted when we're certain no prior crash/churn cycle cleared
+// last_woke_at.
 func isZeroOrEmpty(v string) bool {
 	v = strings.TrimSpace(v)
 	return v == "" || v == "0"
+}
+
+// isStaleCreating mirrors staleCreatingState in session_reconcile.go without
+// requiring a clock.Clock dependency: a zero CreatedAt is treated as stale,
+// and otherwise the bead is stale once staleCreatingStateTimeout has elapsed.
+// Keeping this shape identical to the reconciler's predicate means the sweep
+// and the reconciler agree about which in-flight create beads are still alive.
+func isStaleCreating(createdAt time.Time) bool {
+	if createdAt.IsZero() {
+		return true
+	}
+	return time.Since(createdAt) >= staleCreatingStateTimeout
 }
 
 func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -319,6 +319,53 @@ func TestSweepUndesiredPoolSessionBeads_SweepsActiveWithoutCreationCompleteAt(t 
 	}
 }
 
+// The reconciler's healStatePatch rewrites a live bead from state=active
+// to state=awake (session_reconcile.go). "awake" is semantically
+// equivalent to "active" in this codebase, and both must receive the
+// same post-create sweep protection — otherwise the same spin loop
+// reopens on the alias path.
+func TestSweepUndesiredPoolSessionBeads_SkipsAwakeStateInPreWakeWindow(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-awake",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			// healStatePatch rewrote state=active → state=awake while the
+			// runtime was alive; the pre-wake condition is preserved
+			// because last_woke_at has not yet landed (or was cleared).
+			"state":                "awake",
+			"state_reason":         "creation_complete",
+			"creation_complete_at": time.Now().UTC().Format(time.RFC3339),
+			"last_woke_at":         "",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — state=awake in pre-wake window must receive same protection as state=active", closed)
+	}
+}
+
 // Recovery of an already-active bead (recoverRunningPendingCreate path:
 // state=active + pending_create_claim=true + alive runtime) must produce
 // a fresh creation_complete_at so the healed bead stays protected in the

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -319,6 +319,55 @@ func TestSweepUndesiredPoolSessionBeads_SweepsActiveWithoutCreationCompleteAt(t 
 	}
 }
 
+// Recovery of an already-active bead (recoverRunningPendingCreate path:
+// state=active + pending_create_claim=true + alive runtime) must produce
+// a fresh creation_complete_at so the healed bead stays protected in the
+// pre-wake window on the following tick. This test asserts the sweep's
+// side of that contract — a state=active bead with a fresh
+// creation_complete_at and empty last_woke_at survives the sweep.
+func TestSweepUndesiredPoolSessionBeads_SkipsRecoveredActiveBead(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-recovered",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			// Post-recovery shape: state was already active, recovery just
+			// cleared pending_create_claim and stamped a fresh marker.
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			"creation_complete_at": time.Now().UTC().Format(time.RFC3339),
+			"last_woke_at":         "",
+			// Historical counters survive recovery.
+			"wake_attempts":      "1",
+			"continuation_epoch": "1",
+			"generation":         "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — recovered active bead with fresh marker must survive pre-wake", closed)
+	}
+}
+
 // Crashed-then-recently-restarted beads: wake_attempts/churn_count are
 // preserved across a successful restart (CommitStartedPatch does not reset
 // them), so the post-create guard CANNOT be keyed on those counters or a

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -195,6 +195,179 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecentlyCreated(t *testing.T) {
 	}
 }
 
+// Stale creating-state beads (CreatedAt older than staleCreatingStateTimeout)
+// MUST be sweepable. Without this, a bead wedged in `creating` past the
+// timeout would be permanently immune from this sweep path, breaking the
+// symmetry with sessionStartRequested.
+func TestSweepUndesiredPoolSessionBeads_SweepsStaleCreatingState(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-stale",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "creating",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	bead.CreatedAt = time.Now().Add(-2 * time.Minute)
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 — stale creating bead must be sweepable", closed)
+	}
+}
+
+// Stale post-creating beads (state=active, last_woke_at="", CreatedAt older
+// than staleCreatingStateTimeout) MUST be sweepable. Without this, the grace
+// window would never expire.
+func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-stale-active",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	bead.CreatedAt = time.Now().Add(-2 * time.Minute)
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 — bead beyond staleCreatingStateTimeout must be sweepable", closed)
+	}
+}
+
+// Crashed beads (state=active, last_woke_at="" cleared by checkStability,
+// wake_attempts>=1) MUST be sweepable. The post-create grace window is
+// gated on no prior wake attempts; checkStability/checkChurn/start-failure
+// paths all increment wake_attempts or churn_count before clearing
+// last_woke_at, so a crashed bead cannot masquerade as post-create.
+func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-crashed",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			// Crashed-after-wake signature: state still active because the
+			// reconciler hasn't transitioned it yet, state_reason still
+			// "creation_complete" from the last successful start, but
+			// last_woke_at cleared by checkStability after recording a
+			// wake failure. The bead is young enough that the unguarded
+			// age check would protect it.
+			"state":              "active",
+			"state_reason":       "creation_complete",
+			"last_woke_at":       "",
+			"wake_attempts":      "1",
+			"continuation_epoch": "1",
+			"generation":         "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 — crashed bead (wake_attempts>0) must not be protected", closed)
+	}
+}
+
+// Churned beads (state=active, last_woke_at="" cleared by checkChurn,
+// churn_count>=1) MUST be sweepable for the same reason as crashed beads.
+func TestSweepUndesiredPoolSessionBeads_SweepsChurnedActiveBead(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-churned",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			"last_woke_at":         "",
+			"churn_count":          "1",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 — churned bead (churn_count>0) must not be protected", closed)
+	}
+}
+
 func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -95,6 +95,149 @@ func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	}
 }
 
+// Pool session beads in the "creating" window (tmux not yet up, work not yet
+// assigned) must not be swept. Otherwise the sweep runs on the same tick the
+// pool creates the bead, observes zero assigned work, and closes it — the
+// pool re-spawns on the next tick, same fate, and the pool spins forever
+// without a session reaching the ready state.
+func TestSweepUndesiredPoolSessionBeads_SkipsCreatingState(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "creating",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — creating state must be preserved", closed)
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("bead in creating state was swept closed: %+v", got)
+	}
+}
+
+// Age grace period: pool session beads that have moved past "creating" but
+// are still younger than staleCreatingStateTimeout must not be swept. The
+// tmux wake pipeline and work assignment happen across multiple ticks after
+// state=creation_complete is set; sweeping in that window causes the same
+// spin as sweeping during creation.
+func TestSweepUndesiredPoolSessionBeads_SkipsRecentlyCreated(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-recent",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			// Post-creating: state/state_reason are advanced but last_woke
+			// hasn't landed yet. The real-world state observed as being
+			// swept incorrectly.
+			"state":              "active",
+			"state_reason":       "creation_complete",
+			"continuation_epoch": "1",
+			"generation":         "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — bead within staleCreatingStateTimeout window must survive", closed)
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("recently-created post-creating bead was swept: %+v", got)
+	}
+}
+
+func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"pending_create_claim": "true",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — pending_create_claim must be preserved", closed)
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("bead with pending_create_claim was swept closed: %+v", got)
+	}
+}
+
 func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -557,7 +557,7 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 
 // pending_create_claim is an authoritative ownership flag for the lifecycle
 // reconciler (sessionStartRequested in session_reconcile.go). The sweep must
-// honour that contract regardless of age — expiring it here would let the
+// honor that contract regardless of age — expiring it here would let the
 // sweep close a bead the reconciler still considers live.
 func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -163,10 +163,11 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecentlyCreated(t *testing.T) {
 			// Post-creating: state/state_reason are advanced but last_woke
 			// hasn't landed yet. The real-world state observed as being
 			// swept incorrectly.
-			"state":              "active",
-			"state_reason":       "creation_complete",
-			"continuation_epoch": "1",
-			"generation":         "1",
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			"creation_complete_at": time.Now().UTC().Format(time.RFC3339),
+			"continuation_epoch":   "1",
+			"generation":           "1",
 		},
 	})
 	if err != nil {
@@ -236,9 +237,9 @@ func TestSweepUndesiredPoolSessionBeads_SweepsStaleCreatingState(t *testing.T) {
 	}
 }
 
-// Stale post-creating beads (state=active, last_woke_at="", CreatedAt older
-// than staleCreatingStateTimeout) MUST be sweepable. Without this, the grace
-// window would never expire.
+// Stale post-creating beads (state=active, last_woke_at="",
+// creation_complete_at older than staleCreatingStateTimeout) MUST be
+// sweepable. Without this, the grace window would never expire.
 func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
@@ -253,6 +254,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 			poolManagedMetadataKey: boolMetadata(true),
 			"state":                "active",
 			"state_reason":         "creation_complete",
+			"creation_complete_at": time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
 			"continuation_epoch":   "1",
 			"generation":           "1",
 		},
@@ -260,7 +262,6 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	bead.CreatedAt = time.Now().Add(-2 * time.Minute)
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
@@ -277,33 +278,24 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 	}
 }
 
-// Crashed beads (state=active, last_woke_at="" cleared by checkStability,
-// wake_attempts>=1) MUST be sweepable. The post-create grace window is
-// gated on no prior wake attempts; checkStability/checkChurn/start-failure
-// paths all increment wake_attempts or churn_count before clearing
-// last_woke_at, so a crashed bead cannot masquerade as post-create.
-func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
+// Missing creation_complete_at (older beads predating the per-start marker,
+// or beads produced by paths that don't stamp the marker) MUST be sweepable
+// rather than protected indefinitely.
+func TestSweepUndesiredPoolSessionBeads_SweepsActiveWithoutCreationCompleteAt(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:worker"},
 		Metadata: map[string]string{
-			"session_name":         "worker-bd-crashed",
+			"session_name":         "worker-bd-no-marker",
 			"template":             "worker",
 			"agent_name":           "worker",
 			"pool_slot":            "1",
 			poolManagedMetadataKey: boolMetadata(true),
-			// Crashed-after-wake signature: state still active because the
-			// reconciler hasn't transitioned it yet, state_reason still
-			// "creation_complete" from the last successful start, but
-			// last_woke_at cleared by checkStability after recording a
-			// wake failure. The bead is young enough that the unguarded
-			// age check would protect it.
-			"state":              "active",
-			"state_reason":       "creation_complete",
-			"last_woke_at":       "",
-			"wake_attempts":      "1",
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			// creation_complete_at intentionally absent.
 			"continuation_epoch": "1",
 			"generation":         "1",
 		},
@@ -323,27 +315,37 @@ func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
 		false,
 	)
 	if closed != 1 {
-		t.Fatalf("closed = %d, want 1 — crashed bead (wake_attempts>0) must not be protected", closed)
+		t.Fatalf("closed = %d, want 1 — bead without creation_complete_at must be sweepable", closed)
 	}
 }
 
-// Churned beads (state=active, last_woke_at="" cleared by checkChurn,
-// churn_count>=1) MUST be sweepable for the same reason as crashed beads.
-func TestSweepUndesiredPoolSessionBeads_SweepsChurnedActiveBead(t *testing.T) {
+// Crashed-then-recently-restarted beads: wake_attempts/churn_count are
+// preserved across a successful restart (CommitStartedPatch does not reset
+// them), so the post-create guard CANNOT be keyed on those counters or a
+// legitimate restart after a prior crash would fall into the same spin
+// loop. Gating on a fresh creation_complete_at lets a just-restarted bead
+// survive the pre-wake window even when its historical counters are
+// non-zero.
+func TestSweepUndesiredPoolSessionBeads_SkipsFreshRestartAfterPriorCrash(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:worker"},
 		Metadata: map[string]string{
-			"session_name":         "worker-bd-churned",
+			"session_name":         "worker-bd-restart-after-crash",
 			"template":             "worker",
 			"agent_name":           "worker",
 			"pool_slot":            "1",
 			poolManagedMetadataKey: boolMetadata(true),
+			// Just-restarted after a prior crash: state transitioned back
+			// to active with a fresh creation_complete_at, but historical
+			// failure counters remain because clearWakeFailures only fires
+			// after the session is stable-long-enough.
 			"state":                "active",
 			"state_reason":         "creation_complete",
-			"last_woke_at":         "",
+			"creation_complete_at": time.Now().UTC().Format(time.RFC3339),
+			"wake_attempts":        "2",
 			"churn_count":          "1",
 			"continuation_epoch":   "1",
 			"generation":           "1",
@@ -363,8 +365,54 @@ func TestSweepUndesiredPoolSessionBeads_SweepsChurnedActiveBead(t *testing.T) {
 		runtime.NewFake(),
 		false,
 	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — fresh restart after prior crash must survive the pre-wake window", closed)
+	}
+}
+
+// Crashed beads (state=active, last_woke_at="" cleared by checkStability,
+// creation_complete_at stale because the last successful start was long
+// ago) MUST be sweepable. checkStability/checkChurn/start-failure do not
+// touch creation_complete_at, so an old marker is the signal that the
+// state=active+empty-last_woke_at shape came from a crash-clear rather
+// than a fresh start.
+func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-crashed",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			"creation_complete_at": time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+			"last_woke_at":         "",
+			"wake_attempts":        "1",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
 	if closed != 1 {
-		t.Fatalf("closed = %d, want 1 — churned bead (churn_count>0) must not be protected", closed)
+		t.Fatalf("closed = %d, want 1 — crashed bead with stale creation_complete_at must be swept", closed)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -411,6 +411,47 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 	}
 }
 
+// pending_create_claim is an authoritative ownership flag for the lifecycle
+// reconciler (sessionStartRequested in session_reconcile.go). The sweep must
+// honour that contract regardless of age — expiring it here would let the
+// sweep close a bead the reconciler still considers live.
+func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-stale-claim",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"pending_create_claim": "true",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	bead.CreatedAt = time.Now().Add(-2 * time.Minute)
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		sessionBeads,
+		nil,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — pending_create_claim must remain authoritative regardless of age", closed)
+	}
+}
+
 func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -596,24 +596,25 @@ func commitStartResultTraced(
 		Actor:   "gc",
 		Subject: tp.DisplayName(),
 	})
-	if err := clearPendingCreateClaim(session, store); err != nil {
-		fmt.Fprintf(stderr, "session reconciler: clearing pending create claim for %s: %v\n", name, err) //nolint:errcheck
-	}
 	coreBreakdown := ""
 	if bdj, err := json.Marshal(result.prepared.coreBreakdown); err == nil {
 		coreBreakdown = string(bdj)
 	}
 	// Transition creating/asleep/drained beads to active once the runtime
 	// spawn has confirmed. Folded into this metadata batch so the state
-	// write is atomic with the hash writes and avoids a second round-trip
-	// per spawn. See confirmPendingStart for the state gate.
+	// write is atomic with the hash writes, the pending_create_claim
+	// clear, and the creation_complete_at marker. This prevents the sweep
+	// from observing a transient state where the claim is gone but the
+	// post-create marker hasn't landed yet. See confirmPendingStart for
+	// the state gate.
 	metadata := sessionpkg.CommitStartedPatch(sessionpkg.CommitStartedPatchInput{
-		CoreHash:         result.prepared.coreHash,
-		LiveHash:         result.prepared.liveHash,
-		CoreBreakdown:    coreBreakdown,
-		ConfirmState:     confirmPendingStart(session.Metadata["state"]),
-		ClearSleepReason: session.Metadata["sleep_reason"] != "",
-		Now:              clk.Now(),
+		CoreHash:                result.prepared.coreHash,
+		LiveHash:                result.prepared.liveHash,
+		CoreBreakdown:           coreBreakdown,
+		ConfirmState:            confirmPendingStart(session.Metadata["state"]),
+		ClearSleepReason:        session.Metadata["sleep_reason"] != "",
+		ClearPendingCreateClaim: shouldRollbackPendingCreate(session),
+		Now:                     clk.Now(),
 	})
 	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
 		fmt.Fprintf(stderr, "session reconciler: storing hashes for %s: %v\n", name, err) //nolint:errcheck
@@ -679,9 +680,6 @@ func recoverRunningPendingCreate(
 		}
 		return false
 	}
-	if err := clearPendingCreateClaim(session, store); err != nil {
-		return false
-	}
 	coreBreakdown := ""
 	if bdj, err := json.Marshal(prepared.coreBreakdown); err == nil {
 		coreBreakdown = string(bdj)
@@ -696,8 +694,9 @@ func recoverRunningPendingCreate(
 		CoreBreakdown: coreBreakdown,
 		ConfirmState: confirmPendingStart(session.Metadata["state"]) ||
 			sessionpkg.State(strings.TrimSpace(session.Metadata["state"])) == sessionpkg.StateAwake,
-		ClearSleepReason: session.Metadata["sleep_reason"] != "",
-		Now:              now,
+		ClearSleepReason:        session.Metadata["sleep_reason"] != "",
+		ClearPendingCreateClaim: shouldRollbackPendingCreate(session),
+		Now:                     now,
 	})
 	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
 		if trace != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -685,8 +685,12 @@ func recoverRunningPendingCreate(
 		CoreBreakdown: coreBreakdown,
 		ConfirmState: confirmPendingStart(session.Metadata["state"]) ||
 			sessionpkg.State(strings.TrimSpace(session.Metadata["state"])) == sessionpkg.StateAwake,
-		ClearSleepReason:        session.Metadata["sleep_reason"] != "",
-		ClearPendingCreateClaim: shouldRollbackPendingCreate(session),
+		ClearSleepReason: session.Metadata["sleep_reason"] != "",
+		// recoverRunningPendingCreate's caller (session_reconciler.go)
+		// already gates entry on shouldRollbackPendingCreate(session), so
+		// at this point the claim is guaranteed to be set — hard-code the
+		// clear rather than re-evaluating the same predicate.
+		ClearPendingCreateClaim: true,
 		Now:                     now,
 	})
 	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -613,6 +613,7 @@ func commitStartResultTraced(
 		CoreBreakdown:    coreBreakdown,
 		ConfirmState:     confirmPendingStart(session.Metadata["state"]),
 		ClearSleepReason: session.Metadata["sleep_reason"] != "",
+		Now:              clk.Now(),
 	})
 	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
 		fmt.Fprintf(stderr, "session reconciler: storing hashes for %s: %v\n", name, err) //nolint:errcheck
@@ -663,6 +664,7 @@ func recoverRunningPendingCreate(
 	tp TemplateParams,
 	cfg *config.City,
 	store beads.Store,
+	clk clock.Clock,
 	trace *sessionReconcilerTraceCycle,
 ) bool {
 	if session == nil || store == nil {
@@ -684,6 +686,10 @@ func recoverRunningPendingCreate(
 	if bdj, err := json.Marshal(prepared.coreBreakdown); err == nil {
 		coreBreakdown = string(bdj)
 	}
+	now := time.Time{}
+	if clk != nil {
+		now = clk.Now()
+	}
 	metadata := sessionpkg.CommitStartedPatch(sessionpkg.CommitStartedPatchInput{
 		CoreHash:      prepared.coreHash,
 		LiveHash:      prepared.liveHash,
@@ -691,6 +697,7 @@ func recoverRunningPendingCreate(
 		ConfirmState: confirmPendingStart(session.Metadata["state"]) ||
 			sessionpkg.State(strings.TrimSpace(session.Metadata["state"])) == sessionpkg.StateAwake,
 		ClearSleepReason: session.Metadata["sleep_reason"] != "",
+		Now:              now,
 	})
 	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
 		if trace != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -646,20 +646,6 @@ func commitStartResultTraced(
 	return true
 }
 
-func clearPendingCreateClaim(session *beads.Bead, store beads.Store) error {
-	if !shouldRollbackPendingCreate(session) || store == nil {
-		return nil
-	}
-	if err := store.SetMetadata(session.ID, "pending_create_claim", ""); err != nil {
-		return err
-	}
-	if session.Metadata == nil {
-		session.Metadata = make(map[string]string)
-	}
-	session.Metadata["pending_create_claim"] = ""
-	return nil
-}
-
 func recoverRunningPendingCreate(
 	session *beads.Bead,
 	tp TemplateParams,
@@ -684,9 +670,14 @@ func recoverRunningPendingCreate(
 	if bdj, err := json.Marshal(prepared.coreBreakdown); err == nil {
 		coreBreakdown = string(bdj)
 	}
-	now := time.Time{}
+	// Fall back to wall clock if the caller didn't inject one — the marker
+	// is load-bearing for the post-create sweep guard, so leaving it unset
+	// would re-open the crash/recovery spin-loop window.
+	var now time.Time
 	if clk != nil {
 		now = clk.Now()
+	} else {
+		now = time.Now()
 	}
 	metadata := sessionpkg.CommitStartedPatch(sessionpkg.CommitStartedPatchInput{
 		CoreHash:      prepared.coreHash,

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -50,20 +50,6 @@ func (s *failNthMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]s
 	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
-type injectPendingCreateAfterClearStore struct {
-	*beads.MemStore
-}
-
-func (s *injectPendingCreateAfterClearStore) SetMetadata(id, key, value string) error {
-	if err := s.MemStore.SetMetadata(id, key, value); err != nil {
-		return err
-	}
-	if key == "pending_create_claim" && value == "" {
-		return s.MemStore.SetMetadata(id, key, "true")
-	}
-	return nil
-}
-
 type gatedStartProvider struct {
 	*runtime.Fake
 	mu            sync.Mutex
@@ -903,7 +889,14 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 	}
 }
 
-func TestCommitStartResult_ClearsPendingCreateClaimBeforeHashBatch(t *testing.T) {
+// When the atomic start batch fails, NO state change lands: state stays
+// "creating", pending_create_claim stays "true", and the post-create marker
+// is absent. The reconciler's next tick retries via recoverRunningPendingCreate.
+// This is the intentional consequence of folding the claim clear into the
+// same SetMetadataBatch as the state/state_reason/creation_complete_at
+// transition so the sweep never observes a transient state without either
+// the claim or the marker.
+func TestCommitStartResult_AtomicBatchFailureLeavesClaimIntact(t *testing.T) {
 	store := &failingMetadataBatchStore{MemStore: beads.NewMemStore(), failBatch: true}
 	bead, err := store.Create(beads.Bead{
 		Title:  "helper",
@@ -913,6 +906,7 @@ func TestCommitStartResult_ClearsPendingCreateClaimBeforeHashBatch(t *testing.T)
 			"session_name":          "sky",
 			"session_name_explicit": "true",
 			"pending_create_claim":  "true",
+			"state":                 "creating",
 		},
 	})
 	if err != nil {
@@ -944,8 +938,14 @@ func TestCommitStartResult_ClearsPendingCreateClaimBeforeHashBatch(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Metadata["pending_create_claim"] != "" {
-		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	if got.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want preserved (atomic batch failed, state unchanged)", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["state"] != "creating" {
+		t.Fatalf("state = %q, want creating (atomic batch failed)", got.Metadata["state"])
+	}
+	if got.Metadata["creation_complete_at"] != "" {
+		t.Fatalf("creation_complete_at = %q, want empty (atomic batch failed)", got.Metadata["creation_complete_at"])
 	}
 }
 
@@ -1009,8 +1009,13 @@ func TestExecutePlannedStartsClearsLegacyDrainAckAfterProviderStartBeforeMetadat
 	}
 }
 
-func TestCommitStartResult_DoesNotClearFreshPendingCreateClaimInHashBatch(t *testing.T) {
-	store := &injectPendingCreateAfterClearStore{MemStore: beads.NewMemStore()}
+// A successful atomic start batch must land state=active, state_reason,
+// creation_complete_at, AND the pending_create_claim clear together —
+// downstream readers (e.g. the pool bead sweep) rely on this atomicity so
+// they never observe state=active without either the claim or the
+// creation_complete_at marker that the post-create guard keys on.
+func TestCommitStartResult_AtomicBatchLandsStateAndClaimClearTogether(t *testing.T) {
+	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
 		Title:  "helper",
 		Type:   sessionBeadType,
@@ -1041,7 +1046,8 @@ func TestCommitStartResult_DoesNotClearFreshPendingCreateClaimInHashBatch(t *tes
 		finished: time.Date(2026, 3, 18, 12, 0, 1, 0, time.UTC),
 	}
 
-	ok := commitStartResult(result, store, &clock.Fake{Time: time.Date(2026, 3, 18, 12, 0, 1, 0, time.UTC)}, events.Discard, 0, ioDiscard{}, ioDiscard{})
+	clkTime := time.Date(2026, 3, 18, 12, 0, 1, 0, time.UTC)
+	ok := commitStartResult(result, store, &clock.Fake{Time: clkTime}, events.Discard, 0, ioDiscard{}, ioDiscard{})
 	if !ok {
 		t.Fatal("commitStartResult returned false for successful start")
 	}
@@ -1050,8 +1056,17 @@ func TestCommitStartResult_DoesNotClearFreshPendingCreateClaimInHashBatch(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Metadata["pending_create_claim"] != "true" {
-		t.Fatalf("pending_create_claim = %q, want fresh claim preserved by hash batch", got.Metadata["pending_create_claim"])
+	if got.Metadata["state"] != "active" {
+		t.Fatalf("state = %q, want active", got.Metadata["state"])
+	}
+	if got.Metadata["state_reason"] != "creation_complete" {
+		t.Fatalf("state_reason = %q, want creation_complete", got.Metadata["state_reason"])
+	}
+	if got.Metadata["creation_complete_at"] == "" {
+		t.Fatal("creation_complete_at empty — sweep guard would not key on post-create window")
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared atomically with state transition", got.Metadata["pending_create_claim"])
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1009,6 +1009,52 @@ func TestExecutePlannedStartsClearsLegacyDrainAckAfterProviderStartBeforeMetadat
 	}
 }
 
+// recoverRunningPendingCreate heals an already-active bead whose runtime
+// is alive but whose pending_create_claim flag was left set (typically
+// after a partial write on a prior tick). The heal MUST stamp a fresh
+// creation_complete_at alongside the claim clear, otherwise the sweep's
+// post-create guard treats the healed bead as stale and the bead can be
+// closed on the next tick if the runtime briefly dies — re-opening the
+// spin loop this PR is meant to close.
+func TestRecoverRunningPendingCreate_StampsCreationCompleteAtForAlreadyActive(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "sky",
+			"pending_create_claim": "true",
+			"state":                "active",
+			"state_reason":         "creation_complete",
+			// No creation_complete_at from the original start — the
+			// exact legacy shape recovery needs to heal.
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Agents: []config.Agent{{Name: "helper"}}}
+	tp := TemplateParams{SessionName: "sky", TemplateName: "helper"}
+	clkTime := time.Date(2026, 3, 18, 12, 0, 1, 0, time.UTC)
+
+	if !recoverRunningPendingCreate(&bead, tp, cfg, store, &clock.Fake{Time: clkTime}, nil) {
+		t.Fatal("recoverRunningPendingCreate returned false, want true")
+	}
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["creation_complete_at"] != clkTime.Format(time.RFC3339) {
+		t.Fatalf("creation_complete_at = %q, want %q — sweep guard would treat healed bead as stale without this stamp",
+			got.Metadata["creation_complete_at"], clkTime.Format(time.RFC3339))
+	}
+}
+
 // A successful atomic start batch must land state=active, state_reason,
 // creation_complete_at, AND the pending_create_claim clear together —
 // downstream readers (e.g. the pool bead sweep) rely on this atomicity so

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -471,7 +471,7 @@ func reconcileSessionBeadsTraced(
 			clearChurn(session, store)
 		}
 		if alive && shouldRollbackPendingCreate(session) {
-			if !recoverRunningPendingCreate(session, tp, cfg, store, trace) {
+			if !recoverRunningPendingCreate(session, tp, cfg, store, clk, trace) {
 				fmt.Fprintf(stderr, "session reconciler: recovering pending create %s: metadata repair incomplete\n", name) //nolint:errcheck
 			}
 		}

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -105,14 +105,18 @@ func ConfirmStartedPatch(now time.Time) MetadataPatch {
 // has completed. Hashes describe the runtime configuration that actually
 // launched; ConfirmState controls whether this start should stamp lifecycle
 // state active. Now is used to stamp creation_complete_at when ConfirmState
-// is true.
+// is true. ClearPendingCreateClaim folds the pending_create_claim clear
+// into the same atomic batch so downstream readers (e.g. the pool bead
+// sweep) never observe a transient state where the claim is gone but the
+// post-create marker hasn't landed yet.
 type CommitStartedPatchInput struct {
-	CoreHash         string
-	LiveHash         string
-	CoreBreakdown    string
-	ConfirmState     bool
-	ClearSleepReason bool
-	Now              time.Time
+	CoreHash                 string
+	LiveHash                 string
+	CoreBreakdown            string
+	ConfirmState             bool
+	ClearSleepReason         bool
+	ClearPendingCreateClaim  bool
+	Now                      time.Time
 }
 
 // CommitStartedPatch records a successful runtime start atomically with the
@@ -135,6 +139,9 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	}
 	if input.ClearSleepReason {
 		patch["sleep_reason"] = ""
+	}
+	if input.ClearPendingCreateClaim {
+		patch["pending_create_claim"] = ""
 	}
 	return patch
 }

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -87,11 +87,15 @@ func ClearExpiredQuarantinePatch(sleepReason string) MetadataPatch {
 	return patch
 }
 
-// ConfirmStartedPatch records a confirmed runtime start.
-func ConfirmStartedPatch() MetadataPatch {
+// ConfirmStartedPatch records a confirmed runtime start. The timestamp pins
+// the "creation_complete" transition so downstream readers (e.g. the pool
+// bead sweep) can distinguish a just-committed start from a long-stable
+// bead whose last_woke_at was later cleared by crash/churn recovery.
+func ConfirmStartedPatch(now time.Time) MetadataPatch {
 	return MetadataPatch{
 		"state":                string(StateActive),
 		"state_reason":         "creation_complete",
+		"creation_complete_at": now.UTC().Format(time.RFC3339),
 		"pending_create_claim": "",
 		"sleep_reason":         "",
 	}
@@ -100,13 +104,15 @@ func ConfirmStartedPatch() MetadataPatch {
 // CommitStartedPatchInput describes metadata persisted after a runtime start
 // has completed. Hashes describe the runtime configuration that actually
 // launched; ConfirmState controls whether this start should stamp lifecycle
-// state active.
+// state active. Now is used to stamp creation_complete_at when ConfirmState
+// is true.
 type CommitStartedPatchInput struct {
 	CoreHash         string
 	LiveHash         string
 	CoreBreakdown    string
 	ConfirmState     bool
 	ClearSleepReason bool
+	Now              time.Time
 }
 
 // CommitStartedPatch records a successful runtime start atomically with the
@@ -123,6 +129,9 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	if input.ConfirmState {
 		patch["state"] = string(StateActive)
 		patch["state_reason"] = "creation_complete"
+		if !input.Now.IsZero() {
+			patch["creation_complete_at"] = input.Now.UTC().Format(time.RFC3339)
+		}
 	}
 	if input.ClearSleepReason {
 		patch["sleep_reason"] = ""

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -133,9 +133,15 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	if input.ConfirmState {
 		patch["state"] = string(StateActive)
 		patch["state_reason"] = "creation_complete"
-		if !input.Now.IsZero() {
-			patch["creation_complete_at"] = input.Now.UTC().Format(time.RFC3339)
-		}
+	}
+	// creation_complete_at tracks when the runtime was last confirmed started.
+	// Stamp it whenever Now is non-zero — the ConfirmState path marks the
+	// fresh transition from creating/asleep; the recovery path (already-
+	// active bead with pending_create_claim=true) re-confirms an existing
+	// start, so it needs the same marker so the post-create sweep guard
+	// doesn't treat the healed bead as stale on subsequent ticks.
+	if !input.Now.IsZero() {
+		patch["creation_complete_at"] = input.Now.UTC().Format(time.RFC3339)
 	}
 	if input.ClearSleepReason {
 		patch["sleep_reason"] = ""

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -104,19 +104,21 @@ func ConfirmStartedPatch(now time.Time) MetadataPatch {
 // CommitStartedPatchInput describes metadata persisted after a runtime start
 // has completed. Hashes describe the runtime configuration that actually
 // launched; ConfirmState controls whether this start should stamp lifecycle
-// state active. Now is used to stamp creation_complete_at when ConfirmState
-// is true. ClearPendingCreateClaim folds the pending_create_claim clear
-// into the same atomic batch so downstream readers (e.g. the pool bead
-// sweep) never observe a transient state where the claim is gone but the
-// post-create marker hasn't landed yet.
+// state active. Now is used to stamp creation_complete_at whenever it is
+// non-zero (independent of ConfirmState, so the recovery path that commits
+// a fresh start on an already-active bead still refreshes the sweep's
+// post-create marker). ClearPendingCreateClaim folds the
+// pending_create_claim clear into the same atomic batch so downstream
+// readers (e.g. the pool bead sweep) never observe a transient state
+// where the claim is gone but the post-create marker hasn't landed yet.
 type CommitStartedPatchInput struct {
-	CoreHash                 string
-	LiveHash                 string
-	CoreBreakdown            string
-	ConfirmState             bool
-	ClearSleepReason         bool
-	ClearPendingCreateClaim  bool
-	Now                      time.Time
+	CoreHash                string
+	LiveHash                string
+	CoreBreakdown           string
+	ConfirmState            bool
+	ClearSleepReason        bool
+	ClearPendingCreateClaim bool
+	Now                     time.Time
 }
 
 // CommitStartedPatch records a successful runtime start atomically with the

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -333,12 +333,13 @@ func TestMetadataPatchApplyReturnsMergedCopy(t *testing.T) {
 func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	patch := CommitStartedPatch(CommitStartedPatchInput{
-		CoreHash:         "core-hash",
-		LiveHash:         "live-hash",
-		CoreBreakdown:    `{"command":"core-hash"}`,
-		ConfirmState:     true,
-		ClearSleepReason: true,
-		Now:              now,
+		CoreHash:                "core-hash",
+		LiveHash:                "live-hash",
+		CoreBreakdown:           `{"command":"core-hash"}`,
+		ConfirmState:            true,
+		ClearSleepReason:        true,
+		ClearPendingCreateClaim: true,
+		Now:                     now,
 	})
 
 	want := MetadataPatch{
@@ -350,9 +351,34 @@ func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 		"state_reason":         "creation_complete",
 		"creation_complete_at": now.Format(time.RFC3339),
 		"sleep_reason":         "",
+		"pending_create_claim": "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)
+	}
+}
+
+// Callers that set ClearPendingCreateClaim must see the claim cleared in the
+// same batch as state/state_reason/creation_complete_at so the sweep never
+// observes a transient state where the claim is gone but the post-create
+// marker isn't set yet.
+func TestCommitStartedPatchClearsPendingCreateClaimAtomicallyWithStateTransition(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	patch := CommitStartedPatch(CommitStartedPatchInput{
+		CoreHash:                "c",
+		LiveHash:                "l",
+		ConfirmState:            true,
+		ClearPendingCreateClaim: true,
+		Now:                     now,
+	})
+	required := []string{"state", "state_reason", "creation_complete_at", "pending_create_claim"}
+	for _, key := range required {
+		if _, ok := patch[key]; !ok {
+			t.Fatalf("patch missing %q — sweep-visibility atomicity broken: %#v", key, patch)
+		}
+	}
+	if patch["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", patch["pending_create_claim"])
 	}
 }
 

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -33,10 +33,11 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 		},
 		{
 			name:  "confirm started",
-			patch: ConfirmStartedPatch(),
+			patch: ConfirmStartedPatch(now),
 			want: MetadataPatch{
 				"state":                string(StateActive),
 				"state_reason":         "creation_complete",
+				"creation_complete_at": now.UTC().Format(time.RFC3339),
 				"pending_create_claim": "",
 				"sleep_reason":         "",
 			},
@@ -330,22 +331,25 @@ func TestMetadataPatchApplyReturnsMergedCopy(t *testing.T) {
 }
 
 func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	patch := CommitStartedPatch(CommitStartedPatchInput{
 		CoreHash:         "core-hash",
 		LiveHash:         "live-hash",
 		CoreBreakdown:    `{"command":"core-hash"}`,
 		ConfirmState:     true,
 		ClearSleepReason: true,
+		Now:              now,
 	})
 
 	want := MetadataPatch{
-		"started_config_hash": "core-hash",
-		"live_hash":           "live-hash",
-		"started_live_hash":   "live-hash",
-		"core_hash_breakdown": `{"command":"core-hash"}`,
-		"state":               string(StateActive),
-		"state_reason":        "creation_complete",
-		"sleep_reason":        "",
+		"started_config_hash":  "core-hash",
+		"live_hash":            "live-hash",
+		"started_live_hash":    "live-hash",
+		"core_hash_breakdown":  `{"command":"core-hash"}`,
+		"state":                string(StateActive),
+		"state_reason":         "creation_complete",
+		"creation_complete_at": now.Format(time.RFC3339),
+		"sleep_reason":         "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -733,7 +733,7 @@ func (m *Manager) Reactivate(id string) error {
 // ConfirmCreation transitions a session from creating to active after the
 // runtime process has been confirmed alive.
 func (m *Manager) ConfirmCreation(id string) error {
-	return m.store.SetMetadataBatch(id, ConfirmStartedPatch())
+	return m.store.SetMetadataBatch(id, ConfirmStartedPatch(time.Now()))
 }
 
 // Rename updates the title of a chat session.


### PR DESCRIPTION
## Summary

The pool reconciler creates a new session bead and on the same tick calls `sweepUndesiredPoolSessionBeads`, which in turn runs `GCSweepSessionBeads` — that function closes any session bead whose session_name has no open work-bead assignee. A brand-new pool session bead always fails that test (tmux hasn't come up yet, no work assigned), so it gets closed immediately. The pool respawns on the next tick, same fate.

There are actually **two distinct windows** where this happens, so the guard needs two checks:

1. **`state=creating` / `pending_create_claim=true`** — the bead is mid-way through creation (tmux hasn't started). Matches the guard `reapStaleSessionBeads` already uses.
2. **Post-creating, pre-wake** — after `session_lifecycle_parallel.go:604` flips state to `active` + `state_reason=creation_complete`, there's still a gap before the wake pipeline records `last_woke_at`. Live captures from `/proc/<supervisor-pid>/fd/2` showed pool session beads with `state=active, last_woke=empty` getting swept inside this window. Guarded by an age check (same `staleCreatingStateTimeout = 1m` used elsewhere) scoped specifically to that `state=active` + empty `last_woke_at` combination — legitimate `drained` / `asleep` / `failed-create` beads remain sweepable regardless of age.

## Fix

Add both guards to `sweepUndesiredPoolSessionBeads` in `cmd/gc/city_runtime.go`. Narrow change in both cases (mirror existing symmetric checks in `reapStaleSessionBeads`).

## Test plan

- [x] `TestSweepUndesiredPoolSessionBeads_SkipsCreatingState` — a bead with `state=creating` must not be swept.
- [x] `TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim` — a bead with `pending_create_claim=true` must not be swept.
- [x] `TestSweepUndesiredPoolSessionBeads_SkipsRecentlyCreated` — a fresh bead with `state=active` + `last_woke_at=""` must not be swept.
- [x] Existing sweep tests unchanged (`KeepsRunningSessionsOpen`, `ClosesStoppedSessions`, `KeepsAssignedSessionsOpen`, `SkipsPartialAssignedSnapshot`).
- [x] `go test ./cmd/gc -run 'TestSweepUndesiredPoolSessionBeads' -count=1` → PASS (all 7).
- [x] All three new tests fail cleanly without the corresponding guard.

## Notes

- Orthogonal to #833 (drop `pool.check` from FingerprintExtra, fixes the drift-drain cascade). Both needed to stop live pool sessions from being reaped.