### PR TITLE
Fix rig pack command discovery

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -89,6 +89,11 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				return fmt.Errorf("rig %q pack %q: [[service]] is only allowed in city-scoped packs", rig.Name, ref)
 			}
 			rigGlobals = append(rigGlobals, globals...)
+			packName := tcPackName(fs, topoPath)
+			cfg.PackCommands = appendDiscoveredCommands(
+				cfg.PackCommands,
+				stampDefaultBinding(cachedPackCommands(cache, topoDir), packName)...,
+			)
 			cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, topoDir)...)
 
 			// Validate rig-scoped requirements.
@@ -166,6 +171,7 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				if len(services) > 0 {
 					return fmt.Errorf("rig %q import %q: [[service]] is only allowed in city-scoped packs", rig.Name, bindingName)
 				}
+				commands := cachedPackCommands(cache, impDir)
 				rigGlobals = append(rigGlobals, globals...)
 				cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, impDir)...)
 
@@ -177,6 +183,13 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 				for i := range namedSessions {
 					namedSessions[i].BindingName = bindingName
+				}
+				for i := range commands {
+					if commands[i].BindingName == "" {
+						commands[i].BindingName = bindingName
+					} else if imp.Export {
+						commands[i].BindingName = bindingName
+					}
 				}
 
 				// Re-qualify depends_on with binding name now that it's stamped.
@@ -214,6 +227,11 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 						agents[i].PackName = packName
 					}
 				}
+				for i := range commands {
+					if commands[i].PackName == "" {
+						commands[i].PackName = packName
+					}
+				}
 
 				// Validate rig-scoped requirements.
 				for _, req := range reqs {
@@ -248,6 +266,7 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 
 				rigAgents = append(rigAgents, agents...)
 				rigNamedSessions = append(rigNamedSessions, namedSessions...)
+				cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, commands...)
 
 				if len(providers) > 0 {
 					if cfg.Providers == nil {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -172,8 +172,21 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					return fmt.Errorf("rig %q import %q: [[service]] is only allowed in city-scoped packs", rig.Name, bindingName)
 				}
 				commands := cachedPackCommands(cache, impDir)
+				doctors := cachedPackDoctors(cache, impDir)
+				if !imp.ImportIsTransitive() {
+					absImpDir, _ := filepath.Abs(impDir)
+					var direct []Agent
+					for _, a := range agents {
+						absSrc, _ := filepath.Abs(a.SourceDir)
+						if absSrc == absImpDir {
+							direct = append(direct, a)
+						}
+					}
+					agents = direct
+					commands = filterCommandsByPackDir(commands, impDir)
+					doctors = filterDoctorsByPackDir(doctors, impDir)
+				}
 				rigGlobals = append(rigGlobals, globals...)
-				cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, impDir)...)
 
 				// Stamp binding name on agents and named sessions.
 				// At the rig level, ALL agents from an import get the rig's
@@ -189,6 +202,13 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 						commands[i].BindingName = bindingName
 					} else if imp.Export {
 						commands[i].BindingName = bindingName
+					}
+				}
+				for i := range doctors {
+					if doctors[i].BindingName == "" {
+						doctors[i].BindingName = bindingName
+					} else if imp.Export {
+						doctors[i].BindingName = bindingName
 					}
 				}
 
@@ -267,6 +287,7 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				rigAgents = append(rigAgents, agents...)
 				rigNamedSessions = append(rigNamedSessions, namedSessions...)
 				cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, commands...)
+				cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, doctors...)
 
 				if len(providers) > 0 {
 					if cfg.Providers == nil {
@@ -491,8 +512,8 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 					}
 				}
 				agents = direct
-				commands = filterCommandsBySourceDir(commands, impDir)
-				doctors = filterDoctorsBySourceDir(doctors, impDir)
+				commands = filterCommandsByPackDir(commands, impDir)
+				doctors = filterDoctorsByPackDir(doctors, impDir)
 			}
 
 			// Stamp binding name on all agents and named sessions.
@@ -1013,8 +1034,8 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 				}
 			}
 			impAgents = direct
-			impCommands = filterCommandsBySourceDir(impCommands, impDir)
-			impDoctors = filterDoctorsBySourceDir(impDoctors, impDir)
+			impCommands = filterCommandsByPackDir(impCommands, impDir)
+			impDoctors = filterDoctorsByPackDir(impDoctors, impDir)
 		}
 
 		// Stamp binding name on all agents and named sessions from this import.
@@ -1424,24 +1445,24 @@ func cachedPackDoctors(cache *packLoadCache, topoDir string) []DiscoveredDoctor 
 	return out
 }
 
-func filterCommandsBySourceDir(commands []DiscoveredCommand, sourceDir string) []DiscoveredCommand {
-	absSource, _ := filepath.Abs(sourceDir)
+func filterCommandsByPackDir(commands []DiscoveredCommand, packDir string) []DiscoveredCommand {
+	absPackDir, _ := filepath.Abs(packDir)
 	var out []DiscoveredCommand
 	for _, cmd := range commands {
-		absDir, _ := filepath.Abs(cmd.SourceDir)
-		if absDir == absSource || strings.HasPrefix(absDir, absSource+string(filepath.Separator)) {
+		absDir, _ := filepath.Abs(cmd.PackDir)
+		if absDir == absPackDir {
 			out = append(out, cmd)
 		}
 	}
 	return out
 }
 
-func filterDoctorsBySourceDir(doctors []DiscoveredDoctor, sourceDir string) []DiscoveredDoctor {
-	absSource, _ := filepath.Abs(sourceDir)
+func filterDoctorsByPackDir(doctors []DiscoveredDoctor, packDir string) []DiscoveredDoctor {
+	absPackDir, _ := filepath.Abs(packDir)
 	var out []DiscoveredDoctor
 	for _, check := range doctors {
-		absDir, _ := filepath.Abs(check.SourceDir)
-		if absDir == absSource || strings.HasPrefix(absDir, absSource+string(filepath.Separator)) {
+		absDir, _ := filepath.Abs(check.PackDir)
+		if absDir == absPackDir {
 			out = append(out, check)
 		}
 	}

--- a/internal/config/pack_discovery_integration_test.go
+++ b/internal/config/pack_discovery_integration_test.go
@@ -284,7 +284,7 @@ transitive = false
 	}
 }
 
-func TestExpandPacks_RigImportsContributeDoctorsButNotCommands(t *testing.T) {
+func TestExpandPacks_RigImportsContributeDoctorsAndCommands(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
 	cityDir := filepath.Join(dir, "city")
@@ -314,11 +314,62 @@ source = "../helper"
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
 
-	if len(cfg.PackCommands) != 0 {
-		t.Fatalf("got %d PackCommands, want 0 for rig import commands", len(cfg.PackCommands))
+	if len(cfg.PackCommands) != 1 {
+		t.Fatalf("got %d PackCommands, want 1 for rig import commands", len(cfg.PackCommands))
+	}
+	if !reflect.DeepEqual(cfg.PackCommands[0].Command, []string{"status"}) {
+		t.Fatalf("command words = %#v, want %#v", cfg.PackCommands[0].Command, []string{"status"})
+	}
+	if cfg.PackCommands[0].BindingName != "helper" {
+		t.Fatalf("command BindingName = %q, want %q", cfg.PackCommands[0].BindingName, "helper")
 	}
 	if len(cfg.PackDoctors) != 1 {
 		t.Fatalf("got %d PackDoctors, want 1 for rig import doctors", len(cfg.PackDoctors))
+	}
+	if cfg.PackDoctors[0].Name != "binaries" {
+		t.Fatalf("doctor Name = %q, want %q", cfg.PackDoctors[0].Name, "binaries")
+	}
+}
+
+func TestExpandPacks_RigIncludesContributePackNameBoundCommands(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "commands/status/run.sh", "#!/bin/sh\nexit 0\n")
+	writeTestFile(t, packDir, "doctor/binaries/run.sh", "#!/bin/sh\nexit 0\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+includes = ["../helper"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.PackCommands) != 1 {
+		t.Fatalf("got %d PackCommands, want 1 for rig include commands", len(cfg.PackCommands))
+	}
+	if !reflect.DeepEqual(cfg.PackCommands[0].Command, []string{"status"}) {
+		t.Fatalf("command words = %#v, want %#v", cfg.PackCommands[0].Command, []string{"status"})
+	}
+	if cfg.PackCommands[0].BindingName != "helper" {
+		t.Fatalf("command BindingName = %q, want %q", cfg.PackCommands[0].BindingName, "helper")
+	}
+	if len(cfg.PackDoctors) != 1 {
+		t.Fatalf("got %d PackDoctors, want 1 for rig include doctors", len(cfg.PackDoctors))
 	}
 	if cfg.PackDoctors[0].Name != "binaries" {
 		t.Fatalf("doctor Name = %q, want %q", cfg.PackDoctors[0].Name, "binaries")

--- a/internal/config/pack_discovery_integration_test.go
+++ b/internal/config/pack_discovery_integration_test.go
@@ -230,7 +230,7 @@ includes = ["../legacy"]
 func TestLoadWithIncludes_TransitiveFalseFiltersNestedCommandsAndDoctors(t *testing.T) {
 	dir := t.TempDir()
 	parentDir := filepath.Join(dir, "parent")
-	childDir := filepath.Join(dir, "child")
+	childDir := filepath.Join(parentDir, "child")
 	cityDir := filepath.Join(dir, "city")
 
 	writeTestFile(t, childDir, "pack.toml", `
@@ -247,7 +247,7 @@ name = "parent"
 schema = 1
 
 [imports.child]
-source = "../child"
+source = "./child"
 `)
 	writeTestFile(t, parentDir, "commands/status/run.sh", "#!/bin/sh\nexit 0\n")
 	writeTestFile(t, parentDir, "doctor/parent-check/run.sh", "#!/bin/sh\nexit 0\n")
@@ -328,6 +328,87 @@ source = "../helper"
 	}
 	if cfg.PackDoctors[0].Name != "binaries" {
 		t.Fatalf("doctor Name = %q, want %q", cfg.PackDoctors[0].Name, "binaries")
+	}
+}
+
+func TestExpandPacks_RigImportTransitiveFalseFiltersNestedCommandsAndDoctors(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(parentDir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+
+[[agent]]
+name = "nested"
+scope = "rig"
+`)
+	writeTestFile(t, childDir, "commands/repo/sync/run.sh", "#!/bin/sh\nexit 0\n")
+	writeTestFile(t, childDir, "doctor/child-check/run.sh", "#!/bin/sh\nexit 0\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "./child"
+
+[[agent]]
+name = "direct"
+scope = "rig"
+`)
+	writeTestFile(t, parentDir, "commands/status/run.sh", "#!/bin/sh\nexit 0\n")
+	writeTestFile(t, parentDir, "doctor/parent-check/run.sh", "#!/bin/sh\nexit 0\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+
+[rigs.imports.ops]
+source = "../parent"
+transitive = false
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.PackCommands) != 1 {
+		t.Fatalf("got %d PackCommands, want 1 direct rig import command", len(cfg.PackCommands))
+	}
+	if !reflect.DeepEqual(cfg.PackCommands[0].Command, []string{"status"}) {
+		t.Fatalf("command words = %#v, want %#v", cfg.PackCommands[0].Command, []string{"status"})
+	}
+	if cfg.PackCommands[0].BindingName != "ops" {
+		t.Fatalf("command BindingName = %q, want %q", cfg.PackCommands[0].BindingName, "ops")
+	}
+
+	if len(cfg.PackDoctors) != 1 {
+		t.Fatalf("got %d PackDoctors, want 1 direct rig import doctor", len(cfg.PackDoctors))
+	}
+	if cfg.PackDoctors[0].Name != "parent-check" {
+		t.Fatalf("doctor Name = %q, want %q", cfg.PackDoctors[0].Name, "parent-check")
+	}
+
+	explicit := explicitAgents(cfg.Agents)
+	found := map[string]bool{}
+	for _, a := range explicit {
+		found[a.QualifiedName()] = true
+	}
+	if !found["frontend/ops.direct"] {
+		t.Errorf("missing frontend/ops.direct; got: %v", found)
+	}
+	if found["frontend/child.nested"] || found["frontend/ops.nested"] {
+		t.Errorf("nested transitive rig import agent should not appear; got: %v", found)
 	}
 }
 


### PR DESCRIPTION
Fixes #786

## Summary
- surface convention-discovered pack commands from rig includes using the pack name binding
- surface convention-discovered pack commands from rig-level imports using the import binding
- add regression coverage for both rig import and rig include paths

## Tests
- go test ./internal/config -run 'TestExpandPacks_Rig(ImportsContributeDoctorsAndCommands|IncludesContributePackNameBoundCommands)' -count=1\n- go test ./internal/config ./cmd/gc -run 'PackCommands|RigImports|RootPackCommands|DefaultRigIncludes' -count=1\n- go test ./cmd/gc -run '^TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind$' -count=1 -timeout=5m\n\nFull go test ./... was attempted, but cmd/gc hit its package timeout in TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind under concurrent local load; the isolated rerun of that test passed.