### PR TITLE
docs: prefer gc bd in prompt and formula guidance

### DIFF
--- a/cmd/gc/prompts/mayor.md
+++ b/cmd/gc/prompts/mayor.md
@@ -18,7 +18,7 @@ or `/gc-city` to load command reference for any topic.
 
 ## Working with rig beads
 
-Use `gc bd` to run bd commands against any rig from the city root:
+Use `gc bd` to run bead commands against any rig from the city root:
 
     gc bd --rig <rig-name> list
     gc bd --rig <rig-name> create "<title>"
@@ -28,7 +28,7 @@ The rig is auto-detected from the bead prefix when possible:
 
     gc bd show my-project-abc    # auto-routes to the correct rig
 
-For city-level beads (no rig), `gc bd` works the same as plain `bd`.
+For city-level beads (no rig), `gc bd` works the same way without `--rig`.
 
 ## Handoff
 

--- a/examples/bd/template-fragments/bead-worktree.template.md
+++ b/examples/bd/template-fragments/bead-worktree.template.md
@@ -5,11 +5,11 @@ When you create a git worktree (via `git worktree add` or the EnterWorktree tool
 
 1. Find your assigned bead:
    ```
-   bd list --json --assignee="{{.AgentName}}" --status=in-progress
+   gc bd list --json --assignee="{{.AgentName}}" --status=in-progress
    ```
 2. Update the bead with the absolute worktree path:
    ```
-   bd update <bead_id> --set-metadata work_dir=<absolute_worktree_path>
+   gc bd update <bead_id> --set-metadata work_dir=<absolute_worktree_path>
    ```
 
 Replace `<bead_id>` with the `id` field from step 1 and `<absolute_worktree_path>` with the full path to the worktree directory.

--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -99,7 +99,7 @@ gc nudge deacon/ "DOG_DONE: backup — synced <count>/<total>, offsite: <status>
 
 **3. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "Backup sync complete"
+gc bd close <work-bead> --reason "Backup sync complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/dolt/formulas/mol-dog-compactor.toml
+++ b/examples/dolt/formulas/mol-dog-compactor.toml
@@ -1,7 +1,7 @@
 description = """
 Compact Dolt commit history on production databases.
 
-Every bd mutation creates a Dolt commit. Over time, this builds an enormous
+Every bead mutation creates a Dolt commit. Over time, this builds an enormous
 commit graph (5,000-10,000 commits/day from wisp churn). The commit graph IS
 the storage cost — deleting rows without compaction leaves ghost commits forever.
 
@@ -182,7 +182,7 @@ gc nudge deacon/ "DOG_DONE: compactor — compacted <count> databases, mode: {{m
 
 **3. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "Compaction cycle complete"
+gc bd close <work-bead> --reason "Compaction cycle complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/dolt/formulas/mol-dog-doctor.toml
+++ b/examples/dolt/formulas/mol-dog-doctor.toml
@@ -141,7 +141,7 @@ gc nudge deacon/ "DOG_DONE: doctor — server: <status>, conns: <count>/<max>, o
 
 **4. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "Doctor probe complete"
+gc bd close <work-bead> --reason "Doctor probe complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/dolt/formulas/mol-dog-phantom-db.toml
+++ b/examples/dolt/formulas/mol-dog-phantom-db.toml
@@ -121,7 +121,7 @@ gc nudge deacon/ "DOG_DONE: phantom-db — scanned: <count>, phantoms: <count>"
 
 **3. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "Phantom DB scan complete"
+gc bd close <work-bead> --reason "Phantom DB scan complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -142,7 +142,7 @@ gc nudge deacon/ "DOG_DONE: stale-db — orphans: <count>, removed: <count>"
 
 **4. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "Stale DB scan complete"
+gc bd close <work-bead> --reason "Stale DB scan complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -519,9 +519,9 @@ func TestIdeaToPlanFormulaUsesSupportedPrimitives(t *testing.T) {
 	for _, want := range []string{
 		`formula = "mol-idea-to-plan"`,
 		`gc sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}`,
-		`bd create`,
+		`gc bd create`,
 		`gc mail send`,
-		`bd dep add`,
+		`gc bd dep add`,
 		`Do NOT use unsupported upstream shortcuts`,
 		`This is the only required human gate.`,
 	} {
@@ -542,9 +542,9 @@ func TestReviewLegFormulaPersistsReportAndNotifiesCoordinator(t *testing.T) {
 	for _, want := range []string{
 		`formula = "mol-review-leg"`,
 		`coordinator`,
-		`bd update {{issue}} --notes`,
+		`gc bd update {{issue}} --notes`,
 		`gc mail send "$COORD"`,
-		`bd update {{issue}} --status=closed`,
+		`gc bd update {{issue}} --status=closed`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("review-leg formula missing %q", want)

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -49,7 +49,7 @@ detects dead agents and restarts them — that's its job, not yours.
 {{ cmd }} agent peek deacon 30
 
 # Deacon's current patrol wisp — how fresh is it?
-bd list --assignee=deacon --status=in_progress --json --limit=5
+gc bd list --assignee=deacon --status=in_progress --json --limit=5
 
 # Does the deacon have unread mail? (may explain idle state)
 gc mail inbox --address=deacon --json 2>/dev/null | jq length
@@ -89,7 +89,7 @@ Drain-ack and exit. Next Boot tick will re-evaluate.
 
 **Clearly stuck (very stale wisp, no output, errors visible):** File a warrant:
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck: deacon" \
   --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot"}' \
   --label=pool:dog
@@ -122,9 +122,9 @@ up your session and spawns you again next tick.
 | Want to... | Correct command |
 |------------|----------------|
 | View deacon output | `{{ cmd }} agent peek deacon 30` |
-| Check deacon work | `bd list --assignee=deacon --status=in_progress --json` |
+| Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} nudge deacon "message"` |
-| File stuck warrant | `bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| File stuck warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
 | Check agents | `{{ cmd }} agent list` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -59,14 +59,14 @@ Your formula: `mol-deacon-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-bd list --assignee="$GC_ALIAS" --status=in_progress
+gc bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 2: Nothing? Check mail for attached work
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
-bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
 ```
@@ -88,7 +88,7 @@ re-reads formula steps and resumes from context.
 
 Mail beads can be hooked for ad-hoc instruction handoff:
 - Mayor or human sends mail with special instructions
-- Your next session sees the mail on the hook via `bd list --assignee="$GC_ALIAS"`
+- Your next session sees the mail on the hook via `gc bd list --assignee="$GC_ALIAS"`
 - GUPP applies: read the content, interpret, execute
 
 This enables ad-hoc tasks (e.g., "focus on debugging convoy resolution this
@@ -103,7 +103,7 @@ response is always the same:
 
 1. **File a warrant bead:**
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --label=pool:dog
@@ -155,18 +155,18 @@ Individual stuck agents don't need escalation — the warrant system handles the
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `bd mol wisp mol-deacon-patrol --root-only` |
+| Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only` |
 | Context exhaustion | `gc runtime request-restart` |
 | Request target restart | `gc session kill <target>` |
-| Check gates | `bd gate check --type=timer --escalate` |
-| List gate beads | `bd gate list --json` |
+| Check gates | `gc bd gate check --type=timer --escalate` |
+| List gate beads | `gc bd gate list --json` |
 | List convoys | `gc convoy list` |
-| Find cross-rig deps | `bd dep list <id> --direction=up --type=blocks --json` |
-| Convert dep type | `bd dep remove <id> <dep>` then `bd dep add <id> <dep> --type=related` |
-| File stuck-agent warrant | `bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |
+| Convert dep type | `gc bd dep remove <id> <dep>` then `gc bd dep add <id> <dep> --type=related` |
+| File stuck-agent warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
 | Run system diagnostics | `gc doctor` |
-| Compact wisps (dry run) | `bd mol wisp gc --age 24h --dry-run` |
-| Compact wisps | `bd mol wisp gc --age 24h` |
+| Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
+| Compact wisps | `gc bd mol wisp gc --age 24h` |
 
 Working directory: {{ .WorkDir }}
 Your mail address: deacon/

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -20,8 +20,8 @@ You CAN and SHOULD edit code when it's the fastest path. The key is balance.
 When you file a bead, default to immediately dispatching it to a polecat:
 
 ```bash
-bd create "Fix the auth timeout bug" -t task --json   # file it
-bd update <bead-id> --set-metadata gc.routed_to=<rig>/polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
+gc bd create "Fix the auth timeout bug" -t task --json   # file it
+gc bd update <bead-id> --set-metadata gc.routed_to=<rig>/polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
 ```
 
 **Why this is the default:**
@@ -63,7 +63,7 @@ Use these locations consistently:
 | Location | Use for |
 |----------|---------|
 | `{{ .WorkDir }}` | Your own coordination home, runtime files, scratch notes |
-| `{{ .CityRoot }}` | `{{ cmd }} mail`, coordination commands, `bd` with `hq-` prefix |
+| `{{ .CityRoot }}` | `{{ cmd }} mail`, coordination commands, `gc bd` with `hq-` prefix |
 | configured rig repo root (`{{ cmd }} rig status <rig>`) | **ALL git/code operations** for that rig via `git -C` |
 | `{{ .CityRoot }}/.gc/worktrees/<rig>/...` | Agent sandboxes/worktrees — don't use these directly |
 
@@ -86,11 +86,11 @@ Never work in another agent's worktree. Use the configured rig repo root with
 
 ## Prefix-Based Routing
 
-`bd` commands automatically route to the correct rig based on issue ID prefix:
+`gc bd` commands automatically route to the correct rig based on issue ID prefix:
 
 ```
-bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
-bd show hq-abc      # Routes to town beads
+gc bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
+gc bd show hq-abc      # Routes to town beads
 ```
 
 **How it works:**
@@ -98,9 +98,9 @@ bd show hq-abc      # Routes to town beads
 - `{{ cmd }} rig add` auto-registers new rig prefixes
 - Each rig's prefix (e.g., `gt-`) maps to its beads location
 
-**Debug routing:** `BD_DEBUG_ROUTING=1 bd show <id>`
+**Debug routing:** `BD_DEBUG_ROUTING=1 gc bd show <id>`
 
-**Conflicts:** If two rigs share a prefix, use `bd rename-prefix <new>` to fix.
+**Conflicts:** If two rigs share a prefix, use `gc bd rename-prefix <new>` to fix.
 
 ## Where to File Beads - Create issues (CRITICAL)
 
@@ -108,30 +108,30 @@ bd show hq-abc      # Routes to town beads
 
 | Issue is about... | File in | Command |
 |-------------------|---------|---------|
-| `bd` CLI (beads tool bugs, features, docs) | **beads** | `bd create --rig beads "..."` |
-| `gc` CLI (gas city tool bugs, features) | **gastown** | `bd create --rig gastown "..."` |
-| Polecat/witness/refinery/convoy code | **gastown** | `bd create --rig gastown "..."` |
-| Wyvern game features | **wyvern** | `bd create --rig wyvern "..."` |
-| Cross-rig coordination, convoys, mail threads | **HQ** | `bd create "..."` (default) |
-| Agent role descriptions, assignments | **HQ** | `bd create "..."` (default) |
+| Beads CLI (tool bugs, features, docs) | **beads** | `gc bd create --rig beads "..."` |
+| `gc` CLI (gas city tool bugs, features) | **gastown** | `gc bd create --rig gastown "..."` |
+| Polecat/witness/refinery/convoy code | **gastown** | `gc bd create --rig gastown "..."` |
+| Wyvern game features | **wyvern** | `gc bd create --rig wyvern "..."` |
+| Cross-rig coordination, convoys, mail threads | **HQ** | `gc bd create "..."` (default) |
+| Agent role descriptions, assignments | **HQ** | `gc bd create "..."` (default) |
 
-**IMPORTANT: Issues are created with `bd create`, not `gc` commands.** There is no `{{ cmd }} issue`, `{{ cmd }} issues`, or `{{ cmd }} bd create` command. Always use `bd create`.
+**IMPORTANT: File issues with `gc bd create`.** There is no `{{ cmd }} issue` or `{{ cmd }} issues` namespace here. Use `gc bd create` directly.
 
 **The test**: "Which repo would the fix be committed to?"
 - Fix in `anthropics/beads` -> file in beads rig
 - Fix in `anthropics/gas-town` -> file in gastown rig
 - Pure coordination (no code) -> file in HQ
 
-**Common mistake**: Filing `bd` CLI issues in HQ because you're "coordinating."
+**Common mistake**: Filing Beads CLI issues in HQ because you're "coordinating."
 Wrong. The issue is about beads code, so it goes in the beads rig.
 
 ## Gotchas when Filing Beads
 
 **Temporal language inverts dependencies.** "Phase 1 blocks Phase 2" is backwards.
-- WRONG: `bd dep add phase1 phase2` (temporal: "1 before 2")
-- RIGHT: `bd dep add phase2 phase1` (requirement: "2 needs 1")
+- WRONG: `gc bd dep add phase1 phase2` (temporal: "1 before 2")
+- RIGHT: `gc bd dep add phase2 phase1` (requirement: "2 needs 1")
 
-**Rule**: Think "X needs Y", not "X comes before Y". Verify with `bd blocked`.
+**Rule**: Think "X needs Y", not "X comes before Y". Verify with `gc bd blocked`.
 
 ## Responsibilities
 
@@ -214,13 +214,13 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
 | Drain stuck polecat | `{{ cmd }} agent drain <name>` | ~~gc polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |
 | Create convoy for batch work | `{{ cmd }} convoy create "name" <issues>` | |
 | View convoy progress | `{{ cmd }} convoy status <id>` | |
-| Create issues | `bd create "title"` | ~~gc issue create~~ (not a command) |
+| Create issues | `gc bd create "title"` | ~~gc issue create~~ (not a command) |
 
 **Rig lifecycle commands:**
 - `suspend/resume` — Dormant toggle. Daemon skips suspended rigs entirely.

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -61,7 +61,7 @@ sees the existing branch and reason, and resumes instead of redoing everything.
 
 Read metadata:
 ```bash
-bd show <issue> --json | jq '.metadata'
+gc bd show <issue> --json | jq '.metadata'
 ```
 
 ## Work Protocol
@@ -84,9 +84,9 @@ Your formula: `mol-polecat-work`
 
 ```bash
 # Step 1: Check for assigned work
-bd list --assignee="$GC_SESSION_NAME" --status=in_progress
+gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress
 {{ .WorkQuery }}                                             # Find pool work
-bd update <id> --claim                                       # Atomic grab
+gc bd update <id> --claim                                       # Atomic grab
 
 # Step 2: Work found? -> Follow formula steps. Nothing? -> Check mail
 gc mail inbox
@@ -129,8 +129,8 @@ conflict, test failure, etc.), and resubmit. Don't redo all the work.
 
 ```bash
 # Check for rejection
-bd show <issue> --json | jq -r '.metadata.rejection_reason // empty'
-bd show <issue> --json | jq -r '.metadata.branch // empty'
+gc bd show <issue> --json | jq -r '.metadata.rejection_reason // empty'
+gc bd show <issue> --json | jq -r '.metadata.branch // empty'
 
 # If both exist: resume the branch, fix the issue, resubmit
 ```
@@ -156,7 +156,7 @@ gc mail send {{ .RigName }}/witness -s "ESCALATION: Brief description [HIGH]" -m
 gc mail send mayor/ -s "BLOCKED: <topic>" -m "Context"
 ```
 
-After escalating: continue if possible, otherwise `bd update <bead> --status=escalated && gc runtime drain-ack && exit`.
+After escalating: continue if possible, otherwise `gc bd update <bead> --status=escalated && gc runtime drain-ack && exit`.
 
 ---
 
@@ -192,11 +192,11 @@ Nudges from other agents may arrive via your hook. When working:
 
 ```bash
 git push origin HEAD
-bd update <work-bead> \
+gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
+gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit
 ```
@@ -215,7 +215,7 @@ is the "Idle Polecat heresy."
 | Want to... | Correct command |
 |------------|----------------|
 | Signal work complete | Done sequence (push, set metadata, reassign, `gc runtime drain-ack`, exit) |
-| Read formula steps | `bd show <wisp-id>` (shows formula ref) |
+| Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
 | Escalate blocker | `gc mail send {{ .RigName }}/witness -s "ESCALATION: desc [HIGH]" -m "..."` |
 | Context exhaustion | `gc runtime request-restart` |
 | Handoff to next session | `gc mail send -s "HANDOFF: ..." -m "..."` then `gc runtime drain-ack && exit` |

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -50,11 +50,11 @@ Your formula: `mol-refinery-patrol`
 
 ```bash
 # Check for an in-progress patrol wisp
-bd list --assignee="$GC_ALIAS" --status=in_progress
+gc bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # If none found, pour one (root-only — no child step beads) and assign it
-WISP=$(bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --json | jq -r '.new_epic_id')
-bd update "$WISP" --assignee="$GC_ALIAS"
+WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --json | jq -r '.new_epic_id')
+gc bd update "$WISP" --assignee="$GC_ALIAS"
 ```
 
 Then follow the formula. The step descriptions below are your instructions —
@@ -93,9 +93,9 @@ Polecats set these metadata fields before assigning a work bead to you:
 
 Read them mechanically:
 ```bash
-bd show $WORK --json | jq -r '.metadata.branch'
-bd show $WORK --json | jq -r '.metadata.target // "{{ .DefaultBranch }}"'
-bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"'
+gc bd show $WORK --json | jq -r '.metadata.branch'
+gc bd show $WORK --json | jq -r '.metadata.target // "{{ .DefaultBranch }}"'
+gc bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"'
 ```
 
 Never infer a branch name. If `metadata.branch` is missing, reject the bead.
@@ -104,7 +104,7 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 On rebase conflict or test failure:
 1. Put work bead back in pool:
-   `bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
+   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
 2. Branch handling depends on failure type:
    - Conflict: leave branch intact (polecat needs it for rebase)
    - Test failure: delete branch (polecat redoes work)
@@ -157,14 +157,14 @@ alert the witness, not `gc mail send`.
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `bd mol wisp mol-refinery-patrol --root-only` |
-| Burn current wisp | `bd mol burn <wisp-id> --force` |
-| Find assigned work | `bd list --assignee="$GC_ALIAS" --status=open` |
+| Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only` |
+| Burn current wisp | `gc bd mol burn <wisp-id> --force` |
+| Find assigned work | `gc bd list --assignee="$GC_ALIAS" --status=open` |
 | Snapshot event position | `gc events --seq` |
 | Wait for assignment | `gc events --watch --type=bead.updated --after=$SEQ` |
-| Read work metadata | `bd show $WORK --json \| jq '.metadata'` |
-| Set metadata field | `bd update $WORK --set-metadata key=value` |
-| Remove metadata field | `bd update $WORK --unset-metadata key` |
+| Read work metadata | `gc bd show $WORK --json \| jq '.metadata'` |
+| Set metadata field | `gc bd update $WORK --set-metadata key=value` |
+| Remove metadata field | `gc bd update $WORK --unset-metadata key` |
 | Fetch remote branches | `git fetch --prune origin` |
 | Rebase on target | `git rebase origin/$TARGET` |
 | Fast-forward merge | `git merge --ff-only temp` |

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -127,7 +127,7 @@ A long tool call is different from an infinite loop.
 for the dog pool:
 
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"witness"}' \
   --label=pool:dog
@@ -151,14 +151,14 @@ Your formula: `mol-witness-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-bd list --assignee="$GC_ALIAS" --status=in_progress
+gc bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 2: Nothing? Check mail for attached work
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
-bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+NEW_WISP=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
 ```
@@ -244,13 +244,13 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `bd mol wisp mol-witness-patrol --root-only` |
+| Pour next wisp | `gc bd mol wisp mol-witness-patrol --root-only` |
 | Context exhaustion | `gc runtime request-restart` |
 | Recover orphaned bead | `gc workflow delete-source <id> --apply && gc workflow reopen-source <id>` |
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
-| Set branch metadata | `bd update <id> --set-metadata branch=<name>` |
-| File stuck-agent warrant | `bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
+| File stuck-agent warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/assets/prompts/crew.template.md
+++ b/examples/gastown/packs/gastown/assets/prompts/crew.template.md
@@ -40,23 +40,23 @@ the overseer, not as part of a transient worker pool.
 
 **Key points:**
 - Mail ALWAYS uses town beads - `{{ cmd }} mail` routes there automatically
-- Project issues use your clone's beads - `bd` commands use local `.beads/`
+- Project issues use your clone's beads - `gc bd` uses local `.beads/`
 - Beads changes are persisted immediately via Dolt - no sync step needed
 - **GitHub URLs**: Use `git remote -v` to verify repo URLs - never assume orgs like `anthropics/`
 
 ## Prefix-Based Routing
 
-`bd` commands automatically route to the correct rig based on issue ID prefix:
+`gc bd` commands automatically route to the correct rig based on issue ID prefix:
 
 ```
-bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
-bd show hq-abc      # Routes to town beads
+gc bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
+gc bd show hq-abc      # Routes to town beads
 ```
 
 **How it works:**
 - Routes defined in `{{ .CityRoot }}/.beads/routes.jsonl`
 - Each rig's prefix (e.g., `gt-`) maps to its beads location
-- Debug with: `BD_DEBUG_ROUTING=1 bd show <id>`
+- Debug with: `BD_DEBUG_ROUTING=1 gc bd show <id>`
 
 ## Your Workspace
 
@@ -100,7 +100,7 @@ git worktree remove {{ .CityRoot }}/.gc/worktrees/$TARGET_RIG/crew/{{ basename .
 |----------|----------|
 | Quick fix in another rig | Use `git worktree add` |
 | Substantial work in another rig | Use `git worktree add` |
-| Work should be done by target rig's workers | `{{ cmd }} convoy create` + `bd update --label=pool:<rig>/polecat` |
+| Work should be done by target rig's workers | `{{ cmd }} convoy create` + `gc bd update --label=pool:<rig>/polecat` |
 | Infrastructure task | Leave it to the Deacon's dogs |
 
 **Note**: Dogs are utility agents that handle infrastructure tasks (warrants,
@@ -116,20 +116,20 @@ go here by default. But if you discover bugs/issues in OTHER projects:
 
 | Issue is about... | File in | Command |
 |-------------------|---------|---------|
-| This rig's code ({{ .RigName }}) | Here (default) | `bd create "..."` |
-| `bd` CLI (beads tool) | **beads** | `bd create --rig beads "..."` |
-| `gc` CLI (gas city tool) | **gastown** | `bd create --rig gastown "..."` |
-| Cross-rig coordination | **HQ** | `bd create --prefix hq- "..."` |
+| This rig's code ({{ .RigName }}) | Here (default) | `gc bd create "..."` |
+| Beads CLI (beads tool) | **beads** | `gc bd create --rig beads "..."` |
+| `gc` CLI (gas city tool) | **gastown** | `gc bd create --rig gastown "..."` |
+| Cross-rig coordination | **HQ** | `gc bd create --prefix hq- "..."` |
 
 **The test**: "Which repo would the fix be committed to?"
 
 ## Gotchas when Filing Beads
 
 **Temporal language inverts dependencies.** "Phase 1 blocks Phase 2" is backwards.
-- WRONG: `bd dep add phase1 phase2` (temporal: "1 before 2")
-- RIGHT: `bd dep add phase2 phase1` (requirement: "2 needs 1")
+- WRONG: `gc bd dep add phase1 phase2` (temporal: "1 before 2")
+- RIGHT: `gc bd dep add phase2 phase1` (requirement: "2 needs 1")
 
-**Rule**: Think "X needs Y", not "X comes before Y". Verify with `bd blocked`.
+**Rule**: Think "X needs Y", not "X comes before Y". Verify with `gc bd blocked`.
 
 ## Handoff
 
@@ -324,7 +324,7 @@ you are!" - that is a FAILURE. YOU must push, not the user.
 
 1. **File beads for remaining work** that needs follow-up:
    ```bash
-   bd create "Follow-up: description" -t task
+   gc bd create "Follow-up: description" -t task
    ```
 
 2. **Run quality gates** (only if code changes were made):
@@ -336,7 +336,7 @@ you are!" - that is a FAILURE. YOU must push, not the user.
 
 3. **Update beads** - close finished work, update status:
    ```bash
-   bd close <id> --reason "Completed"
+   gc bd close <id> --reason "Completed"
    ```
 
 4. **PUSH TO REMOTE - NON-NEGOTIABLE:**
@@ -387,7 +387,7 @@ When a command fails but your guess felt reasonable ("this should have worked"):
 3. **If no**: Your mental model was off - note it and move on
 
 Example: Trying `{{ cmd }} convoy land hq-abc` (expected to land a convoy) and getting "unknown command".
-That's a desire path - the syntax makes sense. File it: `bd new -t task "Add gc convoy land" -l desire-path`
+That's a desire path - the syntax makes sense. File it: `gc bd new -t task "Add gc convoy land" -l desire-path`
 
 See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 
@@ -399,7 +399,7 @@ See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
 | Stop my session | `{{ cmd }} agent drain {{ basename .AgentName }}` | ~~gc rig stop~~ (stops rig agents, not crew) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -1,8 +1,8 @@
 description = """
 Deacon patrol loop. Poured as a root-only wisp on startup:
 
-  bd mol wisp mol-deacon-patrol --root-only
-  bd update $WISP --assignee=$GC_AGENT
+  gc bd mol wisp mol-deacon-patrol --root-only
+  gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check inbox, run town-wide coordination
 tasks, pour the next iteration. On crash, re-read the formula steps
@@ -159,7 +159,7 @@ something is stuck. This is exactly why an LLM does it, not Go code.
 
 **For stuck coordination agents, file a warrant:**
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck: <rig>/<role>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --set-metadata gc.routed_to=dog
@@ -186,7 +186,7 @@ wisp timestamps.
 
 **Step 1: Find active utility agent work:**
 ```bash
-bd list --status=in_progress --metadata-field gc.routed_to=dog --json --limit=0
+gc bd list --status=in_progress --metadata-field gc.routed_to=dog --json --limit=0
 ```
 
 **Step 2: For each, assess progress:**
@@ -199,7 +199,7 @@ No hardcoded thresholds. Use judgment.
 
 **Step 3: For stuck utility agents, file a warrant:**
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck dog: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --set-metadata gc.routed_to=dog
@@ -340,8 +340,8 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
-bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
 **4. Wait for activity (exponential backoff):**
@@ -356,7 +356,7 @@ On timeout: double the timeout (cap 300s) and proceed anyway.
 
 **5. Burn this wisp:**
 ```bash
-bd mol burn <this-wisp-id> --force
+gc bd mol burn <this-wisp-id> --force
 ```
 
 The new wisp is ready. Re-read formula steps to start

--- a/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
@@ -85,8 +85,8 @@ gc rig list
 
 a) **Issues filed and closed:**
 ```bash
-bd list --created-after=$SINCE --json --limit=0
-bd list --status=closed --closed-after=$SINCE --json --limit=0
+gc bd list --created-after=$SINCE --json --limit=0
+gc bd list --status=closed --closed-after=$SINCE --json --limit=0
 ```
 
 b) **Merge activity:**
@@ -96,7 +96,7 @@ git -C <rig-path> log --merges --since=$SINCE --oneline main
 
 c) **Incidents:**
 ```bash
-bd list --label=incident --created-after=$SINCE --json
+gc bd list --label=incident --created-after=$SINCE --json
 ```
 
 **3. Collect town-level data:**
@@ -108,12 +108,12 @@ gc events --since=$SINCE --type=agent.started,agent.stopped,agent.crashed --json
 
 b) **Escalations:**
 ```bash
-bd list --label=escalation --created-after=$SINCE --json
+gc bd list --label=escalation --created-after=$SINCE --json
 ```
 
 c) **Warrants filed:**
 ```bash
-bd list --type=warrant --created-after=$SINCE --json
+gc bd list --type=warrant --created-after=$SINCE --json
 ```
 
 Close this step when all data is collected."""
@@ -160,14 +160,14 @@ gc mail send mayor/ -s "Gas Town Digest: $DATE" -m "$DIGEST"
 
 **3. Archive as bead:**
 ```bash
-bd create --type=digest \
+gc bd create --type=digest \
   --title="Digest: $DATE" \
   --label=digest,{{period}}
 ```
 
 **4. Close work bead, signal reconciler, and exit:**
 ```bash
-bd close <work-bead> --reason "Digest generated and sent"
+gc bd close <work-bead> --reason "Digest generated and sent"
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
@@ -9,11 +9,11 @@ shortcuts today, so this formula maps the same intent onto primitives we do
 have:
 
 - repo-local artifacts (`.prd-reviews/`, `.designs/`, `.plan-reviews/`)
-- review task beads created with `bd create`
+- review task beads created with `gc bd create`
 - parallel dispatch via `gc sling ... --on mol-review-leg`
 - completion mail via `gc mail send`
 - one human clarification gate in the live conversation
-- final bead graph creation with `bd create` + `bd dep add`
+- final bead graph creation with `gc bd create` + `gc bd dep add`
 
 Run this from a coordinator workspace that has the target repo checked out
 (typically a crew worker, or a mayor who has already `cd`'d into the rig repo).
@@ -67,7 +67,7 @@ Use only the primitives listed in this formula.
 **1. Prime and move to the repo root:**
 ```bash
 gc prime
-bd prime
+gc bd prime
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 ```
@@ -141,7 +141,7 @@ description = """
 Fan out parallel PRD review using review task beads plus `mol-review-leg`.
 
 **Dispatch pattern for EVERY review leg in this workflow:**
-1. `bd create` a task bead with a detailed description
+1. `gc bd create` a task bead with a detailed description
 2. set metadata:
    - `coordinator=$COORDINATOR`
    - `review_id=$REVIEW_ID`
@@ -153,7 +153,7 @@ gc sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
 ```
 4. record the bead ID in the round log
 5. wait for completion mail or poll the bead until it closes
-6. read the full report from the bead notes with `bd show <id>`
+6. read the full report from the bead notes with `gc bd show <id>`
 
 **Standard instructions each review bead must include:**
 - read `.prd-reviews/$REVIEW_ID/prd-draft.md`
@@ -454,10 +454,10 @@ After creating the task beads, add them to the convoy with:
 gc convoy add <convoy-id> <task-id>
 ```
 
-**4. Wire dependencies with `bd dep add`:**
+**4. Wire dependencies with `gc bd dep add`:**
 Model the actual "X needs Y" relationships. Verify with:
 ```bash
-bd blocked
+gc bd blocked
 ```
 
 **5. Record the created bead IDs in:**

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -60,7 +60,7 @@ git fetch --prune origin
 
 Check if `metadata.work_dir` already records your worktree path:
 ```bash
-WORKTREE=$(bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
+WORKTREE=$(gc bd show {{issue}} --json | jq -r '.metadata.work_dir // empty')
 ```
 
 **If worktree path exists in metadata** — reuse it:
@@ -78,7 +78,7 @@ cd "$WORKTREE_PATH"
 ```
 Record immediately so restarts and witness recovery can find it:
 ```bash
-bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
+gc bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
 ```
 
 Worktrees are scoped to the work bead (not the agent name) so that:
@@ -90,7 +90,7 @@ Worktrees are scoped to the work bead (not the agent name) so that:
 
 Check if `metadata.branch` already records a branch:
 ```bash
-BRANCH=$(bd show {{issue}} --json | jq -r '.metadata.branch // empty')
+BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
 ```
 
 **If branch exists in metadata** — check it out:
@@ -99,12 +99,12 @@ git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH" origin/"$BRANCH"
 ```
 If resuming a rejected branch, rebase onto latest base:
 ```bash
-REJECTION=$(bd show {{issue}} --json | jq -r '.metadata.rejection_reason // empty')
+REJECTION=$(gc bd show {{issue}} --json | jq -r '.metadata.rejection_reason // empty')
 if [ -n "$REJECTION" ]; then
     git rebase origin/{{base_branch}}
     # If conflicts: resolve them (this is likely the rejection reason)
     # After resolving: git rebase --continue
-    bd update {{issue}} --unset-metadata rejection_reason
+    gc bd update {{issue}} --unset-metadata rejection_reason
 fi
 ```
 
@@ -112,7 +112,7 @@ fi
 ```bash
 BRANCH="polecat/{{issue}}"
 git checkout -b "$BRANCH" origin/{{base_branch}}
-bd update {{issue}} --set-metadata branch="$BRANCH"
+gc bd update {{issue}} --set-metadata branch="$BRANCH"
 ```
 
 Recording the branch early means:
@@ -167,7 +167,7 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 
 **4. Update metadata on the work bead:**
 ```bash
-bd update {{issue}} \
+gc bd update {{issue}} \
   --set-metadata target={{base_branch}} \
   --notes "Implemented: <brief summary>"
 ```
@@ -176,7 +176,7 @@ This adds the target for the refinery.
 
 **5. Reassign to refinery:**
 ```bash
-bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
+gc bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
 ```
 
 Update both `assignee` AND `gc.routed_to` so the reconciler stops

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -1,8 +1,8 @@
 description = """
 Refinery patrol loop. Poured as a root-only wisp on startup:
 
-  bd mol wisp mol-refinery-patrol --root-only
-  bd update $WISP --assignee=$GC_AGENT
+  gc bd mol wisp mol-refinery-patrol --root-only
+  gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, merge one branch, pour
 the next iteration. On crash, re-read the formula steps and determine
@@ -110,13 +110,13 @@ description = """
 
 Search for work beads assigned to you with branch metadata:
 ```bash
-WORK=$(bd list --assignee=$GC_AGENT --status=open \
+WORK=$(gc bd list --assignee=$GC_AGENT --status=open \
   --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
 ```
 
 If found: read the bead metadata to confirm it has a branch:
 ```bash
-bd show $WORK --json | jq '.metadata'
+gc bd show $WORK --json | jq '.metadata'
 ```
 The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
@@ -142,8 +142,8 @@ description = """
 
 Read the work bead metadata:
 ```bash
-BRANCH=$(bd show $WORK --json | jq -r '.metadata.branch')
-TARGET=$(bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
+BRANCH=$(gc bd show $WORK --json | jq -r '.metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
 ```
 
 Fetch and attempt mechanical rebase:
@@ -164,7 +164,7 @@ gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 ```
 3. Put the work bead back in the pool with rejection metadata:
 ```bash
-bd update $WORK \
+gc bd update $WORK \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
   --set-metadata gc.routed_to=<rig>/polecat
 ```
@@ -172,10 +172,10 @@ bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-NEXT=$(bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
-7. Burn this wisp: `bd mol burn <wisp-id> --force`
+7. Burn this wisp: `gc bd mol burn <wisp-id> --force`
 
 **A new polecat will pick up the bead, see the branch and rejection,
 rebase, and reassign to refinery.**"""
@@ -221,8 +221,8 @@ If any check or test FAILED:
 
 Read the current branch and target again:
 ```bash
-BRANCH=$(bd show $WORK --json | jq -r '.metadata.branch')
-TARGET=$(bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
+BRANCH=$(gc bd show $WORK --json | jq -r '.metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
 ```
 
 1. Diagnose: branch regression or pre-existing on target?
@@ -234,27 +234,27 @@ TARGET=$(bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
      ```
    - Put the work bead back in the pool with rejection metadata:
      ```bash
-     bd update $WORK \
+     gc bd update $WORK \
        --set-metadata rejection_reason="<failure summary>"
      ```
    - Delete branch: `git push origin --delete $BRANCH`
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     NEXT=$(bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-     bd update "$NEXT" --assignee=$GC_AGENT
+     NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+     gc bd update "$NEXT" --assignee=$GC_AGENT
      ```
-   - Burn this wisp: `bd mol burn <wisp-id> --force`
+   - Burn this wisp: `gc bd mol burn <wisp-id> --force`
 
 3. If pre-existing on target:
    - Check for duplicates first:
      ```bash
-     bd list --type=bug --status=open --search "<failure summary>"
+     gc bd list --type=bug --status=open --search "<failure summary>"
      ```
    - If a matching bug already exists: note its ID and proceed with merge.
    - If no duplicate: file a new bead:
      ```bash
-     bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>"
+     gc bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>"
      ```
    - Proceed with merge (failure not caused by this branch)
 
@@ -271,9 +271,9 @@ description = """
 
 Read the merge target and merge strategy from the work bead metadata:
 ```bash
-BRANCH=$(bd show $WORK --json | jq -r '.metadata.branch')
-TARGET=$(bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
-MERGE_STRATEGY=$(bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"')
+BRANCH=$(gc bd show $WORK --json | jq -r '.metadata.branch')
+TARGET=$(gc bd show $WORK --json | jq -r '.metadata.target // "{{target_branch}}"')
+MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"')
 if [ "$MERGE_STRATEGY" = "pr" ]; then
   MERGE_STRATEGY="mr"
 fi
@@ -299,11 +299,11 @@ If SHAs differ: STOP. Debug and retry. Do NOT continue.
 
 **3. Record merge metadata and close work bead:**
 ```bash
-bd update $WORK \
+gc bd update $WORK \
   --set-metadata merge_result=merged \
   --set-metadata merged_sha=$(git rev-parse HEAD) \
   --set-metadata merged_target=$TARGET
-bd close $WORK --reason "Merged to $TARGET at $(git rev-parse --short HEAD)"
+gc bd close $WORK --reason "Merged to $TARGET at $(git rev-parse --short HEAD)"
 ```
 
 **4. Cleanup:**
@@ -325,7 +325,7 @@ git push origin HEAD:$BRANCH --force-with-lease
 
 **2. Create or discover the pull request:**
 ```bash
-ISSUE_TITLE=$(bd show $WORK --json | jq -r '.title')
+ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.title')
 PR_BODY=$(cat <<EOF
 ## Summary
 
@@ -359,12 +359,12 @@ If this command fails or prints empty output: STOP. Debug and retry. Do NOT cont
 **4. Record PR metadata and close the work bead:**
 ```bash
 PR_NUMBER=$(gh pr view "$BRANCH" --json number -q '.number')
-bd update $WORK \
+gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \
   --set-metadata pr_number="$PR_NUMBER" \
   --set-metadata merged_target="$TARGET"
-bd close $WORK --reason "Pull request ready: $PR_URL"
+gc bd close $WORK --reason "Pull request ready: $PR_URL"
 ```
 
 **5. Cleanup:**
@@ -407,7 +407,7 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `bd list --type=wisp
+closing reason. The next session can find it via `gc bd list --type=wisp
 --status=closed --limit=5` if it needs predecessor context."""
 
 [[steps]]
@@ -422,13 +422,13 @@ description = """
 If the merge target was an integration branch, check if the parent
 owned convoy is now fully closed:
 ```bash
-bd list --type=convoy --status=open
+gc bd list --type=convoy --status=open
 ```
 For each owned convoy with an integration branch: if ALL children are
 closed, assign the convoy bead itself to you with the metadata needed
 for a merge:
 ```bash
-bd update <convoy-id> --assignee=$GC_AGENT \
+gc bd update <convoy-id> --assignee=$GC_AGENT \
   --set-metadata branch=<integration-branch> \
   --set-metadata target={{target_branch}}
 ```
@@ -442,13 +442,13 @@ If auto_land = "false": skip this entirely.
 
 **2. Pour next iteration:**
 ```bash
-NEXT=$(bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
 **4. Burn this wisp:**
 ```bash
-bd mol burn <this-wisp-id> --force
+gc bd mol burn <this-wisp-id> --force
 ```
 
 Close this step. The new wisp is ready — re-read formula steps to begin."""

--- a/examples/gastown/packs/gastown/formulas/mol-review-leg.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-review-leg.toml
@@ -31,13 +31,13 @@ Prime your environment and read the assignment bead carefully.
 **1. Prime:**
 ```bash
 gc prime
-bd prime
+gc bd prime
 ```
 
 **2. Read the bead and metadata:**
 ```bash
-bd show {{issue}}
-bd show {{issue}} --json | jq '.metadata'
+gc bd show {{issue}}
+gc bd show {{issue}} --json | jq '.metadata'
 ```
 
 **Expected metadata:**
@@ -64,7 +64,7 @@ session exits.
 
 Suggested pattern:
 ```bash
-bd update {{issue}} --notes "$(cat <<'EOF'
+gc bd update {{issue}} --notes "$(cat <<'EOF'
 # <report title>
 
 ## Summary
@@ -93,10 +93,10 @@ After the report is stored on the bead, notify the coordinator and close out.
 
 **1. Read metadata for the mail header:**
 ```bash
-COORD=$(bd show {{issue}} --json | jq -r '.metadata.coordinator // empty')
-REVIEW_ID=$(bd show {{issue}} --json | jq -r '.metadata.review_id // empty')
-PHASE=$(bd show {{issue}} --json | jq -r '.metadata.review_phase // empty')
-LEG=$(bd show {{issue}} --json | jq -r '.metadata.review_leg // empty')
+COORD=$(gc bd show {{issue}} --json | jq -r '.metadata.coordinator // empty')
+REVIEW_ID=$(gc bd show {{issue}} --json | jq -r '.metadata.review_id // empty')
+PHASE=$(gc bd show {{issue}} --json | jq -r '.metadata.review_phase // empty')
+LEG=$(gc bd show {{issue}} --json | jq -r '.metadata.review_leg // empty')
 ```
 
 **2. If `COORD` is present, mail completion:**
@@ -115,7 +115,7 @@ EOF
 
 **3. Close the bead and drain:**
 ```bash
-bd update {{issue}} --status=closed
+gc bd update {{issue}} --status=closed
 gc runtime drain-ack
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -1,8 +1,8 @@
 description = """
 Witness patrol loop. Poured as a root-only wisp on startup:
 
-  bd mol wisp mol-witness-patrol --root-only
-  bd update $WISP --assignee=$GC_AGENT
+  gc bd mol wisp mol-witness-patrol --root-only
+  gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, patrol, pour the next
 iteration. On crash, re-read the formula steps and determine where
@@ -138,8 +138,8 @@ This happens when:
 
 List beads assigned to agents in YOUR rig:
 ```bash
-bd list --status=in_progress --json --limit=0
-bd list --status=open --json --limit=0
+gc bd list --status=in_progress --json --limit=0
+gc bd list --status=open --json --limit=0
 ```
 
 Filter for beads assigned to polecat-pattern agents (e.g., `<rig>/polecats/<name>`).
@@ -169,7 +169,7 @@ Our job is to ensure work reaches the branch so it's schedulable.
 
 Read the bead metadata to find the worktree and branch:
 ```bash
-META=$(bd show <bead> --json | jq '.metadata')
+META=$(gc bd show <bead> --json | jq '.metadata')
 WORKTREE=$(echo "$META" | jq -r '.worktree // empty')
 BRANCH=$(echo "$META" | jq -r '.branch // empty')
 ```
@@ -209,7 +209,7 @@ git commit -m "witness: salvage uncommitted work (<bead>)"
 Publish the work to make branch canonical:
 ```bash
 git push origin HEAD
-bd update <bead> --set-metadata branch=$BRANCH
+gc bd update <bead> --set-metadata branch=$BRANCH
 ```
 Skip to Step 3 (cleanup).
 
@@ -221,7 +221,7 @@ git add -A
 git commit -m "witness: salvage work from orphaned agent (<bead>)"
 BRANCH=$(git branch --show-current)
 git push origin HEAD
-bd update <bead> --set-metadata branch=$BRANCH
+gc bd update <bead> --set-metadata branch=$BRANCH
 ```
 Skip to Step 3 (cleanup).
 
@@ -243,7 +243,7 @@ git merge-base --is-ancestor origin/$BRANCH origin/main
 If the work is already on main:
 - **Close the bead** (work is done, don't re-dispatch):
 ```bash
-bd close <bead>
+gc bd close <bead>
 gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
   -m "Branch $BRANCH already on main. Closed instead of resetting."
 ```
@@ -291,7 +291,7 @@ Concern: <why this one warrants attention>"
 
 Mark recovered beads so spawn storm detection can track patterns:
 ```bash
-bd update <bead> --set-metadata recovered=true
+gc bd update <bead> --set-metadata recovered=true
 ```
 
 **Exit criteria:** All orphaned beads recovered, worktrees cleaned.
@@ -306,7 +306,7 @@ Ensure the refinery is processing work and the queue is healthy.
 
 **Step 1: Check work beads assigned to refinery:**
 ```bash
-bd list --assignee=<rig>/refinery --status=open --json
+gc bd list --assignee=<rig>/refinery --status=open --json
 ```
 
 These are work beads with `metadata.branch` and `metadata.target` that
@@ -352,7 +352,7 @@ progressing. The controller can't detect this; it's a work-layer judgment.
 
 **Step 1: Find active polecat work beads:**
 ```bash
-bd list --status=in_progress --json --limit=0
+gc bd list --status=in_progress --json --limit=0
 ```
 Filter for beads assigned to polecat-pattern agents in YOUR rig.
 
@@ -375,7 +375,7 @@ Do NOT kill the agent directly. File a warrant bead and let the dog pool
 handle the shutdown dance (multi-stage interrogation with due process):
 
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness"}' \
   --label=pool:dog
@@ -414,8 +414,8 @@ is already assigned — the new session resumes from context.
 
 **2. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
-bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
 **3. Wait for activity (exponential backoff):**
@@ -430,7 +430,7 @@ On timeout: double the timeout (cap 300s) and proceed anyway.
 
 **4. Burn this wisp:**
 ```bash
-bd mol burn <this-wisp-id> --force
+gc bd mol burn <this-wisp-id> --force
 ```
 
 The new wisp is ready. Re-read formula steps to start

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -37,11 +37,11 @@ your implementation work is done, you run the done sequence.
 
 ```bash
 git push origin HEAD
-bd update <work-bead> \
+gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
+gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
@@ -15,7 +15,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When you (or the human) assign work to yourself, the contract is:
 1. You will find it on your hook
-2. You will understand what it is (`bd list --assignee="$GC_ALIAS" --status=in_progress` / `bd show`)
+2. You will understand what it is (`gc bd list --assignee="$GC_ALIAS" --status=in_progress` / `gc bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -30,7 +30,7 @@ drive shaft - if you stall, the whole town stalls.
 - Work sits idle. Witnesses wait. Polecats idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for user instructions
@@ -63,7 +63,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When someone assigns work to you (or you assign to yourself), they trust that:
 1. You will find it on your hook
-2. You will understand what it is (`bd list --assignee="$GC_SESSION_NAME" --status=in_progress` / `bd show`)
+2. You will understand what it is (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress` / `gc bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -77,7 +77,7 @@ run on politeness - they run on pistons firing. You are the piston.
 - Work sits idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for assignment
@@ -102,7 +102,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If patrol wisp assigned -> EXECUTE immediately (read formula steps)
 3. If nothing assigned -> Create patrol wisp and execute
 
@@ -127,7 +127,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If patrol wisp assigned -> EXECUTE immediately (read formula steps)
 3. If nothing assigned -> Create patrol wisp and execute
 
@@ -153,12 +153,12 @@ finds work for you, you EXECUTE. No confirmation. No questions. No waiting.
 
 **The handoff contract:**
 When you were spawned, work was assigned to you:
-1. You will find it via `bd list --assignee="$GC_SESSION_NAME" --status=in_progress`
-2. You will understand the work (`bd show <issue>`)
+1. You will find it via `gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`
+2. You will understand the work (`gc bd show <issue>`)
 3. You will BEGIN IMMEDIATELY
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
 2. Work MUST be assigned (polecats always have work) -> EXECUTE immediately
 3. If nothing assigned -> ERROR: escalate to Witness
 
@@ -187,7 +187,7 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for an in-progress patrol wisp (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If found -> Resume where you left off (read formula steps, determine current position)
 3. If none -> Pour a new wisp and assign it to yourself
 
@@ -210,10 +210,10 @@ idle. The witness escalates. All because the gearbox seized.
 Gas Town is a steam engine. You are a piston that fires when called.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
 2. If work found -> EXECUTE immediately (read formula steps)
 3. If nothing -> `{{ .WorkQuery }}` to find pool work
-4. If pool work found -> Claim it: `bd update <id> --claim`
+4. If pool work found -> Claim it: `gc bd update <id> --claim`
 5. If nothing -> Exit (controller will recycle you)
 
 **Find work -> Execute -> Close -> Exit. No waiting.**

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -62,7 +62,7 @@ ample opportunity to respond even if they're in long-running operations.
 **CRITICAL**: When you finish, you MUST close your work and exit:
 
 ```bash
-bd close <work-bead>    # Close your assigned work
+gc bd close <work-bead>    # Close your assigned work
 gc runtime drain-ack    # Signal reconciler you're done
 exit                     # Return to pool (controller recycles you)
 ```
@@ -108,11 +108,11 @@ gc nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Read formula steps | `bd show <wisp-id>` (shows formula ref) |
+| Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
 | Find pool work | `{{ .WorkQuery }}` |
-| Claim pool work | `bd update <id> --claim` |
-| View work details | `bd show <id> --json` |
-| Close completed work | `bd close <id> --reason "..."` |
+| Claim pool work | `gc bd update <id> --claim` |
+| View work details | `gc bd show <id> --json` |
+| Close completed work | `gc bd close <id> --reason "..."` |
 | Request target restart | `gc session kill <target>` |
 | List orphan databases | `gc dolt cleanup` |
 | Remove orphan databases | `gc dolt cleanup --force` |

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -176,7 +176,7 @@ gc nudge deacon/ "DOG_DONE: jsonl — exported <count>/<total>, push: <status>"
 
 **3. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "JSONL export complete"
+gc bd close <work-bead> --reason "JSONL export complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -258,7 +258,7 @@ gc nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, mail:<cou
 
 **4. Close work and exit:**
 ```bash
-bd close <work-bead> --reason "Reaper cycle complete"
+gc bd close <work-bead> --reason "Reaper cycle complete"
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -4,7 +4,7 @@ Shutdown dance — due process for stuck agents.
 Dispatched by filing a warrant bead with `--label=pool:dog`:
 
 ```bash
-bd create --type=warrant \
+gc bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>"}' \
   --label=pool:dog
@@ -73,13 +73,13 @@ Entry point. Read the warrant metadata from your wisp.
 
 **1. Read warrant details:**
 ```bash
-bd show <wisp-id> --json | jq '.metadata'
+gc bd show <wisp-id> --json | jq '.metadata'
 ```
 Extract: `target`, `reason`, `requester`, `warrant_id`.
 
 **2. Verify the warrant bead exists and is open:**
 ```bash
-bd show {{warrant_id}} --json | jq '.status'
+gc bd show {{warrant_id}} --json | jq '.status'
 ```
 If warrant is already closed (another dog handled it, or requester
 cancelled): close this step, burn the wisp, exit.
@@ -89,7 +89,7 @@ cancelled): close this step, burn the wisp, exit.
 gc session peek {{target}} 1
 ```
 If target session doesn't exist (already dead):
-- Close warrant: `bd close {{warrant_id}} --reason "Target already dead"`
+- Close warrant: `gc bd close {{warrant_id}} --reason "Target already dead"`
 - Send DOG_DONE mail to requester
 - Burn this wisp, exit
 
@@ -127,7 +127,7 @@ generated). Use judgment — explicit "ALIVE" is definitive, but active
 output also indicates the agent is functioning.
 
 **4. If ALIVE or active:**
-- Close warrant: `bd close {{warrant_id}} --reason "Session responded at attempt 1"`
+- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 1"`
 - Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
 - Burn wisp, exit
 
@@ -163,7 +163,7 @@ gc session peek {{target}} 50
 Same evaluation as attempt 1: ALIVE keyword or active output.
 
 **4. If ALIVE or active:**
-- Close warrant: `bd close {{warrant_id}} --reason "Session responded at attempt 2"`
+- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 2"`
 - Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 2"`
 - Burn wisp, exit
 
@@ -197,7 +197,7 @@ gc session peek {{target}} 50
 ```
 
 **4. If ALIVE or active:**
-- Close warrant: `bd close {{warrant_id}} --reason "Session responded at attempt 3"`
+- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 3"`
 - Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 3 (close call)"`
 - Burn wisp, exit
 
@@ -232,7 +232,7 @@ gc mail send {{requester}}/ -s "EXECUTE_FAILED: {{target}}" \
 
 **3. Record execution on the warrant:**
 ```bash
-bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
+gc bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
 ```
 
 Close this step, proceed to epitaph."""
@@ -257,7 +257,7 @@ Action: session killed, reconciler will restart"
 **2. Close work bead (if separate from warrant):**
 If your assigned work bead is different from the warrant bead, close it:
 ```bash
-bd close <work-bead> --reason "Shutdown dance complete: {{target}} executed"
+gc bd close <work-bead> --reason "Shutdown dance complete: {{target}} executed"
 ```
 
 **3. Exit:**

--- a/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
@@ -15,7 +15,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When you (or the human) assign work to yourself, the contract is:
 1. You will find it on your hook
-2. You will understand what it is (`bd list --assignee=$GC_AGENT --status=in_progress` / `bd show`)
+2. You will understand what it is (`gc bd list --assignee=$GC_AGENT --status=in_progress` / `gc bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -30,7 +30,7 @@ drive shaft - if you stall, the whole town stalls.
 - Work sits idle. Witnesses wait. Polecats idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for user instructions
@@ -63,7 +63,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When someone assigns work to you (or you assign to yourself), they trust that:
 1. You will find it on your hook
-2. You will understand what it is (`bd list --assignee=$GC_AGENT --status=in_progress` / `bd show`)
+2. You will understand what it is (`gc bd list --assignee=$GC_AGENT --status=in_progress` / `gc bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -77,7 +77,7 @@ run on politeness - they run on pistons firing. You are the piston.
 - Work sits idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for assignment
@@ -102,7 +102,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If patrol wisp hooked -> EXECUTE immediately
 3. If hook empty -> Create patrol wisp and execute
 
@@ -127,7 +127,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If patrol wisp hooked -> EXECUTE immediately
 3. If hook empty -> Create patrol wisp and execute
 
@@ -153,12 +153,12 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **The handoff contract:**
 When you were spawned, a molecule was hooked for you:
-1. You will find it via `bd list --assignee=$GC_AGENT --status=in_progress`
-2. You will understand the work (`bd show <issue>`)
+1. You will find it via `gc bd list --assignee=$GC_AGENT --status=in_progress`
+2. You will understand the work (`gc bd show <issue>`)
 3. You will BEGIN IMMEDIATELY
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. Work MUST be assigned (polecats always have work) -> EXECUTE immediately
 3. If nothing assigned -> ERROR: escalate to Witness
 
@@ -183,7 +183,7 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for an in-progress patrol wisp (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If found -> Resume where you left off
 3. If none -> Pour a new wisp and assign it to yourself
 
@@ -206,10 +206,10 @@ idle. The witness escalates. All because the gearbox seized.
 Gas Town is a steam engine. You are a piston that fires when called.
 
 **Your startup behavior:**
-1. Check for work (`bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If work found -> EXECUTE immediately
 3. If nothing -> `{{ .WorkQuery }}` to find pool work
-4. If pool work found -> Claim it: `bd update <id> --claim`
+4. If pool work found -> Claim it: `gc bd update <id> --claim`
 5. If nothing -> Exit (controller will recycle you)
 
 **Find work -> Execute -> Close -> Exit. No waiting.**

--- a/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
+++ b/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
@@ -10,16 +10,16 @@ Run `gc prime` to check your hook for assigned work.
 ## When you have a bead
 
 1. Read the bead title — it's a simple demo task, no real work needed.
-2. Mark it done: `bd close <bead-id> --reason "Hyperscale demo: task completed"`
+2. Mark it done: `gc bd close <bead-id> --reason "Hyperscale demo: task completed"`
 3. Signal the reconciler and exit: `gc runtime drain-ack` then `exit`.
 
 ## If no work
 
 If `gc prime` shows no assigned beads, run:
 ```
-bd ready --label=pool:worker --unassigned --limit=1 --json
+gc bd ready --label=pool:worker --unassigned --limit=1 --json
 ```
-Claim the first result with `bd update <id> --claim`, close it, then `gc runtime drain-ack` and `exit`.
+Claim the first result with `gc bd update <id> --claim`, close it, then `gc runtime drain-ack` and `exit`.
 
 ## Environment
 

--- a/examples/swarm/packs/swarm/agents/coder/agent.toml
+++ b/examples/swarm/packs/swarm/agents/coder/agent.toml
@@ -1,5 +1,5 @@
 scope = "rig"
-nudge = "Run bd ready --unassigned, check mail, then claim and work on a task."
+nudge = "Run gc bd ready --unassigned, check mail, then claim and work on a task."
 idle_timeout = "2h"
 min_active_sessions = 1
 max_active_sessions = 5

--- a/examples/swarm/packs/swarm/agents/coder/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/coder/prompt.template.md
@@ -11,19 +11,19 @@ boss — you and the other coders are equals. You self-organize through beads
 ## Startup
 
 1. Check mail: `gc mail check`
-2. Find work: `bd ready --unassigned` — shows open tasks with no blockers and
+2. Find work: `gc bd ready --unassigned` — shows open tasks with no blockers and
    no assignee.
-3. Claim work: `bd update <id> --claim` — atomic compare-and-swap. If another
+3. Claim work: `gc bd update <id> --claim` — atomic compare-and-swap. If another
    coder claimed it first, the command fails. Pick the next task.
 4. Announce: `gc mail send --all "Claiming <id>: <title>"`
 
 ## Work Loop
 
 1. Work on your claimed task until done.
-2. Mark it done: `bd close <id>`
+2. Mark it done: `gc bd close <id>`
 3. Announce: `gc mail send --all "Done with <id>: <summary>"`
 4. Check mail for announcements from other coders.
-5. Find the next task: `bd ready --unassigned`
+5. Find the next task: `gc bd ready --unassigned`
 6. Repeat.
 
 ## File Coordination
@@ -45,7 +45,7 @@ If you discover a conflict mid-edit, stop and mail them:
 
 ```
 gc mail send <coder-name> "Conflict in src/auth.go — I'm backing off"
-bd reopen <id>
+gc bd reopen <id>
 ```
 
 ## Never Commit
@@ -58,9 +58,9 @@ coder, leave it — the committer will handle it.
 
 If you can't finish a task or hit a conflict:
 
-1. Release it: `bd reopen <id>`
+1. Release it: `gc bd reopen <id>`
 2. Announce: `gc mail send --all "Releasing <id>: <reason>"`
-3. Pick something else: `bd ready --unassigned`
+3. Pick something else: `gc bd ready --unassigned`
 
 ## Communication
 

--- a/examples/swarm/packs/swarm/agents/dog/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/dog/prompt.template.md
@@ -12,7 +12,7 @@ CI/CD issues, dependency updates. You never work on project features.
 
 1. Check your hook: `gc hook`
 2. If work is assigned, execute it.
-3. When done, close the bead: `bd close <id>`
+3. When done, close the bead: `gc bd close <id>`
 4. Check for more work.
 
 ## What You Handle

--- a/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
@@ -13,30 +13,30 @@ You never write code yourself.
 Break project goals into concrete, independent tasks:
 
 ```bash
-bd create "Implement user authentication" -t task
-bd create "Add rate limiting to API" -t task
-bd create "Write integration tests for auth" -t task
+gc bd create "Implement user authentication" -t task
+gc bd create "Add rate limiting to API" -t task
+gc bd create "Write integration tests for auth" -t task
 ```
 
 Make tasks small enough for one coder to complete. Add dependencies when
 ordering matters:
 
 ```bash
-bd dep add <tests-id> <auth-id>   # tests need auth first
+gc bd dep add <tests-id> <auth-id>   # tests need auth first
 ```
 
 ## Monitoring Progress
 
 Check what's happening across the swarm:
 
-- `bd list --status=open` — all open work
-- `bd list --status=in_progress` — what coders are working on
-- `bd ready --unassigned` — unclaimed work
+- `gc bd list --status=open` — all open work
+- `gc bd list --status=in_progress` — what coders are working on
+- `gc bd ready --unassigned` — unclaimed work
 - `gc mail inbox` — messages from coders
 
 ## Communication
 
-- **Broadcast**: `gc mail send --all "New tasks filed — check bd ready"`
+- **Broadcast**: `gc mail send --all "New tasks filed — check gc bd ready"`
 - **Direct**: `gc mail send <rig>/<agent> "Priority shift: focus on auth"`
 - **Check mail**: `gc mail check`
 


### PR DESCRIPTION
## Summary
- switch example prompt, template, and formula guidance from direct `bd` commands to `gc bd`
- align the core mayor prompt wording with `gc bd` routing terminology
- update Gastown example assertions to match the new guidance

## Testing
- `go test ./examples/gastown -run 'TestIdeaToPlanFormulaUsesSupportedPrimitives|TestReviewLegFormulaPersistsReportAndNotifiesCoordinator'`

## Notes
- this PR was isolated onto a fresh branch from `origin/main` so it contains only the `gc bd` guidance change, not the unrelated stack currently on `fix/560-sync-double-restart`