### PR TITLE
fix: quiet rig registry config scans

### DIFF
--- a/cmd/gc/city_config_quiet.go
+++ b/cmd/gc/city_config_quiet.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"io"
+	"log"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+var quietCityConfigLogMu sync.Mutex
+
+// loadCityConfigQuiet performs a full config load while suppressing migration
+// warnings emitted through the process logger. Use it for secondary config
+// reads, such as scanning registered cities, where warnings would be unrelated
+// to the command the user ran.
+func loadCityConfigQuiet(cityPath string) (*config.City, error) {
+	quietCityConfigLogMu.Lock()
+	defer quietCityConfigLogMu.Unlock()
+
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	oldPrefix := log.Prefix()
+	log.SetOutput(io.Discard)
+	defer func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+		log.SetPrefix(oldPrefix)
+	}()
+
+	return loadCityConfig(cityPath)
+}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -915,7 +915,7 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 			// Update .beads/.env and routes for the rig's new default city.
 			if newDefault != "" {
 				_ = writeBeadsEnvGTRoot(fsys.OSFS{}, removedPath, newDefault)
-				if newCfg, err := loadCityConfig(newDefault); err == nil {
+				if newCfg, err := loadCityConfigQuiet(newDefault); err == nil {
 					resolveRigPaths(newDefault, newCfg.Rigs)
 					newRigs := collectRigRoutes(newDefault, newCfg)
 					_ = writeAllRoutes(newRigs)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -572,7 +572,7 @@ func rigCityEntries(reg *supervisor.Registry, rigPath string) []supervisor.CityE
 	}
 	var matched []supervisor.CityEntry
 	for _, c := range cities {
-		cfg, err := loadCityConfig(c.Path)
+		cfg, err := loadCityConfigQuiet(c.Path)
 		if err != nil {
 			continue
 		}

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -998,6 +999,75 @@ func TestRigAnywhere_RigRemove(t *testing.T) {
 		_, ok := reg.LookupRigByName("solo-rig")
 		if ok {
 			t.Error("rig should be removed from cities.toml when no other city has it")
+		}
+	})
+
+	t.Run("does_not_emit_deprecated_order_warnings_from_unrelated_registered_city", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+		resetFlags(t)
+
+		cityPath := setupCity(t, "quiet-remove")
+		rigDir := filepath.Join(t.TempDir(), "quiet-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := "[workspace]\nname = \"quiet-remove\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"quiet-rig\"\npath = \"" + rigDir + "\"\n"
+		writeRigAnywhereCityToml(t, cityPath, toml)
+
+		unrelatedCity := setupCity(t, "unrelated-noisy")
+		legacyOrderDir := filepath.Join(unrelatedCity, ".gc", "system", "packs", "maintenance", "formulas", "orders", "legacy-health")
+		if err := os.MkdirAll(legacyOrderDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(unrelatedCity, ".gc", "system", "packs", "maintenance", "pack.toml"), []byte(`[pack]
+name = "maintenance"
+schema = 2
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(legacyOrderDir, "order.toml"), []byte(`[order]
+formula = "mol-legacy-health"
+gate = "manual"
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		reg := registryAt(t, gcHome)
+		if err := reg.Register(cityPath, "quiet-remove"); err != nil {
+			t.Fatal(err)
+		}
+		if err := reg.Register(unrelatedCity, "unrelated-noisy"); err != nil {
+			t.Fatal(err)
+		}
+		if err := reg.RegisterRig(rigDir, "quiet-rig", cityPath); err != nil {
+			t.Fatal(err)
+		}
+
+		var logs bytes.Buffer
+		oldWriter := log.Writer()
+		oldFlags := log.Flags()
+		oldPrefix := log.Prefix()
+		log.SetOutput(&logs)
+		log.SetFlags(0)
+		log.SetPrefix("")
+		t.Cleanup(func() {
+			log.SetOutput(oldWriter)
+			log.SetFlags(oldFlags)
+			log.SetPrefix(oldPrefix)
+		})
+
+		cityFlag = cityPath
+		var stdout, stderr bytes.Buffer
+		code := cmdRigRemove("quiet-rig", &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("cmdRigRemove = %d, stderr: %s", code, stderr.String())
+		}
+		if strings.Contains(logs.String(), "deprecated order path") {
+			t.Fatalf("cmdRigRemove emitted unrelated order migration warning:\n%s", logs.String())
+		}
+		if !strings.Contains(stdout.String(), "Removed rig 'quiet-rig'") {
+			t.Fatalf("stdout = %q, want removal confirmation", stdout.String())
 		}
 	})
 


### PR DESCRIPTION
## Summary
- suppress process-logger migration warnings during secondary city config loads used by rig registry scans
- use the quiet load when updating route state for a remaining default city during rig removal
- add regression coverage for gc rig remove with an unrelated registered city that has deprecated order paths

Fixes #607.

## Verification
- go test ./cmd/gc -run TestRigAnywhere_RigRemove -count=1
- go test ./cmd/gc -run TestRigAnywhere -count=1
- git diff --check HEAD~1..HEAD

Note: go test ./cmd/gc was attempted and timed out in unrelated TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind while waiting in BD/Dolt provider health under local contention.