### PR TITLE
fix: make gc init emit a pack-first scaffold

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -94,6 +96,61 @@ func writeCityConfigForEditFS(fs fsys.FS, tomlPath string, cfg *config.City) err
 		return fmt.Errorf("writing .gc/site.toml failed after city.toml was rewritten — rigs may be unbound; re-run the command or `gc doctor --fix` to retry: %w", err)
 	}
 	return nil
+}
+
+func loadCityPackConfigForEditFS(fs fsys.FS, packPath string) (*initPackConfig, error) {
+	data, err := fs.ReadFile(packPath)
+	if err != nil {
+		return nil, err
+	}
+	cfg := initPackConfig{}
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return nil, fmt.Errorf("loading pack config %q: %w", packPath, err)
+	}
+	return &cfg, nil
+}
+
+func writeCityPackConfigForEditFS(fs fsys.FS, packPath string, cfg *initPackConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("writing pack config: nil pack")
+	}
+	content, err := marshalInitPackConfig(*cfg)
+	if err != nil {
+		return err
+	}
+	return fsys.WriteFileIfChangedAtomic(fs, packPath, content, 0o644)
+}
+
+func updateRootPackAgentSuspended(fs fsys.FS, cityPath string, cityCfg *config.City, name string, suspended bool) (bool, error) {
+	packPath := filepath.Join(cityPath, "pack.toml")
+	packCfg, err := loadCityPackConfigForEditFS(fs, packPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	rawPack := &config.City{
+		Workspace: cityCfg.Workspace,
+		Rigs:      append([]config.Rig(nil), cityCfg.Rigs...),
+		Agents:    append([]config.Agent(nil), packCfg.Agents...),
+	}
+	resolved, ok := resolveAgentIdentity(rawPack, name, currentRigContext(rawPack))
+	if !ok {
+		return false, nil
+	}
+	resolvedQN := resolved.QualifiedName()
+	for i := range packCfg.Agents {
+		if packCfg.Agents[i].QualifiedName() == resolvedQN {
+			packCfg.Agents[i].Suspended = suspended
+			break
+		}
+	}
+	if err := writeCityPackConfigForEditFS(fs, packPath, packCfg); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // resolveAgentIdentity resolves an agent input string to a config.Agent using
@@ -454,6 +511,13 @@ func doAgentSuspend(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 		fmt.Fprintf(stdout, "Suspended agent '%s'\n", name) //nolint:errcheck // best-effort stdout
 		return 0
 	}
+	if updated, err := updateRootPackAgentSuspended(fs, cityPath, cfg, name, true); err != nil {
+		fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	} else if updated {
+		fmt.Fprintf(stdout, "Suspended agent '%s'\n", name) //nolint:errcheck // best-effort stdout
+		return 0
+	}
 
 	// Phase 2: not in raw config — check expanded config for pack-derived agents.
 	expanded, err := loadCityConfigFS(fs, tomlPath)
@@ -547,6 +611,13 @@ func doAgentResume(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer) 
 			fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
+		fmt.Fprintf(stdout, "Resumed agent '%s'\n", name) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+	if updated, err := updateRootPackAgentSuspended(fs, cityPath, cfg, name, false); err != nil {
+		fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	} else if updated {
 		fmt.Fprintf(stdout, "Resumed agent '%s'\n", name) //nolint:errcheck // best-effort stdout
 		return 0
 	}

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -131,6 +132,183 @@ func TestDoAgentResumePackDerivedError(t *testing.T) {
 	}
 	if !strings.Contains(errMsg, "[[patches]]") {
 		t.Errorf("stderr should mention patches: %s", errMsg)
+	}
+}
+
+func TestDoAgentSuspendRootPackAgent(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[[agent]]
+name = "mayor"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Suspended agent 'mayor'") {
+		t.Fatalf("stdout = %q, want suspend message", stdout.String())
+	}
+	if !strings.Contains(string(fs.Files["/city/pack.toml"]), "suspended = true") {
+		t.Fatalf("pack.toml missing suspended = true:\n%s", string(fs.Files["/city/pack.toml"]))
+	}
+	if strings.Contains(string(fs.Files["/city/city.toml"]), "suspended") {
+		t.Fatalf("city.toml should not be rewritten with pack agent suspension:\n%s", string(fs.Files["/city/city.toml"]))
+	}
+	renamed := false
+	for _, call := range fs.Calls {
+		if call.Method == "Rename" {
+			renamed = true
+			break
+		}
+	}
+	if !renamed {
+		t.Fatal("expected atomic rename when writing pack.toml")
+	}
+}
+
+func TestDoAgentResumeRootPackAgent(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+
+[[agent]]
+name = "mayor"
+suspended = true
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentResume(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Resumed agent 'mayor'") {
+		t.Fatalf("stdout = %q, want resume message", stdout.String())
+	}
+	if strings.Contains(string(fs.Files["/city/pack.toml"]), "suspended = true") {
+		t.Fatalf("pack.toml should clear suspended flag:\n%s", string(fs.Files["/city/pack.toml"]))
+	}
+	renamed := false
+	for _, call := range fs.Calls {
+		if call.Method == "Rename" {
+			renamed = true
+			break
+		}
+	}
+	if !renamed {
+		t.Fatal("expected atomic rename when writing pack.toml")
+	}
+}
+
+func TestDoAgentSuspendRootPackReadError(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	fs.Errors["/city/pack.toml"] = fmt.Errorf("permission denied")
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "permission denied") {
+		t.Fatalf("stderr = %q, want permission denied", stderr.String())
+	}
+}
+
+func TestDoAgentSuspendRootPackPreservesPackFields(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+version = "0.1.0"
+requires_gc = ">=0.16.0"
+includes = ["../shared"]
+
+[[pack.requires]]
+agent = "mayor"
+scope = "city"
+
+[imports.helper]
+source = "../helper"
+
+[agent_defaults]
+append_fragments = ["shared"]
+
+[providers.claude]
+command = "claude"
+
+[formulas]
+dir = "custom-formulas"
+
+[[service]]
+name = "api"
+kind = "workflow"
+
+[[patches.agent]]
+name = "mayor"
+
+[[doctor]]
+name = "check-env"
+script = "doctor/check-env.sh"
+
+[[commands]]
+name = "status"
+description = "show status"
+long_description = "docs/status.md"
+script = "commands/status.sh"
+
+[global]
+session_live = ["echo live"]
+
+[[agent]]
+name = "mayor"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentSuspend(fs, "/city", "mayor", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packToml := string(fs.Files["/city/pack.toml"])
+	for _, want := range []string{
+		`version = "0.1.0"`,
+		`requires_gc = ">=0.16.0"`,
+		`includes = ["../shared"]`,
+		`[imports.helper]`,
+		`append_fragments = ["shared"]`,
+		`[providers.claude]`,
+		`dir = "custom-formulas"`,
+		`[[service]]`,
+		`name = "api"`,
+		`[[patches.agent]]`,
+		`[[doctor]]`,
+		`script = "doctor/check-env.sh"`,
+		`[[commands]]`,
+		`script = "commands/status.sh"`,
+		`[global]`,
+		`session_live = ["echo live"]`,
+		`suspended = true`,
+	} {
+		if !strings.Contains(packToml, want) {
+			t.Fatalf("pack.toml missing %q after suspend:\n%s", want, packToml)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -24,6 +27,33 @@ const initPackSchemaVersion = 2
 // handler behind POST /v0/city) dispatch on this exit code instead of
 // string-matching stderr.
 const initExitAlreadyInitialized = 2
+
+type initPackMeta struct {
+	Name       string                   `toml:"name"`
+	Version    string                   `toml:"version,omitempty"`
+	Schema     int                      `toml:"schema"`
+	RequiresGC string                   `toml:"requires_gc,omitempty"`
+	Includes   []string                 `toml:"includes,omitempty"`
+	Requires   []config.PackRequirement `toml:"requires,omitempty"`
+}
+
+type initPackConfig struct {
+	// Keep this layout in lockstep with internal/config.packConfig so
+	// pack.toml write paths in cmd/gc can round-trip the canonical root
+	// pack shape without dropping supported fields.
+	Pack          initPackMeta                   `toml:"pack"`
+	Imports       map[string]config.Import       `toml:"imports,omitempty"`
+	AgentDefaults config.AgentDefaults           `toml:"agent_defaults,omitempty"`
+	Agents        []config.Agent                 `toml:"agent"`
+	NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
+	Services      []config.Service               `toml:"service,omitempty"`
+	Providers     map[string]config.ProviderSpec `toml:"providers,omitempty"`
+	Formulas      config.FormulasConfig          `toml:"formulas,omitempty"`
+	Patches       config.Patches                 `toml:"patches,omitempty"`
+	Doctor        []config.PackDoctorEntry       `toml:"doctor,omitempty"`
+	Commands      []config.PackCommandEntry      `toml:"commands,omitempty"`
+	Global        config.PackGlobal              `toml:"global,omitempty"`
+}
 
 var initConventionDirs = []string{
 	"agents",
@@ -408,9 +438,179 @@ func ensureInitConventionDirs(fs fsys.FS, cityPath string) error {
 	return nil
 }
 
-func writeInitPackToml(fs fsys.FS, cityPath, packName string) error {
-	content := []byte(fmt.Sprintf("[pack]\nname = %q\nschema = %d\n", packName, initPackSchemaVersion))
+func writeInitPackToml(fs fsys.FS, cityPath string, packCfg initPackConfig) error {
+	content, err := marshalInitPackConfig(packCfg)
+	if err != nil {
+		return err
+	}
 	return fs.WriteFile(filepath.Join(cityPath, "pack.toml"), content, 0o644)
+}
+
+func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
+	type encodedInitPackConfig struct {
+		Pack          initPackMeta                   `toml:"pack"`
+		Imports       map[string]config.Import       `toml:"imports,omitempty"`
+		AgentDefaults *config.AgentDefaults          `toml:"agent_defaults,omitempty"`
+		Agents        []config.Agent                 `toml:"agent"`
+		NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
+		Services      []config.Service               `toml:"service,omitempty"`
+		Providers     map[string]config.ProviderSpec `toml:"providers,omitempty"`
+		Formulas      *config.FormulasConfig         `toml:"formulas,omitempty"`
+		Patches       *config.Patches                `toml:"patches,omitempty"`
+		Doctor        []config.PackDoctorEntry       `toml:"doctor,omitempty"`
+		Commands      []config.PackCommandEntry      `toml:"commands,omitempty"`
+		Global        *config.PackGlobal             `toml:"global,omitempty"`
+	}
+
+	encCfg := encodedInitPackConfig{
+		Pack:          cfg.Pack,
+		Imports:       cfg.Imports,
+		Agents:        cfg.Agents,
+		NamedSessions: cfg.NamedSessions,
+		Services:      cfg.Services,
+		Providers:     cfg.Providers,
+		Doctor:        cfg.Doctor,
+		Commands:      cfg.Commands,
+	}
+	if !isZeroValue(cfg.AgentDefaults) {
+		encCfg.AgentDefaults = &cfg.AgentDefaults
+	}
+	if !isZeroValue(cfg.Formulas) {
+		encCfg.Formulas = &cfg.Formulas
+	}
+	if !isZeroValue(cfg.Patches) {
+		encCfg.Patches = &cfg.Patches
+	}
+	if !isZeroValue(cfg.Global) {
+		encCfg.Global = &cfg.Global
+	}
+
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc.Indent = ""
+	if err := enc.Encode(encCfg); err != nil {
+		return nil, fmt.Errorf("marshal pack.toml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func isZeroValue(v any) bool {
+	return reflect.ValueOf(v).IsZero()
+}
+
+func newInitPackConfig(cityName string) initPackConfig {
+	return initPackConfig{
+		Pack: initPackMeta{
+			Name:   cityName,
+			Schema: initPackSchemaVersion,
+		},
+	}
+}
+
+func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.City) {
+	packCfg := newInitPackConfig(cityName)
+	if cfg == nil {
+		return packCfg, config.City{}
+	}
+
+	cityCfg := *cfg
+	cityCfg.Agents = nil
+	cityCfg.NamedSessions = nil
+	cityCfg.Imports = nil
+	cityCfg.Providers = nil
+	cityCfg.Services = nil
+	cityCfg.Formulas = config.FormulasConfig{}
+	cityCfg.Patches = config.Patches{}
+	cityCfg.AgentDefaults = config.AgentDefaults{}
+	cityCfg.AgentsDefaults = config.AgentDefaults{}
+
+	packCfg.Agents = append([]config.Agent(nil), cfg.Agents...)
+	packCfg.NamedSessions = append([]config.NamedSession(nil), cfg.NamedSessions...)
+	if len(cfg.Imports) > 0 {
+		packCfg.Imports = make(map[string]config.Import, len(cfg.Imports))
+		for name, imp := range cfg.Imports {
+			packCfg.Imports[name] = imp
+		}
+	}
+	if len(cfg.Providers) > 0 {
+		packCfg.Providers = make(map[string]config.ProviderSpec, len(cfg.Providers))
+		for name, spec := range cfg.Providers {
+			packCfg.Providers[name] = spec
+		}
+	}
+	packCfg.AgentDefaults = cfg.AgentDefaults
+	if isZeroValue(packCfg.AgentDefaults) && !isZeroValue(cfg.AgentsDefaults) {
+		packCfg.AgentDefaults = cfg.AgentsDefaults
+	}
+	packCfg.Formulas = cfg.Formulas
+	packCfg.Patches = cfg.Patches
+	for _, svc := range cfg.Services {
+		if svc.PublishMode == "direct" {
+			cityCfg.Services = append(cityCfg.Services, svc)
+			continue
+		}
+		packCfg.Services = append(packCfg.Services, svc)
+	}
+
+	if len(cfg.Workspace.Includes) > 0 {
+		packCfg.Pack.Includes = appendUniqueStrings(
+			append([]string(nil), packCfg.Pack.Includes...),
+			cfg.Workspace.Includes...,
+		)
+		cityCfg.Workspace.Includes = nil
+	}
+	if len(cfg.Workspace.GlobalFragments) > 0 {
+		packCfg.AgentDefaults.AppendFragments = appendUniqueStrings(
+			append([]string(nil), packCfg.AgentDefaults.AppendFragments...),
+			cfg.Workspace.GlobalFragments...,
+		)
+		cityCfg.Workspace.GlobalFragments = nil
+	}
+
+	return packCfg, cityCfg
+}
+
+func decodeInitPackTemplate(data []byte, cityName string) (initPackConfig, error) {
+	cfg := newInitPackConfig(cityName)
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return initPackConfig{}, fmt.Errorf("parse pack template: %w", err)
+	}
+	// Fresh init always materializes a city-scoped root pack, so the target
+	// city name and current schema override any template header identity.
+	cfg.Pack.Name = cityName
+	cfg.Pack.Schema = initPackSchemaVersion
+	return cfg, nil
+}
+
+func applyInitPackTemplateExtras(dst *initPackConfig, src initPackConfig) {
+	if dst == nil {
+		return
+	}
+	dst.Pack.Version = src.Pack.Version
+	dst.Pack.RequiresGC = src.Pack.RequiresGC
+	dst.Pack.Includes = appendUniqueStrings(
+		append([]string(nil), dst.Pack.Includes...),
+		src.Pack.Includes...,
+	)
+	dst.Pack.Requires = append([]config.PackRequirement(nil), src.Pack.Requires...)
+	dst.Doctor = append([]config.PackDoctorEntry(nil), src.Doctor...)
+	dst.Commands = append([]config.PackCommandEntry(nil), src.Commands...)
+	dst.Global = src.Global
+}
+
+func appendUniqueStrings(dst []string, items ...string) []string {
+	seen := make(map[string]struct{}, len(dst))
+	for _, item := range dst {
+		seen[item] = struct{}{}
+	}
+	for _, item := range items {
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		dst = append(dst, item)
+	}
+	return dst
 }
 
 func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
@@ -455,6 +655,11 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 
 	// --file creates a new city from a template; default to target dir name.
 	cityName := resolveCityName(nameOverride, cityPath)
+	templatePack, err := decodeInitPackTemplate(data, cityName)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	cfg.Workspace.Name = cityName
 
 	// Create directory structure.
@@ -480,25 +685,20 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return code
 	}
 
-	// Default formulas/orders now arrive via the core bootstrap pack.
-	if err := writeInitPackToml(fs, cityPath, cityName); err != nil {
+	// Rewrite legacy prompt paths only after we've copied the embedded prompt
+	// scaffolds that still live under prompts/.
+	rewriteInitPromptTemplates(cfg)
+	packCfg, cityCfg := splitInitConfig(cityName, cfg)
+	applyInitPackTemplateExtras(&packCfg, templatePack)
+
+	// Re-marshal so the name and rewritten prompt paths are updated.
+	content, err := cityCfg.Marshal()
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	// Resolve formulas symlinks so bd finds them immediately after init.
-	formulasInitDir := filepath.Join(cityPath, citylayout.FormulasRoot)
-	if rfErr := ResolveFormulas(cityPath, []string{formulasInitDir}); rfErr != nil {
-		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
-	}
-
-	// Rewrite legacy prompt paths only after we've copied the embedded prompt
-	// scaffolds that still live under prompts/.
-	rewriteInitPromptTemplates(cfg)
-
-	// Re-marshal so the name and rewritten prompt paths are updated.
-	content, err := cfg.Marshal()
-	if err != nil {
+	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -507,6 +707,13 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	if err := fs.WriteFile(filepath.Join(cityPath, "city.toml"), content, 0o644); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+
+	// Resolve formulas symlinks only after pack.toml and city.toml are both
+	// on disk so root-pack includes participate in the initial materialization.
+	formulasInitDir := filepath.Join(cityPath, citylayout.FormulasRoot)
+	if rfErr := ResolveFormulas(cityPath, []string{formulasInitDir}); rfErr != nil {
+		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
 	}
 
 	// Write .gitignore entries for city-managed directories.
@@ -602,24 +809,19 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		return code
 	}
 
-	// Default formulas/orders now arrive via the core bootstrap pack.
-	// Resolve formulas symlinks so bd finds them immediately after init.
-	formulasDir := filepath.Join(cityPath, citylayout.FormulasRoot)
-	if err := ResolveFormulas(cityPath, []string{formulasDir}); err != nil {
-		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", err) //nolint:errcheck // best-effort stderr
-	}
-
-	// Write city.toml — wizard path gets one agent + provider/startCommand;
-	// --provider path gets the same city shape non-interactively;
-	// custom path gets one mayor + no provider (user configures manually).
+	// Write pack.toml + city.toml in the transitional v2 split: pack.toml
+	// owns portable definition, while city.toml keeps deployment/runtime
+	// state. We intentionally retain current compatibility fields such as
+	// workspace.provider in city.toml until the runtime cutover is complete.
 	rewriteInitPromptTemplates(&cfg)
-	content, err := cfg.Marshal()
+	packCfg, cityCfg := splitInitConfig(cityName, &cfg)
+	content, err := cityCfg.Marshal()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	logInitProgress(stdout, 5, "Writing pack.toml")
-	if err := writeInitPackToml(fs, cityPath, cityName); err != nil {
+	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -627,6 +829,13 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+
+	// Default formulas/orders now arrive via the root pack layer, so resolve
+	// them after the split config has been written to disk.
+	formulasDir := filepath.Join(cityPath, citylayout.FormulasRoot)
+	if err := ResolveFormulas(cityPath, []string{formulasDir}); err != nil {
+		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", err) //nolint:errcheck // best-effort stderr
 	}
 
 	// Write .gitignore entries for city-managed directories.

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"path/filepath"
@@ -109,6 +113,75 @@ func explicitAgents(agents []config.Agent) []config.Agent {
 		out = append(out, a)
 	}
 	return out
+}
+
+type schemaField struct {
+	Name string
+	Tag  string
+	Type string
+}
+
+func loadStructFields(t *testing.T, path, typeName string) []schemaField {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != typeName {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				t.Fatalf("%s in %s is not a struct", typeName, path)
+			}
+			var fields []schemaField
+			for _, field := range st.Fields.List {
+				if len(field.Names) != 1 {
+					continue
+				}
+				tag := ""
+				if field.Tag != nil {
+					tag = strings.Trim(field.Tag.Value, "`")
+				}
+				var typeBuf bytes.Buffer
+				if err := format.Node(&typeBuf, fset, field.Type); err != nil {
+					t.Fatalf("format %s.%s type: %v", typeName, field.Names[0].Name, err)
+				}
+				fields = append(fields, schemaField{
+					Name: field.Names[0].Name,
+					Tag:  tag,
+					Type: typeBuf.String(),
+				})
+			}
+			return fields
+		}
+	}
+	t.Fatalf("type %s not found in %s", typeName, path)
+	return nil
+}
+
+func normalizeSchemaTag(tag string) string {
+	for _, part := range strings.Split(tag, " ") {
+		if strings.HasPrefix(part, `toml:"`) {
+			return strings.ReplaceAll(part, ",omitempty", "")
+		}
+	}
+	return ""
+}
+
+func normalizeSchemaType(typ string) string {
+	typ = strings.ReplaceAll(typ, "config.", "")
+	typ = strings.ReplaceAll(typ, "initPackMeta", "PackMeta")
+	return typ
 }
 
 func TestMain(m *testing.M) {
@@ -1523,11 +1596,11 @@ func TestDoInitSuccess(t *testing.T) {
 		t.Errorf("pack.toml missing schema 2:\n%s", packToml)
 	}
 
-	// Verify written config parses correctly.
-	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
-	cfg, err := config.Parse(data)
+	// Verify the full composed config loads correctly from pack.toml +
+	// city.toml + convention-discovered agents.
+	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
 	if err != nil {
-		t.Fatalf("parsing written config: %v", err)
+		t.Fatalf("loading written config: %v", err)
 	}
 	if cfg.Workspace.Name != "bright-lights" {
 		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
@@ -1538,8 +1611,14 @@ func TestDoInitSuccess(t *testing.T) {
 	if cfg.Agents[0].Name != "mayor" {
 		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if !strings.HasSuffix(cfg.Agents[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
+		t.Errorf("Agents[0].PromptTemplate = %q, want suffix %q", cfg.Agents[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
+	}
+	if len(cfg.NamedSessions) != 1 {
+		t.Fatalf("len(NamedSessions) = %d, want 1", len(cfg.NamedSessions))
+	}
+	if got := cfg.NamedSessions[0].QualifiedName(); got != "mayor" {
+		t.Errorf("NamedSessions[0] = %q, want mayor", got)
 	}
 }
 
@@ -1555,14 +1634,6 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 	got := string(f.Files[filepath.Join("/bright-lights", "city.toml")])
 	want := `[workspace]
 name = "bright-lights"
-
-[[agent]]
-name = "mayor"
-prompt_template = "agents/mayor/prompt.template.md"
-
-[[named_session]]
-template = "mayor"
-mode = "always"
 `
 	if got != want {
 		t.Errorf("city.toml content:\ngot:\n%s\nwant:\n%s", got, want)
@@ -1572,9 +1643,180 @@ mode = "always"
 	packWant := `[pack]
 name = "bright-lights"
 schema = 2
+
+[[agent]]
+name = "mayor"
+prompt_template = "agents/mayor/prompt.template.md"
+
+[[named_session]]
+template = "mayor"
+mode = "always"
 `
 	if packGot != packWant {
 		t.Errorf("pack.toml content:\ngot:\n%s\nwant:\n%s", packGot, packWant)
+	}
+}
+
+func TestDoInitGastownWritesTransitionalPackShape(t *testing.T) {
+	f := fsys.NewFake()
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/bright-lights", wizardConfig{configName: "gastown", provider: "claude"}, "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	cityToml := string(f.Files[filepath.Join("/bright-lights", "city.toml")])
+	if strings.Contains(cityToml, "\nincludes = [\".gc/system/packs/gastown\"]") {
+		t.Fatalf("city.toml should not keep city-wide includes in fresh init:\n%s", cityToml)
+	}
+	if strings.Contains(cityToml, "global_fragments") {
+		t.Fatalf("city.toml should not keep legacy global_fragments in fresh init:\n%s", cityToml)
+	}
+	if !strings.Contains(cityToml, `default_rig_includes = [".gc/system/packs/gastown"]`) {
+		t.Fatalf("city.toml missing transitional default_rig_includes compatibility:\n%s", cityToml)
+	}
+
+	packToml := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
+	if !strings.Contains(packToml, `includes = [".gc/system/packs/gastown"]`) {
+		t.Fatalf("pack.toml missing gastown include:\n%s", packToml)
+	}
+	if !strings.Contains(packToml, "[agent_defaults]") || !strings.Contains(packToml, "append_fragments") {
+		t.Fatalf("pack.toml missing migrated append_fragments bridge:\n%s", packToml)
+	}
+}
+
+func TestSplitInitConfigMovesPackOwnedFields(t *testing.T) {
+	maxActive := 5
+	cfg := &config.City{
+		Workspace: config.Workspace{
+			Name:            "bright-lights",
+			Includes:        []string{"./packs/gastown"},
+			GlobalFragments: []string{"workspace-frag"},
+		},
+		Imports: map[string]config.Import{
+			"helper": {Source: "./packs/helper"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"claude": {},
+		},
+		Agents: []config.Agent{
+			{
+				Name:              "mayor",
+				PromptTemplate:    "agents/mayor/prompt.template.md",
+				MaxActiveSessions: &maxActive,
+				ScaleCheck:        "echo 3",
+			},
+		},
+		NamedSessions: []config.NamedSession{{Template: "mayor", Mode: "always"}},
+		Services: []config.Service{
+			{Name: "api"},
+			{Name: "dashboard", PublishMode: "direct"},
+		},
+		Formulas: config.FormulasConfig{Dir: "formula-dir"},
+		Patches: config.Patches{
+			Agents: []config.AgentPatch{{Name: "mayor"}},
+		},
+		AgentDefaults: config.AgentDefaults{
+			AppendFragments: []string{"pack-frag"},
+		},
+	}
+
+	packCfg, cityCfg := splitInitConfig("bright-lights", cfg)
+
+	if len(cityCfg.Agents) != 0 {
+		t.Fatalf("cityCfg.Agents = %d, want 0", len(cityCfg.Agents))
+	}
+	if len(cityCfg.NamedSessions) != 0 {
+		t.Fatalf("cityCfg.NamedSessions = %d, want 0", len(cityCfg.NamedSessions))
+	}
+	if len(cityCfg.Imports) != 0 {
+		t.Fatalf("cityCfg.Imports = %d, want 0", len(cityCfg.Imports))
+	}
+	if len(cityCfg.Providers) != 0 {
+		t.Fatalf("cityCfg.Providers = %d, want 0", len(cityCfg.Providers))
+	}
+	if len(cityCfg.Services) != 1 || cityCfg.Services[0].Name != "dashboard" {
+		t.Fatalf("cityCfg.Services = %+v, want one direct dashboard service", cityCfg.Services)
+	}
+	if cityCfg.Formulas.Dir != "" {
+		t.Fatalf("cityCfg.Formulas.Dir = %q, want empty", cityCfg.Formulas.Dir)
+	}
+	if !cityCfg.Patches.IsEmpty() {
+		t.Fatalf("cityCfg.Patches should be empty, got %#v", cityCfg.Patches)
+	}
+	if len(cityCfg.Workspace.Includes) != 0 {
+		t.Fatalf("cityCfg.Workspace.Includes = %v, want empty", cityCfg.Workspace.Includes)
+	}
+	if len(cityCfg.Workspace.GlobalFragments) != 0 {
+		t.Fatalf("cityCfg.Workspace.GlobalFragments = %v, want empty", cityCfg.Workspace.GlobalFragments)
+	}
+
+	if len(packCfg.Agents) != 1 {
+		t.Fatalf("packCfg.Agents = %d, want 1", len(packCfg.Agents))
+	}
+	if packCfg.Agents[0].MaxActiveSessions == nil || *packCfg.Agents[0].MaxActiveSessions != 5 {
+		t.Fatalf("packCfg.Agents[0].MaxActiveSessions = %v, want 5", packCfg.Agents[0].MaxActiveSessions)
+	}
+	if packCfg.Agents[0].ScaleCheck != "echo 3" {
+		t.Fatalf("packCfg.Agents[0].ScaleCheck = %q, want %q", packCfg.Agents[0].ScaleCheck, "echo 3")
+	}
+	if len(packCfg.NamedSessions) != 1 {
+		t.Fatalf("packCfg.NamedSessions = %d, want 1", len(packCfg.NamedSessions))
+	}
+	if len(packCfg.Services) != 1 || packCfg.Services[0].Name != "api" {
+		t.Fatalf("packCfg.Services = %+v, want one api service", packCfg.Services)
+	}
+	if packCfg.Formulas.Dir != "formula-dir" {
+		t.Fatalf("packCfg.Formulas.Dir = %q, want %q", packCfg.Formulas.Dir, "formula-dir")
+	}
+	if len(packCfg.Patches.Agents) != 1 || packCfg.Patches.Agents[0].Name != "mayor" {
+		t.Fatalf("packCfg.Patches = %+v, want mayor patch", packCfg.Patches)
+	}
+	if len(packCfg.Imports) != 1 {
+		t.Fatalf("packCfg.Imports = %d, want 1", len(packCfg.Imports))
+	}
+	if _, ok := packCfg.Imports["helper"]; !ok {
+		t.Fatalf("packCfg.Imports missing helper: %+v", packCfg.Imports)
+	}
+	if len(packCfg.Pack.Includes) != 1 || packCfg.Pack.Includes[0] != "./packs/gastown" {
+		t.Fatalf("packCfg.Pack.Includes = %v, want [./packs/gastown]", packCfg.Pack.Includes)
+	}
+	if len(packCfg.Providers) != 1 {
+		t.Fatalf("packCfg.Providers = %d, want 1", len(packCfg.Providers))
+	}
+	if got := packCfg.AgentDefaults.AppendFragments; len(got) != 2 || got[0] != "pack-frag" || got[1] != "workspace-frag" {
+		t.Fatalf("packCfg.AgentDefaults.AppendFragments = %v, want [pack-frag workspace-frag]", got)
+	}
+}
+
+func TestInitPackSchemaStaysInSyncWithCanonicalPackSchema(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+
+	gotPack := loadStructFields(t, filepath.Join(repoRoot, "cmd", "gc", "cmd_init.go"), "initPackConfig")
+	wantPack := loadStructFields(t, filepath.Join(repoRoot, "internal", "config", "pack.go"), "packConfig")
+	if len(gotPack) != len(wantPack) {
+		t.Fatalf("initPackConfig fields = %v, want %v", gotPack, wantPack)
+	}
+	for i := range wantPack {
+		if gotPack[i].Name != wantPack[i].Name ||
+			normalizeSchemaTag(gotPack[i].Tag) != normalizeSchemaTag(wantPack[i].Tag) ||
+			normalizeSchemaType(gotPack[i].Type) != normalizeSchemaType(wantPack[i].Type) {
+			t.Fatalf("initPackConfig field[%d] = %+v, want %+v", i, gotPack[i], wantPack[i])
+		}
+	}
+
+	gotMeta := loadStructFields(t, filepath.Join(repoRoot, "cmd", "gc", "cmd_init.go"), "initPackMeta")
+	wantMeta := loadStructFields(t, filepath.Join(repoRoot, "internal", "config", "config.go"), "PackMeta")
+	if len(gotMeta) != len(wantMeta) {
+		t.Fatalf("initPackMeta fields = %v, want %v", gotMeta, wantMeta)
+	}
+	for i := range wantMeta {
+		if gotMeta[i].Name != wantMeta[i].Name ||
+			normalizeSchemaTag(gotMeta[i].Tag) != normalizeSchemaTag(wantMeta[i].Tag) ||
+			normalizeSchemaType(gotMeta[i].Type) != normalizeSchemaType(wantMeta[i].Type) {
+			t.Fatalf("initPackMeta field[%d] = %+v, want %+v", i, gotMeta[i], wantMeta[i])
+		}
 	}
 }
 
@@ -2098,23 +2340,29 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 		t.Errorf("stdout missing wizard message: %q", out)
 	}
 
-	// Verify written config has one agent and provider.
+	// Verify written config keeps the provider in city.toml and still loads
+	// a convention-discovered mayor agent.
 	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Provider != "claude" {
-		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
+	if raw.Workspace.Provider != "claude" {
+		t.Errorf("Workspace.Provider = %q, want %q", raw.Workspace.Provider, "claude")
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
 	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
+	explicit := explicitAgents(cfg.Agents)
+	if len(explicit) != 1 {
+		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if explicit[0].Name != "mayor" {
+		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
+	}
+	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
+		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
 	}
 	// Verify provider appears in TOML.
 	if !strings.Contains(string(data), `provider = "claude"`) {
@@ -2138,15 +2386,19 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 
 	// Verify written config has start_command and no provider.
 	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.StartCommand != "my-agent --auto" {
-		t.Errorf("Workspace.StartCommand = %q, want %q", cfg.Workspace.StartCommand, "my-agent --auto")
+	if raw.Workspace.StartCommand != "my-agent --auto" {
+		t.Errorf("Workspace.StartCommand = %q, want %q", raw.Workspace.StartCommand, "my-agent --auto")
 	}
-	if cfg.Workspace.Provider != "" {
-		t.Errorf("Workspace.Provider = %q, want empty", cfg.Workspace.Provider)
+	if raw.Workspace.Provider != "" {
+		t.Errorf("Workspace.Provider = %q, want empty", raw.Workspace.Provider)
+	}
+	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
 	}
 	if len(cfg.Agents) != 1 {
 		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
@@ -2182,8 +2434,8 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
 	}
-	if len(cfg.Workspace.Includes) != 1 || cfg.Workspace.Includes[0] != ".gc/system/packs/gastown" {
-		t.Errorf("Workspace.Includes = %v, want [.gc/system/packs/gastown]", cfg.Workspace.Includes)
+	if len(cfg.Workspace.Includes) != 0 {
+		t.Errorf("Workspace.Includes = %v, want empty (moved to pack.toml)", cfg.Workspace.Includes)
 	}
 	if len(cfg.Workspace.DefaultRigIncludes) != 1 || cfg.Workspace.DefaultRigIncludes[0] != ".gc/system/packs/gastown" {
 		t.Errorf("Workspace.DefaultRigIncludes = %v, want [.gc/system/packs/gastown]", cfg.Workspace.DefaultRigIncludes)
@@ -2191,6 +2443,10 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 	// No inline agents.
 	if len(cfg.Agents) != 0 {
 		t.Errorf("len(Agents) = %d, want 0 (agents come from pack)", len(cfg.Agents))
+	}
+	packToml := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
+	if !strings.Contains(packToml, `includes = [".gc/system/packs/gastown"]`) {
+		t.Errorf("pack.toml missing gastown include:\n%s", packToml)
 	}
 	// Daemon config.
 	if cfg.Daemon.PatrolInterval != "30s" {
@@ -2211,20 +2467,24 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	// Custom template → DefaultCity (one mayor, no provider).
+	// Custom template → mayor discovered from agents/mayor.
 	data := f.Files[filepath.Join("/my-city", "city.toml")]
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
+	}
+	if raw.Workspace.Provider != "" {
+		t.Errorf("Workspace.Provider = %q, want empty", raw.Workspace.Provider)
+	}
+	cfg, err := loadCityConfigFS(f, filepath.Join("/my-city", "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
 	}
 	if len(cfg.Agents) != 1 {
 		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
 	}
 	if cfg.Agents[0].Name != "mayor" {
 		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
-	}
-	if cfg.Workspace.Provider != "" {
-		t.Errorf("Workspace.Provider = %q, want empty", cfg.Workspace.Provider)
 	}
 }
 
@@ -2406,20 +2666,29 @@ scale_check = "echo 3"
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
 	}
-	if len(cfg.Agents) != 2 {
-		t.Fatalf("len(Agents) = %d, want 2", len(cfg.Agents))
+	if len(cfg.Agents) != 0 {
+		t.Fatalf("len(raw city Agents) = %d, want 0", len(cfg.Agents))
 	}
-	if cfg.Agents[1].Name != "worker" {
-		t.Errorf("Agents[1].Name = %q, want %q", cfg.Agents[1].Name, "worker")
+
+	composed, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading composed config: %v", err)
 	}
-	if cfg.Agents[1].MaxActiveSessions == nil {
+	explicit := explicitAgents(composed.Agents)
+	if len(explicit) != 2 {
+		t.Fatalf("len(explicitAgents) = %d, want 2", len(explicit))
+	}
+	if explicit[1].Name != "worker" {
+		t.Errorf("Agents[1].Name = %q, want %q", explicit[1].Name, "worker")
+	}
+	if explicit[1].MaxActiveSessions == nil {
 		t.Fatal("Agents[1].MaxActiveSessions is nil, want non-nil")
 	}
-	if *cfg.Agents[1].MaxActiveSessions != 5 {
-		t.Errorf("Agents[1].MaxActiveSessions = %d, want 5", *cfg.Agents[1].MaxActiveSessions)
+	if *explicit[1].MaxActiveSessions != 5 {
+		t.Errorf("Agents[1].MaxActiveSessions = %d, want 5", *explicit[1].MaxActiveSessions)
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if explicit[0].PromptTemplate != "agents/mayor/prompt.template.md" {
+		t.Errorf("Agents[0].PromptTemplate = %q, want %q", explicit[0].PromptTemplate, "agents/mayor/prompt.template.md")
 	}
 
 	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
@@ -2429,6 +2698,12 @@ scale_check = "echo 3"
 	if !strings.Contains(string(packData), `name = "bright-lights"`) {
 		t.Errorf("pack.toml missing pack name:\n%s", packData)
 	}
+	if !strings.Contains(string(packData), "[[agent]]") || !strings.Contains(string(packData), `prompt_template = "agents/mayor/prompt.template.md"`) {
+		t.Errorf("pack.toml missing moved agents:\n%s", packData)
+	}
+	if !strings.Contains(string(packData), `max_active_sessions = 5`) || !strings.Contains(string(packData), `scale_check = "echo 3"`) {
+		t.Errorf("pack.toml missing worker scaling config:\n%s", packData)
+	}
 	if _, err := os.Stat(filepath.Join(cityPath, "agents", "mayor", "prompt.template.md")); err != nil {
 		t.Errorf("agents/mayor/prompt.template.md missing: %v", err)
 	}
@@ -2436,6 +2711,131 @@ scale_check = "echo 3"
 		if _, err := os.Stat(filepath.Join(cityPath, dir)); !os.IsNotExist(err) {
 			t.Errorf("%s/ should not be created by init: %v", dir, err)
 		}
+	}
+}
+
+func TestCmdInitFromTOMLFilePreservesPackTemplateSections(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sharedPack := filepath.Join(dir, "shared")
+	if err := os.MkdirAll(sharedPack, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedPack, "pack.toml"), []byte(`[pack]
+name = "shared"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := filepath.Join(dir, "template.toml")
+	tomlContent := []byte(`[workspace]
+name = "placeholder"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+
+[pack]
+version = "0.1.0"
+requires_gc = ">=0.16.0"
+includes = ["../shared"]
+
+[[pack.requires]]
+scope = "city"
+agent = "mayor"
+
+[[doctor]]
+name = "check-env"
+script = "doctor/check-env.sh"
+
+[[commands]]
+name = "status"
+description = "show status"
+long_description = "docs/status.md"
+script = "commands/status.sh"
+
+[formulas]
+dir = "custom-formulas"
+
+[[service]]
+name = "api"
+kind = "workflow"
+
+[[service]]
+name = "dashboard"
+kind = "proxy_process"
+publish_mode = "direct"
+
+[global]
+session_live = ["echo live"]
+`)
+	if err := os.WriteFile(src, tomlContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFile(fsys.OSFS{}, src, cityPath, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFile = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	packToml := string(packData)
+	for _, want := range []string{
+		`name = "bright-lights"`,
+		`version = "0.1.0"`,
+		`requires_gc = ">=0.16.0"`,
+		`includes = ["../shared"]`,
+		`[[pack.requires]]`,
+		`agent = "mayor"`,
+		`[[doctor]]`,
+		`script = "doctor/check-env.sh"`,
+		`[[commands]]`,
+		`script = "commands/status.sh"`,
+		`dir = "custom-formulas"`,
+		`[[service]]`,
+		`name = "api"`,
+		`[global]`,
+		`session_live = ["echo live"]`,
+	} {
+		if !strings.Contains(packToml, want) {
+			t.Fatalf("pack.toml missing %q:\n%s", want, packToml)
+		}
+	}
+
+	composed, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading composed config: %v", err)
+	}
+	if composed.Formulas.Dir != "custom-formulas" {
+		t.Fatalf("Formulas.Dir = %q, want %q", composed.Formulas.Dir, "custom-formulas")
+	}
+	cityData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	if !strings.Contains(string(cityData), `publish_mode = "direct"`) || !strings.Contains(string(cityData), `name = "dashboard"`) {
+		t.Fatalf("city.toml missing direct service:\n%s", string(cityData))
+	}
+	if len(composed.Services) != 2 {
+		t.Fatalf("len(Services) = %d, want 2", len(composed.Services))
+	}
+	if composed.Services[0].Name != "api" || composed.Services[1].Name != "dashboard" {
+		t.Fatalf("Services = %+v, want [api dashboard]", composed.Services)
+	}
+	if len(composed.PackGlobals) != 1 || len(composed.PackGlobals[0].SessionLive) != 1 || composed.PackGlobals[0].SessionLive[0] != "echo live" {
+		t.Fatalf("PackGlobals = %+v, want one session_live command", composed.PackGlobals)
 	}
 }
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -52,6 +52,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	prov := newProvenance(path)
 	prov.Warnings = append(prov.Warnings, rootWarnings...)
 	root.ResolvedWorkspaceName = filepath.Base(cityRoot)
+	cityAgentsForProvenance := root.Agents
 
 	// V2: if a pack.toml exists alongside city.toml, it is the city's
 	// definition layer. Parse it and merge its content (imports, agents,
@@ -76,6 +77,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 		// Preserve the city.toml agents so they can override pack-defined
 		// and convention-discovered agents.
 		cityAgents := append([]Agent{}, root.Agents...)
+		cityAgentsForProvenance = cityAgents
 		rootPackIncludes = append([]string(nil), pc.Pack.Includes...)
 		rootPackRequires = append([]PackRequirement(nil), pc.Pack.Requires...)
 		// Dedup: city.toml agents override pack.toml agents with the same
@@ -122,6 +124,9 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 			packServices := make([]Service, len(pc.Services))
 			copy(packServices, pc.Services)
 			for i := range packServices {
+				if packServices[i].PublishMode == "direct" {
+					return nil, nil, fmt.Errorf("city pack.toml: service %q: packs may not set publish_mode=direct", packServices[i].Name)
+				}
 				packServices[i].SourceDir = cityRoot
 			}
 			root.Services = append(packServices, root.Services...)
@@ -189,6 +194,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
 		}
+		trackAgents(prov, packDiscoveredAgents, packPath)
 		root.Agents = append([]Agent{}, packAgents...)
 		root.Agents = append(root.Agents, packDiscoveredAgents...)
 		root.Agents = append(root.Agents, cityAgents...)
@@ -203,7 +209,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	}
 
 	// Track root's resources.
-	trackAgents(prov, root.Agents, path)
+	trackAgents(prov, cityAgentsForProvenance, path)
 	trackRigs(prov, root.Rigs, path)
 	trackWorkspace(prov, rootMeta, path)
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -60,6 +60,9 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	// deployment (rigs, substrates, capacity) plus any inline agents.
 	cityImportCount := len(root.Imports)
 	packExists := false
+	var rootPackIncludes []string
+	var rootPackGlobals []ResolvedPackGlobal
+	var rootPackRequires []PackRequirement
 	packPath := filepath.Join(cityRoot, packFile)
 	if packData, pErr := fs.ReadFile(packPath); pErr == nil {
 		packExists = true
@@ -73,6 +76,8 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 		// Preserve the city.toml agents so they can override pack-defined
 		// and convention-discovered agents.
 		cityAgents := append([]Agent{}, root.Agents...)
+		rootPackIncludes = append([]string(nil), pc.Pack.Includes...)
+		rootPackRequires = append([]PackRequirement(nil), pc.Pack.Requires...)
 		// Dedup: city.toml agents override pack.toml agents with the same
 		// name. Build a set of city.toml agent names and skip pack.toml
 		// agents that would duplicate.
@@ -110,15 +115,37 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 		}
 		// Merge named sessions.
 		root.NamedSessions = append(pc.NamedSessions, root.NamedSessions...)
+		// Merge root-pack services as the portable base layer. city.toml
+		// services stay later in the slice and therefore remain the more
+		// local declaration when callers inspect the merged config.
+		if len(pc.Services) > 0 {
+			packServices := make([]Service, len(pc.Services))
+			copy(packServices, pc.Services)
+			for i := range packServices {
+				packServices[i].SourceDir = cityRoot
+			}
+			root.Services = append(packServices, root.Services...)
+		}
 		// Merge patches (accumulated, applied later).
 		root.Patches.Agents = append(pc.Patches.Agents, root.Patches.Agents...)
 		root.Patches.Rigs = append(pc.Patches.Rigs, root.Patches.Rigs...)
 		root.Patches.Providers = append(pc.Patches.Providers, root.Patches.Providers...)
+		// Merge formulas config with pack.toml as the base and city.toml as
+		// the more local override.
+		if root.Formulas.Dir == "" {
+			root.Formulas = pc.Formulas
+		}
 		// Merge pack-level agent defaults before city fragments so the
 		// city layer can append on top of the portable baseline.
 		mergedAgentDefaults := pc.AgentDefaults
 		mergeAgentDefaults(&mergedAgentDefaults, root.AgentDefaults, packPath, nil)
 		root.AgentDefaults = mergedAgentDefaults
+		if len(pc.Global.SessionLive) > 0 {
+			rootPackGlobals = append(rootPackGlobals, ResolvedPackGlobal{
+				SessionLive: resolveConfigDirInCommands(pc.Global.SessionLive, cityRoot),
+				PackName:    pc.Pack.Name,
+			})
+		}
 		// Track pack.toml agents in provenance.
 		trackAgents(prov, pc.Agents, packPath)
 		prov.Sources = append(prov.Sources, packPath)
@@ -241,6 +268,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	// Skip packs already reachable from user includes or top-level imports
 	// (avoids duplicate agent errors when a user pack transitively includes
 	// a system pack).
+	root.Workspace.Includes = append(rootPackIncludes, root.Workspace.Includes...)
 	existingPacks := resolvedPackNames(root.Workspace.Includes, root.Imports, fs, cityRoot)
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
@@ -296,6 +324,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	if ctErr != nil {
 		return nil, nil, ctErr
 	}
+	cityReqs = append(cityReqs, rootPackRequires...)
 	prov.Warnings = append(prov.Warnings, shadowWarnings...)
 	// Track city pack agents in provenance.
 	for _, ref := range root.Workspace.Includes {
@@ -340,6 +369,7 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	}
 
 	// Apply [global] sections from packs to agents in scope.
+	root.PackGlobals = append(root.PackGlobals, rootPackGlobals...)
 	applyPackGlobals(root)
 
 	// Validate city-scoped pack requirements.

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -147,6 +147,9 @@ name = "mayor"
 	if len(prov.Sources) != 2 {
 		t.Errorf("len(Sources) = %d, want 2", len(prov.Sources))
 	}
+	if prov.Agents["mayor"] != "/city/pack.toml" {
+		t.Errorf("mayor source = %q, want /city/pack.toml", prov.Agents["mayor"])
+	}
 }
 
 func TestLoadWithIncludes_ConcatAgents(t *testing.T) {

--- a/internal/config/import_negative_test.go
+++ b/internal/config/import_negative_test.go
@@ -117,6 +117,34 @@ scope = "city"
 	}
 }
 
+func TestImport_RootPackDirectServiceRejected(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeTestFile(t, cityDir, "pack.toml", `
+[pack]
+name = "test"
+schema = 2
+
+[[service]]
+name = "ui"
+publish_mode = "direct"
+`)
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected error for direct service in root pack.toml")
+	}
+	if !strings.Contains(err.Error(), "city pack.toml") || !strings.Contains(err.Error(), "publish_mode=direct") {
+		t.Errorf("error should mention city pack.toml direct service; got: %v", err)
+	}
+}
+
 func TestImport_TransitiveFalseWithExport(t *testing.T) {
 	// transitive=false on an import should suppress its nested deps
 	// even if the nested pack uses export=true internally.

--- a/internal/config/import_negative_test.go
+++ b/internal/config/import_negative_test.go
@@ -89,6 +89,34 @@ name = "test"
 	}
 }
 
+func TestImport_RootPackRequirementFailure(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeTestFile(t, cityDir, "pack.toml", `
+[pack]
+name = "test"
+schema = 2
+
+[[pack.requires]]
+agent = "missing-agent"
+scope = "city"
+`)
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected error for unsatisfied root pack requirement")
+	}
+	if !strings.Contains(err.Error(), "missing-agent") {
+		t.Errorf("error should mention required agent; got: %v", err)
+	}
+}
+
 func TestImport_TransitiveFalseWithExport(t *testing.T) {
 	// transitive=false on an import should suppress its nested deps
 	// even if the nested pack uses export=true internally.


### PR DESCRIPTION
## Summary
- split fresh `gc init` output into root `pack.toml` and `city.toml` without changing root-pack include identities
- keep direct-publish services in `city.toml`, preserve pack metadata on suspend/resume, and validate root-pack requirements during load
- add coverage for template preservation, root-pack agent edits, schema sync, and root-pack requirement failures

## Testing
- `go test ./cmd/gc -run 'TestDoInit|TestSplitInitConfigMovesPackOwnedFields|TestInitPackSchemaStaysInSyncWithCanonicalPackSchema|TestCmdInitFromTOMLFile(Success|PreservesPackTemplateSections)|TestDoAgent(Suspend|Resume)|TestInitTutorialProviderWritesWorkspaceProvider'`
- `go test ./internal/config`
- `make lint`

## Review
- Claude review: clean on the last successful full run
- Codex review: clean on the final text-only diff review
- Gemini review was attempted earlier but hit repeated 429 rate limits from the provider