### PR TITLE
fix: route beads providers by scope in mixed workspaces

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -160,12 +160,13 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 		if strings.TrimSpace(rig.Path) == "" {
 			continue
 		}
-		scopeProvider := rawBeadsProviderForScope(rig.Path, cs.cityPath)
+		scopeRoot := resolveStoreScopeRoot(cs.cityPath, rig.Path)
+		scopeProvider := rawBeadsProviderForScope(scopeRoot, cs.cityPath)
 		store := beads.Store(nil)
-		if sharedLegacyFileStore != nil && scopeProvider == "file" {
+		if sharedLegacyFileStore != nil && scopeProvider == "file" && !scopeUsesFileStoreContract(scopeRoot) {
 			store = sharedLegacyFileStore
 		} else {
-			store = cs.openRigStore(scopeProvider, rig.Name, rig.Path, rig.EffectivePrefix())
+			store = cs.openRigStore(scopeProvider, rig.Name, scopeRoot, rig.EffectivePrefix())
 		}
 		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, store, cs.eventProv)
 	}

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -140,11 +140,11 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 // Mail providers are NOT built here — all mail uses the city-level store.
 // Pure function of cfg — does not read or write cs fields (safe to call unlocked).
 func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store {
-	provider := beadsProviderFor(cfg)
+	cityProvider := rawBeadsProviderForScope(cs.cityPath, cs.cityPath)
 	stores := make(map[string]beads.Store, len(cfg.Rigs))
 
 	var sharedLegacyFileStore beads.Store
-	if provider == "file" && !fileStoreUsesScopedRoots(cs.cityPath) {
+	if cityProvider == "file" && !fileStoreUsesScopedRoots(cs.cityPath) {
 		store, err := openCompatibleFileStore(cs.cityPath, cs.cityPath)
 		if err == nil {
 			sharedLegacyFileStore = store
@@ -160,9 +160,12 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 		if strings.TrimSpace(rig.Path) == "" {
 			continue
 		}
-		store := sharedLegacyFileStore
-		if store == nil {
-			store = cs.openRigStore(provider, rig.Name, rig.Path, rig.EffectivePrefix())
+		scopeProvider := rawBeadsProviderForScope(rig.Path, cs.cityPath)
+		store := beads.Store(nil)
+		if sharedLegacyFileStore != nil && scopeProvider == "file" {
+			store = sharedLegacyFileStore
+		} else {
+			store = cs.openRigStore(scopeProvider, rig.Name, rig.Path, rig.EffectivePrefix())
 		}
 		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, store, cs.eventProv)
 	}

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -172,18 +172,6 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 	return stores
 }
 
-// beadsProviderFor returns the bead store provider name from the given config.
-// Pure function — does not read controllerState fields.
-func beadsProviderFor(cfg *config.City) string {
-	if v := os.Getenv("GC_BEADS"); v != "" {
-		return v
-	}
-	if cfg.Beads.Provider != "" {
-		return cfg.Beads.Provider
-	}
-	return "bd"
-}
-
 // openRigStore creates a bead store for a rig path using the given provider.
 func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix string) beads.Store {
 	scopeRoot := resolveStoreScopeRoot(cs.cityPath, rigPath)

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -455,6 +455,70 @@ provider = "file"
 	}
 }
 
+func TestControllerStateBuildStoresUsesRigFileMarkerUnderLegacyFileCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   rigDir,
+			Prefix: "fe",
+		}},
+	}
+
+	cs := &controllerState{cityPath: cityDir, cfg: cfg}
+	stores := cs.buildStores(cfg)
+	rigStore, ok := stores["frontend"]
+	if !ok {
+		t.Fatal("buildStores() missing frontend store")
+	}
+	if _, err := rigStore.Create(beads.Bead{Title: "rig bead", Type: "task"}); err != nil {
+		t.Fatalf("rig Create: %v", err)
+	}
+
+	cityStore, err := openScopeLocalFileStore(cityDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cityList, err := cityStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("city List: %v", err)
+	}
+	if len(cityList) != 0 {
+		t.Fatalf("city store should stay empty after rig create, got %#v", cityList)
+	}
+
+	persistedRigStore, err := openScopeLocalFileStore(rigDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rigList, err := persistedRigStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("rig List: %v", err)
+	}
+	if len(rigList) != 1 || rigList[0].Title != "rig bead" {
+		t.Fatalf("rig store should contain its own bead, got %#v", rigList)
+	}
+}
+
 func TestControllerStateNilEventProvider(t *testing.T) {
 	sp := runtime.NewFake()
 	cfg := &config.City{

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -418,6 +418,43 @@ func TestControllerStateOpenRigStoreFileOpenErrorDoesNotFallbackToBd(t *testing.
 	}
 }
 
+func TestControllerStateBuildStoresUsesScopeAwareProviderForMixedRig(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   rigDir,
+			Prefix: "fe",
+		}},
+	}
+
+	cs := &controllerState{cityPath: cityDir, cfg: cfg}
+	stores := cs.buildStores(cfg)
+	store, ok := stores["frontend"]
+	if !ok {
+		t.Fatal("buildStores() missing frontend store")
+	}
+	if _, ok := store.(*beads.FileStore); ok {
+		t.Fatalf("buildStores() returned %T, want scope-aware non-file store for bd-backed rig", store)
+	}
+}
+
 func TestControllerStateNilEventProvider(t *testing.T) {
 	sp := runtime.NewFake()
 	cfg := &config.City{

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -249,7 +249,7 @@ func managedBDRecoveryAllowed(cityPath, scopeRoot string, env map[string]string)
 }
 
 func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
-	if err == nil || !cityUsesBdStoreContract(cityPath) || !managedBDRecoveryAllowed(cityPath, scopeRoot, env) {
+	if err == nil || !providerUsesBdStoreContract(rawBeadsProviderForScope(scopeRoot, cityPath)) || !managedBDRecoveryAllowed(cityPath, scopeRoot, env) {
 		return false
 	}
 	msg := strings.ToLower(err.Error())

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -1081,6 +1081,38 @@ prefix = "fe"
 	}
 }
 
+func TestOpenStoreAtForCityUsesRigFileStoreUnderBdBackedCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".gc", "beads.json"), []byte("{\"seq\":0,\"beads\":[]}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	if _, ok := store.(*beads.FileStore); !ok {
+		t.Fatalf("openStoreAtForCity(rig) returned %T, want *beads.FileStore", store)
+	}
+}
+
 func TestOpenStoreAtForCityLegacyEmptyFileCityDoesNotFailOrCreateRigState(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2300,6 +2300,9 @@ dolt.auto-start: false
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"repo"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	env := map[string]string{"GC_DOLT_HOST": "", "GC_DOLT_PORT": "3307"}
 
 	if !bdTransportRetryableError(cityPath, rigDir, env, fmt.Errorf("server unreachable at 127.0.0.1:3307")) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -1049,6 +1049,38 @@ name = "demo"
 	}
 }
 
+func TestOpenStoreAtForCityUsesRigBdStoreUnderFileBackedCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	if _, ok := store.(*beads.BdStore); !ok {
+		t.Fatalf("openStoreAtForCity(rig) returned %T, want *beads.BdStore", store)
+	}
+}
+
 func TestOpenStoreAtForCityLegacyEmptyFileCityDoesNotFailOrCreateRigState(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2246,6 +2246,35 @@ func TestBdTransportRetryableErrorDoesNotTreatCommandTimeoutAsTransportFailure(t
 	}
 }
 
+func TestBdTransportRetryableErrorUsesScopeProviderForMixedRig(t *testing.T) {
+	cityPath := t.TempDir()
+	_ = writeReachableManagedDoltState(t, cityPath)
+	rigDir := filepath.Join(cityPath, "repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte(`issue_prefix: repo
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{"GC_DOLT_HOST": "", "GC_DOLT_PORT": "3307"}
+
+	if !bdTransportRetryableError(cityPath, rigDir, env, fmt.Errorf("server unreachable at 127.0.0.1:3307")) {
+		t.Fatal("bd-backed rig under file-backed city should still be transport-retryable")
+	}
+}
+
 func TestBdCommandRunnerWithManagedRetryRecoversAndRerunsWithFreshEnv(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1043,7 +1043,7 @@ func wrapInvalidEndpointStateError(scope string, err error) error {
 }
 
 func validateCanonicalCompatDoltDrift(cityPath string, cfg *config.City) error {
-	if cfg == nil || !cityUsesBdStoreContract(cityPath) {
+	if cfg == nil || !workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs) {
 		return nil
 	}
 	cityResolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, cityPath, config.EffectiveHQPrefix(cfg))

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -859,26 +859,40 @@ func enforceCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase st
 }
 
 func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City) error {
-	if cfg == nil || !cityUsesBdStoreContract(cityPath) {
+	if cfg == nil {
 		return nil
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
-	if err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, cityPath, defaultScopeDoltDatabase(cityPath, cityPath, config.EffectiveHQPrefix(cfg))); err != nil {
-		return fmt.Errorf("canonicalizing city metadata: %w", err)
+	if scopeUsesManagedBdStoreContract(cityPath, cityPath) {
+		if err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, cityPath, defaultScopeDoltDatabase(cityPath, cityPath, config.EffectiveHQPrefix(cfg))); err != nil {
+			return fmt.Errorf("canonicalizing city metadata: %w", err)
+		}
 	}
 	for i := range cfg.Rigs {
+		if !rigUsesManagedBdStoreContract(cityPath, cfg.Rigs[i]) {
+			continue
+		}
 		if err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, cfg.Rigs[i].Path, defaultScopeDoltDatabase(cityPath, cfg.Rigs[i].Path, cfg.Rigs[i].EffectivePrefix())); err != nil {
 			return fmt.Errorf("canonicalizing rig %q metadata: %w", cfg.Rigs[i].Name, err)
 		}
 	}
-	if err := syncConfiguredDoltPortFiles(cityPath, rawBeadsProvider(cityPath), cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs); err != nil {
+	if err := syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs); err != nil {
 		return fmt.Errorf("syncing canonical dolt config: %w", err)
 	}
 	return nil
 }
 
-func syncConfiguredDoltPortFiles(cityPath, provider string, cityDolt config.DoltConfig, cityPrefix string, rigs []config.Rig) error {
-	if !providerUsesBdStoreContract(provider) {
+func syncConfiguredDoltPortFiles(cityPath string, cityDolt config.DoltConfig, cityPrefix string, rigs []config.Rig) error {
+	resolveRigPaths(cityPath, rigs)
+	cityUsesBd := scopeUsesManagedBdStoreContract(cityPath, cityPath)
+	anyRigUsesBd := false
+	for _, rig := range rigs {
+		if rigUsesManagedBdStoreContract(cityPath, rig) {
+			anyRigUsesBd = true
+			break
+		}
+	}
+	if !cityUsesBd && !anyRigUsesBd {
 		return nil
 	}
 	// .beads/config.yaml is a bd compatibility mirror, not the canonical
@@ -895,11 +909,15 @@ func syncConfiguredDoltPortFiles(cityPath, provider string, cityDolt config.Dolt
 	if cityState.EndpointOrigin == contract.EndpointOriginManagedCity {
 		managedPort = currentDoltPort(cityPath)
 	}
-	if err := normalizeScopeDoltConfig(cityPath, cityState); err != nil {
-		return err
-	}
-	if managedPort != "" {
-		writeDoltPortFile(cityPath, managedPort)
+	if cityUsesBd {
+		if err := normalizeScopeDoltConfig(cityPath, cityState); err != nil {
+			return err
+		}
+		if managedPort != "" {
+			writeDoltPortFile(cityPath, managedPort)
+		} else {
+			removeDoltPortFile(cityPath)
+		}
 	} else {
 		removeDoltPortFile(cityPath)
 	}
@@ -907,6 +925,10 @@ func syncConfiguredDoltPortFiles(cityPath, provider string, cityDolt config.Dolt
 	for i := range rigs {
 		rig := normalizedRigConfig(cityPath, rigs[i])
 		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		if !rigUsesManagedBdStoreContract(cityPath, rig) {
+			removeDoltPortFile(rig.Path)
 			continue
 		}
 		rigState, err := syncDesiredRigDoltConfigState(cityPath, rig, cityState)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -164,6 +164,129 @@ exit 0
 	}
 }
 
+func TestPublishManagedDoltRuntimeStateIfOwnedPublishesForInheritedBdRigUnderFileCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigPath, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "fe",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ln := listenOnRandomPort(t)
+	defer func() { _ = ln.Close() }()
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   filepath.Join(cityPath, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
+		t.Fatalf("publishManagedDoltRuntimeStateIfOwned: %v", err)
+	}
+
+	published, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("read published dolt runtime state: %v", err)
+	}
+	if published.Port != port {
+		t.Fatalf("published port = %d, want %d", published.Port, port)
+	}
+	portData, err := os.ReadFile(filepath.Join(rigPath, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("ReadFile(rig dolt-server.port): %v", err)
+	}
+	if strings.TrimSpace(string(portData)) != strconv.Itoa(port) {
+		t.Fatalf("rig dolt-server.port = %q, want %d", strings.TrimSpace(string(portData)), port)
+	}
+}
+
+func TestManagedDoltLifecycleOwnedIgnoresExplicitBdRigUnderFileCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+dolt_host = "db.example.com"
+dolt_port = "4406"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigPath, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "fe",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	owned, err := managedDoltLifecycleOwned(cityPath)
+	if err != nil {
+		t.Fatalf("managedDoltLifecycleOwned: %v", err)
+	}
+	if owned {
+		t.Fatal("managed Dolt lifecycle should not be owned for explicit rig endpoint under file-backed city")
+	}
+}
+
+func TestManagedDoltLifecycleOwnedReportsInvalidCityConfigForFileCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname =\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	owned, err := managedDoltLifecycleOwned(cityPath)
+	if err == nil {
+		t.Fatalf("managedDoltLifecycleOwned() err = nil, owned = %v; want config load error", owned)
+	}
+	if !strings.Contains(err.Error(), "load city config for managed dolt ownership") {
+		t.Fatalf("managedDoltLifecycleOwned() error = %v, want ownership config context", err)
+	}
+}
+
 // TestEnsureBeadsProvider_bd_skip verifies bd provider is no-op when GC_DOLT=skip.
 func TestEnsureBeadsProvider_bd_skip(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -511,7 +511,8 @@ func TestCurrentManagedDoltPortUsesCanonicalPackStateOnly(t *testing.T) {
 //nolint:unparam // test helper keeps signature aligned with call sites under comparison
 func requireSyncConfiguredDoltPortFiles(t *testing.T, cityPath, provider string, cityDolt config.DoltConfig, cityPrefix string, rigs []config.Rig) {
 	t.Helper()
-	if err := syncConfiguredDoltPortFiles(cityPath, provider, cityDolt, cityPrefix, rigs); err != nil {
+	_ = provider
+	if err := syncConfiguredDoltPortFiles(cityPath, cityDolt, cityPrefix, rigs); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1175,7 +1176,7 @@ dolt.port: 3307
 		t.Fatal(err)
 	}
 	before := mustReadFile(t, filepath.Join(cityDir, ".beads", "config.yaml"))
-	err := syncConfiguredDoltPortFiles(cityDir, "bd", config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
+	err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
 	if err == nil || !strings.Contains(err.Error(), "invalid canonical city endpoint state") {
 		t.Fatalf("syncConfiguredDoltPortFiles() error = %v, want invalid canonical city endpoint state", err)
 	}
@@ -1220,7 +1221,7 @@ dolt.auto-start: false
 		t.Fatal(err)
 	}
 	before := mustReadFile(t, filepath.Join(rigDir, ".beads", "config.yaml"))
-	err := syncConfiguredDoltPortFiles(cityDir, "bd", config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
+	err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
 	if err == nil || !strings.Contains(err.Error(), "invalid canonical rig endpoint state") {
 		t.Fatalf("syncConfiguredDoltPortFiles() error = %v, want invalid canonical rig endpoint state", err)
 	}
@@ -1231,6 +1232,7 @@ dolt.auto-start: false
 }
 
 func TestSyncConfiguredDoltPortFilesSkipsNonBDProviders(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(t.TempDir(), "frontend")
 
@@ -1245,6 +1247,60 @@ func TestSyncConfiguredDoltPortFilesSkipsNonBDProviders(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected non-bd sync to leave %s absent, stat err = %v", path, err)
 		}
+	}
+}
+
+func TestSyncConfiguredDoltPortFilesRepairsBdRigUnderFileBackedCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "fe",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	wantPort := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
+
+	requireSyncConfiguredDoltPortFiles(t, cityDir, "file", config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
+
+	data, err := os.ReadFile(filepath.Join(rigDir, ".beads", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "gc.endpoint_origin: inherited_city") {
+		t.Fatalf("rig config missing inherited city origin:\n%s", text)
+	}
+	portData, err := os.ReadFile(filepath.Join(rigDir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(portData)) != wantPort {
+		t.Fatalf("rig port file = %q, want %s", strings.TrimSpace(string(portData)), wantPort)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, ".beads", "dolt-server.port")); !os.IsNotExist(err) {
+		t.Fatalf("city port file should remain absent for file-backed city, stat err = %v", err)
 	}
 }
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -102,14 +102,14 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc bd: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if !cityUsesBdStoreContract(cityPath) {
-		fmt.Fprintln(stderr, "gc bd: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
-		return 1
-	}
 
 	target, err := resolveBdScopeTarget(cfg, cityPath, rigName, bdArgs)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !providerUsesBdStoreContract(rawBeadsProviderForScope(target.ScopeRoot, cityPath)) {
+		fmt.Fprintln(stderr, "gc bd: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -614,6 +614,85 @@ provider = "file"
 	}
 }
 
+func TestGcBdAllowsRigPassthroughForBdBackedRigUnderFileCity(t *testing.T) {
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	defer func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	}()
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	capture := filepath.Join(t.TempDir(), "gc-bd-mixed-provider.txt")
+	script := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+set -eu
+{
+  printf 'pwd=%s\n' "$PWD"
+  printf 'args=%s\n' "$*"
+  printf 'BEADS_DIR=%s\n' "${BEADS_DIR:-}"
+} > "${CAPTURE_PATH}"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CAPTURE_PATH", capture)
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if got := doBd([]string{"--rig", "frontend", "list"}, &stdout, &stderr); got != 0 {
+		t.Fatalf("doBd() = %d, want 0; stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "only supported for bd-backed beads providers") {
+		t.Fatalf("stderr = %q, want rig passthrough instead of provider gate", stderr.String())
+	}
+
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			got[key] = value
+		}
+	}
+	if got["pwd"] != rigDir {
+		t.Fatalf("pwd = %q, want %q", got["pwd"], rigDir)
+	}
+	if got["args"] != "list" {
+		t.Fatalf("args = %q, want %q", got["args"], "list")
+	}
+	if got["BEADS_DIR"] != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", got["BEADS_DIR"], filepath.Join(rigDir, ".beads"))
+	}
+}
+
 func runRawBDFromDir(t *testing.T, bdPath, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command(bdPath, args...)

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -261,8 +261,22 @@ func cmdConvoyList(stdout, stderr io.Writer) int {
 }
 
 func convoyStoreCandidates(cfg *config.City, cityPath, beadID string) []string {
-	if rawBeadsProvider(cityPath) == "file" && !fileStoreUsesScopedRoots(cityPath) {
-		return []string{cityPath}
+	if rawBeadsProviderForScope(cityPath, cityPath) == "file" && !fileStoreUsesScopedRoots(cityPath) {
+		legacyCityOnly := true
+		if cfg != nil {
+			for _, rig := range cfg.Rigs {
+				if strings.TrimSpace(rig.Path) == "" {
+					continue
+				}
+				if rawBeadsProviderForScope(rig.Path, cityPath) != "file" {
+					legacyCityOnly = false
+					break
+				}
+			}
+		}
+		if legacyCityOnly {
+			return []string{cityPath}
+		}
 	}
 	capacity := 2
 	if cfg != nil {

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -268,7 +268,8 @@ func convoyStoreCandidates(cfg *config.City, cityPath, beadID string) []string {
 				if strings.TrimSpace(rig.Path) == "" {
 					continue
 				}
-				if rawBeadsProviderForScope(rig.Path, cityPath) != "file" {
+				scopeRoot := resolveStoreScopeRoot(cityPath, rig.Path)
+				if rawBeadsProviderForScope(scopeRoot, cityPath) != "file" || (!samePath(scopeRoot, cityPath) && scopeUsesFileStoreContract(scopeRoot)) {
 					legacyCityOnly = false
 					break
 				}

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -380,6 +382,43 @@ func TestConvoyStoreCandidatesKeepFileProviderCityScoped(t *testing.T) {
 	got := convoyStoreCandidates(cfg, "/city", "HW-42")
 	if len(got) != 1 || got[0] != "/city" {
 		t.Fatalf("convoyStoreCandidates = %v, want [/city]", got)
+	}
+}
+
+func TestConvoyStoreCandidatesIncludeBdRigUnderLegacyFileCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "hello-world")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"hw"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name:   "hello-world",
+			Path:   rigDir,
+			Prefix: "HW",
+		}},
+	}
+
+	got := convoyStoreCandidates(cfg, cityDir, "HW-42")
+	want := []string{rigDir, cityDir}
+	if len(got) != len(want) {
+		t.Fatalf("convoyStoreCandidates len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("convoyStoreCandidates[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -422,6 +422,43 @@ provider = "file"
 	}
 }
 
+func TestConvoyStoreCandidatesIncludeMarkedFileRigUnderLegacyFileCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "hello-world")
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name:   "hello-world",
+			Path:   rigDir,
+			Prefix: "HW",
+		}},
+	}
+
+	got := convoyStoreCandidates(cfg, cityDir, "HW-42")
+	want := []string{rigDir, cityDir}
+	if len(got) != len(want) {
+		t.Fatalf("convoyStoreCandidates len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("convoyStoreCandidates[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestResolveConvoyStoreFindsUnprefixedRigConvoy(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	cityStore := beads.NewMemStore()

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -45,7 +45,15 @@ health. Use --fix to attempt automatic repairs.`,
 
 // doDoctor runs all health checks and prints results.
 func doctorSkipsDoltChecks(cityPath string) bool {
-	return !cityUsesBdStoreContract(cityPath) || os.Getenv("GC_DOLT") == "skip"
+	if os.Getenv("GC_DOLT") == "skip" {
+		return true
+	}
+	cfg, err := loadCityConfig(cityPath)
+	if err != nil {
+		return !cityUsesBdStoreContract(cityPath)
+	}
+	resolveRigPaths(cityPath, cfg.Rigs)
+	return !workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs)
 }
 
 type doltTopologyCheck struct {
@@ -156,8 +164,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
 		d.Register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
-	skipDolt := doctorSkipsDoltChecks(cityPath)
-	d.Register(doctor.NewDoltServerCheck(cityPath, skipDolt))
+	d.Register(doctor.NewDoltServerCheck(cityPath, !scopeUsesManagedBdStoreContract(cityPath, cityPath) || os.Getenv("GC_DOLT") == "skip"))
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
 
@@ -177,7 +184,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
 			d.Register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
-			d.Register(doctor.NewRigDoltServerCheck(cityPath, rig, skipDolt))
+			d.Register(doctor.NewRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || os.Getenv("GC_DOLT") == "skip"))
 			// Custom types check — rig store.
 			d.Register(doctor.NewCustomTypesCheck(rig.Path, rig.Name))
 		}

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -9,11 +9,17 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/spf13/cobra"
+)
+
+var (
+	newDoctorDoltServerCheck    = doctor.NewDoltServerCheck
+	newDoctorRigDoltServerCheck = doctor.NewRigDoltServerCheck
 )
 
 func newDoctorCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -54,6 +60,22 @@ func doctorSkipsDoltChecks(cityPath string) bool {
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
 	return !workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs)
+}
+
+func workspaceNeedsCityDoltCheck(cityPath string, cfg *config.City) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, rig := range cfg.Rigs {
+		if !rigUsesManagedBdStoreContract(cityPath, rig) {
+			continue
+		}
+		explicit, err := contract.ScopeUsesExplicitEndpoint(fsys.OSFS{}, cityPath, rig.Path)
+		if err != nil || !explicit {
+			return true
+		}
+	}
+	return false
 }
 
 type doltTopologyCheck struct {
@@ -164,7 +186,8 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
 		d.Register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
-	d.Register(doctor.NewDoltServerCheck(cityPath, !scopeUsesManagedBdStoreContract(cityPath, cityPath) || os.Getenv("GC_DOLT") == "skip"))
+	skipCityDoltCheck := os.Getenv("GC_DOLT") == "skip" || (!scopeUsesManagedBdStoreContract(cityPath, cityPath) && !workspaceNeedsCityDoltCheck(cityPath, cfg))
+	d.Register(newDoctorDoltServerCheck(cityPath, skipCityDoltCheck))
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
 
@@ -184,7 +207,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
 			d.Register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
-			d.Register(doctor.NewRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || os.Getenv("GC_DOLT") == "skip"))
+			d.Register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || os.Getenv("GC_DOLT") == "skip"))
 			// Custom types check — rig store.
 			d.Register(doctor.NewCustomTypesCheck(rig.Path, rig.Name))
 		}

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -91,7 +91,7 @@ func (c *doltTopologyCheck) Name() string { return "dolt-topology" }
 
 func (c *doltTopologyCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	r := &doctor.CheckResult{Name: c.Name()}
-	if !cityUsesBdStoreContract(c.cityPath) {
+	if c.cfg == nil || !workspaceUsesManagedBdStoreContract(c.cityPath, c.cfg.Rigs) {
 		r.Status = doctor.StatusOK
 		r.Message = "not using bd-backed Dolt topology"
 		return r
@@ -133,7 +133,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	cfg, cfgErr := loadCityConfig(cityPath)
 	if cfgErr == nil {
 		resolveRigPaths(cityPath, cfg.Rigs)
-		if cityUsesBdStoreContract(cityPath) {
+		if workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs) {
 			d.Register(newDoltTopologyCheck(cityPath, cfg))
 		}
 		d.Register(doctor.NewConfigValidCheck(cfg))

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -22,6 +22,34 @@ func TestDoctorSkipsDoltChecksTreatsExecGcBeadsBdAsBdContract(t *testing.T) {
 	}
 }
 
+func TestDoctorSkipsDoltChecksDetectsBdRigUnderFileBackedCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if doctorSkipsDoltChecks(cityDir) {
+		t.Fatal("doctorSkipsDoltChecks() = true, want false for bd-backed rig")
+	}
+}
+
 func TestCollectPackDirsEmpty(t *testing.T) {
 	cfg := &config.City{}
 	dirs := collectPackDirs(cfg)

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -117,6 +117,66 @@ prefix = "fe"
 	}
 }
 
+func TestDoDoctorRunsDoltTopologyForBdRigUnderFileBackedCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+dolt_host = "rig.example.com"
+dolt_port = "3308"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCanonicalScopeConfig(t, rigDir, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "fe",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	oldCityCheck := newDoctorDoltServerCheck
+	oldRigCheck := newDoctorRigDoltServerCheck
+	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
+		return doctor.NewDoltServerCheck(cityPath, true)
+	}
+	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
+		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	}
+	t.Cleanup(func() {
+		newDoctorDoltServerCheck = oldCityCheck
+		newDoctorRigDoltServerCheck = oldRigCheck
+	})
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, false, &stdout, &stderr)
+
+	if !strings.Contains(stdout.String(), "canonical/compat Dolt drift") {
+		t.Fatalf("doctor output missing Dolt topology drift:\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+}
+
 func TestCollectPackDirsEmpty(t *testing.T) {
 	cfg := &config.City{}
 	dirs := collectPackDirs(cfg)

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/supervisor"
 )
 
@@ -47,6 +48,72 @@ prefix = "fe"
 
 	if doctorSkipsDoltChecks(cityDir) {
 		t.Fatal("doctorSkipsDoltChecks() = true, want false for bd-backed rig")
+	}
+}
+
+func TestDoDoctorRunsCityDoltCheckForInheritedBdRigUnderFileBackedCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalConfig(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "config.yaml"), contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "fe",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	oldCityCheck := newDoctorDoltServerCheck
+	oldRigCheck := newDoctorRigDoltServerCheck
+	var citySkip, rigSkip *bool
+	newDoctorDoltServerCheck = func(cityPath string, skip bool) *doctor.DoltServerCheck {
+		citySkip = &skip
+		return doctor.NewDoltServerCheck(cityPath, true)
+	}
+	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, skip bool) *doctor.RigDoltServerCheck {
+		rigSkip = &skip
+		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	}
+	t.Cleanup(func() {
+		newDoctorDoltServerCheck = oldCityCheck
+		newDoctorRigDoltServerCheck = oldRigCheck
+	})
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, false, &stdout, &stderr)
+
+	if citySkip == nil || *citySkip {
+		t.Fatalf("city dolt check skip = %v, want false when a bd-backed rig inherits the city endpoint", citySkip)
+	}
+	if rigSkip == nil || *rigSkip {
+		t.Fatalf("rig dolt check skip = %v, want false for bd-backed rig", rigSkip)
 	}
 }
 

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -81,10 +81,6 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if !cityUsesBdStoreContract(cityPath) {
-		fmt.Fprintln(stderr, "gc rig set-endpoint: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
-		return 1
-	}
 
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
@@ -108,6 +104,10 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		// relative `.beads/...` writes under the current working directory
 		// instead of erroring cleanly.
 		fmt.Fprintf(stderr, "gc rig set-endpoint: rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it before setting its endpoint\n", rig.Name, rig.Name) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !scopeUsesManagedBdStoreContract(cityPath, rig.Path) {
+		fmt.Fprintln(stderr, "gc rig set-endpoint: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1335,6 +1335,45 @@ func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
 	}
 }
 
+func TestDoRigSetEndpointAllowsBdRigUnderFileBackedCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[[rigs]]\nname = \"frontend\"\npath = %q\nprefix = \"fe\"\n", rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeRigEndpointMetadata(t, rigDir, "fe")
+	writeRigEndpointRuntimeState(t, cityDir, 3311)
+	writeRigEndpointCanonicalConfig(t, rigDir, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginExplicit,
+		EndpointStatus: contract.EndpointStatusVerified,
+		DoltHost:       "rig-db.example.com",
+		DoltPort:       "4406",
+		DoltUser:       "rig-user",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doRigSetEndpoint(fsys.OSFS{}, cityDir, "frontend", rigEndpointOptions{Inherit: true}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigSetEndpoint() = %d, stderr = %s", code, stderr.String())
+	}
+
+	state := readRigEndpointConfigState(t, rigDir)
+	if state.EndpointOrigin != contract.EndpointOriginInheritedCity {
+		t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginInheritedCity)
+	}
+}
+
 func writeRigEndpointCityConfig(t *testing.T, cityDir, rigDir string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -257,19 +257,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		return 1
 	}
 	storeRef := workflowStoreRefForDir(storeDir, cityPath, cfg.Workspace.Name, cfg)
-	storeEnv := map[string]string{}
-	switch provider := rawBeadsProvider(cityPath); {
-	case provider == "file":
-		// Built-in routing now goes through beads.Store; custom queries own any
-		// provider-specific shell environment when they opt out of that path.
-	case strings.HasPrefix(provider, "exec:"):
-		// Explicit custom sling_query commands own their env for exec providers.
-	default:
-		storeEnv = bdRuntimeEnv(cityPath)
-		if !samePath(storeDir, cityPath) {
-			storeEnv = bdRuntimeEnvForRig(cityPath, cfg, storeDir)
-		}
-	}
+	storeEnv := slingStoreEnv(cfg, cityPath, storeDir)
 
 	// Inline text mode: if the argument doesn't look like a bead ID
 	// (and we're not in formula mode), create a task bead from the text.
@@ -347,6 +335,23 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	}
 
 	return doSlingBatch(opts, deps, store, stdout, stderr)
+}
+
+func slingStoreEnv(cfg *config.City, cityPath, storeDir string) map[string]string {
+	storeEnv := map[string]string{}
+	switch provider := rawBeadsProviderForScope(storeDir, cityPath); {
+	case provider == "file":
+		// Built-in routing now goes through beads.Store; custom queries own any
+		// provider-specific shell environment when they opt out of that path.
+	case strings.HasPrefix(provider, "exec:"):
+		// Explicit custom sling_query commands own their env for exec providers.
+	default:
+		storeEnv = bdRuntimeEnv(cityPath)
+		if !samePath(storeDir, cityPath) {
+			storeEnv = bdRuntimeEnvForRig(cityPath, cfg, storeDir)
+		}
+	}
+	return storeEnv
 }
 
 // findRigByPrefix returns the rig whose effective prefix matches (case-insensitive).

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -975,6 +975,9 @@ dolt.auto-start: false
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"repo"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: rigDir}}}
 
 	env := slingStoreEnv(cfg, cityDir, rigDir)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -949,6 +950,42 @@ dir = "frontend"
 	}
 	if len(cityBeads) != 0 {
 		t.Fatalf("city store bead count = %d, want 0: %#v", len(cityBeads), cityBeads)
+	}
+}
+
+func TestSlingStoreEnvUsesRigBdRuntimeForMixedProviderRig(t *testing.T) {
+	cityDir := t.TempDir()
+	wantPort := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
+	rigDir := filepath.Join(cityDir, "repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte(`issue_prefix: repo
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: rigDir}}}
+
+	env := slingStoreEnv(cfg, cityDir, rigDir)
+	if got := env["GC_DOLT_PORT"]; got != wantPort {
+		t.Fatalf("GC_DOLT_PORT = %q, want %q", got, wantPort)
+	}
+	if got := env["BEADS_DIR"]; got != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", got, filepath.Join(rigDir, ".beads"))
+	}
+	if got := env["GC_RIG"]; got != "repo" {
+		t.Fatalf("GC_RIG = %q, want %q", got, "repo")
 	}
 }
 

--- a/cmd/gc/dolt_runtime_publication.go
+++ b/cmd/gc/dolt_runtime_publication.go
@@ -62,7 +62,7 @@ func syncManagedDoltPortMirrors(cityPath string) error {
 		removeDoltPortFile(cityPath)
 		return nil
 	}
-	return syncConfiguredDoltPortFiles(cityPath, rawBeadsProvider(cityPath), cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs)
+	return syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs)
 }
 
 func publishManagedDoltRuntimeState(cityPath string) error {

--- a/cmd/gc/dolt_runtime_publication.go
+++ b/cmd/gc/dolt_runtime_publication.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -46,14 +48,45 @@ func removeDoltRuntimeStateFile(path string) error {
 }
 
 func managedDoltLifecycleOwned(cityPath string) (bool, error) {
-	if !cityUsesBdStoreContract(cityPath) {
+	if cityUsesBdStoreContract(cityPath) {
+		_, _, ok, invalid := resolveConfiguredCityDoltTarget(cityPath)
+		if invalid {
+			return false, fmt.Errorf("invalid canonical city endpoint state")
+		}
+		return !ok, nil
+	}
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("load city config for managed dolt ownership: %w", err)
+	}
+	if cfg == nil {
 		return false, nil
 	}
-	_, _, ok, invalid := resolveConfiguredCityDoltTarget(cityPath)
-	if invalid {
-		return false, fmt.Errorf("invalid canonical city endpoint state")
+	resolveRigPaths(cityPath, cfg.Rigs)
+	cityState, err := syncDesiredCityDoltConfigState(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg))
+	if err != nil {
+		return false, err
 	}
-	return !ok, nil
+	if cityState.EndpointOrigin != contract.EndpointOriginManagedCity {
+		return false, nil
+	}
+	for _, rig := range cfg.Rigs {
+		if !rigUsesManagedBdStoreContract(cityPath, rig) {
+			continue
+		}
+		rigState, err := syncDesiredRigDoltConfigState(cityPath, rig, cityState)
+		if err != nil {
+			return false, err
+		}
+		if rigState.EndpointOrigin == contract.EndpointOriginInheritedCity {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func syncManagedDoltPortMirrors(cityPath string) error {
@@ -104,7 +137,14 @@ func publishManagedDoltRuntimeStateIfOwned(cityPath string) error {
 }
 
 func clearManagedDoltRuntimeStateIfOwned(cityPath string) error {
-	if !cityUsesBdStoreContract(cityPath) {
+	if cityUsesBdStoreContract(cityPath) {
+		return clearManagedDoltRuntimeState(cityPath)
+	}
+	owned, err := managedDoltLifecycleOwned(cityPath)
+	if err != nil {
+		return err
+	}
+	if !owned {
 		return nil
 	}
 	return clearManagedDoltRuntimeState(cityPath)

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -520,8 +520,13 @@ func checkHardDependencies(cityPath string) []missingDep {
 		condition   func() bool // if non-nil, only checked when true
 	}
 
-	beadsProvider := rawBeadsProvider(cityPath)
-	needsBd := providerUsesBdStoreContract(beadsProvider)
+	needsBd := false
+	if cfg, err := loadCityConfig(cityPath); err == nil {
+		resolveRigPaths(cityPath, cfg.Rigs)
+		needsBd = workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs)
+	} else {
+		needsBd = cityUsesBdStoreContract(cityPath)
+	}
 
 	deps := []dep{
 		{

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -637,6 +637,57 @@ func TestCheckHardDependenciesTreatsExecGcBeadsBdAsBdContract(t *testing.T) {
 	}
 }
 
+func TestCheckHardDependenciesRequiresBdToolsForBdRigUnderFileCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		if name == "dolt" {
+			return "", os.ErrNotExist
+		}
+		return "/usr/bin/" + name, nil
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version " + bdMinVersion, nil
+		case "flock", "tmux", "jq", "git", "pgrep", "lsof":
+			return binary + " version", nil
+		default:
+			return binary + " version " + doltMinVersion, nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+
+	missing := checkHardDependencies(cityDir)
+	if len(missing) != 1 || missing[0].name != "dolt" {
+		t.Fatalf("missing deps = %#v, want only dolt for bd-backed rig", missing)
+	}
+}
+
 func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -716,7 +716,7 @@ func openStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
 		runtimeCityPath = cityForStoreDir(storePath)
 	}
 	scopeRoot := resolveStoreScopeRoot(runtimeCityPath, storePath)
-	provider := rawBeadsProvider(runtimeCityPath)
+	provider := rawBeadsProviderForScope(scopeRoot, runtimeCityPath)
 	if strings.HasPrefix(provider, "exec:") {
 		target, err := resolveConfiguredExecStoreTarget(runtimeCityPath, scopeRoot)
 		if err != nil {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -704,6 +704,10 @@ func openExistingScopeLocalFileStore(scopeRoot string) (*beads.FileStore, error)
 }
 
 func openCompatibleFileStore(scopeRoot, cityPath string) (*beads.FileStore, error) {
+	scopeRoot = resolveStoreScopeRoot(cityPath, scopeRoot)
+	if !samePath(scopeRoot, cityPath) && scopeUsesFileStoreContract(scopeRoot) {
+		return openExistingScopeLocalFileStore(scopeRoot)
+	}
 	if fileStoreUsesScopedRoots(cityPath) {
 		return openExistingScopeLocalFileStore(scopeRoot)
 	}

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -248,10 +248,6 @@ func configuredBeadsProviderValue(cityPath string) string {
 	return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))
 }
 
-func configuredBeadsProviderValueFromConfig(cityPath string) string {
-	return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))
-}
-
 func scopedBeadsProviderOverride(cityPath, scopeRoot string) (string, bool) {
 	provider := strings.TrimSpace(os.Getenv("GC_BEADS"))
 	if provider == "" {
@@ -296,7 +292,7 @@ func rawBeadsProvider(cityPath string) string {
 }
 
 func rawBeadsProviderFromConfig(cityPath string) string {
-	if provider := configuredBeadsProviderValueFromConfig(cityPath); provider != "" {
+	if provider := strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml"))); provider != "" {
 		return normalizeRawBeadsProvider(cityPath, provider)
 	}
 	return "bd"
@@ -339,7 +335,8 @@ func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
 	// Mixed-provider workspaces can keep legacy bd-backed rigs under a
 	// file-backed city (and vice versa). Prefer explicit scope-local store
 	// markers over the city default so scoped commands keep talking to the
-	// rig's actual beads backend.
+	// rig's actual beads backend. The bd routing identity is metadata.json;
+	// config.yaml is a compatibility mirror and can survive migrations.
 	if scopeUsesBdStoreContract(resolvedScopeRoot) {
 		return "bd"
 	}
@@ -373,18 +370,14 @@ func workspaceUsesManagedBdStoreContract(cityPath string, rigs []config.Rig) boo
 }
 
 func scopeUsesBdStoreContract(scopeRoot string) bool {
-	for _, marker := range []string{
-		filepath.Join(scopeRoot, ".beads", "metadata.json"),
-		filepath.Join(scopeRoot, ".beads", "config.yaml"),
-	} {
-		if _, err := os.Stat(marker); err == nil {
-			return true
-		}
-	}
-	return false
+	_, err := os.Stat(filepath.Join(scopeRoot, ".beads", "metadata.json"))
+	return err == nil
 }
 
 func scopeUsesFileStoreContract(scopeRoot string) bool {
+	if scopeUsesBdStoreContract(scopeRoot) {
+		return false
+	}
 	_, err := os.Stat(filepath.Join(scopeRoot, ".gc", "beads.json"))
 	return err == nil
 }

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -296,9 +296,15 @@ func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
 	if runtimeCityPath == "" {
 		runtimeCityPath = cityForStoreDir(scopeRoot)
 	}
+	if explicit := strings.TrimSpace(os.Getenv("GC_BEADS")); explicit != "" {
+		return normalizeRawBeadsProvider(runtimeCityPath, explicit)
+	}
 	provider := rawBeadsProvider(runtimeCityPath)
 	resolvedScopeRoot := resolveStoreScopeRoot(runtimeCityPath, scopeRoot)
 	if samePath(resolvedScopeRoot, runtimeCityPath) {
+		return provider
+	}
+	if strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider) {
 		return provider
 	}
 	// Mixed-provider workspaces can keep legacy bd-backed rigs under a

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -248,6 +248,25 @@ func configuredBeadsProviderValue(cityPath string) string {
 	return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))
 }
 
+func configuredBeadsProviderValueFromConfig(cityPath string) string {
+	return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))
+}
+
+func scopedBeadsProviderOverride(cityPath, scopeRoot string) (string, bool) {
+	provider := strings.TrimSpace(os.Getenv("GC_BEADS"))
+	if provider == "" {
+		return "", false
+	}
+	scopedRoot := strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT"))
+	if scopedRoot == "" {
+		return provider, true
+	}
+	if samePath(resolveStoreScopeRoot(cityPath, scopedRoot), scopeRoot) {
+		return provider, true
+	}
+	return "", false
+}
+
 // normalizeRawBeadsProvider maps the city-managed gc-beads-bd wrapper back to
 // the logical "bd" provider for command-time store selection. Managed sessions
 // set GC_BEADS=exec:<cityPath>/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh
@@ -276,6 +295,13 @@ func rawBeadsProvider(cityPath string) string {
 	return "bd"
 }
 
+func rawBeadsProviderFromConfig(cityPath string) string {
+	if provider := configuredBeadsProviderValueFromConfig(cityPath); provider != "" {
+		return normalizeRawBeadsProvider(cityPath, provider)
+	}
+	return "bd"
+}
+
 func providerUsesBdStoreContract(provider string) bool {
 	provider = strings.TrimSpace(provider)
 	if provider == "" || provider == "bd" {
@@ -296,11 +322,14 @@ func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
 	if runtimeCityPath == "" {
 		runtimeCityPath = cityForStoreDir(scopeRoot)
 	}
-	if explicit := strings.TrimSpace(os.Getenv("GC_BEADS")); explicit != "" {
+	resolvedScopeRoot := resolveStoreScopeRoot(runtimeCityPath, scopeRoot)
+	if explicit, ok := scopedBeadsProviderOverride(runtimeCityPath, resolvedScopeRoot); ok {
 		return normalizeRawBeadsProvider(runtimeCityPath, explicit)
 	}
 	provider := rawBeadsProvider(runtimeCityPath)
-	resolvedScopeRoot := resolveStoreScopeRoot(runtimeCityPath, scopeRoot)
+	if strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT")) != "" {
+		provider = rawBeadsProviderFromConfig(runtimeCityPath)
+	}
 	if samePath(resolvedScopeRoot, runtimeCityPath) {
 		return provider
 	}
@@ -318,6 +347,29 @@ func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
 		return "file"
 	}
 	return provider
+}
+
+func scopeUsesManagedBdStoreContract(cityPath, scopeRoot string) bool {
+	return providerUsesBdStoreContract(rawBeadsProviderForScope(scopeRoot, cityPath))
+}
+
+func rigUsesManagedBdStoreContract(cityPath string, rig config.Rig) bool {
+	if strings.TrimSpace(rig.Path) == "" {
+		return false
+	}
+	return scopeUsesManagedBdStoreContract(cityPath, rig.Path)
+}
+
+func workspaceUsesManagedBdStoreContract(cityPath string, rigs []config.Rig) bool {
+	if scopeUsesManagedBdStoreContract(cityPath, cityPath) {
+		return true
+	}
+	for _, rig := range rigs {
+		if rigUsesManagedBdStoreContract(cityPath, rig) {
+			return true
+		}
+	}
+	return false
 }
 
 func scopeUsesBdStoreContract(scopeRoot string) bool {

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -291,6 +291,46 @@ func cityUsesBdStoreContract(cityPath string) bool {
 	return providerUsesBdStoreContract(rawBeadsProvider(cityPath))
 }
 
+func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
+	runtimeCityPath := cityPath
+	if runtimeCityPath == "" {
+		runtimeCityPath = cityForStoreDir(scopeRoot)
+	}
+	provider := rawBeadsProvider(runtimeCityPath)
+	resolvedScopeRoot := resolveStoreScopeRoot(runtimeCityPath, scopeRoot)
+	if samePath(resolvedScopeRoot, runtimeCityPath) {
+		return provider
+	}
+	// Mixed-provider workspaces can keep legacy bd-backed rigs under a
+	// file-backed city (and vice versa). Prefer explicit scope-local store
+	// markers over the city default so scoped commands keep talking to the
+	// rig's actual beads backend.
+	if scopeUsesBdStoreContract(resolvedScopeRoot) {
+		return "bd"
+	}
+	if scopeUsesFileStoreContract(resolvedScopeRoot) {
+		return "file"
+	}
+	return provider
+}
+
+func scopeUsesBdStoreContract(scopeRoot string) bool {
+	for _, marker := range []string{
+		filepath.Join(scopeRoot, ".beads", "metadata.json"),
+		filepath.Join(scopeRoot, ".beads", "config.yaml"),
+	} {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func scopeUsesFileStoreContract(scopeRoot string) bool {
+	_, err := os.Stat(filepath.Join(scopeRoot, ".gc", "beads.json"))
+	return err == nil
+}
+
 // beadsProvider returns the bead store provider name for lifecycle operations.
 // Maps "bd" → "exec:<cityPath>/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh"
 // so all lifecycle operations route through the exec: protocol. Other providers

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -128,6 +128,34 @@ provider = "exec:/tmp/custom-beads"
 	}
 }
 
+func TestRawBeadsProviderForScopeKeepsSessionOverrideScoped(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", rigDir)
+
+	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "bd" {
+		t.Fatalf("rawBeadsProviderForScope(rig) = %q, want bd", got)
+	}
+	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "file" {
+		t.Fatalf("rawBeadsProviderForScope(city) = %q, want file outside scoped override", got)
+	}
+}
+
 func TestConfiguredACPSessionNames_UsesProvidedSnapshot(t *testing.T) {
 	snapshot := newSessionBeadSnapshot([]beads.Bead{{
 		Type:   sessionBeadType,

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -156,6 +156,58 @@ provider = "file"
 	}
 }
 
+func TestRawBeadsProviderForScopeIgnoresConfigYamlWithoutMetadata(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte("issue_prefix: fe\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "file" {
+		t.Fatalf("rawBeadsProviderForScope() = %q, want city provider without bd metadata", got)
+	}
+}
+
+func TestRawBeadsProviderForScopePrefersBdMetadataOverFileMarker(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".gc", "beads.json"), []byte("[]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "bd" {
+		t.Fatalf("rawBeadsProviderForScope() = %q, want bd metadata to outrank stale file marker", got)
+	}
+}
+
 func TestConfiguredACPSessionNames_UsesProvidedSnapshot(t *testing.T) {
 	snapshot := newSessionBeadSnapshot([]beads.Bead{{
 		Type:   sessionBeadType,

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -81,6 +81,53 @@ func TestRawBeadsProviderPreservesCustomExecOverride(t *testing.T) {
 	}
 }
 
+func TestRawBeadsProviderForScopePreservesExplicitEnvOverride(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "file")
+
+	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "file" {
+		t.Fatalf("rawBeadsProviderForScope() = %q, want explicit env override", got)
+	}
+}
+
+func TestRawBeadsProviderForScopePreservesCustomExecProvider(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "exec:/tmp/custom-beads"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "exec:/tmp/custom-beads" {
+		t.Fatalf("rawBeadsProviderForScope() = %q, want custom exec provider", got)
+	}
+}
+
 func TestConfiguredACPSessionNames_UsesProvidedSnapshot(t *testing.T) {
 	snapshot := newSessionBeadSnapshot([]beads.Bead{{
 		Type:   sessionBeadType,

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -229,7 +229,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	for key, value := range citylayout.CityRuntimeEnvMap(p.cityPath) {
 		agentEnv[key] = value
 	}
-	agentEnv["GC_BEADS"] = rawBeadsProvider(p.cityPath)
+	agentEnv["GC_BEADS"] = rawBeadsProviderForScope(rigRoot, p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe
 	}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -206,14 +206,15 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 
 	// Step 8: Build agent environment.
 	agentEnv := map[string]string{
-		"GC_SESSION_NAME":   sessName,
-		"GC_SESSION_ID":     sessionBeadID,
-		"GC_TEMPLATE":       templateNameFor(cfgAgent, qualifiedName),
-		"GC_SESSION_ORIGIN": "ephemeral",
-		"GC_AGENT":          sessName,
-		"GC_ALIAS":          qualifiedName,
-		"BEADS_ACTOR":       sessName,
-		"GC_DIR":            workDir,
+		"GC_SESSION_NAME":     sessName,
+		"GC_SESSION_ID":       sessionBeadID,
+		"GC_TEMPLATE":         templateNameFor(cfgAgent, qualifiedName),
+		"GC_SESSION_ORIGIN":   "ephemeral",
+		"GC_AGENT":            sessName,
+		"GC_ALIAS":            qualifiedName,
+		"BEADS_ACTOR":         sessName,
+		"GC_DIR":              workDir,
+		"GC_BEADS_SCOPE_ROOT": p.cityPath,
 		// Explicit empty values matter here. tmux session creation uses `env -u`
 		// only for keys present with empty strings, which prevents stale rig
 		// scope from leaking out of the tmux server's inherited environment.
@@ -240,6 +241,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		agentEnv["GC_RIG"] = rigName
 		agentEnv["GC_RIG_ROOT"] = rigRoot
 		agentEnv["BEADS_DIR"] = filepath.Join(rigRoot, ".beads")
+		agentEnv["GC_BEADS_SCOPE_ROOT"] = rigRoot
 	}
 
 	// Step 9: Render prompt with beacon.

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -175,6 +175,41 @@ func TestResolveTemplateDefaultsRigScopedAgentsToRigRootWithoutWorkDir(t *testin
 	}
 }
 
+func TestResolveTemplateUsesRigScopeBeadsProviderForBdBackedRig(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	rigRoot := filepath.Join(cityPath, "demo")
+	if err := os.MkdirAll(filepath.Join(rigRoot, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigRoot, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"de"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		rigs:       []config.Rig{{Name: "demo", Path: rigRoot}},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	agent := &config.Agent{Name: "worker", Dir: "demo"}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_BEADS"]; got != "bd" {
+		t.Fatalf("GC_BEADS = %q, want bd for bd-backed rig", got)
+	}
+}
+
 func TestResolveTemplateRigScopedEnvCarriesRigRoots(t *testing.T) {
 	cityPath := t.TempDir()
 	writeTemplateResolveCityConfig(t, cityPath, "file")

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -208,6 +208,9 @@ func TestResolveTemplateUsesRigScopeBeadsProviderForBdBackedRig(t *testing.T) {
 	if got := tp.Env["GC_BEADS"]; got != "bd" {
 		t.Fatalf("GC_BEADS = %q, want bd for bd-backed rig", got)
 	}
+	if got := tp.Env["GC_BEADS_SCOPE_ROOT"]; got != rigRoot {
+		t.Fatalf("GC_BEADS_SCOPE_ROOT = %q, want %q", got, rigRoot)
+	}
 }
 
 func TestResolveTemplateRigScopedEnvCarriesRigRoots(t *testing.T) {

--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -16,17 +16,23 @@ func controllerQueryRuntimeEnv(cityPath string, cfg *config.City, agentCfg *conf
 	if strings.TrimSpace(cityPath) == "" || cfg == nil || agentCfg == nil {
 		return nil
 	}
-	if !cityUsesBdStoreContract(cityPath) {
-		return nil
-	}
 	var source map[string]string
 	if rigName := configuredRigName(cityPath, agentCfg, cfg.Rigs); rigName != "" {
 		if rigRoot := rigRootForName(rigName, cfg.Rigs); rigRoot != "" {
+			if !scopeUsesManagedBdStoreContract(cityPath, rigRoot) {
+				return nil
+			}
 			source = bdRuntimeEnvForRig(cityPath, cfg, rigRoot)
 		} else {
+			if !scopeUsesManagedBdStoreContract(cityPath, cityPath) {
+				return nil
+			}
 			source = bdRuntimeEnv(cityPath)
 		}
 	} else {
+		if !scopeUsesManagedBdStoreContract(cityPath, cityPath) {
+			return nil
+		}
 		source = bdRuntimeEnv(cityPath)
 	}
 	if len(source) == 0 {

--- a/cmd/gc/work_query_probe_test.go
+++ b/cmd/gc/work_query_probe_test.go
@@ -65,6 +65,14 @@ func TestControllerQueryRuntimeEnvExplicitRigUsesRigStorePassword(t *testing.T) 
 		DoltPort:       "4406",
 		DoltUser:       "rig-user",
 	})
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "de",
+	}); err != nil {
+		t.Fatal(err)
+	}
 	writeScopePassword(t, rigDir, "rig-secret")
 
 	env := controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[0])
@@ -191,6 +199,14 @@ provider = "file"
 		DoltPort:       "4406",
 		DoltUser:       "rig-user",
 	})
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "de",
+	}); err != nil {
+		t.Fatal(err)
+	}
 	writeScopePassword(t, rigDir, "rig-secret")
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},

--- a/cmd/gc/work_query_probe_test.go
+++ b/cmd/gc/work_query_probe_test.go
@@ -165,6 +165,58 @@ func TestControllerQueryRuntimeEnvReturnsNilForNonBD(t *testing.T) {
 	}
 }
 
+func TestControllerQueryRuntimeEnvUsesRigBdScopeUnderFileBackedCity(t *testing.T) {
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(cityPath, "demo")
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	_ = os.Unsetenv("GC_DOLT_PASSWORD")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCanonicalScopeConfig(t, rigDir, contract.ConfigState{
+		IssuePrefix:    "de",
+		EndpointOrigin: contract.EndpointOriginExplicit,
+		EndpointStatus: contract.EndpointStatusVerified,
+		DoltHost:       "rig-db.example.com",
+		DoltPort:       "4406",
+		DoltUser:       "rig-user",
+	})
+	writeScopePassword(t, rigDir, "rig-secret")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name:   "demo",
+			Path:   rigDir,
+			Prefix: "de",
+		}},
+		Agents: []config.Agent{{
+			Name: "worker",
+			Dir:  "demo",
+		}},
+	}
+
+	env := controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[0])
+	if got := env["GC_DOLT_HOST"]; got != "rig-db.example.com" {
+		t.Fatalf("GC_DOLT_HOST = %q, want %q", got, "rig-db.example.com")
+	}
+	if got := env["GC_DOLT_PORT"]; got != "4406" {
+		t.Fatalf("GC_DOLT_PORT = %q, want %q", got, "4406")
+	}
+	if got := env["GC_DOLT_PASSWORD"]; got != "rig-secret" {
+		t.Fatalf("GC_DOLT_PASSWORD = %q, want %q", got, "rig-secret")
+	}
+}
+
 func newControllerProbeFixture(t *testing.T) (string, string, *config.City) {
 	t.Helper()
 	t.Setenv("GC_BEADS", "bd")


### PR DESCRIPTION
## Summary
- resolve bead store providers per scope so bd-backed rigs under file-backed cities and file-backed rigs under bd-backed cities route to the correct store
- propagate scope-aware provider checks through `gc bd`, doctor/init readiness, rig endpoint management, session env, work-query probes, and Dolt mirror repair paths
- add mixed-provider regressions across store opening, runtime env wiring, doctor skip decisions, dependency checks, and canonical Dolt config sync

## Verification
- `go test ./cmd/gc -run 'TestRawBeadsProviderForScope(KeepsSessionOverrideScoped|PreservesExplicitEnvOverride|PreservesCustomExecProvider)$|TestControllerStateBuildStoresUsesScopeAwareProviderForMixedRig$|TestConvoyStoreCandidatesIncludeBdRigUnderLegacyFileCity$|TestSlingStoreEnvUsesRigBdRuntimeForMixedProviderRig$|TestBdTransportRetryableErrorUsesScopeProviderForMixedRig$|TestGcBdAllowsRigPassthroughForBdBackedRigUnderFileCity$|TestOpenStoreAtForCityUsesRig(BdStoreUnderFileBackedCity|FileStoreUnderBdBackedCity)$|TestResolveTemplateUsesRigScopeBeadsProviderForBdBackedRig$|TestControllerQueryRuntimeEnvUsesRigBdScopeUnderFileBackedCity$|TestDoRigSetEndpointAllowsBdRigUnderFileBackedCity$|TestDoctorSkipsDoltChecks(DetectsBdRigUnderFileBackedCity|TreatsExecGcBeadsBdAsBdContract)$|TestCheckHardDependencies(RequiresBdToolsForBdRigUnderFileCity|TreatsExecGcBeadsBdAsBdContract)$|TestSyncConfiguredDoltPortFilesRepairsBdRigUnderFileBackedCity$'`
- `go test ./cmd/gc -run 'Test(SyncConfiguredDoltPortFiles|NormalizeCanonicalBdScopeFiles|ControllerQueryRuntimeEnv|DoctorSkipsDoltChecks|CheckHardDependencies|DoRigSetEndpointAllowsBdRigUnderFileBackedCity|OpenStoreAtForCityUsesRig(FileStoreUnderBdBackedCity|BdStoreUnderFileBackedCity)|RawBeadsProviderForScopeKeepsSessionOverrideScoped)'`
- `make lint`
- dual-model `review-pr` rerun on the final branch tip returned no blocker/major findings

Closes #830