### PR TITLE
fix: defer config drift while workers have active demand

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -37,6 +37,33 @@ type wakeTarget struct {
 	alive   bool
 }
 
+func assignedWorkAssigneeMap(assignedWorkBeads []beads.Bead) map[string]bool {
+	if len(assignedWorkBeads) == 0 {
+		return nil
+	}
+	assigneeHasWork := make(map[string]bool, len(assignedWorkBeads))
+	for _, wb := range assignedWorkBeads {
+		if wb.Status != "open" && wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee != "" {
+			assigneeHasWork[assignee] = true
+		}
+	}
+	return assigneeHasWork
+}
+
+func poolSessionHasActiveDemand(session beads.Bead, template string, poolDesired map[string]int) bool {
+	if strings.TrimSpace(session.Metadata[poolManagedMetadataKey]) != "true" {
+		return false
+	}
+	if strings.TrimSpace(template) == "" || poolDesired == nil {
+		return false
+	}
+	return poolDesired[template] > 0
+}
+
 // buildDepsMap extracts template dependency edges from config for topo ordering.
 // Maps template QualifiedName -> list of dependency template QualifiedNames.
 func buildDepsMap(cfg *config.City) map[string][]string {
@@ -242,6 +269,7 @@ func reconcileSessionBeadsTraced(
 	// Phase 1: Forward pass (topo order) — wake sessions, handle alive state.
 	var startCandidates []startCandidate
 	var wakeTargets []wakeTarget
+	assigneeHasWork := assignedWorkAssigneeMap(assignedWorkBeads)
 	for i := range ordered {
 		session := &ordered[i]
 
@@ -573,6 +601,16 @@ func reconcileSessionBeadsTraced(
 							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
 						}
 						runtime.LogCoreFingerprintDrift(stderr, name, storedBreakdown, agentCfg)
+						if sessionHasAssignedWork(*session, assigneeHasWork) ||
+							poolSessionHasActiveDemand(*session, template, poolDesired) {
+							if trace != nil {
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "active_work", "deferred_active_work", traceRecordPayload{
+									"stored_hash":  storedHash,
+									"current_hash": currentHash,
+								}, nil, "")
+							}
+							continue
+						}
 						if isNamedSessionBead(*session) {
 							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, "creating", stderr)
 							if trace != nil {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -212,10 +212,24 @@ func (e *reconcilerTestEnv) reconcile(sessions []beads.Bead) int {
 }
 
 func (e *reconcilerTestEnv) reconcileWithPoolDesired(sessions []beads.Bead, poolDesired map[string]int) int {
+	return e.reconcileWithPoolDesiredAndAssignedWork(sessions, poolDesired, nil)
+}
+
+func (e *reconcilerTestEnv) reconcileWithAssignedWork(sessions []beads.Bead, assignedWorkBeads []beads.Bead) int {
+	poolDesired := make(map[string]int)
+	for _, tp := range e.desiredState {
+		if tp.TemplateName != "" {
+			poolDesired[tp.TemplateName]++
+		}
+	}
+	return e.reconcileWithPoolDesiredAndAssignedWork(sessions, poolDesired, assignedWorkBeads)
+}
+
+func (e *reconcilerTestEnv) reconcileWithPoolDesiredAndAssignedWork(sessions []beads.Bead, poolDesired map[string]int, assignedWorkBeads []beads.Bead) int {
 	cfgNames := configuredSessionNames(e.cfg, "", e.store)
 	return reconcileSessionBeads(
 		context.Background(), sessions, e.desiredState, cfgNames, e.cfg, e.sp,
-		e.store, nil, nil, nil, e.dt, poolDesired, false, nil, "",
+		e.store, nil, assignedWorkBeads, nil, e.dt, poolDesired, false, nil, "",
 		nil, e.clk, e.rec, 0, 0, &e.stdout, &e.stderr,
 	)
 }
@@ -1102,6 +1116,42 @@ func TestReconcileSessionBeads_ConfigDriftInitiatesDrain(t *testing.T) {
 	}
 	if ds.reason != "config-drift" {
 		t.Errorf("drain reason = %q, want %q", ds.reason, "config-drift")
+	}
+}
+
+func TestReconcileSessionBeads_ConfigDriftDefersWhileWorkAssigned(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesiredWithConfig("worker", "worker", true, "new-cmd")
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"}),
+	})
+	assigned := []beads.Bead{{ID: "work-1", Status: "in_progress", Assignee: "worker"}}
+
+	env.reconcileWithAssignedWork([]beads.Bead{session}, assigned)
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected assigned work to defer config-drift drain, got %+v", ds)
+	}
+}
+
+func TestReconcileSessionBeads_ConfigDriftDefersPoolDemandBeforeAssignment(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+	env.addDesiredWithConfig("worker-mc-1", "worker", true, "new-cmd")
+	session := env.createSessionBead("worker-mc-1", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash":  runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"}),
+		poolManagedMetadataKey: boolMetadata(true),
+	})
+
+	env.reconcileWithPoolDesiredAndAssignedWork([]beads.Bead{session}, map[string]int{"worker": 1}, nil)
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected pool demand to defer config-drift drain before assignment, got %+v", ds)
 	}
 }
 


### PR DESCRIPTION
## Summary
- defer config-drift drains when the concrete session has assigned open or in-progress work
- defer config-drift drains for pool-managed sessions while that template still has active demand
- add regression tests for assigned work and pre-assignment pool demand

## Tests
- `go test ./cmd/gc -run 'TestReconcileSessionBeads_ConfigDrift(DefersWhileWorkAssigned|DefersPoolDemandBeforeAssignment|InitiatesDrain|NoDriftWhenHashMatches)' -count=1`
