### PR TITLE
Fix imported pack skill discovery and materialization

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -55,6 +55,14 @@ type agentBuildParams struct {
 	// fingerprints or PreStart injection. The load error is logged to
 	// stderr at params-construction time.
 	skillCatalog *materialize.CityCatalog
+	// rigSkillCatalogs caches rig-specific shared catalogs. Each entry
+	// includes city-shared skills plus any rig-import shared catalogs.
+	rigSkillCatalogs map[string]*materialize.CityCatalog
+	// failedRigSkillCatalogs tracks rig scopes whose shared catalog
+	// failed to load for this build. Agents in those rigs must not
+	// fall back to the city catalog or they will inject stage-2 skill
+	// hooks that reload the broken rig catalog and fail at runtime.
+	failedRigSkillCatalogs map[string]bool
 
 	// sessionProvider is cfg.Session.Provider (the city-level session
 	// runtime selector: "" / "tmux" / "subprocess" / "acp" / "k8s" /
@@ -92,7 +100,7 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 	// fingerprints or PreStart, which matches the spec's "no spurious
 	// drain-restart cycles on remote-runtime agents" principle when
 	// discovery breaks transiently.
-	cat, err := materialize.LoadCityCatalog(cfg.PackSkillsDir)
+	cat, err := loadSharedSkillCatalog(cfg, "")
 	if err != nil {
 		if stderr != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: LoadCityCatalog %v (skills will not contribute to fingerprints this tick)\n", err) //nolint:errcheck // best-effort stderr
@@ -100,7 +108,41 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 	} else {
 		params.skillCatalog = &cat
 	}
+	for rigName := range cfg.RigPackSkills {
+		cat, err := loadSharedSkillCatalog(cfg, rigName)
+		if err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "buildDesiredState: LoadCityCatalog rig %q %v (skills will not contribute to fingerprints this tick)\n", rigName, err) //nolint:errcheck // best-effort stderr
+			}
+			if params.failedRigSkillCatalogs == nil {
+				params.failedRigSkillCatalogs = make(map[string]bool)
+			}
+			params.failedRigSkillCatalogs[rigName] = true
+			continue
+		}
+		if params.rigSkillCatalogs == nil {
+			params.rigSkillCatalogs = make(map[string]*materialize.CityCatalog)
+		}
+		catCopy := cat
+		params.rigSkillCatalogs[rigName] = &catCopy
+	}
 	return params
+}
+
+func (p *agentBuildParams) sharedSkillCatalogForAgent(agent *config.Agent) *materialize.CityCatalog {
+	if p == nil || agent == nil {
+		return nil
+	}
+	rigName := agentRigScopeName(agent, p.rigs)
+	if rigName != "" && p.failedRigSkillCatalogs != nil && p.failedRigSkillCatalogs[rigName] {
+		return nil
+	}
+	if p.rigSkillCatalogs != nil && rigName != "" {
+		if cat := p.rigSkillCatalogs[rigName]; cat != nil {
+			return cat
+		}
+	}
+	return p.skillCatalog
 }
 
 // effectiveOverlayDirs merges city-level and rig-level pack overlay dirs.

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -357,11 +357,12 @@ func ensureBeadsProvider(cityPath string) error {
 	provider := beadsProvider(cityPath)
 	if strings.HasPrefix(provider, "exec:") {
 		script := strings.TrimPrefix(provider, "exec:")
+		managedBDProvider := samePath(script, gcBeadsBdScriptPath(cityPath))
 		if err := runProviderOpWithEnv(script, providerLifecycleProcessEnv(cityPath, provider), "start"); err != nil {
 			// Managed bd startup occasionally reports a start error even though
 			// the Dolt server is already live. If the follow-up health probe
 			// succeeds, prefer the actual server state over the start error.
-			if rawBeadsProvider(cityPath) == "bd" {
+			if managedBDProvider {
 				if healthErr := runProviderOpWithEnv(script, providerLifecycleProcessEnv(cityPath, provider), "health"); healthErr == nil {
 					if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
 						return err

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -280,6 +280,92 @@ func TestEnsureBeadsProvider_execDoesNotMaskStartErrorWithHealth(t *testing.T) {
 	}
 }
 
+func TestEnsureBeadsProvider_execDoesNotReclassifyProviderAfterStart(t *testing.T) {
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "provider.log")
+	marker := filepath.Join(dir, "started")
+	release := filepath.Join(dir, "release")
+	script := filepath.Join(dir, "provider.sh")
+	content := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"echo \"$1\" >> \"" + callLog + "\"\n" +
+		"case \"${1:-}\" in\n" +
+		"  start)\n" +
+		"    : > \"" + marker + "\"\n" +
+		"    i=0\n" +
+		"    while [ ! -f \"" + release + "\" ]; do\n" +
+		"      i=$((i + 1))\n" +
+		"      [ \"$i\" -le 1000 ] || exit 42\n" +
+		"      sleep 0.01\n" +
+		"    done\n" +
+		"    echo 'signal: terminated' >&2\n" +
+		"    exit 1\n" +
+		"    ;;\n" +
+		"  health)\n" +
+		"    [ -f \"" + marker + "\" ]\n" +
+		"    ;;\n" +
+		"  *)\n" +
+		"    exit 0\n" +
+		"    ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalProvider, hadProvider := os.LookupEnv("GC_BEADS")
+	if err := os.Setenv("GC_BEADS", "exec:"+script); err != nil {
+		t.Fatalf("set GC_BEADS: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadProvider {
+			_ = os.Setenv("GC_BEADS", originalProvider)
+			return
+		}
+		_ = os.Unsetenv("GC_BEADS")
+	})
+
+	releaseErr := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(marker); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				releaseErr <- fmt.Errorf("provider start marker was not written")
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if err := os.Setenv("GC_BEADS", "bd"); err != nil {
+			releaseErr <- err
+			return
+		}
+		releaseErr <- os.WriteFile(release, []byte("ok"), 0o644)
+	}()
+
+	err := ensureBeadsProvider(dir)
+	if releaseErr := <-releaseErr; releaseErr != nil {
+		t.Fatalf("release provider script: %v", releaseErr)
+	}
+	if err == nil {
+		t.Fatal("ensureBeadsProvider = nil, want original start error")
+	}
+	if !strings.Contains(err.Error(), "signal: terminated") {
+		t.Fatalf("ensureBeadsProvider error = %v, want start error", err)
+	}
+
+	data, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read call log: %v", readErr)
+	}
+	got := strings.Fields(string(data))
+	want := []string{"start"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("provider calls = %v, want %v", got, want)
+	}
+}
+
 // TestShutdownBeadsProvider_file verifies that file provider is a no-op.
 func TestShutdownBeadsProvider_file(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -76,10 +76,12 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 				return nil
 			}
 
-			cityCat, err := materialize.LoadCityCatalog(cfg.PackSkillsDir)
+			rigName := agentRigScopeName(&agent, cfg.Rigs)
+			cityCat, err := loadSharedSkillCatalog(cfg, rigName)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
-				return errExit
+				fmt.Fprintf(stderr, "gc internal materialize-skills: shared skill catalog unavailable for %q: %v\n", agent.QualifiedName(), err) //nolint:errcheck // best-effort stderr
+				cityCat.Entries = nil
+				cityCat.Shadowed = nil
 			}
 			agentCat, err := materialize.LoadAgentCatalog(agent.SkillsDir)
 			if err != nil {

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,6 +77,204 @@ template = "mayor"
 	// Stdout should include the "materialized" summary line.
 	if !strings.Contains(stdout.String(), "materialized 1 skill") {
 		t.Errorf("stdout missing summary: %q", stdout.String())
+	}
+}
+
+func TestInternalMaterializeSkillsMaterializesImportedSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	rootDir := t.TempDir()
+	cityDir := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "helper")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+start_command = "echo"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city\"\nversion = \"0.1.0\"\nschema = 2\n\n[imports.helper]\nsource = \"../helper\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(helper): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte("[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(helper/pack.toml): %v", err)
+	}
+	writeSkillSource(t, filepath.Join(packDir, "skills", "plan"))
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	link := filepath.Join(workdir, ".claude", "skills", "helper.plan")
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat(%s): %v", link, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink", link)
+	}
+	tgt, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	wantTarget := filepath.Join(packDir, "skills", "plan")
+	if tgt != wantTarget {
+		t.Fatalf("symlink target = %q, want %q", tgt, wantTarget)
+	}
+}
+
+func TestInternalMaterializeSkillsCityScopedDirMatchingRigDoesNotMaterializeRigSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	helperDir := filepath.Join(cityDir, "assets", "helper")
+	rigDir := filepath.Join(cityDir, "fe")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := os.MkdirAll(helperDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(helper): %v", err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "fe"
+path = %q
+
+[rigs.imports.helper]
+source = "./assets/helper"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+dir = "fe"
+provider = "claude"
+start_command = "echo"
+`, rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(helperDir, "pack.toml"), []byte("[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(helper/pack.toml): %v", err)
+	}
+	writeSkillSource(t, filepath.Join(helperDir, "skills", "plan"))
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Lstat(filepath.Join(workdir, ".claude", "skills", "helper.plan")); !os.IsNotExist(err) {
+		t.Fatalf("city-scoped agent should not receive rig-shared skill, lstat err=%v", err)
+	}
+}
+
+func TestInternalMaterializeSkillsSharedCatalogFailurePrunesStaleSharedSymlink(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "claude"
+start_command = "echo"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	skillsDir := filepath.Join(cityDir, "skills")
+	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
+
+	workdir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("initial exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	link := filepath.Join(workdir, ".claude", "skills", "plan")
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("initial shared symlink missing: %v", err)
+	}
+
+	if err := os.Chmod(skillsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+	if _, err := os.ReadDir(skillsDir); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = run([]string{
+		"internal", "materialize-skills",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "shared skill catalog unavailable") {
+		t.Fatalf("stderr = %q, want shared catalog warning", stderr.String())
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("stale shared symlink should be pruned on catalog failure, lstat err=%v", err)
 	}
 }
 

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -155,18 +155,25 @@ func doUnregister(args []string, stdout, stderr io.Writer) int {
 }
 
 func newCitiesCmd(stdout, stderr io.Writer) *cobra.Command {
+	runList := func(_ *cobra.Command, _ []string) error {
+		if doCities(stdout, stderr) != 0 {
+			return errExit
+		}
+		return nil
+	}
 	cmd := &cobra.Command{
 		Use:   "cities",
 		Short: "List registered cities",
 		Long:  `List all cities registered with the machine-wide supervisor.`,
 		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if doCities(stdout, stderr) != 0 {
-				return errExit
-			}
-			return nil
-		},
+		RunE:  runList,
 	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List registered cities",
+		Args:  cobra.NoArgs,
+		RunE:  runList,
+	})
 	return cmd
 }
 

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -303,3 +303,30 @@ func TestDoCities(t *testing.T) {
 		t.Errorf("expected 'bright-lights' in output, got: %s", stdout.String())
 	}
 }
+
+func TestCitiesListSubcommandAliasesDefaultAction(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := newCitiesCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc cities list failed: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "bright-lights") {
+		t.Errorf("expected 'bright-lights' in output, got: %s", stdout.String())
+	}
+}

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -24,6 +24,7 @@ func newSkillCmd(stdout, stderr io.Writer) *cobra.Command {
 
 Output includes:
   - City pack skills (skills/<name>/SKILL.md under the city root)
+  - Imported pack shared skills (binding-qualified, e.g. ops.code-review)
   - Bootstrap implicit-import pack skills (e.g. core)
   - With --agent/--session: that agent's agents/<name>/skills/ catalog
 
@@ -52,7 +53,7 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List visible skills",
-		Long:  "List the current city pack's visible skills, optionally scoped to an agent or session.",
+		Long:  "List the current shared and agent-local visible skills, optionally scoped to an agent or session.",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if strings.TrimSpace(agentName) != "" && strings.TrimSpace(sessionID) != "" {
@@ -101,6 +102,7 @@ func listVisibleSkillEntries(cityPath string, cfg *config.City, store beads.Stor
 	// listing reflects what the materializer actually delivers.
 	entries = append(entries, discoverBootstrapSkillEntries()...)
 	if strings.TrimSpace(agentName) == "" && strings.TrimSpace(sessionID) == "" {
+		entries = append(entries, discoverImportedSkillEntries(sharedSkillCatalogInputs(cfg, currentRigContext(cfg)))...)
 		sortVisibilityEntries(entries)
 		return entries, nil
 	}
@@ -110,6 +112,7 @@ func listVisibleSkillEntries(cityPath string, cfg *config.City, store beads.Stor
 	}
 	// Every agent sees the entire city+bootstrap catalog plus its own
 	// agent-local skills. No attachment filtering.
+	entries = append(entries, discoverImportedSkillEntries(sharedSkillCatalogInputs(cfg, agentRigScopeName(agent, cfg.Rigs)))...)
 	entries = append(entries, discoverAgentSkillEntries(agentAssetRoot(cityPath, agent), agent.Name, "agent")...)
 	sortVisibilityEntries(entries)
 	return entries, nil
@@ -202,6 +205,44 @@ func agentAssetRoot(cityPath string, agent *config.Agent) string {
 
 func discoverSkillEntries(root, source string) []visibilityEntry {
 	return discoverSkillDirEntries(filepath.Join(root, "skills"), "skills", source)
+}
+
+func discoverImportedSkillEntries(catalogs []config.DiscoveredSkillCatalog) []visibilityEntry {
+	var out []visibilityEntry
+	for _, catalog := range catalogs {
+		source := strings.TrimSpace(catalog.BindingName)
+		if source == "" {
+			source = strings.TrimSpace(catalog.PackName)
+		}
+		entries, err := os.ReadDir(catalog.SourceDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+				continue
+			}
+			skillPath := filepath.Join(catalog.SourceDir, name, "SKILL.md")
+			if info, err := os.Stat(skillPath); err != nil || info.IsDir() {
+				continue
+			}
+			publicName := name
+			if catalog.BindingName != "" {
+				publicName = catalog.BindingName + "." + name
+			}
+			out = append(out, visibilityEntry{
+				Name:   publicName,
+				Source: source,
+				Path:   filepath.ToSlash(skillPath),
+			})
+		}
+	}
+	sortVisibilityEntries(out)
+	return out
 }
 
 func discoverAgentSkillEntries(root, agentName, source string) []visibilityEntry {

--- a/cmd/gc/cmd_skill_test.go
+++ b/cmd/gc/cmd_skill_test.go
@@ -65,6 +65,65 @@ func TestSkillListAgentCatalog(t *testing.T) {
 	}
 }
 
+func TestSkillListImportedSharedCatalog(t *testing.T) {
+	clearGCEnv(t)
+	rootDir := t.TempDir()
+	cityDir := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "helper")
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+	writeCatalogFile(t, packDir, "pack.toml", "[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n")
+	writeCatalogFile(t, packDir, "skills/code-review/SKILL.md", "imported skill")
+	writeCatalogFile(t, cityDir, "pack.toml", "[pack]\nname = \"city\"\nversion = \"0.1.0\"\nschema = 2\n\n[imports.helper]\nsource = \"../helper\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"skill", "list"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc skill list exited %d: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"helper.code-review", "helper"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("skill list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSkillListAgentCityScopedDirMatchingRigDoesNotShowRigSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "fe")
+	rigSkills := filepath.Join(cityDir, "imports", "helper", "skills")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCatalogFile(t, cityDir, "imports/helper/skills/plan/SKILL.md", "rig-import skill")
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "fe", Path: rigDir}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{
+			"fe": {{
+				SourceDir:   rigSkills,
+				BindingName: "helper",
+				PackName:    "helper",
+			}},
+		},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Dir: "fe"},
+		},
+	}
+
+	entries, err := listVisibleSkillEntries(cityDir, cfg, nil, "mayor", "")
+	if err != nil {
+		t.Fatalf("listVisibleSkillEntries: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name == "helper.plan" {
+			t.Fatalf("city-scoped agent should not list rig-shared skill: %+v", entries)
+		}
+	}
+}
+
 func TestSkillListSessionCatalog(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()

--- a/cmd/gc/skill_catalog.go
+++ b/cmd/gc/skill_catalog.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/materialize"
+)
+
+func sharedSkillCatalogInputs(cfg *config.City, rigName string) []config.DiscoveredSkillCatalog {
+	if cfg == nil {
+		return nil
+	}
+	var catalogs []config.DiscoveredSkillCatalog
+	if rigName != "" && cfg.RigPackSkills != nil {
+		catalogs = append(catalogs, cfg.RigPackSkills[rigName]...)
+	}
+	catalogs = append(catalogs, cfg.PackSkills...)
+	return catalogs
+}
+
+func loadSharedSkillCatalog(cfg *config.City, rigName string) (materialize.CityCatalog, error) {
+	if cfg == nil {
+		return materialize.CityCatalog{}, nil
+	}
+	return materialize.LoadCityCatalog(cfg.PackSkillsDir, sharedSkillCatalogInputs(cfg, rigName)...)
+}
+
+// agentRigScopeName returns the configured rig name that should
+// contribute rig-local shared skills for this agent. Only actual
+// rig-scoped agents attached to a declared rig get a non-empty name.
+// City-scoped agents, and inline agents whose Dir is just a working
+// directory hint, must not pull in rig catalogs solely because
+// agent.Dir happens to match a rig name.
+func agentRigScopeName(agent *config.Agent, rigs []config.Rig) string {
+	if agent == nil {
+		return ""
+	}
+	if strings.TrimSpace(agent.Scope) == "city" {
+		return ""
+	}
+	dir := strings.TrimSpace(agent.Dir)
+	if dir == "" {
+		return ""
+	}
+	for _, rig := range rigs {
+		if rig.Name == dir {
+			return rig.Name
+		}
+	}
+	return ""
+}

--- a/cmd/gc/skill_integration.go
+++ b/cmd/gc/skill_integration.go
@@ -260,7 +260,7 @@ func effectiveInjectAssignedSkills(agent *config.Agent) bool {
 
 // buildAssignedSkillsPromptFragment renders a markdown appendix that
 // lists every skill the agent sees, partitioned into (assigned-to-this-
-// agent, shared-with-every-agent-in-the-city). The goal is that agents
+// agent, shared-with-the-current-scope). The goal is that agents
 // sharing a scope-root sink (multiple city-scoped agents, multiple
 // rig-scoped agents on the same rig) can tell which skills are their
 // specialisation vs which are the shared set — the materialiser
@@ -314,7 +314,7 @@ func buildAssignedSkillsPromptFragment(
 	}
 
 	if len(shared) > 0 {
-		b.WriteString("### Shared (visible to every agent in this city)\n\n")
+		b.WriteString("### Shared in this scope\n\n")
 		writeSkillBullets(&b, shared, "origin")
 		b.WriteString("\n")
 	}

--- a/cmd/gc/skill_integration_test.go
+++ b/cmd/gc/skill_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/materialize"
@@ -69,6 +70,35 @@ func TestAgentScopeRoot(t *testing.T) {
 			got := agentScopeRoot(&c.agent, "/city", rigs)
 			if got != c.want {
 				t.Fatalf("agentScopeRoot(%+v) = %q, want %q", c.agent, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAgentRigScopeName(t *testing.T) {
+	t.Parallel()
+
+	rigs := []config.Rig{
+		{Name: "fe", Path: "/rigs/fe"},
+		{Name: "be", Path: "/rigs/be"},
+	}
+	cases := []struct {
+		name  string
+		agent *config.Agent
+		want  string
+	}{
+		{name: "nil agent", agent: nil, want: ""},
+		{name: "city-scoped matching dir stays city", agent: &config.Agent{Scope: "city", Dir: "fe"}, want: ""},
+		{name: "rig-scoped matching dir uses rig", agent: &config.Agent{Scope: "rig", Dir: "fe"}, want: "fe"},
+		{name: "empty scope matching dir defaults to rig", agent: &config.Agent{Dir: "be"}, want: "be"},
+		{name: "plain dir not a rig", agent: &config.Agent{Dir: "workdir"}, want: ""},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := agentRigScopeName(c.agent, rigs); got != c.want {
+				t.Fatalf("agentRigScopeName(%+v) = %q, want %q", c.agent, got, c.want)
 			}
 		})
 	}
@@ -180,6 +210,46 @@ func TestEffectiveSkillsForAgentFourBranches(t *testing.T) {
 			t.Errorf("expected stderr to mention LoadAgentCatalog, got %q", buf.String())
 		}
 	})
+}
+
+func TestSharedSkillCatalogForAgentDoesNotFallBackWhenRigCatalogFails(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	writeSkillSource(t, filepath.Join(cityPath, "skills", "city-shared"))
+
+	badRigCatalog := filepath.Join(cityPath, "broken-rig-catalog")
+	if err := os.Mkdir(badRigCatalog, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badRigCatalog, 0o755) })
+	if _, err := os.ReadDir(badRigCatalog); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	cfg := &config.City{
+		PackSkillsDir: filepath.Join(cityPath, "skills"),
+		Rigs:          []config.Rig{{Name: "fe", Path: filepath.Join(cityPath, "rigs", "fe")}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{
+			"fe": {{
+				SourceDir:   badRigCatalog,
+				BindingName: "ops",
+				PackName:    "helper",
+			}},
+		},
+	}
+
+	var stderr strings.Builder
+	params := newAgentBuildParams("test-city", cityPath, cfg, nil, time.Now(), nil, &stderr)
+	if params.skillCatalog == nil {
+		t.Fatal("city skill catalog should still load")
+	}
+	if got := params.sharedSkillCatalogForAgent(&config.Agent{Name: "rig-agent", Scope: "rig", Dir: "fe"}); got != nil {
+		t.Fatalf("sharedSkillCatalogForAgent() = %+v, want nil when rig catalog load fails", got)
+	}
+	if !strings.Contains(stderr.String(), `LoadCityCatalog rig "fe"`) {
+		t.Fatalf("stderr = %q, want rig catalog load error", stderr.String())
+	}
 }
 
 func TestMergeSkillFingerprintEntries(t *testing.T) {

--- a/cmd/gc/skill_integration_test.go
+++ b/cmd/gc/skill_integration_test.go
@@ -361,7 +361,7 @@ func TestBuildAssignedSkillsPromptFragmentPartitions(t *testing.T) {
 		"### Assigned to you",
 		"`mayor-planning` — Mayor-only strategy",
 		"`planning` — Mayor's planning override",
-		"### Shared (visible to every agent in this city)",
+		"### Shared in this scope",
 		"`code-review` — Review pull requests *(city)*",
 		"`gc-work` — Working with beads *(core)*",
 	}

--- a/cmd/gc/skill_supervisor.go
+++ b/cmd/gc/skill_supervisor.go
@@ -25,24 +25,38 @@ import (
 // root; acp runs in-process and doesn't read from it). Hybrid is
 // per-session-routed; conservatively ineligible until v0.15.2.
 //
-// Catalog load happens once per call and feeds every agent's
-// materialization in this tick. Per-agent errors (LoadAgentCatalog,
-// MaterializeAgent) are logged to stderr and do not abort the pass
-// — the supervisor should continue reconciling every other agent.
-// Catalog-level failures cause the whole pass to exit early with
-// the error logged inline so the caller doesn't double-log.
+// Catalog load happens once per scope per call and feeds every
+// agent's materialization in this tick. Per-agent errors
+// (LoadAgentCatalog, MaterializeAgent) are logged to stderr and do
+// not abort the pass — the supervisor should continue reconciling
+// every other agent. Shared-catalog load failures are also logged and
+// then downgraded to an empty shared desired set, while preserving
+// owned-root cleanup so stale gc-managed symlinks can still be pruned.
 func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.Writer) error {
 	if cfg == nil {
 		return nil
 	}
-	cityCat, err := materialize.LoadCityCatalog(cfg.PackSkillsDir)
-	if err != nil {
-		// Log inline and return nil so the supervisor tick's
-		// runStep wrapper doesn't double-log the same message.
-		if stderr != nil {
-			fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load city skill catalog: %v\n", err) //nolint:errcheck // best-effort stderr
+	catalogs := make(map[string]materialize.CityCatalog)
+	loadCatalog := func(rigName string) materialize.CityCatalog {
+		if cat, ok := catalogs[rigName]; ok {
+			return cat
 		}
-		return nil
+		cat, err := loadSharedSkillCatalog(cfg, rigName)
+		if err != nil {
+			if stderr != nil {
+				if rigName == "" {
+					fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load shared skill catalog for city scope: %v\n", err) //nolint:errcheck // best-effort stderr
+				} else {
+					fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load shared skill catalog for rig %q: %v\n", rigName, err) //nolint:errcheck // best-effort stderr
+				}
+			}
+			cat.Entries = nil
+			cat.Shadowed = nil
+			catalogs[rigName] = cat
+			return catalogs[rigName]
+		}
+		catalogs[rigName] = cat
+		return cat
 	}
 
 	for i := range cfg.Agents {
@@ -65,10 +79,9 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 			agentCat = materialize.AgentCatalog{}
 		}
 
+		rigName := agentRigScopeName(agent, cfg.Rigs)
+		cityCat := loadCatalog(rigName)
 		desired := materialize.EffectiveSet(cityCat, agentCat)
-		if len(desired) == 0 {
-			continue
-		}
 
 		// Resolve the agent's scope root to an absolute path. Use the
 		// un-canonicalized form here so the materializer writes into
@@ -85,6 +98,9 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 		owned := append([]string{}, cityCat.OwnedRoots...)
 		if agentCat.OwnedRoot != "" {
 			owned = append(owned, agentCat.OwnedRoot)
+		}
+		if len(desired) == 0 && len(owned) == 0 {
+			continue
 		}
 
 		res, merr := materialize.Run(materialize.Request{

--- a/cmd/gc/skill_supervisor_test.go
+++ b/cmd/gc/skill_supervisor_test.go
@@ -50,6 +50,45 @@ func TestRunStage1SkillMaterializationCityScoped(t *testing.T) {
 	}
 }
 
+func TestRunStage1CityScopedDirMatchingRigDoesNotGetRigSharedSkills(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	rigPath := filepath.Join(cityPath, "rigs", "fe")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rigSkills := filepath.Join(cityPath, "imports", "helper", "skills")
+	writeSkillSource(t, filepath.Join(rigSkills, "plan"))
+
+	cfg := &config.City{
+		Session: config.SessionConfig{Provider: "tmux"},
+		Rigs:    []config.Rig{{Name: "fe", Path: rigPath}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{
+			"fe": {{
+				SourceDir:   rigSkills,
+				BindingName: "helper",
+				PackName:    "helper",
+			}},
+		},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Dir: "fe", Provider: "claude"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("runStage1SkillMaterialization: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(cityPath, ".claude", "skills", "helper.plan")); !os.IsNotExist(err) {
+		t.Fatalf("city-scoped agent should not receive rig-shared skill, lstat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, ".claude", "skills")); !os.IsNotExist(err) {
+		t.Fatalf("rig sink should remain untouched for city-scoped agent, stat err=%v", err)
+	}
+}
+
 // TestRunStage1MaterializesIntoRigScope confirms that a rig-scoped
 // agent materializes into the rig path, not the city path.
 func TestRunStage1MaterializesIntoRigScope(t *testing.T) {
@@ -333,6 +372,93 @@ func TestRunStage1MaterializesBootstrapPackSkills(t *testing.T) {
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
 		t.Errorf("%q is not a symlink", link)
+	}
+}
+
+func TestRunStage1MaterializesAgentLocalWhenSharedCatalogFails(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+	rigPath := filepath.Join(cityPath, "rigs", "fe")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	badRigCatalog := filepath.Join(cityPath, "broken-rig-catalog")
+	if err := os.Mkdir(badRigCatalog, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badRigCatalog, 0o755) })
+	if _, err := os.ReadDir(badRigCatalog); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	agentSkills := filepath.Join(cityPath, "agents", "polecat", "skills")
+	writeSkillSource(t, filepath.Join(agentSkills, "local-only"))
+
+	cfg := &config.City{
+		Session:       config.SessionConfig{Provider: "tmux"},
+		Rigs:          []config.Rig{{Name: "fe", Path: rigPath}},
+		RigPackSkills: map[string][]config.DiscoveredSkillCatalog{"fe": {{SourceDir: badRigCatalog, BindingName: "ops"}}},
+		Agents: []config.Agent{
+			{Name: "polecat", Scope: "rig", Dir: "fe", Provider: "claude", SkillsDir: agentSkills},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("runStage1SkillMaterialization: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "load shared skill catalog") {
+		t.Fatalf("stderr = %q, want shared catalog load warning", stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, ".claude", "skills", "local-only")); err != nil {
+		t.Fatalf("agent-local skill should still materialize: %v", err)
+	}
+}
+
+func TestRunStage1SharedCatalogFailurePrunesStaleSharedSymlink(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_HOME", t.TempDir())
+
+	skillsDir := filepath.Join(cityPath, "skills")
+	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
+
+	cfg := &config.City{
+		PackSkillsDir: skillsDir,
+		Session:       config.SessionConfig{Provider: "tmux"},
+		Agents: []config.Agent{
+			{Name: "mayor", Scope: "city", Provider: "claude"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("initial runStage1SkillMaterialization: %v", err)
+	}
+	link := filepath.Join(cityPath, ".claude", "skills", "plan")
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("initial shared symlink missing: %v", err)
+	}
+
+	if err := os.Chmod(skillsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+	if _, err := os.ReadDir(skillsDir); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	stderr.Reset()
+	if err := runStage1SkillMaterialization(cityPath, cfg, &stderr); err != nil {
+		t.Fatalf("second runStage1SkillMaterialization: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "load shared skill catalog") {
+		t.Fatalf("stderr = %q, want shared catalog load warning", stderr.String())
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("stale shared symlink should be pruned on catalog failure, lstat err=%v", err)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -312,7 +312,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 						agentCat = c
 					}
 				}
-				if frag := buildAssignedSkillsPromptFragment(cfgAgent, p.skillCatalog, agentCat); frag != "" {
+				if frag := buildAssignedSkillsPromptFragment(cfgAgent, p.sharedSkillCatalogForAgent(cfgAgent), agentCat); frag != "" {
 					prompt = prompt + "\n\n" + frag
 				}
 			}
@@ -363,7 +363,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		if p.workspace != nil {
 			wsProvider = p.workspace.Provider
 		}
-		desired := effectiveSkillsForAgent(p.skillCatalog, cfgAgent, wsProvider, p.stderr)
+		desired := effectiveSkillsForAgent(p.sharedSkillCatalogForAgent(cfgAgent), cfgAgent, wsProvider, p.stderr)
 		if len(desired) > 0 {
 			fpExtra = mergeSkillFingerprintEntries(fpExtra, desired)
 			if canonWorkDir != scopeRoot {

--- a/examples/gastown/packs/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/adopt-pr-review-approved.sh
@@ -23,6 +23,20 @@ json_payload() {
     awk 'found || /^[[:space:]]*[[{]/{ found=1; print }'
 }
 
+bd_json() {
+    local attempt=0
+    local output=""
+    while [ "$attempt" -lt 10 ]; do
+        if output=$(bd "$@" 2>/dev/null | json_payload) && [ -n "$output" ]; then
+            printf '%s\n' "$output"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 0.2
+    done
+    return 1
+}
+
 load_verdict() {
     local apply_ref="$1"
     local root_id="$2"
@@ -84,7 +98,7 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null | json_payload)
+BEAD_JSON=$(bd_json show "$BEAD_ID" --json)
 ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end' 2>/dev/null || printf '')
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end' 2>/dev/null || printf '')
 if [ -z "$ATTEMPT" ] || [ -z "$ROOT_ID" ]; then

--- a/examples/gastown/packs/gastown/assets/scripts/checks/code-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/code-review-approved.sh
@@ -19,6 +19,20 @@ json_payload() {
     awk 'found || /^[[:space:]]*[[{]/{ found=1; print }'
 }
 
+bd_json() {
+    local attempt=0
+    local output=""
+    while [ "$attempt" -lt 10 ]; do
+        if output=$(bd "$@" 2>/dev/null | json_payload) && [ -n "$output" ]; then
+            printf '%s\n' "$output"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 0.2
+    done
+    return 1
+}
+
 load_verdict() {
     local apply_ref="$1"
     local root_id="$2"
@@ -76,7 +90,7 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null | json_payload)
+BEAD_JSON=$(bd_json show "$BEAD_ID" --json)
 ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end' 2>/dev/null || printf '')
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end' 2>/dev/null || printf '')
 if [ -z "$ATTEMPT" ] || [ -z "$ROOT_ID" ]; then

--- a/examples/gastown/packs/gastown/assets/scripts/checks/design-review-approved.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/checks/design-review-approved.sh
@@ -19,6 +19,20 @@ json_payload() {
     awk 'found || /^[[:space:]]*[[{]/{ found=1; print }'
 }
 
+bd_json() {
+    local attempt=0
+    local output=""
+    while [ "$attempt" -lt 10 ]; do
+        if output=$(bd "$@" 2>/dev/null | json_payload) && [ -n "$output" ]; then
+            printf '%s\n' "$output"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 0.2
+    done
+    return 1
+}
+
 load_verdict() {
     local apply_ref="$1"
     local root_id="$2"
@@ -76,7 +90,7 @@ if [ -z "$BEAD_ID" ]; then
     exit 1
 fi
 
-BEAD_JSON=$(bd show "$BEAD_ID" --json 2>/dev/null | json_payload)
+BEAD_JSON=$(bd_json show "$BEAD_ID" --json)
 ATTEMPT=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.attempt"] // "") else (.metadata["gc.attempt"] // "") end' 2>/dev/null || printf '')
 ROOT_ID=$(printf '%s\n' "$BEAD_JSON" | jq -r 'if type == "array" then (.[0].metadata["gc.root_bead_id"] // "") else (.metadata["gc.root_bead_id"] // "") end' 2>/dev/null || printf '')
 if [ -z "$ATTEMPT" ] || [ -z "$ROOT_ID" ]; then

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,12 +223,18 @@ type City struct {
 	// PackDoctors holds convention-discovered pack doctor checks composed
 	// during city and rig expansion. Runtime-only.
 	PackDoctors []DiscoveredDoctor `toml:"-" json:"-"`
+	// PackSkills holds binding-qualified shared skill catalogs composed
+	// from city-level imported packs. Runtime-only.
+	PackSkills []DiscoveredSkillCatalog `toml:"-" json:"-"`
 	// PackSkillsDir holds the current city pack's shared skills catalog root.
 	// Runtime-only — not persisted to TOML or JSON.
 	PackSkillsDir string `toml:"-" json:"-"`
 	// PackMCPDir holds the current city pack's shared MCP catalog root.
 	// Runtime-only — not persisted to TOML or JSON.
 	PackMCPDir string `toml:"-" json:"-"`
+	// RigPackSkills maps rig name to the binding-qualified shared skill
+	// catalogs composed from that rig's imports. Runtime-only.
+	RigPackSkills map[string][]DiscoveredSkillCatalog `toml:"-" json:"-"`
 }
 
 // NamedSession defines a canonical persistent session backed by an agent

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -205,7 +205,7 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 				cfg.RigPackSkills[rig.Name] = appendDiscoveredSkills(
 					cfg.RigPackSkills[rig.Name],
-					stampSkillBinding(skills, bindingName)...,
+					stampImportedSkillBinding(skills, bindingName, imp.Export)...,
 				)
 
 				// Stamp binding name on agents and named sessions.
@@ -617,7 +617,7 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 			cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, commands...)
 			cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, doctors...)
 			if !slices.Contains(BootstrapManagedImportNames(), bindingName) {
-				cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampSkillBinding(skills, bindingName)...)
+				cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampImportedSkillBinding(skills, bindingName, imp.Export)...)
 			}
 			allPackDirs = appendUnique(allPackDirs, topoDirs...)
 
@@ -1102,9 +1102,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 				impDoctors[i].BindingName = bindingName
 			}
 		}
-		for i := range impSkills {
-			impSkills[i].BindingName = bindingName
-		}
+		impSkills = stampImportedSkillBinding(impSkills, bindingName, imp.Export)
 
 		// Read the imported pack name for provenance tracking.
 		impData, readErr := fs.ReadFile(impPath)
@@ -1620,7 +1618,19 @@ func stampDefaultBinding(commands []DiscoveredCommand, defaultBinding string) []
 func stampSkillBinding(skills []DiscoveredSkillCatalog, bindingName string) []DiscoveredSkillCatalog {
 	out := deepCopySkills(skills)
 	for i := range out {
-		out[i].BindingName = bindingName
+		if out[i].BindingName == "" {
+			out[i].BindingName = bindingName
+		}
+	}
+	return out
+}
+
+func stampImportedSkillBinding(skills []DiscoveredSkillCatalog, bindingName string, export bool) []DiscoveredSkillCatalog {
+	out := deepCopySkills(skills)
+	for i := range out {
+		if out[i].BindingName == "" || export {
+			out[i].BindingName = bindingName
+		}
 	}
 	return out
 }

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -95,6 +95,17 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				stampDefaultBinding(cachedPackCommands(cache, topoDir), packName)...,
 			)
 			cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, topoDir)...)
+			skills := cachedPackSkills(cache, topoDir)
+			if packName == "" && len(skills) > 0 {
+				return fmt.Errorf("rig %q pack %q: discovered skills require [pack].name for binding", rig.Name, ref)
+			}
+			if cfg.RigPackSkills == nil {
+				cfg.RigPackSkills = make(map[string][]DiscoveredSkillCatalog)
+			}
+			cfg.RigPackSkills[rig.Name] = appendDiscoveredSkills(
+				cfg.RigPackSkills[rig.Name],
+				stampSkillBinding(skills, packName)...,
+			)
 
 			// Validate rig-scoped requirements.
 			for _, req := range reqs {
@@ -173,6 +184,7 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				}
 				commands := cachedPackCommands(cache, impDir)
 				doctors := cachedPackDoctors(cache, impDir)
+				skills := cachedPackSkills(cache, impDir)
 				if !imp.ImportIsTransitive() {
 					absImpDir, _ := filepath.Abs(impDir)
 					var direct []Agent
@@ -185,8 +197,16 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 					agents = direct
 					commands = filterCommandsByPackDir(commands, impDir)
 					doctors = filterDoctorsByPackDir(doctors, impDir)
+					skills = filterSkillsByPackDir(skills, impDir)
 				}
 				rigGlobals = append(rigGlobals, globals...)
+				if cfg.RigPackSkills == nil {
+					cfg.RigPackSkills = make(map[string][]DiscoveredSkillCatalog)
+				}
+				cfg.RigPackSkills[rig.Name] = appendDiscoveredSkills(
+					cfg.RigPackSkills[rig.Name],
+					stampSkillBinding(skills, bindingName)...,
+				)
 
 				// Stamp binding name on agents and named sessions.
 				// At the rig level, ALL agents from an import get the rig's
@@ -438,6 +458,11 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 		}
 		cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, stampDefaultBinding(cachedPackCommands(cache, topoDir), packName)...)
 		cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, cachedPackDoctors(cache, topoDir)...)
+		skills := cachedPackSkills(cache, topoDir)
+		if packName == "" && len(skills) > 0 {
+			return nil, nil, nil, fmt.Errorf("city pack %q: discovered skills require [pack].name for shared binding", ref)
+		}
+		cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampSkillBinding(skills, packName)...)
 
 		// Accumulate pack dirs (deduped).
 		allPackDirs = appendUnique(allPackDirs, topoDirs...)
@@ -499,6 +524,7 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 			}
 			commands := cachedPackCommands(cache, impDir)
 			doctors := cachedPackDoctors(cache, impDir)
+			skills := cachedPackSkills(cache, impDir)
 
 			// When transitive = false, keep only agents directly defined
 			// by this import (not its own transitive dependencies).
@@ -514,6 +540,7 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 				agents = direct
 				commands = filterCommandsByPackDir(commands, impDir)
 				doctors = filterDoctorsByPackDir(doctors, impDir)
+				skills = filterSkillsByPackDir(skills, impDir)
 			}
 
 			// Stamp binding name on all agents and named sessions.
@@ -589,6 +616,9 @@ func ExpandCityPacks(cfg *City, fs fsys.FS, cityRoot string) ([]string, []PackRe
 			cfg.Services = append(cfg.Services, services...)
 			cfg.PackCommands = appendDiscoveredCommands(cfg.PackCommands, commands...)
 			cfg.PackDoctors = appendDiscoveredDoctors(cfg.PackDoctors, doctors...)
+			if !slices.Contains(BootstrapManagedImportNames(), bindingName) {
+				cfg.PackSkills = appendDiscoveredSkills(cfg.PackSkills, stampSkillBinding(skills, bindingName)...)
+			}
 			allPackDirs = appendUnique(allPackDirs, topoDirs...)
 
 			// Filter by scope for city expansion.
@@ -892,6 +922,7 @@ type packLoadResult struct {
 	globals       []ResolvedPackGlobal
 	commands      []DiscoveredCommand
 	doctors       []DiscoveredDoctor
+	skills        []DiscoveredSkillCatalog
 }
 
 //nolint:unparam // compatibility wrapper keeps the recursion-set argument at the public helper boundary.
@@ -958,6 +989,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 	var includedGlobals []ResolvedPackGlobal
 	var includedCommands []DiscoveredCommand
 	var includedDoctors []DiscoveredDoctor
+	var includedSkills []DiscoveredSkillCatalog
 	includedProviders := make(map[string]ProviderSpec)
 
 	for _, inc := range tc.Pack.Includes {
@@ -981,6 +1013,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		includedGlobals = append(includedGlobals, incGlobals...)
 		includedCommands = append(includedCommands, cachedPackCommands(cache, incTopoDir)...)
 		includedDoctors = append(includedDoctors, cachedPackDoctors(cache, incTopoDir)...)
+		includedSkills = append(includedSkills, cachedPackSkills(cache, incTopoDir)...)
 
 		// Merge providers: included first, no overwrite.
 		for name, spec := range incProviders {
@@ -1020,6 +1053,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		}
 		impCommands := cachedPackCommands(cache, impDir)
 		impDoctors := cachedPackDoctors(cache, impDir)
+		impSkills := cachedPackSkills(cache, impDir)
 
 		// When transitive = false, strip agents that came from the
 		// imported pack's own imports (i.e., transitive deps). We keep
@@ -1036,6 +1070,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 			impAgents = direct
 			impCommands = filterCommandsByPackDir(impCommands, impDir)
 			impDoctors = filterDoctorsByPackDir(impDoctors, impDir)
+			impSkills = filterSkillsByPackDir(impSkills, impDir)
 		}
 
 		// Stamp binding name on all agents and named sessions from this import.
@@ -1067,6 +1102,9 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 				impDoctors[i].BindingName = bindingName
 			}
 		}
+		for i := range impSkills {
+			impSkills[i].BindingName = bindingName
+		}
 
 		// Read the imported pack name for provenance tracking.
 		impData, readErr := fs.ReadFile(impPath)
@@ -1092,6 +1130,11 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 				impDoctors[i].PackName = packName
 			}
 		}
+		for i := range impSkills {
+			if impSkills[i].PackName == "" {
+				impSkills[i].PackName = packName
+			}
+		}
 
 		includedAgents = append(includedAgents, impAgents...)
 		includedNamedSessions = append(includedNamedSessions, impNamedSessions...)
@@ -1101,6 +1144,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		includedGlobals = append(includedGlobals, impGlobals...)
 		includedCommands = append(includedCommands, impCommands...)
 		includedDoctors = append(includedDoctors, impDoctors...)
+		includedSkills = append(includedSkills, impSkills...)
 
 		for name, spec := range impProviders {
 			if _, exists := includedProviders[name]; !exists {
@@ -1131,6 +1175,10 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	doctors = append(doctors, legacyPackDoctors(tc.Doctor, topoDir, tc.Pack.Name)...)
+	skills, err := DiscoverPackSkills(fs, topoDir, tc.Pack.Name)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, err
+	}
 
 	// V2 convention-based order discovery: top-level orders/ flat files are the
 	// standard layout. Deprecated locations are still discovered so pack loads
@@ -1191,6 +1239,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 	includedServices = append(includedServices, services...)
 	includedCommands = append(includedCommands, commands...)
 	includedDoctors = append(includedDoctors, doctors...)
+	includedSkills = append(includedSkills, skills...)
 
 	// Apply pack-level patches to the merged agent list.
 	if !tc.Patches.IsEmpty() {
@@ -1264,6 +1313,7 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 		globals:       allGlobals,
 		commands:      includedCommands,
 		doctors:       includedDoctors,
+		skills:        includedSkills,
 	})
 
 	return includedAgents, includedNamedSessions, mergedProviders, includedServices, topoDirs, allRequires, allGlobals, nil
@@ -1283,6 +1333,7 @@ func clonePackLoadResult(in *packLoadResult) *packLoadResult {
 		globals:       deepCopyResolvedPackGlobals(in.globals),
 		commands:      deepCopyCommands(in.commands),
 		doctors:       deepCopyDoctors(in.doctors),
+		skills:        deepCopySkills(in.skills),
 	}
 }
 
@@ -1445,6 +1496,21 @@ func cachedPackDoctors(cache *packLoadCache, topoDir string) []DiscoveredDoctor 
 	return out
 }
 
+func cachedPackSkills(cache *packLoadCache, topoDir string) []DiscoveredSkillCatalog {
+	if cache == nil {
+		return nil
+	}
+	absDir, err := filepath.Abs(topoDir)
+	if err != nil {
+		absDir = topoDir
+	}
+	result, ok := cache.results[absDir]
+	if !ok {
+		return nil
+	}
+	return deepCopySkills(result.skills)
+}
+
 func filterCommandsByPackDir(commands []DiscoveredCommand, packDir string) []DiscoveredCommand {
 	absPackDir, _ := filepath.Abs(packDir)
 	var out []DiscoveredCommand
@@ -1464,6 +1530,18 @@ func filterDoctorsByPackDir(doctors []DiscoveredDoctor, packDir string) []Discov
 		absDir, _ := filepath.Abs(check.PackDir)
 		if absDir == absPackDir {
 			out = append(out, check)
+		}
+	}
+	return out
+}
+
+func filterSkillsByPackDir(skills []DiscoveredSkillCatalog, packDir string) []DiscoveredSkillCatalog {
+	absPackDir, _ := filepath.Abs(packDir)
+	var out []DiscoveredSkillCatalog
+	for _, skill := range skills {
+		absDir, _ := filepath.Abs(skill.PackDir)
+		if absDir == absPackDir {
+			out = append(out, skill)
 		}
 	}
 	return out
@@ -1513,12 +1591,36 @@ func appendDiscoveredDoctors(dst []DiscoveredDoctor, src ...DiscoveredDoctor) []
 	return dst
 }
 
+func appendDiscoveredSkills(dst []DiscoveredSkillCatalog, src ...DiscoveredSkillCatalog) []DiscoveredSkillCatalog {
+	for _, skill := range src {
+		duplicate := false
+		for _, existing := range dst {
+			if existing.SourceDir == skill.SourceDir && existing.BindingName == skill.BindingName {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			dst = append(dst, skill)
+		}
+	}
+	return dst
+}
+
 func stampDefaultBinding(commands []DiscoveredCommand, defaultBinding string) []DiscoveredCommand {
 	out := deepCopyCommands(commands)
 	for i := range out {
 		if out[i].BindingName == "" {
 			out[i].BindingName = defaultBinding
 		}
+	}
+	return out
+}
+
+func stampSkillBinding(skills []DiscoveredSkillCatalog, bindingName string) []DiscoveredSkillCatalog {
+	out := deepCopySkills(skills)
+	for i := range out {
+		out[i].BindingName = bindingName
 	}
 	return out
 }
@@ -1536,6 +1638,12 @@ func deepCopyCommands(in []DiscoveredCommand) []DiscoveredCommand {
 
 func deepCopyDoctors(in []DiscoveredDoctor) []DiscoveredDoctor {
 	out := make([]DiscoveredDoctor, len(in))
+	copy(out, in)
+	return out
+}
+
+func deepCopySkills(in []DiscoveredSkillCatalog) []DiscoveredSkillCatalog {
+	out := make([]DiscoveredSkillCatalog, len(in))
 	copy(out, in)
 	return out
 }

--- a/internal/config/pack_discovery_integration_test.go
+++ b/internal/config/pack_discovery_integration_test.go
@@ -72,6 +72,43 @@ source = "../helper"
 	}
 }
 
+func TestLoadWithIncludes_ComposesImportedPackSkills(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# imported skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[imports.helper]
+source = "../helper"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.PackSkills) != 1 {
+		t.Fatalf("got %d PackSkills, want 1", len(cfg.PackSkills))
+	}
+	if cfg.PackSkills[0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.PackSkills[0].BindingName, "helper")
+	}
+	if !strings.HasSuffix(cfg.PackSkills[0].SourceDir, filepath.ToSlash(filepath.Join("helper", "skills"))) &&
+		!strings.HasSuffix(filepath.ToSlash(cfg.PackSkills[0].SourceDir), "helper/skills") {
+		t.Fatalf("SourceDir = %q, want helper skills dir", cfg.PackSkills[0].SourceDir)
+	}
+}
+
 func TestLoadWithIncludes_CityPackCommandsUsePackNameBinding(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
@@ -99,6 +136,36 @@ includes = ["../helper"]
 	}
 	if cfg.PackCommands[0].BindingName != "helper" {
 		t.Fatalf("BindingName = %q, want %q", cfg.PackCommands[0].BindingName, "helper")
+	}
+}
+
+func TestLoadWithIncludes_CityPackSkillsUsePackNameBinding(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# city include skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+includes = ["../helper"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.PackSkills) != 1 {
+		t.Fatalf("got %d PackSkills, want 1", len(cfg.PackSkills))
+	}
+	if cfg.PackSkills[0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.PackSkills[0].BindingName, "helper")
 	}
 }
 
@@ -284,6 +351,54 @@ transitive = false
 	}
 }
 
+func TestLoadWithIncludes_TransitiveFalseFiltersNestedPackSkills(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(parentDir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "./child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[imports.ops]
+source = "../parent"
+transitive = false
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.PackSkills) != 1 {
+		t.Fatalf("got %d PackSkills, want 1", len(cfg.PackSkills))
+	}
+	if cfg.PackSkills[0].BindingName != "ops" {
+		t.Fatalf("BindingName = %q, want %q", cfg.PackSkills[0].BindingName, "ops")
+	}
+	if !strings.HasSuffix(filepath.ToSlash(cfg.PackSkills[0].SourceDir), "parent/skills") {
+		t.Fatalf("SourceDir = %q, want parent skills dir", cfg.PackSkills[0].SourceDir)
+	}
+}
+
 func TestExpandPacks_RigImportsContributeDoctorsAndCommands(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
@@ -412,6 +527,58 @@ transitive = false
 	}
 }
 
+func TestExpandPacks_RigImportTransitiveFalseFiltersNestedSharedSkills(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(parentDir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "./child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+
+[rigs.imports.ops]
+source = "../parent"
+transitive = false
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.RigPackSkills["frontend"]) != 1 {
+		t.Fatalf("got %d rig PackSkills, want 1", len(cfg.RigPackSkills["frontend"]))
+	}
+	if cfg.RigPackSkills["frontend"][0].BindingName != "ops" {
+		t.Fatalf("BindingName = %q, want %q", cfg.RigPackSkills["frontend"][0].BindingName, "ops")
+	}
+	if !strings.HasSuffix(filepath.ToSlash(cfg.RigPackSkills["frontend"][0].SourceDir), "parent/skills") {
+		t.Fatalf("SourceDir = %q, want parent skills dir", cfg.RigPackSkills["frontend"][0].SourceDir)
+	}
+}
+
 func TestExpandPacks_RigIncludesContributePackNameBoundCommands(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
@@ -454,6 +621,78 @@ includes = ["../helper"]
 	}
 	if cfg.PackDoctors[0].Name != "binaries" {
 		t.Fatalf("doctor Name = %q, want %q", cfg.PackDoctors[0].Name, "binaries")
+	}
+}
+
+func TestExpandPacks_RigIncludesContributeSharedSkills(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# rig include skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+includes = ["../helper"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.RigPackSkills["frontend"]) != 1 {
+		t.Fatalf("got %d rig PackSkills, want 1", len(cfg.RigPackSkills["frontend"]))
+	}
+	if cfg.RigPackSkills["frontend"][0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.RigPackSkills["frontend"][0].BindingName, "helper")
+	}
+}
+
+func TestExpandPacks_RigImportsContributeSharedSkills(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "helper")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "helper"
+schema = 1
+`)
+	writeTestFile(t, packDir, "skills/code-review/SKILL.md", "# imported skill\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+
+[rigs.imports.helper]
+source = "../helper"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if len(cfg.RigPackSkills["frontend"]) != 1 {
+		t.Fatalf("got %d rig PackSkills, want 1", len(cfg.RigPackSkills["frontend"]))
+	}
+	if cfg.RigPackSkills["frontend"][0].BindingName != "helper" {
+		t.Fatalf("BindingName = %q, want %q", cfg.RigPackSkills["frontend"][0].BindingName, "helper")
 	}
 }
 

--- a/internal/config/pack_discovery_integration_test.go
+++ b/internal/config/pack_discovery_integration_test.go
@@ -399,6 +399,167 @@ transitive = false
 	}
 }
 
+func TestLoadWithIncludes_TransitivePackSkillsPreserveNestedBindings(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(dir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "../child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[imports.ops]
+source = "../parent"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, catalog := range cfg.PackSkills {
+		got[filepath.Base(filepath.Dir(catalog.SourceDir))] = catalog.BindingName
+	}
+
+	if got["parent"] != "ops" {
+		t.Fatalf("parent BindingName = %q, want %q (all bindings: %v)", got["parent"], "ops", got)
+	}
+	if got["child"] != "child" {
+		t.Fatalf("child BindingName = %q, want %q (all bindings: %v)", got["child"], "child", got)
+	}
+}
+
+func TestLoadWithIncludes_ExportedTransitivePackSkillsUseImportBinding(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(dir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "../child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[imports.ops]
+source = "../parent"
+export = true
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, catalog := range cfg.PackSkills {
+		got[filepath.Base(filepath.Dir(catalog.SourceDir))] = catalog.BindingName
+	}
+
+	if got["parent"] != "ops" {
+		t.Fatalf("parent BindingName = %q, want %q (all bindings: %v)", got["parent"], "ops", got)
+	}
+	if got["child"] != "ops" {
+		t.Fatalf("child BindingName = %q, want %q when export=true (all bindings: %v)", got["child"], "ops", got)
+	}
+}
+
+func TestLoadWithIncludes_RecursiveExportedPackSkillsUseInnerImportBinding(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(dir, "child")
+	grandchildDir := filepath.Join(dir, "grandchild")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, grandchildDir, "pack.toml", `
+[pack]
+name = "grandchild"
+schema = 1
+`)
+	writeTestFile(t, grandchildDir, "skills/grandchild-skill/SKILL.md", "# grandchild\n")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+
+[imports.grandchild]
+source = "../grandchild"
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "../child"
+export = true
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+includes = ["../parent"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, catalog := range cfg.PackSkills {
+		got[filepath.Base(filepath.Dir(catalog.SourceDir))] = catalog.BindingName
+	}
+
+	if got["parent"] != "parent" {
+		t.Fatalf("parent BindingName = %q, want %q (all bindings: %v)", got["parent"], "parent", got)
+	}
+	if got["child"] != "child" {
+		t.Fatalf("child BindingName = %q, want %q (all bindings: %v)", got["child"], "child", got)
+	}
+	if got["grandchild"] != "child" {
+		t.Fatalf("grandchild BindingName = %q, want %q from recursive export=true (all bindings: %v)", got["grandchild"], "child", got)
+	}
+}
+
 func TestExpandPacks_RigImportsContributeDoctorsAndCommands(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "helper")
@@ -693,6 +854,113 @@ source = "../helper"
 	}
 	if cfg.RigPackSkills["frontend"][0].BindingName != "helper" {
 		t.Fatalf("BindingName = %q, want %q", cfg.RigPackSkills["frontend"][0].BindingName, "helper")
+	}
+}
+
+func TestExpandPacks_RigExportedTransitivePackSkillsUseImportBinding(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(dir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "../child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+
+[rigs.imports.ops]
+source = "../parent"
+export = true
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, catalog := range cfg.RigPackSkills["frontend"] {
+		got[filepath.Base(filepath.Dir(catalog.SourceDir))] = catalog.BindingName
+	}
+
+	if got["parent"] != "ops" {
+		t.Fatalf("parent BindingName = %q, want %q (all bindings: %v)", got["parent"], "ops", got)
+	}
+	if got["child"] != "ops" {
+		t.Fatalf("child BindingName = %q, want %q when export=true (all bindings: %v)", got["child"], "ops", got)
+	}
+}
+
+func TestExpandPacks_RigTransitivePackSkillsPreserveNestedBindings(t *testing.T) {
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	childDir := filepath.Join(dir, "child")
+	cityDir := filepath.Join(dir, "city")
+
+	writeTestFile(t, childDir, "pack.toml", `
+[pack]
+name = "child"
+schema = 1
+`)
+	writeTestFile(t, childDir, "skills/child-skill/SKILL.md", "# child\n")
+
+	writeTestFile(t, parentDir, "pack.toml", `
+[pack]
+name = "parent"
+schema = 1
+
+[imports.child]
+source = "../child"
+`)
+	writeTestFile(t, parentDir, "skills/parent-skill/SKILL.md", "# parent\n")
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../rig"
+
+[rigs.imports.ops]
+source = "../parent"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, catalog := range cfg.RigPackSkills["frontend"] {
+		got[filepath.Base(filepath.Dir(catalog.SourceDir))] = catalog.BindingName
+	}
+
+	if got["parent"] != "ops" {
+		t.Fatalf("parent BindingName = %q, want %q (all bindings: %v)", got["parent"], "ops", got)
+	}
+	if got["child"] != "child" {
+		t.Fatalf("child BindingName = %q, want %q (all bindings: %v)", got["child"], "child", got)
 	}
 }
 

--- a/internal/config/skill_discovery.go
+++ b/internal/config/skill_discovery.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// DiscoveredSkillCatalog is a convention-discovered shared skills/
+// catalog from a pack. One entry represents one pack-level skills root.
+type DiscoveredSkillCatalog struct {
+	SourceDir   string
+	PackDir     string
+	PackName    string
+	BindingName string
+}
+
+// DiscoverPackSkills reports the top-level shared skills/ directory for
+// a pack when it exists.
+func DiscoverPackSkills(fs fsys.FS, packDir, packName string) ([]DiscoveredSkillCatalog, error) {
+	skillsDir := filepath.Join(packDir, "skills")
+	info, err := fs.Stat(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+	return []DiscoveredSkillCatalog{{
+		SourceDir: skillsDir,
+		PackDir:   packDir,
+		PackName:  packName,
+	}}, nil
+}

--- a/internal/config/skill_discovery_test.go
+++ b/internal/config/skill_discovery_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestDiscoverPackSkills_PropagatesStatErrors(t *testing.T) {
+	t.Parallel()
+
+	fake := fsys.NewFake()
+	packDir := "/packs/helper"
+	skillsDir := filepath.Join(packDir, "skills")
+	wantErr := errors.New("boom")
+	fake.Errors[skillsDir] = wantErr
+
+	_, err := DiscoverPackSkills(fake, packDir, "helper")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("DiscoverPackSkills() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -153,11 +153,15 @@ type AgentCatalog struct {
 // cfg.PackSkillsDir from the loaded config). Pass "" if the city pack
 // has no skills/ subdirectory.
 //
+// imported catalogs are binding-qualified shared skills roots composed
+// from pack imports. Each catalog contributes `<binding>.<name>`
+// entries to the shared city catalog.
+//
 // Bootstrap implicit-import packs are read from
 // ~/.gc/implicit-import.toml via config.ReadImplicitImports. Each
 // pack's skills/ subdirectory is enumerated and added to the catalog.
 // City-pack entries win on name collision with bootstrap entries.
-func LoadCityCatalog(packSkillsDir string) (CityCatalog, error) {
+func LoadCityCatalog(packSkillsDir string, imported ...config.DiscoveredSkillCatalog) (CityCatalog, error) {
 	var (
 		cat       CityCatalog
 		nameOwner = make(map[string]int) // name → index into cat.Entries
@@ -194,12 +198,34 @@ func LoadCityCatalog(packSkillsDir string) (CityCatalog, error) {
 
 	// City pack first — wins precedence over bootstrap entries.
 	if packSkillsDir != "" {
+		addRoot(packSkillsDir)
 		entries, err := readSkillDir(packSkillsDir, "city")
 		if err != nil {
-			return CityCatalog{}, fmt.Errorf("reading city pack skills %q: %w", packSkillsDir, err)
+			return cat, fmt.Errorf("reading city pack skills %q: %w", packSkillsDir, err)
 		}
-		addRoot(packSkillsDir)
 		for _, e := range entries {
+			addEntry(e)
+		}
+	}
+
+	for _, catalog := range imported {
+		origin := strings.TrimSpace(catalog.BindingName)
+		if origin == "" {
+			origin = strings.TrimSpace(catalog.PackName)
+		}
+		if origin == "" {
+			origin = "import"
+		}
+		addRoot(catalog.SourceDir)
+		entries, err := readSkillDir(catalog.SourceDir, origin)
+		if err != nil {
+			return cat, fmt.Errorf("reading imported pack %q skills %q: %w", origin, catalog.SourceDir, err)
+		}
+		for _, e := range entries {
+			if catalog.BindingName != "" {
+				e.Name = catalog.BindingName + "." + e.Name
+				e.Origin = catalog.BindingName
+			}
 			addEntry(e)
 		}
 	}
@@ -209,11 +235,11 @@ func LoadCityCatalog(packSkillsDir string) (CityCatalog, error) {
 		return CityCatalog{}, err
 	}
 	for _, bd := range bootstrapDirs {
+		addRoot(bd.Dir)
 		entries, err := readSkillDir(bd.Dir, bd.Name)
 		if err != nil {
-			return CityCatalog{}, fmt.Errorf("reading bootstrap pack %q skills %q: %w", bd.Name, bd.Dir, err)
+			return cat, fmt.Errorf("reading bootstrap pack %q skills %q: %w", bd.Name, bd.Dir, err)
 		}
-		addRoot(bd.Dir)
 		for _, e := range entries {
 			addEntry(e)
 		}

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -196,9 +196,22 @@ func LoadCityCatalog(packSkillsDir string, imported ...config.DiscoveredSkillCat
 		cat.OwnedRoots = append(cat.OwnedRoots, abs)
 	}
 
-	// City pack first — wins precedence over bootstrap entries.
 	if packSkillsDir != "" {
 		addRoot(packSkillsDir)
+	}
+	for _, catalog := range imported {
+		addRoot(catalog.SourceDir)
+	}
+	bootstrapDirs, err := bootstrapSkillDirs()
+	if err != nil {
+		return cat, err
+	}
+	for _, bd := range bootstrapDirs {
+		addRoot(bd.Dir)
+	}
+
+	// City pack first — wins precedence over bootstrap entries.
+	if packSkillsDir != "" {
 		entries, err := readSkillDir(packSkillsDir, "city")
 		if err != nil {
 			return cat, fmt.Errorf("reading city pack skills %q: %w", packSkillsDir, err)
@@ -216,7 +229,6 @@ func LoadCityCatalog(packSkillsDir string, imported ...config.DiscoveredSkillCat
 		if origin == "" {
 			origin = "import"
 		}
-		addRoot(catalog.SourceDir)
 		entries, err := readSkillDir(catalog.SourceDir, origin)
 		if err != nil {
 			return cat, fmt.Errorf("reading imported pack %q skills %q: %w", origin, catalog.SourceDir, err)
@@ -230,12 +242,7 @@ func LoadCityCatalog(packSkillsDir string, imported ...config.DiscoveredSkillCat
 		}
 	}
 
-	bootstrapDirs, err := bootstrapSkillDirs()
-	if err != nil {
-		return CityCatalog{}, err
-	}
 	for _, bd := range bootstrapDirs {
-		addRoot(bd.Dir)
 		entries, err := readSkillDir(bd.Dir, bd.Name)
 		if err != nil {
 			return cat, fmt.Errorf("reading bootstrap pack %q skills %q: %w", bd.Name, bd.Dir, err)

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -249,6 +249,73 @@ func TestLoadCityCatalogBootstrapMerge(t *testing.T) {
 	}
 }
 
+func TestLoadCityCatalogImportedPackSkills(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+	cityPack := t.TempDir()
+	importedPack := t.TempDir()
+
+	cityDir := filepath.Join(cityPack, "skills")
+	importedDir := filepath.Join(importedPack, "skills")
+	mkSkill(t, cityDir, "city-only")
+	mkSkill(t, importedDir, "plan")
+
+	cat, err := LoadCityCatalog(cityDir, config.DiscoveredSkillCatalog{
+		SourceDir:   importedDir,
+		PackDir:     importedPack,
+		PackName:    "tools",
+		BindingName: "ops",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]string, len(cat.Entries))
+	for _, e := range cat.Entries {
+		got[e.Name] = e.Origin
+	}
+	want := map[string]string{
+		"city-only": "city",
+		"ops.plan":  "ops",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entries: got %v, want %v", got, want)
+	}
+
+	if len(cat.OwnedRoots) != 2 {
+		t.Fatalf("owned roots = %v, want 2 roots", cat.OwnedRoots)
+	}
+}
+
+func TestLoadCityCatalogPreservesOwnedRootsOnReadError(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+	pack := t.TempDir()
+	skillsDir := filepath.Join(pack, "skills")
+	mkSkill(t, skillsDir, "alpha")
+
+	if err := os.Chmod(skillsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(skillsDir, 0o755) })
+	if _, err := os.ReadDir(skillsDir); err == nil {
+		t.Skip("environment ignores chmod 000 (likely running as root)")
+	}
+
+	cat, err := LoadCityCatalog(skillsDir)
+	if err == nil {
+		t.Fatal("LoadCityCatalog should fail when skills dir is unreadable")
+	}
+	if len(cat.OwnedRoots) != 1 {
+		t.Fatalf("owned roots = %v, want 1 root preserved on error", cat.OwnedRoots)
+	}
+	wantRoot, absErr := filepath.Abs(skillsDir)
+	if absErr != nil {
+		t.Fatal(absErr)
+	}
+	if cat.OwnedRoots[0] != wantRoot {
+		t.Fatalf("owned root = %q, want %q", cat.OwnedRoots[0], wantRoot)
+	}
+}
+
 func TestLoadCityCatalogIgnoresUnknownImplicitImport(t *testing.T) {
 	requireBootstrapNames(t, "core")
 	gcHome := setupBootstrapHome(t, map[string][]string{

--- a/internal/materialize/skills_test.go
+++ b/internal/materialize/skills_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -313,6 +314,35 @@ func TestLoadCityCatalogPreservesOwnedRootsOnReadError(t *testing.T) {
 	}
 	if cat.OwnedRoots[0] != wantRoot {
 		t.Fatalf("owned root = %q, want %q", cat.OwnedRoots[0], wantRoot)
+	}
+}
+
+func TestLoadCityCatalogPreservesLaterImportedOwnedRootsOnEarlyReadError(t *testing.T) {
+	t.Setenv("GC_HOME", "")
+	laterDir := filepath.Join(t.TempDir(), "later", "skills")
+	mkSkill(t, laterDir, "beta")
+
+	tooLongDir := filepath.Join(t.TempDir(), strings.Repeat("x", 5000))
+	cat, err := LoadCityCatalog("",
+		config.DiscoveredSkillCatalog{
+			SourceDir:   tooLongDir,
+			BindingName: "broken",
+		},
+		config.DiscoveredSkillCatalog{
+			SourceDir:   laterDir,
+			BindingName: "later",
+		},
+	)
+	if err == nil {
+		t.Fatal("LoadCityCatalog should fail when an imported skills dir cannot be stated")
+	}
+
+	wantLater, absErr := filepath.Abs(laterDir)
+	if absErr != nil {
+		t.Fatal(absErr)
+	}
+	if !slices.Contains(cat.OwnedRoots, wantLater) {
+		t.Fatalf("owned roots = %v, want later imported root %q preserved", cat.OwnedRoots, wantLater)
 	}
 }
 

--- a/test/agents/graph-dispatch.sh
+++ b/test/agents/graph-dispatch.sh
@@ -575,7 +575,7 @@ while true; do
     # failures (which the controller DOESN'T use to skip siblings) don't
     # trigger false positives.
     sibling_hard_fail="false"
-    if [ -n "$root_id" ]; then
+    if [ -n "$root_id" ] && [[ "$ref" != *.cleanup-worktree* ]]; then
         if sibling_json=$(timeout 10 bd list --all --limit=0 --json 2>/dev/null); then
             if printf '%s\n' "$sibling_json" | json_payload | jq -e \
                 --arg root "$root_id" --arg self "$bead_id" '

--- a/test/integration/e2e_events_test.go
+++ b/test/integration/e2e_events_test.go
@@ -3,6 +3,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -115,5 +117,26 @@ func TestE2E_AgentLifecycleEvents(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Verify session.stopped event exists.
-	verifyEvents(t, cityDir, "session.stopped")
+	verifyEventLog(t, cityDir, "session.stopped")
+}
+
+func verifyEventLog(t *testing.T, cityDir, eventType string) {
+	t.Helper()
+
+	eventLog := filepath.Join(cityDir, ".gc", "events.jsonl")
+	deadline := time.Now().Add(5 * time.Second)
+	needle := `"type":"` + eventType + `"`
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(eventLog)
+		if err == nil && strings.Contains(string(data), needle) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(eventLog)
+	if err != nil {
+		t.Fatalf("reading event log: %v", err)
+	}
+	t.Fatalf("event log missing %s:\n%s", eventType, string(data))
 }

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -115,124 +115,158 @@ func (r *e2eReport) hasKey(key string) bool {
 	return ok
 }
 
-// writeE2EToml generates a full city.toml from the e2eCity config.
+// renderE2EToml generates a full single-file template for gc init --file.
 func renderE2EToml(city e2eCity) string {
 	var b strings.Builder
 
-	// [workspace]
-	fmt.Fprintf(&b, "[workspace]\nname = %s\n", quote(city.Workspace.Name))
-	if city.Workspace.StartCommand != "" {
-		fmt.Fprintf(&b, "start_command = %s\n", quote(city.Workspace.StartCommand))
-	}
-	if city.Workspace.SessionTemplate != "" {
-		fmt.Fprintf(&b, "session_template = %s\n", quote(city.Workspace.SessionTemplate))
-	}
-	if len(city.Workspace.InstallAgentHooks) > 0 {
-		fmt.Fprintf(&b, "install_agent_hooks = [%s]\n", quoteSlice(city.Workspace.InstallAgentHooks))
-	}
-	if city.Workspace.Suspended {
-		b.WriteString("suspended = true\n")
-	}
+	writeE2EWorkspaceSection(&b, city.Workspace)
+	b.WriteString("\n[beads]\nprovider = \"file\"\n")
+	writeE2EProviderSections(&b, city.Providers)
+	writeE2EAgentSections(&b, city.Agents)
+	writeE2ENamedSessionSections(&b, city.Agents)
 
-	// [beads] — use file store so tests don't need bd init or dolt.
+	return b.String()
+}
+
+func renderE2ECityRuntimeToml(city e2eCity) string {
+	var b strings.Builder
+
+	writeE2EWorkspaceSection(&b, city.Workspace)
 	b.WriteString("\n[beads]\nprovider = \"file\"\n")
 
-	// [providers.xxx]
-	for name, prov := range city.Providers {
-		fmt.Fprintf(&b, "\n[providers.%s]\n", name)
+	return b.String()
+}
+
+func renderE2EPackToml(city e2eCity) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "[pack]\nname = %s\nschema = 2\n", quote(city.Workspace.Name))
+	writeE2EProviderSections(&b, city.Providers)
+	writeE2EAgentSections(&b, city.Agents)
+	writeE2ENamedSessionSections(&b, city.Agents)
+
+	return b.String()
+}
+
+func writeE2EWorkspaceSection(b *strings.Builder, workspace e2eWorkspace) {
+	fmt.Fprintf(b, "[workspace]\nname = %s\n", quote(workspace.Name))
+	if workspace.StartCommand != "" {
+		fmt.Fprintf(b, "start_command = %s\n", quote(workspace.StartCommand))
+	}
+	if workspace.SessionTemplate != "" {
+		fmt.Fprintf(b, "session_template = %s\n", quote(workspace.SessionTemplate))
+	}
+	if len(workspace.InstallAgentHooks) > 0 {
+		fmt.Fprintf(b, "install_agent_hooks = [%s]\n", quoteSlice(workspace.InstallAgentHooks))
+	}
+	if workspace.Suspended {
+		b.WriteString("suspended = true\n")
+	}
+}
+
+func writeE2EProviderSections(b *strings.Builder, providers map[string]e2eProvider) {
+	for name, prov := range providers {
+		fmt.Fprintf(b, "\n[providers.%s]\n", name)
 		if prov.Command != "" {
-			fmt.Fprintf(&b, "command = %s\n", quote(prov.Command))
+			fmt.Fprintf(b, "command = %s\n", quote(prov.Command))
 		}
 		if len(prov.Env) > 0 {
 			b.WriteString("[providers." + name + ".env]\n")
 			for k, v := range prov.Env {
-				fmt.Fprintf(&b, "%s = %s\n", k, quote(v))
+				fmt.Fprintf(b, "%s = %s\n", k, quote(v))
 			}
 		}
 	}
+}
 
-	// [[agent]]
-	for _, a := range city.Agents {
-		fmt.Fprintf(&b, "\n[[agent]]\nname = %s\n", quote(a.Name))
+func writeE2EAgentSections(b *strings.Builder, agents []e2eAgent) {
+	for _, a := range agents {
+		fmt.Fprintf(b, "\n[[agent]]\nname = %s\n", quote(a.Name))
 		if a.StartCommand != "" {
-			fmt.Fprintf(&b, "start_command = %s\n", quote(a.StartCommand))
+			fmt.Fprintf(b, "start_command = %s\n", quote(a.StartCommand))
 		}
 		if a.IdleTimeout != "" {
-			fmt.Fprintf(&b, "idle_timeout = %s\n", quote(a.IdleTimeout))
+			fmt.Fprintf(b, "idle_timeout = %s\n", quote(a.IdleTimeout))
 		}
 		if a.Dir != "" {
-			fmt.Fprintf(&b, "dir = %s\n", quote(a.Dir))
+			fmt.Fprintf(b, "dir = %s\n", quote(a.Dir))
 		}
 		if a.OverlayDir != "" {
-			fmt.Fprintf(&b, "overlay_dir = %s\n", quote(a.OverlayDir))
+			fmt.Fprintf(b, "overlay_dir = %s\n", quote(a.OverlayDir))
 		}
 		if a.PromptTemplate != "" {
-			fmt.Fprintf(&b, "prompt_template = %s\n", quote(a.PromptTemplate))
+			fmt.Fprintf(b, "prompt_template = %s\n", quote(a.PromptTemplate))
 		}
 		if len(a.InstallAgentHooks) > 0 {
-			fmt.Fprintf(&b, "install_agent_hooks = [%s]\n", quoteSlice(a.InstallAgentHooks))
+			fmt.Fprintf(b, "install_agent_hooks = [%s]\n", quoteSlice(a.InstallAgentHooks))
 		}
 		if len(a.PreStart) > 0 {
-			fmt.Fprintf(&b, "pre_start = [%s]\n", quoteSlice(a.PreStart))
+			fmt.Fprintf(b, "pre_start = [%s]\n", quoteSlice(a.PreStart))
 		}
 		if len(a.SessionSetup) > 0 {
-			fmt.Fprintf(&b, "session_setup = [%s]\n", quoteSlice(a.SessionSetup))
+			fmt.Fprintf(b, "session_setup = [%s]\n", quoteSlice(a.SessionSetup))
 		}
 		if a.Suspended {
 			b.WriteString("suspended = true\n")
 		}
 		if a.WorkQuery != "" {
-			fmt.Fprintf(&b, "work_query = %s\n", quote(a.WorkQuery))
+			fmt.Fprintf(b, "work_query = %s\n", quote(a.WorkQuery))
 		}
 		if a.Nudge != "" {
-			fmt.Fprintf(&b, "nudge = %s\n", quote(a.Nudge))
+			fmt.Fprintf(b, "nudge = %s\n", quote(a.Nudge))
 		}
 		if a.Pool == nil {
 			// E2E helpers expect a plain test agent to behave like a singleton
 			// session unless the test explicitly opts into pool semantics.
-			fmt.Fprintf(&b, "max_active_sessions = 1\n")
+			fmt.Fprintf(b, "max_active_sessions = 1\n")
 			if strings.TrimSpace(a.IdleTimeout) == "" {
-				fmt.Fprintf(&b, "idle_timeout = %s\n", quote("1h"))
+				fmt.Fprintf(b, "idle_timeout = %s\n", quote("1h"))
 			}
 		} else {
-			fmt.Fprintf(&b, "min_active_sessions = %d\n", a.Pool.Min)
-			fmt.Fprintf(&b, "max_active_sessions = %d\n", a.Pool.Max)
+			fmt.Fprintf(b, "min_active_sessions = %d\n", a.Pool.Min)
+			fmt.Fprintf(b, "max_active_sessions = %d\n", a.Pool.Max)
 			if a.Pool.Check != "" {
-				fmt.Fprintf(&b, "scale_check = %s\n", quote(a.Pool.Check))
+				fmt.Fprintf(b, "scale_check = %s\n", quote(a.Pool.Check))
 			}
 		}
 		if len(a.Env) > 0 {
 			b.WriteString("\n[agent.env]\n")
 			for k, v := range a.Env {
-				fmt.Fprintf(&b, "%s = %s\n", k, quote(v))
+				fmt.Fprintf(b, "%s = %s\n", k, quote(v))
 			}
 		}
 	}
+}
 
+func writeE2ENamedSessionSections(b *strings.Builder, agents []e2eAgent) {
 	// [[named_session]]
 	// Plain singleton agents are no longer controller-managed by template
 	// alone. Materialize a canonical named session for the common E2E helper
 	// case so tests that target the bare agent name keep exercising a stable,
 	// managed runtime.
-	for _, a := range city.Agents {
+	for _, a := range agents {
 		if a.Pool != nil {
 			continue
 		}
-		fmt.Fprintf(&b, "\n[[named_session]]\ntemplate = %s\nmode = \"always\"\n", quote(a.Name))
+		fmt.Fprintf(b, "\n[[named_session]]\ntemplate = %s\nmode = \"always\"\n", quote(a.Name))
 		if a.Dir != "" {
-			fmt.Fprintf(&b, "dir = %s\n", quote(a.Dir))
+			fmt.Fprintf(b, "dir = %s\n", quote(a.Dir))
 		}
 	}
-
-	return b.String()
 }
 
-// writeE2EToml generates a full city.toml from the e2eCity config.
+// writeE2EToml updates a post-init v2 city. Definition-bearing sections go
+// into pack.toml; city.toml is written last to trigger the controller watcher
+// after the pack update is durable.
 func writeE2EToml(t *testing.T, cityDir string, city e2eCity) {
 	t.Helper()
 
+	packPath := filepath.Join(cityDir, "pack.toml")
+	if err := os.WriteFile(packPath, []byte(renderE2EPackToml(city)), 0o644); err != nil {
+		t.Fatalf("writing pack.toml: %v", err)
+	}
 	tomlPath := filepath.Join(cityDir, "city.toml")
-	if err := os.WriteFile(tomlPath, []byte(renderE2EToml(city)), 0o644); err != nil {
+	if err := os.WriteFile(tomlPath, []byte(renderE2ECityRuntimeToml(city)), 0o644); err != nil {
 		t.Fatalf("writing city.toml: %v", err)
 	}
 }
@@ -333,6 +367,7 @@ func setupE2ECityNoStart(t *testing.T, city e2eCity) string {
 	if err != nil {
 		t.Fatalf("gc stop after init failed: %v\noutput: %s", err, out)
 	}
+	restartIsolatedSupervisor(t, env)
 
 	t.Cleanup(func() {
 		unregisterCityCommandEnv(cityDir)

--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -44,6 +44,8 @@ func TestHumaBinary_SupervisorBootsAndServesSpec(t *testing.T) {
 	env := append(os.Environ(),
 		"GC_HOME="+gcHome,
 		"XDG_RUNTIME_DIR="+runtimeDir,
+		"GC_BEADS=file",
+		"GC_DOLT=skip",
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -105,18 +107,17 @@ func TestHumaBinary_SupervisorBootsAndServesSpec(t *testing.T) {
 
 	// 3) Create a city the supervisor can see, then exercise per-city commands.
 	cityRoot := filepath.Join(gcHome, "city")
-	runCLI(t, bin, env, "gc init", "init", cityRoot, "--provider", "claude")
-	runCLI(t, bin, env, "gc register", "register", cityRoot, "--name", "humatest")
+	runCLI(t, bin, env, "gc init", "init", "--skip-provider-readiness", cityRoot, "--provider", "claude", "--name", "humatest")
 
 	// Give the supervisor a moment to pick up the registered city.
 	cityListURL := baseURL + "/v0/cities"
 	waitForCityRegistered(t, cityListURL, "humatest", 5*time.Second)
 
 	// 4) `gc city status` — resolves the city, calls per-city status.
-	runCLI(t, bin, env, "gc city status", "--city", "humatest", "status")
+	runCLI(t, bin, env, "gc city status", "--city", cityRoot, "status")
 
-	// 5) `gc agents list` — per-city, exercises a different domain handler.
-	runCLI(t, bin, env, "gc agents list", "--city", "humatest", "agents", "list")
+	// 5) `gc session list` — per-city, exercises a different domain handler.
+	runCLI(t, bin, env, "gc session list", "--city", cityRoot, "session", "list")
 }
 
 // runCLI executes a gc subcommand against the live supervisor and fails

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -638,6 +638,14 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env = filterEnv(env, "XDG_RUNTIME_DIR")
 	env = filterEnv(env, integrationRealBDBinaryEnv)
 	env = filterEnv(env, "DOLT_ROOT_PATH")
+	env = filterEnv(env, "GC_DOLT_HOST")
+	env = filterEnv(env, "GC_DOLT_PORT")
+	env = filterEnv(env, "GC_DOLT_USER")
+	env = filterEnv(env, "GC_DOLT_PASSWORD")
+	env = filterEnv(env, "BEADS_DOLT_SERVER_HOST")
+	env = filterEnv(env, "BEADS_DOLT_SERVER_PORT")
+	env = filterEnv(env, "BEADS_DOLT_SERVER_USER")
+	env = filterEnv(env, "BEADS_DOLT_PASSWORD")
 	env = filterEnv(env, integrationGCBinaryEnv)
 	env = filterEnv(env, integrationDoltBinaryEnv)
 	env = filterEnv(env, "BEADS_DOLT_AUTO_START")
@@ -872,7 +880,7 @@ func ensureManagedDoltPortForTest(cityDir string) (string, bool) {
 	if startErr != nil && !isGCStartAlreadyRunning(startOut) {
 		return "", false
 	}
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		if port, ok := currentManagedDoltPortForTest(cityDir); ok {
 			return port, true
@@ -981,6 +989,18 @@ func startIsolatedSupervisor(t *testing.T, env []string, gcHome string) {
 	t.Fatalf("isolated supervisor did not become ready:\n%s", string(logData))
 }
 
+func restartIsolatedSupervisor(t *testing.T, env []string) {
+	t.Helper()
+
+	_, _ = runCommand("", env, 15*time.Second, gcBinary, "supervisor", "stop", "--wait")
+
+	gcHome := parseEnvList(env)["GC_HOME"]
+	if gcHome == "" {
+		t.Fatal("isolated env missing GC_HOME")
+	}
+	startIsolatedSupervisor(t, env, gcHome)
+}
+
 func reserveLoopbackPort() (int, error) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1017,6 +1037,14 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	integrationToolBinDir = filepath.Join(t.TempDir(), "bin")
 
 	t.Setenv("HOME", "/host/home")
+	t.Setenv("GC_DOLT_HOST", "ambient-host")
+	t.Setenv("GC_DOLT_PORT", "0")
+	t.Setenv("GC_DOLT_USER", "ambient-user")
+	t.Setenv("GC_DOLT_PASSWORD", "ambient-password")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "ambient-beads-host")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
+	t.Setenv("BEADS_DOLT_SERVER_USER", "ambient-beads-user")
+	t.Setenv("BEADS_DOLT_PASSWORD", "ambient-beads-password")
 	env := integrationEnv()
 	got := parseEnvList(env)
 
@@ -1037,6 +1065,20 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	}
 	if got["BEADS_DOLT_AUTO_START"] != "0" {
 		t.Fatalf("BEADS_DOLT_AUTO_START = %q, want %q; tests must match bdRuntimeEnv and suppress bd's rogue auto-start", got["BEADS_DOLT_AUTO_START"], "0")
+	}
+	for _, key := range []string{
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_PASSWORD",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("%s leaked into integration env: %v", key, got[key])
+		}
 	}
 }
 

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -262,6 +262,8 @@ func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {
 	)
 	if port, ok := ensureManagedDoltPortForTest(cityDir); ok {
 		env = append(env, "GC_DOLT_PORT="+port)
+	} else {
+		t.Fatalf("managed Dolt port did not become ready for %s", cityDir)
 	}
 	return env
 }


### PR DESCRIPTION
## Summary
- discover shared skills from imported packs and include them in city and rig skill catalogs
- materialize and list imported shared skills through the existing skill pipeline, including legacy include expansion
- tighten imported skill handling around rig scope resolution, stale shared-symlink cleanup, and regression coverage
- add adoption-review fixups for transitive skill binding preservation, up-front owned-root registration, and scope-neutral shared-skill prompt wording

Supersedes #887.
Fixes ga-2658.

Credit: Original fix by @julianknutsen. The contributor commit is preserved with original authorship; this PR adds the maintainer fixup commit from the adoption review.

## Testing
- go test ./internal/config ./internal/materialize
- go test ./cmd/gc -run 'Test(AgentRigScopeName|SharedSkillCatalogForAgentDoesNotFallBackWhenRigCatalogFails|SkillListImportedSharedCatalog|SkillListAgentCityScopedDirMatchingRigDoesNotShowRigSharedSkills|InternalMaterializeSkillsMaterializesImportedSharedSkills|InternalMaterializeSkillsCityScopedDirMatchingRigDoesNotMaterializeRigSharedSkills|InternalMaterializeSkillsSharedCatalogFailurePrunesStaleSharedSymlink|RunStage1CityScopedDirMatchingRigDoesNotGetRigSharedSkills|RunStage1MaterializesAgentLocalWhenSharedCatalogFails|RunStage1SharedCatalogFailurePrunesStaleSharedSymlink|BuildAssignedSkillsPromptFragmentPartitions)' -count=1 -timeout=5m
- go test ./cmd/gc -run '^TestManagedBdRigWorktreeStoreConsistentAcrossRawBdGcBdAndProviderStore$' -count=1 -timeout=5m
- go test ./cmd/gc -run '^TestPrepareWaitWakeState_ResolvesRigDependencyBeads$' -count=1 -timeout=5m
- go vet ./...

Note: `go test ./...` was attempted locally twice, with 10m and 20m package timeouts. Both runs timed out in the `cmd/gc` package under shared machine load; the individual tests named at the timeout boundary passed when rerun directly.
