### PR TITLE
Fix polecat branch and existing PR metadata handling

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -40,6 +40,18 @@ func currentBranch(t *testing.T, dir string) string {
 	return runCmd(t, dir, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
+func assertContainsInOrder(t *testing.T, body string, wants ...string) {
+	t.Helper()
+	offset := 0
+	for _, want := range wants {
+		idx := strings.Index(body[offset:], want)
+		if idx == -1 {
+			t.Fatalf("missing %q after byte offset %d", want, offset)
+		}
+		offset += idx + len(want)
+	}
+}
+
 // loadExpanded loads city.toml with full pack expansion.
 func loadExpanded(t *testing.T) *config.City {
 	t.Helper()
@@ -150,7 +162,9 @@ func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
 	}
 	body := string(data)
 	for _, want := range []string{
-		`git fetch --prune origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"`,
+		`git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"`,
+		`Could not fetch metadata.branch=$BRANCH from origin`,
+		`git merge --ff-only "origin/$BRANCH"`,
 		`metadata.branch=$BRANCH was set but no local or origin branch exists`,
 		`STOP. Do not create a different branch.`,
 	} {
@@ -158,6 +172,10 @@ func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
 			t.Errorf("polecat formula missing metadata.branch authority guidance %q", want)
 		}
 	}
+	assertContainsInOrder(t, body,
+		`if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then`,
+		`if git show-ref --verify --quiet "refs/heads/$BRANCH"; then`,
+	)
 }
 
 func TestPolecatFormulaRecordsExistingPRMetadataOnSubmit(t *testing.T) {
@@ -169,12 +187,14 @@ func TestPolecatFormulaRecordsExistingPRMetadataOnSubmit(t *testing.T) {
 	}
 	body := string(data)
 	for _, want := range []string{
-		`EXISTING_PR=$(gc bd show {{issue}} --json | jq -r '.metadata.existing_pr // empty')`,
-		`--set-metadata pr_url="$EXISTING_PR"`,
+		`metadata.existing_pr` + "`" + ` is preserved for refinery`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("polecat formula missing existing_pr submit handling %q", want)
 		}
+	}
+	if strings.Contains(body, `--set-metadata pr_url="$EXISTING_PR"`) {
+		t.Fatalf("polecat must not record caller-supplied existing_pr as canonical pr_url")
 	}
 	if strings.Contains(body, "gh pr create") {
 		t.Fatalf("polecat submit flow must not create pull requests directly")
@@ -190,19 +210,53 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 	}
 	body := string(data)
 	for _, want := range []string{
-		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')`,
-		`PR_URL="$EXISTING_PR"`,
+		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')`,
+		`ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')`,
+		`metadata.existing_pr requires pull-request handoff; using merge_strategy=mr`,
+		`block_existing_pr()`,
+		`--assignee=""`,
+		`--set-metadata gc.routed_to=human`,
+		`--set-metadata blocked_reason="$reason"`,
+		`gc mail send mayor/ -s "ESCALATION: invalid existing_pr for $WORK"`,
+		`NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')`,
+		`gc bd update "$NEXT" --assignee=$GC_AGENT`,
+		`CURRENT_WISP=${GC_BEAD_ID:-}`,
+		`gc bd mol burn "$CURRENT_WISP" --force`,
+		`pr_lookup_missing()`,
+		`EXISTING_PR_ERR=$(mktemp)`,
+		`EXISTING_PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$EXISTING_PR" 2>"$EXISTING_PR_ERR")`,
+		`EXISTING_PR_STATUS=$?`,
+		`if pr_lookup_missing "$EXISTING_PR_ERROR"; then`,
+		`Existing PR $EXISTING_PR was not found or is not accessible.`,
+		`Could not resolve existing PR $EXISTING_PR. STOP. Debug and retry without mutating bead state.`,
+		`EXISTING_PR_STATE=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.state')`,
+		`EXISTING_PR_HEAD=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.headRefName')`,
+		`EXISTING_PR_BASE=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.baseRefName')`,
+		`EXISTING_PR_REPO=$(printf '%s\n' "$EXISTING_PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')`,
+		`EXISTING_PR_HEAD_REPO=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')`,
+		`metadata.existing_pr is set but metadata.branch is missing`,
+		`Existing PR $EXISTING_PR is $EXISTING_PR_STATE, want OPEN`,
+		`Existing PR $EXISTING_PR targets branch $EXISTING_PR_HEAD, want $BRANCH`,
+		`Existing PR $EXISTING_PR targets base $EXISTING_PR_BASE, want $TARGET`,
+		`Existing PR $EXISTING_PR belongs to repo $EXISTING_PR_REPO, want $ORIGIN_REPO`,
+		`Existing PR $EXISTING_PR head repo $EXISTING_PR_HEAD_REPO, want $ORIGIN_REPO`,
 		`PR_REF="$EXISTING_PR"`,
+		`PR_STATUS=$?`,
+		`if [ -n "$EXISTING_PR" ] && pr_lookup_missing "$PR_ERROR"; then`,
+		`PR_REPO=$(printf '%s\n' "$PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')`,
+		`Existing PR $EXISTING_PR belongs to repo $PR_REPO, want $ORIGIN_REPO`,
+		`if [ -n "$EXISTING_PR" ]; then`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("refinery formula missing existing_pr handling %q", want)
 		}
 	}
-	existingIdx := strings.Index(body, `EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')`)
-	createIdx := strings.Index(body, "gh pr create")
-	if existingIdx == -1 || createIdx == -1 || existingIdx > createIdx {
-		t.Fatalf("refinery formula must inspect existing_pr before gh pr create")
-	}
+	assertContainsInOrder(t, body,
+		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')`,
+		`EXISTING_PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$EXISTING_PR" 2>"$EXISTING_PR_ERR")`,
+		`git push origin HEAD:$BRANCH --force-with-lease`,
+		`gh pr create`,
+	)
 }
 
 func TestWorktreeSetupKeepsIgnoresLocal(t *testing.T) {

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -141,6 +141,70 @@ func TestRefineryFormulaSupportsMergeStrategies(t *testing.T) {
 	}
 }
 
+func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`git fetch --prune origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"`,
+		`metadata.branch=$BRANCH was set but no local or origin branch exists`,
+		`STOP. Do not create a different branch.`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("polecat formula missing metadata.branch authority guidance %q", want)
+		}
+	}
+}
+
+func TestPolecatFormulaRecordsExistingPRMetadataOnSubmit(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`EXISTING_PR=$(gc bd show {{issue}} --json | jq -r '.metadata.existing_pr // empty')`,
+		`--set-metadata pr_url="$EXISTING_PR"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("polecat formula missing existing_pr submit handling %q", want)
+		}
+	}
+	if strings.Contains(body, "gh pr create") {
+		t.Fatalf("polecat submit flow must not create pull requests directly")
+	}
+}
+
+func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')`,
+		`PR_URL="$EXISTING_PR"`,
+		`PR_REF="$EXISTING_PR"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refinery formula missing existing_pr handling %q", want)
+		}
+	}
+	existingIdx := strings.Index(body, `EXISTING_PR=$(gc bd show $WORK --json | jq -r '.metadata.existing_pr // empty')`)
+	createIdx := strings.Index(body, "gh pr create")
+	if existingIdx == -1 || createIdx == -1 || existingIdx > createIdx {
+		t.Fatalf("refinery formula must inspect existing_pr before gh pr create")
+	}
+}
+
 func TestWorktreeSetupKeepsIgnoresLocal(t *testing.T) {
 	tmp := t.TempDir()
 	repo := filepath.Join(tmp, "repo")

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -47,13 +47,16 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 | `worktree` | polecat (branch-setup) | Early | Absolute path to git worktree |
 | `branch` | polecat (branch-setup) | Early | Source branch name |
 | `target` | polecat (submit) | Late | Target branch (default: {{ .DefaultBranch }}) |
+| `existing_pr` | caller | Before dispatch | Existing PR URL to reuse instead of creating another PR |
+| `pr_url` | polecat/refinery | Submit/PR handoff | PR URL recorded for visibility and closure |
 | `rejection_reason` | refinery (on failure) | On reject | Why the merge was rejected |
 
 **On branch-setup:** You record `worktree` and `branch` immediately.
 This enables crash recovery — the witness can find and salvage your work.
 
 **On submission:** You update `branch` (may have changed after rebase),
-set `target`, then reassign to refinery.
+set `target`, record `pr_url` when `existing_pr` is present, then reassign
+to refinery.
 
 **On rejection:** The refinery puts the bead back in the pool with
 `rejection_reason` set and the branch intact. A new polecat picks it up,
@@ -192,10 +195,19 @@ Nudges from other agents may arrive via your hook. When working:
 
 ```bash
 git push origin HEAD
-gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
-  --set-metadata target={{ .DefaultBranch }} \
-  --notes "Implemented: <brief summary>"
+EXISTING_PR=$(gc bd show <work-bead> --json | jq -r '.metadata.existing_pr // empty')
+if [ -n "$EXISTING_PR" ]; then
+  gc bd update <work-bead> \
+    --set-metadata branch=$(git branch --show-current) \
+    --set-metadata target={{ .DefaultBranch }} \
+    --set-metadata pr_url="$EXISTING_PR" \
+    --notes "Implemented: <brief summary>"
+else
+  gc bd update <work-bead> \
+    --set-metadata branch=$(git branch --show-current) \
+    --set-metadata target={{ .DefaultBranch }} \
+    --notes "Implemented: <brief summary>"
+fi
 gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -44,19 +44,19 @@ Work beads carry structured metadata for lifecycle tracking and handoff:
 
 | Field | Set by | When | Description |
 |-------|--------|------|-------------|
-| `worktree` | polecat (branch-setup) | Early | Absolute path to git worktree |
+| `work_dir` | polecat (branch-setup) | Early | Absolute path to git worktree |
 | `branch` | polecat (branch-setup) | Early | Source branch name |
 | `target` | polecat (submit) | Late | Target branch (default: {{ .DefaultBranch }}) |
 | `existing_pr` | caller | Before dispatch | Existing PR URL to reuse instead of creating another PR |
-| `pr_url` | polecat/refinery | Submit/PR handoff | PR URL recorded for visibility and closure |
+| `pr_url` | refinery | PR handoff | Canonical PR URL recorded after validation |
 | `rejection_reason` | refinery (on failure) | On reject | Why the merge was rejected |
 
-**On branch-setup:** You record `worktree` and `branch` immediately.
+**On branch-setup:** You record `work_dir` and `branch` immediately.
 This enables crash recovery — the witness can find and salvage your work.
 
 **On submission:** You update `branch` (may have changed after rebase),
-set `target`, record `pr_url` when `existing_pr` is present, then reassign
-to refinery.
+set `target`, then reassign to refinery. If `existing_pr` is present, leave
+it for refinery to validate and canonicalize into `pr_url`.
 
 **On rejection:** The refinery puts the bead back in the pool with
 `rejection_reason` set and the branch intact. A new polecat picks it up,
@@ -195,19 +195,10 @@ Nudges from other agents may arrive via your hook. When working:
 
 ```bash
 git push origin HEAD
-EXISTING_PR=$(gc bd show <work-bead> --json | jq -r '.metadata.existing_pr // empty')
-if [ -n "$EXISTING_PR" ]; then
-  gc bd update <work-bead> \
-    --set-metadata branch=$(git branch --show-current) \
-    --set-metadata target={{ .DefaultBranch }} \
-    --set-metadata pr_url="$EXISTING_PR" \
-    --notes "Implemented: <brief summary>"
-else
-  gc bd update <work-bead> \
-    --set-metadata branch=$(git branch --show-current) \
-    --set-metadata target={{ .DefaultBranch }} \
-    --notes "Implemented: <brief summary>"
-fi
+gc bd update <work-bead> \
+  --set-metadata branch=$(git branch --show-current) \
+  --set-metadata target={{ .DefaultBranch }} \
+  --notes "Implemented: <brief summary>"
 gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
 gc runtime drain-ack
 exit

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -90,12 +90,14 @@ Polecats set these metadata fields before assigning a work bead to you:
 - `branch` — source branch name (REQUIRED)
 - `target` — target branch (optional, defaults to {{ .DefaultBranch }})
 - `merge_strategy` — handoff mode (optional, defaults to `direct`)
+- `existing_pr` — existing PR URL to reuse in `mr` / `pr` mode
 
 Read them mechanically:
 ```bash
 gc bd show $WORK --json | jq -r '.[0].metadata.branch'
 gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{ .DefaultBranch }}"'
 gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"'
+gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty'
 ```
 
 Never infer a branch name. If `metadata.branch` is missing, reject the bead.
@@ -123,6 +125,10 @@ A new polecat picks up the bead, sees `metadata.branch` and
 In `mr` mode, this pack treats PR creation as the terminal handoff for the
 direct-bead workflow. Record `pr_url` on the work bead, close the bead, and
 leave the source branch intact for the PR lifecycle.
+
+If `metadata.existing_pr` is set, reuse that PR URL. Do not call
+`gh pr create` for the work bead; verify the existing PR, record it as
+`pr_url`, and close the bead when the branch has been pushed.
 
 ---
 

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -126,9 +126,18 @@ In `mr` mode, this pack treats PR creation as the terminal handoff for the
 direct-bead workflow. Record `pr_url` on the work bead, close the bead, and
 leave the source branch intact for the PR lifecycle.
 
-If `metadata.existing_pr` is set, reuse that PR URL. Do not call
-`gh pr create` for the work bead; verify the existing PR, record it as
-`pr_url`, and close the bead when the branch has been pushed.
+In `mr` / `pr` mode, if `metadata.existing_pr` is set, reuse that PR URL.
+Do not call `gh pr create` for the work bead. Before pushing or closing
+the bead, verify `gh pr view` reports an open same-repository PR whose
+`headRefName` equals `metadata.branch` and whose `baseRefName` equals
+`metadata.target`; then record the canonical PR URL as `pr_url` and close
+the bead when the branch has been pushed. If validation fails, record a
+durable blocked reason on the bead and escalate to mayor instead of
+closing the work.
+
+If `metadata.existing_pr` is present while `merge_strategy` is unset or
+`direct`, treat the handoff as `mr`. An existing PR cannot be validated
+and then ignored by landing directly to the target branch.
 
 ---
 

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -33,7 +33,7 @@ refinery. Resume the existing branch — don't redo all the work.
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
-version = 7
+version = 8
 
 [[steps]]
 id = "workspace-setup"
@@ -93,9 +93,22 @@ Check if `metadata.branch` already records a branch:
 BRANCH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')
 ```
 
-**If branch exists in metadata** — check it out:
+**If branch exists in metadata** — treat it as authoritative. This
+metadata may come from rejection recovery or from a caller that wants
+work applied to an existing branch. Fetch the named remote branch first,
+then check out the local branch if present or create a local tracking
+branch from `origin/$BRANCH`:
 ```bash
-git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH" origin/"$BRANCH"
+git fetch --prune origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null || true
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    git checkout "$BRANCH" || exit 1
+elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    git checkout --track -b "$BRANCH" "origin/$BRANCH" || exit 1
+else
+    echo "metadata.branch=$BRANCH was set but no local or origin branch exists."
+    echo "STOP. Do not create a different branch."
+    exit 1
+fi
 ```
 If resuming a rejected branch, rebase onto latest base:
 ```bash
@@ -167,12 +180,23 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 
 **4. Update metadata on the work bead:**
 ```bash
-gc bd update {{issue}} \
-  --set-metadata target={{base_branch}} \
-  --notes "Implemented: <brief summary>"
+EXISTING_PR=$(gc bd show {{issue}} --json | jq -r '.metadata.existing_pr // empty')
+if [ -n "$EXISTING_PR" ]; then
+  gc bd update {{issue}} \
+    --set-metadata target={{base_branch}} \
+    --set-metadata pr_url="$EXISTING_PR" \
+    --notes "Implemented: <brief summary>"
+else
+  gc bd update {{issue}} \
+    --set-metadata target={{base_branch}} \
+    --notes "Implemented: <brief summary>"
+fi
 ```
 Branch was recorded in workspace-setup and is already in metadata.
-This adds the target for the refinery.
+This adds the target for the refinery. If an existing pull request was
+provided by the caller, this records the URL on the bead. The refinery's
+PR mode also reads `metadata.existing_pr` and must reuse it instead of
+creating a duplicate pull request.
 
 **5. Reassign to refinery:**
 ```bash

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -95,18 +95,30 @@ BRANCH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')
 
 **If branch exists in metadata** — treat it as authoritative. This
 metadata may come from rejection recovery or from a caller that wants
-work applied to an existing branch. Fetch the named remote branch first,
-then check out the local branch if present or create a local tracking
-branch from `origin/$BRANCH`:
+work applied to an existing branch. Fetch the named remote branch first.
+If `origin/$BRANCH` exists, make the local branch fast-forward to that
+remote tip or stop on divergence:
 ```bash
-git fetch --prune origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null || true
-if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || \
+    echo "Could not fetch metadata.branch=$BRANCH from origin. Checking local refs before stopping."
+if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+        git checkout "$BRANCH" || exit 1
+        git merge --ff-only "origin/$BRANCH" || {
+            echo "Local branch $BRANCH diverged from origin/$BRANCH."
+            echo "STOP. Reconcile the branch before continuing."
+            gc runtime drain-ack
+            exit 1
+        }
+    else
+        git checkout --track -b "$BRANCH" "origin/$BRANCH" || exit 1
+    fi
+elif git show-ref --verify --quiet "refs/heads/$BRANCH"; then
     git checkout "$BRANCH" || exit 1
-elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
-    git checkout --track -b "$BRANCH" "origin/$BRANCH" || exit 1
 else
     echo "metadata.branch=$BRANCH was set but no local or origin branch exists."
     echo "STOP. Do not create a different branch."
+    gc runtime drain-ack
     exit 1
 fi
 ```
@@ -180,23 +192,15 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 
 **4. Update metadata on the work bead:**
 ```bash
-EXISTING_PR=$(gc bd show {{issue}} --json | jq -r '.metadata.existing_pr // empty')
-if [ -n "$EXISTING_PR" ]; then
-  gc bd update {{issue}} \
-    --set-metadata target={{base_branch}} \
-    --set-metadata pr_url="$EXISTING_PR" \
-    --notes "Implemented: <brief summary>"
-else
-  gc bd update {{issue}} \
-    --set-metadata target={{base_branch}} \
-    --notes "Implemented: <brief summary>"
-fi
+gc bd update {{issue}} \
+  --set-metadata target={{base_branch}} \
+  --notes "Implemented: <brief summary>"
 ```
 Branch was recorded in workspace-setup and is already in metadata.
 This adds the target for the refinery. If an existing pull request was
-provided by the caller, this records the URL on the bead. The refinery's
-PR mode also reads `metadata.existing_pr` and must reuse it instead of
-creating a duplicate pull request.
+provided by the caller, `metadata.existing_pr` is preserved for refinery
+validation. The refinery records canonical `pr_url` only after verifying
+the PR is open and matches the branch, base, and origin repository.
 
 **5. Reassign to refinery:**
 ```bash

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -274,8 +274,97 @@ Read the merge target and merge strategy from the work bead metadata:
 BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
 TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
+EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
+ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 if [ "$MERGE_STRATEGY" = "pr" ]; then
   MERGE_STRATEGY="mr"
+fi
+if [ -n "$EXISTING_PR" ] && [ "$MERGE_STRATEGY" = "direct" ]; then
+  echo "metadata.existing_pr requires pull-request handoff; using merge_strategy=mr."
+  MERGE_STRATEGY="mr"
+fi
+
+block_existing_pr() {
+  reason="$1"
+  gc bd update $WORK \
+    --assignee="" \
+    --set-metadata merge_result=blocked \
+    --set-metadata gc.routed_to=human \
+    --set-metadata blocked_reason="$reason"
+  gc mail send mayor/ -s "ESCALATION: invalid existing_pr for $WORK" -m "$reason
+Work bead: $WORK
+Existing PR: $EXISTING_PR
+Branch: $BRANCH
+Target: $TARGET"
+  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+  gc bd update "$NEXT" --assignee=$GC_AGENT
+  CURRENT_WISP=${GC_BEAD_ID:-}
+  if [ -n "$CURRENT_WISP" ]; then
+    gc bd mol burn "$CURRENT_WISP" --force
+  else
+    echo "Could not infer current wisp; burn this wisp manually after recording the summary."
+  fi
+  echo "$reason"
+  echo "STOP. Existing PR metadata needs human correction."
+  gc runtime drain-ack
+  exit 1
+}
+
+pr_lookup_missing() {
+  case "$1" in
+    *"Could not resolve to a PullRequest"*|*"could not resolve to a PullRequest"*|*"no pull requests found"*|*"Not Found"*|*"not found"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
+  if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
+    block_existing_pr "metadata.existing_pr is set but metadata.branch is missing."
+  fi
+
+  if [ -z "$ORIGIN_REPO" ]; then
+    echo "Could not resolve origin repository for existing PR validation. STOP. Debug and retry without mutating bead state."
+    gc runtime drain-ack
+    exit 1
+  fi
+
+  EXISTING_PR_ERR=$(mktemp)
+  EXISTING_PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$EXISTING_PR" 2>"$EXISTING_PR_ERR")
+  EXISTING_PR_STATUS=$?
+  EXISTING_PR_ERROR=$(cat "$EXISTING_PR_ERR")
+  rm -f "$EXISTING_PR_ERR"
+  if [ "$EXISTING_PR_STATUS" -ne 0 ] || [ -z "$EXISTING_PR_INFO" ]; then
+    if pr_lookup_missing "$EXISTING_PR_ERROR"; then
+      block_existing_pr "Existing PR $EXISTING_PR was not found or is not accessible."
+    fi
+    echo "Could not resolve existing PR $EXISTING_PR. STOP. Debug and retry without mutating bead state."
+    [ -n "$EXISTING_PR_ERROR" ] && echo "$EXISTING_PR_ERROR"
+    gc runtime drain-ack
+    exit 1
+  fi
+
+  EXISTING_PR_STATE=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.state')
+  EXISTING_PR_HEAD=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.headRefName')
+  EXISTING_PR_BASE=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.baseRefName')
+  EXISTING_PR_URL=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.url')
+  EXISTING_PR_REPO=$(printf '%s\n' "$EXISTING_PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')
+  EXISTING_PR_HEAD_REPO=$(printf '%s\n' "$EXISTING_PR_INFO" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
+
+  if [ "$EXISTING_PR_STATE" != "OPEN" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR is $EXISTING_PR_STATE, want OPEN."
+  fi
+  if [ "$EXISTING_PR_HEAD" != "$BRANCH" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR targets branch $EXISTING_PR_HEAD, want $BRANCH."
+  fi
+  if [ "$EXISTING_PR_BASE" != "$TARGET" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR targets base $EXISTING_PR_BASE, want $TARGET."
+  fi
+  if [ "$EXISTING_PR_REPO" != "$ORIGIN_REPO" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR belongs to repo $EXISTING_PR_REPO, want $ORIGIN_REPO."
+  fi
+  if [ "$EXISTING_PR_HEAD_REPO" != "$ORIGIN_REPO" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR head repo $EXISTING_PR_HEAD_REPO, want $ORIGIN_REPO."
+  fi
 fi
 ```
 
@@ -343,7 +432,6 @@ EOF
 )
 
 if [ -n "$EXISTING_PR" ]; then
-  PR_URL="$EXISTING_PR"
   PR_REF="$EXISTING_PR"
 else
   PR_URL=$(gh pr create \
@@ -361,14 +449,73 @@ fi
 
 **3. Verify the pull request exists:**
 ```bash
-PR_INFO=$(gh pr view "$PR_REF" --json url,number,state,headRefName -q '.url + " " + (.number|tostring) + " " + .state + " " + .headRefName')
-echo "$PR_INFO"
+PR_ERR=$(mktemp)
+PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$PR_REF" 2>"$PR_ERR")
+PR_STATUS=$?
+PR_ERROR=$(cat "$PR_ERR")
+rm -f "$PR_ERR"
+if [ "$PR_STATUS" -ne 0 ] || [ -z "$PR_INFO" ]; then
+  if [ -n "$EXISTING_PR" ] && pr_lookup_missing "$PR_ERROR"; then
+    block_existing_pr "Existing PR $EXISTING_PR was not found or is not accessible."
+  fi
+  echo "Pull request $PR_REF was not found."
+  [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
+  gc runtime drain-ack
+  exit 1
+fi
+PR_URL=$(printf '%s\n' "$PR_INFO" | jq -r '.url')
+PR_NUMBER=$(printf '%s\n' "$PR_INFO" | jq -r '.number')
+PR_STATE=$(printf '%s\n' "$PR_INFO" | jq -r '.state')
+PR_HEAD=$(printf '%s\n' "$PR_INFO" | jq -r '.headRefName')
+PR_BASE=$(printf '%s\n' "$PR_INFO" | jq -r '.baseRefName')
+PR_REPO=$(printf '%s\n' "$PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')
+PR_HEAD_REPO=$(printf '%s\n' "$PR_INFO" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
+echo "$PR_URL $PR_NUMBER $PR_STATE $PR_HEAD $PR_BASE $PR_REPO $PR_HEAD_REPO"
+if [ "$PR_STATE" != "OPEN" ]; then
+  if [ -n "$EXISTING_PR" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR is $PR_STATE, want OPEN."
+  fi
+  echo "Pull request $PR_REF is $PR_STATE, want OPEN."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ "$PR_HEAD" != "$BRANCH" ]; then
+  if [ -n "$EXISTING_PR" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR targets branch $PR_HEAD, want $BRANCH."
+  fi
+  echo "Pull request $PR_REF targets branch $PR_HEAD, want $BRANCH."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ "$PR_BASE" != "$TARGET" ]; then
+  if [ -n "$EXISTING_PR" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR targets base $PR_BASE, want $TARGET."
+  fi
+  echo "Pull request $PR_REF targets base $PR_BASE, want $TARGET."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ "$PR_REPO" != "$ORIGIN_REPO" ]; then
+  if [ -n "$EXISTING_PR" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR belongs to repo $PR_REPO, want $ORIGIN_REPO."
+  fi
+  echo "Pull request $PR_REF belongs to repo $PR_REPO, want $ORIGIN_REPO."
+  gc runtime drain-ack
+  exit 1
+fi
+if [ "$PR_HEAD_REPO" != "$ORIGIN_REPO" ]; then
+  if [ -n "$EXISTING_PR" ]; then
+    block_existing_pr "Existing PR $EXISTING_PR head repo $PR_HEAD_REPO, want $ORIGIN_REPO."
+  fi
+  echo "Pull request $PR_REF head repo $PR_HEAD_REPO, want $ORIGIN_REPO."
+  gc runtime drain-ack
+  exit 1
+fi
 ```
 If this command fails or prints empty output: STOP. Debug and retry. Do NOT continue.
 
 **4. Record PR metadata and close the work bead:**
 ```bash
-PR_NUMBER=$(gh pr view "$PR_REF" --json number -q '.number')
 gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -29,7 +29,7 @@ closes the bead once the PR is verified.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
-version = 1
+version = 2
 
 [vars]
 [vars.run_tests]
@@ -322,9 +322,13 @@ request and treats PR creation as the terminal handoff for this work bead.
 git checkout temp
 git push origin HEAD:$BRANCH --force-with-lease
 ```
+If `--force-with-lease` fails, the existing PR branch moved after your
+fetch. STOP, fetch the latest branch, rebase your temp branch again, and
+retry with `--force-with-lease`. Do not use plain `--force`.
 
-**2. Create or discover the pull request:**
+**2. Reuse, create, or discover the pull request:**
 ```bash
+EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
 ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.[0].title')
 PR_BODY=$(cat <<EOF
 ## Summary
@@ -338,27 +342,33 @@ Automated pull request published by Gastown Refinery.
 EOF
 )
 
-PR_URL=$(gh pr create \
-  --base "$TARGET" \
-  --head "$BRANCH" \
-  --title "$ISSUE_TITLE ($WORK)" \
-  --body "$PR_BODY" 2>/dev/null || true)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL="$EXISTING_PR"
+  PR_REF="$EXISTING_PR"
+else
+  PR_URL=$(gh pr create \
+    --base "$TARGET" \
+    --head "$BRANCH" \
+    --title "$ISSUE_TITLE ($WORK)" \
+    --body "$PR_BODY" 2>/dev/null || true)
 
-if [ -z "$PR_URL" ]; then
-  PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
+  if [ -z "$PR_URL" ]; then
+    PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
+  fi
+  PR_REF="$BRANCH"
 fi
 ```
 
 **3. Verify the pull request exists:**
 ```bash
-PR_INFO=$(gh pr view "$BRANCH" --json url,number,state -q '.url + " " + (.number|tostring) + " " + .state')
+PR_INFO=$(gh pr view "$PR_REF" --json url,number,state,headRefName -q '.url + " " + (.number|tostring) + " " + .state + " " + .headRefName')
 echo "$PR_INFO"
 ```
 If this command fails or prints empty output: STOP. Debug and retry. Do NOT continue.
 
 **4. Record PR metadata and close the work bead:**
 ```bash
-PR_NUMBER=$(gh pr view "$BRANCH" --json number -q '.number')
+PR_NUMBER=$(gh pr view "$PR_REF" --json number -q '.number')
 gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \


### PR DESCRIPTION
## Summary

- Supersedes #891 by @julianknutsen, which correctly identified that polecat must honor `metadata.branch` and preserve caller-supplied `metadata.existing_pr` for refinery handoff.
- Treat `metadata.branch` as authoritative by fetching the named origin branch, fast-forwarding local state when possible, and stopping instead of inventing a different branch.
- Preserve `metadata.existing_pr` through polecat submit, then let refinery validate the PR-owning repo, head repo, branch, base, and open state before recording canonical `pr_url`.
- Add maintainer review fixups for current `bd show --json` array accessors, retryable GitHub lookup failures, semantic existing-PR blocking, and patrol-loop continuation.

Fixes #709
Supersedes #891
Credit: Original fix by @julianknutsen.

## Testing

- [x] `go test ./examples/gastown -run 'TestPolecatFormulaTreatsMetadataBranchAsAuthoritative|TestPolecatFormulaRecordsExistingPRMetadataOnSubmit|TestRefineryFormulaRespectsExistingPRMetadata'`
- [x] `go test ./examples/gastown ./internal/formula`
- [x] `go vet ./...`
- [ ] `make check` / `go test ./...` - local full-suite run hit unrelated `cmd/gc` flake tracked as `ga-41yb`; focused failing tests passed directly.
- [x] `make check-docs` if docs, navigation, or links changed - not applicable.
- [x] `make test-integration` if runtime, controller, or workflow behavior changed - not applicable; this touches the Gastown example pack formulas/prompts and focused formula coverage.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes - not applicable
- [x] Called out breaking changes or migration notes - none
