### PR TITLE
fix: increase default gate timeout and add per-step timeout override

### DIFF
--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -109,7 +109,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().IntVar(&maxIterations, "max-iterations", 5, "Maximum iterations")
 	cmd.Flags().StringVar(&gateMode, "gate", "manual", "Gate mode: manual, condition, hybrid")
 	cmd.Flags().StringVar(&gateCondition, "gate-condition", "", "Path to gate condition script")
-	cmd.Flags().StringVar(&gateTimeout, "gate-timeout", "30s", "Gate execution timeout")
+	cmd.Flags().StringVar(&gateTimeout, "gate-timeout", convergence.DefaultGateTimeout.String(), "Gate execution timeout")
 	cmd.Flags().StringVar(&gateTimeoutAction, "gate-timeout-action", "iterate", "Action on gate timeout: iterate, retry, manual, terminate")
 	cmd.Flags().StringVar(&title, "title", "", "Convergence loop title")
 	cmd.Flags().StringVar(&evaluatePrompt, "evaluate-prompt", "", "Custom evaluate prompt (overrides formula default)")

--- a/cmd/gc/cmd_converge_test.go
+++ b/cmd/gc/cmd_converge_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/convergence"
+)
+
+func TestConvergeCreateGateTimeoutDefaultMatchesSharedDefault(t *testing.T) {
+	cmd := newConvergeCreateCmd(io.Discard, io.Discard)
+	flag := cmd.Flags().Lookup("gate-timeout")
+	if flag == nil {
+		t.Fatal("gate-timeout flag not found")
+	}
+
+	want := convergence.DefaultGateTimeout.String()
+	if flag.DefValue != want {
+		t.Fatalf("gate-timeout default = %q, want %q", flag.DefValue, want)
+	}
+	if got := flag.Value.String(); got != want {
+		t.Fatalf("gate-timeout bound value = %q, want %q", got, want)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -422,7 +422,7 @@ gc converge create [flags]
 | `--formula` | string |  | Formula to use (required) |
 | `--gate` | string | `manual` | Gate mode: manual, condition, hybrid |
 | `--gate-condition` | string |  | Path to gate condition script |
-| `--gate-timeout` | string | `30s` | Gate execution timeout |
+| `--gate-timeout` | string | `5m0s` | Gate execution timeout |
 | `--gate-timeout-action` | string | `iterate` | Action on gate timeout: iterate, retry, manual, terminate |
 | `--max-iterations` | int | `5` | Maximum iterations |
 | `--target` | string |  | Target agent (required) |

--- a/docs/reference/formula.md
+++ b/docs/reference/formula.md
@@ -63,6 +63,7 @@ molecule.
 | `children` | []step | Nested sub-steps; parent acts as a container dependency |
 | `loop` | object | Static loop expansion: `count` iterations at compile time |
 | `check` | object | Runtime retry: `max_attempts` with a `check` script after each attempt |
+| `timeout` | duration string | Default timeout for this step's `check` script; `check.check.timeout` takes precedence |
 
 ## Variable Substitution
 

--- a/internal/convergence/gate.go
+++ b/internal/convergence/gate.go
@@ -6,7 +6,9 @@ import (
 )
 
 // DefaultGateTimeout is the default timeout for gate condition scripts.
-const DefaultGateTimeout = 60 * time.Second
+// Set to 5 minutes to accommodate build/test commands (e.g., make check)
+// that commonly exceed the previous 60-second default.
+const DefaultGateTimeout = 5 * time.Minute
 
 // MaxGateRetries is the maximum number of retries for gate_timeout_action=retry.
 const MaxGateRetries = 3

--- a/internal/convergence/gate.go
+++ b/internal/convergence/gate.go
@@ -17,7 +17,7 @@ const MaxGateRetries = 3
 type GateConfig struct {
 	Mode          string        // "manual", "condition", "hybrid"
 	Condition     string        // path to gate condition script (empty for manual-only)
-	Timeout       time.Duration // gate script timeout (default 60s)
+	Timeout       time.Duration // gate script timeout (default 5m)
 	TimeoutAction string        // "iterate", "retry", "manual", "terminate"
 }
 
@@ -40,7 +40,7 @@ func GateManualResult() GateResult {
 }
 
 // ParseGateConfig extracts gate configuration from convergence metadata.
-// Uses defaults for missing fields: timeout=60s, timeout_action=iterate.
+// Uses defaults for missing fields: timeout=5m, timeout_action=iterate.
 func ParseGateConfig(meta map[string]string) (GateConfig, error) {
 	mode := meta[FieldGateMode]
 	if mode == "" {

--- a/internal/convergence/gate_test.go
+++ b/internal/convergence/gate_test.go
@@ -188,6 +188,12 @@ func TestNeedsConditionExecution(t *testing.T) {
 	}
 }
 
+func TestDefaultGateTimeoutIs5Minutes(t *testing.T) {
+	if DefaultGateTimeout != 5*time.Minute {
+		t.Errorf("DefaultGateTimeout = %v, want 5m", DefaultGateTimeout)
+	}
+}
+
 func TestGateManualResult(t *testing.T) {
 	r := GateManualResult()
 	if r.Outcome != GatePass {

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -433,6 +433,9 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 					childMeta["gc.check_mode"] = child.Ralph.Check.Mode
 					childMeta["gc.check_path"] = child.Ralph.Check.Path
 					childMeta["gc.check_timeout"] = child.Ralph.Check.Timeout
+					if child.Timeout != "" {
+						childMeta["gc.step_timeout"] = child.Timeout
+					}
 				}
 				if step := newSpecRecipeStep(childID, child); step != nil {
 					recipe.Steps = append(recipe.Steps, *step)

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -431,9 +431,10 @@ func TestBuildAttemptRecipeEnrichesNestedRalphChildren(t *testing.T) {
 		Ralph: &formula.RalphSpec{MaxAttempts: 5},
 		Children: []*formula.Step{
 			{
-				ID:    "inner-converge",
-				Title: "Inner Converge",
-				Type:  "task",
+				ID:      "inner-converge",
+				Title:   "Inner Converge",
+				Type:    "task",
+				Timeout: "2m",
 				Ralph: &formula.RalphSpec{
 					MaxAttempts: 3,
 					Check: &formula.RalphCheckSpec{
@@ -482,6 +483,9 @@ func TestBuildAttemptRecipeEnrichesNestedRalphChildren(t *testing.T) {
 	}
 	if innerStep.Metadata["gc.check_timeout"] != "30s" {
 		t.Errorf("inner gc.check_timeout = %q, want 30s", innerStep.Metadata["gc.check_timeout"])
+	}
+	if innerStep.Metadata["gc.step_timeout"] != "2m" {
+		t.Errorf("inner gc.step_timeout = %q, want 2m", innerStep.Metadata["gc.step_timeout"])
 	}
 	// Frozen step spec stored as a separate spec bead.
 	var innerSpecStep *formula.RecipeStep

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -166,6 +166,16 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	}
 
 	timeout := convergence.DefaultGateTimeout
+	// Per-step timeout (from formula step.timeout) applies first as a
+	// general override. The check-specific gc.check_timeout (from
+	// ralph.check.timeout) takes precedence if also set.
+	if raw := bead.Metadata["gc.step_timeout"]; raw != "" {
+		parsed, parseErr := time.ParseDuration(raw)
+		if parseErr != nil {
+			return convergence.GateResult{}, fmt.Errorf("%s: parsing gc.step_timeout %q: %w", bead.ID, raw, parseErr)
+		}
+		timeout = parsed
+	}
 	if raw := bead.Metadata["gc.check_timeout"]; raw != "" {
 		parsed, parseErr := time.ParseDuration(raw)
 		if parseErr != nil {

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -170,16 +170,16 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	// general override. The check-specific gc.check_timeout (from
 	// ralph.check.timeout) takes precedence if also set.
 	if raw := bead.Metadata["gc.step_timeout"]; raw != "" {
-		parsed, parseErr := time.ParseDuration(raw)
+		parsed, parseErr := parsePositiveRalphTimeout(bead.ID, "gc.step_timeout", raw)
 		if parseErr != nil {
-			return convergence.GateResult{}, fmt.Errorf("%s: parsing gc.step_timeout %q: %w", bead.ID, raw, parseErr)
+			return convergence.GateResult{}, parseErr
 		}
 		timeout = parsed
 	}
 	if raw := bead.Metadata["gc.check_timeout"]; raw != "" {
-		parsed, parseErr := time.ParseDuration(raw)
+		parsed, parseErr := parsePositiveRalphTimeout(bead.ID, "gc.check_timeout", raw)
 		if parseErr != nil {
-			return convergence.GateResult{}, fmt.Errorf("%s: parsing gc.check_timeout %q: %w", bead.ID, raw, parseErr)
+			return convergence.GateResult{}, parseErr
 		}
 		timeout = parsed
 	}
@@ -191,6 +191,17 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		WorkDir:   resolvedWorkDir,
 	}, timeout, 0)
 	return result, nil
+}
+
+func parsePositiveRalphTimeout(beadID, key, raw string) (time.Duration, error) {
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: parsing %s %q: %w", beadID, key, raw, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%s: %s must be positive, got %v", beadID, key, parsed)
+	}
+	return parsed, nil
 }
 
 func persistCheckResult(store beads.Store, beadID string, result convergence.GateResult) error {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
@@ -2933,6 +2934,85 @@ func TestRunRalphCheckResolvesRelativeWorkDirAgainstCityPath(t *testing.T) {
 	}
 	if result.ExitCode == nil || *result.ExitCode != 0 {
 		t.Fatalf("result.ExitCode = %+v, want 0", result.ExitCode)
+	}
+}
+
+func TestRunRalphCheckRejectsNonPositiveMetadataTimeouts(t *testing.T) {
+	cityPath := t.TempDir()
+	checkPath := writeCheckScript(t, cityPath, "pass.sh", "#!/usr/bin/env bash\nexit 0\n")
+
+	tests := []struct {
+		name string
+		key  string
+		raw  string
+	}{
+		{name: "step zero", key: "gc.step_timeout", raw: "0s"},
+		{name: "step negative", key: "gc.step_timeout", raw: "-1s"},
+		{name: "check zero", key: "gc.check_timeout", raw: "0s"},
+		{name: "check negative", key: "gc.check_timeout", raw: "-1s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			check := beads.Bead{
+				ID:   "check-1",
+				Type: "task",
+				Metadata: map[string]string{
+					"gc.check_path": checkPath,
+					tt.key:          tt.raw,
+				},
+			}
+			subject := beads.Bead{ID: "run-1", Type: "task"}
+
+			_, err := runRalphCheck(store, check, subject, 1, ProcessOptions{CityPath: cityPath})
+			if err == nil {
+				t.Fatalf("runRalphCheck succeeded, want non-positive %s error", tt.key)
+			}
+			if !strings.Contains(err.Error(), "must be positive") {
+				t.Fatalf("runRalphCheck error = %v, want positive timeout error", err)
+			}
+		})
+	}
+}
+
+func TestRunRalphCheckTimeoutMetadataPrecedence(t *testing.T) {
+	cityPath := t.TempDir()
+	checkPath := writeCheckScript(t, cityPath, "sleep.sh", "#!/usr/bin/env bash\nsleep 0.05\nexit 0\n")
+	store := beads.NewMemStore()
+	subject := beads.Bead{ID: "run-1", Type: "task"}
+
+	stepOnly := beads.Bead{
+		ID:   "step-only",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":   checkPath,
+			"gc.step_timeout": "1ms",
+		},
+	}
+	stepResult, err := runRalphCheck(store, stepOnly, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck step-only: %v", err)
+	}
+	if stepResult.Outcome != convergence.GateTimeout {
+		t.Fatalf("step-only outcome = %q, want timeout", stepResult.Outcome)
+	}
+
+	checkOverrides := beads.Bead{
+		ID:   "check-overrides",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    checkPath,
+			"gc.step_timeout":  "1ms",
+			"gc.check_timeout": "30s",
+		},
+	}
+	checkResult, err := runRalphCheck(store, checkOverrides, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck check-overrides: %v", err)
+	}
+	if checkResult.Outcome != convergence.GatePass {
+		t.Fatalf("check-overrides outcome = %q, want pass", checkResult.Outcome)
 	}
 }
 

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -338,6 +338,104 @@ timeout = "30s"
 	assertLacksDep("ralph-demo", "ralph-demo.implement.check.1", "blocks")
 }
 
+func TestCompileExpansionFormulaSubstitutesTimeoutsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "exp-timeout"
+version = 1
+type = "expansion"
+
+[vars.step_timeout]
+default = "10m"
+
+[vars.check_timeout]
+default = "30s"
+
+[[template]]
+id = "{target}.check"
+title = "Check"
+timeout = "{step_timeout}"
+
+[template.check]
+max_attempts = 1
+
+[template.check.check]
+mode = "exec"
+path = "checks/pass.sh"
+timeout = "{check_timeout}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "exp-timeout.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recipe, err := Compile(context.Background(), "exp-timeout", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	for _, step := range recipe.Steps {
+		if step.Metadata["gc.kind"] != "ralph" {
+			continue
+		}
+		if got := step.Metadata["gc.step_timeout"]; got != "10m" {
+			t.Fatalf("gc.step_timeout = %q, want 10m", got)
+		}
+		if got := step.Metadata["gc.check_timeout"]; got != "30s" {
+			t.Fatalf("gc.check_timeout = %q, want 30s", got)
+		}
+		return
+	}
+	t.Fatal("ralph control step not found")
+}
+
+func TestCompileExpansionFormulaAllowsUnresolvedTimeoutVars(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "exp-timeout"
+version = 1
+type = "expansion"
+
+[[template]]
+id = "{target}.check"
+title = "Check"
+timeout = "{step_timeout}"
+
+[template.check]
+max_attempts = 1
+
+[template.check.check]
+mode = "exec"
+path = "checks/pass.sh"
+timeout = "{check_timeout}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "exp-timeout.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, vars := range []map[string]string{nil, {}} {
+		recipe, err := Compile(context.Background(), "exp-timeout", []string{dir}, vars)
+		if err != nil {
+			t.Fatalf("Compile with vars %#v: %v", vars, err)
+		}
+		found := false
+		for _, step := range recipe.Steps {
+			if step.Metadata["gc.kind"] != "ralph" {
+				continue
+			}
+			found = true
+			if got := step.Metadata["gc.step_timeout"]; got != "{step_timeout}" {
+				t.Fatalf("gc.step_timeout = %q, want unresolved placeholder", got)
+			}
+			if got := step.Metadata["gc.check_timeout"]; got != "{check_timeout}" {
+				t.Fatalf("gc.check_timeout = %q, want unresolved placeholder", got)
+			}
+		}
+		if !found {
+			t.Fatal("ralph control step not found")
+		}
+	}
+}
+
 func TestCompileVersion2UsesGraphWorkflowRootAndNoParentChild(t *testing.T) {
 	prev := IsFormulaV2Enabled()
 	SetFormulaV2Enabled(true)

--- a/internal/formula/controlflow.go
+++ b/internal/formula/controlflow.go
@@ -229,39 +229,21 @@ func expandLoopIteration(step *Step, iteration int, iterVars map[string]string) 
 		title := substituteLoopVars(bodyStep.Title, iterVars)
 		description := substituteLoopVars(bodyStep.Description, iterVars)
 
-		clone := &Step{
-			ID:             iterID,
-			Title:          title,
-			Description:    description,
-			Type:           bodyStep.Type,
-			Priority:       bodyStep.Priority,
-			Assignee:       bodyStep.Assignee,
-			Condition:      bodyStep.Condition,
-			WaitsFor:       bodyStep.WaitsFor,
-			Expand:         bodyStep.Expand,
-			Gate:           bodyStep.Gate,
-			Loop:           cloneLoopSpec(bodyStep.Loop), // Support nested loops
-			OnComplete:     cloneOnComplete(bodyStep.OnComplete),
-			SourceFormula:  bodyStep.SourceFormula,                                       // Preserve source
-			SourceLocation: fmt.Sprintf("%s.iter%d", bodyStep.SourceLocation, iteration), // Track iteration
-		}
+		clone := cloneStep(bodyStep)
+		clone.ID = iterID
+		clone.Title = title
+		clone.Description = description
+		clone.Timeout = substituteLoopVars(bodyStep.Timeout, iterVars)
+		clone.SourceLocation = fmt.Sprintf("%s.iter%d", bodyStep.SourceLocation, iteration)
 
-		// Clone ExpandVars if present, adding loop vars
-		if len(bodyStep.ExpandVars) > 0 || len(iterVars) > 0 {
-			clone.ExpandVars = make(map[string]string)
-			for k, v := range bodyStep.ExpandVars {
-				clone.ExpandVars[k] = v
+		// Add loop variables to ExpandVars for nested expansion.
+		if len(iterVars) > 0 {
+			if clone.ExpandVars == nil {
+				clone.ExpandVars = make(map[string]string)
 			}
-			// Add loop variables to ExpandVars for nested expansion
 			for k, v := range iterVars {
 				clone.ExpandVars[k] = v
 			}
-		}
-
-		// Clone labels
-		if len(bodyStep.Labels) > 0 {
-			clone.Labels = make([]string, len(bodyStep.Labels))
-			copy(clone.Labels, bodyStep.Labels)
 		}
 
 		// Clone dependencies - only prefix references to steps WITHIN the loop body
@@ -270,8 +252,9 @@ func expandLoopIteration(step *Step, iteration int, iterVars map[string]string) 
 
 		// Recursively handle children with proper dependency rewriting
 		if len(bodyStep.Children) > 0 {
-			clone.Children = expandLoopChildren(bodyStep.Children, step.ID, iteration, bodyStepIDs)
+			clone.Children = expandLoopChildren(bodyStep.Children, step.ID, iteration, bodyStepIDs, iterVars)
 		}
+		substituteLoopVarsInTimeouts(clone, iterVars)
 
 		result = append(result, clone)
 	}
@@ -329,22 +312,62 @@ func rewriteLoopDependencies(deps []string, loopID string, iteration int, bodySt
 
 // expandLoopChildren expands children within a loop iteration.
 // Rewrites IDs and dependencies appropriately.
-func expandLoopChildren(children []*Step, loopID string, iteration int, bodyStepIDs map[string]bool) []*Step {
+func expandLoopChildren(children []*Step, loopID string, iteration int, bodyStepIDs map[string]bool, iterVars map[string]string) []*Step {
 	result := make([]*Step, len(children))
 	for i, child := range children {
 		clone := cloneStepDeep(child)
 		clone.ID = fmt.Sprintf("%s.iter%d.%s", loopID, iteration, child.ID)
+		clone.Timeout = substituteLoopVars(child.Timeout, iterVars)
 		clone.DependsOn = rewriteLoopDependencies(child.DependsOn, loopID, iteration, bodyStepIDs)
 		clone.Needs = rewriteLoopDependencies(child.Needs, loopID, iteration, bodyStepIDs)
 
 		// Recursively handle nested children
 		if len(child.Children) > 0 {
-			clone.Children = expandLoopChildren(child.Children, loopID, iteration, bodyStepIDs)
+			clone.Children = expandLoopChildren(child.Children, loopID, iteration, bodyStepIDs, iterVars)
 		}
+		substituteLoopVarsInTimeouts(clone, iterVars)
 
 		result[i] = clone
 	}
 	return result
+}
+
+func substituteLoopVarsInTimeouts(step *Step, iterVars map[string]string) {
+	if step == nil {
+		return
+	}
+	step.Timeout = substituteLoopVars(step.Timeout, iterVars)
+	if step.Ralph != nil && step.Ralph.Check != nil {
+		step.Ralph.Check.Timeout = substituteLoopVars(step.Ralph.Check.Timeout, iterVars)
+	}
+	for _, child := range step.Children {
+		substituteLoopVarsInTimeouts(child, iterVars)
+	}
+	if step.Loop != nil {
+		nestedVars := loopBodyTimeoutVars(iterVars, step.Loop)
+		for _, bodyStep := range step.Loop.Body {
+			substituteLoopVarsInTimeouts(bodyStep, nestedVars)
+		}
+	}
+}
+
+func loopBodyTimeoutVars(iterVars map[string]string, loop *LoopSpec) map[string]string {
+	if len(iterVars) == 0 || loop == nil || loop.Var == "" {
+		return iterVars
+	}
+	if _, shadows := iterVars[loop.Var]; !shadows {
+		return iterVars
+	}
+	if len(iterVars) == 1 {
+		return nil
+	}
+	nestedVars := make(map[string]string, len(iterVars)-1)
+	for k, v := range iterVars {
+		if k != loop.Var {
+			nestedVars[k] = v
+		}
+	}
+	return nestedVars
 }
 
 // chainExpandedIterations chains iterations AFTER nested loop expansion.
@@ -534,6 +557,9 @@ func ApplyControlFlow(steps []*Step, compose *ComposeRules) ([]*Step, error) {
 	steps, err = ApplyLoops(steps)
 	if err != nil {
 		return nil, fmt.Errorf("applying loops: %w", err)
+	}
+	if err := validateExpandedStepTimeouts(steps, "applying control flow"); err != nil {
+		return nil, err
 	}
 
 	// Build stepMap once for branches and gates

--- a/internal/formula/controlflow_test.go
+++ b/internal/formula/controlflow_test.go
@@ -64,6 +64,316 @@ func TestApplyLoops_FixedCount(t *testing.T) {
 	}
 }
 
+func TestApplyLoopsPreservesRalphTimeout(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "loop",
+			Title: "Loop",
+			Loop: &LoopSpec{
+				Count: 1,
+				Body: []*Step{
+					{
+						ID:      "check",
+						Title:   "Check",
+						Timeout: "10m",
+						Ralph: &RalphSpec{
+							MaxAttempts: 2,
+							Check: &RalphCheckSpec{
+								Mode: "exec",
+								Path: "checks/pass.sh",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ApplyLoops(steps)
+	if err != nil {
+		t.Fatalf("ApplyLoops failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Timeout != "10m" {
+		t.Fatalf("Timeout = %q, want 10m", got[0].Timeout)
+	}
+	if got[0].Ralph == nil {
+		t.Fatal("Ralph was dropped during loop expansion")
+	}
+	if got[0].Ralph.Check == nil || got[0].Ralph.Check.Path != "checks/pass.sh" {
+		t.Fatalf("Ralph.Check = %+v, want path checks/pass.sh", got[0].Ralph.Check)
+	}
+}
+
+func TestApplyLoopsPreservesBodyStepFields(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "loop",
+			Title: "Loop",
+			Loop: &LoopSpec{
+				Count: 1,
+				Body: []*Step{
+					{
+						ID:              "check",
+						Title:           "Check",
+						DescriptionFile: "docs/check.md",
+						Notes:           "operator note",
+						Metadata: map[string]string{
+							"gc.step_timeout": "10m",
+							"custom":          "value",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ApplyLoops(steps)
+	if err != nil {
+		t.Fatalf("ApplyLoops failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].DescriptionFile != "docs/check.md" {
+		t.Fatalf("DescriptionFile = %q, want docs/check.md", got[0].DescriptionFile)
+	}
+	if got[0].Notes != "operator note" {
+		t.Fatalf("Notes = %q, want operator note", got[0].Notes)
+	}
+	if got[0].Metadata["gc.step_timeout"] != "10m" {
+		t.Fatalf("gc.step_timeout metadata = %q, want 10m", got[0].Metadata["gc.step_timeout"])
+	}
+	if got[0].Metadata["custom"] != "value" {
+		t.Fatalf("custom metadata = %q, want value", got[0].Metadata["custom"])
+	}
+}
+
+func TestApplyControlFlowRejectsInvalidMaterializedLoopTimeout(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "loop",
+			Title: "Loop",
+			Loop: &LoopSpec{
+				Range: "1..1",
+				Var:   "seconds",
+				Body: []*Step{
+					{
+						ID:      "check",
+						Title:   "Check",
+						Timeout: "{seconds}",
+						Ralph: &RalphSpec{
+							MaxAttempts: 1,
+							Check: &RalphCheckSpec{
+								Mode: "exec",
+								Path: "checks/pass.sh",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ApplyControlFlow(steps, nil)
+	if err == nil {
+		t.Fatal("ApplyControlFlow should reject materialized timeout without a duration unit")
+	}
+	if !strings.Contains(err.Error(), "invalid timeout") {
+		t.Fatalf("ApplyControlFlow error = %v, want invalid timeout", err)
+	}
+}
+
+func TestApplyControlFlowSubstitutesLoopVarInChildTimeout(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "loop",
+			Title: "Loop",
+			Loop: &LoopSpec{
+				Range: "2..2",
+				Var:   "seconds",
+				Body: []*Step{
+					{
+						ID:    "parent",
+						Title: "Parent",
+						Children: []*Step{
+							{
+								ID:      "check",
+								Title:   "Check",
+								Timeout: "{seconds}s",
+								Ralph: &RalphSpec{
+									MaxAttempts: 1,
+									Check: &RalphCheckSpec{
+										Mode: "exec",
+										Path: "checks/pass.sh",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ApplyControlFlow(steps, nil)
+	if err != nil {
+		t.Fatalf("ApplyControlFlow failed: %v", err)
+	}
+	if len(got) != 1 || len(got[0].Children) != 1 {
+		t.Fatalf("expanded loop shape = %#v, want one parent with one child", got)
+	}
+	if got[0].Children[0].Timeout != "2s" {
+		t.Fatalf("child Timeout = %q, want 2s", got[0].Children[0].Timeout)
+	}
+}
+
+func TestApplyControlFlowSubstitutesChildRalphTimeoutPerIteration(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "loop",
+			Title: "Loop",
+			Loop: &LoopSpec{
+				Range: "2..3",
+				Var:   "seconds",
+				Body: []*Step{
+					{
+						ID:    "parent",
+						Title: "Parent",
+						Children: []*Step{
+							{
+								ID:    "check",
+								Title: "Check",
+								Ralph: &RalphSpec{
+									MaxAttempts: 1,
+									Check: &RalphCheckSpec{
+										Mode:    "exec",
+										Path:    "checks/pass.sh",
+										Timeout: "{seconds}s",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ApplyControlFlow(steps, nil)
+	if err != nil {
+		t.Fatalf("ApplyControlFlow failed: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	first := got[0].Children[0].Ralph.Check.Timeout
+	second := got[1].Children[0].Ralph.Check.Timeout
+	if first != "2s" {
+		t.Fatalf("first child check timeout = %q, want 2s", first)
+	}
+	if second != "3s" {
+		t.Fatalf("second child check timeout = %q, want 3s", second)
+	}
+}
+
+func TestApplyControlFlowSubstitutesOuterLoopVarInNestedLoopBodyTimeout(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "outer",
+			Title: "Outer",
+			Loop: &LoopSpec{
+				Range: "2..2",
+				Var:   "seconds",
+				Body: []*Step{
+					{
+						ID:    "inner",
+						Title: "Inner",
+						Loop: &LoopSpec{
+							Count: 1,
+							Body: []*Step{
+								{
+									ID:      "check",
+									Title:   "Check",
+									Timeout: "{seconds}s",
+									Ralph: &RalphSpec{
+										MaxAttempts: 1,
+										Check: &RalphCheckSpec{
+											Mode: "exec",
+											Path: "checks/pass.sh",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ApplyControlFlow(steps, nil)
+	if err != nil {
+		t.Fatalf("ApplyControlFlow failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Timeout != "2s" {
+		t.Fatalf("Timeout = %q, want 2s", got[0].Timeout)
+	}
+}
+
+func TestApplyControlFlowNestedLoopVarShadowsOuterTimeout(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "outer",
+			Title: "Outer",
+			Loop: &LoopSpec{
+				Range: "1..1",
+				Var:   "seconds",
+				Body: []*Step{
+					{
+						ID:    "inner",
+						Title: "Inner",
+						Loop: &LoopSpec{
+							Range: "5..5",
+							Var:   "seconds",
+							Body: []*Step{
+								{
+									ID:      "check",
+									Title:   "Check",
+									Timeout: "{seconds}s",
+									Ralph: &RalphSpec{
+										MaxAttempts: 1,
+										Check: &RalphCheckSpec{
+											Mode: "exec",
+											Path: "checks/pass.sh",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ApplyControlFlow(steps, nil)
+	if err != nil {
+		t.Fatalf("ApplyControlFlow failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Timeout != "5s" {
+		t.Fatalf("Timeout = %q, want 5s", got[0].Timeout)
+	}
+}
+
 func TestApplyLoops_Conditional(t *testing.T) {
 	steps := []*Step{
 		{

--- a/internal/formula/expand.go
+++ b/internal/formula/expand.go
@@ -87,6 +87,9 @@ func ApplyExpansionsWithVars(steps []*Step, compose *ComposeRules, parser *Parse
 		if err != nil {
 			return nil, fmt.Errorf("expand %q: %w", rule.Target, err)
 		}
+		if err := validateExpandedStepTimeouts(expandedSteps, fmt.Sprintf("expand %q", rule.Target)); err != nil {
+			return nil, err
+		}
 
 		// Propagate target step's dependencies to root steps of the expansion.
 		// Root steps are those whose needs/dependsOn only reference IDs within
@@ -142,6 +145,9 @@ func ApplyExpansionsWithVars(steps []*Step, compose *ComposeRules, parser *Parse
 			expandedSteps, err := expandStep(targetStep, expFormula.Template, 0, vars)
 			if err != nil {
 				return nil, fmt.Errorf("map %q -> %q: %w", rule.Select, targetStep.ID, err)
+			}
+			if err := validateExpandedStepTimeouts(expandedSteps, fmt.Sprintf("map %q -> %q", rule.Select, targetStep.ID)); err != nil {
+				return nil, err
 			}
 
 			// Propagate target step's dependencies to root steps of the expansion
@@ -235,6 +241,7 @@ func expandStep(target *Step, template []*Step, depth int, vars map[string]strin
 		expanded.Condition = substituteTargetPlaceholders(tmpl.Condition, target)
 		expanded.Expand = substituteVars(substituteTargetPlaceholders(tmpl.Expand, target), vars)
 		expanded.WaitsFor = substituteVars(substituteTargetPlaceholders(tmpl.WaitsFor, target), vars)
+		expanded.Timeout = substituteVars(substituteTargetPlaceholders(tmpl.Timeout, target), vars)
 
 		// Substitute placeholders in labels
 		if len(expanded.Labels) > 0 {
@@ -316,6 +323,15 @@ func expandStep(target *Step, template []*Step, depth int, vars map[string]strin
 	}
 
 	return result, nil
+}
+
+func validateExpandedStepTimeouts(steps []*Step, context string) error {
+	var errs []string
+	validateNestedStepTimeoutsWithOptions(steps, &errs, context, nil, true)
+	if len(errs) > 0 {
+		return fmt.Errorf("%s: timeout validation failed:\n  - %s", context, strings.Join(errs, "\n  - "))
+	}
+	return nil
 }
 
 // substituteTargetPlaceholders replaces {target} and {target.*} placeholders.
@@ -499,6 +515,9 @@ func MaterializeExpansion(f *Formula, targetID string, vars map[string]string) e
 	if err != nil {
 		return fmt.Errorf("materializing expansion %q: %w", f.Formula, err)
 	}
+	if err := validateExpandedStepTimeouts(expandedSteps, fmt.Sprintf("materializing expansion %q", f.Formula)); err != nil {
+		return err
+	}
 
 	f.Steps = expandedSteps
 	return nil
@@ -518,6 +537,9 @@ func MaterializeExpansionForTarget(f *Formula, target *Step, vars map[string]str
 	expandedSteps, err := expandStep(target, f.Template, 0, vars)
 	if err != nil {
 		return fmt.Errorf("materializing expansion %q: %w", f.Formula, err)
+	}
+	if err := validateExpandedStepTimeouts(expandedSteps, fmt.Sprintf("materializing expansion %q", f.Formula)); err != nil {
+		return err
 	}
 
 	f.Steps = expandedSteps
@@ -575,6 +597,9 @@ func applyInlineExpansionsRecursive(steps []*Step, parser *Parser, depth int) ([
 			expandedSteps, err := expandStep(step, expFormula.Template, 0, vars)
 			if err != nil {
 				return nil, fmt.Errorf("inline expand on step %q: %w", step.ID, err)
+			}
+			if err := validateExpandedStepTimeouts(expandedSteps, fmt.Sprintf("inline expand on step %q", step.ID)); err != nil {
+				return nil, err
 			}
 
 			// Propagate the original step's dependencies to root steps of the expansion

--- a/internal/formula/expand_test.go
+++ b/internal/formula/expand_test.go
@@ -116,6 +116,48 @@ func TestExpandStep(t *testing.T) {
 	}
 }
 
+func TestExpandStepSubstitutesStepTimeout(t *testing.T) {
+	target := &Step{
+		ID:    "build",
+		Title: "Build",
+	}
+	template := []*Step{
+		{
+			ID:      "{target}.check",
+			Title:   "Check {target.title}",
+			Timeout: "{step_timeout}",
+			Ralph: &RalphSpec{
+				MaxAttempts: 2,
+				Check: &RalphCheckSpec{
+					Mode:    "exec",
+					Path:    "checks/{target.id}.sh",
+					Timeout: "{check_timeout}",
+				},
+			},
+		},
+	}
+
+	result, err := expandStep(target, template, 0, map[string]string{
+		"step_timeout":  "10m",
+		"check_timeout": "30s",
+	})
+	if err != nil {
+		t.Fatalf("expandStep failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Timeout != "10m" {
+		t.Fatalf("Timeout = %q, want 10m", result[0].Timeout)
+	}
+	if result[0].Ralph == nil || result[0].Ralph.Check == nil {
+		t.Fatal("expanded Ralph check is nil")
+	}
+	if result[0].Ralph.Check.Timeout != "30s" {
+		t.Fatalf("Ralph.Check.Timeout = %q, want 30s", result[0].Ralph.Check.Timeout)
+	}
+}
+
 func TestExpandStepDepthLimit(t *testing.T) {
 	target := &Step{
 		ID:          "root",
@@ -1264,6 +1306,76 @@ func TestMaterializeExpansion(t *testing.T) {
 		}
 		if f.Steps[0].Description != "Build {{feature}} with brief: {{brief}}" {
 			t.Errorf("Description = %q, want double-brace vars preserved", f.Steps[0].Description)
+		}
+	})
+
+	t.Run("invalid template timeout rejected", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			timeout string
+		}{
+			{name: "invalid format", timeout: "bogus"},
+			{name: "zero duration", timeout: "0s"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				f := &Formula{
+					Formula: "exp-timeout",
+					Type:    TypeExpansion,
+					Template: []*Step{
+						{
+							ID:      "{target}.check",
+							Title:   "Check",
+							Timeout: tt.timeout,
+							Ralph: &RalphSpec{
+								MaxAttempts: 1,
+								Check: &RalphCheckSpec{
+									Mode: "exec",
+									Path: "checks/pass.sh",
+								},
+							},
+						},
+					},
+				}
+
+				err := MaterializeExpansion(f, "main", nil)
+				if err == nil {
+					t.Fatal("MaterializeExpansion succeeded, want timeout validation error")
+				}
+				if !strings.Contains(err.Error(), "timeout") {
+					t.Fatalf("MaterializeExpansion error = %v, want timeout validation error", err)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid template ralph check timeout rejected", func(t *testing.T) {
+		f := &Formula{
+			Formula: "exp-check-timeout",
+			Type:    TypeExpansion,
+			Template: []*Step{
+				{
+					ID:    "{target}.check",
+					Title: "Check",
+					Ralph: &RalphSpec{
+						MaxAttempts: 1,
+						Check: &RalphCheckSpec{
+							Mode:    "exec",
+							Path:    "checks/pass.sh",
+							Timeout: "{check_timeout}",
+						},
+					},
+				},
+			},
+		}
+
+		err := MaterializeExpansion(f, "main", map[string]string{"check_timeout": "0s"})
+		if err == nil {
+			t.Fatal("MaterializeExpansion succeeded, want check timeout validation error")
+		}
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("MaterializeExpansion error = %v, want timeout validation error", err)
 		}
 	})
 }

--- a/internal/formula/fragment_test.go
+++ b/internal/formula/fragment_test.go
@@ -182,8 +182,9 @@ func TestExpandStepDoesNotMutateSharedTemplateState(t *testing.T) {
 	t.Parallel()
 
 	template := []*Step{{
-		ID:    "{target}.worker",
-		Title: "Worker {target.title}",
+		ID:      "{target}.worker",
+		Title:   "Worker {target.title}",
+		Timeout: "{target.id}0s",
 		ExpandVars: map[string]string{
 			"who": "{target.id}",
 		},
@@ -200,6 +201,14 @@ func TestExpandStepDoesNotMutateSharedTemplateState(t *testing.T) {
 				ID:    "{target}.loop",
 				Title: "Loop {target.title}",
 			}},
+		},
+		Ralph: &RalphSpec{
+			MaxAttempts: 2,
+			Check: &RalphCheckSpec{
+				Mode:    "exec",
+				Path:    "checks/{target.id}.sh",
+				Timeout: "{target.title}0s",
+			},
 		},
 	}}
 
@@ -227,6 +236,12 @@ func TestExpandStepDoesNotMutateSharedTemplateState(t *testing.T) {
 	if got := second[0].Loop.Body[0].ID; got != "beta.loop" {
 		t.Fatalf("second loop body id = %q, want beta.loop", got)
 	}
+	if got := second[0].Timeout; got != "beta0s" {
+		t.Fatalf("second timeout = %q, want beta0s", got)
+	}
+	if got := second[0].Ralph.Check.Timeout; got != "Beta0s" {
+		t.Fatalf("second ralph check timeout = %q, want Beta0s", got)
+	}
 
 	if got := template[0].ExpandVars["who"]; got != "{target.id}" {
 		t.Fatalf("template ExpandVars mutated to %q", got)
@@ -236,6 +251,12 @@ func TestExpandStepDoesNotMutateSharedTemplateState(t *testing.T) {
 	}
 	if got := template[0].Loop.Body[0].ID; got != "{target}.loop" {
 		t.Fatalf("template loop body id mutated to %q", got)
+	}
+	if got := template[0].Timeout; got != "{target.id}0s" {
+		t.Fatalf("template timeout mutated to %q", got)
+	}
+	if got := template[0].Ralph.Check.Timeout; got != "{target.title}0s" {
+		t.Fatalf("template ralph check timeout mutated to %q", got)
 	}
 }
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -422,6 +422,35 @@ func CheckResidualVars(s string) []string {
 	return names
 }
 
+// CheckResidualTimeoutVars returns unresolved {{var}} and {var} placeholders
+// in timeout strings after all available substitutions have been applied.
+func CheckResidualTimeoutVars(s string) []string {
+	seen := make(map[string]bool)
+	var names []string
+	add := func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	for _, name := range CheckResidualVars(s) {
+		add(name)
+	}
+	for _, match := range rangeVarPattern.FindAllStringSubmatchIndex(s, -1) {
+		start, end := match[0], match[1]
+		if start > 0 && s[start-1] == '{' {
+			continue
+		}
+		if end < len(s) && s[end] == '}' {
+			continue
+		}
+		add(s[match[2]:match[3]])
+	}
+	return names
+}
+
 // ValidateVars checks that all required variables are provided
 // and all values pass their constraints.
 func ValidateVars(formula *Formula, values map[string]string) error {

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -179,9 +179,9 @@ func TestValidate_ValidTimeout(t *testing.T) {
 		Version: 1,
 		Type:    TypeWorkflow,
 		Steps: []*Step{
-			{ID: "build", Title: "Build", Timeout: "5m"},
-			{ID: "test", Title: "Test", Timeout: "10m30s"},
-			{ID: "lint", Title: "Lint", Timeout: "300s"},
+			{ID: "build", Title: "Build", Timeout: "5m", Ralph: validTestRalphSpec()},
+			{ID: "test", Title: "Test", Timeout: "10m30s", Ralph: validTestRalphSpec()},
+			{ID: "lint", Title: "Lint", Timeout: "300s", Ralph: validTestRalphSpec()},
 		},
 	}
 
@@ -190,33 +190,169 @@ func TestValidate_ValidTimeout(t *testing.T) {
 	}
 }
 
-func TestValidate_InvalidTimeout(t *testing.T) {
+func TestValidate_AllowsUnresolvedTimeoutPlaceholders(t *testing.T) {
+	check := validTestRalphSpec()
+	check.Check.Timeout = "{{check_timeout}}"
 	formula := &Formula{
-		Formula: "mol-bad-timeout",
+		Formula: "mol-placeholder-timeout",
 		Version: 1,
 		Type:    TypeWorkflow,
 		Steps: []*Step{
-			{ID: "step1", Title: "Step 1", Timeout: "not-a-duration"},
+			{ID: "step1", Title: "Step 1", Timeout: "{step_timeout}", Ralph: check},
+		},
+	}
+
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate should allow unresolved timeout placeholders, got: %v", err)
+	}
+}
+
+func validTestRalphSpec() *RalphSpec {
+	return &RalphSpec{
+		MaxAttempts: 1,
+		Check: &RalphCheckSpec{
+			Mode: "exec",
+			Path: "checks/pass.sh",
+		},
+	}
+}
+
+func TestValidate_TimeoutRequiresRalph(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-timeout-without-ralph",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{ID: "step1", Title: "Step 1", Timeout: "5m"},
 		},
 	}
 
 	err := formula.Validate()
 	if err == nil {
-		t.Error("Validate should fail for invalid timeout format")
+		t.Fatal("Validate should fail for timeout on a non-Ralph step")
+	}
+	if !strings.Contains(err.Error(), "timeout requires check") {
+		t.Fatalf("Validate error = %v, want timeout requires check", err)
+	}
+}
+
+func TestValidate_InvalidTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{name: "invalid format", timeout: "not-a-duration"},
+		{name: "zero duration", timeout: "0s"},
+		{name: "negative duration", timeout: "-5s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formula := &Formula{
+				Formula: "mol-bad-timeout",
+				Version: 1,
+				Type:    TypeWorkflow,
+				Steps: []*Step{
+					{ID: "step1", Title: "Step 1", Timeout: tt.timeout, Ralph: validTestRalphSpec()},
+				},
+			}
+
+			err := formula.Validate()
+			if err == nil {
+				t.Fatalf("Validate should fail for timeout %q", tt.timeout)
+			}
+		})
+	}
+}
+
+func TestValidate_InvalidRalphCheckTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{name: "invalid format", timeout: "bogus"},
+		{name: "zero duration", timeout: "0s"},
+		{name: "negative duration", timeout: "-5s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := validTestRalphSpec()
+			check.Check.Timeout = tt.timeout
+			formula := &Formula{
+				Formula: "mol-bad-check-timeout",
+				Version: 1,
+				Type:    TypeWorkflow,
+				Steps: []*Step{
+					{ID: "step1", Title: "Step 1", Ralph: check},
+				},
+			}
+
+			err := formula.Validate()
+			if err == nil {
+				t.Fatalf("Validate should fail for ralph check timeout %q", tt.timeout)
+			}
+			if !strings.Contains(err.Error(), "timeout") {
+				t.Fatalf("Validate error = %v, want timeout error", err)
+			}
+		})
 	}
 }
 
 func TestValidate_InvalidTimeoutInChild(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{name: "invalid format", timeout: "bogus"},
+		{name: "zero duration", timeout: "0s"},
+		{name: "negative duration", timeout: "-5s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formula := &Formula{
+				Formula: "mol-bad-child-timeout",
+				Version: 1,
+				Type:    TypeWorkflow,
+				Steps: []*Step{
+					{
+						ID:    "epic",
+						Title: "Epic",
+						Children: []*Step{
+							{ID: "child1", Title: "Child 1", Timeout: tt.timeout},
+						},
+					},
+				},
+			}
+
+			err := formula.Validate()
+			if err == nil {
+				t.Fatalf("Validate should fail for child timeout %q", tt.timeout)
+			}
+		})
+	}
+}
+
+func TestValidate_InvalidTimeoutInLoopBody(t *testing.T) {
 	formula := &Formula{
-		Formula: "mol-bad-child-timeout",
+		Formula: "mol-bad-loop-timeout",
 		Version: 1,
 		Type:    TypeWorkflow,
 		Steps: []*Step{
 			{
-				ID:    "epic",
-				Title: "Epic",
-				Children: []*Step{
-					{ID: "child1", Title: "Child 1", Timeout: "bogus"},
+				ID:    "loop",
+				Title: "Loop",
+				Loop: &LoopSpec{
+					Count: 1,
+					Body: []*Step{
+						{
+							ID:      "check",
+							Title:   "Check",
+							Timeout: "bogus",
+							Ralph:   validTestRalphSpec(),
+						},
+					},
 				},
 			},
 		},
@@ -224,7 +360,40 @@ func TestValidate_InvalidTimeoutInChild(t *testing.T) {
 
 	err := formula.Validate()
 	if err == nil {
-		t.Error("Validate should fail for invalid child timeout format")
+		t.Fatal("Validate should fail for invalid timeout in loop body")
+	}
+	if !strings.Contains(err.Error(), "invalid timeout") {
+		t.Fatalf("Validate error = %v, want invalid timeout", err)
+	}
+}
+
+func TestValidate_LoopBodyTimeoutAllowsLoopVariable(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-loop-timeout-var",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{
+				ID:    "loop",
+				Title: "Loop",
+				Loop: &LoopSpec{
+					Range: "1..2",
+					Var:   "seconds",
+					Body: []*Step{
+						{
+							ID:      "check",
+							Title:   "Check",
+							Timeout: "{seconds}s",
+							Ralph:   validTestRalphSpec(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := formula.Validate(); err != nil {
+		t.Fatalf("Validate failed for loop-variable timeout: %v", err)
 	}
 }
 
@@ -474,6 +643,34 @@ func TestCheckResidualVars(t *testing.T) {
 			for i := range got {
 				if got[i] != tt.want[i] {
 					t.Errorf("CheckResidualVars(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCheckResidualTimeoutVars(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "no placeholders", input: "5m", want: nil},
+		{name: "double brace", input: "{{timeout}}", want: []string{"timeout"}},
+		{name: "single brace", input: "{step_timeout}", want: []string{"step_timeout"}},
+		{name: "mixed", input: "{{timeout}}-{fallback}", want: []string{"timeout", "fallback"}},
+		{name: "dedupes across syntaxes", input: "{{timeout}}/{timeout}", want: []string{"timeout"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckResidualTimeoutVars(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("CheckResidualTimeoutVars(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("CheckResidualTimeoutVars(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
 				}
 			}
 		})
@@ -1403,6 +1600,7 @@ type = "workflow"
 [[steps]]
 id = "implement"
 title = "Implement"
+timeout = "10m"
 
 [steps.check]
 max_attempts = 2
@@ -1425,6 +1623,9 @@ timeout = "30s"
 	step := formula.Steps[0]
 	if step.Ralph == nil {
 		t.Fatal("Steps[0].Ralph is nil")
+	}
+	if step.Timeout != "10m" {
+		t.Fatalf("Steps[0].Timeout = %q, want 10m", step.Timeout)
 	}
 	if step.Ralph.MaxAttempts != 2 {
 		t.Fatalf("Steps[0].Ralph.MaxAttempts = %d, want 2", step.Ralph.MaxAttempts)

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -173,6 +173,61 @@ func TestValidate_InvalidPriority(t *testing.T) {
 	}
 }
 
+func TestValidate_ValidTimeout(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-timeout",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{ID: "build", Title: "Build", Timeout: "5m"},
+			{ID: "test", Title: "Test", Timeout: "10m30s"},
+			{ID: "lint", Title: "Lint", Timeout: "300s"},
+		},
+	}
+
+	if err := formula.Validate(); err != nil {
+		t.Errorf("Validate should pass for valid timeouts: %v", err)
+	}
+}
+
+func TestValidate_InvalidTimeout(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-bad-timeout",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{ID: "step1", Title: "Step 1", Timeout: "not-a-duration"},
+		},
+	}
+
+	err := formula.Validate()
+	if err == nil {
+		t.Error("Validate should fail for invalid timeout format")
+	}
+}
+
+func TestValidate_InvalidTimeoutInChild(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-bad-child-timeout",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{
+				ID:    "epic",
+				Title: "Epic",
+				Children: []*Step{
+					{ID: "child1", Title: "Child 1", Timeout: "bogus"},
+				},
+			},
+		},
+	}
+
+	err := formula.Validate()
+	if err == nil {
+		t.Error("Validate should fail for invalid child timeout format")
+	}
+}
+
 func TestValidate_ChildSteps(t *testing.T) {
 	formula := &Formula{
 		Formula: "mol-children",

--- a/internal/formula/ralph.go
+++ b/internal/formula/ralph.go
@@ -66,7 +66,7 @@ func expandRalph(step *Step) ([]*Step, error) {
 	// Runtime control metadata keeps legacy ralph keys so existing controller
 	// and dispatch paths remain stable while the public formula surface uses
 	// the canonical "check" spelling.
-	control.Metadata = withMetadata(control.Metadata, map[string]string{
+	controlMeta := map[string]string{
 		"gc.kind":          "ralph",
 		"gc.step_id":       step.ID,
 		"gc.max_attempts":  strconv.Itoa(step.Ralph.MaxAttempts),
@@ -74,7 +74,11 @@ func expandRalph(step *Step) ([]*Step, error) {
 		"gc.check_path":    step.Ralph.Check.Path,
 		"gc.check_timeout": step.Ralph.Check.Timeout,
 		"gc.control_epoch": "1",
-	})
+	}
+	if step.Timeout != "" {
+		controlMeta["gc.step_timeout"] = step.Timeout
+	}
+	control.Metadata = withMetadata(control.Metadata, controlMeta)
 	control.Needs = appendUniqueCopy(control.Needs, iterationID)
 	control.WaitsFor = ""
 

--- a/internal/formula/ralph_test.go
+++ b/internal/formula/ralph_test.go
@@ -542,6 +542,62 @@ func TestApplyRalph_NestedRetryControlsPreserveOwnStepID(t *testing.T) {
 	}
 }
 
+func TestApplyRalph_StepTimeoutPropagated(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:      "build",
+			Title:   "Build project",
+			Type:    "task",
+			Timeout: "10m",
+			Ralph: &RalphSpec{
+				MaxAttempts: 3,
+				Check: &RalphCheckSpec{
+					Mode: "exec",
+					Path: "scripts/check.sh",
+				},
+			},
+		},
+	}
+
+	got, err := ApplyRalph(steps)
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+
+	control := got[0]
+	if control.Metadata["gc.step_timeout"] != "10m" {
+		t.Errorf("control gc.step_timeout = %q, want 10m", control.Metadata["gc.step_timeout"])
+	}
+}
+
+func TestApplyRalph_StepTimeoutOmittedWhenEmpty(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:    "build",
+			Title: "Build project",
+			Type:  "task",
+			// No Timeout set
+			Ralph: &RalphSpec{
+				MaxAttempts: 3,
+				Check: &RalphCheckSpec{
+					Mode: "exec",
+					Path: "scripts/check.sh",
+				},
+			},
+		},
+	}
+
+	got, err := ApplyRalph(steps)
+	if err != nil {
+		t.Fatalf("ApplyRalph failed: %v", err)
+	}
+
+	control := got[0]
+	if _, exists := control.Metadata["gc.step_timeout"]; exists {
+		t.Errorf("control should not have gc.step_timeout when step.Timeout is empty, got %q", control.Metadata["gc.step_timeout"])
+	}
+}
+
 func TestApplyRalph_PreservesNonRalphSteps(t *testing.T) {
 	steps := []*Step{
 		{ID: "setup", Title: "Setup"},

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -279,10 +279,10 @@ type Step struct {
 	// work is emitted as first-class graph steps.
 	Retry *RetrySpec `json:"retry,omitempty" toml:"retry,omitempty"`
 
-	// Timeout is the maximum duration for this step's command execution.
-	// Applies to ralph check scripts and gate condition scripts.
+	// Timeout is the maximum duration for this step's Ralph check script.
+	// Gate condition scripts use gate.timeout instead.
 	// Format: Go duration string (e.g., "5m", "2m30s", "300s").
-	// Overrides the default gate timeout (5m) for this step.
+	// Overrides DefaultGateTimeout (5m) unless check.timeout is set.
 	Timeout string `json:"timeout,omitempty" toml:"timeout,omitempty"`
 
 	// Source tracing fields: track where this step came from.
@@ -391,6 +391,7 @@ type stepTOMLAlias struct {
 	Check           json.RawMessage   `json:"check,omitempty"`
 	Ralph           json.RawMessage   `json:"ralph,omitempty"`
 	Retry           *RetrySpec        `json:"retry,omitempty"`
+	Timeout         string            `json:"timeout,omitempty"`
 }
 
 type loopTOMLAlias struct {
@@ -464,6 +465,7 @@ func (a stepTOMLAlias) toStep() (Step, error) {
 		OnComplete:      a.OnComplete,
 		Ralph:           ralph,
 		Retry:           a.Retry,
+		Timeout:         a.Timeout,
 	}, nil
 }
 
@@ -922,11 +924,10 @@ func (f *Formula) Validate() error {
 		}
 
 		// Validate timeout format
-		if step.Timeout != "" {
-			if _, err := time.ParseDuration(step.Timeout); err != nil {
-				errs = append(errs, fmt.Sprintf("%s (%s): invalid timeout %q: %v", prefix, step.ID, step.Timeout, err))
-			}
+		if err := validateStepTimeout(prefix, step.ID, step.Timeout, step.Ralph != nil, nil, true); err != "" {
+			errs = append(errs, err)
 		}
+		validateLoopBodyTimeouts(step.Loop, &errs, fmt.Sprintf("%s (%s).loop", prefix, step.ID), nil, true)
 
 		if step.Ralph != nil {
 			validateRalph(step.Ralph, &errs, fmt.Sprintf("%s (%s)", prefix, step.ID), step)
@@ -1005,6 +1006,92 @@ func (f *Formula) Validate() error {
 	return nil
 }
 
+func validateStepTimeout(prefix, stepID, raw string, hasRalph bool, allowedLoopVars map[string]struct{}, allowUnresolvedVars bool) string {
+	if raw == "" {
+		return ""
+	}
+	if err := validatePositiveTimeout(fmt.Sprintf("%s (%s)", prefix, stepID), raw, allowedLoopVars, allowUnresolvedVars); err != "" {
+		return err
+	}
+	if !hasRalph {
+		return fmt.Sprintf("%s (%s): timeout requires check; convergence gate scripts use convergence.gate_timeout or --gate-timeout", prefix, stepID)
+	}
+	return ""
+}
+
+func validatePositiveTimeout(prefix, raw string, allowedLoopVars map[string]struct{}, allowUnresolvedVars bool) string {
+	if raw == "" {
+		return ""
+	}
+	parseRaw := substituteAllowedTimeoutLoopVars(raw, allowedLoopVars)
+	if allowUnresolvedVars && rangeVarPattern.MatchString(parseRaw) {
+		return ""
+	}
+	d, err := time.ParseDuration(parseRaw)
+	if err != nil {
+		return fmt.Sprintf("%s: invalid timeout %q: %v", prefix, raw, err)
+	}
+	if d <= 0 {
+		return fmt.Sprintf("%s: timeout must be positive, got %v", prefix, d)
+	}
+	return ""
+}
+
+func validateRalphCheckTimeout(prefix, raw string, allowedLoopVars map[string]struct{}, allowUnresolvedVars bool) string {
+	return validatePositiveTimeout(prefix, raw, allowedLoopVars, allowUnresolvedVars)
+}
+
+func substituteAllowedTimeoutLoopVars(raw string, allowedLoopVars map[string]struct{}) string {
+	if len(allowedLoopVars) == 0 {
+		return raw
+	}
+	return rangeVarPattern.ReplaceAllStringFunc(raw, func(match string) string {
+		name := match[1 : len(match)-1]
+		if _, ok := allowedLoopVars[name]; ok {
+			return "1"
+		}
+		return match
+	})
+}
+
+func validateLoopBodyTimeouts(loop *LoopSpec, errs *[]string, prefix string, allowedLoopVars map[string]struct{}, allowUnresolvedVars bool) {
+	if loop == nil {
+		return
+	}
+	validateNestedStepTimeoutsWithOptions(loop.Body, errs, prefix+".body", timeoutLoopVarsFor(loop, allowedLoopVars), allowUnresolvedVars)
+}
+
+func timeoutLoopVarsFor(loop *LoopSpec, parent map[string]struct{}) map[string]struct{} {
+	if loop == nil || loop.Var == "" {
+		return parent
+	}
+	vars := make(map[string]struct{}, len(parent)+1)
+	for k, v := range parent {
+		vars[k] = v
+	}
+	vars[loop.Var] = struct{}{}
+	return vars
+}
+
+func validateNestedStepTimeoutsWithOptions(steps []*Step, errs *[]string, prefix string, allowedLoopVars map[string]struct{}, allowUnresolvedVars bool) {
+	for i, step := range steps {
+		if step == nil {
+			continue
+		}
+		stepPrefix := fmt.Sprintf("%s[%d]", prefix, i)
+		if err := validateStepTimeout(stepPrefix, step.ID, step.Timeout, step.Ralph != nil, allowedLoopVars, allowUnresolvedVars); err != "" {
+			*errs = append(*errs, err)
+		}
+		if step.Ralph != nil && step.Ralph.Check != nil {
+			if err := validateRalphCheckTimeout(fmt.Sprintf("%s (%s).check.check", stepPrefix, step.ID), step.Ralph.Check.Timeout, allowedLoopVars, allowUnresolvedVars); err != "" {
+				*errs = append(*errs, err)
+			}
+		}
+		validateNestedStepTimeoutsWithOptions(step.Children, errs, stepPrefix+".children", allowedLoopVars, allowUnresolvedVars)
+		validateLoopBodyTimeouts(step.Loop, errs, fmt.Sprintf("%s (%s).loop", stepPrefix, step.ID), allowedLoopVars, allowUnresolvedVars)
+	}
+}
+
 // collectChildIDs recursively collects step IDs from children.
 // idLocations maps ID -> location where first defined (for better duplicate error messages).
 func collectChildIDs(children []*Step, idLocations map[string]string, errs *[]string, prefix string) {
@@ -1030,11 +1117,10 @@ func collectChildIDs(children []*Step, idLocations map[string]string, errs *[]st
 		}
 
 		// Validate timeout format for children
-		if child.Timeout != "" {
-			if _, err := time.ParseDuration(child.Timeout); err != nil {
-				*errs = append(*errs, fmt.Sprintf("%s (%s): invalid timeout %q: %v", childPrefix, child.ID, child.Timeout, err))
-			}
+		if err := validateStepTimeout(childPrefix, child.ID, child.Timeout, child.Ralph != nil, nil, true); err != "" {
+			*errs = append(*errs, err)
 		}
+		validateLoopBodyTimeouts(child.Loop, errs, fmt.Sprintf("%s (%s).loop", childPrefix, child.ID), nil, true)
 
 		if child.Ralph != nil {
 			validateRalph(child.Ralph, errs, fmt.Sprintf("%s (%s)", childPrefix, child.ID), child)
@@ -1173,6 +1259,9 @@ func validateRalph(spec *RalphSpec, errs *[]string, prefix string, step *Step) {
 		}
 		if spec.Check.Path == "" {
 			*errs = append(*errs, fmt.Sprintf("%s.check.check: path is required", prefix))
+		}
+		if err := validateRalphCheckTimeout(fmt.Sprintf("%s.check.check", prefix), spec.Check.Timeout, nil, true); err != "" {
+			*errs = append(*errs, err)
 		}
 	}
 

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -31,6 +31,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Type categorizes formulas by their purpose.
@@ -277,6 +278,12 @@ type Step struct {
 	// The original step becomes a stable logical container, and the actionable
 	// work is emitted as first-class graph steps.
 	Retry *RetrySpec `json:"retry,omitempty" toml:"retry,omitempty"`
+
+	// Timeout is the maximum duration for this step's command execution.
+	// Applies to ralph check scripts and gate condition scripts.
+	// Format: Go duration string (e.g., "5m", "2m30s", "300s").
+	// Overrides the default gate timeout (5m) for this step.
+	Timeout string `json:"timeout,omitempty" toml:"timeout,omitempty"`
 
 	// Source tracing fields: track where this step came from.
 	// These are set during parsing/transformation and copied to Issues during cooking.
@@ -914,6 +921,13 @@ func (f *Formula) Validate() error {
 			errs = append(errs, fmt.Sprintf("%s (%s): priority must be 0-4", prefix, step.ID))
 		}
 
+		// Validate timeout format
+		if step.Timeout != "" {
+			if _, err := time.ParseDuration(step.Timeout); err != nil {
+				errs = append(errs, fmt.Sprintf("%s (%s): invalid timeout %q: %v", prefix, step.ID, step.Timeout, err))
+			}
+		}
+
 		if step.Ralph != nil {
 			validateRalph(step.Ralph, &errs, fmt.Sprintf("%s (%s)", prefix, step.ID), step)
 		}
@@ -1013,6 +1027,13 @@ func collectChildIDs(children []*Step, idLocations map[string]string, errs *[]st
 		// Validate priority range for children
 		if child.Priority != nil && (*child.Priority < 0 || *child.Priority > 4) {
 			*errs = append(*errs, fmt.Sprintf("%s (%s): priority must be 0-4", childPrefix, child.ID))
+		}
+
+		// Validate timeout format for children
+		if child.Timeout != "" {
+			if _, err := time.ParseDuration(child.Timeout); err != nil {
+				*errs = append(*errs, fmt.Sprintf("%s (%s): invalid timeout %q: %v", childPrefix, child.ID, child.Timeout, err))
+			}
 		}
 
 		if child.Ralph != nil {

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -178,6 +178,9 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				return nil, false, "", fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
 		}
+		if err := validateTimeoutMetadataVars(step.ID, node.Metadata); err != nil {
+			return nil, false, "", err
+		}
 
 		plan.Nodes = append(plan.Nodes, node)
 	}
@@ -333,6 +336,9 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 			if residual := formula.CheckResidualVars(node.Title); len(residual) > 0 {
 				return nil, fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
+		}
+		if err := validateTimeoutMetadataVars(step.ID, node.Metadata); err != nil {
+			return nil, err
 		}
 
 		plan.Nodes = append(plan.Nodes, node)

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -482,6 +483,10 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				return nil, fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
 		}
+		if err := validateTimeoutMetadataVars(step.ID, b.Metadata); err != nil {
+			markFailed(store, createdIDs)
+			return nil, err
+		}
 
 		created, err := store.Create(b)
 		if err != nil {
@@ -652,6 +657,10 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 				return nil, fmt.Errorf("step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?", step.ID, strings.Join(residual, ", "))
 			}
 		}
+		if err := validateTimeoutMetadataVars(step.ID, b.Metadata); err != nil {
+			markFailed(store, createdIDs)
+			return nil, err
+		}
 
 		created, err := store.Create(b)
 		if err != nil {
@@ -725,6 +734,26 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 	}
 
 	return b
+}
+
+func validateTimeoutMetadataVars(stepID string, metadata map[string]string) error {
+	for _, key := range []string{"gc.step_timeout", "gc.check_timeout"} {
+		raw := metadata[key]
+		if raw == "" {
+			continue
+		}
+		if residual := formula.CheckResidualTimeoutVars(raw); len(residual) > 0 {
+			return fmt.Errorf("step %q: metadata %s contains unresolved timeout variable(s) %s — missing or misspelled --var(s)?", stepID, key, strings.Join(residual, ", "))
+		}
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("step %q: metadata %s has invalid timeout %q: %w", stepID, key, raw, err)
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("step %q: metadata %s timeout must be positive, got %v", stepID, key, parsed)
+		}
+	}
+	return nil
 }
 
 func deferBeadRouting(b *beads.Bead) {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1431,6 +1431,138 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 	})
 }
 
+func TestInstantiateRejectsResidualTimeoutVars(t *testing.T) {
+	makeRecipe := func(stepTimeout string) *formula.Recipe {
+		return &formula.Recipe{
+			Name: "timeout-vars",
+			Steps: []formula.RecipeStep{
+				{ID: "timeout-vars", Title: "Root", Type: "molecule", IsRoot: true},
+				{
+					ID:    "timeout-vars.check",
+					Title: "Check",
+					Type:  "task",
+					Metadata: map[string]string{
+						"gc.kind":          "ralph",
+						"gc.check_path":    "checks/pass.sh",
+						"gc.step_timeout":  stepTimeout,
+						"gc.check_timeout": "{{check_timeout}}",
+					},
+				},
+			},
+			Deps: []formula.RecipeDep{
+				{StepID: "timeout-vars.check", DependsOnID: "timeout-vars", Type: "parent-child"},
+			},
+			Vars: map[string]*formula.VarDef{
+				"check_timeout": {Description: "Check timeout"},
+				"step_timeout":  {Description: "Step timeout"},
+			},
+		}
+	}
+	recipe := makeRecipe("{step_timeout}")
+
+	_, err := Instantiate(context.Background(), beads.NewMemStore(), recipe, Options{
+		Vars: map[string]string{"check_timeout": "30s"},
+	})
+	if err == nil {
+		t.Fatal("Instantiate should reject unresolved single-brace timeout var")
+	}
+	if !strings.Contains(err.Error(), "gc.step_timeout") || !strings.Contains(err.Error(), "step_timeout") {
+		t.Fatalf("Instantiate error = %v, want gc.step_timeout unresolved step_timeout", err)
+	}
+
+	gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	_, err = Instantiate(context.Background(), gaStore, recipe, Options{
+		Vars: map[string]string{"check_timeout": "30s"},
+	})
+	if err == nil {
+		t.Fatal("graph-apply Instantiate should reject unresolved single-brace timeout var")
+	}
+	if !strings.Contains(err.Error(), "gc.step_timeout") || !strings.Contains(err.Error(), "step_timeout") {
+		t.Fatalf("graph-apply Instantiate error = %v, want gc.step_timeout unresolved step_timeout", err)
+	}
+}
+
+func TestInstantiateRejectsInvalidSubstitutedTimeoutVars(t *testing.T) {
+	makeRecipe := func(metadata map[string]string) *formula.Recipe {
+		return &formula.Recipe{
+			Name: "timeout-vars",
+			Steps: []formula.RecipeStep{
+				{ID: "timeout-vars", Title: "Root", Type: "molecule", IsRoot: true},
+				{
+					ID:       "timeout-vars.check",
+					Title:    "Check",
+					Type:     "task",
+					Metadata: metadata,
+				},
+			},
+			Deps: []formula.RecipeDep{
+				{StepID: "timeout-vars.check", DependsOnID: "timeout-vars", Type: "parent-child"},
+			},
+			Vars: map[string]*formula.VarDef{
+				"check_timeout": {Description: "Check timeout"},
+				"step_timeout":  {Description: "Step timeout"},
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		metadata map[string]string
+		vars     map[string]string
+		wantKey  string
+	}{
+		{
+			name: "step timeout",
+			metadata: map[string]string{
+				"gc.kind":          "ralph",
+				"gc.check_path":    "checks/pass.sh",
+				"gc.step_timeout":  "{{step_timeout}}",
+				"gc.check_timeout": "30s",
+			},
+			vars:    map[string]string{"step_timeout": "bogus"},
+			wantKey: "gc.step_timeout",
+		},
+		{
+			name: "check timeout",
+			metadata: map[string]string{
+				"gc.kind":          "ralph",
+				"gc.check_path":    "checks/pass.sh",
+				"gc.step_timeout":  "30s",
+				"gc.check_timeout": "{{check_timeout}}",
+			},
+			vars:    map[string]string{"check_timeout": "0s"},
+			wantKey: "gc.check_timeout",
+		},
+		{
+			name: "negative timeout",
+			metadata: map[string]string{
+				"gc.kind":          "ralph",
+				"gc.check_path":    "checks/pass.sh",
+				"gc.step_timeout":  "{{step_timeout}}",
+				"gc.check_timeout": "30s",
+			},
+			vars:    map[string]string{"step_timeout": "-1s"},
+			wantKey: "gc.step_timeout",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Instantiate(context.Background(), beads.NewMemStore(), makeRecipe(tc.metadata), Options{
+				Vars: tc.vars,
+			})
+			if err == nil {
+				t.Fatal("Instantiate should reject substituted timeout")
+			}
+			if !strings.Contains(err.Error(), tc.wantKey) {
+				t.Fatalf("Instantiate error = %v, want %s", err, tc.wantKey)
+			}
+		})
+	}
+}
+
 func TestInstantiateFragmentRejectsResidualTitleVars(t *testing.T) {
 	fragment := &formula.FragmentRecipe{
 		Name: "frag-residual",


### PR DESCRIPTION
## Summary

- Increase `DefaultGateTimeout` from 60s to 5 minutes so `make check` (which runs `go test ./...`) no longer exceeds the default and crash-loops agents.
- Add a `timeout` field to formula `Step` that propagates as `gc.step_timeout` metadata on ralph control beads, giving formula authors a reliable per-step timeout override.
- Timeout priority order: `gc.check_timeout` > `gc.step_timeout` > `DefaultGateTimeout` (5m).

Fixes #509
Tracking: #912

## Test plan

- [x] `go build ./internal/convergence/ ./internal/formula/ ./internal/dispatch/` passes
- [x] `go test ./internal/convergence/ ./internal/formula/ ./internal/dispatch/ -short -count=1` passes
- [ ] Deploy to staging and verify `make check` completes within the new 5m default
- [ ] Verify per-step `timeout` field in a formula overrides the default correctly