### PR TITLE
test: revive 2 tests skipped during #877 adoption

### DIFF
--- a/cmd/gc/cmd_event_emit_test.go
+++ b/cmd/gc/cmd_event_emit_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -155,19 +158,84 @@ func TestDoEventEmitPayloadInvalidJSON(t *testing.T) {
 	}
 }
 
+// TestEventEmitViaCLI exercises the full `gc event emit` CLI path: flag
+// parsing, city discovery, event-provider open, and local events.jsonl
+// write. The matching read path (`gc events`) now goes through the
+// supervisor/controller API and is covered by TestDoEvents* against a
+// mock API server, so this test focuses on the emit CLI's end-to-end
+// behavior without needing a live controller.
+//
+// Pre-migration this test did an emit-then-read roundtrip via `gc events`,
+// but that readback is incompatible with the API-first contract — `gc
+// events` no longer reads local files. Splitting emit and read into
+// their own tests keeps each side focused without needing a fake
+// controller harness in the cmd/gc test tree.
 func TestEventEmitViaCLI(t *testing.T) {
-	// The original PR rewrote `gc events` to read exclusively from the
-	// supervisor/controller API (no more local events.jsonl fallback).
-	// This test bootstraps a city with no live controller and no
-	// supervisor, so the readback via `gc events` has no source to query
-	// and correctly errors with "could not auto-discover the supervisor
-	// API". The test's premise (emit-then-read via CLI) conflicts with
-	// the API-first contract in the PR's commit messages.
-	//
-	// The event emission path is still covered by the unit test above;
-	// this CLI-end-to-end test is skipped until the suite gets a way to
-	// launch a fake controller for the duration of the test.
-	t.Skip("gc events is API-only; this test needs a fake controller to exercise readback end-to-end")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_SESSION", "fake")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", dir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc init = %d; stderr: %s", code, stderr.String())
+	}
+
+	// Emit two events via the CLI. `gc event emit` is best-effort and
+	// always returns 0, but it should still write the events locally.
+	stdout.Reset()
+	stderr.Reset()
+	code = run([]string{"--city", dir, "event", "emit", "bead.created", "--subject", "gc-1", "--message", "Build Hanoi"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc event emit bead.created = %d; stderr: %s", code, stderr.String())
+	}
+
+	code = run([]string{"--city", dir, "event", "emit", "bead.closed", "--subject", "gc-1", "--message", "Done"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc event emit bead.closed = %d; stderr: %s", code, stderr.String())
+	}
+
+	// Verify events landed in the local JSONL file. Parse line-by-line
+	// because the file is append-only JSONL, not a JSON array.
+	eventsPath := filepath.Join(dir, ".gc", "events.jsonl")
+	data, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatalf("reading events.jsonl: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("events.jsonl has %d lines, want 2; content:\n%s", len(lines), string(data))
+	}
+
+	var created, closed events.Event
+	if err := json.Unmarshal([]byte(lines[0]), &created); err != nil {
+		t.Fatalf("unmarshal line 0: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &closed); err != nil {
+		t.Fatalf("unmarshal line 1: %v", err)
+	}
+
+	if created.Type != "bead.created" {
+		t.Errorf("line 0 type = %q, want bead.created", created.Type)
+	}
+	if created.Subject != "gc-1" {
+		t.Errorf("line 0 subject = %q, want gc-1", created.Subject)
+	}
+	if created.Message != "Build Hanoi" {
+		t.Errorf("line 0 message = %q, want Build Hanoi", created.Message)
+	}
+	if created.Seq != 1 {
+		t.Errorf("line 0 seq = %d, want 1", created.Seq)
+	}
+
+	if closed.Type != "bead.closed" {
+		t.Errorf("line 1 type = %q, want bead.closed", closed.Type)
+	}
+	if closed.Seq != 2 {
+		t.Errorf("line 1 seq = %d, want 2", closed.Seq)
+	}
 }
 
 func TestEventMissingSubcommand(t *testing.T) {

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -44,7 +44,19 @@ type slingResponse struct {
 
 // execSling calls the intent-based Sling API directly. The Huma handler
 // humaHandleSling performs all validation before calling this.
-func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slingResponse, int, string, string) {
+//
+// Return tuple:
+//   - resp: the success body (nil when code != "")
+//   - status: HTTP status for the success or error case
+//   - code: short error code ("" on success)
+//   - message: human-readable error message ("" on success)
+//   - conflict: populated when code == "conflict"; carries the blocking
+//     source_bead_id, workflow IDs, and cleanup hint the caller needs
+//     to render a rich 409 Problem Details body. Returning it out-of-band
+//     keeps Huma's structured error path available without widening the
+//     (*slingResponse, int, string, string) shape every non-conflict
+//     caller already consumes.
+func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slingResponse, int, string, string, *sourceworkflow.ConflictError) {
 	cfg := s.state.Config()
 	agentCfg, _ := findAgent(cfg, body.Target)
 
@@ -70,7 +82,7 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 	}
 	sl, err := sling.New(deps)
 	if err != nil {
-		return nil, http.StatusInternalServerError, "internal", err.Error()
+		return nil, http.StatusInternalServerError, "internal", err.Error(), nil
 	}
 
 	// Build vars slice from map (sorted for determinism).
@@ -127,9 +139,9 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 	if err != nil {
 		var conflictErr *sourceworkflow.ConflictError
 		if errors.As(err, &conflictErr) {
-			return nil, http.StatusConflict, "conflict", err.Error()
+			return nil, http.StatusConflict, "conflict", err.Error(), conflictErr
 		}
-		return nil, http.StatusBadRequest, "invalid", err.Error()
+		return nil, http.StatusBadRequest, "invalid", err.Error(), nil
 	}
 
 	resp := &slingResponse{
@@ -140,7 +152,7 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		Warnings: result.MetadataErrors,
 	}
 	if !workflowLaunch {
-		return resp, http.StatusOK, "", ""
+		return resp, http.StatusOK, "", "", nil
 	}
 
 	resp.Formula = formulaName
@@ -149,9 +161,21 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 	resp.WorkflowID = result.WorkflowID
 	resp.RootBeadID = result.BeadID
 	if resp.WorkflowID == "" && resp.RootBeadID == "" {
-		return nil, http.StatusInternalServerError, "internal", "sling did not produce a workflow or bead id"
+		return nil, http.StatusInternalServerError, "internal", "sling did not produce a workflow or bead id", nil
 	}
-	return resp, http.StatusCreated, "", ""
+	return resp, http.StatusCreated, "", "", nil
+}
+
+// sourceWorkflowCleanupHint renders the CLI command that clears the blocking
+// source workflow. Surfaced in the conflict response body so users can fix
+// the state without grepping docs.
+func sourceWorkflowCleanupHint(sourceBeadID, storeRef string) string {
+	args := []string{"gc workflow delete-source", sourceBeadID}
+	if storeRef = strings.TrimSpace(storeRef); storeRef != "" {
+		args = append(args, "--store-ref", storeRef)
+	}
+	args = append(args, "--apply")
+	return strings.Join(args, " ")
 }
 
 // findSlingStore returns the bead store for sling operations.

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -195,14 +195,33 @@ func TestSlingPoolTarget(t *testing.T) {
 }
 
 func TestSlingConflictReturns409ForExistingLiveWorkflow(t *testing.T) {
-	// Upstream-added test that expects the pre-Huma handleSling handler
-	// behavior. The Huma migration moved sling to /v0/city/{cityName}/sling
-	// and changed how FormulaV2 feature-flag state reaches the handler.
-	// This test needs reworking for the new Huma wiring; skipped for now
-	// as an upstream-only regression, separate from the migration.
-	t.Skip("upstream-added test; needs rework for Huma migration sling routing")
+	// The Huma migration moved sling to /v0/city/{cityName}/sling and
+	// replaced the old plain-JSON `{code, message, source_bead_id, ...}`
+	// error body with RFC 9457 Problem Details. The source-workflow
+	// conflict response now rides in the Problem Details `errors[]`
+	// extensions (keyed by location so consumers can look them up
+	// without format drift) instead of at the top level.
+	//
+	// FormulaV2 flag flow:
+	//   1. newSlingTestServer → New() → syncFeatureFlags(state.cfg) sets the
+	//      package-global `formula.IsFormulaV2Enabled` flag based on config,
+	//      which is default-false out of newFakeMutatorState.
+	//   2. We then set state.cfg.Daemon.FormulaV2 = true for reads that go
+	//      through config (handler-level checks).
+	//   3. The global flag is what formula compile calls, so we call
+	//      formula.SetFormulaV2Enabled(true) AFTER newSlingTestServer so
+	//      New()'s syncFeatureFlags doesn't stomp it back to false.
+	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	prevGraphApply := molecule.IsGraphApplyEnabled()
+	t.Cleanup(func() {
+		formula.SetFormulaV2Enabled(prevFormulaV2)
+		molecule.SetGraphApplyEnabled(prevGraphApply)
+	})
+
 	srv, state := newSlingTestServer(t)
 	state.cfg.Daemon.FormulaV2 = true
+	formula.SetFormulaV2Enabled(true)
+	molecule.SetGraphApplyEnabled(true)
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}
 	state.cfg.Agents = append(state.cfg.Agents,
@@ -245,21 +264,40 @@ title = "Do work"
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body = %s", rec.Code, rec.Body.String())
 	}
-	var resp map[string]any
+
+	// Problem Details body: {title, status, detail, errors: [{location, value}, ...]}.
+	var resp struct {
+		Title  string `json:"title"`
+		Status int    `json:"status"`
+		Detail string `json:"detail"`
+		Errors []struct {
+			Location string `json:"location"`
+			Value    any    `json:"value"`
+		} `json:"errors"`
+	}
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if got := resp["code"]; got != "conflict" {
-		t.Fatalf("code = %#v, want conflict", got)
+	if resp.Status != http.StatusConflict {
+		t.Fatalf("status field = %d, want 409", resp.Status)
 	}
-	if got := resp["source_bead_id"]; got != source.ID {
-		t.Fatalf("source_bead_id = %#v, want %s", got, source.ID)
+
+	// Build a location -> value lookup so assertions don't depend on
+	// the errors[] array order.
+	got := map[string]any{}
+	for _, e := range resp.Errors {
+		got[e.Location] = e.Value
 	}
-	ids, ok := resp["blocking_workflow_ids"].([]any)
+
+	if got["body.source_bead_id"] != source.ID {
+		t.Fatalf("source_bead_id = %#v, want %s", got["body.source_bead_id"], source.ID)
+	}
+	ids, ok := got["body.blocking_workflow_ids"].([]any)
 	if !ok || len(ids) != 1 || ids[0] != root.ID {
-		t.Fatalf("blocking_workflow_ids = %#v, want [%s]", resp["blocking_workflow_ids"], root.ID)
+		t.Fatalf("blocking_workflow_ids = %#v, want [%s]", got["body.blocking_workflow_ids"], root.ID)
 	}
-	if hint, _ := resp["hint"].(string); !strings.Contains(hint, "--store-ref rig:myrig --apply") {
+	hint, _ := got["body.hint"].(string)
+	if !strings.Contains(hint, "--store-ref rig:myrig --apply") {
 		t.Fatalf("hint = %q, want store-ref cleanup command", hint)
 	}
 }

--- a/internal/api/huma_handlers_sling.go
+++ b/internal/api/huma_handlers_sling.go
@@ -89,10 +89,29 @@ func (s *Server) humaHandleSling(ctx context.Context, input *SlingInput) (*Sling
 		}
 	}
 
-	resp, status, code, message := s.execSling(ctx, body, agentCfg.EffectiveDefaultSlingFormula())
+	resp, status, code, message, conflict := s.execSling(ctx, body, agentCfg.EffectiveDefaultSlingFormula())
 	if code != "" {
 		if status == http.StatusNotFound {
 			return nil, huma.Error404NotFound(message)
+		}
+		// Source-workflow conflict: render the rich 409 shape the CLI and
+		// dashboard use to offer a "force or clean up" decision. Huma's
+		// generic Error4xx collapses everything into Problem Details with
+		// only a string detail, so we build the Problem Details error
+		// manually with structured extensions.
+		if conflict != nil && status == http.StatusConflict {
+			storeRef := s.slingStoreRef(body.Rig, agentCfg)
+			hint := sourceWorkflowCleanupHint(conflict.SourceBeadID, storeRef)
+			return nil, &huma.ErrorModel{
+				Status: http.StatusConflict,
+				Title:  http.StatusText(http.StatusConflict),
+				Detail: message,
+				Errors: []*huma.ErrorDetail{
+					{Location: "body.source_bead_id", Value: conflict.SourceBeadID},
+					{Location: "body.blocking_workflow_ids", Value: conflict.WorkflowIDs},
+					{Location: "body.hint", Value: hint},
+				},
+			}
 		}
 		return nil, huma.Error400BadRequest(message)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #877. Two tests were skipped during that PR's adoption review because their original assumptions no longer matched the post-Huma/OpenAPI architecture. This PR reworks both so they pass on the migrated code.

## TestSlingConflictReturns409ForExistingLiveWorkflow (internal/api)

- Restored the rich 409 conflict response (previously collapsed into plain 400 BadRequest during the migration).
- \`execSling\` now returns \`*sourceworkflow.ConflictError\` as a fifth return value so the caller can render structured 409s without widening the success signature every other caller consumes.
- \`humaHandleSling\` detects the conflict path and emits a 409 \`huma.ErrorModel\` with the blocking \`source_bead_id\`, workflow IDs, and cleanup hint carried in the RFC 9457 Problem Details \`errors[]\` array (keyed by location).
- Restored \`sourceWorkflowCleanupHint()\` helper (deleted by mistake during the #877 squash).
- Rewrote the test to assert the Problem Details shape and correctly sequence FormulaV2 flag setup around \`New()\`'s \`syncFeatureFlags\` call (package-global flag must be set AFTER \`newSlingTestServer\` runs).

## TestEventEmitViaCLI (cmd/gc)

- \`gc events\` is now API-only (no local \`events.jsonl\` fallback), so the original emit-then-read roundtrip cannot run without a live controller.
- Rewrote the test to focus on the emit CLI end-to-end: flag parsing, city discovery, event-provider open, and local write-through. Readback belongs in an integration test that stands up a fake controller (tracked as future work).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/api/... -run TestSlingConflict\`
- [x] \`go test ./cmd/gc/... -run TestEventEmitViaCLI\`
- [x] \`golangci-lint run ./...\` (0 issues)
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)