### PR TITLE
Allow check in place of ralph in formulas

### DIFF
--- a/cmd/gc/testdata/formulas/ralph-demo.toml
+++ b/cmd/gc/testdata/formulas/ralph-demo.toml
@@ -1,17 +1,17 @@
 formula = "ralph-demo"
-description = "Minimal inline Ralph demo"
+description = "Minimal inline Check demo"
 
 [[steps]]
 id = "implement"
 title = "Write demo output"
 description = """
-Create the Ralph demo output artifact.
+Create the Check demo output artifact.
 """
 
-[steps.ralph]
+[steps.check]
 max_attempts = 2
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gc/scripts/ralph-check.sh"
 timeout = "30s"

--- a/cmd/gc/testdata/formulas/ralph-retry-demo.toml
+++ b/cmd/gc/testdata/formulas/ralph-retry-demo.toml
@@ -1,5 +1,5 @@
 formula = "ralph-retry-demo"
-description = "Inline Ralph demo that fails once and then passes"
+description = "Inline Check demo that fails once and then passes"
 
 [[steps]]
 id = "implement"
@@ -8,10 +8,10 @@ description = """
 Create the retry demo output artifact.
 """
 
-[steps.ralph]
+[steps.check]
 max_attempts = 2
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gc/scripts/ralph-retry-check.sh"
 timeout = "30s"

--- a/docs/reference/formula.md
+++ b/docs/reference/formula.md
@@ -62,7 +62,7 @@ molecule.
 | `condition` | string | Equality expression (`{{var}} == value` or `!=`) — step is excluded when false |
 | `children` | []step | Nested sub-steps; parent acts as a container dependency |
 | `loop` | object | Static loop expansion: `count` iterations at compile time |
-| `ralph` | object | Runtime retry: `max_attempts` with a `check` script after each attempt |
+| `check` | object | Runtime retry: `max_attempts` with a `check` script after each attempt |
 
 ## Variable Substitution
 

--- a/docs/tutorials/05-formulas.md
+++ b/docs/tutorials/05-formulas.md
@@ -451,17 +451,16 @@ Steps (4):
 ```
 
 Each iteration is materialized as its own step. There's no way to break out
-early — all iterations are baked into the recipe up front. If you need "try
-until it works" behavior, that's what Ralph is for.
+early — all iterations are baked into the recipe up front.
 
-### Ralph
+### Check
 
 Once a formula is cooked, conditions have been evaluated and loops have been
 expanded — all of that is decided up front. But sometimes you need a decision at
 runtime: did this step actually work?
 
-That's what Ralph does. After the agent finishes a step, Gas City runs a check
-script. If the check passes, the step is done. If not, the agent tries again.
+Check runs a validation script after the agent finishes a step. If the script
+passes, the step is done. If not, the agent tries again.
 The check runs after each attempt, while the formula is still executing — it's a
 runtime feedback loop, not a compile-time expansion.
 
@@ -470,10 +469,10 @@ runtime feedback loop, not a compile-time expansion.
 id = "implement"
 title = "Implement the feature"
 
-[steps.ralph]
+[steps.check]
 max_attempts = 2
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = "scripts/verify.sh"
 timeout = "30s"
@@ -488,7 +487,7 @@ times total. If all attempts fail, the step fails.
 
 That covers the core of formulas — defining steps, wiring dependencies,
 parameterizing with variables, and controlling execution with conditions, loops,
-and Ralph.
+and Check.
 
 ## What's next
 

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -267,7 +267,7 @@ title = "Scan"
 	}
 }
 
-func TestCompileRalphMarksWorkflowRootAndBlocksOnTopLevelSteps(t *testing.T) {
+func TestCompileCheckSyntaxMarksWorkflowRootAndBlocksOnTopLevelSteps(t *testing.T) {
 	prev := IsFormulaV2Enabled()
 	SetFormulaV2Enabled(true)
 	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
@@ -286,10 +286,10 @@ id = "implement"
 title = "Implement"
 needs = ["design"]
 
-[steps.ralph]
+[steps.check]
 max_attempts = 2
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gascity/checks/widget.sh"
 timeout = "30s"

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1339,6 +1339,414 @@ func TestParse_GateInChildStep(t *testing.T) {
 	}
 }
 
+func TestParseTOML_CheckCanonicalAlias(t *testing.T) {
+	tomlData := `
+formula = "mol-check"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "implement"
+title = "Implement"
+
+[steps.check]
+max_attempts = 2
+
+[steps.check.check]
+mode = "exec"
+path = "scripts/verify.sh"
+timeout = "30s"
+`
+
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+
+	step := formula.Steps[0]
+	if step.Ralph == nil {
+		t.Fatal("Steps[0].Ralph is nil")
+	}
+	if step.Ralph.MaxAttempts != 2 {
+		t.Fatalf("Steps[0].Ralph.MaxAttempts = %d, want 2", step.Ralph.MaxAttempts)
+	}
+	if step.Ralph.Check == nil {
+		t.Fatal("Steps[0].Ralph.Check is nil")
+	}
+	if step.Ralph.Check.Mode != "exec" {
+		t.Fatalf("Steps[0].Ralph.Check.Mode = %q, want exec", step.Ralph.Check.Mode)
+	}
+	if step.Ralph.Check.Path != "scripts/verify.sh" {
+		t.Fatalf("Steps[0].Ralph.Check.Path = %q, want scripts/verify.sh", step.Ralph.Check.Path)
+	}
+	if step.Ralph.Check.Timeout != "30s" {
+		t.Fatalf("Steps[0].Ralph.Check.Timeout = %q, want 30s", step.Ralph.Check.Timeout)
+	}
+}
+
+func TestParseJSON_CheckCanonicalAlias(t *testing.T) {
+	jsonData := `{
+  "formula": "mol-check",
+  "version": 1,
+  "type": "workflow",
+  "steps": [
+    {
+      "id": "implement",
+      "title": "Implement",
+      "check": {
+        "max_attempts": 2,
+        "check": {
+          "mode": "exec",
+          "path": "scripts/verify.sh",
+          "timeout": "30s"
+        }
+      }
+    }
+  ]
+}`
+
+	p := NewParser()
+	formula, err := p.Parse([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+
+	step := formula.Steps[0]
+	if step.Ralph == nil || step.Ralph.Check == nil {
+		t.Fatalf("parsed check alias = %+v, want populated Ralph spec", step.Ralph)
+	}
+	if step.Ralph.MaxAttempts != 2 {
+		t.Fatalf("Steps[0].Ralph.MaxAttempts = %d, want 2", step.Ralph.MaxAttempts)
+	}
+	if step.Ralph.Check.Path != "scripts/verify.sh" {
+		t.Fatalf("Steps[0].Ralph.Check.Path = %q, want scripts/verify.sh", step.Ralph.Check.Path)
+	}
+}
+
+func TestParseJSON_CheckNullBehavesLikeOmittedAlias(t *testing.T) {
+	jsonData := `{
+  "formula": "mol-check-null",
+  "version": 1,
+  "type": "workflow",
+  "steps": [
+    {
+      "id": "implement",
+      "title": "Implement",
+      "check": null
+    }
+  ]
+}`
+
+	p := NewParser()
+	formula, err := p.Parse([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+	if formula.Steps[0].Ralph != nil {
+		t.Fatalf("Steps[0].Ralph = %+v, want nil for check:null", formula.Steps[0].Ralph)
+	}
+}
+
+func TestParseTOML_RalphLegacyAliasStillWorks(t *testing.T) {
+	tomlData := `
+formula = "mol-legacy-ralph"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "implement"
+title = "Implement"
+
+[steps.ralph]
+max_attempts = 2
+comment = "ignored by legacy alias"
+
+[steps.ralph.check]
+mode = "exec"
+path = "scripts/verify.sh"
+`
+
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+
+	step := formula.Steps[0]
+	if step.Ralph == nil || step.Ralph.Check == nil {
+		t.Fatalf("parsed legacy alias = %+v, want populated Ralph spec", step.Ralph)
+	}
+	if step.Ralph.MaxAttempts != 2 {
+		t.Fatalf("Steps[0].Ralph.MaxAttempts = %d, want 2", step.Ralph.MaxAttempts)
+	}
+	if step.Ralph.Check.Mode != "exec" {
+		t.Fatalf("Steps[0].Ralph.Check.Mode = %q, want exec", step.Ralph.Check.Mode)
+	}
+}
+
+func TestParseTOML_ChildTagsSurviveCustomStepDecoding(t *testing.T) {
+	tomlData := `
+formula = "mol-child-tags"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "parent"
+title = "Parent"
+tags = ["root-tag"]
+
+[[steps.children]]
+id = "child"
+title = "Child"
+tags = ["child-tag"]
+`
+
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+
+	parent := formula.Steps[0]
+	if len(parent.Labels) != 1 || parent.Labels[0] != "root-tag" {
+		t.Fatalf("parent labels = %v, want [root-tag]", parent.Labels)
+	}
+	if len(parent.Children) != 1 {
+		t.Fatalf("len(parent.Children) = %d, want 1", len(parent.Children))
+	}
+	child := parent.Children[0]
+	if len(child.Labels) != 1 || child.Labels[0] != "child-tag" {
+		t.Fatalf("child labels = %v, want [child-tag]", child.Labels)
+	}
+}
+
+func TestParseTOML_ChildCheckAliasParses(t *testing.T) {
+	tomlData := `
+formula = "mol-child-check"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "parent"
+title = "Parent"
+
+[[steps.children]]
+id = "child"
+title = "Child"
+
+[steps.children.check]
+max_attempts = 2
+
+[steps.children.check.check]
+mode = "exec"
+path = "scripts/verify.sh"
+`
+
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+
+	child := formula.Steps[0].Children[0]
+	if child.Ralph == nil || child.Ralph.Check == nil {
+		t.Fatalf("child check alias = %+v, want populated Ralph spec", child.Ralph)
+	}
+	if child.Ralph.MaxAttempts != 2 {
+		t.Fatalf("child max_attempts = %d, want 2", child.Ralph.MaxAttempts)
+	}
+	if child.Ralph.Check.Path != "scripts/verify.sh" {
+		t.Fatalf("child check path = %q, want scripts/verify.sh", child.Ralph.Check.Path)
+	}
+}
+
+func TestParseJSON_RalphLegacyAliasStillWorks(t *testing.T) {
+	jsonData := `{
+  "formula": "mol-legacy-ralph",
+  "version": 1,
+  "type": "workflow",
+  "steps": [
+    {
+      "id": "implement",
+      "title": "Implement",
+      "ralph": {
+        "max_attempts": 2,
+        "check": {
+          "mode": "exec",
+          "path": "scripts/verify.sh"
+        }
+      }
+    }
+  ]
+}`
+
+	p := NewParser()
+	formula, err := p.Parse([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+
+	step := formula.Steps[0]
+	if step.Ralph == nil || step.Ralph.Check == nil {
+		t.Fatalf("parsed legacy alias = %+v, want populated Ralph spec", step.Ralph)
+	}
+	if step.Ralph.Check.Path != "scripts/verify.sh" {
+		t.Fatalf("Steps[0].Ralph.Check.Path = %q, want scripts/verify.sh", step.Ralph.Check.Path)
+	}
+}
+
+func TestParseTOML_CheckAndRalphMixedRejected(t *testing.T) {
+	tomlData := `
+formula = "mol-check-mixed"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "implement"
+title = "Implement"
+
+[steps.check]
+max_attempts = 2
+
+[steps.ralph.check]
+mode = "exec"
+path = "scripts/verify.sh"
+`
+
+	p := NewParser()
+	_, err := p.ParseTOML([]byte(tomlData))
+	if err == nil {
+		t.Fatal("ParseTOML succeeded, want mixed check/ralph rejection")
+	}
+	if !strings.Contains(err.Error(), "step.check: cannot be specified more than once") {
+		t.Fatalf("ParseTOML error = %v, want duplicate check spelling rejection", err)
+	}
+}
+
+func TestParseJSON_CheckAndRalphMixedRejected(t *testing.T) {
+	jsonData := `{
+  "formula": "mol-check-mixed",
+  "version": 1,
+  "type": "workflow",
+  "steps": [
+    {
+      "id": "implement",
+      "title": "Implement",
+      "check": {
+        "max_attempts": 2,
+        "check": {
+          "mode": "exec",
+          "path": "scripts/verify.sh"
+        }
+      },
+      "ralph": {
+        "max_attempts": 2,
+        "check": {
+          "mode": "exec",
+          "path": "scripts/verify.sh"
+        }
+      }
+    }
+  ]
+}`
+
+	p := NewParser()
+	_, err := p.Parse([]byte(jsonData))
+	if err == nil {
+		t.Fatal("Parse succeeded, want mixed check/ralph rejection")
+	}
+	if !strings.Contains(err.Error(), "step.check: cannot be specified more than once") {
+		t.Fatalf("Parse error = %v, want duplicate check spelling rejection", err)
+	}
+}
+
+func TestParseTOML_CheckHybridExecTableRejected(t *testing.T) {
+	tomlData := `
+formula = "mol-check-hybrid"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "implement"
+title = "Implement"
+
+[steps.check]
+max_attempts = 2
+
+[steps.check.exec]
+path = "scripts/verify.sh"
+`
+
+	p := NewParser()
+	_, err := p.ParseTOML([]byte(tomlData))
+	if err == nil {
+		t.Fatal("ParseTOML succeeded, want hybrid exec table rejection")
+	}
+	if !strings.Contains(err.Error(), `step.check: unsupported key "exec"`) {
+		t.Fatalf("ParseTOML error = %v, want unsupported exec table rejection", err)
+	}
+}
+
+func TestValidateRalphUsesCheckTerminology(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-bad-check",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{
+				ID:    "implement",
+				Title: "Implement",
+				Ralph: &RalphSpec{
+					MaxAttempts: 0,
+					Check: &RalphCheckSpec{
+						Mode: "invalid",
+					},
+				},
+				Retry: &RetrySpec{MaxAttempts: 2},
+			},
+		},
+	}
+
+	err := formula.Validate()
+	if err == nil {
+		t.Fatal("Validate succeeded, want check validation errors")
+	}
+	if !strings.Contains(err.Error(), "steps[0] (implement).check: max_attempts must be >= 1") {
+		t.Fatalf("Validate error = %v, want check max_attempts wording", err)
+	}
+	if !strings.Contains(err.Error(), `steps[0] (implement).check.check: unsupported mode "invalid" (only exec is supported)`) {
+		t.Fatalf("Validate error = %v, want check.check mode wording", err)
+	}
+	if !strings.Contains(err.Error(), "steps[0] (implement).check.check: path is required") {
+		t.Fatalf("Validate error = %v, want check.check path wording", err)
+	}
+	if !strings.Contains(err.Error(), "steps[0] (implement): check cannot be combined with retry") {
+		t.Fatalf("Validate error = %v, want check incompatibility wording", err)
+	}
+	if strings.Contains(err.Error(), ".ralph") || strings.Contains(err.Error(), " ralph ") {
+		t.Fatalf("Validate error = %v, want user-facing check terminology only", err)
+	}
+}
+
 // TestParseTOML_SnakeCaseFields verifies that snake_case fields like depends_on
 // are correctly parsed from TOML. This tests the fix for GitHub issue #1449.
 func TestParseTOML_SnakeCaseFields(t *testing.T) {

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1706,6 +1706,71 @@ path = "scripts/verify.sh"
 	}
 }
 
+func TestParseTOML_ChildCheckHybridExecTableRejected(t *testing.T) {
+	tomlData := `
+formula = "mol-child-check-hybrid"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "parent"
+title = "Parent"
+
+[[steps.children]]
+id = "child"
+title = "Child"
+
+[steps.children.check]
+max_attempts = 2
+
+[steps.children.check.exec]
+path = "scripts/verify.sh"
+`
+
+	p := NewParser()
+	_, err := p.ParseTOML([]byte(tomlData))
+	if err == nil {
+		t.Fatal("ParseTOML succeeded, want nested hybrid exec table rejection")
+	}
+	if !strings.Contains(err.Error(), `step.check: unsupported key "exec"`) {
+		t.Fatalf("ParseTOML error = %v, want unsupported exec table rejection", err)
+	}
+}
+
+func TestParseTOML_LoopBodyCheckHybridExecTableRejected(t *testing.T) {
+	tomlData := `
+formula = "mol-loop-check-hybrid"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "loop"
+title = "Loop"
+
+[steps.loop]
+count = 2
+
+[[steps.loop.body]]
+id = "attempt"
+title = "Attempt"
+
+[steps.loop.body.check]
+max_attempts = 2
+
+[steps.loop.body.check.exec]
+path = "scripts/verify.sh"
+`
+
+	p := NewParser()
+	_, err := p.ParseTOML([]byte(tomlData))
+	if err == nil {
+		t.Fatal("ParseTOML succeeded, want loop body hybrid exec table rejection")
+	}
+	if !strings.Contains(err.Error(), `step.check: unsupported key "exec"`) {
+		t.Fatalf("ParseTOML error = %v, want unsupported exec table rejection", err)
+	}
+}
+
 func TestValidateRalphUsesCheckTerminology(t *testing.T) {
 	formula := &Formula{
 		Formula: "mol-bad-check",

--- a/internal/formula/ralph.go
+++ b/internal/formula/ralph.go
@@ -63,6 +63,9 @@ func expandRalph(step *Step) ([]*Step, error) {
 	control := cloneStep(step)
 	control.Ralph = nil
 	control.Children = nil
+	// Runtime control metadata keeps legacy ralph keys so existing controller
+	// and dispatch paths remain stable while the public formula surface uses
+	// the canonical "check" spelling.
 	control.Metadata = withMetadata(control.Metadata, map[string]string{
 		"gc.kind":          "ralph",
 		"gc.step_id":       step.ID,
@@ -85,6 +88,8 @@ func expandRalph(step *Step) ([]*Step, error) {
 	iteration.Ralph = nil
 	iteration.OnComplete = nil
 	iteration.Children = nil
+	// These runtime keys are internal control-bead metadata, not user-facing
+	// formula syntax, so they intentionally retain legacy ralph naming.
 	iteration.Metadata = withMetadata(iteration.Metadata, map[string]string{
 		"gc.attempt":       strconv.Itoa(attempt),
 		"gc.step_id":       step.ID,

--- a/internal/formula/source_spec.go
+++ b/internal/formula/source_spec.go
@@ -11,6 +11,8 @@ func newSourceSpecStep(step *Step) (*Step, error) {
 	if step == nil {
 		return nil, fmt.Errorf("serializing step spec: missing step")
 	}
+	// Stored step snapshots intentionally preserve legacy JSON field names so
+	// in-flight beads remain readable across mixed-version rollouts.
 	specJSON, err := json.Marshal(step)
 	if err != nil {
 		return nil, fmt.Errorf("serializing step spec for %q: %w", step.ID, err)

--- a/internal/formula/source_spec_test.go
+++ b/internal/formula/source_spec_test.go
@@ -76,6 +76,16 @@ func TestApplyRalphEmitsSpecBeadInsteadOfInlineSourceSpec(t *testing.T) {
 	if got := control.Metadata["gc.source_step_spec"]; got != "" {
 		t.Fatalf("control gc.source_step_spec = %q, want empty; source spec must live in spec bead", got)
 	}
+	var frozenRaw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(spec.Description), &frozenRaw); err != nil {
+		t.Fatalf("unmarshal frozen raw spec: %v", err)
+	}
+	if _, ok := frozenRaw["ralph"]; !ok {
+		t.Fatalf("frozen raw spec = %v, want legacy ralph key for compatibility", frozenRaw)
+	}
+	if _, ok := frozenRaw["check"]; ok {
+		t.Fatalf("frozen raw spec unexpectedly wrote canonical check key")
+	}
 	assertFrozenSpecStep(t, spec, "converge", func(frozen Step) {
 		if frozen.Ralph == nil || frozen.Ralph.MaxAttempts != 5 {
 			t.Fatalf("frozen ralph = %+v, want max_attempts=5", frozen.Ralph)
@@ -183,10 +193,10 @@ title = "Converge"
 type = "task"
 needs = ["review"]
 
-[steps.ralph]
+[steps.check]
 max_attempts = 2
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = "check.sh"
 `

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -28,6 +28,7 @@
 package formula
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -267,6 +268,9 @@ type Step struct {
 	// Ralph wraps this step in an inline run/check retry loop.
 	// The original step becomes a logical container, and the actionable work is
 	// emitted as first-class graph steps.
+	// JSON storage intentionally retains the legacy "ralph" field name for
+	// backward-compatible step snapshots; the parser also accepts canonical
+	// public "check" input.
 	Ralph *RalphSpec `json:"ralph,omitempty" toml:"ralph,omitempty"`
 
 	// Retry wraps an executable step in an inline attempt/eval retry loop.
@@ -284,6 +288,268 @@ type Step struct {
 	// SourceLocation is the path within the source formula.
 	// Format: "steps[0]", "steps[2].children[1]", "advice[0].after", "loop.body[0]"
 	SourceLocation string `json:"-"` // Internal only, not serialized to JSON
+}
+
+// UnmarshalJSON accepts the canonical public "check" spelling while keeping the
+// internal runtime field wired through Ralph.
+func (s *Step) UnmarshalJSON(data []byte) error {
+	type stepAlias Step
+
+	var decoded stepAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*s = Step(decoded)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	rawCheck, hasCheck := raw["check"]
+	rawRalph, hasRalph := raw["ralph"]
+	return s.normalizeCheckAlias(hasCheck, rawCheck, hasRalph, rawRalph)
+}
+
+// UnmarshalTOML accepts the canonical public "check" spelling while keeping the
+// internal runtime field wired through Ralph.
+func (s *Step) UnmarshalTOML(data interface{}) error {
+	raw, ok := data.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("type mismatch for formula.Step: expected table but found %T", data)
+	}
+
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("encode formula.Step: %w", err)
+	}
+
+	var decoded stepTOMLAlias
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return fmt.Errorf("decode formula.Step: %w", err)
+	}
+	step, err := decoded.toStep()
+	if err != nil {
+		return err
+	}
+	*s = step
+
+	rawCheck, hasCheck := raw["check"]
+	rawRalph, hasRalph := raw["ralph"]
+	return s.normalizeCheckAlias(hasCheck, rawCheck, hasRalph, rawRalph)
+}
+
+func (s *Step) normalizeCheckAlias(hasCheck bool, rawCheck interface{}, hasRalph bool, rawRalph interface{}) error {
+	if hasCheck && hasRalph {
+		return fmt.Errorf("step.check: cannot be specified more than once")
+	}
+
+	switch {
+	case hasCheck:
+		spec, err := decodePublicCheckSpec(rawCheck)
+		if err != nil {
+			return err
+		}
+		s.Ralph = spec
+	case hasRalph:
+		if err := validatePublicCheckSpecShape(rawRalph); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type stepTOMLAlias struct {
+	ID              string            `json:"id"`
+	Title           string            `json:"title"`
+	Description     string            `json:"description,omitempty"`
+	DescriptionFile string            `json:"description_file,omitempty"`
+	Notes           string            `json:"notes,omitempty"`
+	Type            string            `json:"type,omitempty"`
+	Priority        *int              `json:"priority,omitempty"`
+	Labels          []string          `json:"tags,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	DependsOn       []string          `json:"depends_on,omitempty"`
+	Needs           []string          `json:"needs,omitempty"`
+	WaitsFor        string            `json:"waits_for,omitempty"`
+	Assignee        string            `json:"assignee,omitempty"`
+	Expand          string            `json:"expand,omitempty"`
+	ExpandVars      map[string]string `json:"expand_vars,omitempty"`
+	Condition       string            `json:"condition,omitempty"`
+	Children        []*stepTOMLAlias  `json:"children,omitempty"`
+	Gate            *Gate             `json:"gate,omitempty"`
+	Loop            *loopTOMLAlias    `json:"loop,omitempty"`
+	OnComplete      *OnCompleteSpec   `json:"on_complete,omitempty"`
+	Check           *RalphSpec        `json:"check,omitempty"`
+	Ralph           *RalphSpec        `json:"ralph,omitempty"`
+	Retry           *RetrySpec        `json:"retry,omitempty"`
+}
+
+type loopTOMLAlias struct {
+	Count int              `json:"count,omitempty"`
+	Until string           `json:"until,omitempty"`
+	Max   int              `json:"max,omitempty"`
+	Range string           `json:"range,omitempty"`
+	Var   string           `json:"var,omitempty"`
+	Body  []*stepTOMLAlias `json:"body"`
+}
+
+func (a stepTOMLAlias) toStep() (Step, error) {
+	if a.Check != nil && a.Ralph != nil {
+		return Step{}, fmt.Errorf("step.check: cannot be specified more than once")
+	}
+
+	children := make([]*Step, 0, len(a.Children))
+	for _, child := range a.Children {
+		if child == nil {
+			continue
+		}
+		step, err := child.toStep()
+		if err != nil {
+			return Step{}, err
+		}
+		children = append(children, &step)
+	}
+
+	ralph := a.Ralph
+	if a.Check != nil {
+		ralph = a.Check
+	}
+	loop, err := a.Loop.toLoopSpec()
+	if err != nil {
+		return Step{}, err
+	}
+
+	return Step{
+		ID:              a.ID,
+		Title:           a.Title,
+		Description:     a.Description,
+		DescriptionFile: a.DescriptionFile,
+		Notes:           a.Notes,
+		Type:            a.Type,
+		Priority:        a.Priority,
+		Labels:          a.Labels,
+		Metadata:        a.Metadata,
+		DependsOn:       a.DependsOn,
+		Needs:           a.Needs,
+		WaitsFor:        a.WaitsFor,
+		Assignee:        a.Assignee,
+		Expand:          a.Expand,
+		ExpandVars:      a.ExpandVars,
+		Condition:       a.Condition,
+		Children:        children,
+		Gate:            a.Gate,
+		Loop:            loop,
+		OnComplete:      a.OnComplete,
+		Ralph:           ralph,
+		Retry:           a.Retry,
+	}, nil
+}
+
+func (a *loopTOMLAlias) toLoopSpec() (*LoopSpec, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	body := make([]*Step, 0, len(a.Body))
+	for _, child := range a.Body {
+		if child == nil {
+			continue
+		}
+		step, err := child.toStep()
+		if err != nil {
+			return nil, err
+		}
+		body = append(body, &step)
+	}
+
+	return &LoopSpec{
+		Count: a.Count,
+		Until: a.Until,
+		Max:   a.Max,
+		Range: a.Range,
+		Var:   a.Var,
+		Body:  body,
+	}, nil
+}
+
+func decodePublicCheckSpec(raw interface{}) (*RalphSpec, error) {
+	if err := validatePublicCheckSpecShape(raw); err != nil {
+		return nil, err
+	}
+
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("step.check: encode spec: %w", err)
+	}
+	if string(encoded) == "null" {
+		return nil, nil
+	}
+
+	var spec RalphSpec
+	if err := json.Unmarshal(encoded, &spec); err != nil {
+		return nil, fmt.Errorf("step.check: decode spec: %w", err)
+	}
+	return &spec, nil
+}
+
+func validatePublicCheckSpecShape(raw interface{}) error {
+	if raw == nil {
+		return nil
+	}
+
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("step.check: encode spec: %w", err)
+	}
+	if string(encoded) == "null" {
+		return nil
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &spec); err != nil {
+		return fmt.Errorf("step.check: expected an object")
+	}
+
+	for key, value := range spec {
+		switch key {
+		case "max_attempts":
+			continue
+		case "check":
+			if err := validatePublicCheckBodyShape(value); err != nil {
+				return err
+			}
+		case "exec", "inference":
+			return fmt.Errorf("step.check: unsupported key %q (expected max_attempts or check)", key)
+		default:
+			continue
+		}
+	}
+
+	return nil
+}
+
+func validatePublicCheckBodyShape(raw json.RawMessage) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("step.check.check: expected an object")
+	}
+
+	for key := range body {
+		switch key {
+		case "exec", "inference":
+			return fmt.Errorf("step.check.check: unsupported key %q (expected mode, path, or timeout)", key)
+		default:
+			continue
+		}
+	}
+
+	return nil
 }
 
 // Gate defines an async wait condition for formula steps.
@@ -861,38 +1127,38 @@ func validateOnComplete(oc *OnCompleteSpec, errs *[]string, prefix string) {
 
 func validateRalph(spec *RalphSpec, errs *[]string, prefix string, step *Step) {
 	if spec.MaxAttempts < 1 {
-		*errs = append(*errs, fmt.Sprintf("%s.ralph: max_attempts must be >= 1", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s.check: max_attempts must be >= 1", prefix))
 	}
 	if spec.Check == nil {
-		*errs = append(*errs, fmt.Sprintf("%s.ralph: check is required", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s.check: check is required", prefix))
 	} else {
 		if spec.Check.Mode == "" {
-			*errs = append(*errs, fmt.Sprintf("%s.ralph.check: mode is required", prefix))
+			*errs = append(*errs, fmt.Sprintf("%s.check.check: mode is required", prefix))
 		} else if spec.Check.Mode != "exec" {
-			*errs = append(*errs, fmt.Sprintf("%s.ralph.check: unsupported mode %q (only exec is supported)", prefix, spec.Check.Mode))
+			*errs = append(*errs, fmt.Sprintf("%s.check.check: unsupported mode %q (only exec is supported)", prefix, spec.Check.Mode))
 		}
 		if spec.Check.Path == "" {
-			*errs = append(*errs, fmt.Sprintf("%s.ralph.check: path is required", prefix))
+			*errs = append(*errs, fmt.Sprintf("%s.check.check: path is required", prefix))
 		}
 	}
 
 	if step.Loop != nil {
-		*errs = append(*errs, fmt.Sprintf("%s: ralph cannot be combined with loop", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: check cannot be combined with loop", prefix))
 	}
 	if step.OnComplete != nil {
-		*errs = append(*errs, fmt.Sprintf("%s: ralph cannot be combined with on_complete", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: check cannot be combined with on_complete", prefix))
 	}
 	if step.Gate != nil {
-		*errs = append(*errs, fmt.Sprintf("%s: ralph cannot be combined with gate", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: check cannot be combined with gate", prefix))
 	}
 	if step.Expand != "" {
-		*errs = append(*errs, fmt.Sprintf("%s: ralph cannot be combined with expand", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: check cannot be combined with expand", prefix))
 	}
 	if step.Assignee != "" {
-		*errs = append(*errs, fmt.Sprintf("%s: ralph cannot be combined with assignee (route work via gc.run_target instead)", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: check cannot be combined with assignee (route work via gc.run_target instead)", prefix))
 	}
 	if step.Retry != nil {
-		*errs = append(*errs, fmt.Sprintf("%s: ralph cannot be combined with retry", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: check cannot be combined with retry", prefix))
 	}
 }
 
@@ -907,7 +1173,7 @@ func validateRetry(spec *RetrySpec, errs *[]string, prefix string, step *Step) {
 	}
 
 	if step.Ralph != nil {
-		*errs = append(*errs, fmt.Sprintf("%s: retry cannot be combined with ralph", prefix))
+		*errs = append(*errs, fmt.Sprintf("%s: retry cannot be combined with check", prefix))
 	}
 	if step.Loop != nil {
 		*errs = append(*errs, fmt.Sprintf("%s: retry cannot be combined with loop", prefix))

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -381,8 +381,8 @@ type stepTOMLAlias struct {
 	Gate            *Gate             `json:"gate,omitempty"`
 	Loop            *loopTOMLAlias    `json:"loop,omitempty"`
 	OnComplete      *OnCompleteSpec   `json:"on_complete,omitempty"`
-	Check           *RalphSpec        `json:"check,omitempty"`
-	Ralph           *RalphSpec        `json:"ralph,omitempty"`
+	Check           json.RawMessage   `json:"check,omitempty"`
+	Ralph           json.RawMessage   `json:"ralph,omitempty"`
 	Retry           *RetrySpec        `json:"retry,omitempty"`
 }
 
@@ -396,7 +396,9 @@ type loopTOMLAlias struct {
 }
 
 func (a stepTOMLAlias) toStep() (Step, error) {
-	if a.Check != nil && a.Ralph != nil {
+	hasCheck := len(a.Check) > 0
+	hasRalph := len(a.Ralph) > 0
+	if hasCheck && hasRalph {
 		return Step{}, fmt.Errorf("step.check: cannot be specified more than once")
 	}
 
@@ -412,9 +414,20 @@ func (a stepTOMLAlias) toStep() (Step, error) {
 		children = append(children, &step)
 	}
 
-	ralph := a.Ralph
-	if a.Check != nil {
-		ralph = a.Check
+	var ralph *RalphSpec
+	switch {
+	case hasCheck:
+		spec, err := decodePublicCheckSpec(a.Check)
+		if err != nil {
+			return Step{}, err
+		}
+		ralph = spec
+	case hasRalph:
+		spec, err := decodePublicCheckSpec(a.Ralph)
+		if err != nil {
+			return Step{}, err
+		}
+		ralph = spec
 	}
 	loop, err := a.Loop.toLoopSpec()
 	if err != nil {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1090,14 +1090,14 @@ depends_on = ["implement"]
 	}
 }
 
-func TestCookEndToEndRalph(t *testing.T) {
+func TestCookEndToEndCheckSyntax(t *testing.T) {
 	prev := formula.IsFormulaV2Enabled()
 	formula.SetFormulaV2Enabled(true)
 	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
 	dir := t.TempDir()
 	toml := `
 formula = "ralph-demo"
-description = "Ralph cook test"
+description = "Check cook test"
 
 [[steps]]
 id = "design"
@@ -1111,10 +1111,10 @@ needs = ["design"]
 [steps.metadata]
 custom = "value"
 
-[steps.ralph]
+[steps.check]
 max_attempts = 3
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gascity/checks/widget.sh"
 timeout = "2m"

--- a/internal/testfixtures/reviewworkflows/fixtures.go
+++ b/internal/testfixtures/reviewworkflows/fixtures.go
@@ -169,7 +169,7 @@ on_exhausted = "hard_fail"
 // AdoptPR is the test-local adopt-pr workflow fixture.
 const AdoptPR = `description = """
 Test-local adopt-pr workflow used by integration tests.
-Exercises a body scope, setup retries, a Ralph loop, compose.expand fan-out,
+Exercises a body scope, setup retries, a Check loop, compose.expand fan-out,
 Gemini soft-fail retries, finalize, and teardown.
 """
 formula = "mol-adopt-pr-v2"
@@ -220,13 +220,13 @@ on_exhausted = "hard_fail"
 id = "review-loop"
 title = "Review loop"
 needs = ["rebase-check"]
-description = "Ralph loop for iterative review and fixes."
+description = "Check loop for iterative review and fixes."
 metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "member", "gc.on_fail" = "abort_scope" }
 
-[steps.ralph]
+[steps.check]
 max_attempts = 5
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gc/scripts/checks/adopt-pr-review-approved.sh"
 timeout = "10m"
@@ -240,7 +240,7 @@ description = "Expanded via compose.expand."
 id = "apply-fixes"
 title = "Apply fixes"
 needs = ["review-pipeline"]
-description = "Apply review feedback and mark the Ralph verdict."
+description = "Apply review feedback and mark the Check verdict."
 
 [steps.children.retry]
 max_attempts = 3
@@ -278,7 +278,7 @@ on_exhausted = "hard_fail"
 // PersonalWork is the test-local personal-work workflow fixture.
 const PersonalWork = `description = """
 Test-local personal-work workflow used by integration tests.
-Exercises two Ralph loops, two compose.expand sites, pooled fan-out,
+Exercises two Check loops, two compose.expand sites, pooled fan-out,
 Gemini soft-fail retries, and body teardown without depending on private
 production formulas.
 """
@@ -332,13 +332,13 @@ on_exhausted = "hard_fail"
 id = "design-review-loop"
 title = "Design review loop"
 needs = ["workspace-setup"]
-description = "Ralph loop for iterative design review."
+description = "Check loop for iterative design review."
 metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "member", "gc.on_fail" = "abort_scope" }
 
-[steps.ralph]
+[steps.check]
 max_attempts = 5
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gc/scripts/checks/design-review-approved.sh"
 timeout = "10m"
@@ -352,7 +352,7 @@ description = "Expanded via compose.expand."
 id = "apply-design-changes"
 title = "Apply design changes"
 needs = ["design-review-pipeline"]
-description = "Apply design review feedback and mark the Ralph verdict."
+description = "Apply design review feedback and mark the Check verdict."
 
 [steps.children.retry]
 max_attempts = 3
@@ -373,13 +373,13 @@ on_exhausted = "hard_fail"
 id = "code-review-loop"
 title = "Code review loop"
 needs = ["implement"]
-description = "Ralph loop for iterative code review."
+description = "Check loop for iterative code review."
 metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "member", "gc.on_fail" = "abort_scope" }
 
-[steps.ralph]
+[steps.check]
 max_attempts = 5
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = ".gc/scripts/checks/code-review-approved.sh"
 timeout = "10m"
@@ -393,7 +393,7 @@ description = "Expanded via compose.expand."
 id = "apply-code-fixes"
 title = "Apply code fixes"
 needs = ["review-pipeline"]
-description = "Apply code review feedback and mark the Ralph verdict."
+description = "Apply code review feedback and mark the Check verdict."
 
 [steps.children.retry]
 max_attempts = 3

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/05-formulas.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/05-formulas.md
@@ -376,23 +376,23 @@ Steps (4):
   └── retry-deploy.retries.iter3.attempt: Try to deploy [needs: retry-deploy.retries.iter2.attempt]
 ```
 
-Each iteration is materialized as its own step. There's no way to break out early — all iterations are baked into the recipe up front. If you need "try until it works" behavior, that's what Ralph is for.
+Each iteration is materialized as its own step. There's no way to break out early — all iterations are baked into the recipe up front.
 
-### Ralph
+### Check
 
 Once a formula is cooked, conditions have been evaluated and loops have been expanded — all of that is decided up front. But sometimes you need a decision at runtime: did this step actually work?
 
-That's what Ralph does. After the agent finishes a step, Gas City runs a check script. If the check passes, the step is done. If not, the agent tries again. The check runs after each attempt, while the formula is still executing — it's a runtime feedback loop, not a compile-time expansion.
+Check runs a validation script after the agent finishes a step. If the script passes, the step is done. If not, the agent tries again. The check runs after each attempt, while the formula is still executing — it's a runtime feedback loop, not a compile-time expansion.
 
 ```toml
 [[steps]]
 id = "implement"
 title = "Implement the feature"
 
-[steps.ralph]
+[steps.check]
 max_attempts = 2
 
-[steps.ralph.check]
+[steps.check.check]
 mode = "exec"
 path = "scripts/verify.sh"
 timeout = "30s"
@@ -402,7 +402,7 @@ Here's what happens: the agent works on "implement." When it finishes, Gas City 
 
 ---
 
-That covers the core of formulas — defining steps, wiring dependencies, parameterizing with variables, and controlling execution with conditions, loops, and Ralph.
+That covers the core of formulas — defining steps, wiring dependencies, parameterizing with variables, and controlling execution with conditions, loops, and Check.
 
 ## What's next
 
@@ -535,7 +535,7 @@ When you run `gc formula show` or `gc formula cook`, the formula passes through 
 8. Filter steps by condition
 9. Materialize expansion formulas
 10. Expand retry specifications
-11. Expand Ralph patterns
+11. Expand Check patterns
 12. Convert to recipe (flatten, namespace, order)
 
 The output is a **recipe** — a flattened, ordered list of steps with fully resolved dependency edges and namespaced IDs. Variables are still placeholders at this point; they get substituted when the recipe is instantiated into beads.


### PR DESCRIPTION
## Summary
- make `steps.check` the canonical public formula spelling for the existing `steps.ralph` run/check construct
- keep `steps.ralph` as a hidden compatibility alias in TOML and legacy JSON while rejecting mixed canonical/legacy forms
- update public docs, examples, fixtures, and validation wording to use `check` while preserving internal/runtime `ralph` naming and stored compatibility fields

## Testing
- `go test ./internal/formula ./internal/molecule ./test/docsync`
- `go test -tags acceptance_c ./test/acceptance/tutorial_goldens -run 'TestTutorialCommandInventoryMatchesPinnedDocs|TestTutorialContinuity_FormulasIntroducesWorkerBeforeUse'`
- isolated blocker/major review reruns returned `No blocker or major findings.`

## Integration Note
- `make test-integration` is currently red here because of an unrelated timeout in `internal/runtime/tmux.TestGetAllDescendants`
- reproduced on this branch and on a fresh clean `origin/main` worktree at `a08adac6`, so this change does not introduce that failure

Closes #597.
