### PR TITLE
fix: stabilize suspend/resume and review-check flakes

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -468,32 +468,44 @@ func (cs *controllerState) DisableOrder(name, rig string) error {
 // SuspendAgent writes suspended=true to city.toml (durable desired state).
 // Uses configedit.Editor for provenance-aware edit (inline vs patch).
 func (cs *controllerState) SuspendAgent(name string) error {
-	return cs.editor.SuspendAgent(name)
+	return cs.mutateAndPoke(func() error {
+		return cs.editor.SuspendAgent(name)
+	})
 }
 
 // ResumeAgent clears suspended in city.toml (durable desired state).
 func (cs *controllerState) ResumeAgent(name string) error {
-	return cs.editor.ResumeAgent(name)
+	return cs.mutateAndPoke(func() error {
+		return cs.editor.ResumeAgent(name)
+	})
 }
 
 // SuspendRig writes suspended=true on the rig in city.toml.
 func (cs *controllerState) SuspendRig(name string) error {
-	return cs.editor.SuspendRig(name)
+	return cs.mutateAndPoke(func() error {
+		return cs.editor.SuspendRig(name)
+	})
 }
 
 // ResumeRig clears suspended on the rig in city.toml.
 func (cs *controllerState) ResumeRig(name string) error {
-	return cs.editor.ResumeRig(name)
+	return cs.mutateAndPoke(func() error {
+		return cs.editor.ResumeRig(name)
+	})
 }
 
 // SuspendCity sets workspace.suspended = true.
 func (cs *controllerState) SuspendCity() error {
-	return cs.editor.SuspendCity()
+	return cs.mutateAndPoke(func() error {
+		return cs.editor.SuspendCity()
+	})
 }
 
 // ResumeCity sets workspace.suspended = false.
 func (cs *controllerState) ResumeCity() error {
-	return cs.editor.ResumeCity()
+	return cs.mutateAndPoke(func() error {
+		return cs.editor.ResumeCity()
+	})
 }
 
 // CreateAgent adds a new agent to city.toml.
@@ -585,6 +597,14 @@ func (cs *controllerState) SetProviderPatch(patch config.ProviderPatch) error {
 // DeleteProviderPatch removes a provider patch from city.toml.
 func (cs *controllerState) DeleteProviderPatch(name string) error {
 	return cs.editor.DeleteProviderPatch(name)
+}
+
+func (cs *controllerState) mutateAndPoke(mutate func() error) error {
+	if err := mutate(); err != nil {
+		return err
+	}
+	cs.Poke()
+	return nil
 }
 
 // Poke signals the controller to trigger an immediate reconciler tick.

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/configedit"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -455,6 +457,179 @@ interval = "24h"
 	if aa[0].Name != "digest" {
 		t.Fatalf("order name = %q, want digest", aa[0].Name)
 	}
+}
+
+func TestControllerStateMutationsPokeController(t *testing.T) {
+	cases := []struct {
+		name    string
+		initial func(*config.City)
+		mutate  func(*controllerState) error
+		verify  func(*testing.T, *config.City)
+	}{
+		{
+			name: "suspend agent",
+			mutate: func(cs *controllerState) error {
+				return cs.SuspendAgent("rig1/worker")
+			},
+			verify: func(t *testing.T, cfg *config.City) {
+				t.Helper()
+				if !cfg.Agents[0].Suspended {
+					t.Fatal("agent should be suspended after SuspendAgent")
+				}
+			},
+		},
+		{
+			name: "resume agent",
+			initial: func(cfg *config.City) {
+				cfg.Agents[0].Suspended = true
+			},
+			mutate: func(cs *controllerState) error {
+				return cs.ResumeAgent("rig1/worker")
+			},
+			verify: func(t *testing.T, cfg *config.City) {
+				t.Helper()
+				if cfg.Agents[0].Suspended {
+					t.Fatal("agent should not be suspended after ResumeAgent")
+				}
+			},
+		},
+		{
+			name: "suspend rig",
+			mutate: func(cs *controllerState) error {
+				return cs.SuspendRig("rig1")
+			},
+			verify: func(t *testing.T, cfg *config.City) {
+				t.Helper()
+				if !cfg.Rigs[0].Suspended {
+					t.Fatal("rig should be suspended after SuspendRig")
+				}
+			},
+		},
+		{
+			name: "resume rig",
+			initial: func(cfg *config.City) {
+				cfg.Rigs[0].Suspended = true
+			},
+			mutate: func(cs *controllerState) error {
+				return cs.ResumeRig("rig1")
+			},
+			verify: func(t *testing.T, cfg *config.City) {
+				t.Helper()
+				if cfg.Rigs[0].Suspended {
+					t.Fatal("rig should not be suspended after ResumeRig")
+				}
+			},
+		},
+		{
+			name: "suspend city",
+			mutate: func(cs *controllerState) error {
+				return cs.SuspendCity()
+			},
+			verify: func(t *testing.T, cfg *config.City) {
+				t.Helper()
+				if !cfg.Workspace.Suspended {
+					t.Fatal("city should be suspended after SuspendCity")
+				}
+			},
+		},
+		{
+			name: "resume city",
+			initial: func(cfg *config.City) {
+				cfg.Workspace.Suspended = true
+			},
+			mutate: func(cs *controllerState) error {
+				return cs.ResumeCity()
+			},
+			verify: func(t *testing.T, cfg *config.City) {
+				t.Helper()
+				if cfg.Workspace.Suspended {
+					t.Fatal("city should not be suspended after ResumeCity")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, tomlPath := newControllerStateMutationHarness(t)
+
+			cfg, err := config.Load(fsys.OSFS{}, tomlPath)
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			if tc.initial != nil {
+				tc.initial(cfg)
+				content, err := cfg.Marshal()
+				if err != nil {
+					t.Fatalf("marshal initial config: %v", err)
+				}
+				if err := os.WriteFile(tomlPath, content, 0o644); err != nil {
+					t.Fatalf("write initial config: %v", err)
+				}
+			}
+
+			if err := tc.mutate(cs); err != nil {
+				t.Fatalf("mutation failed: %v", err)
+			}
+			select {
+			case <-cs.pokeCh:
+			default:
+				t.Fatal("expected controller mutation to poke reconciler")
+			}
+
+			got, err := config.Load(fsys.OSFS{}, tomlPath)
+			if err != nil {
+				t.Fatalf("reload config: %v", err)
+			}
+			tc.verify(t, got)
+		})
+	}
+}
+
+func TestControllerStateMutationErrorDoesNotPokeController(t *testing.T) {
+	cs, _ := newControllerStateMutationHarness(t)
+
+	if err := cs.SuspendAgent("rig1/missing"); err == nil {
+		t.Fatal("SuspendAgent unexpectedly succeeded for missing agent")
+	}
+	select {
+	case <-cs.pokeCh:
+		t.Fatal("failed mutation should not poke reconciler")
+	default:
+	}
+}
+
+func newControllerStateMutationHarness(t *testing.T) (*controllerState, string) {
+	t.Helper()
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rig1")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "rig1"},
+		},
+		Rigs: []config.Rig{
+			{Name: "rig1", Path: rigDir},
+		},
+	}
+	content, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, content, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	return &controllerState{
+		editor: configedit.NewEditor(fsys.OSFS{}, tomlPath),
+		pokeCh: make(chan struct{}, 1),
+	}, tomlPath
 }
 
 // Verify controllerState satisfies the api.State interface at compile time.

--- a/examples/gastown/packs/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
@@ -23,7 +23,18 @@ load_verdict() {
         verdict=$(
             bd list --all --json --limit=0 2>/dev/null |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
-                    [ .[] | select(.metadata["gc.step_ref"] == $ref and .metadata["gc.root_bead_id"] == $root) | .metadata["review.verdict"] ] | first // ""
+                    [
+                        .[]
+                        | select(.metadata["gc.step_ref"] == $ref and .metadata["gc.root_bead_id"] == $root)
+                        | {
+                            verdict: .metadata["review.verdict"],
+                            timestamp: (.updated_at // .created_at // ""),
+                            id: (.id // "")
+                        }
+                        | select(.verdict != null and .verdict != "")
+                    ]
+                    | sort_by(.timestamp, .id)
+                    | .[-1].verdict // ""
                 ' 2>/dev/null
         ) || verdict=""
         if [ -n "$verdict" ]; then

--- a/examples/gastown/packs/gastown/assets/scripts/checks/code-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/code-review-approved.sh
@@ -19,7 +19,18 @@ load_verdict() {
         verdict=$(
             bd list --all --json --limit=0 2>/dev/null |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
-                    [ .[] | select(.metadata["gc.step_ref"] == $ref and .metadata["gc.root_bead_id"] == $root) | .metadata["code_review.verdict"] ] | first // ""
+                    [
+                        .[]
+                        | select(.metadata["gc.step_ref"] == $ref and .metadata["gc.root_bead_id"] == $root)
+                        | {
+                            verdict: .metadata["code_review.verdict"],
+                            timestamp: (.updated_at // .created_at // ""),
+                            id: (.id // "")
+                        }
+                        | select(.verdict != null and .verdict != "")
+                    ]
+                    | sort_by(.timestamp, .id)
+                    | .[-1].verdict // ""
                 ' 2>/dev/null
         ) || verdict=""
         if [ -n "$verdict" ]; then

--- a/examples/gastown/packs/gastown/assets/scripts/checks/design-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/design-review-approved.sh
@@ -19,7 +19,18 @@ load_verdict() {
         verdict=$(
             bd list --all --json --limit=0 2>/dev/null |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
-                    [ .[] | select(.metadata["gc.step_ref"] == $ref and .metadata["gc.root_bead_id"] == $root) | .metadata["design_review.verdict"] ] | first // ""
+                    [
+                        .[]
+                        | select(.metadata["gc.step_ref"] == $ref and .metadata["gc.root_bead_id"] == $root)
+                        | {
+                            verdict: .metadata["design_review.verdict"],
+                            timestamp: (.updated_at // .created_at // ""),
+                            id: (.id // "")
+                        }
+                        | select(.verdict != null and .verdict != "")
+                    ]
+                    | sort_by(.timestamp, .id)
+                    | .[-1].verdict // ""
                 ' 2>/dev/null
         ) || verdict=""
         if [ -n "$verdict" ]; then

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -143,6 +143,36 @@ func TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep(t *testing.T) {
 	}
 }
 
+func TestReviewCheckScriptsPreferNewestVerdictWhenListOrderIsStale(t *testing.T) {
+	for _, tc := range reviewCheckCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeDir := t.TempDir()
+			writeFakeBDCommand(t, filepath.Join(fakeDir, "bd"), tc)
+
+			env := newIsolatedToolEnv(t, false)
+			envMap := parseEnvList(env)
+			env = replaceEnv(env, "PATH", prependPath(fakeDir, envMap["PATH"]))
+			env = filterEnvMany(env,
+				"GC_BEAD_ID",
+				"GC_CITY",
+				"GC_CITY_PATH",
+				"GC_CITY_ROOT",
+				"GC_CITY_RUNTIME_DIR",
+			)
+			env = append(env, "GC_BEAD_ID=check-1")
+
+			scriptPath := filepath.Join(repoRoot(t), "examples", "gastown", "packs", "gastown", "assets", "scripts", "checks", tc.script)
+			out, err := runCommand(repoRoot(t), env, 30*time.Second, "bash", scriptPath)
+			if err != nil {
+				t.Fatalf("%s failed: %v\noutput: %s", tc.script, err, out)
+			}
+			if !strings.Contains(out, tc.approvedText) {
+				t.Fatalf("%s output = %q, want %q", tc.script, out, tc.approvedText)
+			}
+		})
+	}
+}
+
 func setupReviewCheckScriptCity(t *testing.T) string {
 	t.Helper()
 	env := newIsolatedCommandEnv(t, true)
@@ -234,4 +264,53 @@ func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {
 		env = append(env, "GC_DOLT_PORT="+port)
 	}
 	return env
+}
+
+func writeFakeBDCommand(t *testing.T, path string, tc reviewCheckCase) {
+	t.Helper()
+
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+cmd="$1"
+shift || true
+
+case "$cmd" in
+  show)
+    printf '%%s\n' '{"metadata":{"gc.attempt":"1","gc.root_bead_id":"root-1"}}'
+    ;;
+  list)
+    cat <<'EOF'
+[
+  {
+    "id": "old-verdict",
+    "created_at": "2026-01-01T00:00:00Z",
+    "metadata": {
+      "gc.step_ref": %q,
+      "gc.root_bead_id": "root-1",
+      %q: "iterate"
+    }
+  },
+  {
+    "id": "new-verdict",
+    "created_at": "2026-01-01T00:00:01Z",
+    "metadata": {
+      "gc.step_ref": %q,
+      "gc.root_bead_id": "root-1",
+      %q: "done"
+    }
+  }
+]
+EOF
+    ;;
+  *)
+    echo "unexpected bd command: $cmd" >&2
+    exit 1
+    ;;
+esac
+`, tc.attemptStepRef(1), tc.verdictKey, tc.attemptStepRef(1), tc.verdictKey)
+
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd command: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- poke the managed controller immediately after agent, rig, and city suspend/resume mutations so the reconciler does not wait on file-watch timing
- make the Gastown review approval check scripts choose the newest matching verdict instead of the first arbitrary bead returned by `bd list`
- add deterministic regression tests for both behaviors alongside repeated integration runs of the original flaky cases

## Testing
- go test ./cmd/gc -run ^TestControllerStateMutationsPokeController$