### PR TITLE
fix: formula jq filters drop .[0] and silently return empty on bd show --json (#810)

### DIFF
--- a/engdocs/archive/analysis/feature-parity.md
+++ b/engdocs/archive/analysis/feature-parity.md
@@ -286,7 +286,7 @@ become role-agnostic infrastructure that any pack can use.
 |---------|----------|--------|-------|
 | `gt mq submit` | — | **REMAP** | Just bd: polecat sets `metadata.branch`/`metadata.target` + assigns to refinery |
 | `gt mq list` | — | **REMAP** | Just bd: `bd list --assignee=refinery --status=open` |
-| `gt mq status` | — | **REMAP** | Just bd: `bd show $WORK --json \| jq '.metadata'` |
+| `gt mq status` | — | **REMAP** | Just bd: `bd show $WORK --json \| jq '.[0].metadata'` |
 | `gt mq retry` | — | **REMAP** | Just bd: refinery rejects back to pool, new polecat picks up |
 | `gt mq reject` | — | **REMAP** | Just bd: `bd update --status=open --assignee="" --set-metadata rejection_reason=...` |
 | `gt mq next` | — | **REMAP** | Just bd: `bd list --assignee=$GC_AGENT --limit=1` |

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -61,7 +61,7 @@ sees the existing branch and reason, and resumes instead of redoing everything.
 
 Read metadata:
 ```bash
-gc bd show <issue> --json | jq '.metadata'
+gc bd show <issue> --json | jq '.[0].metadata'
 ```
 
 ## Work Protocol
@@ -129,8 +129,8 @@ conflict, test failure, etc.), and resubmit. Don't redo all the work.
 
 ```bash
 # Check for rejection
-gc bd show <issue> --json | jq -r '.metadata.rejection_reason // empty'
-gc bd show <issue> --json | jq -r '.metadata.branch // empty'
+gc bd show <issue> --json | jq -r '.[0].metadata.rejection_reason // empty'
+gc bd show <issue> --json | jq -r '.[0].metadata.branch // empty'
 
 # If both exist: resume the branch, fix the issue, resubmit
 ```

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -93,9 +93,9 @@ Polecats set these metadata fields before assigning a work bead to you:
 
 Read them mechanically:
 ```bash
-gc bd show $WORK --json | jq -r '.metadata.branch'
-gc bd show $WORK --json | jq -r '.metadata.target // "{{ .DefaultBranch }}"'
-gc bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"'
+gc bd show $WORK --json | jq -r '.[0].metadata.branch'
+gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{ .DefaultBranch }}"'
+gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"'
 ```
 
 Never infer a branch name. If `metadata.branch` is missing, reject the bead.
@@ -162,7 +162,7 @@ alert the witness, not `gc mail send`.
 | Find assigned work | `gc bd list --assignee="$GC_ALIAS" --status=open` |
 | Snapshot event position | `gc events --seq` |
 | Wait for assignment | `gc events --watch --type=bead.updated --after=$SEQ` |
-| Read work metadata | `gc bd show $WORK --json \| jq '.metadata'` |
+| Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |
 | Set metadata field | `gc bd update $WORK --set-metadata key=value` |
 | Remove metadata field | `gc bd update $WORK --unset-metadata key` |
 | Fetch remote branches | `git fetch --prune origin` |

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -60,7 +60,7 @@ git fetch --prune origin
 
 Check if `metadata.work_dir` already records your worktree path:
 ```bash
-WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.work_dir // empty')
 ```
 
 **If worktree path exists in metadata** — reuse it:
@@ -90,7 +90,7 @@ Worktrees are scoped to the work bead (not the agent name) so that:
 
 Check if `metadata.branch` already records a branch:
 ```bash
-BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')
 ```
 
 **If branch exists in metadata** — check it out:
@@ -99,7 +99,7 @@ git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH" origin/"$BRANCH"
 ```
 If resuming a rejected branch, rebase onto latest base:
 ```bash
-REJECTION=$(gc bd show {{issue}} --json | jq -r '.metadata.rejection_reason // empty')
+REJECTION=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.rejection_reason // empty')
 if [ -n "$REJECTION" ]; then
     git rebase origin/{{base_branch}}
     # If conflicts: resolve them (this is likely the rejection reason)

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -116,7 +116,7 @@ WORK=$(gc bd list --assignee=$GC_AGENT --status=open \
 
 If found: read the bead metadata to confirm it has a branch:
 ```bash
-gc bd show $WORK --json | jq '.metadata'
+gc bd show $WORK --json | jq '.[0].metadata'
 ```
 The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
@@ -142,8 +142,8 @@ description = """
 
 Read the work bead metadata:
 ```bash
-BRANCH=$(gc bd show $WORK --json | jq -r '.metadata.branch')
-TARGET=$(gc bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
+BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 ```
 
 Fetch and attempt mechanical rebase:
@@ -221,8 +221,8 @@ If any check or test FAILED:
 
 Read the current branch and target again:
 ```bash
-BRANCH=$(gc bd show $WORK --json | jq -r '.metadata.branch')
-TARGET=$(gc bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
+BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 ```
 
 1. Diagnose: branch regression or pre-existing on target?
@@ -271,9 +271,9 @@ description = """
 
 Read the merge target and merge strategy from the work bead metadata:
 ```bash
-BRANCH=$(gc bd show $WORK --json | jq -r '.metadata.branch')
-TARGET=$(gc bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
-MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"')
+BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
+MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
 if [ "$MERGE_STRATEGY" = "pr" ]; then
   MERGE_STRATEGY="mr"
 fi
@@ -325,7 +325,7 @@ git push origin HEAD:$BRANCH --force-with-lease
 
 **2. Create or discover the pull request:**
 ```bash
-ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.title')
+ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.[0].title')
 PR_BODY=$(cat <<EOF
 ## Summary
 

--- a/examples/gastown/packs/gastown/formulas/mol-review-leg.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-review-leg.toml
@@ -37,7 +37,7 @@ gc bd prime
 **2. Read the bead and metadata:**
 ```bash
 gc bd show {{issue}}
-gc bd show {{issue}} --json | jq '.metadata'
+gc bd show {{issue}} --json | jq '.[0].metadata'
 ```
 
 **Expected metadata:**
@@ -93,10 +93,10 @@ After the report is stored on the bead, notify the coordinator and close out.
 
 **1. Read metadata for the mail header:**
 ```bash
-COORD=$(gc bd show {{issue}} --json | jq -r '.metadata.coordinator // empty')
-REVIEW_ID=$(gc bd show {{issue}} --json | jq -r '.metadata.review_id // empty')
-PHASE=$(gc bd show {{issue}} --json | jq -r '.metadata.review_phase // empty')
-LEG=$(gc bd show {{issue}} --json | jq -r '.metadata.review_leg // empty')
+COORD=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.coordinator // empty')
+REVIEW_ID=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.review_id // empty')
+PHASE=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.review_phase // empty')
+LEG=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.review_leg // empty')
 ```
 
 **2. If `COORD` is present, mail completion:**

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -169,7 +169,7 @@ Our job is to ensure work reaches the branch so it's schedulable.
 
 Read the bead metadata to find the worktree and branch:
 ```bash
-META=$(gc bd show <bead> --json | jq '.metadata')
+META=$(gc bd show <bead> --json | jq '.[0].metadata')
 WORKTREE=$(echo "$META" | jq -r '.worktree // empty')
 BRANCH=$(echo "$META" | jq -r '.branch // empty')
 ```

--- a/examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh
@@ -48,7 +48,7 @@ echo "$OPEN_BEADS" | jq -r '.[] | select(.metadata.rejection_reason != null or .
     COUNTS=$(echo "$COUNTS" | jq --arg id "$bead_id" --argjson n "$NEW" '.[$id] = $n')
 
     if [ "$NEW" -ge "$THRESHOLD" ]; then
-        TITLE=$(bd show "$bead_id" --json 2>/dev/null | jq -r '.title // "unknown"')
+        TITLE=$(bd show "$bead_id" --json 2>/dev/null | jq -r '.[0].title // "unknown"')
         gc mail send mayor/ \
             -s "SPAWN_STORM: bead $bead_id reset ${NEW}x" \
             -m "Bead $bead_id ($TITLE) has been reset to pool $NEW times (threshold: $THRESHOLD).

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -73,13 +73,13 @@ Entry point. Read the warrant metadata from your wisp.
 
 **1. Read warrant details:**
 ```bash
-gc bd show <wisp-id> --json | jq '.metadata'
+gc bd show <wisp-id> --json | jq '.[0].metadata'
 ```
 Extract: `target`, `reason`, `requester`, `warrant_id`.
 
 **2. Verify the warrant bead exists and is open:**
 ```bash
-gc bd show {{warrant_id}} --json | jq '.status'
+gc bd show {{warrant_id}} --json | jq '.[0].status'
 ```
 If warrant is already closed (another dog handled it, or requester
 cancelled): close this step, burn the wisp, exit.

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -70,7 +70,7 @@ with you when they become ready:
 
 ```bash
 # After claiming your first bead, read its continuation group
-GROUP=$(bd show <id> --json | jq -r '.metadata["gc.continuation_group"] // empty')
+GROUP=$(bd show <id> --json | jq -r '.[0].metadata["gc.continuation_group"] // empty')
 
 if [ -n "$GROUP" ]; then
   # Find all open beads in the same group and pre-assign them

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
@@ -70,7 +70,7 @@ bd list --assignee=$GC_AGENT --status=in_progress
 The hook_bead is your assigned issue. Read it carefully:
 ```bash
 bd show {{issue}}           # Full issue details
-bd show {{issue}} --json | jq '.metadata'  # Check for existing metadata
+bd show {{issue}} --json | jq '.[0].metadata'  # Check for existing metadata
 ```
 
 **3. Check for rejection (IMPORTANT):**

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
@@ -49,7 +49,7 @@ git fetch --prune origin
 
 Check if `metadata.work_dir` already records your worktree path:
 ```bash
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(bd show {{issue}} --json | jq -r '.[0].metadata.work_dir // empty')
 ```
 
 **If worktree path exists in metadata** — reuse it:

--- a/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
@@ -54,7 +54,7 @@ metadata before doing anything destructive.
 gc prime
 bd prime
 bd show {{issue}}
-bd show {{issue}} --json | jq '.metadata'
+bd show {{issue}} --json | jq '.[0].metadata'
 gc mail inbox
 ```
 """
@@ -86,7 +86,7 @@ Ensure there is an isolated worktree for this work item.
 
 ```bash
 git fetch --prune origin
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(bd show {{issue}} --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -z "$WORKTREE" ]; then
   WORKTREE_PATH=$(pwd)/worktrees/{{issue}}
   git worktree add "$WORKTREE_PATH" --detach origin/{{base_branch}}
@@ -186,7 +186,7 @@ description = """
 Remove the temporary worktree after the body reaches terminal state.
 
 ```bash
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(bd show {{issue}} --json | jq -r '.[0].metadata.work_dir // empty')
 if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
   git worktree remove --force "$WORKTREE" || rm -rf "$WORKTREE"
 fi

--- a/test/packlint/bd_show_jq_test.go
+++ b/test/packlint/bd_show_jq_test.go
@@ -1,0 +1,93 @@
+// Package packlint verifies mechanical invariants across shipped packs and
+// example shell snippets.
+//
+// TestBdShowJqScalarExpect guards issue #810: bd show --json returns a JSON
+// array ([{...}]), so scalar-expect filters like `jq -r '.metadata.X'`
+// silently yield empty strings. The correct form prefixes `.[0].` or handles
+// both shapes with an `if type == "array"` conditional.
+package packlint
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func repoRoot() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..")
+}
+
+// badScalarExtractRE matches a `bd show ... --json ... | jq[...] '.<lowercase-field>`
+// pattern where the field is read directly off the top-level value. Such reads
+// fail silently on `bd show --json` because the output is always an array.
+//
+// Safe forms we explicitly allow elsewhere and do NOT match:
+//   - `.[0].field` or `.[0]` (explicit index)
+//   - `if type == "array" then ... else ... end` (defensive conditional)
+//   - wrapper functions like `jq_bead` that normalize shape internally
+//
+// Known limit: patterns with an intermediary command between `bd show` and
+// `jq` (`bd show --json | tee /tmp/out | jq '.field'`) are not caught. That
+// shape does not occur in the current codebase.
+var badScalarExtractRE = regexp.MustCompile(`bd show\b[^|]*--json[^|]*\|[^|']*jq\b[^']*'\.[a-zA-Z_]`)
+
+// scanDirs is the set of repo-root-relative directories whose shell snippets
+// and formula descriptions must use the correct array-aware jq pattern.
+var scanDirs = []string{
+	"examples",
+	"internal/bootstrap/packs",
+}
+
+// scanExts limits walking to files that ship embedded shell text.
+var scanExts = map[string]bool{
+	".toml": true,
+	".md":   true,
+	".sh":   true,
+}
+
+func TestBdShowJqScalarExpect(t *testing.T) {
+	root := repoRoot()
+	var violations []string
+	for _, dir := range scanDirs {
+		abs := filepath.Join(root, dir)
+		err := filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !scanExts[filepath.Ext(path)] {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+			for lineNum, line := range strings.Split(string(data), "\n") {
+				if !badScalarExtractRE.MatchString(line) {
+					continue
+				}
+				rel, _ := filepath.Rel(root, path)
+				violations = append(violations, rel+":"+strconv.Itoa(lineNum+1)+": "+strings.TrimSpace(line))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", dir, err)
+		}
+	}
+	if len(violations) > 0 {
+		t.Errorf("bd show --json pipelines use scalar-expect jq filter without `.[0].` prefix (see issue #810).\n"+
+			"bd show --json returns a JSON array; `jq -r '.metadata.X'` silently returns empty.\n"+
+			"Fix: change `jq -r '.field'` to `jq -r '.[0].field'`.\n\n%s",
+			strings.Join(violations, "\n"))
+	}
+}


### PR DESCRIPTION
## Summary

`bd show <id> --json` returns a JSON array `[{...}]`, consistent with `bd list --json`. Formula authors wrote `jq -r '.metadata.X'` as if it returned an object, so every metadata read returned an empty string and any `// "fallback"` default fired as the live value.

Fixes #810.

## Observable impact

- **Refinery merge strategy** always empty → falls through to `// "direct"`, overriding any configured `integration`/`mr` strategy. Convoy work intended for PR flow can be ff-merged directly to master.
- **Refinery target** always empty → falls through to `{{target_branch}}`, potentially picking the wrong default branch in multi-rig setups.
- **Polecat worktree/branch recovery** always empty → polecat always takes the "create new worktree/branch" path on resume, producing duplicate branches and abandoned worktrees after any restart.

## Fix

Mechanical: change `jq '.metadata.X'` → `jq '.[0].metadata.X'` (and `jq '.title'` → `jq '.[0].title'`) at every site.

## Scope beyond the sites listed in #810

The issue lists 11 sites in 2 files. Grepping for the sibling pattern revealed the same bug in 6 additional files, including the **bootstrap core pack that ships with every gascity install**. Fixed all of them rather than leaving the class bug half-repaired:

- `examples/gastown/packs/gastown/formulas/` — mol-refinery-patrol, mol-polecat-work, **mol-review-leg** (5 sites), **mol-witness-patrol**
- `examples/gastown/packs/gastown/agents/` — polecat/prompt.template.md, refinery/prompt.template.md (agents copy these literally)
- `examples/gastown/packs/maintenance/` — formulas/mol-shutdown-dance.toml, assets/scripts/spawn-storm-detect.sh
- `internal/bootstrap/packs/core/formulas/` — mol-scoped-work, mol-polecat-base, mol-polecat-commit
- `internal/bootstrap/packs/core/assets/prompts/graph-worker.md`
- `engdocs/archive/analysis/feature-parity.md` (one remaining table reference)

## Already-safe sites left untouched

- `test/agents/graph-dispatch.sh` uses a `jq_bead` wrapper (L210-217) that normalizes array vs object internally.
- `examples/gastown/packs/gastown/assets/scripts/checks/*-review-approved.sh` use the defensive `if type == \"array\"` pattern.
- `internal/beads/bdstore.go:459` already parses `bd show --json` as a typed array in Go.

## Regression guard

New test `test/packlint/bd_show_jq_test.go` walks `examples/` and `internal/bootstrap/packs/` and fails if any `bd show --json | jq '.<field>` pattern reappears without `.[0].` or a defensive conditional. Verified manually: temporarily reverting any one fix fails the test with a precise file:line violation.

Known limit documented in the regex docblock: patterns with an intermediary command (`bd show --json | tee /tmp/out | jq '.field'`) are not caught. That shape does not occur in the current codebase.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make check` — all tests pass (including new `test/packlint`)
- [x] `make check-docs` — clean
- [x] Regression test verified: reverting any one fix fails the guard; all three safe forms (`.[0].X`, `if type == \"array\"`, `jq_bead` wrapper) do not trigger false positives

## Cross-provider review

Reviewed with Codex (`gpt-5.4`) and Copilot (`gpt-5.3-codex`). Both independently confirmed regex correctness, fix completeness, bootstrap safety (no fixtures pin old syntax; `examples/gastown/gastown_test.go:133` substring check still matches post-fix), and behavior-change safety (no test/caller depends on the buggy always-fallback behavior).