### PR TITLE
Fix imported pack skill discovery and materialization

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -55,6 +55,14 @@ type agentBuildParams struct {
 	// fingerprints or PreStart injection. The load error is logged to
 	// stderr at params-construction time.
 	skillCatalog *materialize.CityCatalog
+	// rigSkillCatalogs caches rig-specific shared catalogs. Each entry
+	// includes city-shared skills plus any rig-import shared catalogs.
+	rigSkillCatalogs map[string]*materialize.CityCatalog
+	// failedRigSkillCatalogs tracks rig scopes whose shared catalog
+	// failed to load for this build. Agents in those rigs must not
+	// fall back to the city catalog or they will inject stage-2 skill
+	// hooks that reload the broken rig catalog and fail at runtime.
+	failedRigSkillCatalogs map[string]bool
 
 	// sessionProvider is cfg.Session.Provider (the city-level session
 	// runtime selector: "" / "tmux" / "subprocess" / "acp" / "k8s" /
@@ -92,7 +100,7 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 	// fingerprints or PreStart, which matches the spec's "no spurious
 	// drain-restart cycles on remote-runtime agents" principle when
 	// discovery breaks transiently.
-	cat, err := materialize.LoadCityCatalog(cfg.PackSkillsDir)
+	cat, err := loadSharedSkillCatalog(cfg, "")
 	if err != nil {
 		if stderr != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: LoadCityCatalog %v (skills will not contribute to fingerprints this tick)\n", err) //nolint:errcheck // best-effort stderr
@@ -100,7 +108,41 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 	} else {
 		params.skillCatalog = &cat
 	}
+	for rigName := range cfg.RigPackSkills {
+		cat, err := loadSharedSkillCatalog(cfg, rigName)
+		if err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "buildDesiredState: LoadCityCatalog rig %q %v (skills will not contribute to fingerprints this tick)\n", rigName, err) //nolint:errcheck // best-effort stderr
+			}
+			if params.failedRigSkillCatalogs == nil {
+				params.failedRigSkillCatalogs = make(map[string]bool)
+			}
+			params.failedRigSkillCatalogs[rigName] = true
+			continue
+		}
+		if params.rigSkillCatalogs == nil {
+			params.rigSkillCatalogs = make(map[string]*materialize.CityCatalog)
+		}
+		catCopy := cat
+		params.rigSkillCatalogs[rigName] = &catCopy
+	}
 	return params
+}
+
+func (p *agentBuildParams) sharedSkillCatalogForAgent(agent *config.Agent) *materialize.CityCatalog {
+	if p == nil || agent == nil {
+		return nil
+	}
+	rigName := agentRigScopeName(agent, p.rigs)
+	if rigName != "" && p.failedRigSkillCatalogs != nil && p.failedRigSkillCatalogs[rigName] {
+		return nil
+	}
+	if p.rigSkillCatalogs != nil && rigName != "" {
+		if cat := p.rigSkillCatalogs[rigName]; cat != nil {
+			return cat
+		}
+	}
+	return p.skillCatalog
 }
 
 // effectiveOverlayDirs merges city-level and rig-level pack overlay dirs.

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -76,10 +76,12 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 				return nil
 			}
 
-			cityCat, err := materialize.LoadCityCatalog(cfg.PackSkillsDir)
+			rigName := agentRigScopeName(&agent, cfg.Rigs)
+			cityCat, err := loadSharedSkillCatalog(cfg, rigName)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
-				return errExit
+				fmt.Fprintf(stderr, "gc internal materialize-skills: shared skill catalog unavailable for %q: %v\n", agent.QualifiedName(), err) //nolint:errcheck // best-effort stderr
+				cityCat.Entries = nil
+				cityCat.Shadowed = nil
 			}
 			agentCat, err := materialize.LoadAgentCatalog(agent.SkillsDir)
 			if err != nil {

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,6 +77,204 @@ template = "mayor"
 	// Stdout should include the "materialized" summary line.
 	if !strings.Contains(stdout.String(), "materialized 1 skill") {
 		t.Errorf("stdout missing summary: %q", stdout.String())
+	}
+}
+
+func TestInternalMaterializeSkillsMaterializesImportedSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	rootDir := t.TempDir()
+	cityDir := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "helper")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+start_command = "echo"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city\"\nversion = \"0.1.0\"\nschema = 2\n\n[imports.helper]\nsource = \"../helper\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(helper): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte("[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(helper/pack.toml): %v", err)
+	}
+	writeSkillSource(t, filepath.Join(packDir, "skills", "plan"))
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	link := filepath.Join(workdir, ".claude", "skills", "helper.plan")
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat(%s): %v", link, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink", link)
+	}
+	tgt, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	wantTarget := filepath.Join(packDir, "skills", "plan")
+	if tgt != wantTarget {
+		t.Fatalf("symlink target = %q, want %q", tgt, wantTarget)
+	}
+}
+
+func TestInternalMaterializeSkillsCityScopedDirMatchingRigDoesNotMaterializeRigSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	helperDir := filepath.Join(cityDir, "assets", "helper")
+	rigDir := filepath.Join(cityDir, "fe")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := os.MkdirAll(helperDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(helper): %v", err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "fe"
+path = %q
+
+[rigs.imports.helper]
+source = "./assets/helper"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+dir = "fe"
+provider = "claude"
+start_command = "echo"
+`, rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(helperDir, "pack.toml"), []byte("[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(helper/pack.toml): %v", err)
+	}
+	writeSkillSource(t, filepath.Join(helperDir, "skills", "plan"))
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Lstat(filepath.Join(workdir, ".claude", "skills", "helper.plan")); !os.IsNotExist(err) {
+		t.Fatalf("city-scoped agent should not receive rig-shared skill, lstat err=%v", err)
+	}
+}
+
+func TestInternalMaterializeSkillsSharedCatalogFailurePrunesStaleSharedSymlink(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+start_command = "echo"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	skillsDir := filepath.Join(cityDir, "skills")
+	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("initial exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	link := filepath.Join(workdir, ".claude", "skills", "plan")
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("initial shared symlink missing: %v", err)
+	}
+
+	if err := os.Chmod(skillsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+	if _, err := os.ReadDir(skillsDir); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "shared skill catalog unavailable") {
+		t.Fatalf("stderr = %q, want shared catalog warning", stderr.String())
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("stale shared symlink should be pruned on catalog failure, lstat err=%v", err)
 	}
 }
 

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -24,6 +24,7 @@ func newSkillCmd(stdout, stderr io.Writer) *cobra.Command {
 
 Output includes:
   - City pack skills (skills/<name>/SKILL.md under the city root)
+  - Imported pack shared skills (binding-qualified, e.g. ops.code-review)
   - Bootstrap implicit-import pack skills (e.g. core)
   - With --agent/--session: that agent's agents/<name>/skills/ catalog
 
@@ -52,7 +53,7 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List visible skills",
-		Long:  "List the current city pack's visible skills, optionally scoped to an agent or session.",
+		Long:  "List the current shared and agent-local visible skills, optionally scoped to an agent or session.",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if strings.TrimSpace(agentName) != "" && strings.TrimSpace(sessionID) != "" {
@@ -101,6 +102,7 @@ func listVisibleSkillEntries(cityPath string, cfg *config.City, store beads.Stor
 	// listing reflects what the materializer actually delivers.
 	entries = append(entries, discoverBootstrapSkillEntries()...)
 	if strings.TrimSpace(agentName) == "" && strings.TrimSpace(sessionID) == "" {
+		entries = append(entries, discoverImportedSkillEntries(sharedSkillCatalogInputs(cfg, currentRigContext(cfg)))...)
 		sortVisibilityEntries(entries)
 		return entries, nil
 	}
@@ -110,6 +112,7 @@ func listVisibleSkillEntries(cityPath string, cfg *config.City, store beads.Stor
 	}
 	// Every agent sees the entire city+bootstrap catalog plus its own
 	// agent-local skills. No attachment filtering.
+	entries = append(entries, discoverImportedSkillEntries(sharedSkillCatalogInputs(cfg, agentRigScopeName(agent, cfg.Rigs)))...)
 	entries = append(entries, discoverAgentSkillEntries(agentAssetRoot(cityPath, agent), agent.Name, "agent")...)
 	sortVisibilityEntries(entries)
 	return entries, nil
@@ -202,6 +205,44 @@ func agentAssetRoot(cityPath string, agent *config.Agent) string {
 
 func discoverSkillEntries(root, source string) []visibilityEntry {
 	return discoverSkillDirEntries(filepath.Join(root, "skills"), "skills", source)
+}
+
+func discoverImportedSkillEntries(catalogs []config.DiscoveredSkillCatalog) []visibilityEntry {
+	var out []visibilityEntry
+	for _, catalog := range catalogs {
+		source := strings.TrimSpace(catalog.BindingName)
+		if source == "" {
+			source = strings.TrimSpace(catalog.PackName)
+		}
+		entries, err := os.ReadDir(catalog.SourceDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+				continue
+			}
+			skillPath := filepath.Join(catalog.SourceDir, name, "SKILL.md")
+			if info, err := os.Stat(skillPath); err != nil || info.IsDir() {
+				continue
+			}
+			publicName := name
+			if catalog.BindingName != "" {
+				publicName = catalog.BindingName + "." + name
+			}
+			out = append(out, visibilityEntry{
+				Name:   publicName,
+				Source: source,
+				Path:   filepath.ToSlash(skillPath),
+			})
+		}
+	}
+	sortVisibilityEntries(out)
+	return out
 }
 
 func discoverAgentSkillEntries(root, agentName, source string) []visibilityEntry {

--- a/cmd/gc/cmd_skill_test.go
+++ b/cmd/gc/cmd_skill_test.go
@@ -65,6 +65,65 @@ func TestSkillListAgentCatalog(t *testing.T) {
 	}
 }
 
+func TestSkillListImportedSharedCatalog(t *testing.T) {
+	clearGCEnv(t)
+	rootDir := t.TempDir()
+	cityDir := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "helper")
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+	writeCatalogFile(t, packDir, "pack.toml", "[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n")
+	writeCatalogFile(t, packDir, "skills/code-review/SKILL.md", "imported skill")
+	writeCatalogFile(t, cityDir, "pack.toml", "[pack]\nname = \"city\"\nversion = \"0.1.0\"\nschema = 2\n\n[imports.helper]\nsource = \"../helper\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"skill", "list"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc skill list exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"helper.code-review", "helper"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("skill list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSkillListAgentCityScopedDirMatchingRigDoesNotShowRigSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "fe")
+	rigSkills := filepath.Join(cityDir, "imports", "helper", "skills")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCatalogFile(t, cityDir, "imports/helper/skills/plan/SKILL.md", "rig-import skill")
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "fe", Path: rigDir}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{
+			"fe": {{
+				SourceDir:   rigSkills,
+				BindingName: "helper",
+				PackName:    "helper",
+			}},
+		},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Dir: "fe"},
+		},
+	}
+
+	entries, err := listVisibleSkillEntries(cityDir, cfg, nil, "mayor", "")
+	if err != nil {
+		t.Fatalf("listVisibleSkillEntries: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name == "helper.plan" {
+			t.Fatalf("city-scoped agent should not list rig-shared skill: %+v", entries)
+		}
+	}
+}
+
 func TestSkillListSessionCatalog(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()

--- a/cmd/gc/skill_catalog.go
+++ b/cmd/gc/skill_catalog.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/materialize"
+)
+
+func sharedSkillCatalogInputs(cfg *config.City, rigName string) []config.DiscoveredSkillCatalog {
+	if cfg == nil {
+		return nil
+	}
+	var catalogs []config.DiscoveredSkillCatalog
+	if rigName != "" && cfg.RigPackSkills != nil {
+		catalogs = append(catalogs, cfg.RigPackSkills[rigName]...)
+	}
+	catalogs = append(catalogs, cfg.PackSkills...)
+	return catalogs
+}
+
+func loadSharedSkillCatalog(cfg *config.City, rigName string) (materialize.CityCatalog, error) {
+	if cfg == nil {
+		return materialize.CityCatalog{}, nil
+	}
+	return materialize.LoadCityCatalog(cfg.PackSkillsDir, sharedSkillCatalogInputs(cfg, rigName)...)
+}
+
+// agentRigScopeName returns the configured rig name that should
+// contribute rig-local shared skills for this agent. Only actual
+// rig-scoped agents attached to a declared rig get a non-empty name.
+// City-scoped agents, and inline agents whose Dir is just a working
+// directory hint, must not pull in rig catalogs solely because
+// agent.Dir happens to match a rig name.
+func agentRigScopeName(agent *config.Agent, rigs []config.Rig) string {
+	if agent == nil {
+		return ""
+	}
+	if strings.TrimSpace(agent.Scope) == "city" {
+		return ""
+	}
+	dir := strings.TrimSpace(agent.Dir)
+	if dir == "" {
+		return ""
+	}
+	for _, rig := range rigs {
+		if rig.Name == dir {
+			return rig.Name
+		}
+	}
+	return ""
+}

--- a/cmd/gc/skill_integration_test.go
+++ b/cmd/gc/skill_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/materialize"
@@ -69,6 +70,35 @@ func TestAgentScopeRoot(t *testing.T) {
 			got := agentScopeRoot(&c.agent, "/city", rigs)
 			if got != c.want {
 				t.Fatalf("agentScopeRoot(%+v) = %q, want %q", c.agent, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAgentRigScopeName(t *testing.T) {
+	t.Parallel()
+
+	rigs := []config.Rig{
+		{Name: "fe", Path: "/rigs/fe"},
+		{Name: "be", Path: "/rigs/be"},
+	}
+	cases := []struct {
+		name  string
+		agent *config.Agent
+		want  string
+	}{
+		{name: "nil agent", agent: nil, want: ""},
+		{name: "city-scoped matching dir stays city", agent: &config.Agent{Scope: "city", Dir: "fe"}, want: ""},
+		{name: "rig-scoped matching dir uses rig", agent: &config.Agent{Scope: "rig", Dir: "fe"}, want: "fe"},
+		{name: "empty scope matching dir defaults to rig", agent: &config.Agent{Dir: "be"}, want: "be"},
+		{name: "plain dir not a rig", agent: &config.Agent{Dir: "workdir"}, want: ""},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := agentRigScopeName(c.agent, rigs); got != c.want {
+				t.Fatalf("agentRigScopeName(%+v) = %q, want %q", c.agent, got, c.want)
 			}
 		})
 	}
@@ -180,6 +210,46 @@ func TestEffectiveSkillsForAgentFourBranches(t *testing.T) {
 			t.Errorf("expected stderr to mention LoadAgentCatalog, got %q", buf.String())
 		}
 	})
+}
+
+func TestSharedSkillCatalogForAgentDoesNotFallBackWhenRigCatalogFails(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	writeSkillSource(t, filepath.Join(cityPath, "skills", "city-shared"))
+
+	badRigCatalog := filepath.Join(cityPath, "broken-rig-catalog")
+	if err := os.Mkdir(badRigCatalog, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badRigCatalog, 0o755) })
+	if _, err := os.ReadDir(badRigCatalog); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	cfg := &config.City{
+		PackSkillsDir: filepath.Join(cityPath, "skills"),
+		Rigs:          []config.Rig{{Name: "fe", Path: filepath.Join(cityPath, "rigs", "fe")}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{
+			"fe": {{
+				SourceDir:   badRigCatalog,
+				BindingName: "ops",
+				PackName:    "helper",
+			}},
+		},
+	}
+
+	var stderr strings.Builder
+	params := newAgentBuildParams("test-city", cityPath, cfg, nil, time.Now(), nil, &stderr)
+	if params.skillCatalog == nil {
+		t.Fatal("city skill catalog should still load")
+	}
+	if got := params.sharedSkillCatalogForAgent(&config.Agent{Name: "rig-agent", Scope: "rig", Dir: "fe"}); got != nil {
+		t.Fatalf("sharedSkillCatalogForAgent() = %+v, want nil when rig catalog load fails", got)
+	}
+	if !strings.Contains(stderr.String(), `LoadCityCatalog rig "fe"`) {
+		t.Fatalf("stderr = %q, want rig catalog load error", stderr.String())
+	}
 }
 
 func TestMergeSkillFingerprintEntries(t *testing.T) {

--- a/cmd/gc/skill_supervisor.go
+++ b/cmd/gc/skill_supervisor.go
@@ -37,9 +37,9 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 		return nil
 	}
 	catalogs := make(map[string]materialize.CityCatalog)
-	loadCatalog := func(rigName string) (materialize.CityCatalog, bool) {
+	loadCatalog := func(rigName string) materialize.CityCatalog {
 		if cat, ok := catalogs[rigName]; ok {
-			return cat, true
+			return cat
 		}
 		cat, err := loadSharedSkillCatalog(cfg, rigName)
 		if err != nil {
@@ -53,10 +53,10 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 			cat.Entries = nil
 			cat.Shadowed = nil
 			catalogs[rigName] = cat
-			return catalogs[rigName], true
+			return catalogs[rigName]
 		}
 		catalogs[rigName] = cat
-		return cat, true
+		return cat
 	}
 
 	for i := range cfg.Agents {
@@ -80,7 +80,7 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 		}
 
 		rigName := agentRigScopeName(agent, cfg.Rigs)
-		cityCat, _ := loadCatalog(rigName)
+		cityCat := loadCatalog(rigName)
 		desired := materialize.EffectiveSet(cityCat, agentCat)
 
 		// Resolve the agent's scope root to an absolute path. Use the

--- a/cmd/gc/skill_supervisor.go
+++ b/cmd/gc/skill_supervisor.go
@@ -25,24 +25,38 @@ import (
 // root; acp runs in-process and doesn't read from it). Hybrid is
 // per-session-routed; conservatively ineligible until v0.15.2.
 //
-// Catalog load happens once per call and feeds every agent's
-// materialization in this tick. Per-agent errors (LoadAgentCatalog,
-// MaterializeAgent) are logged to stderr and do not abort the pass
-// — the supervisor should continue reconciling every other agent.
-// Catalog-level failures cause the whole pass to exit early with
-// the error logged inline so the caller doesn't double-log.
+// Catalog load happens once per scope per call and feeds every
+// agent's materialization in this tick. Per-agent errors
+// (LoadAgentCatalog, MaterializeAgent) are logged to stderr and do
+// not abort the pass — the supervisor should continue reconciling
+// every other agent. Shared-catalog load failures are also logged and
+// then downgraded to an empty shared desired set, while preserving
+// owned-root cleanup so stale gc-managed symlinks can still be pruned.
 func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.Writer) error {
 	if cfg == nil {
 		return nil
 	}
-	cityCat, err := materialize.LoadCityCatalog(cfg.PackSkillsDir)
-	if err != nil {
-		// Log inline and return nil so the supervisor tick's
-		// runStep wrapper doesn't double-log the same message.
-		if stderr != nil {
-			fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load city skill catalog: %v\n", err) //nolint:errcheck // best-effort stderr
+	catalogs := make(map[string]materialize.CityCatalog)
+	loadCatalog := func(rigName string) (materialize.CityCatalog, bool) {
+		if cat, ok := catalogs[rigName]; ok {
+			return cat, true
 		}
-		return nil
+		cat, err := loadSharedSkillCatalog(cfg, rigName)
+		if err != nil {
+			if stderr != nil {
+				if rigName == "" {
+					fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load shared skill catalog for city scope: %v\n", err) //nolint:errcheck // best-effort stderr
+				} else {
+					fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load shared skill catalog for rig %q: %v\n", rigName, err) //nolint:errcheck // best-effort stderr
+				}
+			}
+			cat.Entries = nil
+			cat.Shadowed = nil
+			catalogs[rigName] = cat
+			return catalogs[rigName], true
+		}
+		catalogs[rigName] = cat
+		return cat, true
 	}
 
 	for i := range cfg.Agents {
@@ -65,10 +79,9 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 			agentCat = materialize.AgentCatalog{}
 		}
 
+		rigName := agentRigScopeName(agent, cfg.Rigs)
+		cityCat, _ := loadCatalog(rigName)
 		desired := materialize.EffectiveSet(cityCat, agentCat)
-		if len(desired) == 0 {
-			continue
-		}
 
 		// Resolve the agent's scope root to an absolute path. Use the
 		// un-canonicalized form here so the materializer writes into
@@ -85,6 +98,9 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 		owned := append([]string{}, cityCat.OwnedRoots...)
 		if agentCat.OwnedRoot != "" {
 			owned = append(owned, agentCat.OwnedRoot)
+		}
+		if len(desired) == 0 && len(owned) == 0 {
+			continue
 		}
 
 		res, merr := materialize.Run(materialize.Request{

--- a/cmd/gc/skill_supervisor_test.go
+++ b/cmd/gc/skill_supervisor_test.go
@@ -50,6 +50,45 @@ func TestRunStage1SkillMaterializationCityScoped(t *testing.T) {
 	}
 }
 
+func TestRunStage1CityScopedDirMatchingRigDoesNotGetRigSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	rigPath := filepath.Join(cityPath, "rigs", "fe")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rigSkills := filepath.Join(cityPath, "imports", "helper", "skills")
+	writeSkillSource(t, filepath.Join(rigSkills, "plan"))
+
+	cfg := &config.City{
+		Session: config.SessionConfig{Provider: "tmux"},
+		Rigs:    []config.Rig{{Name: "fe", Path: rigPath}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{
+			"fe": {{
+				SourceDir:   rigSkills,
+				BindingName: "helper",
+				PackName:    "helper",
+			}},
+		},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Dir: "fe", Provider: "claude"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("runStage1SkillMaterialization: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(cityPath, ".claude", "skills", "helper.plan")); !os.IsNotExist(err) {
+		t.Fatalf("city-scoped agent should not receive rig-shared skill, lstat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, ".claude", "skills")); !os.IsNotExist(err) {
+		t.Fatalf("rig sink should remain untouched for city-scoped agent, stat err=%v", err)
+	}
+}
+
 // TestRunStage1MaterializesIntoRigScope confirms that a rig-scoped
 // agent materializes into the rig path, not the city path.
 func TestRunStage1MaterializesIntoRigScope(t *testing.T) {
@@ -333,6 +372,93 @@ func TestRunStage1MaterializesBootstrapPackSkills(t *testing.T) {
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
 		t.Errorf("%q is not a symlink", link)
+	}
+}
+
+func TestRunStage1MaterializesAgentLocalWhenSharedCatalogFails(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+	rigPath := filepath.Join(cityPath, "rigs", "fe")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	badRigCatalog := filepath.Join(cityPath, "broken-rig-catalog")
+	if err := os.Mkdir(badRigCatalog, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badRigCatalog, 0o755) })
+	if _, err := os.ReadDir(badRigCatalog); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	agentSkills := filepath.Join(cityPath, "agents", "polecat", "skills")
+	writeSkillSource(t, filepath.Join(agentSkills, "local-only"))
+
+	cfg := &config.City{
+		Session:       config.SessionConfig{Provider: "tmux"},
+		Rigs:          []config.Rig{{Name: "fe", Path: rigPath}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{"fe": {{SourceDir: badRigCatalog, BindingName: "ops"}}},
+		Agents: []config.Agent{
+			{Name: "polecat", Scope: "rig", Dir: "fe", Provider: "claude", SkillsDir: agentSkills},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("runStage1SkillMaterialization: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "load shared skill catalog") {
+		t.Fatalf("stderr = %q, want shared catalog load warning", stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, ".claude", "skills", "local-only")); err != nil {
+		t.Fatalf("agent-local skill should still materialize: %v", err)
+	}
+}
+
+func TestRunStage1SharedCatalogFailurePrunesStaleSharedSymlink(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	skillsDir := filepath.Join(cityPath, "skills")
+	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
+
+	cfg := &config.City{
+		PackSkillsDir: skillsDir,
+		Session:       config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "claude"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("initial runStage1SkillMaterialization: %v", err)
+	}
+	link := filepath.Join(cityPath, ".claude", "skills", "plan")
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("initial shared symlink missing: %v", err)
+	}
+
+	if err := os.Chmod(skillsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+	if _, err := os.ReadDir(skillsDir); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	stderr.Reset()
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("second runStage1SkillMaterialization: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "load shared skill catalog") {
+		t.Fatalf("stderr = %q, want shared catalog load warning", stderr.String())
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("stale shared symlink should be pruned on catalog failure, lstat err=%v", err)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -312,7 +312,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 						agentCat = c
 					}
 				}
-				if frag := buildAssignedSkillsPromptFragment(cfgAgent, p.skillCatalog, agentCat); frag != "" {
+				if frag := buildAssignedSkillsPromptFragment(cfgAgent, p.sharedSkillCatalogForAgent(cfgAgent), agentCat); frag != "" {
 					prompt = prompt + "\n\n" + frag
 				}
 			}
@@ -363,7 +363,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		if p.workspace != nil {
 			wsProvider = p.workspace.Provider
 		}
-		desired := effectiveSkillsForAgent(p.skillCatalog, cfgAgent, wsProvider, p.stderr)
+		desired := effectiveSkillsForAgent(p.sharedSkillCatalogForAgent(cfgAgent), cfgAgent, wsProvider, p.stderr)
 		if len(desired) > 0 {
 			fpExtra = mergeSkillFingerprintEntries(fpExtra, desired)
 			if canonWorkDir != scopeRoot {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,12 +223,18 @@ type City struct {
 	// PackDoctors holds convention-discovered pack doctor checks composed
 	// during city and rig expansion. Runtime-only.
 	PackDoctors []DiscoveredDoctor `toml:"-" json:"-"`
+	// PackSkills holds binding-qualified shared skill catalogs composed
+	// from city-level imported packs. Runtime-only.
+	PackSkills []DiscoveredSkillCatalog `toml:"-" json:"-"`
 	// PackSkillsDir holds the current city pack's shared skills catalog root.
 	// Runtime-only — not persisted to TOML or JSON.
 	PackSkillsDir string `toml:"-" json:"-"`
 	// PackMCPDir holds the current city pack's shared MCP catalog root.
 	// Runtime-only — not persisted to TOML or JSON.
 	PackMCPDir string `toml:"-" json:"-"`
+	// RigPackSkills maps rig name to the binding-qualified shared skill
+	// catalogs composed from that rig's imports. Runtime-only.
+	RigPackSkills map[string][]DiscoveredSkillCatalog `toml:"-" json:"-"`
 }
 
 // NamedSession defines a canonical persistent session backed by an agent

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -90,6 +90,18 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 			}
 			rigGlobals = append(rigGlobals, globals...)
 			cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, topoDir)...)
+			packName := tcPackName(fs, topoPath)
+			skills := cachedPackSkills(cache, topoDir)
+			if packName == "" && len(skills) > 0 {
+				return fmt.Errorf("rig %q pack %q: discovered skills require [pack].name for binding", rig.Name, ref)
+			}
+			if cfg.RigPackSkills == nil {
+				cfg.RigPackSkills = make(map[string][]DiscoveredSkillCatalog)
+			}
+			cfg.RigPackSkills[rig.Name] = appendDiscoveredSkills(
+				cfg.RigPackSkills[rig.Name],
+				stampSkillBinding(skills, packName)...,
+			)
 
 			// Validate rig-scoped requirements.
 			for _, req := range reqs {
@@ -168,6 +180,17 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 				rigGlobals = append(rigGlobals, globals...)
 				cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, impDir)...)
+				if cfg.RigPackSkills == nil {
+					cfg.RigPackSkills = make(map[string][]DiscoveredSkillCatalog)
+				}
+				skills := cachedPackSkills(cache, impDir)
+				if !imp.ImportIsTransitive() {
+					skills = filterSkillsBySourceDir(skills, impDir)
+				}
+				cfg.RigPackSkills[rig.Name] = appendDiscoveredSkills(
+					cfg.RigPackSkills[rig.Name],
+					stampSkillBinding(skills, bindingName)...,
+				)
 
 				// Stamp binding name on agents and named sessions.
 				// At the rig level, ALL agents from an import get the rig's
@@ -398,6 +421,11 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 		}
 		cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, stampDefaultBinding(cachedPackCommands(cache, topoDir), packName)...)
 		cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, topoDir)...)
+		skills := cachedPackSkills(cache, topoDir)
+		if packName == "" && len(skills) > 0 {
+			return nil, nil, nil, fmt.Errorf("city pack %q: discovered skills require [pack].name for shared binding", ref)
+		}
+		cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampSkillBinding(skills, packName)...)
 
 		// Accumulate pack dirs (deduped).
 		allPackDirs = appendUnique(allPackDirs, topoDirs...)
@@ -459,6 +487,7 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 			}
 			commands := cachedPackCommands(cache, impDir)
 			doctors := cachedPackDoctors(cache, impDir)
+			skills := cachedPackSkills(cache, impDir)
 
 			// When transitive = false, keep only agents directly defined
 			// by this import (not its own transitive dependencies).
@@ -474,6 +503,7 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 				agents = direct
 				commands = filterCommandsBySourceDir(commands, impDir)
 				doctors = filterDoctorsBySourceDir(doctors, impDir)
+				skills = filterSkillsBySourceDir(skills, impDir)
 			}
 
 			// Stamp binding name on all agents and named sessions.
@@ -549,6 +579,9 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 			cfg.Services = append(cfg.Services, services...)
 			cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, commands...)
 			cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, doctors...)
+			if !slices.Contains(BootstrapManagedImportNames(), bindingName) {
+				cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampSkillBinding(skills, bindingName)...)
+			}
 			allPackDirs = appendUnique(allPackDirs, topoDirs...)
 
 			// Filter by scope for city expansion.
@@ -852,6 +885,7 @@ type packLoadResult struct {
 	globals       []ResolvedPackGlobal
 	commands      []DiscoveredCommand
 	doctors       []DiscoveredDoctor
+	skills        []DiscoveredSkillCatalog
 }
 
 //nolint:unparam // compatibility wrapper keeps the recursion-set argument at the public helper boundary.
@@ -918,6 +952,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 	var includedGlobals []ResolvedPackGlobal
 	var includedCommands []DiscoveredCommand
 	var includedDoctors []DiscoveredDoctor
+	var includedSkills []DiscoveredSkillCatalog
 	includedProviders := make(map[string]ProviderSpec)
 
 	for _, inc := range tc.Pack.Includes {
@@ -941,6 +976,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		includedGlobals = append(includedGlobals, incGlobals...)
 		includedCommands = append(includedCommands, cachedPackCommands(cache, incTopoDir)...)
 		includedDoctors = append(includedDoctors, cachedPackDoctors(cache, incTopoDir)...)
+		includedSkills = append(includedSkills, cachedPackSkills(cache, incTopoDir)...)
 
 		// Merge providers: included first, no overwrite.
 		for name, spec := range incProviders {
@@ -980,6 +1016,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		}
 		impCommands := cachedPackCommands(cache, impDir)
 		impDoctors := cachedPackDoctors(cache, impDir)
+		impSkills := cachedPackSkills(cache, impDir)
 
 		// When transitive = false, strip agents that came from the
 		// imported pack's own imports (i.e., transitive deps). We keep
@@ -996,6 +1033,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 			impAgents = direct
 			impCommands = filterCommandsBySourceDir(impCommands, impDir)
 			impDoctors = filterDoctorsBySourceDir(impDoctors, impDir)
+			impSkills = filterSkillsBySourceDir(impSkills, impDir)
 		}
 
 		// Stamp binding name on all agents and named sessions from this import.
@@ -1027,6 +1065,9 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 				impDoctors[i].BindingName = bindingName
 			}
 		}
+		for i := range impSkills {
+			impSkills[i].BindingName = bindingName
+		}
 
 		// Read the imported pack name for provenance tracking.
 		impData, readErr := fs.ReadFile(impPath)
@@ -1052,6 +1093,11 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 				impDoctors[i].PackName = packName
 			}
 		}
+		for i := range impSkills {
+			if impSkills[i].PackName == "" {
+				impSkills[i].PackName = packName
+			}
+		}
 
 		includedAgents = append(includedAgents, impAgents...)
 		includedNamedSessions = append(includedNamedSessions, impNamedSessions...)
@@ -1061,6 +1107,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		includedGlobals = append(includedGlobals, impGlobals...)
 		includedCommands = append(includedCommands, impCommands...)
 		includedDoctors = append(includedDoctors, impDoctors...)
+		includedSkills = append(includedSkills, impSkills...)
 
 		for name, spec := range impProviders {
 			if _, exists := includedProviders[name]; !exists {
@@ -1091,6 +1138,10 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	doctors = append(doctors, legacyPackDoctors(tc.Doctor, topoDir, tc.Pack.Name)...)
+	skills, err := DiscoverPackSkills(fs, topoDir, tc.Pack.Name)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, err
+	}
 
 	// V2 convention-based order discovery: top-level orders/ flat files are the
 	// standard layout. Deprecated locations are still discovered so pack loads
@@ -1151,6 +1202,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 	includedServices = append(includedServices, services...)
 	includedCommands = append(includedCommands, commands...)
 	includedDoctors = append(includedDoctors, doctors...)
+	includedSkills = append(includedSkills, skills...)
 
 	// Apply pack-level patches to the merged agent list.
 	if !tc.Patches.IsEmpty() {
@@ -1224,6 +1276,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		globals:       allGlobals,
 		commands:      includedCommands,
 		doctors:       includedDoctors,
+		skills:        includedSkills,
 	})
 
 	return includedAgents, includedNamedSessions, mergedProviders, includedServices, topoDirs, allRequires, allGlobals, nil
@@ -1243,6 +1296,7 @@ func clonePackLoadResult(in *packLoadResult) *packLoadResult {
 		globals:       deepCopyResolvedPackGlobals(in.globals),
 		commands:      deepCopyCommands(in.commands),
 		doctors:       deepCopyDoctors(in.doctors),
+		skills:        deepCopySkills(in.skills),
 	}
 }
 
@@ -1405,6 +1459,21 @@ func cachedPackDoctors(cache *packLoadCache, topoDir string) []DiscoveredDoctor 
 	return out
 }
 
+func cachedPackSkills(cache *packLoadCache, topoDir string) []DiscoveredSkillCatalog {
+	if cache == nil {
+		return nil
+	}
+	absDir, err := filepath.Abs(topoDir)
+	if err != nil {
+		absDir = topoDir
+	}
+	result, ok := cache.results[absDir]
+	if !ok {
+		return nil
+	}
+	return deepCopySkills(result.skills)
+}
+
 func filterCommandsBySourceDir(commands []DiscoveredCommand, sourceDir string) []DiscoveredCommand {
 	absSource, _ := filepath.Abs(sourceDir)
 	var out []DiscoveredCommand
@@ -1424,6 +1493,18 @@ func filterDoctorsBySourceDir(doctors []DiscoveredDoctor, sourceDir string) []Di
 		absDir, _ := filepath.Abs(check.SourceDir)
 		if absDir == absSource || strings.HasPrefix(absDir, absSource+string(filepath.Separator)) {
 			out = append(out, check)
+		}
+	}
+	return out
+}
+
+func filterSkillsBySourceDir(skills []DiscoveredSkillCatalog, sourceDir string) []DiscoveredSkillCatalog {
+	absSource, _ := filepath.Abs(sourceDir)
+	var out []DiscoveredSkillCatalog
+	for _, skill := range skills {
+		absDir, _ := filepath.Abs(skill.SourceDir)
+		if absDir == absSource || strings.HasPrefix(absDir, absSource+string(filepath.Separator)) {
+			out = append(out, skill)
 		}
 	}
 	return out
@@ -1473,12 +1554,36 @@ func appendDiscoveredDoctors(dst []DiscoveredDoctor, src ...DiscoveredDoctor) []
 	return dst
 }
 
+func appendDiscoveredSkills(dst []DiscoveredSkillCatalog, src ...DiscoveredSkillCatalog) []DiscoveredSkillCatalog {
+	for _, skill := range src {
+		duplicate := false
+		for _, existing := range dst {
+			if existing.SourceDir == skill.SourceDir && existing.BindingName == skill.BindingName {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			dst = append(dst, skill)
+		}
+	}
+	return dst
+}
+
 func stampDefaultBinding(commands []DiscoveredCommand, defaultBinding string) []DiscoveredCommand {
 	out := deepCopyCommands(commands)
 	for i := range out {
 		if out[i].BindingName == "" {
 			out[i].BindingName = defaultBinding
 		}
+	}
+	return out
+}
+
+func stampSkillBinding(skills []DiscoveredSkillCatalog, bindingName string) []DiscoveredSkillCatalog {
+	out := deepCopySkills(skills)
+	for i := range out {
+		out[i].BindingName = bindingName
 	}
 	return out
 }
@@ -1496,6 +1601,12 @@ func deepCopyCommands(in []DiscoveredCommand) []DiscoveredCommand {
 
 func deepCopyDoctors(in []DiscoveredDoctor) []DiscoveredDoctor {
 	out := make([]DiscoveredDoctor, len(in))
+	copy(out, in)
+	return out
+}
+
+func deepCopySkills(in []DiscoveredSkillCatalog) []DiscoveredSkillCatalog {
+	out := make([]DiscoveredSkillCatalog, len(in))
 	copy(out, in)
 	return out
 }

--- a/internal/config/pack_discovery_integration_test.go
+++ b/internal/config/pack_discovery_integration_test.go
@@ -72,6 +72,43 @@ source = "../helper"
 	}
 }
 
+func TestLoadWithIncludes_ComposesImportedPackSkills(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# imported skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[imports.helper]
+source = "../helper"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.PackSkills) != 1 {
+		t.Fatalf("got %d PackSkills, want 1", len(cfg.PackSkills))
+	}
+	if cfg.PackSkills[0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.PackSkills[0].BindingName, "helper")
+	}
+	if !strings.HasSuffix(cfg.PackSkills[0].SourceDir, filepath.ToSlash(filepath.Join("helper", "skills"))) &&
+		!strings.HasSuffix(filepath.ToSlash(cfg.PackSkills[0].SourceDir), "helper/skills") {
+		t.Fatalf("SourceDir = %q, want helper skills dir", cfg.PackSkills[0].SourceDir)
+	}
+}
+
 func TestLoadWithIncludes_CityPackCommandsUsePackNameBinding(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
@@ -99,6 +136,36 @@ includes = ["../helper"]
 	}
 	if cfg.PackCommands[0].BindingName != "helper" {
 		t.Fatalf("BindingName = %q, want %q", cfg.PackCommands[0].BindingName, "helper")
+	}
+}
+
+func TestLoadWithIncludes_CityPackSkillsUsePackNameBinding(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# city include skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+includes = ["../helper"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.PackSkills) != 1 {
+		t.Fatalf("got %d PackSkills, want 1", len(cfg.PackSkills))
+	}
+	if cfg.PackSkills[0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.PackSkills[0].BindingName, "helper")
 	}
 }
 
@@ -284,6 +351,54 @@ transitive = false
 	}
 }
 
+func TestLoadWithIncludes_TransitiveFalseFiltersNestedPackSkills(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(dir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "../child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[imports.ops]
+source = "../parent"
+transitive = false
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.PackSkills) != 1 {
+		t.Fatalf("got %d PackSkills, want 1", len(cfg.PackSkills))
+	}
+	if cfg.PackSkills[0].BindingName != "ops" {
+		t.Fatalf("BindingName = %q, want %q", cfg.PackSkills[0].BindingName, "ops")
+	}
+	if !strings.HasSuffix(filepath.ToSlash(cfg.PackSkills[0].SourceDir), "parent/skills") {
+		t.Fatalf("SourceDir = %q, want parent skills dir", cfg.PackSkills[0].SourceDir)
+	}
+}
+
 func TestExpandPacks_RigImportsContributeDoctorsButNotCommands(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
@@ -322,6 +437,78 @@ source = "../helper"
 	}
 	if cfg.PackDoctors[0].Name != "binaries" {
 		t.Fatalf("doctor Name = %q, want %q", cfg.PackDoctors[0].Name, "binaries")
+	}
+}
+
+func TestExpandPacks_RigIncludesContributeSharedSkills(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# rig include skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+includes = ["../helper"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.RigPackSkills["frontend"]) != 1 {
+		t.Fatalf("got %d rig PackSkills, want 1", len(cfg.RigPackSkills["frontend"]))
+	}
+	if cfg.RigPackSkills["frontend"][0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.RigPackSkills["frontend"][0].BindingName, "helper")
+	}
+}
+
+func TestExpandPacks_RigImportsContributeSharedSkills(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# imported skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+
+[rigs.imports.helper]
+source = "../helper"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.RigPackSkills["frontend"]) != 1 {
+		t.Fatalf("got %d rig PackSkills, want 1", len(cfg.RigPackSkills["frontend"]))
+	}
+	if cfg.RigPackSkills["frontend"][0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.RigPackSkills["frontend"][0].BindingName, "helper")
 	}
 }
 

--- a/internal/config/skill_discovery.go
+++ b/internal/config/skill_discovery.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// DiscoveredSkillCatalog is a convention-discovered shared skills/
+// catalog from a pack. One entry represents one pack-level skills root.
+type DiscoveredSkillCatalog struct {
+	SourceDir   string
+	PackDir     string
+	PackName    string
+	BindingName string
+}
+
+// DiscoverPackSkills reports the top-level shared skills/ directory for
+// a pack when it exists.
+func DiscoverPackSkills(fs fsys.FS, packDir, packName string) ([]DiscoveredSkillCatalog, error) {
+	skillsDir := filepath.Join(packDir, "skills")
+	info, err := fs.Stat(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+	return []DiscoveredSkillCatalog{{
+		SourceDir: skillsDir,
+		PackDir:   packDir,
+		PackName:  packName,
+	}}, nil
+}

--- a/internal/config/skill_discovery_test.go
+++ b/internal/config/skill_discovery_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestDiscoverPackSkills_PropagatesStatErrors(t *testing.T) {
+	t.Parallel()
+
+	fake := fsys.NewFake()
+	packDir := "/packs/helper"
+	skillsDir := filepath.Join(packDir, "skills")
+	wantErr := errors.New("boom")
+	fake.Errors[skillsDir] = wantErr
+
+	_, err := DiscoverPackSkills(fake, packDir, "helper")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("DiscoverPackSkills() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -153,11 +153,15 @@ type AgentCatalog struct {
 // cfg.PackSkillsDir from the loaded config). Pass "" if the city pack
 // has no skills/ subdirectory.
 //
+// imported catalogs are binding-qualified shared skills roots composed
+// from pack imports. Each catalog contributes `<binding>.<name>`
+// entries to the shared city catalog.
+//
 // Bootstrap implicit-import packs are read from
 // ~/.gc/implicit-import.toml via config.ReadImplicitImports. Each
 // pack's skills/ subdirectory is enumerated and added to the catalog.
 // City-pack entries win on name collision with bootstrap entries.
-func LoadCityCatalog(packSkillsDir string) (CityCatalog, error) {
+func LoadCityCatalog(packSkillsDir string, imported ...config.DiscoveredSkillCatalog) (CityCatalog, error) {
 	var (
 		cat       CityCatalog
 		nameOwner = make(map[string]int) // name → index into cat.Entries
@@ -194,12 +198,34 @@ func LoadCityCatalog(packSkillsDir string) (CityCatalog, error) {
 
 	// City pack first — wins precedence over bootstrap entries.
 	if packSkillsDir != "" {
+		addRoot(packSkillsDir)
 		entries, err := readSkillDir(packSkillsDir, "city")
 		if err != nil {
-			return CityCatalog{}, fmt.Errorf("reading city pack skills %q: %w", packSkillsDir, err)
+			return cat, fmt.Errorf("reading city pack skills %q: %w", packSkillsDir, err)
 		}
-		addRoot(packSkillsDir)
 		for _, e := range entries {
+			addEntry(e)
+		}
+	}
+
+	for _, catalog := range imported {
+		origin := strings.TrimSpace(catalog.BindingName)
+		if origin == "" {
+			origin = strings.TrimSpace(catalog.PackName)
+		}
+		if origin == "" {
+			origin = "import"
+		}
+		addRoot(catalog.SourceDir)
+		entries, err := readSkillDir(catalog.SourceDir, origin)
+		if err != nil {
+			return cat, fmt.Errorf("reading imported pack %q skills %q: %w", origin, catalog.SourceDir, err)
+		}
+		for _, e := range entries {
+			if catalog.BindingName != "" {
+				e.Name = catalog.BindingName + "." + e.Name
+				e.Origin = catalog.BindingName
+			}
 			addEntry(e)
 		}
 	}
@@ -209,11 +235,11 @@ func LoadCityCatalog(packSkillsDir string) (CityCatalog, error) {
 		return CityCatalog{}, err
 	}
 	for _, bd := range bootstrapDirs {
+		addRoot(bd.Dir)
 		entries, err := readSkillDir(bd.Dir, bd.Name)
 		if err != nil {
-			return CityCatalog{}, fmt.Errorf("reading bootstrap pack %q skills %q: %w", bd.Name, bd.Dir, err)
+			return cat, fmt.Errorf("reading bootstrap pack %q skills %q: %w", bd.Name, bd.Dir, err)
 		}
-		addRoot(bd.Dir)
 		for _, e := range entries {
 			addEntry(e)
 		}

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -249,6 +249,73 @@ func TestLoadCityCatalogBootstrapMerge(t *testing.T) {
 	}
 }
 
+func TestLoadCityCatalogImportedPackSkills(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+	cityPack := t.TempDir()
+	importedPack := t.TempDir()
+
+	cityDir := filepath.Join(cityPack, "skills")
+	importedDir := filepath.Join(importedPack, "skills")
+	mkSkill(t, cityDir, "city-only")
+	mkSkill(t, importedDir, "plan")
+
+	cat, err := LoadCityCatalog(cityDir, config.DiscoveredSkillCatalog{
+		SourceDir:   importedDir,
+		PackDir:     importedPack,
+		PackName:    "tools",
+		BindingName: "ops",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]string, len(cat.Entries))
+	for _, e := range cat.Entries {
+		got[e.Name] = e.Origin
+	}
+	want := map[string]string{
+		"city-only": "city",
+		"ops.plan":  "ops",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entries: got %v, want %v", got, want)
+	}
+
+	if len(cat.OwnedRoots) != 2 {
+		t.Fatalf("owned roots = %v, want 2 roots", cat.OwnedRoots)
+	}
+}
+
+func TestLoadCityCatalogPreservesOwnedRootsOnReadError(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+	pack := t.TempDir()
+	skillsDir := filepath.Join(pack, "skills")
+	mkSkill(t, skillsDir, "alpha")
+
+	if err := os.Chmod(skillsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+	if _, err := os.ReadDir(skillsDir); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	cat, err := LoadCityCatalog(skillsDir)
+	if err == nil {
+		t.Fatal("LoadCityCatalog should fail when skills dir is unreadable")
+	}
+	if len(cat.OwnedRoots) != 1 {
+		t.Fatalf("owned roots = %v, want 1 root preserved on error", cat.OwnedRoots)
+	}
+	wantRoot, absErr := filepath.Abs(skillsDir)
+	if absErr != nil {
+		t.Fatal(absErr)
+	}
+	if cat.OwnedRoots[0] != wantRoot {
+		t.Fatalf("owned root = %q, want %q", cat.OwnedRoots[0], wantRoot)
+	}
+}
+
 func TestLoadCityCatalogIgnoresUnknownImplicitImport(t *testing.T) {
 	requireBootstrapNames(t, "core")
 	gcHome := setupBootstrapHome(t, map[string][]string{


### PR DESCRIPTION
## Summary
- discover shared skills from imported packs and include them in city and rig skill catalogs
- materialize and list imported shared skills through the existing skill pipeline, including legacy include expansion
- tighten imported skill handling around rig scope resolution, stale shared-symlink cleanup, and regression coverage

## Testing
- go test ./internal/config ./internal/materialize
- go test ./cmd/gc -run 'Test(AgentRigScopeName|SharedSkillCatalogForAgentDoesNotFallBackWhenRigCatalogFails|SkillListImportedSharedCatalog|SkillListAgentCityScopedDirMatchingRigDoesNotShowRigSharedSkills|InternalMaterializeSkillsMaterializesImportedSharedSkills|InternalMaterializeSkillsCityScopedDirMatchingRigDoesNotMaterializeRigSharedSkills|InternalMaterializeSkillsSharedCatalogFailurePrunesStaleSharedSymlink|RunStage1CityScopedDirMatchingRigDoesNotGetRigSharedSkills|RunStage1MaterializesAgentLocalWhenSharedCatalogFails|RunStage1SharedCatalogFailurePrunesStaleSharedSymlink)'

Fixes ga-2658.
