### PR TITLE
Fix polecat branch and existing PR metadata handling

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -141,6 +141,70 @@ func TestRefineryFormulaSupportsMergeStrategies(t *testing.T) {
 	}
 }
 
+func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`git fetch --prune origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"`,
+		`metadata.branch=$BRANCH was set but no local or origin branch exists`,
+		`STOP. Do not create a different branch.`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("polecat formula missing metadata.branch authority guidance %q", want)
+		}
+	}
+}
+
+func TestPolecatFormulaRecordsExistingPRMetadataOnSubmit(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`EXISTING_PR=$(gc bd show {{issue}} --json | jq -r '.metadata.existing_pr // empty')`,
+		`--set-metadata pr_url="$EXISTING_PR"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("polecat formula missing existing_pr submit handling %q", want)
+		}
+	}
+	if strings.Contains(body, "gh pr create") {
+		t.Fatalf("polecat submit flow must not create pull requests directly")
+	}
+}
+
+func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')`,
+		`PR_URL="$EXISTING_PR"`,
+		`PR_REF="$EXISTING_PR"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refinery formula missing existing_pr handling %q", want)
+		}
+	}
+	existingIdx := strings.Index(body, `EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')`)
+	createIdx := strings.Index(body, "gh pr create")
+	if existingIdx == -1 || createIdx == -1 || existingIdx > createIdx {
+		t.Fatalf("refinery formula must inspect existing_pr before gh pr create")
+	}
+}
+
 func TestWorktreeSetupKeepsIgnoresLocal(t *testing.T) {
 	tmp := t.TempDir()
 	repo := filepath.Join(tmp, "repo")

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -47,13 +47,16 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 | `worktree` | polecat (branch-setup) | Early | Absolute path to git worktree |
 | `branch` | polecat (branch-setup) | Early | Source branch name |
 | `target` | polecat (submit) | Late | Target branch (default: {{ .DefaultBranch }}) |
+| `existing_pr` | caller | Before dispatch | Existing PR URL to reuse instead of creating another PR |
+| `pr_url` | polecat/refinery | Submit/PR handoff | PR URL recorded for visibility and closure |
 | `rejection_reason` | refinery (on failure) | On reject | Why the merge was rejected |
 
 **On branch-setup:** You record `worktree` and `branch` immediately.
 This enables crash recovery — the witness can find and salvage your work.
 
 **On submission:** You update `branch` (may have changed after rebase),
-set `target`, then reassign to refinery.
+set `target`, record `pr_url` when `existing_pr` is present, then reassign
+to refinery.
 
 **On rejection:** The refinery puts the bead back in the pool with
 `rejection_reason` set and the branch intact. A new polecat picks it up,
@@ -192,10 +195,19 @@ Nudges from other agents may arrive via your hook. When working:
 
 ```bash
 git push origin HEAD
-gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
-  --set-metadata target={{ .DefaultBranch }} \
-  --notes "Implemented: <brief summary>"
+EXISTING_PR=$(gc bd show <work-bead> --json | jq -r '.metadata.existing_pr // empty')
+if [ -n "$EXISTING_PR" ]; then
+  gc bd update <work-bead> \
+    --set-metadata branch=$(git branch --show-current) \
+    --set-metadata target={{ .DefaultBranch }} \
+    --set-metadata pr_url="$EXISTING_PR" \
+    --notes "Implemented: <brief summary>"
+else
+  gc bd update <work-bead> \
+    --set-metadata branch=$(git branch --show-current) \
+    --set-metadata target={{ .DefaultBranch }} \
+    --notes "Implemented: <brief summary>"
+fi
 gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -90,12 +90,14 @@ Polecats set these metadata fields before assigning a work bead to you:
 - `branch` — source branch name (REQUIRED)
 - `target` — target branch (optional, defaults to {{ .DefaultBranch }})
 - `merge_strategy` — handoff mode (optional, defaults to `direct`)
+- `existing_pr` — existing PR URL to reuse in `mr` / `pr` mode
 
 Read them mechanically:
 ```bash
 gc bd show $WORK --json | jq -r '.metadata.branch'
 gc bd show $WORK --json | jq -r '.metadata.target // "{{ .DefaultBranch }}"'
 gc bd show $WORK --json | jq -r '.metadata.merge_strategy // "direct"'
+gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty'
 ```
 
 Never infer a branch name. If `metadata.branch` is missing, reject the bead.
@@ -123,6 +125,10 @@ A new polecat picks up the bead, sees `metadata.branch` and
 In `mr` mode, this pack treats PR creation as the terminal handoff for the
 direct-bead workflow. Record `pr_url` on the work bead, close the bead, and
 leave the source branch intact for the PR lifecycle.
+
+If `metadata.existing_pr` is set, reuse that PR URL. Do not call
+`gh pr create` for the work bead; verify the existing PR, record it as
+`pr_url`, and close the bead when the branch has been pushed.
 
 ---
 

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -33,7 +33,7 @@ refinery. Resume the existing branch — don't redo all the work.
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
-version = 7
+version = 8
 
 [[steps]]
 id = "workspace-setup"
@@ -93,9 +93,22 @@ Check if `metadata.branch` already records a branch:
 BRANCH=$(gc bd show {{issue}} --json | jq -r '.metadata.branch // empty')
 ```
 
-**If branch exists in metadata** — check it out:
+**If branch exists in metadata** — treat it as authoritative. This
+metadata may come from rejection recovery or from a caller that wants
+work applied to an existing branch. Fetch the named remote branch first,
+then check out the local branch if present or create a local tracking
+branch from `origin/$BRANCH`:
 ```bash
-git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH" origin/"$BRANCH"
+git fetch --prune origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null || true
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    git checkout "$BRANCH" || exit 1
+elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    git checkout --track -b "$BRANCH" "origin/$BRANCH" || exit 1
+else
+    echo "metadata.branch=$BRANCH was set but no local or origin branch exists."
+    echo "STOP. Do not create a different branch."
+    exit 1
+fi
 ```
 If resuming a rejected branch, rebase onto latest base:
 ```bash
@@ -167,12 +180,23 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 
 **4. Update metadata on the work bead:**
 ```bash
-gc bd update {{issue}} \
-  --set-metadata target={{base_branch}} \
-  --notes "Implemented: <brief summary>"
+EXISTING_PR=$(gc bd show {{issue}} --json | jq -r '.metadata.existing_pr // empty')
+if [ -n "$EXISTING_PR" ]; then
+  gc bd update {{issue}} \
+    --set-metadata target={{base_branch}} \
+    --set-metadata pr_url="$EXISTING_PR" \
+    --notes "Implemented: <brief summary>"
+else
+  gc bd update {{issue}} \
+    --set-metadata target={{base_branch}} \
+    --notes "Implemented: <brief summary>"
+fi
 ```
 Branch was recorded in workspace-setup and is already in metadata.
-This adds the target for the refinery.
+This adds the target for the refinery. If an existing pull request was
+provided by the caller, this records the URL on the bead. The refinery's
+PR mode also reads `metadata.existing_pr` and must reuse it instead of
+creating a duplicate pull request.
 
 **5. Reassign to refinery:**
 ```bash

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -29,7 +29,7 @@ closes the bead once the PR is verified.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
-version = 1
+version = 2
 
 [vars]
 [vars.run_tests]
@@ -322,9 +322,13 @@ request and treats PR creation as the terminal handoff for this work bead.
 git checkout temp
 git push origin HEAD:$BRANCH --force-with-lease
 ```
+If `--force-with-lease` fails, the existing PR branch moved after your
+fetch. STOP, fetch the latest branch, rebase your temp branch again, and
+retry with `--force-with-lease`. Do not use plain `--force`.
 
-**2. Create or discover the pull request:**
+**2. Reuse, create, or discover the pull request:**
 ```bash
+EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')
 ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.title')
 PR_BODY=$(cat <<EOF
 ## Summary
@@ -338,27 +342,33 @@ Automated pull request published by Gastown Refinery.
 EOF
 )
 
-PR_URL=$(gh pr create \
-  --base "$TARGET" \
-  --head "$BRANCH" \
-  --title "$ISSUE_TITLE ($WORK)" \
-  --body "$PR_BODY" 2>/dev/null || true)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL="$EXISTING_PR"
+  PR_REF="$EXISTING_PR"
+else
+  PR_URL=$(gh pr create \
+    --base "$TARGET" \
+    --head "$BRANCH" \
+    --title "$ISSUE_TITLE ($WORK)" \
+    --body "$PR_BODY" 2>/dev/null || true)
 
-if [ -z "$PR_URL" ]; then
-  PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
+  if [ -z "$PR_URL" ]; then
+    PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
+  fi
+  PR_REF="$BRANCH"
 fi
 ```
 
 **3. Verify the pull request exists:**
 ```bash
-PR_INFO=$(gh pr view "$BRANCH" --json url,number,state -q '.url + " " + (.number|tostring) + " " + .state')
+PR_INFO=$(gh pr view "$PR_REF" --json url,number,state,headRefName -q '.url + " " + (.number|tostring) + " " + .state + " " + .headRefName')
 echo "$PR_INFO"
 ```
 If this command fails or prints empty output: STOP. Debug and retry. Do NOT continue.
 
 **4. Record PR metadata and close the work bead:**
 ```bash
-PR_NUMBER=$(gh pr view "$BRANCH" --json number -q '.number')
+PR_NUMBER=$(gh pr view "$PR_REF" --json number -q '.number')
 gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \


### PR DESCRIPTION
## Summary

- Treat `metadata.branch` as authoritative in `mol-polecat-work` by fetching the named origin branch before checkout and stopping instead of creating a different branch when it is missing.
- Preserve `metadata.existing_pr` by recording `pr_url` during polecat submit and reusing that PR in refinery PR mode before any `gh pr create` path.
- Update polecat/refinery prompt guidance and add regression coverage for the formula behavior.

Fixes #709

## Tests

- `go test ./examples/gastown ./internal/formula`
- `git diff --check`

Note: `go test ./...` was attempted, but it produced no output for several minutes and was terminated; the scoped tests above cover the touched formula/prompt surface.