### PR TITLE
test: fix two main-branch CI flakes

### DIFF
--- a/internal/runtime/k8s/controller_script_test.go
+++ b/internal/runtime/k8s/controller_script_test.go
@@ -350,9 +350,14 @@ exit 1
 		t.Fatalf("read manifest: %v", readManifestErr)
 	}
 
+	// Strip tmpDir from the call log so substring assertions (e.g. searching
+	// for a port number) aren't corrupted by random digits Go inserts into
+	// t.TempDir() paths — those digits leak into the log via `kubectl cp`.
+	callLog := strings.ReplaceAll(string(callLogBytes), tmpDir, "<TMPDIR>")
+
 	return controllerScriptDeployResult{
 		manifestEnv: manifestEnv,
-		callLog:     string(callLogBytes),
+		callLog:     callLog,
 		output:      string(out),
 		err:         err,
 	}

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -13,7 +13,11 @@ import (
 	"time"
 )
 
-const reviewWorkflowTimeout = 8 * time.Minute
+// reviewWorkflowTimeout bounds waits for review-formula workflow beads to
+// close. Successful runs on CI average ~5 min per test, but runner variance
+// pushes individual runs past 8 min; keep the budget at 12 min so slow
+// runners don't flake the lane.
+const reviewWorkflowTimeout = 12 * time.Minute
 
 const testReviewExpansionFormula = `description = """
 Test-local review expansion used by integration tests.


### PR DESCRIPTION
## Summary

Two recent CI failures on `main` (commit 9edd9a34) were both real flakes, not regressions. Fixing both here.

### 1. `TestControllerScriptDeployDoesNotProjectDeprecatedK8sDoltTarget` — temp-dir substring collision

The assertion checks that the deprecated K8s Dolt target (`GC_K8S_DOLT_HOST=legacy-dolt.example.com`, `GC_K8S_DOLT_PORT=3308`) doesn't leak into the controller bootstrap by grepping the kubectl call log for either value. But the fake kubectl in the test logs the full `kubectl cp $tmpDir/...` command, and Go's `t.TempDir()` inserts a random numeric ID into the path. In the failing run the tmpdir was `.../TestControllerScriptDeployDoesNotProjectDeprecatedK8sDoltTarget533308397/001/...` — that random `533308397` happens to contain `3308`, so the substring match tripped falsely even though nothing actually leaked.

Fix: strip `tmpDir` from the call log before the assertion runs. The random ID can no longer corrupt substring matches, and the manifest-env check (which is the real semantic assertion) is unchanged.

### 2. `TestPersonalWorkFormulaCompileAndRun` — timeout budget too tight

The test failed at `waitForBeadClosed(rft-6pbs) ended with context deadline exceeded` at 513s. The workflow actually completed at ~513s + ~14s, meaning CI runner variance pushed one run ~3% past the 8-min budget. Average runtime on successful CI is ~5 min per test, but individual runs regularly land between 7–9 min on GH runners.

Fix: bump `reviewWorkflowTimeout` from 8 → 12 min and document the reasoning inline.

## Scope

- Only the two flakes above — both reproduced from the failing run at 9edd9a34.
- Nightly Tier B failures on the 2026-04-18 nightly were already fixed on main by PR #831 (26c83995 + 66a0e552).
- Mac Regression has several long-standing macOS-specific bugs (`stat -c` vs BSD `stat`, `/var` → `/private/var` symlink resolution in path comparisons). Those predate the recent flakes and are out of scope for this stability pass.

## Test plan

- [x] `go test ./internal/runtime/k8s/ -count=5` — all 6 controller-script tests pass, 5 times each
- [x] `go test -run TestControllerScriptDeployDoesNotProjectDeprecatedK8sDoltTarget -count=30 ./internal/runtime/k8s/` — 30/30 pass
- [x] `go vet ./internal/runtime/k8s/ ./test/integration/...` — clean
- [x] `golangci-lint run ./internal/runtime/k8s/` — 0 issues
- [x] `go build ./...` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>