### PR TITLE
fix: preserve template GC_ALIAS when bead alias is empty (root-cause fix, alt to #798)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -893,6 +893,7 @@ func setTemplateEnvIdentity(tp *TemplateParams, identity string) {
 	}
 	tp.Env["GC_AGENT"] = identity
 	tp.Env["GC_ALIAS"] = identity
+	tp.EnvIdentityStamped = true
 }
 
 func resolveTemplateForSessionBead(

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -404,16 +404,15 @@ func buildPreparedStart(
 		continuationEpoch,
 		instanceToken,
 	)
-	// When the bead has no alias but the template assigned a non-empty
-	// GC_ALIAS (e.g. pool workers via setTemplateEnvIdentity), don't let
-	// mergeEnv's override-wins semantics clobber it with the runtime's
-	// empty value. Leaving GC_ALIAS="" when the template has no alias is
-	// preserved on purpose: the tmux runtime translates empty entries
-	// into "env -u <key>" to scrub inherited env from the tmux server.
-	if beadAlias == "" {
-		if tplAlias, ok := agentCfg.Env["GC_ALIAS"]; ok && tplAlias != "" {
-			delete(runtimeEnv, "GC_ALIAS")
-		}
+	// When the bead has no alias but the template was identity-stamped
+	// (pool workers and dependency floors via setTemplateEnvIdentity),
+	// don't let mergeEnv's override-wins semantics clobber the stamped
+	// GC_ALIAS with the runtime's empty value. For ordinary sessions the
+	// resolver-stamped GC_ALIAS is left to be overwritten by the empty
+	// runtime value so the tmux runtime emits `env -u GC_ALIAS` and scrubs
+	// any inherited GC_ALIAS from the tmux server.
+	if beadAlias == "" && tp.EnvIdentityStamped {
+		delete(runtimeEnv, "GC_ALIAS")
 	}
 	agentCfg.Env = mergeEnv(agentCfg.Env, runtimeEnv)
 	if gcProvider := strings.TrimSpace(session.Metadata["provider_kind"]); gcProvider != "" {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -393,16 +393,29 @@ func buildPreparedStart(
 		}
 		session.Metadata["instance_token"] = instanceToken
 	}
-	agentCfg.Env = mergeEnv(agentCfg.Env, sessionpkg.RuntimeEnvWithSessionContext(
+	beadAlias := strings.TrimSpace(session.Metadata["alias"])
+	runtimeEnv := sessionpkg.RuntimeEnvWithSessionContext(
 		session.ID,
 		candidate.name(),
-		strings.TrimSpace(session.Metadata["alias"]),
+		beadAlias,
 		strings.TrimSpace(session.Metadata["template"]),
 		strings.TrimSpace(session.Metadata["session_origin"]),
 		generation,
 		continuationEpoch,
 		instanceToken,
-	))
+	)
+	// When the bead has no alias but the template assigned a non-empty
+	// GC_ALIAS (e.g. pool workers via setTemplateEnvIdentity), don't let
+	// mergeEnv's override-wins semantics clobber it with the runtime's
+	// empty value. Leaving GC_ALIAS="" when the template has no alias is
+	// preserved on purpose: the tmux runtime translates empty entries
+	// into "env -u <key>" to scrub inherited env from the tmux server.
+	if beadAlias == "" {
+		if tplAlias, ok := agentCfg.Env["GC_ALIAS"]; ok && tplAlias != "" {
+			delete(runtimeEnv, "GC_ALIAS")
+		}
+	}
+	agentCfg.Env = mergeEnv(agentCfg.Env, runtimeEnv)
 	if gcProvider := strings.TrimSpace(session.Metadata["provider_kind"]); gcProvider != "" {
 		agentCfg.Env = mergeEnv(agentCfg.Env, map[string]string{"GC_PROVIDER": gcProvider})
 	} else if gcProvider := strings.TrimSpace(session.Metadata["provider"]); gcProvider != "" {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -2170,6 +2170,131 @@ func TestPrepareStartCandidate_PreservesRuntimeConfigAndProviderEnv(t *testing.T
 	}
 }
 
+func TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title: "ants-ant-1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"session_name": "ants-ant-1",
+			"provider":     "claude",
+			"state":        "creating",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	tp := TemplateParams{
+		Command:          "claude",
+		Env:              map[string]string{"GC_ALIAS": "ants-ant-1", "GC_AGENT": "ants-ant-1"},
+		WorkDir:          t.TempDir(),
+		SessionName:      "ants-ant-1",
+		InstanceName:     "ants-ant-1",
+		ResolvedProvider: &config.ResolvedProvider{Name: "claude", PromptMode: "none"},
+		TemplateName:     "ants",
+	}
+
+	prepared, err := prepareStartCandidate(
+		startCandidate{session: &bead, tp: tp},
+		&config.City{},
+		store,
+		clock.Real{},
+	)
+	if err != nil {
+		t.Fatalf("prepareStartCandidate: %v", err)
+	}
+
+	if got := prepared.cfg.Env["GC_ALIAS"]; got != "ants-ant-1" {
+		t.Fatalf("GC_ALIAS = %q, want %q (template value must survive merge when bead alias is empty)", got, "ants-ant-1")
+	}
+}
+
+func TestPrepareStartCandidate_EmptyAliasEverywhereKeepsEmptyForTmuxScrub(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title: "s-gc-test",
+		Type:  "task",
+		Metadata: map[string]string{
+			"session_name": "s-gc-test",
+			"provider":     "claude",
+			"state":        "creating",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	tp := TemplateParams{
+		Command:          "claude",
+		Env:              map[string]string{"BASE": "1"},
+		WorkDir:          t.TempDir(),
+		SessionName:      "s-gc-test",
+		InstanceName:     "s-gc-test",
+		ResolvedProvider: &config.ResolvedProvider{Name: "claude", PromptMode: "none"},
+		TemplateName:     "s",
+	}
+
+	prepared, err := prepareStartCandidate(
+		startCandidate{session: &bead, tp: tp},
+		&config.City{},
+		store,
+		clock.Real{},
+	)
+	if err != nil {
+		t.Fatalf("prepareStartCandidate: %v", err)
+	}
+
+	got, ok := prepared.cfg.Env["GC_ALIAS"]
+	if !ok {
+		t.Fatalf("GC_ALIAS should be present with empty value so tmux emits `env -u GC_ALIAS`; got absent")
+	}
+	if got != "" {
+		t.Fatalf("GC_ALIAS = %q, want empty (tmux env -u scrub)", got)
+	}
+}
+
+func TestPrepareStartCandidate_NonEmptyBeadAliasOverridesTemplate(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title: "mayor",
+		Type:  "task",
+		Metadata: map[string]string{
+			"session_name": "s-mayor",
+			"provider":     "claude",
+			"alias":        "mayor",
+			"state":        "creating",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	tp := TemplateParams{
+		Command:          "claude",
+		Env:              map[string]string{"GC_ALIAS": "stale-from-template"},
+		WorkDir:          t.TempDir(),
+		SessionName:      "s-mayor",
+		InstanceName:     "mayor",
+		ResolvedProvider: &config.ResolvedProvider{Name: "claude", PromptMode: "none"},
+		TemplateName:     "mayor",
+	}
+
+	prepared, err := prepareStartCandidate(
+		startCandidate{session: &bead, tp: tp},
+		&config.City{},
+		store,
+		clock.Real{},
+	)
+	if err != nil {
+		t.Fatalf("prepareStartCandidate: %v", err)
+	}
+
+	if got := prepared.cfg.Env["GC_ALIAS"]; got != "mayor" {
+		t.Fatalf("GC_ALIAS = %q, want %q (runtime alias must override stale template value)", got, "mayor")
+	}
+}
+
 func TestConfirmPendingStart(t *testing.T) {
 	// commitStartResultTraced must transition freshly-spawned pool
 	// session beads from the pending states ("", creating, asleep,

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -2186,13 +2186,17 @@ func TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias(t *testing
 	}
 
 	tp := TemplateParams{
-		Command:          "claude",
-		Env:              map[string]string{"GC_ALIAS": "ants-ant-1", "GC_AGENT": "ants-ant-1"},
-		WorkDir:          t.TempDir(),
-		SessionName:      "ants-ant-1",
-		InstanceName:     "ants-ant-1",
-		ResolvedProvider: &config.ResolvedProvider{Name: "claude", PromptMode: "none"},
-		TemplateName:     "ants",
+		Command: "claude",
+		// Shape matches setTemplateEnvIdentity output (GC_ALIAS+GC_AGENT stamped)
+		// plus an unrelated template key to verify the merge preserves it.
+		Env:                map[string]string{"GC_ALIAS": "ants-ant-1", "GC_AGENT": "ants-ant-1", "TEMPLATE_KEY": "keep"},
+		WorkDir:            t.TempDir(),
+		SessionName:        "ants-ant-1",
+		InstanceName:       "ants-ant-1",
+		PoolSlot:           1,
+		EnvIdentityStamped: true,
+		ResolvedProvider:   &config.ResolvedProvider{Name: "claude", PromptMode: "none"},
+		TemplateName:       "ants",
 	}
 
 	prepared, err := prepareStartCandidate(
@@ -2207,6 +2211,12 @@ func TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias(t *testing
 
 	if got := prepared.cfg.Env["GC_ALIAS"]; got != "ants-ant-1" {
 		t.Fatalf("GC_ALIAS = %q, want %q (template value must survive merge when bead alias is empty)", got, "ants-ant-1")
+	}
+	if got := prepared.cfg.Env["GC_AGENT"]; got != "ants-ant-1" {
+		t.Fatalf("GC_AGENT = %q, want %q (companion identity key must also survive)", got, "ants-ant-1")
+	}
+	if got := prepared.cfg.Env["TEMPLATE_KEY"]; got != "keep" {
+		t.Fatalf("TEMPLATE_KEY = %q, want %q (unrelated template env must survive merge)", got, "keep")
 	}
 }
 
@@ -2226,13 +2236,19 @@ func TestPrepareStartCandidate_EmptyAliasEverywhereKeepsEmptyForTmuxScrub(t *tes
 	}
 
 	tp := TemplateParams{
-		Command:          "claude",
-		Env:              map[string]string{"BASE": "1"},
+		Command: "claude",
+		// Shape matches resolveTemplate output: GC_ALIAS is unconditionally
+		// seeded with qualifiedName on every session, pool or not. The guard
+		// must distinguish identity-stamped templates from the resolver's
+		// default stamping so that the empty runtime value still wins here
+		// and tmux emits `env -u GC_ALIAS`.
+		Env:              map[string]string{"GC_ALIAS": "s-gc-test", "GC_AGENT": "s-gc-test", "BASE": "1"},
 		WorkDir:          t.TempDir(),
 		SessionName:      "s-gc-test",
 		InstanceName:     "s-gc-test",
 		ResolvedProvider: &config.ResolvedProvider{Name: "claude", PromptMode: "none"},
 		TemplateName:     "s",
+		// EnvIdentityStamped is false — setTemplateEnvIdentity was not called.
 	}
 
 	prepared, err := prepareStartCandidate(

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -84,6 +84,13 @@ type TemplateParams struct {
 	// pool_slot metadata without reverse-engineering the slot from the name
 	// (which fails for namepool-themed instances like "fenrir").
 	PoolSlot int
+	// EnvIdentityStamped reports whether setTemplateEnvIdentity has written
+	// an authoritative GC_ALIAS/GC_AGENT identity into Env. resolveTemplate
+	// always seeds GC_ALIAS=qualifiedName, so "Env has GC_ALIAS" is not a
+	// sufficient signal on its own — callers use this flag to distinguish
+	// identity-stamped templates (pool workers, dependency floors) from the
+	// resolver's default stamping on ordinary sessions.
+	EnvIdentityStamped bool
 }
 
 // DisplayName returns the name to use for log messages and event subjects.


### PR DESCRIPTION
## Summary

Alternative root-cause fix for the same bug targeted by #798. Instead of changing `RuntimeEnvWithAlias` (which loses the tmux `env -u GC_ALIAS` scrub for truly unaliased sessions), this fixes the override-ordering bug at the `mergeEnv` call site in `cmd/gc/session_lifecycle_parallel.go`.

**Bug.** `RuntimeEnvWithAlias` writes `GC_ALIAS` unconditionally on purpose — the tmux runtime translates empty env values into `env -u <key>` to scrub inherited env from the tmux server. But `mergeEnv` is override-wins (`cmd/gc/cmd_start.go:919`), so an empty runtime alias clobbers the non-empty `GC_ALIAS` that `setTemplateEnvIdentity` assigned to pool workers (e.g. `ants-ant-1`, `build_desired_state.go:887`). Pool workers launched with `session.Metadata[\"alias\"]` unset land with `GC_ALIAS=\"\"` even though their template carried the correct identity.

**Fix.** At the merge call site, when the bead alias is empty and the template already carries a non-empty `GC_ALIAS`, drop the empty entry from the runtime env map before merging so the template value survives. When the template has no alias either, the empty `GC_ALIAS` is left in place so the tmux `env -u` scrub still runs for truly unaliased sessions (Claude reviewer's concern on #798 — nested `gc start` from a shell with `GC_ALIAS` exported would otherwise have it inherited by children).

### Behavior matrix

| Scenario | `tp.Env[GC_ALIAS]` | `session.Metadata[alias]` | Result | Why |
|---|---|---|---|---|
| Pool worker | `ants-ant-1` | (empty) | `GC_ALIAS=ants-ant-1` | template value preserved (bug fixed) |
| Unaliased session | (absent) | (empty) | `GC_ALIAS=\"\"` → tmux `env -u GC_ALIAS` | scrubs inherited env |
| Normal alias | (stale) | `mayor` | `GC_ALIAS=mayor` | runtime overrides stale template value |

### Contrast with #798

#798 makes `RuntimeEnvWithAlias` omit the key when alias is empty. That fixes the pool worker case but breaks the tmux scrub path: a `GC_ALIAS` inherited from the caller's shell is no longer explicitly unset in the child. This PR keeps `RuntimeEnvWithAlias` as-is (the empty-means-unset contract is load-bearing) and fixes the merge semantics instead.

## Testing

Three new unit tests in `cmd/gc/session_lifecycle_parallel_test.go`:
- `TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias` — pool worker case
- `TestPrepareStartCandidate_EmptyAliasEverywhereKeepsEmptyForTmuxScrub` — unaliased case
- `TestPrepareStartCandidate_NonEmptyBeadAliasOverridesTemplate` — normal case (stale template + fresh runtime alias)

- [x] `go test ./cmd/gc/ -run TestPrepareStartCandidate` (all pass)
- [x] `go vet ./cmd/gc/... ./internal/session/...` (clean)
- [ ] `make check-docs` — no docs/nav/link changes
- [ ] `make test-integration` — no runtime/controller/workflow behavior changes

## Checklist

- [x] Linked context: surfaces the root cause behind #798
- [x] Added tests for behavior change
- [ ] Updated docs for user-facing changes — no user-facing surface change
- [ ] Breaking changes / migration notes — none