### PR TITLE
Fix source-workflow singleton recovery for #720

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -300,10 +300,10 @@ name = "test-city"
 
 func TestLoadCityConfigFSAppliesFeatureFlags(t *testing.T) {
 	oldFormulaV2 := formula.IsFormulaV2Enabled()
-	oldGraphApply := molecule.GraphApplyEnabled
+	oldGraphApply := molecule.IsGraphApplyEnabled()
 	t.Cleanup(func() {
 		formula.SetFormulaV2Enabled(oldFormulaV2)
-		molecule.GraphApplyEnabled = oldGraphApply
+		molecule.SetGraphApplyEnabled(oldGraphApply)
 	})
 
 	fs := fsys.NewFake()
@@ -324,7 +324,7 @@ formula_v2 = true
 	if !formula.IsFormulaV2Enabled() {
 		t.Fatalf("formula.IsFormulaV2Enabled() = false, want true")
 	}
-	if !molecule.GraphApplyEnabled {
-		t.Fatalf("molecule.GraphApplyEnabled = false, want true")
+	if !molecule.IsGraphApplyEnabled() {
+		t.Fatalf("molecule.IsGraphApplyEnabled() = false, want true")
 	}
 }

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1,20 +1,29 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/spf13/cobra"
 )
 
 var dispatchControlSessionProvider = newSessionProvider
+
+func sourceWorkflowCommandContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}
 
 // convoyDispatchSubcommands returns the dispatch-related subcommands to add to gc convoy.
 func convoyDispatchSubcommands(stdout, stderr io.Writer) []*cobra.Command {
@@ -22,6 +31,8 @@ func convoyDispatchSubcommands(stdout, stderr io.Writer) []*cobra.Command {
 		newConvoyControlCmd(stdout, stderr),
 		newConvoyPokeCmd(stdout, stderr),
 		newConvoyDeleteCmd(stdout, stderr),
+		newConvoyDeleteSourceCmd(stdout, stderr),
+		newConvoyReopenSourceCmd(stdout, stderr),
 	}
 }
 
@@ -168,38 +179,79 @@ func runControlDispatcher(beadID string, stdout, _ io.Writer) error {
 	return nil
 }
 
-// findBeadAcrossStores tries the city store first, then all rig stores,
-// returning the store and bead on first match.
+// findBeadAcrossStores preserves the historical city-first lookup semantics.
 func findBeadAcrossStores(cityPath, beadID string) (beads.Store, beads.Bead, error) {
-	// Try city store first.
 	cityStore, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
 		return nil, beads.Bead{}, fmt.Errorf("opening city store: %w", err)
 	}
-	if b, err := cityStore.Get(beadID); err == nil {
-		return cityStore, b, nil
+	if bead, err := cityStore.Get(beadID); err == nil {
+		return cityStore, bead, nil
 	} else if !errors.Is(err, beads.ErrNotFound) {
-		return nil, beads.Bead{}, fmt.Errorf("getting bead %q from city store: %w", beadID, err)
+		return nil, beads.Bead{}, fmt.Errorf("getting bead %q from %s: %w", beadID, cityPath, err)
 	}
-
-	// Try rig stores.
 	cfg, err := loadCityConfig(cityPath)
 	if err != nil {
-		return nil, beads.Bead{}, fmt.Errorf("getting bead %q: not in city store, and config unavailable: %w", beadID, err)
+		return nil, beads.Bead{}, err
 	}
-	for _, rig := range cfg.Rigs {
-		rigStore, err := openStoreAtForCity(rig.Path, cityPath)
+	for _, dir := range convoyStoreCandidates(cfg, cityPath, beadID) {
+		if dir == cityPath {
+			continue
+		}
+		store, err := openStoreAtForCity(dir, cityPath)
 		if err != nil {
-			return nil, beads.Bead{}, fmt.Errorf("opening rig store %q: %w", rig.Name, err)
+			return nil, beads.Bead{}, fmt.Errorf("opening store %s: %w", dir, err)
 		}
-		if b, err := rigStore.Get(beadID); err == nil {
-			return rigStore, b, nil
-		} else if !errors.Is(err, beads.ErrNotFound) {
-			return nil, beads.Bead{}, fmt.Errorf("getting bead %q from rig store %q: %w", beadID, rig.Name, err)
+		bead, err := store.Get(beadID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return nil, beads.Bead{}, fmt.Errorf("getting bead %q from %s: %w", beadID, dir, err)
 		}
+		return store, bead, nil
 	}
+	return nil, beads.Bead{}, fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+}
 
-	return nil, beads.Bead{}, fmt.Errorf("getting bead %q: bead not found", beadID)
+func findUniqueBeadAcrossStoresView(cityPath, beadID string) (convoyStoreView, beads.Bead, error) {
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		return convoyStoreView{}, beads.Bead{}, fmt.Errorf("loading city config for bead %q: %w", beadID, err)
+	}
+	stores, err := openSourceWorkflowStores(cfg, cityPath, beadID)
+	if err != nil {
+		return convoyStoreView{}, beads.Bead{}, err
+	}
+	var (
+		foundView convoyStoreView
+		foundBead beads.Bead
+		found     bool
+	)
+	for _, candidate := range stores {
+		bead, err := candidate.store.Get(beadID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return convoyStoreView{}, beads.Bead{}, fmt.Errorf("getting bead %q from %s: %w", beadID, candidate.path, err)
+		}
+		if found {
+			return convoyStoreView{}, beads.Bead{}, fmt.Errorf(
+				"source bead %s exists in multiple stores (%s and %s); source workflow commands require a uniquely resolvable source bead id",
+				beadID,
+				foundView.path,
+				candidate.path,
+			)
+		}
+		foundView = candidate
+		foundBead = bead
+		found = true
+	}
+	if !found {
+		return convoyStoreView{}, beads.Bead{}, fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+	}
+	return foundView, foundBead, nil
 }
 
 func workflowFormulaSearchPaths(cfg *config.City, bead beads.Bead) []string {
@@ -368,6 +420,59 @@ also remove them from the store after closing.`,
 	return cmd
 }
 
+func newConvoyDeleteSourceCmd(stdout, stderr io.Writer) *cobra.Command {
+	var apply bool
+	var deleteBeads bool
+	var rigName string
+	var storeRef string
+	cmd := &cobra.Command{
+		Use:   "delete-source <source-bead-id>",
+		Short: "Close workflows sourced from a bead",
+		Long: `Find every live workflow root sourced from the given bead and close
+its subtree. By default this is a preview. Use --apply to mutate.
+Use --delete with --apply to also delete closed beads.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if deleteBeads && !apply {
+				fmt.Fprintln(stderr, "gc workflow delete-source: --delete requires --apply") //nolint:errcheck
+				return errExit
+			}
+			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			return exitForCode(cmdWorkflowDeleteSource(args[0], selector, apply, deleteBeads, stdout, stderr))
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "Actually close/delete matched workflows")
+	cmd.Flags().BoolVar(&deleteBeads, "delete", false, "Also delete beads from the store after closing")
+	cmd.Flags().StringVar(&rigName, "rig", "", "Select the rig store for the source bead")
+	cmd.Flags().StringVar(&storeRef, "store-ref", "", "Select the source bead store (city:<name> or rig:<name>)")
+	return cmd
+}
+
+func newConvoyReopenSourceCmd(stdout, stderr io.Writer) *cobra.Command {
+	var rigName string
+	var storeRef string
+	cmd := &cobra.Command{
+		Use:   "reopen-source <source-bead-id>",
+		Short: "Reopen a source bead after workflow cleanup",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			return exitForCode(cmdWorkflowReopenSource(args[0], selector, stdout, stderr))
+		},
+	}
+	cmd.Flags().StringVar(&rigName, "rig", "", "Select the rig store for the source bead")
+	cmd.Flags().StringVar(&storeRef, "store-ref", "", "Select the source bead store (city:<name> or rig:<name>)")
+	return cmd
+}
+
 func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
@@ -465,6 +570,359 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 	return 0
 }
 
+type sourceWorkflowStoreMatch struct {
+	label string
+	store beads.Store
+	roots []beads.Bead
+	beads []beads.Bead
+}
+
+type sourceWorkflowStoreSelector struct {
+	storeRef string
+}
+
+type resolvedSourceWorkflowTarget struct {
+	sourceBeadID string
+	storeRef     string
+	storeView    convoyStoreView
+	sourceBead   beads.Bead
+}
+
+func parseSourceWorkflowStoreSelector(rigName, storeRef string) (sourceWorkflowStoreSelector, error) {
+	rigName = strings.TrimSpace(rigName)
+	storeRef = strings.TrimSpace(storeRef)
+	if rigName != "" && storeRef != "" {
+		return sourceWorkflowStoreSelector{}, fmt.Errorf("--rig and --store-ref are mutually exclusive")
+	}
+	if rigName != "" {
+		storeRef = "rig:" + rigName
+	}
+	return sourceWorkflowStoreSelector{storeRef: storeRef}, nil
+}
+
+func resolveSourceWorkflowTarget(cfg *config.City, cityPath, sourceBeadID string, selector sourceWorkflowStoreSelector, requireSource bool) (resolvedSourceWorkflowTarget, error) {
+	sourceBeadID = sourceworkflow.NormalizeSourceBeadID(sourceBeadID)
+	target := resolvedSourceWorkflowTarget{sourceBeadID: sourceBeadID}
+	if selector.storeRef != "" {
+		view, resolvedStoreRef, err := openSourceWorkflowStoreRef(cfg, cityPath, selector.storeRef)
+		if err != nil {
+			return resolvedSourceWorkflowTarget{}, err
+		}
+		target.storeRef = resolvedStoreRef
+		target.storeView = view
+		bead, err := view.store.Get(sourceBeadID)
+		switch {
+		case err == nil:
+			target.sourceBead = bead
+		case errors.Is(err, beads.ErrNotFound):
+			if requireSource {
+				return resolvedSourceWorkflowTarget{}, fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
+			}
+		default:
+			return resolvedSourceWorkflowTarget{}, fmt.Errorf("getting bead %q from %s: %w", sourceBeadID, workflowDeleteStoreLabel(cfg, cityPath, view.path), err)
+		}
+		return target, nil
+	}
+	view, bead, err := findUniqueBeadAcrossStoresView(cityPath, sourceBeadID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) && !requireSource {
+			return target, nil
+		}
+		return resolvedSourceWorkflowTarget{}, sourceWorkflowSelectionError(err, sourceBeadID)
+	}
+	target.storeView = view
+	target.sourceBead = bead
+	target.storeRef = workflowStoreRefForDir(view.path, cityPath, cfg.Workspace.Name, cfg)
+	return target, nil
+}
+
+func sourceWorkflowSelectionError(err error, sourceBeadID string) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "exists in multiple stores") {
+		return fmt.Errorf("%v; rerun with --rig <name> or --store-ref <city:name|rig:name>", err)
+	}
+	if errors.Is(err, beads.ErrNotFound) {
+		return fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
+	}
+	return err
+}
+
+func openSourceWorkflowStoreRef(cfg *config.City, cityPath, storeRef string) (convoyStoreView, string, error) {
+	storeRef = strings.TrimSpace(storeRef)
+	switch {
+	case storeRef == "", storeRef == "city":
+		store, err := openStoreAtForCity(cityPath, cityPath)
+		if err != nil {
+			return convoyStoreView{}, "", fmt.Errorf("opening city store: %w", err)
+		}
+		cityName := "city"
+		if cfg != nil && strings.TrimSpace(cfg.Workspace.Name) != "" {
+			cityName = cfg.Workspace.Name
+		}
+		return convoyStoreView{path: cityPath, store: store}, "city:" + cityName, nil
+	case strings.HasPrefix(storeRef, "city:"):
+		store, err := openStoreAtForCity(cityPath, cityPath)
+		if err != nil {
+			return convoyStoreView{}, "", fmt.Errorf("opening city store: %w", err)
+		}
+		return convoyStoreView{path: cityPath, store: store}, storeRef, nil
+	case strings.HasPrefix(storeRef, "rig:"):
+		rigName := strings.TrimPrefix(storeRef, "rig:")
+		for _, rig := range cfg.Rigs {
+			if rig.Name != rigName {
+				continue
+			}
+			rigPath := resolveStoreScopeRoot(cityPath, rig.Path)
+			store, err := openStoreAtForCity(rigPath, cityPath)
+			if err != nil {
+				return convoyStoreView{}, "", fmt.Errorf("opening rig store %s: %w", rigName, err)
+			}
+			return convoyStoreView{path: rigPath, store: store}, "rig:" + rigName, nil
+		}
+		return convoyStoreView{}, "", fmt.Errorf("rig %q not found", rigName)
+	default:
+		return convoyStoreView{}, "", fmt.Errorf("invalid --store-ref %q (want city:<name> or rig:<name>)", storeRef)
+	}
+}
+
+func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads bool, stderr io.Writer) (closed, deleted int, incomplete bool) {
+	ids := workflowBeadIDs(match.beads)
+	n, closeErr := match.store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
+	closed += n
+	if closeErr != nil {
+		incomplete = true
+		fmt.Fprintf(stderr, "store=%s close_error=%v\n", match.label, closeErr) //nolint:errcheck
+		return closed, deleted, incomplete
+	}
+	if !deleteBeads {
+		return closed, deleted, incomplete
+	}
+	count, errs := deleteWorkflowBeads(match.store, ids)
+	deleted += count
+	for _, deleteErr := range errs {
+		incomplete = true
+		fmt.Fprintf(stderr, "store=%s delete_error=%v\n", match.label, deleteErr) //nolint:errcheck
+	}
+	return closed, deleted, incomplete
+}
+
+func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSelector, apply, deleteBeads bool, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	var (
+		resultCode int
+		runErr     error
+	)
+	target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, false)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	lockScope := target.storeView.path
+	if strings.TrimSpace(lockScope) == "" {
+		lockScope = cityPath
+	}
+	ctx, cancel := sourceWorkflowCommandContext()
+	defer cancel()
+	runErr = sourceworkflow.WithLock(ctx, cityPath, lockScope, sourceBeadID, func() error {
+		target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, false)
+		if err != nil {
+			return err
+		}
+		matches, err := collectSourceWorkflowMatches(cfg, cityPath, sourceBeadID, target.storeRef)
+		if err != nil {
+			return err
+		}
+		if target.storeRef == "" && len(matches) > 1 {
+			return fmt.Errorf(
+				"source workflow %s has live roots in multiple stores (%s); rerun with --rig <name> or --store-ref <city:name|rig:name>",
+				sourceBeadID,
+				strings.Join(sourceWorkflowMatchLabels(matches), ", "),
+			)
+		}
+		totalRoots, totalBeads, openCount := summarizeSourceWorkflowMatches(matches)
+		if totalRoots == 0 {
+			cleared := false
+			if apply {
+				var clearErr error
+				cleared, clearErr = clearSourceWorkflowMetadata(cfg, cityPath, target)
+				if clearErr != nil {
+					return clearErr
+				}
+			}
+			fmt.Fprintf(
+				stdout,
+				"result=already_clean source_bead_id=%s matched_roots=0 matched_beads=0 closed=0 deleted=0 metadata_cleared=%t\n",
+				sourceBeadID,
+				cleared,
+			) //nolint:errcheck
+			resultCode = 0
+			return nil
+		}
+		if !apply {
+			fmt.Fprintf(
+				stdout,
+				"result=preview source_bead_id=%s matched_roots=%d matched_beads=%d open_beads=%d\n",
+				sourceBeadID,
+				totalRoots,
+				totalBeads,
+				openCount,
+			) //nolint:errcheck
+			for _, match := range matches {
+				fmt.Fprintf(stdout, "store=%s roots=%s beads=%d\n", match.label, strings.Join(rootIDs(match.roots), ","), len(match.beads)) //nolint:errcheck
+			}
+			resultCode = 0
+			return nil
+		}
+
+		closed := 0
+		deleted := 0
+		incomplete := false
+		for _, match := range matches {
+			matchClosed, matchDeleted, matchIncomplete := applySourceWorkflowMatchCleanup(match, deleteBeads, stderr)
+			closed += matchClosed
+			deleted += matchDeleted
+			if matchIncomplete {
+				incomplete = true
+			}
+		}
+
+		stillOpen, verifyErr := countOpenMatchedBeads(matches)
+		if verifyErr != nil {
+			return verifyErr
+		}
+		if stillOpen > 0 {
+			incomplete = true
+		}
+		cleared := false
+		if !incomplete {
+			var clearErr error
+			cleared, clearErr = clearSourceWorkflowMetadata(cfg, cityPath, target)
+			if clearErr != nil {
+				return clearErr
+			}
+		}
+		if incomplete {
+			fmt.Fprintf(
+				stdout,
+				"result=incomplete source_bead_id=%s matched_roots=%d matched_beads=%d closed=%d deleted=%d metadata_cleared=false still_open=%d\n",
+				sourceBeadID,
+				totalRoots,
+				totalBeads,
+				closed,
+				deleted,
+				stillOpen,
+			) //nolint:errcheck
+			resultCode = 1
+			return nil
+		}
+		fmt.Fprintf(
+			stdout,
+			"result=cleaned source_bead_id=%s matched_roots=%d matched_beads=%d closed=%d deleted=%d metadata_cleared=%t\n",
+			sourceBeadID,
+			totalRoots,
+			totalBeads,
+			closed,
+			deleted,
+			cleared,
+		) //nolint:errcheck
+		resultCode = 0
+		return nil
+	})
+	if runErr != nil {
+		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", runErr) //nolint:errcheck
+		return 1
+	}
+	return resultCode
+}
+
+func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSelector, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	resultCode := 0
+	target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, true)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if target.storeView.store == nil || strings.TrimSpace(target.sourceBead.ID) == "" {
+		fmt.Fprintf(stderr, "gc workflow reopen-source: getting bead %q: %v\n", sourceBeadID, beads.ErrNotFound) //nolint:errcheck
+		return 1
+	}
+	ctx, cancel := sourceWorkflowCommandContext()
+	defer cancel()
+	runErr := sourceworkflow.WithLock(ctx, cityPath, target.storeView.path, sourceBeadID, func() error {
+		target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, true)
+		if err != nil {
+			return err
+		}
+		if target.storeView.store == nil || strings.TrimSpace(target.sourceBead.ID) == "" {
+			return fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
+		}
+		matches, err := collectSourceWorkflowMatches(cfg, cityPath, sourceBeadID, target.storeRef)
+		if err != nil {
+			return err
+		}
+		totalRoots, _, _ := summarizeSourceWorkflowMatches(matches)
+		if totalRoots > 0 {
+			ids := make([]string, 0, totalRoots)
+			for _, match := range matches {
+				ids = append(ids, rootIDs(match.roots)...)
+			}
+			fmt.Fprintf(
+				stderr,
+				"result=conflict source_bead_id=%s blocking_workflow_ids=%s\n",
+				sourceBeadID,
+				strings.Join(ids, ","),
+			) //nolint:errcheck
+			resultCode = 3
+			return nil
+		}
+		currentSource, err := target.storeView.store.Get(target.sourceBead.ID)
+		if err != nil {
+			return err
+		}
+		open := "open"
+		unassigned := ""
+		if err := target.storeView.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
+			return err
+		}
+		if err := target.storeView.store.Update(currentSource.ID, beads.UpdateOpts{
+			Status:   &open,
+			Assignee: &unassigned,
+		}); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "result=reopened source_bead_id=%s\n", sourceBeadID) //nolint:errcheck
+		return nil
+	})
+	if runErr != nil {
+		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", runErr) //nolint:errcheck
+		return 1
+	}
+	return resultCode
+}
+
 // findWorkflowBeads returns all beads belonging to a workflow resolved by
 // either root bead ID or logical gc.workflow_id, plus descendants keyed by the
 // resolved root bead IDs.
@@ -553,6 +1011,149 @@ func restoreWorkflowDeleteDeps(store beads.Store, downDeps, upDeps []beads.Dep) 
 		}
 	}
 	return restoreErr
+}
+
+func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sourceStoreRef string) ([]sourceWorkflowStoreMatch, error) {
+	stores, err := openSourceWorkflowStores(cfg, cityPath, sourceBeadID)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]sourceWorkflowStoreMatch, 0, len(stores))
+	for _, info := range stores {
+		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cfg.Workspace.Name, cfg)
+		roots, err := sourceworkflow.ListLiveRoots(info.store, sourceBeadID, sourceStoreRef, rootStoreRef)
+		if err != nil {
+			return nil, err
+		}
+		if len(roots) == 0 {
+			continue
+		}
+		beadSet := make([]beads.Bead, 0, len(roots))
+		for _, root := range roots {
+			beadSet = append(beadSet, findWorkflowBeads(info.store, root.ID)...)
+		}
+		matches = append(matches, sourceWorkflowStoreMatch{
+			label: workflowDeleteStoreLabel(cfg, cityPath, info.path),
+			store: info.store,
+			roots: roots,
+			beads: uniqueBeads(beadSet),
+		})
+	}
+	return matches, nil
+}
+
+func sourceWorkflowMatchLabels(matches []sourceWorkflowStoreMatch) []string {
+	labels := make([]string, 0, len(matches))
+	for _, match := range matches {
+		labels = append(labels, match.label)
+	}
+	return labels
+}
+
+func summarizeSourceWorkflowMatches(matches []sourceWorkflowStoreMatch) (roots, beadsTotal, openCount int) {
+	for _, match := range matches {
+		roots += len(match.roots)
+		beadsTotal += len(match.beads)
+		for _, bead := range match.beads {
+			if bead.Status != "closed" {
+				openCount++
+			}
+		}
+	}
+	return roots, beadsTotal, openCount
+}
+
+func countOpenMatchedBeads(matches []sourceWorkflowStoreMatch) (int, error) {
+	open := 0
+	for _, match := range matches {
+		for _, bead := range match.beads {
+			current, err := match.store.Get(bead.ID)
+			if err != nil {
+				if errors.Is(err, beads.ErrNotFound) {
+					continue
+				}
+				return 0, err
+			}
+			if current.Status != "closed" {
+				open++
+			}
+		}
+	}
+	return open, nil
+}
+
+func openSourceWorkflowStores(cfg *config.City, cityPath, beadID string) ([]convoyStoreView, error) {
+	stores := make([]convoyStoreView, 0, len(convoyStoreCandidates(cfg, cityPath, beadID)))
+	for _, dir := range convoyStoreCandidates(cfg, cityPath, beadID) {
+		store, err := openStoreAtForCity(dir, cityPath)
+		if err != nil {
+			return nil, fmt.Errorf("opening source workflow store %s: %w", dir, err)
+		}
+		stores = append(stores, convoyStoreView{path: dir, store: store})
+	}
+	if len(stores) == 0 {
+		return nil, fmt.Errorf("no source workflow stores available")
+	}
+	return stores, nil
+}
+
+func clearSourceWorkflowMetadata(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget) (bool, error) {
+	bead := target.sourceBead
+	storeView := target.storeView
+	if storeView.store == nil || strings.TrimSpace(storeView.path) == "" {
+		if target.storeRef == "" {
+			return false, nil
+		}
+		var err error
+		storeView, _, err = openSourceWorkflowStoreRef(cfg, cityPath, target.storeRef)
+		if err != nil {
+			return false, err
+		}
+	}
+	if strings.TrimSpace(bead.ID) == "" {
+		current, err := storeView.store.Get(target.sourceBeadID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				return false, nil
+			}
+			return false, err
+		}
+		bead = current
+	}
+	if strings.TrimSpace(bead.Metadata["workflow_id"]) == "" {
+		return false, nil
+	}
+	if err := storeView.store.SetMetadata(bead.ID, "workflow_id", ""); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func rootIDs(roots []beads.Bead) []string {
+	ids := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root.ID == "" {
+			continue
+		}
+		ids = append(ids, root.ID)
+	}
+	return ids
+}
+
+func uniqueBeads(bb []beads.Bead) []beads.Bead {
+	out := make([]beads.Bead, 0, len(bb))
+	seen := make(map[string]struct{}, len(bb))
+	for _, bead := range bb {
+		if bead.ID == "" {
+			continue
+		}
+		if _, ok := seen[bead.ID]; ok {
+			continue
+		}
+		seen[bead.ID] = struct{}{}
+		out = append(out, bead)
+	}
+	return out
 }
 
 func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -71,7 +71,7 @@ Use --follow <agent> to filter the serve loop to a specific agent template.`,
 				if errors.Is(err, dispatch.ErrControlPending) {
 					return nil
 				}
-				fmt.Fprintf(stderr, "gc convoy control: %v\n", err) //nolint:errcheck
+				_, _ = fmt.Fprintf(stderr, "gc convoy control: %v\n", err)
 				return errExit
 			}
 			return nil
@@ -91,11 +91,11 @@ func newConvoyPokeCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc convoy poke: %v\n", err) //nolint:errcheck
+				_, _ = fmt.Fprintf(stderr, "gc convoy poke: %v\n", err)
 				return errExit
 			}
 			if err := pokeControlDispatch(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc convoy poke: %v\n", err) //nolint:errcheck
+				_, _ = fmt.Fprintf(stderr, "gc convoy poke: %v\n", err)
 				return errExit
 			}
 			return nil
@@ -167,12 +167,12 @@ func runControlDispatcher(beadID string, stdout, _ io.Writer) error {
 		return err
 	}
 	if result.Processed {
-		fmt.Fprintf(stdout, "control dispatch: bead=%s action=%s", beadID, result.Action) //nolint:errcheck
+		_, _ = fmt.Fprintf(stdout, "control dispatch: bead=%s action=%s", beadID, result.Action)
 		if result.Created > 0 {
-			fmt.Fprintf(stdout, " created=%d", result.Created) //nolint:errcheck
+			_, _ = fmt.Fprintf(stdout, " created=%d", result.Created)
 		}
 		if result.Skipped > 0 {
-			fmt.Fprintf(stdout, " skipped=%d", result.Skipped) //nolint:errcheck
+			_, _ = fmt.Fprintf(stdout, " skipped=%d", result.Skipped)
 		}
 		fmt.Fprintln(stdout) //nolint:errcheck
 	}
@@ -219,9 +219,14 @@ func findUniqueBeadAcrossStoresView(cityPath, beadID string) (convoyStoreView, b
 	if err != nil {
 		return convoyStoreView{}, beads.Bead{}, fmt.Errorf("loading city config for bead %q: %w", beadID, err)
 	}
-	stores, err := openSourceWorkflowStores(cfg, cityPath, beadID)
+	stores, skips, err := openSourceWorkflowStores(cfg, cityPath, beadID)
 	if err != nil {
 		return convoyStoreView{}, beads.Bead{}, err
+	}
+	if len(skips) > 0 {
+		// Surface skipped stores so a not-found isn't silently masking a
+		// store we couldn't open.
+		fmt.Fprintln(os.Stderr, "warning:", formatSourceWorkflowStoreSkips(skips)) //nolint:errcheck
 	}
 	var (
 		foundView convoyStoreView
@@ -439,7 +444,7 @@ Use --delete with --apply to also delete closed beads.`,
 			}
 			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+				_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
 				return errExit
 			}
 			return exitForCode(cmdWorkflowDeleteSource(args[0], selector, apply, deleteBeads, stdout, stderr))
@@ -462,7 +467,7 @@ func newConvoyReopenSourceCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+				_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
 				return errExit
 			}
 			return exitForCode(cmdWorkflowReopenSource(args[0], selector, stdout, stderr))
@@ -476,7 +481,7 @@ func newConvoyReopenSourceCmd(stdout, stderr io.Writer) *cobra.Command {
 func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
+		_, _ = fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath)
@@ -641,7 +646,7 @@ func sourceWorkflowSelectionError(err error, sourceBeadID string) error {
 		return nil
 	}
 	if strings.Contains(err.Error(), "exists in multiple stores") {
-		return fmt.Errorf("%v; rerun with --rig <name> or --store-ref <city:name|rig:name>", err)
+		return fmt.Errorf("%w; rerun with --rig <name> or --store-ref <city:name|rig:name>", err)
 	}
 	if errors.Is(err, beads.ErrNotFound) {
 		return fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
@@ -693,7 +698,7 @@ func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads
 	closed += n
 	if closeErr != nil {
 		incomplete = true
-		fmt.Fprintf(stderr, "store=%s close_error=%v\n", match.label, closeErr) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "store=%s close_error=%v\n", match.label, closeErr)
 		return closed, deleted, incomplete
 	}
 	if !deleteBeads {
@@ -703,7 +708,7 @@ func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads
 	deleted += count
 	for _, deleteErr := range errs {
 		incomplete = true
-		fmt.Fprintf(stderr, "store=%s delete_error=%v\n", match.label, deleteErr) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "store=%s delete_error=%v\n", match.label, deleteErr)
 	}
 	return closed, deleted, incomplete
 }
@@ -711,12 +716,12 @@ func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads
 func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSelector, apply, deleteBeads bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
 		return 1
 	}
 
@@ -726,7 +731,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 	)
 	target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, false)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
 		return 1
 	}
 	lockScope := target.storeView.path
@@ -740,9 +745,14 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if err != nil {
 			return err
 		}
-		matches, err := collectSourceWorkflowMatches(cfg, cityPath, sourceBeadID, target.storeRef)
+		matches, skips, err := collectSourceWorkflowMatches(cfg, cityPath, sourceBeadID, target.storeRef)
 		if err != nil {
 			return err
+		}
+		if len(skips) > 0 {
+			// delete-source cannot close live roots it can't see. Warn
+			// rather than silently declaring success.
+			fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips(skips)) //nolint:errcheck
 		}
 		if target.storeRef == "" && len(matches) > 1 {
 			return fmt.Errorf(
@@ -761,26 +771,26 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 					return clearErr
 				}
 			}
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				stdout,
 				"result=already_clean source_bead_id=%s matched_roots=0 matched_beads=0 closed=0 deleted=0 metadata_cleared=%t\n",
 				sourceBeadID,
 				cleared,
-			) //nolint:errcheck
+			)
 			resultCode = 0
 			return nil
 		}
 		if !apply {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				stdout,
 				"result=preview source_bead_id=%s matched_roots=%d matched_beads=%d open_beads=%d\n",
 				sourceBeadID,
 				totalRoots,
 				totalBeads,
 				openCount,
-			) //nolint:errcheck
+			)
 			for _, match := range matches {
-				fmt.Fprintf(stdout, "store=%s roots=%s beads=%d\n", match.label, strings.Join(rootIDs(match.roots), ","), len(match.beads)) //nolint:errcheck
+				_, _ = fmt.Fprintf(stdout, "store=%s roots=%s beads=%d\n", match.label, strings.Join(rootIDs(match.roots), ","), len(match.beads))
 			}
 			resultCode = 0
 			return nil
@@ -814,7 +824,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			}
 		}
 		if incomplete {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				stdout,
 				"result=incomplete source_bead_id=%s matched_roots=%d matched_beads=%d closed=%d deleted=%d metadata_cleared=false still_open=%d\n",
 				sourceBeadID,
@@ -823,11 +833,11 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 				closed,
 				deleted,
 				stillOpen,
-			) //nolint:errcheck
+			)
 			resultCode = 1
 			return nil
 		}
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			stdout,
 			"result=cleaned source_bead_id=%s matched_roots=%d matched_beads=%d closed=%d deleted=%d metadata_cleared=%t\n",
 			sourceBeadID,
@@ -836,12 +846,12 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			closed,
 			deleted,
 			cleared,
-		) //nolint:errcheck
+		)
 		resultCode = 0
 		return nil
 	})
 	if runErr != nil {
-		fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", runErr) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", runErr)
 		return 1
 	}
 	return resultCode
@@ -850,23 +860,23 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSelector, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
 		return 1
 	}
 
 	resultCode := 0
 	target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, true)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
 		return 1
 	}
 	if target.storeView.store == nil || strings.TrimSpace(target.sourceBead.ID) == "" {
-		fmt.Fprintf(stderr, "gc workflow reopen-source: getting bead %q: %v\n", sourceBeadID, beads.ErrNotFound) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: getting bead %q: %v\n", sourceBeadID, beads.ErrNotFound)
 		return 1
 	}
 	ctx, cancel := sourceWorkflowCommandContext()
@@ -879,9 +889,15 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if target.storeView.store == nil || strings.TrimSpace(target.sourceBead.ID) == "" {
 			return fmt.Errorf("getting bead %q: %w", sourceBeadID, beads.ErrNotFound)
 		}
-		matches, err := collectSourceWorkflowMatches(cfg, cityPath, sourceBeadID, target.storeRef)
+		matches, skips, err := collectSourceWorkflowMatches(cfg, cityPath, sourceBeadID, target.storeRef)
 		if err != nil {
 			return err
+		}
+		if len(skips) > 0 {
+			// reopen-source risks re-slinging a bead whose true blocking
+			// root sits in a store we couldn't scan. Surface the skipped
+			// stores so operators know coverage was degraded.
+			fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips(skips)) //nolint:errcheck
 		}
 		totalRoots, _, _ := summarizeSourceWorkflowMatches(matches)
 		if totalRoots > 0 {
@@ -889,12 +905,12 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 			for _, match := range matches {
 				ids = append(ids, rootIDs(match.roots)...)
 			}
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				stderr,
 				"result=conflict source_bead_id=%s blocking_workflow_ids=%s\n",
 				sourceBeadID,
 				strings.Join(ids, ","),
-			) //nolint:errcheck
+			)
 			resultCode = 3
 			return nil
 		}
@@ -907,17 +923,25 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if err := target.storeView.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
 			return err
 		}
+		// Clear gc.routed_to so a subsequent re-sling is not silently
+		// short-circuited by CheckBeadState's idempotency fast-path.
+		// CheckBeadState treats a bead with gc.routed_to == target as
+		// already routed; a recovered bead must look like a fresh
+		// candidate for assignment.
+		if err := target.storeView.store.SetMetadata(currentSource.ID, "gc.routed_to", ""); err != nil {
+			return err
+		}
 		if err := target.storeView.store.Update(currentSource.ID, beads.UpdateOpts{
 			Status:   &open,
 			Assignee: &unassigned,
 		}); err != nil {
 			return err
 		}
-		fmt.Fprintf(stdout, "result=reopened source_bead_id=%s\n", sourceBeadID) //nolint:errcheck
+		_, _ = fmt.Fprintf(stdout, "result=reopened source_bead_id=%s\n", sourceBeadID)
 		return nil
 	})
 	if runErr != nil {
-		fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", runErr) //nolint:errcheck
+		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", runErr)
 		return 1
 	}
 	return resultCode
@@ -1013,17 +1037,17 @@ func restoreWorkflowDeleteDeps(store beads.Store, downDeps, upDeps []beads.Dep) 
 	return restoreErr
 }
 
-func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sourceStoreRef string) ([]sourceWorkflowStoreMatch, error) {
-	stores, err := openSourceWorkflowStores(cfg, cityPath, sourceBeadID)
+func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sourceStoreRef string) ([]sourceWorkflowStoreMatch, []sourceWorkflowStoreSkip, error) {
+	stores, skips, err := openSourceWorkflowStores(cfg, cityPath, sourceBeadID)
 	if err != nil {
-		return nil, err
+		return nil, skips, err
 	}
 	matches := make([]sourceWorkflowStoreMatch, 0, len(stores))
 	for _, info := range stores {
 		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cfg.Workspace.Name, cfg)
 		roots, err := sourceworkflow.ListLiveRoots(info.store, sourceBeadID, sourceStoreRef, rootStoreRef)
 		if err != nil {
-			return nil, err
+			return nil, skips, err
 		}
 		if len(roots) == 0 {
 			continue
@@ -1039,7 +1063,7 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 			beads: uniqueBeads(beadSet),
 		})
 	}
-	return matches, nil
+	return matches, skips, nil
 }
 
 func sourceWorkflowMatchLabels(matches []sourceWorkflowStoreMatch) []string {
@@ -1082,19 +1106,83 @@ func countOpenMatchedBeads(matches []sourceWorkflowStoreMatch) (int, error) {
 	return open, nil
 }
 
-func openSourceWorkflowStores(cfg *config.City, cityPath, beadID string) ([]convoyStoreView, error) {
-	stores := make([]convoyStoreView, 0, len(convoyStoreCandidates(cfg, cityPath, beadID)))
-	for _, dir := range convoyStoreCandidates(cfg, cityPath, beadID) {
-		store, err := openStoreAtForCity(dir, cityPath)
+// sourceWorkflowStoreSkip records a candidate store that could not be opened
+// during a source-workflow singleton scan. Tolerating unopenable stores
+// avoids turning a rig-local problem into a city-wide outage, but the
+// silent skip creates a correctness hole: a cross-store live root living
+// in the broken rig is invisible to the singleton check. Callers MUST
+// surface skips (stderr, SlingResult.MetadataErrors, etc.) so operators
+// can see when singleton coverage has degraded and decide whether to
+// proceed or repair the rig first.
+type sourceWorkflowStoreSkip struct {
+	path string
+	err  error
+}
+
+// formatSourceWorkflowStoreSkips renders skipped stores as a single
+// human-readable warning line suitable for stderr or MetadataErrors.
+func formatSourceWorkflowStoreSkips(skips []sourceWorkflowStoreSkip) string {
+	if len(skips) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(skips))
+	for _, skip := range skips {
+		parts = append(parts, fmt.Sprintf("%s (%v)", skip.path, skip.err))
+	}
+	return fmt.Sprintf(
+		"source-workflow singleton scan skipped %d unopenable store(s); cross-store roots in those stores are invisible: %s",
+		len(skips),
+		strings.Join(parts, "; "),
+	)
+}
+
+// openSourceWorkflowStores opens every candidate bead store used for
+// source-workflow singleton checks. It tolerates broken non-selected stores
+// the same way openConvoyStores does: a failure to open one rig's store must
+// not block launches or recovery city-wide. Only when *every* candidate is
+// unopenable do we surface the first error, because at that point the
+// singleton check has no stores to scan and we cannot proceed safely. Stores
+// explicitly selected via --rig / --store-ref still go through
+// openSourceWorkflowStoreRef, which is strict on purpose.
+//
+// The second return value lists the stores that were skipped — callers are
+// expected to surface these (see formatSourceWorkflowStoreSkips) so operators
+// can see when singleton coverage degraded.
+func openSourceWorkflowStores(cfg *config.City, cityPath, beadID string) ([]convoyStoreView, []sourceWorkflowStoreSkip, error) {
+	return openSourceWorkflowStoresWith(cfg, cityPath, beadID, func(dir string) (beads.Store, error) {
+		return openStoreAtForCity(dir, cityPath)
+	})
+}
+
+// openSourceWorkflowStoresWith is the testable core of openSourceWorkflowStores.
+// It takes the store-opening callback explicitly so tests can inject broken
+// rig stores without touching the filesystem.
+func openSourceWorkflowStoresWith(cfg *config.City, cityPath, beadID string, openStore func(string) (beads.Store, error)) ([]convoyStoreView, []sourceWorkflowStoreSkip, error) {
+	candidates := convoyStoreCandidates(cfg, cityPath, beadID)
+	var (
+		stores   = make([]convoyStoreView, 0, len(candidates))
+		skips    []sourceWorkflowStoreSkip
+		firstErr error
+	)
+	for _, dir := range candidates {
+		store, err := openStore(dir)
 		if err != nil {
-			return nil, fmt.Errorf("opening source workflow store %s: %w", dir, err)
+			wrapped := fmt.Errorf("opening source workflow store %s: %w", dir, err)
+			skips = append(skips, sourceWorkflowStoreSkip{path: dir, err: err})
+			if firstErr == nil {
+				firstErr = wrapped
+			}
+			continue
 		}
 		stores = append(stores, convoyStoreView{path: dir, store: store})
 	}
-	if len(stores) == 0 {
-		return nil, fmt.Errorf("no source workflow stores available")
+	if len(stores) > 0 {
+		return stores, skips, nil
 	}
-	return stores, nil
+	if firstErr != nil {
+		return nil, skips, firstErr
+	}
+	return nil, skips, fmt.Errorf("no source workflow stores available")
 }
 
 func clearSourceWorkflowMetadata(cfg *config.City, cityPath string, target resolvedSourceWorkflowTarget) (bool, error) {
@@ -1173,7 +1261,12 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 	}
 	addRoot := func(root beads.Bead) {
 		resolvedWorkflowID := strings.TrimSpace(root.Metadata["gc.workflow_id"])
-		if strings.TrimSpace(root.Metadata["gc.kind"]) != "workflow" {
+		// Match sourceworkflow.IsWorkflowRoot so graph.v2-only roots (marked
+		// via gc.formula_contract=graph.v2 without gc.kind=workflow) are
+		// collected here. Without this, delete-source lists the root but
+		// fails to close its descendants — a hole in the singleton recovery
+		// flow that this PR is trying to enforce.
+		if !sourceworkflow.IsWorkflowRoot(root) {
 			return
 		}
 		if root.ID != workflowID && resolvedWorkflowID != workflowID {
@@ -1189,9 +1282,10 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 	if root, err := store.Get(workflowID); err == nil {
 		addRoot(root)
 	}
+	// Query on gc.workflow_id only; the predicate is applied in-memory via
+	// addRoot so we pick up graph.v2-only roots alongside legacy roots.
 	if roots, err := store.List(beads.ListQuery{
 		Metadata: map[string]string{
-			"gc.kind":        "workflow",
 			"gc.workflow_id": workflowID,
 		},
 		IncludeClosed: true,

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -21,6 +21,82 @@ import (
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
+func TestOpenSourceWorkflowStoresSkipsBrokenRigs(t *testing.T) {
+	// Regression: when a single rig's bead store is unopenable (broken
+	// filesystem permissions, missing .gc directory, corrupt dolt, etc.),
+	// the previous implementation failed the whole source-workflow call
+	// site — so every graph-workflow launch and every workflow
+	// delete-source/reopen-source aborted city-wide. That turned a
+	// rig-local problem into a global outage. Now a broken non-selected
+	// rig is skipped in favor of any store that opens.
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: "rigs/alpha"},
+			{Name: "broken", Path: "rigs/broken"},
+		},
+	}
+
+	openStore := func(dir string) (beads.Store, error) {
+		if strings.Contains(dir, "rigs/broken") {
+			return nil, fmt.Errorf("simulated broken rig store at %s", dir)
+		}
+		return beads.NewMemStore(), nil
+	}
+
+	stores, skips, err := openSourceWorkflowStoresWith(cfg, cityPath, "", openStore)
+	if err != nil {
+		t.Fatalf("openSourceWorkflowStoresWith returned err = %v; want tolerance of broken rig", err)
+	}
+	if len(stores) == 0 {
+		t.Fatal("len(stores) = 0, want at least one store (city + alpha rig)")
+	}
+	for _, s := range stores {
+		if strings.Contains(s.path, "rigs/broken") {
+			t.Fatalf("broken rig should have been skipped, got path %q", s.path)
+		}
+	}
+	// The broken rig must appear in skips so callers can surface a warning.
+	// Without this, singleton coverage silently degrades.
+	foundBrokenSkip := false
+	for _, skip := range skips {
+		if strings.Contains(skip.path, "rigs/broken") {
+			foundBrokenSkip = true
+			break
+		}
+	}
+	if !foundBrokenSkip {
+		t.Fatalf("skips = %#v, want an entry for the broken rig so callers can warn", skips)
+	}
+	msg := formatSourceWorkflowStoreSkips(skips)
+	if !strings.Contains(msg, "rigs/broken") || !strings.Contains(msg, "invisible") {
+		t.Fatalf("format message = %q, want reference to broken rig and invisibility", msg)
+	}
+}
+
+func TestOpenSourceWorkflowStoresFailsOnlyWhenEverythingBroken(t *testing.T) {
+	// If every candidate store is unopenable, the singleton check cannot
+	// run safely — surface the first underlying error so the caller knows
+	// why. This is the only case where intolerance is correct.
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+	}
+
+	openStore := func(dir string) (beads.Store, error) {
+		return nil, fmt.Errorf("every store at %s is broken", dir)
+	}
+
+	_, _, err := openSourceWorkflowStoresWith(cfg, cityPath, "", openStore)
+	if err == nil {
+		t.Fatal("openSourceWorkflowStoresWith returned nil error; want underlying store failure")
+	}
+	if !strings.Contains(err.Error(), "every store") {
+		t.Fatalf("error = %v, want propagation of underlying failure", err)
+	}
+}
+
 type closeAllFailStore struct {
 	beads.Store
 	failOn map[string]struct{}
@@ -314,6 +390,161 @@ func TestCmdWorkflowDeleteSourceClosesMatchedRootsAndClearsWorkflowID(t *testing
 	}
 	if updatedChild.Status != "closed" {
 		t.Fatalf("child status = %q, want closed", updatedChild.Status)
+	}
+}
+
+func TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot(t *testing.T) {
+	// Regression: after the ListLiveRoots contract fix, the singleton
+	// scanner surfaces graph.v2-only roots (marked with
+	// gc.formula_contract=graph.v2 and no gc.kind=workflow). But
+	// findWorkflowBeads — the cleanup collector called from
+	// collectSourceWorkflowMatches — still required gc.kind=workflow, so
+	// delete-source would list the root and close nothing. This is the
+	// exact root shape #720 exists to recover.
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	// graph.v2-only root: no gc.kind=workflow label.
+	root, err := store.Create(beads.Bead{
+		Title:  "Graph workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:  "Child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowDeleteSource = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=cleaned") {
+		t.Fatalf("stdout = %q, want cleaned result", stdout.String())
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updatedRoot, err := reloaded.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if updatedRoot.Status != "closed" {
+		t.Fatalf("root status = %q, want closed (graph.v2-only root must be collected by findWorkflowBeads)", updatedRoot.Status)
+	}
+	updatedChild, err := reloaded.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if updatedChild.Status != "closed" {
+		t.Fatalf("child status = %q, want closed", updatedChild.Status)
+	}
+	updatedSource, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := strings.TrimSpace(updatedSource.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("source workflow_id = %q, want cleared", got)
+	}
+}
+
+func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
+	// Regression: reopen-source is the documented recovery path for a
+	// closed/assigned source bead whose workflow died. It cleared
+	// workflow_id + status + assignee but left gc.routed_to populated.
+	// sling.CheckBeadState treats a bead with gc.routed_to == target as
+	// already-routed and short-circuits on idempotency — so a re-sling
+	// of the recovered bead to the same target appeared to succeed while
+	// producing no live workflow. Operators following the cleanup hint
+	// ended up silently stuck.
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	// Simulate the state left behind by a previous sling that died:
+	// workflow_id pointed at a now-gone root, gc.routed_to still set.
+	if err := store.SetMetadata(source.ID, "workflow_id", "wf-gone"); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.routed_to", "mayor"); err != nil {
+		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=reopened") {
+		t.Fatalf("stdout = %q, want reopened result", stdout.String())
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updated, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("workflow_id = %q, want cleared", got)
+	}
+	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != "" {
+		t.Fatalf("gc.routed_to = %q, want cleared (else re-sling hits idempotency short-circuit)", got)
+	}
+	if updated.Status != "open" {
+		t.Fatalf("status = %q, want open", updated.Status)
+	}
+	if updated.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", updated.Assignee)
 	}
 }
 
@@ -1463,8 +1694,7 @@ prefix = "BL"
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
-	cityStore, err := openStoreAtForCity(cityDir, cityDir)
-	if err != nil {
+	if _, err := openStoreAtForCity(cityDir, cityDir); err != nil {
 		t.Fatalf("openStoreAtForCity(city init): %v", err)
 	}
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
@@ -1473,7 +1703,7 @@ prefix = "BL"
 	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
 		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
 	}
-	cityStore, err = openStoreAtForCity(cityDir, cityDir)
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
 		t.Fatalf("openStoreAtForCity(city scoped): %v", err)
 	}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -18,7 +18,22 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
+
+type closeAllFailStore struct {
+	beads.Store
+	failOn map[string]struct{}
+}
+
+func (s closeAllFailStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	for _, id := range ids {
+		if _, ok := s.failOn[id]; ok {
+			return 0, fmt.Errorf("forced close failure for %s", id)
+		}
+	}
+	return s.Store.CloseAll(ids, metadata)
+}
 
 func TestDecorateDynamicFragmentRecipeSupportsExplicitPerStepAgents(t *testing.T) {
 	store := beads.NewMemStore()
@@ -218,6 +233,261 @@ func TestFindWorkflowBeadsResolvesLogicalWorkflowID(t *testing.T) {
 	}
 	if !slices.Contains(ids, child.ID) {
 		t.Fatalf("findWorkflowBeads(logical) missing child %q: %#v", child.ID, ids)
+	}
+}
+
+func TestCmdWorkflowDeleteSourceClosesMatchedRootsAndClearsWorkflowID(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title:  "Workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:  "Child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{}, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowDeleteSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=cleaned") {
+		t.Fatalf("stdout = %q, want cleaned result", stdout.String())
+	}
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updatedSource, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := strings.TrimSpace(updatedSource.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("source workflow_id = %q, want empty", got)
+	}
+	updatedRoot, err := reloaded.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if updatedRoot.Status != "closed" {
+		t.Fatalf("root status = %q, want closed", updatedRoot.Status)
+	}
+	updatedChild, err := reloaded.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if updatedChild.Status != "closed" {
+		t.Fatalf("child status = %q, want closed", updatedChild.Status)
+	}
+}
+
+func TestCmdWorkflowReopenSourceConflictsWhenLiveRootExists(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title:  "Workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 3 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "blocking_workflow_ids="+root.ID) {
+		t.Fatalf("stderr = %q, want blocking root id", stderr.String())
+	}
+}
+
+func TestCmdWorkflowDeleteSourcePreviewDoesNotClearStaleMetadata(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", "wf-stale"); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowDeleteSource(source.ID, sourceWorkflowStoreSelector{}, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowDeleteSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updatedSource, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != "wf-stale" {
+		t.Fatalf("source workflow_id = %q, want stale metadata preserved in preview", got)
+	}
+	if !strings.Contains(stdout.String(), "result=already_clean") {
+		t.Fatalf("stdout = %q, want already_clean result", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata_cleared=false") {
+		t.Fatalf("stdout = %q, want metadata_cleared=false", stdout.String())
+	}
+}
+
+func TestApplySourceWorkflowMatchCleanupSkipsDeleteAfterCloseError(t *testing.T) {
+	base := beads.NewMemStore()
+	root, err := base.Create(beads.Bead{Title: "workflow", Type: "task", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := base.Create(beads.Bead{
+		Title:  "child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	store := closeAllFailStore{
+		Store:  base,
+		failOn: map[string]struct{}{root.ID: {}},
+	}
+
+	var stderr bytes.Buffer
+	closed, deleted, incomplete := applySourceWorkflowMatchCleanup(sourceWorkflowStoreMatch{
+		label: "city",
+		store: store,
+		roots: []beads.Bead{root},
+		beads: []beads.Bead{root, child},
+	}, true, &stderr)
+
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0", deleted)
+	}
+	if !incomplete {
+		t.Fatal("incomplete = false, want true")
+	}
+	if !strings.Contains(stderr.String(), "close_error") {
+		t.Fatalf("stderr = %q, want close_error", stderr.String())
+	}
+	if _, err := base.Get(root.ID); err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if _, err := base.Get(child.ID); err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+}
+
+func TestRunWorkflowReopenSourceConflictPropagatesExitCode(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "Workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": source.ID,
+		},
+	}); err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"workflow", "reopen-source", source.ID}, &stdout, &stderr); code != 3 {
+		t.Fatalf("run(...) returned %d, want 3; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 }
 
@@ -1164,11 +1434,359 @@ name = "test-city"
 	if err == nil {
 		t.Fatal("findBeadAcrossStores() error = nil, want provider failure")
 	}
-	if !strings.Contains(err.Error(), "getting bead \"gc-missing\" from city store") {
-		t.Fatalf("findBeadAcrossStores() error = %v, want city store context", err)
+	if !strings.Contains(err.Error(), "getting bead \"gc-missing\" from "+cityPath) {
+		t.Fatalf("findBeadAcrossStores() error = %v, want city store path context", err)
 	}
 	if strings.Contains(err.Error(), "bead not found") {
 		t.Fatalf("findBeadAcrossStores() error = %v, want provider failure instead of masked not-found", err)
+	}
+}
+
+func TestCmdWorkflowDeleteSourceAllowsStoreSelectorForAmbiguousSourceIDs(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rigDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "alpha"
+path = "rigs/alpha"
+prefix = "BL"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city init): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	cityStore, err = openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city scoped): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig .gc): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	citySource, err := cityStore.Create(beads.Bead{Title: "City source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(city source): %v", err)
+	}
+	rigSource, err := rigStore.Create(beads.Bead{Title: "Rig source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(rig source): %v", err)
+	}
+	if citySource.ID != rigSource.ID {
+		t.Fatalf("city source id = %q, rig source id = %q, want identical ids for ambiguity test", citySource.ID, rigSource.ID)
+	}
+	if err := cityStore.SetMetadata(citySource.ID, "workflow_id", "wf-city-stale"); err != nil {
+		t.Fatalf("SetMetadata(city workflow_id): %v", err)
+	}
+	if err := rigStore.SetMetadata(rigSource.ID, "workflow_id", "wf-rig-stale"); err != nil {
+		t.Fatalf("SetMetadata(rig workflow_id): %v", err)
+	}
+	root, err := cityStore.Create(beads.Bead{
+		ID:     "wf-city",
+		Title:  "Workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.source_bead_id":                      citySource.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	selector := sourceWorkflowStoreSelector{storeRef: "rig:alpha"}
+	if code := cmdWorkflowDeleteSource(citySource.ID, selector, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowDeleteSource returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=cleaned") {
+		t.Fatalf("stdout = %q, want cleaned result", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	reloadedCity, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reload): %v", err)
+	}
+	updatedRoot, err := reloadedCity.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if updatedRoot.Status != "closed" {
+		t.Fatalf("root status = %q, want closed", updatedRoot.Status)
+	}
+	updatedCitySource, err := reloadedCity.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("Get(city source): %v", err)
+	}
+	if got := updatedCitySource.Metadata["workflow_id"]; got != "wf-city-stale" {
+		t.Fatalf("city source workflow_id = %q, want wf-city-stale", got)
+	}
+	reloadedRig, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig reload): %v", err)
+	}
+	updatedRigSource, err := reloadedRig.Get(rigSource.ID)
+	if err != nil {
+		t.Fatalf("Get(rig source): %v", err)
+	}
+	if got := strings.TrimSpace(updatedRigSource.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("rig source workflow_id = %q, want cleared", got)
+	}
+}
+
+func TestCmdWorkflowDeleteSourceStoreSelectorIgnoresLegacyRootInDifferentStore(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rigDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "alpha"
+path = "rigs/alpha"
+prefix = "BL"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig .gc): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+
+	citySource, err := cityStore.Create(beads.Bead{Title: "City source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(city source): %v", err)
+	}
+	rigSource, err := rigStore.Create(beads.Bead{Title: "Rig source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(rig source): %v", err)
+	}
+	if citySource.ID != rigSource.ID {
+		t.Fatalf("city source id = %q, rig source id = %q, want identical ids for ambiguity test", citySource.ID, rigSource.ID)
+	}
+	if err := cityStore.SetMetadata(citySource.ID, "workflow_id", "wf-city-stale"); err != nil {
+		t.Fatalf("SetMetadata(city workflow_id): %v", err)
+	}
+	if err := rigStore.SetMetadata(rigSource.ID, "workflow_id", "wf-rig-stale"); err != nil {
+		t.Fatalf("SetMetadata(rig workflow_id): %v", err)
+	}
+	root, err := cityStore.Create(beads.Bead{
+		ID:     "wf-city-legacy",
+		Title:  "Legacy city workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": citySource.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	selector := sourceWorkflowStoreSelector{storeRef: "rig:alpha"}
+	if code := cmdWorkflowDeleteSource(citySource.ID, selector, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowDeleteSource returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=already_clean") {
+		t.Fatalf("stdout = %q, want already_clean result", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata_cleared=true") {
+		t.Fatalf("stdout = %q, want metadata_cleared=true", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	reloadedCity, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reload): %v", err)
+	}
+	updatedRoot, err := reloadedCity.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if updatedRoot.Status != root.Status {
+		t.Fatalf("root status = %q, want unchanged %q", updatedRoot.Status, root.Status)
+	}
+	updatedCitySource, err := reloadedCity.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("Get(city source): %v", err)
+	}
+	if got := updatedCitySource.Metadata["workflow_id"]; got != "wf-city-stale" {
+		t.Fatalf("city source workflow_id = %q, want wf-city-stale", got)
+	}
+
+	reloadedRig, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig reload): %v", err)
+	}
+	updatedRigSource, err := reloadedRig.Get(rigSource.ID)
+	if err != nil {
+		t.Fatalf("Get(rig source): %v", err)
+	}
+	if got := strings.TrimSpace(updatedRigSource.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("rig source workflow_id = %q, want cleared", got)
+	}
+}
+
+func TestCmdWorkflowReopenSourceRejectsLiveRootInDifferentStore(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rigDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "alpha"
+path = "rigs/alpha"
+prefix = "BL"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig .gc): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+
+	if _, err := rigStore.Create(beads.Bead{Title: "Rig warmup", Type: "task", Status: "closed"}); err != nil {
+		t.Fatalf("Create(rig warmup): %v", err)
+	}
+	rigSource, err := rigStore.Create(beads.Bead{Title: "Rig source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(rig source): %v", err)
+	}
+	initialStatus := rigSource.Status
+	if err := rigStore.SetMetadata(rigSource.ID, "workflow_id", "wf-stale"); err != nil {
+		t.Fatalf("SetMetadata(rig workflow_id): %v", err)
+	}
+	cityRoot, err := cityStore.Create(beads.Bead{
+		ID:     "wf-city",
+		Title:  "City workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.source_bead_id":                      rigSource.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(city root): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(rigSource.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 3 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d, want 3; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "blocking_workflow_ids="+cityRoot.ID) {
+		t.Fatalf("stderr = %q, want conflict with %s", stderr.String(), cityRoot.ID)
+	}
+
+	reloadedRig, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig reload): %v", err)
+	}
+	updatedSource, err := reloadedRig.Get(rigSource.ID)
+	if err != nil {
+		t.Fatalf("Get(rig source): %v", err)
+	}
+	if updatedSource.Status != initialStatus {
+		t.Fatalf("rig source status = %q, want unchanged %q", updatedSource.Status, initialStatus)
+	}
+	if got := strings.TrimSpace(updatedSource.Metadata["workflow_id"]); got != "wf-stale" {
+		t.Fatalf("rig source workflow_id = %q, want wf-stale", got)
+	}
+
+	reloadedCity, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reload): %v", err)
+	}
+	updatedRoot, err := reloadedCity.Get(cityRoot.ID)
+	if err != nil {
+		t.Fatalf("Get(city root): %v", err)
+	}
+	if updatedRoot.Status != cityRoot.Status {
+		t.Fatalf("city root status = %q, want unchanged %q", updatedRoot.Status, cityRoot.Status)
 	}
 }
 

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -323,9 +323,16 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		Store:    store,
 		StoreRef: storeRef,
 		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
-			stores, err := openSourceWorkflowStores(cfg, cityPath, "")
+			stores, skips, err := openSourceWorkflowStores(cfg, cityPath, "")
 			if err != nil {
 				return nil, err
+			}
+			if len(skips) > 0 {
+				// The sling callback cannot push into SlingResult from
+				// this depth, but stderr is the only channel operators
+				// look at; silence here means singleton coverage can
+				// degrade without any breadcrumb.
+				fmt.Fprintln(stderr, "warning:", formatSourceWorkflowStoreSkips(skips)) //nolint:errcheck
 			}
 			out := make([]sling.SourceWorkflowStore, 0, len(stores))
 			for _, storeView := range stores {
@@ -669,12 +676,25 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		printSlingResult(result, stdout, stderr)
 	}
 	if err != nil {
-		var conflictErr *sourceworkflow.ConflictError
-		if errors.As(err, &conflictErr) {
-			printSourceWorkflowConflict(stderr, conflictErr, deps.StoreRef)
+		// Batch can surface multiple typed conflicts (one per conflicted
+		// child) via errors.Join. Walking the tree renders a cleanup
+		// hint per affected source bead so a user with N conflicting
+		// children sees N cleanup commands instead of a single hint
+		// misattributed to the first child.
+		if printed := printSourceWorkflowConflicts(stderr, err, deps.StoreRef); printed > 0 {
 			return 3
 		}
-		fmt.Fprintln(stderr, err) //nolint:errcheck
+		// In batch mode, per-child FailReasons have already been rendered
+		// by printBatchSlingResult above. The error returned from
+		// DoSlingBatch is an errors.Join of a "N/M children failed"
+		// summary plus each child's typed error (kept for errors.As),
+		// so printing it verbatim duplicates every child line. Summarize
+		// instead when we have per-child detail.
+		if len(result.Children) > 0 {
+			fmt.Fprintf(stderr, "%d/%d children failed\n", result.Failed, result.Failed+result.Routed+result.IdempotentCt) //nolint:errcheck
+		} else {
+			fmt.Fprintln(stderr, err) //nolint:errcheck
+		}
 		return 1
 	}
 	if result.DryRun {
@@ -714,17 +734,57 @@ func printSourceWorkflowConflict(stderr io.Writer, conflictErr *sourceworkflow.C
 	if conflictErr == nil {
 		return
 	}
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		stderr,
 		"gc sling: source bead %s already has live workflow(s): %s\n",
 		conflictErr.SourceBeadID,
 		strings.Join(conflictErr.WorkflowIDs, ","),
-	) //nolint:errcheck
-	fmt.Fprintf(
+	)
+	_, _ = fmt.Fprintf(
 		stderr,
 		"gc sling: use --force to override, or %s to clean up\n",
 		sourceWorkflowCleanupCommand(conflictErr.SourceBeadID, storeRef),
-	) //nolint:errcheck
+	)
+}
+
+// printSourceWorkflowConflicts renders every *ConflictError in the error
+// chain. Batch preflight emits one ConflictError per conflicted child via
+// errors.Join; printing only the first (via errors.As) misattributes the
+// later children's blocking roots to the first child and suggests a
+// cleanup command that can only fix part of the batch.
+func printSourceWorkflowConflicts(stderr io.Writer, err error, storeRef string) (printed int) {
+	collectConflictErrors(err, func(c *sourceworkflow.ConflictError) {
+		printSourceWorkflowConflict(stderr, c, storeRef)
+		printed++
+	})
+	return printed
+}
+
+// collectConflictErrors walks an error tree (including errors.Join trees)
+// and invokes visit for each *sourceworkflow.ConflictError encountered
+// exactly once. Walks nodes directly via type assertion + Unwrap to avoid
+// the errors.As "first match in chain" behavior which would double-visit
+// conflicts that are themselves members of a multi-error.
+func collectConflictErrors(err error, visit func(*sourceworkflow.ConflictError)) {
+	if err == nil {
+		return
+	}
+	// Intentional direct type assertion (not errors.As) so each node in the
+	// error tree is visited exactly once — errors.As returns the first match
+	// in the chain and we'd lose later ConflictErrors joined via errors.Join.
+	if c, ok := err.(*sourceworkflow.ConflictError); ok { //nolint:errorlint
+		visit(c)
+	}
+	type multiUnwrap interface{ Unwrap() []error }
+	if mu, ok := err.(multiUnwrap); ok { //nolint:errorlint
+		for _, child := range mu.Unwrap() {
+			collectConflictErrors(child, visit)
+		}
+		return
+	}
+	if inner := errors.Unwrap(err); inner != nil {
+		collectConflictErrors(inner, visit)
+	}
 }
 
 // buildSlingFormulaVars merges caller-provided vars with the runtime context

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -20,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/spf13/cobra"
 )
@@ -97,10 +99,7 @@ Examples:
 				return errExit
 			}
 			code := cmdSling(args, formula, nudge, force, title, vars, merge, noConvoy, owned, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
-			if code != 0 {
-				return errExit
-			}
-			return nil
+			return exitForCode(code)
 		},
 	}
 	cmd.Flags().BoolVarP(&formula, "formula", "f", false, "treat argument as formula name")
@@ -323,6 +322,20 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		Runner:   runner,
 		Store:    store,
 		StoreRef: storeRef,
+		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
+			stores, err := openSourceWorkflowStores(cfg, cityPath, "")
+			if err != nil {
+				return nil, err
+			}
+			out := make([]sling.SourceWorkflowStore, 0, len(stores))
+			for _, storeView := range stores {
+				out = append(out, sling.SourceWorkflowStore{
+					Store:    storeView.store,
+					StoreRef: workflowStoreRefForDir(storeView.path, cityPath, cityName, cfg),
+				})
+			}
+			return out, nil
+		},
 	}
 
 	return doSlingBatch(opts, deps, store, stdout, stderr)
@@ -553,14 +566,19 @@ func printBatchSlingResult(result sling.SlingResult, stdout, stderr io.Writer) {
 		case child.Failed:
 			fmt.Fprintf(stderr, "  Failed %s: %s\n", child.BeadID, child.FailReason) //nolint:errcheck
 		case child.Routed:
-			if child.WispRootID != "" {
+			switch {
+			case child.WorkflowID != "":
+				fmt.Fprintf(stdout, "  Attached workflow %s (formula %q) to %s\n", child.WorkflowID, child.FormulaName, child.BeadID) //nolint:errcheck
+			case child.WispRootID != "":
 				label := "formula"
 				if result.Method == "batch-default-on" {
 					label = "default formula"
 				}
 				fmt.Fprintf(stdout, "  Attached wisp %s (%s %q) → %s\n", child.WispRootID, label, child.FormulaName, child.BeadID) //nolint:errcheck
 			}
-			fmt.Fprintf(stdout, "  Slung %s → %s\n", child.BeadID, result.Target) //nolint:errcheck
+			if child.WorkflowID == "" {
+				fmt.Fprintf(stdout, "  Slung %s → %s\n", child.BeadID, result.Target) //nolint:errcheck
+			}
 		}
 	}
 
@@ -598,6 +616,11 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, stderr
 	// even when the operation fails -- they provide context for the error.
 	printSlingWarnings(result, stderr)
 	if err != nil {
+		var conflictErr *sourceworkflow.ConflictError
+		if errors.As(err, &conflictErr) {
+			printSourceWorkflowConflict(stderr, conflictErr, deps.StoreRef)
+			return 3
+		}
 		fmt.Fprintln(stderr, err) //nolint:errcheck
 		return 1
 	}
@@ -646,6 +669,11 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		printSlingResult(result, stdout, stderr)
 	}
 	if err != nil {
+		var conflictErr *sourceworkflow.ConflictError
+		if errors.As(err, &conflictErr) {
+			printSourceWorkflowConflict(stderr, conflictErr, deps.StoreRef)
+			return 3
+		}
 		fmt.Fprintln(stderr, err) //nolint:errcheck
 		return 1
 	}
@@ -671,6 +699,32 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
 	}
 	return 0
+}
+
+func sourceWorkflowCleanupCommand(sourceBeadID, storeRef string) string {
+	args := []string{"gc workflow delete-source", sourceBeadID}
+	if storeRef = strings.TrimSpace(storeRef); storeRef != "" {
+		args = append(args, "--store-ref", storeRef)
+	}
+	args = append(args, "--apply")
+	return strings.Join(args, " ")
+}
+
+func printSourceWorkflowConflict(stderr io.Writer, conflictErr *sourceworkflow.ConflictError, storeRef string) {
+	if conflictErr == nil {
+		return
+	}
+	fmt.Fprintf(
+		stderr,
+		"gc sling: source bead %s already has live workflow(s): %s\n",
+		conflictErr.SourceBeadID,
+		strings.Join(conflictErr.WorkflowIDs, ","),
+	) //nolint:errcheck
+	fmt.Fprintf(
+		stderr,
+		"gc sling: use --force to override, or %s to clean up\n",
+		sourceWorkflowCleanupCommand(conflictErr.SourceBeadID, storeRef),
+	) //nolint:errcheck
 }
 
 // buildSlingFormulaVars merges caller-provided vars with the runtime context

--- a/cmd/gc/cmd_sling_routevars_test.go
+++ b/cmd/gc/cmd_sling_routevars_test.go
@@ -147,12 +147,12 @@ type = "task"
 
 	// Enable graph workflow features.
 	prevFormulaV2 := formula.IsFormulaV2Enabled()
-	prevGraphApply := molecule.GraphApplyEnabled
+	prevGraphApply := molecule.IsGraphApplyEnabled()
 	formula.SetFormulaV2Enabled(true)
-	molecule.GraphApplyEnabled = true
+	molecule.SetGraphApplyEnabled(true)
 	t.Cleanup(func() {
 		formula.SetFormulaV2Enabled(prevFormulaV2)
-		molecule.GraphApplyEnabled = prevGraphApply
+		molecule.SetGraphApplyEnabled(prevGraphApply)
 	})
 
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // selectiveErrStore wraps a beads.Store and injects Create errors for selected
@@ -204,7 +205,7 @@ func testDeps(cfg *config.City, sp runtime.Provider, runner SlingRunner) (slingD
 	var stdout, stderr bytes.Buffer
 	return slingDeps{
 		CityName: "test-city",
-		CityPath: "/city",
+		CityPath: sharedTestCityDir,
 		Cfg:      cfg,
 		SP:       sp,
 		Runner:   runner,
@@ -251,6 +252,7 @@ func assertStoreRoutedTo(t *testing.T, store beads.Store, beadID, want string) {
 // sharedTestFormulaDir is a package-level temp directory containing minimal
 // formula TOML files for all formula names commonly used in sling tests.
 var sharedTestFormulaDir string
+var sharedTestCityDir string
 
 func init() {
 	dir, err := os.MkdirTemp("", "gc-sling-test-formulas-*")
@@ -268,6 +270,12 @@ func init() {
 		_ = os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644)
 	}
 	sharedTestFormulaDir = dir
+
+	cityDir, err := os.MkdirTemp("", "gc-sling-test-city-*")
+	if err != nil {
+		panic(err)
+	}
+	sharedTestCityDir = cityDir
 }
 
 func testFormulaDir(t *testing.T) string {
@@ -1736,6 +1744,9 @@ title = "Do work"
 	if got := root.Metadata["gc.scope_ref"]; got != "test-city" {
 		t.Fatalf("root gc.scope_ref = %q, want test-city", got)
 	}
+	if got := root.Metadata[sourceworkflow.SourceStoreRefMetadataKey]; got != "city:test-city" {
+		t.Fatalf("root %s = %q, want city:test-city", sourceworkflow.SourceStoreRefMetadataKey, got)
+	}
 	if got := root.Metadata["gc.root_store_ref"]; got != "city:test-city" {
 		t.Fatalf("root gc.root_store_ref = %q, want city:test-city", got)
 	}
@@ -1779,6 +1790,189 @@ title = "Do work"
 	}
 	if !strings.Contains(stdout.String(), "Attached workflow") {
 		t.Fatalf("stdout = %q, want attached workflow message", stdout.String())
+	}
+}
+
+func TestDoSlingGraphWorkflowConflictReturnsExit3(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	cfg.Daemon.FormulaV2 = true
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+	cfg.FormulaLayers.City = []string{testFormulaDir(t)}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	graphFormula := `
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "BL-42", Title: "Work", Type: "task", Status: "open"},
+		{
+			ID:     "wf-existing",
+			Title:  "Existing workflow",
+			Type:   "task",
+			Status: "in_progress",
+			Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+				"gc.source_bead_id":   "BL-42",
+			},
+		},
+	}, nil)
+	config.InjectImplicitAgents(cfg)
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "graph-work"
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 3 {
+		t.Fatalf("doSling returned %d, want 3; stderr: %s", code, stderr.String())
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, "source bead BL-42 already has live workflow(s): wf-existing") {
+		t.Fatalf("stderr = %q, want blocking workflow ids", errText)
+	}
+	if !strings.Contains(errText, "gc workflow delete-source BL-42 --store-ref city:test-city --apply") {
+		t.Fatalf("stderr = %q, want cleanup hint", errText)
+	}
+}
+
+func TestBatchOnGraphWorkflowStartsWorkflowWithoutRoutingChild(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	cfg.Daemon.FormulaV2 = true
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+	cfg.FormulaLayers.City = []string{testFormulaDir(t)}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	graphFormula := `
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["CVY-1"] = beads.Bead{ID: "CVY-1", Type: "convoy", Status: "open"}
+	q.childrenOf["CVY-1"] = []beads.Bead{{ID: "BL-1", Status: "open"}}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "CVY-1", Title: "Batch", Type: "convoy", Status: "open"},
+		{ID: "BL-1", Title: "Child", Type: "task", Status: "open"},
+	}, nil)
+	config.InjectImplicitAgents(cfg)
+	opts := testOpts(a, "CVY-1")
+	opts.OnFormula = "graph-work"
+	opts.ScopeKind = "city"
+	opts.ScopeRef = "test-city"
+	code := doSlingBatch(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSlingBatch returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("graph workflow runner calls = %d, want 0; calls=%v", len(runner.calls), runner.calls)
+	}
+	child, err := deps.Store.Get("BL-1")
+	if err != nil {
+		t.Fatalf("Get(BL-1): %v", err)
+	}
+	if child.Metadata["workflow_id"] == "" {
+		t.Fatal("child workflow_id missing")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Attached workflow") {
+		t.Fatalf("stdout = %q, want attached workflow message", out)
+	}
+	if strings.Contains(out, "  Slung BL-1") {
+		t.Fatalf("stdout = %q, want no direct child sling line for graph workflow", out)
+	}
+}
+
+func TestBatchOnGraphWorkflowConflictLeavesExistingRootInPlace(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	cfg.Daemon.FormulaV2 = true
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+	cfg.FormulaLayers.City = []string{testFormulaDir(t)}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	graphFormula := `
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["CVY-1"] = beads.Bead{ID: "CVY-1", Type: "convoy", Status: "open"}
+	q.childrenOf["CVY-1"] = []beads.Bead{{ID: "BL-1", Status: "open"}}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "CVY-1", Title: "Batch", Type: "convoy", Status: "open"},
+		{ID: "BL-1", Title: "Child", Type: "task", Status: "open"},
+		{
+			ID:     "wf-existing",
+			Title:  "Existing workflow",
+			Type:   "task",
+			Status: "in_progress",
+			Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+				"gc.source_bead_id":   "BL-1",
+			},
+		},
+	}, nil)
+	config.InjectImplicitAgents(cfg)
+	opts := testOpts(a, "CVY-1")
+	opts.OnFormula = "graph-work"
+	code := doSlingBatch(opts, deps, q, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSlingBatch returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("graph workflow runner calls = %d, want 0; calls=%v", len(runner.calls), runner.calls)
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, "Failed BL-1: source bead BL-1 already has live workflow(s): wf-existing") {
+		t.Fatalf("stderr = %q, want conflict failure", errText)
+	}
+	child, err := deps.Store.Get("BL-1")
+	if err != nil {
+		t.Fatalf("Get(BL-1): %v", err)
+	}
+	if got := child.Metadata["workflow_id"]; got != "" {
+		t.Fatalf("child workflow_id = %q, want unchanged empty metadata", got)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -251,8 +251,10 @@ func assertStoreRoutedTo(t *testing.T, store beads.Store, beadID, want string) {
 
 // sharedTestFormulaDir is a package-level temp directory containing minimal
 // formula TOML files for all formula names commonly used in sling tests.
-var sharedTestFormulaDir string
-var sharedTestCityDir string
+var (
+	sharedTestFormulaDir string
+	sharedTestCityDir    string
+)
 
 func init() {
 	dir, err := os.MkdirTemp("", "gc-sling-test-formulas-*")
@@ -1957,15 +1959,23 @@ title = "Do work"
 	opts.OnFormula = "graph-work"
 	code := doSlingBatch(opts, deps, q, stdout, stderr)
 
-	if code != 1 {
-		t.Fatalf("doSlingBatch returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	// Batch conflicts must use the same exit-3 contract as single-bead
+	// conflicts so users see the cleanup hint and know to run
+	// `gc workflow delete-source`. Before the adoption-review fixups
+	// batch returned exit 1 with no hint; that was the bug this PR
+	// exists to close for the batch path as well.
+	if code != 3 {
+		t.Fatalf("doSlingBatch returned %d, want 3 (exit-3 contract for batch conflict); stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("graph workflow runner calls = %d, want 0; calls=%v", len(runner.calls), runner.calls)
 	}
 	errText := stderr.String()
 	if !strings.Contains(errText, "Failed BL-1: source bead BL-1 already has live workflow(s): wf-existing") {
-		t.Fatalf("stderr = %q, want conflict failure", errText)
+		t.Fatalf("stderr = %q, want per-child conflict summary", errText)
+	}
+	if !strings.Contains(errText, "gc workflow delete-source BL-1") {
+		t.Fatalf("stderr = %q, want cleanup hint for conflicted child", errText)
 	}
 	child, err := deps.Store.Get("BL-1")
 	if err != nil {

--- a/cmd/gc/dashboard/api.go
+++ b/cmd/gc/dashboard/api.go
@@ -444,6 +444,8 @@ func (h *APIHandler) runViaAPI(command string) (string, bool, error) {
 		for _, p := range parts[1:] {
 			if strings.HasPrefix(p, "--rig=") {
 				payload["rig"] = strings.TrimPrefix(p, "--rig=")
+			} else if p == "--force" {
+				payload["force"] = true
 			} else if strings.HasPrefix(p, "--formula=") {
 				payload["formula"] = strings.TrimPrefix(p, "--formula=")
 			} else if _, ok := payload["bead"]; !ok {

--- a/cmd/gc/dashboard/api_run_test.go
+++ b/cmd/gc/dashboard/api_run_test.go
@@ -9,6 +9,32 @@ import (
 	"time"
 )
 
+func TestValidateCommandAllowsForceOnSling(t *testing.T) {
+	// --force is dangerous in general (bypasses singleton + idempotency
+	// checks) but legitimate on `sling` specifically. The dashboard
+	// permits --force only on explicitly-allowed commands.
+	if _, err := ValidateCommand("sling BL-42 mayor --force"); err != nil {
+		t.Fatalf("ValidateCommand(sling --force): %v, want ok", err)
+	}
+}
+
+func TestValidateCommandRejectsForceOnNonAllowedCommands(t *testing.T) {
+	// Regression: PR #852 removed --force from BlockedPatterns so sling
+	// could use it. Without scoping, any future whitelisted command could
+	// accidentally inherit remote-execution risk when combined with
+	// --force. The scoping check rejects --force on commands not in
+	// ForceAllowedCommands.
+	for _, cmd := range []string{
+		"convoy refresh convoy-1 --force",
+		"unsling BL-42 --force",
+		"hook attach BL-42 --force",
+	} {
+		if _, err := ValidateCommand(cmd); err == nil {
+			t.Fatalf("ValidateCommand(%q) = nil, want rejection of --force", cmd)
+		}
+	}
+}
+
 func TestValidateCommandMarksBeadQueriesAPIOnly(t *testing.T) {
 	meta, err := ValidateCommand("list")
 	if err != nil {

--- a/cmd/gc/dashboard/api_run_test.go
+++ b/cmd/gc/dashboard/api_run_test.go
@@ -125,6 +125,55 @@ func TestAPIHandlerRunExecutesShowViaAPI(t *testing.T) {
 	}
 }
 
+func TestAPIHandlerRunExecutesSlingViaAPIWithForce(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/sling" {
+			t.Fatalf("path = %q, want /v0/sling", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := body["bead"]; got != "BL-42" {
+			t.Fatalf("bead = %#v, want BL-42", got)
+		}
+		if got := body["target"]; got != "myrig/worker" {
+			t.Fatalf("target = %#v, want myrig/worker", got)
+		}
+		if got := body["formula"]; got != "graph-work" {
+			t.Fatalf("formula = %#v, want graph-work", got)
+		}
+		if got := body["force"]; got != true {
+			t.Fatalf("force = %#v, want true", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"slung","workflow_id":"wf-1","root_bead_id":"wf-1","mode":"attached"}`))
+	}))
+	defer srv.Close()
+
+	h := NewAPIHandler("/tmp/city", "test-city", srv.URL, "", 5*time.Second, 10*time.Second, "csrf-token")
+	req := httptest.NewRequest(http.MethodPost, "/api/run", strings.NewReader(`{"command":"sling BL-42 myrig/worker --force --formula=graph-work","confirmed":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Dashboard-Token", "csrf-token")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp CommandResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, error=%q", resp.Error)
+	}
+	if !strings.Contains(resp.Output, `"workflow_id": "wf-1"`) {
+		t.Fatalf("output %q missing workflow payload", resp.Output)
+	}
+}
+
 func TestAPIHandlerRunShowFailsClosedWhenAPIUnavailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)

--- a/cmd/gc/dashboard/commands.go
+++ b/cmd/gc/dashboard/commands.go
@@ -93,6 +93,21 @@ var BlockedPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\bclean\b`),
 }
 
+// forceFlagPattern matches --force as a standalone flag (with word
+// boundary) so it doesn't misfire on --force-with-lease and friends.
+var forceFlagPattern = regexp.MustCompile(`--force\b`)
+
+// ForceAllowedCommands is the set of base commands permitted to carry
+// `--force` through the dashboard gateway. Any other command that passes
+// `--force` is rejected up front — a whitelisted command can still be
+// dangerous when combined with --force, so we keep this check narrow and
+// explicit rather than relying on command authors to remember which flags
+// are safe. Add a new entry only after reviewing what --force does for
+// that specific command.
+var ForceAllowedCommands = map[string]bool{
+	"sling": true,
+}
+
 // ValidateCommand checks if a command is allowed to run from the dashboard.
 func ValidateCommand(rawCommand string) (*CommandMeta, error) {
 	rawCommand = strings.TrimSpace(rawCommand)
@@ -110,6 +125,14 @@ func ValidateCommand(rawCommand string) (*CommandMeta, error) {
 	meta, ok := AllowedCommands[baseCmd]
 	if !ok {
 		return nil, fmt.Errorf("command not in whitelist: %s", baseCmd)
+	}
+
+	// Defense-in-depth: --force bypasses singleton checks and idempotency
+	// short-circuits. Only specific commands have a well-understood --force
+	// semantics worth exposing through the dashboard; everything else gets
+	// rejected even if the base command is whitelisted.
+	if forceFlagPattern.MatchString(rawCommand) && !ForceAllowedCommands[baseCmd] {
+		return nil, fmt.Errorf("--force is not permitted for command %q from the dashboard", baseCmd)
 	}
 
 	return &meta, nil

--- a/cmd/gc/dashboard/commands.go
+++ b/cmd/gc/dashboard/commands.go
@@ -83,7 +83,6 @@ var AllowedCommands = map[string]CommandMeta{
 
 // BlockedPatterns are regex patterns for commands that should never run from the dashboard.
 var BlockedPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`--force`),
 	regexp.MustCompile(`--hard`),
 	regexp.MustCompile(`\brm\b`),
 	regexp.MustCompile(`\bdelete\b`),

--- a/cmd/gc/feature_flags.go
+++ b/cmd/gc/feature_flags.go
@@ -12,5 +12,5 @@ import (
 func applyFeatureFlags(cfg *config.City) {
 	gw := cfg.Daemon.FormulaV2
 	formula.SetFormulaV2Enabled(gw)
-	molecule.GraphApplyEnabled = gw
+	molecule.SetGraphApplyEnabled(gw)
 }

--- a/cmd/gc/graph_dispatch_mem_test.go
+++ b/cmd/gc/graph_dispatch_mem_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 func builtinFormulaDir(t *testing.T) string {
@@ -400,6 +401,9 @@ func TestGraphWorkflowInMemoryCreateExecuteWaitFlow(t *testing.T) {
 	}
 	if root.Metadata["gc.source_bead_id"] != issueID {
 		t.Fatalf("root source_bead_id = %q, want %q", root.Metadata["gc.source_bead_id"], issueID)
+	}
+	if got := root.Metadata[sourceworkflow.SourceStoreRefMetadataKey]; got != "city:test-city" {
+		t.Fatalf("root %s = %q, want city:test-city", sourceworkflow.SourceStoreRefMetadataKey, got)
 	}
 
 	runMemGraphWorkflowToCompletion(t, store, workflowID, issueID, "worker", t.TempDir(), "success")

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -31,6 +31,48 @@ func main() {
 // non-zero exit. The command has already written its own error to stderr.
 var errExit = errors.New("exit")
 
+type commandExitError struct {
+	code int
+}
+
+func (e *commandExitError) Error() string {
+	if e == nil {
+		return "exit"
+	}
+	return fmt.Sprintf("exit %d", e.code)
+}
+
+func (e *commandExitError) ExitCode() int {
+	if e == nil || e.code == 0 {
+		return 1
+	}
+	return e.code
+}
+
+func exitForCode(code int) error {
+	if code == 0 {
+		return nil
+	}
+	if code == 1 {
+		return errExit
+	}
+	return &commandExitError{code: code}
+}
+
+func commandExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	if errors.Is(err, errExit) {
+		return 1
+	}
+	return 1
+}
+
 // cityFlag holds the value of the --city persistent flag.
 // Empty means "discover from cwd."
 var cityFlag string
@@ -64,7 +106,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	root.SetOut(stdout)
 	root.SetErr(stderr)
 	if err := root.Execute(); err != nil {
-		return 1
+		return commandExitCode(err)
 	}
 	return 0
 }

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -246,7 +246,7 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 |------------|----------------|
 | Pour next wisp | `bd mol wisp mol-witness-patrol --root-only` |
 | Context exhaustion | `gc runtime request-restart` |
-| Recover orphaned bead | `bd update <id> --status=open --assignee=""` |
+| Recover orphaned bead | `gc workflow delete-source <id> --apply && gc workflow reopen-source <id>` |
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
 | Set branch metadata | `bd update <id> --set-metadata branch=<name>` |

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -158,20 +158,24 @@ If rebase SUCCEEDED (exit 0): close this step, proceed to run-tests.
 If rebase FAILED (conflicts):
 
 1. Abort: `git rebase --abort`
-2. Put the work bead back in the pool with rejection metadata:
+2. Clean up the existing workflow and reopen the source bead:
 ```bash
-bd update $WORK --status=open --assignee="" \
+gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
+```
+3. Put the work bead back in the pool with rejection metadata:
+```bash
+bd update $WORK \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
   --set-metadata gc.routed_to=<rig>/polecat
 ```
-3. Do NOT delete the branch (new polecat needs it for conflict resolution).
-4. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
-5. Pour next patrol iteration before burning:
+4. Do NOT delete the branch (new polecat needs it for conflict resolution).
+5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
+6. Pour next patrol iteration before burning:
 ```bash
 NEXT=$(bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
 bd update "$NEXT" --assignee=$GC_AGENT
 ```
-6. Burn this wisp: `bd mol burn <wisp-id> --force`
+7. Burn this wisp: `bd mol burn <wisp-id> --force`
 
 **A new polecat will pick up the bead, see the branch and rejection,
 rebase, and reassign to refinery.**"""
@@ -224,9 +228,13 @@ TARGET=$(bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
 1. Diagnose: branch regression or pre-existing on target?
 
 2. If branch caused it:
+   - Clean up the existing workflow and reopen the source bead:
+     ```bash
+     gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
+     ```
    - Put the work bead back in the pool with rejection metadata:
      ```bash
-     bd update $WORK --status=open --assignee="" \
+     bd update $WORK \
        --set-metadata rejection_reason="<failure summary>"
      ```
    - Delete branch: `git push origin --delete $BRANCH`

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -262,9 +262,9 @@ rm -rf <worktree-path> 2>/dev/null  # Fallback
 git worktree prune
 ```
 
-Reset bead to pool:
+Close any orphaned workflow subtree, then return the bead to pool:
 ```bash
-bd update <bead> --status=open --assignee=""
+gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>
 ```
 
 **Step 4: Assess and notify.**

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 type slingBody struct {
@@ -25,6 +27,7 @@ type slingBody struct {
 	Vars           map[string]string `json:"vars"`
 	ScopeKind      string            `json:"scope_kind"`
 	ScopeRef       string            `json:"scope_ref"`
+	Force          bool              `json:"force"`
 }
 
 type slingResponse struct {
@@ -37,6 +40,15 @@ type slingResponse struct {
 	AttachedBeadID string   `json:"attached_bead_id,omitempty"`
 	Mode           string   `json:"mode,omitempty"`
 	Warnings       []string `json:"warnings,omitempty"`
+}
+
+func sourceWorkflowCleanupHint(sourceBeadID, storeRef string) string {
+	args := []string{"gc workflow delete-source", sourceBeadID}
+	if storeRef = strings.TrimSpace(storeRef); storeRef != "" {
+		args = append(args, "--store-ref", storeRef)
+	}
+	args = append(args, "--apply")
+	return strings.Join(args, " ")
 }
 
 func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
@@ -57,6 +69,7 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 	body.ScopeRef = strings.TrimSpace(body.ScopeRef)
 
 	cfg := s.state.Config()
+	syncFeatureFlags(cfg)
 
 	// UI dispatches carry scope_kind/scope_ref but not the CLI's ambient
 	// rig directory. Dashboard dispatches use body.Rig (from --rig=X).
@@ -142,8 +155,18 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp, status, code, message := s.execSlingDirect(r.Context(), body, agentCfg)
+	resp, status, code, message, conflict := s.execSlingDirect(r.Context(), body, agentCfg)
 	if code != "" {
+		if conflict != nil {
+			writeJSON(w, status, map[string]any{
+				"code":                  code,
+				"message":               message,
+				"source_bead_id":        conflict.SourceBeadID,
+				"blocking_workflow_ids": conflict.WorkflowIDs,
+				"hint":                  fmt.Sprintf("use --force to override, or %s to clean up", sourceWorkflowCleanupHint(conflict.SourceBeadID, s.slingStoreRef(body.Rig, agentCfg))),
+			})
+			return
+		}
 		writeError(w, status, code, message)
 		return
 	}
@@ -151,7 +174,7 @@ func (s *Server) handleSling(w http.ResponseWriter, r *http.Request) {
 }
 
 // execSlingDirect calls the intent-based Sling API directly.
-func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg config.Agent) (*slingResponse, int, string, string) {
+func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg config.Agent) (*slingResponse, int, string, string, *sourceworkflow.ConflictError) {
 	formulaName := strings.TrimSpace(body.Formula)
 	attachedBeadID := strings.TrimSpace(body.AttachedBeadID)
 
@@ -164,6 +187,9 @@ func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg c
 		SP:       s.state.SessionProvider(),
 		Store:    store,
 		StoreRef: s.slingStoreRef(body.Rig, agentCfg),
+		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
+			return s.sourceWorkflowStores(), nil
+		},
 		Runner:   s.slingRunner(),
 		Resolver: apiAgentResolver{},
 		Branches: apiBranchResolver{cityPath: s.state.CityPath()},
@@ -171,7 +197,7 @@ func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg c
 	}
 	sl, err := sling.New(deps)
 	if err != nil {
-		return nil, http.StatusInternalServerError, "internal", err.Error()
+		return nil, http.StatusInternalServerError, "internal", err.Error(), nil
 	}
 
 	// Build vars slice from map (sorted for determinism).
@@ -192,6 +218,7 @@ func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg c
 		Vars:      varSlice,
 		ScopeKind: body.ScopeKind,
 		ScopeRef:  body.ScopeRef,
+		Force:     body.Force,
 	}
 
 	// Dispatch to the right intent-based method.
@@ -218,14 +245,18 @@ func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg c
 		attachedBeadID = strings.TrimSpace(body.Bead)
 		formulaName = agentCfg.EffectiveDefaultSlingFormula()
 		// Default formula: route the bead and let the domain apply the default.
-		result, err = sl.RouteBead(ctx, attachedBeadID, agentCfg, sling.RouteOpts{})
+		result, err = sl.RouteBead(ctx, attachedBeadID, agentCfg, sling.RouteOpts{Force: body.Force})
 
 	default:
-		result, err = sl.RouteBead(ctx, body.Bead, agentCfg, sling.RouteOpts{})
+		result, err = sl.RouteBead(ctx, body.Bead, agentCfg, sling.RouteOpts{Force: body.Force})
 	}
 
 	if err != nil {
-		return nil, http.StatusBadRequest, "invalid", err.Error()
+		var conflictErr *sourceworkflow.ConflictError
+		if errors.As(err, &conflictErr) {
+			return nil, http.StatusConflict, "conflict", err.Error(), conflictErr
+		}
+		return nil, http.StatusBadRequest, "invalid", err.Error(), nil
 	}
 
 	resp := &slingResponse{
@@ -236,7 +267,7 @@ func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg c
 		Warnings: result.MetadataErrors,
 	}
 	if !workflowLaunch {
-		return resp, http.StatusOK, "", ""
+		return resp, http.StatusOK, "", "", nil
 	}
 
 	resp.Formula = formulaName
@@ -245,9 +276,9 @@ func (s *Server) execSlingDirect(ctx context.Context, body slingBody, agentCfg c
 	resp.WorkflowID = result.WorkflowID
 	resp.RootBeadID = result.BeadID
 	if resp.WorkflowID == "" && resp.RootBeadID == "" {
-		return nil, http.StatusInternalServerError, "internal", "sling did not produce a workflow or bead id"
+		return nil, http.StatusInternalServerError, "internal", "sling did not produce a workflow or bead id", nil
 	}
-	return resp, http.StatusCreated, "", ""
+	return resp, http.StatusCreated, "", "", nil
 }
 
 // findSlingStore returns the bead store for sling operations.
@@ -274,6 +305,26 @@ func (s *Server) slingStoreRef(rig string, agentCfg config.Agent) string {
 		return "rig:" + agentCfg.Dir
 	}
 	return "city:" + s.state.CityName()
+}
+
+func (s *Server) sourceWorkflowStores() []sling.SourceWorkflowStore {
+	stores := make([]sling.SourceWorkflowStore, 0, len(s.state.BeadStores())+1)
+	if cityStore := s.state.CityBeadStore(); cityStore != nil {
+		stores = append(stores, sling.SourceWorkflowStore{
+			Store:    cityStore,
+			StoreRef: "city:" + s.state.CityName(),
+		})
+	}
+	for rigName, store := range s.state.BeadStores() {
+		if store == nil {
+			continue
+		}
+		stores = append(stores, sling.SourceWorkflowStore{
+			Store:    store,
+			StoreRef: "rig:" + rigName,
+		})
+	}
+	return stores
 }
 
 // slingRunner returns the SlingRunner for the API context.

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
 )
 
 // newSlingTestServer creates a test server with a fake runner that captures
@@ -23,6 +27,29 @@ func newSlingTestServer(t *testing.T) (*Server, *fakeMutatorState) {
 		return "", nil // no-op runner
 	}
 	return srv, state
+}
+
+func TestNewSyncsFormulaV2FeatureFlags(t *testing.T) {
+	state := newFakeMutatorState(t)
+	state.cfg.Daemon.FormulaV2 = true
+
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	prevGraphApply := molecule.IsGraphApplyEnabled()
+	formula.SetFormulaV2Enabled(false)
+	molecule.SetGraphApplyEnabled(false)
+	t.Cleanup(func() {
+		formula.SetFormulaV2Enabled(prevFormulaV2)
+		molecule.SetGraphApplyEnabled(prevGraphApply)
+	})
+
+	_ = New(state)
+
+	if !formula.IsFormulaV2Enabled() {
+		t.Fatal("formula.IsFormulaV2Enabled() = false, want true")
+	}
+	if !molecule.IsGraphApplyEnabled() {
+		t.Fatal("molecule.IsGraphApplyEnabled() = false, want true")
+	}
 }
 
 func TestSlingWithBead(t *testing.T) {
@@ -152,6 +179,70 @@ func TestSlingPoolTarget(t *testing.T) {
 	}
 	if resp["status"] != "slung" {
 		t.Fatalf("status = %q, want slung", resp["status"])
+	}
+}
+
+func TestSlingConflictReturns409ForExistingLiveWorkflow(t *testing.T) {
+	srv, state := newSlingTestServer(t)
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+	state.cfg.Agents = append(state.cfg.Agents,
+		config.Agent{Name: config.ControlDispatcherAgentName, MaxActiveSessions: intPtr(1)},
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "myrig", MaxActiveSessions: intPtr(1)},
+	)
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := state.stores["myrig"]
+	source, err := store.Create(beads.Bead{ID: "BL-42", Title: "test task", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"target":"myrig/worker","formula":"graph-work","attached_bead_id":"` + source.ID + `"}`
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, newPostRequest("/v0/sling", strings.NewReader(body)))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := resp["code"]; got != "conflict" {
+		t.Fatalf("code = %#v, want conflict", got)
+	}
+	if got := resp["source_bead_id"]; got != source.ID {
+		t.Fatalf("source_bead_id = %#v, want %s", got, source.ID)
+	}
+	ids, ok := resp["blocking_workflow_ids"].([]any)
+	if !ok || len(ids) != 1 || ids[0] != root.ID {
+		t.Fatalf("blocking_workflow_ids = %#v, want [%s]", resp["blocking_workflow_ids"], root.ID)
+	}
+	if hint, _ := resp["hint"].(string); !strings.Contains(hint, "--store-ref rig:myrig --apply") {
+		t.Fatalf("hint = %q, want store-ref cleanup command", hint)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sling"
 )
 
@@ -99,6 +101,7 @@ func (s *Server) resolveTitleProvider() *config.ResolvedProvider {
 
 // New creates a Server with all routes registered. Does not start listening.
 func New(state State) *Server {
+	syncFeatureFlags(state.Config())
 	s := &Server{
 		state: state,
 		mux:   http.NewServeMux(),
@@ -111,6 +114,7 @@ func New(state State) *Server {
 // NewReadOnly creates a read-only Server that rejects all mutation requests.
 // Use this when the server binds to a non-localhost address.
 func NewReadOnly(state State) *Server {
+	syncFeatureFlags(state.Config())
 	s := &Server{
 		state:    state,
 		mux:      http.NewServeMux(),
@@ -119,6 +123,16 @@ func NewReadOnly(state State) *Server {
 	}
 	s.registerRoutes()
 	return s
+}
+
+func syncFeatureFlags(cfg *config.City) {
+	enabled := cfg != nil && cfg.Daemon.FormulaV2
+	if formula.IsFormulaV2Enabled() != enabled {
+		formula.SetFormulaV2Enabled(enabled)
+	}
+	if molecule.IsGraphApplyEnabled() != enabled {
+		molecule.SetGraphApplyEnabled(enabled)
+	}
 }
 
 // ServeHTTP implements http.Handler for testing with httptest.

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -235,7 +235,7 @@ func appendRalphRetry(store beads.Store, logicalID string, prevSubject, prevChec
 		return existing, nil
 	}
 	cfg := loadAttemptRouteConfig(cityPath)
-	if molecule.GraphApplyEnabled {
+	if molecule.IsGraphApplyEnabled() {
 		if applier, ok := store.(beads.GraphApplyStore); ok {
 			return appendRalphRetryViaGraphApply(store, applier, logicalID, prevSubject, prevCheck, attemptSet, oldAttempt, nextAttempt, oldScopeRef, newScopeRef, cfg)
 		}

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -414,6 +414,9 @@ func DecorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 			step.Metadata["gc.run_target"] = routedTo
 			if sourceBeadID != "" {
 				step.Metadata["gc.source_bead_id"] = sourceBeadID
+				if rootStoreRef != "" {
+					step.Metadata["gc.source_store_ref"] = rootStoreRef
+				}
 			}
 			if scopeKind != "" {
 				step.Metadata["gc.scope_kind"] = scopeKind

--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -131,8 +131,8 @@ func TestAttachBasic(t *testing.T) {
 }
 
 func TestAttachBasicGraphApplyPreservesWorkflowRootID(t *testing.T) {
-	GraphApplyEnabled = true
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 
 	store := beads.NewMemStore()
 	root := setupWorkflow(t, store)

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -7,16 +7,25 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
-// GraphApplyEnabled controls whether Instantiate uses the GraphApplyStore
+// graphApplyEnabled controls whether Instantiate uses the GraphApplyStore
 // batch path. When false, falls back to sequential bead creation.
 // Set by the daemon config loader from [daemon] formula_v2.
-var GraphApplyEnabled bool
+var graphApplyEnabled atomic.Bool
+
+func SetGraphApplyEnabled(enabled bool) {
+	graphApplyEnabled.Store(enabled)
+}
+
+func IsGraphApplyEnabled() bool {
+	return graphApplyEnabled.Load()
+}
 
 func graphApplyTracef(format string, args ...any) {
 	path := os.Getenv("GC_SLING_TRACE")

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -19,10 +19,13 @@ import (
 // Set by the daemon config loader from [daemon] formula_v2.
 var graphApplyEnabled atomic.Bool
 
+// SetGraphApplyEnabled toggles the graph-batch apply path. Called from the
+// daemon config loader when [daemon] formula_v2 changes.
 func SetGraphApplyEnabled(enabled bool) {
 	graphApplyEnabled.Store(enabled)
 }
 
+// IsGraphApplyEnabled reports whether graph-batch apply is currently active.
 func IsGraphApplyEnabled() bool {
 	return graphApplyEnabled.Load()
 }

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -339,7 +339,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	if len(recipe.Steps) == 0 {
 		return nil, fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
-	if GraphApplyEnabled {
+	if IsGraphApplyEnabled() {
 		if applier, ok := store.(beads.GraphApplyStore); ok {
 			return instantiateViaGraphApply(ctx, applier, recipe, opts)
 		}
@@ -542,7 +542,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 		}
 		priorityOverride = clonePriority(root.Priority)
 	}
-	if GraphApplyEnabled {
+	if IsGraphApplyEnabled() {
 		if applier, ok := store.(beads.GraphApplyStore); ok {
 			opts.PriorityOverride = priorityOverride
 			return instantiateFragmentViaGraphApply(ctx, store, applier, recipe, opts)

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -102,8 +102,8 @@ func TestInstantiateSimple(t *testing.T) {
 
 func TestInstantiateUsesGraphApplyStoreWhenAvailable(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
-	GraphApplyEnabled = true
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -201,8 +201,8 @@ func TestBuildRecipeApplyPlan_GraphWorkflowOwnershipUsesTracks(t *testing.T) {
 
 func TestInstantiateGraphApplyPreservesStepMetadata(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
-	GraphApplyEnabled = true
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -239,8 +239,8 @@ func TestInstantiateGraphApplyPreservesStepMetadata(t *testing.T) {
 func TestInstantiateSequentialPathPreservesStepMetadata(t *testing.T) {
 	// Verify the NON-graph-apply (sequential) path also preserves step metadata.
 	store := beads.NewMemStore() // MemStore does NOT implement GraphApplyStore
-	GraphApplyEnabled = false
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(false)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -279,8 +279,8 @@ func TestInstantiateSequentialPathPreservesStepMetadata(t *testing.T) {
 
 func TestInstantiateUsesGraphApplyStoreForRetryLogicalRefs(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
-	GraphApplyEnabled = true
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -355,8 +355,8 @@ func TestInstantiatePriorityOverrideCopiesToAllBeads(t *testing.T) {
 
 func TestInstantiateUsesGraphApplyPriorityOverride(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
-	GraphApplyEnabled = true
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 
 	recipe := &formula.Recipe{
 		Name: "wf",
@@ -459,8 +459,8 @@ func TestInstantiateRejectsPartialGraphApplyResult(t *testing.T) {
 			},
 		},
 	}
-	GraphApplyEnabled = true
-	t.Cleanup(func() { GraphApplyEnabled = false })
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(false) })
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
@@ -1405,8 +1405,8 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 
 	t.Run("graph-apply path rejects unresolved vars", func(t *testing.T) {
 		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
-		GraphApplyEnabled = true
-		t.Cleanup(func() { GraphApplyEnabled = false })
+		SetGraphApplyEnabled(true)
+		t.Cleanup(func() { SetGraphApplyEnabled(false) })
 
 		_, err := Instantiate(context.Background(), gaStore, recipe, Options{
 			Title: "My Feature",
@@ -1443,8 +1443,8 @@ func TestInstantiateFragmentRejectsResidualTitleVars(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		GraphApplyEnabled = false
-		t.Cleanup(func() { GraphApplyEnabled = false })
+		SetGraphApplyEnabled(false)
+		t.Cleanup(func() { SetGraphApplyEnabled(false) })
 
 		_, err = InstantiateFragment(context.Background(), store, fragment, FragmentOptions{
 			RootID: root.ID,
@@ -1465,8 +1465,8 @@ func TestInstantiateFragmentRejectsResidualTitleVars(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		GraphApplyEnabled = true
-		t.Cleanup(func() { GraphApplyEnabled = false })
+		SetGraphApplyEnabled(true)
+		t.Cleanup(func() { SetGraphApplyEnabled(false) })
 
 		_, err = InstantiateFragment(context.Background(), gaStore, fragment, FragmentOptions{
 			RootID: root.ID,

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -75,6 +75,9 @@ type BeadRouter interface {
 	Route(ctx context.Context, req RouteRequest) error
 }
 
+// SourceWorkflowStore is one entry from the list of bead stores the sling
+// layer should consult when enforcing source-workflow singleton invariants.
+// StoreRef identifies the store scope (e.g. "city:foo" / "rig:alpha").
 type SourceWorkflowStore struct {
 	Store    beads.Store
 	StoreRef string

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -75,6 +75,11 @@ type BeadRouter interface {
 	Route(ctx context.Context, req RouteRequest) error
 }
 
+type SourceWorkflowStore struct {
+	Store    beads.Store
+	StoreRef string
+}
+
 // RouteRequest describes a bead routing operation in typed terms.
 type RouteRequest struct {
 	BeadID   string
@@ -93,6 +98,9 @@ type SlingDeps struct {
 	Runner   SlingRunner
 	Store    beads.Store
 	StoreRef string
+	// SourceWorkflowStores lists every bead store that may contain workflow
+	// roots for source-workflow singleton checks and recovery.
+	SourceWorkflowStores func() ([]SourceWorkflowStore, error)
 
 	// Narrow interfaces (matches established internal package patterns).
 	Resolver AgentResolver  // agent name resolution
@@ -145,6 +153,7 @@ type SlingChildResult struct {
 	Skipped     bool // idempotent or non-open
 	Failed      bool
 	FailReason  string
+	WorkflowID  string // if graph workflow attached
 	WispRootID  string // if formula attached
 	FormulaName string // formula used
 }

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -1,6 +1,7 @@
 package sling
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -223,16 +224,35 @@ func CheckBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store b
 	return checkBatchNoMoleculeChildren(q, open, store, result, false)
 }
 
+// CheckNoMoleculeChildrenAllowLiveWorkflow is like CheckNoMoleculeChildren
+// but permits an existing live workflow attachment (used on --force graph
+// launches that will supersede the existing root under the source-workflow
+// lock).
 func CheckNoMoleculeChildrenAllowLiveWorkflow(q BeadQuerier, beadID string, store beads.Store, result *SlingResult) error {
 	return checkNoMoleculeChildren(q, beadID, store, result, true)
 }
 
+// CheckBatchNoMoleculeChildrenAllowLiveWorkflow is the batch variant of
+// CheckNoMoleculeChildrenAllowLiveWorkflow.
 func CheckBatchNoMoleculeChildrenAllowLiveWorkflow(q BeadChildQuerier, open []beads.Bead, store beads.Store, result *SlingResult) error {
 	return checkBatchNoMoleculeChildren(q, open, store, result, true)
 }
 
 func checkBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store beads.Store, result *SlingResult, allowLiveWorkflow bool) error {
 	var problems []string
+	// workflowConflicts tracks children whose already-attached root is a
+	// live workflow. We emit a typed *sourceworkflow.ConflictError for
+	// those so the CLI/API boundary returns exit 3 + the cleanup hint;
+	// without this, users see a generic "cannot use --on" string and
+	// never learn about `gc workflow delete-source`. The first child's
+	// conflict becomes the typed payload; a combined non-typed error
+	// keeps the legacy message so existing "%d/%d" diagnostics stay
+	// readable.
+	type workflowConflict struct {
+		childID    string
+		workflowID string
+	}
+	var workflowConflicts []workflowConflict
 	for _, child := range open {
 		attachments, err := CollectAttachedBeads(child, store, q)
 		if err != nil && len(attachments) == 0 {
@@ -248,6 +268,7 @@ func checkBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store b
 					continue
 				}
 				problems = append(problems, fmt.Sprintf("%s (has %s %s)", child.ID, AttachmentLabel(attached), attached.ID))
+				workflowConflicts = append(workflowConflicts, workflowConflict{childID: child.ID, workflowID: attached.ID})
 				continue
 			}
 			if childUnassigned && store != nil {
@@ -262,11 +283,39 @@ func checkBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store b
 			problems = append(problems, fmt.Sprintf("%s (has %s %s)", child.ID, AttachmentLabel(attached), attached.ID))
 		}
 	}
-	if len(problems) > 0 {
-		return fmt.Errorf("cannot use --on: beads already have attached molecules: %s",
-			strings.Join(problems, ", "))
+	if len(problems) == 0 {
+		return nil
 	}
-	return nil
+	summary := fmt.Errorf("cannot use --on: beads already have attached molecules: %s",
+		strings.Join(problems, ", "))
+	if len(workflowConflicts) == 0 {
+		return summary
+	}
+	// Emit one typed ConflictError per conflicted child so cleanup hints
+	// stay correctly attributed. Collapsing into a single error keyed to
+	// the first child misreports which source bead owns each blocking
+	// workflow — users running the suggested `gc workflow delete-source
+	// <first-child>` command would see unrelated workflow IDs and only
+	// clean up part of the batch. Group blocking workflow IDs by child,
+	// then join them alongside the legacy summary; the CLI walks the
+	// error chain to render one cleanup hint per affected child.
+	conflictsByChild := make(map[string][]string, len(workflowConflicts))
+	childOrder := make([]string, 0, len(workflowConflicts))
+	for _, c := range workflowConflicts {
+		if _, seen := conflictsByChild[c.childID]; !seen {
+			childOrder = append(childOrder, c.childID)
+		}
+		conflictsByChild[c.childID] = append(conflictsByChild[c.childID], c.workflowID)
+	}
+	joined := make([]error, 0, len(childOrder)+1)
+	for _, childID := range childOrder {
+		joined = append(joined, &sourceworkflow.ConflictError{
+			SourceBeadID: childID,
+			WorkflowIDs:  conflictsByChild[childID],
+		})
+	}
+	joined = append(joined, summary)
+	return errors.Join(joined...)
 }
 
 // CheckBeadState checks whether a bead is already routed and returns a

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // BeadFromGetters tries multiple BeadQuerier implementations and returns
@@ -137,9 +138,35 @@ func HasMoleculeChildren(q BeadQuerier, beadID string, store beads.Store) bool {
 	return label != ""
 }
 
-// CheckNoMoleculeChildren returns an error if the bead already has an attached
-// molecule or wisp child that is still open. Auto-burn messages go to result.AutoBurned.
-func CheckNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, result *SlingResult) error {
+func closeAttachedBead(store beads.Store, attached beads.Bead) error {
+	if store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if IsWorkflowAttachment(attached) {
+		_, err := sourceworkflow.CloseWorkflowSubtree(store, attached.ID)
+		return err
+	}
+	return store.Close(attached.ID)
+}
+
+func clearAttachmentMetadata(store beads.Store, parent beads.Bead, attached beads.Bead) error {
+	if store == nil || strings.TrimSpace(parent.ID) == "" || strings.TrimSpace(attached.ID) == "" {
+		return nil
+	}
+	if strings.TrimSpace(parent.Metadata["workflow_id"]) == attached.ID {
+		if err := store.SetMetadata(parent.ID, "workflow_id", ""); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(parent.Metadata["molecule_id"]) == attached.ID {
+		if err := store.SetMetadata(parent.ID, "molecule_id", ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, result *SlingResult, allowLiveWorkflow bool) error {
 	parent, ok := BeadFromGetters(beadID, q, store)
 	if !ok {
 		return nil
@@ -161,8 +188,20 @@ func CheckNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, re
 		if attached.Status == "closed" {
 			continue
 		}
+		if IsWorkflowAttachment(attached) {
+			if allowLiveWorkflow {
+				continue
+			}
+			return &sourceworkflow.ConflictError{
+				SourceBeadID: beadID,
+				WorkflowIDs:  []string{attached.ID},
+			}
+		}
 		if parentUnassigned && store != nil {
-			if burnErr := store.Close(attached.ID); burnErr == nil {
+			if burnErr := closeAttachedBead(store, attached); burnErr == nil {
+				if clearErr := clearAttachmentMetadata(store, parent, attached); clearErr != nil {
+					return clearErr
+				}
 				result.AutoBurned = append(result.AutoBurned, attached.ID)
 				continue
 			}
@@ -172,9 +211,27 @@ func CheckNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, re
 	return nil
 }
 
+// CheckNoMoleculeChildren returns an error if the bead already has an attached
+// molecule or wisp child that is still open. Auto-burn messages go to result.AutoBurned.
+func CheckNoMoleculeChildren(q BeadQuerier, beadID string, store beads.Store, result *SlingResult) error {
+	return checkNoMoleculeChildren(q, beadID, store, result, false)
+}
+
 // CheckBatchNoMoleculeChildren checks all open children for existing molecule
 // attachments before any wisps are created.
 func CheckBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store beads.Store, result *SlingResult) error {
+	return checkBatchNoMoleculeChildren(q, open, store, result, false)
+}
+
+func CheckNoMoleculeChildrenAllowLiveWorkflow(q BeadQuerier, beadID string, store beads.Store, result *SlingResult) error {
+	return checkNoMoleculeChildren(q, beadID, store, result, true)
+}
+
+func CheckBatchNoMoleculeChildrenAllowLiveWorkflow(q BeadChildQuerier, open []beads.Bead, store beads.Store, result *SlingResult) error {
+	return checkBatchNoMoleculeChildren(q, open, store, result, true)
+}
+
+func checkBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store beads.Store, result *SlingResult, allowLiveWorkflow bool) error {
 	var problems []string
 	for _, child := range open {
 		attachments, err := CollectAttachedBeads(child, store, q)
@@ -186,8 +243,18 @@ func CheckBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store b
 			if attached.Status == "closed" {
 				continue
 			}
+			if IsWorkflowAttachment(attached) {
+				if allowLiveWorkflow {
+					continue
+				}
+				problems = append(problems, fmt.Sprintf("%s (has %s %s)", child.ID, AttachmentLabel(attached), attached.ID))
+				continue
+			}
 			if childUnassigned && store != nil {
-				if burnErr := store.Close(attached.ID); burnErr == nil {
+				if burnErr := closeAttachedBead(store, attached); burnErr == nil {
+					if clearErr := clearAttachmentMetadata(store, child, attached); clearErr != nil {
+						return clearErr
+					}
 					result.AutoBurned = append(result.AutoBurned, attached.ID)
 					continue
 				}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -2,12 +2,18 @@ package sling
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
@@ -122,7 +128,7 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 		return SlingResult{Target: a.QualifiedName()}, fmt.Errorf("instantiating formula %q: %w", opts.BeadOrFormula, err)
 	}
 	if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, mResult.RootID) {
-		wfResult, wfErr := doStartGraphWorkflow(mResult, "", a, method, deps)
+		wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, "", a, method, deps)
 		wfResult.FormulaName = opts.BeadOrFormula
 		return wfResult, wfErr
 	}
@@ -134,31 +140,57 @@ func slingFormula(opts SlingOpts, deps SlingDeps) (SlingResult, error) {
 func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID string, result SlingResult) (SlingResult, error) {
 	a := opts.Target
 	method := "on-formula"
-	if err := CheckNoMoleculeChildren(querier, beadID, deps.Store, &result); err != nil {
-		return result, fmt.Errorf("%w", err)
-	}
 	formulaVars := BuildSlingFormulaVars(opts.OnFormula, beadID, opts.Vars, a, deps)
-	mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
-		Title:            opts.Title,
-		Vars:             formulaVars,
-		PriorityOverride: BeadPriorityOverride(querier, beadID),
-	}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+	searchPaths := SlingFormulaSearchPaths(deps, a)
+	isGraph, err := isGraphSlingFormula(context.Background(), opts.OnFormula, searchPaths, formulaVars)
 	if err != nil {
 		return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
 	}
-	wispRootID := mResult.RootID
-	if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, wispRootID) {
-		wfResult, wfErr := doStartGraphWorkflow(mResult, beadID, a, method, deps)
-		wfResult.FormulaName = opts.OnFormula
-		return wfResult, wfErr
+	checkAttachments := CheckNoMoleculeChildren
+	if isGraph && opts.Force {
+		checkAttachments = CheckNoMoleculeChildrenAllowLiveWorkflow
 	}
-	if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
-		result.MetadataErrors = append(result.MetadataErrors,
-			fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
+	if err := checkAttachments(querier, beadID, deps.Store, &result); err != nil {
+		return result, fmt.Errorf("%w", err)
 	}
-	result.WispRootID = wispRootID
-	result.FormulaName = opts.OnFormula
-	return finalize(opts, deps, beadID, method, result)
+	run := func() (SlingResult, error) {
+		mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+			Title:            opts.Title,
+			Vars:             formulaVars,
+			PriorityOverride: BeadPriorityOverride(querier, beadID),
+		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		if err != nil {
+			return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+		}
+		wispRootID := mResult.RootID
+		if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, wispRootID) {
+			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, beadID, a, method, deps)
+			wfResult.FormulaName = opts.OnFormula
+			return wfResult, wfErr
+		}
+		if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
+			result.MetadataErrors = append(result.MetadataErrors,
+				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
+		}
+		result.WispRootID = wispRootID
+		result.FormulaName = opts.OnFormula
+		return finalize(opts, deps, beadID, method, result)
+	}
+	runGraph := func() (pendingSourceWorkflowLaunch, error) {
+		mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+			Title:            opts.Title,
+			Vars:             formulaVars,
+			PriorityOverride: BeadPriorityOverride(querier, beadID),
+		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		if err != nil {
+			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+		}
+		return pendingGraphWorkflowLaunch(mResult.RootID, beadID, a, method, opts.OnFormula, deps), nil
+	}
+	if !isGraph {
+		return run()
+	}
+	return withSourceWorkflowLaunchLock(context.Background(), deps, beadID, opts.Force, runGraph)
 }
 
 // slingDefaultFormula handles the default formula attachment path.
@@ -166,31 +198,57 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 	a := opts.Target
 	method := "default-on-formula"
 	defaultFormula := a.EffectiveDefaultSlingFormula()
-	if err := CheckNoMoleculeChildren(querier, beadID, deps.Store, &result); err != nil {
-		return result, fmt.Errorf("%w", err)
-	}
 	defaultVars := BuildSlingFormulaVars(defaultFormula, beadID, opts.Vars, a, deps)
-	mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
-		Title:            opts.Title,
-		Vars:             defaultVars,
-		PriorityOverride: BeadPriorityOverride(querier, beadID),
-	}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+	searchPaths := SlingFormulaSearchPaths(deps, a)
+	isGraph, err := isGraphSlingFormula(context.Background(), defaultFormula, searchPaths, defaultVars)
 	if err != nil {
 		return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
 	}
-	wispRootID := mResult.RootID
-	if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, wispRootID) {
-		wfResult, wfErr := doStartGraphWorkflow(mResult, beadID, a, method, deps)
-		wfResult.FormulaName = defaultFormula
-		return wfResult, wfErr
+	checkAttachments := CheckNoMoleculeChildren
+	if isGraph && opts.Force {
+		checkAttachments = CheckNoMoleculeChildrenAllowLiveWorkflow
 	}
-	if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
-		result.MetadataErrors = append(result.MetadataErrors,
-			fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
+	if err := checkAttachments(querier, beadID, deps.Store, &result); err != nil {
+		return result, fmt.Errorf("%w", err)
 	}
-	result.WispRootID = wispRootID
-	result.FormulaName = defaultFormula
-	return finalize(opts, deps, beadID, method, result)
+	run := func() (SlingResult, error) {
+		mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+			Title:            opts.Title,
+			Vars:             defaultVars,
+			PriorityOverride: BeadPriorityOverride(querier, beadID),
+		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		if err != nil {
+			return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
+		}
+		wispRootID := mResult.RootID
+		if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, wispRootID) {
+			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, beadID, a, method, deps)
+			wfResult.FormulaName = defaultFormula
+			return wfResult, wfErr
+		}
+		if err := deps.Store.SetMetadata(beadID, "molecule_id", wispRootID); err != nil {
+			result.MetadataErrors = append(result.MetadataErrors,
+				fmt.Sprintf("setting molecule_id on %s: %v", beadID, err))
+		}
+		result.WispRootID = wispRootID
+		result.FormulaName = defaultFormula
+		return finalize(opts, deps, beadID, method, result)
+	}
+	runGraph := func() (pendingSourceWorkflowLaunch, error) {
+		mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
+			Title:            opts.Title,
+			Vars:             defaultVars,
+			PriorityOverride: BeadPriorityOverride(querier, beadID),
+		}, beadID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		if err != nil {
+			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
+		}
+		return pendingGraphWorkflowLaunch(mResult.RootID, beadID, a, method, defaultFormula, deps), nil
+	}
+	if !isGraph {
+		return run()
+	}
+	return withSourceWorkflowLaunchLock(context.Background(), deps, beadID, opts.Force, runGraph)
 }
 
 // slingPlainBead handles plain bead routing (no formula).
@@ -276,20 +334,29 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 }
 
 // doStartGraphWorkflow performs post-instantiation graph workflow setup.
-func doStartGraphWorkflow(mResult *molecule.Result, sourceBeadID string, a config.Agent, method string, deps SlingDeps) (SlingResult, error) {
+func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method string, deps SlingDeps) (SlingResult, error) {
 	var result SlingResult
 	result.Target = a.QualifiedName()
 	result.Method = method
-	result.WorkflowID = mResult.RootID
-	result.BeadID = mResult.RootID
+	result.WorkflowID = rootID
+	result.BeadID = rootID
 
-	rootID := mResult.RootID
 	SlingTracef("workflow-start begin root=%s source=%s agent=%s method=%s", rootID, sourceBeadID, a.QualifiedName(), method)
 
 	if err := PromoteWorkflowLaunchBead(deps.Store, rootID); err != nil {
 		return result, fmt.Errorf("setting workflow root %s in_progress: %w", rootID, err)
 	}
 	if sourceBeadID != "" {
+		if err := deps.Store.SetMetadata(rootID, "gc.source_bead_id", sourceBeadID); err != nil {
+			return result, fmt.Errorf("setting gc.source_bead_id on workflow %s: %w", rootID, err)
+		}
+		if sourceStoreRef := strings.TrimSpace(deps.StoreRef); sourceStoreRef != "" {
+			if err := deps.Store.SetMetadata(rootID, sourceworkflow.SourceStoreRefMetadataKey, sourceStoreRef); err != nil {
+				return result, fmt.Errorf("setting %s on workflow %s: %w", sourceworkflow.SourceStoreRefMetadataKey, rootID, err)
+			}
+		}
+		// Graph workflow launches repoint the source bead at the active root so
+		// witness/source lookups resume from the workflow currently in control.
 		if err := deps.Store.SetMetadata(sourceBeadID, "workflow_id", rootID); err != nil {
 			return result, fmt.Errorf("setting workflow_id on %s: %w", sourceBeadID, err)
 		}
@@ -302,6 +369,334 @@ func doStartGraphWorkflow(mResult *molecule.Result, sourceBeadID string, a confi
 		deps.Notify.PokeControlDispatch(deps.CityPath)
 	}
 	return result, nil
+}
+
+type pendingSourceWorkflowLaunch struct {
+	workflowID string
+	storeRef   string
+	finalize   func() (SlingResult, error)
+	rollback   func() error
+}
+
+type sourceWorkflowRoot struct {
+	root     beads.Bead
+	store    beads.Store
+	storeRef string
+}
+
+type workflowRestoreState struct {
+	rootID    string
+	store     beads.Store
+	storeRef  string
+	snapshots []sourceworkflow.WorkflowBeadSnapshot
+}
+
+func listSourceWorkflowRoots(deps SlingDeps, sourceBeadID string) ([]sourceWorkflowRoot, error) {
+	sourceStoreRef := strings.TrimSpace(deps.StoreRef)
+	if deps.SourceWorkflowStores == nil {
+		roots, err := sourceworkflow.ListLiveRoots(deps.Store, sourceBeadID, sourceStoreRef, sourceStoreRef)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]sourceWorkflowRoot, 0, len(roots))
+		for _, root := range roots {
+			out = append(out, sourceWorkflowRoot{
+				root:     root,
+				store:    deps.Store,
+				storeRef: sourceStoreRef,
+			})
+		}
+		return out, nil
+	}
+	stores, err := deps.SourceWorkflowStores()
+	if err != nil {
+		return nil, err
+	}
+	roots := make([]sourceWorkflowRoot, 0)
+	seen := make(map[string]struct{}, len(stores))
+	for i, info := range stores {
+		if info.Store == nil {
+			continue
+		}
+		rootStoreRef := strings.TrimSpace(info.StoreRef)
+		matches, err := sourceworkflow.ListLiveRoots(info.Store, sourceBeadID, sourceStoreRef, rootStoreRef)
+		if err != nil {
+			return nil, err
+		}
+		for _, root := range matches {
+			keyScope := rootStoreRef
+			if keyScope == "" {
+				keyScope = fmt.Sprintf("store#%d", i)
+			}
+			key := keyScope + "\x00" + root.ID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			roots = append(roots, sourceWorkflowRoot{
+				root:     root,
+				store:    info.Store,
+				storeRef: rootStoreRef,
+			})
+		}
+	}
+	slices.SortFunc(roots, func(a, b sourceWorkflowRoot) int {
+		if cmp := strings.Compare(a.storeRef, b.storeRef); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.root.ID, b.root.ID)
+	})
+	return roots, nil
+}
+
+func pendingGraphWorkflowLaunch(rootID, sourceBeadID string, a config.Agent, method, formulaName string, deps SlingDeps) pendingSourceWorkflowLaunch {
+	return pendingSourceWorkflowLaunch{
+		workflowID: rootID,
+		storeRef:   strings.TrimSpace(deps.StoreRef),
+		finalize: func() (SlingResult, error) {
+			result, err := doStartGraphWorkflow(rootID, sourceBeadID, a, method, deps)
+			result.FormulaName = formulaName
+			return result, err
+		},
+		rollback: func() error {
+			_, err := sourceworkflow.CloseWorkflowSubtree(deps.Store, rootID)
+			return err
+		},
+	}
+}
+
+func sameWorkflowRoot(root sourceWorkflowRoot, workflowID, storeRef string) bool {
+	return root.root.ID == strings.TrimSpace(workflowID) &&
+		sourceworkflow.NormalizeSourceStoreRef(root.storeRef) == sourceworkflow.NormalizeSourceStoreRef(storeRef)
+}
+
+func blockingWorkflowIDs(roots []sourceWorkflowRoot) []string {
+	ids := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root.root.ID == "" {
+			continue
+		}
+		ids = append(ids, root.root.ID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func snapshotBlockingWorkflowState(roots []sourceWorkflowRoot, replacement pendingSourceWorkflowLaunch) ([]workflowRestoreState, error) {
+	states := make([]workflowRestoreState, 0, len(roots))
+	for _, root := range roots {
+		if root.root.ID == "" || sameWorkflowRoot(root, replacement.workflowID, replacement.storeRef) {
+			continue
+		}
+		snapshots, err := sourceworkflow.SnapshotOpenWorkflowBeads(root.store, root.root.ID)
+		if err != nil {
+			return nil, err
+		}
+		states = append(states, workflowRestoreState{
+			rootID:    root.root.ID,
+			store:     root.store,
+			storeRef:  root.storeRef,
+			snapshots: snapshots,
+		})
+	}
+	return states, nil
+}
+
+func restoreBlockingWorkflowState(states []workflowRestoreState) error {
+	var restoreErr error
+	for _, state := range states {
+		if err := sourceworkflow.RestoreWorkflowBeads(state.store, state.snapshots); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore workflow %s in %s: %w", state.rootID, state.storeRef, err))
+		}
+	}
+	return restoreErr
+}
+
+func rollbackSourceWorkflowReplacement(launch pendingSourceWorkflowLaunch, store beads.Store, sourceBeadID, previousWorkflowID string, states []workflowRestoreState) error {
+	var rollbackErr error
+	if launch.rollback != nil {
+		if err := launch.rollback(); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback new workflow %s: %w", launch.workflowID, err))
+		}
+	}
+	if sourceBeadID != "" {
+		if err := store.SetMetadata(sourceBeadID, "workflow_id", previousWorkflowID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore source workflow_id on %s: %w", sourceBeadID, err))
+		}
+	}
+	if err := restoreBlockingWorkflowState(states); err != nil {
+		rollbackErr = errors.Join(rollbackErr, err)
+	}
+	return rollbackErr
+}
+
+func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBeadID string, force bool, fn func() (pendingSourceWorkflowLaunch, error)) (SlingResult, error) {
+	sourceBeadID = sourceworkflow.NormalizeSourceBeadID(sourceBeadID)
+	if sourceBeadID == "" {
+		launch, err := fn()
+		if err != nil {
+			return SlingResult{}, err
+		}
+		return launch.finalize()
+	}
+	var result SlingResult
+	err := sourceworkflow.WithLock(ctx, deps.CityPath, sourceWorkflowLockScope(deps), sourceBeadID, func() error {
+		previousWorkflowID := ""
+		sourceBead, err := deps.Store.Get(sourceBeadID)
+		if err != nil && !errors.Is(err, beads.ErrNotFound) {
+			return fmt.Errorf("get source bead %s: %w", sourceBeadID, err)
+		}
+		if err == nil {
+			previousWorkflowID = strings.TrimSpace(sourceBead.Metadata["workflow_id"])
+		}
+		roots, err := listSourceWorkflowRoots(deps, sourceBeadID)
+		if err != nil {
+			return fmt.Errorf("list live workflows for %s: %w", sourceBeadID, err)
+		}
+		blockingRoots := append([]sourceWorkflowRoot(nil), roots...)
+		if len(roots) > 0 {
+			if !force {
+				return &sourceworkflow.ConflictError{
+					SourceBeadID: sourceBeadID,
+					WorkflowIDs:  blockingWorkflowIDs(roots),
+				}
+			}
+		}
+		launch, err := fn()
+		if err != nil {
+			return err
+		}
+		if launch.workflowID == "" {
+			return fmt.Errorf("source workflow launch for %s returned empty workflow id", sourceBeadID)
+		}
+		restoreState, err := snapshotBlockingWorkflowState(blockingRoots, launch)
+		if err != nil {
+			if rollbackErr := rollbackSourceWorkflowReplacement(launch, deps.Store, sourceBeadID, previousWorkflowID, nil); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			return err
+		}
+		if force {
+			for _, root := range blockingRoots {
+				if root.root.ID == "" || sameWorkflowRoot(root, launch.workflowID, launch.storeRef) {
+					continue
+				}
+				if _, err := sourceworkflow.CloseWorkflowSubtree(root.store, root.root.ID); err != nil {
+					if rollbackErr := rollbackSourceWorkflowReplacement(launch, deps.Store, sourceBeadID, previousWorkflowID, restoreState); rollbackErr != nil {
+						return errors.Join(fmt.Errorf("close superseded workflow %s for %s: %w", root.root.ID, sourceBeadID, err), rollbackErr)
+					}
+					return fmt.Errorf("close superseded workflow %s for %s: %w", root.root.ID, sourceBeadID, err)
+				}
+			}
+		}
+		result, err = launch.finalize()
+		if err != nil {
+			if rollbackErr := rollbackSourceWorkflowReplacement(launch, deps.Store, sourceBeadID, previousWorkflowID, restoreState); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			return err
+		}
+		roots, err = listSourceWorkflowRoots(deps, sourceBeadID)
+		if err != nil {
+			result.MetadataErrors = append(result.MetadataErrors,
+				fmt.Sprintf("verify live workflows for %s: %v", sourceBeadID, err))
+			return nil
+		}
+		if !slices.ContainsFunc(roots, func(root sourceWorkflowRoot) bool {
+			return sameWorkflowRoot(root, result.WorkflowID, launch.storeRef)
+		}) {
+			result.MetadataErrors = append(result.MetadataErrors,
+				fmt.Sprintf("workflow %s not visible for source bead %s after launch", result.WorkflowID, sourceBeadID))
+		}
+		return nil
+	})
+	return result, err
+}
+
+func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, child beads.Bead, a config.Agent, formulaName, formulaLabel, method string) (SlingResult, error) {
+	childVars := BuildSlingFormulaVars(formulaName, child.ID, opts.Vars, a, deps)
+	searchPaths := SlingFormulaSearchPaths(deps, a)
+	isGraph, err := isGraphSlingFormula(ctx, formulaName, searchPaths, childVars)
+	if err != nil {
+		return SlingResult{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
+	}
+	run := func() (SlingResult, error) {
+		mResult, err := InstantiateSlingFormula(ctx, formulaName, SlingFormulaSearchPaths(deps, a), molecule.Options{
+			Title:            opts.Title,
+			Vars:             childVars,
+			PriorityOverride: ClonePriorityPtr(child.Priority),
+		}, child.ID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		if err != nil {
+			return SlingResult{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
+		}
+		if mResult.GraphWorkflow || IsGraphWorkflowAttachment(deps.Store, mResult.RootID) {
+			wfResult, wfErr := doStartGraphWorkflow(mResult.RootID, child.ID, a, method, deps)
+			wfResult.FormulaName = formulaName
+			return wfResult, wfErr
+		}
+		result := SlingResult{
+			BeadID:      child.ID,
+			Target:      a.QualifiedName(),
+			Method:      method,
+			WispRootID:  mResult.RootID,
+			FormulaName: formulaName,
+		}
+		if err := deps.Store.SetMetadata(child.ID, "molecule_id", mResult.RootID); err != nil {
+			result.MetadataErrors = append(result.MetadataErrors,
+				fmt.Sprintf("setting molecule_id on %s: %v", child.ID, err))
+		}
+		return result, nil
+	}
+	runGraph := func() (pendingSourceWorkflowLaunch, error) {
+		mResult, err := InstantiateSlingFormula(ctx, formulaName, SlingFormulaSearchPaths(deps, a), molecule.Options{
+			Title:            opts.Title,
+			Vars:             childVars,
+			PriorityOverride: ClonePriorityPtr(child.Priority),
+		}, child.ID, opts.ScopeKind, opts.ScopeRef, a, deps)
+		if err != nil {
+			return pendingSourceWorkflowLaunch{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
+		}
+		return pendingGraphWorkflowLaunch(mResult.RootID, child.ID, a, method, formulaName, deps), nil
+	}
+	if !isGraph {
+		return run()
+	}
+	return withSourceWorkflowLaunchLock(ctx, deps, child.ID, opts.Force, runGraph)
+}
+
+func isGraphSlingFormula(ctx context.Context, formulaName string, searchPaths []string, vars map[string]string) (bool, error) {
+	recipe, err := formula.Compile(ctx, formulaName, searchPaths, vars)
+	if err != nil {
+		return false, err
+	}
+	return IsCompiledGraphWorkflow(recipe), nil
+}
+
+func sourceWorkflowLockScope(deps SlingDeps) string {
+	cityPath := strings.TrimSpace(deps.CityPath)
+	if cityPath == "" {
+		return strings.TrimSpace(deps.StoreRef)
+	}
+	storeRef := strings.TrimSpace(deps.StoreRef)
+	switch {
+	case storeRef == "", strings.HasPrefix(storeRef, "city:"):
+		return filepath.Clean(cityPath)
+	case strings.HasPrefix(storeRef, "rig:"):
+		rigName := strings.TrimPrefix(storeRef, "rig:")
+		if deps.Cfg != nil {
+			for _, rig := range deps.Cfg.Rigs {
+				if rig.Name != rigName {
+					continue
+				}
+				rigPath := rig.Path
+				if !filepath.IsAbs(rigPath) {
+					rigPath = filepath.Join(cityPath, rigPath)
+				}
+				return filepath.Clean(rigPath)
+			}
+		}
+	}
+	return storeRef
 }
 
 // DoSlingBatch handles convoy expansion before delegating to DoSling.
@@ -382,7 +777,17 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 		useFormula = a.EffectiveDefaultSlingFormula()
 	}
 	if useFormula != "" {
-		if err := CheckBatchNoMoleculeChildren(querier, open, deps.Store, &batchResult); err != nil {
+		formulaVars := BuildSlingFormulaVars(useFormula, "", opts.Vars, a, deps)
+		searchPaths := SlingFormulaSearchPaths(deps, a)
+		isGraph, err := isGraphSlingFormula(context.Background(), useFormula, searchPaths, formulaVars)
+		if err != nil {
+			return SlingResult{}, fmt.Errorf("instantiating formula %q on %s %s: %w", useFormula, b.Type, b.ID, err)
+		}
+		checkAttachments := CheckBatchNoMoleculeChildren
+		if isGraph && opts.Force {
+			checkAttachments = CheckBatchNoMoleculeChildrenAllowLiveWorkflow
+		}
+		if err := checkAttachments(querier, open, deps.Store, &batchResult); err != nil {
 			return batchResult, fmt.Errorf("%w", err)
 		}
 	}
@@ -413,49 +818,30 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 			batchResult.BeadWarnings = append(batchResult.BeadWarnings, check.Warnings...)
 		}
 
-		// Attach wisp if --on.
-		if opts.OnFormula != "" {
-			childVars := BuildSlingFormulaVars(opts.OnFormula, child.ID, opts.Vars, a, deps)
-			cookResult, err := molecule.Cook(context.Background(), deps.Store, opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
-				Title:            opts.Title,
-				Vars:             childVars,
-				PriorityOverride: ClonePriorityPtr(child.Priority),
-			})
+		if useFormula != "" {
+			formulaLabel := "formula"
+			if opts.OnFormula == "" {
+				formulaLabel = "default formula"
+			}
+			formulaResult, err := attachBatchFormula(context.Background(), opts, deps, child, a, useFormula, formulaLabel, batchMethod)
 			if err != nil {
 				childResult.Failed = true
-				childResult.FailReason = fmt.Sprintf("instantiating formula %q: %v", opts.OnFormula, err)
+				childResult.FailReason = err.Error()
 				batchResult.Children = append(batchResult.Children, childResult)
 				telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), batchMethod, err)
 				failed++
 				continue
 			}
-			if err := deps.Store.SetMetadata(child.ID, "molecule_id", cookResult.RootID); err != nil {
-				batchResult.MetadataErrors = append(batchResult.MetadataErrors,
-					fmt.Sprintf("setting molecule_id on %s: %v", child.ID, err))
-			}
-			childResult.WispRootID = cookResult.RootID
-			childResult.FormulaName = opts.OnFormula
-		} else if !opts.NoFormula && a.EffectiveDefaultSlingFormula() != "" {
-			childVars := BuildSlingFormulaVars(a.EffectiveDefaultSlingFormula(), child.ID, opts.Vars, a, deps)
-			cookResult, err := molecule.Cook(context.Background(), deps.Store, a.EffectiveDefaultSlingFormula(), SlingFormulaSearchPaths(deps, a), molecule.Options{
-				Title:            opts.Title,
-				Vars:             childVars,
-				PriorityOverride: ClonePriorityPtr(child.Priority),
-			})
-			if err != nil {
-				childResult.Failed = true
-				childResult.FailReason = fmt.Sprintf("instantiating default formula %q: %v", a.EffectiveDefaultSlingFormula(), err)
+			batchResult.MetadataErrors = append(batchResult.MetadataErrors, formulaResult.MetadataErrors...)
+			childResult.FormulaName = formulaResult.FormulaName
+			childResult.WorkflowID = formulaResult.WorkflowID
+			childResult.WispRootID = formulaResult.WispRootID
+			if formulaResult.WorkflowID != "" {
+				childResult.Routed = true
 				batchResult.Children = append(batchResult.Children, childResult)
-				telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), batchMethod, err)
-				failed++
+				routed++
 				continue
 			}
-			if err := deps.Store.SetMetadata(child.ID, "molecule_id", cookResult.RootID); err != nil {
-				batchResult.MetadataErrors = append(batchResult.MetadataErrors,
-					fmt.Sprintf("setting molecule_id on %s: %v", child.ID, err))
-			}
-			childResult.WispRootID = cookResult.RootID
-			childResult.FormulaName = a.EffectiveDefaultSlingFormula()
 		}
 
 		childEnv := ResolveSlingEnv(a, deps)

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -598,6 +598,10 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 		}
 		roots, err = listSourceWorkflowRoots(deps, sourceBeadID)
 		if err != nil {
+			// A transient store error while re-listing is recoverable:
+			// the finalize already succeeded, the lock is still held, and
+			// the underlying stores may briefly be unavailable. Warn and
+			// continue.
 			result.MetadataErrors = append(result.MetadataErrors,
 				fmt.Sprintf("verify live workflows for %s: %v", sourceBeadID, err))
 			return nil
@@ -605,21 +609,34 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 		if !slices.ContainsFunc(roots, func(root sourceWorkflowRoot) bool {
 			return sameWorkflowRoot(root, result.WorkflowID, launch.storeRef)
 		}) {
-			result.MetadataErrors = append(result.MetadataErrors,
-				fmt.Sprintf("workflow %s not visible for source bead %s after launch", result.WorkflowID, sourceBeadID))
+			// Under the held lock, a successful finalize that is not
+			// visible via ListLiveRoots is an invariant violation: either
+			// the new root was never persisted or it no longer matches
+			// the singleton predicate. This must NOT be demoted to a
+			// warning — callers that rely on exactly-one-live-root will
+			// otherwise proceed with a phantom success. Run the same
+			// rollback the finalize-failure path uses so superseded
+			// roots are restored and the source bead's workflow_id is
+			// reverted to previousWorkflowID; otherwise we leave the
+			// system in a worse state than the one the invariant check
+			// was supposed to catch.
+			invariantErr := fmt.Errorf("workflow %s not visible for source bead %s after launch", result.WorkflowID, sourceBeadID)
+			if rollbackErr := rollbackSourceWorkflowReplacement(launch, deps.Store, sourceBeadID, previousWorkflowID, restoreState); rollbackErr != nil {
+				return errors.Join(invariantErr, rollbackErr)
+			}
+			return invariantErr
 		}
 		return nil
 	})
 	return result, err
 }
 
-func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, child beads.Bead, a config.Agent, formulaName, formulaLabel, method string) (SlingResult, error) {
+// attachBatchFormula launches one batch-child formula. The caller passes the
+// pre-computed isGraph flag from the one-shot formula compile at the top of
+// DoSlingBatch so that compiling N times for N children becomes a single
+// compile per batch.
+func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, child beads.Bead, a config.Agent, formulaName, formulaLabel, method string, isGraph bool) (SlingResult, error) {
 	childVars := BuildSlingFormulaVars(formulaName, child.ID, opts.Vars, a, deps)
-	searchPaths := SlingFormulaSearchPaths(deps, a)
-	isGraph, err := isGraphSlingFormula(ctx, formulaName, searchPaths, childVars)
-	if err != nil {
-		return SlingResult{}, fmt.Errorf("instantiating %s %q on %s: %w", formulaLabel, formulaName, child.ID, err)
-	}
 	run := func() (SlingResult, error) {
 		mResult, err := InstantiateSlingFormula(ctx, formulaName, SlingFormulaSearchPaths(deps, a), molecule.Options{
 			Title:            opts.Title,
@@ -776,10 +793,16 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 	if useFormula == "" && !opts.IsFormula && !opts.NoFormula && a.EffectiveDefaultSlingFormula() != "" {
 		useFormula = a.EffectiveDefaultSlingFormula()
 	}
+	// isGraph is computed once per batch and threaded into every per-child
+	// attachBatchFormula call. Previously the helper compiled the formula
+	// once here and again per child, turning an O(1) compile into O(N) disk
+	// reads + template expansions for an N-child batch.
+	var isGraph bool
 	if useFormula != "" {
 		formulaVars := BuildSlingFormulaVars(useFormula, "", opts.Vars, a, deps)
 		searchPaths := SlingFormulaSearchPaths(deps, a)
-		isGraph, err := isGraphSlingFormula(context.Background(), useFormula, searchPaths, formulaVars)
+		var err error
+		isGraph, err = isGraphSlingFormula(context.Background(), useFormula, searchPaths, formulaVars)
 		if err != nil {
 			return SlingResult{}, fmt.Errorf("instantiating formula %q on %s %s: %w", useFormula, b.Type, b.ID, err)
 		}
@@ -804,6 +827,11 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 	routed := 0
 	failed := 0
 	idempotent := 0
+	// childErrors preserves typed child errors so errors.As at the top-level
+	// (cmdSling) can recover a *sourceworkflow.ConflictError emitted by any
+	// child and map it to exit code 3 + the cleanup hint. Stringifying into
+	// childResult.FailReason alone loses the type.
+	var childErrors []error
 	for _, child := range open {
 		childResult := SlingChildResult{BeadID: child.ID}
 
@@ -823,11 +851,12 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 			if opts.OnFormula == "" {
 				formulaLabel = "default formula"
 			}
-			formulaResult, err := attachBatchFormula(context.Background(), opts, deps, child, a, useFormula, formulaLabel, batchMethod)
+			formulaResult, err := attachBatchFormula(context.Background(), opts, deps, child, a, useFormula, formulaLabel, batchMethod, isGraph)
 			if err != nil {
 				childResult.Failed = true
 				childResult.FailReason = err.Error()
 				batchResult.Children = append(batchResult.Children, childResult)
+				childErrors = append(childErrors, err)
 				telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), batchMethod, err)
 				failed++
 				continue
@@ -857,6 +886,7 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 				childResult.Failed = true
 				childResult.FailReason = err.Error()
 				batchResult.Children = append(batchResult.Children, childResult)
+				childErrors = append(childErrors, err)
 				telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), batchMethod, err)
 				failed++
 				continue
@@ -867,6 +897,7 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 				childResult.Failed = true
 				childResult.FailReason = err.Error()
 				batchResult.Children = append(batchResult.Children, childResult)
+				childErrors = append(childErrors, err)
 				telemetry.RecordSling(context.Background(), a.QualifiedName(), TargetType(&a), batchMethod, err)
 				failed++
 				continue
@@ -898,7 +929,13 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 	}
 
 	if failed > 0 {
-		return batchResult, fmt.Errorf("%d/%d children failed", failed, len(open))
+		summary := fmt.Errorf("%d/%d children failed", failed, len(open))
+		// errors.Join threads typed child errors through Unwrap() []error so
+		// errors.As at the CLI/API boundary can recover *ConflictError and map
+		// it to exit 3 + the cleanup hint; the summary stays first for the
+		// human-readable message.
+		joined := append([]error{summary}, childErrors...)
+		return batchResult, errors.Join(joined...)
 	}
 	return batchResult, nil
 }

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2,15 +2,19 @@ package sling
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // --- Test helpers ---
@@ -26,6 +30,33 @@ type fakeRunner struct {
 	dirs  []string
 	envs  []map[string]string
 	rules []fakeRunnerRule
+}
+
+type closeAllFailMemStore struct {
+	*beads.MemStore
+	failCloseAllCalls   int
+	failSetMetadataID   string
+	failSetMetadataKey  string
+	failSetMetadataCall int
+}
+
+func (s *closeAllFailMemStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	if s.failCloseAllCalls > 0 {
+		s.failCloseAllCalls--
+		if len(ids) > 0 {
+			return 0, fmt.Errorf("forced close failure for %s", ids[0])
+		}
+		return 0, fmt.Errorf("forced close failure")
+	}
+	return s.MemStore.CloseAll(ids, metadata)
+}
+
+func (s *closeAllFailMemStore) SetMetadata(id, key, value string) error {
+	if s.failSetMetadataCall > 0 && id == s.failSetMetadataID && key == s.failSetMetadataKey {
+		s.failSetMetadataCall--
+		return fmt.Errorf("forced metadata failure for %s %s", id, key)
+	}
+	return s.MemStore.SetMetadata(id, key, value)
 }
 
 func newFakeRunner() *fakeRunner { return &fakeRunner{} }
@@ -72,7 +103,7 @@ func testDeps(cfg *config.City, sp runtime.Provider, runner SlingRunner) SlingDe
 	}
 	return SlingDeps{
 		CityName: "test-city",
-		CityPath: "/city",
+		CityPath: sharedTestCityDir,
 		Cfg:      cfg,
 		SP:       sp,
 		Runner:   runner,
@@ -88,6 +119,7 @@ func testOpts(a config.Agent, beadOrFormula string) SlingOpts {
 }
 
 var sharedTestFormulaDir string
+var sharedTestCityDir string
 
 func init() {
 	dir, err := os.MkdirTemp("", "gc-sling-test-formulas-*")
@@ -105,6 +137,12 @@ func init() {
 		_ = os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644)
 	}
 	sharedTestFormulaDir = dir
+
+	cityDir, err := os.MkdirTemp("", "gc-sling-test-city-*")
+	if err != nil {
+		panic(err)
+	}
+	sharedTestCityDir = cityDir
 }
 
 // --- Pure helper tests ---
@@ -326,6 +364,77 @@ func TestCheckBatchBurnOutputsWarn(t *testing.T) {
 	}
 }
 
+func TestCheckNoMoleculeChildrenRejectsLiveWorkflowWithoutForce(t *testing.T) {
+	store := beads.NewMemStore()
+	source, err := store.Create(beads.Bead{Title: "source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title:  "workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:  "child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	var result SlingResult
+	err = CheckNoMoleculeChildren(store, source.ID, store, &result)
+	if err == nil {
+		t.Fatal("CheckNoMoleculeChildren error = nil, want workflow conflict")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("CheckNoMoleculeChildren error = %v, want ConflictError", err)
+	}
+	if conflictErr.SourceBeadID != source.ID || len(conflictErr.WorkflowIDs) != 1 || conflictErr.WorkflowIDs[0] != root.ID {
+		t.Fatalf("ConflictError = %#v, want source=%s workflow=%s", conflictErr, source.ID, root.ID)
+	}
+	if len(result.AutoBurned) != 0 {
+		t.Fatalf("AutoBurned = %#v, want empty", result.AutoBurned)
+	}
+	updatedRoot, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedRoot.Status != root.Status {
+		t.Fatalf("root status = %q, want %q", updatedRoot.Status, root.Status)
+	}
+	updatedChild, err := store.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedChild.Status != child.Status {
+		t.Fatalf("child status = %q, want %q", updatedChild.Status, child.Status)
+	}
+	updatedSource, err := store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != root.ID {
+		t.Fatalf("source workflow_id = %q, want %q", got, root.ID)
+	}
+}
+
 func TestDoSlingValidatesRequiredDeps(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 	opts := testOpts(a, "BL-42")
@@ -495,6 +604,835 @@ func TestSlingAttachFormula(t *testing.T) {
 	}
 	if result.FormulaName != "code-review" {
 		t.Errorf("FormulaName = %q, want code-review", result.FormulaName)
+	}
+}
+
+func TestSlingAttachGraphFormulaRejectsExistingLiveRoot(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err == nil {
+		t.Fatal("AttachFormula error = nil, want conflict")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("AttachFormula error = %v, want ConflictError", err)
+	}
+	if conflictErr.SourceBeadID != source.ID {
+		t.Fatalf("SourceBeadID = %q, want %q", conflictErr.SourceBeadID, source.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaRejectsExistingLiveRootAcrossStores(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherStore := beads.NewMemStore()
+	root, err := otherStore.Create(beads.Bead{
+		ID:     "wf-other",
+		Title:  "cross-store workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      source.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: deps.StoreRef,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps.SourceWorkflowStores = func() ([]SourceWorkflowStore, error) {
+		return []SourceWorkflowStore{
+			{Store: deps.Store, StoreRef: deps.StoreRef},
+			{Store: otherStore, StoreRef: "rig:alpha"},
+		}, nil
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err == nil {
+		t.Fatal("AttachFormula error = nil, want conflict")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("AttachFormula error = %v, want ConflictError", err)
+	}
+	if conflictErr.SourceBeadID != source.ID {
+		t.Fatalf("SourceBeadID = %q, want %q", conflictErr.SourceBeadID, source.ID)
+	}
+	if len(conflictErr.WorkflowIDs) != 1 || conflictErr.WorkflowIDs[0] != root.ID {
+		t.Fatalf("WorkflowIDs = %#v, want [%s]", conflictErr.WorkflowIDs, root.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaForceReplacesExistingLiveRootAcrossStores(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherStore := beads.NewMemStore()
+	root, err := otherStore.Create(beads.Bead{
+		ID:     "wf-other",
+		Title:  "cross-store workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      source.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: deps.StoreRef,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	deps.SourceWorkflowStores = func() ([]SourceWorkflowStore, error) {
+		return []SourceWorkflowStore{
+			{Store: deps.Store, StoreRef: deps.StoreRef},
+			{Store: otherStore, StoreRef: "rig:alpha"},
+		}, nil
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err != nil {
+		t.Fatalf("AttachFormula force: %v", err)
+	}
+	if result.WorkflowID == "" {
+		t.Fatal("WorkflowID = empty, want new workflow root")
+	}
+
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots(city): %v", err)
+	}
+	if len(roots) != 1 || roots[0].ID != result.WorkflowID {
+		t.Fatalf("live roots in city = %#v, want [%s]", roots, result.WorkflowID)
+	}
+
+	updatedOtherRoot, err := otherStore.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(other root): %v", err)
+	}
+	if updatedOtherRoot.Status != "closed" {
+		t.Fatalf("other root status = %q, want closed", updatedOtherRoot.Status)
+	}
+
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
+		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaForceRestoresCrossStoreRootWhenFinalizeFails(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherStore := beads.NewMemStore()
+	root, err := otherStore.Create(beads.Bead{
+		ID:     "wf-other",
+		Title:  "cross-store workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      source.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: deps.StoreRef,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	baseStore, ok := deps.Store.(*beads.MemStore)
+	if !ok {
+		t.Fatalf("deps.Store type = %T, want *beads.MemStore", deps.Store)
+	}
+	failStore := &closeAllFailMemStore{
+		MemStore:            baseStore,
+		failSetMetadataID:   source.ID,
+		failSetMetadataKey:  "workflow_id",
+		failSetMetadataCall: 1,
+	}
+	deps.Store = failStore
+	deps.SourceWorkflowStores = func() ([]SourceWorkflowStore, error) {
+		return []SourceWorkflowStore{
+			{Store: deps.Store, StoreRef: deps.StoreRef},
+			{Store: otherStore, StoreRef: "rig:alpha"},
+		}, nil
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err == nil {
+		t.Fatal("AttachFormula force error = nil, want finalize failure")
+	}
+	if !strings.Contains(err.Error(), "workflow_id") {
+		t.Fatalf("AttachFormula force error = %v, want workflow_id context", err)
+	}
+
+	updatedOtherRoot, err := otherStore.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(other root): %v", err)
+	}
+	if updatedOtherRoot.Status != root.Status {
+		t.Fatalf("other root status = %q, want restored %q", updatedOtherRoot.Status, root.Status)
+	}
+
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != root.ID {
+		t.Fatalf("source workflow_id = %q, want restored %q", got, root.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaForceAllowsExistingLiveRoot(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open", Assignee: "mayor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingRoot, err := deps.Store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", existingRoot.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err != nil {
+		t.Fatalf("AttachFormula force: %v", err)
+	}
+	if result.WorkflowID == "" {
+		t.Fatal("WorkflowID = empty, want new workflow root")
+	}
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("live roots = %d, want 1", len(roots))
+	}
+	if roots[0].ID != result.WorkflowID {
+		t.Fatalf("live root = %q, want %q", roots[0].ID, result.WorkflowID)
+	}
+	existing, err := deps.Store.Get(existingRoot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if existing.Status != "closed" {
+		t.Fatalf("existing root status = %q, want closed", existing.Status)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
+		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaForceRollsBackNewRootWhenSupersededCloseFails(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open", Assignee: "mayor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingRoot, err := deps.Store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", existingRoot.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	baseStore, ok := deps.Store.(*beads.MemStore)
+	if !ok {
+		t.Fatalf("deps.Store type = %T, want *beads.MemStore", deps.Store)
+	}
+	failStore := &closeAllFailMemStore{MemStore: baseStore}
+	deps.Store = failStore
+	rootsBefore, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots(before): %v", err)
+	}
+	if len(rootsBefore) != 1 || rootsBefore[0].ID != existingRoot.ID {
+		t.Fatalf("roots before force = %#v, want [%s]", rootsBefore, existingRoot.ID)
+	}
+	failStore.failCloseAllCalls = 1
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err == nil {
+		rootsAfter, listErr := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+		if listErr != nil {
+			t.Fatalf("AttachFormula force error = nil and ListLiveRoots(after) failed: %v", listErr)
+		}
+		t.Fatalf(
+			"AttachFormula force error = nil, want close failure (remaining failCalls=%d workflow=%s existing=%s roots_after=%#v)",
+			failStore.failCloseAllCalls,
+			result.WorkflowID,
+			existingRoot.ID,
+			rootsAfter,
+		)
+	}
+	if !strings.Contains(err.Error(), "close superseded workflow") {
+		t.Fatalf("AttachFormula force error = %v, want close superseded workflow", err)
+	}
+
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("live roots = %d, want 1", len(roots))
+	}
+	if roots[0].ID != existingRoot.ID {
+		t.Fatalf("live root = %q, want %q", roots[0].ID, existingRoot.ID)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != existingRoot.ID {
+		t.Fatalf("source workflow_id = %q, want restored %q", got, existingRoot.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaForceRestoresSupersededRootWhenFinalizeFails(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open", Assignee: "mayor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingRoot, err := deps.Store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", existingRoot.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	baseStore, ok := deps.Store.(*beads.MemStore)
+	if !ok {
+		t.Fatalf("deps.Store type = %T, want *beads.MemStore", deps.Store)
+	}
+	failStore := &closeAllFailMemStore{
+		MemStore:            baseStore,
+		failSetMetadataID:   source.ID,
+		failSetMetadataKey:  "workflow_id",
+		failSetMetadataCall: 1,
+	}
+	deps.Store = failStore
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err == nil {
+		t.Fatal("AttachFormula force error = nil, want finalize failure")
+	}
+	if !strings.Contains(err.Error(), "setting workflow_id") {
+		t.Fatalf("AttachFormula force error = %v, want setting workflow_id", err)
+	}
+
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("live roots = %d, want 1", len(roots))
+	}
+	if roots[0].ID != existingRoot.ID {
+		t.Fatalf("live root = %q, want %q", roots[0].ID, existingRoot.ID)
+	}
+	existing, err := deps.Store.Get(existingRoot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if existing.Status != existingRoot.Status {
+		t.Fatalf("existing root status = %q, want restored %q", existing.Status, existingRoot.Status)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != existingRoot.ID {
+		t.Fatalf("source workflow_id = %q, want restored %q", got, existingRoot.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaConcurrentLaunchCreatesSingleRoot(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	start := make(chan struct{})
+	type attempt struct {
+		result SlingResult
+		err    error
+	}
+	results := make(chan attempt, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			res, err := s.AttachFormula(context.Background(), "graph-work", source.ID, agent, FormulaOpts{})
+			results <- attempt{result: res, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	conflicts := 0
+	for attempt := range results {
+		if attempt.err == nil {
+			successes++
+			continue
+		}
+		var conflictErr *sourceworkflow.ConflictError
+		if errors.As(attempt.err, &conflictErr) {
+			conflicts++
+			continue
+		}
+		t.Fatalf("unexpected error: %v", attempt.err)
+	}
+	if successes == 0 {
+		t.Fatal("successes=0, want at least one successful launch")
+	}
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("successes=%d conflicts=%d live roots=%d, want singleton live root", successes, conflicts, len(roots))
+	}
+}
+
+func TestDoSlingBatchGraphFormulaForceAllowsAttachedWorkflow(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	store := deps.Store
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "work",
+		Type:     "task",
+		ParentID: convoy.ID,
+		Status:   "open",
+		Assignee: "mayor",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingRoot, err := store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": child.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(child.ID, "workflow_id", existingRoot.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	result, err := DoSlingBatch(SlingOpts{
+		Target:        config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		BeadOrFormula: convoy.ID,
+		OnFormula:     "graph-work",
+		Force:         true,
+	}, deps, store)
+	if err != nil {
+		t.Fatalf("DoSlingBatch force: %v", err)
+	}
+	if result.Routed != 1 {
+		t.Fatalf("Routed = %d, want 1", result.Routed)
+	}
+	if len(result.Children) != 1 {
+		t.Fatalf("Children = %d, want 1", len(result.Children))
+	}
+	if result.Children[0].WorkflowID == "" {
+		t.Fatal("child workflow id = empty, want replacement workflow")
+	}
+	updatedRoot, err := store.Get(existingRoot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedRoot.Status != "closed" {
+		t.Fatalf("existing root status = %q, want closed", updatedRoot.Status)
+	}
+	updatedChild, err := store.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedChild.Metadata["workflow_id"]; got != result.Children[0].WorkflowID {
+		t.Fatalf("child workflow_id = %q, want %q", got, result.Children[0].WorkflowID)
+	}
+}
+
+func TestSlingAttachNonGraphFormulaAllowsExistingLiveWorkflow(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{sharedTestFormulaDir},
+		},
+	}
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deps.Store.Create(beads.Bead{
+		Title:  "existing workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "code-review", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula non-graph: %v", err)
+	}
+	if result.WispRootID == "" {
+		t.Fatal("WispRootID = empty, want attached wisp")
+	}
+}
+
+func TestSourceWorkflowLockScopeUsesStorePath(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: "rigs/alpha"},
+		},
+	}
+	if got := sourceWorkflowLockScope(SlingDeps{
+		CityPath: "/city",
+		StoreRef: "city:test-city",
+		Cfg:      cfg,
+	}); got != filepath.Clean("/city") {
+		t.Fatalf("city scope = %q, want /city", got)
+	}
+	if got := sourceWorkflowLockScope(SlingDeps{
+		CityPath: "/city",
+		StoreRef: "rig:alpha",
+		Cfg:      cfg,
+	}); got != filepath.Join("/city", "rigs", "alpha") {
+		t.Fatalf("rig scope = %q, want %q", got, filepath.Join("/city", "rigs", "alpha"))
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -118,8 +118,10 @@ func testOpts(a config.Agent, beadOrFormula string) SlingOpts {
 	return SlingOpts{Target: a, BeadOrFormula: beadOrFormula}
 }
 
-var sharedTestFormulaDir string
-var sharedTestCityDir string
+var (
+	sharedTestFormulaDir string
+	sharedTestCityDir    string
+)
 
 func init() {
 	dir, err := os.MkdirTemp("", "gc-sling-test-formulas-*")
@@ -1372,6 +1374,319 @@ title = "Do work"
 	}
 	if got := updatedChild.Metadata["workflow_id"]; got != result.Children[0].WorkflowID {
 		t.Fatalf("child workflow_id = %q, want %q", got, result.Children[0].WorkflowID)
+	}
+}
+
+func TestDoSlingBatchPropagatesConflictErrorToCaller(t *testing.T) {
+	// Regression: DoSlingBatch captured per-child errors only as strings in
+	// SlingChildResult.FailReason and returned a generic "%d/%d children
+	// failed" at the end. That broke the top-level errors.As check in
+	// cmdSling, so batch users with live-workflow conflicts got exit 1
+	// instead of exit 3 and never saw the "gc workflow delete-source"
+	// cleanup hint — the whole user-facing point of the fix.
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	store := deps.Store
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "work",
+		Type:     "task",
+		ParentID: convoy.ID,
+		Status:   "open",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Orphan live root: exists with gc.source_bead_id=child.ID, but the
+	// child's workflow_id pointer was never set (or was cleared by a
+	// previous recovery). The pre-check via CollectAttachedBeads reads
+	// workflow_id/molecule_id on the child, so it passes; the inner
+	// attachBatchFormula then acquires the source-workflow launch lock
+	// and discovers the orphan via ListLiveRoots — that's where the
+	// typed ConflictError originates.
+	existingRoot, err := store.Create(beads.Bead{
+		Title:  "orphan live workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": child.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No --force: child hits the live-workflow singleton and attachBatchFormula
+	// returns *sourceworkflow.ConflictError. The batch wrapper must preserve
+	// the typed error so errors.As at the CLI boundary finds it.
+	_, err = DoSlingBatch(SlingOpts{
+		Target:        config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		BeadOrFormula: convoy.ID,
+		OnFormula:     "graph-work",
+	}, deps, store)
+	if err == nil {
+		t.Fatal("DoSlingBatch error = nil, want conflict from child")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("errors.As(ConflictError) = false; err = %v\n(regression: batch loses typed error → exit 1 instead of exit 3)", err)
+	}
+	if conflictErr.SourceBeadID != child.ID {
+		t.Fatalf("ConflictError.SourceBeadID = %q, want %q", conflictErr.SourceBeadID, child.ID)
+	}
+	if len(conflictErr.WorkflowIDs) != 1 || conflictErr.WorkflowIDs[0] != existingRoot.ID {
+		t.Fatalf("ConflictError.WorkflowIDs = %#v, want [%s]", conflictErr.WorkflowIDs, existingRoot.ID)
+	}
+}
+
+func TestDoSlingBatchPreflightEmitsConflictErrorForWorkflowAttachment(t *testing.T) {
+	// Regression: non-force batch with a graph formula whose child already
+	// has workflow_id pointing at a live workflow hit
+	// checkBatchNoMoleculeChildren, which returned a plain string error
+	// ("cannot use --on: beads already have attached molecules...") — so
+	// cmdSling's errors.As(&ConflictError) missed, returning exit 1 and
+	// dropping the `gc workflow delete-source` cleanup hint. Users saw
+	// a generic error and didn't know the recovery command existed. The
+	// pre-check now emits a typed ConflictError alongside the legacy
+	// summary so errors.As succeeds at the CLI boundary.
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	store := deps.Store
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "work",
+		Type:     "task",
+		ParentID: convoy.ID,
+		Status:   "open",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Live workflow attachment: child.workflow_id set, which is the
+	// regular "user already launched this" case the pre-check catches.
+	existingRoot, err := store.Create(beads.Bead{
+		Title:  "existing live workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": child.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(child.ID, "workflow_id", existingRoot.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+
+	// No --force: pre-check rejects via checkBatchNoMoleculeChildren.
+	// The returned error must expose *ConflictError via errors.As so
+	// cmdSling can return exit 3 and print the cleanup hint.
+	_, err = DoSlingBatch(SlingOpts{
+		Target:        config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		BeadOrFormula: convoy.ID,
+		OnFormula:     "graph-work",
+	}, deps, store)
+	if err == nil {
+		t.Fatal("DoSlingBatch error = nil, want pre-check rejection")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("errors.As(ConflictError) = false; err = %v\n(regression: batch preflight still returns plain string)", err)
+	}
+	if conflictErr.SourceBeadID != child.ID {
+		t.Fatalf("ConflictError.SourceBeadID = %q, want %q", conflictErr.SourceBeadID, child.ID)
+	}
+	if len(conflictErr.WorkflowIDs) != 1 || conflictErr.WorkflowIDs[0] != existingRoot.ID {
+		t.Fatalf("ConflictError.WorkflowIDs = %#v, want [%s]", conflictErr.WorkflowIDs, existingRoot.ID)
+	}
+}
+
+func TestDoSlingBatchPreflightEmitsPerChildConflictErrors(t *testing.T) {
+	// Regression: iter-3's batch preflight fix collapsed N conflicting
+	// children into a single ConflictError keyed to the first child,
+	// which misattributed every other child's blocking workflow IDs.
+	// The cleanup hint then only addressed the first child; users
+	// running it saw unrelated workflow IDs and failed to clean up the
+	// rest of the batch. The preflight now emits one ConflictError per
+	// conflicted child via errors.Join so each child's blocking IDs
+	// stay correctly attributed.
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formula.SetFormulaV2Enabled(true)
+	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	store := deps.Store
+
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two children, each with their own live workflow attachment.
+	child1, err := store.Create(beads.Bead{Title: "work-1", Type: "task", ParentID: convoy.ID, Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child2, err := store.Create(beads.Bead{Title: "work-2", Type: "task", ParentID: convoy.ID, Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root1, err := store.Create(beads.Bead{
+		Title:  "workflow-1",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": child1.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root2, err := store.Create(beads.Bead{
+		Title:  "workflow-2",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": child2.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(child1.ID, "workflow_id", root1.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(child2.ID, "workflow_id", root2.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = DoSlingBatch(SlingOpts{
+		Target:        config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		BeadOrFormula: convoy.ID,
+		OnFormula:     "graph-work",
+	}, deps, store)
+	if err == nil {
+		t.Fatal("DoSlingBatch error = nil, want preflight rejection")
+	}
+
+	// Walk the error tree and collect every typed ConflictError. Both
+	// children should appear with their own root IDs — the critical
+	// invariant is that root2.ID is NOT attributed to child1.ID.
+	var collected []*sourceworkflow.ConflictError
+	{
+		var walk func(error)
+		walk = func(e error) {
+			if e == nil {
+				return
+			}
+			// Test walker intentionally uses direct type assertion to
+			// collect every ConflictError in the tree (errors.As collapses
+			// to the first match). See collectConflictErrors in cmd/gc.
+			if c, ok := e.(*sourceworkflow.ConflictError); ok { //nolint:errorlint
+				collected = append(collected, c)
+			}
+			type mu interface{ Unwrap() []error }
+			if m, ok := e.(mu); ok { //nolint:errorlint
+				for _, child := range m.Unwrap() {
+					walk(child)
+				}
+				return
+			}
+			if inner := errors.Unwrap(e); inner != nil {
+				walk(inner)
+			}
+		}
+		walk(err)
+	}
+
+	if len(collected) != 2 {
+		t.Fatalf("ConflictError count = %d, want 2 (one per conflicted child)", len(collected))
+	}
+
+	byChild := map[string][]string{}
+	for _, c := range collected {
+		byChild[c.SourceBeadID] = c.WorkflowIDs
+	}
+	if got := byChild[child1.ID]; len(got) != 1 || got[0] != root1.ID {
+		t.Fatalf("child1 ConflictError.WorkflowIDs = %#v, want [%s]", got, root1.ID)
+	}
+	if got := byChild[child2.ID]; len(got) != 1 || got[0] != root2.ID {
+		t.Fatalf("child2 ConflictError.WorkflowIDs = %#v, want [%s]", got, root2.ID)
 	}
 }
 

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -1,0 +1,366 @@
+package sourceworkflow
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
+)
+
+type ConflictError struct {
+	SourceBeadID string
+	WorkflowIDs  []string
+}
+
+const SourceStoreRefMetadataKey = "gc.source_store_ref"
+
+func (e *ConflictError) Error() string {
+	if e == nil {
+		return "source workflow conflict"
+	}
+	if len(e.WorkflowIDs) == 0 {
+		return fmt.Sprintf("source bead %s already has a live workflow", e.SourceBeadID)
+	}
+	return fmt.Sprintf(
+		"source bead %s already has live workflow(s): %s",
+		e.SourceBeadID,
+		strings.Join(e.WorkflowIDs, ","),
+	)
+}
+
+func NormalizeSourceBeadID(sourceBeadID string) string {
+	return strings.TrimSpace(sourceBeadID)
+}
+
+func NormalizeSourceStoreRef(sourceStoreRef string) string {
+	return strings.TrimSpace(sourceStoreRef)
+}
+
+func WorkflowMatchesSource(root beads.Bead, sourceBeadID, sourceStoreRef, rootStoreRef string) bool {
+	sourceBeadID = NormalizeSourceBeadID(sourceBeadID)
+	if sourceBeadID == "" {
+		return false
+	}
+	if NormalizeSourceBeadID(root.Metadata["gc.source_bead_id"]) != sourceBeadID {
+		return false
+	}
+	sourceStoreRef = NormalizeSourceStoreRef(sourceStoreRef)
+	if sourceStoreRef == "" {
+		return true
+	}
+	rootSourceStoreRef := NormalizeSourceStoreRef(root.Metadata[SourceStoreRefMetadataKey])
+	if rootSourceStoreRef != "" {
+		return rootSourceStoreRef == sourceStoreRef
+	}
+	rootStoreRef = NormalizeSourceStoreRef(rootStoreRef)
+	if rootStoreRef == "" {
+		return false
+	}
+	return rootStoreRef == sourceStoreRef
+}
+
+func ListLiveRoots(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef string) ([]beads.Bead, error) {
+	sourceBeadID = NormalizeSourceBeadID(sourceBeadID)
+	if store == nil || sourceBeadID == "" {
+		return nil, nil
+	}
+	roots, err := store.List(beads.ListQuery{
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": sourceBeadID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	roots = slices.DeleteFunc(roots, func(root beads.Bead) bool {
+		return !WorkflowMatchesSource(root, sourceBeadID, sourceStoreRef, rootStoreRef)
+	})
+	slices.SortFunc(roots, func(a, b beads.Bead) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return roots, nil
+}
+
+func BlockingWorkflowIDs(roots []beads.Bead) []string {
+	ids := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root.ID == "" {
+			continue
+		}
+		ids = append(ids, root.ID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+var (
+	localLocksMu sync.Mutex
+	localLocks   = map[string]*localLock{}
+)
+
+const fileLockRetryInterval = 25 * time.Millisecond
+
+type localLock struct {
+	token chan struct{}
+	refs  int
+}
+
+func WithLock(ctx context.Context, cityPath, scopeRef, sourceBeadID string, fn func() error) error {
+	sourceBeadID = NormalizeSourceBeadID(sourceBeadID)
+	if sourceBeadID == "" {
+		return fn()
+	}
+	lockPath, key, err := lockIdentity(cityPath, scopeRef, sourceBeadID)
+	if err != nil {
+		return err
+	}
+	mu := inProcessMutex(key)
+	defer releaseInProcessMutex(key, mu)
+	if err := mu.Lock(ctx); err != nil {
+		return err
+	}
+	defer mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return fmt.Errorf("create source workflow lock dir: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open source workflow lock: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort cleanup
+	if err := lockFile(ctx, f, sourceBeadID); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck // best-effort unlock
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return fn()
+}
+
+func inProcessMutex(key string) *localLock {
+	localLocksMu.Lock()
+	defer localLocksMu.Unlock()
+	mu := localLocks[key]
+	if mu == nil {
+		mu = newLocalLock()
+		localLocks[key] = mu
+	}
+	mu.refs++
+	return mu
+}
+
+func releaseInProcessMutex(key string, mu *localLock) {
+	localLocksMu.Lock()
+	defer localLocksMu.Unlock()
+	current := localLocks[key]
+	if current == nil || current != mu {
+		return
+	}
+	if current.refs > 0 {
+		current.refs--
+	}
+	if current.refs == 0 {
+		delete(localLocks, key)
+	}
+}
+
+func newLocalLock() *localLock {
+	lock := &localLock{token: make(chan struct{}, 1)}
+	lock.token <- struct{}{}
+	return lock
+}
+
+func (l *localLock) Lock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-l.token:
+		return nil
+	}
+}
+
+func (l *localLock) Unlock() {
+	l.token <- struct{}{}
+}
+
+func lockFile(ctx context.Context, f *os.File, sourceBeadID string) error {
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return fmt.Errorf("lock source workflow %q: %w", sourceBeadID, err)
+		}
+		timer := time.NewTimer(fileLockRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func lockIdentity(cityPath, scopeRef, sourceBeadID string) (lockPath, key string, _ error) {
+	cityPath, err := canonicalCityPath(cityPath)
+	if err != nil {
+		return "", "", err
+	}
+	scopeRef = canonicalScopeRef(scopeRef)
+	if scopeRef == "" {
+		scopeRef = "city"
+	}
+	hash := sha256.Sum256([]byte(scopeRef + "\x00" + sourceBeadID))
+	key = cityPath + "\x00" + scopeRef + "\x00" + sourceBeadID
+	lockPath = filepath.Join(
+		citylayout.RuntimeDataDir(cityPath),
+		"sling-source-locks",
+		hex.EncodeToString(hash[:])+".lock",
+	)
+	return lockPath, key, nil
+}
+
+func canonicalScopeRef(scopeRef string) string {
+	scopeRef = strings.TrimSpace(scopeRef)
+	if scopeRef == "" {
+		return ""
+	}
+	scopeRef = filepath.Clean(scopeRef)
+	if resolved, err := filepath.EvalSymlinks(scopeRef); err == nil && strings.TrimSpace(resolved) != "" {
+		return resolved
+	}
+	return scopeRef
+}
+
+func ListWorkflowBeads(store beads.Store, rootID string) ([]beads.Bead, error) {
+	rootID = strings.TrimSpace(rootID)
+	if store == nil || rootID == "" {
+		return nil, nil
+	}
+	root, err := store.Get(rootID)
+	if err != nil {
+		return nil, err
+	}
+	descendants, err := store.List(beads.ListQuery{
+		IncludeClosed: true,
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	beadsByID := map[string]beads.Bead{
+		root.ID: root,
+	}
+	for _, bead := range descendants {
+		beadsByID[bead.ID] = bead
+	}
+	out := make([]beads.Bead, 0, len(beadsByID))
+	for _, bead := range beadsByID {
+		out = append(out, bead)
+	}
+	slices.SortFunc(out, func(a, b beads.Bead) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return out, nil
+}
+
+func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
+	matched, err := ListWorkflowBeads(store, rootID)
+	if err != nil {
+		return 0, err
+	}
+	ids := make([]string, 0, len(matched))
+	for _, bead := range matched {
+		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		ids = append(ids, bead.ID)
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	return store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
+}
+
+type WorkflowBeadSnapshot struct {
+	ID       string
+	Status   string
+	Assignee string
+	Outcome  string
+}
+
+func SnapshotOpenWorkflowBeads(store beads.Store, rootID string) ([]WorkflowBeadSnapshot, error) {
+	matched, err := ListWorkflowBeads(store, rootID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]WorkflowBeadSnapshot, 0, len(matched))
+	for _, bead := range matched {
+		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		out = append(out, WorkflowBeadSnapshot{
+			ID:       bead.ID,
+			Status:   bead.Status,
+			Assignee: bead.Assignee,
+			Outcome:  bead.Metadata["gc.outcome"],
+		})
+	}
+	return out, nil
+}
+
+func RestoreWorkflowBeads(store beads.Store, snapshots []WorkflowBeadSnapshot) error {
+	var restoreErr error
+	for _, snapshot := range snapshots {
+		if strings.TrimSpace(snapshot.ID) == "" {
+			continue
+		}
+		status := snapshot.Status
+		assignee := snapshot.Assignee
+		if err := store.Update(snapshot.ID, beads.UpdateOpts{
+			Status:   &status,
+			Assignee: &assignee,
+		}); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore bead %s: %w", snapshot.ID, err))
+			continue
+		}
+		if err := store.SetMetadata(snapshot.ID, "gc.outcome", snapshot.Outcome); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore bead %s outcome: %w", snapshot.ID, err))
+		}
+	}
+	return restoreErr
+}
+
+func canonicalCityPath(cityPath string) (string, error) {
+	cleaned := filepath.Clean(strings.TrimSpace(cityPath))
+	if cleaned == "" || cleaned == "." {
+		return "", fmt.Errorf("source workflow lock requires city path")
+	}
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize city path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil && strings.TrimSpace(resolved) != "" {
+		return resolved, nil
+	}
+	return abs, nil
+}

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -1,3 +1,11 @@
+// Package sourceworkflow provides primitives for enforcing the "one live
+// graph workflow per source bead" invariant. It owns the singleton scanner
+// (ListLiveRoots), the cross-process launch lock (WithLock), the conflict
+// error type (ConflictError), and helpers for snapshotting / closing /
+// restoring workflow subtrees during force-replacement flows. Callers in
+// internal/sling and cmd/gc use this package to gate graph launches and
+// to drive the `gc workflow delete-source` / `reopen-source` recovery
+// commands.
 package sourceworkflow
 
 import (
@@ -18,12 +26,29 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 )
 
+// ConflictError is returned when a graph workflow launch is blocked by one
+// or more already-live workflow roots for the same source bead. The CLI
+// maps this to exit code 3 and renders a `gc workflow delete-source`
+// cleanup hint; the API maps it to HTTP 409.
 type ConflictError struct {
 	SourceBeadID string
 	WorkflowIDs  []string
 }
 
+// SourceStoreRefMetadataKey is the bead metadata key recording which store
+// a workflow root's source bead lives in (e.g. "city:foo" or "rig:alpha").
+// Used by WorkflowMatchesSource to scope cross-store singleton checks.
 const SourceStoreRefMetadataKey = "gc.source_store_ref"
+
+// IsWorkflowRoot reports whether a bead is a source-workflow root. It must
+// stay in sync with sling.IsWorkflowAttachment: roots may be marked via the
+// legacy gc.kind=workflow label, via gc.formula_contract=graph.v2, or both.
+// Queries that only match one label miss graph.v2-only roots and allow
+// --force to spawn duplicates.
+func IsWorkflowRoot(b beads.Bead) bool {
+	return strings.EqualFold(strings.TrimSpace(b.Metadata["gc.kind"]), "workflow") ||
+		strings.EqualFold(strings.TrimSpace(b.Metadata["gc.formula_contract"]), "graph.v2")
+}
 
 func (e *ConflictError) Error() string {
 	if e == nil {
@@ -39,14 +64,21 @@ func (e *ConflictError) Error() string {
 	)
 }
 
+// NormalizeSourceBeadID trims whitespace from a source bead ID so equality
+// checks don't fail on stray spaces from user-entered labels.
 func NormalizeSourceBeadID(sourceBeadID string) string {
 	return strings.TrimSpace(sourceBeadID)
 }
 
+// NormalizeSourceStoreRef trims whitespace from a store ref for comparison.
 func NormalizeSourceStoreRef(sourceStoreRef string) string {
 	return strings.TrimSpace(sourceStoreRef)
 }
 
+// WorkflowMatchesSource reports whether a workflow root belongs to the
+// given source bead and (optionally) a specific source store ref. Legacy
+// roots without SourceStoreRefMetadataKey are treated as belonging to the
+// store they physically live in (rootStoreRef).
 func WorkflowMatchesSource(root beads.Bead, sourceBeadID, sourceStoreRef, rootStoreRef string) bool {
 	sourceBeadID = NormalizeSourceBeadID(sourceBeadID)
 	if sourceBeadID == "" {
@@ -70,6 +102,10 @@ func WorkflowMatchesSource(root beads.Bead, sourceBeadID, sourceStoreRef, rootSt
 	return rootStoreRef == sourceStoreRef
 }
 
+// ListLiveRoots returns the live (not-closed) workflow roots in store that
+// belong to sourceBeadID, scoped to sourceStoreRef when set. The query
+// indexes on gc.source_bead_id and filters via IsWorkflowRoot so both
+// legacy gc.kind=workflow roots and graph.v2-only roots are visible.
 func ListLiveRoots(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef string) ([]beads.Bead, error) {
 	sourceBeadID = NormalizeSourceBeadID(sourceBeadID)
 	if store == nil || sourceBeadID == "" {
@@ -77,7 +113,6 @@ func ListLiveRoots(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef
 	}
 	roots, err := store.List(beads.ListQuery{
 		Metadata: map[string]string{
-			"gc.kind":           "workflow",
 			"gc.source_bead_id": sourceBeadID,
 		},
 	})
@@ -85,6 +120,9 @@ func ListLiveRoots(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef
 		return nil, err
 	}
 	roots = slices.DeleteFunc(roots, func(root beads.Bead) bool {
+		if !IsWorkflowRoot(root) {
+			return true
+		}
 		return !WorkflowMatchesSource(root, sourceBeadID, sourceStoreRef, rootStoreRef)
 	})
 	slices.SortFunc(roots, func(a, b beads.Bead) int {
@@ -93,6 +131,8 @@ func ListLiveRoots(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef
 	return roots, nil
 }
 
+// BlockingWorkflowIDs extracts sorted root IDs from a list of blocking
+// workflows for rendering in ConflictError messages and cleanup hints.
 func BlockingWorkflowIDs(roots []beads.Bead) []string {
 	ids := make([]string, 0, len(roots))
 	for _, root := range roots {
@@ -117,6 +157,10 @@ type localLock struct {
 	refs  int
 }
 
+// WithLock acquires a per-source-bead lock (in-process mutex + on-disk
+// flock) rooted at cityPath before invoking fn. Guarantees at-most-one
+// concurrent graph-workflow launch or recovery per (scopeRef, sourceBeadID)
+// across processes. Honors ctx cancellation for both mutex and flock waits.
 func WithLock(ctx context.Context, cityPath, scopeRef, sourceBeadID string, fn func() error) error {
 	sourceBeadID = NormalizeSourceBeadID(sourceBeadID)
 	if sourceBeadID == "" {
@@ -249,6 +293,9 @@ func canonicalScopeRef(scopeRef string) string {
 	return scopeRef
 }
 
+// ListWorkflowBeads returns the root and all descendant beads tagged with
+// gc.root_bead_id=rootID (closed included). Used by CloseWorkflowSubtree
+// and force-replacement snapshot/restore.
 func ListWorkflowBeads(store beads.Store, rootID string) ([]beads.Bead, error) {
 	rootID = strings.TrimSpace(rootID)
 	if store == nil || rootID == "" {
@@ -283,6 +330,9 @@ func ListWorkflowBeads(store beads.Store, rootID string) ([]beads.Bead, error) {
 	return out, nil
 }
 
+// CloseWorkflowSubtree closes the root and every open descendant of a
+// workflow, marking each gc.outcome=skipped. Returns the count of newly
+// closed beads.
 func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 	matched, err := ListWorkflowBeads(store, rootID)
 	if err != nil {
@@ -301,6 +351,9 @@ func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 	return store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
 }
 
+// WorkflowBeadSnapshot captures the mutable fields of a workflow subtree
+// bead so force-replacement can restore them if the replacement's finalize
+// or post-finalize invariant check fails.
 type WorkflowBeadSnapshot struct {
 	ID       string
 	Status   string
@@ -308,6 +361,9 @@ type WorkflowBeadSnapshot struct {
 	Outcome  string
 }
 
+// SnapshotOpenWorkflowBeads records the status/assignee/outcome of every
+// open bead in a workflow subtree, used to roll back a force-replacement
+// on finalize failure.
 func SnapshotOpenWorkflowBeads(store beads.Store, rootID string) ([]WorkflowBeadSnapshot, error) {
 	matched, err := ListWorkflowBeads(store, rootID)
 	if err != nil {
@@ -328,6 +384,9 @@ func SnapshotOpenWorkflowBeads(store beads.Store, rootID string) ([]WorkflowBead
 	return out, nil
 }
 
+// RestoreWorkflowBeads re-applies a prior WorkflowBeadSnapshot set.
+// Continues past individual failures and joins them into one error so the
+// caller sees every restoration problem at once.
 func RestoreWorkflowBeads(store beads.Store, snapshots []WorkflowBeadSnapshot) error {
 	var restoreErr error
 	for _, snapshot := range snapshots {

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -1,0 +1,206 @@
+package sourceworkflow
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestWithLockHonorsContextWhileWaitingForLocalLock(t *testing.T) {
+	cityPath := t.TempDir()
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan error, 1)
+
+	go func() {
+		holderDone <- WithLock(context.Background(), cityPath, "city:test", "BL-42", func() error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+
+	<-locked
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := WithLock(ctx, cityPath, "city:test", "BL-42", func() error {
+		t.Fatal("WithLock ran callback while lock was already held")
+		return nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WithLock error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("WithLock waited %s after context deadline, want bounded wait", elapsed)
+	}
+
+	close(release)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("holder WithLock: %v", err)
+	}
+}
+
+func TestWithLockReleasesLocalLockEntryAfterUnlock(t *testing.T) {
+	cityPath := t.TempDir()
+	_, key, err := lockIdentity(cityPath, "city:test", "BL-42")
+	if err != nil {
+		t.Fatalf("lockIdentity: %v", err)
+	}
+
+	if err := WithLock(context.Background(), cityPath, "city:test", "BL-42", func() error {
+		localLocksMu.Lock()
+		_, ok := localLocks[key]
+		localLocksMu.Unlock()
+		if !ok {
+			t.Fatal("local lock entry missing while lock held")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WithLock: %v", err)
+	}
+
+	localLocksMu.Lock()
+	_, ok := localLocks[key]
+	localLocksMu.Unlock()
+	if ok {
+		t.Fatal("local lock entry still present after unlock")
+	}
+}
+
+func TestLockIdentityCanonicalizesScopeRefSymlinks(t *testing.T) {
+	cityPath := t.TempDir()
+	targetDir := filepath.Join(t.TempDir(), "rig")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(targetDir): %v", err)
+	}
+	linkDir := filepath.Join(t.TempDir(), "rig-link")
+	if err := os.Symlink(targetDir, linkDir); err != nil {
+		t.Fatalf("Symlink(linkDir): %v", err)
+	}
+
+	lockPathA, keyA, err := lockIdentity(cityPath, targetDir, "BL-42")
+	if err != nil {
+		t.Fatalf("lockIdentity(targetDir): %v", err)
+	}
+	lockPathB, keyB, err := lockIdentity(cityPath, linkDir, "BL-42")
+	if err != nil {
+		t.Fatalf("lockIdentity(linkDir): %v", err)
+	}
+	if lockPathA != lockPathB {
+		t.Fatalf("lockPath mismatch = %q vs %q", lockPathA, lockPathB)
+	}
+	if keyA != keyB {
+		t.Fatalf("key mismatch = %q vs %q", keyA, keyB)
+	}
+}
+
+func TestWorkflowMatchesSourceUsesSourceStoreRefWhenPresent(t *testing.T) {
+	root := beads.Bead{
+		ID: "wf-1",
+		Metadata: map[string]string{
+			"gc.source_bead_id":       "BL-42",
+			SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	}
+	if !WorkflowMatchesSource(root, "BL-42", "rig:alpha", "rig:beta") {
+		t.Fatal("WorkflowMatchesSource() = false, want true for matching store ref")
+	}
+	if WorkflowMatchesSource(root, "BL-42", "rig:beta", "rig:alpha") {
+		t.Fatal("WorkflowMatchesSource() = true, want false for mismatched store ref")
+	}
+}
+
+func TestWorkflowMatchesSourceTreatsMissingSourceStoreRefAsLegacyMatchInOwningStore(t *testing.T) {
+	root := beads.Bead{
+		ID: "wf-legacy",
+		Metadata: map[string]string{
+			"gc.source_bead_id": "BL-42",
+		},
+	}
+	if !WorkflowMatchesSource(root, "BL-42", "rig:alpha", "rig:alpha") {
+		t.Fatal("WorkflowMatchesSource() = false, want true for legacy root in owning store")
+	}
+	if WorkflowMatchesSource(root, "BL-42", "rig:alpha", "rig:beta") {
+		t.Fatal("WorkflowMatchesSource() = true, want false for legacy root in different store")
+	}
+}
+
+func TestListLiveRootsFiltersBySourceStoreRef(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		ID:     "wf-alpha",
+		Title:  "alpha workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                 "workflow",
+			"gc.source_bead_id":       "BL-42",
+			SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	}); err != nil {
+		t.Fatalf("Create(alpha): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		ID:     "wf-beta",
+		Title:  "beta workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                 "workflow",
+			"gc.source_bead_id":       "BL-42",
+			SourceStoreRefMetadataKey: "rig:beta",
+		},
+	}); err != nil {
+		t.Fatalf("Create(beta): %v", err)
+	}
+
+	roots, err := ListLiveRoots(store, "BL-42", "rig:alpha", "rig:alpha")
+	if err != nil {
+		t.Fatalf("ListLiveRoots: %v", err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("ListLiveRoots(...) = %#v, want 1 root", roots)
+	}
+	if got := roots[0].Metadata[SourceStoreRefMetadataKey]; got != "rig:alpha" {
+		t.Fatalf("root %s = %q, want rig:alpha", SourceStoreRefMetadataKey, got)
+	}
+}
+
+func TestListLiveRootsTreatsLegacyRootAsStoreScoped(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		ID:     "wf-legacy",
+		Title:  "legacy workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": "BL-42",
+		},
+	}); err != nil {
+		t.Fatalf("Create(legacy): %v", err)
+	}
+
+	alphaRoots, err := ListLiveRoots(store, "BL-42", "rig:alpha", "rig:alpha")
+	if err != nil {
+		t.Fatalf("ListLiveRoots(alpha): %v", err)
+	}
+	if len(alphaRoots) != 1 {
+		t.Fatalf("ListLiveRoots(alpha) = %#v, want 1 root", alphaRoots)
+	}
+
+	betaRoots, err := ListLiveRoots(store, "BL-42", "rig:alpha", "rig:beta")
+	if err != nil {
+		t.Fatalf("ListLiveRoots(beta): %v", err)
+	}
+	if len(betaRoots) != 0 {
+		t.Fatalf("ListLiveRoots(beta) = %#v, want 0 roots", betaRoots)
+	}
+}

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -173,6 +173,82 @@ func TestListLiveRootsFiltersBySourceStoreRef(t *testing.T) {
 	}
 }
 
+func TestListLiveRootsIncludesGraphV2OnlyRoots(t *testing.T) {
+	// Regression: sling.IsWorkflowAttachment treats a bead as a workflow
+	// root if it carries gc.formula_contract=graph.v2 even without
+	// gc.kind=workflow. If ListLiveRoots queries only on gc.kind=workflow,
+	// such roots are invisible to the singleton scanner and --force can
+	// launch a duplicate root alongside the live one.
+	store := beads.NewMemStore()
+	graphRoot, err := store.Create(beads.Bead{
+		Title:  "graph.v2 root without gc.kind",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.formula_contract":     "graph.v2",
+			"gc.source_bead_id":       "BL-42",
+			SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(graph-only): %v", err)
+	}
+
+	roots, err := ListLiveRoots(store, "BL-42", "rig:alpha", "rig:alpha")
+	if err != nil {
+		t.Fatalf("ListLiveRoots: %v", err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("ListLiveRoots(...) = %d roots, want 1 (graph.v2-only root must not be hidden)", len(roots))
+	}
+	if roots[0].ID != graphRoot.ID {
+		t.Fatalf("root ID = %q, want %q", roots[0].ID, graphRoot.ID)
+	}
+	if roots[0].Metadata["gc.formula_contract"] != "graph.v2" {
+		t.Fatalf("root gc.formula_contract = %q, want graph.v2", roots[0].Metadata["gc.formula_contract"])
+	}
+}
+
+func TestListLiveRootsExcludesNonWorkflowBeadsUnderSameSource(t *testing.T) {
+	// Beads tagged with gc.source_bead_id but not marked as workflow roots
+	// (neither gc.kind=workflow nor gc.formula_contract=graph.v2) must be
+	// filtered out — the source_bead_id label alone is not enough to promote
+	// a bead to a live root.
+	store := beads.NewMemStore()
+	realRoot, err := store.Create(beads.Bead{
+		Title:  "real workflow root",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                 "workflow",
+			"gc.source_bead_id":       "BL-42",
+			SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(real root): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "free-floating note about BL-42",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.source_bead_id":       "BL-42",
+			SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	}); err != nil {
+		t.Fatalf("Create(note): %v", err)
+	}
+
+	roots, err := ListLiveRoots(store, "BL-42", "rig:alpha", "rig:alpha")
+	if err != nil {
+		t.Fatalf("ListLiveRoots: %v", err)
+	}
+	if len(roots) != 1 || roots[0].ID != realRoot.ID {
+		t.Fatalf("ListLiveRoots(...) = %#v, want exactly the real root %q", roots, realRoot.ID)
+	}
+}
+
 func TestListLiveRootsTreatsLegacyRootAsStoreScoped(t *testing.T) {
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary
- add a source-workflow helper package and enforce live-workflow singleton checks across every candidate store
- make force replacement store-aware so snapshot, close, restore, and rollback all target the store that owns each workflow root
- tighten delete-source/reopen-source selection with store refs, explicit cleanup hints, and witness/patrol formula updates

## Testing
- go test ./internal/sourceworkflow ./internal/sling
- go test ./cmd/gc -run 'Test(CmdWorkflowDeleteSourceAllowsStoreSelectorForAmbiguousSourceIDs|CmdWorkflowDeleteSourceStoreSelectorIgnoresLegacyRootInDifferentStore|CmdWorkflowReopenSourceRejectsLiveRootInDifferentStore|DoSlingGraphWorkflowConflictReturnsExit3|InstantiateSlingFormulaGraphWorkflowPreservesRoutedTo|LoadCityConfigFSAppliesFeatureFlags|GraphWorkflowInMemoryCreateExecuteWaitFlow)'
- go test ./internal/api -run 'Test(NewSyncsFormulaV2FeatureFlags|Sling)'
- go test ./cmd/gc/dashboard -run 'Test(APIHandlerRunExecutes(SlingViaAPIWithForce|ListViaAPI|ShowViaAPI)|ParseCommandArgs)'
- go test ./internal/formula -run 'TestCompile(RalphMarksWorkflowRootAndBlocksOnTopLevelSteps|Version2UsesGraphWorkflowRootAndNoParentChild|ScopedWorkCarriesScopeAndCleanupMetadata|GraphWorkflowRejectsCycles)'
- go test ./internal/molecule -run 'TestCookEndToEnd(Ralph|ScopedWorkflowStampsRootAndScopeMetadata)'

Closes #720