### PR TITLE
test: lock root city-pack command regression

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -161,6 +161,10 @@ func TestPackV2ImportsScript(t *testing.T) {
 	testscript.Run(t, newTestscriptParams(t, filepath.Join("testdata", "pack-v2-imports.txtar")))
 }
 
+func TestRootPackCommandsScript(t *testing.T) {
+	testscript.Run(t, newTestscriptParams(t, filepath.Join("testdata", "root-pack-commands.txtar")))
+}
+
 func newTestscriptParams(t *testing.T, files ...string) testscript.Params {
 	params := testscript.Params{
 		Dir:         "testdata",

--- a/cmd/gc/testdata/root-pack-commands.txtar
+++ b/cmd/gc/testdata/root-pack-commands.txtar
@@ -1,0 +1,31 @@
+# Root city-pack commands are exposed through the root pack name.
+#
+# Tests:
+# - root city-pack commands surface under the root pack name
+# - the namespace help exposes the discovered command
+# - executing the command carries the root pack and city runtime context
+
+env GC_BEADS=file
+env GC_DOLT=skip
+env GC_SESSION=fake
+
+cd $WORK/city
+
+chmod 755 $WORK/city/commands/hello/run.sh
+
+exec gc backstage --help
+stdout 'hello'
+
+exec gc backstage hello alpha beta
+stdout 'root pack=backstage city=dogfood args=alpha beta'
+
+-- city/city.toml --
+[workspace]
+name = "dogfood"
+-- city/pack.toml --
+[pack]
+name = "backstage"
+schema = 2
+-- city/commands/hello/run.sh --
+#!/bin/sh
+echo "root pack=$GC_PACK_NAME city=$GC_CITY_NAME args=$*"


### PR DESCRIPTION
## Summary
- add a dedicated `testscript` case for root city-pack commands under the root pack name
- exercise the reported `gc backstage --help` and `gc backstage hello ...` CLI paths
- register the new regression script in the `cmd/gc` test suite

## Context
The `#604` behavior already reproduces correctly on current `main`; this PR locks that behavior down with direct CLI-level coverage so it cannot regress silently.

## Verification
- `go test ./cmd/gc -run 'TestRootPackCommandsScript|TestNewRootCmdExposesRootPackCommands' -v`
