### PR TITLE
Add gc reload command

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -575,7 +575,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	result, err := tryReloadConfig(cr.tomlPath, cr.cityName, cityRoot, cr.stderr)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: config reload: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
-		telemetry.RecordConfigReload(ctx, "", source, reloadOutcomeFailed, len(warnings), err)
+		telemetry.RecordConfigReload(ctx, "", string(source), string(reloadOutcomeFailed), len(warnings), err)
 		if trace != nil {
 			trace.RecordConfigReload("", "", TraceOutcomeFailed, source, nil, nil, false, warnings, err)
 		}
@@ -584,11 +584,14 @@ func (cr *CityRuntime) reloadConfigTraced(
 			Error:   err.Error(),
 		}
 	}
+	for _, warning := range result.Warnings {
+		appendWarning(warning)
+	}
 	if cr.configRev != "" && result.Revision == cr.configRev {
 		if trace != nil {
 			trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeNoChange, source, nil, nil, false, warnings, nil)
 		}
-		telemetry.RecordConfigReload(ctx, result.Revision, source, reloadOutcomeNoChange, len(warnings), nil)
+		telemetry.RecordConfigReload(ctx, result.Revision, string(source), string(reloadOutcomeNoChange), len(warnings), nil)
 		return reloadControlReply{
 			Outcome:  reloadOutcomeNoChange,
 			Message:  "No config changes detected.",
@@ -762,7 +765,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		configReloadSummary(oldAgentCount, oldRigCount, len(nextCfg.Agents), len(nextCfg.Rigs)),
 		shortRev(result.Revision))
 	fmt.Fprintln(cr.stdout, message) //nolint:errcheck // best-effort stdout
-	telemetry.RecordConfigReload(ctx, result.Revision, source, reloadOutcomeApplied, len(warnings), nil)
+	telemetry.RecordConfigReload(ctx, result.Revision, string(source), string(reloadOutcomeApplied), len(warnings), nil)
 	if trace != nil {
 		trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeApplied, source, nil, nil, providerChanged, warnings, nil)
 	}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -183,7 +183,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 			if p.ReloadReqCh != nil {
 				return p.ReloadReqCh
 			}
-			return make(chan reloadRequest, 1)
+			return make(chan reloadRequest)
 		}(),
 		pokeCh: func() chan struct{} {
 			if p.PokeCh != nil {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -65,8 +65,10 @@ type CityRuntime struct {
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
 	convergenceReqCh    chan convergenceRequest  // receives CLI commands from controller.sock
+	reloadReqCh         chan reloadRequest       // receives structured reload requests from controller.sock
 	pokeCh              chan struct{}            // non-blocking signal to trigger immediate reconciler tick
 	controlDispatcherCh chan struct{}            // non-blocking signal for control-dispatcher-only reconcile
+	activeReload        *reloadRequest
 	onStarted           func()
 	onStatus            func(string)
 
@@ -99,6 +101,7 @@ type CityRuntimeParams struct {
 	PoolDeathHandlers map[string]poolDeathInfo
 
 	ConvergenceReqCh    chan convergenceRequest // may be nil
+	ReloadReqCh         chan reloadRequest      // may be nil; receives structured reload commands
 	PokeCh              chan struct{}           // may be nil; triggers immediate tick
 	ControlDispatcherCh chan struct{}           // may be nil; triggers control-dispatcher-only reconcile
 	OnStarted           func()                  // called after initial reconciliation succeeds
@@ -176,6 +179,12 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		poolDeathHandlers:       p.PoolDeathHandlers,
 		suspendedNames:          suspendedNames,
 		convergenceReqCh:        p.ConvergenceReqCh,
+		reloadReqCh: func() chan reloadRequest {
+			if p.ReloadReqCh != nil {
+				return p.ReloadReqCh
+			}
+			return make(chan reloadRequest, 1)
+		}(),
 		pokeCh: func() chan struct{} {
 			if p.PokeCh != nil {
 				return p.PokeCh
@@ -381,6 +390,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, "poke")
 		case <-cr.controlDispatcherCh:
 			cr.controlDispatcherTick(ctx)
+		case req := <-cr.reloadReqCh:
+			cr.handleReloadRequest(&req)
 		case req := <-cr.convergenceReqCh:
 			// Low-latency path: process convergence commands between ticks.
 			// processConvergenceRequests() in tick() drains any that arrived
@@ -408,7 +419,13 @@ func (cr *CityRuntime) tick(
 	trigger string,
 ) {
 	sessionBeads := cr.loadSessionBeadSnapshot()
-	trace := cr.beginTraceCycle(trigger, "controller_tick", sessionBeads)
+	traceTrigger := trigger
+	traceDetail := "controller_tick"
+	if cr.activeReload != nil {
+		traceTrigger = string(TraceTickTriggerPoke)
+		traceDetail = "manual_reload"
+	}
+	trace := cr.beginTraceCycle(traceTrigger, traceDetail, sessionBeads)
 	// Detect pool instance deaths since last tick.
 	if len(cr.poolDeathHandlers) > 0 {
 		currentRunning, _ := cr.sp.ListRunning("")
@@ -434,7 +451,15 @@ func (cr *CityRuntime) tick(
 	}
 
 	if dirty.Swap(false) {
-		cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace)
+		source := reloadSourceWatch
+		if cr.activeReload != nil {
+			source = reloadSourceManual
+		}
+		reply := cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace, source)
+		if cr.activeReload != nil {
+			cr.activeReload.doneCh <- reply
+			cr.activeReload = nil
+		}
 	}
 
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
@@ -499,6 +524,31 @@ func (cr *CityRuntime) tick(
 	}
 }
 
+func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {
+	if req == nil {
+		return
+	}
+	if cr.activeReload != nil {
+		req.acceptedCh <- reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because another reload is already in progress.",
+		}
+		return
+	}
+	cr.activeReload = req
+	if cr.configDirty != nil {
+		cr.configDirty.Store(true)
+	}
+	select {
+	case cr.pokeCh <- struct{}{}:
+	default:
+	}
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+}
+
 // reloadConfig attempts to reload city.toml and update all internal
 // components. On error, the old config is kept.
 func (cr *CityRuntime) reloadConfig(
@@ -506,7 +556,7 @@ func (cr *CityRuntime) reloadConfig(
 	lastProviderName *string,
 	cityRoot string,
 ) {
-	cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, nil)
+	cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, nil, reloadSourceWatch)
 }
 
 func (cr *CityRuntime) reloadConfigTraced(
@@ -514,21 +564,37 @@ func (cr *CityRuntime) reloadConfigTraced(
 	lastProviderName *string,
 	cityRoot string,
 	trace *sessionReconcilerTraceCycle,
-) {
+	source reloadSource,
+) reloadControlReply {
+	var warnings []string
+	appendWarning := func(message string) {
+		warnings = append(warnings, message)
+		fmt.Fprintf(cr.stderr, "%s: %s\n", cr.logPrefix, message) //nolint:errcheck // best-effort stderr
+	}
+
 	result, err := tryReloadConfig(cr.tomlPath, cr.cityName, cityRoot, cr.stderr)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: config reload: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
-		telemetry.RecordConfigReload(ctx, "", err)
+		telemetry.RecordConfigReload(ctx, "", source, reloadOutcomeFailed, len(warnings), err)
 		if trace != nil {
-			trace.RecordConfigReload("", "", TraceOutcomeFailed, nil, nil, false, err)
+			trace.RecordConfigReload("", "", TraceOutcomeFailed, source, nil, nil, false, warnings, err)
 		}
-		return
+		return reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   err.Error(),
+		}
 	}
 	if cr.configRev != "" && result.Revision == cr.configRev {
 		if trace != nil {
-			trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeNoChange, nil, nil, false, nil)
+			trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeNoChange, source, nil, nil, false, warnings, nil)
 		}
-		return
+		telemetry.RecordConfigReload(ctx, result.Revision, source, reloadOutcomeNoChange, len(warnings), nil)
+		return reloadControlReply{
+			Outcome:  reloadOutcomeNoChange,
+			Message:  "No config changes detected.",
+			Revision: result.Revision,
+			Warnings: warnings,
+		}
 	}
 
 	oldAgentCount := len(cr.cfg.Agents)
@@ -548,8 +614,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	if newProviderName != *lastProviderName {
 		newSp, spErr := newSessionProviderByName(newProviderName, nextCfg.Session, cr.cityName, cr.cityPath)
 		if spErr != nil {
-			fmt.Fprintf(cr.stderr, "%s: new session provider %q: %v (keeping old provider)\n", //nolint:errcheck
-				cr.logPrefix, newProviderName, spErr)
+			appendWarning(fmt.Sprintf("new session provider %q: %v (keeping old provider)", newProviderName, spErr))
 		} else {
 			providerChanged = true
 			nextSp = newSp
@@ -562,23 +627,18 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// gc-beads-bd ships inside the bd pack's assets/scripts/ and is
 	// materialized alongside the rest of the pack content.
 	if err := MaterializeBuiltinPacks(cityRoot); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: config reload: materializing builtin packs: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+		appendWarning(fmt.Sprintf("config reload: materializing builtin packs: %v", err))
 	}
 	if err := config.ValidateRigs(nextCfg.Rigs, config.EffectiveHQPrefix(nextCfg)); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: config reload: %v\n", cr.logPrefix, err) //nolint:errcheck
+		appendWarning(fmt.Sprintf("config reload: %v", err))
 	}
 	resolveRigPaths(cityRoot, nextCfg.Rigs)
 	if err := cityRuntimeStartBeadsLifecycle(cityRoot, cr.cityName, nextCfg, cr.stderr); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: config reload: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck
-		telemetry.RecordConfigReload(ctx, "", err)
-		if trace != nil {
-			trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeFailed, nil, nil, false, err)
-		}
-		return
+		appendWarning(fmt.Sprintf("config reload: %v", err))
 	}
 	if len(nextCfg.FormulaLayers.City) > 0 {
 		if err := ResolveFormulas(cityRoot, nextCfg.FormulaLayers.City); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: config reload: city formulas: %v\n", cr.logPrefix, err) //nolint:errcheck
+			appendWarning(fmt.Sprintf("config reload: city formulas: %v", err))
 		}
 	}
 	for _, r := range nextCfg.Rigs {
@@ -588,7 +648,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		}
 		if len(layers) > 0 {
 			if err := ResolveFormulas(r.Path, layers); err != nil {
-				fmt.Fprintf(cr.stderr, "%s: config reload: rig %q formulas: %v\n", cr.logPrefix, r.Name, err) //nolint:errcheck
+				appendWarning(fmt.Sprintf("config reload: rig %q formulas: %v", r.Name, err))
 			}
 		}
 	}
@@ -596,13 +656,13 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// Resolve script symlinks for newly activated packs.
 	if len(nextCfg.ScriptLayers.City) > 0 {
 		if err := ResolveScripts(cityRoot, nextCfg.ScriptLayers.City); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: config reload: city scripts: %v\n", cr.logPrefix, err) //nolint:errcheck
+			appendWarning(fmt.Sprintf("config reload: city scripts: %v", err))
 		}
 	}
 	for _, r := range nextCfg.Rigs {
 		if layers, ok := nextCfg.ScriptLayers.Rigs[r.Name]; ok && len(layers) > 0 {
 			if err := ResolveScripts(r.Path, layers); err != nil {
-				fmt.Fprintf(cr.stderr, "%s: config reload: rig %q scripts: %v\n", cr.logPrefix, r.Name, err) //nolint:errcheck
+				appendWarning(fmt.Sprintf("config reload: rig %q scripts: %v", r.Name, err))
 			}
 		}
 	}
@@ -671,7 +731,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	}
 	if cr.svc != nil {
 		if err := cr.svc.Reload(); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: service reload: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+			appendWarning(fmt.Sprintf("service reload: %v", err))
 		}
 	}
 
@@ -680,7 +740,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		// Also recovers from nil → non-nil when bd becomes available after startup.
 		if s, err := openCityStoreAt(cityRoot); err != nil {
 			if cr.standaloneCityStore != nil {
-				fmt.Fprintf(cr.stderr, "%s: city bead store reload: %v\n", cr.logPrefix, err) //nolint:errcheck
+				appendWarning(fmt.Sprintf("city bead store reload: %v", err))
 			}
 		} else {
 			cr.standaloneCityStore = s
@@ -698,12 +758,19 @@ func (cr *CityRuntime) reloadConfigTraced(
 		trace.syncArms(time.Now().UTC(), nextCfg)
 	}
 
-	fmt.Fprintf(cr.stdout, "Config reloaded: %s (rev %s)\n", //nolint:errcheck
+	message := fmt.Sprintf("Config reloaded: %s (rev %s)",
 		configReloadSummary(oldAgentCount, oldRigCount, len(nextCfg.Agents), len(nextCfg.Rigs)),
 		shortRev(result.Revision))
-	telemetry.RecordConfigReload(ctx, result.Revision, nil)
+	fmt.Fprintln(cr.stdout, message) //nolint:errcheck // best-effort stdout
+	telemetry.RecordConfigReload(ctx, result.Revision, source, reloadOutcomeApplied, len(warnings), nil)
 	if trace != nil {
-		trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeApplied, nil, nil, providerChanged, nil)
+		trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeApplied, source, nil, nil, providerChanged, warnings, nil)
+	}
+	return reloadControlReply{
+		Outcome:  reloadOutcomeApplied,
+		Message:  message,
+		Revision: result.Revision,
+		Warnings: warnings,
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1209,7 +1209,7 @@ func TestCityRuntimeReloadProviderSwapPreservesDrainTracker(t *testing.T) {
 	}
 }
 
-func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
+func TestCityRuntimeReloadLifecycleFailureWarnsAndAppliesConfig(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -1254,30 +1254,36 @@ func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
 		cityRuntimeStartBeadsLifecycle = prev
 	})
 
-	writeCityRuntimeConfig(t, tomlPath, "fail")
+	data := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n\n[daemon]\nshutdown_timeout = \"1s\"\n")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 	lastProviderName := "fake"
 	cr.reloadConfig(context.Background(), &lastProviderName, cityPath)
 
-	if cr.cfg != oldCfg {
-		t.Fatal("cfg changed after lifecycle reload failure")
+	if cr.cfg == oldCfg {
+		t.Fatal("cfg did not change after lifecycle reload warning")
 	}
 	if cr.sp != oldSP {
-		t.Fatal("provider changed after lifecycle reload failure")
+		t.Fatal("provider changed after lifecycle reload warning")
 	}
 	if cr.dops != oldDops {
-		t.Fatal("drain ops changed after lifecycle reload failure")
+		t.Fatal("drain ops changed after lifecycle reload warning")
 	}
-	if cr.configRev != oldRev {
-		t.Fatalf("configRev = %q, want %q", cr.configRev, oldRev)
+	if cr.configRev == oldRev {
+		t.Fatalf("configRev = %q, want it to change", cr.configRev)
 	}
 	if lastProviderName != "fake" {
 		t.Fatalf("lastProviderName = %q, want fake", lastProviderName)
 	}
-	if !strings.Contains(stderr.String(), "keeping old config") {
-		t.Fatalf("stderr = %q, want keeping old config message", stderr.String())
+	if !strings.Contains(stderr.String(), "config reload: boom") {
+		t.Fatalf("stderr = %q, want lifecycle warning", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Session provider swapped") {
 		t.Fatalf("stdout = %q, want no provider swap message", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Config reloaded:") {
+		t.Fatalf("stdout = %q, want reload success message", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -111,9 +111,11 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 
 	reply, err := sendReloadControlRequestHook(cityPath, req)
 	if err != nil {
-		if msg := reloadUnavailableMessageHook(cityPath); msg != "" {
-			fmt.Fprintf(stderr, "gc reload: %s\n", msg) //nolint:errcheck // best-effort stderr
-			return 1
+		if isControllerUnavailableError(err) {
+			if msg := reloadUnavailableMessageHook(cityPath); msg != "" {
+				fmt.Fprintf(stderr, "gc reload: %s\n", msg) //nolint:errcheck // best-effort stderr
+				return 1
+			}
 		}
 		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -148,6 +150,13 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 		fmt.Fprintf(stderr, "gc reload: unexpected controller outcome %q\n", reply.Outcome) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+}
+
+func isControllerUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "connecting to controller:")
 }
 
 func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reloadControlReply, error) {

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -131,11 +131,12 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 		}
 		return 0
 	case reloadOutcomeFailed:
-		if strings.TrimSpace(reply.Error) != "" {
+		switch {
+		case strings.TrimSpace(reply.Error) != "":
 			fmt.Fprintln(stderr, strings.TrimSpace(reply.Error)) //nolint:errcheck // best-effort stderr
-		} else if strings.TrimSpace(reply.Message) != "" {
+		case strings.TrimSpace(reply.Message) != "":
 			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
-		} else {
+		default:
 			fmt.Fprintln(stderr, "gc reload: reload failed") //nolint:errcheck // best-effort stderr
 		}
 		return 1

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -34,6 +34,7 @@ var (
 	controllerReloadAcceptTimeout = 5 * time.Second
 	sendReloadControlRequestHook  = sendReloadControlRequest
 	reloadUnavailableMessageHook  = reloadUnavailableMessage
+	supervisorAPIBaseURLHook      = supervisorAPIBaseURL
 )
 
 type reloadControlRequest struct {
@@ -197,7 +198,7 @@ func supervisorCityInfo(cityPath string) (api.CityInfo, bool) {
 	if err != nil || !registered || supervisorAliveHook() == 0 {
 		return api.CityInfo{}, false
 	}
-	baseURL, err := supervisorAPIBaseURL()
+	baseURL, err := supervisorAPIBaseURLHook()
 	if err != nil {
 		return api.CityInfo{}, false
 	}
@@ -207,7 +208,7 @@ func supervisorCityInfo(cityPath string) (api.CityInfo, bool) {
 		return api.CityInfo{}, false
 	}
 	for _, city := range cities {
-		if city.Path == entry.Path {
+		if samePath(city.Path, entry.Path) {
 			return city, true
 		}
 	}

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/spf13/cobra"
+)
+
+type reloadOutcome string
+
+const (
+	reloadOutcomeApplied  reloadOutcome = "applied"
+	reloadOutcomeNoChange reloadOutcome = "no_change"
+	reloadOutcomeAccepted reloadOutcome = "accepted"
+	reloadOutcomeFailed   reloadOutcome = "failed"
+	reloadOutcomeBusy     reloadOutcome = "busy"
+	reloadOutcomeTimeout  reloadOutcome = "timeout"
+)
+
+type reloadSource string
+
+const (
+	reloadSourceWatch  reloadSource = "watch"
+	reloadSourceManual reloadSource = "manual"
+)
+
+var (
+	controllerReloadAcceptTimeout = 5 * time.Second
+	sendReloadControlRequestHook  = sendReloadControlRequest
+	reloadUnavailableMessageHook  = reloadUnavailableMessage
+)
+
+type reloadControlRequest struct {
+	Wait    bool   `json:"wait"`
+	Timeout string `json:"timeout,omitempty"`
+}
+
+type reloadControlReply struct {
+	Outcome  reloadOutcome `json:"outcome,omitempty"`
+	Message  string        `json:"message,omitempty"`
+	Revision string        `json:"revision,omitempty"`
+	Warnings []string      `json:"warnings,omitempty"`
+	Error    string        `json:"error,omitempty"`
+}
+
+type reloadRequest struct {
+	wait       bool
+	timeout    time.Duration
+	acceptedCh chan reloadControlReply
+	doneCh     chan reloadControlReply
+}
+
+func newReloadCmd(stdout, stderr io.Writer) *cobra.Command {
+	var async bool
+	var timeoutValue string
+	cmd := &cobra.Command{
+		Use:   "reload [path]",
+		Short: "Reload the current city's config without restarting the city/controller",
+		Long: `Force the current city controller to re-read effective config and
+process one reload tick without restarting the city/controller.
+
+Reload may fetch configured remote packs before recomputing effective
+config. Existing per-session restarts may still happen if normal config
+drift rules require them.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			timeoutChanged := cmd.Flags().Changed("timeout")
+			if cmdReload(args, async, timeoutValue, timeoutChanged, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&async, "async", false, "Return after the controller accepts the reload request")
+	cmd.Flags().StringVar(&timeoutValue, "timeout", "5m", "How long to wait for reload completion")
+	return cmd
+}
+
+func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCommandCity(args)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	if async && timeoutChanged {
+		fmt.Fprintln(stderr, "gc reload: --async and --timeout cannot be used together") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	req := reloadControlRequest{Wait: !async}
+	if !async {
+		timeout, err := time.ParseDuration(timeoutValue)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc reload: invalid --timeout %q: %v\n", timeoutValue, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if timeout <= 0 {
+			fmt.Fprintln(stderr, "gc reload: --timeout must be greater than 0") //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		req.Timeout = timeout.String()
+	}
+
+	reply, err := sendReloadControlRequestHook(cityPath, req)
+	if err != nil {
+		if msg := reloadUnavailableMessageHook(cityPath); msg != "" {
+			fmt.Fprintf(stderr, "gc reload: %s\n", msg) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	switch reply.Outcome {
+	case reloadOutcomeAccepted, reloadOutcomeApplied, reloadOutcomeNoChange:
+		if strings.TrimSpace(reply.Message) != "" {
+			fmt.Fprintln(stdout, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stdout
+		}
+		for _, warning := range reply.Warnings {
+			fmt.Fprintf(stderr, "gc reload: warning: %s\n", warning) //nolint:errcheck // best-effort stderr
+		}
+		return 0
+	case reloadOutcomeFailed:
+		if strings.TrimSpace(reply.Error) != "" {
+			fmt.Fprintln(stderr, strings.TrimSpace(reply.Error)) //nolint:errcheck // best-effort stderr
+		} else if strings.TrimSpace(reply.Message) != "" {
+			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
+		} else {
+			fmt.Fprintln(stderr, "gc reload: reload failed") //nolint:errcheck // best-effort stderr
+		}
+		return 1
+	case reloadOutcomeBusy, reloadOutcomeTimeout:
+		if strings.TrimSpace(reply.Message) != "" {
+			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
+		} else {
+			fmt.Fprintf(stderr, "gc reload: %s\n", reply.Outcome) //nolint:errcheck // best-effort stderr
+		}
+		return 1
+	default:
+		fmt.Fprintf(stderr, "gc reload: unexpected controller outcome %q\n", reply.Outcome) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+}
+
+func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return reloadControlReply{}, fmt.Errorf("marshaling request: %w", err)
+	}
+	readTimeout := 15 * time.Second
+	if req.Wait && req.Timeout != "" {
+		timeout, err := time.ParseDuration(req.Timeout)
+		if err != nil {
+			return reloadControlReply{}, fmt.Errorf("parsing request timeout: %w", err)
+		}
+		readTimeout = controllerReloadAcceptTimeout + timeout + 10*time.Second
+	}
+	resp, err := sendControllerCommandWithReadTimeout(cityPath, "reload:"+string(data), readTimeout)
+	if err != nil {
+		return reloadControlReply{}, err
+	}
+	var reply reloadControlReply
+	if err := json.Unmarshal(resp, &reply); err != nil {
+		return reloadControlReply{}, fmt.Errorf("parsing response: %w", err)
+	}
+	return reply, nil
+}
+
+func reloadUnavailableMessage(cityPath string) string {
+	info, ok := supervisorCityInfo(cityPath)
+	if !ok {
+		return ""
+	}
+	switch {
+	case info.Running:
+		return "controller is running but not responding"
+	case info.Status == "init_failed" && strings.TrimSpace(info.Error) != "":
+		return fmt.Sprintf("city failed to start under supervisor: %s", strings.TrimSpace(info.Error))
+	case info.Status == "init_failed":
+		return "city failed to start under supervisor"
+	case strings.TrimSpace(info.Status) != "":
+		return fmt.Sprintf("city is still starting under supervisor (%s)", controllerSupervisorStatusText(info.Status))
+	default:
+		return "city controller is not running"
+	}
+}
+
+func supervisorCityInfo(cityPath string) (api.CityInfo, bool) {
+	entry, registered, err := registeredCityEntry(cityPath)
+	if err != nil || !registered || supervisorAliveHook() == 0 {
+		return api.CityInfo{}, false
+	}
+	baseURL, err := supervisorAPIBaseURL()
+	if err != nil {
+		return api.CityInfo{}, false
+	}
+	client := api.NewClient(baseURL)
+	cities, err := client.ListCities()
+	if err != nil {
+		return api.CityInfo{}, false
+	}
+	for _, city := range cities {
+		if city.Path == entry.Path {
+			return city, true
+		}
+	}
+	return api.CityInfo{}, false
+}
+
+func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout time.Duration) ([]byte, error) {
+	sockPath := controllerSocketPath(cityPath)
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to controller: %w (is the controller running?)", err)
+	}
+	defer conn.Close()                                     //nolint:errcheck
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	conn.SetReadDeadline(time.Now().Add(readTimeout))      //nolint:errcheck
+	if _, err := conn.Write([]byte(command + "\n")); err != nil {
+		return nil, fmt.Errorf("sending command: %w", err)
+	}
+	var data []byte
+	buf := make([]byte, 64*1024)
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			data = append(data, buf[:n]...)
+			if strings.Contains(string(data), "\n") {
+				break
+			}
+		}
+		if err != nil {
+			if len(data) > 0 && strings.Contains(string(data), "\n") {
+				break
+			}
+			return nil, fmt.Errorf("reading response: %w", err)
+		}
+	}
+	return []byte(strings.TrimSpace(string(data))), nil
+}

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -87,7 +87,7 @@ func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
 	})
 
 	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
-		return reloadControlReply{}, errors.New("dial failed")
+		return reloadControlReply{}, errors.New("connecting to controller: dial failed")
 	}
 	reloadUnavailableMessageHook = func(string) string {
 		return "city failed to start under supervisor: fetching packs: auth denied"
@@ -98,6 +98,33 @@ func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestCmdReloadPreservesProtocolErrors(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-protocol-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{}, errors.New("parsing response: invalid character 'o' in literal null")
+	}
+	reloadUnavailableMessageHook = func(string) string {
+		return "city is still starting under supervisor"
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: parsing response: invalid character 'o' in literal null" {
 		t.Fatalf("stderr = %q", got)
 	}
 }

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestCmdReloadApplied(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-cli-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+		if cityPath != canonicalTestPath(dir) {
+			t.Fatalf("cityPath = %q, want %q", cityPath, canonicalTestPath(dir))
+		}
+		if !req.Wait || req.Timeout != "30s" {
+			t.Fatalf("req = %+v, want wait=true timeout=30s", req)
+		}
+		return reloadControlReply{
+			Outcome:  reloadOutcomeApplied,
+			Message:  "Config reloaded: 1 agents, 0 rigs (rev abc123def456)",
+			Revision: "abc123def4567890",
+			Warnings: []string{"service reload: boom"},
+		}, nil
+	}
+	reloadUnavailableMessageHook = func(string) string { return "" }
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "30s", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "Config reloaded: 1 agents, 0 rigs (rev abc123def456)" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: warning: service reload: boom" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestCmdReloadAsyncExplicitTimeoutInvalid(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-flags-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, true, "30s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "--async and --timeout cannot be used together") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-unavail-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{}, errors.New("dial failed")
+	}
+	reloadUnavailableMessageHook = func(string) string {
+		return "city failed to start under supervisor: fetching packs: auth denied"
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestHandleReloadSocketCmdAsyncAccepted(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest, 1)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false}`, reloadReqCh)
+		close(done)
+	}()
+
+	req := <-reloadReqCh
+	if req.wait {
+		t.Fatal("req.wait = true, want false")
+	}
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeAccepted {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeAccepted)
+	}
+	if reply.Message != "Reload requested." {
+		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestHandleReloadSocketCmdSyncTimeout(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest, 1)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":true,"timeout":"20ms"}`, reloadReqCh)
+		close(done)
+	}()
+
+	req := <-reloadReqCh
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeTimeout {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeTimeout)
+	}
+	if !strings.Contains(reply.Message, "may still complete later") {
+		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestHandleReloadSocketCmdBusyOnAcceptTimeout(t *testing.T) {
+	oldAccept := controllerReloadAcceptTimeout
+	controllerReloadAcceptTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { controllerReloadAcceptTimeout = oldAccept })
+
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest, 1)
+	reloadReqCh <- reloadRequest{}
+
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false}`, reloadReqCh)
+		close(done)
+	}()
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeBusy {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeBusy)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestSendReloadControlRequestNoChange(t *testing.T) {
+	sp := runtime.NewFake()
+
+	var reconcileCount atomic.Int32
+	buildFn := func(c *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		reconcileCount.Add(1)
+		ds := make(map[string]TemplateParams)
+		for _, a := range c.Agents {
+			if a.Implicit {
+				continue
+			}
+			ds[a.Name] = TemplateParams{SessionName: a.Name, TemplateName: a.Name, Command: "echo hello"}
+		}
+		return DesiredStateResult{State: ds}
+	}
+
+	dir := shortSocketTempDir(t, "gc-reload-no-change-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := writeCityTOML(t, dir, "test", "mayor")
+	cfg, prov, err := config.LoadWithIncludes(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configRev := config.Revision(osFS{}, prov, cfg, dir)
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, tomlPath, cfg, configRev, buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &stdout, &stderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		tryStopController(dir, &bytes.Buffer{})
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForController(t, dir)
+	deadline := time.After(5 * time.Second)
+	for reconcileCount.Load() < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for initial reconcile")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	reply, err := sendReloadControlRequest(dir, reloadControlRequest{Wait: true, Timeout: "1s"})
+	if err != nil {
+		t.Fatalf("sendReloadControlRequest: %v", err)
+	}
+	if reply.Outcome != reloadOutcomeNoChange {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeNoChange)
+	}
+	if reply.Message != "No config changes detected." {
+		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+	if len(reply.Warnings) != 0 {
+		t.Fatalf("reply.Warnings = %v, want none", reply.Warnings)
+	}
+}
+
+func TestSendReloadControlRequestInvalidConfig(t *testing.T) {
+	sp := runtime.NewFake()
+
+	var reconcileCount atomic.Int32
+	buildFn := func(c *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		reconcileCount.Add(1)
+		ds := make(map[string]TemplateParams)
+		for _, a := range c.Agents {
+			if a.Implicit {
+				continue
+			}
+			ds[a.Name] = TemplateParams{SessionName: a.Name, TemplateName: a.Name, Command: "echo hello"}
+		}
+		return DesiredStateResult{State: ds}
+	}
+
+	dir := shortSocketTempDir(t, "gc-reload-invalid-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := writeCityTOML(t, dir, "test", "mayor")
+	cfg, prov, err := config.LoadWithIncludes(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configRev := config.Revision(osFS{}, prov, cfg, dir)
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, tomlPath, cfg, configRev, buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &stdout, &stderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		tryStopController(dir, &bytes.Buffer{})
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForController(t, dir)
+	deadline := time.After(5 * time.Second)
+	for reconcileCount.Load() < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for initial reconcile")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if err := os.WriteFile(tomlPath, []byte("[[[ bad toml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reply, err := sendReloadControlRequest(dir, reloadControlRequest{Wait: true, Timeout: "1s"})
+	if err != nil {
+		t.Fatalf("sendReloadControlRequest: %v", err)
+	}
+	if reply.Outcome != reloadOutcomeFailed {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeFailed)
+	}
+	if !strings.Contains(reply.Error, "parsing city.toml") {
+		t.Fatalf("reply.Error = %q", reply.Error)
+	}
+	if strings.Contains(stdout.String(), "Config reloaded:") {
+		t.Fatalf("stdout unexpectedly contains reload success: %q", stdout.String())
+	}
+}
+
+func readReloadSocketReply(t *testing.T, conn net.Conn) reloadControlReply {
+	t.Helper()
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			t.Fatalf("read reply: %v", err)
+		}
+		t.Fatal("read reply: connection closed")
+	}
+	var reply reloadControlReply
+	if err := json.Unmarshal(scanner.Bytes(), &reply); err != nil {
+		t.Fatalf("decode reply: %v", err)
+	}
+	return reply
+}

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,10 +15,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/supervisor"
 )
 
 func TestCmdReloadApplied(t *testing.T) {
@@ -102,7 +106,7 @@ func TestHandleReloadSocketCmdAsyncAccepted(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close() //nolint:errcheck
 
-	reloadReqCh := make(chan reloadRequest, 1)
+	reloadReqCh := make(chan reloadRequest)
 	done := make(chan struct{})
 	go func() {
 		handleReloadSocketCmd(server, `{"wait":false}`, reloadReqCh)
@@ -138,7 +142,7 @@ func TestHandleReloadSocketCmdSyncTimeout(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close() //nolint:errcheck
 
-	reloadReqCh := make(chan reloadRequest, 1)
+	reloadReqCh := make(chan reloadRequest)
 	done := make(chan struct{})
 	go func() {
 		handleReloadSocketCmd(server, `{"wait":true,"timeout":"20ms"}`, reloadReqCh)
@@ -175,8 +179,7 @@ func TestHandleReloadSocketCmdBusyOnAcceptTimeout(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close() //nolint:errcheck
 
-	reloadReqCh := make(chan reloadRequest, 1)
-	reloadReqCh <- reloadRequest{}
+	reloadReqCh := make(chan reloadRequest)
 
 	done := make(chan struct{})
 	go func() {
@@ -194,6 +197,11 @@ func TestHandleReloadSocketCmdBusyOnAcceptTimeout(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("reload socket handler did not exit")
+	}
+	select {
+	case req := <-reloadReqCh:
+		t.Fatalf("unexpected queued reload request after busy reply: %+v", req)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -350,4 +358,58 @@ func readReloadSocketReply(t *testing.T, conn net.Conn) reloadControlReply {
 		t.Fatalf("decode reply: %v", err)
 	}
 	return reply
+}
+
+func TestSupervisorCityInfoMatchesNormalizedPath(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	realDir := shortSocketTempDir(t, "gc-reload-supervisor-real-")
+	linkDir := filepath.Join(t.TempDir(), "city-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(supervisor.RegistryPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(realDir, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/cities" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		payload := map[string]any{
+			"items": []api.CityInfo{{
+				Name:   "test",
+				Path:   linkDir,
+				Status: "starting_agents",
+			}},
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode cities: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	oldAlive := supervisorAliveHook
+	oldBaseURL := supervisorAPIBaseURLHook
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorAPIBaseURLHook = oldBaseURL
+	})
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorAPIBaseURLHook = func() (string, error) { return server.URL, nil }
+
+	info, ok := supervisorCityInfo(realDir)
+	if !ok {
+		t.Fatal("supervisorCityInfo returned ok=false")
+	}
+	if info.Path != linkDir {
+		t.Fatalf("info.Path = %q, want %q", info.Path, linkDir)
+	}
 }

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1210,7 +1210,7 @@ func reconcileCities(
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, path)
 		pokeCh := make(chan struct{}, 1)
 		configDirty := &atomic.Bool{}
-		reloadReqCh := make(chan reloadRequest, 1)
+		reloadReqCh := make(chan reloadRequest)
 		cityCtx, cityCancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
 		mc := &managedCity{name: cityName, cancel: cityCancel, done: done, closer: fr}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1210,6 +1210,7 @@ func reconcileCities(
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, path)
 		pokeCh := make(chan struct{}, 1)
 		configDirty := &atomic.Bool{}
+		reloadReqCh := make(chan reloadRequest, 1)
 		cityCtx, cityCancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
 		mc := &managedCity{name: cityName, cancel: cityCancel, done: done, closer: fr}
@@ -1235,6 +1236,7 @@ func reconcileCities(
 				Rec:                     rec,
 				PoolSessions:            poolSessions,
 				PoolDeathHandlers:       poolDeathHandlers,
+				ReloadReqCh:             reloadReqCh,
 				ConvergenceReqCh:        convergenceReqCh,
 				PokeCh:                  pokeCh,
 				ControlDispatcherCh:     controlDispatcherCh,
@@ -1329,7 +1331,7 @@ func reconcileCities(
 		// Start controller socket AFTER the alreadyRunning check so we
 		// never destroy a live city's socket or leak a listener.
 		sockPath := filepath.Join(path, ".gc", "controller.sock")
-		lis, lisErr := startControllerSocket(path, cityCancel, configDirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+		lis, lisErr := startControllerSocket(path, cityCancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		if lisErr != nil {
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': controller socket: %v\n", cityName, lisErr) //nolint:errcheck
 			lock.Close()                                                                               //nolint:errcheck // no socket to race with

--- a/cmd/gc/cmd_trace_test.go
+++ b/cmd/gc/cmd_trace_test.go
@@ -150,7 +150,7 @@ func TestTraceControllerSocketInvalidRequestDoesNotPoke(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 
@@ -228,7 +228,7 @@ func sendTraceSocketCommand(t *testing.T, cityDir, command string, req traceCont
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 
@@ -259,7 +259,7 @@ func sendTraceStatusSocketCommand(t *testing.T, cityDir string, pokeCh chan stru
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -249,24 +249,24 @@ func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest)
 		}
 	}
 
-	if timeout := remaining(); timeout <= 0 {
+	acceptTimeout := remaining()
+	if acceptTimeout <= 0 {
 		writeJSONLine(conn, reloadControlReply{
 			Outcome: reloadOutcomeBusy,
 			Message: "Reload request could not be accepted because the controller is busy.",
 		})
 		return
-	} else {
-		timer := time.NewTimer(timeout)
-		defer timer.Stop()
-		select {
-		case ch <- req:
-		case <-timer.C:
-			writeJSONLine(conn, reloadControlReply{
-				Outcome: reloadOutcomeBusy,
-				Message: "Reload request could not be accepted because the controller is busy.",
-			})
-			return
-		}
+	}
+	timer := time.NewTimer(acceptTimeout)
+	defer timer.Stop()
+	select {
+	case ch <- req:
+	case <-timer.C:
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because the controller is busy.",
+		})
+		return
 	}
 
 	reply, ok := waitFor(req.acceptedCh, remaining())

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -452,13 +452,14 @@ type reloadResult struct {
 	Cfg      *config.City
 	Prov     *config.Provenance
 	Revision string
+	Warnings []string
 }
 
 // tryReloadConfig attempts to reload city.toml with includes and patches.
-// Returns the new config, provenance, and revision on success, or an error
-// on failure (parse error, validation error, cityName changed). Callers
-// should keep the old config on error. Warnings are written to stderr;
-// strict mode (default) makes them fatal — use --no-strict to disable.
+// Returns the new config, provenance, revision, and non-fatal warnings on
+// success, or an error on failure (parse error, validation error, cityName
+// changed). Callers should keep the old config on error. Strict mode
+// (default) makes composition warnings fatal — use --no-strict to disable.
 func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer) (*reloadResult, error) {
 	// Auto-fetch remote packs before full config load (mirrors cmd_start).
 	if quickCfg, qErr := config.Load(fsys.OSFS{}, tomlPath); qErr == nil && len(quickCfg.Packs) > 0 {
@@ -479,9 +480,6 @@ func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer
 		fmt.Fprintln(stderr, "gc start: use --no-strict to disable strict checking") //nolint:errcheck // best-effort stderr
 		return nil, fmt.Errorf("strict mode: %d collision warning(s)", len(prov.Warnings))
 	}
-	for _, w := range prov.Warnings {
-		fmt.Fprintf(stderr, "gc start: warning: %s\n", w) //nolint:errcheck // best-effort stderr
-	}
 	if err := config.ValidateAgents(newCfg.Agents); err != nil {
 		return nil, fmt.Errorf("validating agents: %w", err)
 	}
@@ -499,7 +497,7 @@ func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer
 		return nil, fmt.Errorf("workspace.name changed from %q to %q (restart controller to apply)", lockedCityName, newName)
 	}
 	rev := config.Revision(fsys.OSFS{}, prov, newCfg, cityRoot)
-	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev}, nil
+	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev, Warnings: prov.Warnings}, nil
 }
 
 // gracefulStopAll performs two-pass graceful shutdown:

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -75,6 +75,7 @@ func startControllerSocket(
 	cityPath string,
 	cancelFn context.CancelFunc,
 	dirty *atomic.Bool,
+	reloadReqCh chan reloadRequest,
 	convergenceReqCh chan convergenceRequest,
 	pokeCh chan struct{},
 	controlDispatcherCh chan struct{},
@@ -95,7 +96,7 @@ func startControllerSocket(
 			if err != nil {
 				return // listener closed
 			}
-			go handleControllerConn(conn, cityPath, cancelFn, dirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+			go handleControllerConn(conn, cityPath, cancelFn, dirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		}
 	}()
 	return lis, nil
@@ -109,6 +110,7 @@ func handleControllerConn(
 	cityPath string,
 	cancelFn context.CancelFunc,
 	dirty *atomic.Bool,
+	reloadReqCh chan reloadRequest,
 	convergenceReqCh chan convergenceRequest,
 	pokeCh chan struct{},
 	controlDispatcherCh chan struct{},
@@ -143,6 +145,8 @@ func handleControllerConn(
 			default:
 			}
 			conn.Write([]byte("ok\n")) //nolint:errcheck // best-effort ack
+		case strings.HasPrefix(line, "reload:"):
+			handleReloadSocketCmd(conn, line[len("reload:"):], reloadReqCh)
 		case line == "control-dispatcher":
 			select {
 			case controlDispatcherCh <- struct{}{}:
@@ -169,6 +173,128 @@ func handleControllerConn(
 			handleTraceStatusSocketCmd(conn, cityPath)
 		}
 	}
+}
+
+func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest) {
+	if ch == nil {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   "reload control unavailable",
+		})
+		return
+	}
+
+	var wire reloadControlRequest
+	if err := json.Unmarshal([]byte(payload), &wire); err != nil {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   fmt.Sprintf("invalid reload request: %v", err),
+		})
+		return
+	}
+
+	var timeout time.Duration
+	if wire.Timeout != "" {
+		parsed, err := time.ParseDuration(wire.Timeout)
+		if err != nil {
+			writeJSONLine(conn, reloadControlReply{
+				Outcome: reloadOutcomeFailed,
+				Error:   fmt.Sprintf("invalid reload timeout %q: %v", wire.Timeout, err),
+			})
+			return
+		}
+		timeout = parsed
+	}
+	if wire.Wait && timeout <= 0 {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   "reload timeout must be greater than 0",
+		})
+		return
+	}
+
+	totalDeadline := controllerReloadAcceptTimeout + 5*time.Second
+	if wire.Wait {
+		totalDeadline += timeout
+	}
+	conn.SetDeadline(time.Now().Add(totalDeadline)) //nolint:errcheck // command-specific override
+
+	req := reloadRequest{
+		wait:       wire.Wait,
+		timeout:    timeout,
+		acceptedCh: make(chan reloadControlReply, 1),
+		doneCh:     make(chan reloadControlReply, 1),
+	}
+
+	deadline := time.Now().Add(controllerReloadAcceptTimeout)
+	remaining := func() time.Duration {
+		d := time.Until(deadline)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+
+	waitFor := func(ch <-chan reloadControlReply, timeout time.Duration) (reloadControlReply, bool) {
+		if timeout <= 0 {
+			return reloadControlReply{}, false
+		}
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case reply := <-ch:
+			return reply, true
+		case <-timer.C:
+			return reloadControlReply{}, false
+		}
+	}
+
+	if timeout := remaining(); timeout <= 0 {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because the controller is busy.",
+		})
+		return
+	} else {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case ch <- req:
+		case <-timer.C:
+			writeJSONLine(conn, reloadControlReply{
+				Outcome: reloadOutcomeBusy,
+				Message: "Reload request could not be accepted because the controller is busy.",
+			})
+			return
+		}
+	}
+
+	reply, ok := waitFor(req.acceptedCh, remaining())
+	if !ok {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because the controller is busy.",
+		})
+		return
+	}
+	if reply.Outcome != reloadOutcomeAccepted {
+		writeJSONLine(conn, reply)
+		return
+	}
+	if !req.wait {
+		writeJSONLine(conn, reply)
+		return
+	}
+
+	finalReply, ok := waitFor(req.doneCh, req.timeout)
+	if !ok {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeTimeout,
+			Message: "Reload did not finish before timeout; it may still complete later.",
+		})
+		return
+	}
+	writeJSONLine(conn, finalReply)
 }
 
 // handleConvergeSocketCmd parses a convergence JSON request, enqueues it
@@ -210,26 +336,7 @@ func writeJSONLine(w net.Conn, v any) {
 // returns the raw response bytes. Used by CLI commands that need to
 // route through the controller.
 func sendControllerCommand(cityPath, command string) ([]byte, error) {
-	sockPath := controllerSocketPath(cityPath)
-	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
-	if err != nil {
-		return nil, fmt.Errorf("connecting to controller: %w (is the controller running?)", err)
-	}
-	defer conn.Close()                                     //nolint:errcheck
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
-	conn.SetReadDeadline(time.Now().Add(95 * time.Second)) //nolint:errcheck // Must exceed server-side 30s enqueue + 60s reply
-	if _, err := conn.Write([]byte(command + "\n")); err != nil {
-		return nil, fmt.Errorf("sending command: %w", err)
-	}
-	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("reading response: %w", err)
-		}
-		return nil, fmt.Errorf("reading response: connection closed")
-	}
-	return scanner.Bytes(), nil
+	return sendControllerCommandWithReadTimeout(cityPath, command, 95*time.Second)
 }
 
 // controllerAlive checks whether a controller is running by connecting
@@ -606,12 +713,13 @@ func runController(
 	}()
 
 	convergenceReqCh := make(chan convergenceRequest, 16)
+	reloadReqCh := make(chan reloadRequest, 1)
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}
 
 	sockPath := controllerSocketPath(cityPath)
-	lis, err := startControllerSocket(cityPath, cancel, configDirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+	lis, err := startControllerSocket(cityPath, cancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -661,6 +769,7 @@ func runController(
 		Rec:                     rec,
 		PoolSessions:            poolSessions,
 		PoolDeathHandlers:       poolDeathHandlers,
+		ReloadReqCh:             reloadReqCh,
 		ConvergenceReqCh:        convergenceReqCh,
 		PokeCh:                  pokeCh,
 		ControlDispatcherCh:     controlDispatcherCh,

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -711,7 +711,7 @@ func runController(
 	}()
 
 	convergenceReqCh := make(chan convergenceRequest, 16)
-	reloadReqCh := make(chan reloadRequest, 1)
+	reloadReqCh := make(chan reloadRequest)
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -209,7 +209,7 @@ func TestControllerSocketFallbackUsesShortPathForLongCityPath(t *testing.T) {
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}
-	lis, err := startControllerSocket(cityPath, cancel, configDirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+	lis, err := startControllerSocket(cityPath, cancel, configDirty, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
 		t.Fatalf("startControllerSocket: %v", err)
 	}
@@ -819,7 +819,7 @@ func TestHandleControllerConnControlDispatcher(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityPath, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityPath, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -145,6 +145,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root.AddCommand(
 		newStartCmd(stdout, stderr),
 		newInitCmd(stdout, stderr),
+		newReloadCmd(stdout, stderr),
 		newStopCmd(stdout, stderr),
 		newRestartCmd(stdout, stderr),
 		newStatusCmd(stdout, stderr),

--- a/cmd/gc/session_reconciler_trace_collector.go
+++ b/cmd/gc/session_reconciler_trace_collector.go
@@ -552,16 +552,20 @@ func buildTraceDetailScopes(cfg *config.City, arms []TraceArm) map[string]TraceS
 	return scopes
 }
 
-func (c *SessionReconcilerTraceCycle) RecordConfigReload(previousRev, newRev string, outcome TraceOutcomeCode, added, removed []string, providerChanged bool, err error) {
+func (c *SessionReconcilerTraceCycle) RecordConfigReload(previousRev, newRev string, outcome TraceOutcomeCode, source reloadSource, added, removed []string, providerChanged bool, warnings []string, err error) {
 	if c == nil {
 		return
 	}
 	fields := map[string]any{
 		"previous_config_revision": previousRev,
 		"new_config_revision":      newRev,
+		"source":                   string(source),
 		"added_templates":          added,
 		"removed_templates":        removed,
 		"provider_changed":         providerChanged,
+	}
+	if len(warnings) > 0 {
+		fields["warnings"] = warnings
 	}
 	if err != nil {
 		fields["error"] = err.Error()

--- a/docs/guides/gc-reload-design.md
+++ b/docs/guides/gc-reload-design.md
@@ -1,0 +1,362 @@
+# `gc reload` Design
+
+Status: working design for GitHub issue `#787`
+
+## Problem
+
+Gas City has no user-facing command that forces the current city to
+re-read effective config without restarting the city. When file watching
+misses a config or pack edit, the only documented recovery path is
+`gc restart`, which tears down active sessions and disrupts in-flight
+work.
+
+## Goals
+
+- Add a user-facing `gc reload [path]` command for the current city.
+- Work for both standalone and supervisor-managed cities.
+- Reuse the existing config-dirty reload path instead of introducing a
+  second reload implementation.
+- Default to synchronous behavior so the user knows whether one reload
+  tick completed successfully.
+- Preserve existing runtime semantics after config apply, including
+  per-session restarts caused by normal config drift rules.
+- Surface structured outcomes and warnings so CLI behavior, tests, and
+  trace data are stable.
+
+## Non-Goals
+
+- No top-level `gc poke`.
+- No new HTTP API mutation such as `POST /v0/city/reload`.
+- No lockfile update during reload-time remote pack fetches.
+- No special transactional rollback for post-apply runtime side effects.
+- No new troubleshooting guide in this change.
+
+## User-Facing Contract
+
+### Command
+
+```text
+gc reload [path] [--async] [--timeout <duration>]
+```
+
+- `[path]` is optional and follows existing city-command resolution.
+- `--async` returns after the current city controller accepts the reload
+  request.
+- `--timeout` applies only to synchronous mode, must be strictly
+  positive, and defaults to `5m`.
+- `--async --timeout ...` is invalid when `--timeout` is explicitly set.
+  Implementation uses Cobra flag-change detection so the default `5m`
+  does not make a plain `gc reload --async` invalid.
+
+### Scope
+
+- `gc reload` targets exactly one city: the resolved current city.
+- It works whether that city is running standalone or under the
+  supervisor, because both topologies expose the same per-city
+  controller socket.
+- It is a live runtime operation. If the city controller is not running,
+  the command fails.
+
+### Success and Failure Semantics
+
+Sync mode waits for the first reload-processing tick only.
+
+| Outcome | Exit | Stdout/Stderr contract |
+| --- | --- | --- |
+| `applied` | `0` | stdout: `Config reloaded: ... (rev <short>)` |
+| `no_change` | `0` | stdout: `No config changes detected.` |
+| `accepted` (`--async`) | `0` | stdout: `Reload requested.` |
+| `failed` | `1` | stderr: specific config/load/fetch error |
+| `busy` | `1` | stderr: controller too busy to accept reload |
+| `timeout` | `1` | stderr: wait budget expired; reload may still finish later |
+
+Warnings are non-fatal post-apply problems. On sync success with
+warnings:
+
+- stdout prints the main success line
+- stderr prints one line per warning as
+  `gc reload: warning: ...`
+
+Rationale for exit codes:
+
+- `gc reload` keeps the existing `gc` CLI convention of `0` for success
+  and `1` for failure conditions.
+- Finer-grained outcome differentiation lives in the structured
+  controller reply and in trace/telemetry, not in a new CLI exit-code
+  taxonomy for this feature.
+- Scripts must not parse the human `message` text; they should branch on
+  success vs failure at the CLI layer or use the controller protocol in
+  future machine-facing integrations.
+
+### Config Boundary
+
+Reload failure is defined at the config-load boundary:
+
+- remote pack fetch
+- parse/load
+- validation
+- `workspace.name` mismatch
+
+If any of those fail, reload returns non-zero and the old live config
+stays active.
+
+After a config is successfully applied, subsequent runtime-execution
+issues are warnings rather than rollback triggers. Examples include:
+
+- provider swap setup failures
+- rig validation or bead lifecycle refresh errors
+- formula or script resolution errors
+- service reload errors
+- standalone city bead-store refresh errors
+
+### Existing Runtime Behavior Preserved
+
+`gc reload`:
+
+- does not restart the city/controller
+- may still cause normal per-session restarts if the reconciler detects
+  config drift under the existing rules
+- preserves existing service-manager reload behavior
+- works while the city is suspended, as long as the controller is still
+  running
+
+### Remote Pack Behavior
+
+Reload recomputes effective config using the same full-load semantics as
+existing controller reload and startup paths:
+
+- configured remote packs may be fetched before config load
+- fetch failures are hard reload failures
+- `pack.lock` is not modified
+
+## Architecture
+
+## CLI Layer
+
+Add a top-level `reload` command in `cmd/gc`:
+
+- resolve city with existing city-command rules
+- validate `--async`/`--timeout`
+- send a structured `reload` request to the per-city controller socket
+- format reply message and warnings for human output
+- on controller-connect failure, attempt to surface richer
+  supervisor-known state when available:
+  - city still starting under supervisor, including current phase
+  - city failed to start and is in backoff, including last error
+  - city not running
+  - generic controller unavailable fallback when no richer state exists
+
+## Controller Socket Protocol
+
+The controller already has a fire-and-forget `reload` socket command
+that marks config dirty and pokes the event loop. This feature upgrades
+reload control by adding a structured variant:
+
+```text
+reload:<json>
+```
+
+### Request
+
+```json
+{
+  "wait": true,
+  "timeout": "5m"
+}
+```
+
+Semantics:
+
+- `wait=true` means sync mode
+- `wait=false` means async mode
+- `timeout` is required for sync mode, ignored internally for async mode
+
+### Reply
+
+```json
+{
+  "outcome": "applied|no_change|accepted|failed|busy|timeout",
+  "message": "human readable summary",
+  "revision": "full-config-revision-when-known",
+  "warnings": ["normalized warning", "..."],
+  "error": "specific failure string when outcome=failed"
+}
+```
+
+Notes:
+
+- `message` is controller-authored canonical wording; the CLI mainly
+  relays it.
+- `revision` is included for `applied` and `no_change`.
+- `accepted` is used only for async acceptance.
+- `busy` may be returned in both sync and async mode if the controller
+  cannot register the request within the acceptance window.
+- `warnings` are normalized, user-facing strings in encounter order.
+
+The existing bare `reload` command remains as a compatibility
+fire-and-forget path for internal callers and tests. `gc reload` uses
+the structured `reload:<json>` command.
+
+## Event-Loop Integration
+
+Manual reload reuses the existing config-dirty tick path.
+
+Implementation shape:
+
+1. Add a buffered `reloadReqCh` (size `1`) to the controller/runtime
+   plumbing.
+2. The socket handler validates and attempts to enqueue a reload request
+   to `reloadReqCh`.
+3. Acceptance is defined as event-loop registration, not mere channel
+   enqueue.
+4. The socket handler waits up to `5s` for the event loop to consume and
+   register the request.
+5. When the event loop consumes a request:
+   - if another manual reload is already active, it replies `busy`
+   - otherwise it records the request as the active manual reload
+   - then it sets `dirty=true`
+   - then it pokes the reconciler loop
+   - then it acks the request as accepted
+6. The next tick after registration processes reload through the same
+   `dirty`-gated config reload path already used by file watching.
+7. When that tick resolves the reload outcome, it completes the active
+   manual request and clears the slot.
+
+Critical ordering rules:
+
+- An accepted manual reload is never attached to an already-running tick.
+- Registration of the active manual request happens-before
+  `dirty=true`, which happens-before the poke.
+- The reload result is bound to the first tick that starts after manual
+  registration.
+- If the event loop cannot register the request within `5s`, the caller
+  gets `busy`.
+
+Queueing rules:
+
+- one manual reload request may be active at a time
+- no manual-request piggybacking/coalescing contract is added
+- a concurrent manual request may receive `busy`
+- a manual request may coalesce with preexisting watcher dirtiness so
+  the system performs one reload attempt, attributed as `manual`
+
+Timeout rules:
+
+- enqueue timeout (`5s`) and wait timeout (`--timeout`, default `5m`)
+  remain distinct
+- `timeout` means the caller stopped waiting; the reload may still
+  complete later
+
+## Runtime Result Capture
+
+The current reload path prints directly to stdout/stderr and records only
+coarse telemetry. To support `gc reload`, factor it to produce a
+structured result in addition to existing logging behavior.
+
+Proposed internal result shape:
+
+- outcome: `applied`, `no_change`, or `failed`
+- revision
+- message
+- warnings
+- provider-changed marker
+- error
+
+This result is consumed by:
+
+- the active manual reload request
+- trace recording
+- telemetry recording
+
+Watcher-driven reloads continue using the same reload implementation but
+without a waiting CLI caller.
+
+## Observability
+
+### Trace
+
+Extend config-reload trace records to include:
+
+- `source`: `manual` or `watch`
+- `warnings[]`
+
+Rules:
+
+- source is recorded for every actual reload attempt outcome
+- manual wins if a manual reload request is accepted while config is
+  already dirty from watcher activity
+- the resulting reload is still a single reload attempt, not a watcher
+  reload followed by a separate manual replay
+- tick trigger stays `poke`; manual reload is distinguished with
+  `trigger_detail="manual_reload"`
+
+### Telemetry
+
+Keep metrics/logging low-cardinality. Extend `RecordConfigReload` to
+record:
+
+- `status`: `ok` or `error`
+- `source`: `manual` or `watch`
+- `outcome`: `applied`, `no_change`, or `failed`
+- `warning_count`
+
+Full warning strings stay out of telemetry and live in trace plus CLI
+stderr.
+
+## Out-of-Scope Machine Interface
+
+This feature does not add `gc reload --json` or a public HTTP reload
+mutation.
+
+Reasons:
+
+- mutation commands in this CLI generally stay human-oriented
+- the structured controller reply already provides the typed contract
+  needed for the implementation and tests
+- adding a CLI JSON contract or remote API surface would expand scope
+  beyond issue `#787`
+
+## Documentation
+
+Update command help and generated CLI reference to state that:
+
+- `gc reload` reloads the current city without restarting the
+  city/controller
+- it may fetch configured remote packs before recomputing effective
+  config
+- existing per-session restarts may still happen if config drift or
+  provider changes require them
+
+Do not add a separate troubleshooting guide in this feature.
+
+## Testing
+
+Minimum coverage:
+
+- standalone city: sync reload applied
+- supervisor-managed city: sync reload applied
+- sync no-change
+- sync invalid config keeps old config
+- async accepted without waiting
+- busy
+- timeout
+- controller unavailable / richer supervisor-state error surfaces
+- remote pack fetch failure
+- manual source attribution, including manual winning over preexisting
+  watcher dirty state
+- warnings surfaced in controller reply, CLI stderr, and trace
+- `--async --timeout` validation only when the user explicitly sets
+  `--timeout`
+- stable `0`/`1` exit-code behavior for the documented success/failure
+  groups
+
+## Implementation Notes
+
+- Add a new top-level command file for `gc reload`.
+- Add controller request/reply types and socket handling for `reload`.
+- Thread `reloadReqCh` through controller startup in standalone and
+  supervisor-managed cities.
+- Refactor runtime reload so it can return structured outcomes and
+  warnings while preserving the existing watcher-driven behavior.
+- Update telemetry and trace recorders plus their tests.
+- Regenerate CLI reference docs after command help lands.

--- a/docs/guides/gc-reload-design.md
+++ b/docs/guides/gc-reload-design.md
@@ -203,13 +203,14 @@ Manual reload reuses the existing config-dirty tick path.
 
 Implementation shape:
 
-1. Add a buffered `reloadReqCh` (size `1`) to the controller/runtime
-   plumbing.
+1. Add an unbuffered `reloadReqCh` to the controller/runtime plumbing so
+   a request is handed directly to the event loop or rejected within the
+   acceptance timeout.
 2. The socket handler validates and attempts to enqueue a reload request
    to `reloadReqCh`.
 3. Acceptance is defined as event-loop registration, not mere channel
    enqueue.
-4. The socket handler waits up to `5s` for the event loop to consume and
+4. The socket handler waits up to `5s` for the event loop to receive and
    register the request.
 5. When the event loop consumes a request:
    - if another manual reload is already active, it replies `busy`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,6 +45,7 @@ gc [flags]
 | [gc pack](#gc-pack) | Manage remote pack sources |
 | [gc prime](#gc-prime) | Output the behavioral prompt for an agent |
 | [gc register](#gc-register) | Register a city with the machine-wide supervisor |
+| [gc reload](#gc-reload) | Reload the current city's config without restarting the city/controller |
 | [gc restart](#gc-restart) | Restart all agent sessions in the city |
 | [gc resume](#gc-resume) | Resume a suspended city |
 | [gc rig](#gc-rig) | Manage rigs (projects) |
@@ -1517,6 +1518,24 @@ gc register [path] [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--name` | string |  | machine-local alias for this city registration |
+
+## gc reload
+
+Force the current city controller to re-read effective config and
+process one reload tick without restarting the city/controller.
+
+Reload may fetch configured remote packs before recomputing effective
+config. Existing per-session restarts may still happen if normal config
+drift rules require them.
+
+```
+gc reload [path] [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--async` | bool |  | Return after the controller accepts the reload request |
+| `--timeout` | string | `5m` | How long to wait for reload completion |
 
 ## gc restart
 

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -6,7 +6,6 @@ package telemetry
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -309,21 +308,21 @@ func RecordNudge(ctx context.Context, target string, err error) {
 }
 
 // RecordConfigReload records a config reload attempt (metrics + log event).
-func RecordConfigReload(ctx context.Context, revision string, source any, outcome any, warningCount int, err error) {
+func RecordConfigReload(ctx context.Context, revision, source, outcome string, warningCount int, err error) {
 	initInstruments()
 	status := statusStr(err)
 	inst.configReloadTotal.Add(ctx, 1,
 		metric.WithAttributes(
 			attribute.String("status", status),
-			attribute.String("source", fmt.Sprint(source)),
-			attribute.String("outcome", fmt.Sprint(outcome)),
+			attribute.String("source", source),
+			attribute.String("outcome", outcome),
 		),
 	)
 	emit(ctx, "config.reload", severity(err),
 		otellog.String("revision", revision),
 		otellog.String("status", status),
-		otellog.String("source", fmt.Sprint(source)),
-		otellog.String("outcome", fmt.Sprint(outcome)),
+		otellog.String("source", source),
+		otellog.String("outcome", outcome),
 		otellog.Int("warning_count", warningCount),
 		errKV(err),
 	)

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -6,6 +6,7 @@ package telemetry
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -308,15 +309,22 @@ func RecordNudge(ctx context.Context, target string, err error) {
 }
 
 // RecordConfigReload records a config reload attempt (metrics + log event).
-func RecordConfigReload(ctx context.Context, revision string, err error) {
+func RecordConfigReload(ctx context.Context, revision string, source any, outcome any, warningCount int, err error) {
 	initInstruments()
 	status := statusStr(err)
 	inst.configReloadTotal.Add(ctx, 1,
-		metric.WithAttributes(attribute.String("status", status)),
+		metric.WithAttributes(
+			attribute.String("status", status),
+			attribute.String("source", fmt.Sprint(source)),
+			attribute.String("outcome", fmt.Sprint(outcome)),
+		),
 	)
 	emit(ctx, "config.reload", severity(err),
 		otellog.String("revision", revision),
 		otellog.String("status", status),
+		otellog.String("source", fmt.Sprint(source)),
+		otellog.String("outcome", fmt.Sprint(outcome)),
+		otellog.Int("warning_count", warningCount),
 		errKV(err),
 	)
 }

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -139,8 +139,8 @@ func TestRecordConfigReload(t *testing.T) {
 	resetInstruments(t)
 	ctx := context.Background()
 
-	RecordConfigReload(ctx, "abc123", nil)
-	RecordConfigReload(ctx, "", errors.New("parse error"))
+	RecordConfigReload(ctx, "abc123", "manual", "applied", 0, nil)
+	RecordConfigReload(ctx, "", "watch", "failed", 1, errors.New("parse error"))
 }
 
 func TestRecordControllerLifecycle(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a top-level `gc reload [path]` command with sync-by-default behavior, `--async`, and `--timeout`
- route reload through a structured controller request/reply path with explicit outcomes, warnings, and supervisor-aware unavailable errors
- extend reload trace/telemetry coverage, add focused tests, and document the feature contract in `docs/guides/gc-reload-design.md`

Closes #787.

## Verification
- `make lint`
- `go vet ./...`
- `go test ./cmd/gc -run 'TestCmdReload|TestHandleReloadSocketCmd|TestSendReloadControlRequest|TestSupervisorCityInfoMatchesNormalizedPath|TestControllerReloadCommandReloadsConfigImmediately|TestCityRuntimeReloadLifecycleFailureWarnsAndAppliesConfig' -count=1`
- `go test ./internal/telemetry -count=1`

## Notes
- `go test ./...` is not clean in this checkout due unrelated pre-existing failures outside the reload diff:
  - `cmd/gc`: repo-wide timeout in unrelated bd-backed/controller-state coverage
  - `internal/dispatch`: `TestProcessRalphCheckPassClosesCheckBeforeLogicalAndPropagatesOutputJSON`
