### PR TITLE
obs(dispatcher): trace skip reason when control bead is not open

### DIFF
--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -201,6 +201,15 @@ func drainWorkflowServeWork(agentCfg config.Agent, workDir string, workEnv map[s
 				return fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
 			}
 			workflowTracef("serve process bead=%s kind=%s", beadID, kind)
+			// controlDispatcherServe currently returns nil both when it
+			// successfully advanced a control bead AND when ProcessControl
+			// chose to no-op (e.g., status != "open"). The caller cannot
+			// tell those apart without cross-referencing the store, so the
+			// trace line just below was previously identical in both
+			// cases. That masked a 20-minute stall on ga-ttn5z's retry
+			// control ga-fw2fm. The silent no-op now emits a separate
+			// `process-control ... skip reason=bead_not_open` line inside
+			// ProcessControl itself; see runtime.go.
 			if err := controlDispatcherServe(beadID, io.Discard, stderr); err != nil {
 				if errors.Is(err, dispatch.ErrControlPending) {
 					pendingCount++

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -48,6 +48,17 @@ func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (Co
 		return ControlResult{}, fmt.Errorf("store is nil")
 	}
 	if bead.Status != "open" {
+		// A control bead that is not open — typically stuck at in_progress
+		// after a rogue `bd update --status in_progress` from a worker —
+		// can silently strand an entire workflow because the serve loop
+		// treats the no-op return as a successful processed cycle. Emit a
+		// specific trace line so the skip is visible in the dispatcher
+		// trace log instead of looking identical to a processed cycle.
+		// See bug investigation on workflow ga-ttn5z where 20+ minutes of
+		// processing cycles silently no-op'd because ga-fw2fm had been
+		// moved to in_progress by its implement-change worker.
+		opts.tracef("process-control bead=%s kind=%s skip reason=bead_not_open status=%s",
+			bead.ID, bead.Metadata["gc.kind"], bead.Status)
 		return ControlResult{}, nil
 	}
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3349,3 +3349,64 @@ func TestFullMetadataPropagationChain(t *testing.T) {
 		t.Fatalf("iteration body review.verdict = %q, want done (propagated from retry member)", iterBodyAfter.Metadata["review.verdict"])
 	}
 }
+
+// TestProcessControlEmitsSkipReasonWhenNotOpen is the regression guard for
+// the 20-minute silent stall on ga-ttn5z. When a rogue worker had flipped
+// a retry-control bead (ga-fw2fm) to status=in_progress, ProcessControl
+// returned {Processed: false} at the very first guard without any trace
+// output. The serve loop upstream traced "serve processed" either way, so
+// nothing in the dispatcher log revealed why the workflow wasn't moving.
+// The fix emits a specific "process-control ... skip reason=bead_not_open"
+// line before the early return.
+func TestProcessControlEmitsSkipReasonWhenNotOpen(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	control, err := store.Create(beads.Bead{
+		Title:  "rogue in_progress control",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.max_attempts": "3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(control.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("set in_progress: %v", err)
+	}
+	control, err = store.Get(control.ID)
+	if err != nil {
+		t.Fatalf("reload control: %v", err)
+	}
+
+	var traceBuf bytes.Buffer
+	opts := ProcessOptions{
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&traceBuf, format, args...)
+			traceBuf.WriteByte('\n')
+		},
+	}
+
+	result, err := ProcessControl(store, control, opts)
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if result.Processed {
+		t.Fatalf("result.Processed = true, want false when bead is not open")
+	}
+
+	traced := traceBuf.String()
+	if !strings.Contains(traced, "skip reason=bead_not_open") {
+		t.Fatalf("trace missing skip reason; got:\n%s", traced)
+	}
+	if !strings.Contains(traced, control.ID) {
+		t.Fatalf("trace missing control ID %q; got:\n%s", control.ID, traced)
+	}
+	if !strings.Contains(traced, "status=in_progress") {
+		t.Fatalf("trace missing the actual status; got:\n%s", traced)
+	}
+}


### PR DESCRIPTION
## Summary

`ProcessControl` silently no-ops when a control bead is not `status=open`, and the dispatcher's outer serve loop can't tell the no-op apart from a real processed cycle. A stuck retry-control bead (accidentally moved to `in_progress`) will show up in the trace as a steady stream of `serve processed bead=X` lines while nothing actually advances.

Add an explicit skip trace line at the guard:

```
process-control bead=<id> kind=<kind> skip reason=bead_not_open status=<status>
```

Grep for `skip reason=` in the dispatcher trace to find stuck control beads in seconds.

## Repro from production

Workflow `ga-ttn5z` in the `gascity` rig stalled for 20 minutes in the `mol-bug-report-implementation-v2` subflow. An `implement-change` worker ran `bd update <retry-control> --status in_progress` against its own retry-manager bead (`ga-fw2fm`) instead of its attempt bead. That bead was subsequently eligible for the dispatcher's work query, but `ProcessControl` short-circuited on the not-open guard. Each tick traced:

```
serve process bead=ga-fw2fm kind=retry
serve processed bead=ga-fw2fm kind=retry
```

…with no indication anything was wrong. After the fix the same situation would instead produce:

```
serve process bead=ga-fw2fm kind=retry
process-control bead=ga-fw2fm kind=retry skip reason=bead_not_open status=in_progress
serve processed bead=ga-fw2fm kind=retry
```

## Changes

- `internal/dispatch/runtime.go` — emit the skip trace line before the early return. Uses the existing `opts.tracef` plumbing; no new dependencies.
- `cmd/gc/dispatch_runtime.go` — add a comment at the serve-loop trace point pointing readers at the inner trace. No behavior change.
- `internal/dispatch/runtime_test.go` — new regression test `TestProcessControlEmitsSkipReasonWhenNotOpen` that seeds a retry control with `status=in_progress`, captures the trace output, and asserts the skip line is emitted with the bead ID and actual status.

## Not included

Two adjacent bugs surfaced during the same investigation are out of scope for this PR:

1. **The rogue worker write** that started the incident. Prompt fix for `mol-bug-report-implementation-v2.implement-change` lives in the formulas repo, not here.
2. **Named dispatcher cannot consume Tier 3 routed work.** `session_origin=named` hits the `*) exit 0` branch in the default `work_query` Tier 3 clause at `internal/config/config.go:~1670`, so dispatcher sessions created via `[[named_session]]` only pick up beads pre-assigned to their own identifiers. Worth its own PR with a decision on whether to widen Tier 3 or always pre-assign control beads at DAG materialization time.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 -run TestProcessControlEmitsSkipReasonWhenNotOpen ./internal/dispatch/...` passes
- [x] `go test -count=1 ./internal/dispatch/...` passes
- [ ] After merge: `grep 'skip reason=' $GC_WORKFLOW_TRACE` should return nothing on a healthy workflow and surface any stuck control beads on a sick one.

## Risk

Log volume only. One new trace line per skipped tick — bounded by the dispatcher's own cadence and only emitted on the abnormal path.
