### PR TITLE
fix: throttle reconciler drain log on stuck drains (#855)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -307,12 +307,12 @@ func reconcileSessionBeadsTraced(
 					if configuredNames[name] {
 						reason = "suspended"
 					}
-					template := normalizedSessionTemplate(*session, cfg)
-					if template == "" {
-						template = session.Metadata["template"]
-					}
 					if beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout) {
 						if trace != nil {
+							template := normalizedSessionTemplate(*session, cfg)
+							if template == "" {
+								template = session.Metadata["template"]
+							}
 							trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "drain", traceRecordPayload{
 								"store_query_partial": storeQueryPartial,
 								"provider_alive":      providerAlive,

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -311,14 +311,15 @@ func reconcileSessionBeadsTraced(
 					if template == "" {
 						template = session.Metadata["template"]
 					}
-					if trace != nil {
-						trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "drain", traceRecordPayload{
-							"store_query_partial": storeQueryPartial,
-							"provider_alive":      providerAlive,
-						}, nil, "")
+					if beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout) {
+						if trace != nil {
+							trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "drain", traceRecordPayload{
+								"store_query_partial": storeQueryPartial,
+								"provider_alive":      providerAlive,
+							}, nil, "")
+						}
+						fmt.Fprintf(stdout, "Draining session '%s': %s\n", name, reason) //nolint:errcheck
 					}
-					beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout)
-					fmt.Fprintf(stdout, "Draining session '%s': %s\n", name, reason) //nolint:errcheck
 				} else {
 					// Not running and not desired — close the bead.
 					reason := "orphaned"
@@ -629,20 +630,21 @@ func reconcileSessionBeadsTraced(
 						if ddt <= 0 {
 							ddt = defaultDrainTimeout
 						}
-						beginSessionDrain(*session, sp, dt, "config-drift", clk, ddt)
-						fmt.Fprintf(stdout, "Draining session '%s': config-drift\n", name) //nolint:errcheck
-						if trace != nil {
-							trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", traceRecordPayload{
-								"stored_hash":  storedHash,
-								"current_hash": currentHash,
-							}, nil, "")
+						if beginSessionDrain(*session, sp, dt, "config-drift", clk, ddt) {
+							fmt.Fprintf(stdout, "Draining session '%s': config-drift\n", name) //nolint:errcheck
+							if trace != nil {
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", traceRecordPayload{
+									"stored_hash":  storedHash,
+									"current_hash": currentHash,
+								}, nil, "")
+							}
+							rec.Record(events.Event{
+								Type:    events.SessionDraining,
+								Actor:   "gc",
+								Subject: tp.DisplayName(),
+								Message: "config drift detected",
+							})
 						}
-						rec.Record(events.Event{
-							Type:    events.SessionDraining,
-							Actor:   "gc",
-							Subject: tp.DisplayName(),
-							Message: "config drift detected",
-						})
 						continue
 					}
 
@@ -860,12 +862,13 @@ func reconcileSessionBeadsTraced(
 					markIdleSleepPending(target.session, store)
 				}
 			}
-			beginSessionDrain(*target.session, sp, dt, reason, clk, defaultDrainTimeout)
-			fmt.Fprintf(stdout, "Draining session '%s': %s\n", target.session.Metadata["session_name"], reason) //nolint:errcheck
-			if trace != nil {
-				trace.recordDecision("reconciler.session.drain", target.tp.TemplateName, target.session.Metadata["session_name"], reason, "drain", traceRecordPayload{
-					"sleep_intent": intent,
-				}, nil, "")
+			if beginSessionDrain(*target.session, sp, dt, reason, clk, defaultDrainTimeout) {
+				fmt.Fprintf(stdout, "Draining session '%s': %s\n", target.session.Metadata["session_name"], reason) //nolint:errcheck
+				if trace != nil {
+					trace.recordDecision("reconciler.session.drain", target.tp.TemplateName, target.session.Metadata["session_name"], reason, "drain", traceRecordPayload{
+						"sleep_intent": intent,
+					}, nil, "")
+				}
 			}
 		}
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -1602,6 +1603,36 @@ func TestReconcileSessionBeads_OrphanSessionDrained(t *testing.T) {
 	}
 	if ds.reason != "orphaned" {
 		t.Errorf("drain reason = %q, want %q", ds.reason, "orphaned")
+	}
+}
+
+// TestReconcileSessionBeads_OrphanDrainLogThrottled covers issue #855:
+// once a session is draining, the reconciler must not re-emit
+// "Draining session '...': orphaned" on every subsequent tick. The
+// drainTracker is idempotent, so a pre-existing drain entry means the
+// reconciler tick is a no-op with respect to state — the user-visible
+// log must reflect that.
+func TestReconcileSessionBeads_OrphanDrainLogThrottled(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "other"}}}
+	_ = env.sp.Start(context.Background(), "orphan", runtime.Config{})
+	session := env.createSessionBead("orphan", "orphan")
+
+	// Simulate a drain that was begun on a prior tick and has not yet
+	// converged (e.g., in-progress work beads still assigned to the
+	// session block its bead from closing — the exact loop described
+	// in #855).
+	env.dt.set(session.ID, &drainState{
+		startedAt:  env.clk.Now(),
+		deadline:   env.clk.Now().Add(defaultDrainTimeout),
+		reason:     "orphaned",
+		generation: 1,
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	if got := env.stdout.String(); strings.Contains(got, "Draining session 'orphan'") {
+		t.Errorf("stdout contains redundant drain log on repeat tick:\n%s", got)
 	}
 }
 

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -112,6 +112,12 @@ func validateWorkDir(dir string) error {
 // beginSessionDrain initiates an async drain. Returns immediately.
 // The drainTracker stores in-memory state; advanceSessionDrains progresses it.
 //
+// Returns true when this call enqueued a new drain (a state transition) and
+// false when a drain was already enqueued for this session (no-op). Callers
+// that emit user-visible log lines or convergence events tied to the drain
+// MUST gate on the return value — otherwise those emissions fire every
+// reconciler tick for the life of a stuck drain.
+//
 // The interrupt signal (Ctrl-C) is NOT sent immediately. It is deferred to
 // the next reconciler tick via advanceSessionDrains. This gives the drain
 // one full tick to be canceled (e.g., if the session was falsely orphaned
@@ -124,9 +130,13 @@ func beginSessionDrain(
 	reason string,
 	clk clock.Clock,
 	timeout time.Duration,
-) {
+) bool {
+	name := session.Metadata["session_name"]
 	if dt.get(session.ID) != nil {
-		return // already draining
+		if os.Getenv("GC_TMUX_TRACE") == "1" {
+			log.Printf("[DRAIN-TRACE] beginSessionDrain session=%s reason=%s noop=already-draining", name, reason)
+		}
+		return false
 	}
 	gen, _ := strconv.Atoi(session.Metadata["generation"])
 
@@ -137,11 +147,11 @@ func beginSessionDrain(
 		generation: gen,
 	})
 
-	name := session.Metadata["session_name"]
 	if os.Getenv("GC_TMUX_TRACE") == "1" {
 		log.Printf("[DRAIN-TRACE] beginSessionDrain session=%s reason=%s", name, reason)
 	}
 	telemetry.RecordDrainTransition(context.Background(), name, reason, "begin")
+	return true
 }
 
 func drainReasonCancelable(reason string) bool {

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -290,7 +290,9 @@ func TestBeginSessionDrain(t *testing.T) {
 		"generation":   "5",
 	})
 
-	beginSessionDrain(session, sp, dt, "idle", clk, 30*time.Second)
+	if transitioned := beginSessionDrain(session, sp, dt, "idle", clk, 30*time.Second); !transitioned {
+		t.Fatal("first beginSessionDrain = false, want true (state transition)")
+	}
 
 	ds := dt.get("b1")
 	if ds == nil {
@@ -320,8 +322,12 @@ func TestBeginSessionDrain_AlreadyDraining(t *testing.T) {
 		"generation":   "5",
 	})
 
-	beginSessionDrain(session, sp, dt, "idle", clk, 30*time.Second)
-	beginSessionDrain(session, sp, dt, "config-drift", clk, 60*time.Second)
+	if transitioned := beginSessionDrain(session, sp, dt, "idle", clk, 30*time.Second); !transitioned {
+		t.Fatal("first beginSessionDrain = false, want true (state transition)")
+	}
+	if transitioned := beginSessionDrain(session, sp, dt, "config-drift", clk, 60*time.Second); transitioned {
+		t.Error("second beginSessionDrain = true, want false (already draining)")
+	}
 
 	// Second drain should not overwrite first.
 	ds := dt.get("b1")


### PR DESCRIPTION
## Summary

Partial fix for #855 — addresses the "Debug visibility note" from the issue body.

`beginSessionDrain` is idempotent: a second call for an already-draining session is a no-op. But all three reconciler call sites were emitting stdout, trace records, and event-bus emissions on every tick regardless. For a session stuck in drain (orphan with in-progress assigned work beads, naming-format mismatch, etc.), that meant per-tick log spam, per-tick `traceRecordPayload` map allocations, and per-tick `SessionDraining` event emissions at ~1.5s cadence — making the stuck drain "look like a hot path" when it was actually wedged.

This PR makes `beginSessionDrain` return `bool` (`true`=state transition, `false`=no-op) and gates the three call sites' side effects on the return. Also moves `telemetry.RecordDrainTransition` inside the transition branch, where its `"begin"` semantics belong.

**Not in scope** (separate follow-ups, filing issues):
- Convergence fix — the drain still can't close because assigned in-progress beads keep `sessionHasAssignedWork` true; needs an escape hatch for permanently-stuck work beads.
- `continuation_reset_pending: true` + stuck-asleep recovery across supervisor restart (from the #909 comment on this issue).
- `collectAssignedWorkBeads` + stderr writes in `build_desired_state.go:243` that also fire every tick (separate amplifier path).

## Changes

- `cmd/gc/session_wake.go`: `beginSessionDrain` returns `bool`; telemetry + transition trace moved inside transition branch.
- `cmd/gc/session_reconciler.go`: three call sites (orphan/suspended at :314, config-drift at :633, general drain at :865) now gate stdout + `trace.recordDecision` + `rec.Record` on the return.
- `cmd/gc/session_wake_test.go`: existing `TestBeginSessionDrain` / `TestBeginSessionDrain_AlreadyDraining` extended to assert the new return value.
- `cmd/gc/session_reconciler_test.go`: new `TestReconcileSessionBeads_OrphanDrainLogThrottled` — pre-populates drainTracker to simulate the stuck state from #855 and asserts stdout does not re-log.

Diff: +82/-32 across 4 files.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] `go test ./cmd/gc/ -race -count=1` — targeted drain tests pass
- [x] `go test ./cmd/gc/ -count=1 -short` — full `cmd/gc` suite passes (57s)
- [x] Regression test verified: fails with fix reverted, passes with fix applied
- [x] Multi-model review (Anthropic reuse/quality/efficiency + Codex + Copilot) — no CRITICAL/HIGH findings

## Notes for reviewers

All three production callers of `beginSessionDrain` handle the new `bool`. Chaos-test callers at `cmd/gc/session_lifecycle_chaos_test.go` intentionally discard the return (no log-channel assertion).

The regression test is intentionally narrow — it asserts the stdout gate. Since `trace.recordDecision` + `rec.Record` now live in the same `if` block as the stdout emission at each call site, the stdout assertion structurally proves all three are gated together. Defensive per-emission assertions would need trace-recorder mocks and were deferred.