### PR TITLE
fix: update gc init stdout to reflect V2 agents/ prompt layout

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -804,7 +804,9 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	applyBootstrapProfile(&cfg, wiz.bootstrapProfile)
 
 	// Write prompt files only for the agents declared by the init template.
-	logInitProgress(stdout, 3, "Writing default prompts")
+	// Wording matches the V2 layout: prompts scaffold under agents/<name>/
+	// prompt.template.md, not a root prompts/ directory.
+	logInitProgress(stdout, 3, "Scaffolding agent prompts")
 	if code := writeInitAgentPrompts(fs, cityPath, &cfg, stderr); code != 0 {
 		return code
 	}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -215,7 +215,7 @@ func resolveAgentChoice(input string, order []string, builtins map[string]config
 	return ""
 }
 
-const initProgressSteps = 6
+const initProgressSteps = 8
 
 func logInitProgress(stdout io.Writer, step int, msg string) {
 	if stdout == nil {
@@ -822,12 +822,12 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	logInitProgress(stdout, 5, "Writing pack.toml")
+	logInitProgress(stdout, 4, "Writing pack.toml")
 	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	logInitProgress(stdout, 6, "Writing city configuration")
+	logInitProgress(stdout, 5, "Writing city configuration")
 	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1923,6 +1923,48 @@ func TestDoInitWriteFails(t *testing.T) {
 	}
 }
 
+// Regression for gastownhall/gascity#603: gc init must not emit legacy
+// city-first scaffolding. Three seams were audited in the issue:
+//   - stdout says "Writing default prompts" — stale V1 wording; prompts now
+//     scaffold under agents/<name>/prompt.template.md, so the message should
+//     name that.
+//   - city.toml contains [[agent]] — agents now belong in pack.toml under
+//     the transitional v2 split.
+//   - hooks/claude.json is seeded at root on fresh installs — it should be
+//     absent; the gc-managed .gc/settings.json is what init writes.
+//
+// Two of the three seams are already fixed on main at the time of this
+// commit; the test locks them down and also drives the wording fix.
+func TestDoInit_Regression603_NoLegacySeams(t *testing.T) {
+	f := fsys.NewFake()
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "Writing default prompts") {
+		t.Errorf("stdout contains stale V1 wording %q:\n%s", "Writing default prompts", out)
+	}
+	if !strings.Contains(out, "Scaffolding agent prompts") {
+		t.Errorf("stdout missing V2 wording %q:\n%s", "Scaffolding agent prompts", out)
+	}
+
+	cityData, ok := f.Files[filepath.Join("/bright-lights", "city.toml")]
+	if !ok {
+		t.Fatal("city.toml not written")
+	}
+	if strings.Contains(string(cityData), "[[agent]]") {
+		t.Errorf("city.toml contains legacy [[agent]] block; agents belong in pack.toml:\n%s", cityData)
+	}
+
+	hookPath := filepath.Join("/bright-lights", citylayout.ClaudeHookFile)
+	if _, present := f.Files[hookPath]; present {
+		t.Errorf("hooks/claude.json seeded on fresh install; fresh installs must leave it absent and rely on .gc/settings.json")
+	}
+}
+
 // --- settings.json ---
 
 func TestDoInitCreatesSettings(t *testing.T) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1947,8 +1947,17 @@ func TestDoInit_Regression603_NoLegacySeams(t *testing.T) {
 	if strings.Contains(out, "Writing default prompts") {
 		t.Errorf("stdout contains stale V1 wording %q:\n%s", "Writing default prompts", out)
 	}
-	if !strings.Contains(out, "Scaffolding agent prompts") {
-		t.Errorf("stdout missing V2 wording %q:\n%s", "Scaffolding agent prompts", out)
+	if strings.Contains(out, "Writing default formulas") {
+		t.Errorf("stdout contains stale V1 formula wording %q:\n%s", "Writing default formulas", out)
+	}
+	for _, want := range []string{
+		"[3/8] Scaffolding agent prompts",
+		"[4/8] Writing pack.toml",
+		"[5/8] Writing city configuration",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing V2 init progress line %q:\n%s", want, out)
+		}
 	}
 
 	cityData, ok := f.Files[filepath.Join("/bright-lights", "city.toml")]
@@ -1957,6 +1966,13 @@ func TestDoInit_Regression603_NoLegacySeams(t *testing.T) {
 	}
 	if strings.Contains(string(cityData), "[[agent]]") {
 		t.Errorf("city.toml contains legacy [[agent]] block; agents belong in pack.toml:\n%s", cityData)
+	}
+	packData, ok := f.Files[filepath.Join("/bright-lights", "pack.toml")]
+	if !ok {
+		t.Fatal("pack.toml not written")
+	}
+	if !strings.Contains(string(packData), "[[agent]]") {
+		t.Errorf("pack.toml missing agent definitions:\n%s", packData)
 	}
 
 	hookPath := filepath.Join("/bright-lights", citylayout.ClaudeHookFile)

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -77,8 +77,8 @@ Choose your coding agent:
 Agent [1]:
 [1/8] Creating runtime scaffold
 [2/8] Installing hooks (Claude Code)
-[3/8] Writing default prompts
-[4/8] Writing default formulas
+[3/8] Scaffolding agent prompts
+[4/8] Writing pack.toml
 [5/8] Writing city configuration
 Created tutorial config (Level 1) in "my-city".
 [6/8] Checking provider readiness
@@ -122,9 +122,10 @@ At the top level of the city directory:
 - `city.toml` — city-local deployment and runtime settings
 
 This city comes with a built-in `mayor` agent. The mayor's prompt lives at
-`agents/mayor/prompt.template.md`, and `city.toml` defines the always-on mayor
+`agents/mayor/prompt.template.md`, and `pack.toml` defines the always-on mayor
 session that uses it. Assuming you chose the default `tutorial` config
-template and default provider, `city.toml` looks like this:
+template and default provider, `city.toml` keeps the city-local runtime
+settings:
 
 ```shell
 ~/my-city
@@ -132,6 +133,16 @@ $ cat city.toml
 [workspace]
 name = "my-city"
 provider = "claude"
+```
+
+The portable pack definition lives next to it:
+
+```shell
+~/my-city
+$ cat pack.toml
+[pack]
+name = "my-city"
+schema = 2
 
 [[agent]]
 name = "mayor"
@@ -144,15 +155,15 @@ mode = "always"
 
 The `[workspace]` section names your city and sets the default provider.
 
-The `[[agent]]` entry defines the built-in `mayor`, and `[[named_session]]`
-keeps a `mayor` session running so you can talk to it at any time. When you
-add more agents later, Gas City creates `agents/<name>/`, with
+The `[[agent]]` entry in `pack.toml` defines the built-in `mayor`, and
+`[[named_session]]` keeps a `mayor` session running so you can talk to it at
+any time. When you add more agents later, Gas City creates `agents/<name>/`, with
 `prompt.template.md` for the prompt and `agent.toml` for any per-agent
 overrides.
 
 Gas City also gives you an implicit agent for each supported provider — so
 `claude`, `codex`, and `gemini` are available as agent names even though they're
-not listed in `city.toml`. These use the provider's defaults with no custom
+not listed in `pack.toml`. These use the provider's defaults with no custom
 prompt.
 
 To check on the status of your city, use `gc status`:

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -21,12 +21,6 @@ $ cat pack.toml
 name = "my-city"
 schema = 2
 
-~/my-city
-$ cat city.toml
-[workspace]
-name = "my-city"
-provider = "claude"
-
 [[agent]]
 name = "mayor"
 prompt_template = "agents/mayor/prompt.template.md"
@@ -34,6 +28,12 @@ prompt_template = "agents/mayor/prompt.template.md"
 [[named_session]]
 template = "mayor"
 mode = "always"
+
+~/my-city
+$ cat city.toml
+[workspace]
+name = "my-city"
+provider = "claude"
 
 [[rigs]]
 name = "my-project"
@@ -163,7 +163,7 @@ City is up and idle. No pending work, no agents running besides me. What would
 ```
 
 So the mayor is clearly idle, but has not been shutdown. Why not? If you take a
-look again at your `city.toml` file, you'll see why:
+look again at your `pack.toml` file, you'll see why:
 
 ```toml
 ...

--- a/docs/tutorials/04-communication.md
+++ b/docs/tutorials/04-communication.md
@@ -150,10 +150,11 @@ install_agent_hooks = ["claude"]
 
 Agent-local overrides like this live in `agents/<name>/agent.toml`.
 
-When a session starts, Gas City installs hook configuration files that the
-provider reads. For Claude, this means a `hooks/claude.json` file that fires Gas
-City commands at key moments — session start, before each turn, on shutdown.
-Those commands deliver mail, drain nudges, and surface pending work.
+When a session starts, Gas City installs hook settings that the provider reads.
+For Claude, fresh cities write the managed `.gc/settings.json` configuration,
+which fires Gas City commands at key moments — session start, before each turn,
+and on shutdown. Those commands deliver mail, drain nudges, and surface pending
+work.
 
 Without hooks, you'd have to manually tell each agent to run `gc mail check` and
 `gc prime`. With hooks, it happens on every turn.

--- a/docs/tutorials/06-beads.md
+++ b/docs/tutorials/06-beads.md
@@ -18,10 +18,10 @@ and `reviewer` (along with the corresponding prompts):
 
 ```shell
 ~/my-city
-$ cat city.toml
-[workspace]
+$ cat pack.toml
+[pack]
 name = "my-city"
-provider = "claude"
+schema = 2
 
 [[agent]]
 name = "mayor"
@@ -30,6 +30,12 @@ prompt_template = "agents/mayor/prompt.template.md"
 [[named_session]]
 template = "mayor"
 mode = "always"
+
+~/my-city
+$ cat city.toml
+[workspace]
+name = "my-city"
+provider = "claude"
 
 [[rigs]]
 name = "my-project"

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
@@ -66,8 +66,8 @@ Choose your coding agent:
 Agent [1]:
 [1/8] Creating runtime scaffold
 [2/8] Installing hooks (Claude Code)
-[3/8] Writing default prompts
-[4/8] Writing default formulas
+[3/8] Scaffolding agent prompts
+[4/8] Writing pack.toml
 [5/8] Writing city configuration
 Created tutorial config (Level 1) in "my-city".
 [6/8] Checking provider readiness
@@ -92,8 +92,9 @@ same command, just providing the provider explicitly.
 $ gc init ~/my-city --provider claude
 ```
 
-Gas City created the city directory, registered it, and started it. Let's look
-at what's inside:
+Gas City created the city directory, registered it, and started it. A city
+created with `gc init` comes with `pack.toml`, `city.toml`, and the standard
+top-level directories, so let's look at what's inside:
 
 ```shell
 ~
@@ -101,13 +102,19 @@ $ cd ~/my-city
 
 ~/my-city
 $ ls
-city.toml  formulas  hooks  orders  prompts
+agents  assets  city.toml  commands  doctor  formulas  orders  overlays  pack.toml  template-fragments
 ```
 
-The main file is `city.toml` — it defines your city, using the contents of those
-directories as well as containing some definitions and local config. Assuming
-you chose the default `tutorial` config template and default provider,
-`city.toml` looks like this:
+At the top level of the city directory:
+
+- `pack.toml` — the portable pack definition layer
+- `city.toml` — city-local deployment and runtime settings
+
+This city comes with a built-in `mayor` agent. The mayor's prompt lives at
+`agents/mayor/prompt.template.md`, and `pack.toml` defines the always-on mayor
+session that uses it. Assuming you chose the default `tutorial` config
+template and default provider, `city.toml` keeps the city-local runtime
+settings:
 
 ```shell
 ~/my-city
@@ -115,10 +122,20 @@ $ cat city.toml
 [workspace]
 name = "my-city"
 provider = "claude"
+```
+
+The portable pack definition lives next to it:
+
+```shell
+~/my-city
+$ cat pack.toml
+[pack]
+name = "my-city"
+schema = 2
 
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
@@ -127,16 +144,15 @@ mode = "always"
 
 The `[workspace]` section names your city and sets the default provider.
 
-Each `[[agent]]` table you configure lets you create a named set of config
-including things like the provider, the model, the prompt you want to use to
-define its role, etc. An agent is named so that you can assign it work (aka
-"sling"). Here we've created an agent called the `mayor` with a prompt template
-(the instructions for the mayor) and a default session where you instructions
-go.
+The `[[agent]]` entry in `pack.toml` defines the built-in `mayor`, and
+`[[named_session]]` keeps a `mayor` session running so you can talk to it at
+any time. When you add more agents later, Gas City creates `agents/<name>/`, with
+`prompt.template.md` for the prompt and `agent.toml` for any per-agent
+overrides.
 
 Gas City also gives you an implicit agent for each supported provider — so
 `claude`, `codex`, and `gemini` are available as agent names even though they're
-not listed in `city.toml`. These use the provider's defaults with no custom
+not listed in `pack.toml`. These use the provider's defaults with no custom
 prompt.
 
 To check on the status of your city, use `gc status`:

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/03-sessions.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/03-sessions.md
@@ -11,28 +11,29 @@ each other. You'll also learn the difference between "polecats" (agents spun up
 on demand to handle work) and "crew" (persistent agents with named sessions),
 
 To continue with this tutorial, you'll want to start from where the last
-tutorial left off, with a `city.toml` that looks like the following and the
-appropriate agent prompts and rig folders in place to match:
+tutorial left off, with `pack.toml` and `city.toml` that look like the
+following and the appropriate agent prompts and rig folders in place to match:
 
 ```shell
 ~/my-city
-$ cat city.toml
-[workspace]
+$ cat pack.toml
+[pack]
 name = "my-city"
-provider = "claude"
+schema = 2
 
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"
 mode = "always"
 
-[[agent]]
-name = "reviewer"
-prompt_template = "prompts/reviewer.md"
-provider = "codex"
+~/my-city
+$ cat city.toml
+[workspace]
+name = "my-city"
+provider = "claude"
 
 [[rigs]]
 name = "my-project"
@@ -41,6 +42,11 @@ path = "/Users/csells/my-project"
 [[rigs]]
 name = "my-api"
 path = "/Users/csells/my-api"
+
+~/my-city
+$ cat agents/reviewer/agent.toml
+dir = "my-project"
+provider = "codex"
 ```
 
 ## Looking in on Polecats
@@ -152,13 +158,13 @@ City is up and idle. No pending work, no agents running besides me. What would
 ```
 
 So the mayor is clearly idle, but has not been shutdown. Why not? If you take a
-look again at your `city.toml` file, you'll see why:
+look again at your `pack.toml` file, you'll see why:
 
 ```toml
 ...
 [[agent]]
 name = "mayor"
-prompt_template = "prompts/mayor.md"
+prompt_template = "agents/mayor/prompt.template.md"
 
 [[named_session]]
 template = "mayor"

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/04-communication.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/04-communication.md
@@ -133,15 +133,15 @@ install_agent_hooks = ["claude"]
 You can also set them per agent:
 
 ```toml
-[[agent]]
-name = "mayor"
+# agents/mayor/agent.toml
 install_agent_hooks = ["claude"]
 ```
 
-When a session starts, Gas City installs hook configuration files that the
-provider reads. For Claude, this means a `hooks/claude.json` file that fires Gas
-City commands at key moments — session start, before each turn, on shutdown.
-Those commands deliver mail, drain nudges, and surface pending work.
+When a session starts, Gas City installs hook settings that the provider reads.
+For Claude, fresh cities write the managed `.gc/settings.json` configuration,
+which fires Gas City commands at key moments — session start, before each turn,
+and on shutdown. Those commands deliver mail, drain nudges, and surface pending
+work.
 
 Without hooks, you'd have to manually tell each agent to run `gc mail check` and
 `gc prime`. With hooks, it happens on every turn.

--- a/test/acceptance/tutorial_goldens/tutorial01_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial01_test.go
@@ -113,11 +113,29 @@ func TestTutorial01Cities(t *testing.T) {
 			for _, want := range []string{
 				`name = "my-city"`,
 				`provider = "claude"`,
-				`name = "mayor"`,
-				`prompt_template = "agents/mayor/prompt.template.md"`,
 			} {
 				if !strings.Contains(out, want) {
 					t.Fatalf("city.toml missing %q:\n%s", want, out)
+				}
+			}
+			if strings.Contains(out, "[[agent]]") {
+				t.Fatalf("city.toml contains legacy [[agent]] block:\n%s", out)
+			}
+		})
+
+		t.Run("cat pack.toml", func(t *testing.T) {
+			out, err := ws.runShell("cat pack.toml", "")
+			if err != nil {
+				t.Fatalf("cat pack.toml: %v\n%s", err, out)
+			}
+			for _, want := range []string{
+				`name = "mayor"`,
+				`prompt_template = "agents/mayor/prompt.template.md"`,
+				`template = "mayor"`,
+				`mode = "always"`,
+			} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("pack.toml missing %q:\n%s", want, out)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- Closes #603 by locking down the three V1-legacy seams that were audited in the issue
- Two of the three were already fixed on main; this PR adds a regression test so they cannot silently come back
- The remaining seam — stdout saying `Writing default prompts` — is now `Scaffolding agent prompts` to match the V2 `agents/<name>/prompt.template.md` layout

## Why
The #603 audit (donbox, 2026-04-17) called out:
1. `city.toml` still contained `[[agent]]` — agents belong in `pack.toml`
2. `hooks/claude.json` was being seeded at root on fresh installs
3. `gc init` stdout said `Writing default prompts`, which implies a root `prompts/` directory that no longer exists

Empirically verifying on current `origin/main` with `gc init`: (1) and (2) are already fixed — `city.toml` is runtime-only and `hooks/` is never created. Only (3) remained.

Since (1) and (2) had no guarding tests, they could silently regress. This PR adds `TestDoInit_Regression603_NoLegacySeams` which asserts all three at once: no `[[agent]]` in `city.toml`, no `hooks/claude.json` seeded, and stdout uses the V2 wording.

## Test plan
- [x] `go test ./cmd/gc/ -run 'TestDoInit_Regression603_NoLegacySeams' -count=1 -timeout 30s` — new test passes
- [x] `go test ./cmd/gc/ -run 'TestDoInit' -count=1 -timeout 60s` — full TestDoInit family passes, no regressions
- [x] `go vet ./cmd/gc/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)