### PR TITLE
fix: prefer session id for mail identity

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -138,8 +138,8 @@ func newMailCheckCmd(stdout, stderr io.Writer) *cobra.Command {
 
 Without --inject: prints the count and exits 0 if mail exists, 1 if
 empty. With --inject: outputs a <system-reminder> block suitable for
-hook injection (always exits 0). The recipient defaults to $GC_ALIAS,
-$GC_SESSION_ID, or "human".`,
+hook injection (always exits 0). The recipient defaults to $GC_SESSION_ID,
+$GC_ALIAS, or "human".`,
 		Example: `  gc mail check
   gc mail check --inject
   gc mail check mayor`,
@@ -247,10 +247,9 @@ func defaultMailIdentity() string {
 }
 
 // defaultMailIdentityCandidates returns ordered non-empty identity candidates
-// (GC_ALIAS, GC_SESSION_ID, GC_AGENT), falling back to ["human"] when all are
-// unset. Multiple candidates matter for pool workers where GC_ALIAS may be a
-// pool-instance qualified name absent from the session bead's metadata while
-// GC_SESSION_ID still matches via session_name.
+// (GC_SESSION_ID, GC_ALIAS, GC_AGENT), falling back to ["human"] when all are
+// unset. Multiple candidates preserve compatibility for sessions whose concrete
+// ID is unavailable while still preferring the concrete mailbox when it exists.
 func defaultMailIdentityCandidates() []string {
 	seen := map[string]bool{}
 	var out []string
@@ -262,8 +261,8 @@ func defaultMailIdentityCandidates() []string {
 		seen[v] = true
 		out = append(out, v)
 	}
-	add(os.Getenv("GC_ALIAS"))
 	add(os.Getenv("GC_SESSION_ID"))
+	add(os.Getenv("GC_ALIAS"))
 	add(os.Getenv("GC_AGENT"))
 	if len(out) == 0 {
 		out = append(out, "human")
@@ -719,7 +718,7 @@ func newMailSendCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Send a message to a session alias or human.
 
 Creates a message bead addressed to the recipient. The sender defaults
-to $GC_ALIAS or $GC_SESSION_ID (in sessions) or "human". Use --notify to nudge
+to $GC_SESSION_ID or $GC_ALIAS (in sessions) or "human". Use --notify to nudge
 the recipient after sending. Use --from to override the sender identity.
 Use --to as an alternative to the positional <to> argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
@@ -741,7 +740,7 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 	}
 	cmd.Flags().BoolVar(&notify, "notify", false, "nudge the recipient after sending")
 	cmd.Flags().BoolVar(&all, "all", false, "broadcast to all live sessions (excludes sender and human)")
-	cmd.Flags().StringVar(&from, "from", "", "sender identity (default: $GC_ALIAS, $GC_SESSION_ID, or \"human\")")
+	cmd.Flags().StringVar(&from, "from", "", "sender identity (default: $GC_SESSION_ID, $GC_ALIAS, or \"human\")")
 	cmd.Flags().StringVar(&to, "to", "", "recipient address (alternative to positional argument)")
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "message subject line")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "message body text")
@@ -756,7 +755,7 @@ func newMailInboxCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `List all unread messages for a session alias or human.
 
 Shows message ID, sender, subject, and body in a table. The recipient defaults
-to $GC_ALIAS, $GC_SESSION_ID, or "human". Pass a session alias to view another inbox.`,
+to $GC_SESSION_ID, $GC_ALIAS, or "human". Pass a session alias to view another inbox.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailInbox(args, stdout, stderr) != 0 {
@@ -893,7 +892,7 @@ func newMailCountCmd(stdout, stderr io.Writer) *cobra.Command {
 		Use:   "count [session]",
 		Short: "Show total/unread message count",
 		Long: `Show total and unread message counts for a session alias or human.
-The recipient defaults to $GC_ALIAS, $GC_SESSION_ID, or "human".`,
+The recipient defaults to $GC_SESSION_ID, $GC_ALIAS, or "human".`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailCount(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -200,15 +200,25 @@ func TestDefaultMailIdentityPrefersSessionIDOverGCAgentFallback(t *testing.T) {
 	}
 }
 
-func TestDefaultMailIdentityCandidates_OrdersAliasFirstThenSessionIDThenAgent(t *testing.T) {
+func TestDefaultMailIdentityCandidates_OrdersSessionIDFirstThenAliasThenAgent(t *testing.T) {
 	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
 	t.Setenv("GC_SESSION_ID", "codeprobe-worker-gc-1941")
 	t.Setenv("GC_AGENT", "codeprobe-worker")
 
 	got := defaultMailIdentityCandidates()
-	want := []string{"codeprobe-worker-1", "codeprobe-worker-gc-1941", "codeprobe-worker"}
+	want := []string{"codeprobe-worker-gc-1941", "codeprobe-worker-1", "codeprobe-worker"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("defaultMailIdentityCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDefaultMailIdentityPrefersSessionIDOverAlias(t *testing.T) {
+	t.Setenv("GC_ALIAS", "public-alias")
+	t.Setenv("GC_AGENT", "worker")
+	t.Setenv("GC_SESSION_ID", "session-123")
+
+	if got := defaultMailIdentity(); got != "session-123" {
+		t.Fatalf("defaultMailIdentity() = %q, want session-123", got)
 	}
 }
 
@@ -236,13 +246,11 @@ func TestDefaultMailIdentityCandidates_FallsBackToHumanWhenAllEmpty(t *testing.T
 	}
 }
 
-// TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMissing
-// reproduces a live pool-worker state where GC_ALIAS was set to the
-// pool-instance qualified name (e.g. "codeprobe-worker-1") but the session
-// bead's alias metadata is empty. The bead's session_name matches
-// GC_SESSION_ID. Inbox lookup must succeed via the session_name path rather
-// than failing on the first candidate.
-func TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMissing(t *testing.T) {
+// TestResolveDefaultMailTargetsForCommand_UsesGCSessionIDBeforeAlias
+// sets up two possible matches: GC_SESSION_ID points at the concrete worker,
+// while GC_ALIAS points at another session. Default mail resolution must choose
+// the concrete session identity first.
+func TestResolveDefaultMailTargetsForCommand_UsesGCSessionIDBeforeAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_MAIL", "")
 
@@ -265,7 +273,18 @@ func TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMiss
 		},
 	})
 	if err != nil {
-		t.Fatalf("Create: %v", err)
+		t.Fatalf("Create concrete session: %v", err)
+	}
+	aliasOnly, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "codeprobe-worker-1",
+			"session_name": "stale-alias-session",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create alias session: %v", err)
 	}
 
 	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
@@ -280,19 +299,22 @@ func TestResolveDefaultMailTargetsForCommand_FallsBackToGCSessionIDWhenAliasMiss
 	if stderr.Len() != 0 {
 		t.Errorf("stderr = %q, want empty", stderr.String())
 	}
-	foundBeadID := false
+	foundConcrete := false
+	foundAliasOnly := false
 	for _, r := range target.recipients {
 		if r == b.ID {
-			foundBeadID = true
-			break
+			foundConcrete = true
+		}
+		if r == aliasOnly.ID {
+			foundAliasOnly = true
 		}
 	}
-	if !foundBeadID {
-		t.Fatalf("target.recipients = %#v, want to include bead ID %q", target.recipients, b.ID)
+	if !foundConcrete || foundAliasOnly {
+		t.Fatalf("target.recipients = %#v, want concrete bead %q and not alias bead %q", target.recipients, b.ID, aliasOnly.ID)
 	}
 }
 
-func TestResolveDefaultMailTargetsForCommand_UsesGCAliasWhenItResolves(t *testing.T) {
+func TestResolveDefaultMailTargetsForCommand_FallsBackToGCAliasWhenSessionIDMissing(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_MAIL", "")
 
@@ -349,8 +371,7 @@ func TestResolveDefaultMailTargetsForCommand_HumanDefaultWhenNoEnv(t *testing.T)
 
 // TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate
 // confirms the storeless-provider shortcut forwards only candidates[0] —
-// the same identity the old defaultMailIdentity() returned — rather than
-// iterating.
+// the same identity defaultMailIdentity() returns — rather than iterating.
 func TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate(t *testing.T) {
 	t.Setenv("GC_MAIL", "fake")
 	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
@@ -362,11 +383,11 @@ func TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate
 	if !ok {
 		t.Fatalf("resolveDefaultMailTargetsForCommand() = not ok; stderr=%q", stderr.String())
 	}
-	if target.display != "codeprobe-worker-1" {
-		t.Fatalf("target.display = %q, want codeprobe-worker-1", target.display)
+	if target.display != "codeprobe-worker-gc-1941" {
+		t.Fatalf("target.display = %q, want codeprobe-worker-gc-1941", target.display)
 	}
-	if len(target.recipients) != 1 || target.recipients[0] != "codeprobe-worker-1" {
-		t.Fatalf("target.recipients = %#v, want [codeprobe-worker-1]", target.recipients)
+	if len(target.recipients) != 1 || target.recipients[0] != "codeprobe-worker-gc-1941" {
+		t.Fatalf("target.recipients = %#v, want [codeprobe-worker-gc-1941]", target.recipients)
 	}
 }
 
@@ -399,8 +420,8 @@ func TestResolveDefaultMailTargetsForCommand_SurfacesAmbiguousError_AndStops(t *
 		}
 	}
 
-	t.Setenv("GC_ALIAS", "ambiguous-target")
-	t.Setenv("GC_SESSION_ID", "would-resolve-if-reached")
+	t.Setenv("GC_SESSION_ID", "ambiguous-target")
+	t.Setenv("GC_ALIAS", "would-resolve-if-reached")
 	_ = os.Unsetenv("GC_AGENT")
 
 	var stderr bytes.Buffer

--- a/cmd/gc/session_target.go
+++ b/cmd/gc/session_target.go
@@ -14,9 +14,18 @@ type sessionRuntimeTarget struct {
 	sessionName string
 }
 
+func defaultSessionDisplayIdentity() string {
+	for _, key := range []string{"GC_ALIAS", "GC_SESSION_ID", "GC_AGENT"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func currentSessionRuntimeTarget() (sessionRuntimeTarget, error) {
-	display := defaultMailIdentity()
-	if display == "human" {
+	display := defaultSessionDisplayIdentity()
+	if display == "" {
 		return sessionRuntimeTarget{}, fmt.Errorf("not in session context (GC_ALIAS/GC_SESSION_ID not set)")
 	}
 	sessionName := strings.TrimSpace(os.Getenv("GC_TMUX_SESSION"))


### PR DESCRIPTION
## Summary
- make `gc mail` default to `GC_SESSION_ID` before `GC_ALIAS`
- update command help text to match the actual identity precedence
- add a regression test for sessions that have both a concrete ID and public alias

## Tests
- `go test ./cmd/gc -run 'TestDefaultMailIdentity' -count=1`
