### PR TITLE
Fix rig-scoped order bead store targeting

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -595,7 +596,7 @@ func cmdOrderCheck(stdout, stderr io.Writer) int {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderCheckWithStoreResolver(aa, time.Now(), ep, cachedOrderStoreResolver(cityPath, cfg), stdout, stderr)
+	return doOrderCheckWithStoresResolver(aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), stdout, stderr)
 }
 
 // orderLastRunFn returns a LastRunFunc that queries BdStore for the most
@@ -619,9 +620,31 @@ func orderLastRunFn(store beads.Store) orders.LastRunFunc {
 	}
 }
 
+func orderLastRunFnAcrossStores(stores ...beads.Store) orders.LastRunFunc {
+	fns := make([]orders.LastRunFunc, 0, len(stores))
+	for _, store := range stores {
+		if store != nil {
+			fns = append(fns, orderLastRunFn(store))
+		}
+	}
+	return func(name string) (time.Time, error) {
+		var latest time.Time
+		for _, fn := range fns {
+			t, err := fn(name)
+			if err != nil {
+				return time.Time{}, err
+			}
+			if t.After(latest) {
+				latest = t
+			}
+		}
+		return latest, nil
+	}
+}
+
 // doOrderCheck evaluates gates for all orders and prints a table.
 // Returns 0 if any are due, 1 if none are due.
-func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc, ep events.Provider, cursorFn orders.CursorFunc, stdout io.Writer) int {
+func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc, stdout io.Writer) int {
 	if len(aa) == 0 {
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
 		return 1
@@ -635,7 +658,7 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 	}
 	anyDue := false
 	for _, a := range aa {
-		result := orders.CheckGate(a, now, lastRunFn, ep, cursorFn)
+		result := orders.CheckGate(a, now, lastRunFn, nil, nil)
 		due := "no"
 		if result.Due {
 			due = "yes"
@@ -658,15 +681,14 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 	return 1
 }
 
-type orderStoreResolver func(orders.Order) (beads.Store, error)
+type (
+	orderStoreResolver  func(orders.Order) (beads.Store, error)
+	orderStoresResolver func(orders.Order) ([]beads.Store, error)
+)
 
-func cachedOrderStoreResolver(cityPath string, cfg *config.City) orderStoreResolver {
+func cachedOrderStoresResolver(cityPath string, cfg *config.City) orderStoresResolver {
 	stores := make(map[string]beads.Store)
-	return func(a orders.Order) (beads.Store, error) {
-		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
-		if err != nil {
-			return nil, err
-		}
+	openCached := func(target execStoreTarget) (beads.Store, error) {
 		key := orderStoreTargetKey(target)
 		if store, ok := stores[key]; ok {
 			return store, nil
@@ -678,9 +700,76 @@ func cachedOrderStoreResolver(cityPath string, cfg *config.City) orderStoreResol
 		stores[key] = store
 		return store, nil
 	}
+	return func(a orders.Order) ([]beads.Store, error) {
+		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+		if err != nil {
+			return nil, err
+		}
+		primary, err := openCached(target)
+		if err != nil {
+			return nil, err
+		}
+		out := []beads.Store{primary}
+		if legacyOrderCityFallbackNeeded(cityPath, target) {
+			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, legacy)
+		}
+		return out, nil
+	}
 }
 
-func doOrderCheckWithStoreResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStore orderStoreResolver, stdout, stderr io.Writer) int {
+func cachedOrderHistoryStoresResolver(cityPath string, cfg *config.City, stderr io.Writer) orderStoresResolver {
+	stores := make(map[string]beads.Store)
+	openCached := func(target execStoreTarget) (beads.Store, error) {
+		key := orderStoreTargetKey(target)
+		if store, ok := stores[key]; ok {
+			return store, nil
+		}
+		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+		if err != nil {
+			return nil, err
+		}
+		stores[key] = store
+		return store, nil
+	}
+	return func(a orders.Order) ([]beads.Store, error) {
+		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+		if err != nil {
+			return nil, err
+		}
+		primary, err := openCached(target)
+		if err != nil {
+			return nil, err
+		}
+		out := []beads.Store{primary}
+		if legacyOrderCityFallbackNeeded(cityPath, target) {
+			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
+			if err != nil {
+				fmt.Fprintf(stderr, "gc order history: legacy city fallback unavailable for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+				return out, nil
+			}
+			out = append(out, legacy)
+		}
+		return out, nil
+	}
+}
+
+func legacyOrderCityFallbackNeeded(cityPath string, target execStoreTarget) bool {
+	return target.ScopeKind == "rig" && filepath.Clean(target.ScopeRoot) != filepath.Clean(cityPath)
+}
+
+func legacyOrderCityTarget(cityPath string, cfg *config.City) execStoreTarget {
+	prefix := ""
+	if cfg != nil {
+		prefix = config.EffectiveHQPrefix(cfg)
+	}
+	return execStoreTarget{ScopeRoot: cityPath, ScopeKind: "city", Prefix: prefix}
+}
+
+func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
 	if len(aa) == 0 {
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
 		return 1
@@ -694,12 +783,36 @@ func doOrderCheckWithStoreResolver(aa []orders.Order, now time.Time, ep events.P
 	}
 	anyDue := false
 	for _, a := range aa {
-		store, err := resolveStore(a)
+		stores, err := resolveStores(a)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		result := orders.CheckGate(a, now, orderLastRunFn(store), ep, bdCursorFunc(store))
+		baseLastRunFn := orderLastRunFnAcrossStores(stores...)
+		var lastRunErr error
+		lastRunFn := func(orderName string) (time.Time, error) {
+			last, err := baseLastRunFn(orderName)
+			if err != nil {
+				lastRunErr = err
+			}
+			return last, err
+		}
+		cursorFn := bdCursorFuncAcrossStores(stores...)
+		if a.Gate == "event" {
+			cursor, err := bdCursorAcrossStores(a.ScopedName(), stores...)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc order check: reading event cursor for %s: %v\n", a.ScopedName(), err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			cursorFn = func(string) uint64 {
+				return cursor
+			}
+		}
+		result := orders.CheckGate(a, now, lastRunFn, ep, cursorFn)
+		if lastRunErr != nil {
+			fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		due := "no"
 		if result.Due {
 			due = "yes"
@@ -729,7 +842,7 @@ func cmdOrderHistory(name, rig string, stdout, stderr io.Writer) int {
 	if code != 0 {
 		return code
 	}
-	return doOrderHistoryWithStoreResolver(name, rig, aa, cachedOrderStoreResolver(cityPath, cfg), stdout, stderr)
+	return doOrderHistoryWithStoresResolver(name, rig, aa, cachedOrderHistoryStoresResolver(cityPath, cfg, stderr), stdout, stderr)
 }
 
 // doOrderHistory queries bead history for order runs and prints a table.
@@ -742,6 +855,16 @@ func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdo
 }
 
 func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolveStore orderStoreResolver, stdout, stderr io.Writer) int {
+	return doOrderHistoryWithStoresResolver(name, rig, aa, func(a orders.Order) ([]beads.Store, error) {
+		store, err := resolveStore(a)
+		if err != nil {
+			return nil, err
+		}
+		return []beads.Store{store}, nil
+	}, stdout, stderr)
+}
+
+func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
 	// Filter orders if name or rig specified.
 	targets := aa
 	if name != "" || rig != "" {
@@ -758,36 +881,50 @@ func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolv
 	}
 
 	type historyEntry struct {
-		order string
-		rig   string
-		id    string
-		time  string
+		order     string
+		rig       string
+		id        string
+		createdAt time.Time
 	}
 	var entries []historyEntry
+	seenEntries := make(map[string]bool)
 
 	for _, a := range targets {
-		store, err := resolveStore(a)
+		stores, err := resolveStores(a)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		label := "order-run:" + a.ScopedName()
-		results, err := store.List(beads.ListQuery{
-			Label:         label,
-			IncludeClosed: true,
-			Sort:          beads.SortCreatedDesc,
-		})
-		if err != nil {
-			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		for _, b := range results {
-			entries = append(entries, historyEntry{
-				order: a.Name,
-				rig:   a.Rig,
-				id:    b.ID,
-				time:  b.CreatedAt.Format(time.RFC3339),
+		for i, store := range stores {
+			if store == nil {
+				continue
+			}
+			results, err := store.List(beads.ListQuery{
+				Label:         label,
+				IncludeClosed: true,
+				Sort:          beads.SortCreatedDesc,
 			})
+			if err != nil {
+				fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+				if i == 0 {
+					return 1
+				}
+				continue
+			}
+			for _, b := range results {
+				key := a.ScopedName() + "\x00" + b.ID + "\x00" + b.CreatedAt.Format(time.RFC3339Nano) + "\x00" + b.Title
+				if seenEntries[key] {
+					continue
+				}
+				seenEntries[key] = true
+				entries = append(entries, historyEntry{
+					order:     a.Name,
+					rig:       a.Rig,
+					id:        b.ID,
+					createdAt: b.CreatedAt,
+				})
+			}
 		}
 	}
 
@@ -799,6 +936,10 @@ func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolv
 		}
 		return 0
 	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].createdAt.After(entries[j].createdAt)
+	})
 
 	hasRig := false
 	for _, e := range entries {
@@ -815,12 +956,12 @@ func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolv
 			if rig == "" {
 				rig = "-"
 			}
-			fmt.Fprintf(stdout, "%-20s %-15s %-15s %s\n", e.order, rig, e.id, e.time) //nolint:errcheck
+			fmt.Fprintf(stdout, "%-20s %-15s %-15s %s\n", e.order, rig, e.id, e.createdAt.Format(time.RFC3339)) //nolint:errcheck
 		}
 	} else {
 		fmt.Fprintf(stdout, "%-20s %-15s %s\n", "ORDER", "BEAD", "EXECUTED") //nolint:errcheck
 		for _, e := range entries {
-			fmt.Fprintf(stdout, "%-20s %-15s %s\n", e.order, e.id, e.time) //nolint:errcheck
+			fmt.Fprintf(stdout, "%-20s %-15s %s\n", e.order, e.id, e.createdAt.Format(time.RFC3339)) //nolint:errcheck
 		}
 	}
 	return 0
@@ -842,18 +983,61 @@ func findOrder(aa []orders.Order, name, rig string) (orders.Order, bool) {
 // label on wisps labeled order:<name>.
 func bdCursorFunc(store beads.Store) orders.CursorFunc {
 	return func(orderName string) uint64 {
-		beadList, err := store.List(beads.ListQuery{
-			Label:         "order:" + orderName,
-			IncludeClosed: true,
-			Sort:          beads.SortCreatedDesc,
-		})
+		seq, err := bdCursor(store, orderName)
 		if err != nil {
 			return 0
 		}
-		labelSets := make([][]string, len(beadList))
-		for i, b := range beadList {
-			labelSets[i] = b.Labels
-		}
-		return orders.MaxSeqFromLabels(labelSets)
+		return seq
 	}
+}
+
+func bdCursor(store beads.Store, orderName string) (uint64, error) {
+	beadList, err := store.List(beads.ListQuery{
+		Label:         "order:" + orderName,
+		IncludeClosed: true,
+		Sort:          beads.SortCreatedDesc,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing event cursor beads for order %q: %w", orderName, err)
+	}
+	labelSets := make([][]string, len(beadList))
+	for i, b := range beadList {
+		labelSets[i] = b.Labels
+	}
+	return orders.MaxSeqFromLabels(labelSets), nil
+}
+
+func bdCursorFuncAcrossStores(stores ...beads.Store) orders.CursorFunc {
+	fns := make([]orders.CursorFunc, 0, len(stores))
+	for _, store := range stores {
+		if store != nil {
+			fns = append(fns, bdCursorFunc(store))
+		}
+	}
+	return func(orderName string) uint64 {
+		var maxSeq uint64
+		for _, fn := range fns {
+			if seq := fn(orderName); seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+		return maxSeq
+	}
+}
+
+func bdCursorAcrossStores(orderName string, stores ...beads.Store) (uint64, error) {
+	var maxSeq uint64
+	for i, store := range stores {
+		if store == nil {
+			continue
+		}
+		seq, err := bdCursor(store, orderName)
+		if err != nil {
+			return 0, fmt.Errorf("store %d: %w", i, err)
+		}
+		if seq > maxSeq {
+			maxSeq = seq
+		}
+	}
+	return maxSeq, nil
 }

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -157,17 +157,23 @@ name. Use --rig to filter by rig.`,
 // loadOrders is the common preamble for order commands: resolve city,
 // load config, scan formula layers for all orders (city + rig).
 func loadOrders(stderr io.Writer, cmdName string) ([]orders.Order, int) {
+	_, _, aa, code := loadOrdersWithCity(stderr, cmdName)
+	return aa, code
+}
+
+func loadOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.City, []orders.Order, int) {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
+		return "", nil, nil, 1
 	}
 	cfg, err := loadCityConfig(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
+		return "", nil, nil, 1
 	}
-	return loadAllOrders(cityPath, cfg, stderr, cmdName)
+	aa, code := loadAllOrders(cityPath, cfg, stderr, cmdName)
+	return cityPath, cfg, aa, code
 }
 
 // loadAllOrders scans city layers + per-rig exclusive layers for orders.
@@ -413,15 +419,25 @@ func openCityOrderStore(stderr io.Writer, cmdName string) (beads.Store, int) {
 	return store, 0
 }
 
+func openOrderStoreForOrder(cityPath string, cfg *config.City, a orders.Order, stderr io.Writer, cmdName string) (beads.Store, int) {
+	target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	return store, 0
+}
+
 func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order run")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order run")
 	if code != 0 {
 		return code
-	}
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
 	}
 	a, ok := findOrder(aa, name, rig)
 	if !ok {
@@ -429,14 +445,9 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if a.IsExec() {
-		cfg, cfgErr := loadCityConfig(cityPath)
-		if cfgErr != nil {
-			fmt.Fprintf(stderr, "gc order run: %v\n", cfgErr) //nolint:errcheck // best-effort stderr
-			return 1
-		}
 		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
 	}
-	store, storeCode := openCityOrderStore(stderr, "gc order run")
+	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
 	if store == nil {
 		return storeCode
 	}
@@ -554,7 +565,7 @@ func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, s
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	env := orderExecEnv(cityPath, target, a)
+	env := orderExecEnv(cityPath, cfg, target, a)
 
 	output, err := shellExecRunner(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
@@ -574,24 +585,17 @@ func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, s
 // --- gc order check ---
 
 func cmdOrderCheck(stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order check")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order check")
 	if code != 0 {
 		return code
 	}
-
-	store, storeCode := openCityOrderStore(stderr, "gc order check")
-	if store == nil {
-		return storeCode
-	}
-	lastRunFn := orderLastRunFn(store)
-	cursorFn := bdCursorFunc(store)
 
 	ep, epCode := openCityEventsProvider(stderr, "gc order check")
 	if ep == nil {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderCheck(aa, time.Now(), lastRunFn, ep, cursorFn, stdout)
+	return doOrderCheckWithStoreResolver(aa, time.Now(), ep, cachedOrderStoreResolver(cityPath, cfg), stdout, stderr)
 }
 
 // orderLastRunFn returns a LastRunFunc that queries BdStore for the most
@@ -654,24 +658,90 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 	return 1
 }
 
+type orderStoreResolver func(orders.Order) (beads.Store, error)
+
+func cachedOrderStoreResolver(cityPath string, cfg *config.City) orderStoreResolver {
+	stores := make(map[string]beads.Store)
+	return func(a orders.Order) (beads.Store, error) {
+		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+		if err != nil {
+			return nil, err
+		}
+		key := orderStoreTargetKey(target)
+		if store, ok := stores[key]; ok {
+			return store, nil
+		}
+		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+		if err != nil {
+			return nil, err
+		}
+		stores[key] = store
+		return store, nil
+	}
+}
+
+func doOrderCheckWithStoreResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStore orderStoreResolver, stdout, stderr io.Writer) int {
+	if len(aa) == 0 {
+		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
+		return 1
+	}
+
+	hasRig := anyOrderHasRig(aa)
+	if hasRig {
+		fmt.Fprintf(stdout, "%-20s %-12s %-15s %-5s %s\n", "NAME", "GATE", "RIG", "DUE", "REASON") //nolint:errcheck
+	} else {
+		fmt.Fprintf(stdout, "%-20s %-12s %-5s %s\n", "NAME", "GATE", "DUE", "REASON") //nolint:errcheck
+	}
+	anyDue := false
+	for _, a := range aa {
+		store, err := resolveStore(a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		result := orders.CheckGate(a, now, orderLastRunFn(store), ep, bdCursorFunc(store))
+		due := "no"
+		if result.Due {
+			due = "yes"
+			anyDue = true
+		}
+		if hasRig {
+			rig := a.Rig
+			if rig == "" {
+				rig = "-"
+			}
+			fmt.Fprintf(stdout, "%-20s %-12s %-15s %-5s %s\n", a.Name, a.Gate, rig, due, result.Reason) //nolint:errcheck
+		} else {
+			fmt.Fprintf(stdout, "%-20s %-12s %-5s %s\n", a.Name, a.Gate, due, result.Reason) //nolint:errcheck
+		}
+	}
+
+	if anyDue {
+		return 0
+	}
+	return 1
+}
+
 // --- gc order history ---
 
 func cmdOrderHistory(name, rig string, stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order history")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order history")
 	if code != 0 {
 		return code
 	}
-	store, storeCode := openCityOrderStore(stderr, "gc order history")
-	if store == nil {
-		return storeCode
-	}
-	return doOrderHistory(name, rig, aa, store, stdout)
+	return doOrderHistoryWithStoreResolver(name, rig, aa, cachedOrderStoreResolver(cityPath, cfg), stdout, stderr)
 }
 
 // doOrderHistory queries bead history for order runs and prints a table.
 // When name is empty, shows history for all orders. When name is given,
 // filters to that order only. When rig is non-empty, also filters by rig.
 func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdout io.Writer) int {
+	return doOrderHistoryWithStoreResolver(name, rig, aa, func(orders.Order) (beads.Store, error) {
+		return store, nil
+	}, stdout, io.Discard)
+}
+
+func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolveStore orderStoreResolver, stdout, stderr io.Writer) int {
 	// Filter orders if name or rig specified.
 	targets := aa
 	if name != "" || rig != "" {
@@ -696,6 +766,11 @@ func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdo
 	var entries []historyEntry
 
 	for _, a := range targets {
+		store, err := resolveStore(a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		label := "order-run:" + a.ScopedName()
 		results, err := store.List(beads.ListQuery{
 			Label:         label,
@@ -703,7 +778,8 @@ func doOrderHistory(name, rig string, aa []orders.Order, store beads.Store, stdo
 			Sort:          beads.SortCreatedDesc,
 		})
 		if err != nil {
-			continue
+			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
 		}
 		for _, b := range results {
 			entries = append(entries, historyEntry{

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -427,7 +428,7 @@ func TestOrderCheck(t *testing.T) {
 	neverRan := func(_ string) (time.Time, error) { return time.Time{}, nil }
 
 	var stdout bytes.Buffer
-	code := doOrderCheck(aa, now, neverRan, nil, nil, &stdout)
+	code := doOrderCheck(aa, now, neverRan, &stdout)
 	if code != 0 {
 		t.Fatalf("doOrderCheck = %d, want 0 (due)", code)
 	}
@@ -448,7 +449,7 @@ func TestOrderCheckNoneDue(t *testing.T) {
 	neverRan := func(_ string) (time.Time, error) { return time.Time{}, nil }
 
 	var stdout bytes.Buffer
-	code := doOrderCheck(aa, now, neverRan, nil, nil, &stdout)
+	code := doOrderCheck(aa, now, neverRan, &stdout)
 	if code != 1 {
 		t.Fatalf("doOrderCheck = %d, want 1 (none due)", code)
 	}
@@ -459,7 +460,7 @@ func TestOrderCheckEmpty(t *testing.T) {
 	neverRan := func(_ string) (time.Time, error) { return time.Time{}, nil }
 
 	var stdout bytes.Buffer
-	code := doOrderCheck(nil, now, neverRan, nil, nil, &stdout)
+	code := doOrderCheck(nil, now, neverRan, &stdout)
 	if code != 1 {
 		t.Fatalf("doOrderCheck = %d, want 1 (empty)", code)
 	}
@@ -508,7 +509,7 @@ func TestOrderCheckWithLastRun(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	code := doOrderCheck(aa, now, recentRun, nil, nil, &stdout)
+	code := doOrderCheck(aa, now, recentRun, &stdout)
 	if code != 1 {
 		t.Fatalf("doOrderCheck = %d, want 1 (not due)", code)
 	}
@@ -521,7 +522,7 @@ func TestOrderCheckWithLastRun(t *testing.T) {
 	}
 }
 
-func TestOrderCheckWithStoreResolverUsesRigStore(t *testing.T) {
+func TestOrderCheckWithStoresResolverUsesRigStore(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 	if _, err := rigStore.Create(beads.Bead{
@@ -538,20 +539,118 @@ func TestOrderCheckWithStoreResolverUsesRigStore(t *testing.T) {
 		Interval: "24h",
 		Formula:  "mol-digest",
 	}}
-	resolver := func(a orders.Order) (beads.Store, error) {
+	resolver := func(a orders.Order) ([]beads.Store, error) {
 		if a.Rig == "frontend" {
-			return rigStore, nil
+			return []beads.Store{rigStore}, nil
 		}
-		return cityStore, nil
+		return []beads.Store{cityStore}, nil
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doOrderCheckWithStoreResolver(aa, time.Now().Add(time.Second), nil, resolver, &stdout, &stderr)
+	code := doOrderCheckWithStoresResolver(aa, time.Now().Add(time.Second), nil, resolver, &stdout, &stderr)
 	if code != 1 {
-		t.Fatalf("doOrderCheckWithStoreResolver = %d, want 1 (rig cooldown active); stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+		t.Fatalf("doOrderCheckWithStoresResolver = %d, want 1 (rig cooldown active); stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "no") {
 		t.Fatalf("stdout missing not-due row:\n%s", stdout.String())
+	}
+}
+
+func TestOrderCheckWithStoresResolverUsesLegacyCityStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	if _, err := cityStore.Create(beads.Bead{
+		Title:  "legacy rig run",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "digest",
+		Rig:      "frontend",
+		Gate:     "cooldown",
+		Interval: "24h",
+		Formula:  "mol-digest",
+	}}
+	resolver := func(a orders.Order) ([]beads.Store, error) {
+		if a.Rig == "frontend" {
+			return []beads.Store{rigStore, cityStore}, nil
+		}
+		return []beads.Store{cityStore}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolver(aa, time.Now().Add(time.Second), nil, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolver = %d, want 1 (legacy city cooldown active); stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "no") {
+		t.Fatalf("stdout missing not-due row:\n%s", stdout.String())
+	}
+}
+
+func TestOrderCheckWithStoresResolverFailsWhenLegacyEventCursorReadFails(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order:watch:rig:frontend",
+	}
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+
+	aa := []orders.Order{{
+		Name:    "watch",
+		Rig:     "frontend",
+		Gate:    "event",
+		On:      events.BeadClosed,
+		Formula: "mol-watch",
+	}}
+	resolver := func(a orders.Order) ([]beads.Store, error) {
+		if a.Rig == "frontend" {
+			return []beads.Store{rigStore, legacyStore}, nil
+		}
+		return []beads.Store{rigStore}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolver(aa, time.Now(), eventLog, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolver = %d, want 1 when legacy event cursor cannot be read; stdout: %s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "event cursor") {
+		t.Fatalf("stderr missing event cursor error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderCheckWithStoresResolverFailsWhenLegacyLastRunReadFails(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:digest:rig:frontend",
+	}
+
+	aa := []orders.Order{{
+		Name:     "digest",
+		Rig:      "frontend",
+		Gate:     "cooldown",
+		Interval: "24h",
+		Formula:  "mol-digest",
+	}}
+	resolver := func(a orders.Order) ([]beads.Store, error) {
+		if a.Rig == "frontend" {
+			return []beads.Store{rigStore, legacyStore}, nil
+		}
+		return []beads.Store{rigStore}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolver(aa, time.Now(), nil, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolver = %d, want 1 when legacy last-run state cannot be read; stdout: %s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "last run") {
+		t.Fatalf("stderr missing last-run error:\n%s", stderr.String())
 	}
 }
 
@@ -900,6 +999,159 @@ func TestOrderHistoryWithStoreResolverUsesRigStore(t *testing.T) {
 	}
 }
 
+func TestOrderHistoryWithStoresResolverSkipsUnreadableLegacyStore(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:digest:rig:frontend",
+	}
+	run, err := rigStore.Create(beads.Bead{
+		Title:  "rig digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:    "digest",
+		Rig:     "frontend",
+		Formula: "mol-digest",
+	}}
+	resolver := func(a orders.Order) ([]beads.Store, error) {
+		if a.Rig == "frontend" {
+			return []beads.Store{rigStore, legacyStore}, nil
+		}
+		return []beads.Store{rigStore}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoresResolver("", "", aa, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderHistoryWithStoresResolver = %d, want 0 for partial history; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), run.ID) {
+		t.Fatalf("stdout missing primary rig history %q:\n%s", run.ID, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "list failed") {
+		t.Fatalf("stderr missing legacy list warning:\n%s", stderr.String())
+	}
+}
+
+func TestOrderHistoryWithStoresResolverFailsUnreadablePrimaryStore(t *testing.T) {
+	rigStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:digest:rig:frontend",
+	}
+	legacyStore := beads.NewMemStore()
+	if _, err := legacyStore.Create(beads.Bead{
+		Title:  "legacy digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:    "digest",
+		Rig:     "frontend",
+		Formula: "mol-digest",
+	}}
+	resolver := func(a orders.Order) ([]beads.Store, error) {
+		if a.Rig == "frontend" {
+			return []beads.Store{rigStore, legacyStore}, nil
+		}
+		return []beads.Store{legacyStore}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoresResolver("", "", aa, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderHistoryWithStoresResolver = %d, want 1 for unreadable primary history; stdout: %s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "list failed") {
+		t.Fatalf("stderr missing primary list error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderHistoryWithStoresResolverDeduplicatesSameBackingStore(t *testing.T) {
+	store := beads.NewMemStore()
+	run, err := store.Create(beads.Bead{
+		Title:  "rig digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:    "digest",
+		Rig:     "frontend",
+		Formula: "mol-digest",
+	}}
+	resolver := func(orders.Order) ([]beads.Store, error) {
+		return []beads.Store{store, store}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoresResolver("", "", aa, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderHistoryWithStoresResolver = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if count := strings.Count(stdout.String(), run.ID); count != 1 {
+		t.Fatalf("stdout contains history row %q %d times, want 1:\n%s", run.ID, count, stdout.String())
+	}
+}
+
+func TestOrderHistoryWithStoresResolverSortsMergedStoresByRecency(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := beads.NewMemStore()
+	if _, err := legacyStore.Create(beads.Bead{
+		Title:  "unrelated",
+		Labels: []string{"order-run:other:rig:frontend"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldRun, err := rigStore.Create(beads.Bead{
+		Title:  "old rig digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Millisecond)
+	newRun, err := legacyStore.Create(beads.Bead{
+		Title:  "new legacy digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:    "digest",
+		Rig:     "frontend",
+		Formula: "mol-digest",
+	}}
+	resolver := func(orders.Order) ([]beads.Store, error) {
+		return []beads.Store{rigStore, legacyStore}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoresResolver("", "", aa, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderHistoryWithStoresResolver = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	newIndex := strings.Index(out, newRun.ID)
+	oldIndex := strings.LastIndex(out, oldRun.ID)
+	if newIndex == -1 || oldIndex == -1 {
+		t.Fatalf("stdout missing history rows old=%q new=%q:\n%s", oldRun.ID, newRun.ID, out)
+	}
+	if newIndex > oldIndex {
+		t.Fatalf("newer legacy row appears after older primary row:\n%s", out)
+	}
+}
+
 // --- rig-scoped tests ---
 
 func TestOrderListWithRig(t *testing.T) {
@@ -981,7 +1233,7 @@ func TestOrderCheckWithRig(t *testing.T) {
 	neverRan := func(_ string) (time.Time, error) { return time.Time{}, nil }
 
 	var stdout bytes.Buffer
-	code := doOrderCheck(aa, now, neverRan, nil, nil, &stdout)
+	code := doOrderCheck(aa, now, neverRan, &stdout)
 	if code != 0 {
 		t.Fatalf("doOrderCheck = %d, want 0", code)
 	}

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -521,6 +521,40 @@ func TestOrderCheckWithLastRun(t *testing.T) {
 	}
 }
 
+func TestOrderCheckWithStoreResolverUsesRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:  "recent rig run",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "digest",
+		Rig:      "frontend",
+		Gate:     "cooldown",
+		Interval: "24h",
+		Formula:  "mol-digest",
+	}}
+	resolver := func(a orders.Order) (beads.Store, error) {
+		if a.Rig == "frontend" {
+			return rigStore, nil
+		}
+		return cityStore, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoreResolver(aa, time.Now().Add(time.Second), nil, resolver, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoreResolver = %d, want 1 (rig cooldown active); stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "no") {
+		t.Fatalf("stdout missing not-due row:\n%s", stdout.String())
+	}
+}
+
 // --- gc order run ---
 
 func TestOrderRun(t *testing.T) {
@@ -692,7 +726,7 @@ prefix = "fe"
 		Rig:      "frontend",
 		Gate:     "cooldown",
 		Interval: "1m",
-		Exec:     fmt.Sprintf(`pwd > %q && printf '%%s\n%%s\n%%s\n%%s\n%%s\n' "$GC_STORE_ROOT" "$GC_STORE_SCOPE" "$GC_BEADS_PREFIX" "$GC_RIG" "$GC_RIG_ROOT" >> %q`, outPath, outPath),
+		Exec:     fmt.Sprintf(`pwd > %q && printf '%%s\n%%s\n%%s\n%%s\n%%s\n%%s\n' "$BEADS_DIR" "$GC_STORE_ROOT" "$GC_STORE_SCOPE" "$GC_BEADS_PREFIX" "$GC_RIG" "$GC_RIG_ROOT" >> %q`, outPath, outPath),
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -705,26 +739,29 @@ prefix = "fe"
 		t.Fatalf("ReadFile(exec-env): %v", err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) != 6 {
-		t.Fatalf("exec env lines = %d, want 6 (%q)", len(lines), string(data))
+	if len(lines) != 7 {
+		t.Fatalf("exec env lines = %d, want 7 (%q)", len(lines), string(data))
 	}
 	if lines[0] != rigDir {
 		t.Fatalf("pwd = %q, want %q", lines[0], rigDir)
 	}
-	if lines[1] != rigDir {
-		t.Fatalf("GC_STORE_ROOT = %q, want %q", lines[1], rigDir)
+	if lines[1] != filepath.Join(rigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want %q", lines[1], filepath.Join(rigDir, ".beads"))
 	}
-	if lines[2] != "rig" {
-		t.Fatalf("GC_STORE_SCOPE = %q, want rig", lines[2])
+	if lines[2] != rigDir {
+		t.Fatalf("GC_STORE_ROOT = %q, want %q", lines[2], rigDir)
 	}
-	if lines[3] != "fe" {
-		t.Fatalf("GC_BEADS_PREFIX = %q, want fe", lines[3])
+	if lines[3] != "rig" {
+		t.Fatalf("GC_STORE_SCOPE = %q, want rig", lines[3])
 	}
-	if lines[4] != "frontend" {
-		t.Fatalf("GC_RIG = %q, want frontend", lines[4])
+	if lines[4] != "fe" {
+		t.Fatalf("GC_BEADS_PREFIX = %q, want fe", lines[4])
 	}
-	if lines[5] != rigDir {
-		t.Fatalf("GC_RIG_ROOT = %q, want %q", lines[5], rigDir)
+	if lines[5] != "frontend" {
+		t.Fatalf("GC_RIG = %q, want frontend", lines[5])
+	}
+	if lines[6] != rigDir {
+		t.Fatalf("GC_RIG_ROOT = %q, want %q", lines[6], rigDir)
 	}
 }
 
@@ -823,6 +860,43 @@ func TestOrderHistoryEmpty(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No order history") {
 		t.Errorf("stdout = %q, want 'No order history'", stdout.String())
+	}
+}
+
+func TestOrderHistoryWithStoreResolverUsesRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	run, err := rigStore.Create(beads.Bead{
+		Title:  "rig digest",
+		Labels: []string{"order-run:digest:rig:frontend"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:    "digest",
+		Rig:     "frontend",
+		Formula: "mol-digest",
+	}}
+	resolver := func(a orders.Order) (beads.Store, error) {
+		if a.Rig == "frontend" {
+			return rigStore, nil
+		}
+		return cityStore, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoreResolver("", "", aa, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderHistoryWithStoreResolver = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, run.ID) {
+		t.Fatalf("stdout missing rig run %q:\n%s", run.ID, out)
+	}
+	if !strings.Contains(out, "frontend") {
+		t.Fatalf("stdout missing rig name:\n%s", out)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -43,7 +43,7 @@ func shellExecRunner(ctx context.Context, command, dir string, env []string) ([]
 	return cmd.CombinedOutput()
 }
 
-type orderStoreFunc func() (beads.Store, error)
+type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
 type memoryOrderDispatcher struct {
@@ -94,8 +94,8 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 
 	return &memoryOrderDispatcher{
 		aa: auto,
-		storeFn: func() (beads.Store, error) {
-			return openStoreAtForCity(cityPath, cityPath)
+		storeFn: func(target execStoreTarget) (beads.Store, error) {
+			return openStoreAtForCity(target.ScopeRoot, cityPath)
 		},
 		ep:         ep,
 		execRun:    shellExecRunner,
@@ -113,23 +113,35 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		return
 	}
 
-	store, err := m.storeFn()
-	if err != nil {
-		fmt.Fprintf(m.stderr, "gc: order dispatch: opening store: %v\n", err) //nolint:errcheck // best-effort stderr
-		return
-	}
-
-	lastRunFn := orderLastRunFn(store)
-	cursorFn := bdCursorFunc(store)
+	stores := make(map[string]beads.Store)
 
 	for _, a := range m.aa {
-		result := orders.CheckGate(a, now, lastRunFn, m.ep, cursorFn)
-		if !result.Due {
+		// Skip orders targeting suspended rigs.
+		if m.orderRigSuspended(a) {
 			continue
 		}
 
-		// Skip orders targeting suspended rigs.
-		if m.orderRigSuspended(a) {
+		target, err := resolveOrderStoreTarget(cityPath, m.cfg, a)
+		if err != nil {
+			fmt.Fprintf(m.stderr, "gc: order dispatch: resolving target for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+			continue
+		}
+
+		storeKey := orderStoreTargetKey(target)
+		store, ok := stores[storeKey]
+		if !ok {
+			store, err = m.storeFn(target)
+			if err != nil {
+				fmt.Fprintf(m.stderr, "gc: order dispatch: opening %s store for %s: %v\n", target.ScopeKind, a.ScopedName(), err) //nolint:errcheck
+				continue
+			}
+			stores[storeKey] = store
+		}
+
+		lastRunFn := orderLastRunFn(store)
+		cursorFn := bdCursorFunc(store)
+		result := orders.CheckGate(a, now, lastRunFn, m.ep, cursorFn)
+		if !result.Due {
 			continue
 		}
 
@@ -152,14 +164,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 		// Fire and forget with timeout.
 		a := a // capture loop variable
-		go m.dispatchOne(ctx, store, a, cityPath, trackingBead.ID)
+		go m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
 	}
 }
 
 // dispatchOne runs a single order dispatch in its own goroutine.
 // For exec orders, runs the script directly. For formula orders,
 // instantiates a wisp. Emits events and updates the tracking bead.
-func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, a orders.Order, cityPath, trackingID string) {
+func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
 	defer store.Close(trackingID) //nolint:errcheck // best-effort close
 
 	timeout := effectiveTimeout(a, m.maxTimeout)
@@ -174,32 +186,18 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 	})
 
 	if a.IsExec() {
-		m.dispatchExec(childCtx, store, a, cityPath, trackingID)
+		m.dispatchExec(childCtx, store, target, a, cityPath, trackingID)
 	} else {
 		m.dispatchWisp(childCtx, store, a, cityPath, trackingID)
 	}
 }
 
 // dispatchExec runs an exec order's shell command.
-func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.Store, a orders.Order, cityPath, trackingID string) {
+func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
 	scoped := a.ScopedName()
 	labels := []string{"exec"}
 
-	target, err := resolveOrderExecTarget(cityPath, m.cfg, a)
-	if err != nil {
-		labels = append(labels, "exec-failed")
-		fmt.Fprintf(m.stderr, "gc: order exec %s failed: %v\n", scoped, err) //nolint:errcheck
-		m.rec.Record(events.Event{
-			Type:    events.OrderFailed,
-			Actor:   "controller",
-			Subject: scoped,
-			Message: err.Error(),
-		})
-		store.Update(trackingID, beads.UpdateOpts{Labels: labels}) //nolint:errcheck // best-effort
-		return
-	}
-
-	env := orderExecEnv(cityPath, target, a)
+	env := orderExecEnv(cityPath, m.cfg, target, a)
 	output, err := m.execRun(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
 		labels = append(labels, "exec-failed")
@@ -225,7 +223,7 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.St
 	store.Update(trackingID, beads.UpdateOpts{Labels: labels}) //nolint:errcheck // best-effort
 }
 
-func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
+func resolveOrderStoreTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
 	if strings.TrimSpace(a.Rig) == "" {
 		prefix := ""
 		if cfg != nil {
@@ -252,8 +250,24 @@ func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (
 	}, nil
 }
 
-func orderExecEnv(cityPath string, target execStoreTarget, a orders.Order) []string {
-	env := citylayout.CityRuntimeEnvMap(cityPath)
+func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
+	return resolveOrderStoreTarget(cityPath, cfg, a)
+}
+
+func orderStoreTargetKey(target execStoreTarget) string {
+	return target.ScopeKind + "\x00" + filepath.Clean(target.ScopeRoot)
+}
+
+func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) []string {
+	var env map[string]string
+	if target.ScopeKind == "rig" {
+		env = bdRuntimeEnvForRig(cityPath, cfg, target.ScopeRoot)
+	} else {
+		env = bdRuntimeEnv(cityPath)
+		env["BEADS_DIR"] = filepath.Join(target.ScopeRoot, ".beads")
+		env["GC_RIG"] = ""
+		env["GC_RIG_ROOT"] = ""
+	}
 	env["GC_STORE_ROOT"] = target.ScopeRoot
 	env["GC_STORE_SCOPE"] = target.ScopeKind
 	env["GC_BEADS_PREFIX"] = target.Prefix

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -138,16 +138,51 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			stores[storeKey] = store
 		}
 
-		lastRunFn := orderLastRunFn(store)
-		cursorFn := bdCursorFunc(store)
+		storesForGate := []beads.Store{store}
+		legacyStore, legacyOK := m.legacyCityStoreForTarget(cityPath, target, stores)
+		if !legacyOK {
+			continue
+		}
+		if legacyStore != nil {
+			storesForGate = append(storesForGate, legacyStore)
+		}
+		baseLastRunFn := orderLastRunFnAcrossStores(storesForGate...)
+		var lastRunErr error
+		lastRunFn := func(orderName string) (time.Time, error) {
+			last, err := baseLastRunFn(orderName)
+			if err != nil {
+				lastRunErr = err
+			}
+			return last, err
+		}
+		cursorFn := bdCursorFuncAcrossStores(storesForGate...)
+		if a.Gate == "event" {
+			cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
+			if err != nil {
+				fmt.Fprintf(m.stderr, "gc: order dispatch: reading event cursor for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+				continue
+			}
+			cursorFn = func(string) uint64 {
+				return cursor
+			}
+		}
 		result := orders.CheckGate(a, now, lastRunFn, m.ep, cursorFn)
+		if lastRunErr != nil {
+			fmt.Fprintf(m.stderr, "gc: order dispatch: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck
+			continue
+		}
 		if !result.Due {
 			continue
 		}
 
 		// Skip dispatch if previous work hasn't been processed yet.
 		scoped := a.ScopedName()
-		if m.hasOpenWork(store, scoped) {
+		hasOpenWork, err := m.hasOpenWorkInStoresStrict(storesForGate, scoped)
+		if err != nil {
+			fmt.Fprintf(m.stderr, "gc: order dispatch: checking open work for %s: %v\n", scoped, err) //nolint:errcheck
+			continue
+		}
+		if hasOpenWork {
 			continue
 		}
 
@@ -166,6 +201,24 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		a := a // capture loop variable
 		go m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
 	}
+}
+
+func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target execStoreTarget, stores map[string]beads.Store) (beads.Store, bool) {
+	if !legacyOrderCityFallbackNeeded(cityPath, target) {
+		return nil, true
+	}
+	legacyTarget := legacyOrderCityTarget(cityPath, m.cfg)
+	key := orderStoreTargetKey(legacyTarget)
+	if store, ok := stores[key]; ok {
+		return store, true
+	}
+	store, err := m.storeFn(legacyTarget)
+	if err != nil {
+		fmt.Fprintf(m.stderr, "gc: order dispatch: opening legacy city store for rig order fallback: %v\n", err) //nolint:errcheck
+		return nil, false
+	}
+	stores[key] = store
+	return store, true
 }
 
 // dispatchOne runs a single order dispatch in its own goroutine.
@@ -265,17 +318,16 @@ func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a o
 	} else {
 		env = bdRuntimeEnv(cityPath)
 		env["BEADS_DIR"] = filepath.Join(target.ScopeRoot, ".beads")
-		env["GC_RIG"] = ""
-		env["GC_RIG_ROOT"] = ""
 	}
 	env["GC_STORE_ROOT"] = target.ScopeRoot
 	env["GC_STORE_SCOPE"] = target.ScopeKind
 	env["GC_BEADS_PREFIX"] = target.Prefix
-	env["GC_RIG"] = ""
-	env["GC_RIG_ROOT"] = ""
 	if target.ScopeKind == "rig" {
 		env["GC_RIG"] = target.RigName
 		env["GC_RIG_ROOT"] = target.ScopeRoot
+	} else {
+		env["GC_RIG"] = ""
+		env["GC_RIG_ROOT"] = ""
 	}
 	if a.Source != "" {
 		env["ORDER_DIR"] = filepath.Dir(a.Source)
@@ -415,25 +467,40 @@ func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
 	return false
 }
 
-// hasOpenWork reports whether any non-closed work bead exists for this
-// order. Tracking beads (title "order:<name>") are excluded —
-// only actual work (wisps, exec results) counts. Returns false on error
-// (fail open: allow dispatch rather than block).
-func (m *memoryOrderDispatcher) hasOpenWork(store beads.Store, scopedName string) bool {
+// hasOpenWorkStrict reports whether any non-closed work bead exists for this
+// order. Tracking beads (title "order:<name>") are excluded, so only actual
+// work (wisps, exec results) counts.
+func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
 		Label: "order-run:" + scopedName,
 		Sort:  beads.SortCreatedDesc,
 	})
 	if err != nil {
-		return false
+		return false, fmt.Errorf("listing order work beads: %w", err)
 	}
 	trackingTitle := "order:" + scopedName
 	for _, b := range results {
 		if b.Status != "closed" && b.Title != trackingTitle {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, scopedName string) (bool, error) {
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		hasOpen, err := m.hasOpenWorkStrict(store, scopedName)
+		if err != nil {
+			return false, err
+		}
+		if hasOpen {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // sweepOrphanedOrderTracking closes any open order-tracking beads left

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -601,6 +601,7 @@ func TestOrderDispatchExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
 	checks := map[string]string{
 		"GC_CITY":         cityDir,
 		"GC_CITY_PATH":    cityDir,
+		"BEADS_DIR":       filepath.Join(rigDir, ".beads"),
 		"GC_STORE_ROOT":   rigDir,
 		"GC_STORE_SCOPE":  "rig",
 		"GC_BEADS_PREFIX": "fe",
@@ -1125,9 +1126,15 @@ func buildOrderDispatcherFromList(aa []orders.Order, store beads.Store, ep event
 // buildOrderDispatcherFromListExec builds a dispatcher with exec runner support.
 func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep events.Provider, execRun ExecRunner, rec events.Recorder) orderDispatcher {
 	var auto []orders.Order
+	cfg := &config.City{}
+	seenRigs := make(map[string]bool)
 	for _, a := range aa {
 		if a.Gate != "manual" {
 			auto = append(auto, a)
+		}
+		if a.Rig != "" && !seenRigs[a.Rig] {
+			cfg.Rigs = append(cfg.Rigs, config.Rig{Name: a.Rig, Path: a.Rig})
+			seenRigs[a.Rig] = true
 		}
 	}
 	if len(auto) == 0 {
@@ -1141,13 +1148,14 @@ func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep e
 	}
 	return &memoryOrderDispatcher{
 		aa: auto,
-		storeFn: func() (beads.Store, error) {
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
 			return store, nil
 		},
 		ep:      ep,
 		execRun: execRun,
 		rec:     rec,
 		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
 	}
 }
 
@@ -1372,6 +1380,83 @@ pool = "worker"
 	work := workBeadByOrderLabel(t, store, "order-run:file-order")
 	if work.Metadata["gc.routed_to"] != "worker" {
 		t.Errorf("gc.routed_to = %q, want %q", work.Metadata["gc.routed_to"], "worker")
+	}
+}
+
+func TestBuildOrderDispatcherRigOrderUsesRigFileStore(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	cityLayer := filepath.Join(cityDir, "formulas")
+	rigLayer := filepath.Join(rigDir, "formulas")
+	orderDir := filepath.Join(rigDir, "orders", "rig-digest")
+	for _, dir := range []string{cityLayer, rigLayer, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+formula = "test-formula"
+gate = "cooldown"
+interval = "1m"
+pool = "worker"
+`)
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(test-formula): %v", err)
+	}
+	writeFile(t, filepath.Join(rigLayer, "test-formula.formula.toml"), string(formulaText))
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo", Prefix: "ct"},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{
+				"frontend": {cityLayer, rigLayer},
+			},
+		},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   "frontend",
+			Prefix: "fe",
+		}},
+	}
+
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	if ad == nil {
+		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
+	}
+
+	ad.dispatch(context.Background(), cityDir, time.Now())
+	time.Sleep(100 * time.Millisecond)
+
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	cityRuns := trackingBeads(t, cityStore, "order-run:rig-digest:rig:frontend")
+	if len(cityRuns) != 0 {
+		t.Fatalf("city store has %d rig order bead(s), want 0", len(cityRuns))
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	work := workBeadByOrderLabel(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if work.Metadata["gc.routed_to"] != "frontend/worker" {
+		t.Errorf("gc.routed_to = %q, want %q", work.Metadata["gc.routed_to"], "frontend/worker")
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1115,7 +1115,23 @@ func (f *closeFailStore) CloseAll(_ []string, _ map[string]string) (int, error) 
 	return f.closeN, fmt.Errorf("close failed")
 }
 
+type labelFailListStore struct {
+	beads.Store
+	failLabel string
+}
+
+func (s labelFailListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == s.failLabel {
+		return nil, fmt.Errorf("list failed for %s", query.Label)
+	}
+	return s.Store.List(query)
+}
+
 // --- helpers ---
+
+func successfulExec(context.Context, string, string, []string) ([]byte, error) {
+	return nil, nil
+}
 
 // buildOrderDispatcherFromList builds a dispatcher from pre-scanned orders,
 // bypassing the filesystem scan. Returns nil if no auto-dispatchable orders.
@@ -1457,6 +1473,273 @@ pool = "worker"
 	work := workBeadByOrderLabel(t, rigStore, "order-run:rig-digest:rig:frontend")
 	if work.Metadata["gc.routed_to"] != "frontend/worker" {
 		t.Errorf("gc.routed_to = %q, want %q", work.Metadata["gc.routed_to"], "frontend/worker")
+	}
+}
+
+func TestBuildOrderDispatcherRigOrderHonorsLegacyCityRunHistory(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	cityLayer := filepath.Join(cityDir, "formulas")
+	rigLayer := filepath.Join(rigDir, "formulas")
+	orderDir := filepath.Join(rigDir, "orders", "rig-digest")
+	for _, dir := range []string{cityLayer, rigLayer, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+formula = "test-formula"
+gate = "cooldown"
+interval = "24h"
+pool = "worker"
+`)
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(test-formula): %v", err)
+	}
+	writeFile(t, filepath.Join(rigLayer, "test-formula.formula.toml"), string(formulaText))
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	if _, err := cityStore.Create(beads.Bead{
+		Title:  "legacy rig digest run",
+		Labels: []string{"order-run:rig-digest:rig:frontend"},
+	}); err != nil {
+		t.Fatalf("Create(legacy city run): %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo", Prefix: "ct"},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{
+				"frontend": {cityLayer, rigLayer},
+			},
+		},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   "frontend",
+			Prefix: "fe",
+		}},
+	}
+
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	if ad == nil {
+		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
+	}
+
+	ad.dispatch(context.Background(), cityDir, time.Now())
+	time.Sleep(100 * time.Millisecond)
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if len(rigRuns) != 0 {
+		t.Fatalf("rig store has %d new run bead(s), want 0 because legacy city run is still inside cooldown", len(rigRuns))
+	}
+}
+
+func TestOrderDispatchSkipsRigOrderWhenLegacyCityFallbackUnavailable(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	stderr := &bytes.Buffer{}
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "rig-digest",
+			Rig:          "frontend",
+			Gate:         "cooldown",
+			Interval:     "1m",
+			Formula:      "test-formula",
+			Pool:         "worker",
+			FormulaLayer: sharedTestFormulaDir,
+		}},
+		storeFn: func(target execStoreTarget) (beads.Store, error) {
+			if target.ScopeKind == "city" {
+				return nil, fmt.Errorf("legacy city store unavailable")
+			}
+			return rigStore, nil
+		},
+		execRun:    shellExecRunner,
+		rec:        events.Discard,
+		stderr:     stderr,
+		maxTimeout: time.Minute,
+		cfg: &config.City{
+			Rigs: []config.Rig{{
+				Name: "frontend",
+				Path: "frontend",
+			}},
+		},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if len(rigRuns) != 0 {
+		t.Fatalf("rig store has %d new run bead(s), want 0 when legacy city fallback cannot be checked", len(rigRuns))
+	}
+	if !strings.Contains(stderr.String(), "legacy city store") {
+		t.Fatalf("stderr missing legacy fallback error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderDispatchSkipsRigEventWhenLegacyCursorReadFails(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order:release-watch:rig:frontend",
+	}
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+
+	stderr := &bytes.Buffer{}
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:    "release-watch",
+			Rig:     "frontend",
+			Gate:    "event",
+			On:      events.BeadClosed,
+			Exec:    "true",
+			Pool:    "worker",
+			Timeout: "1m",
+		}},
+		storeFn: func(target execStoreTarget) (beads.Store, error) {
+			if target.ScopeKind == "city" {
+				return legacyStore, nil
+			}
+			return rigStore, nil
+		},
+		ep:      eventLog,
+		execRun: successfulExec,
+		rec:     events.Discard,
+		stderr:  stderr,
+		cfg: &config.City{
+			Rigs: []config.Rig{{
+				Name: "frontend",
+				Path: "frontend",
+			}},
+		},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	rigRuns := trackingBeads(t, rigStore, "order-run:release-watch:rig:frontend")
+	if len(rigRuns) != 0 {
+		t.Fatalf("rig store has %d new run bead(s), want 0 when legacy event cursor cannot be read", len(rigRuns))
+	}
+	if !strings.Contains(stderr.String(), "event cursor") {
+		t.Fatalf("stderr missing event cursor error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:rig-digest:rig:frontend",
+	}
+
+	stderr := &bytes.Buffer{}
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:    "rig-digest",
+			Rig:     "frontend",
+			Gate:    "condition",
+			Check:   "true",
+			Exec:    "true",
+			Pool:    "worker",
+			Timeout: "1m",
+		}},
+		storeFn: func(target execStoreTarget) (beads.Store, error) {
+			if target.ScopeKind == "city" {
+				return legacyStore, nil
+			}
+			return rigStore, nil
+		},
+		execRun: successfulExec,
+		rec:     events.Discard,
+		stderr:  stderr,
+		cfg: &config.City{
+			Rigs: []config.Rig{{
+				Name: "frontend",
+				Path: "frontend",
+			}},
+		},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if len(rigRuns) != 0 {
+		t.Fatalf("rig store has %d new run bead(s), want 0 when legacy open-work state cannot be read", len(rigRuns))
+	}
+	if !strings.Contains(stderr.String(), "open work") {
+		t.Fatalf("stderr missing open-work error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderDispatchSkipsRigCooldownWhenLegacyLastRunReadFails(t *testing.T) {
+	rigStore := beads.NewMemStore()
+	legacyStore := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:rig-digest:rig:frontend",
+	}
+
+	stderr := &bytes.Buffer{}
+	m := &memoryOrderDispatcher{
+		aa: []orders.Order{{
+			Name:         "rig-digest",
+			Rig:          "frontend",
+			Gate:         "cooldown",
+			Interval:     "1m",
+			Formula:      "test-formula",
+			Pool:         "worker",
+			FormulaLayer: sharedTestFormulaDir,
+		}},
+		storeFn: func(target execStoreTarget) (beads.Store, error) {
+			if target.ScopeKind == "city" {
+				return legacyStore, nil
+			}
+			return rigStore, nil
+		},
+		execRun:    shellExecRunner,
+		rec:        events.Discard,
+		stderr:     stderr,
+		maxTimeout: time.Minute,
+		cfg: &config.City{
+			Rigs: []config.Rig{{
+				Name: "frontend",
+				Path: "frontend",
+			}},
+		},
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if len(rigRuns) != 0 {
+		t.Fatalf("rig store has %d new run bead(s), want 0 when legacy last-run state cannot be read", len(rigRuns))
+	}
+	if !strings.Contains(stderr.String(), "last run") {
+		t.Fatalf("stderr missing last-run error:\n%s", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- supersedes #896 and preserves @julianknutsen's original rig-scoped order store routing fix
- keep rig-scoped order tracking/work writes on the resolved rig store
- add legacy city-store read fallback for rig-scoped check/history/dispatch state so existing run history still gates cooldowns/events
- fail closed with diagnostics for unreadable check/dispatch safety state, while keeping history best-effort only for secondary legacy history reads
- dedupe and globally sort merged order history rows

Closes #137.
Supersedes #896.
Credit: Original fix by @julianknutsen.

## Verification
- go test ./cmd/gc -run 'Test(OrderDispatch|BuildOrderDispatcher|OrderRun|OrderCheck|OrderHistory|ResolveOrderExecTarget)' -count=1
- go vet ./cmd/gc
- go vet ./...
- git diff --check origin/main..HEAD

`go test ./cmd/gc -count=1 -timeout=15m` was also attempted during adoption and timed out in unrelated managed Dolt preflight cleanup (`TestDoltStateRecoverManagedCmdFailsWhenPostStartHealthFails`), outside the order-dispatch changes.

## Adoption Notes
Adopted via `/adopt-pr` workflow (Path C — new PR). Original: #896. Contributor commit preserved as the first commit in this PR; maintainer fixups are layered on top.