### PR TITLE
fix: suppress pool scaling for mode=always named_session templates

### DIFF
--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -103,6 +103,11 @@ func computePoolDesiredStates(
 		}
 	}
 
+	// Templates claimed by a mode="always" named_session are owned by the
+	// named-session reconciler; the pool path must skip them entirely to
+	// avoid the duplicate-session collision in gastownhall/gascity#909.
+	reservedByNamedSession := templatesReservedByAlwaysNamedSession(cfg)
+
 	// Collect uncapped requests per agent template.
 	var allRequests []SessionRequest
 
@@ -115,6 +120,9 @@ func computePoolDesiredStates(
 			continue
 		}
 		template := agent.QualifiedName()
+		if reservedByNamedSession[template] {
+			continue
+		}
 
 		// Resume tier: actionable assigned work beads whose assignee resolves
 		// to a non-closed session bead. These sessions must stay alive.
@@ -166,6 +174,9 @@ func computePoolDesiredStates(
 				continue
 			}
 			template := agent.QualifiedName()
+			if reservedByNamedSession[template] {
+				continue
+			}
 			scaleCount, ok := scaleCheckCounts[template]
 			if !ok {
 				continue
@@ -180,12 +191,32 @@ func computePoolDesiredStates(
 		}
 	}
 
-	return applyNestedCaps(cfg, allRequests, trace)
+	return applyNestedCaps(cfg, allRequests, trace, reservedByNamedSession)
+}
+
+// templatesReservedByAlwaysNamedSession returns the set of agent template
+// qualified identities that are claimed by at least one [[named_session]]
+// with mode="always". Such templates are managed exclusively by the
+// named-session reconciler; pool scaling for them must be suppressed to
+// avoid the session collision in gastownhall/gascity#909.
+func templatesReservedByAlwaysNamedSession(cfg *config.City) map[string]bool {
+	if cfg == nil || len(cfg.NamedSessions) == 0 {
+		return nil
+	}
+	reserved := make(map[string]bool, len(cfg.NamedSessions))
+	for i := range cfg.NamedSessions {
+		ns := &cfg.NamedSessions[i]
+		if ns.ModeOrDefault() != "always" {
+			continue
+		}
+		reserved[ns.TemplateQualifiedName()] = true
+	}
+	return reserved
 }
 
 // applyNestedCaps enforces workspace, rig, and agent max_active_sessions caps.
 // Accepts requests in priority order, rejecting any that would exceed a cap.
-func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *sessionReconcilerTraceCycle) []PoolDesiredState {
+func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *sessionReconcilerTraceCycle, reservedByNamedSession map[string]bool) []PoolDesiredState {
 	// Sort by priority DESC, resume tier first within same priority.
 	sort.SliceStable(requests, func(i, j int) bool {
 		if requests[i].BeadPriority != requests[j].BeadPriority {
@@ -312,6 +343,9 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 			continue
 		}
 		template := agent.QualifiedName()
+		if reservedByNamedSession[template] {
+			continue
+		}
 		minSess := agent.EffectiveMinActiveSessions()
 		for agentCount[template] < minSess {
 			rig := agentRigMap[template]

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -637,3 +637,80 @@ func TestComputePoolDesiredStates_RoutedRigScopedDoesNotSpawnNew(t *testing.T) {
 		t.Fatalf("total requests = %d, want 0", total)
 	}
 }
+
+// Regression for gastownhall/gascity#909: when a template is claimed by a
+// [[named_session]] with mode="always", the pool reconciler must not produce
+// pool requests for that template. The named_session reconciler owns the
+// template's lifecycle; duplicating it through the pool path causes the
+// failed-create loop described in the issue.
+func TestComputePoolDesiredStates_SuppressPoolForModeAlwaysNamedSession(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("mayor", "", intPtr(1), 0)},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+		},
+	}
+	// scale_check reports 1 — as it does on a fresh repro city that has a
+	// named mayor plus a [[agent]] mayor block.
+	scaleCheck := map[string]int{"mayor": 1}
+
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+
+	total := 0
+	for _, ds := range result {
+		if ds.Template == "mayor" {
+			total += len(ds.Requests)
+		}
+	}
+	if total != 0 {
+		t.Fatalf("pool requests for 'mayor' = %d, want 0 (reserved by mode=always named_session)", total)
+	}
+}
+
+// Regression for gastownhall/gascity#909: min_active_sessions must also be
+// suppressed for a template owned by a mode="always" named_session. Otherwise
+// min_fill re-introduces the collision that scale_check suppression prevents.
+func TestComputePoolDesiredStates_SuppressMinFillForModeAlwaysNamedSession(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("mayor", "", intPtr(2), 1)},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+		},
+	}
+
+	result := ComputePoolDesiredStates(cfg, nil, nil, nil)
+
+	total := 0
+	for _, ds := range result {
+		if ds.Template == "mayor" {
+			total += len(ds.Requests)
+		}
+	}
+	if total != 0 {
+		t.Fatalf("pool requests for 'mayor' = %d, want 0 (min_fill must defer to named_session)", total)
+	}
+}
+
+// on_demand named sessions do NOT reserve the template — pool scaling is
+// still allowed. This guards against over-suppression.
+func TestComputePoolDesiredStates_OnDemandNamedSessionDoesNotSuppressPool(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("mayor", "", intPtr(2), 0)},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "on_demand"},
+		},
+	}
+	scaleCheck := map[string]int{"mayor": 1}
+
+	result := ComputePoolDesiredStates(cfg, nil, nil, scaleCheck)
+
+	total := 0
+	for _, ds := range result {
+		if ds.Template == "mayor" {
+			total += len(ds.Requests)
+		}
+	}
+	if total != 1 {
+		t.Fatalf("pool requests for 'mayor' = %d, want 1 (on_demand does not reserve template)", total)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #909: pool reconciler no longer duplicates sessions for templates owned by a mode="always" `[[named_session]]`
- Adds `templatesReservedByAlwaysNamedSession()` helper; both the scale_check path and the min_fill path now skip reserved templates
- `on_demand` named sessions do NOT reserve the template (guards against over-suppression)

## Why
When a city config had both:
- `[[agent]] name = "mayor"`
- `[[named_session]] template = "mayor" mode = "always"`

…the pool reconciler kept producing `PoolDesiredState` requests for `mayor` alongside the named_session reconciler's real mayor. Every ephemeral spawn (`mayor-gc-NNNN`) hit `failed-create` and the pool path retried indefinitely.

The fix treats a `mode="always"` named_session as a claim on the template: the named_session reconciler owns the lifecycle, and the pool path skips that template entirely.

## Test plan
- [x] New unit tests in `pool_desired_state_test.go`:
  - `TestComputePoolDesiredStates_SuppressPoolForModeAlwaysNamedSession` — scale_check path suppressed
  - `TestComputePoolDesiredStates_SuppressMinFillForModeAlwaysNamedSession` — min_fill path suppressed
  - `TestComputePoolDesiredStates_OnDemandNamedSessionDoesNotSuppressPool` — on_demand still allows pool scaling
- [x] Full `TestComputePoolDesiredStates*` family passes (no regressions in sibling tests)
- [x] `go vet ./cmd/gc/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)