### PR TITLE
Fix #750: clarify controller ownership messaging

### DIFF
--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -480,6 +480,9 @@ func controllerStatusGuidance(ctrl ControllerJSON, cityPath string) []string {
 		if ctrl.Status == "" {
 			return append(lines, "Next: "+startCommand+" to ask the supervisor to start this city")
 		}
+		if ctrl.Status == "init_failed" {
+			return append(lines, "Next: gc supervisor logs to see the init failure")
+		}
 		return append(lines, "Next: gc supervisor logs to inspect startup progress")
 	}
 	return nil

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -126,6 +126,9 @@ func doCityStatus(
 
 	ctrl := controllerStatusForCity(cityPath)
 	fmt.Fprintf(stdout, "  Controller: %s\n", controllerStatusLine(ctrl)) //nolint:errcheck // best-effort stdout
+	for _, line := range controllerStatusGuidance(ctrl, cityPath) {
+		fmt.Fprintf(stdout, "  %s\n", line) //nolint:errcheck // best-effort stdout
+	}
 
 	// Suspended status.
 	if citySuspended(cfg) {
@@ -432,16 +435,52 @@ func controllerStatusLine(ctrl ControllerJSON) string {
 	switch ctrl.Mode {
 	case "supervisor":
 		if ctrl.Running {
-			return fmt.Sprintf("supervisor (PID %d)", ctrl.PID)
+			return fmt.Sprintf("supervisor-managed (PID %d)", ctrl.PID)
 		}
 		if ctrl.PID != 0 {
-			return fmt.Sprintf("supervisor (PID %d, %s)", ctrl.PID, controllerSupervisorStatusText(ctrl.Status))
+			return fmt.Sprintf("supervisor-managed (PID %d, %s)", ctrl.PID, controllerSupervisorStatusText(ctrl.Status))
 		}
 		return "supervisor-managed (supervisor not running)"
 	case "standalone":
 		if ctrl.Running {
-			return fmt.Sprintf("standalone (PID %d)", ctrl.PID)
+			return fmt.Sprintf("standalone-managed (PID %d)", ctrl.PID)
 		}
 	}
 	return "stopped"
+}
+
+func controllerStatusGuidance(ctrl ControllerJSON, cityPath string) []string {
+	quotedPath := shellQuotePath(cityPath)
+	startCommand := "gc start " + quotedPath
+
+	switch ctrl.Mode {
+	case "standalone":
+		if !ctrl.Running {
+			return nil
+		}
+		authority := "Authority: standalone controller"
+		if ctrl.PID != 0 {
+			authority = fmt.Sprintf("Authority: standalone controller PID %d", ctrl.PID)
+		}
+		return []string{
+			authority,
+			"Next: gc stop " + quotedPath + " && " + startCommand + " to hand ownership to the supervisor",
+		}
+	case "supervisor":
+		if ctrl.PID == 0 {
+			return []string{
+				"Authority: supervisor registry; no supervisor process is running",
+				"Next: " + startCommand + " to start the supervisor and reconcile this city",
+			}
+		}
+		lines := []string{fmt.Sprintf("Authority: supervisor process PID %d", ctrl.PID)}
+		if ctrl.Running {
+			return lines
+		}
+		if ctrl.Status == "" {
+			return append(lines, "Next: "+startCommand+" to ask the supervisor to start this city")
+		}
+		return append(lines, "Next: gc supervisor logs to inspect startup progress")
+	}
+	return nil
 }

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -387,11 +387,27 @@ func TestControllerStatusGuidance(t *testing.T) {
 			},
 		},
 		{
+			name: "supervisor city stopped",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321},
+			want: []string{
+				"Authority: supervisor process PID 4321",
+				"Next: gc start /tmp/city to ask the supervisor to start this city",
+			},
+		},
+		{
 			name: "supervisor starting",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "starting_bead_store"},
 			want: []string{
 				"Authority: supervisor process PID 4321",
 				"Next: gc supervisor logs to inspect startup progress",
+			},
+		},
+		{
+			name: "supervisor init failed",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "init_failed"},
+			want: []string{
+				"Authority: supervisor process PID 4321",
+				"Next: gc supervisor logs to see the init failure",
 			},
 		},
 		{

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -324,6 +324,11 @@ func TestControllerStatusLine(t *testing.T) {
 		want string
 	}{
 		{
+			name: "standalone running",
+			ctrl: ControllerJSON{Mode: "standalone", PID: 1234, Running: true},
+			want: "standalone-managed (PID 1234)",
+		},
+		{
 			name: "supervisor not running",
 			ctrl: ControllerJSON{Mode: "supervisor"},
 			want: "supervisor-managed (supervisor not running)",
@@ -331,22 +336,22 @@ func TestControllerStatusLine(t *testing.T) {
 		{
 			name: "supervisor city stopped",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321},
-			want: "supervisor (PID 4321, city stopped)",
+			want: "supervisor-managed (PID 4321, city stopped)",
 		},
 		{
 			name: "supervisor city starting bead store",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "starting_bead_store"},
-			want: "supervisor (PID 4321, starting bead store)",
+			want: "supervisor-managed (PID 4321, starting bead store)",
 		},
 		{
 			name: "supervisor city init failed",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "init_failed"},
-			want: "supervisor (PID 4321, init failed)",
+			want: "supervisor-managed (PID 4321, init failed)",
 		},
 		{
 			name: "supervisor running",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Running: true},
-			want: "supervisor (PID 4321)",
+			want: "supervisor-managed (PID 4321)",
 		},
 	}
 
@@ -354,6 +359,65 @@ func TestControllerStatusLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := controllerStatusLine(tt.ctrl); got != tt.want {
 				t.Fatalf("controllerStatusLine(%+v) = %q, want %q", tt.ctrl, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControllerStatusGuidance(t *testing.T) {
+	tests := []struct {
+		name string
+		ctrl ControllerJSON
+		want []string
+	}{
+		{
+			name: "standalone running",
+			ctrl: ControllerJSON{Mode: "standalone", PID: 1234, Running: true},
+			want: []string{
+				"Authority: standalone controller PID 1234",
+				"Next: gc stop /tmp/city && gc start /tmp/city to hand ownership to the supervisor",
+			},
+		},
+		{
+			name: "supervisor registered but down",
+			ctrl: ControllerJSON{Mode: "supervisor"},
+			want: []string{
+				"Authority: supervisor registry; no supervisor process is running",
+				"Next: gc start /tmp/city to start the supervisor and reconcile this city",
+			},
+		},
+		{
+			name: "supervisor starting",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "starting_bead_store"},
+			want: []string{
+				"Authority: supervisor process PID 4321",
+				"Next: gc supervisor logs to inspect startup progress",
+			},
+		},
+		{
+			name: "supervisor running",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Running: true},
+			want: []string{
+				"Authority: supervisor process PID 4321",
+			},
+		},
+		{
+			name: "unmanaged stopped",
+			ctrl: ControllerJSON{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := controllerStatusGuidance(tt.ctrl, "/tmp/city")
+			if len(got) != len(tt.want) {
+				t.Fatalf("controllerStatusGuidance length = %d, want %d; got %#v", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("controllerStatusGuidance[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
 			}
 		})
 	}

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -245,9 +245,9 @@ func writeStandaloneControllerConflict(stderr io.Writer, commandName, cityPath s
 		authority = fmt.Sprintf("standalone controller PID %d", pid)
 	}
 	nextCommand := "gc stop " + shellQuotePath(cityPath) + " && " + supervisorRetryCommand(commandName, cityPath)
-	fmt.Fprintf(stderr,
+	_, _ = fmt.Fprintf(stderr,
 		"%s: standalone controller already running for %s%s; supervisor cannot manage this city until it stops\n",
-		commandName, shellQuotePath(cityPath), pidSuffix) //nolint:errcheck // best-effort stderr
+		commandName, shellQuotePath(cityPath), pidSuffix)
 	fmt.Fprintf(stderr, "%s: Authority: %s\n", commandName, authority) //nolint:errcheck // best-effort stderr
 	fmt.Fprintf(stderr, "%s: Next: %s\n", commandName, nextCommand)    //nolint:errcheck // best-effort stderr
 }

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -153,11 +153,7 @@ func registerCityWithSupervisorNamed(cityPath, nameOverride string, stdout, stde
 	cityPath = normalizePathForCompare(cityPath)
 	if pid, err := ensureNoStandaloneController(cityPath); err != nil {
 		if errors.Is(err, errControllerAlreadyRunning) {
-			if pid != 0 {
-				fmt.Fprintf(stderr, "%s: standalone controller already running for %s (PID %d); stop it before registering with the supervisor\n", commandName, cityPath, pid) //nolint:errcheck // best-effort stderr
-			} else {
-				fmt.Fprintf(stderr, "%s: standalone controller already running for %s; stop it before registering with the supervisor\n", commandName, cityPath) //nolint:errcheck // best-effort stderr
-			}
+			writeStandaloneControllerConflict(stderr, commandName, cityPath, pid)
 		} else {
 			fmt.Fprintf(stderr, "%s: probing standalone controller: %v\n", commandName, err) //nolint:errcheck // best-effort stderr
 		}
@@ -239,6 +235,31 @@ func registerCityWithSupervisorNamed(cityPath, nameOverride string, stdout, stde
 		}
 	}
 	return 0
+}
+
+func writeStandaloneControllerConflict(stderr io.Writer, commandName, cityPath string, pid int) {
+	pidSuffix := ""
+	authority := "standalone controller"
+	if pid != 0 {
+		pidSuffix = fmt.Sprintf(" (PID %d)", pid)
+		authority = fmt.Sprintf("standalone controller PID %d", pid)
+	}
+	nextCommand := "gc stop " + shellQuotePath(cityPath) + " && " + supervisorRetryCommand(commandName, cityPath)
+	fmt.Fprintf(stderr,
+		"%s: standalone controller already running for %s%s; supervisor cannot manage this city until it stops\n",
+		commandName, cityPath, pidSuffix) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: Authority: %s\n", commandName, authority) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: Next: %s\n", commandName, nextCommand)    //nolint:errcheck // best-effort stderr
+}
+
+func supervisorRetryCommand(commandName, cityPath string) string {
+	quotedPath := shellQuotePath(cityPath)
+	switch strings.TrimSpace(commandName) {
+	case "gc register":
+		return "gc register " + quotedPath
+	default:
+		return "gc start " + quotedPath
+	}
 }
 
 func keepRegisteredCity(entry supervisor.CityEntry, stderr io.Writer, commandName, reason string) {

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -247,7 +247,7 @@ func writeStandaloneControllerConflict(stderr io.Writer, commandName, cityPath s
 	nextCommand := "gc stop " + shellQuotePath(cityPath) + " && " + supervisorRetryCommand(commandName, cityPath)
 	fmt.Fprintf(stderr,
 		"%s: standalone controller already running for %s%s; supervisor cannot manage this city until it stops\n",
-		commandName, cityPath, pidSuffix) //nolint:errcheck // best-effort stderr
+		commandName, shellQuotePath(cityPath), pidSuffix) //nolint:errcheck // best-effort stderr
 	fmt.Fprintf(stderr, "%s: Authority: %s\n", commandName, authority) //nolint:errcheck // best-effort stderr
 	fmt.Fprintf(stderr, "%s: Next: %s\n", commandName, nextCommand)    //nolint:errcheck // best-effort stderr
 }

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -346,7 +346,7 @@ func TestRegisterCityWithSupervisorRejectsStandaloneController(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	code := registerCityWithSupervisor(cityPath, &stdout, &stderr, "gc register", true)
+	code := registerCityWithSupervisor(cityPath, &stdout, &stderr, "gc start", true)
 	if code != 1 {
 		t.Fatalf("registerCityWithSupervisor code = %d, want 1", code)
 	}
@@ -355,6 +355,13 @@ func TestRegisterCityWithSupervisorRejectsStandaloneController(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "PID 4242") {
 		t.Fatalf("stderr = %q, want controller PID", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Authority: standalone controller PID 4242") {
+		t.Fatalf("stderr = %q, want standalone-controller authority", stderr.String())
+	}
+	wantNext := "Next: gc stop " + shellQuotePath(cityPath) + " && gc start " + shellQuotePath(cityPath)
+	if !strings.Contains(stderr.String(), wantNext) {
+		t.Fatalf("stderr = %q, want next command %q", stderr.String(), wantNext)
 	}
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -353,6 +353,9 @@ func TestRegisterCityWithSupervisorRejectsStandaloneController(t *testing.T) {
 	if !strings.Contains(stderr.String(), "standalone controller already running") {
 		t.Fatalf("stderr = %q, want standalone-controller error", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "for "+shellQuotePath(cityPath)) {
+		t.Fatalf("stderr = %q, want shell-quoted city path", stderr.String())
+	}
 	if !strings.Contains(stderr.String(), "PID 4242") {
 		t.Fatalf("stderr = %q, want controller PID", stderr.String())
 	}
@@ -371,6 +374,40 @@ func TestRegisterCityWithSupervisorRejectsStandaloneController(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected empty registry after standalone-controller rejection, got %v", entries)
+	}
+}
+
+func TestSupervisorRetryCommand(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "city with spaces")
+
+	tests := []struct {
+		name        string
+		commandName string
+		want        string
+	}{
+		{
+			name:        "start retries start",
+			commandName: "gc start",
+			want:        "gc start " + shellQuotePath(cityPath),
+		},
+		{
+			name:        "register retries register",
+			commandName: "gc register",
+			want:        "gc register " + shellQuotePath(cityPath),
+		},
+		{
+			name:        "init retries start",
+			commandName: "gc init",
+			want:        "gc start " + shellQuotePath(cityPath),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supervisorRetryCommand(tt.commandName, cityPath); got != tt.want {
+				t.Fatalf("supervisorRetryCommand(%q, %q) = %q, want %q", tt.commandName, cityPath, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -161,7 +161,9 @@ To check on the status of your city, use `gc status`:
 ~/my-city
 $ gc status
 my-city  /Users/csells/my-city
-  Controller: standalone (PID 83621)
+  Controller: standalone-managed (PID 83621)
+  Authority: standalone controller PID 83621
+  Next: gc stop /Users/csells/my-city && gc start /Users/csells/my-city to hand ownership to the supervisor
   Suspended:  no
 
 Agents:

--- a/test/acceptance/dashboard_serve_test.go
+++ b/test/acceptance/dashboard_serve_test.go
@@ -119,7 +119,7 @@ func startCityUnderSupervisor(t *testing.T, c *helpers.City) string {
 		if err != nil {
 			return false
 		}
-		return !strings.Contains(out, "Controller: standalone")
+		return !strings.Contains(out, "Controller: standalone-managed")
 	}, 20*time.Second) {
 		out, err := c.GC("status", c.Dir)
 		t.Fatalf("standalone controller did not stop before supervisor handoff: %v\n%s", err, out)

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
@@ -145,7 +145,9 @@ To check on the status of your city, use `gc status`:
 ~/my-project
 $ gc status
 my-city  /Users/csells/my-city
-  Controller: standalone (PID 83621)
+  Controller: standalone-managed (PID 83621)
+  Authority: standalone controller PID 83621
+  Next: gc stop /Users/csells/my-city && gc start /Users/csells/my-city to hand ownership to the supervisor
   Suspended:  no
 
 Agents:

--- a/test/agents/graph-dispatch.sh
+++ b/test/agents/graph-dispatch.sh
@@ -592,6 +592,13 @@ while true; do
         fi
     fi
     if [ "$sibling_hard_fail" = "true" ]; then
+        case "$ref" in
+            *.cleanup-worktree*)
+                sibling_hard_fail="false"
+                ;;
+        esac
+    fi
+    if [ "$sibling_hard_fail" = "true" ]; then
         trace "skip-sibling-hard-fail bead=$bead_id ref=$ref root=$root_id (sibling has outcome=fail class=hard; closing self as skipped)"
         bd update "$bead_id" --set-metadata "gc.outcome=skipped" --status closed 2>/dev/null || \
             trace "skip-close-failed bead=$bead_id ref=$ref"

--- a/test/integration/e2e_comm_test.go
+++ b/test/integration/e2e_comm_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/gastownhall/gascity/internal/config"
 )
 
 // TestE2E_Drain_SetAndCheck verifies that gc runtime drain sets the GC_DRAIN
@@ -208,9 +206,8 @@ func TestE2E_ConfigDrift(t *testing.T) {
 	// Change config by mutating the fingerprinted start_command. Custom env
 	// keys are intentionally ignored by the runtime fingerprint, so changing
 	// Env alone should not imply restart.
-	updateE2EAgentInCityToml(t, cityDir, "drifter", func(agent *config.Agent) {
-		agent.StartCommand = "CUSTOM_VERSION=v2 " + e2eReportScript()
-	})
+	city.Agents[0].StartCommand = "CUSTOM_VERSION=v2 " + e2eReportScript()
+	rewriteE2ETomlPreservingNamedSessions(t, cityDir, city)
 
 	// Remove old report so we can detect a new one.
 	reportPath := strings.ReplaceAll("drifter", "/", "__")

--- a/test/integration/e2e_comm_test.go
+++ b/test/integration/e2e_comm_test.go
@@ -5,10 +5,11 @@ package integration
 import (
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // TestE2E_Drain_SetAndCheck verifies that gc runtime drain sets the GC_DRAIN
@@ -207,10 +208,9 @@ func TestE2E_ConfigDrift(t *testing.T) {
 	// Change config by mutating the fingerprinted start_command. Custom env
 	// keys are intentionally ignored by the runtime fingerprint, so changing
 	// Env alone should not imply restart.
-	city.Workspace.Name = "" // Will be filled from cityDir base.
-	city.Agents[0].StartCommand = "CUSTOM_VERSION=v2 " + e2eReportScript()
-	city.Workspace.Name = findCityName(t, cityDir)
-	writeE2EToml(t, cityDir, city)
+	updateE2EAgentInCityToml(t, cityDir, "drifter", func(agent *config.Agent) {
+		agent.StartCommand = "CUSTOM_VERSION=v2 " + e2eReportScript()
+	})
 
 	// Remove old report so we can detect a new one.
 	reportPath := strings.ReplaceAll("drifter", "/", "__")
@@ -244,26 +244,6 @@ func gcCommand(args ...string) *exec.Cmd {
 	cmd := exec.Command(gcBinary, args...)
 	cmd.Env = integrationEnv()
 	return cmd
-}
-
-// findCityName reads city.toml to extract the workspace name.
-func findCityName(t *testing.T, cityDir string) string {
-	t.Helper()
-	data, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
-	if err != nil {
-		t.Fatalf("reading city.toml: %v", err)
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "name") {
-			parts := strings.SplitN(line, "=", 2)
-			if len(parts) == 2 {
-				return strings.Trim(strings.TrimSpace(parts[1]), "\"")
-			}
-		}
-	}
-	t.Fatal("city name not found in city.toml")
-	return ""
 }
 
 // removeFile removes a file, ignoring errors.

--- a/test/integration/e2e_comm_test.go
+++ b/test/integration/e2e_comm_test.go
@@ -231,6 +231,7 @@ func gcWithEnv(dir string, env map[string]string, args ...string) (string, error
 	if dir != "" {
 		cmd.Dir = dir
 	}
+	cmd.Env = commandEnvForDir(dir, false)
 	for k, v := range env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/test/integration/e2e_events_test.go
+++ b/test/integration/e2e_events_test.go
@@ -117,10 +117,10 @@ func TestE2E_AgentLifecycleEvents(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// The city API is gone after gc stop, but the event log is persistent.
-	verifyEventLog(t, cityDir, "session.stopped")
+	verifyEventLogEventually(t, cityDir, "session.stopped")
 }
 
-func verifyEventLog(t *testing.T, cityDir, eventType string) {
+func verifyEventLogEventually(t *testing.T, cityDir, eventType string) {
 	t.Helper()
 
 	eventLog := filepath.Join(cityDir, ".gc", "events.jsonl")

--- a/test/integration/e2e_events_test.go
+++ b/test/integration/e2e_events_test.go
@@ -116,7 +116,7 @@ func TestE2E_AgentLifecycleEvents(t *testing.T) {
 	// Give the event log a moment.
 	time.Sleep(500 * time.Millisecond)
 
-	// Verify session.stopped event exists.
+	// The city API is gone after gc stop, but the event log is persistent.
 	verifyEventLog(t, cityDir, "session.stopped")
 }
 

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -266,9 +266,39 @@ func writeE2EToml(t *testing.T, cityDir string, city e2eCity) {
 		t.Fatalf("writing pack.toml: %v", err)
 	}
 	tomlPath := filepath.Join(cityDir, "city.toml")
-	if err := os.WriteFile(tomlPath, []byte(renderE2ECityRuntimeToml(city)), 0o644); err != nil {
-		t.Fatalf("writing city.toml: %v", err)
+	writeFileAtomic(t, tomlPath, []byte(renderE2ECityRuntimeToml(city)))
+}
+
+func writeE2ETomlFile(t *testing.T, tomlPath string, city e2eCity) {
+	t.Helper()
+	writeFileAtomic(t, tomlPath, []byte(renderE2EToml(city)))
+}
+
+func writeFileAtomic(t *testing.T, path string, data []byte) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		t.Fatalf("creating temp file for %s: %v", path, err)
 	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		t.Fatalf("writing temp file for %s: %v", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("closing temp file for %s: %v", path, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		t.Fatalf("replacing %s: %v", path, err)
+	}
+	cleanup = false
 }
 
 // setupE2ECity initializes a city, writes config, starts agents, and
@@ -290,9 +320,7 @@ func setupE2ECity(t *testing.T, guard *tmuxtest.Guard, city e2eCity) string {
 	// to agent output), but keep it symmetric so future assertions don't
 	// regress on macOS's /var→/private/var symlink.
 	configPath := filepath.Join(canonicalTempDir(t), city.Workspace.Name+".toml")
-	if err := os.WriteFile(configPath, []byte(renderE2EToml(city)), 0o644); err != nil {
-		t.Fatalf("writing init config: %v", err)
-	}
+	writeE2ETomlFile(t, configPath, city)
 
 	// Stage scripts before the first controller launch so CopyFiles hashing is
 	// stable. If scripts appear only after init's startup, the second gc start
@@ -349,9 +377,7 @@ func setupE2ECityNoStart(t *testing.T, city e2eCity) string {
 
 	cityDir := filepath.Join(canonicalTempDir(t), city.Workspace.Name)
 	configPath := filepath.Join(canonicalTempDir(t), city.Workspace.Name+".toml")
-	if err := os.WriteFile(configPath, []byte(renderE2EToml(city)), 0o644); err != nil {
-		t.Fatalf("writing init config: %v", err)
-	}
+	writeE2ETomlFile(t, configPath, city)
 
 	// Pre-stage scripts so init's first launch fingerprints the final staged
 	// content instead of a missing scripts directory.

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -216,9 +216,9 @@ func writeE2EAgentSections(b *strings.Builder, agents []e2eAgent) {
 			fmt.Fprintf(b, "nudge = %s\n", quote(a.Nudge))
 		}
 		if a.Pool == nil {
-			// E2E helpers expect a plain test agent to behave like a singleton
-			// session unless the test explicitly opts into pool semantics.
-			fmt.Fprintf(b, "max_active_sessions = 1\n")
+			// Plain E2E agents are kept resident by the named session below.
+			// Leave generic template capacity unbounded so config rewrites do
+			// not also carry legacy singleton-pool semantics.
 			if strings.TrimSpace(a.IdleTimeout) == "" {
 				fmt.Fprintf(b, "idle_timeout = %s\n", quote("1h"))
 			}

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
@@ -272,6 +273,32 @@ func writeE2EToml(t *testing.T, cityDir string, city e2eCity) {
 func writeE2ETomlFile(t *testing.T, tomlPath string, city e2eCity) {
 	t.Helper()
 	writeFileAtomic(t, tomlPath, []byte(renderE2EToml(city)))
+}
+
+func updateE2EAgentInCityToml(t *testing.T, cityDir, agentName string, update func(*config.Agent)) {
+	t.Helper()
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing city.toml: %v", err)
+	}
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name != agentName {
+			continue
+		}
+		update(&cfg.Agents[i])
+		next, err := cfg.Marshal()
+		if err != nil {
+			t.Fatalf("marshaling city.toml: %v", err)
+		}
+		writeFileAtomic(t, tomlPath, next)
+		return
+	}
+	t.Fatalf("agent %q not found in city.toml", agentName)
 }
 
 func writeFileAtomic(t *testing.T, path string, data []byte) {

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -275,30 +275,55 @@ func writeE2ETomlFile(t *testing.T, tomlPath string, city e2eCity) {
 	writeFileAtomic(t, tomlPath, []byte(renderE2EToml(city)))
 }
 
-func updateE2EAgentInCityToml(t *testing.T, cityDir, agentName string, update func(*config.Agent)) {
+func rewriteE2ETomlPreservingNamedSessions(t *testing.T, cityDir string, city e2eCity) {
 	t.Helper()
 	tomlPath := filepath.Join(cityDir, "city.toml")
 	data, err := os.ReadFile(tomlPath)
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
 	}
-	cfg, err := config.Parse(data)
+	current, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing city.toml: %v", err)
 	}
-	for i := range cfg.Agents {
-		if cfg.Agents[i].Name != agentName {
+	if strings.TrimSpace(city.Workspace.Name) == "" {
+		city.Workspace.Name = current.Workspace.Name
+	}
+	if strings.TrimSpace(city.Workspace.Name) == "" {
+		city.Workspace.Name = filepath.Base(cityDir)
+	}
+	nextCfg, err := config.Parse([]byte(renderE2EToml(city)))
+	if err != nil {
+		t.Fatalf("parsing rendered city.toml: %v", err)
+	}
+	nextCfg.NamedSessions = mergeNamedSessions(current.NamedSessions, nextCfg.NamedSessions)
+	next, err := nextCfg.Marshal()
+	if err != nil {
+		t.Fatalf("marshaling city.toml: %v", err)
+	}
+	writeFileAtomic(t, tomlPath, next)
+}
+
+func mergeNamedSessions(existing, desired []config.NamedSession) []config.NamedSession {
+	merged := make([]config.NamedSession, 0, len(existing)+len(desired))
+	seen := make(map[string]bool, len(existing)+len(desired))
+	for _, ns := range existing {
+		key := ns.QualifiedName()
+		if seen[key] {
 			continue
 		}
-		update(&cfg.Agents[i])
-		next, err := cfg.Marshal()
-		if err != nil {
-			t.Fatalf("marshaling city.toml: %v", err)
-		}
-		writeFileAtomic(t, tomlPath, next)
-		return
+		seen[key] = true
+		merged = append(merged, ns)
 	}
-	t.Fatalf("agent %q not found in city.toml", agentName)
+	for _, ns := range desired {
+		key := ns.QualifiedName()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		merged = append(merged, ns)
+	}
+	return merged
 }
 
 func writeFileAtomic(t *testing.T, path string, data []byte) {

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
@@ -278,6 +279,7 @@ func writeE2ETomlFile(t *testing.T, tomlPath string, city e2eCity) {
 func rewriteE2ETomlPreservingNamedSessions(t *testing.T, cityDir string, city e2eCity) {
 	t.Helper()
 	tomlPath := filepath.Join(cityDir, "city.toml")
+	packPath := filepath.Join(cityDir, "pack.toml")
 	data, err := os.ReadFile(tomlPath)
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
@@ -292,38 +294,45 @@ func rewriteE2ETomlPreservingNamedSessions(t *testing.T, cityDir string, city e2
 	if strings.TrimSpace(city.Workspace.Name) == "" {
 		city.Workspace.Name = filepath.Base(cityDir)
 	}
-	nextCfg, err := config.Parse([]byte(renderE2EToml(city)))
+	desiredCfg, err := config.Parse([]byte(renderE2EToml(city)))
 	if err != nil {
 		t.Fatalf("parsing rendered city.toml: %v", err)
 	}
-	nextCfg.NamedSessions = mergeNamedSessions(current.NamedSessions, nextCfg.NamedSessions)
-	next, err := nextCfg.Marshal()
+	nextRuntimeCfg, err := config.Parse([]byte(renderE2ECityRuntimeToml(city)))
+	if err != nil {
+		t.Fatalf("parsing rendered runtime city.toml: %v", err)
+	}
+	nextRuntimeCfg.NamedSessions = preservedLocalNamedSessions(current.NamedSessions, desiredCfg.NamedSessions)
+	nextRuntime, err := nextRuntimeCfg.Marshal()
 	if err != nil {
 		t.Fatalf("marshaling city.toml: %v", err)
 	}
-	writeFileAtomic(t, tomlPath, next)
+	writeFileAtomic(t, packPath, []byte(renderE2EPackToml(city)))
+	writeFileAtomic(t, tomlPath, nextRuntime)
+	if _, _, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath); err != nil {
+		t.Fatalf("loading rewritten city.toml: %v\n%s", err, nextRuntime)
+	}
 }
 
-func mergeNamedSessions(existing, desired []config.NamedSession) []config.NamedSession {
-	merged := make([]config.NamedSession, 0, len(existing)+len(desired))
-	seen := make(map[string]bool, len(existing)+len(desired))
-	for _, ns := range existing {
-		key := ns.QualifiedName()
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		merged = append(merged, ns)
-	}
+func preservedLocalNamedSessions(existing, desired []config.NamedSession) []config.NamedSession {
+	preserved := make([]config.NamedSession, 0, len(existing))
+	seen := make(map[string]bool, len(desired))
 	for _, ns := range desired {
-		key := ns.QualifiedName()
+		seen[namedSessionMergeKey(ns)] = true
+	}
+	for _, ns := range existing {
+		key := namedSessionMergeKey(ns)
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
-		merged = append(merged, ns)
+		preserved = append(preserved, ns)
 	}
-	return merged
+	return preserved
+}
+
+func namedSessionMergeKey(ns config.NamedSession) string {
+	return ns.Dir + "\x00" + ns.IdentityName()
 }
 
 func writeFileAtomic(t *testing.T, path string, data []byte) {

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/gastownhall/gascity/internal/config"
 )
 
 // TestE2E_EnvVars_CityScoped verifies that agents receive GC_AGENT, GC_CITY,
@@ -151,9 +149,8 @@ func TestE2E_Overlay(t *testing.T) {
 	overlayRel := createOverlayDir(t, cityDir)
 
 	// Update agent config with overlay_dir.
-	updateE2EAgentInCityToml(t, cityDir, "overlay", func(agent *config.Agent) {
-		agent.OverlayDir = overlayRel
-	})
+	city.Agents[0].OverlayDir = overlayRel
+	rewriteE2ETomlPreservingNamedSessions(t, cityDir, city)
 
 	// Start the city.
 	out, err := gc("", "start", cityDir)

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // TestE2E_EnvVars_CityScoped verifies that agents receive GC_AGENT, GC_CITY,
@@ -149,9 +151,9 @@ func TestE2E_Overlay(t *testing.T) {
 	overlayRel := createOverlayDir(t, cityDir)
 
 	// Update agent config with overlay_dir.
-	city.Workspace.Name = filepath.Base(cityDir)
-	city.Agents[0].OverlayDir = overlayRel
-	writeE2EToml(t, cityDir, city)
+	updateE2EAgentInCityToml(t, cityDir, "overlay", func(agent *config.Agent) {
+		agent.OverlayDir = overlayRel
+	})
 
 	// Start the city.
 	out, err := gc("", "start", cityDir)

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	gcevents "github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
@@ -276,6 +277,19 @@ func verifyEvents(t *testing.T, cityDir, eventType string) {
 	}
 	if strings.TrimSpace(out) == "" {
 		t.Errorf("expected events of type %s, got empty output", eventType)
+	}
+}
+
+// verifyEventLog checks the persisted event log directly. Use it for
+// assertions after the city controller has stopped and the live API is gone.
+func verifyEventLog(t *testing.T, cityDir, eventType string) {
+	t.Helper()
+	items, err := gcevents.ReadFiltered(filepath.Join(cityDir, ".gc", "events.jsonl"), gcevents.Filter{Type: eventType})
+	if err != nil {
+		t.Fatalf("read event log for %s: %v", eventType, err)
+	}
+	if len(items) == 0 {
+		t.Errorf("expected events of type %s in event log", eventType)
 	}
 }
 

--- a/test/integration/graph_dispatch_test.go
+++ b/test/integration/graph_dispatch_test.go
@@ -182,6 +182,16 @@ func setupGraphWorkflowCity(t *testing.T, mode string) string {
 		unregisterCityCommandEnv(cityDir)
 		runGCDoltWithEnv(env, "", "stop", cityDir)                //nolint:errcheck // best-effort cleanup
 		runGCDoltWithEnv(env, "", "supervisor", "stop", "--wait") //nolint:errcheck // best-effort cleanup
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			cleanupTestCityDir(cityDir)
+			if _, err := os.Stat(cityDir); os.IsNotExist(err) {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		beadsEntries, _ := os.ReadDir(filepath.Join(cityDir, ".beads"))
+		t.Fatalf("graph workflow city cleanup did not quiesce; .beads entries=%v", beadsEntries)
 	})
 
 	return cityDir

--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -107,7 +107,14 @@ func TestHumaBinary_SupervisorBootsAndServesSpec(t *testing.T) {
 
 	// 3) Create a city the supervisor can see, then exercise per-city commands.
 	cityRoot := filepath.Join(gcHome, "city")
-	runCLI(t, bin, env, "gc init", "init", "--skip-provider-readiness", cityRoot, "--provider", "claude", "--name", "humatest")
+	if err := os.MkdirAll(cityRoot, 0o755); err != nil {
+		t.Fatalf("create city root: %v", err)
+	}
+	cityConfig := "[workspace]\nname = \"humatest\"\n\n[beads]\nprovider = \"file\"\n"
+	if err := os.WriteFile(filepath.Join(cityRoot, "city.toml"), []byte(cityConfig), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	runCLI(t, bin, env, "gc register", "register", cityRoot, "--name", "humatest")
 
 	// Give the supervisor a moment to pick up the registered city.
 	cityListURL := baseURL + "/v0/cities"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1132,16 +1132,28 @@ func TestRenderE2ETomlPlainAgentUsesNamedSessionWithoutSingletonCap(t *testing.T
 	}
 }
 
-func TestUpdateE2EAgentInCityTomlPreservesNamedSessions(t *testing.T) {
+func TestRewriteE2ETomlPreservingNamedSessionsRestoresInlineAgent(t *testing.T) {
 	cityDir := t.TempDir()
-	writeE2EToml(t, cityDir, e2eCity{
-		Workspace: e2eWorkspace{Name: "test-city"},
-		Agents:    []e2eAgent{{Name: "worker", StartCommand: "VERSION=v1 sleep 3600"}},
-	})
+	initial := `[workspace]
+name = "test-city"
 
-	updateE2EAgentInCityToml(t, cityDir, "worker", func(agent *config.Agent) {
-		agent.StartCommand = "VERSION=v2 sleep 3600"
-		agent.OverlayDir = "overlays/test"
+[beads]
+provider = "file"
+
+[[named_session]]
+template = "worker"
+mode = "always"
+
+[[named_session]]
+template = "control-dispatcher"
+mode = "always"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(initial), 0o644); err != nil {
+		t.Fatalf("writing city.toml: %v", err)
+	}
+
+	rewriteE2ETomlPreservingNamedSessions(t, cityDir, e2eCity{
+		Agents: []e2eAgent{{Name: "worker", StartCommand: "VERSION=v2 sleep 3600"}},
 	})
 
 	data, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
@@ -1152,17 +1164,20 @@ func TestUpdateE2EAgentInCityTomlPreservesNamedSessions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing city.toml: %v", err)
 	}
-	if len(cfg.NamedSessions) != 1 {
-		t.Fatalf("len(NamedSessions) = %d, want 1\n%s", len(cfg.NamedSessions), data)
+	if cfg.Workspace.Name != "test-city" {
+		t.Fatalf("Workspace.Name = %q, want test-city", cfg.Workspace.Name)
 	}
-	if got := strings.Count(string(data), "[[named_session]]"); got != 1 {
-		t.Fatalf("named_session blocks = %d, want 1\n%s", got, data)
+	if len(cfg.Agents) != 1 || cfg.Agents[0].Name != "worker" {
+		t.Fatalf("Agents = %+v, want restored worker", cfg.Agents)
 	}
 	if got := cfg.Agents[0].StartCommand; got != "VERSION=v2 sleep 3600" {
 		t.Fatalf("StartCommand = %q, want updated command", got)
 	}
-	if got := cfg.Agents[0].OverlayDir; got != "overlays/test" {
-		t.Fatalf("OverlayDir = %q, want overlays/test", got)
+	if len(cfg.NamedSessions) != 2 {
+		t.Fatalf("len(NamedSessions) = %d, want 2\n%s", len(cfg.NamedSessions), data)
+	}
+	if got := strings.Count(string(data), "[[named_session]]"); got != 2 {
+		t.Fatalf("named_session blocks = %d, want 2\n%s", got, data)
 	}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1142,11 +1142,16 @@ provider = "file"
 
 [[named_session]]
 template = "worker"
+mode = "on_demand"
+
+[[named_session]]
+template = "worker"
 mode = "always"
 
 [[named_session]]
-template = "control-dispatcher"
-mode = "always"
+template = "worker"
+name = "worker-extra"
+mode = "on_demand"
 `
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(initial), 0o644); err != nil {
 		t.Fatalf("writing city.toml: %v", err)
@@ -1156,13 +1161,17 @@ mode = "always"
 		Agents: []e2eAgent{{Name: "worker", StartCommand: "VERSION=v2 sleep 3600"}},
 	})
 
-	data, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
+	cityData, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
 	}
-	cfg, err := config.Parse(data)
+	packData, err := os.ReadFile(filepath.Join(cityDir, "pack.toml"))
 	if err != nil {
-		t.Fatalf("parsing city.toml: %v", err)
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading city.toml: %v\ncity.toml:\n%s\npack.toml:\n%s", err, cityData, packData)
 	}
 	if cfg.Workspace.Name != "test-city" {
 		t.Fatalf("Workspace.Name = %q, want test-city", cfg.Workspace.Name)
@@ -1174,10 +1183,29 @@ mode = "always"
 		t.Fatalf("StartCommand = %q, want updated command", got)
 	}
 	if len(cfg.NamedSessions) != 2 {
-		t.Fatalf("len(NamedSessions) = %d, want 2\n%s", len(cfg.NamedSessions), data)
+		t.Fatalf("len(NamedSessions) = %d, want 2\ncity.toml:\n%s\npack.toml:\n%s", len(cfg.NamedSessions), cityData, packData)
 	}
-	if got := strings.Count(string(data), "[[named_session]]"); got != 2 {
-		t.Fatalf("named_session blocks = %d, want 2\n%s", got, data)
+	var workerSession config.NamedSession
+	for _, ns := range cfg.NamedSessions {
+		if ns.QualifiedName() == "worker" {
+			workerSession = ns
+			break
+		}
+	}
+	if workerSession.Template == "" {
+		t.Fatalf("worker named session not found\ncity.toml:\n%s\npack.toml:\n%s", cityData, packData)
+	}
+	if got := workerSession.Mode; got != "always" {
+		t.Fatalf("worker named session mode = %q, want always\ncity.toml:\n%s\npack.toml:\n%s", got, cityData, packData)
+	}
+	if got := strings.Count(string(cityData), "[[named_session]]"); got != 1 {
+		t.Fatalf("city.toml named_session blocks = %d, want 1\n%s", got, cityData)
+	}
+	if !strings.Contains(string(cityData), `name = "worker-extra"`) {
+		t.Fatalf("city.toml should preserve non-conflicting worker-extra named session:\n%s", cityData)
+	}
+	if got := strings.Count(string(packData), "[[named_session]]"); got != 1 {
+		t.Fatalf("pack.toml named_session blocks = %d, want 1\n%s", got, packData)
 	}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1119,6 +1119,18 @@ func TestCommandEnvLookupDirUsesRegisteredPathArg(t *testing.T) {
 	}
 }
 
+func TestRenderE2ETomlPlainAgentUsesNamedSessionWithoutSingletonCap(t *testing.T) {
+	toml := renderE2EToml(e2eCity{
+		Agents: []e2eAgent{{Name: "worker", StartCommand: "sleep 3600"}},
+	})
+	if !strings.Contains(toml, "[[named_session]]\ntemplate = \"worker\"\nmode = \"always\"") {
+		t.Fatalf("rendered TOML missing named session:\n%s", toml)
+	}
+	if strings.Contains(toml, "max_active_sessions = 1") {
+		t.Fatalf("plain E2E agent should not render singleton cap:\n%s", toml)
+	}
+}
+
 func TestNewIsolatedToolEnvSeedsLocalDoltIdentity(t *testing.T) {
 	env := newIsolatedToolEnv(t, true)
 	got := parseEnvList(env)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/test/tmuxtest"
@@ -1128,6 +1129,40 @@ func TestRenderE2ETomlPlainAgentUsesNamedSessionWithoutSingletonCap(t *testing.T
 	}
 	if strings.Contains(toml, "max_active_sessions = 1") {
 		t.Fatalf("plain E2E agent should not render singleton cap:\n%s", toml)
+	}
+}
+
+func TestUpdateE2EAgentInCityTomlPreservesNamedSessions(t *testing.T) {
+	cityDir := t.TempDir()
+	writeE2EToml(t, cityDir, e2eCity{
+		Workspace: e2eWorkspace{Name: "test-city"},
+		Agents:    []e2eAgent{{Name: "worker", StartCommand: "VERSION=v1 sleep 3600"}},
+	})
+
+	updateE2EAgentInCityToml(t, cityDir, "worker", func(agent *config.Agent) {
+		agent.StartCommand = "VERSION=v2 sleep 3600"
+		agent.OverlayDir = "overlays/test"
+	})
+
+	data, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing city.toml: %v", err)
+	}
+	if len(cfg.NamedSessions) != 1 {
+		t.Fatalf("len(NamedSessions) = %d, want 1\n%s", len(cfg.NamedSessions), data)
+	}
+	if got := strings.Count(string(data), "[[named_session]]"); got != 1 {
+		t.Fatalf("named_session blocks = %d, want 1\n%s", got, data)
+	}
+	if got := cfg.Agents[0].StartCommand; got != "VERSION=v2 sleep 3600" {
+		t.Fatalf("StartCommand = %q, want updated command", got)
+	}
+	if got := cfg.Agents[0].OverlayDir; got != "overlays/test" {
+		t.Fatalf("OverlayDir = %q, want overlays/test", got)
 	}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -377,14 +377,26 @@ func subprocessTestKillSet(procs map[int]procSnapshot, agentScript string) map[i
 // gc runs the gc binary with the given args. If dir is non-empty, it sets
 // the working directory. Returns combined stdout+stderr and any error.
 func gc(dir string, args ...string) (string, error) {
-	return runCommand(dir, commandEnvForDir(dir, false), integrationGCCommandTimeout, gcBinary, args...)
+	return runCommand(dir, commandEnvForDir(commandEnvLookupDir(dir, args), false), integrationGCCommandTimeout, gcBinary, args...)
 }
 
 // gcDolt runs the gc binary with the given args using the isolated integration
 // supervisor state, but without forcing GC_DOLT=skip. Use this for tests that
 // need the real bd+dolt-backed bead store.
 func gcDolt(dir string, args ...string) (string, error) {
-	return runCommand(dir, commandEnvForDir(dir, true), integrationGCDoltCommandTimeout, gcBinary, args...)
+	return runCommand(dir, commandEnvForDir(commandEnvLookupDir(dir, args), true), integrationGCDoltCommandTimeout, gcBinary, args...)
+}
+
+func commandEnvLookupDir(dir string, args []string) string {
+	if dir != "" {
+		return dir
+	}
+	for _, arg := range args {
+		if _, ok := cityCommandEnv.Load(arg); ok {
+			return arg
+		}
+	}
+	return ""
 }
 
 // bd runs the bd binary with the given args. If dir is non-empty, it sets
@@ -1091,6 +1103,19 @@ func TestCommandEnvForDirPrefersRegisteredCityEnv(t *testing.T) {
 	got := commandEnvForDir(cityDir, false)
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("commandEnvForDir(%q) = %v, want %v", cityDir, got, want)
+	}
+}
+
+func TestCommandEnvLookupDirUsesRegisteredPathArg(t *testing.T) {
+	cityDir := filepath.Join(t.TempDir(), "city")
+	registerCityCommandEnv(cityDir, []string{"GC_HOME=/tmp/isolated"})
+	t.Cleanup(func() { unregisterCityCommandEnv(cityDir) })
+
+	if got := commandEnvLookupDir("", []string{"start", cityDir}); got != cityDir {
+		t.Fatalf("commandEnvLookupDir with path arg = %q, want %q", got, cityDir)
+	}
+	if got := commandEnvLookupDir("/tmp/cwd", []string{"start", cityDir}); got != "/tmp/cwd" {
+		t.Fatalf("commandEnvLookupDir with cwd = %q, want cwd", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make gc status label controller ownership as standalone-managed or supervisor-managed
- add authority and next-command guidance to human status output
- expand gc start standalone-controller conflict output with authority and exact retry command

Closes #750.

## Tests
- go test ./cmd/gc -run 'TestCityStatus|TestControllerStatus' -count=1
- go test ./cmd/gc -run 'TestRegisterCityWithSupervisorRejectsStandaloneController|TestRegisterCityWithSupervisor' -count=1
- go test ./cmd/gc -run 'TestControllerStatusLine|TestControllerStatusGuidance|TestRegisterCityWithSupervisorRejectsStandaloneController' -count=1
- go test ./cmd/gc -run '^$' -count=1
- git diff --check