### PR TITLE
fix: release work owned by drained pool sessions

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -55,6 +55,9 @@ func releaseOrphanedPoolAssignments(
 		if sb.Status == "closed" {
 			continue
 		}
+		if isDrainedSessionBead(sb) {
+			continue
+		}
 		if id := strings.TrimSpace(sb.ID); id != "" {
 			openIdentifiers[id] = struct{}{}
 		}

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -238,6 +238,61 @@ func TestReleaseOrphanedPoolAssignments_KeepsOpenSessionOwnership(t *testing.T) 
 	}
 }
 
+func TestReleaseOrphanedPoolAssignments_ReopensDrainedSessionOwnership(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   "session",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-drained",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"state":                "drained",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "drained pool work",
+		Assignee: "worker-drained",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		[]beads.Bead{session},
+		[]beads.Bead{work},
+	)
+	if len(released) != 1 || released[0] != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_ReopensStaleDirectAssigneeForNamedBackedTemplate(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary
- exclude drained session beads from the live pool ownership identifiers
- reopen in-progress pool work assigned to a drained worker so it can be picked up again
- add a regression test for drained pool-session ownership release

## Tests
- `go test ./cmd/gc -run 'TestReleaseOrphanedPoolAssignments_(ReopensDrainedSessionOwnership|KeepsOpenSessionOwnership|ReopensMissingPoolAssignee|ReopensStaleDirectAssigneeForNamedBackedTemplate)' -count=1`
