### PR TITLE
fix: isolate pooled session workdirs by concrete instance identity

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/hooks"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 // DesiredStateResult bundles the desired session state with the scale_check
@@ -706,17 +707,34 @@ func discoverSessionBeadsWithRoots(
 		}
 		// Resolve TemplateParams for this bead's session.
 		//
-		// Canonicalize agent identity before calling resolveTemplate so a
-		// pool-managed bead with pool_slot stamped fingerprints as the
-		// pool-instance form here — the same shape realizePoolDesiredSessions
-		// uses. Without this, GC_ALIAS (part of CoreFingerprint) would read
-		// as the base "rig/dog" in rediscovery and "rig/dog-1" in realize on
-		// the next tick, and the reconciler would declare config drift and
-		// drain the live session. Named beads intentionally pass through
-		// with the base shape (see canonicalSessionIdentity).
-		resolveAgent, resolveQN := canonicalSessionIdentity(cfgAgent, b)
+		// Pool-managed beads and manual pooled sessions recover identity from
+		// different sources:
+		//   - Pool-managed rediscovery must canonicalize stamped pool slots to
+		//     the same instance identity realizePoolDesiredSessions uses, or
+		//     GC_ALIAS / FingerprintExtra will oscillate across ticks.
+		//   - Manual sessions must preserve the concrete identity persisted on
+		//     the bead (agent_name / explicit session_name / alias), even when
+		//     that identity is not a numbered pool slot.
+		var (
+			resolveAgent         *config.Agent
+			sessionQualifiedName string
+		)
+		if isManualSessionBead(b) {
+			sessionQualifiedName = sessionBeadQualifiedName(bp.cityPath, cfgAgent, bp.rigs, b)
+			resolveAgent = sessionBeadConfigAgent(cfgAgent, sessionQualifiedName)
+		} else {
+			// Canonicalize agent identity before calling resolveTemplate so a
+			// pool-managed bead with pool_slot stamped fingerprints as the
+			// pool-instance form here — the same shape realizePoolDesiredSessions
+			// uses. Without this, GC_ALIAS (part of CoreFingerprint) would read
+			// as the base "rig/dog" in rediscovery and "rig/dog-1" in realize on
+			// the next tick, and the reconciler would declare config drift and
+			// drain the live session. Named beads intentionally pass through
+			// with the base shape (see canonicalSessionIdentity).
+			resolveAgent, sessionQualifiedName = canonicalSessionIdentity(cfgAgent, b)
+		}
 		fpExtra := buildFingerprintExtra(resolveAgent)
-		tp, err := resolveTemplateForSessionBead(bp, resolveAgent, resolveQN, fpExtra, b)
+		tp, err := resolveTemplateForSessionBead(bp, resolveAgent, sessionQualifiedName, fpExtra, b)
 		if err != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: bead %s template %q: %v (skipping)\n", b.ID, template, err) //nolint:errcheck
 			continue
@@ -866,17 +884,6 @@ func desiredHasTemplate(desired map[string]TemplateParams, template string) bool
 	return false
 }
 
-func isMultiSessionCfgAgent(a *config.Agent) bool {
-	if a == nil {
-		return false
-	}
-	if strings.TrimSpace(a.Namepool) != "" || len(a.NamepoolNames) > 0 {
-		return true
-	}
-	maxSess := a.EffectiveMaxActiveSessions()
-	return maxSess == nil || *maxSess != 1
-}
-
 func realizePoolDesiredSessions(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,
@@ -991,6 +998,62 @@ func canonicalSessionIdentity(cfgAgent *config.Agent, bead beads.Bead) (*config.
 	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
 	instanceAgent := deepCopyAgent(cfgAgent, instanceName, cfgAgent.Dir)
 	return &instanceAgent, qualifiedInstance
+}
+
+func sessionBeadQualifiedName(cityPath string, cfgAgent *config.Agent, rigs []config.Rig, sessionBead beads.Bead) string {
+	if cfgAgent == nil {
+		return ""
+	}
+	if agentName := normalizeSessionBeadQualifiedName(cfgAgent, sessionBeadAgentName(sessionBead)); agentName != "" {
+		return agentName
+	}
+	explicitName := ""
+	if strings.TrimSpace(sessionBead.Metadata["session_name_explicit"]) == boolMetadata(true) {
+		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
+	}
+	qualifiedName := workdirutil.SessionQualifiedName(
+		cityPath,
+		*cfgAgent,
+		rigs,
+		strings.TrimSpace(sessionBead.Metadata["alias"]),
+		explicitName,
+	)
+	if qualifiedName != "" {
+		return qualifiedName
+	}
+	return cfgAgent.QualifiedName()
+}
+
+func normalizeSessionBeadQualifiedName(cfgAgent *config.Agent, identity string) string {
+	if cfgAgent == nil {
+		return strings.TrimSpace(identity)
+	}
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return ""
+	}
+	if identity == cfgAgent.QualifiedName() || strings.Contains(identity, "/") {
+		return identity
+	}
+	if cfgAgent.BindingName != "" && strings.HasPrefix(identity, cfgAgent.BindingName+".") {
+		return identity
+	}
+	return cfgAgent.QualifiedInstanceName(identity)
+}
+
+func sessionBeadConfigAgent(cfgAgent *config.Agent, qualifiedName string) *config.Agent {
+	if cfgAgent == nil || !cfgAgent.SupportsInstanceExpansion() || strings.TrimSpace(qualifiedName) == "" || qualifiedName == cfgAgent.QualifiedName() {
+		return cfgAgent
+	}
+	localName := strings.TrimSpace(qualifiedName)
+	if cfgAgent.Dir != "" {
+		localName = strings.TrimPrefix(localName, cfgAgent.Dir+"/")
+	}
+	if cfgAgent.BindingName != "" {
+		localName = strings.TrimPrefix(localName, cfgAgent.BindingName+".")
+	}
+	instanceAgent := deepCopyAgent(cfgAgent, localName, cfgAgent.Dir)
+	return &instanceAgent
 }
 
 func claimPoolSlot(cfgAgent *config.Agent, sessionBead beads.Bead, used map[int]bool) int {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1011,6 +1011,9 @@ func sessionBeadQualifiedName(cityPath string, cfgAgent *config.Agent, rigs []co
 	if strings.TrimSpace(sessionBead.Metadata["session_name_explicit"]) == boolMetadata(true) {
 		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
 	}
+	if explicitName == "" && strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && strings.TrimSpace(sessionBeadAgentName(sessionBead)) == "" && cfgAgent.SupportsMultipleSessions() {
+		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
+	}
 	qualifiedName := workdirutil.SessionQualifiedName(
 		cityPath,
 		*cfgAgent,

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1018,6 +1018,10 @@ func sessionBeadQualifiedName(cityPath string, cfgAgent *config.Agent, rigs []co
 	if strings.TrimSpace(sessionBead.Metadata["session_name_explicit"]) == boolMetadata(true) {
 		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
 	}
+	// Legacy aliasless pooled beads predate agent_name/session_name_explicit
+	// backfills. Their persisted session_name is the only stable concrete
+	// identity we can recover during rediscovery, even when it used the
+	// historical s-<id> form.
 	if explicitName == "" && strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && persistedAgentName == cfgAgent.QualifiedName() && cfgAgent.SupportsMultipleSessions() {
 		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
 	}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -696,7 +696,7 @@ func discoverSessionBeadsWithRoots(
 		// scaling and causes infinite wake→drain→stop loops when there's
 		// no work.
 		if isEphemeralSessionBeadForAgent(b, cfgAgent) {
-			manualSession := isManualSessionBead(b)
+			manualSession := isManualSessionBeadForAgent(b, cfgAgent)
 			creating := b.Metadata["state"] == "creating"
 			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating {
 				continue
@@ -719,7 +719,7 @@ func discoverSessionBeadsWithRoots(
 			resolveAgent         *config.Agent
 			sessionQualifiedName string
 		)
-		if isManualSessionBead(b) {
+		if isManualSessionBeadForAgent(b, cfgAgent) {
 			sessionQualifiedName = sessionBeadQualifiedName(bp.cityPath, cfgAgent, bp.rigs, b)
 			resolveAgent = sessionBeadConfigAgent(cfgAgent, sessionQualifiedName)
 		} else {
@@ -739,7 +739,7 @@ func discoverSessionBeadsWithRoots(
 			fmt.Fprintf(stderr, "buildDesiredState: bead %s template %q: %v (skipping)\n", b.ID, template, err) //nolint:errcheck
 			continue
 		}
-		tp.ManualSession = isManualSessionBead(b)
+		tp.ManualSession = isManualSessionBeadForAgent(b, cfgAgent)
 		if tp.ManualSession {
 			if manualAlias := strings.TrimSpace(b.Metadata["alias"]); manualAlias != "" {
 				// Explicit aliases from `gc session new --alias ...` are
@@ -751,7 +751,11 @@ func discoverSessionBeadsWithRoots(
 			if !tp.ManualSession || strings.TrimSpace(b.Metadata["alias"]) == "" {
 				tp.Alias = ""
 			}
-			tp.InstanceName = sn
+			if tp.ManualSession && sessionQualifiedName != "" {
+				tp.InstanceName = sessionQualifiedName
+			} else {
+				tp.InstanceName = sn
+			}
 		}
 		installAgentSideEffects(bp, cfgAgent, tp, stderr)
 		desired[sn] = tp
@@ -1004,14 +1008,20 @@ func sessionBeadQualifiedName(cityPath string, cfgAgent *config.Agent, rigs []co
 	if cfgAgent == nil {
 		return ""
 	}
-	if agentName := normalizeSessionBeadQualifiedName(cfgAgent, sessionBeadAgentName(sessionBead)); agentName != "" {
-		return agentName
+	persistedAgentName := normalizeSessionBeadQualifiedName(cfgAgent, sessionBeadAgentName(sessionBead))
+	if persistedAgentName != "" {
+		if !cfgAgent.SupportsMultipleSessions() || persistedAgentName != cfgAgent.QualifiedName() {
+			return persistedAgentName
+		}
 	}
 	explicitName := ""
 	if strings.TrimSpace(sessionBead.Metadata["session_name_explicit"]) == boolMetadata(true) {
 		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
 	}
-	if explicitName == "" && strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && strings.TrimSpace(sessionBeadAgentName(sessionBead)) == "" && cfgAgent.SupportsMultipleSessions() {
+	if explicitName == "" && strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && persistedAgentName == cfgAgent.QualifiedName() && cfgAgent.SupportsMultipleSessions() {
+		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
+	}
+	if explicitName == "" && strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && persistedAgentName == "" && cfgAgent.SupportsMultipleSessions() {
 		explicitName = strings.TrimSpace(sessionBead.Metadata["session_name"])
 	}
 	qualifiedName := workdirutil.SessionQualifiedName(
@@ -1045,7 +1055,7 @@ func normalizeSessionBeadQualifiedName(cfgAgent *config.Agent, identity string) 
 }
 
 func sessionBeadConfigAgent(cfgAgent *config.Agent, qualifiedName string) *config.Agent {
-	if cfgAgent == nil || !cfgAgent.SupportsInstanceExpansion() || strings.TrimSpace(qualifiedName) == "" || qualifiedName == cfgAgent.QualifiedName() {
+	if cfgAgent == nil || !cfgAgent.SupportsMultipleSessions() || strings.TrimSpace(qualifiedName) == "" || qualifiedName == cfgAgent.QualifiedName() {
 		return cfgAgent
 	}
 	localName := strings.TrimSpace(qualifiedName)
@@ -1118,6 +1128,7 @@ func selectOrCreatePoolSessionBead(
 	preferred *beads.Bead,
 	used map[string]bool,
 ) (beads.Bead, error) {
+	cfgAgent := findAgentByTemplate(&config.City{Agents: bp.agents}, template)
 	// Resume tier: reuse the session that has in-progress work assigned.
 	if preferred != nil && preferred.ID != "" && !used[preferred.ID] {
 		return *preferred, nil
@@ -1135,7 +1146,7 @@ func selectOrCreatePoolSessionBead(
 		if bead.Metadata["state"] == "asleep" {
 			continue
 		}
-		if isManualSessionBead(bead) {
+		if isManualSessionBeadForAgent(bead, cfgAgent) {
 			continue
 		}
 		if isNamedSessionBead(bead) {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1452,6 +1452,59 @@ func TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings(t
 	}
 }
 
+func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	workDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", "ant-adhoc-abc123")
+	if _, err := store.Create(beads.Bead{
+		Title:  "adhoc ant",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:demo/ant"},
+		Metadata: map[string]string{
+			"template":              "demo/ant",
+			"session_name":          "ant-adhoc-abc123",
+			"session_name_explicit": boolMetadata(true),
+			"agent_name":            "demo/ant-adhoc-abc123",
+			"session_origin":        "manual",
+			"pending_create_claim":  boolMetadata(true),
+			"state":                 "creating",
+			"work_dir":              workDir,
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}},
+		Agents: []config.Agent{{
+			Name:              "ant",
+			Dir:               "demo",
+			Provider:          "test-agent",
+			StartCommand:      "true",
+			WorkDir:           ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(4),
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State["ant-adhoc-abc123"]
+	if !ok {
+		t.Fatalf("desired state missing pending create session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.TemplateName != "demo/ant" {
+		t.Fatalf("TemplateName = %q, want %q", got.TemplateName, "demo/ant")
+	}
+	if got.InstanceName != "demo/ant-adhoc-abc123" {
+		t.Fatalf("InstanceName = %q, want %q", got.InstanceName, "demo/ant-adhoc-abc123")
+	}
+	if got.WorkDir != workDir {
+		t.Fatalf("WorkDir = %q, want %q", got.WorkDir, workDir)
+	}
+	if got.Env["GC_ALIAS"] != "demo/ant-adhoc-abc123" {
+		t.Fatalf("GC_ALIAS = %q, want %q", got.Env["GC_ALIAS"], "demo/ant-adhoc-abc123")
+	}
+}
+
 func TestBuildDesiredState_DoesNotCreateDuplicatePoolBeadForDiscoveredSession(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1415,6 +1415,7 @@ func TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings(t
 		Agents: []config.Agent{{
 			Name:              "worker",
 			BindingName:       "ops",
+			WorkDir:           ".gc/worktrees/{{.AgentBase}}",
 			MinActiveSessions: intPtr(0),
 			MaxActiveSessions: intPtr(2),
 			ScaleCheck:        "printf 1",
@@ -1444,6 +1445,10 @@ func TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings(t
 	}
 	if got.Env["GC_AGENT"] != wantInstance {
 		t.Fatalf("GC_AGENT = %q, want %q", got.Env["GC_AGENT"], wantInstance)
+	}
+	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "ops.worker-1")
+	if got.WorkDir != wantWorkDir {
+		t.Fatalf("WorkDir = %q, want %q", got.WorkDir, wantWorkDir)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1505,7 +1505,7 @@ func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *t
 	}
 }
 
-func TestBuildDesiredState_LegacyAliaslessManualPoolSessionFallsBackToSessionNameIdentity(t *testing.T) {
+func TestBuildDesiredState_LegacyAliaslessEphemeralPoolSessionFallsBackToSessionNameIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{
@@ -1514,8 +1514,9 @@ func TestBuildDesiredState_LegacyAliaslessManualPoolSessionFallsBackToSessionNam
 		Labels: []string{sessionBeadLabel, "template:demo/ant"},
 		Metadata: map[string]string{
 			"template":       "demo/ant",
+			"agent_name":     "demo/ant",
 			"session_name":   "s-gc-legacy",
-			"session_origin": "manual",
+			"session_origin": "ephemeral",
 			"state":          "creating",
 			"work_dir":       filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", "ant"),
 		},
@@ -2309,6 +2310,28 @@ func agentName(a *config.Agent) string {
 		return "<nil>"
 	}
 	return a.Name
+}
+
+func TestSessionBeadConfigAgent_UsesMultipleSessionShapeForMaxZero(t *testing.T) {
+	cfgAgent := &config.Agent{
+		Name:              "ant",
+		Dir:               "demo",
+		MaxActiveSessions: intPtr(0),
+	}
+
+	got := sessionBeadConfigAgent(cfgAgent, "demo/ant-adhoc-123")
+	if got == cfgAgent {
+		t.Fatal("sessionBeadConfigAgent returned base agent, want deep-copied instance agent")
+	}
+	if got == nil || got.Name != "ant-adhoc-123" {
+		t.Fatalf("agent.Name = %q, want %q", agentName(got), "ant-adhoc-123")
+	}
+	if got.PoolName != "demo/ant" {
+		t.Fatalf("agent.PoolName = %q, want %q", got.PoolName, "demo/ant")
+	}
+	if template := templateNameFor(got, "demo/ant-adhoc-123"); template != "demo/ant" {
+		t.Fatalf("templateNameFor(instance) = %q, want %q", template, "demo/ant")
+	}
 }
 
 // TestEnsureDependencyOnlyTemplate_StoreBackedUsesInstanceIdentity is a

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1505,6 +1505,50 @@ func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *t
 	}
 }
 
+func TestBuildDesiredState_LegacyAliaslessManualPoolSessionFallsBackToSessionNameIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "legacy ant",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:demo/ant"},
+		Metadata: map[string]string{
+			"template":       "demo/ant",
+			"session_name":   "s-gc-legacy",
+			"session_origin": "manual",
+			"state":          "creating",
+			"work_dir":       filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", "ant"),
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}},
+		Agents: []config.Agent{{
+			Name:              "ant",
+			Dir:               "demo",
+			Provider:          "test-agent",
+			StartCommand:      "true",
+			WorkDir:           ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(4),
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State["s-gc-legacy"]
+	if !ok {
+		t.Fatalf("desired state missing legacy session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.InstanceName != "demo/s-gc-legacy" {
+		t.Fatalf("InstanceName = %q, want %q", got.InstanceName, "demo/s-gc-legacy")
+	}
+	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", "s-gc-legacy")
+	if got.WorkDir != wantWorkDir {
+		t.Fatalf("WorkDir = %q, want %q", got.WorkDir, wantWorkDir)
+	}
+}
+
 func TestBuildDesiredState_DoesNotCreateDuplicatePoolBeadForDiscoveredSession(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -175,7 +175,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if alias != "" && isMultiSessionCfgAgent(&found) {
+	if alias != "" && found.SupportsMultipleSessions() {
 		alias = workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, "")
 	}
 	explicitName, err := sessionExplicitNameForNewSession(&found, alias)
@@ -194,11 +194,12 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	mgr := newSessionManager(store, sp)
 
 	// Build the work directory.
+	sessionQualifiedName := workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, explicitName)
 	workDir, err := resolveWorkDirForQualifiedName(
 		cityPath,
 		cfg,
 		&found,
-		workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, explicitName),
+		sessionQualifiedName,
 	)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -225,16 +226,22 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		if pokeErr := pokeController(cityPath); pokeErr == nil {
 			// Controller is running — create bead only, let reconciler start it.
 			var info session.Info
-			err := session.WithCitySessionAliasLock(cityPath, alias, func() error {
+			err := session.WithCitySessionIdentifierLocks(cityPath, []string{alias, explicitName}, func() error {
 				if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, alias, "", configuredOwner); err != nil {
 					return err
 				}
+				if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
+					return err
+				}
 				var createErr error
-				kindMeta := map[string]string{"session_origin": "ephemeral"}
+				kindMeta := map[string]string{
+					"agent_name":     sessionQualifiedName,
+					"session_origin": "manual",
+				}
 				if resolved.Kind != "" && resolved.Kind != resolved.Name {
 					kindMeta["provider_kind"] = resolved.Kind
 				}
-				info, createErr = mgr.CreateAliasedBeadOnlyNamedWithMetadata(alias, "", canonicalTemplate, title, resolved.CommandString(), workDir, resolved.Name, found.Session, session.ProviderResume{
+				info, createErr = mgr.CreateAliasedBeadOnlyNamedWithMetadata(alias, explicitName, canonicalTemplate, title, resolved.CommandString(), workDir, resolved.Name, found.Session, session.ProviderResume{
 					ResumeFlag:    resolved.ResumeFlag,
 					ResumeStyle:   resolved.ResumeStyle,
 					ResumeCommand: resolved.ResumeCommand,
@@ -291,17 +298,23 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		SessionIDFlag: resolved.SessionIDFlag,
 	}
 
-	kindMeta := map[string]string{"session_origin": "ephemeral"}
+	kindMeta := map[string]string{
+		"agent_name":     sessionQualifiedName,
+		"session_origin": "manual",
+	}
 	if resolved.Kind != "" && resolved.Kind != resolved.Name {
 		kindMeta["provider_kind"] = resolved.Kind
 	}
 	var info session.Info
-	err = session.WithCitySessionAliasLock(cityPath, alias, func() error {
+	err = session.WithCitySessionIdentifierLocks(cityPath, []string{alias, explicitName}, func() error {
 		if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, alias, "", configuredOwner); err != nil {
 			return err
 		}
+		if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
+			return err
+		}
 		var createErr error
-		info, createErr = mgr.CreateAliasedNamedWithTransportAndMetadata(context.Background(), alias, "", canonicalTemplate, title, resolved.CommandString(), workDir, resolved.Name, found.Session, resolved.Env, resume, hints, kindMeta)
+		info, createErr = mgr.CreateAliasedNamedWithTransportAndMetadata(context.Background(), alias, explicitName, canonicalTemplate, title, resolved.CommandString(), workDir, resolved.Name, found.Session, resolved.Env, resume, hints, kindMeta)
 		return createErr
 	})
 	if err != nil {
@@ -1410,7 +1423,7 @@ func resolveWorkDirForQualifiedName(cityPath string, cfg *config.City, agent *co
 }
 
 func sessionExplicitNameForNewSession(agent *config.Agent, alias string) (string, error) {
-	if agent == nil || !isMultiSessionCfgAgent(agent) || strings.TrimSpace(alias) != "" {
+	if agent == nil || !agent.SupportsMultipleSessions() || strings.TrimSpace(alias) != "" {
 		return "", nil
 	}
 	return session.GenerateAdhocExplicitName(agent.Name)

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 	"github.com/spf13/cobra"
 )
 
@@ -174,6 +175,9 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if alias != "" {
+		alias = workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, "")
+	}
 	explicitName, err := sessionExplicitNameForNewSession(&found, alias)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -194,7 +198,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		cityPath,
 		cfg,
 		&found,
-		sessionWorkDirQualifiedName(cityPath, cfg, &found, alias, explicitName),
+		workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, explicitName),
 	)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1405,59 +1409,11 @@ func resolveWorkDirForQualifiedName(cityPath string, cfg *config.City, agent *co
 	return resolveConfiguredWorkDir(cityPath, cityName, qualifiedName, agent, rigs)
 }
 
-func sessionWorkDirQualifiedName(cityPath string, cfg *config.City, agent *config.Agent, alias, explicitName string) string {
-	if agent == nil {
-		return ""
-	}
-	alias = strings.TrimSpace(alias)
-	if !isMultiSessionCfgAgent(agent) {
-		return agent.QualifiedName()
-	}
-	identity := alias
-	if identity == "" {
-		identity = strings.TrimSpace(explicitName)
-	}
-	if identity == "" {
-		return agent.QualifiedName()
-	}
-	if strings.Contains(identity, "/") {
-		return identity
-	}
-	var rigs []config.Rig
-	if cfg != nil {
-		rigs = cfg.Rigs
-	}
-	if rigName := configuredRigName(cityPath, agent, rigs); rigName != "" {
-		return rigName + "/" + identity
-	}
-	return identity
-}
-
 func sessionExplicitNameForNewSession(agent *config.Agent, alias string) (string, error) {
 	if agent == nil || !isMultiSessionCfgAgent(agent) || strings.TrimSpace(alias) != "" {
 		return "", nil
 	}
-	token, err := session.GenerateSessionKey()
-	if err != nil {
-		return "", fmt.Errorf("generate pooled session identity: %w", err)
-	}
-	compact := strings.ReplaceAll(token, "-", "")
-	if len(compact) > 10 {
-		compact = compact[:10]
-	}
-	base := strings.TrimSpace(agent.Name)
-	if base == "" {
-		base = "session"
-	}
-	suffix := "-adhoc-" + compact
-	maxBaseLen := 64 - len(suffix)
-	if maxBaseLen < 1 {
-		maxBaseLen = 1
-	}
-	if len(base) > maxBaseLen {
-		base = base[:maxBaseLen]
-	}
-	return session.ValidateExplicitName(base + suffix)
+	return session.GenerateAdhocExplicitName(agent.Name)
 }
 
 func shouldAttachNewSession(noAttach bool, transport string) bool {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -170,13 +170,14 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	alias, err = session.ValidateAlias(alias)
+	requestedAlias, err := session.ValidateAlias(alias)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	alias = requestedAlias
 	if alias != "" && found.SupportsMultipleSessions() {
-		alias = workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, "")
+		alias = workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, requestedAlias, "")
 	}
 	explicitName, err := sessionExplicitNameForNewSession(&found, alias)
 	if err != nil {
@@ -194,7 +195,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	mgr := newSessionManager(store, sp)
 
 	// Build the work directory.
-	sessionQualifiedName := workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, explicitName)
+	sessionQualifiedName := workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, requestedAlias, explicitName)
 	workDir, err := resolveWorkDirForQualifiedName(
 		cityPath,
 		cfg,

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -175,7 +175,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if alias != "" {
+	if alias != "" && isMultiSessionCfgAgent(&found) {
 		alias = workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, alias, "")
 	}
 	explicitName, err := sessionExplicitNameForNewSession(&found, alias)

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -185,7 +185,12 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	mgr := newSessionManager(store, sp)
 
 	// Build the work directory.
-	workDir, err := resolveWorkDir(cityPath, cfg, &found)
+	workDir, err := resolveWorkDirForQualifiedName(
+		cityPath,
+		cfg,
+		&found,
+		sessionWorkDirQualifiedName(cityPath, cfg, &found, alias),
+	)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1380,6 +1385,10 @@ func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, stdout, stderr i
 // resolveWorkDir determines the working directory for a session based on the
 // agent config. work_dir overrides dir, while dir still carries rig identity.
 func resolveWorkDir(cityPath string, cfg *config.City, agent *config.Agent) (string, error) {
+	return resolveWorkDirForQualifiedName(cityPath, cfg, agent, "")
+}
+
+func resolveWorkDirForQualifiedName(cityPath string, cfg *config.City, agent *config.Agent, qualifiedName string) (string, error) {
 	cityName := filepath.Base(cityPath)
 	if cfg != nil && cfg.Workspace.Name != "" {
 		cityName = cfg.Workspace.Name
@@ -1388,7 +1397,28 @@ func resolveWorkDir(cityPath string, cfg *config.City, agent *config.Agent) (str
 	if cfg != nil {
 		rigs = cfg.Rigs
 	}
-	return resolveConfiguredWorkDir(cityPath, cityName, agent, rigs)
+	return resolveConfiguredWorkDir(cityPath, cityName, qualifiedName, agent, rigs)
+}
+
+func sessionWorkDirQualifiedName(cityPath string, cfg *config.City, agent *config.Agent, alias string) string {
+	if agent == nil {
+		return ""
+	}
+	alias = strings.TrimSpace(alias)
+	if alias == "" || !isMultiSessionCfgAgent(agent) {
+		return agent.QualifiedName()
+	}
+	if strings.Contains(alias, "/") {
+		return alias
+	}
+	var rigs []config.Rig
+	if cfg != nil {
+		rigs = cfg.Rigs
+	}
+	if rigName := configuredRigName(cityPath, agent, rigs); rigName != "" {
+		return rigName + "/" + alias
+	}
+	return alias
 }
 
 func shouldAttachNewSession(noAttach bool, transport string) bool {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -210,6 +210,11 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	// via findAgentByTemplate (which compares against QualifiedName()).
 	canonicalTemplate := found.QualifiedName()
 	configuredOwner := sessionNewAliasOwner(cfg, &found)
+	reservationIDs := []string{alias, explicitName}
+	reserveConcreteIdentity := found.SupportsMultipleSessions() && strings.TrimSpace(sessionQualifiedName) != ""
+	if reserveConcreteIdentity {
+		reservationIDs = append(reservationIDs, sessionQualifiedName)
+	}
 
 	// Resolve the workspace default provider for title generation. This
 	// mirrors api.Server.resolveTitleProvider: use an empty Agent so we
@@ -226,9 +231,14 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		if pokeErr := pokeController(cityPath); pokeErr == nil {
 			// Controller is running — create bead only, let reconciler start it.
 			var info session.Info
-			err := session.WithCitySessionIdentifierLocks(cityPath, []string{alias, explicitName}, func() error {
+			err := session.WithCitySessionIdentifierLocks(cityPath, reservationIDs, func() error {
 				if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, alias, "", configuredOwner); err != nil {
 					return err
+				}
+				if reserveConcreteIdentity && sessionQualifiedName != alias {
+					if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, sessionQualifiedName, "", configuredOwner); err != nil {
+						return err
+					}
 				}
 				if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
 					return err
@@ -306,9 +316,14 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		kindMeta["provider_kind"] = resolved.Kind
 	}
 	var info session.Info
-	err = session.WithCitySessionIdentifierLocks(cityPath, []string{alias, explicitName}, func() error {
+	err = session.WithCitySessionIdentifierLocks(cityPath, reservationIDs, func() error {
 		if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, alias, "", configuredOwner); err != nil {
 			return err
+		}
+		if reserveConcreteIdentity && sessionQualifiedName != alias {
+			if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, sessionQualifiedName, "", configuredOwner); err != nil {
+				return err
+			}
 		}
 		if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
 			return err

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -174,6 +174,11 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	explicitName, err := sessionExplicitNameForNewSession(&found, alias)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	// Open the bead store.
 	store, code := openCityStore(stderr, "gc session new")
@@ -189,7 +194,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		cityPath,
 		cfg,
 		&found,
-		sessionWorkDirQualifiedName(cityPath, cfg, &found, alias),
+		sessionWorkDirQualifiedName(cityPath, cfg, &found, alias, explicitName),
 	)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1400,25 +1405,59 @@ func resolveWorkDirForQualifiedName(cityPath string, cfg *config.City, agent *co
 	return resolveConfiguredWorkDir(cityPath, cityName, qualifiedName, agent, rigs)
 }
 
-func sessionWorkDirQualifiedName(cityPath string, cfg *config.City, agent *config.Agent, alias string) string {
+func sessionWorkDirQualifiedName(cityPath string, cfg *config.City, agent *config.Agent, alias, explicitName string) string {
 	if agent == nil {
 		return ""
 	}
 	alias = strings.TrimSpace(alias)
-	if alias == "" || !isMultiSessionCfgAgent(agent) {
+	if !isMultiSessionCfgAgent(agent) {
 		return agent.QualifiedName()
 	}
-	if strings.Contains(alias, "/") {
-		return alias
+	identity := alias
+	if identity == "" {
+		identity = strings.TrimSpace(explicitName)
+	}
+	if identity == "" {
+		return agent.QualifiedName()
+	}
+	if strings.Contains(identity, "/") {
+		return identity
 	}
 	var rigs []config.Rig
 	if cfg != nil {
 		rigs = cfg.Rigs
 	}
 	if rigName := configuredRigName(cityPath, agent, rigs); rigName != "" {
-		return rigName + "/" + alias
+		return rigName + "/" + identity
 	}
-	return alias
+	return identity
+}
+
+func sessionExplicitNameForNewSession(agent *config.Agent, alias string) (string, error) {
+	if agent == nil || !isMultiSessionCfgAgent(agent) || strings.TrimSpace(alias) != "" {
+		return "", nil
+	}
+	token, err := session.GenerateSessionKey()
+	if err != nil {
+		return "", fmt.Errorf("generate pooled session identity: %w", err)
+	}
+	compact := strings.ReplaceAll(token, "-", "")
+	if len(compact) > 10 {
+		compact = compact[:10]
+	}
+	base := strings.TrimSpace(agent.Name)
+	if base == "" {
+		base = "session"
+	}
+	suffix := "-adhoc-" + compact
+	maxBaseLen := 64 - len(suffix)
+	if maxBaseLen < 1 {
+		maxBaseLen = 1
+	}
+	if len(base) > maxBaseLen {
+		base = base[:maxBaseLen]
+	}
+	return session.ValidateExplicitName(base + suffix)
 }
 
 func shouldAttachNewSession(noAttach bool, transport string) bool {

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sessionlog"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 	"github.com/spf13/cobra"
 )
 
@@ -159,7 +160,8 @@ func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, ident
 		cityName = filepath.Base(cityPath)
 	}
 	if spec, ok, _ := findNamedSessionSpecForTarget(cfg, cityName, identifier); ok && spec.Agent != nil {
-		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, spec.Identity)
+		workDirQualifiedName := workdirutil.SessionQualifiedName(cityPath, *spec.Agent, cfg.Rigs, spec.Identity, "")
+		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, workDirQualifiedName)
 		if err != nil || strings.TrimSpace(workDir) == "" {
 			return "", false
 		}

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -159,7 +159,7 @@ func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, ident
 		cityName = filepath.Base(cityPath)
 	}
 	if spec, ok, _ := findNamedSessionSpecForTarget(cfg, cityName, identifier); ok && spec.Agent != nil {
-		workDir, err := resolveWorkDir(cityPath, cfg, spec.Agent)
+		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, spec.Identity)
 		if err != nil || strings.TrimSpace(workDir) == "" {
 			return "", false
 		}

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -561,6 +561,34 @@ func TestResolveSessionLogContext_ReservedNamedTargetIgnoresClosedHistoricalBead
 	}
 }
 
+func TestResolveConfiguredSessionLogContext_RebrandedSingletonUsesTemplateWorkDirIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gastown"},
+		Rigs:      []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}},
+		Agents: []config.Agent{{
+			Name:              "witness",
+			Dir:               "demo",
+			WorkDir:           ".gc/worktrees/{{.Rig}}/{{.AgentBase}}",
+			MaxActiveSessions: intPtr(1),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "boot",
+			Template: "witness",
+			Dir:      "demo",
+		}},
+	}
+
+	got, ok := resolveConfiguredSessionLogContext(cityPath, cfg, "demo/boot")
+	if !ok {
+		t.Fatal("resolveConfiguredSessionLogContext() = not found, want found")
+	}
+	want := filepath.Join(cityPath, ".gc", "worktrees", "demo", "witness")
+	if got != want {
+		t.Fatalf("resolveConfiguredSessionLogContext() workDir = %q, want %q", got, want)
+	}
+}
+
 func TestResolveConfiguredSessionLogContext_RejectsNonExactOrPoolTargets(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -305,6 +305,12 @@ func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *t
 		if sessionName == "" {
 			t.Fatal("session_name should be populated for aliasless pooled session")
 		}
+		if got := bead.Metadata["session_name_explicit"]; got != boolMetadata(true) {
+			t.Fatalf("session_name_explicit = %q, want %q", got, boolMetadata(true))
+		}
+		if !strings.HasPrefix(sessionName, "ant-adhoc-") {
+			t.Fatalf("session_name = %q, want ant-adhoc-*", sessionName)
+		}
 		if seenSessionName[sessionName] {
 			t.Fatalf("duplicate session_name %q for aliasless pooled sessions", sessionName)
 		}
@@ -324,6 +330,9 @@ func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *t
 			t.Fatalf("duplicate work_dir %q for aliasless pooled sessions", workDir)
 		}
 		seenWorkDir[workDir] = true
+		if got := bead.Metadata["agent_name"]; got != "demo/"+sessionName {
+			t.Fatalf("agent_name(%q) = %q, want %q", sessionName, got, "demo/"+sessionName)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -199,6 +199,49 @@ func TestResolveWorkDir(t *testing.T) {
 	}
 }
 
+func TestCmdSessionNew_PoolTemplateUsesAliasBackedWorkDirIdentity(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writePoolSessionCityTOML(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	for _, alias := range []string{"demo/ant-fenrir", "demo/ant-grendel"} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := cmdSessionNew([]string{"demo/ant"}, alias, "", "", true, &stdout, &stderr); code != 0 {
+			t.Fatalf("cmdSessionNew(%q) = %d, want 0; stderr=%s", alias, code, stderr.String())
+		}
+	}
+
+	all := sessionBeads(t, cityDir)
+	if len(all) != 2 {
+		t.Fatalf("session beads = %d, want 2", len(all))
+	}
+
+	wantWorkDir := map[string]string{
+		"demo/ant-fenrir":  filepath.Join(cityDir, ".gc", "worktrees", "demo", "ants", "ant-fenrir"),
+		"demo/ant-grendel": filepath.Join(cityDir, ".gc", "worktrees", "demo", "ants", "ant-grendel"),
+	}
+	seenWorkDir := make(map[string]string, len(all))
+	for _, bead := range all {
+		alias := bead.Metadata["alias"]
+		want, ok := wantWorkDir[alias]
+		if !ok {
+			t.Fatalf("unexpected alias %q in bead metadata", alias)
+		}
+		if got := bead.Metadata["work_dir"]; got != want {
+			t.Fatalf("work_dir(%q) = %q, want %q", alias, got, want)
+		}
+		if otherAlias, collision := seenWorkDir[bead.Metadata["work_dir"]]; collision {
+			t.Fatalf("work_dir collision: %q and %q both use %q", otherAlias, alias, bead.Metadata["work_dir"])
+		}
+		seenWorkDir[bead.Metadata["work_dir"]] = alias
+	}
+}
+
 // NOTE: session kill is tested via internal/session.Manager.Kill which
 // delegates to Provider.Stop. The CLI layer (cmdSessionKill) is a thin
 // wrapper that resolves the session ID and calls mgr.Kill, so it does
@@ -783,7 +826,40 @@ template = "mayor"
 	}
 }
 
-func onlySessionBead(t *testing.T, cityDir string) beads.Bead {
+func writePoolSessionCityTOML(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	rigRoot := filepath.Join(dir, "repos", "demo")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig root): %v", err)
+	}
+	data := []byte(fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "demo"
+path = %q
+
+[[agent]]
+name = "ant"
+dir = "demo"
+provider = "codex"
+start_command = "echo"
+work_dir = ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}"
+min_active_sessions = 0
+max_active_sessions = 4
+`, rigRoot))
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+}
+
+func sessionBeads(t *testing.T, cityDir string) []beads.Bead {
 	t.Helper()
 	store, err := openCityStoreAt(cityDir)
 	if err != nil {
@@ -793,6 +869,12 @@ func onlySessionBead(t *testing.T, cityDir string) beads.Bead {
 	if err != nil {
 		t.Fatalf("ListByLabel(session): %v", err)
 	}
+	return all
+}
+
+func onlySessionBead(t *testing.T, cityDir string) beads.Bead {
+	t.Helper()
+	all := sessionBeads(t, cityDir)
 	if len(all) != 1 {
 		t.Fatalf("session beads = %d, want 1", len(all))
 	}

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -273,6 +273,41 @@ func TestCmdSessionNew_PoolTemplateCanonicalizesQualifiedAliasCollisions(t *test
 	}
 }
 
+func TestCmdSessionNew_PoolTemplateBareAliasStillResolves(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writePoolSessionCityTOML(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNew([]string{"demo/ant"}, "ant-fenrir", "", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionNew = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig(%q): %v", cityDir, err)
+	}
+	store, code := openCityStore(io.Discard, "test")
+	if store == nil {
+		t.Fatalf("openCityStore = nil, code=%d", code)
+	}
+
+	id, err := resolveSessionIDMaterializingNamed(cityDir, cfg, store, "ant-fenrir")
+	if err != nil {
+		t.Fatalf("resolveSessionIDMaterializingNamed(ant-fenrir): %v", err)
+	}
+	all := sessionBeads(t, cityDir)
+	if len(all) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(all))
+	}
+	if id != all[0].ID {
+		t.Fatalf("resolved ID = %q, want %q", id, all[0].ID)
+	}
+}
+
 func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")
@@ -333,6 +368,38 @@ func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *t
 		if got := bead.Metadata["agent_name"]; got != "demo/"+sessionName {
 			t.Fatalf("agent_name(%q) = %q, want %q", sessionName, got, "demo/"+sessionName)
 		}
+	}
+}
+
+func TestCmdSessionNew_PoolTemplateRejectsAliasMatchingConcreteIdentity(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writePoolSessionCityTOML(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionNew(aliasless) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	all := sessionBeads(t, cityDir)
+	if len(all) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(all))
+	}
+	sessionName := all[0].Metadata["session_name"]
+	if sessionName == "" {
+		t.Fatal("session_name should be populated for aliasless pooled session")
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := cmdSessionNew([]string{"demo/ant"}, "demo/"+sessionName, "", "", true, &stdout, &stderr); code == 0 {
+		t.Fatal("cmdSessionNew(alias collision) = 0, want conflict")
+	}
+	if !strings.Contains(stderr.String(), session.ErrSessionAliasExists.Error()) {
+		t.Fatalf("stderr = %q, want alias conflict", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -278,14 +278,21 @@ func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *t
 			t.Fatalf("duplicate session_name %q for aliasless pooled sessions", sessionName)
 		}
 		seenSessionName[sessionName] = true
-		wantWorkDir := filepath.Join(cityDir, ".gc", "worktrees", "demo", "ants", sessionName)
-		if got := bead.Metadata["work_dir"]; got != wantWorkDir {
-			t.Fatalf("work_dir(%q) = %q, want %q", sessionName, got, wantWorkDir)
+		workDir := bead.Metadata["work_dir"]
+		if filepath.Dir(workDir) != filepath.Join(cityDir, ".gc", "worktrees", "demo", "ants") {
+			t.Fatalf("work_dir(%q) parent = %q, want %q", sessionName, filepath.Dir(workDir), filepath.Join(cityDir, ".gc", "worktrees", "demo", "ants"))
 		}
-		if seenWorkDir[wantWorkDir] {
-			t.Fatalf("duplicate work_dir %q for aliasless pooled sessions", wantWorkDir)
+		base := filepath.Base(workDir)
+		if base == "ant" {
+			t.Fatalf("work_dir(%q) base = %q, want unique generated identity", sessionName, base)
 		}
-		seenWorkDir[wantWorkDir] = true
+		if !strings.HasPrefix(base, "ant-adhoc-") {
+			t.Fatalf("work_dir(%q) base = %q, want ant-adhoc-*", sessionName, base)
+		}
+		if seenWorkDir[workDir] {
+			t.Fatalf("duplicate work_dir %q for aliasless pooled sessions", workDir)
+		}
+		seenWorkDir[workDir] = true
 	}
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -242,6 +242,37 @@ func TestCmdSessionNew_PoolTemplateUsesAliasBackedWorkDirIdentity(t *testing.T) 
 	}
 }
 
+func TestCmdSessionNew_PoolTemplateCanonicalizesQualifiedAliasCollisions(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writePoolSessionCityTOML(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNew([]string{"demo/ant"}, "ant-fenrir", "", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionNew(first) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := cmdSessionNew([]string{"demo/ant"}, "demo/ant-fenrir", "", "", true, &stdout, &stderr); code == 0 {
+		t.Fatal("cmdSessionNew(second) = 0, want alias conflict")
+	}
+	if !strings.Contains(stderr.String(), session.ErrSessionAliasExists.Error()) {
+		t.Fatalf("stderr = %q, want alias conflict", stderr.String())
+	}
+
+	all := sessionBeads(t, cityDir)
+	if len(all) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(all))
+	}
+	if got := all[0].Metadata["alias"]; got != "demo/ant-fenrir" {
+		t.Fatalf("alias = %q, want canonical qualified alias", got)
+	}
+}
+
 func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -242,6 +242,53 @@ func TestCmdSessionNew_PoolTemplateUsesAliasBackedWorkDirIdentity(t *testing.T) 
 	}
 }
 
+func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writePoolSessionCityTOML(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	for i := 0; i < 2; i++ {
+		stdout.Reset()
+		stderr.Reset()
+		if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code != 0 {
+			t.Fatalf("cmdSessionNew(aliasless #%d) = %d, want 0; stderr=%s", i+1, code, stderr.String())
+		}
+	}
+
+	all := sessionBeads(t, cityDir)
+	if len(all) != 2 {
+		t.Fatalf("session beads = %d, want 2", len(all))
+	}
+
+	seenSessionName := make(map[string]bool, len(all))
+	seenWorkDir := make(map[string]bool, len(all))
+	for _, bead := range all {
+		if got := bead.Metadata["alias"]; got != "" {
+			t.Fatalf("alias = %q, want empty for aliasless pooled session", got)
+		}
+		sessionName := bead.Metadata["session_name"]
+		if sessionName == "" {
+			t.Fatal("session_name should be populated for aliasless pooled session")
+		}
+		if seenSessionName[sessionName] {
+			t.Fatalf("duplicate session_name %q for aliasless pooled sessions", sessionName)
+		}
+		seenSessionName[sessionName] = true
+		wantWorkDir := filepath.Join(cityDir, ".gc", "worktrees", "demo", "ants", sessionName)
+		if got := bead.Metadata["work_dir"]; got != wantWorkDir {
+			t.Fatalf("work_dir(%q) = %q, want %q", sessionName, got, wantWorkDir)
+		}
+		if seenWorkDir[wantWorkDir] {
+			t.Fatalf("duplicate work_dir %q for aliasless pooled sessions", wantWorkDir)
+		}
+		seenWorkDir[wantWorkDir] = true
+	}
+}
+
 // NOTE: session kill is tested via internal/session.Manager.Kill which
 // delegates to Provider.Stop. The CLI layer (cmdSessionKill) is a thin
 // wrapper that resolves the session ID and calls mgr.Kill, so it does

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -850,11 +850,14 @@ func sessionSetupContextForAgent(cityPath, cityName, qualifiedName string, a *co
 	}
 }
 
-func resolveConfiguredWorkDir(cityPath, cityName string, a *config.Agent, rigs []config.Rig) (string, error) {
+func resolveConfiguredWorkDir(cityPath, cityName, qualifiedName string, a *config.Agent, rigs []config.Rig) (string, error) {
 	if a == nil {
 		return resolveAgentDir(cityPath, "")
 	}
-	workDir, err := workdirutil.ResolveWorkDirPathStrict(cityPath, cityName, a.QualifiedName(), *a, rigs)
+	if strings.TrimSpace(qualifiedName) == "" {
+		qualifiedName = a.QualifiedName()
+	}
+	workDir, err := workdirutil.ResolveWorkDirPathStrict(cityPath, cityName, qualifiedName, *a, rigs)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -579,6 +579,8 @@ func syncSessionBeadsWithSnapshot(
 		// For pool instances, use the qualified instance name as the agent_name.
 		if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
 			agentName = tp.InstanceName
+		} else if tp.InstanceName != "" && tp.InstanceName != tp.TemplateName {
+			agentName = tp.InstanceName
 		}
 		isManagedPool := origin == "ephemeral"
 
@@ -777,8 +779,12 @@ func syncSessionBeadsWithSnapshot(
 				queueMeta("pool_slot", strconv.Itoa(slot))
 			}
 		}
-		if b.Metadata["work_dir"] == "" && tp.WorkDir != "" {
+		legacyMissingConcreteIdentity := strings.TrimSpace(b.Metadata["agent_name"]) == ""
+		if tp.WorkDir != "" && (b.Metadata["work_dir"] == "" || (legacyMissingConcreteIdentity && b.Metadata["work_dir"] != tp.WorkDir)) {
 			queueMeta("work_dir", tp.WorkDir)
+		}
+		if legacyMissingConcreteIdentity && agentName != "" {
+			queueMeta("agent_name", agentName)
 		}
 		if b.Metadata["dependency_only"] != boolMetadata(tp.DependencyOnly) {
 			queueMeta("dependency_only", boolMetadata(tp.DependencyOnly))

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -779,11 +779,24 @@ func syncSessionBeadsWithSnapshot(
 				queueMeta("pool_slot", strconv.Itoa(slot))
 			}
 		}
-		legacyMissingConcreteIdentity := strings.TrimSpace(b.Metadata["agent_name"]) == ""
-		if tp.WorkDir != "" && (b.Metadata["work_dir"] == "" || (legacyMissingConcreteIdentity && b.Metadata["work_dir"] != tp.WorkDir)) {
-			queueMeta("work_dir", tp.WorkDir)
+		existingAgentName := strings.TrimSpace(b.Metadata["agent_name"])
+		legacyTemplateIdentity := agentName != "" &&
+			agentName != tp.TemplateName &&
+			(existingAgentName == tp.TemplateName || existingAgentName == targetBasename(tp.TemplateName))
+		legacyNeedsConcreteIdentity := existingAgentName == "" || legacyTemplateIdentity
+		if tp.WorkDir != "" {
+			switch {
+			case b.Metadata["work_dir"] == "":
+				// Legacy active sessions are still running in their original
+				// work_dir. Don't repoint metadata until the session stops.
+				if !legacyNeedsConcreteIdentity || state != "active" {
+					queueMeta("work_dir", tp.WorkDir)
+				}
+			case legacyNeedsConcreteIdentity && b.Metadata["work_dir"] != tp.WorkDir && state != "active":
+				queueMeta("work_dir", tp.WorkDir)
+			}
 		}
-		if legacyMissingConcreteIdentity && agentName != "" {
+		if legacyNeedsConcreteIdentity && agentName != "" {
 			queueMeta("agent_name", agentName)
 		}
 		if b.Metadata["dependency_only"] != boolMetadata(tp.DependencyOnly) {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -645,6 +645,53 @@ func TestSyncSessionBeads_ReopensClosedConfiguredNamedSession(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_BackfillsLegacyConcretePoolIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	bead, err := store.Create(beads.Bead{
+		Title:  "legacy ant",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":   "s-gc-legacy",
+			"template":       "demo/ant",
+			"session_origin": "manual",
+			"state":          "creating",
+			"work_dir":       "/tmp/stale",
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating legacy bead: %v", err)
+	}
+
+	ds := map[string]TemplateParams{
+		"s-gc-legacy": {
+			TemplateName: "demo/ant",
+			InstanceName: "demo/s-gc-legacy",
+			Command:      "true",
+			WorkDir:      "/tmp/fixed",
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", bead.ID, err)
+	}
+	if got.Metadata["agent_name"] != "demo/s-gc-legacy" {
+		t.Fatalf("agent_name = %q, want %q", got.Metadata["agent_name"], "demo/s-gc-legacy")
+	}
+	if got.Metadata["work_dir"] != "/tmp/fixed" {
+		t.Fatalf("work_dir = %q, want %q", got.Metadata["work_dir"], "/tmp/fixed")
+	}
+}
+
 func TestSyncSessionBeads_UpdatesNamedModeForWizardMayor(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -654,9 +654,10 @@ func TestSyncSessionBeads_BackfillsLegacyConcretePoolIdentity(t *testing.T) {
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel},
 		Metadata: map[string]string{
+			"agent_name":     "demo/ant",
 			"session_name":   "s-gc-legacy",
 			"template":       "demo/ant",
-			"session_origin": "manual",
+			"session_origin": "ephemeral",
 			"state":          "creating",
 			"work_dir":       "/tmp/stale",
 		},
@@ -667,10 +668,11 @@ func TestSyncSessionBeads_BackfillsLegacyConcretePoolIdentity(t *testing.T) {
 
 	ds := map[string]TemplateParams{
 		"s-gc-legacy": {
-			TemplateName: "demo/ant",
-			InstanceName: "demo/s-gc-legacy",
-			Command:      "true",
-			WorkDir:      "/tmp/fixed",
+			TemplateName:  "demo/ant",
+			InstanceName:  "demo/s-gc-legacy",
+			Command:       "true",
+			WorkDir:       "/tmp/fixed",
+			ManualSession: true,
 		},
 	}
 
@@ -689,6 +691,64 @@ func TestSyncSessionBeads_BackfillsLegacyConcretePoolIdentity(t *testing.T) {
 	}
 	if got.Metadata["work_dir"] != "/tmp/fixed" {
 		t.Fatalf("work_dir = %q, want %q", got.Metadata["work_dir"], "/tmp/fixed")
+	}
+	if got.Metadata["session_origin"] != "manual" {
+		t.Fatalf("session_origin = %q, want %q", got.Metadata["session_origin"], "manual")
+	}
+}
+
+func TestSyncSessionBeads_ActiveLegacyConcretePoolIdentityKeepsCurrentWorkDir(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "s-gc-legacy", runtime.Config{}); err != nil {
+		t.Fatalf("start fake session: %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:  "legacy ant",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":     "demo/ant",
+			"session_name":   "s-gc-legacy",
+			"template":       "demo/ant",
+			"session_origin": "ephemeral",
+			"state":          "active",
+			"work_dir":       "/tmp/stale",
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating legacy bead: %v", err)
+	}
+
+	ds := map[string]TemplateParams{
+		"s-gc-legacy": {
+			TemplateName:  "demo/ant",
+			InstanceName:  "demo/s-gc-legacy",
+			Command:       "true",
+			WorkDir:       "/tmp/fixed",
+			ManualSession: true,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", bead.ID, err)
+	}
+	if got.Metadata["agent_name"] != "demo/s-gc-legacy" {
+		t.Fatalf("agent_name = %q, want %q", got.Metadata["agent_name"], "demo/s-gc-legacy")
+	}
+	if got.Metadata["work_dir"] != "/tmp/stale" {
+		t.Fatalf("work_dir = %q, want %q", got.Metadata["work_dir"], "/tmp/stale")
+	}
+	if got.Metadata["session_origin"] != "manual" {
+		t.Fatalf("session_origin = %q, want %q", got.Metadata["session_origin"], "manual")
 	}
 }
 

--- a/cmd/gc/session_model_phase0_cli_surface_spec_test.go
+++ b/cmd/gc/session_model_phase0_cli_surface_spec_test.go
@@ -500,8 +500,8 @@ mode = "on_demand"
 	if got := b.Metadata["alias"]; got != "" {
 		t.Fatalf("alias = %q, want empty because factory create must not claim named identity mayor", got)
 	}
-	if got := b.Metadata["session_origin"]; got != "ephemeral" {
-		t.Fatalf("session_origin = %q, want ephemeral", got)
+	if got := b.Metadata["session_origin"]; got != "manual" {
+		t.Fatalf("session_origin = %q, want manual", got)
 	}
 }
 

--- a/cmd/gc/session_model_phase0_spec_test.go
+++ b/cmd/gc/session_model_phase0_spec_test.go
@@ -224,8 +224,8 @@ func TestPhase0CanonicalMetadata_TemplateFactoryMaterializationWritesEphemeralOr
 	if err != nil {
 		t.Fatalf("Get(%s): %v", id, err)
 	}
-	if got := bead.Metadata["session_origin"]; got != "ephemeral" {
-		t.Fatalf("session_origin = %q, want ephemeral", got)
+	if got := bead.Metadata["session_origin"]; got != "manual" {
+		t.Fatalf("session_origin = %q, want manual", got)
 	}
 	if got := bead.Metadata["manual_session"]; got != "" {
 		t.Fatalf("manual_session = %q, want empty", got)

--- a/cmd/gc/session_origin.go
+++ b/cmd/gc/session_origin.go
@@ -43,6 +43,34 @@ func isEphemeralSessionBead(bead beads.Bead) bool {
 	return sessionOrigin(bead) == "ephemeral"
 }
 
+// Legacy pooled sessions created before manual-session origin backfill were
+// persisted as session_origin="ephemeral" even though they were user-created.
+// Pool-managed controller beads always stamp pool_managed/pool_slot, so a
+// multi-session bead with ephemeral origin but without those markers is the
+// upgrade shape we need to preserve and migrate.
+func isLegacyManualSessionBeadForAgent(bead beads.Bead, cfgAgent *config.Agent) bool {
+	if cfgAgent == nil || !cfgAgent.SupportsMultipleSessions() {
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata["session_origin"]) != "ephemeral" {
+		return false
+	}
+	if isNamedSessionBead(bead) {
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata[poolManagedMetadataKey]) == boolMetadata(true) {
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata["pool_slot"]) != "" {
+		return false
+	}
+	return strings.TrimSpace(bead.Metadata["dependency_only"]) != boolMetadata(true)
+}
+
+func isManualSessionBeadForAgent(bead beads.Bead, cfgAgent *config.Agent) bool {
+	return isManualSessionBead(bead) || isLegacyManualSessionBeadForAgent(bead, cfgAgent)
+}
+
 func isEphemeralSessionBeadForAgent(bead beads.Bead, cfgAgent *config.Agent) bool {
 	if isEphemeralSessionBead(bead) {
 		return true

--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -155,6 +155,11 @@ func resolveSessionIDWithOptions(
 	} else if !errors.Is(err, session.ErrSessionNotFound) {
 		return "", err
 	}
+	if id, err := resolveOpenQualifiedAliasBasename(store, identifier); err == nil {
+		return id, nil
+	} else if !errors.Is(err, session.ErrSessionNotFound) {
+		return "", err
+	}
 	if opts.allowClosed {
 		if cfg != nil {
 			cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
@@ -171,4 +176,39 @@ func resolveSessionIDWithOptions(
 		}
 	}
 	return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
+}
+
+func resolveOpenQualifiedAliasBasename(store beads.Store, identifier string) (string, error) {
+	identifier = strings.TrimSpace(identifier)
+	if store == nil || identifier == "" || strings.Contains(identifier, "/") {
+		return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
+	}
+	all, err := store.List(beads.ListQuery{Label: session.LabelSession})
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
+	}
+	matches := make([]beads.Bead, 0, 1)
+	for _, b := range all {
+		if !session.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
+			continue
+		}
+		session.RepairEmptyType(store, &b)
+		alias := strings.TrimSpace(b.Metadata["alias"])
+		if alias == "" || !strings.Contains(alias, "/") || session.TargetBasename(alias) != identifier {
+			continue
+		}
+		matches = append(matches, b)
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
+	case 1:
+		return matches[0].ID, nil
+	default:
+		labels := make([]string, 0, len(matches))
+		for _, match := range matches {
+			labels = append(labels, fmt.Sprintf("%s (%s)", match.ID, strings.TrimSpace(match.Metadata["alias"])))
+		}
+		return "", fmt.Errorf("%w: %q matches %d sessions: %s", session.ErrAmbiguous, identifier, len(matches), strings.Join(labels, ", "))
+	}
 }

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -78,7 +78,7 @@ func TestResolveSessionID_QualifiedAliasBasename(t *testing.T) {
 		},
 	})
 
-	id, err := resolveSessionID(store, "witness")
+	id, err := resolveSessionIDWithConfig(t.TempDir(), nil, store, "witness")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -68,6 +68,25 @@ func TestResolveSessionID_QualifiedAlias(t *testing.T) {
 	}
 }
 
+func TestResolveSessionID_QualifiedAliasBasename(t *testing.T) {
+	store := beads.NewMemStore()
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias": "myrig/witness",
+		},
+	})
+
+	id, err := resolveSessionID(store, "witness")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Errorf("got %q, want %q", id, b.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveHistoricalAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -118,7 +118,7 @@ func materializeSessionForTemplateWithOptions(
 		if err != nil {
 			return "", err
 		}
-		workDir, err := resolveWorkDir(cityPath, cfg, spec.Agent)
+		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, spec.Identity)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -278,11 +278,12 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 	if err != nil {
 		return "", err
 	}
+	sessionQualifiedName := workdirutil.SessionQualifiedName(cityPath, *agentCfg, cfg.Rigs, "", explicitName)
 	workDir, err := resolveWorkDirForQualifiedName(
 		cityPath,
 		cfg,
 		agentCfg,
-		workdirutil.SessionQualifiedName(cityPath, *agentCfg, cfg.Rigs, "", explicitName),
+		sessionQualifiedName,
 	)
 	if err != nil {
 		return "", err
@@ -300,18 +301,29 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 
 	if cityUsesManagedReconciler(cityPath) {
 		if pokeErr := pokeController(cityPath); pokeErr == nil {
-			info, createErr := mgr.CreateAliasedBeadOnlyNamedWithMetadata(
-				"",
-				"",
-				agentCfg.QualifiedName(),
-				title,
-				resolved.CommandString(),
-				workDir,
-				resolved.Name,
-				agentCfg.Session,
-				resume,
-				map[string]string{"session_origin": "ephemeral"},
-			)
+			var info session.Info
+			createErr := session.WithCitySessionIdentifierLocks(cityPath, []string{explicitName}, func() error {
+				if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
+					return err
+				}
+				var err error
+				info, err = mgr.CreateAliasedBeadOnlyNamedWithMetadata(
+					"",
+					explicitName,
+					agentCfg.QualifiedName(),
+					title,
+					resolved.CommandString(),
+					workDir,
+					resolved.Name,
+					agentCfg.Session,
+					resume,
+					map[string]string{
+						"agent_name":     sessionQualifiedName,
+						"session_origin": "manual",
+					},
+				)
+				return err
+			})
 			if createErr == nil {
 				_ = pokeController(cityPath)
 				return info.SessionName, nil
@@ -326,21 +338,32 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 		ProcessNames:           resolved.ProcessNames,
 		EmitsPermissionWarning: resolved.EmitsPermissionWarning,
 	}
-	info, err := mgr.CreateAliasedNamedWithTransportAndMetadata(
-		context.Background(),
-		"",
-		"",
-		agentCfg.QualifiedName(),
-		title,
-		resolved.CommandString(),
-		workDir,
-		resolved.Name,
-		agentCfg.Session,
-		resolved.Env,
-		resume,
-		hints,
-		map[string]string{"session_origin": "ephemeral"},
-	)
+	var info session.Info
+	err = session.WithCitySessionIdentifierLocks(cityPath, []string{explicitName}, func() error {
+		if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
+			return err
+		}
+		var createErr error
+		info, createErr = mgr.CreateAliasedNamedWithTransportAndMetadata(
+			context.Background(),
+			"",
+			explicitName,
+			agentCfg.QualifiedName(),
+			title,
+			resolved.CommandString(),
+			workDir,
+			resolved.Name,
+			agentCfg.Session,
+			resolved.Env,
+			resume,
+			hints,
+			map[string]string{
+				"agent_name":     sessionQualifiedName,
+				"session_origin": "manual",
+			},
+		)
+		return createErr
+	})
 	if err == nil {
 		return info.SessionName, nil
 	}

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -298,11 +298,15 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 		ResumeCommand: resolved.ResumeCommand,
 		SessionIDFlag: resolved.SessionIDFlag,
 	}
+	reservationIDs := []string{explicitName, sessionQualifiedName}
 
 	if cityUsesManagedReconciler(cityPath) {
 		if pokeErr := pokeController(cityPath); pokeErr == nil {
 			var info session.Info
-			createErr := session.WithCitySessionIdentifierLocks(cityPath, []string{explicitName}, func() error {
+			createErr := session.WithCitySessionIdentifierLocks(cityPath, reservationIDs, func() error {
+				if err := session.EnsureAliasAvailableWithConfig(store, cfg, sessionQualifiedName, ""); err != nil {
+					return err
+				}
 				if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
 					return err
 				}
@@ -339,7 +343,10 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 		EmitsPermissionWarning: resolved.EmitsPermissionWarning,
 	}
 	var info session.Info
-	err = session.WithCitySessionIdentifierLocks(cityPath, []string{explicitName}, func() error {
+	err = session.WithCitySessionIdentifierLocks(cityPath, reservationIDs, func() error {
+		if err := session.EnsureAliasAvailableWithConfig(store, cfg, sessionQualifiedName, ""); err != nil {
+			return err
+		}
 		if err := session.EnsureSessionNameAvailableWithConfig(store, cfg, explicitName, ""); err != nil {
 			return err
 		}

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 var errTemplateTargetNotFound = errors.New("template target not found")
@@ -118,7 +119,8 @@ func materializeSessionForTemplateWithOptions(
 		if err != nil {
 			return "", err
 		}
-		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, spec.Identity)
+		workDirQualifiedName := workdirutil.SessionQualifiedName(cityPath, *spec.Agent, cfg.Rigs, spec.Identity, "")
+		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, workDirQualifiedName)
 		if err != nil {
 			return "", err
 		}
@@ -280,7 +282,7 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 		cityPath,
 		cfg,
 		agentCfg,
-		sessionWorkDirQualifiedName(cityPath, cfg, agentCfg, "", explicitName),
+		workdirutil.SessionQualifiedName(cityPath, *agentCfg, cfg.Rigs, "", explicitName),
 	)
 	if err != nil {
 		return "", err

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -272,7 +272,16 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 	if err != nil {
 		return "", err
 	}
-	workDir, err := resolveWorkDir(cityPath, cfg, agentCfg)
+	explicitName, err := sessionExplicitNameForNewSession(agentCfg, "")
+	if err != nil {
+		return "", err
+	}
+	workDir, err := resolveWorkDirForQualifiedName(
+		cityPath,
+		cfg,
+		agentCfg,
+		sessionWorkDirQualifiedName(cityPath, cfg, agentCfg, "", explicitName),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/session_template_start_test.go
+++ b/cmd/gc/session_template_start_test.go
@@ -155,6 +155,12 @@ func TestEnsureSessionForTemplate_PoolTemplateWithoutAliasUsesGeneratedWorkDirId
 		if sessionName == "" {
 			t.Fatal("session_name should be populated")
 		}
+		if got := bead.Metadata["session_name_explicit"]; got != boolMetadata(true) {
+			t.Fatalf("session_name_explicit = %q, want %q", got, boolMetadata(true))
+		}
+		if !strings.HasPrefix(sessionName, "ant-adhoc-") {
+			t.Fatalf("session_name = %q, want ant-adhoc-*", sessionName)
+		}
 		workDir := bead.Metadata["work_dir"]
 		if filepath.Dir(workDir) != filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants") {
 			t.Fatalf("work_dir(%q) parent = %q, want %q", sessionName, filepath.Dir(workDir), filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants"))
@@ -170,6 +176,9 @@ func TestEnsureSessionForTemplate_PoolTemplateWithoutAliasUsesGeneratedWorkDirId
 			t.Fatalf("duplicate work_dir %q for aliasless pooled sessions", workDir)
 		}
 		seenWorkDir[workDir] = true
+		if got := bead.Metadata["agent_name"]; got != "demo/"+sessionName {
+			t.Fatalf("agent_name(%q) = %q, want %q", sessionName, got, "demo/"+sessionName)
+		}
 	}
 }
 

--- a/cmd/gc/session_template_start_test.go
+++ b/cmd/gc/session_template_start_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -148,14 +149,26 @@ func TestEnsureSessionForTemplate_PoolTemplateWithoutAliasUsesGeneratedWorkDirId
 	if len(all) != 2 {
 		t.Fatalf("session bead count = %d, want 2", len(all))
 	}
+	seenWorkDir := make(map[string]bool, len(all))
 	for _, bead := range all {
 		sessionName := bead.Metadata["session_name"]
 		if sessionName == "" {
 			t.Fatal("session_name should be populated")
 		}
-		wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", sessionName)
-		if got := bead.Metadata["work_dir"]; got != wantWorkDir {
-			t.Fatalf("work_dir(%q) = %q, want %q", sessionName, got, wantWorkDir)
+		workDir := bead.Metadata["work_dir"]
+		if filepath.Dir(workDir) != filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants") {
+			t.Fatalf("work_dir(%q) parent = %q, want %q", sessionName, filepath.Dir(workDir), filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants"))
 		}
+		base := filepath.Base(workDir)
+		if base == "ant" {
+			t.Fatalf("work_dir(%q) base = %q, want unique generated identity", sessionName, base)
+		}
+		if !strings.HasPrefix(base, "ant-adhoc-") {
+			t.Fatalf("work_dir(%q) base = %q, want ant-adhoc-*", sessionName, base)
+		}
+		if seenWorkDir[workDir] {
+			t.Fatalf("duplicate work_dir %q for aliasless pooled sessions", workDir)
+		}
+		seenWorkDir[workDir] = true
 	}
 }

--- a/cmd/gc/session_template_start_test.go
+++ b/cmd/gc/session_template_start_test.go
@@ -172,3 +172,46 @@ func TestEnsureSessionForTemplate_PoolTemplateWithoutAliasUsesGeneratedWorkDirId
 		seenWorkDir[workDir] = true
 	}
 }
+
+func TestEnsureSessionForTemplate_RebrandedSingletonKeepsTemplateWorkDirIdentity(t *testing.T) {
+	t.Setenv("GC_SESSION", "fake")
+
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}},
+		Agents: []config.Agent{{
+			Name:              "witness",
+			Dir:               "demo",
+			StartCommand:      "true",
+			WorkDir:           ".gc/worktrees/{{.Rig}}/{{.AgentBase}}",
+			MaxActiveSessions: intPtr(1),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "boot",
+			Template: "witness",
+			Dir:      "demo",
+		}},
+	}
+	store := beads.NewMemStore()
+
+	sessionName, err := ensureSessionForTemplate(cityPath, cfg, store, "demo/boot", io.Discard)
+	if err != nil {
+		t.Fatalf("ensureSessionForTemplate = %v", err)
+	}
+	if sessionName == "" {
+		t.Fatal("session name should be populated")
+	}
+
+	all, err := store.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(all))
+	}
+	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "witness")
+	if got := all[0].Metadata["work_dir"]; got != wantWorkDir {
+		t.Fatalf("work_dir = %q, want %q", got, wantWorkDir)
+	}
+}

--- a/cmd/gc/session_template_start_test.go
+++ b/cmd/gc/session_template_start_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -107,5 +108,54 @@ func TestEnsureSessionForTemplate_ReopensClosedNamedSessionWithCleanMetadata(t *
 	}
 	if reopened.Metadata["pending_create_claim"] != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", reopened.Metadata["pending_create_claim"])
+	}
+}
+
+func TestEnsureSessionForTemplate_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *testing.T) {
+	t.Setenv("GC_SESSION", "fake")
+
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}},
+		Agents: []config.Agent{{
+			Name:              "ant",
+			Dir:               "demo",
+			StartCommand:      "true",
+			WorkDir:           ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(4),
+		}},
+	}
+	store := beads.NewMemStore()
+
+	firstName, err := ensureSessionForTemplate(cityPath, cfg, store, "demo/ant", io.Discard)
+	if err != nil {
+		t.Fatalf("ensureSessionForTemplate(first) = %v", err)
+	}
+	secondName, err := ensureSessionForTemplate(cityPath, cfg, store, "demo/ant", io.Discard)
+	if err != nil {
+		t.Fatalf("ensureSessionForTemplate(second) = %v", err)
+	}
+	if firstName == secondName {
+		t.Fatalf("session names should be unique, got %q for both", firstName)
+	}
+
+	all, err := store.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("session bead count = %d, want 2", len(all))
+	}
+	for _, bead := range all {
+		sessionName := bead.Metadata["session_name"]
+		if sessionName == "" {
+			t.Fatal("session_name should be populated")
+		}
+		wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", sessionName)
+		if got := bead.Metadata["work_dir"]; got != wantWorkDir {
+			t.Fatalf("work_dir(%q) = %q, want %q", sessionName, got, wantWorkDir)
+		}
 	}
 }

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -127,7 +127,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 
 	// Step 3: Expand dir template.
 	dirCtx := sessionSetupContextForAgent(p.cityPath, p.cityName, qualifiedName, cfgAgent, p.rigs)
-	workDir, err := resolveConfiguredWorkDir(p.cityPath, p.cityName, cfgAgent, p.rigs)
+	workDir, err := resolveConfiguredWorkDir(p.cityPath, p.cityName, qualifiedName, cfgAgent, p.rigs)
 	if err != nil {
 		return TemplateParams{}, fmt.Errorf("agent %q: %w", qualifiedName, err)
 	}

--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -117,7 +117,7 @@ func prefixedWorkQueryForProbeWithEnv(
 		return ""
 	}
 	command := strings.TrimSpace(agentCfg.EffectiveWorkQuery())
-	if command == "" || isMultiSessionCfgAgent(agentCfg) {
+	if command == "" || agentCfg.SupportsMultipleSessions() {
 		return prefixShellEnv(queryEnv, command)
 	}
 	sessionName := probeSessionNameForTemplate(cfg, cityName, store, sessionBeads, agentCfg.QualifiedName())

--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -107,16 +107,8 @@ func sessionResumeHints(resolved *config.ResolvedProvider, workDir string) runti
 	}
 }
 
-func agentSupportsMultipleSessions(agentCfg config.Agent) bool {
-	if strings.TrimSpace(agentCfg.Namepool) != "" || len(agentCfg.NamepoolNames) > 0 {
-		return true
-	}
-	maxSessions := agentCfg.EffectiveMaxActiveSessions()
-	return maxSessions == nil || *maxSessions != 1
-}
-
 func sessionExplicitNameForCreate(agentCfg config.Agent, alias string) (string, error) {
-	if !agentSupportsMultipleSessions(agentCfg) || strings.TrimSpace(alias) != "" {
+	if !agentCfg.SupportsMultipleSessions() || strings.TrimSpace(alias) != "" {
 		return "", nil
 	}
 	return session.GenerateAdhocExplicitName(agentCfg.Name)
@@ -369,17 +361,20 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		writeSessionManagerError(w, err)
 		return
 	}
-	if kind == "agent" && alias != "" && agentSupportsMultipleSessions(agentCfg) {
+	if kind == "agent" && alias != "" && agentCfg.SupportsMultipleSessions() {
 		alias = workdirutil.SessionQualifiedName(s.state.CityPath(), agentCfg, s.state.Config().Rigs, alias, "")
 	}
+	explicitName := ""
+	workDirQualifiedName := ""
 	if kind == "agent" {
-		explicitName, explicitErr := sessionExplicitNameForCreate(agentCfg, alias)
+		var explicitErr error
+		explicitName, explicitErr = sessionExplicitNameForCreate(agentCfg, alias)
 		if explicitErr != nil {
 			s.idem.unreserve(idemKey)
 			writeSessionManagerError(w, explicitErr)
 			return
 		}
-		workDirQualifiedName := workdirutil.SessionQualifiedName(s.state.CityPath(), agentCfg, s.state.Config().Rigs, alias, explicitName)
+		workDirQualifiedName = workdirutil.SessionQualifiedName(s.state.CityPath(), agentCfg, s.state.Config().Rigs, alias, explicitName)
 		workDir, err = s.resolveSessionWorkDir(agentCfg, workDirQualifiedName)
 		if err != nil {
 			s.idem.unreserve(idemKey)
@@ -429,14 +424,24 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	// show the session in the sidebar immediately via optimistic UI.
 	mgr := s.sessionManager(store)
 	var info session.Info
-	err = session.WithCitySessionAliasLock(s.state.CityPath(), alias, func() error {
+	err = session.WithCitySessionIdentifierLocks(s.state.CityPath(), []string{alias, explicitName}, func() error {
 		if err := session.EnsureAliasAvailableWithConfig(store, s.state.Config(), alias, ""); err != nil {
 			return err
+		}
+		if err := session.EnsureSessionNameAvailableWithConfig(store, s.state.Config(), explicitName, ""); err != nil {
+			return err
+		}
+		if kind == "agent" {
+			if extraMeta == nil {
+				extraMeta = make(map[string]string)
+			}
+			extraMeta["agent_name"] = workDirQualifiedName
+			extraMeta["session_origin"] = "manual"
 		}
 		var createErr error
 		info, createErr = mgr.CreateAliasedBeadOnlyNamedWithMetadata(
 			alias,
-			"",
+			explicitName,
 			template,
 			title,
 			command,

--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -424,9 +424,19 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	// show the session in the sidebar immediately via optimistic UI.
 	mgr := s.sessionManager(store)
 	var info session.Info
-	err = session.WithCitySessionIdentifierLocks(s.state.CityPath(), []string{alias, explicitName}, func() error {
+	reservationIDs := []string{alias, explicitName}
+	reserveConcreteIdentity := kind == "agent" && agentCfg.SupportsMultipleSessions() && strings.TrimSpace(workDirQualifiedName) != ""
+	if reserveConcreteIdentity {
+		reservationIDs = append(reservationIDs, workDirQualifiedName)
+	}
+	err = session.WithCitySessionIdentifierLocks(s.state.CityPath(), reservationIDs, func() error {
 		if err := session.EnsureAliasAvailableWithConfig(store, s.state.Config(), alias, ""); err != nil {
 			return err
+		}
+		if reserveConcreteIdentity && workDirQualifiedName != alias {
+			if err := session.EnsureAliasAvailableWithConfig(store, s.state.Config(), workDirQualifiedName, ""); err != nil {
+				return err
+			}
 		}
 		if err := session.EnsureSessionNameAvailableWithConfig(store, s.state.Config(), explicitName, ""); err != nil {
 			return err

--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -107,6 +107,42 @@ func sessionResumeHints(resolved *config.ResolvedProvider, workDir string) runti
 	}
 }
 
+func agentSupportsMultipleSessions(agentCfg config.Agent) bool {
+	if strings.TrimSpace(agentCfg.Namepool) != "" || len(agentCfg.NamepoolNames) > 0 {
+		return true
+	}
+	maxSessions := agentCfg.EffectiveMaxActiveSessions()
+	return maxSessions == nil || *maxSessions != 1
+}
+
+func sessionExplicitNameForCreate(agentCfg config.Agent, alias string) (string, error) {
+	if !agentSupportsMultipleSessions(agentCfg) || strings.TrimSpace(alias) != "" {
+		return "", nil
+	}
+	return session.GenerateAdhocExplicitName(agentCfg.Name)
+}
+
+func (s *Server) resolveSessionWorkDir(agentCfg config.Agent, qualifiedName string) (string, error) {
+	cfg := s.state.Config()
+	if cfg == nil {
+		return "", errors.New("no city config loaded")
+	}
+	workDir, err := workdirutil.ResolveWorkDirPathStrict(
+		s.state.CityPath(),
+		workdirutil.CityName(s.state.CityPath(), cfg),
+		qualifiedName,
+		agentCfg,
+		cfg.Rigs,
+	)
+	if err != nil {
+		return "", err
+	}
+	if workDir == "" {
+		workDir = s.state.CityPath()
+	}
+	return workDir, nil
+}
+
 func (s *Server) resolveSessionTemplate(template string) (*config.ResolvedProvider, string, string, string, error) {
 	cfg := s.state.Config()
 	if cfg == nil {
@@ -120,18 +156,9 @@ func (s *Server) resolveSessionTemplate(template string) (*config.ResolvedProvid
 	if err != nil {
 		return nil, "", "", "", err
 	}
-	workDir, err := workdirutil.ResolveWorkDirPathStrict(
-		s.state.CityPath(),
-		workdirutil.CityName(s.state.CityPath(), cfg),
-		agentCfg.QualifiedName(),
-		agentCfg,
-		cfg.Rigs,
-	)
+	workDir, err := s.resolveSessionWorkDir(agentCfg, agentCfg.QualifiedName())
 	if err != nil {
 		return nil, "", "", "", err
-	}
-	if workDir == "" {
-		workDir = s.state.CityPath()
 	}
 	return resolved, workDir, agentCfg.Session, agentCfg.QualifiedName(), nil
 }
@@ -270,23 +297,34 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var resolved *config.ResolvedProvider
+	var agentCfg config.Agent
 	var workDir, transport, template string
 	var optMeta map[string]string
+	var err error
 
 	switch kind {
 	case "agent":
-		var err error
-		resolved, workDir, transport, template, err = s.resolveSessionTemplate(name)
+		cfg := s.state.Config()
+		if cfg == nil {
+			s.idem.unreserve(idemKey)
+			writeError(w, http.StatusInternalServerError, "internal", "no city config loaded")
+			return
+		}
+		var ok bool
+		agentCfg, ok = resolveSessionTemplateAgent(cfg, name)
+		if !ok {
+			s.idem.unreserve(idemKey)
+			writeError(w, http.StatusNotFound, "agent_not_found", "agent '"+name+"' not found")
+			return
+		}
+		resolved, err = config.ResolveProvider(&agentCfg, &cfg.Workspace, cfg.Providers, exec.LookPath)
 		if err != nil {
-			if errors.Is(err, errSessionTemplateNotFound) {
-				s.idem.unreserve(idemKey)
-				writeError(w, http.StatusNotFound, "agent_not_found", "agent '"+name+"' not found")
-				return
-			}
 			s.idem.unreserve(idemKey)
 			writeError(w, http.StatusInternalServerError, "internal", err.Error())
 			return
 		}
+		transport = agentCfg.Session
+		template = agentCfg.QualifiedName()
 		// Agent track: command comes from the agent config as-is.
 		// Do NOT inject OptionsSchema defaults — agents encode their own CLI flags.
 		// Options are stored as template_overrides and applied at start time
@@ -330,6 +368,24 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		s.idem.unreserve(idemKey)
 		writeSessionManagerError(w, err)
 		return
+	}
+	if kind == "agent" && alias != "" {
+		alias = workdirutil.SessionQualifiedName(s.state.CityPath(), agentCfg, s.state.Config().Rigs, alias, "")
+	}
+	if kind == "agent" {
+		explicitName, explicitErr := sessionExplicitNameForCreate(agentCfg, alias)
+		if explicitErr != nil {
+			s.idem.unreserve(idemKey)
+			writeSessionManagerError(w, explicitErr)
+			return
+		}
+		workDirQualifiedName := workdirutil.SessionQualifiedName(s.state.CityPath(), agentCfg, s.state.Config().Rigs, alias, explicitName)
+		workDir, err = s.resolveSessionWorkDir(agentCfg, workDirQualifiedName)
+		if err != nil {
+			s.idem.unreserve(idemKey)
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
 	}
 
 	// Merge explicit options with provider effective defaults.

--- a/internal/api/handler_session_chat.go
+++ b/internal/api/handler_session_chat.go
@@ -369,7 +369,7 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		writeSessionManagerError(w, err)
 		return
 	}
-	if kind == "agent" && alias != "" {
+	if kind == "agent" && alias != "" && agentSupportsMultipleSessions(agentCfg) {
 		alias = workdirutil.SessionQualifiedName(s.state.CityPath(), agentCfg, s.state.Config().Rigs, alias, "")
 	}
 	if kind == "agent" {

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1002,6 +1002,13 @@ func TestHandleSessionCreateAsync_PoolTemplateWithoutAliasUsesGeneratedWorkDirId
 		if got := bead.Metadata["alias"]; got != "" {
 			t.Fatalf("alias = %q, want empty", got)
 		}
+		sessionName := bead.Metadata["session_name"]
+		if got := bead.Metadata["session_name_explicit"]; got != "true" {
+			t.Fatalf("session_name_explicit = %q, want %q", got, "true")
+		}
+		if !strings.HasPrefix(sessionName, "ant-adhoc-") {
+			t.Fatalf("session_name = %q, want ant-adhoc-*", sessionName)
+		}
 		workDir := bead.Metadata["work_dir"]
 		if filepath.Dir(workDir) != filepath.Join(fs.cityPath, ".gc", "worktrees", "myrig", "ants") {
 			t.Fatalf("work_dir parent = %q, want %q", filepath.Dir(workDir), filepath.Join(fs.cityPath, ".gc", "worktrees", "myrig", "ants"))
@@ -1014,6 +1021,9 @@ func TestHandleSessionCreateAsync_PoolTemplateWithoutAliasUsesGeneratedWorkDirId
 			t.Fatalf("duplicate work_dir %q", workDir)
 		}
 		seenWorkDir[workDir] = true
+		if got := bead.Metadata["agent_name"]; got != "myrig/"+sessionName {
+			t.Fatalf("agent_name(%q) = %q, want %q", sessionName, got, "myrig/"+sessionName)
+		}
 	}
 }
 

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -967,6 +967,93 @@ func TestHandleSessionCreateAsyncAcceptsInlineMessage(t *testing.T) {
 	}
 }
 
+func TestHandleSessionCreateAsync_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents = []config.Agent{{
+		Name:              "ant",
+		Dir:               "myrig",
+		Provider:          "test-agent",
+		WorkDir:           ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(4),
+	}}
+	fs.cfg.NamedSessions = nil
+	srv := New(fs)
+
+	for i := 0; i < 2; i++ {
+		req := newPostRequest("/v0/sessions", strings.NewReader(`{"kind":"agent","name":"myrig/ant"}`))
+		req.Header.Set("Idempotency-Key", "pool-create-"+string(rune('a'+i)))
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("create #%d status = %d, want %d; body: %s", i+1, rec.Code, http.StatusAccepted, rec.Body.String())
+		}
+	}
+
+	items, err := fs.cityBeadStore.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("session bead count = %d, want 2", len(items))
+	}
+	seenWorkDir := make(map[string]bool, len(items))
+	for _, bead := range items {
+		if got := bead.Metadata["alias"]; got != "" {
+			t.Fatalf("alias = %q, want empty", got)
+		}
+		workDir := bead.Metadata["work_dir"]
+		if filepath.Dir(workDir) != filepath.Join(fs.cityPath, ".gc", "worktrees", "myrig", "ants") {
+			t.Fatalf("work_dir parent = %q, want %q", filepath.Dir(workDir), filepath.Join(fs.cityPath, ".gc", "worktrees", "myrig", "ants"))
+		}
+		base := filepath.Base(workDir)
+		if !strings.HasPrefix(base, "ant-adhoc-") {
+			t.Fatalf("work_dir base = %q, want ant-adhoc-*", base)
+		}
+		if seenWorkDir[workDir] {
+			t.Fatalf("duplicate work_dir %q", workDir)
+		}
+		seenWorkDir[workDir] = true
+	}
+}
+
+func TestHandleSessionCreateAsync_PoolTemplateCanonicalizesAliasCollisions(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents = []config.Agent{{
+		Name:              "ant",
+		Dir:               "myrig",
+		Provider:          "test-agent",
+		WorkDir:           ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(4),
+	}}
+	fs.cfg.NamedSessions = nil
+	srv := New(fs)
+
+	req := newPostRequest("/v0/sessions", strings.NewReader(`{"kind":"agent","name":"myrig/ant","alias":"ant-fenrir"}`))
+	req.Header.Set("Idempotency-Key", "pool-alias-1")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("first create status = %d, want %d; body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	var resp sessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Alias != "myrig/ant-fenrir" {
+		t.Fatalf("Alias = %q, want canonical qualified alias", resp.Alias)
+	}
+
+	req = newPostRequest("/v0/sessions", strings.NewReader(`{"kind":"agent","name":"myrig/ant","alias":"myrig/ant-fenrir"}`))
+	req.Header.Set("Idempotency-Key", "pool-alias-2")
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("second create status = %d, want %d; body: %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+}
+
 func TestHandleProviderSessionCreateRejectsAsync(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)
@@ -984,6 +1071,43 @@ func TestHandleProviderSessionCreateRejectsAsync(t *testing.T) {
 	}
 	if fs.pokeCount != 0 {
 		t.Fatalf("pokeCount = %d, want 0", fs.pokeCount)
+	}
+}
+
+func TestMaterializeNamedSession_RebrandedSingletonKeepsTemplateWorkDirIdentity(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents = []config.Agent{{
+		Name:              "witness",
+		Dir:               "myrig",
+		Provider:          "test-agent",
+		WorkDir:           ".gc/worktrees/{{.Rig}}/{{.AgentBase}}",
+		MaxActiveSessions: intPtr(1),
+	}}
+	fs.cfg.NamedSessions = []config.NamedSession{{
+		Name:     "boot",
+		Template: "witness",
+		Dir:      "myrig",
+	}}
+	srv := New(fs)
+
+	spec, ok, err := srv.findNamedSessionSpecForTarget(fs.cityBeadStore, "myrig/boot")
+	if err != nil {
+		t.Fatalf("findNamedSessionSpecForTarget: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected named session spec")
+	}
+	id, err := srv.materializeNamedSession(fs.cityBeadStore, spec)
+	if err != nil {
+		t.Fatalf("materializeNamedSession: %v", err)
+	}
+	bead, err := fs.cityBeadStore.Get(id)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	wantWorkDir := filepath.Join(fs.cityPath, ".gc", "worktrees", "myrig", "witness")
+	if got := bead.Metadata["work_dir"]; got != wantWorkDir {
+		t.Fatalf("work_dir = %q, want %q", got, wantWorkDir)
 	}
 }
 

--- a/internal/api/session_materialization_guard_test.go
+++ b/internal/api/session_materialization_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -35,5 +36,38 @@ func TestResolveSessionIDMaterializingNamed_DoesNotMaterializeMissingMultiSessio
 	}
 	if len(all) != 0 {
 		t.Fatalf("session count = %d, want 0", len(all))
+	}
+}
+
+func TestResolveSessionIDWithConfig_RejectsOrphanedNamedSessionBead(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	b, err := fs.cityBeadStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":              "test-city--worker",
+			"alias":                     "myrig/worker",
+			"configured_named_session":  "true",
+			"configured_named_identity": "myrig/worker",
+			"configured_named_mode":     "on_demand",
+			"continuity_eligible":       "true",
+			"state":                     "active",
+			"template":                  "myrig/worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	fs.cfg.NamedSessions = nil
+
+	if id, err := session.ResolveSessionID(fs.cityBeadStore, "myrig/worker"); err != nil || id != b.ID {
+		t.Fatalf("session.ResolveSessionID = %q, %v, want %q and nil", id, err, b.ID)
+	}
+	_, err = srv.resolveSessionIDWithConfig(fs.cityBeadStore, "myrig/worker")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("resolveSessionIDWithConfig(myrig/worker) = %v, want ErrSessionNotFound", err)
 	}
 }

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -202,10 +202,11 @@ func (s *Server) materializeNamedSessionWithContext(ctx context.Context, store b
 		return "", err
 	}
 
-	resolved, workDir, transport, qualifiedTemplate, err := s.resolveSessionTemplate(spec.Agent.QualifiedName())
+	resolved, _, transport, qualifiedTemplate, err := s.resolveSessionTemplate(spec.Agent.QualifiedName())
 	if err != nil {
 		return "", err
 	}
+	var workDir string
 	workDirQualifiedName := workdirutil.SessionQualifiedName(s.state.CityPath(), *spec.Agent, s.state.Config().Rigs, spec.Identity, "")
 	workDir, err = s.resolveSessionWorkDir(*spec.Agent, workDirQualifiedName)
 	if err != nil {
@@ -289,6 +290,14 @@ func (s *Server) resolveSessionTargetIDWithContext(ctx context.Context, store be
 		return "", err
 	}
 	if id, err := session.ResolveSessionID(store, identifier); err == nil {
+		if cfg := s.state.Config(); cfg != nil {
+			if bead, getErr := store.Get(id); getErr == nil && apiIsNamedSessionBead(bead) {
+				identity := apiNamedSessionIdentity(bead)
+				if identity != "" && config.FindNamedSession(cfg, identity) == nil {
+					return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
+				}
+			}
+		}
 		return id, nil
 	} else if !errors.Is(err, session.ErrSessionNotFound) {
 		return "", err
@@ -304,9 +313,6 @@ func (s *Server) resolveSessionTargetIDWithContext(ctx context.Context, store be
 		} else if !errors.Is(err, session.ErrSessionNotFound) {
 			return "", err
 		}
-	}
-	if !opts.materialize {
-		return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 	}
 	return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 }

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/session"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 const (
@@ -202,6 +203,11 @@ func (s *Server) materializeNamedSessionWithContext(ctx context.Context, store b
 	}
 
 	resolved, workDir, transport, qualifiedTemplate, err := s.resolveSessionTemplate(spec.Agent.QualifiedName())
+	if err != nil {
+		return "", err
+	}
+	workDirQualifiedName := workdirutil.SessionQualifiedName(s.state.CityPath(), *spec.Agent, s.state.Config().Rigs, spec.Identity, "")
+	workDir, err = s.resolveSessionWorkDir(*spec.Agent, workDirQualifiedName)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1828,6 +1828,22 @@ func (a *Agent) SupportsGenericEphemeralSessions() bool {
 	return true
 }
 
+// SupportsMultipleSessions reports whether the template may materialize more
+// than one distinct concrete session identity. Unlike
+// SupportsGenericEphemeralSessions, max_active_sessions = 0 still represents a
+// multi-session template shape even though generic ephemeral session creation
+// is disabled.
+func (a *Agent) SupportsMultipleSessions() bool {
+	if a == nil {
+		return false
+	}
+	if strings.TrimSpace(a.Namepool) != "" || len(a.NamepoolNames) > 0 {
+		return true
+	}
+	maxSessions := a.EffectiveMaxActiveSessions()
+	return maxSessions == nil || *maxSessions != 1
+}
+
 // SupportsInstanceExpansion reports whether the template may have multiple
 // simultaneously addressable concrete instances and therefore needs instance
 // discovery / synthetic member naming.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -299,6 +299,7 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 		}
 		if explicitName != "" {
 			meta["session_name"] = explicitName
+			meta["session_name_explicit"] = "true"
 		}
 		for k, v := range extraMeta {
 			meta[k] = v
@@ -332,6 +333,9 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 			b.Metadata = make(map[string]string)
 		}
 		b.Metadata["session_name"] = sessName
+		if explicitName != "" {
+			b.Metadata["session_name_explicit"] = "true"
+		}
 
 		unroute := m.routeACPIfNeeded(provider, transport, sessName)
 		rollbackFailedCreate := func() error {
@@ -342,7 +346,11 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 				if err := m.store.SetMetadata(b.ID, "session_name", ""); err != nil {
 					return fmt.Errorf("clearing session name during rollback: %w", err)
 				}
+				if err := m.store.SetMetadata(b.ID, "session_name_explicit", ""); err != nil {
+					return fmt.Errorf("clearing explicit session name flag during rollback: %w", err)
+				}
 				b.Metadata["session_name"] = ""
+				b.Metadata["session_name_explicit"] = ""
 			}
 			if err := m.store.Close(b.ID); err != nil {
 				return fmt.Errorf("closing rolled-back session bead: %w", err)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -368,10 +368,14 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 		cfg := hints
 		cfg.Command = startCommand
 		cfg.WorkDir = workDir
+		runtimeAlias := alias
+		if runtimeAlias == "" {
+			runtimeAlias = strings.TrimSpace(extraMeta["agent_name"])
+		}
 		cfg.Env = mergeEnv(mergeEnv(cfg.Env, env), RuntimeEnvWithSessionContext(
 			b.ID,
 			sessName,
-			alias,
+			runtimeAlias,
 			template,
 			meta["session_origin"],
 			DefaultGeneration,

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -713,6 +713,58 @@ func TestCreateInjectsUnifiedSessionRuntimeEnv(t *testing.T) {
 	}
 }
 
+func TestCreateAliaslessMultiSessionUsesConcreteRuntimeIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.CreateAliasedNamedWithTransportAndMetadata(
+		context.Background(),
+		"",
+		"ant-adhoc-123",
+		"demo/ant",
+		"Ant",
+		"claude",
+		"/tmp",
+		"claude",
+		"",
+		nil,
+		ProviderResume{},
+		runtime.Config{},
+		map[string]string{
+			"agent_name":     "demo/ant-adhoc-123",
+			"session_origin": "manual",
+		},
+	)
+	if err != nil {
+		t.Fatalf("CreateAliasedNamedWithTransportAndMetadata: %v", err)
+	}
+
+	var start *runtime.Call
+	for i := range sp.Calls {
+		if sp.Calls[i].Method == "Start" {
+			start = &sp.Calls[i]
+			break
+		}
+	}
+	if start == nil {
+		t.Fatalf("Start call not recorded: %#v", sp.Calls)
+	}
+	env := start.Config.Env
+	for key, want := range map[string]string{
+		"GC_SESSION_ID":     info.ID,
+		"GC_SESSION_NAME":   "ant-adhoc-123",
+		"GC_ALIAS":          "demo/ant-adhoc-123",
+		"GC_TEMPLATE":       "demo/ant",
+		"GC_SESSION_ORIGIN": "manual",
+		"GC_AGENT":          "demo/ant-adhoc-123",
+	} {
+		if got := env[key]; got != want {
+			t.Fatalf("Env[%s] = %q, want %q (env=%v)", key, got, want, env)
+		}
+	}
+}
+
 func TestCloseSuspended(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -545,6 +545,9 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			return fmt.Errorf("%w: %q already belongs to %s", ErrSessionAliasExists, alias, b.ID)
 		}
 		if strings.TrimSpace(b.Metadata["agent_name"]) == alias {
+			if selfOwner != "" && selfOwner == alias {
+				continue
+			}
 			return fmt.Errorf("%w: %q conflicts with concrete session identity on %s", ErrSessionAliasExists, alias, b.ID)
 		}
 		// Historical aliases are compatibility-only input and do not reserve

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -544,6 +544,9 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 		if strings.TrimSpace(b.Metadata["alias"]) == alias {
 			return fmt.Errorf("%w: %q already belongs to %s", ErrSessionAliasExists, alias, b.ID)
 		}
+		if strings.TrimSpace(b.Metadata["agent_name"]) == alias {
+			return fmt.Errorf("%w: %q conflicts with concrete session identity on %s", ErrSessionAliasExists, alias, b.ID)
+		}
 		// Historical aliases are compatibility-only input and do not reserve
 		// namespace for new alias claims.
 	}

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -80,6 +80,32 @@ func ValidateExplicitName(name string) (string, error) {
 	return name, nil
 }
 
+// GenerateAdhocExplicitName produces a tmux-safe explicit session name for
+// multi-session templates that are materialized without a user alias.
+func GenerateAdhocExplicitName(base string) (string, error) {
+	token, err := GenerateSessionKey()
+	if err != nil {
+		return "", fmt.Errorf("generate pooled session identity: %w", err)
+	}
+	compact := strings.ReplaceAll(token, "-", "")
+	if len(compact) > 10 {
+		compact = compact[:10]
+	}
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "session"
+	}
+	suffix := "-adhoc-" + compact
+	maxBaseLen := explicitSessionNameMaxLen - len(suffix)
+	if maxBaseLen < 1 {
+		maxBaseLen = 1
+	}
+	if len(base) > maxBaseLen {
+		base = base[:maxBaseLen]
+	}
+	return ValidateExplicitName(base + suffix)
+}
+
 // ValidateAlias validates a human-chosen session alias. Empty means
 // "no alias".
 func ValidateAlias(alias string) (string, error) {

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -357,6 +357,31 @@ func TestEnsureAliasAvailableWithConfigForOwner_AllowsConfiguredSingletonCreate(
 	}
 }
 
+func TestEnsureAliasAvailableWithConfigForOwner_AllowsConfiguredAliasAgainstOrdinaryConcreteIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{
+			{Template: "worker", Dir: "myrig"},
+		},
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "s-gc-ordinary-worker",
+			"template":     "myrig/worker",
+			"agent_name":   "myrig/worker",
+			"state":        "asleep",
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := EnsureAliasAvailableWithConfigForOwner(store, cfg, "myrig/worker", "", "myrig/worker"); err != nil {
+		t.Fatalf("EnsureAliasAvailableWithConfigForOwner(named owner vs concrete identity) = %v, want nil", err)
+	}
+}
+
 func TestEnsureSessionNameAvailableWithConfig_UsesResolvedWorkspaceName(t *testing.T) {
 	store := beads.NewMemStore()
 	cfg := &config.City{

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -69,10 +69,8 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 
 	var openSessionNameMatches []beads.Bead
 	var openAliasMatches []beads.Bead
-	var openQualifiedAliasBasenameMatches []beads.Bead
 	var closedSessionNameMatches []beads.Bead
 	var closedAliasMatches []beads.Bead
-	var closedQualifiedAliasBasenameMatches []beads.Bead
 	for _, b := range all {
 		if !IsSessionBeadOrRepairable(b) {
 			continue
@@ -86,8 +84,6 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 				openAliasMatches = append(openAliasMatches, b)
 			case sessionName == identifier:
 				openSessionNameMatches = append(openSessionNameMatches, b)
-			case alias != "" && strings.Contains(alias, "/") && TargetBasename(alias) == identifier:
-				openQualifiedAliasBasenameMatches = append(openQualifiedAliasBasenameMatches, b)
 			}
 			continue
 		}
@@ -99,15 +95,12 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 			closedAliasMatches = append(closedAliasMatches, b)
 		case sessionName == identifier:
 			closedSessionNameMatches = append(closedSessionNameMatches, b)
-		case alias != "" && strings.Contains(alias, "/") && TargetBasename(alias) == identifier:
-			closedQualifiedAliasBasenameMatches = append(closedQualifiedAliasBasenameMatches, b)
 		}
 	}
 
 	for _, matches := range [][]beads.Bead{
 		openSessionNameMatches,
 		openAliasMatches,
-		openQualifiedAliasBasenameMatches,
 	} {
 		if len(matches) > 0 {
 			return chooseSessionMatch(identifier, matches)
@@ -119,7 +112,6 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 	for _, matches := range [][]beads.Bead{
 		closedSessionNameMatches,
 		closedAliasMatches,
-		closedQualifiedAliasBasenameMatches,
 	} {
 		if len(matches) > 0 {
 			return chooseSessionMatch(identifier, matches)

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -69,8 +69,10 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 
 	var openSessionNameMatches []beads.Bead
 	var openAliasMatches []beads.Bead
+	var openQualifiedAliasBasenameMatches []beads.Bead
 	var closedSessionNameMatches []beads.Bead
 	var closedAliasMatches []beads.Bead
+	var closedQualifiedAliasBasenameMatches []beads.Bead
 	for _, b := range all {
 		if !IsSessionBeadOrRepairable(b) {
 			continue
@@ -84,6 +86,8 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 				openAliasMatches = append(openAliasMatches, b)
 			case sessionName == identifier:
 				openSessionNameMatches = append(openSessionNameMatches, b)
+			case alias != "" && strings.Contains(alias, "/") && TargetBasename(alias) == identifier:
+				openQualifiedAliasBasenameMatches = append(openQualifiedAliasBasenameMatches, b)
 			}
 			continue
 		}
@@ -95,12 +99,15 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 			closedAliasMatches = append(closedAliasMatches, b)
 		case sessionName == identifier:
 			closedSessionNameMatches = append(closedSessionNameMatches, b)
+		case alias != "" && strings.Contains(alias, "/") && TargetBasename(alias) == identifier:
+			closedQualifiedAliasBasenameMatches = append(closedQualifiedAliasBasenameMatches, b)
 		}
 	}
 
 	for _, matches := range [][]beads.Bead{
 		openSessionNameMatches,
 		openAliasMatches,
+		openQualifiedAliasBasenameMatches,
 	} {
 		if len(matches) > 0 {
 			return chooseSessionMatch(identifier, matches)
@@ -112,6 +119,7 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 	for _, matches := range [][]beads.Bead{
 		closedSessionNameMatches,
 		closedAliasMatches,
+		closedQualifiedAliasBasenameMatches,
 	} {
 		if len(matches) > 0 {
 			return chooseSessionMatch(identifier, matches)

--- a/internal/workdir/workdir.go
+++ b/internal/workdir/workdir.go
@@ -90,7 +90,7 @@ func PathContextForQualifiedName(cityPath, cityName, qualifiedName string, a con
 // session instance. Single-session agents keep their template identity; pooled
 // agents use the alias or generated explicit name.
 func SessionQualifiedName(cityPath string, a config.Agent, rigs []config.Rig, alias, explicitName string) string {
-	if !supportsMultipleSessions(a) {
+	if !a.SupportsMultipleSessions() {
 		return a.QualifiedName()
 	}
 	identity := strings.TrimSpace(alias)
@@ -175,14 +175,6 @@ func ResolveWorkDirPath(cityPath, cityName, qualifiedName string, a config.Agent
 		return ResolveDirPath(cityPath, ExpandTemplate(a.WorkDir, ctx))
 	}
 	return path
-}
-
-func supportsMultipleSessions(a config.Agent) bool {
-	if strings.TrimSpace(a.Namepool) != "" || len(a.NamepoolNames) > 0 {
-		return true
-	}
-	maxSessions := a.EffectiveMaxActiveSessions()
-	return maxSessions == nil || *maxSessions != 1
 }
 
 func samePath(a, b string) bool {

--- a/internal/workdir/workdir.go
+++ b/internal/workdir/workdir.go
@@ -86,6 +86,39 @@ func PathContextForQualifiedName(cityPath, cityName, qualifiedName string, a con
 	}
 }
 
+// SessionQualifiedName returns the canonical work_dir identity for a concrete
+// session instance. Single-session agents keep their template identity; pooled
+// agents use the alias or generated explicit name.
+func SessionQualifiedName(cityPath string, a config.Agent, rigs []config.Rig, alias, explicitName string) string {
+	if !supportsMultipleSessions(a) {
+		return a.QualifiedName()
+	}
+	identity := strings.TrimSpace(alias)
+	if identity == "" {
+		identity = strings.TrimSpace(explicitName)
+	}
+	if identity == "" {
+		return a.QualifiedName()
+	}
+
+	_, instanceName := config.ParseQualifiedName(identity)
+	if instanceName != "" {
+		identity = instanceName
+	}
+	if a.BindingName != "" {
+		prefix := a.BindingName + "."
+		identity = strings.TrimPrefix(identity, prefix)
+	}
+
+	qualified := a.QualifiedInstanceName(identity)
+	rigName := ConfiguredRigName(cityPath, a, rigs)
+	if rigName == "" {
+		return qualified
+	}
+	_, agentBase := config.ParseQualifiedName(qualified)
+	return rigName + "/" + agentBase
+}
+
 // ExpandTemplateStrict expands Go text/template placeholders in a work_dir
 // string and returns an error when parsing or execution fails.
 func ExpandTemplateStrict(spec string, ctx PathContext) (string, error) {
@@ -142,6 +175,14 @@ func ResolveWorkDirPath(cityPath, cityName, qualifiedName string, a config.Agent
 		return ResolveDirPath(cityPath, ExpandTemplate(a.WorkDir, ctx))
 	}
 	return path
+}
+
+func supportsMultipleSessions(a config.Agent) bool {
+	if strings.TrimSpace(a.Namepool) != "" || len(a.NamepoolNames) > 0 {
+		return true
+	}
+	maxSessions := a.EffectiveMaxActiveSessions()
+	return maxSessions == nil || *maxSessions != 1
 }
 
 func samePath(a, b string) bool {

--- a/internal/workdir/workdir_test.go
+++ b/internal/workdir/workdir_test.go
@@ -85,6 +85,25 @@ func TestSessionQualifiedNameKeepsSingletonTemplateIdentity(t *testing.T) {
 	}
 }
 
+func TestSessionQualifiedNamePreservesRigQualifiedBindingIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	rigs := []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}}
+	agent := config.Agent{
+		Name:              "worker",
+		Dir:               "demo",
+		BindingName:       "ops",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(2),
+	}
+
+	if got := SessionQualifiedName(cityPath, agent, rigs, "ops.worker-1", ""); got != "demo/ops.worker-1" {
+		t.Fatalf("SessionQualifiedName(bare binding) = %q, want %q", got, "demo/ops.worker-1")
+	}
+	if got := SessionQualifiedName(cityPath, agent, rigs, "demo/ops.worker-1", ""); got != "demo/ops.worker-1" {
+		t.Fatalf("SessionQualifiedName(rig-qualified binding) = %q, want %q", got, "demo/ops.worker-1")
+	}
+}
+
 func TestCityNameFallsBackToCityDirBase(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "city-root")
 	got := CityName(cityPath, &config.City{})

--- a/internal/workdir/workdir_test.go
+++ b/internal/workdir/workdir_test.go
@@ -56,6 +56,35 @@ func TestResolveWorkDirPathUsesPoolInstanceBase(t *testing.T) {
 	}
 }
 
+func TestSessionQualifiedNameCanonicalizesBareAndQualifiedPoolAliases(t *testing.T) {
+	cityPath := t.TempDir()
+	rigs := []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}}
+	agent := config.Agent{
+		Name:              "polecat",
+		Dir:               "demo",
+		MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+	}
+
+	bare := SessionQualifiedName(cityPath, agent, rigs, "polecat-fenrir", "")
+	qualified := SessionQualifiedName(cityPath, agent, rigs, "demo/polecat-fenrir", "")
+	if bare != "demo/polecat-fenrir" {
+		t.Fatalf("SessionQualifiedName(bare) = %q, want %q", bare, "demo/polecat-fenrir")
+	}
+	if qualified != bare {
+		t.Fatalf("SessionQualifiedName(qualified) = %q, want %q", qualified, bare)
+	}
+}
+
+func TestSessionQualifiedNameKeepsSingletonTemplateIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	rigs := []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}}
+	agent := config.Agent{Name: "witness", Dir: "demo", MaxActiveSessions: intPtr(1)}
+
+	if got := SessionQualifiedName(cityPath, agent, rigs, "demo/boot", ""); got != "demo/witness" {
+		t.Fatalf("SessionQualifiedName() = %q, want %q", got, "demo/witness")
+	}
+}
+
 func TestCityNameFallsBackToCityDirBase(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "city-root")
 	got := CityName(cityPath, &config.City{})


### PR DESCRIPTION
## Summary
- resolve pooled session workdirs from concrete per-session identities instead of template identities across CLI, template materialization, and API creation
- canonicalize pooled aliases so bare and qualified spellings map to the same instance identity while preserving singleton alias behavior
- add regression coverage for alias-backed, aliasless, API, named-session, and workdir helper paths

Closes #774.

## Testing
- go test ./cmd/gc -run 'TestCmdSessionNew_(AllowsReservedNamedAliasWithController|AllowsReservedNamedAliasWithoutController|PoolTemplateUsesAliasBackedWorkDirIdentity|PoolTemplateCanonicalizesQualifiedAliasCollisions|PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity)|TestEnsureSessionForTemplate_(PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity|RebrandedSingletonKeepsTemplateWorkDirIdentity)|TestResolveConfiguredSessionLogContext_(ByExactSingletonAlias|RebrandedSingletonUsesTemplateWorkDirIdentity)|TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings|TestResolveWorkDir'
- go test ./internal/api -run 'TestHandleSessionCreate(Async|PersistsAlias|RejectsDuplicateAlias|Async_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity|Async_PoolTemplateCanonicalizesAliasCollisions)|TestMaterializeNamedSession_RebrandedSingletonKeepsTemplateWorkDirIdentity|TestResolveSessionTemplateUses(ConfiguredWorkDir|CityNameFallbackForWorkDirTemplates|QualifiedNameForWorkDirTemplates)'
- go test ./internal/workdir ./internal/session -run 'Test(SessionQualifiedName|ResolveWorkDirPath|CityName|ConfiguredRigName|ValidateAlias|GenerateAdhocExplicitName)'