### PR TITLE
fix: suspend scaffolded agents via agent.toml

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -473,15 +473,15 @@ func (cs *controllerState) DisableOrder(name, rig string) error {
 	})
 }
 
-// SuspendAgent writes suspended=true to city.toml (durable desired state).
-// Uses configedit.Editor for provenance-aware edit (inline vs patch).
+// SuspendAgent writes suspended=true to durable agent config.
+// Uses configedit.Editor for provenance-aware edit (inline vs discovered vs patch).
 func (cs *controllerState) SuspendAgent(name string) error {
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.SuspendAgent(name)
 	})
 }
 
-// ResumeAgent clears suspended in city.toml (durable desired state).
+// ResumeAgent clears suspended in durable agent config.
 func (cs *controllerState) ResumeAgent(name string) error {
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.ResumeAgent(name)

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/configedit"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/spf13/cobra"
 )
@@ -453,7 +454,7 @@ func newAgentSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "suspend <name>",
 		Short: "Suspend an agent (reconciler will skip it)",
-		Long: `Suspend an agent by setting suspended=true in city.toml.
+		Long: `Suspend an agent by setting suspended=true in its durable config.
 
 Suspended agents are skipped by the reconciler — their sessions are not
 started or restarted. Existing sessions continue running but won't be
@@ -495,69 +496,19 @@ func cmdAgentSuspend(args []string, stdout, stderr io.Writer) int {
 	return doAgentSuspend(fsys.OSFS{}, cityPath, args[0], stdout, stderr)
 }
 
-// doAgentSuspend sets suspended=true on the named agent in city.toml.
-// Uses raw config (no pack expansion) to preserve includes/patches on write-back.
-// If the agent isn't found in raw config but exists in expanded config, it's
-// pack-derived and the user gets a helpful error directing them to [[patches]].
+// doAgentSuspend sets suspended=true on the named agent's durable config.
+// Inline agents are edited in city.toml; city-local discovered agents update
+// agents/<name>/agent.toml. Pack-derived agents still require [[patches]].
 // Accepts an injected FS for testability.
 func doAgentSuspend(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer) int {
-	tomlPath := filepath.Join(cityPath, "city.toml")
-
-	// Phase 1: load raw config (no expansion) for safe write-back.
-	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-
-	// Try to find agent in raw config.
-	resolved, ok := resolveAgentIdentity(cfg, name, currentRigContext(cfg))
-	if ok {
-		// Found in raw config — toggle and write back.
-		resolvedQN := resolved.QualifiedName()
-		for i := range cfg.Agents {
-			if cfg.Agents[i].QualifiedName() == resolvedQN {
-				cfg.Agents[i].Suspended = true
-				break
-			}
-		}
-		if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
-			fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		fmt.Fprintf(stdout, "Suspended agent '%s'\n", name) //nolint:errcheck // best-effort stdout
-		return 0
-	}
-	if updated, err := updateRootPackAgentSuspended(fs, cityPath, cfg, name, true); err != nil {
-		fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	} else if updated {
-		fmt.Fprintf(stdout, "Suspended agent '%s'\n", name) //nolint:errcheck // best-effort stdout
-		return 0
-	}
-
-	// Phase 2: not in raw config — check expanded config for pack-derived agents.
-	expanded, err := loadCityConfigFS(fs, tomlPath)
-	if err != nil {
-		// Fall through to generic not-found using raw cfg.
-		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent suspend", name, cfg)) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if _, ok := resolveAgentIdentity(expanded, name, currentRigContext(expanded)); ok {
-		fmt.Fprintf(stderr, "gc agent suspend: agent %q is defined by a pack — use [[patches]] to override\n", name) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-
-	// Not found anywhere.
-	fmt.Fprintln(stderr, agentNotFoundMsg("gc agent suspend", name, expanded)) //nolint:errcheck // best-effort stderr
-	return 1
+	return doAgentSuspendOrResume(fs, cityPath, name, true, stdout, stderr)
 }
 
 func newAgentResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "resume <name>",
 		Short: "Resume a suspended agent",
-		Long: `Resume a suspended agent by clearing suspended in city.toml.
+		Long: `Resume a suspended agent by clearing suspended in its durable config.
 
 The reconciler will start the agent on its next tick. Supports bare
 names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
@@ -598,60 +549,92 @@ func cmdAgentResume(args []string, stdout, stderr io.Writer) int {
 	return doAgentResume(fsys.OSFS{}, cityPath, args[0], stdout, stderr)
 }
 
-// doAgentResume clears suspended on the named agent in city.toml.
-// Uses raw config (no pack expansion) to preserve includes/patches on write-back.
-// If the agent isn't found in raw config but exists in expanded config, it's
-// pack-derived and the user gets a helpful error directing them to [[patches]].
+// doAgentResume clears suspended on the named agent's durable config.
+// Inline agents are edited in city.toml; city-local discovered agents update
+// agents/<name>/agent.toml. Pack-derived agents still require [[patches]].
 // Accepts an injected FS for testability.
 func doAgentResume(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer) int {
+	return doAgentSuspendOrResume(fs, cityPath, name, false, stdout, stderr)
+}
+
+// doAgentSuspendOrResume is the shared CLI fallback for `gc agent suspend`
+// and `gc agent resume`. It mirrors [configedit.Editor.SuspendAgent] /
+// ResumeAgent for the no-API path:
+//
+//   - Inline city.toml [[agent]]: toggle Suspended, write city.toml.
+//   - Convention-discovered (agents/<name>/): write agent.toml, and
+//     strip any legacy [[patches.agent]] suspended override that would
+//     otherwise shadow the new value.
+//   - Pack-declared [[agent]] (city.toml or pack.toml): tell the user
+//     to use [[patches]].
+func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, stdout, stderr io.Writer) int {
+	verb, past := "suspend", "Suspended"
+	if !suspended {
+		verb, past = "resume", "Resumed"
+	}
 	tomlPath := filepath.Join(cityPath, "city.toml")
 
 	// Phase 1: load raw config (no expansion) for safe write-back.
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	// Try to find agent in raw config.
-	resolved, ok := resolveAgentIdentity(cfg, name, currentRigContext(cfg))
-	if ok {
-		// Found in raw config — toggle and write back.
+	if resolved, ok := resolveAgentIdentity(cfg, name, currentRigContext(cfg)); ok {
 		resolvedQN := resolved.QualifiedName()
 		for i := range cfg.Agents {
 			if cfg.Agents[i].QualifiedName() == resolvedQN {
-				cfg.Agents[i].Suspended = false
+				cfg.Agents[i].Suspended = suspended
 				break
 			}
 		}
 		if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
-			fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		fmt.Fprintf(stdout, "Resumed agent '%s'\n", name) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stdout, "%s agent '%s'\n", past, name) //nolint:errcheck // best-effort stdout
 		return 0
 	}
-	if updated, err := updateRootPackAgentSuspended(fs, cityPath, cfg, name, false); err != nil {
-		fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+	if updated, err := updateRootPackAgentSuspended(fs, cityPath, cfg, name, suspended); err != nil {
+		fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
 		return 1
 	} else if updated {
-		fmt.Fprintf(stdout, "Resumed agent '%s'\n", name) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stdout, "%s agent '%s'\n", past, name) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 
-	// Phase 2: not in raw config — check expanded config for pack-derived agents.
+	// Phase 2: not in raw config — check expanded config for provenance.
 	expanded, err := loadCityConfigFS(fs, tomlPath)
 	if err != nil {
-		// Fall through to generic not-found using raw cfg.
-		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent resume", name, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent "+verb, name, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if _, ok := resolveAgentIdentity(expanded, name, currentRigContext(expanded)); ok {
-		fmt.Fprintf(stderr, "gc agent resume: agent %q is defined by a pack — use [[patches]] to override\n", name) //nolint:errcheck // best-effort stderr
+	resolved, ok := resolveAgentIdentity(expanded, name, currentRigContext(expanded))
+	if !ok {
+		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent "+verb, name, expanded)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-
-	// Not found anywhere.
-	fmt.Fprintln(stderr, agentNotFoundMsg("gc agent resume", name, expanded)) //nolint:errcheck // best-effort stderr
+	if configedit.LocalDiscoveredAgent(fs, cityPath, resolved) {
+		if err := configedit.WriteLocalDiscoveredAgentSuspended(fs, cityPath, resolved, suspended); err != nil {
+			fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		// Also strip any pre-existing [[patches.agent]] suspended override
+		// so the new agent.toml value is what wins after composition. Use
+		// the resolved agent's qualified identity (dir/name) so a bare
+		// CLI input does not accidentally clear or skip a rig-scoped
+		// patch.
+		if configedit.StripAgentPatchSuspended(cfg, resolved.QualifiedName()) {
+			if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
+				fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
+		fmt.Fprintf(stdout, "%s agent '%s'\n", past, name) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	fmt.Fprintf(stderr, "gc agent %s: agent %q is defined by a pack — use [[patches]] to override\n", verb, name) //nolint:errcheck // best-effort stderr
 	return 1
 }

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -456,6 +456,204 @@ func TestDoAgentAddDuplicateScaffold(t *testing.T) {
 	}
 }
 
+func TestDoAgentSuspendScaffoldedAgentWritesAgentToml(t *testing.T) {
+	fs := v2CityWithPack(t)
+	if err := fs.MkdirAll("/city/agents/worker", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fs.Files["/city/agents/worker/prompt.template.md"] = []byte("You are the worker.\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+
+	agentToml, ok := fs.Files["/city/agents/worker/agent.toml"]
+	if !ok {
+		t.Fatal("agent.toml missing")
+	}
+	if !strings.Contains(string(agentToml), "suspended = true") {
+		t.Errorf("agent.toml = %q, want suspended = true", agentToml)
+	}
+	if strings.Contains(string(fs.Files["/city/city.toml"]), "[[patches.agent]]") {
+		t.Errorf("city.toml should not gain agent patch:\n%s", fs.Files["/city/city.toml"])
+	}
+
+	cfg, err := loadCityConfigFS(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("loadCityConfigFS: %v", err)
+	}
+	found := false
+	for _, a := range cfg.Agents {
+		if a.Name != "worker" {
+			continue
+		}
+		found = true
+		if !a.Suspended {
+			t.Error("Suspended = false, want true")
+		}
+	}
+	if !found {
+		t.Fatalf("cfg.Agents = %#v, want worker", cfg.Agents)
+	}
+}
+
+func TestDoAgentResumeScaffoldedAgentClearsAgentTomlSuspended(t *testing.T) {
+	fs := v2CityWithPack(t)
+	if err := fs.MkdirAll("/city/agents/worker", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fs.Files["/city/agents/worker/prompt.template.md"] = []byte("You are the worker.\n")
+	fs.Files["/city/agents/worker/agent.toml"] = []byte("provider = \"codex\"\nsuspended = true\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentResume(fs, "/city", "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+
+	agentToml, ok := fs.Files["/city/agents/worker/agent.toml"]
+	if !ok {
+		t.Fatal("agent.toml missing")
+	}
+	if !strings.Contains(string(agentToml), "provider = \"codex\"") {
+		t.Errorf("agent.toml = %q, want provider preserved", agentToml)
+	}
+	if strings.Contains(string(agentToml), "suspended") {
+		t.Errorf("agent.toml = %q, want suspended cleared", agentToml)
+	}
+	if strings.Contains(string(fs.Files["/city/city.toml"]), "[[patches.agent]]") {
+		t.Errorf("city.toml should not gain agent patch:\n%s", fs.Files["/city/city.toml"])
+	}
+
+	cfg, err := loadCityConfigFS(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("loadCityConfigFS: %v", err)
+	}
+	found := false
+	for _, a := range cfg.Agents {
+		if a.Name != "worker" {
+			continue
+		}
+		found = true
+		if a.Suspended {
+			t.Error("Suspended = true, want false")
+		}
+		if a.Provider != "codex" {
+			t.Errorf("Provider = %q, want codex", a.Provider)
+		}
+	}
+	if !found {
+		t.Fatalf("cfg.Agents = %#v, want worker", cfg.Agents)
+	}
+}
+
+// TestDoAgentSuspendPackDeclaredAgentEditsPackToml ensures the CLI
+// fallback (no API) edits the pack.toml [[agent]] entry directly when an
+// agent is declared there, even when a conventional prompt template
+// exists at agents/<name>/. The conventional prompt template must NOT
+// trigger the agent.toml write path because pack.toml takes precedence
+// during composition (see internal/configedit.LocalDiscoveredAgent).
+//
+// This validates the iter-1 finding (was-blocker): a SourceDir-based
+// heuristic would have routed the suspend write to a shadowed
+// agents/worker/agent.toml. Today the route is updateRootPackAgentSuspended
+// (added by #892) → write pack.toml, which is the correct durable
+// surface and is consistent with the API path.
+func TestDoAgentSuspendPackDeclaredAgentEditsPackToml(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[[agent]]
+name = "worker"
+provider = "claude"
+`)
+	if err := fs.MkdirAll("/city/agents/worker", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fs.Files["/city/agents/worker/prompt.template.md"] = []byte("You are the worker.\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Suspended agent 'worker'") {
+		t.Errorf("stdout = %q, want 'Suspended agent worker'", stdout.String())
+	}
+	// agent.toml must NOT be created — pack.toml [[agent]] is the
+	// authoritative declaration and would shadow agent.toml on load.
+	if _, ok := fs.Files["/city/agents/worker/agent.toml"]; ok {
+		t.Errorf("agent.toml must not be created for pack-declared agent")
+	}
+	// pack.toml must now carry suspended = true.
+	pack := string(fs.Files["/city/pack.toml"])
+	if !strings.Contains(pack, "suspended = true") {
+		t.Errorf("pack.toml = %q, want suspended = true on the [[agent]] entry", pack)
+	}
+	// city.toml must NOT gain a [[patches.agent]].
+	city := string(fs.Files["/city/city.toml"])
+	if strings.Contains(city, "[[patches.agent]]") {
+		t.Errorf("city.toml should not gain a patch:\n%s", city)
+	}
+}
+
+// TestDoAgentResumeStripsLegacyPatchSuspended covers the CLI fallback's
+// migration behavior for cities whose city.toml has a stale
+// [[patches.agent]] suspended override left behind by older code.
+func TestDoAgentResumeStripsLegacyPatchSuspended(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+
+[[patches.agent]]
+dir = ""
+name = "worker"
+suspended = true
+`)
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+`)
+	if err := fs.MkdirAll("/city/agents/worker", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fs.Files["/city/agents/worker/prompt.template.md"] = []byte("You are the worker.\n")
+	fs.Files["/city/agents/worker/agent.toml"] = []byte("suspended = true\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentResume(fs, "/city", "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	cityToml := string(fs.Files["/city/city.toml"])
+	if strings.Contains(cityToml, "[[patches.agent]]") {
+		t.Errorf("legacy patch should be stripped; city.toml=\n%s", cityToml)
+	}
+
+	cfg, err := loadCityConfigFS(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("loadCityConfigFS: %v", err)
+	}
+	for _, a := range cfg.Agents {
+		if a.Name == "worker" && a.Suspended {
+			t.Error("worker should not be suspended after resume")
+		}
+	}
+}
+
 func TestDoAgentAddRequiresPackToml(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`[workspace]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -114,7 +114,7 @@ gc agent add --name mayor
 
 ## gc agent resume
 
-Resume a suspended agent by clearing suspended in city.toml.
+Resume a suspended agent by clearing suspended in its durable config.
 
 The reconciler will start the agent on its next tick. Supports bare
 names (resolved via rig context) and qualified names (e.g. "myrig/worker").
@@ -125,7 +125,7 @@ gc agent resume <name>
 
 ## gc agent suspend
 
-Suspend an agent by setting suspended=true in city.toml.
+Suspend an agent by setting suspended=true in its durable config.
 
 Suspended agents are skipped by the reconciler — their sessions are not
 started or restarted. Existing sessions continue running but won't be

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -7,11 +7,15 @@
 package configedit
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 
+	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -37,6 +41,15 @@ var (
 	// config (duplicate names, missing required fields, etc.). Maps to
 	// HTTP 400.
 	ErrValidation = errors.New("validation failed")
+
+	// ErrUnmodified signals that an [Editor.EditExpanded] callback
+	// completed successfully without mutating the raw config, and the
+	// writeback should be skipped. The Editor still releases its lock
+	// and returns nil to the caller. Use this when a mutation lives
+	// entirely outside city.toml (e.g., a write to
+	// agents/<name>/agent.toml) so that we don't churn city.toml's
+	// mtime or risk losing comments on a no-op rewrite.
+	ErrUnmodified = errors.New("configedit: raw config unmodified")
 )
 
 // Origin describes where an agent or rig is defined in the config.
@@ -127,6 +140,9 @@ func (e *Editor) EditExpanded(fn func(raw, expanded *config.City) error) error {
 	}
 
 	if err := fn(raw, expanded); err != nil {
+		if errors.Is(err, ErrUnmodified) {
+			return nil
+		}
 		return err
 	}
 
@@ -279,39 +295,234 @@ func AddOrUpdateRigPatch(cfg *config.City, name string, fn func(p *config.RigPat
 // boolPtr returns a pointer to a bool value.
 func boolPtr(b bool) *bool { return &b }
 
-// SuspendAgent suspends an agent, using inline edit or patch depending
-// on provenance. This is the correct implementation that writes desired
-// state to city.toml (not ephemeral session metadata).
+// SuspendAgent suspends an agent, using inline edit, agent.toml write,
+// or [[patches.agent]] depending on provenance. Writes desired state
+// to durable config (not ephemeral session metadata).
 func (e *Editor) SuspendAgent(name string) error {
 	return e.EditExpanded(func(raw, expanded *config.City) error {
-		switch AgentOrigin(raw, expanded, name) {
-		case OriginInline:
-			return SetAgentSuspended(raw, name, true)
-		case OriginDerived:
-			return AddOrUpdateAgentPatch(raw, name, func(p *config.AgentPatch) {
-				p.Suspended = boolPtr(true)
-			})
-		default:
-			return fmt.Errorf("%w: agent %q", ErrNotFound, name)
-		}
+		return mutateAgentSuspended(e.fs, filepath.Dir(e.tomlPath), raw, expanded, name, true)
 	})
 }
 
-// ResumeAgent resumes a suspended agent, using inline edit or patch
-// depending on provenance.
+// ResumeAgent resumes a suspended agent, mirroring [Editor.SuspendAgent].
 func (e *Editor) ResumeAgent(name string) error {
 	return e.EditExpanded(func(raw, expanded *config.City) error {
-		switch AgentOrigin(raw, expanded, name) {
-		case OriginInline:
-			return SetAgentSuspended(raw, name, false)
-		case OriginDerived:
-			return AddOrUpdateAgentPatch(raw, name, func(p *config.AgentPatch) {
-				p.Suspended = boolPtr(false)
-			})
-		default:
-			return fmt.Errorf("%w: agent %q", ErrNotFound, name)
-		}
+		return mutateAgentSuspended(e.fs, filepath.Dir(e.tomlPath), raw, expanded, name, false)
 	})
+}
+
+// mutateAgentSuspended is the shared dispatch for SuspendAgent and
+// ResumeAgent. Branches on agent provenance:
+//   - OriginInline (city.toml [[agent]]): edit the raw struct.
+//   - OriginDerived + convention-discovered (agents/<name>/): write
+//     agents/<name>/agent.toml; also strip any legacy [[patches.agent]]
+//     suspended override so it can't shadow the new value.
+//   - OriginDerived + pack-declared: add or update [[patches.agent]].
+//
+// Returns [ErrUnmodified] when the change lives entirely in agent.toml
+// and raw was not touched, so EditExpanded skips the city.toml writeback.
+func mutateAgentSuspended(fs fsys.FS, cityRoot string, raw, expanded *config.City, name string, suspended bool) error {
+	switch AgentOrigin(raw, expanded, name) {
+	case OriginInline:
+		return SetAgentSuspended(raw, name, suspended)
+	case OriginDerived:
+		if agent, ok := findLocalDiscoveredAgent(fs, expanded, cityRoot, name); ok {
+			if err := WriteLocalDiscoveredAgentSuspended(fs, cityRoot, agent, suspended); err != nil {
+				return err
+			}
+			// A pre-existing [[patches.agent]] suspended override would
+			// silently shadow the agent.toml write (patch precedence).
+			// Strip it here so the durable agent.toml value wins. Use
+			// the discovered agent's full (Dir, Name) identity so we
+			// only strip the matching patch, not a same-named entry
+			// targeting a different rig.
+			if StripAgentPatchSuspended(raw, agent.QualifiedName()) {
+				return nil
+			}
+			return ErrUnmodified
+		}
+		return AddOrUpdateAgentPatch(raw, name, func(p *config.AgentPatch) {
+			p.Suspended = boolPtr(suspended)
+		})
+	case OriginNotFound:
+		return fmt.Errorf("%w: agent %q", ErrNotFound, name)
+	}
+	return fmt.Errorf("agent %q: unknown origin", name)
+}
+
+func findLocalDiscoveredAgent(fs fsys.FS, expanded *config.City, cityRoot, name string) (config.Agent, bool) {
+	cityRoot = filepath.Clean(cityRoot)
+	for _, a := range expanded.Agents {
+		if !config.AgentMatchesIdentity(&a, name) {
+			continue
+		}
+		if !LocalDiscoveredAgent(fs, cityRoot, a) {
+			continue
+		}
+		return a, true
+	}
+	return config.Agent{}, false
+}
+
+// LocalDiscoveredAgent reports whether an agent's durable configuration
+// lives in agents/<name>/agent.toml. Such agents are scaffolded purely by
+// the convention layout (a prompt file under agents/<name>/) and are not
+// declared in either city.toml [[agent]] or the city's pack.toml [[agent]].
+//
+// Pack-declared [[agent]] entries that happen to point at a conventional
+// prompt template are intentionally excluded — for those, [[patches.agent]]
+// is the correct mutation surface, since pack.toml [[agent]] takes
+// precedence over agent.toml during composition. The pack-declared check
+// matches on the agent's full (Dir, Name) identity so that a city-scoped
+// discovered agent and a pack rig-scoped agent that happen to share a
+// bare Name remain distinct.
+func LocalDiscoveredAgent(fs fsys.FS, cityRoot string, agent config.Agent) bool {
+	if agent.BindingName != "" {
+		return false
+	}
+	// Convention discovery scans <cityRoot>/agents/<Name>/, which is
+	// strictly city-scoped (Agent.Dir == ""). A rig-scoped agent that
+	// happens to point its prompt_template at the city's agents/<name>/
+	// prompt template is a different identity and must NOT be classified
+	// as local-discovered — writing agent.toml there would corrupt the
+	// city agent's durable state.
+	if agent.Dir != "" {
+		return false
+	}
+	cityRoot = filepath.Clean(cityRoot)
+	agentDir := filepath.Join(cityRoot, "agents", agent.Name)
+	switch filepath.Clean(agent.PromptTemplate) {
+	case filepath.Join(agentDir, "prompt.template.md"),
+		filepath.Join(agentDir, "prompt.md.tmpl"),
+		filepath.Join(agentDir, "prompt.md"):
+		// Conventional layout — eligible unless explicitly declared.
+	default:
+		return false
+	}
+	return !agentDeclaredInCityPack(fs, cityRoot, agent.Dir, agent.Name)
+}
+
+// agentDeclaredInCityPack reports whether (dir, name) appears as an
+// explicit [[agent]] entry in <cityRoot>/pack.toml. Convention-discovered
+// agents from agents/<name>/ are not [[agent]] entries and return false.
+// Matching uses the full (Dir, Name) identity so that, for example, a
+// rig-scoped pack agent (dir="rig", name="worker") does not shadow a
+// city-scoped discovered agent of the same bare name.
+func agentDeclaredInCityPack(fs fsys.FS, cityRoot, dir, name string) bool {
+	packPath := filepath.Join(cityRoot, "pack.toml")
+	data, err := fs.ReadFile(packPath)
+	if err != nil {
+		return false
+	}
+	var pc struct {
+		Agents []struct {
+			Dir  string `toml:"dir"`
+			Name string `toml:"name"`
+		} `toml:"agent"`
+	}
+	if _, err := toml.Decode(string(data), &pc); err != nil {
+		return false
+	}
+	for _, a := range pc.Agents {
+		if a.Dir == dir && a.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// StripAgentPatchSuspended clears the Suspended override from any
+// matching [[patches.agent]] entry so it can't shadow a durable
+// agent.toml write. If a patch had only Suspended set (the shape produced
+// by older suspend/resume code), the entire entry is dropped to avoid
+// leaving an identity-only [[patches.agent]] block in city.toml.
+// Returns true if any patch was modified.
+func StripAgentPatchSuspended(cfg *config.City, name string) bool {
+	dir, base := config.ParseQualifiedName(name)
+	modified := false
+	kept := cfg.Patches.Agents[:0:0]
+	for _, p := range cfg.Patches.Agents {
+		if p.Dir == dir && p.Name == base && p.Suspended != nil {
+			p.Suspended = nil
+			modified = true
+			if isAgentPatchOnlyIdentity(p) {
+				continue
+			}
+		}
+		kept = append(kept, p)
+	}
+	if modified {
+		cfg.Patches.Agents = kept
+	}
+	return modified
+}
+
+// isAgentPatchOnlyIdentity reports whether every field of p other than
+// Dir and Name is the zero value — i.e., the patch carries no overrides.
+// Reflection avoids drift as new fields are added to AgentPatch.
+func isAgentPatchOnlyIdentity(p config.AgentPatch) bool {
+	v := reflect.ValueOf(p)
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		switch t.Field(i).Name {
+		case "Dir", "Name":
+			continue
+		}
+		if !v.Field(i).IsZero() {
+			return false
+		}
+	}
+	return true
+}
+
+// WriteLocalDiscoveredAgentSuspended writes the suspended state to
+// agents/<name>/agent.toml using an atomic temp-file rename. When
+// suspended is false and the file would become empty (no other fields),
+// it is removed instead.
+//
+// Decoding into map[string]any (rather than a typed struct) preserves
+// any user-set fields the caller didn't ask about. TOML comments and
+// key ordering are not preserved — that is a limitation of the
+// underlying decode/encode round trip, not this helper.
+func WriteLocalDiscoveredAgentSuspended(fs fsys.FS, cityRoot string, agent config.Agent, suspended bool) error {
+	agentTomlPath := filepath.Join(cityRoot, "agents", agent.Name, "agent.toml")
+
+	values := make(map[string]any)
+	data, err := fs.ReadFile(agentTomlPath)
+	switch {
+	case err == nil:
+		if len(bytes.TrimSpace(data)) > 0 {
+			if _, decodeErr := toml.Decode(string(data), &values); decodeErr != nil {
+				return fmt.Errorf("reading agents/%s/agent.toml: %w", agent.Name, decodeErr)
+			}
+		}
+	case os.IsNotExist(err):
+		// Start from an empty config; suspend=true may create the file.
+	default:
+		return fmt.Errorf("reading agents/%s/agent.toml: %w", agent.Name, err)
+	}
+
+	if suspended {
+		values["suspended"] = true
+	} else {
+		delete(values, "suspended")
+	}
+
+	if len(values) == 0 {
+		if err := fs.Remove(agentTomlPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing agents/%s/agent.toml: %w", agent.Name, err)
+		}
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
+		return fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err)
+	}
+	if err := fsys.WriteFileAtomic(fs, agentTomlPath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err)
+	}
+	return nil
 }
 
 // SuspendRig suspends a rig by setting suspended=true in city.toml.

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -3,6 +3,7 @@ package configedit_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -59,6 +60,22 @@ func readEffectiveTOML(t *testing.T, path string) *config.City {
 	cfg := readTOML(t, path)
 	if _, err := config.ApplySiteBindings(fsys.OSFS{}, filepath.Dir(path), cfg); err != nil {
 		t.Fatalf("ApplySiteBindings: %v", err)
+	}
+	return cfg
+}
+
+// readExpandedTOML loads the city config with full pack expansion via
+// LoadWithIncludes. Use this when a test needs to observe the merged
+// state of pack-discovered or convention-discovered agents (e.g. that
+// suspended state set in agents/<name>/agent.toml propagates back into
+// the expanded config). Tests that only need the raw city.toml should
+// use readTOML; tests verifying site-binding rig paths should use
+// readEffectiveTOML.
+func readExpandedTOML(t *testing.T, path string) *config.City {
+	t.Helper()
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatalf("reloading expanded config: %v", err)
 	}
 	return cfg
 }
@@ -329,6 +346,313 @@ suspended = true
 	}
 }
 
+func TestSuspendAgent_LocalDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.SuspendAgent("worker"); err != nil {
+		t.Fatalf("SuspendAgent: %v", err)
+	}
+
+	raw := string(mustReadFile(t, path))
+	if strings.Contains(raw, "[[patches.agent]]") {
+		t.Fatalf("city.toml should not gain agent patch:\n%s", raw)
+	}
+	agentToml := string(mustReadFile(t, filepath.Join(agentDir, "agent.toml")))
+	if !strings.Contains(agentToml, "suspended = true") {
+		t.Fatalf("agent.toml = %q, want suspended = true", agentToml)
+	}
+
+	cfg := readExpandedTOML(t, path)
+	if !findAgent(t, cfg, "worker").Suspended {
+		t.Fatal("worker should be suspended in expanded config")
+	}
+}
+
+func TestResumeAgent_LocalDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("provider = \"codex\"\nsuspended = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.ResumeAgent("worker"); err != nil {
+		t.Fatalf("ResumeAgent: %v", err)
+	}
+
+	raw := string(mustReadFile(t, path))
+	if strings.Contains(raw, "[[patches.agent]]") {
+		t.Fatalf("city.toml should not gain agent patch:\n%s", raw)
+	}
+	agentToml := string(mustReadFile(t, filepath.Join(agentDir, "agent.toml")))
+	if !strings.Contains(agentToml, "provider = \"codex\"") {
+		t.Fatalf("agent.toml = %q, want provider preserved", agentToml)
+	}
+	if strings.Contains(agentToml, "suspended") {
+		t.Fatalf("agent.toml = %q, want suspended cleared", agentToml)
+	}
+
+	cfg := readExpandedTOML(t, path)
+	worker := findAgent(t, cfg, "worker")
+	if worker.Suspended {
+		t.Fatal("worker should not be suspended in expanded config")
+	}
+	if worker.Provider != "codex" {
+		t.Fatalf("worker.Provider = %q, want codex", worker.Provider)
+	}
+}
+
+// TestSuspendAgent_PackDeclaredAgentUsesPatch ensures that an [[agent]]
+// explicitly declared in the city's pack.toml is suspended via
+// [[patches.agent]] in city.toml — not via agents/<name>/agent.toml,
+// which would be silently shadowed by the pack.toml declaration during
+// composition. Regression for the SourceDir == cityRoot heuristic that
+// also matched pack-declared agents.
+func TestSuspendAgent_PackDeclaredAgentUsesPatch(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[[agent]]
+name = "worker"
+provider = "claude"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A conventional prompt template at the discovery location must NOT
+	// trigger the agent.toml write path when an [[agent]] entry exists.
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.SuspendAgent("worker"); err != nil {
+		t.Fatalf("SuspendAgent: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(agentDir, "agent.toml")); err == nil {
+		t.Fatalf("agent.toml must not be created for pack-declared agent")
+	}
+
+	raw := string(mustReadFile(t, path))
+	if !strings.Contains(raw, "[[patches.agent]]") {
+		t.Fatalf("city.toml should gain agent patch:\n%s", raw)
+	}
+
+	cfg := readExpandedTOML(t, path)
+	if !findAgent(t, cfg, "worker").Suspended {
+		t.Fatal("worker should be suspended in expanded config")
+	}
+}
+
+// TestResumeAgent_StripsLegacyPatchSuspended covers the migration case
+// where a city.toml has a stale [[patches.agent]] suspended override
+// from older code. Resuming a convention-discovered agent must strip
+// that patch override so it doesn't continue to shadow agent.toml.
+func TestResumeAgent_StripsLegacyPatchSuspended(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+
+[[patches.agent]]
+dir = ""
+name = "worker"
+suspended = true
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("suspended = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.ResumeAgent("worker"); err != nil {
+		t.Fatalf("ResumeAgent: %v", err)
+	}
+
+	raw := string(mustReadFile(t, path))
+	if strings.Contains(raw, "[[patches.agent]]") {
+		t.Fatalf("legacy patch should be stripped:\n%s", raw)
+	}
+
+	cfg := readExpandedTOML(t, path)
+	if findAgent(t, cfg, "worker").Suspended {
+		t.Fatal("worker should not be suspended in expanded config after resume")
+	}
+}
+
+// TestSuspendAgent_StripsLegacyPatchSuspendedKeepsOtherFields ensures
+// that an existing patch with overrides beyond Suspended keeps the
+// non-Suspended fields intact when the Suspended override is stripped.
+func TestSuspendAgent_StripsLegacyPatchSuspendedKeepsOtherFields(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+
+[[patches.agent]]
+dir = ""
+name = "worker"
+suspended = false
+provider = "codex"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the worker.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+	if err := ed.SuspendAgent("worker"); err != nil {
+		t.Fatalf("SuspendAgent: %v", err)
+	}
+
+	raw := string(mustReadFile(t, path))
+	if !strings.Contains(raw, `provider = "codex"`) {
+		t.Fatalf("non-Suspended patch fields should be preserved:\n%s", raw)
+	}
+	if strings.Contains(raw, "suspended =") {
+		t.Fatalf("Suspended override should be removed from patch:\n%s", raw)
+	}
+}
+
+// TestStripAgentPatchSuspended_OnlyMatchingIdentity unit-tests the
+// patch-stripping helper directly. Iteration-2 fix: callers must thread
+// the resolved (Dir, Name) qualified identity so a same-bare-name patch
+// targeting a different rig is never accidentally cleared.
+func TestStripAgentPatchSuspended_OnlyMatchingIdentity(t *testing.T) {
+	cfg := &config.City{
+		Patches: config.Patches{
+			Agents: []config.AgentPatch{
+				{Dir: "rigA", Name: "worker", Suspended: boolPtrTest(true)},
+				{Dir: "rigB", Name: "worker", Suspended: boolPtrTest(true)},
+				{Dir: "", Name: "worker", Suspended: boolPtrTest(true)},
+			},
+		},
+	}
+	// Strip city-scoped (dir="") only.
+	if !configedit.StripAgentPatchSuspended(cfg, "worker") {
+		t.Fatal("StripAgentPatchSuspended should report a change")
+	}
+	if got := len(cfg.Patches.Agents); got != 2 {
+		t.Fatalf("Patches.Agents len = %d, want 2; got %#v", got, cfg.Patches.Agents)
+	}
+	for _, p := range cfg.Patches.Agents {
+		if p.Dir == "" {
+			t.Errorf("city-scoped patch should be removed; remaining: %#v", p)
+		}
+	}
+
+	// Strip rigA-scoped via qualified identity.
+	if !configedit.StripAgentPatchSuspended(cfg, "rigA/worker") {
+		t.Fatal("StripAgentPatchSuspended should report a change for rigA")
+	}
+	if got := len(cfg.Patches.Agents); got != 1 || cfg.Patches.Agents[0].Dir != "rigB" {
+		t.Fatalf("after stripping rigA, expected only rigB patch, got %#v", cfg.Patches.Agents)
+	}
+
+	// Stripping a non-matching identity is a no-op.
+	if configedit.StripAgentPatchSuspended(cfg, "rigC/worker") {
+		t.Fatal("StripAgentPatchSuspended should be a no-op for non-matching identity")
+	}
+}
+
+func boolPtrTest(b bool) *bool { return &b }
+
+// TestLocalDiscoveredAgent_RejectsRigScopedAgentWithCityPromptPath
+// guards against the iteration-3 Major finding (Gemini): a rig-scoped
+// agent whose prompt_template happens to point at the city's
+// <cityRoot>/agents/<name>/ template must NOT be classified as local
+// discovered. Writing agent.toml for it would corrupt the city agent's
+// durable state instead of producing the correct [[patches.agent]].
+func TestLocalDiscoveredAgent_RejectsRigScopedAgentWithCityPromptPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "agents", "worker"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
+name = "test-city"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rigAgent := config.Agent{
+		Dir:            "myrig",
+		Name:           "worker",
+		PromptTemplate: filepath.Join(dir, "agents", "worker", "prompt.template.md"),
+	}
+	if configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, rigAgent) {
+		t.Fatal("rig-scoped agent must not be classified as local-discovered even when prompt_template points at the city's agents/<name>/ tree")
+	}
+
+	cityAgent := config.Agent{
+		Dir:            "",
+		Name:           "worker",
+		PromptTemplate: filepath.Join(dir, "agents", "worker", "prompt.template.md"),
+	}
+	if !configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, cityAgent) {
+		t.Fatal("city-scoped scaffolded agent should be classified as local-discovered")
+	}
+}
+
 func TestSuspendAgent_NotFound(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, minimalCity())
@@ -375,6 +699,26 @@ suspended = true
 	if cfg.Rigs[0].Suspended {
 		t.Error("expected my-rig to not be suspended")
 	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return data
+}
+
+func findAgent(t *testing.T, cfg *config.City, name string) config.Agent { //nolint:unparam // helper kept generic for future tests
+	t.Helper()
+	for _, a := range cfg.Agents {
+		if a.Name == name {
+			return a
+		}
+	}
+	t.Fatalf("agent %q not found in %#v", name, cfg.Agents)
+	return config.Agent{}
 }
 
 func TestSuspendCity(t *testing.T) {


### PR DESCRIPTION
## Summary

- treat city-local discovered agents as durable directory scaffolds when `gc agent suspend` / `gc agent resume` run
- update both the direct CLI fallback and the controller/editor path to write `agents/<name>/agent.toml` instead of falling back to legacy `city.toml` patches for those agents
- add regression coverage and refresh the CLI reference/help text to describe durable agent config rather than `city.toml`

Closes #608.

## Testing

- [x] `go test ./internal/configedit -count=1`
- [x] `go test ./cmd/gc -run 'TestDoAgent(Add|Suspend|Resume)' -count=1`
- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
