### PR TITLE
fix: crash-safe speculative pour before gate evaluation

### DIFF
--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -327,6 +330,87 @@ func TestConvergence_EnqueueTimeout(t *testing.T) {
 	// Drain the channel.
 	for len(cr.convergenceReqCh) > 0 {
 		<-cr.convergenceReqCh
+	}
+}
+
+func TestConvergenceStore_PourSpeculativeWispDefersAssignmentsUntilActivation(t *testing.T) {
+	dir := t.TempDir()
+	formulaText := `formula = "assigned-flow"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Work"
+assignee = "worker"
+metadata = { "gc.routed_to" = "pool/worker", "gc.execution_routed_to" = "pool/worker" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "assigned-flow.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("writing formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	adapter := newConvergenceStoreAdapter(store, []string{dir})
+	parent, err := store.Create(beads.Bead{Title: "root", Type: "convergence"})
+	if err != nil {
+		t.Fatalf("creating parent: %v", err)
+	}
+
+	wispID, err := adapter.PourSpeculativeWisp(parent.ID, "assigned-flow",
+		convergence.IdempotencyKey(parent.ID, 1), nil, "")
+	if err != nil {
+		t.Fatalf("PourSpeculativeWisp: %v", err)
+	}
+
+	children, err := store.Children(wispID)
+	if err != nil {
+		t.Fatalf("Children: %v", err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("children = %d, want 1", len(children))
+	}
+	if children[0].Assignee != "" {
+		t.Fatalf("speculative child assignee = %q, want empty", children[0].Assignee)
+	}
+	if children[0].Type != "gate" {
+		t.Fatalf("speculative child type = %q, want gate", children[0].Type)
+	}
+	if got := children[0].Metadata[molecule.DeferredAssigneeMetadataKey]; got != "worker" {
+		t.Fatalf("deferred assignee metadata = %q, want worker", got)
+	}
+	if got := children[0].Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("speculative child gc.routed_to = %q, want empty", got)
+	}
+	if got := children[0].Metadata[molecule.DeferredRoutedToMetadataKey]; got != "pool/worker" {
+		t.Fatalf("deferred gc.routed_to metadata = %q, want pool/worker", got)
+	}
+	ready, err := store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	for _, bead := range ready {
+		if bead.ID == children[0].ID {
+			t.Fatalf("speculative child %s appeared in Ready before activation", bead.ID)
+		}
+	}
+
+	if err := adapter.ActivateWisp(wispID); err != nil {
+		t.Fatalf("ActivateWisp: %v", err)
+	}
+	activated, err := store.Get(children[0].ID)
+	if err != nil {
+		t.Fatalf("Get child: %v", err)
+	}
+	if activated.Assignee != "worker" {
+		t.Fatalf("activated child assignee = %q, want worker", activated.Assignee)
+	}
+	if activated.Type != "task" {
+		t.Fatalf("activated child type = %q, want task", activated.Type)
+	}
+	if activated.Metadata["gc.routed_to"] != "pool/worker" {
+		t.Fatalf("activated child gc.routed_to = %q, want pool/worker", activated.Metadata["gc.routed_to"])
+	}
+	if activated.Metadata["gc.execution_routed_to"] != "pool/worker" {
+		t.Fatalf("activated child gc.execution_routed_to = %q, want pool/worker", activated.Metadata["gc.execution_routed_to"])
 	}
 }
 

--- a/cmd/gc/convergence_store.go
+++ b/cmd/gc/convergence_store.go
@@ -122,6 +122,16 @@ func (a *convergenceStoreAdapter) CloseBead(id string) error {
 	return nil
 }
 
+func (a *convergenceStoreAdapter) DeleteBead(id string) error {
+	if err := a.store.Delete(id); err != nil {
+		return err
+	}
+	if a.activeIndex != nil {
+		delete(a.activeIndex, id)
+	}
+	return nil
+}
+
 func (a *convergenceStoreAdapter) Children(parentID string) ([]convergence.BeadInfo, error) {
 	children, err := a.store.List(beads.ListQuery{
 		ParentID: parentID,
@@ -138,6 +148,14 @@ func (a *convergenceStoreAdapter) Children(parentID string) ([]convergence.BeadI
 }
 
 func (a *convergenceStoreAdapter) PourWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error) {
+	return a.pourWisp(parentID, formula, idempotencyKey, vars, evaluatePrompt, false)
+}
+
+func (a *convergenceStoreAdapter) PourSpeculativeWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error) {
+	return a.pourWisp(parentID, formula, idempotencyKey, vars, evaluatePrompt, true)
+}
+
+func (a *convergenceStoreAdapter) pourWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string, deferAssignees bool) (string, error) {
 	// Idempotency: check if a wisp with this key already exists (crash-retry safety).
 	// Fail closed on lookup errors to prevent duplicate wisps.
 	existing, found, err := a.FindByIdempotencyKey(idempotencyKey)
@@ -160,11 +178,56 @@ func (a *convergenceStoreAdapter) PourWisp(parentID, formula, idempotencyKey str
 		Vars:           cookVars,
 		ParentID:       parentID,
 		IdempotencyKey: idempotencyKey,
+		DeferAssignees: deferAssignees,
 	})
 	if err != nil {
 		return "", err
 	}
 	return result.RootID, nil
+}
+
+func (a *convergenceStoreAdapter) ActivateWisp(id string) error {
+	return a.activateDeferredAssignees(id)
+}
+
+func (a *convergenceStoreAdapter) activateDeferredAssignees(id string) error {
+	b, err := a.store.Get(id)
+	if err != nil {
+		return err
+	}
+	update := beads.UpdateOpts{}
+	if assignee := b.Metadata[molecule.DeferredAssigneeMetadataKey]; assignee != "" && b.Assignee != assignee {
+		update.Assignee = &assignee
+	}
+	metadata := map[string]string{}
+	if routedTo := b.Metadata[molecule.DeferredRoutedToMetadataKey]; routedTo != "" && b.Metadata["gc.routed_to"] != routedTo {
+		metadata["gc.routed_to"] = routedTo
+	}
+	if executionRoutedTo := b.Metadata[molecule.DeferredExecutionRoutedToMetadataKey]; executionRoutedTo != "" && b.Metadata["gc.execution_routed_to"] != executionRoutedTo {
+		metadata["gc.execution_routed_to"] = executionRoutedTo
+	}
+	if typ := b.Metadata[molecule.DeferredTypeMetadataKey]; typ != "" && b.Type != typ {
+		update.Type = &typ
+	}
+	if len(metadata) > 0 {
+		update.Metadata = metadata
+	}
+	if update.Assignee != nil || update.Type != nil || len(update.Metadata) > 0 {
+		if err := a.store.Update(id, update); err != nil {
+			return fmt.Errorf("assigning deferred bead %q: %w", id, err)
+		}
+	}
+
+	children, err := a.store.Children(id, beads.IncludeClosed)
+	if err != nil {
+		return fmt.Errorf("listing children for activation %q: %w", id, err)
+	}
+	for _, child := range children {
+		if err := a.activateDeferredAssignees(child.ID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *convergenceStoreAdapter) FindByIdempotencyKey(key string) (string, bool, error) {

--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -65,12 +65,23 @@ type Store interface {
 	// CloseBead sets a bead's status to "closed".
 	CloseBead(id string) error
 
+	// DeleteBead permanently removes a bead. Used to burn discarded
+	// speculative wisps so they are not counted as completed iterations.
+	DeleteBead(id string) error
+
 	// Children returns child beads of a parent.
 	Children(parentID string) ([]BeadInfo, error)
 
 	// PourWisp creates a new convergence wisp with an idempotency key.
 	// If a wisp with this key already exists, returns the existing wisp's ID.
 	PourWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error)
+
+	// PourSpeculativeWisp creates a hidden/unassigned convergence wisp that can
+	// be activated after a nonterminal gate outcome adopts it.
+	PourSpeculativeWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error)
+
+	// ActivateWisp publishes a previously speculative wisp for agent work.
+	ActivateWisp(id string) error
 
 	// FindByIdempotencyKey looks up a wisp by its idempotency key.
 	FindByIdempotencyKey(key string) (string, bool, error)
@@ -183,38 +194,59 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 
 	maxIterations, _ := DecodeInt(meta[FieldMaxIterations])
 
-	// Step 3b: Speculative pour — create the next wisp BEFORE gate evaluation
-	// so that a crash between gate eval and commit cannot break the chain.
-	// If the outcome is terminal or waiting_manual, we burn this wisp.
-	var speculativeWispID string
-	if wispIteration < maxIterations {
-		nextIter := wispIteration + 1
-		nextKey := IdempotencyKey(rootBeadID, nextIter)
-		formula := meta[FieldFormula]
-		vars := ExtractVars(meta)
-		evaluatePrompt := meta[FieldEvaluatePrompt]
-		speculativeWispID, err = h.Store.PourWisp(rootBeadID, formula, nextKey, vars, evaluatePrompt)
-		if err != nil {
-			existingID, found, lookupErr := h.Store.FindByIdempotencyKey(nextKey)
-			if lookupErr == nil && found {
-				speculativeWispID = existingID
-			}
-		}
-		if speculativeWispID != "" {
-			_ = h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, speculativeWispID)
-		}
-	}
-
-	// Parse gate config.
+	// Parse gate config before creating speculative work. Invalid config or
+	// deterministic manual-waiting paths must not leave behind a successor wisp.
 	gateConfig, err := ParseGateConfig(meta)
 	if err != nil {
 		return HandlerResult{}, fmt.Errorf("parsing gate config: %w", err)
 	}
 
-	// Step 4: Gate evaluation (idempotent).
-	var gateResult GateResult
+	nextIteration := wispIteration + 1
+	nextKey := IdempotencyKey(rootBeadID, nextIteration)
+
 	gateOutcomeWisp := meta[FieldGateOutcomeWisp]
 	skipGateEval := gateOutcomeWisp == wispID
+	if !skipGateEval && gateConfig.Mode == GateModeCondition && gateConfig.Condition == "" {
+		if pending := h.validPendingNextWisp(rootBeadID, nextKey, meta[FieldPendingNextWisp]); pending != "" {
+			if burnErr := h.burnSpeculativeWisp(rootBeadID, pending); burnErr != nil {
+				return HandlerResult{}, fmt.Errorf("gate mode is %q but no condition path configured; additionally burning pending wisp: %w", GateModeCondition, burnErr)
+			}
+		}
+		return HandlerResult{}, fmt.Errorf("gate mode is %q but no condition path configured", GateModeCondition)
+	}
+
+	// Step 3b: Speculative pour - create the next wisp BEFORE gate evaluation
+	// so that a crash between gate eval and commit cannot break the chain.
+	// If the outcome is terminal or waiting_manual, we burn this wisp.
+	speculativeWispID := h.validPendingNextWisp(rootBeadID, nextKey, meta[FieldPendingNextWisp])
+	var speculativePourErr error
+	needsManualWithoutGate := gateConfig.Mode == GateModeManual ||
+		(gateConfig.Mode == GateModeHybrid && HybridNeedsManual(gateConfig))
+	if wispIteration < maxIterations && !needsManualWithoutGate && speculativeWispID == "" {
+		formula := meta[FieldFormula]
+		vars := ExtractVars(meta)
+		evaluatePrompt := meta[FieldEvaluatePrompt]
+		speculativeWispID, err = h.Store.PourSpeculativeWisp(rootBeadID, formula, nextKey, vars, evaluatePrompt)
+		if err != nil {
+			existingID, found, lookupErr := h.Store.FindByIdempotencyKey(nextKey)
+			if lookupErr == nil && found {
+				speculativeWispID = existingID
+			} else {
+				speculativePourErr = err
+			}
+		}
+		if speculativeWispID != "" {
+			if err := h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, speculativeWispID); err != nil {
+				if burnErr := h.burnSpeculativeWisp(rootBeadID, speculativeWispID); burnErr != nil {
+					return HandlerResult{}, fmt.Errorf("setting pending next wisp: %w; additionally burning speculative wisp: %w", err, burnErr)
+				}
+				return HandlerResult{}, fmt.Errorf("setting pending next wisp: %w", err)
+			}
+		}
+	}
+
+	// Step 4: Gate evaluation (idempotent).
+	var gateResult GateResult
 
 	if skipGateEval {
 		// Replay: use persisted outcome.
@@ -238,21 +270,20 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	} else {
 		// Manual mode: no gate evaluation, transition to waiting_manual.
 		if gateConfig.Mode == GateModeManual {
-			h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
+			if err := h.burnSpeculativeWisp(rootBeadID, speculativeWispID); err != nil {
+				return HandlerResult{}, fmt.Errorf("burning speculative wisp before waiting_manual: %w", err)
+			}
 			return h.transitionToWaitingManual(rootBeadID, wispID, wispIteration,
 				gateConfig, GateResult{}, WaitManual, "", meta, now)
 		}
 
 		// Hybrid mode with no condition: fallback to manual.
 		if gateConfig.Mode == GateModeHybrid && HybridNeedsManual(gateConfig) {
-			h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
+			if err := h.burnSpeculativeWisp(rootBeadID, speculativeWispID); err != nil {
+				return HandlerResult{}, fmt.Errorf("burning speculative wisp before waiting_manual: %w", err)
+			}
 			return h.transitionToWaitingManual(rootBeadID, wispID, wispIteration,
 				gateConfig, GateResult{}, WaitHybridNoCondition, "", meta, now)
-		}
-
-		// Condition mode with no condition path: this is a configuration error.
-		if gateConfig.Mode == GateModeCondition && gateConfig.Condition == "" {
-			return HandlerResult{}, fmt.Errorf("gate mode is %q but no condition path configured", GateModeCondition)
 		}
 
 		// Read agent verdict (only if scoped to this wisp).
@@ -270,6 +301,9 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	// Step 5: Persist gate outcome.
 	if !skipGateEval {
 		if err := h.persistGateOutcome(rootBeadID, wispID, gateResult); err != nil {
+			if burnErr := h.burnSpeculativeWisp(rootBeadID, speculativeWispID); burnErr != nil {
+				return HandlerResult{}, fmt.Errorf("persisting gate outcome: %w; additionally burning speculative wisp: %w", err, burnErr)
+			}
 			return HandlerResult{}, fmt.Errorf("persisting gate outcome: %w", err)
 		}
 	}
@@ -280,7 +314,9 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	// Step 7: Prepare outcome.
 	// Check for timeout with manual action first.
 	if gateResult.Outcome == GateTimeout && gateConfig.TimeoutAction == TimeoutActionManual {
-		h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
+		if err := h.burnSpeculativeWisp(rootBeadID, speculativeWispID); err != nil {
+			return HandlerResult{}, fmt.Errorf("burning speculative wisp before waiting_manual: %w", err)
+		}
 		return h.transitionToWaitingManual(rootBeadID, wispID, wispIteration,
 			gateConfig, gateResult, WaitTimeout, gateResult.Outcome, meta, now)
 	}
@@ -303,12 +339,18 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	}
 
 	if !isTerminal {
+		if speculativePourErr != nil {
+			return h.handleSlingFailure(rootBeadID, wispID, wispIteration,
+				gateConfig, gateResult, meta, now)
+		}
 		// Iterate: clear verdict and use speculatively poured wisp.
 		return h.iterate(ctx, rootBeadID, wispID, wispIteration, gateConfig, gateResult, meta, now, speculativeWispID)
 	}
 
-	// Terminal transition — burn the speculative wisp if one was poured.
-	h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
+	// Terminal transition - burn the speculative wisp if one was poured.
+	if err := h.burnSpeculativeWisp(rootBeadID, speculativeWispID); err != nil {
+		return HandlerResult{}, fmt.Errorf("burning speculative wisp before terminal transition: %w", err)
+	}
 	return h.terminate(rootBeadID, wispID, wispIteration, gateConfig, gateResult,
 		terminalReason, "controller", globalIteration, meta, now)
 }
@@ -446,6 +488,9 @@ func (h *Handler) iterate(
 			}
 		}
 	}
+	if err := h.Store.ActivateWisp(nextWispID); err != nil {
+		return HandlerResult{}, fmt.Errorf("activating next wisp %q: %w", nextWispID, err)
+	}
 
 	// Compute durations.
 	iterDur, cumDur := h.computeDurations(rootBeadID, wispID)
@@ -478,13 +523,12 @@ func (h *Handler) iterate(
 	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, nextWispID); err != nil {
 		return HandlerResult{}, fmt.Errorf("setting active wisp: %w", err)
 	}
-	// Clear pending_next_wisp: the speculative wisp has been adopted.
-	if err := h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, ""); err != nil {
-		return HandlerResult{}, fmt.Errorf("clearing pending next wisp: %w", err)
-	}
 	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
 		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
 	}
+	// Clear pending_next_wisp after the dedup marker commits. If this best-effort
+	// cleanup fails, validPendingNextWisp will self-heal on the next entry.
+	_ = h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, "")
 
 	return HandlerResult{
 		Action:      ActionIterate,
@@ -724,15 +768,46 @@ func (h *Handler) clock() time.Time {
 	return time.Now()
 }
 
-// burnSpeculativeWisp closes a speculatively poured wisp and clears the
+// burnSpeculativeWisp deletes a speculatively poured wisp and clears the
 // pending_next_wisp metadata field. Called when the gate outcome is terminal
 // or waiting_manual and the speculative wisp is not needed.
-func (h *Handler) burnSpeculativeWisp(rootBeadID, speculativeWispID string) {
+func (h *Handler) burnSpeculativeWisp(rootBeadID, speculativeWispID string) error {
 	if speculativeWispID == "" {
-		return
+		return nil
 	}
-	_ = h.Store.CloseBead(speculativeWispID)
+	if err := h.deleteBeadSubtree(speculativeWispID); err != nil {
+		return err
+	}
 	_ = h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, "")
+	return nil
+}
+
+func (h *Handler) deleteBeadSubtree(id string) error {
+	children, err := h.Store.Children(id)
+	if err != nil {
+		return fmt.Errorf("listing children for delete %q: %w", id, err)
+	}
+	for _, child := range children {
+		if err := h.deleteBeadSubtree(child.ID); err != nil {
+			return err
+		}
+	}
+	if err := h.Store.DeleteBead(id); err != nil {
+		return fmt.Errorf("deleting bead %q: %w", id, err)
+	}
+	return nil
+}
+
+func (h *Handler) validPendingNextWisp(rootBeadID, nextKey, pendingID string) string {
+	if pendingID == "" {
+		return ""
+	}
+	info, err := h.Store.GetBead(pendingID)
+	if err != nil || info.ParentID != rootBeadID || info.IdempotencyKey != nextKey || info.Status == "closed" {
+		_ = h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, "")
+		return ""
+	}
+	return pendingID
 }
 
 // CheckNestedConvergence validates that creating a new convergence loop

--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -120,6 +120,12 @@ type Handler struct {
 
 // HandleWispClosed processes a wisp_closed event for a convergence root bead.
 // This is the core 9-step algorithm from the spec.
+//
+// Crash safety: the next wisp is speculatively poured BEFORE gate evaluation
+// (step 3b). If the outcome is terminal or waiting_manual, the speculative
+// wisp is burned. If the process crashes after the pour but before the burn,
+// the reconciler finds the speculative wisp via pending_next_wisp or
+// FindByIdempotencyKey and adopts it.
 func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID string) (HandlerResult, error) {
 	now := h.clock()
 
@@ -177,6 +183,28 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 
 	maxIterations, _ := DecodeInt(meta[FieldMaxIterations])
 
+	// Step 3b: Speculative pour — create the next wisp BEFORE gate evaluation
+	// so that a crash between gate eval and commit cannot break the chain.
+	// If the outcome is terminal or waiting_manual, we burn this wisp.
+	var speculativeWispID string
+	if wispIteration < maxIterations {
+		nextIter := wispIteration + 1
+		nextKey := IdempotencyKey(rootBeadID, nextIter)
+		formula := meta[FieldFormula]
+		vars := ExtractVars(meta)
+		evaluatePrompt := meta[FieldEvaluatePrompt]
+		speculativeWispID, err = h.Store.PourWisp(rootBeadID, formula, nextKey, vars, evaluatePrompt)
+		if err != nil {
+			existingID, found, lookupErr := h.Store.FindByIdempotencyKey(nextKey)
+			if lookupErr == nil && found {
+				speculativeWispID = existingID
+			}
+		}
+		if speculativeWispID != "" {
+			_ = h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, speculativeWispID)
+		}
+	}
+
 	// Parse gate config.
 	gateConfig, err := ParseGateConfig(meta)
 	if err != nil {
@@ -210,12 +238,14 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	} else {
 		// Manual mode: no gate evaluation, transition to waiting_manual.
 		if gateConfig.Mode == GateModeManual {
+			h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
 			return h.transitionToWaitingManual(rootBeadID, wispID, wispIteration,
 				gateConfig, GateResult{}, WaitManual, "", meta, now)
 		}
 
 		// Hybrid mode with no condition: fallback to manual.
 		if gateConfig.Mode == GateModeHybrid && HybridNeedsManual(gateConfig) {
+			h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
 			return h.transitionToWaitingManual(rootBeadID, wispID, wispIteration,
 				gateConfig, GateResult{}, WaitHybridNoCondition, "", meta, now)
 		}
@@ -250,6 +280,7 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	// Step 7: Prepare outcome.
 	// Check for timeout with manual action first.
 	if gateResult.Outcome == GateTimeout && gateConfig.TimeoutAction == TimeoutActionManual {
+		h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
 		return h.transitionToWaitingManual(rootBeadID, wispID, wispIteration,
 			gateConfig, gateResult, WaitTimeout, gateResult.Outcome, meta, now)
 	}
@@ -272,11 +303,12 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	}
 
 	if !isTerminal {
-		// Iterate: clear verdict and pour next wisp.
-		return h.iterate(ctx, rootBeadID, wispID, wispIteration, gateConfig, gateResult, meta, now)
+		// Iterate: clear verdict and use speculatively poured wisp.
+		return h.iterate(ctx, rootBeadID, wispID, wispIteration, gateConfig, gateResult, meta, now, speculativeWispID)
 	}
 
-	// Terminal transition.
+	// Terminal transition — burn the speculative wisp if one was poured.
+	h.burnSpeculativeWisp(rootBeadID, speculativeWispID)
 	return h.terminate(rootBeadID, wispID, wispIteration, gateConfig, gateResult,
 		terminalReason, "controller", globalIteration, meta, now)
 }
@@ -366,7 +398,9 @@ func (h *Handler) transitionToWaitingManual(
 	}, nil
 }
 
-// iterate clears verdict and pours the next convergence wisp.
+// iterate clears verdict and adopts the speculatively poured wisp (or pours
+// a new one as fallback). The speculative wisp was created in step 3b of
+// HandleWispClosed before gate evaluation, ensuring crash safety.
 func (h *Handler) iterate(
 	_ context.Context,
 	rootBeadID, wispID string,
@@ -375,6 +409,7 @@ func (h *Handler) iterate(
 	gateResult GateResult,
 	meta map[string]string,
 	now time.Time,
+	speculativeWispID string,
 ) (HandlerResult, error) {
 	// Clear verdict for next iteration (only if verdict belongs to this wisp).
 	if meta[FieldAgentVerdictWisp] == wispID {
@@ -386,24 +421,29 @@ func (h *Handler) iterate(
 		}
 	}
 
-	// Pour next wisp.
+	// Adopt speculatively poured wisp, or pour a new one as fallback.
 	nextIteration := iteration + 1
 	nextKey := IdempotencyKey(rootBeadID, nextIteration)
-	formula := meta[FieldFormula]
-	vars := ExtractVars(meta)
-	evaluatePrompt := meta[FieldEvaluatePrompt] // may be empty for default
 
-	nextWispID, err := h.Store.PourWisp(rootBeadID, formula, nextKey, vars, evaluatePrompt)
-	if err != nil {
-		// Sling failure: check if wisp was created despite the error.
-		existingID, found, lookupErr := h.Store.FindByIdempotencyKey(nextKey)
-		if lookupErr == nil && found {
-			// Wisp was created — adopt it.
-			nextWispID = existingID
-		} else {
-			// Genuine sling failure: transition to waiting_manual.
-			return h.handleSlingFailure(rootBeadID, wispID, iteration,
-				gateConfig, gateResult, meta, now)
+	var nextWispID string
+	if speculativeWispID != "" {
+		// Speculative wisp was pre-poured in step 3b — adopt it.
+		nextWispID = speculativeWispID
+	} else {
+		// Fallback: pour now (e.g., at max iterations boundary or error).
+		formula := meta[FieldFormula]
+		vars := ExtractVars(meta)
+		evaluatePrompt := meta[FieldEvaluatePrompt]
+		var pourErr error
+		nextWispID, pourErr = h.Store.PourWisp(rootBeadID, formula, nextKey, vars, evaluatePrompt)
+		if pourErr != nil {
+			existingID, found, lookupErr := h.Store.FindByIdempotencyKey(nextKey)
+			if lookupErr == nil && found {
+				nextWispID = existingID
+			} else {
+				return h.handleSlingFailure(rootBeadID, wispID, iteration,
+					gateConfig, gateResult, meta, now)
+			}
 		}
 	}
 
@@ -437,6 +477,10 @@ func (h *Handler) iterate(
 	// Write last_processed_wisp LAST — it is the dedup marker.
 	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, nextWispID); err != nil {
 		return HandlerResult{}, fmt.Errorf("setting active wisp: %w", err)
+	}
+	// Clear pending_next_wisp: the speculative wisp has been adopted.
+	if err := h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, ""); err != nil {
+		return HandlerResult{}, fmt.Errorf("clearing pending next wisp: %w", err)
 	}
 	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
 		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
@@ -678,6 +722,17 @@ func (h *Handler) clock() time.Time {
 		return h.Clock()
 	}
 	return time.Now()
+}
+
+// burnSpeculativeWisp closes a speculatively poured wisp and clears the
+// pending_next_wisp metadata field. Called when the gate outcome is terminal
+// or waiting_manual and the speculative wisp is not needed.
+func (h *Handler) burnSpeculativeWisp(rootBeadID, speculativeWispID string) {
+	if speculativeWispID == "" {
+		return
+	}
+	_ = h.Store.CloseBead(speculativeWispID)
+	_ = h.Store.SetMetadata(rootBeadID, FieldPendingNextWisp, "")
 }
 
 // CheckNestedConvergence validates that creating a new convergence loop

--- a/internal/convergence/handler_test.go
+++ b/internal/convergence/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -24,14 +26,19 @@ type fakeStore struct {
 	beads map[string]*fakeBeadRecord
 
 	// PourWispFunc can be set to simulate sling failures.
-	PourWispFunc func(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error)
-	GetBeadFunc  func(id string) (BeadInfo, error)
+	PourWispFunc             func(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error)
+	PourSpeculativeWispFunc  func(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error)
+	FindByIdempotencyKeyFunc func(key string) (string, bool, error)
+	ActivateWispFunc         func(id string) error
+	GetBeadFunc              func(id string) (BeadInfo, error)
 
 	pourCounter int // auto-increment for wisp IDs
 
 	// WriteLog records the key of every SetMetadata call in order,
 	// enabling tests to verify write ordering contracts.
 	WriteLog []string
+
+	ActivatedWispIDs []string
 }
 
 func newFakeStore() *fakeStore {
@@ -115,6 +122,28 @@ func (s *fakeStore) CloseBead(id string) error {
 	return nil
 }
 
+func (s *fakeStore) DeleteBead(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.beads[id]
+	if !ok {
+		return fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
+	}
+	if rec.info.ParentID != "" {
+		if parent, ok := s.beads[rec.info.ParentID]; ok {
+			filtered := parent.children[:0]
+			for _, childID := range parent.children {
+				if childID != id {
+					filtered = append(filtered, childID)
+				}
+			}
+			parent.children = filtered
+		}
+	}
+	delete(s.beads, id)
+	return nil
+}
+
 func (s *fakeStore) Children(parentID string) ([]BeadInfo, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -135,6 +164,17 @@ func (s *fakeStore) PourWisp(parentID, formula, idempotencyKey string, vars map[
 	if s.PourWispFunc != nil {
 		return s.PourWispFunc(parentID, formula, idempotencyKey, vars, evaluatePrompt)
 	}
+	return s.pourWisp(parentID, idempotencyKey)
+}
+
+func (s *fakeStore) PourSpeculativeWisp(parentID, formula, idempotencyKey string, vars map[string]string, evaluatePrompt string) (string, error) {
+	if s.PourSpeculativeWispFunc != nil {
+		return s.PourSpeculativeWispFunc(parentID, formula, idempotencyKey, vars, evaluatePrompt)
+	}
+	return s.pourWisp(parentID, idempotencyKey)
+}
+
+func (s *fakeStore) pourWisp(parentID, idempotencyKey string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -165,6 +205,9 @@ func (s *fakeStore) PourWisp(parentID, formula, idempotencyKey string, vars map[
 }
 
 func (s *fakeStore) FindByIdempotencyKey(key string) (string, bool, error) {
+	if s.FindByIdempotencyKeyFunc != nil {
+		return s.FindByIdempotencyKeyFunc(key)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, rec := range s.beads {
@@ -173,6 +216,19 @@ func (s *fakeStore) FindByIdempotencyKey(key string) (string, bool, error) {
 		}
 	}
 	return "", false, nil
+}
+
+func (s *fakeStore) ActivateWisp(id string) error {
+	if s.ActivateWispFunc != nil {
+		return s.ActivateWispFunc(id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.beads[id]; !ok {
+		return fmt.Errorf("bead %q: %w", id, beads.ErrNotFound)
+	}
+	s.ActivatedWispIDs = append(s.ActivatedWispIDs, id)
+	return nil
 }
 
 func (s *fakeStore) CountActiveConvergenceLoops(targetAgent string) (int, error) {
@@ -621,8 +677,8 @@ func TestHandleWispClosed_SlingFailure_WaitingManual(t *testing.T) {
 	store.addBead("wisp-iter-1", "closed", "root-1",
 		IdempotencyKey("root-1", 1), nil)
 
-	// Simulate PourWisp failure.
-	store.PourWispFunc = func(_, _, _ string, _ map[string]string, _ string) (string, error) {
+	// Simulate speculative PourWisp failure on a nonterminal gate outcome.
+	store.PourSpeculativeWispFunc = func(_, _, _ string, _ map[string]string, _ string) (string, error) {
 		return "", fmt.Errorf("sling failure: connection refused")
 	}
 
@@ -775,8 +831,9 @@ func TestHandleWispClosed_WriteOrdering_TerminalReasonBeforeState(t *testing.T) 
 	}
 }
 
-func TestHandleWispClosed_WriteOrdering_IterateLastProcessedWispLast(t *testing.T) {
-	// Verify last_processed_wisp is the final write in the iterate path.
+func TestHandleWispClosed_WriteOrdering_IterateLastProcessedBeforePendingCleanup(t *testing.T) {
+	// Verify last_processed_wisp remains the final load-bearing write in the
+	// iterate path; pending_next_wisp cleanup is best-effort after commit.
 	store := newFakeStore()
 	emitter := &fakeEmitter{}
 
@@ -805,10 +862,15 @@ func TestHandleWispClosed_WriteOrdering_IterateLastProcessedWispLast(t *testing.
 		t.Fatalf("Action = %q, want %q", result.Action, ActionIterate)
 	}
 
-	// last_processed_wisp must be the very last write.
-	lastKey := store.WriteLog[len(store.WriteLog)-1]
-	if lastKey != FieldLastProcessedWisp {
-		t.Errorf("last write = %q, want %q (dedup marker must be last)", lastKey, FieldLastProcessedWisp)
+	commitKeys := extractCommitKeys(store.WriteLog)
+	if len(commitKeys) < 2 {
+		t.Fatalf("commit log too short: %v", commitKeys)
+	}
+	if commitKeys[len(commitKeys)-2] != FieldLastProcessedWisp {
+		t.Errorf("last_processed_wisp should precede pending cleanup, log=%v", commitKeys)
+	}
+	if commitKeys[len(commitKeys)-1] != FieldPendingNextWisp {
+		t.Errorf("pending_next_wisp cleanup should be last, log=%v", commitKeys)
 	}
 }
 
@@ -1120,7 +1182,60 @@ func TestHandleWispClosed_SpeculativePour_WispExistsBeforeGateEval(t *testing.T)
 	}
 }
 
-func TestHandleWispClosed_SpeculativePourBurnedOnTerminal(t *testing.T) {
+func TestHandleWispClosed_SpeculativePourFailureStillAllowsTerminalGate(t *testing.T) {
+	dir := t.TempDir()
+	gatePath := filepath.Join(dir, "pass.sh")
+	if err := os.WriteFile(gatePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("writing gate script: %v", err)
+	}
+
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldGateCondition: gatePath,
+	})
+	store.PourSpeculativeWispFunc = func(_, _, _ string, _ map[string]string, _ string) (string, error) {
+		return "", fmt.Errorf("transient speculative pour failure")
+	}
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionApproved {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionApproved)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateTerminated {
+		t.Fatalf("state = %q, want %q", meta[FieldState], StateTerminated)
+	}
+	if meta[FieldWaitingReason] == WaitSlingFailure {
+		t.Fatalf("waiting_reason = %q, should not enter sling failure when gate passes", meta[FieldWaitingReason])
+	}
+}
+
+func TestHandleWispClosed_InvalidConditionDoesNotBurnUnvalidatedPendingWisp(t *testing.T) {
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldPendingNextWisp: "other-wisp",
+	})
+	store.addBead("other-root", "in_progress", "", "", nil)
+	store.addBead("other-wisp", "in_progress", "other-root",
+		IdempotencyKey("other-root", 2), nil)
+
+	_, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err == nil {
+		t.Fatal("expected missing condition error")
+	}
+	if _, err := store.GetBead("other-wisp"); err != nil {
+		t.Fatalf("stale pending wisp from another parent was deleted: %v", err)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldPendingNextWisp] != "" {
+		t.Fatalf("pending_next_wisp = %q, want cleared", meta[FieldPendingNextWisp])
+	}
+}
+
+func TestHandleWispClosed_SpeculativePourDeletedOnTerminal(t *testing.T) {
 	handler, store, _ := setupBasicHandler(t, map[string]string{
 		FieldGateOutcomeWisp: "wisp-iter-1",
 		FieldGateOutcome:     GatePass,
@@ -1135,16 +1250,9 @@ func TestHandleWispClosed_SpeculativePourBurnedOnTerminal(t *testing.T) {
 	}
 
 	iter2Key := IdempotencyKey("root-1", 2)
-	iter2ID, found, _ := store.FindByIdempotencyKey(iter2Key)
-	if !found {
-		t.Fatal("expected speculative wisp for iteration 2 to exist")
-	}
-	iter2Info, err := store.GetBead(iter2ID)
-	if err != nil {
-		t.Fatalf("reading speculative wisp: %v", err)
-	}
-	if iter2Info.Status != "closed" {
-		t.Errorf("speculative wisp status = %q, want %q (should be burned)", iter2Info.Status, "closed")
+	_, found, _ := store.FindByIdempotencyKey(iter2Key)
+	if found {
+		t.Fatal("speculative wisp for iteration 2 should be deleted")
 	}
 
 	meta, _ := store.GetMetadata("root-1")
@@ -1153,7 +1261,36 @@ func TestHandleWispClosed_SpeculativePourBurnedOnTerminal(t *testing.T) {
 	}
 }
 
-func TestHandleWispClosed_SpeculativePourBurnedOnWaitingManual(t *testing.T) {
+func TestHandleWispClosed_IterateActivatesSpeculativeWispBeforeCommit(t *testing.T) {
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldGateOutcomeWisp: "wisp-iter-1",
+		FieldGateOutcome:     GateFail,
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionIterate {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionIterate)
+	}
+	if len(store.ActivatedWispIDs) != 1 || store.ActivatedWispIDs[0] != result.NextWispID {
+		t.Fatalf("activated wisps = %v, want [%s]", store.ActivatedWispIDs, result.NextWispID)
+	}
+
+	commitLog := extractCommitKeys(store.WriteLog)
+	if len(commitLog) < 2 {
+		t.Fatalf("commit log too short: %v", commitLog)
+	}
+	if commitLog[len(commitLog)-2] != FieldLastProcessedWisp {
+		t.Fatalf("last_processed_wisp should be the final load-bearing commit write, log=%v", commitLog)
+	}
+	if commitLog[len(commitLog)-1] != FieldPendingNextWisp {
+		t.Fatalf("pending_next_wisp should clear only after last_processed_wisp, log=%v", commitLog)
+	}
+}
+
+func TestHandleWispClosed_NoSpeculativePourOnWaitingManual(t *testing.T) {
 	handler, store, _ := setupBasicHandler(t, map[string]string{
 		FieldGateMode: GateModeManual,
 	})
@@ -1167,16 +1304,38 @@ func TestHandleWispClosed_SpeculativePourBurnedOnWaitingManual(t *testing.T) {
 	}
 
 	iter2Key := IdempotencyKey("root-1", 2)
-	iter2ID, found, _ := store.FindByIdempotencyKey(iter2Key)
-	if !found {
-		t.Fatal("expected speculative wisp for iteration 2 to exist")
+	_, found, _ := store.FindByIdempotencyKey(iter2Key)
+	if found {
+		t.Fatal("manual gate should not pour a speculative wisp")
 	}
-	iter2Info, err := store.GetBead(iter2ID)
+}
+
+func TestHandleWispClosed_ManualThenIterateUsesNextSequentialIteration(t *testing.T) {
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldGateMode: GateModeManual,
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
 	if err != nil {
-		t.Fatalf("reading speculative wisp: %v", err)
+		t.Fatalf("HandleWispClosed: %v", err)
 	}
-	if iter2Info.Status != "closed" {
-		t.Errorf("speculative wisp status = %q, want %q (should be burned)", iter2Info.Status, "closed")
+	if result.Action != ActionWaitingManual {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionWaitingManual)
+	}
+
+	result, err = handler.IterateHandler(context.Background(), "root-1", "operator", "")
+	if err != nil {
+		t.Fatalf("IterateHandler: %v", err)
+	}
+	if result.Iteration != 2 {
+		t.Fatalf("Iteration = %d, want 2", result.Iteration)
+	}
+	iter2Info, err := store.GetBead(result.NextWispID)
+	if err != nil {
+		t.Fatalf("reading next wisp: %v", err)
+	}
+	if iter2Info.IdempotencyKey != IdempotencyKey("root-1", 2) {
+		t.Fatalf("next wisp key = %q, want %q", iter2Info.IdempotencyKey, IdempotencyKey("root-1", 2))
 	}
 }
 
@@ -1284,5 +1443,49 @@ func TestCrashAfterSpeculativePour_NoActiveWisp_ReconcilerAdoptsSpeculative(t *t
 	}
 	if meta[FieldState] != StateActive {
 		t.Errorf("state = %q, want %q", meta[FieldState], StateActive)
+	}
+}
+
+func TestCrashAfterSpeculativePour_ReconcilerUsesPendingNextWispBeforeLookup(t *testing.T) {
+	store := newFakeStore()
+	emitter := &fakeEmitter{}
+
+	rootMeta := map[string]string{
+		FieldState:             StateActive,
+		FieldIteration:         "1",
+		FieldMaxIterations:     "5",
+		FieldFormula:           "test-formula",
+		FieldTarget:            "test-agent",
+		FieldGateMode:          GateModeCondition,
+		FieldActiveWisp:        "",
+		FieldLastProcessedWisp: "wisp-iter-1",
+		FieldPendingNextWisp:   "wisp-iter-2",
+	}
+	store.addBead("root-1", "in_progress", "", "", rootMeta)
+	store.addBead("wisp-iter-1", "closed", "root-1",
+		IdempotencyKey("root-1", 1), nil)
+	store.addBead("wisp-iter-2", "in_progress", "root-1",
+		IdempotencyKey("root-1", 2), nil)
+	store.FindByIdempotencyKeyFunc = func(key string) (string, bool, error) {
+		return "", false, fmt.Errorf("FindByIdempotencyKey should not be called for valid pending %q", key)
+	}
+
+	handler := &Handler{Store: store, Emitter: emitter}
+	reconciler := &Reconciler{Handler: handler}
+
+	report, err := reconciler.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("reconciliation error: %v", err)
+	}
+	if report.Errors > 0 {
+		t.Fatalf("reconciliation had %d errors: %+v", report.Errors, report.Details)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldActiveWisp] != "wisp-iter-2" {
+		t.Fatalf("active_wisp = %q, want wisp-iter-2", meta[FieldActiveWisp])
+	}
+	if len(store.ActivatedWispIDs) != 1 || store.ActivatedWispIDs[0] != "wisp-iter-2" {
+		t.Fatalf("activated wisps = %v, want [wisp-iter-2]", store.ActivatedWispIDs)
 	}
 }

--- a/internal/convergence/handler_test.go
+++ b/internal/convergence/handler_test.go
@@ -1064,6 +1064,7 @@ func extractCommitKeys(log []string) []string {
 		FieldWaitingReason:     true,
 		FieldIteration:         true,
 		FieldRetrySource:       true,
+		FieldPendingNextWisp:   true,
 	}
 	var result []string
 	for _, key := range log {
@@ -1086,4 +1087,202 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// --- Crash-safety (speculative pour) tests ---
+
+func TestHandleWispClosed_SpeculativePour_WispExistsBeforeGateEval(t *testing.T) {
+	// Verify that when HandleWispClosed processes a non-terminal gate outcome
+	// (fail, below max), the next wisp is speculatively poured BEFORE gate
+	// evaluation and adopted in iterate().
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldGateOutcomeWisp: "wisp-iter-1",
+		FieldGateOutcome:     GateFail,
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionIterate {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionIterate)
+	}
+	if result.NextWispID == "" {
+		t.Fatal("expected NextWispID to be set")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldActiveWisp] != result.NextWispID {
+		t.Errorf("active_wisp = %q, want %q", meta[FieldActiveWisp], result.NextWispID)
+	}
+	if meta[FieldPendingNextWisp] != "" {
+		t.Errorf("pending_next_wisp should be cleared, got %q", meta[FieldPendingNextWisp])
+	}
+}
+
+func TestHandleWispClosed_SpeculativePourBurnedOnTerminal(t *testing.T) {
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldGateOutcomeWisp: "wisp-iter-1",
+		FieldGateOutcome:     GatePass,
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionApproved {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionApproved)
+	}
+
+	iter2Key := IdempotencyKey("root-1", 2)
+	iter2ID, found, _ := store.FindByIdempotencyKey(iter2Key)
+	if !found {
+		t.Fatal("expected speculative wisp for iteration 2 to exist")
+	}
+	iter2Info, err := store.GetBead(iter2ID)
+	if err != nil {
+		t.Fatalf("reading speculative wisp: %v", err)
+	}
+	if iter2Info.Status != "closed" {
+		t.Errorf("speculative wisp status = %q, want %q (should be burned)", iter2Info.Status, "closed")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldPendingNextWisp] != "" {
+		t.Errorf("pending_next_wisp should be cleared, got %q", meta[FieldPendingNextWisp])
+	}
+}
+
+func TestHandleWispClosed_SpeculativePourBurnedOnWaitingManual(t *testing.T) {
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldGateMode: GateModeManual,
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionWaitingManual {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionWaitingManual)
+	}
+
+	iter2Key := IdempotencyKey("root-1", 2)
+	iter2ID, found, _ := store.FindByIdempotencyKey(iter2Key)
+	if !found {
+		t.Fatal("expected speculative wisp for iteration 2 to exist")
+	}
+	iter2Info, err := store.GetBead(iter2ID)
+	if err != nil {
+		t.Fatalf("reading speculative wisp: %v", err)
+	}
+	if iter2Info.Status != "closed" {
+		t.Errorf("speculative wisp status = %q, want %q (should be burned)", iter2Info.Status, "closed")
+	}
+}
+
+func TestHandleWispClosed_NoSpeculativePourAtMaxIterations(t *testing.T) {
+	handler, store, _ := setupBasicHandler(t, map[string]string{
+		FieldMaxIterations:   "1",
+		FieldGateOutcomeWisp: "wisp-iter-1",
+		FieldGateOutcome:     GateFail,
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Action != ActionNoConvergence {
+		t.Fatalf("Action = %q, want %q", result.Action, ActionNoConvergence)
+	}
+
+	iter2Key := IdempotencyKey("root-1", 2)
+	_, found, _ := store.FindByIdempotencyKey(iter2Key)
+	if found {
+		t.Error("should not pour speculative wisp at max iterations")
+	}
+}
+
+func TestCrashAfterSpeculativePour_ReconcilerRecoversChain(t *testing.T) {
+	store := newFakeStore()
+	emitter := &fakeEmitter{}
+
+	rootMeta := map[string]string{
+		FieldState:           StateActive,
+		FieldIteration:       "1",
+		FieldMaxIterations:   "5",
+		FieldFormula:         "test-formula",
+		FieldTarget:          "test-agent",
+		FieldGateMode:        GateModeManual,
+		FieldActiveWisp:      "wisp-iter-1",
+		FieldPendingNextWisp: "wisp-iter-2",
+	}
+	store.addBead("root-1", "in_progress", "", "", rootMeta)
+	store.addBead("wisp-iter-1", "closed", "root-1",
+		IdempotencyKey("root-1", 1), nil)
+	store.addBead("wisp-iter-2", "in_progress", "root-1",
+		IdempotencyKey("root-1", 2), nil)
+
+	handler := &Handler{Store: store, Emitter: emitter}
+	reconciler := &Reconciler{Handler: handler}
+
+	report, err := reconciler.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("reconciliation error: %v", err)
+	}
+	if report.Errors > 0 {
+		var errMsgs []string
+		for _, d := range report.Details {
+			if d.Error != nil {
+				errMsgs = append(errMsgs, d.Error.Error())
+			}
+		}
+		t.Fatalf("reconciliation had %d errors: %v", report.Errors, errMsgs)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	state := meta[FieldState]
+	if state != StateWaitingManual {
+		t.Errorf("state after reconciliation = %q, want %q", state, StateWaitingManual)
+	}
+}
+
+func TestCrashAfterSpeculativePour_NoActiveWisp_ReconcilerAdoptsSpeculative(t *testing.T) {
+	store := newFakeStore()
+	emitter := &fakeEmitter{}
+
+	rootMeta := map[string]string{
+		FieldState:             StateActive,
+		FieldIteration:         "1",
+		FieldMaxIterations:     "5",
+		FieldFormula:           "test-formula",
+		FieldTarget:            "test-agent",
+		FieldGateMode:          GateModeManual,
+		FieldActiveWisp:        "",
+		FieldLastProcessedWisp: "wisp-iter-1",
+		FieldPendingNextWisp:   "wisp-iter-2",
+	}
+	store.addBead("root-1", "in_progress", "", "", rootMeta)
+	store.addBead("wisp-iter-1", "closed", "root-1",
+		IdempotencyKey("root-1", 1), nil)
+	store.addBead("wisp-iter-2", "in_progress", "root-1",
+		IdempotencyKey("root-1", 2), nil)
+
+	handler := &Handler{Store: store, Emitter: emitter}
+	reconciler := &Reconciler{Handler: handler}
+
+	report, err := reconciler.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("reconciliation error: %v", err)
+	}
+	if report.Errors > 0 {
+		t.Fatalf("reconciliation had %d errors", report.Errors)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldActiveWisp] != "wisp-iter-2" {
+		t.Errorf("active_wisp = %q, want %q", meta[FieldActiveWisp], "wisp-iter-2")
+	}
+	if meta[FieldState] != StateActive {
+		t.Errorf("state = %q, want %q", meta[FieldState], StateActive)
+	}
 }

--- a/internal/convergence/metadata.go
+++ b/internal/convergence/metadata.go
@@ -37,6 +37,7 @@ const (
 	FieldGateStderr        = "convergence.gate_stderr"
 	FieldGateDurationMs    = "convergence.gate_duration_ms"
 	FieldGateTruncated     = "convergence.gate_truncated"
+	FieldPendingNextWisp   = "convergence.pending_next_wisp"
 )
 
 // VarPrefix is the metadata key prefix for template variables.

--- a/internal/convergence/reconcile.go
+++ b/internal/convergence/reconcile.go
@@ -467,34 +467,45 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 	nextIter := closedIter + 1
 	nextKey := IdempotencyKey(beadID, nextIter)
 
-	// Check if a wisp for the next iteration already exists.
-	existingID, found, err := r.Handler.Store.FindByIdempotencyKey(nextKey)
-	if err != nil {
-		return ReconcileDetail{
-			BeadID: beadID, Action: "no_action",
-			Error: fmt.Errorf("looking up next wisp: %w", err),
-		}
-	}
-
 	var wispID string
 	action := "adopted_wisp"
 
-	if found {
-		wispID = existingID
+	if pendingID := r.Handler.validPendingNextWisp(beadID, nextKey, meta[FieldPendingNextWisp]); pendingID != "" {
+		wispID = pendingID
 	} else {
-		// Pour the next wisp.
-		formula := meta[FieldFormula]
-		vars := ExtractVars(meta)
-		evaluatePrompt := meta[FieldEvaluatePrompt]
-
-		wispID, err = r.Handler.Store.PourWisp(beadID, formula, nextKey, vars, evaluatePrompt)
+		// Check if a wisp for the next iteration already exists.
+		existingID, found, err := r.Handler.Store.FindByIdempotencyKey(nextKey)
 		if err != nil {
 			return ReconcileDetail{
-				BeadID: beadID, Action: "poured_wisp",
-				Error: fmt.Errorf("pouring wisp for iter %d: %w", nextIter, err),
+				BeadID: beadID, Action: "no_action",
+				Error: fmt.Errorf("looking up next wisp: %w", err),
 			}
 		}
-		action = "poured_wisp"
+
+		if found {
+			wispID = existingID
+		} else {
+			// Pour the next wisp.
+			formula := meta[FieldFormula]
+			vars := ExtractVars(meta)
+			evaluatePrompt := meta[FieldEvaluatePrompt]
+
+			wispID, err = r.Handler.Store.PourWisp(beadID, formula, nextKey, vars, evaluatePrompt)
+			if err != nil {
+				return ReconcileDetail{
+					BeadID: beadID, Action: "poured_wisp",
+					Error: fmt.Errorf("pouring wisp for iter %d: %w", nextIter, err),
+				}
+			}
+			action = "poured_wisp"
+		}
+	}
+
+	if err := r.Handler.Store.ActivateWisp(wispID); err != nil {
+		return ReconcileDetail{
+			BeadID: beadID, Action: action,
+			Error: fmt.Errorf("activating wisp %q: %w", wispID, err),
+		}
 	}
 
 	if err := r.Handler.Store.SetMetadata(beadID, FieldActiveWisp, wispID); err != nil {
@@ -503,6 +514,7 @@ func (r *Reconciler) reconcileActive(ctx context.Context, beadID string, meta ma
 			Error: fmt.Errorf("setting active_wisp: %w", err),
 		}
 	}
+	_ = r.Handler.Store.SetMetadata(beadID, FieldPendingNextWisp, "")
 
 	return ReconcileDetail{BeadID: beadID, Action: action}
 }

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -129,6 +129,9 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 		if err != nil {
 			return nil, false, "", err
 		}
+		if opts.DeferAssignees {
+			deferGraphNodeRouting(&node)
+		}
 		if step.IsRoot {
 			rootIncluded = true
 			if !opts.PreserveRootType && step.Metadata["gc.kind"] != "workflow" {
@@ -220,6 +223,33 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 	}
 
 	return plan, graphWorkflow, rootKey, nil
+}
+
+func deferGraphNodeRouting(node *beads.GraphApplyNode) {
+	if node.Assignee != "" {
+		ensureGraphNodeMetadata(node)
+		node.Metadata[DeferredAssigneeMetadataKey] = node.Assignee
+		node.Assignee = ""
+		node.AssignAfterCreate = false
+	}
+	deferGraphNodeMetadataValue(node, "gc.routed_to", DeferredRoutedToMetadataKey)
+	deferGraphNodeMetadataValue(node, "gc.execution_routed_to", DeferredExecutionRoutedToMetadataKey)
+}
+
+func deferGraphNodeMetadataValue(node *beads.GraphApplyNode, sourceKey, deferredKey string) {
+	if node.Metadata == nil {
+		return
+	}
+	if value := node.Metadata[sourceKey]; value != "" {
+		node.Metadata[deferredKey] = value
+		delete(node.Metadata, sourceKey)
+	}
+}
+
+func ensureGraphNodeMetadata(node *beads.GraphApplyNode) {
+	if node.Metadata == nil {
+		node.Metadata = make(map[string]string, 1)
+	}
 }
 
 func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, opts FragmentOptions) (*beads.GraphApplyPlan, error) {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -45,7 +45,30 @@ type Options struct {
 	// coercing legacy non-workflow roots to molecule containers. Attach uses
 	// this for executable sub-DAG roots such as retry attempts.
 	PreserveRootType bool
+
+	// DeferAssignees creates assignable beads without an assignee and stores
+	// the intended assignee in metadata for later activation.
+	DeferAssignees bool
 }
+
+const (
+	// DeferredAssigneeMetadataKey stores an assignee withheld during speculative
+	// molecule creation. Activating the molecule restores the value as Assignee.
+	DeferredAssigneeMetadataKey = "gc.deferred_assignee"
+
+	// DeferredRoutedToMetadataKey stores gc.routed_to withheld during
+	// speculative molecule creation.
+	DeferredRoutedToMetadataKey = "gc.deferred_routed_to"
+
+	// DeferredExecutionRoutedToMetadataKey stores gc.execution_routed_to withheld
+	// during speculative molecule creation.
+	DeferredExecutionRoutedToMetadataKey = "gc.deferred_execution_routed_to"
+
+	// DeferredTypeMetadataKey stores the bead type withheld during speculative
+	// molecule creation. Speculative actionable work is created as a ready-
+	// excluded type and restored on activation.
+	DeferredTypeMetadataKey = "gc.deferred_type"
+)
 
 // FragmentOptions configures instantiation of a rootless recipe fragment into
 // an existing workflow root.
@@ -339,7 +362,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	if len(recipe.Steps) == 0 {
 		return nil, fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
-	if IsGraphApplyEnabled() {
+	if !opts.DeferAssignees && IsGraphApplyEnabled() {
 		if applier, ok := store.(beads.GraphApplyStore); ok {
 			return instantiateViaGraphApply(ctx, applier, recipe, opts)
 		}
@@ -364,6 +387,9 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 		}
 
 		b := stepToBead(step, vars, priorityOverride)
+		if opts.DeferAssignees {
+			deferBeadRouting(&b)
+		}
 		hasFutureBlocker := false
 		for _, dep := range recipe.Deps {
 			if dep.StepID != step.ID || dep.Type == "parent-child" {
@@ -699,6 +725,41 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 	}
 
 	return b
+}
+
+func deferBeadRouting(b *beads.Bead) {
+	beadType := b.Type
+	if beadType == "" {
+		beadType = "task"
+	}
+	if !beads.IsReadyExcludedType(beadType) {
+		ensureBeadMetadata(b)
+		b.Metadata[DeferredTypeMetadataKey] = beadType
+		b.Type = "gate"
+	}
+	if b.Assignee != "" {
+		ensureBeadMetadata(b)
+		b.Metadata[DeferredAssigneeMetadataKey] = b.Assignee
+		b.Assignee = ""
+	}
+	deferBeadMetadataValue(b, "gc.routed_to", DeferredRoutedToMetadataKey)
+	deferBeadMetadataValue(b, "gc.execution_routed_to", DeferredExecutionRoutedToMetadataKey)
+}
+
+func deferBeadMetadataValue(b *beads.Bead, sourceKey, deferredKey string) {
+	if b.Metadata == nil {
+		return
+	}
+	if value := b.Metadata[sourceKey]; value != "" {
+		b.Metadata[deferredKey] = value
+		delete(b.Metadata, sourceKey)
+	}
+}
+
+func ensureBeadMetadata(b *beads.Bead) {
+	if b.Metadata == nil {
+		b.Metadata = make(map[string]string, 1)
+	}
 }
 
 // substituteLabels applies variable substitution to each label.


### PR DESCRIPTION
## Summary

Fixes #140 — wisp chain fragility where a single crash permanently breaks self-pouring patrol loops.

Implements **Option C** from the issue: pour the next wisp *before* gate evaluation (step 3b), not after. This closes the crash window where a failure between gate eval and `PourWisp` permanently breaks the chain.

## Root cause

The convergence handler ran gate evaluation → outcome decision → pour next wisp sequentially. If the process crashed after gate eval but before pour, no successor wisp existed. The chain was permanently broken — 6 work beads sat unprocessed for hours until manual intervention.

## Fix

- Speculatively pour the next wisp **before** gate evaluation
- If the outcome is terminal (`pass`, `fail`, `max_iterations`) or `waiting_manual`, burn the speculative wisp
- Track the speculative wisp ID in `convergence.pending_next_wisp` metadata for crash recovery
- If a crash occurs after pour but before burn, the reconciler finds the wisp via `pending_next_wisp` or `FindByIdempotencyKey` and adopts it

## Changes

- `internal/convergence/handler.go` — reorder pour-before-gate, add speculative burn logic
- `internal/convergence/handler_test.go` — 6 new crash-safety tests
- `internal/convergence/metadata.go` — add `FieldPendingNextWisp` constant

## Test plan

- [x] `go test ./internal/convergence/ -short` passes (all existing + 6 new tests)
- [x] `go build ./...` clean
- [ ] New tests cover: speculative pour adoption, burn on terminal/waiting_manual, no-pour at max iterations, two reconciler recovery scenarios