### PR TITLE
fix: watch v2-resolved pack dirs in WatchDirs and Revision

### DIFF
--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -35,7 +35,7 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 		h.Write([]byte{0})    //nolint:errcheck // hash.Write never errors
 	}
 
-	// Hash rig pack directory contents (all pack sources).
+	// Hash rig pack directory contents (v1 Includes-based refs).
 	rigs := cfg.Rigs
 	for _, r := range rigs {
 		for _, ref := range r.Includes {
@@ -48,7 +48,7 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 		}
 	}
 
-	// Hash city-level pack directory contents.
+	// Hash city-level pack directory contents (v1 Includes-based refs).
 	for _, ref := range cfg.Workspace.Includes {
 		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
 		topoHash := PackContentHashRecursive(fs, topoDir)
@@ -56,6 +56,32 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 		h.Write([]byte{0})                  //nolint:errcheck // hash.Write never errors
 		h.Write([]byte(topoHash))           //nolint:errcheck // hash.Write never errors
 		h.Write([]byte{0})                  //nolint:errcheck // hash.Write never errors
+	}
+
+	// Hash v2-resolved pack directories (populated by ExpandPacks from
+	// [imports.X] and [rigs.imports.X]). Without this, editing a file in
+	// an imported pack does not change the revision, so the reconciler
+	// never notices. Regression guard: gastownhall/gascity#779.
+	for _, dir := range cfg.PackDirs {
+		topoHash := PackContentHashRecursive(fs, dir)
+		h.Write([]byte("city-packdir:" + dir)) //nolint:errcheck // hash.Write never errors
+		h.Write([]byte{0})                     //nolint:errcheck // hash.Write never errors
+		h.Write([]byte(topoHash))              //nolint:errcheck // hash.Write never errors
+		h.Write([]byte{0})                     //nolint:errcheck // hash.Write never errors
+	}
+	rigPackDirNames := make([]string, 0, len(cfg.RigPackDirs))
+	for name := range cfg.RigPackDirs {
+		rigPackDirNames = append(rigPackDirNames, name)
+	}
+	sort.Strings(rigPackDirNames)
+	for _, rigName := range rigPackDirNames {
+		for _, dir := range cfg.RigPackDirs[rigName] {
+			topoHash := PackContentHashRecursive(fs, dir)
+			h.Write([]byte("rig-packdir:" + rigName + ":" + dir)) //nolint:errcheck // hash.Write never errors
+			h.Write([]byte{0})                                    //nolint:errcheck // hash.Write never errors
+			h.Write([]byte(topoHash))                             //nolint:errcheck // hash.Write never errors
+			h.Write([]byte{0})                                    //nolint:errcheck // hash.Write never errors
+		}
 	}
 
 	// Hash convention-discovered city-pack trees so adding or editing
@@ -93,7 +119,7 @@ func WatchDirs(prov *Provenance, cfg *City, cityRoot string) []string {
 		}
 	}
 
-	// Rig pack directories (all pack sources).
+	// Rig pack directories (v1 Includes-based refs).
 	for _, r := range cfg.Rigs {
 		for _, ref := range r.Includes {
 			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
@@ -101,10 +127,24 @@ func WatchDirs(prov *Provenance, cfg *City, cityRoot string) []string {
 		}
 	}
 
-	// City-level pack directories.
+	// City-level pack directories (v1 Includes-based refs).
 	for _, ref := range cfg.Workspace.Includes {
 		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
 		addDir(topoDir)
+	}
+
+	// v2-resolved pack directories (populated by ExpandPacks from
+	// [imports.X] and [rigs.imports.X]). Without these, cities composing
+	// packs via v2 imports get zero fsnotify coverage for the imported
+	// pack tree — hot-reload silently breaks.
+	// Regression guard: gastownhall/gascity#779.
+	for _, dir := range cfg.PackDirs {
+		addDir(dir)
+	}
+	for _, rigDirs := range cfg.RigPackDirs {
+		for _, dir := range rigDirs {
+			addDir(dir)
+		}
 	}
 
 	// Convention-discovered city-pack trees are loaded directly from the city

--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -271,6 +271,79 @@ func TestWatchDirs_IncludesConventionDiscoveryRoots(t *testing.T) {
 	}
 }
 
+// Regression for gastownhall/gascity#779:
+// WatchDirs iterated only the v1 Includes slices and ignored v2-resolved
+// PackDirs / RigPackDirs, so cities composing packs via [imports.X] or
+// [rigs.imports.X] got zero fsnotify coverage for imported pack trees.
+// Hot reload was silently broken for v2 layouts.
+func TestWatchDirs_Regression779_IncludesV2ResolvedPackDirs(t *testing.T) {
+	dir := t.TempDir()
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+
+	cityPack := filepath.Join(dir, "imported", "city-pack")
+	rigPack := filepath.Join(dir, "imported", "rig-pack")
+
+	cfg := &City{
+		PackDirs: []string{cityPack},
+		RigPackDirs: map[string][]string{
+			"api-server": {rigPack},
+		},
+		Rigs: []Rig{{Name: "api-server", Path: "/srv/api"}},
+	}
+
+	dirs := WatchDirs(prov, cfg, dir)
+	sort.Strings(dirs)
+
+	for _, want := range []string{cityPack, rigPack} {
+		found := false
+		for _, d := range dirs {
+			if d == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("watch dirs = %v, want %q present (v2 resolved pack dir, gascity#779)", dirs, want)
+		}
+	}
+}
+
+// Regression for gastownhall/gascity#779:
+// Revision hashed only v1 Includes-based pack content. Cities using v2
+// [imports.X] saw no revision change when imported pack files were edited,
+// so the reconciler never detected the change.
+func TestRevision_Regression779_HashesV2ResolvedPackDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+`)
+	packRel := filepath.Join("imported", "city-pack")
+	writeFile(t, dir, filepath.Join(packRel, "pack.toml"), `[pack]
+name = "imported"
+schema = 2
+`)
+
+	packAbs := filepath.Join(dir, packRel)
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+	cfg := &City{PackDirs: []string{packAbs}}
+
+	h1 := Revision(fsys.OSFS{}, prov, cfg, dir)
+
+	writeFile(t, dir, filepath.Join(packRel, "pack.toml"), `[pack]
+name = "imported-v2-changed"
+schema = 2
+`)
+
+	h2 := Revision(fsys.OSFS{}, prov, cfg, dir)
+	if h1 == h2 {
+		t.Errorf("Revision did not change when v2-imported pack content changed (gascity#779)")
+	}
+}
+
 func TestWatchDirs_Deduplicates(t *testing.T) {
 	dir := t.TempDir()
 	prov := &Provenance{


### PR DESCRIPTION
## Summary
- Fixes #779: `WatchDirs` and `Revision` in `internal/config/revision.go` only iterated v1-shape `Workspace.Includes` / `Rigs[].Includes`, so cities composing packs via v2 `[imports.X]` or `[rigs.imports.X]` got no fsnotify coverage for imported pack trees and no revision hash change when those files were edited.
- Extend both functions to also walk `cfg.PackDirs` and `cfg.RigPackDirs` — the runtime-resolved superset that `ExpandPacks` populates from both v1 Includes and v2 Imports.

## Why
Hot-reload silently broke in v2 layouts. A student clones a v2-shaped factory, edits `packs/architect/pack.toml`, and nothing happens — no reload, no warning. `WatchDirs` never calls `watcher.Add()` for the imported pack tree, and `Revision` hashes no file content from it, so even a manual poke sees "no change." The fix closes both holes at once by consuming the already-resolved `PackDirs` / `RigPackDirs` that the pack-expansion pass writes.

## Test plan
- [x] `TestWatchDirs_Regression779_IncludesV2ResolvedPackDirs` — asserts both city-level and per-rig v2 pack dirs appear in the watch set. Fails on main, passes after the fix.
- [x] `TestRevision_Regression779_HashesV2ResolvedPackDirs` — asserts `Revision` changes when a file inside a v2-imported pack changes. Fails on main, passes after the fix.
- [x] Targeted tests pass: `go test ./internal/config/ -run 'TestWatchDirs_Regression779|TestRevision_Regression779'`
- [x] Full `internal/config/` package suite passes.
- [x] `go vet ./internal/config/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)