### PR TITLE
fix: drop pool.check from FingerprintExtra to stop drift oscillation

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -705,8 +705,18 @@ func discoverSessionBeadsWithRoots(
 			}
 		}
 		// Resolve TemplateParams for this bead's session.
-		fpExtra := buildFingerprintExtra(cfgAgent)
-		tp, err := resolveTemplateForSessionBead(bp, cfgAgent, cfgAgent.QualifiedName(), fpExtra, b)
+		//
+		// Canonicalize agent identity before calling resolveTemplate so a
+		// pool-managed bead with pool_slot stamped fingerprints as the
+		// pool-instance form here — the same shape realizePoolDesiredSessions
+		// uses. Without this, GC_ALIAS (part of CoreFingerprint) would read
+		// as the base "rig/dog" in rediscovery and "rig/dog-1" in realize on
+		// the next tick, and the reconciler would declare config drift and
+		// drain the live session. Named beads intentionally pass through
+		// with the base shape (see canonicalSessionIdentity).
+		resolveAgent, resolveQN := canonicalSessionIdentity(cfgAgent, b)
+		fpExtra := buildFingerprintExtra(resolveAgent)
+		tp, err := resolveTemplateForSessionBead(bp, resolveAgent, resolveQN, fpExtra, b)
 		if err != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: bead %s template %q: %v (skipping)\n", b.ID, template, err) //nolint:errcheck
 			continue
@@ -800,14 +810,42 @@ func ensureDependencyOnlyTemplate(
 		return
 	}
 
+	// Bead selection keys off the configured base template, not the pool-
+	// instance form, because normalizedSessionTemplate reads the bead's
+	// "template" metadata which is always the base.
 	qualifiedName := cfgAgent.QualifiedName()
 	sessionBead, err := selectOrCreateDependencyPoolSessionBead(bp, cfgAgent, qualifiedName)
 	if err != nil {
 		fmt.Fprintf(stderr, "buildDesiredState: dependency floor %q: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 		return
 	}
-	fpExtra := buildFingerprintExtra(cfgAgent)
-	tp, err := resolveTemplateForSessionBead(bp, cfgAgent, qualifiedName, fpExtra, sessionBead)
+	// Env/fingerprint resolution, on the other hand, must use the pool-
+	// instance identity so this store-backed path agrees with both the
+	// no-store dependency-floor path above and realizePoolDesiredSessions.
+	// Otherwise GC_ALIAS would be the base "rig/dog" here and "rig/dog-1"
+	// on the realize path, oscillating across ticks and triggering the
+	// reconciler's config-drift drain on the live dependency-floor session.
+	resolveAgent, resolveQN := canonicalSessionIdentity(cfgAgent, sessionBead)
+	// Dep-floor slot-1 fallback. The guard triggers when the helper returned
+	// the BASE form — meaning no pool_slot was stamped yet. Keying off
+	// resolveQN (a stable value) rather than pointer identity keeps the
+	// fallback correct if the helper ever normalizes fields into a copy of
+	// the base agent. The !isNamedSessionBead guard is defensive:
+	// selectOrCreateDependencyPoolSessionBead already filters named beads
+	// (dependency_only beads are never named), but the guard keeps intent
+	// explicit so a future change that relaxes that filter can't silently
+	// overwrite a named identity with "rig/<agent>-1".
+	if cfgAgent.SupportsInstanceExpansion() && resolveQN == cfgAgent.QualifiedName() && !isNamedSessionBead(sessionBead) {
+		// No pool_slot stamp yet on this freshly-created dep-floor bead.
+		// Default to slot 1, mirroring the no-store path above.
+		instanceName := poolInstanceName(cfgAgent.Name, 1, cfgAgent)
+		qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
+		instanceAgent := deepCopyAgent(cfgAgent, instanceName, cfgAgent.Dir)
+		resolveAgent = &instanceAgent
+		resolveQN = qualifiedInstance
+	}
+	fpExtra := buildFingerprintExtra(resolveAgent)
+	tp, err := resolveTemplateForSessionBead(bp, resolveAgent, resolveQN, fpExtra, sessionBead)
 	if err != nil {
 		fmt.Fprintf(stderr, "buildDesiredState: dependency floor %q: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 		return
@@ -815,7 +853,7 @@ func ensureDependencyOnlyTemplate(
 	tp.Alias = ""
 	tp.InstanceName = sessionBead.Metadata["session_name"]
 	tp.DependencyOnly = true
-	installAgentSideEffects(bp, cfgAgent, tp, stderr)
+	installAgentSideEffects(bp, resolveAgent, tp, stderr)
 	desired[tp.SessionName] = tp
 }
 
@@ -905,6 +943,53 @@ func resolveTemplateForSessionBead(
 	local := *bp
 	local.beadNames = map[string]string{qualifiedName: sessionBead.Metadata["session_name"]}
 	return resolveTemplate(&local, cfgAgent, qualifiedName, fpExtra)
+}
+
+// canonicalSessionIdentity returns the agent and qualified name to use when
+// resolving a pool-managed session bead through resolveTemplate /
+// resolveTemplateForSessionBead. Scoped to the pool case on purpose:
+// realizePoolDesiredSessions uses a deep-copied instance agent +
+// qualifiedInstance, and this helper is what makes the other pool-backed
+// paths (rediscovery, store-backed dependency-floor) agree. GC_ALIAS and
+// FingerprintExtra are part of CoreFingerprint, so divergent shapes across
+// ticks trip the reconciler's config-drift drain.
+//
+// Named beads are deliberately NOT canonicalized here. The named-session
+// TemplateParams contract (ConfiguredNamedIdentity/Mode, GC_SESSION_ORIGIN,
+// canonical session_name, ...) is authored by the main named-session loop
+// and reconstructNamedSessionTemplateParams; rewriting only the (agent,
+// qualifiedName) pair in rediscovery while leaving the rest of the shape
+// as plain ephemeral would produce a partially-named TemplateParams that
+// downstream consumers don't expect. The Env-side drift that named beads
+// can still exhibit across rediscovery vs. the named-session loop is a
+// separate fix — the accompanying PR explicitly scopes it out.
+//
+// Rules:
+//   - Named bead → (cfgAgent, cfgAgent.QualifiedName()). Identical to the
+//     pre-change rediscovery shape so named-bead handling is unchanged.
+//   - Non-expanding agent → (cfgAgent, cfgAgent.QualifiedName()).
+//   - Instance-expanding agent with a stamped pool_slot → (deepCopyAgent
+//     at that slot, qualifiedInstance). Matches realizePoolDesiredSessions.
+//   - Instance-expanding agent without a slot stamp → (cfgAgent,
+//     cfgAgent.QualifiedName()); realize will claim and stamp later.
+func canonicalSessionIdentity(cfgAgent *config.Agent, bead beads.Bead) (*config.Agent, string) {
+	if cfgAgent == nil {
+		return nil, ""
+	}
+	if isNamedSessionBead(bead) {
+		return cfgAgent, cfgAgent.QualifiedName()
+	}
+	if !cfgAgent.SupportsInstanceExpansion() {
+		return cfgAgent, cfgAgent.QualifiedName()
+	}
+	slot := existingPoolSlot(cfgAgent, bead)
+	if slot <= 0 {
+		return cfgAgent, cfgAgent.QualifiedName()
+	}
+	instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
+	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
+	instanceAgent := deepCopyAgent(cfgAgent, instanceName, cfgAgent.Dir)
+	return &instanceAgent, qualifiedInstance
 }
 
 func claimPoolSlot(cfgAgent *config.Agent, sessionBead beads.Bead, used map[int]bool) int {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -2085,6 +2086,324 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) 
 	}
 }
 
-// PR #216 — skipped for now. Cross-rig pool work visibility is a new
-// feature, not a bug fix. Left as open PR for discussion about the
-// gastown experience with this flow.
+// TestCanonicalSessionIdentity is a regression test for the config-drift
+// oscillation caused by divergent agent-identity resolution across the
+// paths in buildDesiredState. Different paths (rediscovery, store-backed
+// dependency-floor, realizePoolDesiredSessions) were feeding the same
+// session bead through resolveTemplate with either the base qualified
+// name or a deep-copied instance-agent qualified name. GC_ALIAS is part
+// of the CoreFingerprint allow-list, so the resulting fingerprint flipped
+// every tick and the reconciler drained the live session as config drift.
+// See PR #833.
+//
+// Pool-instance agents with a stamped pool_slot must resolve to the
+// instance identity; named beads must resolve to the named identity;
+// everything else falls back to the base qualified name.
+func TestCanonicalSessionIdentity(t *testing.T) {
+	poolAgent := &config.Agent{
+		Name:              "dog",
+		Dir:               "gascity",
+		MinActiveSessions: intPtr(0),
+		// MaxActiveSessions nil = unlimited, which makes SupportsInstanceExpansion true.
+	}
+	singleton := &config.Agent{
+		Name:              "refinery",
+		Dir:               "gascity",
+		MaxActiveSessions: intPtr(1),
+	}
+
+	stampedPoolBead := beads.Bead{
+		Metadata: map[string]string{
+			"template":     "gascity/dog",
+			"agent_name":   "gascity/dog",
+			"pool_slot":    "1",
+			"pool_managed": "true",
+			"session_name": "s-dog-1",
+			"state":        "active",
+		},
+	}
+	unstampedCreatingBead := beads.Bead{
+		Metadata: map[string]string{
+			"template":     "gascity/dog",
+			"agent_name":   "gascity/dog",
+			"pool_managed": "true",
+			"session_name": "s-dog-new",
+			"state":        "creating",
+		},
+	}
+	namedBead := beads.Bead{
+		Metadata: map[string]string{
+			"template":                   "gascity/dog",
+			"agent_name":                 "gascity/dog",
+			"session_name":               "s-opus",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "gascity/opus",
+		},
+	}
+
+	t.Run("pool-instance agent with stamped slot returns instance identity", func(t *testing.T) {
+		agent, qn := canonicalSessionIdentity(poolAgent, stampedPoolBead)
+		if agent == poolAgent {
+			t.Errorf("agent = base cfgAgent, want deep-copied instance agent")
+		}
+		if agent == nil || agent.Name != "dog-1" {
+			t.Errorf("agent.Name = %q, want %q", agentName(agent), "dog-1")
+		}
+		if agent != nil && agent.PoolName != "gascity/dog" {
+			t.Errorf("agent.PoolName = %q, want %q", agent.PoolName, "gascity/dog")
+		}
+		if qn != "gascity/dog-1" {
+			t.Errorf("qn = %q, want %q", qn, "gascity/dog-1")
+		}
+	})
+
+	t.Run("pool-instance agent without slot stamp falls back to base", func(t *testing.T) {
+		agent, qn := canonicalSessionIdentity(poolAgent, unstampedCreatingBead)
+		if agent != poolAgent {
+			t.Errorf("agent = deep-copy, want base cfgAgent (no slot stamped yet)")
+		}
+		if qn != "gascity/dog" {
+			t.Errorf("qn = %q, want base %q", qn, "gascity/dog")
+		}
+	})
+
+	t.Run("named bead keeps base identity (out of scope for this canonicalization)", func(t *testing.T) {
+		// Named-session TemplateParams carry ConfiguredNamedIdentity/Mode,
+		// GC_SESSION_ORIGIN=named, and a canonical session_name set by the
+		// main named-sessions loop and reconstructNamedSessionTemplateParams.
+		// Rewriting just the identity qualifier in rediscovery without also
+		// repopulating that contract would produce a partially-named
+		// TemplateParams that downstream consumers don't expect — so the
+		// helper intentionally leaves named beads on the base shape.
+		agent, qn := canonicalSessionIdentity(poolAgent, namedBead)
+		if agent != poolAgent {
+			t.Errorf("named bead must not produce a deep-copied instance agent")
+		}
+		if qn != "gascity/dog" {
+			t.Errorf("qn = %q, want base %q (named canonicalization is scoped out)", qn, "gascity/dog")
+		}
+	})
+
+	t.Run("singleton (non-expanding) agent returns base regardless of bead shape", func(t *testing.T) {
+		agent, qn := canonicalSessionIdentity(singleton, stampedPoolBead)
+		if agent != singleton {
+			t.Errorf("singleton agent should not be deep-copied")
+		}
+		if qn != "gascity/refinery" {
+			t.Errorf("qn = %q, want base %q", qn, "gascity/refinery")
+		}
+	})
+
+	t.Run("nil agent returns empty", func(t *testing.T) {
+		agent, qn := canonicalSessionIdentity(nil, stampedPoolBead)
+		if agent != nil || qn != "" {
+			t.Errorf("nil agent: got (%v, %q), want (nil, \"\")", agent, qn)
+		}
+	})
+}
+
+func agentName(a *config.Agent) string {
+	if a == nil {
+		return "<nil>"
+	}
+	return a.Name
+}
+
+// TestEnsureDependencyOnlyTemplate_StoreBackedUsesInstanceIdentity is a
+// regression test for the second half of PR #833's fix. Before the fix,
+// the store-backed dependency-floor path used the base agent identity
+// ("rig/db") while the no-store path used the pool-instance identity
+// ("rig/db-1"). Both paths build FingerprintExtra from their agent and
+// feed qualifiedName into resolveTemplate → GC_ALIAS. GC_ALIAS is part
+// of CoreFingerprint. If a live dep-floor session ever had its bead
+// touched by both code paths, or the system transitioned from no-store
+// to store-backed mid-lifetime, the divergent shape drove the reconciler
+// to declare config drift and drain.
+//
+// The fix canonicalizes the store-backed path onto instance identity to
+// match the no-store branch and realizePoolDesiredSessions. This test
+// exercises the store-backed path (via a seeded pool-managed root bead
+// that anchors realizeDependencyFloors) and asserts GC_ALIAS is the
+// instance qualified name.
+func TestEnsureDependencyOnlyTemplate_StoreBackedUsesInstanceIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "db",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+			},
+			{
+				Name:              "api",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+				DependsOn:         []string{"gascity/db"},
+			},
+		},
+	}
+
+	// Seed a pool-managed root bead for api so discoverSessionBeadsWithRoots
+	// reports api as a realized root; realizeDependencyFloors then walks the
+	// dep graph and materializes the dep-floor for db via the store-backed
+	// branch of ensureDependencyOnlyTemplate.
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "api",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/api"},
+		Metadata: map[string]string{
+			"template":     "gascity/api",
+			"agent_name":   "gascity/api",
+			"session_name": "s-api-root",
+			"state":        "active",
+			"pool_managed": "true",
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatalf("seed api root bead: %v", err)
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	var tp TemplateParams
+	var found bool
+	for _, entry := range dsResult.State {
+		if entry.TemplateName == "gascity/db" && entry.DependencyOnly {
+			tp = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		entries := make([]string, 0, len(dsResult.State))
+		for k, v := range dsResult.State {
+			entries = append(entries, fmt.Sprintf("%s{template=%s depOnly=%v alias=%s}", k, v.TemplateName, v.DependencyOnly, v.Env["GC_ALIAS"]))
+		}
+		t.Fatalf("store-backed dependency floor for db not found, desired = %v", entries)
+	}
+
+	alias := tp.Env["GC_ALIAS"]
+	if want := "gascity/db-1"; alias != want {
+		t.Fatalf("store-backed dep-floor GC_ALIAS = %q, want instance identity %q. "+
+			"Before PR #833's canonicalization this came back as base %q, which "+
+			"disagreed with realizePoolDesiredSessions and triggered config-drift drain.",
+			alias, want, "gascity/db")
+	}
+	if template := tp.Env["GC_TEMPLATE"]; template != "gascity/db" {
+		t.Fatalf("store-backed dep-floor GC_TEMPLATE = %q, want base %q", template, "gascity/db")
+	}
+}
+
+// TestBuildDesiredState_PoolBeadIdentityAgreesAcrossRealizeAndCanonicalHelper
+// is the round-trip regression for PR #833's canonicalization. It locks in the
+// actual invariant the fix promises: a pool-managed session bead produces the
+// same CoreFingerprint-contributing (GC_ALIAS, GC_TEMPLATE, FingerprintExtra)
+// triple whether it is resolved through realizePoolDesiredSessions or through
+// canonicalSessionIdentity (the shared helper rediscovery and the store-backed
+// dependency-floor path both use).
+//
+// Catching a regression here matters because the drift bug was silent — the
+// reconciler just drained live sessions every other tick. If a future change
+// to realizePoolDesiredSessions (different poolInstanceName format, new
+// identity field in deepCopyAgent) diverges from the helper, nothing else in
+// CI will notice until a city starts losing sessions again.
+func TestBuildDesiredState_PoolBeadIdentityAgreesAcrossRealizeAndCanonicalHelper(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "dog",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 1",
+			},
+		},
+	}
+
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "dog pool session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/dog"},
+		Metadata: map[string]string{
+			"template":     "gascity/dog",
+			"agent_name":   "gascity/dog-1",
+			"session_name": "s-dog-1",
+			"state":        "active",
+			"pool_managed": "true",
+			"pool_slot":    "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed pool bead: %v", err)
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	// realize should have claimed our seeded bead (slot 1) and produced a
+	// desired entry keyed by session_name.
+	var realizeTP TemplateParams
+	var realized bool
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "gascity/dog" && !tp.DependencyOnly {
+			realizeTP = tp
+			realized = true
+			break
+		}
+	}
+	if !realized {
+		keys := make([]string, 0, len(dsResult.State))
+		for k, v := range dsResult.State {
+			keys = append(keys, fmt.Sprintf("%s{template=%s depOnly=%v}", k, v.TemplateName, v.DependencyOnly))
+		}
+		t.Fatalf("realize did not produce a desired entry for gascity/dog; desired = %v", keys)
+	}
+
+	// The helper is what rediscovery and the store-backed dep-floor path
+	// feed into resolveTemplate. For a stamped pool bead this must exactly
+	// match what realize produced — same qualified name, same agent shape,
+	// same FingerprintExtra.
+	helperAgent, helperQN := canonicalSessionIdentity(&cfg.Agents[0], bead)
+	if helperAgent == nil || helperAgent.Name != "dog-1" {
+		t.Fatalf("canonicalSessionIdentity agent = %v, want dog-1", helperAgent)
+	}
+	if want := "gascity/dog-1"; helperQN != want {
+		t.Fatalf("canonicalSessionIdentity qn = %q, want %q", helperQN, want)
+	}
+
+	if realizeAlias := realizeTP.Env["GC_ALIAS"]; realizeAlias != helperQN {
+		t.Fatalf("realize GC_ALIAS = %q, canonical helper qn = %q — divergence will oscillate CoreFingerprint across rediscovery/realize",
+			realizeAlias, helperQN)
+	}
+	if want := "gascity/dog"; realizeTP.Env["GC_TEMPLATE"] != want {
+		t.Fatalf("realize GC_TEMPLATE = %q, want base %q", realizeTP.Env["GC_TEMPLATE"], want)
+	}
+
+	helperFPExtra := buildFingerprintExtra(helperAgent)
+	if len(helperFPExtra) != len(realizeTP.FPExtra) {
+		t.Fatalf("FPExtra size mismatch: realize=%v helper=%v", realizeTP.FPExtra, helperFPExtra)
+	}
+	for k, rv := range realizeTP.FPExtra {
+		if hv, present := helperFPExtra[k]; !present {
+			t.Errorf("helper FPExtra missing key %q (realize has %q)", k, rv)
+		} else if hv != rv {
+			t.Errorf("FPExtra[%q] mismatch: realize=%q helper=%q", k, rv, hv)
+		}
+	}
+	// pool.check must be absent from both — it was the QualifiedName-bearing
+	// field that drove the original oscillation.
+	if _, has := realizeTP.FPExtra["pool.check"]; has {
+		t.Errorf("realize FPExtra still contains pool.check — fix incomplete: %v", realizeTP.FPExtra)
+	}
+}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -1047,15 +1047,24 @@ func countRunningPoolInstances(agentName, agentDir string, sp0 scaleParams, a *c
 
 // buildFingerprintExtra builds the fpExtra map for an agent's fingerprint
 // from its config. Returns nil if no extra fields are present.
+//
+// Note on pool.check omission: the default EffectiveScaleCheck string bakes
+// the agent's QualifiedName into the shell expression. Different code paths
+// in buildDesiredState resolve the same session bead with sometimes a base
+// agent ("pool-name") and sometimes a deep-copied instance agent
+// ("pool-name-1"), producing different pool.check strings and a different
+// fingerprint for the same session bead on different ticks. The constant
+// oscillation drives config-drift drain on every live pool/named session
+// (minutes-into-work reaps — see gascity ga-00f). scale_check is a runtime
+// probe for demand, not a behavioral-identity field; changes to ScaleCheck
+// don't need to reap live sessions. pool.min / pool.max / depends_on /
+// wake_mode continue to contribute since those are genuinely identity.
 func buildFingerprintExtra(a *config.Agent) map[string]string {
 	m := make(map[string]string)
 	if a.MinActiveSessions != nil || a.MaxActiveSessions != nil || a.ScaleCheck != "" || a.DrainTimeout != "" {
 		sp := scaleParamsFor(a)
 		m["pool.min"] = strconv.Itoa(sp.Min)
 		m["pool.max"] = strconv.Itoa(sp.Max)
-		if sp.Check != "" {
-			m["pool.check"] = sp.Check
-		}
 	}
 	if len(a.DependsOn) > 0 {
 		m["depends_on"] = strings.Join(a.DependsOn, ",")

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -337,3 +337,48 @@ func TestConfiguredRigNameUnmatchedPathReturnsEmpty(t *testing.T) {
 		t.Fatalf("configuredRigName() = %q, want empty", got)
 	}
 }
+
+// TestBuildFingerprintExtra_StableAcrossBaseAndInstance is a regression test
+// for the config-drift oscillation that was reaping live pool and named
+// sessions "minutes into work". Different code paths in buildDesiredState
+// resolve the same session bead with either the BASE agent
+// (cfgAgent, QualifiedName = "rig/pool") or a deepCopied INSTANCE agent
+// (QualifiedName = "rig/pool-1"). Those two shapes must produce the same
+// FingerprintExtra or the reconciler's CoreFingerprint flips every tick
+// and drains every live pool session with close_reason=stale-session.
+//
+// The fix drops pool.check from FingerprintExtra — it's a runtime probe for
+// demand, not a behavioral-identity field, and it was the only piece that
+// carried the agent's QualifiedName into the fingerprint. pool.min,
+// pool.max, depends_on, wake_mode remain.
+func TestBuildFingerprintExtra_StableAcrossBaseAndInstance(t *testing.T) {
+	baseAgent := &config.Agent{
+		Name:              "opus",
+		Dir:               "gascity",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: nil, // unlimited
+	}
+	instanceAgent := deepCopyAgent(baseAgent, "opus-1", "gascity")
+
+	baseExtra := buildFingerprintExtra(baseAgent)
+	instExtra := buildFingerprintExtra(&instanceAgent)
+
+	if len(baseExtra) != len(instExtra) {
+		t.Fatalf("buildFingerprintExtra size differs base=%d instance=%d (base=%v instance=%v)",
+			len(baseExtra), len(instExtra), baseExtra, instExtra)
+	}
+	for k, bv := range baseExtra {
+		iv, ok := instExtra[k]
+		if !ok {
+			t.Fatalf("instance fpExtra missing key %q (base=%q)", k, bv)
+		}
+		if bv != iv {
+			t.Fatalf("fpExtra[%q] differs: base=%q instance=%q — this drives the reconciler's CoreFingerprint to oscillate between ticks and drains every live pool/named session", k, bv, iv)
+		}
+	}
+	// pool.check must NOT be present — it bakes QualifiedName which differs
+	// between base and instance agents and is the drift source.
+	if _, has := baseExtra["pool.check"]; has {
+		t.Fatalf("buildFingerprintExtra must not include pool.check (it bakes QualifiedName and differs across base/instance forms): %v", baseExtra)
+	}
+}


### PR DESCRIPTION
## Summary

In gc-management today, every unattached pool and named session was getting drained ~minutes after start with `close_reason=stale-session`. Only user-attached sessions (mayor) survived because drift drain is deferred while attached. Captured the mechanism live via `/proc/<supervisor-pid>/fd/2`:

```
config-drift-diag dog-gm-tnsjgl: drifted fields: Env, FPExtra
    Env: map[... GC_ALIAS:dog-2 ...]
    FPExtra: map[pool.check:... gc.routed_to=dog-2 ... pool.max:3 pool.min:0]
Draining session 'dog-gm-tnsjgl': config-drift
```

...then the next tick's diag for the same bead showed `GC_ALIAS:dog-1` and `pool.check` with `gc.routed_to=dog-1`. Same pattern for `ProjectWrenUnity/opus` ↔ `ProjectWrenUnity/opus-1`. The session bead was being resolved with a different identity on every other reconciler tick.

## Cause

`Agent.EffectiveScaleCheck()` in `internal/config/config.go:1789` bakes `a.QualifiedName()` into the default pool-probe shell expression:

```go
template := a.QualifiedName()
return `ready=$(bd ready --metadata-field gc.routed_to=` + template + ...
```

`buildDesiredState` handles pool instances via several code paths (fixed-agent line 213, pool no-store line 287, store-backed realize path, `discoverSessionBeadsWithRoots` line 709, `ensureDependencyOnlyTemplate` line 812/829 etc.). Some pass the base `cfg.Agent` (QualifiedName = "pool-name"), others pass a deep-copied pool-instance agent (QualifiedName = "pool-name-1"). The resulting `pool.check` strings differ, FingerprintExtra differs, `CoreFingerprint` differs, and the reconciler declares config drift and drains.

Every live pool session ends up in a wake → drift-drain → reap loop; in-flight work gets orphaned because the reaped session's assignee is still on the bead.

## Fix

Drop `pool.check` from `buildFingerprintExtra`. The scale-check expression is a **runtime probe for demand**, not a behavioral-identity field. Changing `scale_check` in `city.toml` need not drain active sessions — the next scaling evaluation naturally picks up the new expression. `pool.min`, `pool.max`, `depends_on`, `wake_mode` stay in FingerprintExtra (those are genuine identity).

Two lines removed (`m[\"pool.check\"]` + the conditional), plus a comment explaining why.

## Test plan

- [x] `TestBuildFingerprintExtra_StableAcrossBaseAndInstance` — fails cleanly without the fix with a clear error showing the two divergent `pool.check` strings; passes with the fix.
- [x] `go build ./cmd/gc` clean.
- [x] Existing fingerprint/pool tests unchanged: `go test ./cmd/gc -run 'TestBuildFingerprintExtra|TestFingerprint|TestCoreFingerprint|TestPool' -count=1` → PASS.
- [ ] Manual verification in a live city (after merge): confirm `config-drift-diag` stops firing on stable pool and named sessions, and session count no longer oscillates.

## Notes

- There's a narrower remaining drift window for **named sessions** specifically, where `GC_ALIAS` can still flip between base/instance identity depending on whether the namedSpec loop or `discoverSessionBeadsWithRoots` handles the bead. That's a separate issue (Env-side) and warrants a follow-up audit; this PR addresses the dominant pool case.
- Companion / orthogonal issue: sweep race on `state=creating` pool beads — see #832.

Closes gc-management tracking bead `ga-00f`.