### PR TITLE
fix: watch nested subdirs so v2 convention edits trigger hot reload

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -27,13 +27,15 @@ import (
 // across runController and controllerLoop. A machine-wide supervisor can
 // instantiate multiple CityRuntimes — one per registered city.
 type CityRuntime struct {
-	cityPath    string
-	cityName    string
-	configName  string
-	tomlPath    string
-	watchDirs   []string
-	configRev   string
-	configDirty *atomic.Bool
+	cityPath     string
+	cityName     string
+	configName   string
+	tomlPath     string
+	watchTargets []config.WatchTarget
+	configRev    string
+	configDirty  *atomic.Bool
+	watchMu      sync.Mutex
+	watchCleanup func()
 
 	serviceStateMu          sync.RWMutex
 	cfg                     *config.City
@@ -82,12 +84,12 @@ type CityRuntime struct {
 // CityRuntime. Internal components (crashTracker, etc.) are built by the
 // constructor from these inputs.
 type CityRuntimeParams struct {
-	CityPath    string
-	CityName    string
-	TomlPath    string
-	WatchDirs   []string
-	ConfigRev   string
-	ConfigDirty *atomic.Bool
+	CityPath     string
+	CityName     string
+	TomlPath     string
+	WatchTargets []config.WatchTarget
+	ConfigRev    string
+	ConfigDirty  *atomic.Bool
 
 	Cfg                     *config.City
 	SP                      runtime.Provider
@@ -162,7 +164,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		cityName:                p.CityName,
 		configName:              lockedConfigName(p.Cfg, p.CityPath),
 		tomlPath:                p.TomlPath,
-		watchDirs:               p.WatchDirs,
+		watchTargets:            p.WatchTargets,
 		configRev:               p.ConfigRev,
 		configDirty:             configDirty,
 		cfg:                     p.Cfg,
@@ -237,22 +239,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	}
 
 	if cr.tomlPath != "" {
-		watchPaths := append([]string{}, cr.watchDirs...)
-		if len(watchPaths) == 0 {
-			watchPaths = []string{filepath.Dir(cr.tomlPath)}
-		}
-		var hasTomlPath bool
-		for _, path := range watchPaths {
-			if samePath(path, cr.tomlPath) {
-				hasTomlPath = true
-				break
-			}
-		}
-		if !hasTomlPath {
-			watchPaths = append(watchPaths, cr.tomlPath)
-		}
-		cleanup := watchConfigDirs(watchPaths, dirty, cr.pokeCh, cr.stderr)
-		defer cleanup()
+		cr.restartConfigWatcher()
+		defer cr.stopConfigWatcher()
 	}
 
 	// Track effective provider name for hot-reload detection.
@@ -826,6 +814,8 @@ func (cr *CityRuntime) reloadConfigTraced(
 		cr.sessionDrains = newDrainTracker()
 	}
 	cr.configRev = result.Revision
+	cr.watchTargets = config.WatchTargets(result.Prov, nextCfg, cityRoot)
+	cr.restartConfigWatcher()
 	if trace != nil {
 		trace.configRevision = result.Revision
 		trace.syncArms(time.Now().UTC(), nextCfg)
@@ -852,6 +842,56 @@ func lockedConfigName(cfg *config.City, cityPath string) string {
 		return cfg.Workspace.Name
 	}
 	return filepath.Base(cityPath)
+}
+
+func (cr *CityRuntime) configWatcherTargets() []config.WatchTarget {
+	watchTargets := append([]config.WatchTarget{}, cr.watchTargets...)
+	if len(watchTargets) == 0 && cr.tomlPath != "" {
+		watchTargets = []config.WatchTarget{{
+			Path:                filepath.Dir(cr.tomlPath),
+			DiscoverConventions: true,
+		}}
+	}
+
+	var hasTomlPath bool
+	for _, target := range watchTargets {
+		if samePath(target.Path, cr.tomlPath) {
+			hasTomlPath = true
+			break
+		}
+	}
+	if cr.tomlPath != "" && !hasTomlPath {
+		watchTargets = append(watchTargets, config.WatchTarget{Path: cr.tomlPath})
+	}
+	return watchTargets
+}
+
+func (cr *CityRuntime) restartConfigWatcher() {
+	if cr.tomlPath == "" {
+		return
+	}
+	cr.stopConfigWatcher()
+
+	dirty := cr.configDirty
+	if dirty == nil {
+		dirty = &atomic.Bool{}
+		cr.configDirty = dirty
+	}
+	cleanup := watchConfigTargets(cr.configWatcherTargets(), dirty, cr.pokeCh, cr.stderr)
+
+	cr.watchMu.Lock()
+	cr.watchCleanup = cleanup
+	cr.watchMu.Unlock()
+}
+
+func (cr *CityRuntime) stopConfigWatcher() {
+	cr.watchMu.Lock()
+	cleanup := cr.watchCleanup
+	cr.watchCleanup = nil
+	cr.watchMu.Unlock()
+	if cleanup != nil {
+		cleanup()
+	}
 }
 
 // beadReconcileTick runs one reconciliation tick using the bead-driven

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1648,6 +1648,96 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeReloadRestartsConfigWatcherWithNewPackTargets(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfigWithIncludes(t, tomlPath, nil)
+
+	packFile := filepath.Join(cityPath, "packs", "extra", "docs", "note.txt")
+	if err := os.MkdirAll(filepath.Dir(packFile), 0o755); err != nil {
+		t.Fatalf("mkdir pack docs: %v", err)
+	}
+	if err := os.WriteFile(packFile, []byte("first\n"), 0o644); err != nil {
+		t.Fatalf("seed pack file: %v", err)
+	}
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	sp := runtime.NewFake()
+	dirty := &atomic.Bool{}
+	pokeCh := make(chan struct{}, 8)
+	var stdout, stderr bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:     cityPath,
+		CityName:     "test-city",
+		TomlPath:     tomlPath,
+		WatchTargets: config.WatchTargets(prov, cfg, cityPath),
+		ConfigRev:    configRev,
+		ConfigDirty:  dirty,
+		Cfg:          cfg,
+		SP:           sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		PokeCh: pokeCh,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	cr.restartConfigWatcher()
+	defer cr.stopConfigWatcher()
+
+	writeCityRuntimeConfigWithIncludes(t, tomlPath, []string{"packs/extra"})
+	lastProviderName := "fake"
+	cr.reloadConfig(context.Background(), &lastProviderName, cityPath)
+
+	packDir := filepath.Join(cityPath, "packs", "extra")
+	foundPackTarget := false
+	for _, target := range cr.watchTargets {
+		if target.Path == packDir && target.Recursive {
+			foundPackTarget = true
+			break
+		}
+	}
+	if !foundPackTarget {
+		t.Fatalf("watchTargets = %#v, want recursive pack target %q", cr.watchTargets, packDir)
+	}
+
+	drainPokes := func() {
+		for {
+			select {
+			case <-pokeCh:
+			default:
+				return
+			}
+		}
+	}
+	time.Sleep(25 * time.Millisecond)
+	drainPokes()
+	dirty.Store(false)
+
+	if err := os.WriteFile(packFile, []byte("second\n"), 0o644); err != nil {
+		t.Fatalf("edit pack file: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after editing newly watched pack file; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after editing newly watched pack file; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
 func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
@@ -1771,4 +1861,20 @@ func warningsContain(warnings []string, substr string) bool {
 		}
 	}
 	return false
+}
+
+func writeCityRuntimeConfigWithIncludes(t *testing.T, tomlPath string, includes []string) {
+	t.Helper()
+	var quoted []string
+	for _, include := range includes {
+		quoted = append(quoted, fmt.Sprintf("%q", include))
+	}
+	includesLine := ""
+	if len(quoted) > 0 {
+		includesLine = "includes = [" + strings.Join(quoted, ", ") + "]\n"
+	}
+	data := []byte("[workspace]\nname = \"test-city\"\n" + includesLine + "\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 }

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -580,10 +580,10 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	if controllerMode {
 		poolSessions := computePoolSessions(cfg, cityName, cityPath, sp)
 		poolDeathHandlers := computePoolDeathHandlers(cfg, cityName, cityPath, sp, stderr)
-		watchDirs := config.WatchDirs(prov, cfg, cityPath)
+		watchTargets := config.WatchTargets(prov, cfg, cityPath)
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
 		return runController(cityPath, tomlPath, cfg, configRev, buildAgents, buildAgentsWithSessionBeads, sp,
-			newDrainOps(sp), poolSessions, poolDeathHandlers, watchDirs, recorder, eventProv, stdout, stderr)
+			newDrainOps(sp), poolSessions, poolDeathHandlers, watchTargets, recorder, eventProv, stdout, stderr)
 	}
 
 	// One-shot reconciliation (default): no drain (kill is fine).

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1097,7 +1097,7 @@ func reconcileCities(
 			}
 		}
 
-		// Load city config with provenance so WatchDirs covers included files.
+		// Load city config with provenance so WatchTargets covers included files.
 		// System packs are appended as extra includes for normal pack expansion.
 		cfg, prov, loadErr := config.LoadWithIncludes(fsys.OSFS{}, tomlPath, builtinPackIncludes(path)...)
 		if loadErr != nil {
@@ -1217,7 +1217,7 @@ func reconcileCities(
 		dops := newDrainOps(sp)
 		poolSessions := computePoolSessions(cfg, cityName, path, sp)
 		poolDeathHandlers := computePoolDeathHandlers(cfg, cityName, path, sp, stderr)
-		watchDirs := config.WatchDirs(prov, cfg, path)
+		watchTargets := config.WatchTargets(prov, cfg, path)
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, path)
 		pokeCh := make(chan struct{}, 1)
 		configDirty := &atomic.Bool{}
@@ -1235,7 +1235,7 @@ func reconcileCities(
 				CityPath:                path,
 				CityName:                cityName,
 				TomlPath:                tomlPath,
-				WatchDirs:               watchDirs,
+				WatchTargets:            watchTargets,
 				ConfigRev:               configRev,
 				ConfigDirty:             configDirty,
 				Cfg:                     cfg,

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -438,62 +439,231 @@ func controllerAlive(cityPath string) int {
 // single dirty signal. Tests may override this for faster response.
 var debounceDelay = 200 * time.Millisecond
 
-// watchConfigDirs starts an fsnotify watcher on the given directories and
-// sets dirty to true after a debounce window. Watches directories instead
-// of individual files to handle vim/emacs rename-swap atomic saves.
+// watchConfigTargets starts an fsnotify watcher on the given config paths and
+// sets dirty to true after a debounce window. Config source directories are
+// watched shallowly to handle vim/emacs rename-swap atomic saves; pack and
+// convention roots are watched recursively because fsnotify is non-recursive.
 // Returns a cleanup function. If the watcher cannot be created, returns a
 // no-op cleanup (degraded to tick-only, no file watching).
-// addWatchRecursive walks root and adds every directory it finds to the
-// watcher, skipping subtrees that shouldIgnoreConfigWatchEvent flags
-// (.gc/, .beads/, and their descendants). Non-existent roots and permission
-// errors are logged and skipped — a missing subdir is not fatal because
-// fsnotify only needs the parent to observe the create event.
-func addWatchRecursive(watcher *fsnotify.Watcher, root string, stderr io.Writer) {
+type configWatchRegistrar struct {
+	watcher        *fsnotify.Watcher
+	stderr         io.Writer
+	mu             sync.Mutex
+	recursiveRoots map[string]struct{}
+	discoveryRoots map[string]struct{}
+}
+
+func newConfigWatchRegistrar(watcher *fsnotify.Watcher, stderr io.Writer) *configWatchRegistrar {
+	return &configWatchRegistrar{
+		watcher:        watcher,
+		stderr:         stderr,
+		recursiveRoots: make(map[string]struct{}),
+		discoveryRoots: make(map[string]struct{}),
+	}
+}
+
+func (r *configWatchRegistrar) addPath(root string, recursive bool, done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return false
+	default:
+	}
 	info, err := os.Stat(root)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: config watcher: cannot stat %s: %v\n", root, err) //nolint:errcheck // best-effort stderr
-		return
+		fmt.Fprintf(r.stderr, "config watcher: cannot stat %s: %v\n", root, err) //nolint:errcheck // best-effort stderr
+		return false
+	}
+	if !r.addOne(root, done) {
+		return false
 	}
 	if !info.IsDir() {
-		return
+		return true
 	}
-	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+	if !recursive {
+		return true
+	}
+	walkRoot := root
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		walkRoot = resolved
+	}
+	walkErr := filepath.WalkDir(walkRoot, func(path string, d os.DirEntry, walkErr error) error {
+		select {
+		case <-done:
+			return filepath.SkipAll
+		default:
+		}
 		if walkErr != nil {
-			fmt.Fprintf(stderr, "gc start: config watcher: walk %s: %v\n", path, walkErr) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(r.stderr, "config watcher: walk %s: %v\n", path, walkErr) //nolint:errcheck // best-effort stderr
 			return nil
 		}
 		if !d.IsDir() {
 			return nil
 		}
+		if samePath(path, root) {
+			return nil
+		}
 		if path != root && shouldIgnoreConfigWatchEvent(path) {
 			return filepath.SkipDir
 		}
-		if err := watcher.Add(path); err != nil {
-			fmt.Fprintf(stderr, "gc start: config watcher: cannot watch %s: %v\n", path, err) //nolint:errcheck // best-effort stderr
-		}
+		r.addOne(path, done)
 		return nil
 	})
 	if walkErr != nil {
-		fmt.Fprintf(stderr, "gc start: config watcher: walk %s: %v\n", root, walkErr) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(r.stderr, "config watcher: walk %s: %v\n", walkRoot, walkErr) //nolint:errcheck // best-effort stderr
 	}
+	return true
 }
 
-func watchConfigDirs(dirs []string, dirty *atomic.Bool, pokeCh chan struct{}, stderr io.Writer) func() {
+func (r *configWatchRegistrar) addOne(path string, done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return false
+	default:
+	}
+	if err := r.watcher.Add(path); err != nil {
+		if errors.Is(err, syscall.ENOSPC) {
+			fmt.Fprintf(r.stderr, "config watcher: cannot watch %s: inotify watch limit reached; increase fs.inotify.max_user_watches or reduce watched pack size: %v\n", path, err) //nolint:errcheck // best-effort stderr
+			return false
+		}
+		fmt.Fprintf(r.stderr, "config watcher: cannot watch %s: %v\n", path, err) //nolint:errcheck // best-effort stderr
+		return false
+	}
+	return true
+}
+
+func (r *configWatchRegistrar) markRecursiveRoot(root string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recursiveRoots[normalizePathForCompare(root)] = struct{}{}
+}
+
+func (r *configWatchRegistrar) unmarkRecursiveRoot(root string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.recursiveRoots, normalizePathForCompare(root))
+}
+
+func (r *configWatchRegistrar) markDiscoveryRoot(root string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.discoveryRoots[normalizePathForCompare(root)] = struct{}{}
+}
+
+func (r *configWatchRegistrar) watchesRecursively(path string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for root := range r.recursiveRoots {
+		if pathIsWithin(root, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *configWatchRegistrar) isConventionRootCreate(path string) bool {
+	parent := filepath.Dir(path)
+	base := filepath.Base(filepath.Clean(path))
+	if !isConventionDiscoveryDirName(base) {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for root := range r.discoveryRoots {
+		if samePath(root, parent) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathIsWithin(root, path string) bool {
+	root = normalizePathForCompare(root)
+	path = normalizePathForCompare(path)
+	if samePath(root, path) {
+		return true
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func isConventionDiscoveryDirName(base string) bool {
+	for _, name := range config.ConventionDiscoveryDirNames() {
+		if base == name {
+			return true
+		}
+	}
+	return false
+}
+
+func watchConfigTargets(targets []config.WatchTarget, dirty *atomic.Bool, pokeCh chan struct{}, stderr io.Writer) func() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: config watcher: %v (reload on tick only)\n", err) //nolint:errcheck // best-effort stderr
 		return func() {}
 	}
-	// fsnotify is non-recursive — watcher.Add(dir) covers only the immediate
-	// directory. Pack v2's convention layout pushes agent prompts, commands,
-	// and formulas into subdirectories that exist at startup, and v1 pack
-	// dirs usually do the same. Walk each seed recursively so nested edits
-	// trigger reloads. Regression guard: gastownhall/gascity#780.
-	for _, dir := range dirs {
-		addWatchRecursive(watcher, dir, stderr)
+	registrar := newConfigWatchRegistrar(watcher, stderr)
+
+	markDirty := func() {
+		dirty.Store(true)
+		if pokeCh != nil {
+			select {
+			case pokeCh <- struct{}{}:
+			default:
+			}
+		}
+	}
+
+	done := make(chan struct{})
+	eventLoopDone := make(chan struct{})
+	var registrationWG sync.WaitGroup
+	var enqueueMu sync.Mutex
+	enqueueRecursiveWatch := func(root string, trackRoot bool) {
+		enqueueMu.Lock()
+		select {
+		case <-done:
+			enqueueMu.Unlock()
+			return
+		default:
+		}
+		if trackRoot {
+			registrar.markRecursiveRoot(root)
+		}
+		registrationWG.Add(1)
+		enqueueMu.Unlock()
+		go func() {
+			defer registrationWG.Done()
+			if ok := registrar.addPath(root, true, done); !ok && trackRoot {
+				registrar.unmarkRecursiveRoot(root)
+			}
+		}()
+	}
+
+	// fsnotify is non-recursive. Watch config source directories shallowly,
+	// but recurse through pack and convention roots where config-bearing
+	// files live below pre-existing subdirectories. Regression guard:
+	// gastownhall/gascity#780.
+	for _, target := range targets {
+		if target.DiscoverConventions {
+			registrar.markDiscoveryRoot(target.Path)
+		}
+		if target.Recursive {
+			registrar.markRecursiveRoot(target.Path)
+		}
+		if ok := registrar.addPath(target.Path, target.Recursive, done); !ok && target.Recursive {
+			registrar.unmarkRecursiveRoot(target.Path)
+		}
 	}
 	go func() {
+		defer close(eventLoopDone)
 		var debounce *time.Timer
+		defer func() {
+			if debounce != nil {
+				debounce.Stop()
+			}
+		}()
 		for {
 			select {
 			case event, ok := <-watcher.Events:
@@ -505,15 +675,13 @@ func watchConfigDirs(dirs []string, dirty *atomic.Bool, pokeCh chan struct{}, st
 				}
 				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
 					if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-						// Walk the newly created subtree so anything pre-populated
-						// inside it is watched too (gastownhall/gascity#780).
-						addWatchRecursive(watcher, event.Name, stderr)
-						dirty.Store(true)
-						if pokeCh != nil {
-							select {
-							case pokeCh <- struct{}{}:
-							default:
-							}
+						// Convention roots may appear after startup, and nested
+						// dirs inside recursive roots may be pre-populated. Queue
+						// the walk so fsnotify consumption stays fast.
+						if registrar.isConventionRootCreate(event.Name) {
+							enqueueRecursiveWatch(event.Name, true)
+						} else if registrar.watchesRecursively(event.Name) {
+							enqueueRecursiveWatch(event.Name, false)
 						}
 					}
 				}
@@ -522,13 +690,7 @@ func watchConfigDirs(dirs []string, dirty *atomic.Bool, pokeCh chan struct{}, st
 					debounce.Stop()
 				}
 				debounce = time.AfterFunc(debounceDelay, func() {
-					dirty.Store(true)
-					if pokeCh != nil {
-						select {
-						case pokeCh <- struct{}{}:
-						default:
-						}
-					}
+					markDirty()
 				})
 			case _, ok := <-watcher.Errors:
 				if !ok {
@@ -537,7 +699,17 @@ func watchConfigDirs(dirs []string, dirty *atomic.Bool, pokeCh chan struct{}, st
 			}
 		}
 	}()
-	return func() { watcher.Close() } //nolint:errcheck // best-effort cleanup
+	var cleanupOnce sync.Once
+	return func() {
+		cleanupOnce.Do(func() {
+			enqueueMu.Lock()
+			close(done)
+			enqueueMu.Unlock()
+			registrationWG.Wait()
+			watcher.Close() //nolint:errcheck // best-effort cleanup
+			<-eventLoopDone
+		})
+	}
 }
 
 func shouldIgnoreConfigWatchEvent(path string) bool {
@@ -778,7 +950,7 @@ func controllerLoop(
 	cfg *config.City,
 	cityName string,
 	tomlPath string,
-	watchDirs []string,
+	watchTargets []config.WatchTarget,
 	buildFn func(*config.City, runtime.Provider, beads.Store) DesiredStateResult,
 	sp runtime.Provider,
 	dops drainOps,
@@ -809,7 +981,7 @@ func controllerLoop(
 		cityPath:            cityPath,
 		cityName:            cityName,
 		tomlPath:            tomlPath,
-		watchDirs:           watchDirs,
+		watchTargets:        watchTargets,
 		cfg:                 loopCfg,
 		sp:                  sp,
 		buildFn:             buildFn,
@@ -865,8 +1037,8 @@ func configReloadSummary(oldAgents, oldRigs, newAgents, newRigs int) string {
 
 // runController runs the persistent controller loop. It acquires a lock,
 // opens a control socket, runs the reconciliation loop, and on shutdown
-// stops all agents. Returns an exit code. initialWatchDirs is the set of
-// directories to watch for config changes (from initial provenance).
+// stops all agents. Returns an exit code. initialWatchTargets is the set of
+// paths to watch for config changes (from initial provenance).
 func runController(
 	cityPath string,
 	tomlPath string,
@@ -878,7 +1050,7 @@ func runController(
 	dops drainOps,
 	poolSessions map[string]time.Duration,
 	poolDeathHandlers map[string]poolDeathInfo,
-	initialWatchDirs []string,
+	initialWatchTargets []config.WatchTarget,
 	rec events.Recorder,
 	eventProv events.Provider,
 	stdout, stderr io.Writer,
@@ -946,7 +1118,7 @@ func runController(
 		CityPath:                cityPath,
 		CityName:                cityName,
 		TomlPath:                tomlPath,
-		WatchDirs:               initialWatchDirs,
+		WatchTargets:            initialWatchTargets,
 		ConfigRev:               configRev,
 		ConfigDirty:             configDirty,
 		Cfg:                     cfg,

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -443,16 +443,54 @@ var debounceDelay = 200 * time.Millisecond
 // of individual files to handle vim/emacs rename-swap atomic saves.
 // Returns a cleanup function. If the watcher cannot be created, returns a
 // no-op cleanup (degraded to tick-only, no file watching).
+// addWatchRecursive walks root and adds every directory it finds to the
+// watcher, skipping subtrees that shouldIgnoreConfigWatchEvent flags
+// (.gc/, .beads/, and their descendants). Non-existent roots and permission
+// errors are logged and skipped — a missing subdir is not fatal because
+// fsnotify only needs the parent to observe the create event.
+func addWatchRecursive(watcher *fsnotify.Watcher, root string, stderr io.Writer) {
+	info, err := os.Stat(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc start: config watcher: cannot stat %s: %v\n", root, err) //nolint:errcheck // best-effort stderr
+		return
+	}
+	if !info.IsDir() {
+		return
+	}
+	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			fmt.Fprintf(stderr, "gc start: config watcher: walk %s: %v\n", path, walkErr) //nolint:errcheck // best-effort stderr
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path != root && shouldIgnoreConfigWatchEvent(path) {
+			return filepath.SkipDir
+		}
+		if err := watcher.Add(path); err != nil {
+			fmt.Fprintf(stderr, "gc start: config watcher: cannot watch %s: %v\n", path, err) //nolint:errcheck // best-effort stderr
+		}
+		return nil
+	})
+	if walkErr != nil {
+		fmt.Fprintf(stderr, "gc start: config watcher: walk %s: %v\n", root, walkErr) //nolint:errcheck // best-effort stderr
+	}
+}
+
 func watchConfigDirs(dirs []string, dirty *atomic.Bool, pokeCh chan struct{}, stderr io.Writer) func() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: config watcher: %v (reload on tick only)\n", err) //nolint:errcheck // best-effort stderr
 		return func() {}
 	}
+	// fsnotify is non-recursive — watcher.Add(dir) covers only the immediate
+	// directory. Pack v2's convention layout pushes agent prompts, commands,
+	// and formulas into subdirectories that exist at startup, and v1 pack
+	// dirs usually do the same. Walk each seed recursively so nested edits
+	// trigger reloads. Regression guard: gastownhall/gascity#780.
 	for _, dir := range dirs {
-		if err := watcher.Add(dir); err != nil {
-			fmt.Fprintf(stderr, "gc start: config watcher: cannot watch %s: %v\n", dir, err) //nolint:errcheck // best-effort stderr
-		}
+		addWatchRecursive(watcher, dir, stderr)
 	}
 	go func() {
 		var debounce *time.Timer
@@ -467,9 +505,9 @@ func watchConfigDirs(dirs []string, dirty *atomic.Bool, pokeCh chan struct{}, st
 				}
 				if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
 					if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-						if err := watcher.Add(event.Name); err != nil {
-							fmt.Fprintf(stderr, "gc start: config watcher: cannot watch %s: %v\n", event.Name, err) //nolint:errcheck // best-effort stderr
-						}
+						// Walk the newly created subtree so anything pre-populated
+						// inside it is watched too (gastownhall/gascity#780).
+						addWatchRecursive(watcher, event.Name, stderr)
 						dirty.Store(true)
 						if pokeCh != nil {
 							select {

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -533,7 +533,7 @@ func TestControllerReloadsConventionDiscoveredAgentOnWatchEvent(t *testing.T) {
 // fsnotify → debounce → dirty flag wiring. This is the integration
 // complement to the reload-logic unit test above: if this test breaks
 // but the unit test passes, the watcher glue has regressed
-// independently. Focuses on the primitive (watchConfigDirs) rather
+// independently. Focuses on the primitive (watchConfigTargets) rather
 // than a full controllerLoop to keep the test fast and free of
 // bead-store dependencies.
 func TestWatchConfigDirs_DetectsFileChangeAndSetsDirty(t *testing.T) {
@@ -550,7 +550,7 @@ func TestWatchConfigDirs_DetectsFileChangeAndSetsDirty(t *testing.T) {
 	var dirty atomic.Bool
 	pokeCh := make(chan struct{}, 1)
 	var stderr bytes.Buffer
-	cleanup := watchConfigDirs([]string{dir}, &dirty, pokeCh, &stderr)
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: dir, DiscoverConventions: true}}, &dirty, pokeCh, &stderr)
 	defer cleanup()
 
 	// Rewrite city.toml — fsnotify watches the dir, so the write fires
@@ -594,7 +594,7 @@ func TestWatchConfigDirs_DetectsFileChangeAndSetsDirty(t *testing.T) {
 
 	// Now prove the subtree-add path actually registered agents/: create
 	// a file INSIDE agents/ and verify the watcher fires again. Without
-	// the watcher.Add(event.Name) in watchConfigDirs's event loop, this
+	// the watcher.Add(event.Name) in watchConfigTargets's event loop, this
 	// write would silently miss and a real-world regression (conv-agent
 	// file showing up after startup) would be invisible.
 	dirty.Store(false)
@@ -617,6 +617,185 @@ func TestWatchConfigDirs_DetectsFileChangeAndSetsDirty(t *testing.T) {
 	}
 }
 
+func TestWatchConfigDirs_FileSeedStillWatchesFile(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	tomlPath := filepath.Join(dir, "city.toml")
+	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: tomlPath}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test-v2\"\n"), 0o644); err != nil {
+		t.Fatalf("rewrite city.toml: %v", err)
+	}
+
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after direct file seed changed; stderr=%q", stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after direct file seed changed; stderr=%q", stderr.String())
+	}
+}
+
+func TestWatchConfigDirs_CityRootDoesNotWatchUnrelatedNestedSubdir(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	nestedDir := filepath.Join(dir, "rigs", "checkout")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll nested unrelated dir: %v", err)
+	}
+	nestedFile := filepath.Join(nestedDir, "generated.txt")
+	if err := os.WriteFile(nestedFile, []byte("first\n"), 0o644); err != nil {
+		t.Fatalf("seed nested file: %v", err)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: dir, DiscoverConventions: true}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	select {
+	case <-pokeCh:
+	default:
+	}
+	dirty.Store(false)
+
+	if err := os.WriteFile(nestedFile, []byte("second\n"), 0o644); err != nil {
+		t.Fatalf("rewrite nested unrelated file: %v", err)
+	}
+
+	select {
+	case <-pokeCh:
+		t.Fatalf("unexpected watcher poke after unrelated nested city-root file changed; stderr=%q", stderr.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+	if dirty.Load() {
+		t.Fatalf("dirty flag set after unrelated nested city-root file changed; stderr=%q", stderr.String())
+	}
+}
+
+func TestWatchConfigDirs_SymlinkSeedDirWatchesNestedPreExistingDir(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	targetDir := filepath.Join(dir, "agents-target")
+	nestedAgentDir := filepath.Join(targetDir, "sample-agent")
+	if err := os.MkdirAll(nestedAgentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll nested symlink target dir: %v", err)
+	}
+	linkDir := filepath.Join(dir, "agents")
+	if err := os.Symlink(targetDir, linkDir); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	promptPath := filepath.Join(nestedAgentDir, "prompt.template.md")
+	if err := os.WriteFile(promptPath, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("seed nested symlink target file: %v", err)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: linkDir, Recursive: true}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	if err := os.WriteFile(promptPath, []byte("edited\n"), 0o644); err != nil {
+		t.Fatalf("rewrite symlink target file: %v", err)
+	}
+
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after nested symlink seed dir changed; stderr=%q", stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after nested symlink seed dir changed; stderr=%q", stderr.String())
+	}
+}
+
+func TestWatchConfigDirs_RecreatedRecursiveSubdirStillWatched(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "agents")
+	agentDir := filepath.Join(agentsDir, "sample-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll agent dir: %v", err)
+	}
+	promptPath := filepath.Join(agentDir, "prompt.template.md")
+	if err := os.WriteFile(promptPath, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: agentsDir, Recursive: true}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	if err := os.RemoveAll(agentDir); err != nil {
+		t.Fatalf("RemoveAll agent dir: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after recursive subdir removal; stderr=%q", stderr.String())
+	}
+
+	dirty.Store(false)
+	select {
+	case <-pokeCh:
+	default:
+	}
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("recreate agent dir: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte("recreated\n"), 0o644); err != nil {
+		t.Fatalf("seed recreated prompt: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after recursive subdir recreation; stderr=%q", stderr.String())
+	}
+
+	dirty.Store(false)
+	select {
+	case <-pokeCh:
+	default:
+	}
+	if err := os.WriteFile(promptPath, []byte("edited\n"), 0o644); err != nil {
+		t.Fatalf("edit recreated prompt: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after edit in recreated recursive subdir; stderr=%q", stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after edit in recreated recursive subdir; stderr=%q", stderr.String())
+	}
+}
+
 // Regression for gastownhall/gascity#780:
 // fsnotify watches are non-recursive — watcher.Add(dir) covers only the
 // immediate directory. Pack v2's convention layout pushes agent prompts,
@@ -631,7 +810,8 @@ func TestWatchConfigDirs_Regression780_DetectsEditInPreExistingNestedSubdir(t *t
 	dir := t.TempDir()
 	// Pre-existing nested layout (mirrors pack v2 convention discovery):
 	// agents/<name>/prompt.template.md and agents/<name>/overlay/settings.json.
-	nestedAgentDir := filepath.Join(dir, "agents", "mayor")
+	agentsDir := filepath.Join(dir, "agents")
+	nestedAgentDir := filepath.Join(agentsDir, "sample-agent")
 	if err := os.MkdirAll(filepath.Join(nestedAgentDir, "overlay"), 0o755); err != nil {
 		t.Fatalf("MkdirAll nested: %v", err)
 	}
@@ -647,7 +827,10 @@ func TestWatchConfigDirs_Regression780_DetectsEditInPreExistingNestedSubdir(t *t
 	var dirty atomic.Bool
 	pokeCh := make(chan struct{}, 1)
 	var stderr bytes.Buffer
-	cleanup := watchConfigDirs([]string{dir}, &dirty, pokeCh, &stderr)
+	cleanup := watchConfigTargets([]config.WatchTarget{
+		{Path: dir, DiscoverConventions: true},
+		{Path: agentsDir, Recursive: true},
+	}, &dirty, pokeCh, &stderr)
 	defer cleanup()
 
 	// Drain any startup poke.
@@ -770,7 +953,7 @@ func TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		controllerLoop(ctx, 20*time.Millisecond, cfg, "test", tomlPath, config.WatchDirs(prov, cfg, dir),
+		controllerLoop(ctx, 20*time.Millisecond, cfg, "test", tomlPath, config.WatchTargets(prov, cfg, dir),
 			buildFn, sp, nil, nil, nil, nil, nil, events.Discard, nil, nil, nil, nil, &stdout, &stderr)
 		close(done)
 	}()

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -617,6 +617,78 @@ func TestWatchConfigDirs_DetectsFileChangeAndSetsDirty(t *testing.T) {
 	}
 }
 
+// Regression for gastownhall/gascity#780:
+// fsnotify watches are non-recursive — watcher.Add(dir) covers only the
+// immediate directory. Pack v2's convention layout pushes agent prompts,
+// commands, and formulas into subdirectories that exist at startup. Edits
+// to those nested files used to fire no event, silently breaking hot
+// reload. This test proves nested edits to pre-existing subtrees now fire.
+func TestWatchConfigDirs_Regression780_DetectsEditInPreExistingNestedSubdir(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	// Pre-existing nested layout (mirrors pack v2 convention discovery):
+	// agents/<name>/prompt.template.md and agents/<name>/overlay/settings.json.
+	nestedAgentDir := filepath.Join(dir, "agents", "mayor")
+	if err := os.MkdirAll(filepath.Join(nestedAgentDir, "overlay"), 0o755); err != nil {
+		t.Fatalf("MkdirAll nested: %v", err)
+	}
+	promptPath := filepath.Join(nestedAgentDir, "prompt.template.md")
+	if err := os.WriteFile(promptPath, []byte("original prompt\n"), 0o644); err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+	overlayPath := filepath.Join(nestedAgentDir, "overlay", "settings.json")
+	if err := os.WriteFile(overlayPath, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatalf("seed overlay: %v", err)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigDirs([]string{dir}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	// Drain any startup poke.
+	select {
+	case <-pokeCh:
+	default:
+	}
+	dirty.Store(false)
+
+	// Edit a two-levels-deep file. Without recursive watching, no event fires.
+	if err := os.WriteFile(promptPath, []byte("edited prompt\n"), 0o644); err != nil {
+		t.Fatalf("edit prompt: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for poke after edit to %s; pre-existing nested subdir was not watched; stderr=%q", promptPath, stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after edit to nested file %s; stderr=%q", promptPath, stderr.String())
+	}
+
+	// And a three-levels-deep edit, for overlay/ subtrees.
+	dirty.Store(false)
+	select {
+	case <-pokeCh:
+	default:
+	}
+	if err := os.WriteFile(overlayPath, []byte(`{"a":2}`), 0o644); err != nil {
+		t.Fatalf("edit overlay: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for poke after edit to %s; overlay subtree was not watched; stderr=%q", overlayPath, stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after edit to %s; stderr=%q", overlayPath, stderr.String())
+	}
+}
+
 func TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout(t *testing.T) {
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // Revision computes a deterministic bundle hash from all resolved config
@@ -39,7 +41,10 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	rigs := cfg.Rigs
 	for _, r := range rigs {
 		for _, ref := range r.Includes {
-			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+			topoDir, ok := revisionPackDir(ref, cityRoot, cityRoot)
+			if !ok {
+				continue
+			}
 			topoHash := PackContentHashRecursive(fs, topoDir)
 			h.Write([]byte("pack:" + r.Name + ":" + ref)) //nolint:errcheck // hash.Write never errors
 			h.Write([]byte{0})                            //nolint:errcheck // hash.Write never errors
@@ -50,7 +55,10 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 
 	// Hash city-level pack directory contents (v1 Includes-based refs).
 	for _, ref := range cfg.Workspace.Includes {
-		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+		topoDir, ok := revisionPackDir(ref, cityRoot, cityRoot)
+		if !ok {
+			continue
+		}
 		topoHash := PackContentHashRecursive(fs, topoDir)
 		h.Write([]byte("city-pack:" + ref)) //nolint:errcheck // hash.Write never errors
 		h.Write([]byte{0})                  //nolint:errcheck // hash.Write never errors
@@ -63,6 +71,9 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	// an imported pack does not change the revision, so the reconciler
 	// never notices. Regression guard: gastownhall/gascity#779.
 	for _, dir := range cfg.PackDirs {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
 		topoHash := PackContentHashRecursive(fs, dir)
 		h.Write([]byte("city-packdir:" + dir)) //nolint:errcheck // hash.Write never errors
 		h.Write([]byte{0})                     //nolint:errcheck // hash.Write never errors
@@ -76,6 +87,9 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	sort.Strings(rigPackDirNames)
 	for _, rigName := range rigPackDirNames {
 		for _, dir := range cfg.RigPackDirs[rigName] {
+			if strings.TrimSpace(dir) == "" {
+				continue
+			}
 			topoHash := PackContentHashRecursive(fs, dir)
 			h.Write([]byte("rig-packdir:" + rigName + ":" + dir)) //nolint:errcheck // hash.Write never errors
 			h.Write([]byte{0})                                    //nolint:errcheck // hash.Write never errors
@@ -85,7 +99,7 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	}
 
 	// Hash convention-discovered city-pack trees so adding or editing
-	// agents/commands/doctor content changes the effective revision too.
+	// convention content changes the effective revision too.
 	for _, dir := range existingConventionDiscoveryDirsFS(fs, cityRoot) {
 		topoHash := PackContentHashRecursive(fs, dir)
 		h.Write([]byte("city-discovery:" + dir)) //nolint:errcheck // hash.Write never errors
@@ -97,67 +111,130 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// WatchDirs returns the set of directories that should be watched for
-// config changes. This includes the directory of each source file,
-// rig pack directories, and city-level pack directories.
-// Returns deduplicated, sorted paths.
-func WatchDirs(prov *Provenance, cfg *City, cityRoot string) []string {
-	seen := make(map[string]bool)
-	var dirs []string
+// WatchTarget describes a filesystem path that should be watched for config
+// changes and how much of its subtree participates in discovery.
+type WatchTarget struct {
+	Path                string
+	Recursive           bool
+	DiscoverConventions bool
+}
 
-	addDir := func(dir string) {
-		if dir != "" && !seen[dir] {
-			seen[dir] = true
-			dirs = append(dirs, dir)
+// WatchTargets returns the set of paths that should be watched for config
+// changes. Config source directories are shallow; city roots discover
+// convention subdirectories; pack roots and convention roots are recursive.
+// Returns deduplicated targets sorted by path.
+func WatchTargets(prov *Provenance, cfg *City, cityRoot string) []WatchTarget {
+	seen := make(map[string]int)
+	var targets []WatchTarget
+
+	addTarget := func(path string, recursive, discoverConventions bool) {
+		if path == "" {
+			return
 		}
+		if idx, ok := seen[path]; ok {
+			targets[idx].Recursive = targets[idx].Recursive || recursive
+			targets[idx].DiscoverConventions = targets[idx].DiscoverConventions || discoverConventions
+			return
+		}
+		seen[path] = len(targets)
+		targets = append(targets, WatchTarget{
+			Path:                path,
+			Recursive:           recursive,
+			DiscoverConventions: discoverConventions,
+		})
 	}
 
 	// Config source file directories.
 	if prov != nil {
 		for _, src := range prov.Sources {
-			addDir(filepath.Dir(src))
+			dir := filepath.Dir(src)
+			addTarget(dir, false, pathutil.SamePath(dir, cityRoot))
 		}
 	}
 
 	// Rig pack directories (v1 Includes-based refs).
 	for _, r := range cfg.Rigs {
 		for _, ref := range r.Includes {
-			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
-			addDir(topoDir)
+			topoDir, ok := revisionPackDir(ref, cityRoot, cityRoot)
+			if !ok {
+				continue
+			}
+			addTarget(topoDir, true, false)
 		}
 	}
 
 	// City-level pack directories (v1 Includes-based refs).
 	for _, ref := range cfg.Workspace.Includes {
-		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
-		addDir(topoDir)
+		topoDir, ok := revisionPackDir(ref, cityRoot, cityRoot)
+		if !ok {
+			continue
+		}
+		addTarget(topoDir, true, false)
 	}
 
-	// v2-resolved pack directories (populated by ExpandPacks from
-	// [imports.X] and [rigs.imports.X]). Without these, cities composing
-	// packs via v2 imports get zero fsnotify coverage for the imported
-	// pack tree — hot-reload silently breaks.
-	// Regression guard: gastownhall/gascity#779.
+	// v2-resolved pack directories populated by ExpandPacks from [imports.X]
+	// and [rigs.imports.X]. Regression guard: gastownhall/gascity#779.
 	for _, dir := range cfg.PackDirs {
-		addDir(dir)
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		addTarget(dir, true, false)
 	}
-	for _, rigDirs := range cfg.RigPackDirs {
-		for _, dir := range rigDirs {
-			addDir(dir)
+	rigPackDirNames := make([]string, 0, len(cfg.RigPackDirs))
+	for name := range cfg.RigPackDirs {
+		rigPackDirNames = append(rigPackDirNames, name)
+	}
+	sort.Strings(rigPackDirNames)
+	for _, rigName := range rigPackDirNames {
+		for _, dir := range cfg.RigPackDirs[rigName] {
+			if strings.TrimSpace(dir) == "" {
+				continue
+			}
+			addTarget(dir, true, false)
 		}
 	}
 
 	// Convention-discovered city-pack trees are loaded directly from the city
 	// root, so watch them too when they already exist.
 	for _, dir := range existingConventionDiscoveryDirsOS(cityRoot) {
-		addDir(dir)
+		addTarget(dir, true, false)
 	}
 
-	sort.Strings(dirs)
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Path < targets[j].Path
+	})
+	return targets
+}
+
+func revisionPackDir(ref, declDir, cityRoot string) (string, bool) {
+	if strings.TrimSpace(ref) == "" {
+		return "", false
+	}
+	dir, err := resolvePackRef(ref, declDir, cityRoot)
+	if err != nil || strings.TrimSpace(dir) == "" {
+		return "", false
+	}
+	return dir, true
+}
+
+// WatchDirs returns the deduplicated paths from WatchTargets. It is retained
+// for callers that only need the legacy path list.
+func WatchDirs(prov *Provenance, cfg *City, cityRoot string) []string {
+	targets := WatchTargets(prov, cfg, cityRoot)
+	dirs := make([]string, len(targets))
+	for i, target := range targets {
+		dirs[i] = target.Path
+	}
 	return dirs
 }
 
-var conventionDiscoveryDirNames = []string{"agents", "commands", "doctor"}
+var conventionDiscoveryDirNames = []string{"agents", "commands", "doctor", "formulas", "orders", "template-fragments", "skills", "mcp"}
+
+// ConventionDiscoveryDirNames returns the fixed top-level directory names
+// whose contents participate in convention-based pack discovery.
+func ConventionDiscoveryDirNames() []string {
+	return append([]string(nil), conventionDiscoveryDirNames...)
+}
 
 func existingConventionDiscoveryDirsFS(fs fsys.FS, cityRoot string) []string {
 	var dirs []string

--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -220,6 +221,51 @@ func TestWatchDirs_WithPack(t *testing.T) {
 	}
 }
 
+func TestWatchDirs_WithPackConventionRoots(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/gt/formulas/mol-test.formula.toml", "formula = \"mol-test\"\n")
+	writeFile(t, dir, "packs/gt/orders/test.order.toml", "name = \"test\"\n")
+
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+	cfg := &City{Rigs: []Rig{{Name: "hw", Path: "/hw", Includes: []string{"packs/gt"}}}}
+
+	dirs := WatchDirs(prov, cfg, dir)
+	for _, want := range []string{
+		filepath.Join(dir, "packs", "gt"),
+	} {
+		found := false
+		for _, got := range dirs {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("watch dirs = %v, want %q present", dirs, want)
+		}
+	}
+}
+
+func TestWatchTargets_WithPackConventionRoots(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "gt")
+	writeFile(t, dir, "packs/gt/formulas/mol-test.formula.toml", "formula = \"mol-test\"\n")
+	writeFile(t, dir, "packs/gt/orders/test.order.toml", "name = \"test\"\n")
+
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+	cfg := &City{Rigs: []Rig{{Name: "hw", Path: "/hw", Includes: []string{"packs/gt"}}}}
+
+	targets := WatchTargets(prov, cfg, dir)
+	assertWatchTarget(t, targets, dir, false, true)
+	assertWatchTarget(t, targets, packDir, true, false)
+	assertNoWatchTarget(t, targets, filepath.Join(packDir, "formulas"))
+	assertNoWatchTarget(t, targets, filepath.Join(packDir, "orders"))
+}
+
 func TestWatchDirs_WithCityPack(t *testing.T) {
 	dir := t.TempDir()
 	prov := &Provenance{
@@ -242,9 +288,14 @@ func TestWatchDirs_WithCityPack(t *testing.T) {
 
 func TestWatchDirs_IncludesConventionDiscoveryRoots(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, dir, "agents/mayor/prompt.template.md", "prompt\n")
+	writeFile(t, dir, "agents/sample-agent/prompt.template.md", "prompt\n")
 	writeFile(t, dir, "commands/reload/run.sh", "#!/bin/sh\n")
 	writeFile(t, dir, "doctor/runtime/run.sh", "#!/bin/sh\n")
+	writeFile(t, dir, "formulas/reload.formula.toml", "formula = \"reload\"\n")
+	writeFile(t, dir, "orders/reload.order.toml", "name = \"reload\"\n")
+	writeFile(t, dir, "template-fragments/footer.template.md", "{{ define \"footer\" }}ok{{ end }}\n")
+	writeFile(t, dir, "skills/review/SKILL.md", "# review\n")
+	writeFile(t, dir, "mcp/review.toml", "command = [\"review\"]\n")
 
 	prov := &Provenance{
 		Sources: []string{filepath.Join(dir, "city.toml")},
@@ -257,6 +308,11 @@ func TestWatchDirs_IncludesConventionDiscoveryRoots(t *testing.T) {
 		filepath.Join(dir, "agents"),
 		filepath.Join(dir, "commands"),
 		filepath.Join(dir, "doctor"),
+		filepath.Join(dir, "formulas"),
+		filepath.Join(dir, "orders"),
+		filepath.Join(dir, "template-fragments"),
+		filepath.Join(dir, "skills"),
+		filepath.Join(dir, "mcp"),
 	} {
 		found := false
 		for _, got := range dirs {
@@ -271,6 +327,96 @@ func TestWatchDirs_IncludesConventionDiscoveryRoots(t *testing.T) {
 	}
 }
 
+func TestWatchTargets_IncludesConventionDiscoveryRoots(t *testing.T) {
+	dir := t.TempDir()
+	for _, rel := range []string{
+		"agents/sample-agent/prompt.template.md",
+		"commands/reload/run.sh",
+		"doctor/runtime/run.sh",
+		"formulas/reload.formula.toml",
+		"orders/reload.order.toml",
+		"template-fragments/footer.template.md",
+		"skills/review/SKILL.md",
+		"mcp/review.toml",
+	} {
+		writeFile(t, dir, rel, "x\n")
+	}
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+
+	targets := WatchTargets(prov, &City{}, dir)
+	assertWatchTarget(t, targets, dir, false, true)
+	for _, name := range ConventionDiscoveryDirNames() {
+		assertWatchTarget(t, targets, filepath.Join(dir, name), true, false)
+	}
+}
+
+// Regression for gastownhall/gascity#779:
+// WatchTargets must include v2-resolved PackDirs / RigPackDirs, not only v1
+// include refs, or cities composing packs via [imports.X] get no fsnotify
+// coverage for imported pack trees.
+func TestWatchTargets_Regression779_IncludesV2ResolvedPackDirs(t *testing.T) {
+	dir := t.TempDir()
+	cityPack := filepath.Join(dir, "imported", "city-pack")
+	rigPack := filepath.Join(dir, "imported", "rig-pack")
+	writeFile(t, cityPack, "formulas/city.formula.toml", "formula = \"city\"\n")
+	writeFile(t, rigPack, "skills/rig/SKILL.md", "# rig\n")
+
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+	cfg := &City{
+		PackDirs: []string{cityPack},
+		RigPackDirs: map[string][]string{
+			"api-server": {rigPack},
+		},
+		Rigs: []Rig{{Name: "api-server", Path: "/srv/api"}},
+	}
+
+	targets := WatchTargets(prov, cfg, dir)
+	assertWatchTarget(t, targets, cityPack, true, false)
+	assertNoWatchTarget(t, targets, filepath.Join(cityPack, "formulas"))
+	assertWatchTarget(t, targets, rigPack, true, false)
+	assertNoWatchTarget(t, targets, filepath.Join(rigPack, "skills"))
+}
+
+func TestWatchTargets_SkipsEmptyPackDirsWithoutCWDConventionLeak(t *testing.T) {
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	cwd := t.TempDir()
+	if err := os.Mkdir(filepath.Join(cwd, "agents"), 0o755); err != nil {
+		t.Fatalf("Mkdir cwd agents: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("Chdir temp cwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	dir := t.TempDir()
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+	cfg := &City{
+		Workspace: Workspace{Includes: []string{""}},
+		PackDirs:  []string{""},
+		Rigs:      []Rig{{Name: "api", Path: "/api", Includes: []string{""}}},
+		RigPackDirs: map[string][]string{
+			"api": {""},
+		},
+	}
+
+	targets := WatchTargets(prov, cfg, dir)
+	assertNoWatchTarget(t, targets, "")
+	assertNoWatchTarget(t, targets, "agents")
+}
+
 // Regression for gastownhall/gascity#779:
 // WatchDirs iterated only the v1 Includes slices and ignored v2-resolved
 // PackDirs / RigPackDirs, so cities composing packs via [imports.X] or
@@ -281,7 +427,6 @@ func TestWatchDirs_Regression779_IncludesV2ResolvedPackDirs(t *testing.T) {
 	prov := &Provenance{
 		Sources: []string{filepath.Join(dir, "city.toml")},
 	}
-
 	cityPack := filepath.Join(dir, "imported", "city-pack")
 	rigPack := filepath.Join(dir, "imported", "rig-pack")
 
@@ -298,8 +443,8 @@ func TestWatchDirs_Regression779_IncludesV2ResolvedPackDirs(t *testing.T) {
 
 	for _, want := range []string{cityPack, rigPack} {
 		found := false
-		for _, d := range dirs {
-			if d == want {
+		for _, got := range dirs {
+			if got == want {
 				found = true
 				break
 			}
@@ -319,13 +464,9 @@ func TestRevision_Regression779_HashesV2ResolvedPackDirs(t *testing.T) {
 	writeFile(t, dir, "city.toml", `[workspace]
 name = "test"
 `)
-	packRel := filepath.Join("imported", "city-pack")
-	writeFile(t, dir, filepath.Join(packRel, "pack.toml"), `[pack]
-name = "imported"
-schema = 2
-`)
+	packAbs := filepath.Join(dir, "imported", "support")
+	writeFile(t, packAbs, "agents/helper/prompt.template.md", "first prompt\n")
 
-	packAbs := filepath.Join(dir, packRel)
 	prov := &Provenance{
 		Sources: []string{filepath.Join(dir, "city.toml")},
 	}
@@ -333,10 +474,7 @@ schema = 2
 
 	h1 := Revision(fsys.OSFS{}, prov, cfg, dir)
 
-	writeFile(t, dir, filepath.Join(packRel, "pack.toml"), `[pack]
-name = "imported-v2-changed"
-schema = 2
-`)
+	writeFile(t, packAbs, "agents/helper/prompt.template.md", "second prompt\n")
 
 	h2 := Revision(fsys.OSFS{}, prov, cfg, dir)
 	if h1 == h2 {
@@ -356,5 +494,28 @@ func TestWatchDirs_Deduplicates(t *testing.T) {
 	dirs := WatchDirs(prov, &City{}, dir)
 	if len(dirs) != 1 {
 		t.Errorf("got %d dirs, want 1 (deduplicated): %v", len(dirs), dirs)
+	}
+}
+
+func assertWatchTarget(t *testing.T, targets []WatchTarget, path string, recursive, discoverConventions bool) {
+	t.Helper()
+	for _, target := range targets {
+		if target.Path == path {
+			if target.Recursive != recursive || target.DiscoverConventions != discoverConventions {
+				t.Fatalf("target %q = {Recursive:%v DiscoverConventions:%v}, want {Recursive:%v DiscoverConventions:%v}; all targets: %#v",
+					path, target.Recursive, target.DiscoverConventions, recursive, discoverConventions, targets)
+			}
+			return
+		}
+	}
+	t.Fatalf("target %q not found in %#v", path, targets)
+}
+
+func assertNoWatchTarget(t *testing.T, targets []WatchTarget, path string) {
+	t.Helper()
+	for _, target := range targets {
+		if target.Path == path {
+			t.Fatalf("target %q unexpectedly found in %#v", path, targets)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes #780: `watchConfigDirs` in `cmd/gc/controller.go` called `watcher.Add(dir)` per seed only; fsnotify is non-recursive, so edits to pre-existing nested files (e.g. `agents/<name>/prompt.template.md`, `agents/<name>/overlay/settings.json`, `commands/<name>/run.sh`) fired no events at all. Hot reload silently broke for pack v2's convention layout.
- Walk each seed recursively with `filepath.WalkDir` and `watcher.Add` every directory we find, skipping `.gc/` and `.beads/` via the existing `shouldIgnoreConfigWatchEvent` filter.
- Extend the post-startup auto-add path so a new subdir's (possibly pre-populated) contents are also walked — matters for git-checkout-style bulk creates.

## Why
Students on the v2 migration path followed "edit `packs/architect/agents/architect/prompt.template.md` and see the next session use it" and got nothing. The 30s patrol tick also saw no revision change because no watcher event flipped the dirty bit. The only escape was `gc restart`, which defeats the hot-reload pedagogical promise.

The recursive walk is cheap (fsnotify handles used to scale to thousands on Linux; `shouldIgnoreConfigWatchEvent` already excludes the noisy `.gc/` and `.beads/` subtrees), and the existing `TestWatchConfigDirs_DetectsFileChangeAndSetsDirty` continues to pass — proving the post-startup auto-add flow still works.

## Test plan
- [x] New regression test: `TestWatchConfigDirs_Regression780_DetectsEditInPreExistingNestedSubdir` exercises two- and three-levels-deep edits; fails on main, passes after the fix.
- [x] Targeted test passes: `go test ./cmd/gc/ -run 'TestWatchConfigDirs_Regression780'`
- [x] Sibling watcher test still passes: `go test ./cmd/gc/ -run 'TestWatchConfigDirs'`
- [x] `go vet ./cmd/gc/` clean
- [x] `go build ./cmd/gc/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)