### PR TITLE
fix: skip restart request for named sessions on self-handoff

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 	"github.com/spf13/cobra"
 )
 
@@ -17,18 +19,26 @@ func newHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
 	var target string
 	cmd := &cobra.Command{
 		Use:   "handoff <subject> [message]",
-		Short: "Send handoff mail and restart this session",
+		Short: "Send handoff mail and restart controller-managed sessions",
 		Long: `Convenience command for context handoff.
 
-Self-handoff (default): sends mail to self and blocks until controller
-restarts the session. Equivalent to:
+Self-handoff (default): sends mail to self. If the current session is
+controller-restartable, requests a restart and blocks until the controller
+stops the session. For on-demand configured named sessions, sends mail and
+returns without requesting restart because the controller cannot restart the
+user-attended process.
+
+For controller-restartable sessions, equivalent to:
 
   gc mail send $GC_ALIAS <subject> [message]
   gc runtime request-restart
 
-Remote handoff (--target): sends mail to a target session and kills its
-session. The reconciler restarts it with the handoff mail waiting.
-Returns immediately. Equivalent to:
+Remote handoff (--target): sends mail to a target session. If the target is
+controller-restartable, kills it so the reconciler restarts it with the handoff
+mail waiting. For on-demand configured named targets, sends mail and returns
+without killing the session.
+
+For controller-restartable targets, equivalent to:
 
   gc mail send <target> <subject> [message]
   gc session kill <target>
@@ -43,7 +53,7 @@ GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&target, "target", "", "Remote session alias or ID to handoff (sends mail + kills session)")
+	cmd.Flags().StringVar(&target, "target", "", "Remote session alias or ID to handoff (kills only controller-restartable sessions)")
 	return cmd
 }
 
@@ -70,17 +80,20 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 	cfg, _ := loadCityConfig(current.cityPath)
 	persistRestart := sessionRestartPersister(current.cityPath, store, sp, cfg, current.sessionName)
 
-	code := doHandoff(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr)
-	if code != 0 {
-		return code
+	outcome := doHandoffWithOutcome(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr)
+	if outcome.code != 0 {
+		return outcome.code
+	}
+	if !outcome.restartRequested {
+		return 0
 	}
 
 	// Block forever. The controller will kill the entire process tree.
 	select {}
 }
 
-// cmdHandoffRemote sends handoff mail to a remote session and kills its runtime.
-// Returns immediately (non-blocking). The reconciler restarts the target.
+// cmdHandoffRemote sends handoff mail to a remote session and stops the target
+// only when the controller can restart it. Returns immediately.
 func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) int {
 	targetInfo, err := resolveSessionRuntimeTarget(target)
 	if err != nil {
@@ -111,11 +124,22 @@ func sessionRestartPersister(cityPath string, store beads.Store, sp runtime.Prov
 	}
 }
 
-// doHandoff sends a handoff mail to self and sets the restart-requested flag.
-// Testable: does not block.
+type handoffOutcome struct {
+	code             int
+	restartRequested bool
+}
+
+// doHandoff sends a handoff mail to self and requests restart when the
+// controller can restart the current session. Testable: does not block.
 func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
 	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer,
 ) int {
+	return doHandoffWithOutcome(store, rec, dops, persistRestart, sessionAddress, sessionName, args, stdout, stderr).code
+}
+
+func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
+	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer,
+) handoffOutcome {
 	subject := args[0]
 	var message string
 	if len(args) > 1 {
@@ -132,7 +156,7 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1}
 	}
 	rec.Record(events.Event{
 		Type:    events.MailSent,
@@ -142,25 +166,27 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 		Payload: mailEventPayload(nil),
 	})
 
-	// Named (human-attended) sessions are started by the user — the
-	// controller cannot respawn them after a restart request, so sending
-	// setRestartRequested would kill the session to a dead shell on every
-	// PreCompact tick. Preserve the handoff mail so context survives, but
-	// skip both restart flags. Regression guard: gastownhall/gascity#744.
-	if sessionIsNamed(store, sessionName) {
-		rec.Record(events.Event{
-			Type:    events.SessionDraining,
-			Actor:   sessionAddress,
-			Subject: sessionAddress,
-			Message: "handoff",
-		})
-		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session — restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
-		return 0
+	restartable, err := sessionRestartableByController(store, sessionName)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+		return handoffOutcome{code: 1}
+	}
+	// On-demand named sessions are human-attended and the controller cannot
+	// respawn their process after a restart request. Preserve the handoff
+	// mail so context survives, but skip both restart flags. Regression
+	// guard: gastownhall/gascity#744.
+	if !restartable {
+		if err := clearRestartRequest(store, dops, sessionName); err != nil {
+			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
+			return handoffOutcome{code: 1, restartRequested: false}
+		}
+		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session; restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
+		return handoffOutcome{code: 0, restartRequested: false}
 	}
 
 	if err := dops.setRestartRequested(sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1}
 	}
 	// Also persist the request through the worker boundary so it survives
 	// tmux session death. Non-fatal: the runtime flag above is primary.
@@ -177,35 +203,62 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 	})
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s, requesting restart...\n", b.ID) //nolint:errcheck // best-effort stdout
-	return 0
+	return handoffOutcome{code: 0, restartRequested: true}
 }
 
-// sessionIsNamed reports whether the open session bead for sessionName is
-// a configured named session (human-attended). Returns false if the store
-// is nil, the lookup errors, or no open bead matches — the caller falls
-// through to the default restart path, preserving legacy behavior.
-func sessionIsNamed(store beads.Store, sessionName string) bool {
+func sessionRestartableByController(store beads.Store, sessionName string) (bool, error) {
 	if store == nil || sessionName == "" {
-		return false
+		return true, nil
 	}
-	all, err := store.List(beads.ListQuery{Label: sessionBeadLabel})
+	id, err := resolveSessionID(store, sessionName)
 	if err != nil {
-		return false
-	}
-	for _, b := range all {
-		if b.Status == "closed" {
-			continue
+		if errors.Is(err, session.ErrSessionNotFound) {
+			return true, nil
 		}
-		if b.Metadata["session_name"] != sessionName {
-			continue
-		}
-		return isNamedSessionBead(b)
+		return false, fmt.Errorf("resolving session %q: %w", sessionName, err)
 	}
-	return false
+	b, err := store.Get(id)
+	if err != nil {
+		return false, fmt.Errorf("loading session %q: %w", id, err)
+	}
+	if !isNamedSessionBead(b) {
+		return true, nil
+	}
+	return namedSessionMode(b) == "always", nil
 }
 
-// doHandoffRemote sends handoff mail to a remote session and kills its runtime.
-// Non-blocking: returns immediately after killing the session.
+func clearRestartRequest(store beads.Store, dops drainOps, sessionName string) error {
+	if sessionName == "" {
+		return nil
+	}
+	var errs []error
+	if dops != nil {
+		if err := dops.clearRestartRequested(sessionName); err != nil {
+			errs = append(errs, fmt.Errorf("clearing runtime restart flag: %w", err))
+		}
+	}
+	if store == nil {
+		return errors.Join(errs...)
+	}
+	id, err := resolveSessionID(store, sessionName)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			return errors.Join(errs...)
+		}
+		errs = append(errs, fmt.Errorf("resolving session %q: %w", sessionName, err))
+		return errors.Join(errs...)
+	}
+	if err := store.SetMetadataBatch(id, map[string]string{
+		"restart_requested":          "",
+		"continuation_reset_pending": "",
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("clearing bead restart flag: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+// doHandoffRemote sends handoff mail to a remote session and stops the target
+// only when the controller can restart it.
 func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider,
 	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
 ) int {
@@ -235,6 +288,20 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 		Message: targetAddress,
 		Payload: mailEventPayload(nil),
 	})
+
+	restartable, err := sessionRestartableByController(store, sessionName)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !restartable {
+		if err := clearRestartRequest(store, newDrainOps(sp), sessionName); err != nil {
+			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (named session; kill skipped because the controller cannot restart it)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
+		return 0
+	}
 
 	// Kill target session (reconciler restarts it).
 	running, err := workerSessionTargetRunningWithConfig("", store, sp, nil, sessionName)

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -142,6 +142,22 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 		Payload: mailEventPayload(nil),
 	})
 
+	// Named (human-attended) sessions are started by the user — the
+	// controller cannot respawn them after a restart request, so sending
+	// setRestartRequested would kill the session to a dead shell on every
+	// PreCompact tick. Preserve the handoff mail so context survives, but
+	// skip both restart flags. Regression guard: gastownhall/gascity#744.
+	if sessionIsNamed(store, sessionName) {
+		rec.Record(events.Event{
+			Type:    events.SessionDraining,
+			Actor:   sessionAddress,
+			Subject: sessionAddress,
+			Message: "handoff",
+		})
+		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session — restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+
 	if err := dops.setRestartRequested(sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -162,6 +178,30 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s, requesting restart...\n", b.ID) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+// sessionIsNamed reports whether the open session bead for sessionName is
+// a configured named session (human-attended). Returns false if the store
+// is nil, the lookup errors, or no open bead matches — the caller falls
+// through to the default restart path, preserving legacy behavior.
+func sessionIsNamed(store beads.Store, sessionName string) bool {
+	if store == nil || sessionName == "" {
+		return false
+	}
+	all, err := store.List(beads.ListQuery{Label: sessionBeadLabel})
+	if err != nil {
+		return false
+	}
+	for _, b := range all {
+		if b.Status == "closed" {
+			continue
+		}
+		if b.Metadata["session_name"] != sessionName {
+			continue
+		}
+		return isNamedSessionBead(b)
+	}
+	return false
 }
 
 // doHandoffRemote sends handoff mail to a remote session and kills its runtime.

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
@@ -74,7 +78,7 @@ func TestHandoffSuccess(t *testing.T) {
 // gc handoff on a named (human-attended) session used to call
 // setRestartRequested unconditionally. The controller cannot respawn a
 // user-started session, so the PreCompact hook crashed the mayor to the
-// user's shell on every context compaction. doHandoff must recognise the
+// user's shell on every context compaction. doHandoff must recognize the
 // named-session case, still send the handoff mail, and skip both the
 // tmux and bead restart flags.
 func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
@@ -87,7 +91,7 @@ func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
 	// mayor). IsNamedSessionBead returns true for beads whose metadata
 	// contains configured_named_session="true".
 	b, err := store.Create(beads.Bead{
-		Type:   "agent_session",
+		Type:   sessionBeadType,
 		Labels: []string{"gc:session"},
 	})
 	if err != nil {
@@ -99,11 +103,28 @@ func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
 	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
 		t.Fatalf("set configured_named_session: %v", err)
 	}
+	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
+		t.Fatalf("set configured_named_mode: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "restart_requested", "true"); err != nil {
+		t.Fatalf("set restart_requested: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "continuation_reset_pending", "true"); err != nil {
+		t.Fatalf("set continuation_reset_pending: %v", err)
+	}
+	dops.restartRequested["mayor"] = true
 
-	code := doHandoff(store, rec, dops, "mayor", "mayor",
+	persistCalled := false
+	outcome := doHandoffWithOutcome(store, rec, dops, func() error {
+		persistCalled = true
+		return nil
+	}, "mayor", "mayor",
 		[]string{"HANDOFF: context full"}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	if outcome.restartRequested {
+		t.Fatal("restartRequested = true, want false for on-demand named session")
 	}
 
 	// Mail must still be sent — context preservation is the whole point.
@@ -122,21 +143,173 @@ func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
 	// Restart must NOT be requested — the controller can't respawn a
 	// user-started named session.
 	if dops.restartRequested["mayor"] {
-		t.Errorf("setRestartRequested(mayor) was called — named sessions must skip restart (gascity#744)")
+		t.Errorf("restart-requested flag is still set — named sessions must skip restart (gascity#744)")
+	}
+	if persistCalled {
+		t.Error("persistRestart was called — named sessions must skip persisted restart requests")
 	}
 
-	// Bead-level restart flag must also be absent.
+	// Bead-level restart flags must also be absent, including stale flags
+	// left behind by older handoff implementations.
 	refreshed, err := store.Get(b.ID)
 	if err != nil {
 		t.Fatalf("fetching seeded bead: %v", err)
 	}
-	if refreshed.Metadata["restart_requested"] == "true" {
-		t.Errorf("bead restart_requested set for named session — should be skipped (gascity#744)")
+	if refreshed.Metadata["restart_requested"] != "" {
+		t.Errorf("bead restart_requested = %q, want cleared for named session", refreshed.Metadata["restart_requested"])
+	}
+	if refreshed.Metadata["continuation_reset_pending"] != "" {
+		t.Errorf("continuation_reset_pending = %q, want cleared for named session", refreshed.Metadata["continuation_reset_pending"])
 	}
 
 	// Stdout should not promise a restart the controller can't deliver.
 	if strings.Contains(stdout.String(), "requesting restart") {
 		t.Errorf("stdout = %q, must not promise a restart for named sessions", stdout.String())
+	}
+	if len(rec.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Type != events.MailSent {
+		t.Fatalf("event[0].Type = %q, want %q", rec.Events[0].Type, events.MailSent)
+	}
+}
+
+func TestDoHandoff_NamedSessionClearRestartFailureReturnsError(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	dops.err = errors.New("tmux borked")
+	var stdout, stderr bytes.Buffer
+
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+		t.Fatalf("set session_name: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+		t.Fatalf("set configured_named_session: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
+		t.Fatalf("set configured_named_mode: %v", err)
+	}
+
+	outcome := doHandoffWithOutcome(store, rec, dops, nil, "mayor", "mayor",
+		[]string{"HANDOFF: context full"}, &stdout, &stderr)
+	if outcome.code != 1 {
+		t.Fatalf("code = %d, want 1", outcome.code)
+	}
+	if outcome.restartRequested {
+		t.Fatal("restartRequested = true, want false")
+	}
+	if !strings.Contains(stderr.String(), "clearing stale restart request") {
+		t.Fatalf("stderr = %q, want stale restart cleanup error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "restart skipped") {
+		t.Fatalf("stdout = %q, must not report success when cleanup fails", stdout.String())
+	}
+}
+
+func TestDoHandoff_NamedAlwaysSessionRequestsRestart(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+		t.Fatalf("set session_name: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+		t.Fatalf("set configured_named_session: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_mode", "always"); err != nil {
+		t.Fatalf("set configured_named_mode: %v", err)
+	}
+
+	persistCalled := false
+	outcome := doHandoffWithOutcome(store, rec, dops, func() error {
+		persistCalled = true
+		return nil
+	}, "mayor", "mayor", []string{"HANDOFF: context full"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	if !outcome.restartRequested {
+		t.Fatal("restartRequested = false, want true for always-mode named session")
+	}
+	if !dops.restartRequested["mayor"] {
+		t.Error("restart-requested flag not set for always-mode named session")
+	}
+	if !persistCalled {
+		t.Error("persistRestart was not called for always-mode named session")
+	}
+	if len(rec.Events) != 2 {
+		t.Fatalf("got %d events, want 2", len(rec.Events))
+	}
+	if rec.Events[1].Type != events.SessionDraining {
+		t.Fatalf("event[1].Type = %q, want %q", rec.Events[1].Type, events.SessionDraining)
+	}
+}
+
+func TestCmdHandoff_Regression744_NamedSessionReturnsWithoutBlocking(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+		t.Fatalf("set session_name: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+		t.Fatalf("set configured_named_session: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
+		t.Fatalf("set configured_named_mode: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- cmdHandoff([]string{"HANDOFF: context full"}, "", &stdout, &stderr)
+	}()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cmdHandoff blocked for named on-demand session")
+	}
+	if !strings.Contains(stdout.String(), "restart skipped") {
+		t.Fatalf("stdout = %q, want restart skipped confirmation", stdout.String())
 	}
 }
 
@@ -261,6 +434,75 @@ func TestHandoffRemoteRunning(t *testing.T) {
 	// Verify stdout says killed.
 	if !strings.Contains(stdout.String(), "killed session") {
 		t.Errorf("stdout = %q, want 'killed session'", stdout.String())
+	}
+}
+
+func TestHandoffRemoteNamedOnDemandSkipsKill(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "mayor", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+		t.Fatalf("set session_name: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+		t.Fatalf("set configured_named_session: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
+		t.Fatalf("set configured_named_mode: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "restart_requested", "true"); err != nil {
+		t.Fatalf("set restart_requested: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "continuation_reset_pending", "true"); err != nil {
+		t.Fatalf("set continuation_reset_pending: %v", err)
+	}
+	if err := sp.SetMeta("mayor", "GC_RESTART_REQUESTED", "1"); err != nil {
+		t.Fatalf("set runtime restart meta: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHandoffRemote(store, rec, sp, "mayor", "mayor", "deacon",
+		[]string{"Context refresh", "Please pick this up manually"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !sp.IsRunning("mayor") {
+		t.Error("named on-demand target should still be running")
+	}
+	if len(rec.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Type != events.MailSent {
+		t.Fatalf("event[0].Type = %q, want %q", rec.Events[0].Type, events.MailSent)
+	}
+	if strings.Contains(stdout.String(), "killed session") {
+		t.Errorf("stdout = %q, must not report killing a named on-demand session", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "named session") {
+		t.Errorf("stdout = %q, want named-session skip confirmation", stdout.String())
+	}
+	refreshed, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("fetching seeded bead: %v", err)
+	}
+	if refreshed.Metadata["restart_requested"] != "" {
+		t.Errorf("bead restart_requested = %q, want cleared for named target", refreshed.Metadata["restart_requested"])
+	}
+	if refreshed.Metadata["continuation_reset_pending"] != "" {
+		t.Errorf("continuation_reset_pending = %q, want cleared for named target", refreshed.Metadata["continuation_reset_pending"])
+	}
+	if got, err := sp.GetMeta("mayor", "GC_RESTART_REQUESTED"); err != nil || got != "" {
+		t.Errorf("runtime restart meta = %q, err=%v; want cleared", got, err)
 	}
 }
 

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -70,6 +70,76 @@ func TestHandoffSuccess(t *testing.T) {
 	}
 }
 
+// Regression for gastownhall/gascity#744:
+// gc handoff on a named (human-attended) session used to call
+// setRestartRequested unconditionally. The controller cannot respawn a
+// user-started session, so the PreCompact hook crashed the mayor to the
+// user's shell on every context compaction. doHandoff must recognise the
+// named-session case, still send the handoff mail, and skip both the
+// tmux and bead restart flags.
+func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	// Seed a session bead marked as a configured named session (i.e. the
+	// mayor). IsNamedSessionBead returns true for beads whose metadata
+	// contains configured_named_session="true".
+	b, err := store.Create(beads.Bead{
+		Type:   "agent_session",
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+		t.Fatalf("set session_name: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+		t.Fatalf("set configured_named_session: %v", err)
+	}
+
+	code := doHandoff(store, rec, dops, "mayor", "mayor",
+		[]string{"HANDOFF: context full"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	// Mail must still be sent — context preservation is the whole point.
+	mailFound := false
+	all, _ := store.ListOpen()
+	for _, got := range all {
+		if got.Title == "HANDOFF: context full" && got.Type == "message" {
+			mailFound = true
+			break
+		}
+	}
+	if !mailFound {
+		t.Fatalf("handoff mail not created; beads=%v", all)
+	}
+
+	// Restart must NOT be requested — the controller can't respawn a
+	// user-started named session.
+	if dops.restartRequested["mayor"] {
+		t.Errorf("setRestartRequested(mayor) was called — named sessions must skip restart (gascity#744)")
+	}
+
+	// Bead-level restart flag must also be absent.
+	refreshed, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("fetching seeded bead: %v", err)
+	}
+	if refreshed.Metadata["restart_requested"] == "true" {
+		t.Errorf("bead restart_requested set for named session — should be skipped (gascity#744)")
+	}
+
+	// Stdout should not promise a restart the controller can't deliver.
+	if strings.Contains(stdout.String(), "requesting restart") {
+		t.Errorf("stdout = %q, must not promise a restart for named sessions", stdout.String())
+	}
+}
+
 func TestHandoffWithMessage(t *testing.T) {
 	store := beads.NewMemStore()
 	rec := events.NewFake()

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -98,7 +98,11 @@ func (o *providerDrainOps) isRestartRequested(sessionName string) (bool, error) 
 }
 
 func (o *providerDrainOps) clearRestartRequested(sessionName string) error {
-	return o.sp.RemoveMeta(sessionName, "GC_RESTART_REQUESTED")
+	err := o.sp.RemoveMeta(sessionName, "GC_RESTART_REQUESTED")
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
 }
 
 func (o *providerDrainOps) setDriftRestart(sessionName string) error {
@@ -367,6 +371,11 @@ The controller will stop the session on its next reconcile tick and
 restart it fresh. The blocking prevents the agent from consuming more
 context while waiting.
 
+For on-demand configured named sessions, the controller cannot restart the
+user-attended process. In that case this command reports that restart was
+skipped and returns without blocking. No session.draining event is emitted
+when restart is skipped.
+
 This command is designed to be called from within a session context.
 It emits a session.draining event before blocking.`,
 		Args: cobra.NoArgs,
@@ -386,12 +395,27 @@ func cmdRuntimeRequestRestart(stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	sp := newSessionProvider()
+	dops := newDrainOps(sp)
 	store, storeErr := openCityStoreAt(current.cityPath)
 	if storeErr != nil {
 		fmt.Fprintf(stderr, "gc runtime request-restart: opening store: %v\n", storeErr) //nolint:errcheck // best-effort stderr
 	}
-	sp := newSessionProvider()
-	dops := newDrainOps(sp)
+	if store != nil {
+		restartable, err := sessionRestartableByController(store, current.sessionName)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc runtime request-restart: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if !restartable {
+			if err := clearRestartRequest(store, dops, current.sessionName); err != nil {
+				fmt.Fprintf(stderr, "gc runtime request-restart: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			fmt.Fprintln(stdout, "Restart skipped for named session; controller cannot restart on-demand named sessions.") //nolint:errcheck // best-effort stdout
+			return 0
+		}
+	}
 	rec := openCityRecorderAt(current.cityPath, stderr)
 	cfg, _ := loadCityConfig(current.cityPath)
 	var persistRestart func() error

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -413,6 +414,77 @@ func TestRequestRestartAcceptsNoArgs(t *testing.T) {
 	}
 }
 
+func TestRuntimeRequestRestartNamedOnDemandReturnsWithoutBlocking(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
+		t.Fatalf("set session_name: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
+		t.Fatalf("set configured_named_session: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
+		t.Fatalf("set configured_named_mode: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "restart_requested", "true"); err != nil {
+		t.Fatalf("set restart_requested: %v", err)
+	}
+	if err := store.SetMetadata(b.ID, "continuation_reset_pending", "true"); err != nil {
+		t.Fatalf("set continuation_reset_pending: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- cmdRuntimeRequestRestart(&stdout, &stderr)
+	}()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cmdRuntimeRequestRestart blocked for named on-demand session")
+	}
+	if !strings.Contains(stdout.String(), "Restart skipped for named session") {
+		t.Fatalf("stdout = %q, want restart skipped confirmation", stdout.String())
+	}
+	freshStore, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	refreshed, err := freshStore.Get(b.ID)
+	if err != nil {
+		t.Fatalf("fetching seeded bead: %v", err)
+	}
+	if refreshed.Metadata["restart_requested"] != "" {
+		t.Fatalf("restart_requested = %q, want cleared", refreshed.Metadata["restart_requested"])
+	}
+	if refreshed.Metadata["continuation_reset_pending"] != "" {
+		t.Fatalf("continuation_reset_pending = %q, want cleared", refreshed.Metadata["continuation_reset_pending"])
+	}
+}
+
 func TestProviderDrainOpsRestartRequestedRoundTrip(t *testing.T) {
 	sp := runtime.NewFake()
 	_ = sp.Start(context.Background(), "worker", runtime.Config{})
@@ -440,6 +512,35 @@ func TestProviderDrainOpsRestartRequestedRoundTrip(t *testing.T) {
 	requested, _ = dops.isRestartRequested("worker")
 	if requested {
 		t.Error("should not be restart-requested after clear")
+	}
+}
+
+type removeMetaErrorProvider struct {
+	*runtime.Fake
+	err error
+}
+
+func (p *removeMetaErrorProvider) RemoveMeta(_, _ string) error {
+	return p.err
+}
+
+func TestProviderDrainOpsClearRestartRequestedIgnoresGoneSession(t *testing.T) {
+	dops := newDrainOps(&removeMetaErrorProvider{
+		Fake: runtime.NewFake(),
+		err:  errors.New("no tmux server running"),
+	})
+	if err := dops.clearRestartRequested("worker"); err != nil {
+		t.Fatalf("clearRestartRequested returned gone-session error: %v", err)
+	}
+}
+
+func TestProviderDrainOpsClearRestartRequestedReturnsCleanupErrors(t *testing.T) {
+	dops := newDrainOps(&removeMetaErrorProvider{
+		Fake: runtime.NewFake(),
+		err:  errors.New("permission denied"),
+	})
+	if err := dops.clearRestartRequested("worker"); err == nil {
+		t.Fatal("clearRestartRequested should return non-gone cleanup errors")
 	}
 }
 

--- a/cmd/gc/testdata/gastown-handoff.txtar
+++ b/cmd/gc/testdata/gastown-handoff.txtar
@@ -16,11 +16,11 @@ cd $WORK/handofftown
 ! exec gc handoff 'Context refresh'
 stderr 'not in session context'
 
-# --- 2. Remote handoff to existing agent (session not running) ---
+# --- 2. Remote handoff to existing on-demand named agent ---
 
 exec gc handoff --target mayor 'Context refresh' 'Please review inbox for latest status'
 stdout 'Handoff.*sent mail.*to mayor'
-stdout 'session not running'
+stdout 'named session; kill skipped'
 
 # --- 3. Remote handoff creates mail ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,7 +33,7 @@ gc [flags]
 | [gc events](#gc-events) | Show events from the GC API |
 | [gc formula](#gc-formula) | Manage and inspect formulas |
 | [gc graph](#gc-graph) | Show dependency graph for beads |
-| [gc handoff](#gc-handoff) | Send handoff mail and restart this session |
+| [gc handoff](#gc-handoff) | Send handoff mail and restart controller-managed sessions |
 | [gc help](#gc-help) | Help about any command |
 | [gc hook](#gc-hook) | Check for available work (use --inject for Stop hook output) |
 | [gc import](#gc-import) | Manage pack imports |
@@ -948,15 +948,23 @@ gc graph gc-42               # expand convoy children
 
 Convenience command for context handoff.
 
-Self-handoff (default): sends mail to self and blocks until controller
-restarts the session. Equivalent to:
+Self-handoff (default): sends mail to self. If the current session is
+controller-restartable, requests a restart and blocks until the controller
+stops the session. For on-demand configured named sessions, sends mail and
+returns without requesting restart because the controller cannot restart the
+user-attended process.
+
+For controller-restartable sessions, equivalent to:
 
   gc mail send $GC_ALIAS &lt;subject&gt; [message]
   gc runtime request-restart
 
-Remote handoff (--target): sends mail to a target session and kills its
-session. The reconciler restarts it with the handoff mail waiting.
-Returns immediately. Equivalent to:
+Remote handoff (--target): sends mail to a target session. If the target is
+controller-restartable, kills it so the reconciler restarts it with the handoff
+mail waiting. For on-demand configured named targets, sends mail and returns
+without killing the session.
+
+For controller-restartable targets, equivalent to:
 
   gc mail send &lt;target&gt; &lt;subject&gt; [message]
   gc session kill &lt;target&gt;
@@ -970,7 +978,7 @@ gc handoff <subject> [message] [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--target` | string |  | Remote session alias or ID to handoff (sends mail + kills session) |
+| `--target` | string |  | Remote session alias or ID to handoff (kills only controller-restartable sessions) |
 
 ## gc help
 
@@ -1841,6 +1849,11 @@ Sets GC_RESTART_REQUESTED metadata on the session, then blocks forever.
 The controller will stop the session on its next reconcile tick and
 restart it fresh. The blocking prevents the agent from consuming more
 context while waiting.
+
+For on-demand configured named sessions, the controller cannot restart the
+user-attended process. In that case this command reports that restart was
+skipped and returns without blocking. No session.draining event is emitted
+when restart is skipped.
 
 This command is designed to be called from within a session context.
 It emits a session.draining event before blocking.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -58,7 +58,8 @@ func IsSessionGone(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "session not found") ||
 		strings.Contains(msg, "not running") ||
-		strings.Contains(msg, "not found")
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "no tmux server running")
 }
 
 // ContentBlock represents a content element in a message.


### PR DESCRIPTION
## Summary
- Fixes #744: the default `PreCompact` hook runs `gc handoff "context cycle"`, which called `setRestartRequested` unconditionally. Named (human-attended) sessions like the mayor are started by the user, and the controller cannot respawn them — so every context compaction killed Claude Code to the user's shell.
- Before requesting a restart, `doHandoff` now looks up the open session bead for the current session and skips both the tmux and bead restart flags when the bead is a configured named session. Mail is still sent — context preservation was the whole point.

## Why
The fix the issue describes — "check whether the current session is a named session, if so skip the restart and return after sending the mail" — matches what I did. `isNamedSessionBead` (the existing helper from `cmd/gc/named_sessions.go`) returns true when `Metadata["configured_named_session"] == "true"`. A new local helper `sessionIsNamed(store, sessionName)` scans open session beads by the existing `gc:session` label and returns true only for a positive match, so pool sessions (which either have no bead at all or a non-named one) stay on the old restart path.

## Test plan
- [x] New regression test: `TestDoHandoff_Regression744_NamedSessionSkipsRestart` in `cmd/gc/cmd_handoff_test.go` seeds a named-session bead and asserts mail is created, `dops.restartRequested` is NOT set, bead `restart_requested` is NOT set, and stdout does not promise a restart. Fails on main, passes after the fix.
- [x] Sibling tests pass: `go test ./cmd/gc/ -run 'TestHandoff|TestDoHandoff'` — the pre-existing `TestHandoffSuccess` / `TestHandoffWithMessage` / `TestHandoffRemote*` all continue to pass.
- [x] `go vet ./cmd/gc/` clean.
- [x] `go build ./cmd/gc/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)