### PR TITLE
feat(mcp): project provider-native MCP config

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -16,6 +16,7 @@ import (
 // agentBuildParams holds shared, per-city parameters for building agents.
 // These are constant across all agents in a single buildDesiredState call.
 type agentBuildParams struct {
+	city            *config.City
 	cityName        string
 	cityPath        string
 	workspace       *config.Workspace
@@ -74,6 +75,7 @@ type agentBuildParams struct {
 // newAgentBuildParams constructs agentBuildParams from the common startup values.
 func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime.Provider, beaconTime time.Time, store beads.Store, stderr io.Writer) *agentBuildParams {
 	params := &agentBuildParams{
+		city:            cfg,
 		cityName:        cityName,
 		cityPath:        cityPath,
 		workspace:       &cfg.Workspace,

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -112,6 +112,8 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		d.Register(doctor.NewDurationRangeCheck(cfg))
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
+		d.Register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))
+		d.Register(newMCPSharedTargetDoctorCheck(cityPath, cfg, exec.LookPath))
 	}
 
 	// System formulas/orders now ship via the core bootstrap pack; pack

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -21,6 +21,7 @@ func newInternalCmd(stdout, stderr io.Writer) *cobra.Command {
 		Hidden: true,
 	}
 	cmd.AddCommand(newInternalMaterializeSkillsCmd(stdout, stderr))
+	cmd.AddCommand(newInternalProjectMCPCmd(stdout, stderr))
 	return cmd
 }
 

--- a/cmd/gc/cmd_internal_project_mcp.go
+++ b/cmd/gc/cmd_internal_project_mcp.go
@@ -56,11 +56,10 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 
 			resolved, err := config.ResolveProvider(&agent, &cfg.Workspace, cfg.Providers, exec.LookPath)
 			if err != nil {
-				cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
 				// A provider-resolution failure only blocks projection when this
 				// agent actually has effective MCP to project. Empty catalogs are a
 				// no-op so unsupported/absent providers can be ignored there.
-				catalog, lerr := loadEffectiveMCPForAgent(cityPath, cityName, cfg, &agent, identity, absWorkdir)
+				catalog, lerr := loadEffectiveMCPForAgent(cityPath, cfg, &agent, identity, absWorkdir)
 				if lerr != nil {
 					fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", lerr) //nolint:errcheck // best-effort stderr
 					return errExit
@@ -72,8 +71,7 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 
-			cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
-			catalog, projection, err := resolveAgentMCPProjection(cityPath, cityName, cfg, &agent, identity, absWorkdir, resolved.Kind)
+			catalog, projection, err := resolveAgentMCPProjection(cityPath, cfg, &agent, identity, absWorkdir, resolved.Kind)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit

--- a/cmd/gc/cmd_internal_project_mcp.go
+++ b/cmd/gc/cmd_internal_project_mcp.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/spf13/cobra"
+)
+
+func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
+	var agentName, identity, workdir string
+	cmd := &cobra.Command{
+		Use:    "project-mcp",
+		Short:  "Project MCP for one agent into one workdir",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(agentName) == "" {
+				fmt.Fprintln(stderr, "gc internal project-mcp: --agent is required") //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if strings.TrimSpace(workdir) == "" {
+				fmt.Fprintln(stderr, "gc internal project-mcp: --workdir is required") //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+
+			cityPath, err := resolveCity()
+			if err != nil {
+				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			cfg, err := loadCityConfig(cityPath)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+
+			agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
+			if !ok {
+				fmt.Fprintf(stderr, "gc internal project-mcp: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if strings.TrimSpace(identity) == "" {
+				identity = agent.QualifiedName()
+			}
+			absWorkdir, err := filepath.Abs(workdir)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc internal project-mcp: resolving workdir %q: %v\n", workdir, err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+
+			resolved, err := config.ResolveProvider(&agent, &cfg.Workspace, cfg.Providers, exec.LookPath)
+			if err != nil {
+				cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+				// A provider-resolution failure only blocks projection when this
+				// agent actually has effective MCP to project. Empty catalogs are a
+				// no-op so unsupported/absent providers can be ignored there.
+				catalog, lerr := loadEffectiveMCPForAgent(cityPath, cityName, cfg, &agent, identity, absWorkdir)
+				if lerr != nil {
+					fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", lerr) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				if len(catalog.Servers) == 0 {
+					return nil
+				}
+				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+
+			cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+			catalog, projection, err := resolveAgentMCPProjection(cityPath, cityName, cfg, &agent, identity, absWorkdir, resolved.Kind)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if projection.Provider == "" {
+				return nil
+			}
+			if err := projection.Apply(fsys.OSFS{}); err != nil {
+				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if len(catalog.Servers) > 0 {
+				ensureMCPGitignoreBestEffort(absWorkdir, stderr)
+				fmt.Fprintf(stdout, "projected %d MCP server(s) into %s\n", len(catalog.Servers), projection.Target) //nolint:errcheck // best-effort stdout
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agentName, "agent", "", "qualified template identity (dir/name or name)")
+	cmd.Flags().StringVar(&identity, "identity", "", "concrete agent/session identity for template expansion")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "workdir whose native provider config should be reconciled")
+	return cmd
+}

--- a/cmd/gc/cmd_internal_project_mcp.go
+++ b/cmd/gc/cmd_internal_project_mcp.go
@@ -79,7 +79,11 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 			if projection.Provider == "" {
 				return nil
 			}
-			if err := projection.Apply(fsys.OSFS{}); err != nil {
+			if err := validateStage2TargetClaimants(cityPath, cfg, &agent, projection, exec.LookPath); err != nil {
+				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if err := projection.ApplyWithStderr(fsys.OSFS{}, stderr); err != nil {
 				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}

--- a/cmd/gc/cmd_internal_project_mcp_test.go
+++ b/cmd/gc/cmd_internal_project_mcp_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInternalProjectMCPProjectsGeminiConfigWithIdentityExpansion(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	cityToml := `[workspace]
+name = "test-city"
+provider = "gemini"
+
+[beads]
+provider = "file"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	writeMCPSource(t, filepath.Join(cityDir, "mcp", "notes.template.toml"), `
+name = "notes"
+command = "uvx"
+args = ["notes-mcp"]
+
+[env]
+AGENT = "{{.AgentName}}"
+`)
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "project-mcp",
+		"--agent", "mayor",
+		"--identity", "rig/mayor-2",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(workdir, ".gemini", "settings.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json): %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	mcpServers, ok := doc["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers missing: %+v", doc)
+	}
+	notes, ok := mcpServers["notes"].(map[string]any)
+	if !ok {
+		t.Fatalf("notes server missing: %+v", mcpServers)
+	}
+	env, ok := notes["env"].(map[string]any)
+	if !ok {
+		t.Fatalf("notes env missing: %+v", notes)
+	}
+	if got := env["AGENT"]; got != "rig/mayor-2" {
+		t.Fatalf("env.AGENT = %v, want rig/mayor-2", got)
+	}
+	if !strings.Contains(stdout.String(), "projected 1 MCP server") {
+		t.Fatalf("stdout missing projection summary: %q", stdout.String())
+	}
+
+	gitignore, err := os.ReadFile(filepath.Join(workdir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("ReadFile(.gitignore): %v", err)
+	}
+	for _, want := range managedMCPGitignoreEntries {
+		if !strings.Contains(string(gitignore), want) {
+			t.Fatalf(".gitignore missing %q:\n%s", want, string(gitignore))
+		}
+	}
+}
+
+func TestInternalProjectMCPMissingFlags(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"internal", "project-mcp", "--workdir", t.TempDir()}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected missing-agent failure, stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--agent is required") {
+		t.Fatalf("stderr missing --agent error: %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = run([]string{"internal", "project-mcp", "--agent", "mayor"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected missing-workdir failure, stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--workdir is required") {
+		t.Fatalf("stderr missing --workdir error: %q", stderr.String())
+	}
+}

--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -3,21 +3,27 @@ package main
 import (
 	"fmt"
 	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/materialize"
+	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/spf13/cobra"
 )
 
 func newMcpCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
-		Short: "List MCP catalog visibility",
-		Long: `List MCP catalog visibility for the current city pack.
+		Short: "Inspect projected MCP config",
+		Long: `Inspect the projected MCP catalog for a concrete target.
 
-The first MCP slice is list-only. Provider projection and reconciliation
-are later work.`,
+Projected MCP is target-specific. Use "gc mcp list --agent <name>" when
+the agent has a single deterministic projection target from config, or
+"gc mcp list --session <id>" for a live session target.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -36,14 +42,21 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var sessionID string
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List visible MCP definitions",
-		Long:  "List the current city pack's visible MCP definitions, optionally scoped to an agent or session.",
+		Short: "Show projected MCP servers",
+		Long:  "Show the precedence-resolved MCP servers that Gas City would project into the provider-native config for one agent or session target.",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if strings.TrimSpace(agentName) != "" && strings.TrimSpace(sessionID) != "" {
+			agentName = strings.TrimSpace(agentName)
+			sessionID = strings.TrimSpace(sessionID)
+			switch {
+			case agentName != "" && sessionID != "":
 				fmt.Fprintln(stderr, "gc mcp list: --agent and --session are mutually exclusive") //nolint:errcheck // best-effort stderr
 				return errExit
+			case agentName == "" && sessionID == "":
+				fmt.Fprintln(stderr, "gc mcp list: projected MCP is target-specific; pass --agent or --session") //nolint:errcheck // best-effort stderr
+				return errExit
 			}
+
 			cityPath, err := resolveCity()
 			if err != nil {
 				fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -55,42 +68,108 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 
-			var store beads.Store
-			if strings.TrimSpace(sessionID) != "" {
+			var (
+				store beads.Store
+				view  resolvedMCPProjection
+			)
+			if sessionID != "" {
 				store, err = openCityStoreAt(cityPath)
 				if err != nil {
 					fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
+				view, err = resolveSessionMCPProjection(cityPath, cfg, store, sessionID, exec.LookPath)
+			} else {
+				agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
+				if !ok {
+					fmt.Fprintf(stderr, "gc mcp list: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				template := resolveAgentTemplate(agent.QualifiedName(), cfg)
+				cfgAgent := findAgentByTemplate(cfg, template)
+				if cfgAgent == nil {
+					fmt.Fprintf(stderr, "gc mcp list: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				view, err = resolveDeterministicAgentMCPProjection(cityPath, cfg, cfgAgent, exec.LookPath)
 			}
-
-			entries, err := listVisibleMcpEntries(cityPath, cfg, store, agentName, sessionID)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
-			writeVisibilityEntries(stdout, entries)
+
+			writeProjectedMCPView(stdout, cityPath, view)
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&agentName, "agent", "", "show the effective MCP view for this agent")
-	cmd.Flags().StringVar(&sessionID, "session", "", "show the effective MCP view for this session")
+	cmd.Flags().StringVar(&agentName, "agent", "", "show the projected MCP config for this agent")
+	cmd.Flags().StringVar(&sessionID, "session", "", "show the projected MCP config for this session")
 	return cmd
 }
 
-func listVisibleMcpEntries(cityPath string, cfg *config.City, store beads.Store, agentName, sessionID string) ([]visibilityEntry, error) {
-	cityEntries := discoverMcpEntries(cityPath, "city")
-	if strings.TrimSpace(agentName) == "" && strings.TrimSpace(sessionID) == "" {
-		return cityEntries, nil
+func writeProjectedMCPView(w io.Writer, cityPath string, view resolvedMCPProjection) {
+	fmt.Fprintf(w, "Provider: %s\n", view.Projection.Provider) //nolint:errcheck // best-effort
+	fmt.Fprintf(w, "Target: %s\n", view.Projection.Target)     //nolint:errcheck // best-effort
+	if view.WorkDir != "" {
+		fmt.Fprintf(w, "Workdir: %s\n", view.WorkDir) //nolint:errcheck // best-effort
 	}
-	agent, err := resolveVisibilityAgent(cityPath, cfg, store, agentName, sessionID)
-	if err != nil {
-		return nil, err
+	if view.Delivery != "" {
+		fmt.Fprintf(w, "Delivery: %s\n", view.Delivery) //nolint:errcheck // best-effort
 	}
-	// Per engdocs/proposals/skill-materialization.md: every agent sees the
-	// entire city catalog plus its own agent-local MCP. No attachment
-	// filtering.
-	cityEntries = append(cityEntries, discoverAgentMcpEntries(agentAssetRoot(cityPath, agent), agent.Name, "agent")...)
-	sortVisibilityEntries(cityEntries)
-	return cityEntries, nil
+	if len(view.Catalog.Servers) == 0 {
+		fmt.Fprintln(w, "No projected MCP servers.") //nolint:errcheck // best-effort
+		return
+	}
+	fmt.Fprintln(w) //nolint:errcheck // best-effort
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tTRANSPORT\tCOMMAND/URL\tSOURCE\tENV\tHEADERS") //nolint:errcheck // best-effort
+	for _, server := range view.Catalog.Servers {
+		fmt.Fprintf(
+			tw,
+			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			server.Name,
+			server.Transport,
+			mcpCommandOrURL(server),
+			displayMCPSourcePath(cityPath, server.SourceFile),
+			formatMCPKeyNames(server.Env),
+			formatMCPKeyNames(server.Headers),
+		) //nolint:errcheck // best-effort
+	}
+	_ = tw.Flush()
+}
+
+func mcpCommandOrURL(server materialize.MCPServer) string {
+	if server.Transport == materialize.MCPTransportHTTP {
+		return server.URL
+	}
+	parts := make([]string, 0, 1+len(server.Args))
+	if strings.TrimSpace(server.Command) != "" {
+		parts = append(parts, server.Command)
+	}
+	parts = append(parts, server.Args...)
+	if len(parts) == 0 {
+		return ""
+	}
+	return shellquote.Join(parts)
+}
+
+func formatMCPKeyNames(values map[string]string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+func displayMCPSourcePath(cityPath, path string) string {
+	path = filepath.Clean(path)
+	if rel, err := filepath.Rel(cityPath, path); err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(path)
 }

--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -125,7 +125,7 @@ func writeProjectedMCPView(w io.Writer, cityPath string, view resolvedMCPProject
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "NAME\tTRANSPORT\tCOMMAND/URL\tSOURCE\tENV\tHEADERS") //nolint:errcheck // best-effort
 	for _, server := range view.Catalog.Servers {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			tw,
 			"%s\t%s\t%s\t%s\t%s\t%s\n",
 			server.Name,
@@ -134,7 +134,7 @@ func writeProjectedMCPView(w io.Writer, cityPath string, view resolvedMCPProject
 			displayMCPSourcePath(cityPath, server.SourceFile),
 			formatMCPKeyNames(server.Env),
 			formatMCPKeyNames(server.Headers),
-		) //nolint:errcheck // best-effort
+		)
 	}
 	_ = tw.Flush()
 }

--- a/cmd/gc/cmd_mcp_test.go
+++ b/cmd/gc/cmd_mcp_test.go
@@ -2,40 +2,77 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/materialize"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
-func TestMcpListCityCatalog(t *testing.T) {
+func TestMcpListRequiresTarget(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir)
-	writeCatalogFile(t, cityDir, "mcp/beads-health.toml", "city mcp")
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+max_active_sessions = 1
+`)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"mcp", "list"}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("gc mcp list exited %d: %s", code, stderr.String())
+	if code == 0 {
+		t.Fatalf("expected gc mcp list to fail without a target, stdout=%q", stdout.String())
 	}
-	out := stdout.String()
-	for _, want := range []string{"NAME", "beads-health", "city", "mcp/beads-health.toml"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("mcp list output missing %q:\n%s", want, out)
-		}
+	if !strings.Contains(stderr.String(), "projected MCP is target-specific") {
+		t.Fatalf("stderr = %q, want target-specific error", stderr.String())
 	}
 }
 
-func TestMcpListAgentCatalog(t *testing.T) {
+func TestMcpListAgentProjectedSummary(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeNamedSessionCityTOML(t, cityDir)
-	writeCatalogFile(t, cityDir, "mcp/beads-health.toml", "city mcp")
-	writeCatalogFile(t, cityDir, "agents/mayor/mcp/private-tool.template.toml", "agent mcp")
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "tmux"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+`)
+	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
+name = "notes"
+command = "npx"
+args = ["@acme/notes"]
+
+[env]
+API_TOKEN = "super-secret"
+`)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"mcp", "list", "--agent", "mayor"}, &stdout, &stderr)
@@ -43,33 +80,111 @@ func TestMcpListAgentCatalog(t *testing.T) {
 		t.Fatalf("gc mcp list --agent exited %d: %s", code, stderr.String())
 	}
 	out := stdout.String()
-	for _, want := range []string{"beads-health", "city", "private-tool", "agent"} {
+	for _, want := range []string{
+		"Provider: gemini",
+		filepath.ToSlash(filepath.Join(cityDir, ".gemini", "settings.json")),
+		"notes",
+		"stdio",
+		"mcp/notes.toml",
+		"API_TOKEN",
+	} {
 		if !strings.Contains(out, want) {
-			t.Fatalf("mcp list --agent output missing %q:\n%s", want, out)
+			t.Fatalf("mcp list output missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "super-secret") {
+		t.Fatalf("mcp list output leaked env value:\n%s", out)
 	}
 }
 
-func TestMcpListSessionCatalog(t *testing.T) {
+func TestMcpListAgentRequiresSessionForMultiSessionTargets(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+max_active_sessions = 2
+work_dir = "worktrees/{{.Agent}}"
+`)
+	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
+name = "notes"
+command = "npx"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"mcp", "list", "--agent", "mayor"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected gc mcp list --agent to fail for multi-session target, stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "session-specific MCP targets; use --session") {
+		t.Fatalf("stderr = %q, want session-specific error", stderr.String())
+	}
+}
+
+func TestMcpListSessionProjectedSummaryUsesSessionIdentity(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
-	writeNamedSessionCityTOML(t, cityDir)
-	writeCatalogFile(t, cityDir, "mcp/beads-health.toml", "city mcp")
-	writeCatalogFile(t, cityDir, "agents/mayor/mcp/private-tool.template.toml", "agent mcp")
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "tmux"
+
+[providers.claude]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+scope = "city"
+max_active_sessions = 1
+`)
+	writeCatalogFile(t, cityDir, "mcp/remote.template.toml", `
+name = "remote"
+url = "https://example.com/{{.AgentName}}"
+
+[headers]
+Authorization = "Bearer top-secret"
+`)
 
 	store, err := openCityStoreAt(cityDir)
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	sessionDir := filepath.Join(cityDir, "worktrees", "ops-mayor-2")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(sessionDir): %v", err)
 	}
 	bead, err := store.Create(beads.Bead{
 		Title:  "mayor session",
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
-			"template":     "mayor",
-			"session_name": "s-mayor-1",
+			"template":      "mayor",
+			"session_name":  "s-mayor-2",
+			"agent_name":    "ops/mayor-2",
+			"provider":      "claude",
+			"provider_kind": "claude",
+			"work_dir":      sessionDir,
+			"state":         "asleep",
 		},
 	})
 	if err != nil {
@@ -82,9 +197,106 @@ func TestMcpListSessionCatalog(t *testing.T) {
 		t.Fatalf("gc mcp list --session exited %d: %s", code, stderr.String())
 	}
 	out := stdout.String()
-	for _, want := range []string{"beads-health", "city", "private-tool", "agent"} {
+	for _, want := range []string{
+		"Provider: claude",
+		filepath.ToSlash(filepath.Join(sessionDir, ".mcp.json")),
+		"https://example.com/ops/mayor-2",
+		"mcp/remote.template.toml",
+		"Authorization",
+	} {
 		if !strings.Contains(out, want) {
-			t.Fatalf("mcp list --session output missing %q:\n%s", want, out)
+			t.Fatalf("mcp list output missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "top-secret") {
+		t.Fatalf("mcp list output leaked header value:\n%s", out)
+	}
+}
+
+func TestMcpListErrorsOnUndeliverableTarget(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "subprocess"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+work_dir = "worktrees/mayor"
+max_active_sessions = 1
+`)
+	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
+name = "notes"
+command = "npx"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"mcp", "list", "--agent", "mayor"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected gc mcp list --agent to fail, stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "effective MCP cannot be delivered") {
+		t.Fatalf("stderr = %q, want delivery error", stderr.String())
+	}
+}
+
+func writeProjectedMCPCity(t *testing.T, dir, cityTOML string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(strings.TrimLeft(cityTOML, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+}
+
+func TestDisplayMCPSourcePathCityRelative(t *testing.T) {
+	cityDir := t.TempDir()
+	got := displayMCPSourcePath(cityDir, filepath.Join(cityDir, "mcp", "notes.toml"))
+	if want := filepath.ToSlash(filepath.Join("mcp", "notes.toml")); got != want {
+		t.Fatalf("displayMCPSourcePath() = %q, want %q", got, want)
+	}
+	got = displayMCPSourcePath(cityDir, filepath.Join(t.TempDir(), "other.toml"))
+	if !strings.HasSuffix(got, "other.toml") {
+		t.Fatalf("displayMCPSourcePath(external) = %q, want absolute path suffix", got)
+	}
+}
+
+func TestFormatMCPKeyNamesSorted(t *testing.T) {
+	got := formatMCPKeyNames(map[string]string{"ZED": "1", "API_TOKEN": "2"})
+	if got != "API_TOKEN,ZED" {
+		t.Fatalf("formatMCPKeyNames() = %q", got)
+	}
+	if got := formatMCPKeyNames(nil); got != "-" {
+		t.Fatalf("formatMCPKeyNames(nil) = %q, want -", got)
+	}
+}
+
+func TestProjectedMCPWriterNoServers(t *testing.T) {
+	var buf bytes.Buffer
+	writeProjectedMCPView(&buf, t.TempDir(), resolvedMCPProjection{
+		Projection: materialize.MCPProjection{
+			Provider: "gemini",
+			Target:   "/tmp/example/.gemini/settings.json",
+		},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "No projected MCP servers.") {
+		t.Fatalf("writeProjectedMCPView() missing empty-state message:\n%s", out)
 	}
 }

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -277,49 +277,6 @@ func discoverSkillDirEntries(dir, relBase, source string) []visibilityEntry {
 	return out
 }
 
-func discoverMcpEntries(root, source string) []visibilityEntry {
-	return discoverMcpDirEntries(filepath.Join(root, "mcp"), "mcp", source)
-}
-
-func discoverAgentMcpEntries(root, agentName, source string) []visibilityEntry {
-	return discoverMcpDirEntries(filepath.Join(root, "agents", agentName, "mcp"), filepath.Join("agents", agentName, "mcp"), source)
-}
-
-func discoverMcpDirEntries(dir, relBase, source string) []visibilityEntry {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var out []visibilityEntry
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name, ok := mcpIdentityForFilename(entry.Name())
-		if !ok {
-			continue
-		}
-		out = append(out, visibilityEntry{
-			Name:   name,
-			Source: source,
-			Path:   filepath.ToSlash(filepath.Join(relBase, entry.Name())),
-		})
-	}
-	sortVisibilityEntries(out)
-	return out
-}
-
-func mcpIdentityForFilename(name string) (string, bool) {
-	switch {
-	case strings.HasSuffix(name, ".template.toml"):
-		return strings.TrimSuffix(name, ".template.toml"), true
-	case strings.HasSuffix(name, ".toml"):
-		return strings.TrimSuffix(name, ".toml"), true
-	default:
-		return "", false
-	}
-}
-
 func sortVisibilityEntries(entries []visibilityEntry) {
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].Source != entries[j].Source {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path"
 	"path/filepath"
@@ -507,6 +508,15 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// errors are logged inline by runStage1SkillMaterialization
 	// itself; it never returns a non-nil error to its caller.
 	_ = runStage1SkillMaterialization(cityPath, cfg, stderr)
+
+	// Stage-1 MCP projection is a hard gate because it mutates the provider's
+	// active runtime config surface. Conflicting shared targets or projection
+	// write failures must block startup before sessions launch against stale or
+	// ambiguous MCP state.
+	if err := runStage1MCPProjection(cityPath, cfg, exec.LookPath, stderr); err != nil {
+		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	// Validate install_agent_hooks (workspace + all agents).
 	if ih := cfg.Workspace.InstallAgentHooks; len(ih) > 0 {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
@@ -1699,6 +1700,12 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 	_ = runStep("materializing_skills", func() error {
 		return runStage1SkillMaterialization(cityPath, cfg, stderr)
 	})
+
+	if err := runStep("projecting_mcp", func() error {
+		return runStage1MCPProjection(cityPath, cfg, exec.LookPath, stderr)
+	}); err != nil {
+		return fmt.Errorf("project MCP: %w", err)
+	}
 
 	// Validate install_agent_hooks (workspace + all agents).
 	if err := runStep("validating_hooks", func() error {

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1214,6 +1214,7 @@ func (osFS) ReadFile(name string) ([]byte, error)                 { return os.Re
 func (osFS) WriteFile(name string, d []byte, p os.FileMode) error { return os.WriteFile(name, d, p) }
 func (osFS) MkdirAll(path string, perm os.FileMode) error         { return os.MkdirAll(path, perm) }
 func (osFS) Stat(name string) (os.FileInfo, error)                { return os.Stat(name) }
+func (osFS) Lstat(name string) (os.FileInfo, error)               { return os.Lstat(name) }
 func (osFS) ReadDir(name string) ([]os.DirEntry, error)           { return os.ReadDir(name) }
 func (osFS) Rename(oldpath, newpath string) error                 { return os.Rename(oldpath, newpath) }
 func (osFS) Remove(name string) error                             { return os.Remove(name) }

--- a/cmd/gc/doctor_mcp_checks.go
+++ b/cmd/gc/doctor_mcp_checks.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+type mcpConfigDoctorCheck struct {
+	cityPath string
+	cfg      *config.City
+	lookPath config.LookPathFunc
+}
+
+type mcpSharedTargetDoctorCheck struct {
+	cityPath string
+	cfg      *config.City
+	lookPath config.LookPathFunc
+}
+
+type mcpTargetConflict struct {
+	Provider string
+	Target   string
+	Agents   []string
+}
+
+func newMCPConfigDoctorCheck(cityPath string, cfg *config.City, lookPath config.LookPathFunc) *mcpConfigDoctorCheck {
+	return &mcpConfigDoctorCheck{cityPath: cityPath, cfg: cfg, lookPath: lookPath}
+}
+
+func newMCPSharedTargetDoctorCheck(cityPath string, cfg *config.City, lookPath config.LookPathFunc) *mcpSharedTargetDoctorCheck {
+	return &mcpSharedTargetDoctorCheck{cityPath: cityPath, cfg: cfg, lookPath: lookPath}
+}
+
+func (*mcpConfigDoctorCheck) Name() string                     { return "mcp-config" }
+func (*mcpConfigDoctorCheck) CanFix() bool                     { return false }
+func (*mcpConfigDoctorCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func (c *mcpConfigDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	issues, _ := inspectMCPProjectionHealth(c.cityPath, c.cfg, c.lookPath)
+	if len(issues) == 0 {
+		return &doctor.CheckResult{Name: c.Name(), Status: doctor.StatusOK, Message: "MCP definitions and delivery paths are valid"}
+	}
+	return &doctor.CheckResult{
+		Name:    c.Name(),
+		Status:  doctor.StatusError,
+		Message: summarizeMCPIssues(issues),
+		Details: issues,
+		FixHint: `fix the reported MCP definitions or provider/runtime settings, then rerun "gc doctor"`,
+	}
+}
+
+func (*mcpSharedTargetDoctorCheck) Name() string                     { return "mcp-shared-target" }
+func (*mcpSharedTargetDoctorCheck) CanFix() bool                     { return false }
+func (*mcpSharedTargetDoctorCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func (c *mcpSharedTargetDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	_, conflicts := inspectMCPProjectionHealth(c.cityPath, c.cfg, c.lookPath)
+	if len(conflicts) == 0 {
+		return &doctor.CheckResult{Name: c.Name(), Status: doctor.StatusOK, Message: "no projected MCP target conflicts"}
+	}
+	details := make([]string, 0, len(conflicts))
+	for _, conflict := range conflicts {
+		details = append(details, fmt.Sprintf(
+			"%s (%s): %s",
+			conflict.Target,
+			conflict.Provider,
+			strings.Join(conflict.Agents, ", "),
+		))
+	}
+	return &doctor.CheckResult{
+		Name:    c.Name(),
+		Status:  doctor.StatusError,
+		Message: summarizeMCPIssues(details),
+		Details: details,
+		FixHint: `make the effective MCP payload identical for every agent that shares a provider-native target, or split them onto different targets`,
+	}
+}
+
+func inspectMCPProjectionHealth(cityPath string, cfg *config.City, lookPath config.LookPathFunc) ([]string, []mcpTargetConflict) {
+	if cfg == nil || len(cfg.Agents) == 0 {
+		return nil, nil
+	}
+
+	type targetState struct {
+		hashes map[string][]string
+	}
+
+	targets := make(map[string]*targetState)
+	var issues []string
+
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		view, err := resolveConfiguredAgentMCPProjection(cityPath, cfg, agent, lookPath)
+		if err != nil {
+			issues = append(issues, fmt.Sprintf("agent %q: %v", agent.QualifiedName(), err))
+			continue
+		}
+		if len(view.Catalog.Servers) == 0 || strings.TrimSpace(view.Projection.Provider) == "" || strings.TrimSpace(view.Projection.Target) == "" {
+			continue
+		}
+		key := view.Projection.Provider + "|" + filepath.Clean(view.Projection.Target)
+		state := targets[key]
+		if state == nil {
+			state = &targetState{hashes: make(map[string][]string)}
+			targets[key] = state
+		}
+		hash := view.Projection.Hash()
+		state.hashes[hash] = append(state.hashes[hash], agent.QualifiedName())
+	}
+
+	sort.Strings(issues)
+
+	conflicts := make([]mcpTargetConflict, 0, len(targets))
+	for key, state := range targets {
+		if len(state.hashes) < 2 {
+			continue
+		}
+		parts := strings.SplitN(key, "|", 2)
+		agents := make([]string, 0, 4)
+		for _, members := range state.hashes {
+			sort.Strings(members)
+			agents = append(agents, members...)
+		}
+		sort.Strings(agents)
+		conflicts = append(conflicts, mcpTargetConflict{
+			Provider: parts[0],
+			Target:   parts[1],
+			Agents:   agents,
+		})
+	}
+	sort.Slice(conflicts, func(i, j int) bool {
+		if conflicts[i].Target != conflicts[j].Target {
+			return conflicts[i].Target < conflicts[j].Target
+		}
+		return conflicts[i].Provider < conflicts[j].Provider
+	})
+	return issues, conflicts
+}
+
+func summarizeMCPIssues(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	default:
+		return fmt.Sprintf("%s (and %d more)", items[0], len(items)-1)
+	}
+}

--- a/cmd/gc/doctor_mcp_checks_test.go
+++ b/cmd/gc/doctor_mcp_checks_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestMCPConfigDoctorCheckReportsTemplateExpansionErrors(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+`)
+	writeCatalogFile(t, cityDir, "mcp/remote.template.toml", `
+name = "remote"
+url = "https://example.com/{{.Missing}}"
+`)
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+	result := newMCPConfigDoctorCheck(cityDir, cfg, stubLookPath).Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error", result.Status)
+	}
+	if !strings.Contains(result.Message, "agent ") {
+		t.Fatalf("message = %q, want agent context", result.Message)
+	}
+	if len(result.Details) == 0 || !strings.Contains(result.Details[0], "remote.template.toml") {
+		t.Fatalf("details = %#v, want template filename", result.Details)
+	}
+}
+
+func TestMCPConfigDoctorCheckReportsUndeliverableTargets(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "subprocess"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+work_dir = "worktrees/mayor"
+`)
+	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
+name = "notes"
+command = "npx"
+`)
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+	result := newMCPConfigDoctorCheck(cityDir, cfg, stubLookPath).Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error", result.Status)
+	}
+	if !strings.Contains(result.Message, "cannot be delivered") {
+		t.Fatalf("message = %q, want delivery failure", result.Message)
+	}
+}
+
+func TestMCPSharedTargetDoctorCheckReportsConflicts(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "tmux"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+
+[[agent]]
+name = "mayor"
+provider = "gemini"
+scope = "city"
+
+[[agent]]
+name = "deputy"
+provider = "gemini"
+scope = "city"
+`)
+	writeCatalogFile(t, cityDir, "agents/mayor/mcp/notes.toml", `
+name = "notes"
+command = "npx"
+`)
+	writeCatalogFile(t, cityDir, "agents/deputy/mcp/notes.toml", `
+name = "notes"
+url = "https://example.com/deputy"
+`)
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+	result := newMCPSharedTargetDoctorCheck(cityDir, cfg, stubLookPath).Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error", result.Status)
+	}
+	if len(result.Details) == 0 {
+		t.Fatal("expected target-conflict details")
+	}
+	if !strings.Contains(result.Details[0], "mayor") || !strings.Contains(result.Details[0], "deputy") {
+		t.Fatalf("details = %#v, want both agents named", result.Details)
+	}
+}

--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -37,7 +37,7 @@ type resolvedMCPProjection struct {
 	Projection   materialize.MCPProjection
 }
 
-func buildMCPTemplateData(cityPath, cityName, qualifiedName, workDir string, agent *config.Agent, rigs []config.Rig) map[string]string {
+func buildMCPTemplateData(cityPath, qualifiedName, workDir string, agent *config.Agent, rigs []config.Rig) map[string]string {
 	rigName := configuredRigName(cityPath, agent, rigs)
 	rigRoot := rigRootForName(rigName, rigs)
 	return buildTemplateData(PromptContext{
@@ -65,12 +65,12 @@ func supportsMCPProviderKind(kind string) bool {
 }
 
 func loadEffectiveMCPForAgent(
-	cityPath, cityName string,
+	cityPath string,
 	cfg *config.City,
 	agent *config.Agent,
 	qualifiedName, workDir string,
 ) (materialize.MCPCatalog, error) {
-	templateData := buildMCPTemplateData(cityPath, cityName, qualifiedName, workDir, agent, cfg.Rigs)
+	templateData := buildMCPTemplateData(cityPath, qualifiedName, workDir, agent, cfg.Rigs)
 	catalog, err := materialize.EffectiveMCPForAgent(cfg, agent, templateData)
 	if err != nil {
 		return materialize.MCPCatalog{}, fmt.Errorf("loading effective MCP: %w", err)
@@ -79,13 +79,13 @@ func loadEffectiveMCPForAgent(
 }
 
 func resolveAgentMCPProjection(
-	cityPath, cityName string,
+	cityPath string,
 	cfg *config.City,
 	agent *config.Agent,
 	qualifiedName, workDir string,
 	providerKind string,
 ) (materialize.MCPCatalog, materialize.MCPProjection, error) {
-	catalog, err := loadEffectiveMCPForAgent(cityPath, cityName, cfg, agent, qualifiedName, workDir)
+	catalog, err := loadEffectiveMCPForAgent(cityPath, cfg, agent, qualifiedName, workDir)
 	if err != nil {
 		return materialize.MCPCatalog{}, materialize.MCPProjection{}, err
 	}
@@ -240,11 +240,10 @@ func resolveConfiguredAgentMCPProjection(
 	if cfg == nil || agent == nil {
 		return resolvedMCPProjection{}, fmt.Errorf("agent unavailable")
 	}
-	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
 	identity := agent.QualifiedName()
 	workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, agent, identity)
 	if err != nil {
-		catalog, catErr := loadEffectiveMCPForAgent(cityPath, cityName, cfg, agent, identity, agentScopeRoot(agent, cityPath, cfg.Rigs))
+		catalog, catErr := loadEffectiveMCPForAgent(cityPath, cfg, agent, identity, agentScopeRoot(agent, cityPath, cfg.Rigs))
 		if catErr != nil {
 			return resolvedMCPProjection{}, fmt.Errorf("loading effective MCP: %w", catErr)
 		}
@@ -314,7 +313,6 @@ func resolveProjectedMCPForTarget(
 	if cfg == nil || agent == nil {
 		return resolvedMCPProjection{}, fmt.Errorf("agent unavailable")
 	}
-	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
 	if strings.TrimSpace(identity) == "" {
 		identity = agent.QualifiedName()
 	}
@@ -322,7 +320,7 @@ func resolveProjectedMCPForTarget(
 	if strings.TrimSpace(providerKind) == "" {
 		resolved, err := config.ResolveProvider(agent, &cfg.Workspace, cfg.Providers, lookPath)
 		if err != nil {
-			catalog, catErr := loadEffectiveMCPForAgent(cityPath, cityName, cfg, agent, identity, workDir)
+			catalog, catErr := loadEffectiveMCPForAgent(cityPath, cfg, agent, identity, workDir)
 			if catErr != nil {
 				return resolvedMCPProjection{}, catErr
 			}
@@ -333,7 +331,7 @@ func resolveProjectedMCPForTarget(
 		}
 		providerKind = strings.TrimSpace(resolved.Kind)
 	}
-	catalog, projection, err := resolveAgentMCPProjection(cityPath, cityName, cfg, agent, identity, workDir, providerKind)
+	catalog, projection, err := resolveAgentMCPProjection(cityPath, cfg, agent, identity, workDir, providerKind)
 	if err != nil {
 		return resolvedMCPProjection{}, err
 	}

--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/materialize"
+	"github.com/gastownhall/gascity/internal/shellquote"
+)
+
+var managedMCPGitignoreEntries = []string{
+	".mcp.json",
+	filepath.ToSlash(filepath.Join(".gemini", "settings.json")),
+	filepath.ToSlash(filepath.Join(".codex", "config.toml")),
+}
+
+type mcpTargetSpec struct {
+	Root       string
+	Projection materialize.MCPProjection
+	Agents     []string
+}
+
+type resolvedMCPProjection struct {
+	Agent        *config.Agent
+	Identity     string
+	WorkDir      string
+	ScopeRoot    string
+	ProviderKind string
+	Delivery     string
+	Catalog      materialize.MCPCatalog
+	Projection   materialize.MCPProjection
+}
+
+func buildMCPTemplateData(cityPath, cityName, qualifiedName, workDir string, agent *config.Agent, rigs []config.Rig) map[string]string {
+	rigName := configuredRigName(cityPath, agent, rigs)
+	rigRoot := rigRootForName(rigName, rigs)
+	return buildTemplateData(PromptContext{
+		CityRoot:      cityPath,
+		AgentName:     qualifiedName,
+		TemplateName:  templateNameFor(agent, qualifiedName),
+		RigName:       rigName,
+		RigRoot:       rigRoot,
+		WorkDir:       workDir,
+		IssuePrefix:   findRigPrefix(rigName, rigs),
+		DefaultBranch: defaultBranchFor(workDir),
+		WorkQuery:     agent.EffectiveWorkQuery(),
+		SlingQuery:    agent.EffectiveSlingQuery(),
+		Env:           agent.Env,
+	})
+}
+
+func supportsMCPProviderKind(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case materialize.MCPProviderClaude, materialize.MCPProviderCodex, materialize.MCPProviderGemini:
+		return true
+	default:
+		return false
+	}
+}
+
+func loadEffectiveMCPForAgent(
+	cityPath, cityName string,
+	cfg *config.City,
+	agent *config.Agent,
+	qualifiedName, workDir string,
+) (materialize.MCPCatalog, error) {
+	templateData := buildMCPTemplateData(cityPath, cityName, qualifiedName, workDir, agent, cfg.Rigs)
+	catalog, err := materialize.EffectiveMCPForAgent(cfg, agent, templateData)
+	if err != nil {
+		return materialize.MCPCatalog{}, fmt.Errorf("loading effective MCP: %w", err)
+	}
+	return catalog, nil
+}
+
+func resolveAgentMCPProjection(
+	cityPath, cityName string,
+	cfg *config.City,
+	agent *config.Agent,
+	qualifiedName, workDir string,
+	providerKind string,
+) (materialize.MCPCatalog, materialize.MCPProjection, error) {
+	catalog, err := loadEffectiveMCPForAgent(cityPath, cityName, cfg, agent, qualifiedName, workDir)
+	if err != nil {
+		return materialize.MCPCatalog{}, materialize.MCPProjection{}, err
+	}
+	if !supportsMCPProviderKind(providerKind) {
+		if len(catalog.Servers) > 0 {
+			return materialize.MCPCatalog{}, materialize.MCPProjection{}, fmt.Errorf(
+				"effective MCP requires a supported provider family, got %q", providerKind)
+		}
+		return catalog, materialize.MCPProjection{}, nil
+	}
+	projection, err := materialize.BuildMCPProjection(providerKind, workDir, catalog.Servers)
+	if err != nil {
+		return materialize.MCPCatalog{}, materialize.MCPProjection{}, err
+	}
+	return catalog, projection, nil
+}
+
+func mergeMCPFingerprintEntry(fpExtra map[string]string, projection materialize.MCPProjection) map[string]string {
+	if projection.Provider == "" {
+		return fpExtra
+	}
+	if fpExtra == nil {
+		fpExtra = make(map[string]string, 1)
+	}
+	fpExtra["mcp:"+projection.Provider] = projection.Hash()
+	return fpExtra
+}
+
+func appendProjectMCPPreStart(prestart []string, agentName, identity, workDir string) []string {
+	cmd := `"${GC_BIN:-gc}" internal project-mcp --agent ` +
+		shellquote.Join([]string{agentName}) +
+		` --identity ` + shellquote.Join([]string{identity}) +
+		` --workdir ` + shellquote.Join([]string{workDir})
+	return append(prestart, cmd)
+}
+
+func ensureMCPGitignoreBestEffort(root string, stderr io.Writer) {
+	if strings.TrimSpace(root) == "" {
+		return
+	}
+	if err := ensureGitignoreEntries(fsys.OSFS{}, root, managedMCPGitignoreEntries); err != nil && stderr != nil {
+		fmt.Fprintf(stderr, "gc: warning: updating %s/.gitignore for MCP: %v\n", root, err) //nolint:errcheck // best-effort stderr
+	}
+}
+
+func buildStage1MCPTargets(cityPath string, cfg *config.City, lookPath config.LookPathFunc) ([]mcpTargetSpec, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	byKey := make(map[string]mcpTargetSpec)
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if !canStage1Materialize(cfg.Session.Provider, agent) {
+			continue
+		}
+		view, err := resolveConfiguredAgentMCPProjection(cityPath, cfg, agent, lookPath)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: %w", agent.QualifiedName(), err)
+		}
+		if view.Delivery != "stage1" {
+			continue
+		}
+		if view.Projection.Provider == "" && len(view.Catalog.Servers) == 0 {
+			continue
+		}
+		key := view.Projection.Provider + "|" + view.Projection.Target
+		existing, ok := byKey[key]
+		if ok {
+			if existing.Projection.Hash() != view.Projection.Hash() {
+				return nil, fmt.Errorf(
+					"MCP target conflict at %s (%s): %s projects %s but %s projects %s",
+					view.Projection.Target,
+					view.Projection.Provider,
+					strings.Join(existing.Agents, ", "),
+					existing.Projection.Hash(),
+					agent.QualifiedName(),
+					view.Projection.Hash(),
+				)
+			}
+			existing.Agents = append(existing.Agents, agent.QualifiedName())
+			sort.Strings(existing.Agents)
+			byKey[key] = existing
+			continue
+		}
+		byKey[key] = mcpTargetSpec{
+			Root:       view.ScopeRoot,
+			Projection: view.Projection,
+			Agents:     []string{agent.QualifiedName()},
+		}
+	}
+
+	keys := make([]string, 0, len(byKey))
+	for key := range byKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]mcpTargetSpec, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, byKey[key])
+	}
+	return out, nil
+}
+
+func runStage1MCPProjection(cityPath string, cfg *config.City, lookPath config.LookPathFunc, stderr io.Writer) error {
+	targets, err := buildStage1MCPTargets(cityPath, cfg, lookPath)
+	if err != nil {
+		return err
+	}
+	for _, target := range targets {
+		if err := target.Projection.Apply(fsys.OSFS{}); err != nil {
+			return fmt.Errorf("reconciling %s: %w", target.Projection.Target, err)
+		}
+		if len(target.Projection.Servers) > 0 {
+			ensureMCPGitignoreBestEffort(target.Root, stderr)
+		}
+	}
+	return nil
+}
+
+func resolveDeterministicAgentMCPProjection(
+	cityPath string,
+	cfg *config.City,
+	agent *config.Agent,
+	lookPath config.LookPathFunc,
+) (resolvedMCPProjection, error) {
+	view, err := resolveConfiguredAgentMCPProjection(cityPath, cfg, agent, lookPath)
+	if err != nil || agent == nil || !agent.SupportsMultipleSessions() || len(view.Catalog.Servers) == 0 {
+		return view, err
+	}
+
+	altIdentity := agent.QualifiedName() + "-alt"
+	altWorkDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, agent, altIdentity)
+	if err != nil {
+		return resolvedMCPProjection{}, fmt.Errorf("agent %q has session-specific MCP targets; use --session", agent.QualifiedName())
+	}
+	altView, err := resolveProjectedMCPForTarget(cityPath, cfg, agent, altIdentity, altWorkDir, "", lookPath)
+	if err != nil {
+		return resolvedMCPProjection{}, fmt.Errorf("agent %q has session-specific MCP targets; use --session", agent.QualifiedName())
+	}
+	if view.Projection.Target != altView.Projection.Target || view.Projection.Hash() != altView.Projection.Hash() {
+		return resolvedMCPProjection{}, fmt.Errorf("agent %q has session-specific MCP targets; use --session", agent.QualifiedName())
+	}
+	return view, nil
+}
+
+func resolveConfiguredAgentMCPProjection(
+	cityPath string,
+	cfg *config.City,
+	agent *config.Agent,
+	lookPath config.LookPathFunc,
+) (resolvedMCPProjection, error) {
+	if cfg == nil || agent == nil {
+		return resolvedMCPProjection{}, fmt.Errorf("agent unavailable")
+	}
+	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	identity := agent.QualifiedName()
+	workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, agent, identity)
+	if err != nil {
+		catalog, catErr := loadEffectiveMCPForAgent(cityPath, cityName, cfg, agent, identity, agentScopeRoot(agent, cityPath, cfg.Rigs))
+		if catErr != nil {
+			return resolvedMCPProjection{}, fmt.Errorf("loading effective MCP: %w", catErr)
+		}
+		if len(catalog.Servers) == 0 {
+			return resolvedMCPProjection{}, nil
+		}
+		return resolvedMCPProjection{}, fmt.Errorf("resolving workdir for agent %q: %w", identity, err)
+	}
+	return resolveProjectedMCPForTarget(cityPath, cfg, agent, identity, workDir, "", lookPath)
+}
+
+func resolveSessionMCPProjection(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	sessionID string,
+	lookPath config.LookPathFunc,
+) (resolvedMCPProjection, error) {
+	if cfg == nil {
+		return resolvedMCPProjection{}, fmt.Errorf("city config unavailable")
+	}
+	if store == nil {
+		return resolvedMCPProjection{}, fmt.Errorf("session store unavailable")
+	}
+	id, err := resolveSessionIDAllowClosedWithConfig(cityPath, cfg, store, sessionID)
+	if err != nil {
+		return resolvedMCPProjection{}, err
+	}
+	bead, err := store.Get(id)
+	if err != nil {
+		return resolvedMCPProjection{}, fmt.Errorf("loading session %q: %w", sessionID, err)
+	}
+	template := normalizedSessionTemplate(bead, cfg)
+	if template == "" {
+		template = strings.TrimSpace(bead.Metadata["agent_name"])
+	}
+	template = resolveAgentTemplate(template, cfg)
+	agent := findAgentByTemplate(cfg, template)
+	if agent == nil {
+		return resolvedMCPProjection{}, fmt.Errorf("session %q maps to unknown agent template %q", sessionID, template)
+	}
+	identity := strings.TrimSpace(bead.Metadata["agent_name"])
+	if identity == "" {
+		identity = agent.QualifiedName()
+	}
+	workDir := strings.TrimSpace(bead.Metadata["work_dir"])
+	if workDir == "" {
+		workDir, err = resolveWorkDirForQualifiedName(cityPath, cfg, agent, identity)
+		if err != nil {
+			return resolvedMCPProjection{}, fmt.Errorf("resolving workdir for session %q: %w", sessionID, err)
+		}
+	}
+	providerKind := strings.TrimSpace(bead.Metadata["provider_kind"])
+	if providerKind == "" {
+		providerKind = strings.TrimSpace(bead.Metadata["provider"])
+	}
+	return resolveProjectedMCPForTarget(cityPath, cfg, agent, identity, workDir, providerKind, lookPath)
+}
+
+func resolveProjectedMCPForTarget(
+	cityPath string,
+	cfg *config.City,
+	agent *config.Agent,
+	identity, workDir, providerKind string,
+	lookPath config.LookPathFunc,
+) (resolvedMCPProjection, error) {
+	if cfg == nil || agent == nil {
+		return resolvedMCPProjection{}, fmt.Errorf("agent unavailable")
+	}
+	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	if strings.TrimSpace(identity) == "" {
+		identity = agent.QualifiedName()
+	}
+	scopeRoot := agentScopeRoot(agent, cityPath, cfg.Rigs)
+	if strings.TrimSpace(providerKind) == "" {
+		resolved, err := config.ResolveProvider(agent, &cfg.Workspace, cfg.Providers, lookPath)
+		if err != nil {
+			catalog, catErr := loadEffectiveMCPForAgent(cityPath, cityName, cfg, agent, identity, workDir)
+			if catErr != nil {
+				return resolvedMCPProjection{}, catErr
+			}
+			if len(catalog.Servers) == 0 {
+				return resolvedMCPProjection{}, nil
+			}
+			return resolvedMCPProjection{}, err
+		}
+		providerKind = strings.TrimSpace(resolved.Kind)
+	}
+	catalog, projection, err := resolveAgentMCPProjection(cityPath, cityName, cfg, agent, identity, workDir, providerKind)
+	if err != nil {
+		return resolvedMCPProjection{}, err
+	}
+	canonWorkDir := canonicaliseFilePath(workDir, cityPath)
+	stage1 := canStage1Materialize(cfg.Session.Provider, agent) && canonWorkDir == scopeRoot
+	stage2 := isStage2EligibleSession(cfg.Session.Provider, agent) && canonWorkDir != scopeRoot
+	if len(catalog.Servers) > 0 && !stage1 && !stage2 {
+		return resolvedMCPProjection{}, fmt.Errorf(
+			"effective MCP cannot be delivered to workdir %q with session provider %q",
+			canonWorkDir,
+			cfg.Session.Provider,
+		)
+	}
+	delivery := ""
+	switch {
+	case stage1:
+		delivery = "stage1"
+	case stage2:
+		delivery = "stage2"
+	}
+	return resolvedMCPProjection{
+		Agent:        agent,
+		Identity:     identity,
+		WorkDir:      canonWorkDir,
+		ScopeRoot:    scopeRoot,
+		ProviderKind: providerKind,
+		Delivery:     delivery,
+		Catalog:      catalog,
+		Projection:   projection,
+	}, nil
+}

--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -194,12 +195,120 @@ func runStage1MCPProjection(cityPath string, cfg *config.City, lookPath config.L
 	if err != nil {
 		return err
 	}
+	desired := make(map[string]bool, len(targets)) // provider+root keys we still own
 	for _, target := range targets {
-		if err := target.Projection.Apply(fsys.OSFS{}); err != nil {
+		if err := target.Projection.ApplyWithStderr(fsys.OSFS{}, stderr); err != nil {
 			return fmt.Errorf("reconciling %s: %w", target.Projection.Target, err)
 		}
+		desired[managedKey(target.Projection.Provider, target.Root)] = true
 		if len(target.Projection.Servers) > 0 {
 			ensureMCPGitignoreBestEffort(target.Root, stderr)
+		}
+	}
+	if err := cleanupOrphanStage1Targets(cityPath, cfg, desired, stderr); err != nil {
+		return err
+	}
+	return nil
+}
+
+// managedKey combines provider and scope-root into the key used by stage-1
+// reconcile to recognize which managed markers still have a live claimant.
+func managedKey(provider, root string) string {
+	return provider + "|" + filepath.Clean(root)
+}
+
+// cleanupOrphanStage1Targets walks .gc/mcp-managed/ under every scope root
+// reachable from the current config and reconciles away managed markers
+// that have no desired claimant. Covered: agents removed from city.toml,
+// provider changes that move a target between provider subtrees, and
+// managed markers under still-attached rig roots that no longer have an
+// agent claiming them.
+//
+// Not covered: rigs detached from city.toml (their path is no longer in
+// cfg.Rigs, so we cannot reach their .gc/mcp-managed/ to sweep it).
+// Detached-rig cleanup is explicit work for an operator — `gc rig detach`
+// or a future `gc mcp reconcile --root <path>` command. If needed, the
+// operator can also delete .gc/mcp-managed/ under the detached rig root
+// by hand; the managed files that remain outside GC's view are
+// structurally equivalent to any other hand-authored MCP surface.
+//
+// Stage-2 workdirs are also not swept here: they are self-reconciled on
+// every session start and have no stable root registry.
+func cleanupOrphanStage1Targets(cityPath string, cfg *config.City, desired map[string]bool, stderr io.Writer) error {
+	if cfg == nil {
+		return nil
+	}
+	roots := collectStage1ScopeRoots(cityPath, cfg)
+	for _, root := range roots {
+		if err := cleanupOrphansAtRoot(root, desired, stderr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectStage1ScopeRoots(cityPath string, cfg *config.City) []string {
+	seen := make(map[string]bool)
+	add := func(root string) {
+		if strings.TrimSpace(root) == "" {
+			return
+		}
+		clean := filepath.Clean(root)
+		if !filepath.IsAbs(clean) {
+			clean = filepath.Clean(filepath.Join(cityPath, clean))
+		}
+		seen[clean] = true
+	}
+	add(cityPath)
+	for _, rig := range cfg.Rigs {
+		add(rig.Path)
+	}
+	out := make([]string, 0, len(seen))
+	for root := range seen {
+		out = append(out, root)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cleanupOrphansAtRoot(root string, desired map[string]bool, stderr io.Writer) error {
+	markersDir := filepath.Join(root, ".gc", "mcp-managed")
+	entries, err := fsys.OSFS{}.ReadDir(markersDir)
+	if err != nil {
+		// Missing directory is the steady state when no targets have ever
+		// been adopted at this root — not an error.
+		if os.IsNotExist(err) {
+			return nil
+		}
+		// Permission or corruption problems must surface — silently
+		// skipping would leave stale managed state unreconciled and
+		// hide operator-facing diagnostics.
+		return fmt.Errorf("scanning %s: %w", markersDir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		provider := strings.TrimSuffix(name, ".json")
+		if !supportsMCPProviderKind(provider) {
+			continue
+		}
+		if desired[managedKey(provider, root)] {
+			continue
+		}
+		orphan, err := materialize.BuildMCPProjection(provider, root, nil)
+		if err != nil {
+			return fmt.Errorf("building orphan projection for %s at %s: %w", provider, root, err)
+		}
+		if err := orphan.ApplyWithStderr(fsys.OSFS{}, stderr); err != nil {
+			return fmt.Errorf("cleaning up orphan %s marker at %s: %w", provider, root, err)
+		}
+		if stderr != nil {
+			fmt.Fprintf(stderr, "gc: cleaned up orphan MCP marker %s at %s\n", provider, root) //nolint:errcheck // best-effort stderr
 		}
 	}
 	return nil
@@ -301,6 +410,118 @@ func resolveSessionMCPProjection(
 		providerKind = strings.TrimSpace(bead.Metadata["provider"])
 	}
 	return resolveProjectedMCPForTarget(cityPath, cfg, agent, identity, workDir, providerKind, lookPath)
+}
+
+// validateStage2TargetClaimants enforces that every configured agent
+// that would actually land on the same provider-native MCP target as
+// the caller projects an identical payload. Stage-1 runs the same check
+// at build-time (buildStage1MCPTargets); stage-2 must run it at
+// write-time because multiple agents can share a workdir and last-
+// writer-wins would otherwise let any of them silently lose their MCP
+// surface.
+//
+// Critically, each candidate agent must be resolved against its **own**
+// provider kind and **own** workdir (template expansion against that
+// agent's identity) rather than the caller's. Reusing the caller's
+// providerKind mis-projects mixed-provider peers (a Codex peer
+// projected as "claude" would appear to collide at the caller's
+// `.mcp.json` even though at runtime the two write disjoint files);
+// reusing the caller's workdir collapses every peer onto the caller's
+// target regardless of the peer's own WorkDir template.
+//
+// The caller's projection is the reference; any other configured agent
+// whose own workdir resolves to the same target with a different hash
+// aborts the write with a conflict error naming both agents.
+//
+// Scope limitation: this check iterates *configured* agents, not live
+// sessions. A pooled template that produces session-varying MCP
+// payloads (e.g., MCP catalogs that expand `{{.AgentName}}`) whose
+// concrete sessions share a workdir is not detected here — the
+// validator sees only one configured agent and no conflict is raised.
+// This is an operator-misconfiguration scenario: if two live sessions
+// share a workdir they are already racing for many shared resources
+// (git state, skill materialization, hook state) beyond MCP. A future
+// enhancement could plumb the session store in and validate against
+// live claimants; for now, stage-2 validation covers the
+// multi-template same-workdir case and defers same-template live-
+// session conflicts to stage-1's build-time check for non-pooled
+// scope-root overlaps and to operator review of pool configuration.
+func validateStage2TargetClaimants(
+	cityPath string,
+	cfg *config.City,
+	caller *config.Agent,
+	want materialize.MCPProjection,
+	lookPath config.LookPathFunc,
+) error {
+	if cfg == nil || want.Provider == "" {
+		return nil
+	}
+	callerName := ""
+	if caller != nil {
+		callerName = caller.QualifiedName()
+	}
+	wantHash := want.Hash()
+	for i := range cfg.Agents {
+		other := &cfg.Agents[i]
+		if other.QualifiedName() == callerName {
+			continue
+		}
+		// Implicit agents are synthetic provider-coverage entries
+		// (config.InjectImplicitAgents) used for sling target
+		// materialization, not real MCP writers. They never invoke
+		// `gc internal project-mcp`, so they cannot race with the
+		// caller for this target.
+		if other.Implicit {
+			continue
+		}
+		identity := other.QualifiedName()
+		// Resolve the candidate's own provider BEFORE projecting.
+		// Reusing the caller's providerKind would mis-project mixed-
+		// provider peers into the caller's target shape — a Codex
+		// peer's catalog projected as "claude" would appear to
+		// collide at the caller's `.mcp.json` even though the peer
+		// would actually write `.codex/config.toml` at runtime.
+		otherResolved, err := config.ResolveProvider(other, &cfg.Workspace, cfg.Providers, lookPath)
+		if err != nil {
+			// Cannot resolve this peer's provider — it can't claim
+			// any target. Not a conflict.
+			continue
+		}
+		otherKind := strings.TrimSpace(otherResolved.Kind)
+		if otherKind != want.Provider {
+			// Different provider family — targets live in disjoint
+			// subtrees (`.mcp.json` / `.gemini/settings.json` /
+			// `.codex/config.toml`), so no collision is possible.
+			continue
+		}
+		// Resolve the candidate's own workdir. Failures here are
+		// treated as "this agent can't claim any target in this city
+		// right now" — not a conflict.
+		otherWorkDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, other, identity)
+		if err != nil {
+			continue
+		}
+		_, projection, err := resolveAgentMCPProjection(cityPath, cfg, other, identity, otherWorkDir, otherKind)
+		if err != nil {
+			continue
+		}
+		if projection.Provider != want.Provider || projection.Target != want.Target {
+			// Different physical target, no conflict.
+			continue
+		}
+		if projection.Hash() != wantHash {
+			return fmt.Errorf(
+				"MCP target conflict at %s (%s): agent %q projects %s but agent %q projects %s",
+				want.Target,
+				want.Provider,
+				callerName,
+				wantHash,
+				other.QualifiedName(),
+				projection.Hash(),
+			)
+		}
+	}
+	return nil
 }
 
 func resolveProjectedMCPForTarget(

--- a/cmd/gc/mcp_supervisor_test.go
+++ b/cmd/gc/mcp_supervisor_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func writeMCPSource(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stubLookPath(_ string) (string, error) {
+	return "/bin/echo", nil
+}
+
+func TestRunStage1MCPProjectionCityScoped(t *testing.T) {
+	cityPath := t.TempDir()
+	writeMCPSource(t, filepath.Join(cityPath, "mcp", "notes.toml"), `
+name = "notes"
+command = "uvx"
+args = ["notes-mcp"]
+`)
+
+	cfg := &config.City{
+		PackMCPDir: filepath.Join(cityPath, "mcp"),
+		Session:    config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "gemini"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1MCPProjection(cityPath, cfg, stubLookPath, &stderr); err != nil {
+		t.Fatalf("runStage1MCPProjection: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, ".gemini", "settings.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json): %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	if _, ok := doc["mcpServers"]; !ok {
+		t.Fatalf("mcpServers missing from projected gemini settings:\n%s", string(data))
+	}
+
+	gitignore, err := os.ReadFile(filepath.Join(cityPath, ".gitignore"))
+	if err != nil {
+		t.Fatalf("ReadFile(.gitignore): %v", err)
+	}
+	for _, want := range managedMCPGitignoreEntries {
+		if !strings.Contains(string(gitignore), want) {
+			t.Fatalf(".gitignore missing %q:\n%s", want, string(gitignore))
+		}
+	}
+}
+
+func TestRunStage1MCPProjectionRemovesStaleManagedTarget(t *testing.T) {
+	cityPath := t.TempDir()
+	target := filepath.Join(cityPath, ".mcp.json")
+	if err := os.WriteFile(target, []byte(`{"mcpServers":{"stale":{"command":"old"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "mcp-managed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".gc", "mcp-managed", "claude.json"), []byte(`{"managed_by":"gc"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Session: config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "claude"},
+		},
+	}
+
+	if err := runStage1MCPProjection(cityPath, cfg, stubLookPath, &bytes.Buffer{}); err != nil {
+		t.Fatalf("runStage1MCPProjection: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("stale .mcp.json should be removed, stat err = %v", err)
+	}
+}
+
+func TestBuildStage1MCPTargetsRejectsConflictingSharedTarget(t *testing.T) {
+	cityPath := t.TempDir()
+	agentLocal := filepath.Join(cityPath, "agents", "mayor", "mcp", "notes.toml")
+	writeMCPSource(t, agentLocal, `
+name = "notes"
+command = "uvx"
+`)
+
+	cfg := &config.City{
+		Session: config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "claude", MCPDir: filepath.Dir(agentLocal)},
+			{Name: "deputy", Scope: "city", Provider: "claude"},
+		},
+	}
+
+	_, err := buildStage1MCPTargets(cityPath, cfg, stubLookPath)
+	if err == nil {
+		t.Fatal("expected MCP target conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "MCP target conflict") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildStage1MCPTargetsSkipsStage2OnlyAgents(t *testing.T) {
+	cityPath := t.TempDir()
+	mayorMCP := filepath.Join(cityPath, "agents", "mayor", "mcp", "notes.toml")
+	deputyMCP := filepath.Join(cityPath, "agents", "deputy", "mcp", "notes.toml")
+	writeMCPSource(t, mayorMCP, `
+name = "notes"
+command = "uvx"
+`)
+	writeMCPSource(t, deputyMCP, `
+name = "notes"
+url = "https://example.com/deputy"
+`)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "gemini"},
+		Providers: map[string]config.ProviderSpec{
+			"gemini": {Command: "echo", PromptMode: "none"},
+		},
+		Session: config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "gemini", WorkDir: ".gc/worktrees/{{.Agent}}", MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(mayorMCP)},
+			{Name: "deputy", Scope: "city", Provider: "gemini", WorkDir: ".gc/worktrees/{{.Agent}}", MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(deputyMCP)},
+		},
+	}
+
+	targets, err := buildStage1MCPTargets(cityPath, cfg, stubLookPath)
+	if err != nil {
+		t.Fatalf("buildStage1MCPTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("stage2-only agents should not contribute stage1 targets, got %+v", targets)
+	}
+}

--- a/cmd/gc/mcp_supervisor_test.go
+++ b/cmd/gc/mcp_supervisor_test.go
@@ -122,6 +122,213 @@ command = "uvx"
 	}
 }
 
+func TestRunStage1MCPProjectionPropagatesManagedDirReadErrors(t *testing.T) {
+	// Permission / corruption errors reading .gc/mcp-managed/ must
+	// surface rather than be silently treated as "nothing to do" —
+	// hiding them would leave stale managed state unreconciled and
+	// rob operators of diagnostic output.
+	if os.Geteuid() == 0 {
+		t.Skip("cannot test permission-denied ReadDir as root")
+	}
+	cityPath := t.TempDir()
+	markersDir := filepath.Join(cityPath, ".gc", "mcp-managed")
+	if err := os.MkdirAll(markersDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Revoke read permission so ReadDir returns EACCES.
+	if err := os.Chmod(markersDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(markersDir, 0o755)
+	})
+
+	cfg := &config.City{Session: config.SessionConfig{Provider: "tmux"}}
+	err := runStage1MCPProjection(cityPath, cfg, stubLookPath, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected EACCES propagation, got nil")
+	}
+	if !strings.Contains(err.Error(), "scanning") {
+		t.Fatalf("error should cite scan context, got: %v", err)
+	}
+}
+
+func TestRunStage1MCPProjectionCleansOrphanedManagedMarkers(t *testing.T) {
+	cityPath := t.TempDir()
+	// Plant an orphaned managed marker + its target: neither is referenced
+	// by any agent in the current config, so stage-1 must clean both up.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "mcp-managed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".gc", "mcp-managed", "gemini.json"),
+		[]byte(`{"managed_by":"gc","provider":"gemini"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	geminiTarget := filepath.Join(cityPath, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(geminiTarget), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(geminiTarget, []byte(`{"mcpServers":{"stale":{"command":"old"}}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Config has no agents — any managed marker under this root is orphaned.
+	cfg := &config.City{
+		Session: config.SessionConfig{Provider: "tmux"},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1MCPProjection(cityPath, cfg, stubLookPath, &stderr); err != nil {
+		t.Fatalf("runStage1MCPProjection: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cityPath, ".gc", "mcp-managed", "gemini.json")); !os.IsNotExist(err) {
+		t.Fatalf("orphaned managed marker should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(geminiTarget); !os.IsNotExist(err) {
+		t.Fatalf("orphaned managed target should be removed, stat err = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "orphan MCP marker gemini") {
+		t.Fatalf("stderr missing orphan cleanup note: %q", stderr.String())
+	}
+}
+
+func TestValidateStage2TargetClaimantsResolvesEachAgentsOwnWorkdir(t *testing.T) {
+	// Two stage-2 agents with distinct per-agent MCP and distinct WorkDir
+	// templates: they never actually land on the same provider-native
+	// target, so the caller's stage-2 launch must not be blocked with a
+	// bogus "conflict" error.
+	cityPath := t.TempDir()
+	alphaMCP := filepath.Join(cityPath, "agents", "alpha", "mcp", "notes.toml")
+	betaMCP := filepath.Join(cityPath, "agents", "beta", "mcp", "notes.toml")
+	writeMCPSource(t, alphaMCP, `
+name = "notes"
+command = "uvx"
+args = ["alpha-notes"]
+`)
+	writeMCPSource(t, betaMCP, `
+name = "notes"
+command = "uvx"
+args = ["beta-notes"]
+`)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "gemini"},
+		Providers: map[string]config.ProviderSpec{
+			"gemini": {Command: "echo", PromptMode: "none"},
+		},
+		Session: config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "alpha", Scope: "city", Provider: "gemini", WorkDir: ".gc/worktrees/{{.Agent}}", MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(alphaMCP)},
+			{Name: "beta", Scope: "city", Provider: "gemini", WorkDir: ".gc/worktrees/{{.Agent}}", MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(betaMCP)},
+		},
+	}
+
+	// Simulate alpha invoking stage-2 pre-start: resolve alpha's workdir
+	// and projection, then validate against other claimants.
+	alphaWorkdir := filepath.Join(cityPath, ".gc", "worktrees", "alpha")
+	_, alphaProj, err := resolveAgentMCPProjection(cityPath, cfg, &cfg.Agents[0], "alpha", alphaWorkdir, "gemini")
+	if err != nil {
+		t.Fatalf("resolveAgentMCPProjection(alpha): %v", err)
+	}
+	if err := validateStage2TargetClaimants(cityPath, cfg, &cfg.Agents[0], alphaProj, stubLookPath); err != nil {
+		t.Fatalf("validateStage2TargetClaimants must allow disjoint-workdir peers, got: %v", err)
+	}
+}
+
+func TestValidateStage2TargetClaimantsSkipsMixedProviderPeers(t *testing.T) {
+	// A Gemini caller sharing a workdir template with a Claude peer
+	// must NOT see a false-positive conflict: their provider-native
+	// targets live in disjoint subtrees
+	// (`.mcp.json` vs `.gemini/settings.json`) and cannot collide.
+	// Prior bug: validator reused caller's providerKind for every
+	// peer, projecting Claude's catalog as if it would land on
+	// Gemini's target, producing a bogus hash mismatch.
+	cityPath := t.TempDir()
+	geminiMCP := filepath.Join(cityPath, "agents", "mayor", "mcp", "notes.toml")
+	claudeMCP := filepath.Join(cityPath, "agents", "deputy", "mcp", "notes.toml")
+	writeMCPSource(t, geminiMCP, `
+name = "notes"
+command = "uvx"
+args = ["mayor-notes"]
+`)
+	writeMCPSource(t, claudeMCP, `
+name = "notes"
+command = "uvx"
+args = ["deputy-notes"]
+`)
+
+	shared := ".gc/worktrees/shared"
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "gemini"},
+		Providers: map[string]config.ProviderSpec{
+			"gemini": {Command: "echo", PromptMode: "none"},
+			"claude": {Command: "echo", PromptMode: "none"},
+		},
+		Session: config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "gemini", WorkDir: shared, MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(geminiMCP)},
+			{Name: "deputy", Scope: "city", Provider: "claude", WorkDir: shared, MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(claudeMCP)},
+		},
+	}
+
+	sharedWorkdir := filepath.Join(cityPath, shared)
+	_, mayorProj, err := resolveAgentMCPProjection(cityPath, cfg, &cfg.Agents[0], "mayor", sharedWorkdir, "gemini")
+	if err != nil {
+		t.Fatalf("resolveAgentMCPProjection(mayor): %v", err)
+	}
+	if err := validateStage2TargetClaimants(cityPath, cfg, &cfg.Agents[0], mayorProj, stubLookPath); err != nil {
+		t.Fatalf("mixed-provider peers in same workdir must not conflict, got: %v", err)
+	}
+}
+
+func TestValidateStage2TargetClaimantsRejectsRealConflicts(t *testing.T) {
+	// Two agents sharing the same WorkDir template with different MCP
+	// catalogs must conflict — this is the safety contract we are
+	// preserving even after fixing the false-positive path.
+	cityPath := t.TempDir()
+	alphaMCP := filepath.Join(cityPath, "agents", "alpha", "mcp", "notes.toml")
+	betaMCP := filepath.Join(cityPath, "agents", "beta", "mcp", "notes.toml")
+	writeMCPSource(t, alphaMCP, `
+name = "notes"
+command = "uvx"
+args = ["alpha-notes"]
+`)
+	writeMCPSource(t, betaMCP, `
+name = "notes"
+command = "uvx"
+args = ["beta-notes"]
+`)
+
+	// Both agents point at the same shared workdir template, so their
+	// projections resolve to the same provider-native target.
+	shared := ".gc/worktrees/shared"
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "gemini"},
+		Providers: map[string]config.ProviderSpec{
+			"gemini": {Command: "echo", PromptMode: "none"},
+		},
+		Session: config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "alpha", Scope: "city", Provider: "gemini", WorkDir: shared, MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(alphaMCP)},
+			{Name: "beta", Scope: "city", Provider: "gemini", WorkDir: shared, MaxActiveSessions: intPtr(2), MCPDir: filepath.Dir(betaMCP)},
+		},
+	}
+
+	alphaWorkdir := filepath.Join(cityPath, shared)
+	_, alphaProj, err := resolveAgentMCPProjection(cityPath, cfg, &cfg.Agents[0], "alpha", alphaWorkdir, "gemini")
+	if err != nil {
+		t.Fatalf("resolveAgentMCPProjection(alpha): %v", err)
+	}
+	err = validateStage2TargetClaimants(cityPath, cfg, &cfg.Agents[0], alphaProj, stubLookPath)
+	if err == nil {
+		t.Fatal("expected conflict for two agents with same workdir and divergent MCP, got nil")
+	}
+	if !strings.Contains(err.Error(), "MCP target conflict") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestBuildStage1MCPTargetsSkipsStage2OnlyAgents(t *testing.T) {
 	cityPath := t.TempDir()
 	mayorMCP := filepath.Join(cityPath, "agents", "mayor", "mcp", "notes.toml")

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -379,6 +379,63 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 
+	// Step 11c: MCP projection integration. Provider-native MCP config is
+	// session/runtime state rather than passive content, so every deliverable
+	// target contributes a projection hash to the runtime fingerprint. When the
+	// session workdir differs from the scope root, tmux sessions reconcile the
+	// workdir-local target via a hidden PreStart command before launch.
+	scopeRoot := agentScopeRoot(cfgAgent, p.cityPath, p.rigs)
+	canonWorkDir := canonicaliseFilePath(workDir, p.cityPath)
+	mcpCity := p.city
+	if mcpCity == nil {
+		// Most production callers route through newAgentBuildParams and carry the
+		// fully-expanded city config. Tests sometimes construct agentBuildParams
+		// directly; keep a best-effort fallback so MCP still sees the city pack's
+		// top-level mcp/ and any explicit pack graph dirs instead of silently
+		// degrading all the way to agent-local MCP only.
+		mcpCity = &config.City{
+			Providers:         p.providers,
+			Rigs:              p.rigs,
+			PackGraphOnlyDirs: append([]string(nil), p.packDirs...),
+		}
+		if p.workspace != nil {
+			mcpCity.Workspace = *p.workspace
+		}
+		cityMCPDir := filepath.Join(p.cityPath, "mcp")
+		if info, err := os.Stat(cityMCPDir); err == nil && info.IsDir() {
+			mcpCity.PackMCPDir = cityMCPDir
+		}
+	}
+	mcpCatalog, mcpProjection, err := resolveAgentMCPProjection(
+		p.cityPath,
+		p.cityName,
+		mcpCity,
+		cfgAgent,
+		qualifiedName,
+		workDir,
+		resolved.Kind,
+	)
+	if err != nil {
+		return TemplateParams{}, fmt.Errorf("agent %q: %w", qualifiedName, err)
+	}
+	if mcpProjection.Provider != "" {
+		stage1Delivers := canStage1Materialize(p.sessionProvider, cfgAgent) && canonWorkDir == scopeRoot
+		stage2Delivers := isStage2EligibleSession(p.sessionProvider, cfgAgent) && canonWorkDir != scopeRoot
+		switch {
+		case stage1Delivers || stage2Delivers:
+			fpExtra = mergeMCPFingerprintEntry(fpExtra, mcpProjection)
+			if stage2Delivers {
+				projectAgent := templateNameFor(cfgAgent, qualifiedName)
+				expandedPreStart = appendProjectMCPPreStart(expandedPreStart, projectAgent, qualifiedName, workDir)
+			}
+		case len(mcpCatalog.Servers) > 0:
+			return TemplateParams{}, fmt.Errorf(
+				"agent %q: effective MCP cannot be delivered to workdir %q with session provider %q",
+				qualifiedName, workDir, p.sessionProvider,
+			)
+		}
+	}
+
 	// Step 12: Build startup hints.
 	hints := agent.StartupHints{
 		ReadyPromptPrefix:      resolved.ReadyPromptPrefix,

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -408,7 +408,6 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	}
 	mcpCatalog, mcpProjection, err := resolveAgentMCPProjection(
 		p.cityPath,
-		p.cityName,
 		mcpCity,
 		cfgAgent,
 		qualifiedName,

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -387,12 +387,17 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	scopeRoot := agentScopeRoot(cfgAgent, p.cityPath, p.rigs)
 	canonWorkDir := canonicaliseFilePath(workDir, p.cityPath)
 	mcpCity := p.city
+	mcpCityIsSynthetic := false
 	if mcpCity == nil {
-		// Most production callers route through newAgentBuildParams and carry the
-		// fully-expanded city config. Tests sometimes construct agentBuildParams
-		// directly; keep a best-effort fallback so MCP still sees the city pack's
-		// top-level mcp/ and any explicit pack graph dirs instead of silently
-		// degrading all the way to agent-local MCP only.
+		// Tests sometimes construct agentBuildParams directly without
+		// setting `city`. Build a minimal synthetic config.City so
+		// non-MCP resolution still works — but mark the result and
+		// hard-error downstream if the synthetic city resolves any
+		// effective MCP. The synthetic city cannot see
+		// ExplicitImportPackDirs/ImplicitImportPackDirs/BootstrapImportPackDirs
+		// or rig import bindings, so silently returning a degraded MCP
+		// catalog would hide production divergence behind "green" tests.
+		mcpCityIsSynthetic = true
 		mcpCity = &config.City{
 			Providers:         p.providers,
 			Rigs:              p.rigs,
@@ -417,7 +422,21 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if err != nil {
 		return TemplateParams{}, fmt.Errorf("agent %q: %w", qualifiedName, err)
 	}
-	if mcpProjection.Provider != "" {
+	if mcpCityIsSynthetic && len(mcpCatalog.Servers) > 0 {
+		return TemplateParams{}, fmt.Errorf(
+			"agent %q: resolveTemplate invoked without config.City but resolved %d MCP server(s) — "+
+				"tests exercising MCP must construct a real config.City (the synthetic fallback "+
+				"cannot see import/implicit/bootstrap layers and would diverge from production)",
+			qualifiedName, len(mcpCatalog.Servers),
+		)
+	}
+	// MCP delivery only fires when there's an actual catalog to project.
+	// An empty catalog with a supported provider kind still produces a
+	// non-empty projection shell (Provider+Target populated) but has no
+	// servers — skipping it here avoids spurious fingerprint churn and
+	// redundant `gc internal project-mcp` PreStart entries (which is what
+	// TestPhase2StartupMaterialization/WC-START-002 guards against).
+	if mcpProjection.Provider != "" && len(mcpCatalog.Servers) > 0 {
 		stage1Delivers := canStage1Materialize(p.sessionProvider, cfgAgent) && canonWorkDir == scopeRoot
 		stage2Delivers := isStage2EligibleSession(p.sessionProvider, cfgAgent) && canonWorkDir != scopeRoot
 		switch {
@@ -427,7 +446,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 				projectAgent := templateNameFor(cfgAgent, qualifiedName)
 				expandedPreStart = appendProjectMCPPreStart(expandedPreStart, projectAgent, qualifiedName, workDir)
 			}
-		case len(mcpCatalog.Servers) > 0:
+		default:
 			return TemplateParams{}, fmt.Errorf(
 				"agent %q: effective MCP cannot be delivered to workdir %q with session provider %q",
 				qualifiedName, workDir, p.sessionProvider,

--- a/cmd/gc/template_resolve_mcp_test.go
+++ b/cmd/gc/template_resolve_mcp_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveTemplateMCPIntegration(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMCPSource(t, filepath.Join(cityPath, "mcp", "notes.toml"), `
+name = "notes"
+command = "uvx"
+args = ["notes-mcp"]
+`)
+
+	cityCfg := &config.City{
+		Workspace:  config.Workspace{Provider: "gemini"},
+		Providers:  map[string]config.ProviderSpec{"gemini": {Command: "echo", PromptMode: "none"}, "cursor": {Command: "echo", PromptMode: "none"}},
+		PackMCPDir: filepath.Join(cityPath, "mcp"),
+	}
+
+	buildParams := func(sessionProvider string) *agentBuildParams {
+		return &agentBuildParams{
+			city:            cityCfg,
+			cityName:        "city",
+			cityPath:        cityPath,
+			workspace:       &cityCfg.Workspace,
+			providers:       cityCfg.Providers,
+			lookPath:        stubLookPath,
+			fs:              fsys.OSFS{},
+			rigs:            nil,
+			beaconTime:      time.Unix(0, 0),
+			beadNames:       make(map[string]string),
+			stderr:          io.Discard,
+			sessionProvider: sessionProvider,
+		}
+	}
+
+	t.Run("scope root uses stage1 hash only", func(t *testing.T) {
+		agent := &config.Agent{Name: "mayor", Scope: "city", Provider: "gemini"}
+		tp, err := resolveTemplate(buildParams("tmux"), agent, agent.QualifiedName(), nil)
+		if err != nil {
+			t.Fatalf("resolveTemplate: %v", err)
+		}
+		if tp.FPExtra["mcp:gemini"] == "" {
+			t.Fatalf("expected mcp fingerprint entry, got %+v", tp.FPExtra)
+		}
+		for _, entry := range tp.Hints.PreStart {
+			if strings.Contains(entry, "internal project-mcp") {
+				t.Fatalf("unexpected stage-2 project-mcp PreStart for scope-root workdir: %v", tp.Hints.PreStart)
+			}
+		}
+	})
+
+	t.Run("non scope root injects project-mcp prestart", func(t *testing.T) {
+		agent := &config.Agent{
+			Name:     "worker",
+			Scope:    "city",
+			Provider: "gemini",
+			WorkDir:  ".gc/worktrees/worker-1",
+		}
+		tp, err := resolveTemplate(buildParams("tmux"), agent, agent.QualifiedName(), nil)
+		if err != nil {
+			t.Fatalf("resolveTemplate: %v", err)
+		}
+		if tp.FPExtra["mcp:gemini"] == "" {
+			t.Fatalf("expected mcp fingerprint entry, got %+v", tp.FPExtra)
+		}
+		found := false
+		for _, entry := range tp.Hints.PreStart {
+			if strings.Contains(entry, "internal project-mcp") {
+				found = true
+				if !strings.Contains(entry, "--agent worker") || !strings.Contains(entry, "--identity worker") {
+					t.Fatalf("project-mcp PreStart missing identity/template flags: %q", entry)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("expected stage-2 project-mcp PreStart, got %v", tp.Hints.PreStart)
+		}
+	})
+
+	t.Run("undeliverable runtime hard errors", func(t *testing.T) {
+		agent := &config.Agent{
+			Name:     "worker",
+			Scope:    "city",
+			Provider: "gemini",
+			WorkDir:  ".gc/worktrees/worker-1",
+		}
+		_, err := resolveTemplate(buildParams("subprocess"), agent, agent.QualifiedName(), nil)
+		if err == nil {
+			t.Fatal("expected undeliverable MCP error, got nil")
+		}
+		if !strings.Contains(err.Error(), "effective MCP cannot be delivered") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unsupported provider hard errors when MCP exists", func(t *testing.T) {
+		agent := &config.Agent{Name: "worker", Scope: "city", Provider: "cursor"}
+		_, err := resolveTemplate(buildParams("tmux"), agent, agent.QualifiedName(), nil)
+		if err == nil {
+			t.Fatal("expected unsupported provider error, got nil")
+		}
+		if !strings.Contains(err.Error(), "effective MCP requires a supported provider family") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("best-effort fallback still sees city-root mcp when city is nil", func(t *testing.T) {
+		params := buildParams("tmux")
+		params.city = nil
+		params.packDirs = []string{cityPath}
+		agent := &config.Agent{Name: "mayor", Scope: "city", Provider: "gemini"}
+		tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+		if err != nil {
+			t.Fatalf("resolveTemplate: %v", err)
+		}
+		if tp.FPExtra["mcp:gemini"] == "" {
+			t.Fatalf("expected city-root MCP to survive fallback, got %+v", tp.FPExtra)
+		}
+	})
+}

--- a/cmd/gc/template_resolve_mcp_test.go
+++ b/cmd/gc/template_resolve_mcp_test.go
@@ -117,17 +117,23 @@ args = ["notes-mcp"]
 		}
 	})
 
-	t.Run("best-effort fallback still sees city-root mcp when city is nil", func(t *testing.T) {
+	t.Run("nil city hard-errors when MCP would resolve non-empty", func(t *testing.T) {
+		// Regression guard: the prior fallback silently constructed a
+		// synthetic City that omitted imports/implicit/bootstrap layers,
+		// so tests saw a different MCP precedence stack than production.
+		// resolveTemplate now refuses to proceed when the synthetic
+		// fallback would yield non-empty MCP — tests exercising MCP
+		// must construct a real config.City.
 		params := buildParams("tmux")
 		params.city = nil
 		params.packDirs = []string{cityPath}
 		agent := &config.Agent{Name: "mayor", Scope: "city", Provider: "gemini"}
-		tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
-		if err != nil {
-			t.Fatalf("resolveTemplate: %v", err)
+		_, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+		if err == nil {
+			t.Fatal("expected hard error when synthetic fallback would resolve MCP, got nil")
 		}
-		if tp.FPExtra["mcp:gemini"] == "" {
-			t.Fatalf("expected city-root MCP to survive fallback, got %+v", tp.FPExtra)
+		if !strings.Contains(err.Error(), "resolveTemplate invoked without config.City") {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }

--- a/docs/packv2/doc-agent-v2.md
+++ b/docs/packv2/doc-agent-v2.md
@@ -217,15 +217,22 @@ Promoting is an explicit human decision — skills don't automatically flow from
 
 MCP (Model Context Protocol) servers provide tools, resources, and prompts to agents over a runtime protocol. Unlike skills (which have a portable file standard), MCP server configuration is provider-specific — each provider embeds it in its own settings file. Gas City abstracts this with a provider-agnostic TOML format.
 
-> **First slice:** MCP discovery and listing are current-city-pack only. Imported-pack MCP catalogs, provider projection, and ownership/reconciliation are later slices.
-
-The first MCP CLI slice is list-only:
+`gc mcp list` is projected-only and target-specific:
 
 ```sh
-gc mcp list
 gc mcp list --agent polecat
 gc mcp list --session <id>
 ```
+
+Bare `gc mcp list` now errors because projected MCP depends on a concrete
+agent or session target.
+
+When a target has effective MCP, Gas City immediately adopts the
+provider-native MCP surface for that target as GC-managed runtime
+state. Cleanup only removes targets that GC previously adopted.
+GC also adds those runtime artifacts to the local `.gitignore`
+best-effort, and effective MCP changes participate in session
+fingerprints so affected sessions restart on drift.
 
 #### Definition format
 

--- a/docs/packv2/doc-agent-v2.md
+++ b/docs/packv2/doc-agent-v2.md
@@ -224,15 +224,37 @@ gc mcp list --agent polecat
 gc mcp list --session <id>
 ```
 
-Bare `gc mcp list` now errors because projected MCP depends on a concrete
-agent or session target.
+> **Breaking change:** bare `gc mcp list` with no target flag now
+> errors. Projected MCP depends on a concrete agent or session target,
+> so the un-targeted form has no well-defined meaning. Automation that
+> previously ran `gc mcp list` as a pack-inventory check must switch
+> to `--agent` or `--session`.
 
-When a target has effective MCP, Gas City immediately adopts the
-provider-native MCP surface for that target as GC-managed runtime
-state. Cleanup only removes targets that GC previously adopted.
-GC also adds those runtime artifacts to the local `.gitignore`
-best-effort, and effective MCP changes participate in session
-fingerprints so affected sessions restart on drift.
+When a target has effective MCP, Gas City adopts the provider-native MCP
+surface as GC-managed runtime state. On first adoption the existing
+provider-native content is snapshotted to
+`.gc/mcp-adopted/<provider>/<timestamp>.<ext>` and a one-line warning
+is emitted to stderr, so hand-authored `.mcp.json`/`settings.json`/
+`config.toml` entries can be recovered. Symlinked targets are rejected
+unconditionally — managed targets must be regular files.
+
+Cleanup on each stage-1 reconcile walks `.gc/mcp-managed/` under the
+city root and every **still-attached** rig and removes managed
+markers/targets that no longer have a claimant (agent removed from
+`city.toml`, provider changed, MCP dir deleted). Rigs detached from
+`city.toml` are no longer reachable from the configured roots, so their
+managed markers persist and must be cleaned up manually or via explicit
+`gc rig detach` tooling. GC also adds managed runtime artifacts to the
+local `.gitignore` best-effort, and effective MCP changes participate
+in session fingerprints so affected sessions restart on drift.
+
+> **Template expansion and TOML escaping.** `.template.toml` files are
+> expanded by Go `text/template` *before* TOML parsing. Values that
+> contain `"`, `\`, or newlines can produce invalid TOML — the parse
+> error will point at the expanded file, not your template. Either
+> keep secret values simple strings (no embedded quotes/backslashes)
+> or escape them yourself with Go's `printf "%q"` template function
+> so the expanded output is valid TOML.
 
 #### Definition format
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1294,10 +1294,15 @@ gc mail thread <thread-id>
 
 ## gc mcp
 
-List MCP catalog visibility for the current city pack.
+Inspect projected MCP config for a concrete target.
 
-The first MCP slice is list-only. Provider projection and reconciliation
-are later work.
+Projected MCP is target-specific. Use `gc mcp list --agent <name>` when
+the agent has a single deterministic projection target from config, or
+`gc mcp list --session <id>` for a live session target.
+
+When effective MCP exists for a target, GC adopts that provider-native
+MCP surface as managed runtime state. Later cleanup only removes files
+that GC already adopted.
 
 ```
 gc mcp
@@ -1305,11 +1310,11 @@ gc mcp
 
 | Subcommand | Description |
 |------------|-------------|
-| [gc mcp list](#gc-mcp-list) | List visible MCP definitions |
+| [gc mcp list](#gc-mcp-list) | Show projected MCP servers |
 
 ## gc mcp list
 
-List the current city pack's visible MCP definitions, optionally scoped to an agent or session.
+Show the precedence-resolved MCP servers that Gas City would project into the provider-native config for one agent or session target.
 
 ```
 gc mcp list [flags]
@@ -1317,8 +1322,8 @@ gc mcp list [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--agent` | string |  | show the effective MCP view for this agent |
-| `--session` | string |  | show the effective MCP view for this session |
+| `--agent` | string |  | show the projected MCP config for this agent |
+| `--session` | string |  | show the projected MCP config for this session |
 
 ## gc nudge
 

--- a/engdocs/proposals/mcp-materialization-implementation-plan.md
+++ b/engdocs/proposals/mcp-materialization-implementation-plan.md
@@ -1,0 +1,143 @@
+---
+title: "MCP Materialization — Implementation Plan"
+---
+
+Companion to `engdocs/proposals/mcp-materialization.md`. Breaks MCP
+projection into reviewable slices that each end at a natural `/review-pr`
+boundary.
+
+## Slice 1: Foundations
+
+Goal: create the neutral MCP model, validator, and effective resolver before
+touching runtime delivery.
+
+Files:
+
+- `internal/materialize/mcp.go` or similar new package for:
+  - neutral server structs
+  - parser and filename/name validation
+  - template expansion
+  - relative command resolution
+  - canonical normalization
+  - effective shared/agent-local catalog resolution
+- `cmd/gc/cmd_mcp.go`
+- `cmd/gc/cmd_mcp_test.go`
+- new unit tests for schema rules, duplicate detection, precedence, and
+  normalization
+
+Scope:
+
+- discover shared + agent-local MCP definitions
+- resolve precedence across city, rig, explicit imports, implicit imports, and
+  bootstrap
+- surface projected-only `gc mcp list` semantics at the model level
+- no provider writes yet
+
+Review boundary:
+
+- run `/review-pr` on the cumulative diff once the model, resolver, and CLI
+  behavior compile and tests pass
+
+## Slice 2: Provider Emitters and File Ownership
+
+Goal: project the canonical model into provider-native surfaces with atomic
+writes and ownership semantics.
+
+Files:
+
+- MCP materialization package emitters for:
+  - Claude `.mcp.json`
+  - Gemini `.gemini/settings.json`
+  - Codex `.codex/config.toml`
+- shared file-write/lock helper in `internal/fsys` or nearby if needed
+- new tests for:
+  - atomic `0600` writes
+  - adoption backup behavior
+  - semantic preservation of sibling Gemini/Codex settings
+  - empty-set cleanup
+  - managed-subtree replacement
+
+Scope:
+
+- provider-family selection via `ResolvedProvider.Kind`
+- per-target OS-level locking
+- adoption snapshot + marker
+- semantic rewrite of JSON/TOML sibling content
+- diagnostics redaction rules for errors from the emitter layer
+
+Review boundary:
+
+- run `/review-pr` once the emitters are wired and covered by unit tests, before
+  integrating them into startup/session flows
+
+## Slice 3: Runtime Integration
+
+Goal: hook provider projection into the same stage-1/stage-2 lifecycle as
+skills.
+
+Files:
+
+- hidden command such as `cmd/gc/cmd_internal_project_mcp.go`
+- `cmd/gc/build_desired_state.go`
+- `cmd/gc/skill_integration.go` or a sibling MCP integration file
+- session/runtime gating sites
+- supervisor/start integration points
+- tests for:
+  - supported vs unsupported runtime/workdir topologies
+  - stage-2 pre-start injection ordering
+  - shared-target conflict handling
+  - last-good-state preservation and unhealthy-target behavior
+
+Scope:
+
+- eager stage-1 reconcile
+- stage-2 per-session projection
+- serialized writer use from both controller and pre-start command
+- startup failure semantics
+- claimant-aware cleanup
+
+Review boundary:
+
+- run `/review-pr` once runtime integration is complete and the feature works
+  end-to-end in unit/integration coverage
+
+## Slice 4: Drift, Doctor, and Acceptance Coverage
+
+Goal: complete the operational contract.
+
+Files:
+
+- drift/fingerprint integration in desired-state/runtime config
+- `internal/doctor` MCP checks
+- acceptance/integration tests for:
+  - provider projection
+  - adoption backup
+  - redaction
+  - shared-target conflicts
+  - cleanup when claims disappear
+  - unsupported runtimes/providers
+  - Codex repo-local acceptance gate
+
+Scope:
+
+- restart on projected MCP drift
+- report-only doctor checks with actionable context
+- target-specific `gc mcp list` output
+- high-signal migration/adoption warnings
+
+Review boundary:
+
+- run `/review-pr` before PR creation
+
+## Docs and Cleanup
+
+After Slice 4, update docs that still describe MCP as list-only:
+
+- `docs/reference/cli.md`
+- `docs/packv2/doc-agent-v2.md`
+- `docs/packv2/doc-pack-v2.md`
+- `docs/guides/migrating-to-pack-vnext.md`
+- any conformance/skew docs that still mention deferred projection
+
+These doc updates can merge with the final slice unless the code review
+suggests splitting them.

--- a/engdocs/proposals/mcp-materialization.md
+++ b/engdocs/proposals/mcp-materialization.md
@@ -1,0 +1,588 @@
+---
+title: "MCP Materialization and Provider Projection"
+---
+
+## Context
+
+Pack V2 introduced a provider-agnostic `mcp/` directory convention and a
+list-only CLI (`gc mcp list`), but Gas City still does not project MCP servers
+into the provider-native runtime config that Claude, Codex, and Gemini
+actually read. The result is the same gap skills had before v0.15.1:
+catalogued content exists in the pack model, but agents never receive the
+runtime effect.
+
+This proposal ships the active MCP slice:
+
+- parse and validate neutral MCP TOML definitions
+- resolve a precedence-ordered effective catalog per target
+- project that catalog into the provider's native MCP config surface
+- reconcile stale entries and restart sessions when projected MCP changes
+
+Unlike skills, MCP delivery is not a directory of symlinks. Each provider owns
+its own config file shape, merge semantics, and scope rules. The core design
+problem is therefore not just discovery, but deterministic projection and
+ownership.
+
+## What Exists Today
+
+- `mcp/` and `agents/<name>/mcp/` are already recognized as pack/agent
+  attachment roots during config composition.
+- `gc mcp list` exists, but it is still a raw visibility view and still claims
+  MCP is list-only.
+- Skills already established the relevant runtime shape:
+  - a two-stage materialization flow
+  - scope-root reconciliation at supervisor time
+  - session/worktree delivery via a hidden internal command
+  - fingerprint-driven restart on content drift
+- The loader already composes ordered city and rig pack graphs, explicit
+  imports, and implicit bootstrap imports.
+- Claude, Codex, and Gemini all have provider-native project-local MCP
+  surfaces, but Gas City does not yet write to them.
+
+## Provider Surface Evidence
+
+This proposal follows the providers' native MCP surfaces instead of inventing a
+GC-specific sidecar format.
+
+- Claude Code documents project MCP in `.mcp.json`.
+- Gemini CLI documents project MCP in `.gemini/settings.json` under
+  `mcpServers`.
+- Codex's published docs still emphasize user-global
+  `~/.codex/config.toml` under `[mcp_servers]`, but current upstream behavior
+  appears to honor repo-local `.codex/config.toml` as well.
+
+Implementation must carry provider acceptance coverage for all three families:
+
+- Claude: project-local `.mcp.json` is read, reconciled, and cleaned up as
+  designed
+- Gemini: project-local `.gemini/settings.json` `mcpServers` subtree is read,
+  preserved outside the managed subtree, and cleaned up as designed
+- Codex: repo-local `.codex/config.toml` is honored in the session workdir
+
+Where provider docs and runtime behavior diverge, the tested runtime behavior
+is the release gate.
+
+Transport support is also provider-gated at projection time. If a provider
+family's current tested build does not support a neutral transport shape
+(for example, HTTP remote MCP on a given provider), projection for that target
+must hard-error instead of emitting a config block the provider will ignore.
+
+The Codex project-local target is therefore a design requirement with an
+explicit merge gate: implementation must land with an acceptance test against
+the current Codex build proving repo-local `.codex/config.toml` is honored in
+the session workdir. If that proof fails, the feature does not merge in its v1
+form because user-global projection would violate workdir-scoped ownership.
+
+## Goals
+
+1. Every agent with an effective MCP catalog receives that catalog in the
+   provider-native MCP config file for the exact workdir the provider runs in.
+2. MCP source of truth remains provider-agnostic and pack-composable:
+   `mcp/*.toml` and `agents/<name>/mcp/*.toml`.
+3. Shared MCP can be shipped from city packs, rig packs, explicit imports,
+   implicit imports, and bootstrap packs with deterministic precedence.
+4. Gas City fully owns the projected MCP target it manages and reconciles it on
+   every tick/startup instead of appending best-effort entries.
+5. Config drift in projected MCP restarts affected sessions.
+6. Users can inspect the realizable projected result through `gc mcp list` and
+   diagnose configuration problems through `gc doctor`.
+
+## Non-Goals (v1)
+
+- Provider-specific extension knobs such as trust policies, OAuth blocks,
+  allowlists, approval defaults, or Codex parallel-tool-call hints.
+- SSE remote MCP servers. v1 remote transport is streamable HTTP only.
+- Live preflight of MCP commands, credentials, or HTTP endpoints during
+  `gc init` or provider readiness checks.
+- Support for providers outside the Claude, Codex, and Gemini families.
+- Partial merge semantics between same-name MCP definitions. Same-name override
+  is whole-definition replacement.
+
+## Durable Source Model
+
+### File identity
+
+An MCP server is one TOML file:
+
+- shared: `mcp/<server>.toml` or `mcp/<server>.template.toml`
+- agent-local: `agents/<name>/mcp/<server>.toml` or
+  `agents/<name>/mcp/<server>.template.toml`
+
+Identity is the filename stem. `foo.toml` and `foo.template.toml` are both the
+same logical server `foo`.
+
+Rules:
+
+- `name` is required and must exactly match the filename stem
+- server names are restricted to lowercase `[a-z0-9-]+`
+- if one directory contains both `foo.toml` and `foo.template.toml`, that is a
+  hard error
+- if two definitions with the same logical name meet through precedence, the
+  higher-precedence definition replaces the lower one entirely
+
+### Schema
+
+The neutral MCP schema stays intentionally small:
+
+- required:
+  - `name`
+- optional metadata:
+  - `description`
+- stdio transport:
+  - `command`
+  - `args`
+  - `[env]`
+- remote transport:
+  - `url`
+  - `[headers]`
+
+Rules:
+
+- exactly one of `command` or `url` must be set
+- stdio definitions may not set `url` or `headers`
+- HTTP definitions may not set `command`, `args`, or `env`
+- `description` is metadata only; it is excluded from runtime equality and
+  restart fingerprints
+
+### Templates
+
+`.template.toml` uses the same deterministic template context as prompt
+templates. There is no implicit access to the controller host environment.
+
+Expansion rules:
+
+- expansion is per effective target (agent/session/workdir), not once globally
+- missing template keys are a hard error
+- template expansion happens before provider mapping
+- expanded values are written literally into the projected runtime config in v1
+
+### Relative command resolution
+
+For stdio definitions:
+
+- bare commands without `/` are preserved verbatim and resolved by the
+  provider/runtime `PATH`
+- relative commands containing `/` are resolved against the owning source
+  directory and projected as absolute paths
+
+This keeps pack-relative scripts stable across pooled worktrees while avoiding
+controller-host-specific absolute resolution for generic commands such as
+`uvx`, `node`, or `python`.
+
+## Catalog Discovery and Precedence
+
+### Shared catalog layers
+
+Shared MCP is not limited to the root city pack. It follows the pack graph and
+import graph, because sharing MCP definitions from packs is a primary use case.
+
+For an agent, the effective shared catalog is layered as:
+
+1. city pack graph
+2. explicit city imports
+3. non-bootstrap implicit imports
+4. bootstrap implicit imports
+
+For an agent inside a rig, a rig-shared layer overlays on top of the city
+shared layer:
+
+1. city shared layers
+2. rig pack graph
+3. rig explicit imports
+
+The full effective precedence is therefore:
+
+1. agent-local
+2. rig-shared
+3. city pack graph
+4. explicit city imports
+5. non-bootstrap implicit imports
+6. bootstrap implicit imports
+
+### Ordering inside each layer
+
+- City and rig pack graphs follow their existing ordered pack directory stacks.
+  Nearer packs win over their transitive dependencies.
+- `workspace.includes` and other legacy include stacks keep their current
+  ordered override model: later includes win over earlier ones.
+- Sibling explicit imports keep deterministic sorted root binding order with
+  first-wins precedence.
+- This is intentionally different from legacy include stacks. MCP preserves
+  each source surface's existing precedence contract instead of inventing one
+  new winner rule for every layer.
+- Shared imported-pack MCP is transitive by default; `transitive = false`
+  limits visibility to the directly imported pack's own `mcp/`.
+- `transitive = false` only limits visibility through that root import. Hidden
+  transitive packs do not participate in shadowing or diagnostics through that
+  route, but can still appear through any other visible import path.
+- `export` has no effect on shared MCP because shared MCP has no namespaced
+  binding surface to flatten.
+- The same pack directory reached multiple times through a graph is deduplicated
+  to its highest-precedence occurrence.
+
+Whole-definition replacement is transport-agnostic: a higher-precedence layer
+may replace a stdio server with an HTTP server or vice versa. That is
+intentional. Partial field merges and metadata-only patching are out of scope
+for v1.
+
+### Shadow diagnostics
+
+Same-name shared MCP collisions resolve by precedence, not hard error.
+
+Diagnostics:
+
+- explicit import shadows warn by default
+- `[imports.<binding>].shadow = "silent"` suppresses shadow warnings for that
+  root import and its transitive closure
+- rig imports mirror the same behavior, but diagnostics identify the rig and
+  root rig import binding
+- legacy include-driven shadows warn by default and have no silent knob
+- bootstrap shadows remain diagnostic-only and are not controlled by import
+  flags
+
+## Effective Runtime Model
+
+Projection is built from a normalized in-memory model:
+
+- one effective server record per logical server name
+- transport already validated
+- templates already expanded
+- relative command paths already resolved
+- metadata separated from behavioral fields
+
+This normalized model is the single source for:
+
+- provider emitters
+- `gc mcp list`
+- doctor checks
+- same-target equality checks
+- restart fingerprints
+
+### Canonical normalization
+
+Shared-target equality and restart fingerprints operate on the normalized
+effective model, not on emitted JSON or TOML bytes.
+
+Canonical rules:
+
+- `args` are order-sensitive and preserved exactly
+- `env` and `headers` are maps and are compared in stable key-sorted order
+- empty optional maps and slices canonicalize to absent in the normalized model
+- provider emitters consume that canonical model but equality does not depend on
+  provider-specific serialization details such as TOML formatting, JSON
+  whitespace, or map iteration order
+- `description` is excluded from the canonical behavioral model
+
+This keeps shared-target equality deterministic across runs and across
+providers even though Claude and Gemini emit JSON while Codex emits TOML.
+
+## Provider Projection
+
+Projection targets the provider's native MCP surface directly.
+
+### Claude-family providers
+
+- target: `<workdir>/.mcp.json`
+- Gas City owns the whole file
+
+### Gemini-family providers
+
+- target: `<workdir>/.gemini/settings.json`
+- Gas City owns only the top-level `mcpServers` object
+- unrelated settings are preserved
+- preservation is semantic, not formatting-preserving; sibling JSON may be
+  reserialized canonically on write
+
+### Codex-family providers
+
+- target: `<workdir>/.codex/config.toml`
+- Gas City owns only the `[mcp_servers]` subtree
+- unrelated settings are preserved
+- preservation is semantic, not formatting-preserving; sibling TOML may be
+  reserialized canonically on write
+
+Because Codex's published docs lag the observed project-local behavior, the
+project-local target is conditioned on the acceptance-test gate described in
+"Provider Surface Evidence." The design does not fall back to user-global
+projection.
+
+Provider selection keys off `ResolvedProvider.Kind`, not just the configured
+provider name, so aliases such as `fast-codex` or `my-claude` still map to the
+correct native MCP surface.
+
+### Ownership and cleanup
+
+If an effective MCP catalog exists for a target, Gas City owns the managed
+projection surface for that target.
+
+Ownership rules:
+
+- first projection overwrites preexisting provider-native MCP content
+- any effective `mcp/` catalog is treated as an explicit opt-in to GC-owned MCP
+  projection for that target
+- for Gemini and Codex, "preserve unrelated settings" means preserve sibling
+  config outside the GC-owned MCP subtree; Gas City owns every server entry
+  inside the managed subtree
+- stale projected servers are removed on reconcile
+- empty effective set removes the managed projection surface:
+  - delete `.mcp.json`
+  - remove `mcpServers` from Gemini settings and delete the file if empty
+  - remove `[mcp_servers]` from Codex config and delete the file if empty
+
+Adoption and migration rules:
+
+- if a target already contains provider-native MCP content, the first
+  reconcile that sees effective MCP takes ownership and replaces that content
+- first adoption is non-interactive but not destructive: before overwrite, Gas
+  City snapshots the exact provider-native MCP content it is about to replace
+  into a GC-owned adoption backup location under `.gc/`
+- after that one-time snapshot, a recorded adoption marker prevents repeated
+  backup churn on every reconcile
+- first adoption also emits a one-time high-signal warning naming the target
+  path and the backup location before the overwrite lands
+- users who want to preserve existing provider-native MCP entries must port
+  them into neutral `mcp/*.toml` before enabling GC-owned MCP
+- `gc doctor` should surface preexisting provider-native MCP content as
+  "will be adopted and replaced" before first projection so the transition is
+  visible, but the runtime behavior remains deterministic and non-interactive
+- once a target is GC-owned, out-of-band edits to the managed MCP surface are
+  treated as drift: reconcile restores the canonical payload, and doctor/warn
+  paths should identify that the managed surface was edited after adoption
+- provider-specific server fields inside the adopted managed subtree that do not
+  exist in the neutral v1 model are preserved only in the adoption backup; they
+  do not survive active GC ownership and should be called out in the adoption
+  warning text
+
+### Security and file permissions
+
+Projected runtime files may contain expanded secrets from `env` or `headers`.
+
+Rules:
+
+- created and rewritten managed MCP files are normalized to `0600`
+- writes use atomic temp-file creation with `0600` before rename; there is no
+  write-then-chmod window on the final path
+- failure to write or tighten permissions is a hard error
+- if the managed target path already exists as a symlink, projection hard-errors
+  instead of following it
+- `.gitignore` updates for `.mcp.json`, `.gemini/settings.json`, and
+  `.codex/config.toml` are best-effort and local-only
+- failed `.gitignore` updates surface as doctor warnings; they are not silent
+- diagnostics, doctor output, equality failures, and drift logs never print
+  expanded secret values; they identify field names and source paths only
+
+## Runtime Delivery Model
+
+MCP follows the same two-stage structure as skills, but writes provider-native
+config instead of skill symlinks.
+
+### Stage 1: scope-root reconcile
+
+At `gc start` and supervisor ticks, Gas City reconciles MCP for every eligible
+scope root even if no session is currently running.
+
+This handles:
+
+- initial projection
+- ongoing drift correction
+- cleanup after catalog removal
+
+Stage-1 and stage-2 both flow through one serialized writer keyed by
+`(provider-kind, target path)`. That writer is responsible for:
+
+- shared-target equality validation for that concrete target
+- acquiring an OS-level per-target lock so the supervisor and
+  `gc internal project-mcp` cannot write the same target concurrently
+- atomic temp-write-and-rename
+- last-good-state preservation when validation fails
+- avoiding concurrent stage-1 vs stage-2 writes to the same target
+
+Each target also carries an unhealthy-state record keyed by the target path and
+current failure signature. Repeated ticks that hit the same unresolved conflict
+or delivery error do not trigger repeated drains or churn; they preserve the
+last good state and continue surfacing the target as unhealthy until the error
+changes or clears.
+
+### Stage 2: per-session workdir projection
+
+When the real provider workdir differs from the scope root, Gas City injects a
+hidden internal pre-start command:
+
+`gc internal project-mcp --agent <qualified-name> --workdir <path>`
+
+This command resolves the target workdir and projects provider-native MCP there
+before the provider starts.
+
+Stage-2 ordering is strict:
+
+1. final session workdir is resolved
+2. any user-provided pre-start steps that create that workdir run
+3. `gc internal project-mcp` runs against that resolved workdir
+4. the provider process starts
+
+Any projection failure aborts the launch before the provider starts.
+
+### Runtime support in v1
+
+MCP v1 hard-errors when effective MCP cannot be delivered.
+
+Supported:
+
+- `tmux`
+- `subprocess` only when the provider runs in the scope root and no stage-2
+  delivery is required
+
+Unsupported with non-empty effective MCP:
+
+- `subprocess` sessions whose real workdir differs from scope root
+- `k8s`
+- `acp`
+- `hybrid`
+- any unresolved runtime topology that cannot receive the provider-native file
+
+This `subprocess` limitation is an implementation reality, not a conceptual MCP
+constraint: current subprocess runtime paths do not offer the same host-side
+stage-2 delivery hook as tmux. Extending subprocess stage-2 support is valid
+follow-up work, but v1 does not pretend it exists.
+
+## Shared Target Validation
+
+Some agents can converge on the same provider-native target file. In that case
+Gas City must avoid last-writer-wins behavior.
+
+Rule:
+
+- if two agents would project to the same `(provider-kind, target path)`, their
+  fully expanded projected behavioral payloads must be identical
+- otherwise startup/reconcile fails with a hard error
+
+Equality is checked after:
+
+1. precedence resolution
+2. template expansion
+3. relative path resolution
+4. provider mapping
+
+`description` is excluded from this equality check.
+
+Lifecycle semantics:
+
+- equality is evaluated for the concrete target context every time that target
+  is reconciled, including stage-2 workdir-specific expansion
+- if a running target becomes conflicted, Gas City does not mutate or clean up
+  the last good projected file; it marks the target unhealthy, blocks affected
+  new session starts, and leaves existing sessions on the last good payload
+  until the conflict is resolved
+- cleanup for an empty effective set happens only when no remaining claimant
+  still owns that target
+
+The claimant set for a target is derived from current desired state plus live
+session records for concrete workdir targets. Session exit does not immediately
+delete provider-native MCP files; cleanup happens only through the serialized
+reconcile path after the target is observed to have zero remaining claimants.
+
+## Drift and Restart Semantics
+
+Projected MCP changes participate in session config drift.
+
+Restart-triggering changes include:
+
+- server add/remove/replace
+- changed `command`, `args`, `env`, `url`, or `headers`
+- changed template expansion result
+- changed resolved absolute command path
+
+Fingerprint scope:
+
+- Claude: normalized canonical MCP payload for the `.mcp.json` target
+- Gemini: normalized canonical MCP payload for the managed `mcpServers`
+  subtree only
+- Codex: normalized canonical MCP payload for the managed `mcp_servers`
+  subtree only
+
+Unrelated preserved Gemini or Codex settings do not participate in MCP drift.
+Drift publication and restart decisions happen only after a target write has
+committed successfully and the new canonical payload has been recorded as that
+target's last good state.
+
+## CLI and Doctor
+
+### `gc mcp list`
+
+`gc mcp list` becomes projected-only and target-specific.
+
+Rules:
+
+- bare `gc mcp list` is an error
+- the error text should be explicit:
+  `gc mcp list: projected MCP is target-specific; pass --agent <name> or --session <id>`
+- `gc mcp list --agent <name>` works only when the target is fully
+  deterministic without a live session
+- otherwise users must pass `--session <id>`
+- unsupported or undeliverable targets return the same hard error reason the
+  runtime would use
+
+`--agent` is non-deterministic and therefore rejected when the effective target
+depends on a live session workdir, such as pooled or stage-2-projected
+sessions.
+
+Output is a human-readable summary, not a raw config dump. It shows:
+
+- provider family
+- target path
+- server name
+- transport
+- command or URL
+- args
+- header/env key names only
+
+Expanded secret values are redacted by default.
+
+### `gc doctor`
+
+MCP-specific doctor checks are report-only in v1.
+
+Checks cover:
+
+- filename/name mismatches
+- duplicate same-layer logical names
+- template expansion failures
+- invalid transport field combinations
+- unsupported provider/runtime delivery
+- conflicting projected payloads for a shared target
+
+Doctor and runtime diagnostics must include:
+
+- the offending source file path
+- the effective target path
+- the winning and losing source layers for shadow/conflict cases
+- the relevant import binding or rig binding when applicable
+- concrete remediation guidance
+
+They must not include expanded secret values.
+
+## Failure Semantics
+
+Projection is fail-closed.
+
+- config validation failures are hard errors
+- provider resolution failures for agents with effective MCP are hard errors
+- unsupported provider families with effective MCP are hard errors
+- undeliverable runtime/workdir topologies with effective MCP are hard errors
+- projection write or permission failures are hard errors
+
+There is no best-effort warning mode once effective MCP exists.
+
+## Implementation Shape
+
+The implementation should land as one coherent vertical slice:
+
+1. neutral parser, validator, and effective model
+2. discovery and precedence across city, rig, import, implicit, and bootstrap
+   layers
+3. provider emitters for Claude, Codex, and Gemini
+4. stage-1 and stage-2 projection hooks
+5. shared-target validation, doctor checks, drift fingerprints, and CLI updates
+6. docs updates replacing the old "list-only / later slice" language
+
+The detailed build order lives in the companion implementation plan.

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestFormulaListReturnsCatalogSummaries(t *testing.T) {
 	state := newFakeState(t)
+	state.cfg.Daemon.FormulaV2 = true
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -334,7 +334,17 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		if root.Imports == nil {
 			root.Imports = make(map[string]Import)
 		}
+		if root.ImplicitImportBindings == nil {
+			root.ImplicitImportBindings = make(map[string]bool)
+		}
+		if root.BootstrapImportBindings == nil {
+			root.BootstrapImportBindings = make(map[string]bool)
+		}
 		addedImplicit := false
+		bootstrapSet := make(map[string]bool, len(bootstrapNames))
+		for _, name := range bootstrapNames {
+			bootstrapSet[name] = true
+		}
 		for name, imp := range implicitImports {
 			if _, exists := root.Imports[name]; exists {
 				continue
@@ -342,6 +352,10 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 			root.Imports[name] = resolveImplicitImport(imp)
 			prov.Imports[name] = "(implicit)"
 			addedImplicit = true
+			root.ImplicitImportBindings[name] = true
+			if bootstrapSet[name] {
+				root.BootstrapImportBindings[name] = true
+			}
 		}
 		if addedImplicit && implicitPath != "" {
 			prov.Sources = append(prov.Sources, implicitPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,10 +198,32 @@ type City struct {
 	//   formulas/        — formula definitions
 	// Populated during pack expansion. Not from TOML.
 	PackDirs []string `toml:"-" json:"-"`
+	// PackGraphOnlyDirs is the city pack closure rooted at workspace.includes,
+	// including nested pack.includes and nested imports reached from those
+	// packs, ordered low→high precedence for MCP resolution.
+	// Runtime-only — not persisted to TOML or JSON.
+	PackGraphOnlyDirs []string `toml:"-" json:"-"`
+	// ExplicitImportPackDirs is the ordered low→high city-level explicit-import
+	// pack closure used by MCP resolution. Runtime-only.
+	ExplicitImportPackDirs []string `toml:"-" json:"-"`
+	// ImplicitImportPackDirs is the ordered low→high city-level non-bootstrap
+	// implicit-import closure used by MCP resolution. Runtime-only.
+	ImplicitImportPackDirs []string `toml:"-" json:"-"`
+	// BootstrapImportPackDirs is the ordered low→high bootstrap implicit-import
+	// closure used by MCP resolution. Runtime-only.
+	BootstrapImportPackDirs []string `toml:"-" json:"-"`
 	// RigPackDirs maps rig name to its ordered pack directories.
 	// Used when rig packs differ from city packs.
 	// Populated during pack expansion. Not from TOML.
 	RigPackDirs map[string][]string `toml:"-" json:"-"`
+	// RigPackGraphOnlyDirs maps rig name to the rig's pack closure rooted at
+	// rig.includes, including nested pack.includes and nested imports reached
+	// from those packs, ordered low→high precedence for MCP resolution.
+	// Runtime-only.
+	RigPackGraphOnlyDirs map[string][]string `toml:"-" json:"-"`
+	// RigImportPackDirs maps rig name to the rig's explicit-import closure,
+	// ordered low→high precedence for MCP resolution. Runtime-only.
+	RigImportPackDirs map[string][]string `toml:"-" json:"-"`
 	// PackOverlayDirs is the ordered list of overlay/ directories
 	// from all loaded city packs. Contents are copied to each agent's
 	// workdir during startup (before the agent's own OverlayDir).
@@ -241,6 +263,28 @@ type City struct {
 	// RigPackSkills maps rig name to the binding-qualified shared skill
 	// catalogs composed from that rig's imports. Runtime-only.
 	RigPackSkills map[string][]DiscoveredSkillCatalog `toml:"-" json:"-"`
+	// ImplicitImportBindings records which city-level import bindings were
+	// injected from ~/.gc/implicit-import.toml. Runtime-only.
+	ImplicitImportBindings map[string]bool `toml:"-" json:"-"`
+	// BootstrapImportBindings records which implicit-import bindings are
+	// bootstrap-managed. Runtime-only.
+	BootstrapImportBindings map[string]bool `toml:"-" json:"-"`
+	// ExplicitImportMCPBindings records the city-level explicit-import binding
+	// that currently owns each MCP pack dir after precedence flattening.
+	// Runtime-only.
+	ExplicitImportMCPBindings map[string]string `toml:"-" json:"-"`
+	// ImplicitImportMCPBindings records the city-level non-bootstrap implicit
+	// binding that currently owns each MCP pack dir after precedence
+	// flattening. Runtime-only.
+	ImplicitImportMCPBindings map[string]string `toml:"-" json:"-"`
+	// BootstrapImportMCPBindings records the bootstrap implicit-import binding
+	// that currently owns each MCP pack dir after precedence flattening.
+	// Runtime-only.
+	BootstrapImportMCPBindings map[string]string `toml:"-" json:"-"`
+	// RigImportMCPBindings records, per rig, the rig-import binding that
+	// currently owns each MCP pack dir after precedence flattening.
+	// Runtime-only.
+	RigImportMCPBindings map[string]map[string]string `toml:"-" json:"-"`
 }
 
 // NamedSession defines a canonical persistent session backed by an agent

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -78,6 +78,8 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 		var rigAgents []Agent
 		var rigNamedSessions []NamedSession
 		var rigTopoDirs []string
+		var rigPackGraphOnlyDirs []string
+		var rigImportPackDirs []string
 		var rigGlobals []ResolvedPackGlobal
 		for _, ref := range topoRefs {
 			topoDir, err := resolvePackRef(ref, cityRoot, cityRoot)
@@ -139,6 +141,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 
 			// Accumulate pack dirs for this rig.
 			rigTopoDirs = appendUnique(rigTopoDirs, topoDirs...)
+			rigPackGraphOnlyDirs = appendUniqueLastWins(rigPackGraphOnlyDirs, topoDirs...)
 
 			// Keep only rig-scoped and unscoped agents for rig expansion.
 			agents = filterAgentsByScope(agents, false)
@@ -220,6 +223,15 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					cfg.RigPackSkills[rig.Name],
 					stampImportedSkillBinding(skills, bindingName, imp.Export)...,
 				)
+				mcpTopoDirs := topoDirs
+
+				if !imp.ImportIsTransitive() {
+					mcpTopoDirs = filterPackDirsByRoot(topoDirs, impDir)
+				}
+				if cfg.RigImportMCPBindings == nil {
+					cfg.RigImportMCPBindings = make(map[string]map[string]string)
+				}
+				cfg.RigImportMCPBindings[rig.Name] = stampMCPDirBindings(cfg.RigImportMCPBindings[rig.Name], mcpTopoDirs, bindingName)
 
 				// Stamp binding name on agents and named sessions.
 				// At the rig level, ALL agents from an import get the rig's
@@ -304,6 +316,7 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 
 				rigTopoDirs = appendUnique(rigTopoDirs, topoDirs...)
+				rigImportPackDirs = prependUniqueBlock(rigImportPackDirs, mcpTopoDirs...)
 
 				agents = filterAgentsByScope(agents, false)
 				namedSessions = filterNamedSessionsByScope(namedSessions, false)
@@ -341,6 +354,18 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 		}
 		if len(rigTopoDirs) > 0 {
 			cfg.RigPackDirs[rig.Name] = rigTopoDirs
+		}
+		if len(rigPackGraphOnlyDirs) > 0 {
+			if cfg.RigPackGraphOnlyDirs == nil {
+				cfg.RigPackGraphOnlyDirs = make(map[string][]string)
+			}
+			cfg.RigPackGraphOnlyDirs[rig.Name] = rigPackGraphOnlyDirs
+		}
+		if len(rigImportPackDirs) > 0 {
+			if cfg.RigImportPackDirs == nil {
+				cfg.RigImportPackDirs = make(map[string][]string)
+			}
+			cfg.RigImportPackDirs[rig.Name] = rigImportPackDirs
 		}
 
 		// Collect overlay/ dirs from rig pack dirs.
@@ -428,6 +453,10 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 	var allNamedSessions []NamedSession
 	var formulaDirs []string
 	var allPackDirs []string
+	var packGraphOnlyDirs []string
+	var explicitImportPackDirs []string
+	var implicitImportPackDirs []string
+	var bootstrapImportPackDirs []string
 	var allRequires []PackRequirement
 	var allGlobals []ResolvedPackGlobal
 	// Shared cache across all pack loads to deduplicate diamond DAGs.
@@ -483,6 +512,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 
 		// Accumulate pack dirs (deduped).
 		allPackDirs = appendUnique(allPackDirs, topoDirs...)
+		packGraphOnlyDirs = appendUniqueLastWins(packGraphOnlyDirs, topoDirs...)
 
 		// Keep only city-scoped and unscoped agents for city expansion.
 		agents = filterAgentsByScope(agents, true)
@@ -542,6 +572,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 			commands := cachedPackCommands(cache, impDir)
 			doctors := cachedPackDoctors(cache, impDir)
 			skills := cachedPackSkills(cache, impDir)
+			mcpTopoDirs := topoDirs
 
 			// When transitive = false, keep only agents directly defined
 			// by this import (not its own transitive dependencies).
@@ -558,6 +589,7 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 				commands = filterCommandsByPackDir(commands, impDir)
 				doctors = filterDoctorsByPackDir(doctors, impDir)
 				skills = filterSkillsByPackDir(skills, impDir)
+				mcpTopoDirs = filterPackDirsByRoot(topoDirs, impDir)
 			}
 
 			// Stamp binding name on all agents and named sessions.
@@ -637,6 +669,17 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 				cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampImportedSkillBinding(skills, bindingName, imp.Export)...)
 			}
 			allPackDirs = appendUnique(allPackDirs, topoDirs...)
+			switch {
+			case cfg.BootstrapImportBindings != nil && cfg.BootstrapImportBindings[bindingName]:
+				bootstrapImportPackDirs = prependUniqueBlock(bootstrapImportPackDirs, mcpTopoDirs...)
+				cfg.BootstrapImportMCPBindings = stampMCPDirBindings(cfg.BootstrapImportMCPBindings, mcpTopoDirs, bindingName)
+			case cfg.ImplicitImportBindings != nil && cfg.ImplicitImportBindings[bindingName]:
+				implicitImportPackDirs = prependUniqueBlock(implicitImportPackDirs, mcpTopoDirs...)
+				cfg.ImplicitImportMCPBindings = stampMCPDirBindings(cfg.ImplicitImportMCPBindings, mcpTopoDirs, bindingName)
+			default:
+				explicitImportPackDirs = prependUniqueBlock(explicitImportPackDirs, mcpTopoDirs...)
+				cfg.ExplicitImportMCPBindings = stampMCPDirBindings(cfg.ExplicitImportMCPBindings, mcpTopoDirs, bindingName)
+			}
 
 			// Filter by scope for city expansion.
 			agents = filterAgentsByScope(agents, true)
@@ -669,6 +712,10 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 
 	// Store city pack dirs.
 	cfg.PackDirs = appendUnique(cfg.PackDirs, allPackDirs...)
+	cfg.PackGraphOnlyDirs = appendUniqueLastWins(cfg.PackGraphOnlyDirs, packGraphOnlyDirs...)
+	cfg.ExplicitImportPackDirs = appendUniqueLastWins(cfg.ExplicitImportPackDirs, explicitImportPackDirs...)
+	cfg.ImplicitImportPackDirs = appendUniqueLastWins(cfg.ImplicitImportPackDirs, implicitImportPackDirs...)
+	cfg.BootstrapImportPackDirs = appendUniqueLastWins(cfg.BootstrapImportPackDirs, bootstrapImportPackDirs...)
 
 	// Collect overlay/ dirs from pack dirs.
 	for _, dir := range allPackDirs {
@@ -1573,6 +1620,34 @@ func filterSkillsByPackDir(skills []DiscoveredSkillCatalog, packDir string) []Di
 	return out
 }
 
+func filterPackDirsByRoot(packDirs []string, rootDir string) []string {
+	absRoot, _ := filepath.Abs(rootDir)
+	var out []string
+	for _, dir := range packDirs {
+		absDir, _ := filepath.Abs(dir)
+		if absDir == absRoot {
+			out = append(out, dir)
+		}
+	}
+	return out
+}
+
+func stampMCPDirBindings(dst map[string]string, packDirs []string, binding string) map[string]string {
+	if len(packDirs) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]string, len(packDirs))
+	}
+	for _, dir := range packDirs {
+		if _, exists := dst[dir]; exists {
+			continue
+		}
+		dst[dir] = binding
+	}
+	return dst
+}
+
 func agentNameSet(agents []Agent) map[string]bool {
 	names := make(map[string]bool, len(agents))
 	for _, a := range agents {
@@ -1874,6 +1949,45 @@ func appendUnique(dst []string, items ...string) []string {
 		}
 	}
 	return dst
+}
+
+// appendUniqueLastWins appends items to dst while keeping only the
+// highest-precedence occurrence of each path. Re-seeing an item moves it to the
+// end of the slice.
+func appendUniqueLastWins(dst []string, items ...string) []string {
+	for _, item := range items {
+		filtered := dst[:0]
+		for _, existing := range dst {
+			if existing == item {
+				continue
+			}
+			filtered = append(filtered, existing)
+		}
+		dst = filtered
+		dst = append(dst, item)
+	}
+	return dst
+}
+
+// prependUniqueBlock prepends one precedence block ahead of dst, keeping the
+// first insertion of any shared path. This lets earlier processed root bindings
+// retain ownership of shared dependency dirs while still placing later sibling
+// roots at lower precedence under later-wins merges.
+func prependUniqueBlock(dst []string, items ...string) []string {
+	if len(items) == 0 {
+		return dst
+	}
+	out := make([]string, 0, len(items)+len(dst))
+	added := setFromSlice(dst)
+	for _, item := range items {
+		if added[item] {
+			continue
+		}
+		out = append(out, item)
+		added[item] = true
+	}
+	out = append(out, dst...)
+	return out
 }
 
 // setFromSlice builds a set from a string slice.

--- a/internal/fsys/atomic.go
+++ b/internal/fsys/atomic.go
@@ -10,15 +10,23 @@ import (
 
 // WriteFileAtomic writes data to path atomically using a temp file + rename.
 // The temp file is created in the same directory as path to ensure the rename
-// is on the same filesystem (required for atomic rename on POSIX).
+// is on the same filesystem (required for atomic rename on POSIX). Permissions
+// are enforced on the temp file before the rename so the final path is never
+// visible with a wider mode (no write-then-chmod window).
 func WriteFileAtomic(fs FS, path string, data []byte, perm os.FileMode) error {
 	suffix := strconv.Itoa(os.Getpid()) + "." + strconv.FormatInt(time.Now().UnixNano(), 36)
 	tmp := path + ".tmp." + suffix
 	if err := fs.WriteFile(tmp, data, perm); err != nil {
 		return fmt.Errorf("writing temp file: %w", err)
 	}
+	// Chmod before rename so the final path never exists with a wider mode
+	// even briefly. umask can relax `perm` on the initial WriteFile; an
+	// explicit Chmod normalises it.
+	if err := fs.Chmod(tmp, perm); err != nil {
+		_ = fs.Remove(tmp)
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
 	if err := fs.Rename(tmp, path); err != nil {
-		// Best-effort cleanup of temp file.
 		_ = fs.Remove(tmp)
 		return fmt.Errorf("renaming temp file: %w", err)
 	}

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -9,13 +9,14 @@ import (
 )
 
 // Fake is an in-memory [FS] for testing. It records all calls (spy) and
-// simulates filesystem state (fake). Pre-populate Dirs, Files, and Errors
-// before calling methods.
+// simulates filesystem state (fake). Pre-populate Dirs, Files, Symlinks,
+// and Errors before calling methods.
 type Fake struct {
-	Dirs   map[string]bool   // pre-populated directories
-	Files  map[string][]byte // pre-populated files
-	Errors map[string]error  // path → injected error (checked first)
-	Calls  []Call            // spy log
+	Dirs     map[string]bool   // pre-populated directories
+	Files    map[string][]byte // pre-populated files
+	Symlinks map[string]string // pre-populated symlinks (path -> target)
+	Errors   map[string]error  // path → injected error (checked first)
+	Calls    []Call            // spy log
 }
 
 // Call records a single method invocation on [Fake].
@@ -27,9 +28,10 @@ type Call struct {
 // NewFake returns a ready-to-use [Fake] with empty maps.
 func NewFake() *Fake {
 	return &Fake{
-		Dirs:   make(map[string]bool),
-		Files:  make(map[string][]byte),
-		Errors: make(map[string]error),
+		Dirs:     make(map[string]bool),
+		Files:    make(map[string][]byte),
+		Symlinks: make(map[string]string),
+		Errors:   make(map[string]error),
 	}
 }
 
@@ -73,10 +75,20 @@ func (f *Fake) ReadFile(name string) ([]byte, error) {
 }
 
 // Stat records the call and returns info based on Dirs/Files maps.
+// Symlinks are followed — use Lstat to detect them without following.
 func (f *Fake) Stat(name string) (os.FileInfo, error) {
 	f.Calls = append(f.Calls, Call{Method: "Stat", Path: name})
 	if err, ok := f.Errors[name]; ok {
 		return nil, err
+	}
+	if target, ok := f.Symlinks[name]; ok {
+		if f.Dirs[target] {
+			return fakeFileInfo{name: filepath.Base(name), dir: true}, nil
+		}
+		if data, ok := f.Files[target]; ok {
+			return fakeFileInfo{name: filepath.Base(name), size: int64(len(data))}, nil
+		}
+		return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
 	}
 	if f.Dirs[name] {
 		return fakeFileInfo{name: filepath.Base(name), dir: true}, nil
@@ -85,6 +97,25 @@ func (f *Fake) Stat(name string) (os.FileInfo, error) {
 		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data))}, nil
 	}
 	return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
+}
+
+// Lstat records the call and reports the entry itself without following
+// symlinks. Tests populate Symlinks to exercise the symlink-rejection path.
+func (f *Fake) Lstat(name string) (os.FileInfo, error) {
+	f.Calls = append(f.Calls, Call{Method: "Lstat", Path: name})
+	if err, ok := f.Errors[name]; ok {
+		return nil, err
+	}
+	if _, ok := f.Symlinks[name]; ok {
+		return fakeFileInfo{name: filepath.Base(name), symlink: true}, nil
+	}
+	if f.Dirs[name] {
+		return fakeFileInfo{name: filepath.Base(name), dir: true}, nil
+	}
+	if data, ok := f.Files[name]; ok {
+		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data))}, nil
+	}
+	return nil, &os.PathError{Op: "lstat", Path: name, Err: os.ErrNotExist}
 }
 
 // ReadDir records the call and returns entries from direct children.
@@ -175,14 +206,20 @@ func (f *Fake) Chmod(name string, _ os.FileMode) error {
 // --- fake os.FileInfo ---
 
 type fakeFileInfo struct {
-	name string
-	size int64
-	dir  bool
+	name    string
+	size    int64
+	dir     bool
+	symlink bool
 }
 
-func (fi fakeFileInfo) Name() string       { return fi.name }
-func (fi fakeFileInfo) Size() int64        { return fi.size }
-func (fi fakeFileInfo) Mode() os.FileMode  { return 0o755 }
+func (fi fakeFileInfo) Name() string { return fi.name }
+func (fi fakeFileInfo) Size() int64  { return fi.size }
+func (fi fakeFileInfo) Mode() os.FileMode {
+	if fi.symlink {
+		return 0o777 | os.ModeSymlink
+	}
+	return 0o755
+}
 func (fi fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (fi fakeFileInfo) IsDir() bool        { return fi.dir }
 func (fi fakeFileInfo) Sys() any           { return nil }
@@ -205,7 +242,7 @@ func (de fakeDirEntry) Type() fs.FileMode {
 }
 
 func (de fakeDirEntry) Info() (fs.FileInfo, error) {
-	return fakeFileInfo(de), nil
+	return fakeFileInfo{name: de.name, size: de.size, dir: de.dir}, nil
 }
 
 var (

--- a/internal/fsys/fsys.go
+++ b/internal/fsys/fsys.go
@@ -24,6 +24,11 @@ type FS interface {
 	// Stat returns file info for the named file.
 	Stat(name string) (os.FileInfo, error)
 
+	// Lstat returns file info for the named file without following symlinks.
+	// Callers that must reject symlinked targets should call Lstat and check
+	// the mode's ModeSymlink bit before touching the path.
+	Lstat(name string) (os.FileInfo, error)
+
 	// ReadDir reads the named directory and returns its entries.
 	ReadDir(name string) ([]os.DirEntry, error)
 
@@ -58,6 +63,11 @@ func (OSFS) ReadFile(name string) ([]byte, error) {
 // Stat delegates to [os.Stat].
 func (OSFS) Stat(name string) (os.FileInfo, error) {
 	return os.Stat(name)
+}
+
+// Lstat delegates to [os.Lstat].
+func (OSFS) Lstat(name string) (os.FileInfo, error) {
+	return os.Lstat(name)
 }
 
 // ReadDir delegates to [os.ReadDir].

--- a/internal/materialize/mcp.go
+++ b/internal/materialize/mcp.go
@@ -15,11 +15,15 @@ import (
 
 var validMCPServerName = regexp.MustCompile(`^[a-z0-9-]+$`)
 
+// MCPTransport identifies the neutral transport type supported by the MCP
+// catalog and provider projections.
 type MCPTransport string
 
 const (
+	// MCPTransportStdio is a stdio-launched MCP server.
 	MCPTransportStdio MCPTransport = "stdio"
-	MCPTransportHTTP  MCPTransport = "http"
+	// MCPTransportHTTP is a streamable HTTP MCP server.
+	MCPTransportHTTP MCPTransport = "http"
 )
 
 // MCPServer is the canonical neutral MCP model after parsing,

--- a/internal/materialize/mcp.go
+++ b/internal/materialize/mcp.go
@@ -1,0 +1,364 @@
+package materialize
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/BurntSushi/toml"
+)
+
+var validMCPServerName = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+type MCPTransport string
+
+const (
+	MCPTransportStdio MCPTransport = "stdio"
+	MCPTransportHTTP  MCPTransport = "http"
+)
+
+// MCPServer is the canonical neutral MCP model after parsing,
+// template expansion, transport validation, and relative path
+// resolution.
+type MCPServer struct {
+	Name        string
+	Description string
+	Transport   MCPTransport
+	Command     string
+	Args        []string
+	Env         map[string]string
+	URL         string
+	Headers     map[string]string
+	SourceFile  string
+	SourceDir   string
+	Template    bool
+	Layer       string
+	Origin      string
+}
+
+// MCPShadow records a same-name replacement across precedence layers.
+type MCPShadow struct {
+	Name       string
+	Winner     string
+	Loser      string
+	WinnerFile string
+	LoserFile  string
+}
+
+// MCPCatalog is a precedence-resolved MCP server set.
+type MCPCatalog struct {
+	Servers  []MCPServer
+	Shadows  []MCPShadow
+	ByName   map[string]MCPServer
+	ByLayer  map[string][]MCPServer
+	RawOrder []string
+}
+
+// MCPKV is a canonical map entry used for deterministic equality and hashing.
+type MCPKV struct {
+	Key   string
+	Value string
+}
+
+// NormalizedMCPServer is the deterministic behavioral form used for equality
+// and drift hashing. Metadata and source provenance are intentionally excluded.
+type NormalizedMCPServer struct {
+	Name      string
+	Transport MCPTransport
+	Command   string
+	Args      []string
+	Env       []MCPKV
+	URL       string
+	Headers   []MCPKV
+}
+
+type rawMCPServer struct {
+	Name        string            `toml:"name"`
+	Description string            `toml:"description"`
+	Command     string            `toml:"command"`
+	Args        []string          `toml:"args"`
+	Env         map[string]string `toml:"env"`
+	URL         string            `toml:"url"`
+	Headers     map[string]string `toml:"headers"`
+}
+
+// MCPDirSource identifies one directory contributing MCP definitions.
+// Sources are merged in the order supplied: later entries win.
+type MCPDirSource struct {
+	Dir    string
+	Label  string
+	Origin string
+}
+
+// MCPIdentityForFilename returns the logical server name for a supported MCP
+// filename. Supported names are "<name>.toml" and "<name>.template.toml".
+func MCPIdentityForFilename(name string) (string, bool) {
+	switch {
+	case strings.HasSuffix(name, ".template.toml"):
+		return strings.TrimSuffix(name, ".template.toml"), true
+	case strings.HasSuffix(name, ".toml"):
+		return strings.TrimSuffix(name, ".toml"), true
+	default:
+		return "", false
+	}
+}
+
+// LoadMCPDir parses every MCP definition in dir. Hidden files and unsupported
+// extensions are ignored. Duplicate logical names within one directory are a
+// hard error.
+func LoadMCPDir(dir, label string, templateData map[string]string) ([]MCPServer, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading mcp dir %q: %w", dir, err)
+	}
+
+	seen := make(map[string]string, len(entries))
+	servers := make([]MCPServer, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+			continue
+		}
+		identity, ok := MCPIdentityForFilename(name)
+		if !ok {
+			continue
+		}
+		if prev, dup := seen[identity]; dup {
+			return nil, fmt.Errorf("mcp directory %q: duplicate logical server %q via %q and %q", dir, identity, prev, name)
+		}
+		seen[identity] = name
+
+		server, err := loadMCPFile(filepath.Join(dir, name), label, templateData)
+		if err != nil {
+			return nil, err
+		}
+		if label != "" {
+			server.Origin = label
+		}
+		servers = append(servers, server)
+	}
+	sort.Slice(servers, func(i, j int) bool { return servers[i].Name < servers[j].Name })
+	return servers, nil
+}
+
+// MergeMCPDirs loads and overlays MCP definitions from low to high precedence.
+// Later directories win on same-name collisions.
+func MergeMCPDirs(sources []MCPDirSource, templateData map[string]string) (MCPCatalog, error) {
+	out := MCPCatalog{
+		ByName:  make(map[string]MCPServer),
+		ByLayer: make(map[string][]MCPServer),
+	}
+	for _, source := range sources {
+		servers, err := LoadMCPDir(source.Dir, source.Label, templateData)
+		if err != nil {
+			return MCPCatalog{}, err
+		}
+		for i := range servers {
+			if strings.TrimSpace(source.Origin) != "" {
+				servers[i].Origin = source.Origin
+			}
+		}
+		for _, server := range servers {
+			if prior, exists := out.ByName[server.Name]; exists {
+				out.Shadows = append(out.Shadows, MCPShadow{
+					Name:       server.Name,
+					Winner:     shadowOrigin(server),
+					Loser:      shadowOrigin(prior),
+					WinnerFile: server.SourceFile,
+					LoserFile:  prior.SourceFile,
+				})
+			}
+			out.ByName[server.Name] = server
+			out.RawOrder = append(out.RawOrder, server.Name)
+		}
+	}
+
+	names := make([]string, 0, len(out.ByName))
+	for name := range out.ByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out.Servers = make([]MCPServer, 0, len(names))
+	for _, name := range names {
+		server := out.ByName[name]
+		out.Servers = append(out.Servers, server)
+		out.ByLayer[server.Layer] = append(out.ByLayer[server.Layer], server)
+	}
+	sort.Slice(out.Shadows, func(i, j int) bool {
+		if out.Shadows[i].Name != out.Shadows[j].Name {
+			return out.Shadows[i].Name < out.Shadows[j].Name
+		}
+		if out.Shadows[i].Winner != out.Shadows[j].Winner {
+			return out.Shadows[i].Winner < out.Shadows[j].Winner
+		}
+		return out.Shadows[i].Loser < out.Shadows[j].Loser
+	})
+	return out, nil
+}
+
+// NormalizeMCPServer returns the deterministic behavioral representation used
+// for equality and hashing.
+func NormalizeMCPServer(server MCPServer) NormalizedMCPServer {
+	n := NormalizedMCPServer{
+		Name:      server.Name,
+		Transport: server.Transport,
+		Command:   server.Command,
+		URL:       server.URL,
+	}
+	if len(server.Args) > 0 {
+		n.Args = append([]string(nil), server.Args...)
+	}
+	if len(server.Env) > 0 {
+		n.Env = normalizeMCPMap(server.Env)
+	}
+	if len(server.Headers) > 0 {
+		n.Headers = normalizeMCPMap(server.Headers)
+	}
+	return n
+}
+
+func shadowOrigin(server MCPServer) string {
+	if strings.TrimSpace(server.Origin) != "" {
+		return server.Origin
+	}
+	return server.Layer
+}
+
+func loadMCPFile(path, label string, templateData map[string]string) (MCPServer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return MCPServer{}, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	isTemplate := strings.HasSuffix(path, ".template.toml")
+	if isTemplate {
+		data, err = expandMCPTemplate(data, templateData)
+		if err != nil {
+			return MCPServer{}, fmt.Errorf("expanding %s: %w", path, err)
+		}
+	}
+
+	var raw rawMCPServer
+	if _, err := toml.Decode(string(data), &raw); err != nil {
+		return MCPServer{}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	identity, ok := MCPIdentityForFilename(filepath.Base(path))
+	if !ok {
+		return MCPServer{}, fmt.Errorf("unsupported MCP filename %q", path)
+	}
+	if strings.TrimSpace(raw.Name) != identity {
+		return MCPServer{}, fmt.Errorf("%s: name %q must match filename stem %q", path, raw.Name, identity)
+	}
+	if !validMCPServerName.MatchString(identity) {
+		return MCPServer{}, fmt.Errorf("%s: invalid server name %q", path, identity)
+	}
+
+	command := strings.TrimSpace(raw.Command)
+	url := strings.TrimSpace(raw.URL)
+	switch {
+	case command == "" && url == "":
+		return MCPServer{}, fmt.Errorf("%s: exactly one of command or url must be set", path)
+	case command != "" && url != "":
+		return MCPServer{}, fmt.Errorf("%s: command and url are mutually exclusive", path)
+	}
+
+	server := MCPServer{
+		Name:        identity,
+		Description: strings.TrimSpace(raw.Description),
+		Args:        append([]string(nil), raw.Args...),
+		Env:         cloneStringMap(raw.Env),
+		Headers:     cloneStringMap(raw.Headers),
+		SourceFile:  path,
+		SourceDir:   filepath.Dir(path),
+		Template:    isTemplate,
+		Layer:       label,
+		Origin:      label,
+	}
+	if command != "" {
+		if len(raw.Headers) > 0 {
+			return MCPServer{}, fmt.Errorf("%s: stdio server may not set headers", path)
+		}
+		server.Transport = MCPTransportStdio
+		server.Command = resolveMCPCommand(command, filepath.Dir(path))
+	} else {
+		if len(raw.Args) > 0 || len(raw.Env) > 0 {
+			return MCPServer{}, fmt.Errorf("%s: http server may not set args or env", path)
+		}
+		server.Transport = MCPTransportHTTP
+		server.URL = url
+	}
+	return server, nil
+}
+
+func expandMCPTemplate(data []byte, templateData map[string]string) ([]byte, error) {
+	tmpl, err := template.New("mcp").Option("missingkey=error").Parse(string(data))
+	if err != nil {
+		return nil, err
+	}
+	if templateData == nil {
+		templateData = map[string]string{}
+	}
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, templateData); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func resolveMCPCommand(command, dir string) string {
+	if strings.TrimSpace(command) == "" {
+		return ""
+	}
+	if filepath.IsAbs(command) {
+		return filepath.Clean(command)
+	}
+	if !strings.ContainsAny(command, `/\`) {
+		return command
+	}
+	if abs, err := filepath.Abs(filepath.Join(dir, command)); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(filepath.Join(dir, command))
+}
+
+func normalizeMCPMap(in map[string]string) []MCPKV {
+	if len(in) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(in))
+	for key := range in {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]MCPKV, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, MCPKV{Key: key, Value: in[key]})
+	}
+	return out
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -17,11 +17,15 @@ import (
 )
 
 const (
+	// MCPProviderClaude projects to Claude Code's project-native MCP file.
 	MCPProviderClaude = "claude"
-	MCPProviderCodex  = "codex"
+	// MCPProviderCodex projects to Codex's project-native TOML config.
+	MCPProviderCodex = "codex"
+	// MCPProviderGemini projects to Gemini CLI's project-native settings file.
 	MCPProviderGemini = "gemini"
 )
 
+// MCPProjection is one provider-native MCP payload for a single target file.
 type MCPProjection struct {
 	Provider string
 	Root     string

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -1,0 +1,379 @@
+package materialize
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+const (
+	MCPProviderClaude = "claude"
+	MCPProviderCodex  = "codex"
+	MCPProviderGemini = "gemini"
+)
+
+type MCPProjection struct {
+	Provider string
+	Root     string
+	Target   string
+	Servers  []MCPServer
+}
+
+// BuildMCPProjection maps the neutral MCP catalog into one provider-native
+// target file rooted at workdir. An empty server list still produces a valid
+// projection so callers can reconcile stale managed config away.
+func BuildMCPProjection(providerKind, workdir string, servers []MCPServer) (MCPProjection, error) {
+	workdir = filepath.Clean(workdir)
+	switch providerKind {
+	case MCPProviderClaude:
+	case MCPProviderCodex:
+	case MCPProviderGemini:
+	default:
+		return MCPProjection{}, fmt.Errorf("unsupported MCP provider %q", providerKind)
+	}
+
+	out := MCPProjection{
+		Provider: providerKind,
+		Root:     workdir,
+		Servers:  append([]MCPServer(nil), servers...),
+	}
+	sort.Slice(out.Servers, func(i, j int) bool { return out.Servers[i].Name < out.Servers[j].Name })
+
+	switch providerKind {
+	case MCPProviderClaude:
+		out.Target = filepath.Join(workdir, ".mcp.json")
+	case MCPProviderCodex:
+		out.Target = filepath.Join(workdir, ".codex", "config.toml")
+	case MCPProviderGemini:
+		out.Target = filepath.Join(workdir, ".gemini", "settings.json")
+	}
+	return out, nil
+}
+
+// Hash returns the deterministic behavioral hash for the projected provider
+// payload only. It intentionally excludes the target path and source metadata.
+func (p MCPProjection) Hash() string {
+	sum := sha256.Sum256(p.normalizedBytes())
+	return hex.EncodeToString(sum[:])
+}
+
+// Apply reconciles the provider-native MCP target. A non-empty projection
+// intentionally adopts the provider-native MCP surface immediately: once an
+// agent/workdir has effective MCP, GC overwrites the provider's MCP target from
+// the neutral source of truth. The managed marker only gates later cleanup when
+// the effective catalog becomes empty, so GC does not remove an unmanaged file
+// it never adopted.
+//
+// Claude owns the whole file; Gemini and Codex preserve unrelated config while
+// replacing the MCP subtree.
+func (p MCPProjection) Apply(fs fsys.FS) error {
+	switch p.Provider {
+	case MCPProviderClaude:
+		return p.applyClaude(fs)
+	case MCPProviderCodex:
+		return p.applyCodex(fs)
+	case MCPProviderGemini:
+		return p.applyGemini(fs)
+	default:
+		return fmt.Errorf("unsupported MCP provider %q", p.Provider)
+	}
+}
+
+func (p MCPProjection) normalizedBytes() []byte {
+	type normalizedProjection struct {
+		Provider string                `json:"provider"`
+		Servers  []NormalizedMCPServer `json:"servers"`
+	}
+	normalized := normalizedProjection{
+		Provider: p.Provider,
+		Servers:  make([]NormalizedMCPServer, 0, len(p.Servers)),
+	}
+	for _, server := range p.Servers {
+		normalized.Servers = append(normalized.Servers, NormalizeMCPServer(server))
+	}
+	data, _ := json.Marshal(normalized)
+	return data
+}
+
+func (p MCPProjection) applyClaude(fs fsys.FS) error {
+	if len(p.Servers) == 0 {
+		if !p.isManaged(fs) {
+			return nil
+		}
+		if err := removeManagedMCPFile(fs, p.Target); err != nil {
+			return err
+		}
+		return removeManagedMCPFile(fs, p.markerPath())
+	}
+	doc := map[string]any{
+		"mcpServers": p.claudeServersDoc(),
+	}
+	data, err := marshalJSONDoc(doc)
+	if err != nil {
+		return err
+	}
+	if err := writeManagedMCPFile(fs, p.Target, data); err != nil {
+		return err
+	}
+	return p.writeManagedMarker(fs)
+}
+
+func (p MCPProjection) applyGemini(fs fsys.FS) error {
+	managed := p.isManaged(fs)
+	if len(p.Servers) == 0 && !managed {
+		return nil
+	}
+	doc, err := readJSONDoc(fs, p.Target)
+	if err != nil {
+		return err
+	}
+	if len(p.Servers) == 0 {
+		delete(doc, "mcpServers")
+		if len(doc) == 0 {
+			if err := removeManagedMCPFile(fs, p.Target); err != nil {
+				return err
+			}
+			return removeManagedMCPFile(fs, p.markerPath())
+		}
+	} else {
+		doc["mcpServers"] = p.geminiServersDoc()
+	}
+	data, err := marshalJSONDoc(doc)
+	if err != nil {
+		return err
+	}
+	if err := writeManagedMCPFile(fs, p.Target, data); err != nil {
+		return err
+	}
+	if len(p.Servers) == 0 {
+		return removeManagedMCPFile(fs, p.markerPath())
+	}
+	return p.writeManagedMarker(fs)
+}
+
+func (p MCPProjection) applyCodex(fs fsys.FS) error {
+	managed := p.isManaged(fs)
+	if len(p.Servers) == 0 && !managed {
+		return nil
+	}
+	doc, err := readTOMLDoc(fs, p.Target)
+	if err != nil {
+		return err
+	}
+	if len(p.Servers) == 0 {
+		delete(doc, "mcp_servers")
+		if len(doc) == 0 {
+			if err := removeManagedMCPFile(fs, p.Target); err != nil {
+				return err
+			}
+			return removeManagedMCPFile(fs, p.markerPath())
+		}
+	} else {
+		doc["mcp_servers"] = p.codexServersDoc()
+	}
+	data, err := marshalTOMLDoc(doc)
+	if err != nil {
+		return err
+	}
+	if err := writeManagedMCPFile(fs, p.Target, data); err != nil {
+		return err
+	}
+	if len(p.Servers) == 0 {
+		return removeManagedMCPFile(fs, p.markerPath())
+	}
+	return p.writeManagedMarker(fs)
+}
+
+func (p MCPProjection) claudeServersDoc() map[string]any {
+	out := make(map[string]any, len(p.Servers))
+	for _, server := range p.Servers {
+		entry := map[string]any{}
+		switch server.Transport {
+		case MCPTransportStdio:
+			entry["command"] = server.Command
+			if len(server.Args) > 0 {
+				entry["args"] = append([]string(nil), server.Args...)
+			}
+			if len(server.Env) > 0 {
+				entry["env"] = cloneStringMap(server.Env)
+			}
+		case MCPTransportHTTP:
+			entry["type"] = "http"
+			entry["url"] = server.URL
+			if len(server.Headers) > 0 {
+				entry["headers"] = cloneStringMap(server.Headers)
+			}
+		}
+		out[server.Name] = entry
+	}
+	return out
+}
+
+func (p MCPProjection) geminiServersDoc() map[string]any {
+	out := make(map[string]any, len(p.Servers))
+	for _, server := range p.Servers {
+		entry := map[string]any{}
+		switch server.Transport {
+		case MCPTransportStdio:
+			entry["command"] = server.Command
+			if len(server.Args) > 0 {
+				entry["args"] = append([]string(nil), server.Args...)
+			}
+			if len(server.Env) > 0 {
+				entry["env"] = cloneStringMap(server.Env)
+			}
+		case MCPTransportHTTP:
+			entry["httpUrl"] = server.URL
+			if len(server.Headers) > 0 {
+				entry["headers"] = cloneStringMap(server.Headers)
+			}
+		}
+		out[server.Name] = entry
+	}
+	return out
+}
+
+func (p MCPProjection) codexServersDoc() map[string]any {
+	out := make(map[string]any, len(p.Servers))
+	for _, server := range p.Servers {
+		entry := map[string]any{}
+		switch server.Transport {
+		case MCPTransportStdio:
+			entry["command"] = server.Command
+			if len(server.Args) > 0 {
+				entry["args"] = append([]string(nil), server.Args...)
+			}
+			if len(server.Env) > 0 {
+				entry["env"] = cloneStringMap(server.Env)
+			}
+		case MCPTransportHTTP:
+			entry["url"] = server.URL
+			if len(server.Headers) > 0 {
+				entry["http_headers"] = cloneStringMap(server.Headers)
+			}
+		}
+		out[server.Name] = entry
+	}
+	return out
+}
+
+func readJSONDoc(fs fsys.FS, path string) (map[string]any, error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		if errorsIsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if doc == nil {
+		doc = map[string]any{}
+	}
+	return doc, nil
+}
+
+func readTOMLDoc(fs fsys.FS, path string) (map[string]any, error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		if errorsIsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var doc map[string]any
+	if _, err := toml.Decode(string(data), &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if doc == nil {
+		doc = map[string]any{}
+	}
+	return doc, nil
+}
+
+func marshalJSONDoc(doc map[string]any) ([]byte, error) {
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling MCP JSON: %w", err)
+	}
+	data = append(data, '\n')
+	return data, nil
+}
+
+func marshalTOMLDoc(doc map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+		return nil, fmt.Errorf("marshaling MCP TOML: %w", err)
+	}
+	data := buf.Bytes()
+	if len(data) > 0 && !bytes.HasSuffix(data, []byte{'\n'}) {
+		data = append(data, '\n')
+	}
+	return data, nil
+}
+
+func writeManagedMCPFile(fs fsys.FS, path string, data []byte) error {
+	if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+	if err := fsys.WriteFileAtomic(fs, path, data, 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := fs.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
+func removeManagedMCPFile(fs fsys.FS, path string) error {
+	if err := fs.Remove(path); err != nil && !errorsIsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", path, err)
+	}
+	return nil
+}
+
+func (p MCPProjection) markerPath() string {
+	return filepath.Join(p.Root, ".gc", "mcp-managed", p.Provider+".json")
+}
+
+func (p MCPProjection) isManaged(fs fsys.FS) bool {
+	_, err := fs.Stat(p.markerPath())
+	return err == nil
+}
+
+func (p MCPProjection) writeManagedMarker(fs fsys.FS) error {
+	if err := fs.MkdirAll(filepath.Dir(p.markerPath()), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(p.markerPath()), err)
+	}
+	data, err := json.Marshal(map[string]string{
+		"managed_by": "gc",
+		"provider":   p.Provider,
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", p.markerPath(), err)
+	}
+	data = append(data, '\n')
+	if err := fsys.WriteFileAtomic(fs, p.markerPath(), data, 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", p.markerPath(), err)
+	}
+	if err := fs.Chmod(p.markerPath(), 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", p.markerPath(), err)
+	}
+	return nil
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && (os.IsNotExist(err) || errors.Is(err, iofs.ErrNotExist))
+}

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	iofs "io/fs"
 	"os"
 	"path/filepath"
@@ -72,25 +73,71 @@ func (p MCPProjection) Hash() string {
 }
 
 // Apply reconciles the provider-native MCP target. A non-empty projection
-// intentionally adopts the provider-native MCP surface immediately: once an
-// agent/workdir has effective MCP, GC overwrites the provider's MCP target from
-// the neutral source of truth. The managed marker only gates later cleanup when
-// the effective catalog becomes empty, so GC does not remove an unmanaged file
-// it never adopted.
+// adopts the provider-native MCP surface on first write: GC snapshots the
+// existing content to .gc/mcp-adopted/<provider>/<timestamp>.<ext>, emits a
+// one-line stderr warning, then overwrites from the neutral catalog. The
+// managed marker gates later cleanup when the effective catalog becomes
+// empty so GC does not remove an unmanaged file it never adopted.
 //
-// Claude owns the whole file; Gemini and Codex preserve unrelated config while
-// replacing the MCP subtree.
+// Claude owns the whole file; Gemini and Codex preserve unrelated config
+// while replacing the MCP subtree.
+//
+// Apply is safe against concurrent writers for the same target: when the
+// backing FS is the real OS filesystem, the read-validate-write sequence
+// runs under an flock keyed by (provider, target). Concurrent supervisor
+// ticks and stage-2 pre-start commands therefore serialize instead of
+// overwriting each other's work.
+//
+// Symlinked target paths are rejected unconditionally — managed targets
+// must be regular files or directories.
 func (p MCPProjection) Apply(fs fsys.FS) error {
-	switch p.Provider {
-	case MCPProviderClaude:
-		return p.applyClaude(fs)
-	case MCPProviderCodex:
-		return p.applyCodex(fs)
-	case MCPProviderGemini:
-		return p.applyGemini(fs)
-	default:
-		return fmt.Errorf("unsupported MCP provider %q", p.Provider)
+	return p.applyWithStderr(fs, adoptionStderr)
+}
+
+// ApplyWithStderr is identical to Apply but routes the one-time adoption
+// warning to the caller-supplied writer. Callers that already plumb their
+// own stderr sink (cmd surfaces, supervisor) prefer this entrypoint so
+// warnings land in a deterministic place.
+func (p MCPProjection) ApplyWithStderr(fs fsys.FS, stderr io.Writer) error {
+	return p.applyWithStderr(fs, stderr)
+}
+
+func (p MCPProjection) applyWithStderr(fs fsys.FS, stderr io.Writer) error {
+	if err := ensureNotSymlink(fs, p); err != nil {
+		return err
 	}
+	// Short-circuit: nothing to do for an empty catalog on an unmanaged
+	// target. Skipping early avoids taking an adoption snapshot of a
+	// file we are not about to overwrite (the prior-review fix moved
+	// snapshotting into Apply, but emitting a snapshot + warning with
+	// no corresponding write violates the "snapshot only before first
+	// overwrite" contract and lets .gc/mcp-adopted/ grow unbounded on
+	// repeated stage-2 pre-starts that resolve to empty catalogs).
+	if len(p.Servers) == 0 && !p.isManaged(fs) {
+		return nil
+	}
+	lockRoot := ""
+	if _, ok := fs.(fsys.OSFS); ok {
+		lockRoot = lockRootForProjection(p)
+	}
+	return withTargetLock(lockRoot, p.Provider, p.Target, func() error {
+		// Snapshot inside the lock so the backup reflects the exact
+		// content about to be replaced — no TOCTOU against another
+		// writer.
+		if err := snapshotExistingIfUnmanaged(fs, p, nil, stderr); err != nil {
+			return err
+		}
+		switch p.Provider {
+		case MCPProviderClaude:
+			return p.applyClaude(fs)
+		case MCPProviderCodex:
+			return p.applyCodex(fs)
+		case MCPProviderGemini:
+			return p.applyGemini(fs)
+		default:
+			return fmt.Errorf("unsupported MCP provider %q", p.Provider)
+		}
+	})
 }
 
 func (p MCPProjection) normalizedBytes() []byte {
@@ -332,11 +379,10 @@ func writeManagedMCPFile(fs fsys.FS, path string, data []byte) error {
 	if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
 	}
+	// WriteFileAtomic chmods the temp file pre-rename, so the final path is
+	// never briefly group/world-readable. No post-rename chmod needed.
 	if err := fsys.WriteFileAtomic(fs, path, data, 0o600); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
-	}
-	if err := fs.Chmod(path, 0o600); err != nil {
-		return fmt.Errorf("chmod %s: %w", path, err)
 	}
 	return nil
 }
@@ -371,9 +417,6 @@ func (p MCPProjection) writeManagedMarker(fs fsys.FS) error {
 	data = append(data, '\n')
 	if err := fsys.WriteFileAtomic(fs, p.markerPath(), data, 0o600); err != nil {
 		return fmt.Errorf("writing %s: %w", p.markerPath(), err)
-	}
-	if err := fs.Chmod(p.markerPath(), 0o600); err != nil {
-		return fmt.Errorf("chmod %s: %w", p.markerPath(), err)
 	}
 	return nil
 }

--- a/internal/materialize/mcp_project_lock.go
+++ b/internal/materialize/mcp_project_lock.go
@@ -1,0 +1,52 @@
+package materialize
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// withTargetLock serializes writers that target the same provider-native MCP
+// file. The lock sits under .gc/mcp-locks/<sha256(provider|target)>.lock and
+// is acquired with flock(LOCK_EX) so supervisor ticks and stage-2 pre-start
+// commands cannot interleave read-modify-write against the same file.
+//
+// Lock files persist across runs (the flock is released when the fd closes);
+// they are small (a single process PID written on first acquire) and reused
+// on subsequent runs, so no cleanup path is required.
+//
+// The lock only engages for the real OSFS. Tests using fsys.Fake never race
+// against another process and should not pay the filesystem cost — callers
+// pass the lock root explicitly and skip it for in-memory fixtures.
+func withTargetLock(lockRoot, provider, target string, fn func() error) error {
+	if lockRoot == "" {
+		return fn()
+	}
+	if err := os.MkdirAll(lockRoot, 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", lockRoot, err)
+	}
+	sum := sha256.Sum256([]byte(provider + "|" + target))
+	lockPath := filepath.Join(lockRoot, hex.EncodeToString(sum[:])+".lock")
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening lock %s: %w", lockPath, err)
+	}
+	defer f.Close() //nolint:errcheck // lock released on close
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("locking %s: %w", lockPath, err)
+	}
+	defer func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	}()
+	return fn()
+}
+
+// lockRootForProjection returns the .gc/mcp-locks directory under the
+// projection's workspace root. Callers using the real OS filesystem pass
+// this into withTargetLock; in-memory tests pass an empty string.
+func lockRootForProjection(p MCPProjection) string {
+	return filepath.Join(p.Root, ".gc", "mcp-locks")
+}

--- a/internal/materialize/mcp_project_safety.go
+++ b/internal/materialize/mcp_project_safety.go
@@ -1,0 +1,105 @@
+package materialize
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// ensureNotSymlink rejects paths that resolve through a symlink, including any
+// ancestor directory inside the managed provider subtree. Refusing to follow
+// the link is the security contract: Apply must never write to or read
+// through an attacker-controlled path.
+//
+// For Claude the managed file sits directly under the workdir, so only the
+// target itself is checked. For Gemini/Codex the provider directory
+// (.gemini/ or .codex/) is also checked because the preserve-unrelated path
+// reads from and writes into that directory.
+func ensureNotSymlink(fs fsys.FS, p MCPProjection) error {
+	toCheck := []string{p.Target}
+	if dir := filepath.Dir(p.Target); dir != "" && dir != p.Root && dir != "." {
+		toCheck = append(toCheck, dir)
+	}
+	for _, path := range toCheck {
+		info, err := fs.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) || errors.Is(err, iofs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("inspecting %s: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf(
+				"refusing to project MCP through symlinked path %s: "+
+					"managed targets must be regular files or directories",
+				path,
+			)
+		}
+	}
+	return nil
+}
+
+// snapshotExistingIfUnmanaged copies the existing provider-native MCP content
+// to an adoption backup before the first managed write. Gas City promises
+// non-destructive adoption: once we've taken ownership of a target we will
+// clobber it on every reconcile, but on the very first adoption the user's
+// pre-existing content is preserved under .gc/mcp-adopted/<provider>/ and a
+// one-time warning is emitted so operators can recover or diff.
+//
+// The snapshot is a no-op when the projection is already managed (marker
+// exists) or the target does not exist yet. Errors reading/writing the
+// backup are fatal: silent destructive adoption is exactly the failure
+// mode this function exists to prevent.
+func snapshotExistingIfUnmanaged(fs fsys.FS, p MCPProjection, now func() time.Time, stderr io.Writer) error {
+	if p.isManaged(fs) {
+		return nil
+	}
+	data, err := fs.ReadFile(p.Target)
+	if err != nil {
+		if errorsIsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading %s for adoption snapshot: %w", p.Target, err)
+	}
+	if now == nil {
+		now = time.Now
+	}
+	timestamp := now().UTC().Format("20060102T150405Z")
+	backupDir := filepath.Join(p.Root, ".gc", "mcp-adopted", p.Provider)
+	ext := filepath.Ext(p.Target)
+	if ext == "" {
+		ext = ".bak"
+	}
+	backup := filepath.Join(backupDir, timestamp+ext)
+	if err := fs.MkdirAll(backupDir, 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", backupDir, err)
+	}
+	if err := fsys.WriteFileAtomic(fs, backup, data, 0o600); err != nil {
+		return fmt.Errorf("writing adoption snapshot %s: %w", backup, err)
+	}
+	if stderr != nil {
+		_, _ = fmt.Fprintf(stderr,
+			"gc: adopting provider-native MCP at %s; existing content snapshotted to %s\n",
+			p.Target, backup,
+		)
+	}
+	return nil
+}
+
+// adoptionStderr returns the stderr sink that Apply should use for adoption
+// warnings. Tests can override via a build-time hook; default is os.Stderr.
+var adoptionStderr io.Writer = os.Stderr
+
+// SetAdoptionStderr overrides the destination for one-time adoption warnings.
+// Tests use this to capture the stderr emission deterministically.
+func SetAdoptionStderr(w io.Writer) (restore func()) {
+	prev := adoptionStderr
+	adoptionStderr = w
+	return func() { adoptionStderr = prev }
+}

--- a/internal/materialize/mcp_project_test.go
+++ b/internal/materialize/mcp_project_test.go
@@ -1,0 +1,428 @@
+package materialize
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestBuildMCPProjectionTargetsAndStableHash(t *testing.T) {
+	serversA := []MCPServer{
+		{
+			Name:      "zeta",
+			Transport: MCPTransportHTTP,
+			URL:       "https://example.com/mcp",
+			Headers:   map[string]string{"B": "2", "A": "1"},
+		},
+		{
+			Name:      "alpha",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"Y": "2", "X": "1"},
+		},
+	}
+	serversB := []MCPServer{
+		{
+			Name:      "alpha",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"X": "1", "Y": "2"},
+		},
+		{
+			Name:      "zeta",
+			Transport: MCPTransportHTTP,
+			URL:       "https://example.com/mcp",
+			Headers:   map[string]string{"A": "1", "B": "2"},
+		},
+	}
+
+	claudeA, err := BuildMCPProjection(MCPProviderClaude, "/work", serversA)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(claude): %v", err)
+	}
+	claudeB, err := BuildMCPProjection(MCPProviderClaude, "/work", serversB)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(claude): %v", err)
+	}
+	if got, want := claudeA.Target, filepath.Join("/work", ".mcp.json"); got != want {
+		t.Fatalf("claude target = %q, want %q", got, want)
+	}
+	if claudeA.Hash() != claudeB.Hash() {
+		t.Fatalf("projection hash must be stable across input ordering: %q vs %q", claudeA.Hash(), claudeB.Hash())
+	}
+
+	codex, err := BuildMCPProjection(MCPProviderCodex, "/work", nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(codex): %v", err)
+	}
+	if got, want := codex.Target, filepath.Join("/work", ".codex", "config.toml"); got != want {
+		t.Fatalf("codex target = %q, want %q", got, want)
+	}
+
+	gemini, err := BuildMCPProjection(MCPProviderGemini, "/work", nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(gemini): %v", err)
+	}
+	if got, want := gemini.Target, filepath.Join("/work", ".gemini", "settings.json"); got != want {
+		t.Fatalf("gemini target = %q, want %q", got, want)
+	}
+}
+
+func TestBuildMCPProjectionRejectsUnsupportedProvider(t *testing.T) {
+	if _, err := BuildMCPProjection("cursor", "/work", nil); err == nil {
+		t.Fatal("expected unsupported provider error")
+	}
+}
+
+func TestApplyMCPProjectionClaudeWritesManagedFile(t *testing.T) {
+	dir := t.TempDir()
+	proj, err := BuildMCPProjection(MCPProviderClaude, dir, []MCPServer{
+		{
+			Name:      "alpha",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"TOKEN": "secret"},
+		},
+		{
+			Name:      "remote",
+			Transport: MCPTransportHTTP,
+			URL:       "https://mcp.example.com",
+			Headers:   map[string]string{"Authorization": "Bearer token"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc struct {
+		MCPServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal .mcp.json: %v", err)
+	}
+	if _, ok := doc.MCPServers["alpha"]["command"]; !ok {
+		t.Fatalf("stdio server missing command: %+v", doc.MCPServers["alpha"])
+	}
+	if got := doc.MCPServers["remote"]["type"]; got != "http" {
+		t.Fatalf("remote type = %v, want http", got)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("stat .mcp.json: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf(".mcp.json perms = %o, want 600", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-managed", "claude.json")); err != nil {
+		t.Fatalf("managed marker missing: %v", err)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderClaude, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf(".mcp.json should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-managed", "claude.json")); !os.IsNotExist(err) {
+		t.Fatalf("managed marker should be removed, stat err = %v", err)
+	}
+}
+
+func TestApplyMCPProjectionGeminiPreservesNonMCPSettings(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{
+  "theme": "ocean",
+  "mcpServers": {
+    "stale": {
+      "command": "old"
+    }
+  }
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proj, err := BuildMCPProjection(MCPProviderGemini, dir, []MCPServer{
+		{
+			Name:      "stdio",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"TOKEN": "secret"},
+		},
+		{
+			Name:      "remote",
+			Transport: MCPTransportHTTP,
+			URL:       "https://mcp.example.com",
+			Headers:   map[string]string{"Authorization": "Bearer token"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	if got := doc["theme"]; got != "ocean" {
+		t.Fatalf("theme = %v, want ocean", got)
+	}
+	mcpServers, ok := doc["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers missing or wrong type: %+v", doc["mcpServers"])
+	}
+	remote, ok := mcpServers["remote"].(map[string]any)
+	if !ok {
+		t.Fatalf("remote server missing: %+v", mcpServers)
+	}
+	if got := remote["httpUrl"]; got != "https://mcp.example.com" {
+		t.Fatalf("remote httpUrl = %v, want https://mcp.example.com", got)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderGemini, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+	data, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(after cleanup): %v", err)
+	}
+	if strings.Contains(string(data), "mcpServers") {
+		t.Fatalf("mcpServers should be removed after cleanup:\n%s", string(data))
+	}
+}
+
+func TestApplyMCPProjectionCodexPreservesNonMCPConfig(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`
+model = "gpt-5"
+
+[mcp_servers.stale]
+command = "old"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proj, err := BuildMCPProjection(MCPProviderCodex, dir, []MCPServer{
+		{
+			Name:      "stdio",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"TOKEN": "secret"},
+		},
+		{
+			Name:      "remote",
+			Transport: MCPTransportHTTP,
+			URL:       "https://mcp.example.com",
+			Headers:   map[string]string{"Authorization": "Bearer token"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if _, err := toml.Decode(string(data), &doc); err != nil {
+		t.Fatalf("decode codex config: %v", err)
+	}
+	if got := doc["model"]; got != "gpt-5" {
+		t.Fatalf("model = %v, want gpt-5", got)
+	}
+	mcpServers, ok := doc["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcp_servers missing or wrong type: %#v", doc["mcp_servers"])
+	}
+	remote, ok := mcpServers["remote"].(map[string]any)
+	if !ok {
+		t.Fatalf("remote server missing: %#v", mcpServers)
+	}
+	if got := remote["url"]; got != "https://mcp.example.com" {
+		t.Fatalf("remote url = %v, want https://mcp.example.com", got)
+	}
+	if _, ok := remote["http_headers"]; !ok {
+		t.Fatalf("remote http_headers missing: %#v", remote)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderCodex, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+	data, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(after cleanup): %v", err)
+	}
+	doc = nil
+	if _, err := toml.Decode(string(data), &doc); err != nil {
+		t.Fatalf("decode cleaned codex config: %v", err)
+	}
+	if _, ok := doc["mcp_servers"]; ok {
+		t.Fatalf("mcp_servers should be removed after cleanup: %#v", doc)
+	}
+}
+
+func TestApplyMCPProjectionCodexRemovesManagedFileWhenItOnlyContainsMCP(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".codex", "config.toml")
+	proj, err := BuildMCPProjection(MCPProviderCodex, dir, []MCPServer{
+		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(non-empty): %v", err)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderCodex, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("codex config should be removed, stat err = %v", err)
+	}
+}
+
+func TestApplyMCPProjectionClaudeLeavesUnmanagedFileWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".mcp.json")
+	if err := os.WriteFile(target, []byte(`{"mcpServers":{"user":{"command":"custom"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderClaude, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target): %v", err)
+	}
+	if !strings.Contains(string(data), `"user"`) {
+		t.Fatalf("unmanaged .mcp.json should be preserved, got:\n%s", string(data))
+	}
+}
+
+func TestApplyMCPProjectionNormalizesPermissionsOnRewrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".mcp.json")
+	if err := os.WriteFile(target, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proj, err := BuildMCPProjection(MCPProviderClaude, dir, []MCPServer{
+		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("target perms = %o, want 600", got)
+	}
+}
+
+func TestApplyMCPProjectionFakeCallsChmod(t *testing.T) {
+	fake := fsys.NewFake()
+	proj, err := BuildMCPProjection(MCPProviderClaude, "/work", []MCPServer{
+		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fake); err != nil {
+		t.Fatalf("Apply(fake): %v", err)
+	}
+
+	var sawChmod bool
+	for _, call := range fake.Calls {
+		if call.Method == "Chmod" && call.Path == filepath.Join("/work", ".mcp.json") {
+			sawChmod = true
+			break
+		}
+	}
+	if !sawChmod {
+		t.Fatalf("expected Chmod call for managed file, calls = %#v", fake.Calls)
+	}
+}
+
+func TestNormalizeMCPProjectionServerOrdering(t *testing.T) {
+	proj, err := BuildMCPProjection(MCPProviderClaude, "/work", []MCPServer{
+		{Name: "b", Transport: MCPTransportStdio, Command: "two"},
+		{Name: "a", Transport: MCPTransportStdio, Command: "one"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	names := make([]string, 0, len(proj.Servers))
+	for _, server := range proj.Servers {
+		names = append(names, server.Name)
+	}
+	if !reflect.DeepEqual(names, []string{"a", "b"}) {
+		t.Fatalf("projection servers ordered = %v, want [a b]", names)
+	}
+}

--- a/internal/materialize/mcp_project_test.go
+++ b/internal/materialize/mcp_project_test.go
@@ -386,7 +386,7 @@ func TestApplyMCPProjectionNormalizesPermissionsOnRewrite(t *testing.T) {
 	}
 }
 
-func TestApplyMCPProjectionFakeCallsChmod(t *testing.T) {
+func TestApplyMCPProjectionFakeChmodsBeforeRename(t *testing.T) {
 	fake := fsys.NewFake()
 	proj, err := BuildMCPProjection(MCPProviderClaude, "/work", []MCPServer{
 		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
@@ -398,15 +398,170 @@ func TestApplyMCPProjectionFakeCallsChmod(t *testing.T) {
 		t.Fatalf("Apply(fake): %v", err)
 	}
 
-	var sawChmod bool
+	// Verify pre-rename chmod: every Chmod on a managed file must target
+	// a temp path (.tmp.*) and precede the matching Rename of that temp
+	// path to the final path. Any Chmod on the final path would reopen
+	// the write-then-chmod window this test guards against.
+	var sawTempChmodBeforeRename bool
+	var pendingTempChmod string
+	targetFinal := filepath.Join("/work", ".mcp.json")
 	for _, call := range fake.Calls {
-		if call.Method == "Chmod" && call.Path == filepath.Join("/work", ".mcp.json") {
-			sawChmod = true
+		if call.Method == "Chmod" {
+			if call.Path == targetFinal {
+				t.Fatalf("Chmod on final path is a write-then-chmod window regression: %s", call.Path)
+			}
+			if strings.Contains(call.Path, targetFinal+".tmp.") {
+				pendingTempChmod = call.Path
+			}
+		}
+		if call.Method == "Rename" && pendingTempChmod != "" && call.Path == pendingTempChmod {
+			sawTempChmodBeforeRename = true
 			break
 		}
 	}
-	if !sawChmod {
-		t.Fatalf("expected Chmod call for managed file, calls = %#v", fake.Calls)
+	if !sawTempChmodBeforeRename {
+		t.Fatalf("expected Chmod(temp) before Rename(temp,final), calls = %#v", fake.Calls)
+	}
+}
+
+func TestApplyMCPProjectionSnapshotsExistingContentBeforeFirstAdoption(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".mcp.json")
+	existing := []byte(`{"mcpServers":{"user-authored":{"command":"custom"}}}` + "\n")
+	if err := os.WriteFile(target, existing, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr strings.Builder
+	restore := SetAdoptionStderr(&stderr)
+	defer restore()
+
+	proj, err := BuildMCPProjection(MCPProviderClaude, dir, []MCPServer{
+		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// The pre-existing hand-authored file must have been preserved under
+	// .gc/mcp-adopted/claude/<timestamp>.json before being overwritten.
+	adoptedDir := filepath.Join(dir, ".gc", "mcp-adopted", "claude")
+	entries, err := os.ReadDir(adoptedDir)
+	if err != nil {
+		t.Fatalf("ReadDir(adopted): %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 adoption snapshot, got %d: %v", len(entries), entries)
+	}
+	snapshot, err := os.ReadFile(filepath.Join(adoptedDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile(snapshot): %v", err)
+	}
+	if !reflect.DeepEqual(snapshot, existing) {
+		t.Fatalf("snapshot content mismatch\n  got:  %q\n  want: %q", snapshot, existing)
+	}
+
+	// Second Apply (already managed) must NOT create a second snapshot.
+	proj2, _ := BuildMCPProjection(MCPProviderClaude, dir, []MCPServer{
+		{Name: "beta", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err := proj2.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(second): %v", err)
+	}
+	entries2, err := os.ReadDir(adoptedDir)
+	if err != nil {
+		t.Fatalf("ReadDir(adopted) second pass: %v", err)
+	}
+	if len(entries2) != 1 {
+		t.Fatalf("adoption snapshot must only be taken once; got %d: %v", len(entries2), entries2)
+	}
+
+	// The stderr warning must name both paths so operators can recover.
+	warning := stderr.String()
+	if !strings.Contains(warning, "adopting provider-native MCP at "+target) {
+		t.Fatalf("stderr missing target path: %q", warning)
+	}
+	if !strings.Contains(warning, "snapshotted to ") {
+		t.Fatalf("stderr missing snapshot path: %q", warning)
+	}
+}
+
+func TestApplyMCPProjectionDoesNotSnapshotWhenApplyIsNoop(t *testing.T) {
+	// An empty catalog against an unmanaged target must NOT take an
+	// adoption snapshot — no write will happen, so no backup is owed.
+	// Prior bug: snapshot fired unconditionally, filling
+	// .gc/mcp-adopted/ with spurious backups of unchanged files on
+	// every stage-2 pre-start that resolved to zero servers.
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".mcp.json")
+	if err := os.WriteFile(target, []byte(`{"mcpServers":{"user":{"command":"custom"}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr strings.Builder
+	restore := SetAdoptionStderr(&stderr)
+	defer restore()
+
+	empty, err := BuildMCPProjection(MCPProviderClaude, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty, unmanaged): %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-adopted")); !os.IsNotExist(err) {
+		t.Fatalf(".gc/mcp-adopted must not exist after no-op apply; stat err = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("no adoption stderr expected on no-op apply, got: %q", stderr.String())
+	}
+	// The original user-authored file must be untouched.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target): %v", err)
+	}
+	if !strings.Contains(string(got), `"user"`) {
+		t.Fatalf("unmanaged target mutated: %q", got)
+	}
+}
+
+func TestApplyMCPProjectionRejectsSymlinkedTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".mcp.json")
+	// Point the managed target at an attacker-controlled file outside the
+	// workdir. Apply must refuse rather than read/write through the link.
+	victim := filepath.Join(dir, "victim.txt")
+	if err := os.WriteFile(victim, []byte("sensitive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, target); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	proj, err := BuildMCPProjection(MCPProviderClaude, dir, []MCPServer{
+		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	err = proj.Apply(fsys.OSFS{})
+	if err == nil {
+		t.Fatal("expected symlink rejection, got nil error")
+	}
+	if !strings.Contains(err.Error(), "symlinked path") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Victim file content must be untouched.
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("ReadFile(victim): %v", err)
+	}
+	if string(got) != "sensitive" {
+		t.Fatalf("victim mutated: %q", got)
 	}
 }
 

--- a/internal/materialize/mcp_resolve.go
+++ b/internal/materialize/mcp_resolve.go
@@ -1,0 +1,110 @@
+package materialize
+
+import (
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// MCPPackSourcesForAgent returns the effective MCP directory stack for one
+// agent, ordered from lowest to highest precedence. Later sources win.
+//
+// Unlike the v0.15.1 skills materializer, MCP intentionally includes imported
+// shared pack layers because shared imported-pack mcp/ is part of the issue
+// #670 contract. Repeated pack directories are collapsed to their
+// highest-precedence occurrence so a shared dependency only participates once in
+// the final stack.
+func MCPPackSourcesForAgent(cfg *config.City, agent *config.Agent) []MCPDirSource {
+	if cfg == nil || agent == nil {
+		return nil
+	}
+	sources := make([]MCPDirSource, 0, 16)
+	for _, dir := range cfg.BootstrapImportPackDirs {
+		sources = append(sources, MCPDirSource{
+			Dir:    filepath.Join(dir, "mcp"),
+			Label:  "bootstrap",
+			Origin: mcpOrigin("bootstrap", cfg.BootstrapImportMCPBindings[dir]),
+		})
+	}
+	for _, dir := range cfg.ImplicitImportPackDirs {
+		sources = append(sources, MCPDirSource{
+			Dir:    filepath.Join(dir, "mcp"),
+			Label:  "implicit",
+			Origin: mcpOrigin("implicit", cfg.ImplicitImportMCPBindings[dir]),
+		})
+	}
+	for _, dir := range cfg.ExplicitImportPackDirs {
+		sources = append(sources, MCPDirSource{
+			Dir:    filepath.Join(dir, "mcp"),
+			Label:  "import",
+			Origin: mcpOrigin("import", cfg.ExplicitImportMCPBindings[dir]),
+		})
+	}
+	for _, dir := range cfg.PackGraphOnlyDirs {
+		sources = append(sources, MCPDirSource{
+			Dir:    filepath.Join(dir, "mcp"),
+			Label:  "city",
+			Origin: "city",
+		})
+	}
+	if cfg.PackMCPDir != "" {
+		sources = append(sources, MCPDirSource{Dir: cfg.PackMCPDir, Label: "city", Origin: "city"})
+	}
+	if agent.Dir != "" {
+		for _, dir := range cfg.RigImportPackDirs[agent.Dir] {
+			origin := "rig-import"
+			if cfg.RigImportMCPBindings != nil {
+				origin = mcpOrigin("rig-import", cfg.RigImportMCPBindings[agent.Dir][dir])
+			}
+			sources = append(sources, MCPDirSource{
+				Dir:    filepath.Join(dir, "mcp"),
+				Label:  "rig-import",
+				Origin: origin,
+			})
+		}
+		for _, dir := range cfg.RigPackGraphOnlyDirs[agent.Dir] {
+			sources = append(sources, MCPDirSource{
+				Dir:    filepath.Join(dir, "mcp"),
+				Label:  "rig",
+				Origin: "rig",
+			})
+		}
+	}
+	if agent.MCPDir != "" {
+		sources = append(sources, MCPDirSource{Dir: agent.MCPDir, Label: "agent", Origin: "agent"})
+	}
+	return dedupeMCPSources(sources)
+}
+
+// EffectiveMCPForAgent loads, expands, and resolves the effective MCP catalog
+// for one agent from the composed config.
+func EffectiveMCPForAgent(cfg *config.City, agent *config.Agent, templateData map[string]string) (MCPCatalog, error) {
+	return MergeMCPDirs(MCPPackSourcesForAgent(cfg, agent), templateData)
+}
+
+func dedupeMCPSources(sources []MCPDirSource) []MCPDirSource {
+	if len(sources) < 2 {
+		return sources
+	}
+	seen := make(map[string]bool, len(sources))
+	deduped := make([]MCPDirSource, 0, len(sources))
+	for i := len(sources) - 1; i >= 0; i-- {
+		key := filepath.Clean(sources[i].Dir)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deduped = append(deduped, sources[i])
+	}
+	for i, j := 0, len(deduped)-1; i < j; i, j = i+1, j-1 {
+		deduped[i], deduped[j] = deduped[j], deduped[i]
+	}
+	return deduped
+}
+
+func mcpOrigin(layer, binding string) string {
+	if binding == "" {
+		return layer
+	}
+	return layer + ":" + binding
+}

--- a/internal/materialize/mcp_test.go
+++ b/internal/materialize/mcp_test.go
@@ -1,0 +1,773 @@
+package materialize
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestMCPIdentityForFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		want     string
+		wantOkay bool
+	}{
+		{name: "foo.toml", want: "foo", wantOkay: true},
+		{name: "foo.template.toml", want: "foo", wantOkay: true},
+		{name: "foo.md", wantOkay: false},
+	}
+	for _, tt := range tests {
+		got, ok := MCPIdentityForFilename(tt.name)
+		if ok != tt.wantOkay || got != tt.want {
+			t.Fatalf("%q => (%q, %v), want (%q, %v)", tt.name, got, ok, tt.want, tt.wantOkay)
+		}
+	}
+}
+
+func TestLoadMCPDirParsesAndNormalizes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tool.template.toml"), []byte(`
+name = "tool"
+description = "desc"
+command = "./scripts/run.sh"
+args = ["--city", "{{.CityRoot}}"]
+[env]
+TOKEN = "{{.Token}}"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	servers, err := LoadMCPDir(dir, "city", map[string]string{
+		"CityRoot": "/tmp/city",
+		"Token":    "abc",
+	})
+	if err != nil {
+		t.Fatalf("LoadMCPDir: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("len(servers)=%d, want 1", len(servers))
+	}
+	server := servers[0]
+	if server.Transport != MCPTransportStdio {
+		t.Fatalf("Transport=%q, want %q", server.Transport, MCPTransportStdio)
+	}
+	if server.Command != filepath.Join(dir, "scripts", "run.sh") {
+		t.Fatalf("Command=%q, want %q", server.Command, filepath.Join(dir, "scripts", "run.sh"))
+	}
+	if server.Args[1] != "/tmp/city" {
+		t.Fatalf("Args=%v, expected template expansion", server.Args)
+	}
+	if got := server.Env["TOKEN"]; got != "abc" {
+		t.Fatalf("Env[TOKEN]=%q, want abc", got)
+	}
+}
+
+func TestLoadMCPDirRejectsDuplicateLogicalNames(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.toml"), `name = "foo"`+"\ncommand = \"uvx\"\n")
+	mustWriteFile(t, filepath.Join(dir, "foo.template.toml"), `name = "foo"`+"\ncommand = \"uvx\"\n")
+
+	_, err := LoadMCPDir(dir, "city", nil)
+	if err == nil || !strings.Contains(err.Error(), `duplicate logical server "foo"`) {
+		t.Fatalf("LoadMCPDir error=%v, want duplicate logical name", err)
+	}
+}
+
+func TestLoadMCPDirWrapsReadDirErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "not-a-dir")
+	mustWriteFile(t, file, "x")
+
+	_, err := LoadMCPDir(file, "city", nil)
+	if err == nil || !strings.Contains(err.Error(), "reading mcp dir") {
+		t.Fatalf("LoadMCPDir error=%v, want wrapped directory read error", err)
+	}
+}
+
+func TestLoadMCPDirValidatesNameAndTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		body     string
+		wantErr  string
+	}{
+		{
+			filename: "foo.toml",
+			body:     "name = \"bar\"\ncommand = \"uvx\"\n",
+			wantErr:  `must match filename stem`,
+		},
+		{
+			filename: "foo.toml",
+			body:     "name = \"foo\"\ncommand = \"uvx\"\nurl = \"https://example.com\"\n",
+			wantErr:  `mutually exclusive`,
+		},
+		{
+			filename: "foo.toml",
+			body:     "name = \"foo\"\nurl = \"https://example.com\"\nargs = [\"x\"]\n",
+			wantErr:  `http server may not set args or env`,
+		},
+		{
+			filename: "bad_name.toml",
+			body:     "name = \"bad_name\"\ncommand = \"uvx\"\n",
+			wantErr:  `invalid server name`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantErr, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWriteFile(t, filepath.Join(dir, tt.filename), tt.body)
+			_, err := LoadMCPDir(dir, "city", nil)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadMCPDir error=%v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMergeMCPDirsLaterWins(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	override := t.TempDir()
+	mustWriteFile(t, filepath.Join(base, "foo.toml"), "name = \"foo\"\ncommand = \"uvx\"\n")
+	mustWriteFile(t, filepath.Join(override, "foo.toml"), "name = \"foo\"\nurl = \"https://example.com\"\n")
+	mustWriteFile(t, filepath.Join(override, "bar.toml"), "name = \"bar\"\ncommand = \"node\"\n")
+
+	cat, err := MergeMCPDirs([]MCPDirSource{
+		{Dir: base, Label: "base"},
+		{Dir: override, Label: "override"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("MergeMCPDirs: %v", err)
+	}
+	if len(cat.Servers) != 2 {
+		t.Fatalf("len(Servers)=%d, want 2", len(cat.Servers))
+	}
+	if got := cat.ByName["foo"].Layer; got != "override" {
+		t.Fatalf("foo.Layer=%q, want override", got)
+	}
+	if len(cat.Shadows) != 1 || cat.Shadows[0].Winner != "override" || cat.Shadows[0].Loser != "base" {
+		t.Fatalf("Shadows=%v, want override shadow", cat.Shadows)
+	}
+}
+
+func TestNormalizeMCPServerStableMapOrder(t *testing.T) {
+	t.Parallel()
+
+	server := MCPServer{
+		Name:      "foo",
+		Transport: MCPTransportStdio,
+		Command:   "uvx",
+		Args:      []string{"b", "a"},
+		Env: map[string]string{
+			"Z": "2",
+			"A": "1",
+		},
+		Headers: map[string]string{
+			"Y": "2",
+			"X": "1",
+		},
+	}
+	got := NormalizeMCPServer(server)
+	want := NormalizedMCPServer{
+		Name:      "foo",
+		Transport: MCPTransportStdio,
+		Command:   "uvx",
+		Args:      []string{"b", "a"},
+		Env:       []MCPKV{{Key: "A", Value: "1"}, {Key: "Z", Value: "2"}},
+		Headers:   []MCPKV{{Key: "X", Value: "1"}, {Key: "Y", Value: "2"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeMCPServer()=%#v, want %#v", got, want)
+	}
+}
+
+func TestMCPPackSourcesForAgentOrdersAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.City{
+		BootstrapImportPackDirs: []string{"/packs/bootstrap", "/packs/shared"},
+		ImplicitImportPackDirs:  []string{"/packs/implicit"},
+		ExplicitImportPackDirs:  []string{"/packs/shared", "/packs/import"},
+		PackGraphOnlyDirs:       []string{"/packs/city"},
+		PackMCPDir:              "/packs/city/mcp",
+		RigImportPackDirs: map[string][]string{
+			"rig": {"/packs/shared", "/packs/rig-import"},
+		},
+		RigPackGraphOnlyDirs: map[string][]string{
+			"rig": {"/packs/rig"},
+		},
+	}
+	agent := &config.Agent{
+		Dir:    "rig",
+		MCPDir: "/packs/agent/mcp",
+	}
+
+	got := MCPPackSourcesForAgent(cfg, agent)
+	want := []MCPDirSource{
+		{Dir: "/packs/bootstrap/mcp", Label: "bootstrap", Origin: "bootstrap"},
+		{Dir: "/packs/implicit/mcp", Label: "implicit", Origin: "implicit"},
+		{Dir: "/packs/import/mcp", Label: "import", Origin: "import"},
+		{Dir: "/packs/city/mcp", Label: "city", Origin: "city"},
+		{Dir: "/packs/shared/mcp", Label: "rig-import", Origin: "rig-import"},
+		{Dir: "/packs/rig-import/mcp", Label: "rig-import", Origin: "rig-import"},
+		{Dir: "/packs/rig/mcp", Label: "rig", Origin: "rig"},
+		{Dir: "/packs/agent/mcp", Label: "agent", Origin: "agent"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MCPPackSourcesForAgent()=%#v, want %#v", got, want)
+	}
+}
+
+func TestEffectiveMCPForAgent_ExplicitImportBeatsShadowedImplicit(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	implicitCacheDir := config.GlobalRepoCachePath(gcHome, "github.com/someone/custom-pack", "zzzz999")
+	if err := os.MkdirAll(filepath.Join(implicitCacheDir, "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(implicitCacheDir, "pack.toml"), `
+[pack]
+name = "custom-pack"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(implicitCacheDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(gcHome, "implicit-import.toml"), `
+schema = 1
+
+[imports.custom]
+source = "github.com/someone/custom-pack"
+version = "1.0.0"
+commit = "zzzz999"
+`)
+
+	cityDir := t.TempDir()
+	explicitDir := filepath.Join(cityDir, "packs", "explicit-custom")
+	if err := os.MkdirAll(filepath.Join(explicitDir, "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(explicitDir, "pack.toml"), `
+[pack]
+name = "explicit-custom"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(explicitDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "node"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[imports.custom]
+source = "./packs/explicit-custom"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if cfg.ImplicitImportBindings["custom"] {
+		t.Fatalf("ImplicitImportBindings[custom]=true, want false for shadowed explicit import")
+	}
+
+	var mayor *config.Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "mayor" && cfg.Agents[i].BindingName == "" {
+			mayor = &cfg.Agents[i]
+			break
+		}
+	}
+	if mayor == nil {
+		t.Fatal("missing mayor agent")
+	}
+
+	catalog, err := EffectiveMCPForAgent(cfg, mayor, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["shared"]
+	if !ok {
+		t.Fatalf("missing shared server in %#v", catalog.ByName)
+	}
+	if server.Layer != "import" {
+		t.Fatalf("shared.Layer=%q, want import", server.Layer)
+	}
+	if server.Command != "node" {
+		t.Fatalf("shared.Command=%q, want node", server.Command)
+	}
+}
+
+func TestEffectiveMCPForAgent_BootstrapLayerIncluded(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	coreCacheDir := config.GlobalRepoCachePath(gcHome, "github.com/gastownhall/gc-core", "deadbeef")
+	mustWriteFile(t, filepath.Join(coreCacheDir, "pack.toml"), `
+[pack]
+name = "core"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(coreCacheDir, "mcp", "bootstrap.toml"), `
+name = "bootstrap"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(gcHome, "implicit-import.toml"), `
+schema = 1
+
+[imports.core]
+source = "github.com/gastownhall/gc-core"
+version = "0.1.0"
+commit = "deadbeef"
+`)
+
+	cityDir := t.TempDir()
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if !cfg.BootstrapImportBindings["core"] {
+		t.Fatalf("BootstrapImportBindings[core]=false, want true")
+	}
+
+	mayor := mustFindAgent(t, cfg, "mayor")
+	catalog, err := EffectiveMCPForAgent(cfg, mayor, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["bootstrap"]
+	if !ok {
+		t.Fatalf("missing bootstrap server in %#v", catalog.ByName)
+	}
+	if server.Layer != "bootstrap" {
+		t.Fatalf("bootstrap.Layer=%q, want bootstrap", server.Layer)
+	}
+}
+
+func TestEffectiveMCPForAgent_CityGraphBeatsExplicitImport(t *testing.T) {
+	cityDir := t.TempDir()
+	baseDir := filepath.Join(cityDir, "packs", "base")
+	importDir := filepath.Join(cityDir, "packs", "extra")
+	mustWriteFile(t, filepath.Join(baseDir, "pack.toml"), `
+[pack]
+name = "base"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(baseDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(importDir, "pack.toml"), `
+[pack]
+name = "extra"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(importDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "node"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+includes = ["packs/base"]
+
+[imports.extra]
+source = "./packs/extra"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	mayor := mustFindAgent(t, cfg, "mayor")
+	catalog, err := EffectiveMCPForAgent(cfg, mayor, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["shared"]
+	if !ok {
+		t.Fatalf("missing shared server in %#v", catalog.ByName)
+	}
+	if server.Layer != "city" {
+		t.Fatalf("shared.Layer=%q, want city", server.Layer)
+	}
+	if server.Command != "uvx" {
+		t.Fatalf("shared.Command=%q, want uvx", server.Command)
+	}
+}
+
+func TestEffectiveMCPForAgent_ExplicitImportBindingOrderFirstWins(t *testing.T) {
+	cityDir := t.TempDir()
+	alphaDir := filepath.Join(cityDir, "packs", "alpha")
+	betaDir := filepath.Join(cityDir, "packs", "beta")
+	mustWriteFile(t, filepath.Join(alphaDir, "pack.toml"), `
+[pack]
+name = "alpha"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(alphaDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "alpha"
+`)
+	mustWriteFile(t, filepath.Join(betaDir, "pack.toml"), `
+[pack]
+name = "beta"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(betaDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "beta"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[imports.alpha]
+source = "./packs/alpha"
+
+[imports.beta]
+source = "./packs/beta"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	mayor := mustFindAgent(t, cfg, "mayor")
+	catalog, err := EffectiveMCPForAgent(cfg, mayor, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["shared"]
+	if !ok {
+		t.Fatalf("missing shared server in %#v", catalog.ByName)
+	}
+	if server.Command != "alpha" {
+		t.Fatalf("shared.Command=%q, want alpha", server.Command)
+	}
+	if server.Origin != "import:alpha" {
+		t.Fatalf("shared.Origin=%q, want import:alpha", server.Origin)
+	}
+}
+
+func TestEffectiveMCPForAgent_ExplicitImportBindingOrderFirstWinsAcrossSharedDependency(t *testing.T) {
+	cityDir := t.TempDir()
+	alphaDir := filepath.Join(cityDir, "packs", "alpha")
+	betaDir := filepath.Join(cityDir, "packs", "beta")
+	sharedDir := filepath.Join(cityDir, "packs", "shared")
+	mustWriteFile(t, filepath.Join(alphaDir, "pack.toml"), `
+[pack]
+name = "alpha"
+schema = 1
+
+[imports.shared]
+source = "../shared"
+`)
+	mustWriteFile(t, filepath.Join(betaDir, "pack.toml"), `
+[pack]
+name = "beta"
+schema = 1
+
+[imports.shared]
+source = "../shared"
+`)
+	mustWriteFile(t, filepath.Join(betaDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "beta"
+`)
+	mustWriteFile(t, filepath.Join(sharedDir, "pack.toml"), `
+[pack]
+name = "shared"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(sharedDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[imports.alpha]
+source = "./packs/alpha"
+
+[imports.beta]
+source = "./packs/beta"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	mayor := mustFindAgent(t, cfg, "mayor")
+	catalog, err := EffectiveMCPForAgent(cfg, mayor, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["shared"]
+	if !ok {
+		t.Fatalf("missing shared server in %#v", catalog.ByName)
+	}
+	if server.Command != "uvx" {
+		t.Fatalf("shared.Command=%q, want uvx from alpha's shared dependency", server.Command)
+	}
+	if server.Origin != "import:alpha" {
+		t.Fatalf("shared.Origin=%q, want import:alpha", server.Origin)
+	}
+}
+
+func TestEffectiveMCPForAgent_TransitiveFalseHidesNestedImportMCP(t *testing.T) {
+	cityDir := t.TempDir()
+	toolboxDir := filepath.Join(cityDir, "packs", "toolbox")
+	utilDir := filepath.Join(cityDir, "packs", "util")
+	mustWriteFile(t, filepath.Join(toolboxDir, "pack.toml"), `
+[pack]
+name = "toolbox"
+schema = 1
+
+[imports.util]
+source = "../util"
+`)
+	mustWriteFile(t, filepath.Join(toolboxDir, "mcp", "direct.toml"), `
+name = "direct"
+command = "node"
+`)
+	mustWriteFile(t, filepath.Join(utilDir, "pack.toml"), `
+[pack]
+name = "util"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(utilDir, "mcp", "nested.toml"), `
+name = "nested"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[imports.toolbox]
+source = "./packs/toolbox"
+transitive = false
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	mayor := mustFindAgent(t, cfg, "mayor")
+	catalog, err := EffectiveMCPForAgent(cfg, mayor, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	if _, ok := catalog.ByName["direct"]; !ok {
+		t.Fatalf("missing direct server in %#v", catalog.ByName)
+	}
+	if _, ok := catalog.ByName["nested"]; ok {
+		t.Fatalf("nested server should be hidden by transitive=false: %#v", catalog.ByName)
+	}
+}
+
+func TestEffectiveMCPForAgent_RigGraphBeatsRigImport(t *testing.T) {
+	cityDir := t.TempDir()
+	baseDir := filepath.Join(cityDir, "packs", "rig-base")
+	importDir := filepath.Join(cityDir, "packs", "rig-helper")
+	mustWriteFile(t, filepath.Join(baseDir, "pack.toml"), `
+[pack]
+name = "rig-base"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(baseDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(importDir, "pack.toml"), `
+[pack]
+name = "rig-helper"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(importDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "node"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+includes = ["packs/rig-base"]
+
+[rigs.imports.helper]
+source = "./packs/rig-helper"
+
+[[agent]]
+name = "witness"
+scope = "rig"
+dir = "proj"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	witness := mustFindAgent(t, cfg, "proj/witness")
+	catalog, err := EffectiveMCPForAgent(cfg, witness, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["shared"]
+	if !ok {
+		t.Fatalf("missing shared server in %#v", catalog.ByName)
+	}
+	if server.Layer != "rig" {
+		t.Fatalf("shared.Layer=%q, want rig", server.Layer)
+	}
+	if server.Command != "uvx" {
+		t.Fatalf("shared.Command=%q, want uvx", server.Command)
+	}
+}
+
+func TestEffectiveMCPForAgent_RigGraphNestedImportBeatsRigImport(t *testing.T) {
+	cityDir := t.TempDir()
+	baseDir := filepath.Join(cityDir, "packs", "rig-base")
+	nestedDir := filepath.Join(cityDir, "packs", "rig-nested")
+	importDir := filepath.Join(cityDir, "packs", "rig-helper")
+	mustWriteFile(t, filepath.Join(baseDir, "pack.toml"), `
+[pack]
+name = "rig-base"
+schema = 1
+
+[imports.nested]
+source = "../rig-nested"
+`)
+	mustWriteFile(t, filepath.Join(nestedDir, "pack.toml"), `
+[pack]
+name = "rig-nested"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(nestedDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "uvx"
+`)
+	mustWriteFile(t, filepath.Join(importDir, "pack.toml"), `
+[pack]
+name = "rig-helper"
+schema = 1
+`)
+	mustWriteFile(t, filepath.Join(importDir, "mcp", "shared.toml"), `
+name = "shared"
+command = "node"
+`)
+	mustWriteFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+includes = ["packs/rig-base"]
+
+[rigs.imports.helper]
+source = "./packs/rig-helper"
+
+[[agent]]
+name = "witness"
+scope = "rig"
+dir = "proj"
+`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	witness := mustFindAgent(t, cfg, "proj/witness")
+	catalog, err := EffectiveMCPForAgent(cfg, witness, nil)
+	if err != nil {
+		t.Fatalf("EffectiveMCPForAgent: %v", err)
+	}
+	server, ok := catalog.ByName["shared"]
+	if !ok {
+		t.Fatalf("missing shared server in %#v", catalog.ByName)
+	}
+	if server.Layer != "rig" {
+		t.Fatalf("shared.Layer=%q, want rig", server.Layer)
+	}
+	if server.Command != "uvx" {
+		t.Fatalf("shared.Command=%q, want uvx", server.Command)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func mustFindAgent(t *testing.T, cfg *config.City, qualifiedName string) *config.Agent {
+	t.Helper()
+	for i := range cfg.Agents {
+		if cfg.Agents[i].QualifiedName() == qualifiedName {
+			return &cfg.Agents[i]
+		}
+	}
+	t.Fatalf("missing agent %q in %#v", qualifiedName, cfg.Agents)
+	return nil
+}


### PR DESCRIPTION
## Summary

- implement provider-native MCP projection for Claude, Codex, and Gemini
- resolve effective MCP catalogs across city, rig, import, implicit-import, bootstrap, and agent-local layers
- add workdir-scoped stage-1 and stage-2 reconciliation, projected-only `gc mcp list`, MCP doctor checks, restart fingerprints, and provider-native config cleanup/ownership rules
- update Pack V2 and CLI docs for the active projection contract

Closes #670.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- Focused Go tests:
  - `go test ./internal/materialize ./internal/config ./cmd/gc -run 'Test(Mcp|MCP|RunStage1MCPProjection|BuildStage1MCPTargets|ResolveTemplateMCPIntegration|InternalProjectMCP|ApplyMCPProjection)' -count=1`

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

## Notes

- GC only removes projected provider MCP targets after it has adopted ownership for that target.
- Projected MCP runtime files are written `0600` and added to local `.gitignore` best-effort.
