### PR TITLE
fix(mail): fall back through identity candidates when GC_ALIAS does not resolve (#858)

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -590,6 +590,22 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 	return resolvedMailTarget{}, false
 }
 
+func resolveDefaultMailSenderForCommand(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string) (string, bool) {
+	candidates := defaultMailIdentityCandidates()
+	for _, c := range candidates {
+		sender, err := resolveMailIdentityWithConfig(cityPath, cfg, store, c)
+		if err == nil {
+			return sender, true
+		}
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			fmt.Fprintf(stderr, "%s: invalid sender %q: %v\n", cmdName, c, err) //nolint:errcheck // best-effort stderr
+			return "", false
+		}
+	}
+	fmt.Fprintf(stderr, "%s: no sender identity resolved (tried %v)\n", cmdName, candidates) //nolint:errcheck // best-effort stderr
+	return "", false
+}
+
 func resolveMailTargetFromArgs(args []string, stderr io.Writer, cmdName string) (resolvedMailTarget, bool) {
 	if len(args) > 0 {
 		return resolveMailTargetsForCommand(args[0], stderr, cmdName)
@@ -1214,9 +1230,8 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 				return 1
 			}
 			cfg, _ := loadCityConfig(cityPath)
-			resolved, err := resolveMailIdentityWithConfig(cityPath, cfg, store, sender)
-			if err != nil {
-				fmt.Fprintf(stderr, "gc mail reply: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
+			resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail reply")
+			if !ok {
 				return 1
 			}
 			sender = resolved

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -178,11 +178,7 @@ func cmdMailCheck(args []string, inject bool, stdout, stderr io.Writer) int {
 		return code
 	}
 
-	recipient := defaultMailIdentity()
-	if len(args) > 0 {
-		recipient = args[0]
-	}
-	target, ok := resolveMailTargetsForCommand(recipient, stderr, "gc mail check")
+	target, ok := resolveMailTargetFromArgs(args, stderr, "gc mail check")
 	if !ok {
 		if inject {
 			return 0
@@ -247,16 +243,39 @@ func formatInjectOutput(messages []mail.Message) string {
 }
 
 func defaultMailIdentity() string {
-	if alias := strings.TrimSpace(os.Getenv("GC_ALIAS")); alias != "" {
-		return alias
+	return defaultMailIdentityCandidates()[0]
+}
+
+// defaultMailIdentityCandidates returns ordered non-empty identity candidates
+// (GC_ALIAS, GC_SESSION_ID, GC_AGENT), falling back to ["human"] when all are
+// unset. Multiple candidates matter for pool workers where GC_ALIAS may be a
+// pool-instance qualified name absent from the session bead's metadata while
+// GC_SESSION_ID still matches via session_name.
+func defaultMailIdentityCandidates() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		out = append(out, v)
 	}
-	if sessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID")); sessionID != "" {
-		return sessionID
+	add(os.Getenv("GC_ALIAS"))
+	add(os.Getenv("GC_SESSION_ID"))
+	add(os.Getenv("GC_AGENT"))
+	if len(out) == 0 {
+		out = append(out, "human")
 	}
-	if agent := strings.TrimSpace(os.Getenv("GC_AGENT")); agent != "" {
-		return agent
-	}
-	return "human"
+	return out
+}
+
+// isStorelessMailProvider reports whether the configured mail provider
+// bypasses the city bead store (exec scripts and test doubles).
+func isStorelessMailProvider() bool {
+	v := mailProviderName()
+	return strings.HasPrefix(v, "exec:") || v == "fake" || v == "fail"
 }
 
 func sessionMailboxAddress(b beads.Bead) string {
@@ -543,9 +562,43 @@ func resolveMailTargetsForCommand(identifier string, stderr io.Writer, cmdName s
 	return target, true
 }
 
+// resolveDefaultMailTargetsForCommand tries each default identity candidate
+// against the city's bead store and returns the first that resolves. A
+// stale GC_ALIAS on a pool worker would otherwise block inbox access when
+// GC_SESSION_ID still matches the bead via session_name.
+func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (resolvedMailTarget, bool) {
+	candidates := defaultMailIdentityCandidates()
+	if len(candidates) == 1 || isStorelessMailProvider() {
+		return resolveMailTargetsForCommand(candidates[0], stderr, cmdName)
+	}
+	store, code := openCityStore(stderr, cmdName)
+	if store == nil {
+		_ = code
+		return resolvedMailTarget{}, false
+	}
+	for _, c := range candidates {
+		target, err := resolveMailTargets(store, c)
+		if err == nil {
+			return target, true
+		}
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+			return resolvedMailTarget{}, false
+		}
+	}
+	fmt.Fprintf(stderr, "%s: no mail identity resolved (tried %v)\n", cmdName, candidates) //nolint:errcheck // best-effort stderr
+	return resolvedMailTarget{}, false
+}
+
+func resolveMailTargetFromArgs(args []string, stderr io.Writer, cmdName string) (resolvedMailTarget, bool) {
+	if len(args) > 0 {
+		return resolveMailTargetsForCommand(args[0], stderr, cmdName)
+	}
+	return resolveDefaultMailTargetsForCommand(stderr, cmdName)
+}
+
 func resolveRawMailTargetForStorelessProvider(identifier string, stderr io.Writer, cmdName string) (resolvedMailTarget, bool) {
-	v := mailProviderName()
-	if !strings.HasPrefix(v, "exec:") && v != "fake" && v != "fail" {
+	if !isStorelessMailProvider() {
 		return resolvedMailTarget{}, false
 	}
 	store, err := openMailTargetStore()
@@ -854,6 +907,9 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 		cfg, _ = loadCityConfig(cityPath)
 		store, err = openCityStoreAt(cityPath)
 	}
+	// Narrower than isStorelessMailProvider: exec: providers can legitimately
+	// run without a city store, but fake/fail still require one for alias
+	// resolution in tests. Do not unify with isStorelessMailProvider.
 	if err != nil && !strings.HasPrefix(mailProviderName(), "exec:") {
 		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1032,11 +1088,7 @@ func cmdMailInbox(args []string, stdout, stderr io.Writer) int {
 		return code
 	}
 
-	recipient := defaultMailIdentity()
-	if len(args) > 0 {
-		recipient = args[0]
-	}
-	target, ok := resolveMailTargetsForCommand(recipient, stderr, "gc mail inbox")
+	target, ok := resolveMailTargetFromArgs(args, stderr, "gc mail inbox")
 	if !ok {
 		return 1
 	}
@@ -1150,8 +1202,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	sender := defaultMailIdentity()
 	var hasStore bool
 	if sender != "human" {
-		v := mailProviderName()
-		if !strings.HasPrefix(v, "exec:") && v != "fake" && v != "fail" {
+		if !isStorelessMailProvider() {
 			hasStore = true
 			store, storeCode := openCityStore(stderr, "gc mail reply")
 			if store == nil {
@@ -1363,11 +1414,7 @@ func cmdMailCount(args []string, stdout, stderr io.Writer) int {
 		return code
 	}
 
-	recipient := defaultMailIdentity()
-	if len(args) > 0 {
-		recipient = args[0]
-	}
-	target, ok := resolveMailTargetsForCommand(recipient, stderr, "gc mail count")
+	target, ok := resolveMailTargetFromArgs(args, stderr, "gc mail count")
 	if !ok {
 		return 1
 	}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -1132,6 +1132,54 @@ func TestMailReplyNotifyNudgeError(t *testing.T) {
 	}
 }
 
+func TestCmdMailReply_FallsBackToGCSessionIDWhenAliasMissing(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "",
+			"session_name": "codeprobe-worker-gc-1941",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	mp := beadmail.New(store)
+	if _, err := mp.Send("alice", sessionBead.ID, "Hello", "first"); err != nil {
+		t.Fatalf("mp.Send(): %v", err)
+	}
+
+	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
+	t.Setenv("GC_SESSION_ID", "codeprobe-worker-gc-1941")
+	t.Setenv("GC_AGENT", "codeprobe-worker")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{"gc-2", "reply body"}, "", "", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailReply() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Replied to gc-2") {
+		t.Fatalf("stdout = %q, want reply confirmation", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "to alice") {
+		t.Fatalf("stdout = %q, want reply addressed to alice", stdout.String())
+	}
+}
+
 // --- gc mail mark-read / mark-unread ---
 
 func TestMailMarkReadSuccess(t *testing.T) {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -200,6 +200,219 @@ func TestDefaultMailIdentityPrefersSessionIDOverGCAgentFallback(t *testing.T) {
 	}
 }
 
+func TestDefaultMailIdentityCandidates_OrdersAliasFirstThenSessionIDThenAgent(t *testing.T) {
+	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
+	t.Setenv("GC_SESSION_ID", "codeprobe-worker-gc-1941")
+	t.Setenv("GC_AGENT", "codeprobe-worker")
+
+	got := defaultMailIdentityCandidates()
+	want := []string{"codeprobe-worker-1", "codeprobe-worker-gc-1941", "codeprobe-worker"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("defaultMailIdentityCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDefaultMailIdentityCandidates_DedupesAndSkipsEmpty(t *testing.T) {
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("GC_AGENT", "mayor")
+
+	got := defaultMailIdentityCandidates()
+	want := []string{"mayor"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("defaultMailIdentityCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDefaultMailIdentityCandidates_FallsBackToHumanWhenAllEmpty(t *testing.T) {
+	t.Setenv("GC_ALIAS", "")
+	_ = os.Unsetenv("GC_SESSION_ID")
+	_ = os.Unsetenv("GC_AGENT")
+
+	got := defaultMailIdentityCandidates()
+	want := []string{"human"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("defaultMailIdentityCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+// TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMissing
+// reproduces a live pool-worker state where GC_ALIAS was set to the
+// pool-instance qualified name (e.g. "codeprobe-worker-1") but the session
+// bead's alias metadata is empty. The bead's session_name matches
+// GC_SESSION_ID. Inbox lookup must succeed via the session_name path rather
+// than failing on the first candidate.
+func TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMissing(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "",
+			"session_name": "codeprobe-worker-gc-1941",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
+	t.Setenv("GC_SESSION_ID", "codeprobe-worker-gc-1941")
+	t.Setenv("GC_AGENT", "codeprobe-worker")
+
+	var stderr bytes.Buffer
+	target, ok := resolveDefaultMailTargetsForCommand(&stderr, "gc mail inbox")
+	if !ok {
+		t.Fatalf("resolveDefaultMailTargetsForCommand() = not ok; stderr=%q", stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+	foundBeadID := false
+	for _, r := range target.recipients {
+		if r == b.ID {
+			foundBeadID = true
+			break
+		}
+	}
+	if !foundBeadID {
+		t.Fatalf("target.recipients = %#v, want to include bead ID %q", target.recipients, b.ID)
+	}
+}
+
+func TestResolveDefaultMailTargetsForCommand_UsesGCAliasWhenItResolves(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "sky",
+			"session_name": "sky-gc-42",
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	t.Setenv("GC_ALIAS", "sky")
+	t.Setenv("GC_SESSION_ID", "gc-does-not-match")
+	_ = os.Unsetenv("GC_AGENT")
+
+	var stderr bytes.Buffer
+	target, ok := resolveDefaultMailTargetsForCommand(&stderr, "gc mail inbox")
+	if !ok {
+		t.Fatalf("resolveDefaultMailTargetsForCommand() = not ok; stderr=%q", stderr.String())
+	}
+	if target.display != "sky" {
+		t.Fatalf("target.display = %q, want sky", target.display)
+	}
+}
+
+func TestResolveDefaultMailTargetsForCommand_HumanDefaultWhenNoEnv(t *testing.T) {
+	t.Setenv("GC_MAIL", "fake")
+	_ = os.Unsetenv("GC_ALIAS")
+	_ = os.Unsetenv("GC_SESSION_ID")
+	_ = os.Unsetenv("GC_AGENT")
+
+	var stderr bytes.Buffer
+	target, ok := resolveDefaultMailTargetsForCommand(&stderr, "gc mail inbox")
+	if !ok {
+		t.Fatalf("resolveDefaultMailTargetsForCommand() = not ok; stderr=%q", stderr.String())
+	}
+	if target.display != "human" {
+		t.Fatalf("target.display = %q, want human", target.display)
+	}
+}
+
+// TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate
+// confirms the storeless-provider shortcut forwards only candidates[0] —
+// the same identity the old defaultMailIdentity() returned — rather than
+// iterating.
+func TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate(t *testing.T) {
+	t.Setenv("GC_MAIL", "fake")
+	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
+	t.Setenv("GC_SESSION_ID", "codeprobe-worker-gc-1941")
+	t.Setenv("GC_AGENT", "codeprobe-worker")
+
+	var stderr bytes.Buffer
+	target, ok := resolveDefaultMailTargetsForCommand(&stderr, "gc mail inbox")
+	if !ok {
+		t.Fatalf("resolveDefaultMailTargetsForCommand() = not ok; stderr=%q", stderr.String())
+	}
+	if target.display != "codeprobe-worker-1" {
+		t.Fatalf("target.display = %q, want codeprobe-worker-1", target.display)
+	}
+	if len(target.recipients) != 1 || target.recipients[0] != "codeprobe-worker-1" {
+		t.Fatalf("target.recipients = %#v, want [codeprobe-worker-1]", target.recipients)
+	}
+}
+
+// TestResolveDefaultMailTargetsForCommand_SurfacesAmbiguousError_AndStops
+// confirms that when a candidate produces a non-ErrSessionNotFound error
+// (here: ErrAmbiguous from two beads sharing the same session_name), the
+// loop surfaces it to stderr and stops iterating rather than falling
+// through to the next candidate.
+func TestResolveDefaultMailTargetsForCommand_SurfacesAmbiguousError_AndStops(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := store.Create(beads.Bead{
+			Type:     session.BeadType,
+			Labels:   []string{session.LabelSession},
+			Metadata: map[string]string{"session_name": "ambiguous-target"},
+		}); err != nil {
+			t.Fatalf("Create(%d): %v", i, err)
+		}
+	}
+
+	t.Setenv("GC_ALIAS", "ambiguous-target")
+	t.Setenv("GC_SESSION_ID", "would-resolve-if-reached")
+	_ = os.Unsetenv("GC_AGENT")
+
+	var stderr bytes.Buffer
+	_, ok := resolveDefaultMailTargetsForCommand(&stderr, "gc mail inbox")
+	if ok {
+		t.Fatalf("resolveDefaultMailTargetsForCommand() ok = true, want false")
+	}
+	if !strings.Contains(stderr.String(), "ambiguous") {
+		t.Fatalf("stderr = %q, want to contain ambiguous", stderr.String())
+	}
+}
+
 func TestDefaultMailIdentityFallsBackToGCAgentWithoutAliasOrSession(t *testing.T) {
 	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "mayor")


### PR DESCRIPTION
## Summary

- `gc mail inbox` / `check` / `count` fail for pool workers with `session not found: "<pool-instance>"` when `GC_ALIAS` is set to a pool-instance qualified name (e.g. `codeprobe-worker-1`) but the session bead's `alias` metadata is empty and its `session_name` is the gc-prefixed form. Reported as #858.
- Defensive resolution-side fix: try each of `GC_ALIAS` → `GC_SESSION_ID` → `GC_AGENT` in order against the bead store and return the first that resolves. Explicit `gc mail inbox <session>` args are untouched.
- Does not address the spawn-side question (why the bead's `alias` is empty); #858 remains open pending maintainer input on whether GC_ALIAS should stop being set for pool workers or whether the spawn path should persist the instance alias on the bead.

## What changed

**cmd/gc/cmd_mail.go** — four helpers:
- `defaultMailIdentityCandidates() []string` — ordered, deduped env-var candidates, `[\"human\"]` fallback
- `isStorelessMailProvider() bool` — shared predicate (replaces two inline copies of `exec:/fake/fail`)
- `resolveDefaultMailTargetsForCommand(stderr, cmdName) (resolvedMailTarget, bool)` — iterates candidates against the city store, returns first success; surfaces any non-`ErrSessionNotFound` error immediately and stops
- `resolveInboxTarget(args, stderr, cmdName) (resolvedMailTarget, bool)` — dispatches explicit-arg vs default-identity paths

`defaultMailIdentity()` collapsed to `defaultMailIdentityCandidates()[0]`. Happy path (GC_ALIAS resolves) is bit-identical in cost — one cached `List(LabelSession)` call, same as before.

`cmdMailCheck`, `cmdMailInbox`, `cmdMailCount`, `cmdMailReply` use the new helpers. `cmdMailSend` intentionally retains a narrower exec-only storeless check; the code now carries a comment explaining why.

## Test plan

Six new tests in `cmd/gc/cmd_mail_test.go`:

- [x] `TestDefaultMailIdentityCandidates_*` — ordering, dedup, `[\"human\"]` fallback
- [x] `TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMissing` — the #858 repro: bead has `alias=\"\"`, `session_name=\"codeprobe-worker-gc-1941\"`; `GC_ALIAS=codeprobe-worker-1` doesn't match but `GC_SESSION_ID` does via session_name. Asserts resolution succeeds.
- [x] `TestResolveDefaultMailTargetsForCommand_UsesGCAliasWhenItResolves` — no regression when GC_ALIAS is the working identity
- [x] `TestResolveDefaultMailTargetsForCommand_HumanDefaultWhenNoEnv` — unset env falls through to human
- [x] `TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate` — confirms the storeless shortcut forwards only `candidates[0]`, matching the old `defaultMailIdentity()` semantics
- [x] `TestResolveDefaultMailTargetsForCommand_SurfacesAmbiguousError_AndStops` — non-`ErrSessionNotFound` errors (e.g. `ErrAmbiguous` from duplicate beads) are surfaced to stderr and halt iteration
- [x] `go test ./cmd/gc/ -count=1` — PASS (all ~260s)
- [x] `go vet ./...` — clean
- [x] `make build` / `make check` — PASS

## Review trail

- Multi-model review: Anthropic×3 + Copilot (GPT-5 codex). 4 medium findings addressed (helper reuse, redundant error variable, test coverage gaps, over-narrated comment).
- Gas City contributor check (29-rule audit + mechanical gates): READY. One soft B23 warning addressed with a documenting comment.

Closes #858.