### PR TITLE
Fix rig-scoped order bead store targeting

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -157,17 +157,23 @@ name. Use --rig to filter by rig.`,
 // loadOrders is the common preamble for order commands: resolve city,
 // load config, scan formula layers for all orders (city + rig).
 func loadOrders(stderr io.Writer, cmdName string) ([]orders.Order, int) {
+	_, _, aa, code := loadOrdersWithCity(stderr, cmdName)
+	return aa, code
+}
+
+func loadOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.City, []orders.Order, int) {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
+		return "", nil, nil, 1
 	}
 	cfg, err := loadCityConfig(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
+		return "", nil, nil, 1
 	}
-	return loadAllOrders(cityPath, cfg, stderr, cmdName)
+	aa, code := loadAllOrders(cityPath, cfg, stderr, cmdName)
+	return cityPath, cfg, aa, code
 }
 
 // loadAllOrders scans city layers + per-rig exclusive layers for orders.
@@ -413,15 +419,25 @@ func openCityOrderStore(stderr io.Writer, cmdName string) (beads.Store, int) {
 	return store, 0
 }
 
+func openOrderStoreForOrder(cityPath string, cfg *config.City, a orders.Order, stderr io.Writer, cmdName string) (beads.Store, int) {
+	target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	return store, 0
+}
+
 func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order run")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order run")
 	if code != 0 {
 		return code
-	}
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
 	}
 	a, ok := findOrder(aa, name, rig)
 	if !ok {
@@ -429,14 +445,9 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if a.IsExec() {
-		cfg, cfgErr := loadCityConfig(cityPath)
-		if cfgErr != nil {
-			fmt.Fprintf(stderr, "gc order run: %v\n", cfgErr) //nolint:errcheck // best-effort stderr
-			return 1
-		}
 		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
 	}
-	store, storeCode := openCityOrderStore(stderr, "gc order run")
+	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
 	if store == nil {
 		return storeCode
 	}
@@ -554,7 +565,7 @@ func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, s
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	env := orderExecEnv(cityPath, target, a)
+	env := orderExecEnv(cityPath, cfg, target, a)
 
 	output, err := shellExecRunner(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
@@ -574,24 +585,17 @@ func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, s
 // --- gc order check ---
 
 func cmdOrderCheck(stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order check")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order check")
 	if code != 0 {
 		return code
 	}
-
-	store, storeCode := openCityOrderStore(stderr, "gc order check")
-	if store == nil {
-		return storeCode
-	}
-	lastRunFn := orderLastRunFn(store)
-	cursorFn := bdCursorFunc(store)
 
 	ep, epCode := openCityEventsProvider(stderr, "gc order check")
 	if ep == nil {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderCheck(aa, time.Now(), lastRunFn, ep, cursorFn, stdout)
+	return doOrderCheckWithStoreResolver(aa, time.Now(), ep, cachedOrderStoreResolver(cityPath, cfg), stdout, stderr)
 }
 
 // orderLastRunFn returns a LastRunFunc that queries BdStore for the most
@@ -654,24 +658,90 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 	return 1
 }
 
+type orderStoreResolver func(orders.Order) (beads.Store, error)
+
+func cachedOrderStoreResolver(cityPath string, cfg *config.City) orderStoreResolver {
+	stores := make(map[string]beads.Store)
+	return func(a orders.Order) (beads.Store, error) {
+		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+		if err != nil {
+			return nil, err
+		}
+		key := orderStoreTargetKey(target)
+		if store, ok := stores[key]; ok {
+			return store, nil
+		}
+		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+		if err != nil {
+			return nil, err
+		}
+		stores[key] = store
+		return store, nil
+	}
+}
+
+func doOrderCheckWithStoreResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStore orderStoreResolver, stdout, stderr io.Writer) int {
+	if len(aa) == 0 {
+		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
+		return 1
+	}
+
+	hasRig := anyOrderHasRig(aa)
+	if hasRig {
+		fmt.Fprintf(stdout, "%-20s %-12s %-15s %-5s %s\n", "NAME", "GATE", "RIG", "DUE", "REASON") //nolint:errcheck
+	} else {
+		fmt.Fprintf(stdout, "%-20s %-12s %-5s %s\n", "NAME", "GATE", "DUE", "REASON") //nolint:errcheck
+	}
+	anyDue := false
+	for _, a := range aa {
+		store, err := resolveStore(a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		result := orders.CheckGate(a, now, orderLastRunFn(store), ep, bdCursorFunc(store))
+		due := "no"
+		if result.Due {
+			due = "yes"
+			anyDue = true
+		}
+		if hasRig {
+			rig := a.Rig
+			if rig == "" {
+				rig = "-"
+			}
+			fmt.Fprintf(stdout, "%-20s %-12s %-15s %-5s %s\n", a.Name, a.Gate, rig, due, result.Reason) //nolint:errcheck
+		} else {
+			fmt.Fprintf(stdout, "%-20s %-12s %-5s %s\n", a.Name, a.Gate, due, result.Reason) //nolint:errcheck
+		}
+	}
+
+	if anyDue {
+		return 0
+	}
+	return 1
+}
+
 // --- gc order history ---
 
 func cmdOrderHistory(name, rig string, stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order history")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order history")
 	if code != 0 {
 		return code
 	}
-	store, storeCode := openCityOrderStore(stderr, "gc order history")
-	if store == nil {
-		return storeCode
-	}
-	return doOrderHistory(name, rig, aa, store, stdout)
+	return doOrderHistoryWithStoreResolver(name, rig, aa, cachedOrderStoreResolver(cityPath, cfg), stdout, stderr)
 }
 
 // doOrderHistory queries bead history for order runs and prints a table.
 // When name is empty, shows history for all orders. When name is given,
 // filters to that order only. When rig is non-empty, also filters by rig.
 func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdout io.Writer) int {
+	return doOrderHistoryWithStoreResolver(name, rig, aa, func(orders.Order) (beads.Store, error) {
+		return store, nil
+	}, stdout, io.Discard)
+}
+
+func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolveStore orderStoreResolver, stdout, stderr io.Writer) int {
 	// Filter orders if name or rig specified.
 	targets := aa
 	if name != "" || rig != "" {
@@ -696,6 +766,11 @@ func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdo
 	var entries []historyEntry
 
 	for _, a := range targets {
+		store, err := resolveStore(a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		label := "order-run:" + a.ScopedName()
 		results, err := store.List(beads.ListQuery{
 			Label:         label,
@@ -703,7 +778,8 @@ func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdo
 			Sort:          beads.SortCreatedDesc,
 		})
 		if err != nil {
-			continue
+			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
 		}
 		for _, b := range results {
 			entries = append(entries, historyEntry{

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -521,6 +521,40 @@ func TestOrderCheckWithLastRun(t *testing.T) {
 	}
 }
 
+func TestOrderCheckWithStoreResolverUsesRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:  "recent rig run",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "digest",
+		Rig:      "frontend",
+		Gate:     "cooldown",
+		Interval: "24h",
+		Formula:  "mol-digest",
+	}}
+	resolver := func(a orders.Order) (beads.Store, error) {
+		if a.Rig == "frontend" {
+			return rigStore, nil
+		}
+		return cityStore, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoreResolver(aa, time.Now().Add(time.Second), nil, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoreResolver = %d, want 1 (rig cooldown active); stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "no") {
+		t.Fatalf("stdout missing not-due row:\n%s", stdout.String())
+	}
+}
+
 // --- gc order run ---
 
 func TestOrderRun(t *testing.T) {
@@ -692,7 +726,7 @@ prefix = "fe"
 		Rig:      "frontend",
 		Gate:     "cooldown",
 		Interval: "1m",
-		Exec:     fmt.Sprintf(`pwd > %q && printf '%%s\n%%s\n%%s\n%%s\n%%s\n' "$GC_STORE_ROOT" "$GC_STORE_SCOPE" "$GC_BEADS_PREFIX" "$GC_RIG" "$GC_RIG_ROOT" >> %q`, outPath, outPath),
+		Exec:     fmt.Sprintf(`pwd > %q && printf '%%s\n%%s\n%%s\n%%s\n%%s\n%%s\n' "$BEADS_DIR" "$GC_STORE_ROOT" "$GC_STORE_SCOPE" "$GC_BEADS_PREFIX" "$GC_RIG" "$GC_RIG_ROOT" >> %q`, outPath, outPath),
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -705,26 +739,29 @@ prefix = "fe"
 		t.Fatalf("ReadFile(exec-env): %v", err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) != 6 {
-		t.Fatalf("exec env lines = %d, want 6 (%q)", len(lines), string(data))
+	if len(lines) != 7 {
+		t.Fatalf("exec env lines = %d, want 7 (%q)", len(lines), string(data))
 	}
 	if lines[0] != rigDir {
 		t.Fatalf("pwd = %q, want %q", lines[0], rigDir)
 	}
-	if lines[1] != rigDir {
-		t.Fatalf("GC_STORE_ROOT = %q, want %q", lines[1], rigDir)
+	if lines[1] != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", lines[1], filepath.Join(rigDir, ".beads"))
 	}
-	if lines[2] != "rig" {
-		t.Fatalf("GC_STORE_SCOPE = %q, want rig", lines[2])
+	if lines[2] != rigDir {
+		t.Fatalf("GC_STORE_ROOT = %q, want %q", lines[2], rigDir)
 	}
-	if lines[3] != "fe" {
-		t.Fatalf("GC_BEADS_PREFIX = %q, want fe", lines[3])
+	if lines[3] != "rig" {
+		t.Fatalf("GC_STORE_SCOPE = %q, want rig", lines[3])
 	}
-	if lines[4] != "frontend" {
-		t.Fatalf("GC_RIG = %q, want frontend", lines[4])
+	if lines[4] != "fe" {
+		t.Fatalf("GC_BEADS_PREFIX = %q, want fe", lines[4])
 	}
-	if lines[5] != rigDir {
-		t.Fatalf("GC_RIG_ROOT = %q, want %q", lines[5], rigDir)
+	if lines[5] != "frontend" {
+		t.Fatalf("GC_RIG = %q, want frontend", lines[5])
+	}
+	if lines[6] != rigDir {
+		t.Fatalf("GC_RIG_ROOT = %q, want %q", lines[6], rigDir)
 	}
 }
 
@@ -823,6 +860,43 @@ func TestOrderHistoryEmpty(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No order history") {
 		t.Errorf("stdout = %q, want 'No order history'", stdout.String())
+	}
+}
+
+func TestOrderHistoryWithStoreResolverUsesRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	run, err := rigStore.Create(beads.Bead{
+		Title:  "rig digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:    "digest",
+		Rig:     "frontend",
+		Formula: "mol-digest",
+	}}
+	resolver := func(a orders.Order) (beads.Store, error) {
+		if a.Rig == "frontend" {
+			return rigStore, nil
+		}
+		return cityStore, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoreResolver("", "", aa, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderHistoryWithStoreResolver = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, run.ID) {
+		t.Fatalf("stdout missing rig run %q:\n%s", run.ID, out)
+	}
+	if !strings.Contains(out, "frontend") {
+		t.Fatalf("stdout missing rig name:\n%s", out)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -43,7 +43,7 @@ func shellExecRunner(ctx context.Context, command, dir string, env []string) ([]
 	return cmd.CombinedOutput()
 }
 
-type orderStoreFunc func() (beads.Store, error)
+type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
 type memoryOrderDispatcher struct {
@@ -94,8 +94,8 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 
 	return &memoryOrderDispatcher{
 		aa: auto,
-		storeFn: func() (beads.Store, error) {
-			return openStoreAtForCity(cityPath, cityPath)
+		storeFn: func(target execStoreTarget) (beads.Store, error) {
+			return openStoreAtForCity(target.ScopeRoot, cityPath)
 		},
 		ep:         ep,
 		execRun:    shellExecRunner,
@@ -113,23 +113,35 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		return
 	}
 
-	store, err := m.storeFn()
-	if err != nil {
-		fmt.Fprintf(m.stderr, "gc: order dispatch: opening store: %v\n", err) //nolint:errcheck // best-effort stderr
-		return
-	}
-
-	lastRunFn := orderLastRunFn(store)
-	cursorFn := bdCursorFunc(store)
+	stores := make(map[string]beads.Store)
 
 	for _, a := range m.aa {
-		result := orders.CheckGate(a, now, lastRunFn, m.ep, cursorFn)
-		if !result.Due {
+		// Skip orders targeting suspended rigs.
+		if m.orderRigSuspended(a) {
 			continue
 		}
 
-		// Skip orders targeting suspended rigs.
-		if m.orderRigSuspended(a) {
+		target, err := resolveOrderStoreTarget(cityPath, m.cfg, a)
+		if err != nil {
+			fmt.Fprintf(m.stderr, "gc: order dispatch: resolving target for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+			continue
+		}
+
+		storeKey := orderStoreTargetKey(target)
+		store, ok := stores[storeKey]
+		if !ok {
+			store, err = m.storeFn(target)
+			if err != nil {
+				fmt.Fprintf(m.stderr, "gc: order dispatch: opening %s store for %s: %v\n", target.ScopeKind, a.ScopedName(), err) //nolint:errcheck
+				continue
+			}
+			stores[storeKey] = store
+		}
+
+		lastRunFn := orderLastRunFn(store)
+		cursorFn := bdCursorFunc(store)
+		result := orders.CheckGate(a, now, lastRunFn, m.ep, cursorFn)
+		if !result.Due {
 			continue
 		}
 
@@ -152,14 +164,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 		// Fire and forget with timeout.
 		a := a // capture loop variable
-		go m.dispatchOne(ctx, store, a, cityPath, trackingBead.ID)
+		go m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
 	}
 }
 
 // dispatchOne runs a single order dispatch in its own goroutine.
 // For exec orders, runs the script directly. For formula orders,
 // instantiates a wisp. Emits events and updates the tracking bead.
-func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, a orders.Order, cityPath, trackingID string) {
+func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
 	defer store.Close(trackingID) //nolint:errcheck // best-effort close
 
 	timeout := effectiveTimeout(a, m.maxTimeout)
@@ -174,32 +186,18 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 	})
 
 	if a.IsExec() {
-		m.dispatchExec(childCtx, store, a, cityPath, trackingID)
+		m.dispatchExec(childCtx, store, target, a, cityPath, trackingID)
 	} else {
 		m.dispatchWisp(childCtx, store, a, cityPath, trackingID)
 	}
 }
 
 // dispatchExec runs an exec order's shell command.
-func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.Store, a orders.Order, cityPath, trackingID string) {
+func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
 	scoped := a.ScopedName()
 	labels := []string{"exec"}
 
-	target, err := resolveOrderExecTarget(cityPath, m.cfg, a)
-	if err != nil {
-		labels = append(labels, "exec-failed")
-		fmt.Fprintf(m.stderr, "gc: order exec %s failed: %v\n", scoped, err) //nolint:errcheck
-		m.rec.Record(events.Event{
-			Type:    events.OrderFailed,
-			Actor:   "controller",
-			Subject: scoped,
-			Message: err.Error(),
-		})
-		store.Update(trackingID, beads.UpdateOpts{Labels: labels}) //nolint:errcheck // best-effort
-		return
-	}
-
-	env := orderExecEnv(cityPath, target, a)
+	env := orderExecEnv(cityPath, m.cfg, target, a)
 	output, err := m.execRun(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
 		labels = append(labels, "exec-failed")
@@ -225,7 +223,7 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.St
 	store.Update(trackingID, beads.UpdateOpts{Labels: labels}) //nolint:errcheck // best-effort
 }
 
-func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
+func resolveOrderStoreTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
 	if strings.TrimSpace(a.Rig) == "" {
 		prefix := ""
 		if cfg != nil {
@@ -252,8 +250,24 @@ func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (
 	}, nil
 }
 
-func orderExecEnv(cityPath string, target execStoreTarget, a orders.Order) []string {
-	env := citylayout.CityRuntimeEnvMap(cityPath)
+func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
+	return resolveOrderStoreTarget(cityPath, cfg, a)
+}
+
+func orderStoreTargetKey(target execStoreTarget) string {
+	return target.ScopeKind + "\x00" + filepath.Clean(target.ScopeRoot)
+}
+
+func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) []string {
+	var env map[string]string
+	if target.ScopeKind == "rig" {
+		env = bdRuntimeEnvForRig(cityPath, cfg, target.ScopeRoot)
+	} else {
+		env = bdRuntimeEnv(cityPath)
+		env["BEADS_DIR"] = filepath.Join(target.ScopeRoot, ".beads")
+		env["GC_RIG"] = ""
+		env["GC_RIG_ROOT"] = ""
+	}
 	env["GC_STORE_ROOT"] = target.ScopeRoot
 	env["GC_STORE_SCOPE"] = target.ScopeKind
 	env["GC_BEADS_PREFIX"] = target.Prefix

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -601,6 +601,7 @@ func TestOrderDispatchExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
 	checks := map[string]string{
 		"GC_CITY":         cityDir,
 		"GC_CITY_PATH":    cityDir,
+		"BEADS_DIR":       filepath.Join(rigDir, ".beads"),
 		"GC_STORE_ROOT":   rigDir,
 		"GC_STORE_SCOPE":  "rig",
 		"GC_BEADS_PREFIX": "fe",
@@ -1125,9 +1126,15 @@ func buildOrderDispatcherFromList(aa []orders.Order, store beads.Store, ep event
 // buildOrderDispatcherFromListExec builds a dispatcher with exec runner support.
 func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep events.Provider, execRun ExecRunner, rec events.Recorder) orderDispatcher {
 	var auto []orders.Order
+	cfg := &config.City{}
+	seenRigs := make(map[string]bool)
 	for _, a := range aa {
 		if a.Gate != "manual" {
 			auto = append(auto, a)
+		}
+		if a.Rig != "" && !seenRigs[a.Rig] {
+			cfg.Rigs = append(cfg.Rigs, config.Rig{Name: a.Rig, Path: a.Rig})
+			seenRigs[a.Rig] = true
 		}
 	}
 	if len(auto) == 0 {
@@ -1141,13 +1148,14 @@ func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep e
 	}
 	return &memoryOrderDispatcher{
 		aa: auto,
-		storeFn: func() (beads.Store, error) {
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
 			return store, nil
 		},
 		ep:      ep,
 		execRun: execRun,
 		rec:     rec,
 		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
 	}
 }
 
@@ -1372,6 +1380,83 @@ pool = "worker"
 	work := workBeadByOrderLabel(t, store, "order-run:file-order")
 	if work.Metadata["gc.routed_to"] != "worker" {
 		t.Errorf("gc.routed_to = %q, want %q", work.Metadata["gc.routed_to"], "worker")
+	}
+}
+
+func TestBuildOrderDispatcherRigOrderUsesRigFileStore(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	cityLayer := filepath.Join(cityDir, "formulas")
+	rigLayer := filepath.Join(rigDir, "formulas")
+	orderDir := filepath.Join(rigDir, "orders", "rig-digest")
+	for _, dir := range []string{cityLayer, rigLayer, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+formula = "test-formula"
+gate = "cooldown"
+interval = "1m"
+pool = "worker"
+`)
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(test-formula): %v", err)
+	}
+	writeFile(t, filepath.Join(rigLayer, "test-formula.formula.toml"), string(formulaText))
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo", Prefix: "ct"},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{
+				"frontend": {cityLayer, rigLayer},
+			},
+		},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   "frontend",
+			Prefix: "fe",
+		}},
+	}
+
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	if ad == nil {
+		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
+	}
+
+	ad.dispatch(context.Background(), cityDir, time.Now())
+	time.Sleep(100 * time.Millisecond)
+
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	cityRuns := trackingBeads(t, cityStore, "order-run:rig-digest:rig:frontend")
+	if len(cityRuns) != 0 {
+		t.Fatalf("city store has %d rig order bead(s), want 0", len(cityRuns))
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	work := workBeadByOrderLabel(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if work.Metadata["gc.routed_to"] != "frontend/worker" {
+		t.Errorf("gc.routed_to = %q, want %q", work.Metadata["gc.routed_to"], "frontend/worker")
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve each order's bead store target before gate checks, tracking bead creation, wisp instantiation, and exec dispatch
- set exec order BEADS_DIR/Dolt env from the selected city or rig bead runtime env
- make order check/history read from the same per-order target store

Fixes #137.

## Verification
- go test ./cmd/gc -run 'Test(OrderDispatch|BuildOrderDispatcher|OrderRun|OrderCheck|OrderHistory|ResolveOrderExecTarget)' -count=1
- go vet ./cmd/gc
- go test ./cmd/gc timed out at the default 10m package timeout in unrelated managed-BD coverage; the timed-out test passed in isolation: go test ./cmd/gc -run '^TestManagedExecBdRigStoreConsistentAcrossRawBdAndProviderStore$' -count=1 -timeout=2m