### PR TITLE
fix: stamp gc.routed_to on legacy [[steps]] formulas (#796)

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -959,8 +959,7 @@ func decorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 			step.Metadata["gc.run_target"] = routedTo
 			continue
 		}
-		switch step.Metadata["gc.kind"] {
-		case "workflow", "scope", "spec":
+		if sling.IsWorkflowTopologyKind(step.Metadata["gc.kind"]) {
 			continue
 		}
 		binding, err := resolveGraphStepBindingWithVars(step.ID, stepByID, stepAlias, depsByStep, bindingCache, resolving, routeVars, defaultRoute, routingRigContext, store, cityName, cityPath, cfg)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2778,7 +2778,7 @@ func TestBatchAutoBurnStaleMolecules(t *testing.T) {
 	assertStoreRoutedTo(t, deps.Store, "BL-2", "mayor")
 }
 
-func TestOnFormulaPoolAttachmentLeavesLegacyStepsUnrouted(t *testing.T) {
+func TestOnFormulaPoolAttachmentRoutesLegacyStepsToTarget(t *testing.T) {
 	dir := testFormulaDir(t)
 	content := `
 formula = "multi-step"
@@ -2851,8 +2851,15 @@ needs = ["prep"]
 		if bead.ParentID == "BL-42" {
 			t.Fatalf("internal bead %s ParentID = %q, want not outer bead", bead.ID, bead.ParentID)
 		}
-		if bead.Metadata["gc.routed_to"] != "" {
-			t.Fatalf("internal bead %s gc.routed_to = %q, want empty", bead.ID, bead.Metadata["gc.routed_to"])
+		// Regression for #796: legacy [[steps]] formulas must stamp
+		// gc.routed_to on every internal step bead so EffectiveWorkQuery
+		// tier-3 and pool scale_check see the work. The sling target is
+		// "repo/polecat".
+		if bead.Ref == "" {
+			continue
+		}
+		if got := bead.Metadata["gc.routed_to"]; got != a.QualifiedName() {
+			t.Fatalf("internal bead %s gc.routed_to = %q, want %q", bead.ID, got, a.QualifiedName())
 		}
 	}
 }

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -61,6 +61,19 @@ func IsControlDispatcherKind(kind string) bool {
 	}
 }
 
+// IsWorkflowTopologyKind reports whether a gc.kind value identifies a
+// workflow-topology step (root workflow, scope latch, or formula spec).
+// Routing never lands on these — they exist to structure the graph, not
+// to be claimed by an agent.
+func IsWorkflowTopologyKind(kind string) bool {
+	switch kind {
+	case "workflow", "scope", "spec":
+		return true
+	default:
+		return false
+	}
+}
+
 // IsCompiledGraphWorkflow reports whether a compiled recipe is a graph.v2
 // workflow.
 func IsCompiledGraphWorkflow(recipe *formula.Recipe) bool {
@@ -426,8 +439,7 @@ func DecorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 			}
 			continue
 		}
-		switch step.Metadata["gc.kind"] {
-		case "workflow", "scope", "spec":
+		if IsWorkflowTopologyKind(step.Metadata["gc.kind"]) {
 			continue
 		}
 		binding, err := ResolveGraphStepBindingWithVars(step.ID, stepByID, stepAlias, depsByStep, bindingCache, resolvingSet, routeVars, defaultRoute, routingRigContext, store, cityName, cfg, deps)
@@ -443,10 +455,22 @@ func DecorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 	return nil
 }
 
-// ApplyGraphRouting decorates a compiled recipe with routing metadata if it
-// is a graph.v2 workflow. No-op for non-graph recipes.
+// ApplyGraphRouting decorates a compiled recipe with routing metadata.
+// For graph.v2 workflows it delegates to DecorateGraphWorkflowRecipe. For
+// legacy [[steps]] recipes it stamps gc.routed_to on every non-root step
+// so EffectiveWorkQuery tier-3 and pool scale_check can see the work
+// (fixes #796). Returns early with no effect when cfg is nil.
 func ApplyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string, vars map[string]string, sourceBeadID, scopeKind, scopeRef, storeRef string, store beads.Store, cityName string, cfg *config.City, deps Deps) error {
-	if !IsCompiledGraphWorkflow(recipe) || cfg == nil {
+	if recipe == nil || cfg == nil {
+		return nil
+	}
+
+	// Legacy path runs before agent resolution: it needs only the routedTo
+	// string, and skipping the ResolveAgent call avoids a config-map lookup
+	// and Agent deep-copy on every controller tick that dispatches a legacy
+	// order.
+	if !IsCompiledGraphWorkflow(recipe) {
+		stampLegacyRecipeRouting(recipe, routedTo)
 		return nil
 	}
 
@@ -469,13 +493,35 @@ func ApplyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string,
 
 	var sessionName string
 	if !agentutil.IsMultiSessionAgent(a) {
-		if true {
-			sessionName = agentutil.LookupSessionName(store, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-			if sessionName == "" {
-				return fmt.Errorf("could not resolve session name for %q", a.QualifiedName())
-			}
+		sessionName = agentutil.LookupSessionName(store, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
+		if sessionName == "" {
+			return fmt.Errorf("could not resolve session name for %q", a.QualifiedName())
 		}
 	}
 	routeVars := GraphWorkflowRouteVars(recipe, vars)
 	return DecorateGraphWorkflowRecipe(recipe, routeVars, sourceBeadID, scopeKind, scopeRef, storeRef, routedTo, sessionName, store, cityName, cfg, deps)
+}
+
+// stampLegacyRecipeRouting mirrors the graph.v2 path in ApplyGraphRouteBinding:
+// routing is set unconditionally on every non-root, non-topology step. The
+// root bead is excluded because InstantiateSlingFormula stamps it via the
+// SlingResult path.
+func stampLegacyRecipeRouting(recipe *formula.Recipe, routedTo string) {
+	routedTo = strings.TrimSpace(routedTo)
+	if recipe == nil || routedTo == "" {
+		return
+	}
+	for i := range recipe.Steps {
+		step := &recipe.Steps[i]
+		if step.IsRoot {
+			continue
+		}
+		if IsWorkflowTopologyKind(step.Metadata["gc.kind"]) {
+			continue
+		}
+		if step.Metadata == nil {
+			step.Metadata = make(map[string]string, 1)
+		}
+		step.Metadata["gc.routed_to"] = routedTo
+	}
 }

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -47,6 +47,19 @@ func TestIsControlDispatcherKind(t *testing.T) {
 	}
 }
 
+func TestIsWorkflowTopologyKind(t *testing.T) {
+	for _, kind := range []string{"workflow", "scope", "spec"} {
+		if !IsWorkflowTopologyKind(kind) {
+			t.Errorf("expected true for %q", kind)
+		}
+	}
+	for _, kind := range []string{"", "task", "check", "fanout", "ralph"} {
+		if IsWorkflowTopologyKind(kind) {
+			t.Errorf("expected false for %q", kind)
+		}
+	}
+}
+
 func TestGraphRouteRigContext(t *testing.T) {
 	if got := GraphRouteRigContext("myrig/worker"); got != "myrig" {
 		t.Errorf("got %q, want myrig", got)
@@ -102,11 +115,8 @@ func TestApplyGraphRouting_LegacyStampsRoutedTo(t *testing.T) {
 }
 
 func TestApplyGraphRouting_LegacyNilAgent(t *testing.T) {
-	// Legacy path with nil agent (order-dispatch before resolution) must
-	// resolve via Deps.Resolver, same as the graph.v2 path.
-	cfg := &config.City{Agents: []config.Agent{
-		{Name: "worker", MaxActiveSessions: intPtr(1)},
-	}}
+	// Legacy path stamps gc.routed_to from the routedTo argument without
+	// needing agent resolution — the order-dispatch caller passes a=nil.
 	r := &formula.Recipe{
 		Name: "mol-legacy",
 		Steps: []formula.RecipeStep{
@@ -114,8 +124,7 @@ func TestApplyGraphRouting_LegacyNilAgent(t *testing.T) {
 			{ID: "mol-legacy.step1", Metadata: map[string]string{}},
 		},
 	}
-	deps := Deps{Resolver: testAgentResolver{}}
-	err := ApplyGraphRouting(r, nil, "worker", nil, "", "", "", "", nil, "city", cfg, deps)
+	err := ApplyGraphRouting(r, nil, "worker", nil, "", "", "", "", nil, "city", &config.City{}, Deps{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,7 +134,7 @@ func TestApplyGraphRouting_LegacyNilAgent(t *testing.T) {
 }
 
 func TestApplyGraphRouting_LegacyNilCfg(t *testing.T) {
-	// Without cfg the legacy path cannot resolve a nil agent; stay no-op.
+	// ApplyGraphRouting is a no-op whenever cfg is nil.
 	r := &formula.Recipe{
 		Steps: []formula.RecipeStep{
 			{IsRoot: true, Metadata: map[string]string{}},
@@ -137,7 +146,7 @@ func TestApplyGraphRouting_LegacyNilCfg(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, ok := r.Steps[1].Metadata["gc.routed_to"]; ok {
-		t.Error("expected no routing on legacy recipe when cfg is nil")
+		t.Error("expected no routing when cfg is nil")
 	}
 }
 

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -74,17 +74,116 @@ func TestGraphWorkflowRouteVars(t *testing.T) {
 
 func intPtr(v int) *int { return &v }
 
-func TestApplyGraphRouting_NonGraph(t *testing.T) {
-	// Non-graph recipe should be a no-op.
+func TestApplyGraphRouting_LegacyStampsRoutedTo(t *testing.T) {
+	// Legacy [[steps]] recipes (no graph.v2 root) must still stamp
+	// gc.routed_to on every non-root step so Agent.EffectiveWorkQuery
+	// tier-3 and pool scale_check can see the work. Regression for #796.
 	r := &formula.Recipe{
-		Steps: []formula.RecipeStep{{
-			Metadata: map[string]string{"gc.kind": "task"},
-		}},
+		Name: "mol-legacy",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-legacy", IsRoot: true, Metadata: map[string]string{}},
+			{ID: "mol-legacy.step1", Metadata: map[string]string{}},
+			{ID: "mol-legacy.step2", Metadata: map[string]string{}},
+		},
 	}
 	a := config.Agent{Name: "worker", MaxActiveSessions: intPtr(1)}
 	err := ApplyGraphRouting(r, &a, "worker", nil, "", "", "", "", nil, "city", &config.City{}, Deps{})
 	if err != nil {
-		t.Fatalf("unexpected error for non-graph recipe: %v", err)
+		t.Fatalf("unexpected error for legacy recipe: %v", err)
+	}
+	if got := r.Steps[0].Metadata["gc.routed_to"]; got != "" {
+		t.Errorf("root gc.routed_to = %q, want empty (root carries routing via InstantiateSlingFormula, not graphroute)", got)
+	}
+	for i := 1; i < len(r.Steps); i++ {
+		if got := r.Steps[i].Metadata["gc.routed_to"]; got != "worker" {
+			t.Errorf("step %d (%s) gc.routed_to = %q, want worker", i, r.Steps[i].ID, got)
+		}
+	}
+}
+
+func TestApplyGraphRouting_LegacyNilAgent(t *testing.T) {
+	// Legacy path with nil agent (order-dispatch before resolution) must
+	// resolve via Deps.Resolver, same as the graph.v2 path.
+	cfg := &config.City{Agents: []config.Agent{
+		{Name: "worker", MaxActiveSessions: intPtr(1)},
+	}}
+	r := &formula.Recipe{
+		Name: "mol-legacy",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-legacy", IsRoot: true, Metadata: map[string]string{}},
+			{ID: "mol-legacy.step1", Metadata: map[string]string{}},
+		},
+	}
+	deps := Deps{Resolver: testAgentResolver{}}
+	err := ApplyGraphRouting(r, nil, "worker", nil, "", "", "", "", nil, "city", cfg, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := r.Steps[1].Metadata["gc.routed_to"]; got != "worker" {
+		t.Errorf("step gc.routed_to = %q, want worker", got)
+	}
+}
+
+func TestApplyGraphRouting_LegacyNilCfg(t *testing.T) {
+	// Without cfg the legacy path cannot resolve a nil agent; stay no-op.
+	r := &formula.Recipe{
+		Steps: []formula.RecipeStep{
+			{IsRoot: true, Metadata: map[string]string{}},
+			{ID: "step1", Metadata: map[string]string{}},
+		},
+	}
+	err := ApplyGraphRouting(r, nil, "worker", nil, "", "", "", "", nil, "city", nil, Deps{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Steps[1].Metadata["gc.routed_to"]; ok {
+		t.Error("expected no routing on legacy recipe when cfg is nil")
+	}
+}
+
+func TestApplyGraphRouting_LegacyOverwritesExistingRouting(t *testing.T) {
+	// Legacy stamping mirrors graph.v2 AssignGraphStepRoute: unconditional
+	// overwrite on every non-topology step.
+	r := &formula.Recipe{
+		Name: "mol-legacy",
+		Steps: []formula.RecipeStep{
+			{IsRoot: true, Metadata: map[string]string{}},
+			{ID: "step1", Metadata: map[string]string{"gc.routed_to": "stale-agent"}},
+		},
+	}
+	a := config.Agent{Name: "worker", MaxActiveSessions: intPtr(1)}
+	err := ApplyGraphRouting(r, &a, "worker", nil, "", "", "", "", nil, "city", &config.City{}, Deps{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := r.Steps[1].Metadata["gc.routed_to"]; got != "worker" {
+		t.Errorf("expected overwrite to worker, got %q", got)
+	}
+}
+
+func TestApplyGraphRouting_LegacySkipsWorkflowKinds(t *testing.T) {
+	// Defensive: if a legacy recipe somehow contains a step with
+	// gc.kind=workflow/scope/spec, skip routing on it — those are
+	// workflow-topology kinds and legacy formulas don't activate the
+	// workflow machinery.
+	r := &formula.Recipe{
+		Name: "mol-legacy",
+		Steps: []formula.RecipeStep{
+			{IsRoot: true, Metadata: map[string]string{}},
+			{ID: "scope", Metadata: map[string]string{"gc.kind": "scope"}},
+			{ID: "work", Metadata: map[string]string{}},
+		},
+	}
+	a := config.Agent{Name: "worker", MaxActiveSessions: intPtr(1)}
+	err := ApplyGraphRouting(r, &a, "worker", nil, "", "", "", "", nil, "city", &config.City{}, Deps{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Steps[1].Metadata["gc.routed_to"]; ok {
+		t.Error("expected scope-kind step to be skipped")
+	}
+	if got := r.Steps[2].Metadata["gc.routed_to"]; got != "worker" {
+		t.Errorf("work step gc.routed_to = %q, want worker", got)
 	}
 }
 

--- a/internal/sling/sling_graph.go
+++ b/internal/sling/sling_graph.go
@@ -27,6 +27,11 @@ func IsControlDispatcherKind(kind string) bool {
 	return graphroute.IsControlDispatcherKind(kind)
 }
 
+// IsWorkflowTopologyKind delegates to graphroute.
+func IsWorkflowTopologyKind(kind string) bool {
+	return graphroute.IsWorkflowTopologyKind(kind)
+}
+
 // GraphRouteRigContext delegates to graphroute.
 func GraphRouteRigContext(route string) string {
 	return graphroute.GraphRouteRigContext(route)


### PR DESCRIPTION
## Summary

Fixes #796. Legacy `[[steps]]` recipes skipped routing metadata decoration in `graphroute.ApplyGraphRouting`, so step beads were created with `gc.step_ref` but never `gc.routed_to`. This starved `Agent.EffectiveWorkQuery` tier-3 and made pool `scale_check` report zero demand, producing a wake/drain ping-pong loop that drained agents while real work sat in front of them.

Extend `ApplyGraphRouting` to stamp `gc.routed_to` on every non-root step for legacy recipes, matching the graph.v2 `AssignGraphStepRoute` path (unconditional overwrite). Add `IsWorkflowTopologyKind` helper to consolidate the three copy-paste `{workflow, scope, spec}` skip switches. Hoist the non-graph branch above agent resolution so the legacy path skips unused `ResolveAgent` work.

## Why

From the issue's repro: a legacy `mol-*` pack, autonomy enabled → agent wakes → hook returns empty → supervisor drains with `no-wake-reason` → repeat. The wisp root has `gc.routed_to`, but none of its step children do, so tier-3 (`gc.routed_to=<template> + ready + unassigned`) can't surface them.

The graph.v2 path already does the right thing via `DecorateGraphWorkflowRecipe` → `AssignGraphStepRoute`. The fix extends the same semantics to the legacy compile path so legacy packs inherit the same canonical "generic unclaimed" state (`assignee` absent, `gc.routed_to` present) described in `engdocs/design/session-model-unification.md` §Workflow Ownership Contract.

## Scope

- `internal/graphroute/graphroute.go`
  - Add `IsWorkflowTopologyKind(kind)` sibling to `IsControlDispatcherKind`
  - `ApplyGraphRouting`: hoist `!IsCompiledGraphWorkflow` check above agent resolution; legacy branch calls new `stampLegacyRecipeRouting(recipe, routedTo)`
  - `DecorateGraphWorkflowRecipe`: use new helper in place of literal switch
- `cmd/gc/cmd_sling.go`: use `sling.IsWorkflowTopologyKind` in place of literal switch
- `internal/sling/sling_graph.go`: add thin `IsWorkflowTopologyKind` re-export
- Tests
  - `internal/graphroute/graphroute_test.go`: replace `TestApplyGraphRouting_NonGraph` with 5 focused cases covering happy path, nil-agent resolve, nil-cfg no-op, overwrite semantics, workflow-kind skip
  - `cmd/gc/cmd_sling_test.go`: rename `TestOnFormulaPoolAttachmentLeavesLegacyStepsUnrouted` → `TestOnFormulaPoolAttachmentRoutesLegacyStepsToTarget` and flip the assertion from "empty" to "target's QualifiedName"

## Test plan

- [x] `make check` — fmt-check, vet, lint, test all green
- [x] `go test -race ./internal/graphroute/... ./internal/sling/... ./cmd/gc/...` (affected packages)
- [x] Multi-model review (3 Anthropic + Copilot GPT-5.3-codex) — one consistency finding addressed: legacy path now overwrites unconditionally to match graph.v2, instead of preserving pre-stamped routes
- [x] 29-rule contributor audit — all rules pass or n/a

## Notes

- Rejected alternative: deprecate legacy `[[steps]]` and auto-upgrade to `graph.v2`. Cleaner long-term, but much larger blast radius.
- Rejected alternative: push supervisor wake logic to traverse `parent_id` for root routing. Violates ZFC (puts orchestration judgment in Go).
- The `skullbloc/gascity#13` fork-only PR proposed a narrower fix but hasn't been submitted upstream.