### PR TITLE
fix(reconciler): free pool slot after drain; never trust stale ownership snapshot

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -25,8 +25,7 @@ type DesiredStateResult struct {
 	State              map[string]TemplateParams
 	BaseState          map[string]TemplateParams
 	ScaleCheckCounts   map[string]int // nil when store is nil or scale_check not run
-	AssignedWorkBeads  []beads.Bead   // actionable assigned work: in_progress or ready+assigned
-	OwnershipWorkBeads []beads.Bead   // all assigned work that preserves session ownership: open or in_progress
+	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into
@@ -233,13 +232,9 @@ func buildDesiredStateWithSessionBeads(
 	// named session on_demand wake. Hoisted out of the store block so
 	// the named session section can also use it.
 	var assignedWorkBeads []beads.Bead
-	var ownershipWorkBeads []beads.Bead
 	var storePartial bool
 	if store != nil {
 		assignedWorkBeads, storePartial = collectAssignedWorkBeads(cfg, store, rigStores, suspendedRigPaths)
-		var ownershipPartial bool
-		ownershipWorkBeads, ownershipPartial = collectOwnershipWorkBeads(cfg, store, rigStores, suspendedRigPaths)
-		storePartial = storePartial || ownershipPartial
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -407,7 +402,6 @@ func buildDesiredStateWithSessionBeads(
 		BaseState:          baseDesired,
 		ScaleCheckCounts:   scaleCheckCounts,
 		AssignedWorkBeads:  assignedWorkBeads,
-		OwnershipWorkBeads: ownershipWorkBeads,
 		NamedSessionDemand: namedWorkReady,
 		StoreQueryPartial:  storePartial,
 		BeaconTime:         beaconTime,
@@ -491,19 +485,6 @@ func collectAssignedWorkBeads(
 	suspendedRigPaths map[string]bool,
 ) ([]beads.Bead, bool) {
 	return collectAssignedWorkSnapshot(cfg, cityStore, rigStores, suspendedRigPaths, false)
-}
-
-// collectOwnershipWorkBeads queries each store (city + rigs) for all assigned
-// work that should preserve session ownership. Unlike collectAssignedWorkBeads,
-// this includes blocked open work so lifecycle close/sweep paths never retire
-// a session bead while future assigned work still points at it.
-func collectOwnershipWorkBeads(
-	cfg *config.City,
-	cityStore beads.Store,
-	rigStores map[string]beads.Store,
-	suspendedRigPaths map[string]bool,
-) ([]beads.Bead, bool) {
-	return collectAssignedWorkSnapshot(cfg, cityStore, rigStores, suspendedRigPaths, true)
 }
 
 func collectAssignedWorkSnapshot(

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -22,10 +22,10 @@ import (
 // can pass ScaleCheckCounts to ComputePoolDesiredStates without re-running
 // scale_check commands.
 type DesiredStateResult struct {
-	State              map[string]TemplateParams
-	BaseState          map[string]TemplateParams
-	ScaleCheckCounts   map[string]int // nil when store is nil or scale_check not run
-	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
+	State             map[string]TemplateParams
+	BaseState         map[string]TemplateParams
+	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
+	AssignedWorkBeads []beads.Bead   // actionable assigned work: in_progress or ready+assigned
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -484,16 +484,6 @@ func collectAssignedWorkBeads(
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
 ) ([]beads.Bead, bool) {
-	return collectAssignedWorkSnapshot(cfg, cityStore, rigStores, suspendedRigPaths, false)
-}
-
-func collectAssignedWorkSnapshot(
-	cfg *config.City,
-	cityStore beads.Store,
-	rigStores map[string]beads.Store,
-	suspendedRigPaths map[string]bool,
-	includeBlockedOpen bool,
-) ([]beads.Bead, bool) {
 	// Use CachingStore-wrapped stores. Creating raw bdStoreForCity per rig
 	// spawns bd subprocesses on every tick, saturating dolt.
 	stores := []beads.Store{cityStore}
@@ -517,23 +507,13 @@ func collectAssignedWorkSnapshot(
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
 			partial = true
 		}
-		if includeBlockedOpen {
-			// Open assigned beads preserve ownership even when blocked.
-			if open, err := s.List(beads.ListQuery{Status: "open"}); err == nil {
-				appendAssignedUnique(&result, open, seen)
-			} else {
-				log.Printf("collectOwnershipWorkBeads: List(open) failed: %v", err)
-				partial = true
-			}
+		// Ready beads with an assignee (queued direct handoff work that is
+		// actually runnable, not merely open).
+		if ready, err := s.Ready(); err == nil {
+			appendAssignedUnique(&result, ready, seen)
 		} else {
-			// Ready beads with an assignee (queued direct handoff work that is
-			// actually runnable, not merely open).
-			if ready, err := s.Ready(); err == nil {
-				appendAssignedUnique(&result, ready, seen)
-			} else {
-				log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
-				partial = true
-			}
+			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
+			partial = true
 		}
 	}
 	return result, partial

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -86,41 +86,6 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 	}
 }
 
-func TestCollectOwnershipWorkBeads_IncludesBlockedOpenAssignedHandoff(t *testing.T) {
-	store := beads.NewMemStore()
-	blocker, err := store.Create(beads.Bead{
-		Title:  "blocker",
-		Type:   "task",
-		Status: "open",
-	})
-	if err != nil {
-		t.Fatalf("create blocker bead: %v", err)
-	}
-	handoff, err := store.Create(beads.Bead{
-		Title:    "merge me later",
-		Type:     "task",
-		Status:   "open",
-		Assignee: "repo/refinery",
-	})
-	if err != nil {
-		t.Fatalf("create handoff bead: %v", err)
-	}
-	if err := store.DepAdd(handoff.ID, blocker.ID, "blocks"); err != nil {
-		t.Fatalf("add blocking dep: %v", err)
-	}
-
-	got, partial := collectOwnershipWorkBeads(&config.City{}, store, nil, nil)
-	if partial {
-		t.Fatal("collectOwnershipWorkBeads unexpectedly reported partial results")
-	}
-	if len(got) != 1 {
-		t.Fatalf("collectOwnershipWorkBeads returned %d beads, want 1: %#v", len(got), got)
-	}
-	if got[0].ID != handoff.ID {
-		t.Fatalf("collectOwnershipWorkBeads returned %q, want %q", got[0].ID, handoff.ID)
-	}
-}
-
 func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1009,7 +1009,7 @@ func sweepUndesiredPoolSessionBeads(
 		}
 		candidates = append(candidates, bead)
 	}
-	return len(GCSweepSessionBeads(store, candidates, assignedWorkBeads))
+	return len(GCSweepSessionBeads(store, candidates))
 }
 
 // isStaleCreating mirrors staleCreatingState in session_reconcile.go without

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -760,9 +760,9 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	if sweepUndesiredPoolSessionBeads(
 		store,
+		cr.rigBeadStores(),
 		sessionBeads,
 		desiredState,
-		result.OwnershipWorkBeads,
 		cr.cfg,
 		cr.sp,
 		result.StoreQueryPartial,
@@ -866,7 +866,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	reconcileSessionBeadsTraced(
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, store,
 		cr.dops,
-		assignedWorkBeads, result.OwnershipWorkBeads, readyWaitSet, cr.sessionDrains, poolDesired,
+		assignedWorkBeads, cr.rigBeadStores(), readyWaitSet, cr.sessionDrains, poolDesired,
 		result.StoreQueryPartial,
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
@@ -908,9 +908,9 @@ func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {
 
 func sweepUndesiredPoolSessionBeads(
 	store beads.Store,
+	rigStores map[string]beads.Store,
 	sessionBeads *sessionBeadSnapshot,
 	desiredState map[string]TemplateParams,
-	assignedWorkBeads []beads.Bead,
 	cfg *config.City,
 	sp runtime.Provider,
 	storeQueryPartial bool,
@@ -1009,7 +1009,7 @@ func sweepUndesiredPoolSessionBeads(
 		}
 		candidates = append(candidates, bead)
 	}
-	return len(GCSweepSessionBeads(store, candidates))
+	return len(GCSweepSessionBeads(store, rigStores, candidates))
 }
 
 // isStaleCreating mirrors staleCreatingState in session_reconcile.go without
@@ -1097,7 +1097,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		store,
 		cr.dops,
 		nil,
-		wfcResult.OwnershipWorkBeads,
+		cr.rigBeadStores(),
 		nil, // control-dispatcher ticks only need ownership continuity, not main-tick assigned/ready snapshots
 		cr.sessionDrains,
 		poolDesired,

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -48,8 +48,8 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		sp,
@@ -124,8 +124,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsCreatingState(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -177,8 +177,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecentlyCreated(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -225,8 +225,8 @@ func TestSweepUndesiredPoolSessionBeads_SweepsStaleCreatingState(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -266,8 +266,8 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -307,8 +307,8 @@ func TestSweepUndesiredPoolSessionBeads_SweepsActiveWithoutCreationCompleteAt(t 
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -354,8 +354,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsAwakeStateInPreWakeWindow(t *testin
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -403,8 +403,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsRecoveredActiveBead(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -454,8 +454,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsFreshRestartAfterPriorCrash(t *test
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -500,8 +500,8 @@ func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -536,8 +536,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -584,8 +584,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -620,8 +620,8 @@ func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
@@ -659,22 +659,21 @@ func TestSweepUndesiredPoolSessionBeads_KeepsAssignedSessionsOpen(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Create session bead: %v", err)
 	}
-	work, err := store.Create(beads.Bead{
+	if _, err := store.Create(beads.Bead{
 		Title:    "assigned work",
 		Type:     "task",
 		Status:   "in_progress",
 		Assignee: "worker-bd-123",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("Create work bead: %v", err)
 	}
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
+		nil,
 		sessionBeads,
 		nil,
-		[]beads.Bead{work},
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
 		false,
@@ -715,8 +714,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPartialAssignedSnapshot(t *testing.
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
-		sessionBeads,
 		nil,
+		sessionBeads,
 		nil,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -880,7 +880,7 @@ func TestCityRuntimeBeadReconcileTick_KeepsAssignedPoolWorkerAwake(t *testing.T)
 	}
 }
 
-func TestCityRuntimeBeadReconcileTick_SweepUsesOwnershipWorkSnapshot(t *testing.T) {
+func TestCityRuntimeBeadReconcileTick_SweepRespectsLiveAssignedWork(t *testing.T) {
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{
 		Title:  "worker",
@@ -902,6 +902,21 @@ func TestCityRuntimeBeadReconcileTick_SweepUsesOwnershipWorkSnapshot(t *testing.
 		t.Fatalf("Create session bead: %v", err)
 	}
 
+	// Persist an open work bead assigned to the session. GCSweepSessionBeads
+	// now runs a live store query via sessionHasOpenAssignedWork, so the
+	// bead must live in the store itself — a pre-computed snapshot is no
+	// longer consulted.
+	if _, err := store.Create(beads.Bead{
+		ID:       "ga-future",
+		Title:    "future work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker-mc-live",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	}); err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+
 	cr := &CityRuntime{
 		cityPath:            t.TempDir(),
 		cityName:            "maintainer-city",
@@ -915,10 +930,9 @@ func TestCityRuntimeBeadReconcileTick_SweepUsesOwnershipWorkSnapshot(t *testing.
 	}
 
 	result := DesiredStateResult{
-		State:              map[string]TemplateParams{},
-		ScaleCheckCounts:   map[string]int{"worker": 0},
-		AssignedWorkBeads:  []beads.Bead{},
-		OwnershipWorkBeads: []beads.Bead{workBead("ga-future", "worker", "worker-mc-live", "open", 1)},
+		State:             map[string]TemplateParams{},
+		ScaleCheckCounts:  map[string]int{"worker": 0},
+		AssignedWorkBeads: []beads.Bead{},
 	}
 
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{session})
@@ -929,7 +943,7 @@ func TestCityRuntimeBeadReconcileTick_SweepUsesOwnershipWorkSnapshot(t *testing.
 		t.Fatalf("Get session bead: %v", err)
 	}
 	if got.Status == "closed" {
-		t.Fatalf("session bead was swept closed despite future assigned work: %+v", got)
+		t.Fatalf("session bead was swept closed despite live assigned work: %+v", got)
 	}
 }
 

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -621,7 +621,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
 	reconcileSessionBeadsAtPath(
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
-		nil, nil, dsResult.OwnershipWorkBeads, nil, dt, poolDesired,
+		nil, nil, nil, nil, dt, poolDesired,
 		dsResult.StoreQueryPartial,
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -19,17 +19,18 @@ func PoolSessionName(template, beadID string) string {
 }
 
 // GCSweepSessionBeads closes open session beads that have no remaining
-// assigned work beads (all assigned beads are closed). Returns the IDs
-// of session beads that were closed.
-func GCSweepSessionBeads(store beads.Store, sessionBeads []beads.Bead, allWorkBeads []beads.Bead) []string {
-	assigneeHasWork := buildAssignedWorkIndex(allWorkBeads)
-
+// open/in-progress work beads. Work-bead assignment is verified by a
+// live store query inside closeSessionBeadIfUnassigned, so the caller
+// does not pass a work snapshot — that pattern was retired to prevent
+// pre-close tick snapshots from poisoning close decisions. Returns the
+// IDs of session beads that were closed.
+func GCSweepSessionBeads(store beads.Store, sessionBeads []beads.Bead) []string {
 	var closed []string
 	for _, sb := range sessionBeads {
 		if sb.Status == "closed" {
 			continue
 		}
-		if !closeSessionBeadIfUnassigned(store, sb, assigneeHasWork, "gc_swept", time.Now().UTC(), nil) {
+		if !closeSessionBeadIfUnassigned(store, sb, "gc_swept", time.Now().UTC(), nil) {
 			continue
 		}
 		closed = append(closed, sb.ID)

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -19,18 +19,19 @@ func PoolSessionName(template, beadID string) string {
 }
 
 // GCSweepSessionBeads closes open session beads that have no remaining
-// open/in-progress work beads. Work-bead assignment is verified by a
-// live store query inside closeSessionBeadIfUnassigned, so the caller
-// does not pass a work snapshot — that pattern was retired to prevent
-// pre-close tick snapshots from poisoning close decisions. Returns the
-// IDs of session beads that were closed.
-func GCSweepSessionBeads(store beads.Store, sessionBeads []beads.Bead) []string {
+// open/in-progress work beads anywhere — primary store OR any attached
+// rig store. Work-bead assignment is verified by a live cross-store
+// query inside closeSessionBeadIfUnassigned, so the caller does not
+// pass a work snapshot — that pattern was retired to prevent pre-close
+// tick snapshots from poisoning close decisions. Returns the IDs of
+// session beads that were closed.
+func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, sessionBeads []beads.Bead) []string {
 	var closed []string
 	for _, sb := range sessionBeads {
 		if sb.Status == "closed" {
 			continue
 		}
-		if !closeSessionBeadIfUnassigned(store, sb, "gc_swept", time.Now().UTC(), nil) {
+		if !closeSessionBeadIfUnassigned(store, rigStores, sb, "gc_swept", time.Now().UTC(), nil) {
 			continue
 		}
 		closed = append(closed, sb.ID)

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -118,20 +118,4 @@ func assigneePreservesNamedSessionRoute(cfg *config.City, template, assignee str
 	return namedSessionBackingTemplate(spec) == template
 }
 
-// sessionHasAssignedWork checks whether any work bead is assigned to this
-// session bead via any of its identifiers: bead ID, session name, or
-// named identity (alias).
-func sessionHasAssignedWork(sb beads.Bead, assigneeHasWork map[string]bool) bool {
-	if assigneeHasWork[sb.ID] {
-		return true
-	}
-	if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" && assigneeHasWork[sn] {
-		return true
-	}
-	if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" && assigneeHasWork[ni] {
-		return true
-	}
-	return false
-}
-
 func stringPtr(s string) *string { return &s }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -45,7 +45,7 @@ func TestGCSweepSessionBeads_ClosesOrphans(t *testing.T) {
 
 	sessionBeads := []beads.Bead{orphan, active}
 
-	closed := GCSweepSessionBeads(store, sessionBeads)
+	closed := GCSweepSessionBeads(store, nil, sessionBeads)
 
 	if len(closed) != 1 {
 		t.Fatalf("closed %d beads, want 1", len(closed))
@@ -89,7 +89,7 @@ func TestGCSweepSessionBeads_KeepsBlockedAssigned(t *testing.T) {
 
 	sessionBeads := []beads.Bead{sess}
 
-	closed := GCSweepSessionBeads(store, sessionBeads)
+	closed := GCSweepSessionBeads(store, nil, sessionBeads)
 
 	if len(closed) != 0 {
 		t.Errorf("closed %d beads, want 0 (blocked work keeps session alive)", len(closed))
@@ -118,7 +118,7 @@ func TestGCSweepSessionBeads_ClosesWhenAllWorkClosed(t *testing.T) {
 
 	sessionBeads := []beads.Bead{sess}
 
-	closed := GCSweepSessionBeads(store, sessionBeads)
+	closed := GCSweepSessionBeads(store, nil, sessionBeads)
 
 	if len(closed) != 1 {
 		t.Errorf("closed %d beads, want 1 (all work done)", len(closed))
@@ -134,7 +134,7 @@ func TestGCSweepSessionBeads_SkipsAlreadyClosed(t *testing.T) {
 
 	sessionBeads := []beads.Bead{sess}
 
-	closed := GCSweepSessionBeads(store, sessionBeads)
+	closed := GCSweepSessionBeads(store, nil, sessionBeads)
 
 	if len(closed) != 0 {
 		t.Errorf("closed %d beads, want 0 (already closed)", len(closed))

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -44,9 +44,8 @@ func TestGCSweepSessionBeads_ClosesOrphans(t *testing.T) {
 	_ = workBead
 
 	sessionBeads := []beads.Bead{orphan, active}
-	allWork := []beads.Bead{workBead}
 
-	closed := GCSweepSessionBeads(store, sessionBeads, allWork)
+	closed := GCSweepSessionBeads(store, sessionBeads)
 
 	if len(closed) != 1 {
 		t.Fatalf("closed %d beads, want 1", len(closed))
@@ -89,9 +88,8 @@ func TestGCSweepSessionBeads_KeepsBlockedAssigned(t *testing.T) {
 	_ = blocked
 
 	sessionBeads := []beads.Bead{sess}
-	allWork := []beads.Bead{blocked}
 
-	closed := GCSweepSessionBeads(store, sessionBeads, allWork)
+	closed := GCSweepSessionBeads(store, sessionBeads)
 
 	if len(closed) != 0 {
 		t.Errorf("closed %d beads, want 0 (blocked work keeps session alive)", len(closed))
@@ -119,9 +117,8 @@ func TestGCSweepSessionBeads_ClosesWhenAllWorkClosed(t *testing.T) {
 	done, _ = store.Get(done.ID)
 
 	sessionBeads := []beads.Bead{sess}
-	allWork := []beads.Bead{done}
 
-	closed := GCSweepSessionBeads(store, sessionBeads, allWork)
+	closed := GCSweepSessionBeads(store, sessionBeads)
 
 	if len(closed) != 1 {
 		t.Errorf("closed %d beads, want 1 (all work done)", len(closed))
@@ -137,7 +134,7 @@ func TestGCSweepSessionBeads_SkipsAlreadyClosed(t *testing.T) {
 
 	sessionBeads := []beads.Bead{sess}
 
-	closed := GCSweepSessionBeads(store, sessionBeads, nil)
+	closed := GCSweepSessionBeads(store, sessionBeads)
 
 	if len(closed) != 0 {
 		t.Errorf("closed %d beads, want 0 (already closed)", len(closed))

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -11,7 +11,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,8 +27,6 @@ import (
 )
 
 const maxIdleSleepProbesPerTick = 3
-
-var errOwnershipSnapshotPartial = errors.New("ownership work snapshot partial")
 
 type wakeTarget struct {
 	session *beads.Bead
@@ -890,7 +887,14 @@ func reconcileSessionBeadsTraced(
 			// Singleton/named controller-managed identities must keep the same
 			// bead so later wake/restart happens in place instead of minting a
 			// fresh canonical owner.
-			closeSessionBeadIfUnassigned(store, *target.session, ownershipWorkIndex, "drained", clk.Now().UTC(), stderr)
+			//
+			// Close directly rather than via closeSessionBeadIfUnassigned: the
+			// live sessionHasOpenAssignedWork query above already established
+			// hasAssignedWork=false. Routing through closeSessionBeadIfUnassigned
+			// would re-consult ownershipWorkIndex (the stale pre-tick snapshot)
+			// and let it veto the close — exactly the behaviour the PR set out
+			// to kill in the drain-ack handler.
+			closeBead(store, target.session.ID, "drained", clk.Now().UTC(), stderr)
 		}
 	}
 
@@ -986,22 +990,6 @@ func sessionHasOpenAssignedWork(store beads.Store, session beads.Bead) (bool, er
 		}
 	}
 	return false, nil
-}
-
-func sessionHasOpenAssignedWorkWithSnapshot(
-	store beads.Store,
-	session beads.Bead,
-	ownershipWorkBeads []beads.Bead,
-	ownershipWorkIndex map[string]bool,
-	storeQueryPartial bool,
-) (bool, error) {
-	if storeQueryPartial {
-		return false, errOwnershipSnapshotPartial
-	}
-	if ownershipWorkBeads != nil {
-		return sessionHasAssignedWork(session, ownershipWorkIndex), nil
-	}
-	return sessionHasOpenAssignedWork(store, session)
 }
 
 func resetConfiguredNamedSessionForConfigDrift(

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -201,7 +201,11 @@ func reconcileSessionBeadsTraced(
 	if cityName == "" {
 		cityName = config.EffectiveCityName(cfg, "")
 	}
-	ownershipWorkIndex := buildAssignedWorkIndex(ownershipWorkBeads)
+	// ownershipWorkBeads is retained for backward-compatible signatures but
+	// is no longer consulted: both the drain-ack decision and the pool-slot
+	// close gate now query the live store via sessionHasOpenAssignedWork so
+	// a pre-close tick snapshot cannot poison terminal state decisions.
+	_ = ownershipWorkBeads
 
 	// Phase 0: Heal expired timers on all sessions.
 	for i := range sessions {
@@ -330,7 +334,7 @@ func reconcileSessionBeadsTraced(
 					if storeQueryPartial {
 						continue
 					}
-					closeSessionBeadIfUnassigned(store, *session, ownershipWorkIndex, reason, clk.Now().UTC(), stderr)
+					closeSessionBeadIfUnassigned(store, *session, reason, clk.Now().UTC(), stderr)
 				}
 				continue
 			}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -140,6 +140,12 @@ func reconcileSessionBeads(
 	)
 }
 
+// reconcileSessionBeadsAtPath runs the reconciler for a specific city
+// path. rigStores supplies the attached rig bead stores so live
+// cross-store ownership checks (sessionHasOpenAssignedWork) can see
+// work that lives outside the primary store. Pass nil when no rig
+// stores are attached; the reconciler will fall back to primary-store-
+// only queries.
 func reconcileSessionBeadsAtPath(
 	ctx context.Context,
 	cityPath string,
@@ -151,7 +157,7 @@ func reconcileSessionBeadsAtPath(
 	store beads.Store,
 	dops drainOps,
 	assignedWorkBeads []beads.Bead,
-	ownershipWorkBeads []beads.Bead,
+	rigStores map[string]beads.Store,
 	readyWaitSet map[string]bool,
 	dt *drainTracker,
 	poolDesired map[string]int,
@@ -166,7 +172,7 @@ func reconcileSessionBeadsAtPath(
 	stdout, stderr io.Writer,
 ) int {
 	return reconcileSessionBeadsTraced(
-		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, ownershipWorkBeads, readyWaitSet, dt,
+		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
 		poolDesired, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
 	)
 }
@@ -182,7 +188,7 @@ func reconcileSessionBeadsTraced(
 	store beads.Store,
 	dops drainOps,
 	assignedWorkBeads []beads.Bead,
-	ownershipWorkBeads []beads.Bead,
+	rigStores map[string]beads.Store,
 	readyWaitSet map[string]bool,
 	dt *drainTracker,
 	poolDesired map[string]int,
@@ -201,11 +207,6 @@ func reconcileSessionBeadsTraced(
 	if cityName == "" {
 		cityName = config.EffectiveCityName(cfg, "")
 	}
-	// ownershipWorkBeads is retained for backward-compatible signatures but
-	// is no longer consulted: both the drain-ack decision and the pool-slot
-	// close gate now query the live store via sessionHasOpenAssignedWork so
-	// a pre-close tick snapshot cannot poison terminal state decisions.
-	_ = ownershipWorkBeads
 
 	// Phase 0: Heal expired timers on all sessions.
 	for i := range sessions {
@@ -334,7 +335,7 @@ func reconcileSessionBeadsTraced(
 					if storeQueryPartial {
 						continue
 					}
-					closeSessionBeadIfUnassigned(store, *session, reason, clk.Now().UTC(), stderr)
+					closeSessionBeadIfUnassigned(store, rigStores, *session, reason, clk.Now().UTC(), stderr)
 				}
 				continue
 			}
@@ -422,7 +423,7 @@ func reconcileSessionBeadsTraced(
 						// the bead from the close gate and stranded new
 						// queue work on a ghost slot. Re-query the store
 						// so the decision reflects reality.
-						hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, *session)
+						hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
 						sleepReason := "idle"
 						if assignedErr != nil {
 							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
@@ -872,21 +873,21 @@ func reconcileSessionBeadsTraced(
 		// a terminal sleep state (drained, or asleep from a normal idle drain)
 		// must free their slot so a fresh worker can spawn for new queue work.
 		// Anything else (wait-hold, pending interaction, named/singleton) is
-		// preserved. The stale `ownershipWorkBeads` snapshot taken earlier in
-		// the tick predates the agent's own `bd close` of its last unit of
-		// work, so we re-query the live store here and at the drain-ack
-		// handler above — never trust a stale snapshot for a decision that
-		// closes a bead.
-		// Only pool-managed sessions are disposable after a completed drain.
-		// Singleton/named controller-managed identities must keep the same
-		// bead so later wake/restart happens in place instead of minting a
-		// fresh canonical owner. Hoist isPoolManagedSessionBead up here so
-		// non-pool sessions skip the live-store query entirely.
+		// preserved.
+		//
+		// A pre-tick ownership snapshot predates the agent's own `bd close`
+		// of its last unit of work, so this gate (and the drain-ack handler
+		// above) queries the live store — across the primary store AND any
+		// attached rig stores — via sessionHasOpenAssignedWork to avoid
+		// closing a session that still owns work. Only pool-managed sessions
+		// are disposable; singleton/named controller-managed identities must
+		// keep the same bead so later wake/restart happens in place instead
+		// of minting a fresh canonical owner.
 		hasAssignedWork := false
 		poolFreeable := !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) && isPoolManagedSessionBead(*target.session)
 		if poolFreeable {
 			var assignedErr error
-			hasAssignedWork, assignedErr = sessionHasOpenAssignedWork(store, *target.session)
+			hasAssignedWork, assignedErr = sessionHasOpenAssignedWork(store, rigStores, *target.session)
 			if assignedErr != nil {
 				fmt.Fprintf(stderr, "session reconciler: checking assigned work for drained %s: %v\n", target.session.Metadata["session_name"], assignedErr) //nolint:errcheck
 				hasAssignedWork = true
@@ -970,7 +971,30 @@ func resolvePreservedConfiguredNamedSessionTemplate(
 	return tp, nil
 }
 
-func sessionHasOpenAssignedWork(store beads.Store, session beads.Bead) (bool, error) {
+// sessionHasOpenAssignedWork reports whether any open or in-progress
+// work bead is assigned to the given session across the primary store
+// AND any attached rig stores. This preserves cross-store ownership
+// coverage that used to come from the retired ownership snapshot.
+//
+// A session's work bead can live in a rig store (e.g., a city-stored
+// session whose work was routed to a rig), so the close gate and
+// drain-ack must check every store the bead could live in before
+// recycling the session's slot. Live queries are used throughout:
+// any individual store failure fails the whole check closed so
+// transient errors cannot cause premature close.
+func sessionHasOpenAssignedWork(store beads.Store, rigStores map[string]beads.Store, session beads.Bead) (bool, error) {
+	if has, err := sessionHasOpenAssignedWorkInStore(store, session); err != nil || has {
+		return has, err
+	}
+	for _, rs := range rigStores {
+		if has, err := sessionHasOpenAssignedWorkInStore(rs, session); err != nil || has {
+			return has, err
+		}
+	}
+	return false, nil
+}
+
+func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (bool, error) {
 	if store == nil {
 		return false, nil
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -873,8 +873,14 @@ func reconcileSessionBeadsTraced(
 		// work, so we re-query the live store here and at the drain-ack
 		// handler above — never trust a stale snapshot for a decision that
 		// closes a bead.
+		// Only pool-managed sessions are disposable after a completed drain.
+		// Singleton/named controller-managed identities must keep the same
+		// bead so later wake/restart happens in place instead of minting a
+		// fresh canonical owner. Hoist isPoolManagedSessionBead up here so
+		// non-pool sessions skip the live-store query entirely.
 		hasAssignedWork := false
-		if !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) {
+		poolFreeable := !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) && isPoolManagedSessionBead(*target.session)
+		if poolFreeable {
 			var assignedErr error
 			hasAssignedWork, assignedErr = sessionHasOpenAssignedWork(store, *target.session)
 			if assignedErr != nil {
@@ -882,19 +888,23 @@ func reconcileSessionBeadsTraced(
 				hasAssignedWork = true
 			}
 		}
-		if !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) && !hasAssignedWork && isPoolManagedSessionBead(*target.session) {
-			// Only pool-managed sessions are disposable after a completed drain.
-			// Singleton/named controller-managed identities must keep the same
-			// bead so later wake/restart happens in place instead of minting a
-			// fresh canonical owner.
-			//
+		if poolFreeable && !hasAssignedWork {
 			// Close directly rather than via closeSessionBeadIfUnassigned: the
 			// live sessionHasOpenAssignedWork query above already established
 			// hasAssignedWork=false. Routing through closeSessionBeadIfUnassigned
 			// would re-consult ownershipWorkIndex (the stale pre-tick snapshot)
 			// and let it veto the close — exactly the behaviour the PR set out
 			// to kill in the drain-ack handler.
-			closeBead(store, target.session.ID, "drained", clk.Now().UTC(), stderr)
+			//
+			// Preserve the original sleep_reason (idle / idle-timeout / drained)
+			// on the closed bead for forensic fidelity; fall back to "drained"
+			// when the metadata is missing. Ops can then distinguish a natural
+			// idle-timeout recycle from an explicit drain in the closed record.
+			closeReason := strings.TrimSpace(target.session.Metadata["sleep_reason"])
+			if closeReason == "" {
+				closeReason = "drained"
+			}
+			closeBead(store, target.session.ID, closeReason, clk.Now().UTC(), stderr)
 		}
 	}
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -410,14 +410,22 @@ func reconcileSessionBeadsTraced(
 							Subject: tp.DisplayName(),
 							Message: "drain acknowledged by agent",
 						})
-						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkWithSnapshot(store, *session, ownershipWorkBeads, ownershipWorkIndex, storeQueryPartial)
+						// Drain-ack lands here right after the agent ran
+						// `bd close` on its last unit of work. The cached
+						// `ownershipWorkBeads` snapshot taken earlier in
+						// this tick predates that close, so it still shows
+						// the bead as open+assigned and falsely flipped
+						// pool workers into CompleteDrainPatch
+						// (state=asleep + sleep_reason=idle) instead of
+						// AcknowledgeDrainPatch (state=drained). That hid
+						// the bead from the close gate and stranded new
+						// queue work on a ghost slot. Re-query the store
+						// so the decision reflects reality.
+						hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, *session)
 						sleepReason := "idle"
 						if assignedErr != nil {
 							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
 							hasAssignedWork = true
-							if errors.Is(assignedErr, errOwnershipSnapshotPartial) {
-								sleepReason = "ownership_snapshot_partial"
-							}
 						}
 						batch := sessionpkg.AcknowledgeDrainPatch(session.Metadata["wake_mode"] == "fresh")
 						if hasAssignedWork {
@@ -859,16 +867,25 @@ func reconcileSessionBeadsTraced(
 			}
 		}
 
+		// Pool-managed sessions whose runtime has exited and whose bead is in
+		// a terminal sleep state (drained, or asleep from a normal idle drain)
+		// must free their slot so a fresh worker can spawn for new queue work.
+		// Anything else (wait-hold, pending interaction, named/singleton) is
+		// preserved. The stale `ownershipWorkBeads` snapshot taken earlier in
+		// the tick predates the agent's own `bd close` of its last unit of
+		// work, so we re-query the live store here and at the drain-ack
+		// handler above — never trust a stale snapshot for a decision that
+		// closes a bead.
 		hasAssignedWork := false
-		if !shouldWake && !target.alive && isDrainedSessionBead(*target.session) {
+		if !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) {
 			var assignedErr error
-			hasAssignedWork, assignedErr = sessionHasOpenAssignedWorkWithSnapshot(store, *target.session, ownershipWorkBeads, ownershipWorkIndex, storeQueryPartial)
+			hasAssignedWork, assignedErr = sessionHasOpenAssignedWork(store, *target.session)
 			if assignedErr != nil {
 				fmt.Fprintf(stderr, "session reconciler: checking assigned work for drained %s: %v\n", target.session.Metadata["session_name"], assignedErr) //nolint:errcheck
 				hasAssignedWork = true
 			}
 		}
-		if !shouldWake && !target.alive && isDrainedSessionBead(*target.session) && !hasAssignedWork && isPoolManagedSessionBead(*target.session) {
+		if !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) && !hasAssignedWork && isPoolManagedSessionBead(*target.session) {
 			// Only pool-managed sessions are disposable after a completed drain.
 			// Singleton/named controller-managed identities must keep the same
 			// bead so later wake/restart happens in place instead of minting a

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -893,12 +893,11 @@ func reconcileSessionBeadsTraced(
 			}
 		}
 		if poolFreeable && !hasAssignedWork {
-			// Close directly rather than via closeSessionBeadIfUnassigned: the
-			// live sessionHasOpenAssignedWork query above already established
-			// hasAssignedWork=false. Routing through closeSessionBeadIfUnassigned
-			// would re-consult ownershipWorkIndex (the stale pre-tick snapshot)
-			// and let it veto the close — exactly the behaviour the PR set out
-			// to kill in the drain-ack handler.
+			// Close directly rather than via closeSessionBeadIfUnassigned.
+			// That helper also runs a live sessionHasOpenAssignedWork query
+			// and would redundantly re-query a store we just hit — skip the
+			// duplicate I/O and pass through the preserved sleep_reason as
+			// the close_reason below.
 			//
 			// Preserve the original sleep_reason (idle / idle-timeout / drained)
 			// on the closed bead for forensic fidelity; fall back to "drained"

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -357,19 +357,21 @@ func TestReconcileSessionBeads_DrainAckWithAssignedOpenWorkSleepsInsteadOfDraini
 	}
 }
 
-// TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot is the
-// regression guard for the stuck-pool-worker bug on ga-ttn5z. The drain-ack
-// handler used to take `hasAssignedWork` from an `ownershipWorkBeads`
-// snapshot captured earlier in the tick. Pool workers close their own
-// work bead with `bd close` BEFORE calling `gc runtime drain-ack`, so
-// the snapshot still reported the now-closed bead as open+assigned.
-// That falsely flipped the session into CompleteDrainPatch (state=asleep,
-// sleep_reason=idle) instead of AcknowledgeDrainPatch (state=drained),
-// which hid the bead from the close gate and stranded new queue work on
-// a ghost slot. Fix: drain-ack re-queries the live store, ignoring the
-// stale snapshot. This test exercises that path by passing a snapshot
-// that lies ("bead assigned, open") while the store says otherwise.
-func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.T) {
+// TestReconcileSessionBeads_DrainAckUsesLiveStoreQuery is the regression
+// guard for the stuck-pool-worker bug on ga-ttn5z. Pool workers close
+// their own work bead with `bd close` BEFORE calling `gc runtime
+// drain-ack`; the old code path then read `hasAssignedWork` from a tick
+// snapshot captured before the close, so the snapshot falsely reported
+// the now-closed bead as open+assigned. That flipped the session into
+// CompleteDrainPatch (state=asleep, sleep_reason=idle) instead of
+// AcknowledgeDrainPatch (state=drained), which hid the bead from the
+// close gate and stranded new queue work on a ghost slot.
+//
+// Fix: the snapshot-based path is gone; drain-ack queries the live
+// store via sessionHasOpenAssignedWork. This test verifies the
+// post-fix outcome: with no open assigned work in the store, drain-ack
+// lands the session in `drained` (the correct terminal for recycling).
+func TestReconcileSessionBeads_DrainAckUsesLiveStoreQuery(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
 		Agents: []config.Agent{{Name: "worker"}},
@@ -377,18 +379,6 @@ func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.
 	env.addDesired("worker", "worker", true)
 	session := env.createSessionBead("worker", "worker")
 	env.markSessionActive(&session)
-
-	// Stale snapshot: claims an assigned open bead exists, but the live
-	// store has no such record (the agent already closed it before
-	// calling drain-ack).
-	stale := beads.Bead{
-		ID:       "stale-work",
-		Title:    "already closed",
-		Type:     "task",
-		Status:   "open",
-		Assignee: session.ID,
-	}
-	staleSnapshot := []beads.Bead{stale}
 
 	dops := newFakeDrainOps()
 	if err := dops.setDrainAck("worker"); err != nil {
@@ -406,7 +396,7 @@ func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.
 		env.store,
 		dops,
 		nil,
-		staleSnapshot, // lies about assigned work
+		nil, // rigStores
 		nil,
 		env.dt,
 		nil,
@@ -427,7 +417,7 @@ func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
 	if got.Metadata["state"] != "drained" {
-		t.Fatalf("state = %q, want drained — live store query must override the stale snapshot that claimed assigned work", got.Metadata["state"])
+		t.Fatalf("state = %q, want drained — drain-ack must query the live store and land a session with no assigned work in drained state", got.Metadata["state"])
 	}
 }
 
@@ -438,14 +428,6 @@ func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.
 // spawn a fresh worker for pending queue work. Before the fix the close
 // gate only fired for state=drained, so idle-asleep pool beads sat open
 // indefinitely and blocked new spawns.
-//
-// The test passes a stale ownership snapshot that lies about assigned
-// work (mirroring the drain-ack regression). Before the close gate was
-// rewired to call closeBead directly, the gate's live query cleared work
-// but the downstream closeSessionBeadIfUnassigned helper re-consulted
-// the stale snapshot and vetoed the close — reintroducing the ghost
-// slot. With the direct closeBead call, the snapshot can no longer veto
-// a close that the live query has already cleared.
 func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -461,20 +443,6 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 		poolManagedMetadataKey: boolMetadata(true),
 	})
 
-	// Stale snapshot: claims the pool worker still has an open assigned
-	// bead. The live store has no such record (the worker already closed
-	// it before its runtime exited). If the close path re-reads this
-	// snapshot, it will veto the close and leak the slot — which is
-	// exactly the regression this test exists to guard.
-	stale := beads.Bead{
-		ID:       "stale-work",
-		Title:   "already closed",
-		Type:     "task",
-		Status:   "open",
-		Assignee: session.ID,
-	}
-	staleSnapshot := []beads.Bead{stale}
-
 	reconcileSessionBeadsAtPath(
 		context.Background(),
 		"",
@@ -486,7 +454,7 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 		env.store,
 		newFakeDrainOps(),
 		nil,
-		staleSnapshot, // lies about assigned work
+		nil, // rigStores
 		nil,
 		env.dt,
 		nil,
@@ -507,7 +475,7 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
 	if got.Status != "closed" {
-		t.Fatalf("status = %q, want closed — asleep-idle pool beads must free their slot even when the stale ownership snapshot falsely reports assigned work", got.Status)
+		t.Fatalf("status = %q, want closed — asleep-idle pool beads must free their slot via the live-query close gate", got.Status)
 	}
 }
 
@@ -646,6 +614,73 @@ func TestReconcileSessionBeads_CloseGateLiveStoreErrorKeepsSlot(t *testing.T) {
 	}
 	if got.Status == "closed" {
 		t.Fatalf("status = %q, want open — close-gate live-query error must fail closed (hasAssignedWork=true) so the pool slot stays open until the store can confirm no assignments", got.Status)
+	}
+}
+
+// TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork
+// verifies that the close gate's live ownership check looks across the
+// primary store AND any attached rig stores. A city-stored asleep+idle
+// pool session with work assigned to it in a rig store must NOT get
+// its slot freed — the rig-stored work would be orphaned.
+func TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", false)
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":              "asleep",
+		"sleep_reason":       "idle",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	// Work assigned to the session lives in a rig store, not the city
+	// store. The live cross-store query must find it and veto the close.
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "cross-store work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	rigStores := map[string]beads.Store{"some-rig": rigStore}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		nil,
+		rigStores,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = %q, want open — close gate must honor cross-store assigned work and leave the pool slot for the rig-stored work to drain", got.Status)
 	}
 }
 
@@ -884,7 +919,7 @@ func TestReconcileSessionBeads_DrainedPoolSessionPartialOwnershipSnapshotStaysOp
 		env.store,
 		nil,
 		nil,
-		[]beads.Bead{},
+		nil, // rigStores
 		nil,
 		env.dt,
 		map[string]int{},

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -438,6 +438,14 @@ func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.
 // spawn a fresh worker for pending queue work. Before the fix the close
 // gate only fired for state=drained, so idle-asleep pool beads sat open
 // indefinitely and blocked new spawns.
+//
+// The test passes a stale ownership snapshot that lies about assigned
+// work (mirroring the drain-ack regression). Before the close gate was
+// rewired to call closeBead directly, the gate's live query cleared work
+// but the downstream closeSessionBeadIfUnassigned helper re-consulted
+// the stale snapshot and vetoed the close — reintroducing the ghost
+// slot. With the direct closeBead call, the snapshot can no longer veto
+// a close that the live query has already cleared.
 func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -453,6 +461,20 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 		poolManagedMetadataKey: boolMetadata(true),
 	})
 
+	// Stale snapshot: claims the pool worker still has an open assigned
+	// bead. The live store has no such record (the worker already closed
+	// it before its runtime exited). If the close path re-reads this
+	// snapshot, it will veto the close and leak the slot — which is
+	// exactly the regression this test exists to guard.
+	stale := beads.Bead{
+		ID:       "stale-work",
+		Title:   "already closed",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}
+	staleSnapshot := []beads.Bead{stale}
+
 	reconcileSessionBeadsAtPath(
 		context.Background(),
 		"",
@@ -464,7 +486,7 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 		env.store,
 		newFakeDrainOps(),
 		nil,
-		nil,
+		staleSnapshot, // lies about assigned work
 		nil,
 		env.dt,
 		nil,
@@ -485,7 +507,7 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
 	if got.Status != "closed" {
-		t.Fatalf("status = %q, want closed — asleep-idle pool beads must free their slot", got.Status)
+		t.Fatalf("status = %q, want closed — asleep-idle pool beads must free their slot even when the stale ownership snapshot falsely reports assigned work", got.Status)
 	}
 }
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -518,6 +518,80 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 // decision. Live store errors still fail closed, but the path that
 // produced the ownership_snapshot_partial reason is gone.)
 
+// listErrStore wraps a beads.Store and returns a configured error from
+// List. Used by the drain-ack fail-closed regression test below.
+type listErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s *listErrStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.Store.List(q)
+}
+
+// TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed guards the
+// drain-ack live-query error path. When sessionHasOpenAssignedWork returns
+// an error, drain-ack treats hasAssignedWork as true (fail-closed) so the
+// session lands in CompleteDrainPatch (asleep+idle) rather than
+// AcknowledgeDrainPatch (drained). This prevents a transient store failure
+// from silently closing a session whose assignment status we cannot verify.
+func TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	// Wrap the store so List returns an error for the live-query check.
+	erroring := &listErrStore{Store: env.store, err: fmt.Errorf("store is unavailable")}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		erroring,
+		dops,
+		nil,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state"] != "asleep" || got.Metadata["sleep_reason"] != "idle" {
+		t.Fatalf("state=%q sleep_reason=%q, want asleep/idle — live-query error must fail closed (hasAssignedWork=true) so the session does not enter drained state",
+			got.Metadata["state"], got.Metadata["sleep_reason"])
+	}
+}
+
 func TestReconcileSessionBeads_DrainAckResumeModePreservesSessionIdentity(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -592,6 +592,142 @@ func TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_CloseGateLiveStoreErrorKeepsSlot guards the
+// mirror-image fail-closed guard in the asleep-idle close gate. When
+// sessionHasOpenAssignedWork errors during the close-gate check, the gate
+// must treat hasAssignedWork as true (fail-closed) and leave the bead
+// open. Without this guard a transient store blip would silently close a
+// pool slot whose assignment status was unverifiable.
+func TestReconcileSessionBeads_CloseGateLiveStoreErrorKeepsSlot(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", false) // NOT running
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":              "asleep",
+		"sleep_reason":       "idle",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	erroring := &listErrStore{Store: env.store, err: fmt.Errorf("store is unavailable")}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		erroring,
+		newFakeDrainOps(),
+		nil,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = %q, want open — close-gate live-query error must fail closed (hasAssignedWork=true) so the pool slot stays open until the store can confirm no assignments", got.Status)
+	}
+}
+
+// TestReconcileSessionBeads_CloseGatePreservesSleepReason verifies that the
+// close gate carries the session's existing sleep_reason (idle,
+// idle-timeout, drained) into the closed bead's close reason. Losing this
+// distinction in closed records erases the forensic difference between an
+// idle-timeout recycle and an explicit drain.
+func TestReconcileSessionBeads_CloseGatePreservesSleepReason(t *testing.T) {
+	cases := []struct {
+		name        string
+		sleepReason string
+		wantReason  string
+	}{
+		{"idle", "idle", "idle"},
+		{"idle-timeout", "idle-timeout", "idle-timeout"},
+		{"drained-reason", "drained", "drained"},
+		{"missing-reason", "", "drained"}, // fallback
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newReconcilerTestEnv()
+			env.cfg = &config.City{
+				Agents: []config.Agent{{Name: "worker"}},
+			}
+			env.addDesired("worker", "worker", false)
+			session := env.createSessionBead("worker", "worker")
+			meta := map[string]string{
+				"state":              "asleep",
+				poolManagedMetadataKey: boolMetadata(true),
+			}
+			if tc.sleepReason != "" {
+				meta["sleep_reason"] = tc.sleepReason
+			} else {
+				// Drained state still qualifies as freeable via
+				// isDrainedSessionBead; use that so the close gate fires
+				// with no sleep_reason set.
+				meta["state"] = "drained"
+			}
+			env.setSessionMetadata(&session, meta)
+
+			reconcileSessionBeadsAtPath(
+				context.Background(),
+				"",
+				[]beads.Bead{session},
+				env.desiredState,
+				map[string]bool{"worker": true},
+				env.cfg,
+				env.sp,
+				env.store,
+				newFakeDrainOps(),
+				nil,
+				nil,
+				nil,
+				env.dt,
+				nil,
+				false,
+				nil,
+				"",
+				nil,
+				env.clk,
+				env.rec,
+				0,
+				0,
+				&env.stdout,
+				&env.stderr,
+			)
+
+			got, err := env.store.Get(session.ID)
+			if err != nil {
+				t.Fatalf("Get(%s): %v", session.ID, err)
+			}
+			if got.Status != "closed" {
+				t.Fatalf("status = %q, want closed", got.Status)
+			}
+			if got.Metadata["close_reason"] != tc.wantReason {
+				t.Fatalf("close_reason = %q, want %q — close gate must preserve the originating sleep_reason for forensic fidelity", got.Metadata["close_reason"], tc.wantReason)
+			}
+		})
+	}
+}
+
 func TestReconcileSessionBeads_DrainAckResumeModePreservesSessionIdentity(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -438,8 +438,8 @@ func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
 	// Simulate the post-drain-ack-ghost state: asleep + sleep_reason=idle
 	// + pool-managed, but the runtime has exited and no work is assigned.
 	env.setSessionMetadata(&session, map[string]string{
-		"state":              "asleep",
-		"sleep_reason":       "idle",
+		"state":                "asleep",
+		"sleep_reason":         "idle",
 		poolManagedMetadataKey: boolMetadata(true),
 	})
 
@@ -574,8 +574,8 @@ func TestReconcileSessionBeads_CloseGateLiveStoreErrorKeepsSlot(t *testing.T) {
 	env.addDesired("worker", "worker", false) // NOT running
 	session := env.createSessionBead("worker", "worker")
 	env.setSessionMetadata(&session, map[string]string{
-		"state":              "asleep",
-		"sleep_reason":       "idle",
+		"state":                "asleep",
+		"sleep_reason":         "idle",
 		poolManagedMetadataKey: boolMetadata(true),
 	})
 
@@ -630,8 +630,8 @@ func TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork(t *testin
 	env.addDesired("worker", "worker", false)
 	session := env.createSessionBead("worker", "worker")
 	env.setSessionMetadata(&session, map[string]string{
-		"state":              "asleep",
-		"sleep_reason":       "idle",
+		"state":                "asleep",
+		"sleep_reason":         "idle",
 		poolManagedMetadataKey: boolMetadata(true),
 	})
 
@@ -709,7 +709,7 @@ func TestReconcileSessionBeads_CloseGatePreservesSleepReason(t *testing.T) {
 			env.addDesired("worker", "worker", false)
 			session := env.createSessionBead("worker", "worker")
 			meta := map[string]string{
-				"state":              "asleep",
+				"state":                "asleep",
 				poolManagedMetadataKey: boolMetadata(true),
 			}
 			if tc.sleepReason != "" {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -893,7 +893,13 @@ func TestReconcileSessionBeads_DrainAckFreshModeClearsSessionIdentity(t *testing
 	}
 }
 
-func TestReconcileSessionBeads_DrainedPoolSessionPartialOwnershipSnapshotStaysOpen(t *testing.T) {
+// TestReconcileSessionBeads_DrainedPoolSessionStoreQueryPartialStaysOpen
+// verifies that when storeQueryPartial is set (a transient bead-store
+// failure produced an incomplete assignedWorkBeads snapshot), the
+// drained pool session bead is NOT closed. Close decisions must fail
+// closed whenever the tick's store visibility is compromised, even if
+// the live ownership check itself returns cleanly.
+func TestReconcileSessionBeads_DrainedPoolSessionStoreQueryPartialStaysOpen(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
 		Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
@@ -923,7 +929,7 @@ func TestReconcileSessionBeads_DrainedPoolSessionPartialOwnershipSnapshotStaysOp
 		nil,
 		env.dt,
 		map[string]int{},
-		true,
+		true, // storeQueryPartial
 		nil,
 		"",
 		nil,
@@ -943,7 +949,7 @@ func TestReconcileSessionBeads_DrainedPoolSessionPartialOwnershipSnapshotStaysOp
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
 	if got.Status == "closed" {
-		t.Fatalf("session bead closed unexpectedly under partial ownership snapshot: metadata=%v", got.Metadata)
+		t.Fatalf("session bead closed unexpectedly under storeQueryPartial: metadata=%v", got.Metadata)
 	}
 }
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -357,7 +357,19 @@ func TestReconcileSessionBeads_DrainAckWithAssignedOpenWorkSleepsInsteadOfDraini
 	}
 }
 
-func TestReconcileSessionBeads_DrainAckPartialOwnershipSnapshotFailsClosed(t *testing.T) {
+// TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot is the
+// regression guard for the stuck-pool-worker bug on ga-ttn5z. The drain-ack
+// handler used to take `hasAssignedWork` from an `ownershipWorkBeads`
+// snapshot captured earlier in the tick. Pool workers close their own
+// work bead with `bd close` BEFORE calling `gc runtime drain-ack`, so
+// the snapshot still reported the now-closed bead as open+assigned.
+// That falsely flipped the session into CompleteDrainPatch (state=asleep,
+// sleep_reason=idle) instead of AcknowledgeDrainPatch (state=drained),
+// which hid the bead from the close gate and stranded new queue work on
+// a ghost slot. Fix: drain-ack re-queries the live store, ignoring the
+// stale snapshot. This test exercises that path by passing a snapshot
+// that lies ("bead assigned, open") while the store says otherwise.
+func TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
 		Agents: []config.Agent{{Name: "worker"}},
@@ -366,12 +378,24 @@ func TestReconcileSessionBeads_DrainAckPartialOwnershipSnapshotFailsClosed(t *te
 	session := env.createSessionBead("worker", "worker")
 	env.markSessionActive(&session)
 
+	// Stale snapshot: claims an assigned open bead exists, but the live
+	// store has no such record (the agent already closed it before
+	// calling drain-ack).
+	stale := beads.Bead{
+		ID:       "stale-work",
+		Title:    "already closed",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}
+	staleSnapshot := []beads.Bead{stale}
+
 	dops := newFakeDrainOps()
 	if err := dops.setDrainAck("worker"); err != nil {
 		t.Fatalf("setDrainAck: %v", err)
 	}
 
-	woken := reconcileSessionBeadsAtPath(
+	reconcileSessionBeadsAtPath(
 		context.Background(),
 		"",
 		[]beads.Bead{session},
@@ -382,11 +406,11 @@ func TestReconcileSessionBeads_DrainAckPartialOwnershipSnapshotFailsClosed(t *te
 		env.store,
 		dops,
 		nil,
-		[]beads.Bead{},
+		staleSnapshot, // lies about assigned work
 		nil,
 		env.dt,
 		nil,
-		true,
+		false,
 		nil,
 		"",
 		nil,
@@ -397,24 +421,80 @@ func TestReconcileSessionBeads_DrainAckPartialOwnershipSnapshotFailsClosed(t *te
 		&env.stdout,
 		&env.stderr,
 	)
-	if woken != 0 {
-		t.Fatalf("woken = %d, want 0", woken)
-	}
 
 	got, err := env.store.Get(session.ID)
 	if err != nil {
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
-	if got.Status == "closed" {
-		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
-	}
-	if got.Metadata["state"] != "asleep" {
-		t.Fatalf("state = %q, want asleep when ownership snapshot is partial", got.Metadata["state"])
-	}
-	if got.Metadata["sleep_reason"] != "ownership_snapshot_partial" {
-		t.Fatalf("sleep_reason = %q, want ownership_snapshot_partial when ownership snapshot is partial", got.Metadata["sleep_reason"])
+	if got.Metadata["state"] != "drained" {
+		t.Fatalf("state = %q, want drained — live store query must override the stale snapshot that claimed assigned work", got.Metadata["state"])
 	}
 }
+
+// TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot is the other half
+// of the fix: even if a pool bead somehow lands in state=asleep +
+// sleep_reason=idle (from the old buggy drain-ack path OR any other
+// route), the close gate must still free the slot so the supervisor can
+// spawn a fresh worker for pending queue work. Before the fix the close
+// gate only fired for state=drained, so idle-asleep pool beads sat open
+// indefinitely and blocked new spawns.
+func TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", false) // NOT running
+	session := env.createSessionBead("worker", "worker")
+	// Simulate the post-drain-ack-ghost state: asleep + sleep_reason=idle
+	// + pool-managed, but the runtime has exited and no work is assigned.
+	env.setSessionMetadata(&session, map[string]string{
+		"state":              "asleep",
+		"sleep_reason":       "idle",
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		nil,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed — asleep-idle pool beads must free their slot", got.Status)
+	}
+}
+
+// (Removed: TestReconcileSessionBeads_DrainAckPartialOwnershipSnapshotFailsClosed
+// guarded the old snapshot-backed fail-closed path — the sleep_reason
+// "ownership_snapshot_partial" branch. Drain-ack now re-queries the store
+// live so the pre-close ownership snapshot can no longer leak into the
+// decision. Live store errors still fail closed, but the path that
+// produced the ownership_snapshot_partial reason is gone.)
 
 func TestReconcileSessionBeads_DrainAckResumeModePreservesSessionIdentity(t *testing.T) {
 	env := newReconcilerTestEnv()

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -29,6 +29,11 @@ func isDrainedSessionBead(session beads.Bead) bool {
 // snapshot falsely reports assigned work. Freeing the slot for idle-asleep
 // pool beads lets the supervisor spawn a fresh worker for ready queue work
 // instead of stranding it on a ghost slot.
+//
+// An explicit sleep_reason is required: deny-by-default for unknown or
+// missing reasons so writes that land in state=asleep without a known
+// reason (legacy beads, regressions, write races) cannot silently free
+// their slot.
 func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	if isDrainedSessionBead(session) {
 		return true
@@ -38,7 +43,7 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "", "idle", "idle-timeout":
+	case "idle", "idle-timeout":
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -17,3 +17,29 @@ func isDrainedSessionMetadata(meta map[string]string) bool {
 func isDrainedSessionBead(session beads.Bead) bool {
 	return isDrainedSessionMetadata(session.Metadata)
 }
+
+// isPoolSessionSlotFreeable reports whether a session's bead is in a terminal
+// state where the pool slot it occupies can be freed — either explicitly
+// drained, or asleep from a normal idle transition. Sessions parked via
+// `gc session wait` (sleep_reason=wait-hold), held by context-churn
+// quarantine, or otherwise signalling "don't touch me" keep their slot.
+//
+// Distinct from `isDrainedSessionBead` because drain-ack can land pool
+// workers in state=asleep+sleep_reason=idle when the pre-close ownership
+// snapshot falsely reports assigned work. Freeing the slot for idle-asleep
+// pool beads lets the supervisor spawn a fresh worker for ready queue work
+// instead of stranding it on a ghost slot.
+func isPoolSessionSlotFreeable(session beads.Bead) bool {
+	if isDrainedSessionBead(session) {
+		return true
+	}
+	if strings.TrimSpace(session.Metadata["state"]) != "asleep" {
+		return false
+	}
+	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
+	switch reason {
+	case "", "idle", "idle-timeout":
+		return true
+	}
+	return false
+}

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -22,7 +22,7 @@ func isDrainedSessionBead(session beads.Bead) bool {
 // state where the pool slot it occupies can be freed — either explicitly
 // drained, or asleep from a normal idle transition. Sessions parked via
 // `gc session wait` (sleep_reason=wait-hold), held by context-churn
-// quarantine, or otherwise signalling "don't touch me" keep their slot.
+// quarantine, or otherwise signaling "don't touch me" keep their slot.
 //
 // Distinct from `isDrainedSessionBead` because drain-ack can land pool
 // workers in state=asleep+sleep_reason=idle when the pre-close ownership

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TestIsPoolSessionSlotFreeable_Matrix exercises the deny-by-default contract
+// of the freeable allowlist. The allowlist is tiny, so regressions that widen
+// it (e.g., adding `default: true`) or narrow it (e.g., removing `idle-timeout`)
+// must be caught by an explicit table rather than by accident.
+func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
+	cases := []struct {
+		name  string
+		meta  map[string]string
+		want  bool
+	}{
+		{"drained-state", map[string]string{"state": "drained"}, true},
+		{"asleep+drained-reason", map[string]string{"state": "asleep", "sleep_reason": "drained"}, true},
+		{"asleep+idle", map[string]string{"state": "asleep", "sleep_reason": "idle"}, true},
+		{"asleep+idle-timeout", map[string]string{"state": "asleep", "sleep_reason": "idle-timeout"}, true},
+		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},
+		{"asleep+missing-reason", map[string]string{"state": "asleep"}, false},
+		{"asleep+wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},
+		{"asleep+context-churn", map[string]string{"state": "asleep", "sleep_reason": "context-churn"}, false},
+		{"asleep+unknown", map[string]string{"state": "asleep", "sleep_reason": "future-reason"}, false},
+		{"awake", map[string]string{"state": "awake"}, false},
+		{"creating", map[string]string{"state": "creating"}, false},
+		{"no-metadata", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPoolSessionSlotFreeable(beads.Bead{Metadata: tc.meta})
+			if got != tc.want {
+				t.Fatalf("isPoolSessionSlotFreeable(%v) = %v, want %v", tc.meta, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -12,9 +12,9 @@ import (
 // must be caught by an explicit table rather than by accident.
 func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 	cases := []struct {
-		name  string
-		meta  map[string]string
-		want  bool
+		name string
+		meta map[string]string
+		want bool
 	}{
 		{"drained-state", map[string]string{"state": "drained"}, true},
 		{"asleep+drained-reason", map[string]string{"state": "asleep", "sleep_reason": "drained"}, true},

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -26,19 +27,30 @@ func buildAssignedWorkIndex(workBeads []beads.Bead) map[string]bool {
 	return index
 }
 
+// closeSessionBeadIfUnassigned closes a session bead only when the live
+// store confirms no open or in-progress work is assigned to it. Callers
+// must NOT pass a pre-computed work snapshot — this helper queries the
+// store itself so its decision cannot be poisoned by a stale snapshot
+// taken earlier in the tick (see the PR that retired the snapshot-based
+// variant). Live-query failures fail closed: the bead stays open until
+// assignment can be re-verified.
 func closeSessionBeadIfUnassigned(
 	store beads.Store,
 	session beads.Bead,
-	assigneeHasWork map[string]bool,
 	reason string,
 	now time.Time,
 	stderr io.Writer,
 ) bool {
-	if sessionHasAssignedWork(session, assigneeHasWork) {
-		return false
-	}
 	if stderr == nil {
 		stderr = io.Discard
+	}
+	hasAssignedWork, err := sessionHasOpenAssignedWork(store, session)
+	if err != nil {
+		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", session.ID, err) //nolint:errcheck
+		return false
+	}
+	if hasAssignedWork {
+		return false
 	}
 	return closeBead(store, session.ID, reason, now, stderr)
 }

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -9,19 +9,16 @@ import (
 )
 
 // closeSessionBeadIfUnassigned closes a session bead only when the live
-// store confirms no open or in-progress work is assigned to it. Callers
-// must NOT pass a pre-computed work snapshot — this helper queries the
-// store itself so its decision cannot be poisoned by a stale snapshot
-// taken earlier in the tick (see the PR that retired the snapshot-based
-// variant). Live-query failures fail closed: the bead stays open until
-// assignment can be re-verified.
-//
-// Scope: consults only the provided store. Cross-store assignment
-// (work in rig stores assigned to a city-stored session) is not
-// inspected here. Callers that need cross-store coverage must chain
-// queries per store themselves.
+// store confirms no open or in-progress work is assigned to it across
+// the primary store AND any attached rig stores. Callers must NOT pass
+// a pre-computed work snapshot — this helper queries the stores itself
+// so its decision cannot be poisoned by a stale snapshot taken earlier
+// in the tick (see the PR that retired the snapshot-based variant).
+// Live-query failures fail closed: the bead stays open until assignment
+// can be re-verified.
 func closeSessionBeadIfUnassigned(
 	store beads.Store,
+	rigStores map[string]beads.Store,
 	session beads.Bead,
 	reason string,
 	now time.Time,
@@ -30,7 +27,7 @@ func closeSessionBeadIfUnassigned(
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWork(store, session)
+	hasAssignedWork, err := sessionHasOpenAssignedWork(store, rigStores, session)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", session.ID, err) //nolint:errcheck
 		return false

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -3,29 +3,10 @@ package main
 import (
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
-
-func buildAssignedWorkIndex(workBeads []beads.Bead) map[string]bool {
-	if workBeads == nil {
-		return nil
-	}
-	index := make(map[string]bool, len(workBeads))
-	for _, wb := range workBeads {
-		if wb.Status != "open" && wb.Status != "in_progress" {
-			continue
-		}
-		assignee := strings.TrimSpace(wb.Assignee)
-		if assignee == "" {
-			continue
-		}
-		index[assignee] = true
-	}
-	return index
-}
 
 // closeSessionBeadIfUnassigned closes a session bead only when the live
 // store confirms no open or in-progress work is assigned to it. Callers
@@ -34,6 +15,11 @@ func buildAssignedWorkIndex(workBeads []beads.Bead) map[string]bool {
 // taken earlier in the tick (see the PR that retired the snapshot-based
 // variant). Live-query failures fail closed: the bead stays open until
 // assignment can be re-verified.
+//
+// Scope: consults only the provided store. Cross-store assignment
+// (work in rig stores assigned to a city-stored session) is not
+// inspected here. Callers that need cross-store coverage must chain
+// queries per store themselves.
 func closeSessionBeadIfUnassigned(
 	store beads.Store,
 	session beads.Bead,


### PR DESCRIPTION
## Summary

Pool workers finishing their work would strand ready queue beads on a ghost slot because the supervisor thought the slot was occupied. Two independent reconciler bugs conspired; fixing both.

## Reproducer (what we saw)

Running `mol-bug-report-flow-v2` against a GitHub issue in the `gascity` rig. After the classification chain completed, `publish-classification.attempt.1` was ready and routed to `gascity/codex-mini`, but nothing claimed it for many minutes. The prior codex-mini bead was visible in `bd list` as state=asleep, sleep_reason=idle. `gc session list` reported `desired=1, open=1` so the scale controller was satisfied and never spawned a replacement. Manually closing the asleep bead (`gc session close <id>`) instantly freed the slot and a fresh worker was spawned within seconds.

## Root causes

**1. Drain-ack's `hasAssignedWork` check read a stale snapshot.**

`cmd/gc/session_reconciler.go` in the drain-ack branch calls `sessionHasOpenAssignedWorkWithSnapshot(store, *session, ownershipWorkBeads, ...)`. `ownershipWorkBeads` is a snapshot taken earlier in the reconcile tick. Pool workers run `bd close <work-id>` immediately before `gc runtime drain-ack`, so the snapshot still shows the now-closed bead as open+assigned. `hasAssignedWork` comes back true → session lands in `CompleteDrainPatch` (`state=asleep`, `sleep_reason=idle`) instead of `AcknowledgeDrainPatch` (`state=drained`).

**2. The close-on-drain gate only fires for `state=drained`.**

`isDrainedSessionBead` matches `state=="drained"` or `state=="asleep" && sleep_reason=="drained"`. Pool beads landing in `state=asleep` + `sleep_reason=idle` never take the close path, so the bead stays open, still counts toward `poolDesired` satisfaction, and blocks a fresh spawn until something else ages it out (churn quarantine, cache reconcile, etc. — none of which are timely).

These two bugs are independent — either alone would be fixable by working around the other, but both together produce the observed stall. Fixing only one would leave edge cases.

## Changes

1. **`cmd/gc/session_reconciler.go` — drain-ack re-queries the store.** `sessionHasOpenAssignedWorkWithSnapshot(...)` → `sessionHasOpenAssignedWork(store, *session)`. No more pre-close ghost data influencing the terminal state decision. The `ownership_snapshot_partial` sleep reason is retired — live queries don't have a "partial" concept; live errors still fail closed via `hasAssignedWork=true`.

2. **`cmd/gc/session_state_helpers.go` — new `isPoolSessionSlotFreeable`.** A pool-managed bead whose runtime has exited and whose state is `drained` OR (`asleep` with `sleep_reason ∈ {idle, idle-timeout, ""}`) frees its slot. Preserves `wait-hold`, `context-churn`, and other "don't touch me" signals. Does not touch named singletons or interactive sessions.

3. **`cmd/gc/session_reconciler.go` — close gate uses the new predicate.** Pool-managed asleep-idle beads (from historical state or whatever path leads there) now free their slot instead of hanging indefinitely.

4. **Retired `TestReconcileSessionBeads_DrainAckPartialOwnershipSnapshotFailsClosed`.** It guarded the `ownership_snapshot_partial` sleep reason, which is gone now that drain-ack is live.

5. **Two new regression tests:**
   - `TestReconcileSessionBeads_DrainAckIgnoresStaleOwnershipSnapshot` — pass a snapshot that lies about assigned work; assert `state=drained` because the live store says otherwise.
   - `TestReconcileSessionBeads_AsleepIdlePoolBeadFreesSlot` — seed the exact state that used to strand pool beads; assert the bead is closed.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 -run 'TestReconcileSessionBeads_(DrainAck|AsleepIdle)' ./cmd/gc/...` passes
- [ ] Deploy to a city with a queue-driven pool workflow and verify: pool workers cycle cleanly after each claim+drain; no asleep-idle ghost beads accumulate.

## Risk

- **Scope of change:** pool-managed sessions only. Named singletons, interactive sessions, and dependency-only beads are explicitly filtered out by the guards (`isPoolManagedSessionBead`, `wait-hold` sleep reason, `pin_awake`).
- **Blast radius:** live store query per drain-ack instead of snapshot read. One `store.List` call per drain per session — negligible relative to the drain itself.
