### PR TITLE
fix(supervisor): propagate shutdown status and harden stop waits (follow-up to #868)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -270,6 +270,10 @@ func handleSupervisorConn(conn net.Conn, cancelFn context.CancelFunc, reconcileC
 				msg := strings.ReplaceAll(res.err.Error(), "\n", "; ")
 				fmt.Fprintf(conn, "done:err:%s\n", msg) //nolint:errcheck
 			}
+			// One command per connection — return explicitly instead of
+			// falling through to scanner.Scan() again. The read deadline
+			// would close us anyway, but this makes the contract explicit.
+			return
 		case "ping":
 			fmt.Fprintf(conn, "%d\n", os.Getpid()) //nolint:errcheck
 		case "reload":
@@ -431,8 +435,10 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 	case errors.Is(statusErr, io.EOF):
 		// Older supervisor — no done:* line. Fall through to polling.
 	default:
-		// Likely i/o deadline hit. Poll once more to see if the supervisor
-		// is already gone; if not, report the original timeout.
+		// Likely i/o deadline hit on ReadString. The absolute deadline is
+		// already consumed, so the fall-through waitForSupervisorExitUntil
+		// will surface the timeout error directly — there is no additional
+		// budget to retry the probe.
 	}
 
 	if err := waitForSupervisorExitUntil(sockPath, deadline); err != nil {
@@ -443,19 +449,17 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 	return 0
 }
 
-// waitForSupervisorExit polls the supervisor socket until it stops answering
-// (i.e., supervisorAliveAtPath returns 0), or until timeout elapses.
-func waitForSupervisorExit(sockPath string, timeout time.Duration) error {
-	return waitForSupervisorExitUntil(sockPath, time.Now().Add(timeout))
-}
-
-// waitForSupervisorExitUntil is waitForSupervisorExit with an explicit
-// absolute deadline. Each probe is capped to the remaining budget so a
-// half-open socket cannot stretch the total wait past the deadline.
+// waitForSupervisorExitUntil polls the supervisor socket until it stops
+// answering (i.e., supervisorAliveAtPathUntil returns 0), or until the
+// absolute deadline elapses. Each probe is capped to the remaining budget
+// so a half-open socket cannot stretch the total wait past the deadline.
+// The original total budget is reconstructed for the timeout error so
+// operators can see which budget was exhausted in CI logs.
 func waitForSupervisorExitUntil(sockPath string, deadline time.Time) error {
+	startBudget := time.Until(deadline)
 	for {
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for supervisor at %s to exit", sockPath)
+			return fmt.Errorf("timed out after %s waiting for supervisor at %s to exit", startBudget, sockPath)
 		}
 		if supervisorAliveAtPathUntil(sockPath, deadline) == 0 {
 			return nil

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -98,7 +98,7 @@ against lingering supervisor / controller subprocesses).`,
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the supervisor process to actually exit before returning")
+	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the supervisor to finish stopping all managed cities and release its socket before returning")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Second, "Maximum time to wait when --wait is set")
 	return cmd
 }
@@ -185,7 +185,30 @@ var (
 	supervisorReloadWaitTimeout  = 5 * time.Minute
 )
 
-func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconcileCh chan reconcileRequest) (net.Listener, error) {
+// shutdownState tracks the supervisor's shutdown progress so socket
+// handlers can report the final result to --wait clients. done is closed
+// when shutdown has finished (successful or not). err is populated (may
+// be nil on clean shutdown) before done is closed.
+type shutdownState struct {
+	done chan struct{}
+	err  atomic.Pointer[shutdownResult]
+}
+
+type shutdownResult struct {
+	err error
+}
+
+func newShutdownState() *shutdownState {
+	return &shutdownState{done: make(chan struct{})}
+}
+
+// finish records the shutdown result and closes done. Safe to call once.
+func (s *shutdownState) finish(err error) {
+	s.err.Store(&shutdownResult{err: err})
+	close(s.done)
+}
+
+func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconcileCh chan reconcileRequest, shut *shutdownState) (net.Listener, error) {
 	os.Remove(sockPath) //nolint:errcheck // remove stale socket from previous crash
 	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -203,7 +226,7 @@ func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconci
 				fmt.Fprintf(os.Stderr, "gc supervisor: socket accept: %v\n", err) //nolint:errcheck
 				continue
 			}
-			go handleSupervisorConn(conn, cancelFn, reconcileCh)
+			go handleSupervisorConn(conn, cancelFn, reconcileCh, shut)
 		}
 	}()
 	return lis, nil
@@ -212,7 +235,12 @@ func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconci
 // handleSupervisorConn reads from a connection and dispatches commands.
 // Supported: "stop" (shutdown), "ping" (liveness check, returns PID),
 // "reload" (trigger immediate reconciliation of all cities).
-func handleSupervisorConn(conn net.Conn, cancelFn context.CancelFunc, reconcileCh chan reconcileRequest) {
+//
+// For "stop", the handler first sends "ok\n" (backward compatible ACK),
+// then — if the client keeps the connection open — blocks until shutdown
+// completes and sends a second line "done:ok\n" or "done:err:<detail>\n"
+// so --wait clients can distinguish clean shutdown from partial failure.
+func handleSupervisorConn(conn net.Conn, cancelFn context.CancelFunc, reconcileCh chan reconcileRequest, shut *shutdownState) {
 	defer conn.Close()                                     //nolint:errcheck
 	conn.SetReadDeadline(time.Now().Add(60 * time.Second)) //nolint:errcheck
 	scanner := bufio.NewScanner(conn)
@@ -220,7 +248,28 @@ func handleSupervisorConn(conn net.Conn, cancelFn context.CancelFunc, reconcileC
 		switch scanner.Text() {
 		case "stop":
 			cancelFn()
-			conn.Write([]byte("ok\n")) //nolint:errcheck
+			if _, err := conn.Write([]byte("ok\n")); err != nil {
+				return
+			}
+			if shut == nil {
+				return
+			}
+			// Wait for shutdown to complete (or client to disconnect)
+			// so we can report the final result.
+			conn.SetWriteDeadline(time.Now().Add(5 * time.Minute)) //nolint:errcheck
+			select {
+			case <-shut.done:
+			case <-time.After(5 * time.Minute):
+				return
+			}
+			res := shut.err.Load()
+			if res == nil || res.err == nil {
+				conn.Write([]byte("done:ok\n")) //nolint:errcheck
+			} else {
+				// Collapse newlines in the error so the protocol stays line-oriented.
+				msg := strings.ReplaceAll(res.err.Error(), "\n", "; ")
+				fmt.Fprintf(conn, "done:err:%s\n", msg) //nolint:errcheck
+			}
 		case "ping":
 			fmt.Fprintf(conn, "%d\n", os.Getpid()) //nolint:errcheck
 		case "reload":
@@ -258,13 +307,33 @@ func runningSupervisorSocket() (string, int) {
 }
 
 func supervisorAliveAtPath(sockPath string) int {
-	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
+	return supervisorAliveAtPathUntil(sockPath, time.Now().Add(3*time.Second))
+}
+
+// supervisorAliveAtPathUntil is supervisorAliveAtPath with a total budget.
+// Dial and read timeouts are each capped to the remaining time before
+// deadline so a wedged socket cannot stretch the probe beyond the caller's
+// wait budget.
+func supervisorAliveAtPathUntil(sockPath string, deadline time.Time) int {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	dialTimeout := 500 * time.Millisecond
+	if dialTimeout > remaining {
+		dialTimeout = remaining
+	}
+	conn, err := net.DialTimeout("unix", sockPath, dialTimeout)
 	if err != nil {
 		return 0
 	}
-	defer conn.Close()                                    //nolint:errcheck
-	conn.Write([]byte("ping\n"))                          //nolint:errcheck
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	defer conn.Close()           //nolint:errcheck
+	conn.Write([]byte("ping\n")) //nolint:errcheck
+	readDeadline := time.Now().Add(2 * time.Second)
+	if readDeadline.After(deadline) {
+		readDeadline = deadline
+	}
+	conn.SetReadDeadline(readDeadline) //nolint:errcheck
 	buf := make([]byte, 64)
 	n, err := conn.Read(buf)
 	if err != nil || n == 0 {
@@ -287,9 +356,12 @@ func stopSupervisor(stdout, stderr io.Writer) int {
 
 // stopSupervisorWithWait is stopSupervisor with an optional wait-for-exit
 // phase. When wait is true, after the supervisor ACKs the stop command the
-// function polls the supervisor socket until it stops answering (or until
-// waitTimeout elapses). This is the shape tests and shell scripts want when
-// they need deterministic cleanup: on return, the supervisor is gone.
+// function keeps the control connection open and reads the post-shutdown
+// status line (done:ok or done:err:<detail>) that runSupervisor emits once
+// every managed city has quiesced. If the supervisor predates that protocol
+// or drops the connection early, we fall back to polling the socket until
+// it stops answering. This is the shape tests and shell scripts want: on
+// return, the supervisor has fully shut down and any failure is visible.
 //
 // It also unloads the platform service (without removing the unit file) so
 // launchd/systemd doesn't immediately restart the supervisor.
@@ -311,9 +383,9 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 	defer conn.Close()                                     //nolint:errcheck
 	conn.Write([]byte("stop\n"))                           //nolint:errcheck
 	conn.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
-	buf := make([]byte, 64)
-	n, _ := conn.Read(buf)
-	if n == 0 || string(buf[:n]) != "ok\n" {
+	reader := bufio.NewReader(conn)
+	ackLine, err := reader.ReadString('\n')
+	if err != nil || strings.TrimSpace(ackLine) != "ok" {
 		fmt.Fprintln(stderr, "gc supervisor stop: no acknowledgment from supervisor") //nolint:errcheck
 		return 1
 	}
@@ -324,7 +396,46 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 	if waitTimeout <= 0 {
 		waitTimeout = 30 * time.Second
 	}
-	if err := waitForSupervisorExit(sockPath, waitTimeout); err != nil {
+
+	// Wait for the supervisor's post-shutdown status line. An older
+	// supervisor binary won't send one; the connection will just close.
+	// Treat EOF / timeout / unexpected input as "fall back to polling".
+	deadline := time.Now().Add(waitTimeout)
+	conn.SetReadDeadline(deadline) //nolint:errcheck
+	statusLine, statusErr := reader.ReadString('\n')
+	switch {
+	case statusErr == nil:
+		line := strings.TrimSpace(statusLine)
+		switch {
+		case line == "done:ok":
+			// Confirm the socket actually goes away, but with a small
+			// budget — the server already told us shutdown finished.
+			if err := waitForSupervisorExitUntil(sockPath, time.Now().Add(5*time.Second)); err != nil {
+				fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+				return 1
+			}
+			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
+			return 0
+		case strings.HasPrefix(line, "done:err:"):
+			fmt.Fprintf(stderr, "gc supervisor stop: %s\n", strings.TrimPrefix(line, "done:err:")) //nolint:errcheck
+			return 1
+		default:
+			fmt.Fprintf(stderr, "gc supervisor stop: unexpected status %q\n", line) //nolint:errcheck
+			// Still make sure the process actually goes away.
+			if err := waitForSupervisorExitUntil(sockPath, deadline); err != nil {
+				fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+				return 1
+			}
+			return 1
+		}
+	case errors.Is(statusErr, io.EOF):
+		// Older supervisor — no done:* line. Fall through to polling.
+	default:
+		// Likely i/o deadline hit. Poll once more to see if the supervisor
+		// is already gone; if not, report the original timeout.
+	}
+
+	if err := waitForSupervisorExitUntil(sockPath, deadline); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
 		return 1
 	}
@@ -335,15 +446,29 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 // waitForSupervisorExit polls the supervisor socket until it stops answering
 // (i.e., supervisorAliveAtPath returns 0), or until timeout elapses.
 func waitForSupervisorExit(sockPath string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+	return waitForSupervisorExitUntil(sockPath, time.Now().Add(timeout))
+}
+
+// waitForSupervisorExitUntil is waitForSupervisorExit with an explicit
+// absolute deadline. Each probe is capped to the remaining budget so a
+// half-open socket cannot stretch the total wait past the deadline.
+func waitForSupervisorExitUntil(sockPath string, deadline time.Time) error {
 	for {
-		if supervisorAliveAtPath(sockPath) == 0 {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for supervisor at %s to exit", sockPath)
+		}
+		if supervisorAliveAtPathUntil(sockPath, deadline) == 0 {
 			return nil
 		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out after %s waiting for supervisor at %s to exit", timeout, sockPath)
+		remaining := time.Until(deadline)
+		sleep := 100 * time.Millisecond
+		if sleep > remaining {
+			sleep = remaining
 		}
-		time.Sleep(100 * time.Millisecond)
+		if sleep <= 0 {
+			continue
+		}
+		time.Sleep(sleep)
 	}
 }
 
@@ -433,12 +558,19 @@ func managedCityStopTimeout(mc *managedCity) time.Duration {
 	return mc.cr.cfg.Daemon.ShutdownTimeoutDuration()
 }
 
-func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
+// stopManagedCity cancels a city's context, waits up to its configured
+// grace period for it to exit, forces shutdown if it doesn't, and then
+// closes the bead provider and file recorder. It returns a non-nil error
+// when the city did not exit cleanly within the budget. Stderr still
+// receives a trace line for operability; the returned error is for
+// callers (runSupervisor) that need to aggregate shutdown status.
+func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 	if mc == nil {
-		return
+		return nil
 	}
 	mc.cancel()
 	timeout := managedCityStopTimeout(mc)
+	var stopErr error
 	if timeout > 0 {
 		select {
 		case <-mc.done:
@@ -448,9 +580,10 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
 			if mc.closer != nil {
 				mc.closer.Close() //nolint:errcheck
 			}
-			return
+			return nil
 		case <-time.After(timeout):
 			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after cancel; forcing shutdown\n", mc.name, timeout) //nolint:errcheck
+			stopErr = fmt.Errorf("city %q did not exit within %s after cancel", mc.name, timeout)
 		}
 	}
 	if mc.cr != nil {
@@ -462,8 +595,12 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
 	if timeout > 0 {
 		select {
 		case <-mc.done:
+			// Forced shutdown completed before the second timeout — the
+			// city is out. Clear the pending error so we report success.
+			stopErr = nil
 		case <-time.After(timeout):
 			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, timeout) //nolint:errcheck
+			stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, timeout)
 		}
 	}
 	if err := shutdownBeadsProvider(cityPath); err != nil {
@@ -472,6 +609,7 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) {
 	if mc.closer != nil {
 		mc.closer.Close() //nolint:errcheck
 	}
+	return stopErr
 }
 
 // runSupervisor is the main supervisor loop. It acquires the lock,
@@ -569,13 +707,36 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc supervisor: creating socket dir: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	lis, err := startSupervisorSocket(sockPath, cancel, reconcileCh)
+	shut := newShutdownState()
+	lis, err := startSupervisorSocket(sockPath, cancel, reconcileCh, shut)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	defer lis.Close()         //nolint:errcheck
-	defer os.Remove(sockPath) //nolint:errcheck
+	// Socket teardown order matters. Defers run in LIFO, so listed last =
+	// executes first. We want:
+	//   1. Signal shutdown completion (shut.finish) so blocked "stop"
+	//      handlers can write their done:* line.
+	//   2. Brief pause (0.5s) so those writes reach the client before the
+	//      socket closes.
+	//   3. Close listener + remove socket path.
+	// The ctx.Done() branch below calls shut.finish directly before it
+	// returns; this defer is the safety net for any other return path
+	// (early errors, panics) so socket handlers never block forever.
+	defer func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	}()
+	defer func() {
+		select {
+		case <-shut.done:
+		default:
+			shut.finish(fmt.Errorf("supervisor exited before shutdown aggregation"))
+		}
+		// Give in-flight "stop" handlers a short window to emit their
+		// done:* line before the listener closes.
+		time.Sleep(500 * time.Millisecond)
+	}()
 
 	fmt.Fprintln(stdout, "Supervisor started.") //nolint:errcheck
 
@@ -632,11 +793,22 @@ func runSupervisor(stdout, stderr io.Writer) int {
 					delete(cities, k)
 				}
 			})
+			var stopFailures []string
 			for name, mc := range toStop {
 				fmt.Fprintf(stdout, "Stopping city '%s'...\n", name) //nolint:errcheck
-				stopManagedCity(mc, name, stderr)
-				fmt.Fprintf(stdout, "City '%s' stopped.\n", name) //nolint:errcheck
+				if err := stopManagedCity(mc, name, stderr); err != nil {
+					stopFailures = append(stopFailures, fmt.Sprintf("%s: %s", name, err.Error()))
+					fmt.Fprintf(stdout, "City '%s' stop reported error (see stderr).\n", name) //nolint:errcheck
+				} else {
+					fmt.Fprintf(stdout, "City '%s' stopped.\n", name) //nolint:errcheck
+				}
 			}
+			var shutErr error
+			if len(stopFailures) > 0 {
+				shutErr = fmt.Errorf("%d cities did not shut down cleanly: %s", len(stopFailures), strings.Join(stopFailures, "; "))
+				fmt.Fprintf(stderr, "gc supervisor: %v\n", shutErr) //nolint:errcheck
+			}
+			shut.finish(shutErr)
 			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
 			return 0
 		}
@@ -703,7 +875,11 @@ func reconcileCities(
 	for i, mc := range toStop {
 		name := filepath.Base(toStopPaths[i])
 		fmt.Fprintf(stdout, "Unregistered city '%s', stopping...\n", name) //nolint:errcheck
-		stopManagedCity(mc, toStopPaths[i], stderr)
+		// Reconcile path: stop error is already logged inside stopManagedCity
+		// and propagating it would require bubbling through the whole
+		// reconcile loop. The supervisor-shutdown aggregator is the path
+		// that cares about these errors.
+		_ = stopManagedCity(mc, toStopPaths[i], stderr)
 		// Clear backoff so re-registering starts immediately.
 		cr.BatchUpdate(func(
 			_ map[string]*managedCity,
@@ -762,7 +938,7 @@ func reconcileCities(
 	})
 	for i, mc := range nameDriftCities {
 		fmt.Fprintf(stdout, "City name changed at '%s', restarting...\n", nameDriftPaths[i]) //nolint:errcheck
-		stopManagedCity(mc, nameDriftPaths[i], stderr)
+		_ = stopManagedCity(mc, nameDriftPaths[i], stderr)
 	}
 
 	// Start new cities (and name-drifted restarts). Build list under lock,

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -179,12 +180,22 @@ func waitForSupervisorReady(stderr io.Writer) int {
 }
 
 // unloadSupervisorService stops the platform service without removing
-// the unit file, so gc start can reload it later.
+// the unit file, so gc start can reload it later. It is a no-op when
+// the platform unit/plist is not installed — this keeps unit tests that
+// invoke the stop helper hermetic on machines where the service has
+// never been registered.
 func unloadSupervisorService() {
 	switch goruntime.GOOS {
 	case "darwin":
-		exec.Command("launchctl", "unload", supervisorLaunchdPlistPath()).Run() //nolint:errcheck // best-effort
+		path := supervisorLaunchdPlistPath()
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		exec.Command("launchctl", "unload", path).Run() //nolint:errcheck // best-effort
 	case "linux":
+		if _, err := os.Stat(supervisorSystemdServicePath()); errors.Is(err, os.ErrNotExist) {
+			return
+		}
 		exec.Command("systemctl", "--user", "stop", "gascity-supervisor.service").Run() //nolint:errcheck // best-effort
 	}
 }

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -839,9 +841,15 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 
 	var stderr bytes.Buffer
 	start := time.Now()
-	stopManagedCity(mc, cityPath, &stderr)
+	err := stopManagedCity(mc, cityPath, &stderr)
 	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
 		t.Fatalf("stopManagedCity took %s, want bounded timeout", elapsed)
+	}
+	if err == nil {
+		t.Fatal("stopManagedCity err = nil, want non-nil because city never exited")
+	}
+	if !strings.Contains(err.Error(), "did not exit") {
+		t.Fatalf("stopManagedCity err = %q, want 'did not exit' detail", err.Error())
 	}
 	if !strings.Contains(stderr.String(), "did not exit within") {
 		t.Fatalf("stderr = %q, want forced-timeout warning", stderr.String())
@@ -888,9 +896,12 @@ func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 
 	var stderr bytes.Buffer
 	start := time.Now()
-	stopManagedCity(mc, cityPath, &stderr)
+	err := stopManagedCity(mc, cityPath, &stderr)
 	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
 		t.Fatalf("stopManagedCity took %s, want shutdown-timeout bound", elapsed)
+	}
+	if err == nil {
+		t.Fatal("stopManagedCity err = nil, want non-nil because city never exited")
 	}
 	if !strings.Contains(stderr.String(), "20ms") {
 		t.Fatalf("stderr = %q, want shutdown-timeout warning", stderr.String())
@@ -933,9 +944,15 @@ func TestStopSupervisorWithWaitBlocksUntilSocketStops(t *testing.T) {
 	})
 
 	stopDelay := 200 * time.Millisecond
+	// stopRequested/stopAt are touched by the "stop" handler goroutine and
+	// read concurrently by every "ping" handler goroutine. Guard with a
+	// mutex so `go test -race` doesn't flag this fake server.
+	var (
+		mu            sync.Mutex
+		stopRequested bool
+		stopAt        time.Time
+	)
 	go func() {
-		stopRequested := false
-		var stopAt time.Time
 		for {
 			conn, err := lis.Accept()
 			if err != nil {
@@ -951,15 +968,26 @@ func TestStopSupervisorWithWaitBlocksUntilSocketStops(t *testing.T) {
 				cmd := strings.TrimSpace(string(buf[:n]))
 				switch cmd {
 				case "ping":
-					if stopRequested && time.Now().After(stopAt) {
+					mu.Lock()
+					finished := stopRequested && time.Now().After(stopAt)
+					mu.Unlock()
+					if finished {
 						// Stop answering ping so the waiter sees us as gone.
 						return
 					}
 					io.WriteString(conn, "4242\n") //nolint:errcheck
 				case "stop":
+					mu.Lock()
 					stopRequested = true
 					stopAt = time.Now().Add(stopDelay)
+					mu.Unlock()
 					io.WriteString(conn, "ok\n") //nolint:errcheck
+					// New protocol: --wait clients also read a final
+					// status line. Emit done:ok after the stop delay so
+					// this test exercises the happy path of the new
+					// protocol in addition to the socket-close fallback.
+					time.Sleep(stopDelay)
+					io.WriteString(conn, "done:ok\n") //nolint:errcheck
 				}
 			}(conn)
 		}
@@ -1018,6 +1046,69 @@ func TestStopSupervisorWithoutWaitReturnsAfterAck(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "Supervisor stopped.") {
 		t.Fatalf("stdout unexpectedly contains 'Supervisor stopped.' — wait flag was false")
+	}
+}
+
+// TestStopSupervisorWithWaitPropagatesDoneErr exercises the new
+// post-shutdown status protocol: the server sends "ok\n" to ack the
+// stop request, then "done:err:<detail>\n" when shutdown finished with
+// errors (e.g., a managed city failed to quiesce). --wait must surface
+// the error to stderr and exit non-zero so test cleanup sees the flake
+// instead of believing shutdown was clean.
+func TestStopSupervisorWithWaitPropagatesDoneErr(t *testing.T) {
+	gcHome := shortTempDir(t, "gc-home-")
+	runtimeDir := shortTempDir(t, "gc-run-")
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	sockPath := filepath.Join(gcHome, "supervisor.sock")
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	})
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close() //nolint:errcheck
+				r := bufio.NewReader(conn)
+				line, err := r.ReadString('\n')
+				if err != nil {
+					return
+				}
+				switch strings.TrimSpace(line) {
+				case "ping":
+					io.WriteString(conn, "4242\n") //nolint:errcheck
+				case "stop":
+					io.WriteString(conn, "ok\n")                                                //nolint:errcheck
+					io.WriteString(conn, "done:err:city \"alpha\" did not exit within 5s\n") //nolint:errcheck
+				}
+			}(conn)
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	code := stopSupervisorWithWait(&stdout, &stderr, true, 2*time.Second)
+
+	if code != 1 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 1 (propagated done:err); stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "alpha") || !strings.Contains(stderr.String(), "did not exit") {
+		t.Fatalf("stderr = %q, want it to include the server's done:err detail", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Supervisor stopped.") {
+		t.Fatalf("stdout unexpectedly contains 'Supervisor stopped.' — shutdown reported errors")
 	}
 }
 

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1091,7 +1091,7 @@ func TestStopSupervisorWithWaitPropagatesDoneErr(t *testing.T) {
 				case "ping":
 					io.WriteString(conn, "4242\n") //nolint:errcheck
 				case "stop":
-					io.WriteString(conn, "ok\n")                                                //nolint:errcheck
+					io.WriteString(conn, "ok\n")                                             //nolint:errcheck
 					io.WriteString(conn, "done:err:city \"alpha\" did not exit within 5s\n") //nolint:errcheck
 				}
 			}(conn)

--- a/test/acceptance/agent_suspend_test.go
+++ b/test/acceptance/agent_suspend_test.go
@@ -150,8 +150,9 @@ func TestAgentSuspendResume(t *testing.T) {
 	t.Run("ThenResume", func(t *testing.T) {
 		// Stop the supervisor so agent suspend/resume falls through to
 		// direct city.toml mutation (the API would reject an agent it
-		// doesn't know about from config reload).
-		c.GC("supervisor", "stop")
+		// doesn't know about from config reload). --wait so subsequent
+		// config edits don't race the supervisor's shutdown path.
+		c.GC("supervisor", "stop", "--wait")
 
 		// Write config with a known agent.
 		c.WriteConfig(`[workspace]

--- a/test/acceptance/helpers/lifecycle.go
+++ b/test/acceptance/helpers/lifecycle.go
@@ -15,9 +15,11 @@ import (
 // previous test first (tests share XDG_RUNTIME_DIR within a suite).
 func (c *City) StartWithSupervisor() {
 	c.t.Helper()
-	// Stop stale supervisor/controller from a previous test.
-	RunGC(c.Env, "", "supervisor", "stop") //nolint:errcheck
-	RunGC(c.Env, c.Dir, "stop", c.Dir)     //nolint:errcheck
+	// Stop stale supervisor/controller from a previous test. --wait blocks
+	// until the supervisor has finished shutting down its managed cities
+	// so the start below doesn't race the prior shutdown.
+	RunGC(c.Env, "", "supervisor", "stop", "--wait") //nolint:errcheck
+	RunGC(c.Env, c.Dir, "stop", c.Dir)               //nolint:errcheck
 	time.Sleep(2 * time.Second)
 
 	out, err := RunGC(c.Env, c.Dir, "start", c.Dir)
@@ -28,7 +30,7 @@ func (c *City) StartWithSupervisor() {
 	c.usedSupervisor = true
 	c.t.Cleanup(func() {
 		c.Stop()
-		RunGC(c.Env, "", "supervisor", "stop") //nolint:errcheck
+		RunGC(c.Env, "", "supervisor", "stop", "--wait") //nolint:errcheck
 	})
 }
 

--- a/test/acceptance/init_lifecycle_test.go
+++ b/test/acceptance/init_lifecycle_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	// Best-effort supervisor stop.
-	helpers.RunGC(testEnv, "", "supervisor", "stop") //nolint:errcheck
+	helpers.RunGC(testEnv, "", "supervisor", "stop", "--wait") //nolint:errcheck
 	os.Exit(code)
 }
 

--- a/test/acceptance/tier_b/lifecycle_b_test.go
+++ b/test/acceptance/tier_b/lifecycle_b_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	// Best-effort supervisor stop.
-	helpers.RunGC(testEnvB, "", "supervisor", "stop") //nolint:errcheck
+	helpers.RunGC(testEnvB, "", "supervisor", "stop", "--wait") //nolint:errcheck
 	os.Exit(code)
 }
 

--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -164,7 +164,7 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
-	helpers.RunGC(testEnvC, "", "supervisor", "stop") //nolint:errcheck
+	helpers.RunGC(testEnvC, "", "supervisor", "stop", "--wait") //nolint:errcheck
 	os.Exit(code)
 }
 

--- a/test/acceptance/tutorial_goldens/harness_test.go
+++ b/test/acceptance/tutorial_goldens/harness_test.go
@@ -59,7 +59,7 @@ func newTutorialWorkspace(t *testing.T) *tutorialWorkspace {
 		for _, cityDir := range cityDirs {
 			_, _ = runEnvCommandWithTimeout(env, cityDir, 20*time.Second, "gc", "stop")
 		}
-		_, _ = runEnvCommandWithTimeout(env, env.Home, 20*time.Second, "gc", "supervisor", "stop")
+		_, _ = runEnvCommandWithTimeout(env, env.Home, 30*time.Second, "gc", "supervisor", "stop", "--wait")
 	})
 	return w
 }

--- a/test/acceptance/tutorial_goldens/main_test.go
+++ b/test/acceptance/tutorial_goldens/main_test.go
@@ -426,7 +426,7 @@ func stopTutorialSupervisor(env *tutorialEnv) {
 		return
 	}
 	if env.Env != nil && env.Home != "" {
-		_, _ = runEnvCommandWithTimeout(env, env.Home, 5*time.Second, "gc", "supervisor", "stop")
+		_, _ = runEnvCommandWithTimeout(env, env.Home, 15*time.Second, "gc", "supervisor", "stop", "--wait")
 	}
 	if env.supervisorDone != nil {
 		select {

--- a/test/integration/dolt_managed_chaos_test.go
+++ b/test/integration/dolt_managed_chaos_test.go
@@ -382,8 +382,8 @@ dir = "frontend"
 	registerCityCommandEnv(cityDir, env)
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCDoltWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCDoltWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		runGCDoltWithEnv(env, "", "stop", cityDir)                //nolint:errcheck // best-effort cleanup
+		runGCDoltWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck // best-effort cleanup
 	})
 
 	waitForActiveSessionTargets(t, cityDir, []string{"city-worker", "frontend/rig-worker"}, 30*time.Second)

--- a/test/integration/graph_dispatch_test.go
+++ b/test/integration/graph_dispatch_test.go
@@ -180,8 +180,8 @@ func setupGraphWorkflowCity(t *testing.T, mode string) string {
 	registerCityCommandEnv(cityDir, env)
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCDoltWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCDoltWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		runGCDoltWithEnv(env, "", "stop", cityDir)                //nolint:errcheck // best-effort cleanup
+		runGCDoltWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck // best-effort cleanup
 	})
 
 	return cityDir

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -81,8 +81,8 @@ func setupCity(t *testing.T, guard *tmuxtest.Guard, agents []agentConfig) string
 	// Register cleanup: gc stop on test end.
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCWithEnv(env, "", "stop", cityDir)      //nolint:errcheck // best-effort cleanup
-		runGCWithEnv(env, "", "supervisor", "stop") //nolint:errcheck // best-effort cleanup
+		runGCWithEnv(env, "", "stop", cityDir)                //nolint:errcheck // best-effort cleanup
+		runGCWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck // best-effort cleanup
 	})
 
 	// Give sessions a moment to register.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -179,8 +179,11 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	// Best-effort: stop any isolated supervisor that survived test cleanup.
+	// Use --wait so the sweep blocks until the supervisor and its managed
+	// cities have actually shut down, avoiding a race with process-table
+	// cleanup below.
 	if gcBinary != "" {
-		stopCmd := exec.Command(gcBinary, "supervisor", "stop")
+		stopCmd := exec.Command(gcBinary, "supervisor", "stop", "--wait")
 		stopCmd.Env = integrationEnv()
 		_ = stopCmd.Run()
 	}
@@ -945,7 +948,9 @@ func startIsolatedSupervisor(t *testing.T, env []string, gcHome string) {
 		out, err := runCommand("", env, 2*time.Second, gcBinary, "supervisor", "status")
 		if err == nil && strings.Contains(out, "Supervisor is running") {
 			t.Cleanup(func() {
-				_, _ = runCommand("", env, 5*time.Second, gcBinary, "supervisor", "stop")
+				// --wait so runCommand blocks until the supervisor fully
+				// shut down, aligning with the cmd.Wait() synchronization below.
+				_, _ = runCommand("", env, 15*time.Second, gcBinary, "supervisor", "stop", "--wait")
 				select {
 				case <-done:
 				case <-time.After(10 * time.Second):

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -208,8 +208,8 @@ func setupReviewCheckScriptCity(t *testing.T) string {
 	registerCityCommandEnv(cityDir, env)
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCDoltWithEnv(env, "", "stop", cityDir)      //nolint:errcheck
-		runGCDoltWithEnv(env, "", "supervisor", "stop") //nolint:errcheck
+		runGCDoltWithEnv(env, "", "stop", cityDir)                //nolint:errcheck
+		runGCDoltWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck
 	})
 
 	return cityDir

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -369,8 +369,8 @@ func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]strin
 	registerCityCommandEnv(cityDir, env)
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)
-		runGCDoltWithEnv(env, "", "stop", cityDir)      //nolint:errcheck
-		runGCDoltWithEnv(env, "", "supervisor", "stop") //nolint:errcheck
+		runGCDoltWithEnv(env, "", "stop", cityDir)                //nolint:errcheck
+		runGCDoltWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck
 		deadline := time.Now().Add(10 * time.Second)
 		for time.Now().Before(deadline) {
 			_ = os.RemoveAll(cityDir)


### PR DESCRIPTION
## Summary

Follow-up to #868 addressing review findings surfaced during `/adopt-pr` of that PR. #868 merged before these fixups could land; this PR contains them as a separate change on top of current `main`.

### Context
#868 landed `gc supervisor stop --wait` and migrated three integration cleanup helpers to use it, resolving the TempDir/orphan-process flake family for those helpers. The automated review flagged six follow-ups that this PR addresses.

## Changes

- **Supervisor stop protocol now reports final status.** `handleSupervisorConn`'s "stop" path still sends `ok\n` as a backward-compatible ACK, then blocks on a new `shutdownState` (populated by `runSupervisor`'s ctx.Done() branch) and writes a second line — `done:ok\n` or `done:err:<detail>\n` — before closing the connection. `stopManagedCity` now returns an error describing graceful- and forced-shutdown timeouts; `runSupervisor` aggregates them into that shutdown state. `stopSupervisorWithWait` keeps the control connection open on `--wait`, parses the `done:*` line, surfaces `done:err` as non-zero + stderr, and confirms the socket actually goes away before printing "Supervisor stopped." Older supervisors that never learned to send `done:*` still work via the existing socket-gone poll fallback.

- **Per-probe deadline in the wait loop.** `supervisorAliveAtPathUntil` caps each dial and read to the remaining budget, so a wedged half-open socket cannot stretch total wait past `--wait-timeout`. `waitForSupervisorExit` is now a thin wrapper over the Until variant; existing "timed out" test assertions continue to pass.

- **`unloadSupervisorService` is hermetic when no unit is installed.** The helper returns early on `errors.Is(err, os.ErrNotExist)` instead of unconditionally invoking `launchctl unload` / `systemctl --user stop`. Hosts with the service installed still unload it; hosts without the service (typical for unit test machines) are no longer mutated.

- **Flag help reflects actual guarantee.** `--wait` help now says "Wait for the supervisor to finish stopping all managed cities and release its socket before returning," avoiding the aspirational "wait for the supervisor process to actually exit" wording that overstated the guarantee given the 5s HTTP-shutdown defer after socket close.

- **Data race in new fake-socket test.** `TestStopSupervisorWithWaitBlocksUntilSocketStops` now guards `stopRequested` / `stopAt` with `sync.Mutex`, so `go test -race` CI won't flag the stabilization PR for introducing a racy test. The same test also emits `done:ok\n` so the happy path of the new protocol is exercised.

- **New test `TestStopSupervisorWithWaitPropagatesDoneErr`** pins the non-zero exit + stderr contract for the `done:err` path.

- **`--wait` propagated to remaining cleanup sites.** #868 migrated three helpers; this PR covers the rest:
  - `test/integration/helpers_test.go`
  - `test/integration/graph_dispatch_test.go`
  - `test/integration/review_formula_test.go`
  - `test/integration/review_check_scripts_test.go`
  - `test/integration/dolt_managed_chaos_test.go`
  - `test/integration/integration_test.go` (TestMain sweep + managed-fixture Cleanup)
  - `test/acceptance/helpers/lifecycle.go` (StartWithSupervisor + cleanup)
  - `test/acceptance/init_lifecycle_test.go`
  - `test/acceptance/tier_b/lifecycle_b_test.go`
  - `test/acceptance/tier_c/tierc_test.go`
  - `test/acceptance/agent_suspend_test.go`
  - `test/acceptance/tutorial_goldens/main_test.go`
  - `test/acceptance/tutorial_goldens/harness_test.go`

Where the original cleanup had a short (5s/20s) timeout, the budget was raised (15s/30s) to leave headroom for managed-city drain plus the supervisor's own HTTP shutdown defer.

## Tests

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 -run '^(TestStop|TestSupervisor|TestDoSupervisor|TestRunSupervisor|TestReconcile)$' ./cmd/gc/` — green
- [ ] CI confirms the broader supervisor/integration paths stay green

## Review

Automated review on this fixup returned `approve` with only minor/nit findings — none blocker or major. Those remaining nits (timeout duration dropped from error wording, doc/comment precision on edge-case branches) can be tracked as follow-ups if desired.