### PR TITLE
fix(config): reject unknown pack.toml fields

### DIFF
--- a/internal/bootstrap/packs/core/pack.toml
+++ b/internal/bootstrap/packs/core/pack.toml
@@ -2,4 +2,3 @@
 name = "core"
 version = "0.1.0"
 schema = 2
-description = "Gas City built-in reference skills (gc-work, gc-dispatch, ...). Shipped with the gc binary, implicitly imported into every city."

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -64,8 +64,12 @@ func LoadWithIncludes(fs fsys.FS, path string, extraIncludes ...string) (*City, 
 	if packData, pErr := fs.ReadFile(packPath); pErr == nil {
 		packExists = true
 		var pc packConfig
-		if _, decErr := toml.Decode(string(packData), &pc); decErr != nil {
+		md, decErr := toml.Decode(string(packData), &pc)
+		if decErr != nil {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", decErr)
+		}
+		if warnings := CheckUndecodedKeys(md, packPath); len(warnings) > 0 {
+			return nil, nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(warnings, "; "))
 		}
 		if err := validatePackMeta(&pc.Pack); err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -900,8 +900,12 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 	}
 
 	var tc packConfig
-	if _, err := toml.Decode(string(data), &tc); err != nil {
+	md, err := toml.Decode(string(data), &tc)
+	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
+	}
+	if warnings := CheckUndecodedKeys(md, topoPath); len(warnings) > 0 {
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(warnings, "; "))
 	}
 
 	if err := validatePackMeta(&tc.Pack); err != nil {

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -382,6 +382,55 @@ version = "1.0.0"
 	}
 }
 
+func TestExpandPacks_RejectsUnknownPackTomlFields(t *testing.T) { //nolint:misspell // intentional typo in test data
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/bad/pack.toml", `
+[pack]
+name = "bad"
+schema = 2
+schemla = 2
+`)
+
+	cfg := &City{
+		Rigs: []Rig{
+			{Name: "hello-world", Path: "/home/user/hello-world", Includes: []string{"packs/bad"}},
+		},
+	}
+
+	err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown pack.toml field")
+	}
+	if !strings.Contains(err.Error(), `unknown field "pack.schemla"`) {
+		t.Fatalf("error = %v, want unknown field detail for pack.schemla", err)
+	}
+	if !strings.Contains(err.Error(), `did you mean "schema"`) {
+		t.Fatalf("error = %v, want schema suggestion", err)
+	}
+}
+
+func TestLoadWithIncludes_RejectsUnknownRootPackTomlFields(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeFile(t, dir, "pack.toml", `
+[pack]
+name = "test"
+schema = 2
+description = "silently accepted before issue 783"
+`)
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected error for unknown root pack.toml field")
+	}
+	if !strings.Contains(err.Error(), `unknown field "pack.description"`) {
+		t.Fatalf("error = %v, want unknown field detail for pack.description", err)
+	}
+}
+
 func TestExpandPacks_PromptPathResolution(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gt/pack.toml", `

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -53,6 +53,9 @@ func suggestKey(unknown string, known []string) string {
 			bestKey = k
 		}
 	}
+	if bestKey == leaf {
+		return ""
+	}
 	return bestKey
 }
 
@@ -114,6 +117,14 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(ServiceWorkflowConfig{}),
 		reflect.TypeOf(ServiceProcessConfig{}),
 		reflect.TypeOf(AgentDefaults{}),
+		reflect.TypeOf(packConfig{}),
+		reflect.TypeOf(PackMeta{}),
+		reflect.TypeOf(Import{}),
+		reflect.TypeOf(NamedSession{}),
+		reflect.TypeOf(PackRequirement{}),
+		reflect.TypeOf(PackDoctorEntry{}),
+		reflect.TypeOf(PackCommandEntry{}),
+		reflect.TypeOf(PackGlobal{}),
 	}
 	for _, t := range types {
 		collectTOMLTags(t, seen)


### PR DESCRIPTION
## Summary
- reject undecoded keys while parsing rig and city-root pack.toml files
- add pack-specific TOML keys to typo suggestions so e.g. pack.schemla points at schema
- remove the invalid [pack] description field from the bundled core pack

Fixes #783

## Verification
- go test ./internal/config
- go test ./cmd/gc -run 'TestGcBeadsBdInitNormalizesScopeAndRemovesLocalServerArtifacts|TestGcBdRigListRecoversAfterManagedHardKillPortRebind|TestManagedBdRigStoreConsistentAcrossRawBdGcBdAndProviderStore|TestManagedExecBdRigStoreConsistentAcrossRawBdAndProviderStore|TestGcBeadsBdStartRestartsServerHoldingDeletedDataInodes|TestManagedBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore'

Note: go test ./... was attempted twice. The first run exposed the bundled core pack description issue fixed in this PR; the second run reached cmd/gc and ended with signal: terminated after ~192s, while the targeted cmd/gc tests above pass on the rebased branch.