### PR TITLE
fix(api): enable formula_v2 in TestFormulaDetailReturnsCompiledPreview

### DIFF
--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -554,6 +554,11 @@ func TestFormulaDetailReturnsCompiledPreview(t *testing.T) {
 	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 
 	state := newFakeState(t)
+	// api.New(state) calls syncFeatureFlags(state.Config()), which pulls
+	// formula_v2 back out of cfg.Daemon and overrides the global set above.
+	// Without this, the server sees v2 as disabled and rejects the v2
+	// formula compile with a 400 "formula_v2 is disabled" error.
+	state.cfg.Daemon.FormulaV2 = true
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}
 


### PR DESCRIPTION
## Summary

`TestFormulaDetailReturnsCompiledPreview` has been failing on `main` since PR #734 landed (2026-04-17). It consistently reported `400 "formula_v2 is disabled"` even though the test explicitly calls `formula.SetFormulaV2Enabled(true)`.

## Root Cause

PR #734 moved `syncFeatureFlags(state.Config())` into `api.New()` and `api.NewReadOnly()`. That helper reads `cfg.Daemon.FormulaV2` and unconditionally overwrites the global `formula.formulaV2Enabled` flag. When the test calls `New(state)`:

1. Test sets global flag to `true` (line 553).
2. `New(state)` calls `syncFeatureFlags` which sees `state.cfg.Daemon.FormulaV2 == false` (default from `newFakeState`) and clobbers the global back to `false`.
3. The v2 formula compile then fails at `internal/formula/compile.go:433`.

## Fix

Set `state.cfg.Daemon.FormulaV2 = true` before calling `New(state)`. This matches the pattern already used in other v2 tests (e.g. `TestBatchOnGraphWorkflowConflictLeavesExistingRootInPlace` in `cmd/gc/cmd_sling_test.go`) and is the minimal change needed for the test to do what it intends.

No production code changes — this is purely a test fix for an existing test that was silently red on main.

## Testing

- `go test ./internal/api/` passes (26s, all tests green).
- `go vet ./internal/api/` clean.
- `golangci-lint run ./internal/api/` clean.

Verified the fix addresses the same failure observed on PR #852 CI (both `Check` and `Integration / packages` jobs).