### PR TITLE
Fix silent errors for invalid gc invocations

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -128,10 +128,15 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 			if tryPackCommandFallback(args, stdout, stderr) {
 				return nil
 			}
-			fmt.Fprintf(stderr, "gc: unknown command %q\n", args[0]) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc: unknown command %q\n\n", args[0]) //nolint:errcheck // best-effort stderr
+			printCommandUsage(stderr, cmd)
 			return errExit
 		},
 	}
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		printCommandUsageError(stderr, cmd, err)
+		return errExit
+	})
 	root.PersistentFlags().StringVar(&cityFlag, "city", "",
 		"path to the city directory (default: walk up from cwd)")
 	root.PersistentFlags().StringVar(&rigFlag, "rig", "",
@@ -193,7 +198,43 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	// Best-effort: discover pack CLI commands if we're inside a city.
 	registerPackCommands(root, stdout, stderr)
 
+	installArgUsageErrors(root, stderr)
+
 	return root
+}
+
+func installArgUsageErrors(cmd *cobra.Command, stderr io.Writer) {
+	if cmd.Args != nil {
+		argsValidator := cmd.Args
+		cmd.Args = func(cmd *cobra.Command, args []string) error {
+			if err := argsValidator(cmd, args); err != nil {
+				printCommandUsageError(stderr, cmd, err)
+				return errExit
+			}
+			return nil
+		}
+	}
+	for _, child := range cmd.Commands() {
+		installArgUsageErrors(child, stderr)
+	}
+}
+
+func printCommandUsageError(stderr io.Writer, cmd *cobra.Command, err error) {
+	if err != nil {
+		fmt.Fprintf(stderr, "gc: %v\n\n", err) //nolint:errcheck // best-effort stderr
+	}
+	printCommandUsage(stderr, cmd)
+}
+
+func printCommandUsage(stderr io.Writer, cmd *cobra.Command) {
+	if cmd == nil {
+		return
+	}
+	usage := strings.TrimRight(cmd.UsageString(), "\n")
+	if usage == "" {
+		return
+	}
+	fmt.Fprintln(stderr, usage) //nolint:errcheck // best-effort stderr
 }
 
 // sessionName returns the session name for a city agent.

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -216,6 +216,78 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestRootInvalidTopLevelFlagPrintsErrorAndUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--version"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("run([--version]) = 0, want non-zero")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "gc: unknown flag: --version") {
+		t.Fatalf("stderr missing unknown flag message, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "Usage:") || !strings.Contains(errOut, "gc [flags]") {
+		t.Fatalf("stderr missing root usage, got:\n%s", errOut)
+	}
+}
+
+func TestRootUnknownCommandPrintsErrorAndUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"bogus"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("run([bogus]) = 0, want non-zero")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, `gc: unknown command "bogus"`) {
+		t.Fatalf("stderr missing unknown command message, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "Usage:") || !strings.Contains(errOut, "gc [flags]") {
+		t.Fatalf("stderr missing root usage, got:\n%s", errOut)
+	}
+}
+
+func TestSubcommandInvalidFlagPrintsErrorAndUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--bogus"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("run([version --bogus]) = 0, want non-zero")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "gc: unknown flag: --bogus") {
+		t.Fatalf("stderr missing unknown flag message, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "Usage:") || !strings.Contains(errOut, "gc version [flags]") {
+		t.Fatalf("stderr missing version usage, got:\n%s", errOut)
+	}
+}
+
+func TestSubcommandInvalidArgsPrintsErrorAndUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "extra"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("run([version extra]) = 0, want non-zero")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, `gc: unknown command "extra" for "gc version"`) {
+		t.Fatalf("stderr missing invalid argument message, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "Usage:") || !strings.Contains(errOut, "gc version [flags]") {
+		t.Fatalf("stderr missing version usage, got:\n%s", errOut)
+	}
+}
+
 func TestConfigureTestscriptEnvDefaultsSetsMissingValues(t *testing.T) {
 	t.Setenv("GC_SESSION", "")
 	t.Setenv("GC_BEADS", "")


### PR DESCRIPTION
Fixes #760.

## Summary
- print a user-facing error and usage for invalid root flags such as `gc --version`
- print usage for unknown root commands and invalid subcommand flags/args
- add regression coverage around the root and `version` command invalid invocation paths

## Tests
- `go test ./cmd/gc -run 'TestVersion|TestRootInvalidTopLevelFlagPrintsErrorAndUsage|TestRootUnknownCommandPrintsErrorAndUsage|TestSubcommandInvalidFlagPrintsErrorAndUsage|TestSubcommandInvalidArgsPrintsErrorAndUsage' -count=1`\n- `git diff --check`\n\n## Note\n- `go test ./cmd/gc -count=1` timed out after 10m in existing managed bd provider test `TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind`; the stack was in `gc-beads-bd.sh start`/provider health, unrelated to this CLI usage change.