### PR TITLE
fix: ignore GC_ALIAS in runtime fingerprint

### DIFF
--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -63,7 +63,6 @@ func LiveFingerprint(cfg Config) string {
 //	  GC_CITY / GC_CITY_PATH — city identity and location
 //	  GC_RIG*         — which rig the agent operates on
 //	  GC_TEMPLATE     — agent template identity
-//	  GC_ALIAS        — agent display identity
 //	  GC_DOLT_PORT    — how to reach dolt (ephemeral port)
 //	  GC_SKILLS_DIR   — skill discovery path
 //	  GC_BLESSED_BIN_DIR — trusted binary path
@@ -72,6 +71,7 @@ func LiveFingerprint(cfg Config) string {
 //	Excluded (runtime/transport, changes don't require restart):
 //	  GC_SESSION_*    — per-session identity
 //	  GC_AGENT        — pool instance name
+//	  GC_ALIAS        — public routing/display alias, synced live where possible
 //	  GC_INSTANCE_TOKEN — restart nonce
 //	  GC_*_EPOCH      — restart counters
 //	  GC_HOME/GC_DIR  — derived paths
@@ -91,7 +91,6 @@ var envFingerprintAllow = map[string]bool{
 
 	// Agent identity
 	"GC_TEMPLATE": true,
-	"GC_ALIAS":    true,
 
 	// Service connectivity — GC_DOLT_PORT intentionally excluded.
 	// The dolt port is ephemeral (changes on every supervisor restart)

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -117,6 +117,21 @@ func TestConfigFingerprintIgnoresGCDir(t *testing.T) {
 	}
 }
 
+func TestConfigFingerprintIgnoresGCAlias(t *testing.T) {
+	base := Config{Command: "claude", Env: map[string]string{
+		"GC_CITY":     "/gc",
+		"GC_TEMPLATE": "repo/coder",
+	}}
+	withAlias := Config{Command: "claude", Env: map[string]string{
+		"GC_CITY":     "/gc",
+		"GC_TEMPLATE": "repo/coder",
+		"GC_ALIAS":    "repo/coder-1",
+	}}
+	if ConfigFingerprint(base) != ConfigFingerprint(withAlias) {
+		t.Error("GC_ALIAS should not affect config fingerprint")
+	}
+}
+
 func TestConfigFingerprintIgnoresNonAllowedGCVars(t *testing.T) {
 	// GC_* vars not on the allow list should not affect the hash.
 	// This is the core invariant: new env vars are safe by default.


### PR DESCRIPTION
## Summary
- remove GC_ALIAS from the runtime config fingerprint allow list
- document GC_ALIAS as routing/display identity rather than behavioral startup config
- add a regression test proving GC_ALIAS changes do not alter the config fingerprint

## Root cause
GC_ALIAS can change as pooled or named sessions are materialized into concrete identities. Treating it as behavioral config made the core fingerprint drift and caused unnecessary config-drift restarts.

## Tests
- `go test ./internal/runtime ./cmd/gc -run 'TestConfigFingerprint|TestReconcileSessionBeads_ConfigDrift' -count=1`