### PR TITLE
fix: remove beadmail label supplement

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -111,7 +111,7 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps,
 		Type:        "message",
 		Assignee:    sessionAddress,
 		From:        sessionAddress,
-		Labels:      []string{"gc:message", "thread:" + handoffThreadID()},
+		Labels:      []string{"thread:" + handoffThreadID()},
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -163,7 +163,7 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 		Type:        "message",
 		Assignee:    targetAddress,
 		From:        sender,
-		Labels:      []string{"gc:message", "thread:" + handoffThreadID()},
+		Labels:      []string{"thread:" + handoffThreadID()},
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/dashboard/api_fetcher.go
+++ b/cmd/gc/dashboard/api_fetcher.go
@@ -640,7 +640,7 @@ func isInternalBead(b apiBead) bool {
 	}
 	for _, l := range b.Labels {
 		switch l {
-		case "gc:message", "gc:convoy", "gc:queue", "gc:merge-request", "gc:wisp", "gc:agent":
+		case "gc:convoy", "gc:queue", "gc:merge-request", "gc:wisp", "gc:agent":
 			return true
 		}
 	}

--- a/engdocs/architecture/messaging.md
+++ b/engdocs/architecture/messaging.md
@@ -15,9 +15,9 @@ is a thin composition layer proving the primitives are sufficient.
 
 ## Key Concepts
 
-- **Mail**: A message bead — a bead with `Type="message"` and the
-  `gc:message` label. `From` is the sender, `Assignee` is the recipient,
-  `Title` holds the subject line, and `Description` holds the message body.
+- **Mail**: A message bead — a bead with `Type="message"`. `From` is the
+  sender, `Assignee` is the recipient, `Title` holds the subject line, and
+  `Description` holds the message body.
   Open beads without a "read" label are unread; beads with the "read"
   label are read but still accessible; closed beads are archived.
 
@@ -71,7 +71,7 @@ is a thin composition layer proving the primitives are sufficient.
 **Sending a message (beadmail path):**
 
 1. `gc mail send agent-1 -s "Hello" -m "body text"` invokes `Provider.Send("sender", "agent-1", "Hello", "body text")`
-2. beadmail calls `store.Create(Bead{Title:"Hello", Description:"body text", Type:"message", Assignee:"agent-1", From:"sender", Labels:["gc:message", "thread:<id>"]})`
+2. beadmail calls `store.Create(Bead{Title:"Hello", Description:"body text", Type:"message", Assignee:"agent-1", From:"sender", Labels:["thread:<id>"]})`
 3. Store assigns ID, sets Status="open", returns the bead
 4. beadmail converts to `mail.Message` and returns
 
@@ -112,8 +112,9 @@ is a thin composition layer proving the primitives are sufficient.
 ## Invariants
 
 1. **Messages are beads.** Every message has a corresponding bead with
-   `Type="message"` and the `gc:message` label. No separate message
-   storage exists.
+   `Type="message"`. No separate message storage exists. `Type="message"`
+   is the authoritative discriminator — the legacy `gc:message` label is
+   neither written nor read.
 2. **Inbox returns only open, unread messages.** Read messages (with
    "read" label) and closed (archived) beads are excluded from inbox.
 3. **Read does not close.** `Read(id)` adds the "read" label but keeps

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -25,9 +25,14 @@ func New(store beads.Store) *Provider {
 }
 
 // Send creates a message bead with subject in Title and body in Description.
+// Returns an error if to is empty: blank recipients produce messages that never
+// appear in any inbox but still inflate global counts.
 func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
+	if to == "" {
+		return mail.Message{}, fmt.Errorf("beadmail send: recipient is required")
+	}
 	threadID := generateThreadID()
-	labels := []string{"gc:message", "thread:" + threadID}
+	labels := []string{"thread:" + threadID}
 
 	title := subject
 	if title == "" && body != "" {
@@ -63,7 +68,7 @@ func (p *Provider) Get(id string) (mail.Message, error) {
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail get: %w", err)
 	}
-	if b.Type != "" && b.Type != "message" {
+	if b.Type != "message" {
 		return mail.Message{}, fmt.Errorf("beadmail get: bead %s is type %q, not message", id, b.Type)
 	}
 	return beadToMessage(b), nil
@@ -143,13 +148,16 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
 	}
+	if original.From == "" {
+		return mail.Message{}, fmt.Errorf("beadmail reply: original message %s has no sender to reply to", id)
+	}
 
 	threadID := extractLabel(original.Labels, "thread:")
 	if threadID == "" {
 		threadID = generateThreadID()
 	}
 
-	labels := []string{"gc:message", "thread:" + threadID, "reply-to:" + id}
+	labels := []string{"thread:" + threadID, "reply-to:" + id}
 
 	b, err := p.store.Create(beads.Bead{
 		Title:       subject,
@@ -236,11 +244,11 @@ func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Me
 // on stores with many beads.
 //
 // For per-recipient queries, list by assignee+type+status — targeted to the
-// recipient's open messages. Beadmail send paths write Type="message", so the
-// label is decoration, not the authoritative discriminator.
+// recipient's open messages. For global queries (recipient==""), falls back
+// to type-based listing since no assignee filter can be applied.
 //
-// For global queries (recipient==""), falls back to type-based listing since
-// no assignee filter can be applied.
+// Type="message" is the authoritative discriminator; the legacy gc:message
+// label supplement was removed in #862 along with writes to that label.
 func (p *Provider) messageCandidates(recipient string) ([]beads.Bead, error) {
 	seen := make(map[string]beads.Bead)
 	order := make([]string, 0)
@@ -283,9 +291,10 @@ func (p *Provider) messageCandidates(recipient string) ([]beads.Bead, error) {
 	return result, nil
 }
 
-// isMessage returns true if the bead is a message (by Type or gc:message label).
+// isMessage reports whether the bead is a message. Type="message" is the
+// authoritative discriminator; the legacy gc:message label is no longer read.
 func isMessage(b beads.Bead) bool {
-	return b.Type == "message" || hasLabel(b.Labels, "gc:message")
+	return b.Type == "message"
 }
 
 // beadToMessage converts a bead to a mail.Message.

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -235,10 +235,9 @@ func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Me
 // targeted queries instead of a broad store scan. This avoids timeouts
 // on stores with many beads.
 //
-// For per-recipient queries, two scoped queries are combined:
-//  1. List by assignee+type+status — targeted to the recipient's open messages
-//  2. List by gc:message label — catches messages that type queries may miss
-//     (some external stores omit messages from generic queries)
+// For per-recipient queries, list by assignee+type+status — targeted to the
+// recipient's open messages. Beadmail send paths write Type="message", so the
+// label is decoration, not the authoritative discriminator.
 //
 // For global queries (recipient==""), falls back to type-based listing since
 // no assignee filter can be applied.
@@ -276,17 +275,6 @@ func (p *Provider) messageCandidates(recipient string) ([]beads.Bead, error) {
 		}
 		add(all)
 	}
-
-	// Supplement: label query catches messages that type/assignee queries
-	// may miss (some external stores omit messages from generic queries).
-	labeled, err := p.store.List(beads.ListQuery{
-		Label: "gc:message",
-		Sort:  beads.SortCreatedDesc,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("listing gc:message beads: %w", err)
-	}
-	add(labeled)
 
 	result := make([]beads.Bead, 0, len(order))
 	for _, id := range order {

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -180,8 +180,36 @@ func TestSend(t *testing.T) {
 	if b.Status != "open" {
 		t.Errorf("bead Status = %q, want %q", b.Status, "open")
 	}
-	if !hasLabel(b.Labels, "gc:message") {
-		t.Error("bead missing gc:message label")
+	if hasLabel(b.Labels, "gc:message") {
+		t.Error("bead should no longer carry the legacy gc:message label")
+	}
+}
+
+func TestSendRejectsEmptyRecipient(t *testing.T) {
+	p := New(beads.NewMemStore())
+	if _, err := p.Send("human", "", "subject", "body"); err == nil {
+		t.Fatal("Send with empty recipient should error")
+	}
+}
+
+func TestGetRejectsNonMessageType(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	b, err := store.Create(beads.Bead{Title: "task", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Get(b.ID); err == nil {
+		t.Error("Get should reject non-message bead")
+	}
+
+	untyped, err := store.Create(beads.Bead{Title: "legacy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Get(untyped.ID); err == nil {
+		t.Error("Get should reject bead with empty type (Type=\"message\" is now required)")
 	}
 }
 

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -2,36 +2,15 @@ package beadmail
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/mail"
 )
 
-type hiddenMessageStore struct {
-	*beads.MemStore
-}
-
-func (s hiddenMessageStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if query.Label == "gc:message" {
-		return s.MemStore.List(query)
-	}
-	all, err := s.MemStore.List(beads.ListQuery{AllowScan: true})
-	if err != nil {
-		return nil, err
-	}
-	filtered := make([]beads.Bead, 0, len(all))
-	for _, b := range all {
-		if !isMessage(b) {
-			filtered = append(filtered, b)
-		}
-	}
-	return beads.ApplyListQuery(filtered, query), nil
-}
-
 // noListScanStore errors when List is called without a filter, proving that
-// Inbox/Count/All use targeted queries (assignee+type or label) instead
-// of broad scans.
+// Inbox/Count/All use targeted type queries instead of broad scans.
 type noListScanStore struct {
 	*beads.MemStore
 }
@@ -57,6 +36,28 @@ func TestInboxDoesNotCallBroadList(t *testing.T) {
 	}
 	if len(msgs) != 1 {
 		t.Errorf("Inbox = %d messages, want 1", len(msgs))
+	}
+}
+
+func TestCheckDoesNotUseMessageLabelSupplement(t *testing.T) {
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		if strings.Contains(cmd, "--label=gc:message") {
+			t.Fatalf("mail check used gc:message label supplement: %s", cmd)
+		}
+		if strings.Contains(cmd, "--assignee=mayor") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open") {
+			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"mayor","from":"human","created_at":"2026-01-02T03:04:05Z","labels":["gc:message"]}]`), nil
+		}
+		return nil, errors.New("unexpected command: " + cmd)
+	}
+	p := New(beads.NewBdStore(t.TempDir(), runner))
+
+	msgs, err := p.Check("mayor")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].ID != "msg-1" {
+		t.Fatalf("Check = %#v, want msg-1", msgs)
 	}
 }
 
@@ -248,26 +249,6 @@ func TestInboxExcludesRead(t *testing.T) {
 	}
 }
 
-func TestInboxUsesMessageLabelQueryWhenListOmitsMessages(t *testing.T) {
-	base := beads.NewMemStore()
-	p := New(hiddenMessageStore{MemStore: base})
-
-	if _, err := p.Send("human", "corp/lawrence", "", "for lawrence"); err != nil {
-		t.Fatal(err)
-	}
-
-	msgs, err := p.Inbox("corp/lawrence")
-	if err != nil {
-		t.Fatalf("Inbox: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("Inbox = %d messages, want 1", len(msgs))
-	}
-	if msgs[0].Body != "for lawrence" {
-		t.Errorf("Body = %q, want %q", msgs[0].Body, "for lawrence")
-	}
-}
-
 // --- Get ---
 
 func TestGet(t *testing.T) {
@@ -427,27 +408,6 @@ func TestMarkReadMarkUnread(t *testing.T) {
 	}
 	if len(msgs) != 1 {
 		t.Errorf("Inbox after MarkUnread = %d, want 1", len(msgs))
-	}
-}
-
-func TestCountUsesMessageLabelQueryWhenListOmitsMessages(t *testing.T) {
-	base := beads.NewMemStore()
-	p := New(hiddenMessageStore{MemStore: base})
-
-	sent, err := p.Send("human", "corp/lawrence", "", "count me")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := p.MarkRead(sent.ID); err != nil {
-		t.Fatal(err)
-	}
-
-	total, unread, err := p.Count("corp/lawrence")
-	if err != nil {
-		t.Fatalf("Count: %v", err)
-	}
-	if total != 1 || unread != 0 {
-		t.Fatalf("Count = (%d,%d), want (1,0)", total, unread)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the broad `gc:message` label supplement from beadmail candidate lookup
- rely on `Type=message` as the authoritative discriminator for native beadmail records
- drop the old label-only compatibility tests and add a regression test proving `gc mail check` does not issue a label supplement query

Current native send paths write `Type: "message"` for mail records, including `gc mail send`, `gc mail send --all`, API/dashboard mail send, replies, and handoff-created mail.

## Tests
- `go test ./internal/mail/beadmail -count=1`
