### PR TITLE
fix(supervisor): add --wait to supervisor stop; use in integration cleanup

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -77,18 +77,29 @@ This forks "gc supervisor run", verifies it became ready, and returns.`,
 }
 
 func newSupervisorStopCmd(stdout, stderr io.Writer) *cobra.Command {
+	var wait bool
+	var waitTimeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop the machine-wide supervisor",
-		Long:  `Stop the running machine-wide supervisor and all its cities.`,
-		Args:  cobra.NoArgs,
+		Long: `Stop the running machine-wide supervisor and all its cities.
+
+By default, returns as soon as the supervisor acknowledges the stop
+request — shutdown continues asynchronously. Pass --wait to block
+until the supervisor socket is no longer answering, which is what
+most callers that need deterministic cleanup want (e.g., integration
+tests that then expect to remove temp directories without racing
+against lingering supervisor / controller subprocesses).`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if stopSupervisor(stdout, stderr) != 0 {
+			if stopSupervisorWithWait(stdout, stderr, wait, waitTimeout) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the supervisor process to actually exit before returning")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Second, "Maximum time to wait when --wait is set")
 	return cmd
 }
 
@@ -266,10 +277,23 @@ func supervisorAliveAtPath(sockPath string) int {
 	return pid
 }
 
-// stopSupervisor sends a stop command to the running supervisor.
-// It also unloads the platform service (without removing the unit file)
-// so launchd/systemd doesn't immediately restart the supervisor.
+// stopSupervisor sends a stop command to the running supervisor and returns
+// as soon as the supervisor acknowledges. Shutdown continues asynchronously.
+// Callers that need to block until the supervisor process has actually
+// exited should use stopSupervisorWithWait(stdout, stderr, true, timeout).
 func stopSupervisor(stdout, stderr io.Writer) int {
+	return stopSupervisorWithWait(stdout, stderr, false, 0)
+}
+
+// stopSupervisorWithWait is stopSupervisor with an optional wait-for-exit
+// phase. When wait is true, after the supervisor ACKs the stop command the
+// function polls the supervisor socket until it stops answering (or until
+// waitTimeout elapses). This is the shape tests and shell scripts want when
+// they need deterministic cleanup: on return, the supervisor is gone.
+//
+// It also unloads the platform service (without removing the unit file) so
+// launchd/systemd doesn't immediately restart the supervisor.
+func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration) int {
 	// Unload the platform service first so the service manager doesn't
 	// restart the supervisor after we send the stop command.
 	unloadSupervisorService()
@@ -289,12 +313,38 @@ func stopSupervisor(stdout, stderr io.Writer) int {
 	conn.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
 	buf := make([]byte, 64)
 	n, _ := conn.Read(buf)
-	if n > 0 && string(buf[:n]) == "ok\n" {
-		fmt.Fprintln(stdout, "Supervisor stopping...") //nolint:errcheck
+	if n == 0 || string(buf[:n]) != "ok\n" {
+		fmt.Fprintln(stderr, "gc supervisor stop: no acknowledgment from supervisor") //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintln(stdout, "Supervisor stopping...") //nolint:errcheck
+	if !wait {
 		return 0
 	}
-	fmt.Fprintln(stderr, "gc supervisor stop: no acknowledgment from supervisor") //nolint:errcheck
-	return 1
+	if waitTimeout <= 0 {
+		waitTimeout = 30 * time.Second
+	}
+	if err := waitForSupervisorExit(sockPath, waitTimeout); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
+	return 0
+}
+
+// waitForSupervisorExit polls the supervisor socket until it stops answering
+// (i.e., supervisorAliveAtPath returns 0), or until timeout elapses.
+func waitForSupervisorExit(sockPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if supervisorAliveAtPath(sockPath) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for supervisor at %s to exit", timeout, sockPath)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 // supervisorStatus checks and reports whether the supervisor is running.

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -907,3 +907,147 @@ func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 		t.Fatalf("unexpected bead provider op: %v", ops)
 	}
 }
+
+// TestStopSupervisorWithWaitBlocksUntilSocketStops exercises the --wait
+// path of `gc supervisor stop`. The fake socket answers "ping" with a PID
+// (so supervisorAliveAtPath keeps returning alive) for ~200ms after the
+// "stop" request, then closes the listener. stopSupervisorWithWait must
+// block across that window and return success.
+func TestStopSupervisorWithWaitBlocksUntilSocketStops(t *testing.T) {
+	gcHome := shortTempDir(t, "gc-home-")
+	runtimeDir := shortTempDir(t, "gc-run-")
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	sockPath := filepath.Join(gcHome, "supervisor.sock")
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	})
+
+	stopDelay := 200 * time.Millisecond
+	go func() {
+		stopRequested := false
+		var stopAt time.Time
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close() //nolint:errcheck
+				buf := make([]byte, 64)
+				n, err := conn.Read(buf)
+				if err != nil || n == 0 {
+					return
+				}
+				cmd := strings.TrimSpace(string(buf[:n]))
+				switch cmd {
+				case "ping":
+					if stopRequested && time.Now().After(stopAt) {
+						// Stop answering ping so the waiter sees us as gone.
+						return
+					}
+					io.WriteString(conn, "4242\n") //nolint:errcheck
+				case "stop":
+					stopRequested = true
+					stopAt = time.Now().Add(stopDelay)
+					io.WriteString(conn, "ok\n") //nolint:errcheck
+				}
+			}(conn)
+		}
+	}()
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	code := stopSupervisorWithWait(&stdout, &stderr, true, 5*time.Second)
+	elapsed := time.Since(start)
+
+	if code != 0 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if elapsed < stopDelay {
+		t.Fatalf("returned after %s, expected at least %s (must have waited for socket to stop answering)", elapsed, stopDelay)
+	}
+	if !strings.Contains(stdout.String(), "Supervisor stopped.") {
+		t.Fatalf("stdout = %q, want final confirmation message", stdout.String())
+	}
+}
+
+// TestStopSupervisorWithoutWaitReturnsAfterAck confirms the default
+// (non-wait) path returns as soon as the supervisor ACKs the stop. The
+// fake socket keeps answering "ping" indefinitely; without --wait,
+// stopSupervisor must not block on the ping result.
+func TestStopSupervisorWithoutWaitReturnsAfterAck(t *testing.T) {
+	gcHome := shortTempDir(t, "gc-home-")
+	runtimeDir := shortTempDir(t, "gc-run-")
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	sockPath := filepath.Join(gcHome, "supervisor.sock")
+	startTestSupervisorSocket(t, sockPath, func(cmd string) string {
+		switch cmd {
+		case "ping":
+			return "4242\n"
+		case "stop":
+			return "ok\n"
+		}
+		return ""
+	})
+
+	start := time.Now()
+	var stdout, stderr bytes.Buffer
+	code := stopSupervisor(&stdout, &stderr)
+	elapsed := time.Since(start)
+
+	if code != 0 {
+		t.Fatalf("stopSupervisor code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("returned after %s, expected fast return (no wait) — waited anyway?", elapsed)
+	}
+	if !strings.Contains(stdout.String(), "Supervisor stopping...") {
+		t.Fatalf("stdout = %q, want 'Supervisor stopping...' message", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Supervisor stopped.") {
+		t.Fatalf("stdout unexpectedly contains 'Supervisor stopped.' — wait flag was false")
+	}
+}
+
+// TestStopSupervisorWithWaitTimesOutWhenSocketKeepsAnswering guards the
+// wait-timeout path. The fake socket keeps answering ping forever; --wait
+// with a tiny timeout must return non-zero and mention the timeout.
+func TestStopSupervisorWithWaitTimesOutWhenSocketKeepsAnswering(t *testing.T) {
+	gcHome := shortTempDir(t, "gc-home-")
+	runtimeDir := shortTempDir(t, "gc-run-")
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	sockPath := filepath.Join(gcHome, "supervisor.sock")
+	startTestSupervisorSocket(t, sockPath, func(cmd string) string {
+		switch cmd {
+		case "ping":
+			return "4242\n"
+		case "stop":
+			return "ok\n"
+		}
+		return ""
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := stopSupervisorWithWait(&stdout, &stderr, true, 300*time.Millisecond)
+
+	if code != 1 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 1 (timeout)", code)
+	}
+	if !strings.Contains(stderr.String(), "timed out") {
+		t.Fatalf("stderr = %q, want timeout message", stderr.String())
+	}
+}

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -287,8 +287,15 @@ func setupE2ECity(t *testing.T, guard *tmuxtest.Guard, city e2eCity) string {
 
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		if out, err := runGCWithEnv(env, "", "stop", cityDir); err != nil {
+			t.Logf("cleanup: gc stop %s: %v\n%s", cityDir, err, out)
+		}
+		// --wait blocks until the supervisor socket stops answering so
+		// cleanupTestCityDir and t.TempDir() don't race against lingering
+		// supervisor/controller subprocesses.
+		if out, err := runGCWithEnv(env, "", "supervisor", "stop", "--wait"); err != nil {
+			t.Logf("cleanup: gc supervisor stop --wait: %v\n%s", err, out)
+		}
 		cleanupTestCityDir(cityDir)
 	})
 
@@ -329,8 +336,15 @@ func setupE2ECityNoStart(t *testing.T, city e2eCity) string {
 
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		if out, err := runGCWithEnv(env, "", "stop", cityDir); err != nil {
+			t.Logf("cleanup: gc stop %s: %v\n%s", cityDir, err, out)
+		}
+		// --wait blocks until the supervisor socket stops answering so
+		// cleanupTestCityDir and t.TempDir() don't race against lingering
+		// supervisor/controller subprocesses.
+		if out, err := runGCWithEnv(env, "", "supervisor", "stop", "--wait"); err != nil {
+			t.Logf("cleanup: gc supervisor stop --wait: %v\n%s", err, out)
+		}
 		cleanupTestCityDir(cityDir)
 	})
 

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -62,8 +62,17 @@ func setupGasTownCity(t *testing.T, guard *tmuxtest.Guard, agents []gasTownAgent
 
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		if out, err := runGCWithEnv(env, "", "stop", cityDir); err != nil {
+			t.Logf("cleanup: gc stop %s: %v\n%s", cityDir, err, out)
+		}
+		// Pass --wait so the supervisor (and its controller children)
+		// is confirmed gone before t.TempDir() tries to rmdir the city.
+		// Without this, the supervisor's async shutdown races against
+		// tempdir cleanup and produces "unlinkat: directory not empty"
+		// flakes tied to orphan gc subprocesses.
+		if out, err := runGCWithEnv(env, "", "supervisor", "stop", "--wait"); err != nil {
+			t.Logf("cleanup: gc supervisor stop --wait: %v\n%s", err, out)
+		}
 	})
 
 	time.Sleep(200 * time.Millisecond)

--- a/test/integration/gastown_reconciler_test.go
+++ b/test/integration/gastown_reconciler_test.go
@@ -118,8 +118,14 @@ func setupReconcilerCity(t *testing.T, agentBlocks string) string {
 
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		if out, err := runGCWithEnv(env, "", "stop", cityDir); err != nil {
+			t.Logf("cleanup: gc stop %s: %v\n%s", cityDir, err, out)
+		}
+		// --wait so the supervisor and its controller subprocesses are
+		// confirmed exited before t.TempDir() / fixRootOwnedFiles run.
+		if out, err := runGCWithEnv(env, "", "supervisor", "stop", "--wait"); err != nil {
+			t.Logf("cleanup: gc supervisor stop --wait: %v\n%s", err, out)
+		}
 		fixRootOwnedFiles(cityDir)
 	})
 


### PR DESCRIPTION
## Summary

Follow-up to #854 addressing a CI flake in the TempDir-cleanup / orphan-process family. Two runs of PR #854 both hit it on different tests (`TestGastown_ControllerStartStop`, then nothing in that family, then `TestGraphWorkflowFailureRunsCleanup` via a different mechanism), and the repo has a well-worn history of "stabilize flakes" commits targeting similar races.

## Root cause

`gc supervisor stop` sent `stop` over the supervisor socket and returned as soon as the supervisor ACKed — shutdown then continued asynchronously. Integration tests called `gc supervisor stop` best-effort in `t.Cleanup`, then `t.TempDir()` tried to `RemoveAll` the city directory and raced against still-shutting-down supervisor/controller subprocesses, producing:

```
--- FAIL: TestGastown_ControllerStartStop (66.11s)
    testing.go:1369: TempDir RemoveAll cleanup:
      unlinkat /tmp/.../gctest-.../.gc: directory not empty
Terminate orphan process: pid (7503) (gc)
Terminate orphan process: pid (113139) (gc)
```

The `//nolint:errcheck // best-effort cleanup` pattern also hid the failure reason.

## Changes

- **`gc supervisor stop`** now accepts `--wait` (with `--wait-timeout`, default 30s). When set, after the ACK, the command polls the supervisor socket via `supervisorAliveAtPath` until it stops answering, then prints `Supervisor stopped.`. Default behavior (no flag) is unchanged.
- **`stopSupervisorWithWait(stdout, stderr, wait, timeout)`** internal helper. `stopSupervisor` delegates to it with `wait=false` so existing callers keep their semantics.
- **`waitForSupervisorExit`** polls every 100ms until the socket stops answering or the deadline expires.
- **Integration test helpers** (`setupGasTownCity`, `setupE2EActiveCity/setupE2ECityNoStart`, `setupGasTownReconcilerCity`) now pass `--wait` to supervisor stop in their `t.Cleanup` funcs, and log cleanup errors via `t.Logf` instead of silently discarding them so future flakes show the specific failure in CI output.

## Tests

Three new unit tests in `cmd/gc/cmd_supervisor_test.go`:

- `TestStopSupervisorWithWaitBlocksUntilSocketStops` — fake socket answers `ping` for 200ms after `stop` ACK, then closes. `stopSupervisorWithWait(true, 5s)` must block across the window and return success.
- `TestStopSupervisorWithoutWaitReturnsAfterAck` — fake socket keeps answering `ping` indefinitely. Without `--wait`, `stopSupervisor` must return fast (< 2s) and not print the final "stopped" confirmation.
- `TestStopSupervisorWithWaitTimesOutWhenSocketKeepsAnswering` — socket never stops answering. `--wait` with 300ms timeout must return non-zero with a `timed out` error.

## Scope

This addresses the TempDir/orphan-process flake family. Other known integration flakes observed during PR #854 CI have different root causes and are not addressed here:

- `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries` — 13-minute Gemini retry test with timing sensitivity.
- `TestGraphWorkflowFailureRunsCleanup` — abort-propagation race where skipped steps still show up in the report.
- `TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep` — review-check script timestamp-ordering sensitivity; related to recent `8e329fbb fix: stabilize suspend resume and review check flakes`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 -run 'TestStopSupervisor|TestSupervisor|TestRunSupervisor|TestDoSupervisor' ./cmd/gc/...`
- [x] `go test -p 1 -run 'TestReconcile|TestSession|TestPool|TestSweep|TestGCSweep|TestRelease|TestCityRuntime|TestBuildDesiredState' ./cmd/gc/...`
- [x] `gofumpt -l` clean
- [x] `golangci-lint run` clean
- [ ] CI on the PR confirms the TempDir-cleanup flake pattern no longer reproduces
