### PR TITLE
fix: address graph-dispatch report-write-order and bd-warning jq-parse flakes

### DIFF
--- a/examples/gastown/packs/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
@@ -13,6 +13,16 @@
 
 set -euo pipefail
 
+# json_payload strips any non-JSON prefix lines (e.g., `bd`'s
+# `warning: beads.role not configured` diagnostic, which is emitted on
+# stdout before the real payload). Without this, jq fails to parse the
+# combined stdout and the script exits with empty output and status 1,
+# which has produced flaky CI failures for
+# TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep.
+json_payload() {
+    awk 'found || /^[[:space:]]*[[{]/{ found=1; print }'
+}
+
 load_verdict() {
     local apply_ref="$1"
     local root_id="$2"
@@ -22,6 +32,7 @@ load_verdict() {
     while [ "$attempt" -lt 5 ]; do
         verdict=$(
             bd list --all --json --limit=0 2>/dev/null |
+                json_payload |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
                     [
                         .[]
@@ -54,9 +65,9 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null)
-ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end')
-ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')
+BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null | json_payload)
+ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end' 2>/dev/null || printf '')
+ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end' 2>/dev/null || printf '')
 if [ -z "$ATTEMPT" ] || [ -z "$ROOT_ID" ]; then
     echo "ERROR: missing gc.attempt or gc.root_bead_id on $BEAD_ID" >&2
     exit 1

--- a/examples/gastown/packs/gastown/assets/scripts/checks/code-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/code-review-approved.sh
@@ -9,6 +9,16 @@
 
 set -euo pipefail
 
+# json_payload strips any non-JSON prefix lines (e.g., `bd`'s
+# `warning: beads.role not configured` diagnostic, which is emitted on
+# stdout before the real payload). Without this, jq fails to parse the
+# combined stdout and the script exits with empty output and status 1,
+# which has produced flaky CI failures for
+# TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep.
+json_payload() {
+    awk 'found || /^[[:space:]]*[[{]/{ found=1; print }'
+}
+
 load_verdict() {
     local apply_ref="$1"
     local root_id="$2"
@@ -18,6 +28,7 @@ load_verdict() {
     while [ "$attempt" -lt 5 ]; do
         verdict=$(
             bd list --all --json --limit=0 2>/dev/null |
+                json_payload |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
                     [
                         .[]
@@ -50,9 +61,9 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null)
-ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end')
-ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')
+BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null | json_payload)
+ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end' 2>/dev/null || printf '')
+ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end' 2>/dev/null || printf '')
 if [ -z "$ATTEMPT" ] || [ -z "$ROOT_ID" ]; then
     echo "ERROR: missing gc.attempt or gc.root_bead_id on $BEAD_ID" >&2
     exit 1

--- a/examples/gastown/packs/gastown/assets/scripts/checks/design-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/design-review-approved.sh
@@ -9,6 +9,16 @@
 
 set -euo pipefail
 
+# json_payload strips any non-JSON prefix lines (e.g., `bd`'s
+# `warning: beads.role not configured` diagnostic, which is emitted on
+# stdout before the real payload). Without this, jq fails to parse the
+# combined stdout and the script exits with empty output and status 1,
+# which has produced flaky CI failures for
+# TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep.
+json_payload() {
+    awk 'found || /^[[:space:]]*[[{]/{ found=1; print }'
+}
+
 load_verdict() {
     local apply_ref="$1"
     local root_id="$2"
@@ -18,6 +28,7 @@ load_verdict() {
     while [ "$attempt" -lt 5 ]; do
         verdict=$(
             bd list --all --json --limit=0 2>/dev/null |
+                json_payload |
                 jq -r --arg ref "$apply_ref" --arg root "$root_id" '
                     [
                         .[]
@@ -50,9 +61,9 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null)
-ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end')
-ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end')
+BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null | json_payload)
+ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end' 2>/dev/null || printf '')
+ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end' 2>/dev/null || printf '')
 if [ -z "$ATTEMPT" ] || [ -z "$ROOT_ID" ]; then
     echo "ERROR: missing gc.attempt or gc.root_bead_id on $BEAD_ID" >&2
     exit 1

--- a/test/agents/graph-dispatch.sh
+++ b/test/agents/graph-dispatch.sh
@@ -452,7 +452,12 @@ while true; do
         exit 1
     fi
 
-    printf '%s\n' "$ref" >> "$REPORT_FILE"
+    # Report emission is deferred until just before close_with_result so a
+    # step that gets skipped by the controller mid-processing (after we
+    # fetched it from the ready queue but before we committed to closing)
+    # does not appear in the report. Writing here would violate
+    # TestGraphWorkflowFailureRunsCleanup's "report should not include
+    # .implement after abort" invariant.
     trace "run bead=$bead_id ref=$ref kind=$kind source=$source_id work_dir=$work_dir"
     trace_store
 
@@ -467,6 +472,7 @@ while true; do
             ;;
         *.preflight-tests*)
             if [ "$MODE" = "fail-preflight" ]; then
+                printf '%s\n' "$ref" >> "$REPORT_FILE"
                 trace "close-fail bead=$bead_id ref=$ref class=hard reason=preflight_failed"
                 close_with_result "$bead_id" "fail" "hard" "preflight_failed"
                 trace "close-returned bead=$bead_id"
@@ -502,6 +508,7 @@ while true; do
 
     if should_fail_transient_once "$ref"; then
         reason=$(transient_reason_for_ref "$ref")
+        printf '%s\n' "$ref" >> "$REPORT_FILE"
         trace "close-fail bead=$bead_id ref=$ref class=transient reason=$reason mode=once"
         close_with_result "$bead_id" "fail" "transient" "$reason"
         trace "close-returned bead=$bead_id"
@@ -512,6 +519,7 @@ while true; do
     fi
     if should_fail_transient_always "$ref"; then
         reason=$(transient_reason_for_ref "$ref")
+        printf '%s\n' "$ref" >> "$REPORT_FILE"
         trace "close-fail bead=$bead_id ref=$ref class=transient reason=$reason mode=always"
         close_with_result "$bead_id" "fail" "transient" "$reason"
         trace "close-returned bead=$bead_id"
@@ -541,6 +549,7 @@ while true; do
         continue
     fi
 
+    printf '%s\n' "$ref" >> "$REPORT_FILE"
     trace "close bead=$bead_id ref=$ref"
     trace_store
     close_with_result "$bead_id" "pass"

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -314,3 +314,104 @@ esac
 		t.Fatalf("write fake bd command: %v", err)
 	}
 }
+
+// TestReviewCheckScriptsStripBeadsRoleWarningFromStdout guards against the
+// `bd list`/`bd show` output being polluted by a stdout warning (e.g.,
+// "warning: beads.role not configured (GH#2950)") that breaks jq parsing
+// in the check scripts. The original flake surfaced as
+// TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep failing with
+// exit status 1 and empty output: `bd` printed its role-not-configured
+// diagnostic ahead of the JSON, and the scripts piped the combined
+// stdout straight into jq. The fix adds a json_payload awk filter that
+// strips lines until the first `{` or `[`; this test drives a fake bd
+// that emits the warning to confirm the filter is in place.
+func TestReviewCheckScriptsStripBeadsRoleWarningFromStdout(t *testing.T) {
+	for _, tc := range reviewCheckCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeDir := t.TempDir()
+			writeFakeBDCommandWithWarning(t, filepath.Join(fakeDir, "bd"), tc)
+
+			env := newIsolatedToolEnv(t, false)
+			envMap := parseEnvList(env)
+			env = replaceEnv(env, "PATH", prependPath(fakeDir, envMap["PATH"]))
+			env = filterEnvMany(env,
+				"GC_BEAD_ID",
+				"GC_CITY",
+				"GC_CITY_PATH",
+				"GC_CITY_ROOT",
+				"GC_CITY_RUNTIME_DIR",
+			)
+			env = append(env, "GC_BEAD_ID=check-1")
+
+			scriptPath := filepath.Join(repoRoot(t), "examples", "gastown", "packs", "gastown", "assets", "scripts", "checks", tc.script)
+			out, err := runCommand(repoRoot(t), env, 30*time.Second, "bash", scriptPath)
+			if err != nil {
+				t.Fatalf("%s failed with bd warning-prefixed output: %v\noutput: %s", tc.script, err, out)
+			}
+			if !strings.Contains(out, tc.approvedText) {
+				t.Fatalf("%s output = %q, want %q", tc.script, out, tc.approvedText)
+			}
+		})
+	}
+}
+
+// writeFakeBDCommandWithWarning is writeFakeBDCommand with a stdout
+// "warning:" prefix prepended to both `show` and `list` output, mirroring
+// real `bd`'s GH#2950 diagnostic so the check scripts' json_payload
+// filter is actually exercised.
+func writeFakeBDCommandWithWarning(t *testing.T, path string, tc reviewCheckCase) {
+	t.Helper()
+
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+emit_warning() {
+  printf 'warning: beads.role not configured (GH#2950).\n'
+  printf '  Fix: git config beads.role maintainer\n'
+  printf '  Or:  git config beads.role contributor\n'
+}
+
+cmd="$1"
+shift || true
+
+case "$cmd" in
+  show)
+    emit_warning
+    printf '%%s\n' '{"metadata":{"gc.attempt":"1","gc.root_bead_id":"root-1"}}'
+    ;;
+  list)
+    emit_warning
+    cat <<'EOF'
+[
+  {
+    "id": "old-verdict",
+    "created_at": "2026-01-01T00:00:00Z",
+    "metadata": {
+      "gc.step_ref": %q,
+      "gc.root_bead_id": "root-1",
+      %q: "iterate"
+    }
+  },
+  {
+    "id": "new-verdict",
+    "created_at": "2026-01-01T00:00:01Z",
+    "metadata": {
+      "gc.step_ref": %q,
+      "gc.root_bead_id": "root-1",
+      %q: "done"
+    }
+  }
+]
+EOF
+    ;;
+  *)
+    echo "unexpected bd command: $cmd" >&2
+    exit 1
+    ;;
+esac
+`, tc.attemptStepRef(1), tc.verdictKey, tc.attemptStepRef(1), tc.verdictKey)
+
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd command: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #854 and #868, fixing two more integration-test flake classes that surfaced in recent CI runs.

## Root causes

### 1. `TestGraphWorkflowFailureRunsCleanup` — worker wrote report entries it later skipped

`test/agents/graph-dispatch.sh` wrote each step's ref to `$REPORT_FILE` **before** acting on the bead:

```
[pre-action status check: outcome != "skipped"?]
printf '%s\n' "$ref" >> "$REPORT_FILE"   # ← too early
[case statement: do the work]
[pre-close status check: outcome != "skipped"?]
close_with_result ...
```

If the controller marked a downstream step `gc.outcome=skipped` in the narrow window between the pre-action refresh (line 419) and the report write (line 455), the worker's later pre-close check correctly bypassed `close_with_result`, but the ref was already in the report. This produced failures like:

```
graph_dispatch_test.go:133: report should not include .implement after abort:
    mol-scoped-work.load-context.attempt.1
    mol-scoped-work.workspace-setup.attempt.1
    mol-scoped-work.preflight-tests.attempt.1
    mol-scoped-work.implement.attempt.1
```

**Fix:** move the report write so it only happens on the path that actually closes the bead. All four `close_with_result` call sites (preflight-tests hard fail, transient-once fail, transient-always fail, success pass) now have the write immediately before them. A step that gets skipped mid-processing never reaches any close call and therefore never appears in the report.

### 2. `TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep` — `bd` warning poisoned jq parsing

The three review-approved check scripts read `bd` stdout and piped it straight into `jq`:

```bash
BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null)
ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r '…')
```

When `bd` emitted its `warning: beads.role not configured (GH#2950)` diagnostic to stdout ahead of the JSON, jq choked with a parse error and the enclosing `var=$(pipeline)` assignment swallowed the failure under bash's pipefail-with-assignment quirk. The script then exited 1 without printing anything, producing:

```
review_check_scripts_test.go:137: code-review-approved.sh failed: exit status 1
    output:
```

**Fix:** add a `json_payload` awk filter (same shape as the helper already used in `graph-dispatch.sh`) that drops lines until the first `{` or `[`. All three check scripts (`code-review-approved.sh`, `design-review-approved.sh`, `adopt-pr-review-approved.sh`) now pipe `bd` stdout through `json_payload` before handing it to jq. The two jq invocations in the main script body also get `2>/dev/null || printf ''` guards so a malformed payload produces a controlled empty string rather than an uncaught pipeline failure.

## Regression test

New `TestReviewCheckScriptsStripBeadsRoleWarningFromStdout` drives a fake `bd` that prints the GH#2950 warning before the JSON. **Verified to fail against the pre-fix scripts** (exit 5, `jq: parse error: Invalid numeric literal at line 1, column 8`) and pass after the fix.

## Deferred

`TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries` has a different root cause — a 12-minute workflow timeout rooted in retry-exhaustion → soft_fail logic in the controller/reconciler, not the worker shell script. Needs separate investigation against a reproducible setup; will tackle in a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./test/integration/...`
- [x] `go test -tags=integration -run 'TestReviewCheckScriptsStripBeadsRoleWarningFromStdout' ./test/integration/...` — new regression test passes.
- [x] Confirmed new test FAILS against pre-fix scripts (pure regression proof).
- [x] `go test -tags=integration -run 'TestReviewCheckScriptsPreferNewestVerdictWhenListOrderIsStale' ./test/integration/...` — existing fake-bd test still passes.
- [x] `bash -n test/agents/graph-dispatch.sh` — syntax valid.
- [x] `golangci-lint run` clean.
- [ ] CI on the PR confirms both flake patterns no longer reproduce.
