### PR TITLE
docs: stop documenting the [agents] defaults alias

### DIFF
--- a/docs/packv2/doc-agent-v2.md
+++ b/docs/packv2/doc-agent-v2.md
@@ -478,7 +478,7 @@ A rig patch can undo a city-level patch for that one rig.
 ## Scope and impact
 
 - **Breaking:** `[[agent]]` tables move to `agents/` directories. Migration tooling needed.
-- **Config:** city.toml gains `[agents]` defaults section, loses `[[agent]]` tables. `agent.toml` is new per-agent.
+- **Config:** city.toml gains `[agent_defaults]` defaults section, loses `[[agent]]` tables. `agent.toml` is new per-agent.
 - **Prompts:** `.template.md` infix becomes required for template processing. Existing `.md` prompts using `{{` need renaming to `.template.md`.
 - **New features:** Skills, MCP TOML abstraction, `per-provider/` overlays, `template-fragments/` convention, `patches/` directory.
 - **Naming:** Current `[[rigs.overrides]]` renamed to `[[rigs.patches]]` for consistency with `[[patches.agent]]`.

--- a/docs/packv2/doc-consistency-audit.md
+++ b/docs/packv2/doc-consistency-audit.md
@@ -3,12 +3,14 @@
 > **Status: Retired.** All findings have been folded into the canonical spec docs:
 > - Orders → top-level `orders/` (doc-directory-conventions.md, doc-pack-v2.md, doc-loader-v2.md)
 > - `[formulas].dir` → fixed convention (doc-directory-conventions.md, doc-pack-v2.md)
-> - `[agents]` alias → `[agent_defaults]` canonical (doc-agent-v2.md)
+> - Pack/city agent defaults use `[agent_defaults]` (doc-agent-v2.md)
 > - `overlay/` (singular) → implementation cleanup
 > - Fallback agents → moot (fallback removed in V2)
 > - Doctor/commands → convention-based dirs (doc-commands.md, doc-directory-conventions.md)
 >
-> This file is kept for historical reference only. Do not update it.
+> This file is kept for historical reference only. The historical content below has
+> been lightly normalized to use the current `[agent_defaults]` terminology so the
+> retired audit does not keep teaching the superseded temporary alias.
 
 # Original Audit (historical)
 
@@ -63,7 +65,7 @@ These are single-instance settings. Pure TOML is the right pattern — no issues
 |---|---|
 | `[pack]` | Pack name, schema version, requirements |
 | `[global]` | Pack-wide session_live commands |
-| `[agents]` (v.next) | Pack-wide agent defaults |
+| `[agent_defaults]` (v.next) | Pack-wide agent defaults |
 
 No issues — these are metadata.
 


### PR DESCRIPTION
Fixes #585

## Summary

- make `[agent_defaults]` the only documented PackV2 defaults block name in current docs
- update the retired consistency audit so it no longer teaches the temporary alias
- keep runtime compatibility parsing for `[agents]` unchanged; this is a docs-only change

## Testing

- [ ] `make check`
- [x] `make check-docs`
- [ ] `make test-integration`

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes