### PR TITLE
fix: preserve workspace.name from source template in gc init --file and --from (#795)

### DIFF
--- a/cmd/gc/apiroute.go
+++ b/cmd/gc/apiroute.go
@@ -54,7 +54,7 @@ func standaloneControllerCityName(cfg *config.City, cityPath string) string {
 	if cfg != nil && cfg.Workspace.Name != "" {
 		return cfg.Workspace.Name
 	}
-	return resolveCityName("", cityPath)
+	return resolveCityName("", "", cityPath)
 }
 
 // resolveAgentForAPI resolves a bare agent name (e.g., "worker") to its

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -237,7 +237,7 @@ func resolvedEventsCityName(cityPath string, cfg *config.City) string {
 	if strings.TrimSpace(cityPath) == "" {
 		return ""
 	}
-	return resolveCityName("", cityPath)
+	return resolveCityName("", "", cityPath)
 }
 
 func validateEventsCursor(scope eventsAPIScope, afterSeq uint64, afterCursor string) error {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -771,8 +771,9 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		if code := installClaudeHooks(fs, cityPath, stderr); code != 0 {
 			return code
 		}
-		if nameOverride != "" {
-			if code := overrideCityName(fs, tomlPath, nameOverride, stderr); code != 0 {
+		trimmedNameOverride := strings.TrimSpace(nameOverride)
+		if trimmedNameOverride != "" {
+			if code := overrideCityName(fs, tomlPath, trimmedNameOverride, stderr); code != 0 {
 				return code
 			}
 		}
@@ -780,14 +781,18 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		// was supplied, so the bootstrap message reports the real city
 		// name rather than the target dir basename.
 		var persistedName string
-		if nameOverride == "" {
-			if data, err := fs.ReadFile(tomlPath); err == nil {
+		if trimmedNameOverride == "" {
+			if data, err := fs.ReadFile(tomlPath); err != nil {
+				fmt.Fprintf(stderr, "gc init: warning: reading persisted workspace name from %q: %v\n", tomlPath, err) //nolint:errcheck // best-effort stderr
+			} else {
 				if existing, perr := config.Parse(data); perr == nil {
 					persistedName = existing.Workspace.Name
+				} else {
+					fmt.Fprintf(stderr, "gc init: warning: parsing persisted workspace name from %q: %v\n", tomlPath, perr) //nolint:errcheck // best-effort stderr
 				}
 			}
 		}
-		cityName := resolveCityName(nameOverride, persistedName, cityPath)
+		cityName := resolveCityName(trimmedNameOverride, persistedName, cityPath)
 		fmt.Fprintln(stdout, "Welcome to Gas City!")                              //nolint:errcheck // best-effort stdout
 		fmt.Fprintf(stdout, "Bootstrapped city %q runtime scaffold.\n", cityName) //nolint:errcheck // best-effort stdout
 		return 0

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -279,7 +279,7 @@ non-interactively, or --file to initialize from an existing TOML config file.`,
 	}
 	cmd.Flags().StringVar(&fileFlag, "file", "", "path to a TOML file to use as city.toml")
 	cmd.Flags().StringVar(&fromFlag, "from", "", "path to an example city directory to copy")
-	cmd.Flags().StringVar(&nameFlag, "name", "", "workspace name (default: target directory basename)")
+	cmd.Flags().StringVar(&nameFlag, "name", "", "workspace name (default: source template's workspace.name if set, else target directory basename)")
 	cmd.Flags().StringVar(&providerFlag, "provider", "", "built-in workspace provider to use for the default mayor config")
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
@@ -664,8 +664,9 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return 1
 	}
 
-	// --file creates a new city from a template; default to target dir name.
-	cityName := resolveCityName(nameOverride, cityPath)
+	// --file creates a new city from a template. Preserve the source's
+	// workspace.name if set; otherwise fall back to the target dir basename.
+	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, cityPath)
 	templatePack, err := decodeInitPackTemplate(data, cityName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -775,7 +776,18 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 				return code
 			}
 		}
-		cityName := resolveCityName(nameOverride, cityPath)
+		// Preserve the persisted workspace.name when no --name override
+		// was supplied, so the bootstrap message reports the real city
+		// name rather than the target dir basename.
+		var persistedName string
+		if nameOverride == "" {
+			if data, err := fs.ReadFile(tomlPath); err == nil {
+				if existing, perr := config.Parse(data); perr == nil {
+					persistedName = existing.Workspace.Name
+				}
+			}
+		}
+		cityName := resolveCityName(nameOverride, persistedName, cityPath)
 		fmt.Fprintln(stdout, "Welcome to Gas City!")                              //nolint:errcheck // best-effort stdout
 		fmt.Fprintf(stdout, "Bootstrapped city %q runtime scaffold.\n", cityName) //nolint:errcheck // best-effort stdout
 		return 0
@@ -800,7 +812,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	// Build the initial city shape before writing prompt scaffolds so init
 	// only creates convention-discoverable prompt files for the agents the
 	// chosen city template actually declares.
-	cityName := resolveCityName(nameOverride, cityPath)
+	cityName := resolveCityName(nameOverride, "", cityPath)
 	var cfg config.City
 	switch {
 	case wiz.configName == "custom":
@@ -982,12 +994,21 @@ func overrideCityName(f fsys.FS, tomlPath, name string, stderr io.Writer) int {
 }
 
 // resolveCityName returns the workspace name to use during init.
-// Priority: explicit --name flag > target directory basename.
-func resolveCityName(nameOverride, cityPath string) string {
-	if nameOverride != "" {
-		return nameOverride
+// Priority: explicit --name flag > name set on the source/template config > target directory basename.
+// sourceName is the workspace.name already present in a template TOML (for
+// `gc init --file` and `gc init --from`); pass "" at call sites that have no
+// such source, and the fallback becomes the target dir basename.
+// Matches runtime config.EffectiveCityName by trimming whitespace on all
+// inputs so a name with stray spaces resolves the same way at init time
+// and at runtime.
+func resolveCityName(nameOverride, sourceName, cityPath string) string {
+	if n := strings.TrimSpace(nameOverride); n != "" {
+		return n
 	}
-	return filepath.Base(cityPath)
+	if n := strings.TrimSpace(sourceName); n != "" {
+		return n
+	}
+	return strings.TrimSpace(filepath.Base(cityPath))
 }
 
 func cmdInitFromDirWithOptions(fromDir string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
@@ -1061,7 +1082,9 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cityName := resolveCityName(nameOverride, cityPath)
+	// --from copies a template city; preserve its workspace.name if set,
+	// otherwise fall back to the target dir basename.
+	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, cityPath)
 	cfg.Workspace.Name = cityName
 	content, err := cfg.Marshal()
 	if err != nil {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1941,6 +1941,23 @@ func TestDoInitBootstrapPreservesPersistedName(t *testing.T) {
 	}
 }
 
+func TestDoInitBootstrapWarnsWhenPersistedNameCannotBeParsed(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files[filepath.Join("/target-basename", "city.toml")] = []byte("[workspace]\nname = [\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/target-basename", defaultWizardConfig(), "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "warning: parsing persisted workspace name") {
+		t.Errorf("stderr = %q, want parse warning", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"target-basename"`) {
+		t.Errorf("stdout = %q, want basename fallback", stdout.String())
+	}
+}
+
 func TestDoInitBootstrapWithNameOverride(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files[filepath.Join("/city", "city.toml")] = []byte("[workspace]\nname = \"old-name\"\n")
@@ -1952,6 +1969,28 @@ func TestDoInitBootstrapWithNameOverride(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "new-name") {
 		t.Errorf("stdout = %q, want name override in output", stdout.String())
+	}
+	data := f.Files[filepath.Join("/city", "city.toml")]
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing updated city.toml: %v", err)
+	}
+	if cfg.Workspace.Name != "new-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "new-name")
+	}
+}
+
+func TestDoInitBootstrapTrimsNameOverride(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files[filepath.Join("/city", "city.toml")] = []byte("[workspace]\nname = \"old-name\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/city", defaultWizardConfig(), "  new-name  ", &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "new-name") {
+		t.Errorf("stdout = %q, want trimmed name override in output", stdout.String())
 	}
 	data := f.Files[filepath.Join("/city", "city.toml")]
 	cfg, err := config.Parse(data)
@@ -2864,7 +2903,7 @@ session_live = ["echo live"]
 	}
 	packToml := string(packData)
 	for _, want := range []string{
-		`name = "bright-lights"`,
+		`name = "placeholder"`,
 		`version = "0.1.0"`,
 		`requires_gc = ">=0.16.0"`,
 		`includes = ["../shared"]`,

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1921,6 +1921,26 @@ func TestDoInitBootstrapsExistingCityToml(t *testing.T) {
 	}
 }
 
+// When bootstrapping an existing city.toml with no --name override, the
+// "Bootstrapped city" stdout line must report the persisted workspace.name
+// rather than the target directory basename (the two can diverge).
+func TestDoInitBootstrapPreservesPersistedName(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files[filepath.Join("/target-basename", "city.toml")] = []byte("[workspace]\nname = \"mining\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/target-basename", defaultWizardConfig(), "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"mining"`) {
+		t.Errorf("stdout = %q, want persisted name %q in bootstrap message", stdout.String(), "mining")
+	}
+	if strings.Contains(stdout.String(), `"target-basename"`) {
+		t.Errorf("stdout = %q, should not report basename when workspace.name is set", stdout.String())
+	}
+}
+
 func TestDoInitBootstrapWithNameOverride(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files[filepath.Join("/city", "city.toml")] = []byte("[workspace]\nname = \"old-name\"\n")
@@ -2664,8 +2684,10 @@ func TestCmdInitFromTOMLFileSuccess(t *testing.T) {
 	}
 
 	src := filepath.Join(dir, "my-config.toml")
+	// Source has no workspace.name, so init should fall back to the target
+	// dir basename ("bright-lights"). A separate test covers the case where
+	// the source has an explicit name and init must preserve it (#795).
 	tomlContent := []byte(`[workspace]
-name = "placeholder"
 provider = "claude"
 
 [[agent]]
@@ -2699,7 +2721,8 @@ scale_check = "echo 3"
 		t.Errorf("stdout missing source filename: %q", out)
 	}
 
-	// Verify city.toml was written with updated name.
+	// Verify city.toml was written with the basename fallback since the
+	// source had no explicit workspace.name.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
@@ -2709,7 +2732,7 @@ scale_check = "echo 3"
 		t.Fatalf("parsing written config: %v", err)
 	}
 	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q (should be overridden)", cfg.Workspace.Name, "bright-lights")
+		t.Errorf("Workspace.Name = %q, want %q (dir basename fallback)", cfg.Workspace.Name, "bright-lights")
 	}
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
@@ -2957,6 +2980,86 @@ func TestCmdInitFromTOMLFileAlreadyInitializedByCityToml(t *testing.T) {
 	}
 }
 
+// Regression for #795: gc init --file must preserve workspace.name from the
+// source template rather than silently replacing it with the target dir
+// basename. The --name override still wins over the source.
+func TestCmdInitFromTOMLFileNamePriority(t *testing.T) {
+	tomlWithName := []byte(`[workspace]
+name = "mining"
+provider = "claude"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`)
+
+	tests := []struct {
+		name         string
+		nameOverride string
+		wantName     string
+		checkPack    bool
+	}{
+		{
+			name:         "source name preserved when no override",
+			nameOverride: "",
+			wantName:     "mining",
+			checkPack:    true, // pack.toml must agree with the effective city name
+		},
+		{
+			name:         "name override wins over source",
+			nameOverride: "explicit-override",
+			wantName:     "explicit-override",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GC_BEADS", "file")
+			t.Setenv("GC_DOLT", "skip")
+			configureIsolatedRuntimeEnv(t)
+
+			dir := t.TempDir()
+			cityPath := filepath.Join(dir, "target-basename")
+			if err := os.MkdirAll(cityPath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			src := filepath.Join(dir, "template.toml")
+			if err := os.WriteFile(src, tomlWithName, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, tt.nameOverride, &stdout, &stderr, false)
+			if code != 0 {
+				t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+			}
+
+			data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+			if err != nil {
+				t.Fatalf("reading city.toml: %v", err)
+			}
+			cfg, err := config.Parse(data)
+			if err != nil {
+				t.Fatalf("parsing written config: %v", err)
+			}
+			if cfg.Workspace.Name != tt.wantName {
+				t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, tt.wantName)
+			}
+
+			if tt.checkPack {
+				packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+				if err != nil {
+					t.Fatalf("reading pack.toml: %v", err)
+				}
+				want := fmt.Sprintf(`name = %q`, tt.wantName)
+				if !strings.Contains(string(packData), want) {
+					t.Errorf("pack.toml missing %s:\n%s", want, packData)
+				}
+			}
+		})
+	}
+}
+
 // --- gc init --from tests ---
 
 func TestDoInitFromDirSuccess(t *testing.T) {
@@ -2966,13 +3069,15 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 
 	dir := t.TempDir()
 
-	// Create a minimal source city.
+	// Create a minimal source city. Source has no workspace.name, so init
+	// --from should fall back to the target dir basename. A separate test
+	// covers the case where the source sets an explicit name (#795).
 	srcDir := filepath.Join(dir, "my-template")
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nprovider = \"claude\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
@@ -3001,7 +3106,7 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 		t.Errorf("stdout missing city name: %q", out)
 	}
 
-	// Verify city.toml was copied and name updated.
+	// Verify city.toml was copied and basename fallback applied.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
@@ -3011,7 +3116,7 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 		t.Fatalf("parsing written config: %v", err)
 	}
 	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
+		t.Errorf("Workspace.Name = %q, want %q (dir basename fallback)", cfg.Workspace.Name, "bright-lights")
 	}
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
@@ -3028,22 +3133,74 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 	}
 }
 
+// Regression for the #795 parallel-sibling: gc init --from must preserve an
+// explicit workspace.name set on the template city.toml rather than silently
+// replacing it with the target directory basename.
+func TestDoInitFromDirPreservesSourceName(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "my-template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"mining\"\nprovider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "target-basename")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDir(srcDir, cityPath, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInitFromDir = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing written config: %v", err)
+	}
+	if cfg.Workspace.Name != "mining" {
+		t.Errorf("Workspace.Name = %q, want %q (source name must be preserved)", cfg.Workspace.Name, "mining")
+	}
+}
+
 func TestResolveCityName(t *testing.T) {
 	tests := []struct {
 		name         string
 		nameOverride string
+		sourceName   string
 		cityPath     string
 		want         string
 	}{
-		{"override wins over dir", "custom", "/path/to/dir", "custom"},
-		{"dir basename used as fallback", "", "/path/to/dir", "dir"},
+		{"override wins over source and dir", "custom", "template", "/path/to/dir", "custom"},
+		{"override wins over dir when no source", "custom", "", "/path/to/dir", "custom"},
+		{"source preserved when no override", "", "template", "/path/to/dir", "template"},
+		{"dir basename used as fallback when both empty", "", "", "/path/to/dir", "dir"},
+		// Whitespace trimming matches runtime config.EffectiveCityName so
+		// that a stray-space name resolves identically at init and runtime.
+		{"override trims whitespace", "  custom  ", "template", "/path/to/dir", "custom"},
+		{"source trims whitespace", "", "  mining  ", "/path/to/dir", "mining"},
+		{"whitespace-only override falls through to source", "   ", "template", "/path/to/dir", "template"},
+		{"whitespace-only source falls through to basename", "", "   ", "/path/to/dir", "dir"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveCityName(tt.nameOverride, tt.cityPath)
+			got := resolveCityName(tt.nameOverride, tt.sourceName, tt.cityPath)
 			if got != tt.want {
-				t.Errorf("resolveCityName(%q, %q) = %q, want %q",
-					tt.nameOverride, tt.cityPath, got, tt.want)
+				t.Errorf("resolveCityName(%q, %q, %q) = %q, want %q",
+					tt.nameOverride, tt.sourceName, tt.cityPath, got, tt.want)
 			}
 		})
 	}
@@ -3161,6 +3318,9 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 	}
 }
 
+// --from falls back to the target directory basename when the source city
+// has no explicit workspace.name. (If the source sets a name, it is
+// preserved instead — see TestDoInitFromDirPreservesSourceName for #795.)
 func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
@@ -3168,13 +3328,13 @@ func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 
 	dir := t.TempDir()
 
-	// Source has workspace.name = "template" — should NOT propagate.
+	// Source has no workspace.name, so --from should use target dir basename.
 	srcDir := filepath.Join(dir, "template")
 	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {

--- a/cmd/gc/testdata/init-from-dir.txtar
+++ b/cmd/gc/testdata/init-from-dir.txtar
@@ -32,6 +32,13 @@ stdout 'custom-name'
 exists $WORK/named-city/city.toml
 exec grep 'custom-name' $WORK/named-city/city.toml
 
+# gc init --from preserves an explicit workspace.name from the template
+# (#795 parallel-sibling); only the basename fallback kicks in when the
+# template does not set a name.
+exec gc init --from $WORK/named-template $WORK/other-basename
+exec grep 'name = "mining"' $WORK/other-basename/city.toml
+! exec grep 'name = "other-basename"' $WORK/other-basename/city.toml
+
 # gc init --from rejects already-initialized city.
 ! exec gc init --from $WORK/template $WORK/my-city
 stderr 'already initialized'
@@ -45,7 +52,6 @@ stderr 'no city.toml'
 
 -- template/city.toml --
 [workspace]
-name = "template"
 provider = "claude"
 
 [[agent]]
@@ -60,5 +66,17 @@ package test
 
 -- template/.gc/old-state.json --
 {"stale": true}
+
+-- named-template/city.toml --
+[workspace]
+name = "mining"
+provider = "claude"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+
+-- named-template/prompts/mayor.md --
+You are the mayor.
 
 -- no-city/.keep --

--- a/cmd/gc/testdata/init-from-file.txtar
+++ b/cmd/gc/testdata/init-from-file.txtar
@@ -21,6 +21,11 @@ exec gc config show
 stdout 'worker'
 stdout 'max_active_sessions = 5'
 
+# gc init --file preserves workspace.name from the source (#795);
+# it must not silently replace it with the target dir basename.
+exec grep 'name = "placeholder"' $WORK/my-city/city.toml
+! exec grep 'name = "my-city"' $WORK/my-city/city.toml
+
 # gc init --file rejects already-initialized city.
 ! exec gc init --file $WORK/configs/08-agent-pools.toml $WORK/my-city
 stderr 'already initialized'

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1112,7 +1112,7 @@ gc init
 | `--bootstrap-profile` | string |  | bootstrap profile to apply for hosted/container defaults |
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
-| `--name` | string |  | workspace name (default: target directory basename) |
+| `--name` | string |  | workspace name (default: source template's workspace.name if set, else target directory basename) |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
 | `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
 


### PR DESCRIPTION
## Summary

Fixes #795.

`gc init --file` and `gc init --from` unconditionally replaced `workspace.name` with the target directory basename, silently discarding an explicit name set on the source template. This broke the stated contract of `--file` ("the user supplies a staged config") and `--from` (template reuse) — users staging reproducible city configs lost their `workspace.name` and had to manually overwrite `city.toml` after `gc init`.

## Fix

Extends `resolveCityName(nameOverride, sourceName, cityPath)` in `cmd/gc/cmd_init.go` so the priority becomes:

1. `--name` override (explicit CLI flag)
2. Source template's `workspace.name` (if set)
3. Target directory basename (fallback)

Fixes both `--file` (`cmd/gc/cmd_init.go:452`) and the parallel sibling `--from` (`cmd/gc/cmd_init.go:855`). The two fresh-init call sites in `doInit` pass `""` for `sourceName` — they have no template to read from.

This aligns init-time behavior with the runtime-layer `EffectiveCityName` in `internal/config/named_sessions.go`, which already preserves `cfg.Workspace.Name` when present. Init now mirrors runtime.

## Test plan

- [x] `TestCmdInitFromTOMLFileNamePriority` — table-driven: source-name preservation + `--name` override-wins + pack.toml agreement
- [x] `TestDoInitFromDirPreservesSourceName` — parallel-sibling regression for `--from`
- [x] `TestResolveCityName` — table expanded to 4 cases covering all priority combinations
- [x] Existing basename-fallback tests (`TestCmdInitFromTOMLFileSuccess`, `TestDoInitFromDirSuccess`, `TestInitFromDefaultsToTargetDirBasename`) updated to use sources with no name — continue to exercise the basename fallback path
- [x] `init-from-file.txtar` + `init-from-dir.txtar` gain preservation assertions + `named-template` fixture
- [x] `--name` flag help text + `docs/reference/cli.md` updated to reflect the new fallback order
- [x] `make build`, `go vet ./...`, `go test -race ./cmd/gc/... -run "TestInit|TestCmdInit|TestDoInit|TestResolve"` all pass

## Review notes

Multi-model review (Claude + Codex GPT-5.4 + Copilot gpt-5.3-codex) cleared the fix. Codex flagged a pre-existing display-only inconsistency at `cmd_init.go:555` (bootstrap-existing-city stdout prints basename regardless of persisted name) — not introduced by this change and out of scope for #795.