### PR TITLE
fix: detect legacy bd split stores in doctor

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -153,6 +153,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 
 	// Data checks.
 	if cfgErr == nil {
+		d.Register(doctor.NewBDSplitStoreCheck(cityPath))
 		d.Register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
 		d.Register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
@@ -176,6 +177,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			}
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
+			d.Register(doctor.NewRigBDSplitStoreCheck(rig))
 			d.Register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
 			d.Register(doctor.NewRigDoltServerCheck(cityPath, rig, skipDolt))
 			// Custom types check — rig store.

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -22,6 +22,40 @@ func TestDoctorSkipsDoltChecksTreatsExecGcBeadsBdAsBdContract(t *testing.T) {
 	}
 }
 
+func TestDoDoctorReportsLegacyBDSplitStore(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{
+		filepath.Join(cityDir, ".beads", "dolt", "hq", ".dolt"),
+		filepath.Join(cityDir, ".beads", "embeddeddolt", "legacy", ".dolt"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("GC_BEADS", "file")
+	origCityFlag := cityFlag
+	cityFlag = cityDir
+	t.Cleanup(func() { cityFlag = origCityFlag })
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, false, &stdout, &stderr)
+	out := stdout.String() + stderr.String()
+	if !strings.Contains(out, "bd-split-store") {
+		t.Fatalf("doctor output missing bd-split-store check:\n%s", out)
+	}
+	if !strings.Contains(out, "legacy split store") {
+		t.Fatalf("doctor output missing split-store warning:\n%s", out)
+	}
+}
+
 func TestCollectPackDirsEmpty(t *testing.T) {
 	cfg := &config.City{}
 	dirs := collectPackDirs(cfg)

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1,11 +1,13 @@
 package doctor
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -673,6 +675,167 @@ func (c *BeadsStoreCheck) CanFix() bool { return false }
 
 // Fix is a no-op.
 func (c *BeadsStoreCheck) Fix(_ *CheckContext) error { return nil }
+
+// BDSplitStoreCheck warns when legacy bd embedded/server store directories
+// coexist and the inactive store still contains Dolt data.
+type BDSplitStoreCheck struct {
+	name      string
+	scopePath string
+}
+
+// NewBDSplitStoreCheck creates a city-level split-store check.
+func NewBDSplitStoreCheck(scopePath string) *BDSplitStoreCheck {
+	return &BDSplitStoreCheck{name: "bd-split-store", scopePath: scopePath}
+}
+
+// NewRigBDSplitStoreCheck creates a rig-level split-store check.
+func NewRigBDSplitStoreCheck(rig config.Rig) *BDSplitStoreCheck {
+	return &BDSplitStoreCheck{name: "rig:" + rig.Name + ":bd-split-store", scopePath: rig.Path}
+}
+
+func (c *BDSplitStoreCheck) Name() string { return c.name }
+
+func (c *BDSplitStoreCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	beadsDir := filepath.Join(c.scopePath, ".beads")
+	serverDir := filepath.Join(beadsDir, "dolt")
+	embeddedDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	serverExists := splitStoreDirExists(serverDir)
+	embeddedExists := splitStoreDirExists(embeddedDir)
+	if !serverExists || !embeddedExists {
+		r.Status = StatusOK
+		r.Message = "no legacy split store detected"
+		return r
+	}
+
+	serverRepos, serverErr := doltReposUnder(serverDir)
+	embeddedRepos, embeddedErr := doltReposUnder(embeddedDir)
+	if serverErr != nil || embeddedErr != nil {
+		r.Status = StatusWarning
+		r.Message = "could not inspect legacy bd split store directories"
+		r.FixHint = "inspect .beads/dolt and .beads/embeddeddolt manually before deleting either directory"
+		if serverErr != nil {
+			r.Details = append(r.Details, fmt.Sprintf("scan .beads/dolt: %v", serverErr))
+		}
+		if embeddedErr != nil {
+			r.Details = append(r.Details, fmt.Sprintf("scan .beads/embeddeddolt: %v", embeddedErr))
+		}
+		return r
+	}
+
+	mode, activeStore := activeBDStoreFromMetadata(filepath.Join(beadsDir, "metadata.json"))
+	if activeStore == "" {
+		if len(serverRepos)+len(embeddedRepos) == 0 {
+			r.Status = StatusOK
+			r.Message = "legacy split store directories present but no Dolt repos found"
+			return r
+		}
+		r.Status = StatusWarning
+		r.Message = "legacy split store detected: both .beads/dolt and .beads/embeddeddolt contain or may contain data, but metadata.json does not declare an active store"
+		r.Details = splitStoreDetails("unknown", mode, serverRepos, embeddedRepos)
+		r.FixHint = splitStoreFixHint()
+		return r
+	}
+
+	inactiveStore := "embeddeddolt"
+	inactiveRepos := embeddedRepos
+	if activeStore == "embeddeddolt" {
+		inactiveStore = "dolt"
+		inactiveRepos = serverRepos
+	}
+	if len(inactiveRepos) == 0 {
+		r.Status = StatusOK
+		r.Message = "legacy split store directories present but inactive store is empty"
+		return r
+	}
+
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("legacy split store detected: active .beads/%s (metadata.json dolt_mode=%s), inactive .beads/%s contains %d Dolt repo(s)", activeStore, mode, inactiveStore, len(inactiveRepos))
+	r.Details = splitStoreDetails(activeStore, mode, serverRepos, embeddedRepos)
+	r.FixHint = splitStoreFixHint()
+	return r
+}
+
+func (c *BDSplitStoreCheck) CanFix() bool { return false }
+
+func (c *BDSplitStoreCheck) Fix(_ *CheckContext) error { return nil }
+
+func activeBDStoreFromMetadata(path string) (string, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", ""
+	}
+	var meta struct {
+		DoltMode string `json:"dolt_mode"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", ""
+	}
+	mode := strings.ToLower(strings.TrimSpace(meta.DoltMode))
+	switch mode {
+	case "server":
+		return mode, "dolt"
+	case "embedded", "local":
+		return mode, "embeddeddolt"
+	default:
+		return mode, ""
+	}
+}
+
+func splitStoreDetails(activeStore, mode string, serverRepos, embeddedRepos []string) []string {
+	activeLine := "active store: unknown"
+	if activeStore != "unknown" && activeStore != "" {
+		activeLine = fmt.Sprintf("active store: .beads/%s (metadata.json dolt_mode=%s)", activeStore, mode)
+	}
+	details := []string{
+		activeLine,
+		fmt.Sprintf(".beads/dolt repositories: %s", describeRepoList(serverRepos)),
+		fmt.Sprintf(".beads/embeddeddolt repositories: %s", describeRepoList(embeddedRepos)),
+		"recovery: export from a copy of the inactive store, review with bd import --dry-run, then import into the active store",
+	}
+	return details
+}
+
+func splitStoreFixHint() string {
+	return "export from the inactive store into a backup JSONL, review with bd import --dry-run, then import into the active store; keep both directories until reconciled"
+}
+
+func describeRepoList(repos []string) string {
+	if len(repos) == 0 {
+		return "(none)"
+	}
+	return strings.Join(repos, ", ")
+}
+
+func doltReposUnder(root string) ([]string, error) {
+	var repos []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if d.Name() != ".dolt" {
+			return nil
+		}
+		parent := filepath.Dir(path)
+		rel, err := filepath.Rel(root, parent)
+		if err != nil || rel == "." {
+			rel = filepath.Base(parent)
+		}
+		repos = append(repos, filepath.ToSlash(rel))
+		return filepath.SkipDir
+	})
+	sort.Strings(repos)
+	return repos, err
+}
+
+func splitStoreDirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
 
 func validateBDStoreTarget(cityPath, scopeRoot string) (contract.DoltConnectionTarget, string, bool, error) {
 	if !usesBDDoltStore(cityPath) {

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -803,6 +803,83 @@ func TestBeadsStoreCheck_FileProviderSkipsDoltPreflight(t *testing.T) {
 	}
 }
 
+// --- BDSplitStoreCheck ---
+
+func TestBDSplitStoreCheck_ServerActiveWarnsWhenEmbeddedStoreHasRepos(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	for _, want := range []string{"legacy split store", ".beads/embeddeddolt", "1 Dolt repo"} {
+		if !strings.Contains(r.Message, want) {
+			t.Fatalf("message = %q, want %q", r.Message, want)
+		}
+	}
+	if !strings.Contains(r.FixHint, "bd import --dry-run") {
+		t.Fatalf("fix hint = %q, want import dry-run guidance", r.FixHint)
+	}
+}
+
+func TestBDSplitStoreCheck_EmbeddedActiveWarnsWhenServerStoreHasRepos(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"legacy"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "embeddeddolt", "legacy"))
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "dolt", "hq"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	for _, want := range []string{"legacy split store", ".beads/dolt", "metadata.json dolt_mode=embedded"} {
+		if !strings.Contains(r.Message, want) {
+			t.Fatalf("message = %q, want %q", r.Message, want)
+		}
+	}
+}
+
+func TestBDSplitStoreCheck_BothDirsButInactiveEmptyIsOK(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	if err := os.MkdirAll(filepath.Join(dir, ".beads", "embeddeddolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func writeDoltRepoMarker(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".dolt", "noms"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // spyPingStore is a minimal Store that records Ping calls.
 type spyPingStore struct {
 	beads.MemStore


### PR DESCRIPTION
## Summary
- add a warning-only gc doctor check for legacy `.beads/dolt` plus `.beads/embeddeddolt` split stores
- register the diagnostic for both city and rig bead stores
- include recovery guidance to export from the inactive store, dry-run import, and preserve both directories until reconciled

Closes #633

## Tests
- `git diff --check`
- `go test ./internal/doctor -count=1`
- `go test ./cmd/gc -run 'Test(DoDoctorReportsLegacyBDSplitStore|DoctorSkipsDoltChecksTreatsExecGcBeadsBdAsBdContract|DoctorSkipsSuspendedRigChecks|DoltTopologyCheck)' -count=1 -timeout 5m`

## Notes
- `go test ./cmd/gc -count=1 -timeout 15m` was also tried during validation and hit an existing Dolt lifecycle flake: `TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure` saw launch count `2`, expected `1`, then the package timed out while `TestDoltStateRecoverManagedCmdReportsReadOnlyAndRestarts` was running.