### PR TITLE
fix: allow root named sessions to target imported PackV2 templates

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2343,8 +2343,8 @@ func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
 		}
 		if !validNamedSessionTemplate.MatchString(s.Template) {
 			return fmt.Errorf(
-				"named_session[%d]: template %q must be an agent template name like %q or %q",
-				i, s.Template, "mayor", "employees.penny",
+				"named_session[%d]: template %q must be an agent template name like %q or a binding-qualified name like %q",
+				i, s.Template, "agent", "binding.agent",
 			)
 		}
 		if s.Name != "" && !validAgentName.MatchString(s.Name) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,12 @@ import (
 // or underscores. Slashes, spaces, and dots are not allowed.
 var validAgentName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
+// validNamedSessionTemplate matches a named_session template reference.
+// Root-authored named sessions may target imported PackV2 templates by
+// binding-qualified name ("binding.agent"), while rig scope is carried
+// separately by NamedSession.Dir during pack expansion.
+var validNamedSessionTemplate = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*(\.[a-zA-Z0-9][a-zA-Z0-9_-]*)?$`)
+
 const (
 	// ControlDispatcherAgentName is the built-in deterministic control lane for
 	// graph.v2 workflow control beads.
@@ -2335,8 +2341,11 @@ func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
 		if s.Template == "" {
 			return fmt.Errorf("named_session[%d]: template is required", i)
 		}
-		if !validAgentName.MatchString(s.Template) {
-			return fmt.Errorf("named_session[%d]: template %q must match [a-zA-Z0-9][a-zA-Z0-9_-]*", i, s.Template)
+		if !validNamedSessionTemplate.MatchString(s.Template) {
+			return fmt.Errorf(
+				"named_session[%d]: template %q must be an agent template name like %q or %q",
+				i, s.Template, "mayor", "employees.penny",
+			)
 		}
 		if s.Name != "" && !validAgentName.MatchString(s.Name) {
 			return fmt.Errorf("named_session[%d]: name %q must match [a-zA-Z0-9][a-zA-Z0-9_-]*", i, s.Name)

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -1433,6 +1433,57 @@ scope = "city"
 	t.Error("polecat named session not found")
 }
 
+func TestImport_RootNamedSessionCanTargetImportedTemplate(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "employees-pack")
+
+	for _, d := range []string{cityDir, packDir} {
+		mustMkdirAll(t, d, 0o755)
+	}
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "corp"
+`)
+	writeTestFile(t, cityDir, "pack.toml", `
+[pack]
+name = "corp"
+schema = 2
+
+[imports.employees]
+source = "../employees-pack"
+
+[[named_session]]
+template = "employees.penny"
+name = "corp--penny-root"
+mode = "on_demand"
+`)
+	writeTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "employees-pack"
+schema = 2
+
+[[agent]]
+name = "penny"
+scope = "city"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	if got := cfg.NamedSessions[0].TemplateQualifiedName(); got != "employees.penny" {
+		t.Fatalf("TemplateQualifiedName() = %q, want employees.penny", got)
+	}
+	if agent := FindAgent(cfg, cfg.NamedSessions[0].TemplateQualifiedName()); agent == nil {
+		t.Fatal("FindAgent() = nil, want imported employees.penny template")
+	} else if got := agent.QualifiedName(); got != "employees.penny" {
+		t.Fatalf("QualifiedName() = %q, want employees.penny", got)
+	}
+}
+
 func TestImport_ReExportNestedPreservesInnerBinding(t *testing.T) {
 	// outer exports inner, inner imports util (not exported).
 	// Agents from inner should be flattened to outer's binding.

--- a/internal/config/session_sleep_test.go
+++ b/internal/config/session_sleep_test.go
@@ -276,3 +276,22 @@ func TestValidateNamedSessions_UsesResolvedWorkspaceName(t *testing.T) {
 		t.Fatalf("ValidateNamedSessions() error = %v, want session_name collision", err)
 	}
 }
+
+func TestValidateNamedSessions_AllowsQualifiedImportedTemplate(t *testing.T) {
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Agents: []Agent{
+			{Name: "penny", BindingName: "employees"},
+		},
+		NamedSessions: []NamedSession{
+			{Name: "corp--penny-root", Template: "employees.penny"},
+		},
+	}
+
+	if err := ValidateNamedSessions(cfg); err != nil {
+		t.Fatalf("ValidateNamedSessions() = %v, want nil", err)
+	}
+	if got := cfg.NamedSessions[0].TemplateQualifiedName(); got != "employees.penny" {
+		t.Fatalf("TemplateQualifiedName() = %q, want employees.penny", got)
+	}
+}

--- a/internal/config/session_sleep_test.go
+++ b/internal/config/session_sleep_test.go
@@ -295,3 +295,86 @@ func TestValidateNamedSessions_AllowsQualifiedImportedTemplate(t *testing.T) {
 		t.Fatalf("TemplateQualifiedName() = %q, want employees.penny", got)
 	}
 }
+
+func TestValidateNamedSessions_RejectsMalformedQualifiedTemplates(t *testing.T) {
+	tests := []string{
+		".penny",
+		"employees.",
+		"employees..penny",
+		"employees.penny.extra",
+	}
+
+	for _, template := range tests {
+		t.Run(template, func(t *testing.T) {
+			cfg := &City{
+				Workspace: Workspace{Name: "test-city"},
+				Agents: []Agent{
+					{Name: "penny", BindingName: "employees"},
+				},
+				NamedSessions: []NamedSession{
+					{Name: "corp--penny-root", Template: template},
+				},
+			}
+
+			if err := ValidateNamedSessions(cfg); err == nil {
+				t.Fatal("ValidateNamedSessions() = nil, want malformed template error")
+			}
+		})
+	}
+}
+
+func TestValidateNamedSessions_TemplateErrorUsesStructuralExamples(t *testing.T) {
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Agents: []Agent{
+			{Name: "worker"},
+		},
+		NamedSessions: []NamedSession{
+			{Name: "corp--worker-root", Template: "workers.worker.extra"},
+		},
+	}
+
+	err := ValidateNamedSessions(cfg)
+	if err == nil {
+		t.Fatal("ValidateNamedSessions() = nil, want malformed template error")
+	}
+	msg := err.Error()
+	for _, forbidden := range []string{"mayor", "employees.penny"} {
+		if strings.Contains(msg, forbidden) {
+			t.Fatalf("ValidateNamedSessions() error = %q, should not contain concrete role example %q", msg, forbidden)
+		}
+	}
+	for _, want := range []string{"agent", "binding.agent"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("ValidateNamedSessions() error = %q, want structural example %q", msg, want)
+		}
+	}
+}
+
+func TestValidateNamedSessions_QualifiedTemplateWithoutNameUsesQualifiedIdentity(t *testing.T) {
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Agents: []Agent{
+			{Name: "penny", BindingName: "employees"},
+		},
+		NamedSessions: []NamedSession{
+			{Template: "employees.penny"},
+		},
+	}
+
+	if err := ValidateNamedSessions(cfg); err != nil {
+		t.Fatalf("ValidateNamedSessions() = %v, want nil", err)
+	}
+	if got := cfg.NamedSessions[0].IdentityName(); got != "employees.penny" {
+		t.Fatalf("IdentityName() = %q, want employees.penny", got)
+	}
+	if got := cfg.NamedSessions[0].QualifiedName(); got != "employees.penny" {
+		t.Fatalf("QualifiedName() = %q, want employees.penny", got)
+	}
+	if got := cfg.NamedSessions[0].TemplateQualifiedName(); got != "employees.penny" {
+		t.Fatalf("TemplateQualifiedName() = %q, want employees.penny", got)
+	}
+	if got := FindNamedSession(cfg, "employees.penny"); got == nil {
+		t.Fatal("FindNamedSession(employees.penny) = nil, want named session")
+	}
+}


### PR DESCRIPTION
## Summary

- Supersedes #902.
- Closes #804.
- Allows root-authored `[[named_session]]` entries to reference imported PackV2 agent templates with binding-qualified names such as `employees.penny`.
- Adds maintainer review fixups that tighten malformed-template coverage, pin the unnamed qualified-template identity behavior, and keep validation error copy role-agnostic.

Credit: Original fix by @julianknutsen. The original commit is preserved with original authorship.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test ./internal/config`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc -run '^TestCmdMailInbox_ManagedExecLifecycleProviderRecoversAfterHardKillPortRebind$' -count=1 -timeout=3m`
- [ ] `go test ./...` timed out in unrelated `cmd/gc` slow test during the full package sweep; the timed-out test passed in isolation and `make check` passed.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No breaking changes or migration steps are required. No docs change was needed because `docs/guides/shareable-packs.md` already documents imported qualified names for `named_session.template`.
