### PR TITLE
fix(config): reject unknown pack.toml fields

### DIFF
--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -35,6 +35,7 @@ type cityPackManifest struct {
 	Pack          config.PackMeta                `toml:"pack"`
 	Imports       map[string]config.Import       `toml:"imports,omitempty"`
 	AgentDefaults config.AgentDefaults           `toml:"agent_defaults,omitempty"`
+	Defaults      packDefaults                   `toml:"defaults,omitempty"`
 	Agents        []config.Agent                 `toml:"agent,omitempty"`
 	NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
 	Services      []config.Service               `toml:"service,omitempty"`

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -87,6 +87,9 @@ includes = ["./packs/base"]
 default_sling_formula = "mol-pack-default"
 append_fragments = ["pack-fragment"]
 
+[defaults.rig.imports.default-pack]
+source = "./packs/default"
+
 [[agent]]
 name = "mayor"
 scope = "city"
@@ -142,6 +145,8 @@ session_live = ["echo hi"]
 		`[agent_defaults]`,
 		`default_sling_formula = "mol-pack-default"`,
 		`append_fragments = ["pack-fragment"]`,
+		`[defaults.rig.imports.default-pack]`,
+		`source = "./packs/default"`,
 		`name = "mayor"`,
 		`[providers.default]`,
 		`[[commands]]`,

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -37,6 +37,14 @@ type initPackMeta struct {
 	Requires   []config.PackRequirement `toml:"requires,omitempty"`
 }
 
+type packDefaults struct {
+	Rig packRigDefaults `toml:"rig,omitempty"`
+}
+
+type packRigDefaults struct {
+	Imports map[string]config.Import `toml:"imports,omitempty"`
+}
+
 type initPackConfig struct {
 	// Keep this layout in lockstep with internal/config.packConfig so
 	// pack.toml write paths in cmd/gc can round-trip the canonical root
@@ -44,6 +52,7 @@ type initPackConfig struct {
 	Pack          initPackMeta                   `toml:"pack"`
 	Imports       map[string]config.Import       `toml:"imports,omitempty"`
 	AgentDefaults config.AgentDefaults           `toml:"agent_defaults,omitempty"`
+	Defaults      packDefaults                   `toml:"defaults,omitempty"`
 	Agents        []config.Agent                 `toml:"agent"`
 	NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
 	Services      []config.Service               `toml:"service,omitempty"`
@@ -451,6 +460,7 @@ func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
 		Pack          initPackMeta                   `toml:"pack"`
 		Imports       map[string]config.Import       `toml:"imports,omitempty"`
 		AgentDefaults *config.AgentDefaults          `toml:"agent_defaults,omitempty"`
+		Defaults      packDefaults                   `toml:"defaults,omitempty"`
 		Agents        []config.Agent                 `toml:"agent"`
 		NamedSessions []config.NamedSession          `toml:"named_session,omitempty"`
 		Services      []config.Service               `toml:"service,omitempty"`
@@ -465,6 +475,7 @@ func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
 	encCfg := encodedInitPackConfig{
 		Pack:          cfg.Pack,
 		Imports:       cfg.Imports,
+		Defaults:      cfg.Defaults,
 		Agents:        cfg.Agents,
 		NamedSessions: cfg.NamedSessions,
 		Services:      cfg.Services,

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -222,6 +222,12 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 		cityDoltConfigs.Store(cityPath, cfg.Dolt)
 		defer cityDoltConfigs.Delete(cityPath)
 	}
+	rootDefaultRigIncludes, err := config.LoadRootPackDefaultRigIncludes(fs, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc rig add: loading root pack defaults: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	defaultRigIncludes := append(append([]string{}, rootDefaultRigIncludes...), cfg.Workspace.DefaultRigIncludes...)
 
 	var reAdd bool
 	existingRigIdx := -1
@@ -292,8 +298,8 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 		switch {
 		case include != "":
 			w(fmt.Sprintf("  Include: %s", include))
-		case len(cfg.Workspace.DefaultRigIncludes) > 0:
-			w(fmt.Sprintf("  Include: %s (default)", strings.Join(cfg.Workspace.DefaultRigIncludes, ", ")))
+		case len(defaultRigIncludes) > 0:
+			w(fmt.Sprintf("  Include: %s (default)", strings.Join(defaultRigIncludes, ", ")))
 		}
 	}
 
@@ -345,8 +351,8 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath, include, nameOverride, prefixOverri
 		switch {
 		case include != "":
 			rig.Includes = []string{include}
-		case len(cfg.Workspace.DefaultRigIncludes) > 0:
-			rig.Includes = append([]string{}, cfg.Workspace.DefaultRigIncludes...)
+		case len(defaultRigIncludes) > 0:
+			rig.Includes = append([]string{}, defaultRigIncludes...)
 		}
 		next := *cfg
 		next.Rigs = append(append([]config.Rig{}, cfg.Rigs...), rig)

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1140,6 +1141,64 @@ func TestDoRigAdd_DefaultRigIncludes(t *testing.T) {
 	}
 	if len(cfg.Rigs[0].Includes) != 1 || cfg.Rigs[0].Includes[0] != "packs/gastown" {
 		t.Errorf("rig includes = %v, want [packs/gastown]", cfg.Rigs[0].Includes)
+	}
+}
+
+func TestDoRigAdd_RootPackDefaultRigIncludes(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\ndefault_rig_includes = [\"packs/city-pack\"]\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	packToml := `[pack]
+name = "test-city"
+schema = 2
+
+[defaults.rig.imports.z-pack]
+source = "packs/z-pack"
+
+[defaults.rig.imports.a-pack]
+source = "packs/a-pack"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Include: packs/z-pack, packs/a-pack, packs/city-pack (default)") {
+		t.Errorf("output missing root pack default includes in declaration order: %s", output)
+	}
+
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Rigs) != 1 {
+		t.Fatalf("expected 1 rig, got %d", len(cfg.Rigs))
+	}
+	want := []string{"packs/z-pack", "packs/a-pack", "packs/city-pack"}
+	if !reflect.DeepEqual(cfg.Rigs[0].Includes, want) {
+		t.Errorf("rig includes = %v, want %v", cfg.Rigs[0].Includes, want)
+	}
+	if !reflect.DeepEqual(cfg.Workspace.DefaultRigIncludes, []string{"packs/city-pack"}) {
+		t.Errorf("derived root pack defaults should not be written back to city.toml, got %v", cfg.Workspace.DefaultRigIncludes)
 	}
 }
 

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -65,6 +65,9 @@ func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.Check
 	if !ok || len(cfg.Workspace.DefaultRigIncludes) == 0 {
 		return okCheck("v2-default-rig-import-format", "workspace.default_rig_includes already migrated")
 	}
+	if len(cfg.Workspace.Includes) == 0 && len(legacyAgentFiles(ctx.CityPath)) == 0 {
+		return okCheck("v2-default-rig-import-format", "workspace.default_rig_includes preserved for ordered rig defaults")
+	}
 	return warnCheck("v2-default-rig-import-format",
 		"workspace.default_rig_includes is deprecated; migrate to [rig_defaults] imports = [...]",
 		v2MigrationHint(),

--- a/cmd/gc/testdata/migrate-v2.txtar
+++ b/cmd/gc/testdata/migrate-v2.txtar
@@ -29,10 +29,10 @@ exists $WORK/legacy-city/agents/mayor/namepool.txt
 ! exists $WORK/legacy-city/overlays/mayor
 ! exists $WORK/legacy-city/namepools/mayor.txt
 exec grep '\[imports.gastown\]' $WORK/legacy-city/pack.toml
-exec grep '\[defaults.rig.imports.default-rig\]' $WORK/legacy-city/pack.toml
+! exec grep '\[defaults.rig.imports' $WORK/legacy-city/pack.toml
 ! exec grep '\[\[agent\]\]' $WORK/legacy-city/city.toml
-! exec grep 'includes =' $WORK/legacy-city/city.toml
-! exec grep 'default_rig_includes' $WORK/legacy-city/city.toml
+! exec grep '^includes =' $WORK/legacy-city/city.toml
+exec grep 'default_rig_includes = \["../packs/default rig"\]' $WORK/legacy-city/city.toml
 
 -- legacy-city/city.toml --
 [workspace]

--- a/internal/bootstrap/packs/core/pack.toml
+++ b/internal/bootstrap/packs/core/pack.toml
@@ -2,4 +2,3 @@
 name = "core"
 version = "0.1.0"
 schema = 2
-description = "Gas City built-in reference skills (gc-work, gc-dispatch, ...). Shipped with the gc binary, implicitly imported into every city."

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -80,8 +80,12 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	if packData, pErr := fs.ReadFile(packPath); pErr == nil {
 		packExists = true
 		var pc packConfig
-		if _, decErr := toml.Decode(string(packData), &pc); decErr != nil {
+		md, decErr := toml.Decode(string(packData), &pc)
+		if decErr != nil {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", decErr)
+		}
+		if warnings := CheckUndecodedKeys(md, packPath); len(warnings) > 0 {
+			return nil, nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(warnings, "; "))
 		}
 		if err := validatePackMeta(&pc.Pack); err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -120,6 +120,13 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
+		defaultRigIncludes, err := defaultRigIncludesFromPackDefaults(pc.Defaults, md)
+		if err != nil {
+			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
+		}
+		if len(defaultRigIncludes) > 0 {
+			root.Workspace.DefaultRigIncludes = append(defaultRigIncludes, root.Workspace.DefaultRigIncludes...)
+		}
 		// Merge pack.toml providers (pack is base, city wins).
 		if len(pc.Providers) > 0 {
 			if root.Providers == nil {
@@ -1004,6 +1011,75 @@ func parseWithMeta(data []byte, source string) (*City, toml.MetaData, []string, 
 	normalizeAgentDefaultsAlias(&cfg, md)
 	warnings := CheckUndecodedKeys(md, source)
 	return &cfg, md, warnings, nil
+}
+
+// LoadRootPackDefaultRigIncludes loads default rig includes from the root
+// city pack without expanding the full config. Edit paths use this to honor
+// pack v2 defaults while still writing only city.toml.
+func LoadRootPackDefaultRigIncludes(fs fsys.FS, cityRoot string) ([]string, error) {
+	packPath := filepath.Join(cityRoot, packFile)
+	packData, err := fs.ReadFile(packPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading city pack.toml: %w", err)
+	}
+	var pc packConfig
+	md, err := toml.Decode(string(packData), &pc)
+	if err != nil {
+		return nil, fmt.Errorf("parsing city pack.toml: %w", err)
+	}
+	if warnings := CheckUndecodedKeys(md, packPath); len(warnings) > 0 {
+		return nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(warnings, "; "))
+	}
+	return defaultRigIncludesFromPackDefaults(pc.Defaults, md)
+}
+
+func defaultRigIncludesFromPackDefaults(defaults packDefaults, md toml.MetaData) ([]string, error) {
+	if len(defaults.Rig.Imports) == 0 {
+		return nil, nil
+	}
+	names := orderedDefaultRigImportNames(defaults.Rig.Imports, md)
+
+	includes := make([]string, 0, len(names))
+	for _, name := range names {
+		imp := defaults.Rig.Imports[name]
+		if strings.TrimSpace(imp.Source) == "" {
+			return nil, fmt.Errorf("defaults.rig.imports.%s.source is required", name)
+		}
+		includes = append(includes, imp.Source)
+	}
+	return includes, nil
+}
+
+func orderedDefaultRigImportNames(imports map[string]Import, md toml.MetaData) []string {
+	if len(imports) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(imports))
+	names := make([]string, 0, len(imports))
+	for _, key := range md.Keys() {
+		if len(key) < 4 || key[0] != "defaults" || key[1] != "rig" || key[2] != "imports" {
+			continue
+		}
+		name := key[3]
+		if _, ok := imports[name]; ok && !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	if len(names) == len(imports) {
+		return names
+	}
+	remaining := make([]string, 0, len(imports)-len(names))
+	for name := range imports {
+		if !seen[name] {
+			remaining = append(remaining, name)
+		}
+	}
+	sort.Strings(remaining)
+	return append(names, remaining...)
 }
 
 func newProvenance(rootPath string) *Provenance {

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -45,6 +45,34 @@ name = "mayor"
 	}
 }
 
+func TestLoadWithIncludes_RootPackDefaultRigImportsPreserveOrder(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "test"
+schema = 2
+
+[defaults.rig.imports.z-pack]
+source = "packs/z-pack"
+
+[defaults.rig.imports.a-pack]
+source = "packs/a-pack"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	want := []string{"packs/z-pack", "packs/a-pack"}
+	if !reflect.DeepEqual(cfg.Workspace.DefaultRigIncludes, want) {
+		t.Fatalf("DefaultRigIncludes = %v, want %v", cfg.Workspace.DefaultRigIncludes, want)
+	}
+}
+
 func TestLoadWithIncludes_SkipsSystemPackWhenReachableFromRootImport(t *testing.T) {
 	dir := t.TempDir()
 	write := func(rel, data string) {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -983,8 +983,12 @@ func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName s
 	}
 
 	var tc packConfig
-	if _, err := toml.Decode(string(data), &tc); err != nil {
+	md, err := toml.Decode(string(data), &tc)
+	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
+	}
+	if warnings := CheckUndecodedKeys(md, topoPath); len(warnings) > 0 {
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(warnings, "; "))
 	}
 
 	if err := validatePackMeta(&tc.Pack); err != nil {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -28,6 +28,7 @@ type packConfig struct {
 	Pack          PackMeta                `toml:"pack"`
 	Imports       map[string]Import       `toml:"imports,omitempty"`
 	AgentDefaults AgentDefaults           `toml:"agent_defaults,omitempty"`
+	Defaults      packDefaults            `toml:"defaults,omitempty"`
 	Agents        []Agent                 `toml:"agent"`
 	NamedSessions []NamedSession          `toml:"named_session,omitempty"`
 	Services      []Service               `toml:"service,omitempty"`
@@ -37,6 +38,14 @@ type packConfig struct {
 	Doctor        []PackDoctorEntry       `toml:"doctor,omitempty"`
 	Commands      []PackCommandEntry      `toml:"commands,omitempty"`
 	Global        PackGlobal              `toml:"global,omitempty"`
+}
+
+type packDefaults struct {
+	Rig packRigDefaults `toml:"rig,omitempty"`
+}
+
+type packRigDefaults struct {
+	Imports map[string]Import `toml:"imports,omitempty"`
 }
 
 // ExpandPacks resolves pack references on all rigs. For each rig
@@ -989,6 +998,9 @@ func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName s
 	}
 	if warnings := CheckUndecodedKeys(md, topoPath); len(warnings) > 0 {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(warnings, "; "))
+	}
+	if len(tc.Defaults.Rig.Imports) > 0 {
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: [defaults.rig.imports] is only supported in a city root pack.toml", packFile)
 	}
 
 	if err := validatePackMeta(&tc.Pack); err != nil {

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -382,6 +382,55 @@ version = "1.0.0"
 	}
 }
 
+func TestExpandPacks_RejectsUnknownPackTomlFields(t *testing.T) { //nolint:misspell // intentional typo in test data
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/bad/pack.toml", `
+[pack]
+name = "bad"
+schema = 2
+schemla = 2
+`)
+
+	cfg := &City{
+		Rigs: []Rig{
+			{Name: "hello-world", Path: "/home/user/hello-world", Includes: []string{"packs/bad"}},
+		},
+	}
+
+	err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown pack.toml field")
+	}
+	if !strings.Contains(err.Error(), `unknown field "pack.schemla"`) {
+		t.Fatalf("error = %v, want unknown field detail for pack.schemla", err)
+	}
+	if !strings.Contains(err.Error(), `did you mean "schema"`) {
+		t.Fatalf("error = %v, want schema suggestion", err)
+	}
+}
+
+func TestLoadWithIncludes_RejectsUnknownRootPackTomlFields(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeFile(t, dir, "pack.toml", `
+[pack]
+name = "test"
+schema = 2
+description = "silently accepted before issue 783"
+`)
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected error for unknown root pack.toml field")
+	}
+	if !strings.Contains(err.Error(), `unknown field "pack.description"`) {
+		t.Fatalf("error = %v, want unknown field detail for pack.description", err)
+	}
+}
+
 func TestExpandPacks_PromptPathResolution(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gt/pack.toml", `

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -53,6 +53,9 @@ func suggestKey(unknown string, known []string) string {
 			bestKey = k
 		}
 	}
+	if bestKey == leaf {
+		return ""
+	}
 	return bestKey
 }
 
@@ -114,6 +117,14 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(ServiceWorkflowConfig{}),
 		reflect.TypeOf(ServiceProcessConfig{}),
 		reflect.TypeOf(AgentDefaults{}),
+		reflect.TypeOf(packConfig{}),
+		reflect.TypeOf(PackMeta{}),
+		reflect.TypeOf(Import{}),
+		reflect.TypeOf(NamedSession{}),
+		reflect.TypeOf(PackRequirement{}),
+		reflect.TypeOf(PackDoctorEntry{}),
+		reflect.TypeOf(PackCommandEntry{}),
+		reflect.TypeOf(PackGlobal{}),
 	}
 	for _, t := range types {
 		collectTOMLTags(t, seen)

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -125,6 +125,8 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(PackDoctorEntry{}),
 		reflect.TypeOf(PackCommandEntry{}),
 		reflect.TypeOf(PackGlobal{}),
+		reflect.TypeOf(packDefaults{}),
+		reflect.TypeOf(packRigDefaults{}),
 	}
 	for _, t := range types {
 		collectTOMLTags(t, seen)

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -40,6 +41,8 @@ type packFile struct {
 	AgentsDefaults config.AgentDefaults           `toml:"agents,omitempty"`
 	Defaults       packDefaults                   `toml:"defaults,omitempty"`
 	Agents         []config.Agent                 `toml:"agent"`
+
+	defaultRigImportOrder []string
 }
 
 type packDefaults struct {
@@ -128,7 +131,7 @@ func Apply(cityPath string, opts Options) (*Report, error) {
 	}
 
 	packPath := filepath.Join(cityPath, "pack.toml")
-	packCfg, packExists, err := loadPackFile(packPath)
+	packCfg, _, err := loadPackFile(packPath)
 	if err != nil {
 		return nil, err
 	}
@@ -160,8 +163,10 @@ func Apply(cityPath string, opts Options) (*Report, error) {
 		cityCfg.Agents = nil
 	}
 
-	if len(selectedAgents) > 0 || len(cityCfg.Workspace.Includes) > 0 || len(cityCfg.Workspace.DefaultRigIncludes) > 0 {
-		ensurePackMeta(&packCfg, cityCfg, cityPath)
+	if len(selectedAgents) > 0 || len(cityCfg.Workspace.Includes) > 0 {
+		if ensurePackMeta(&packCfg, cityCfg, cityPath) {
+			packChanged = true
+		}
 	}
 
 	if len(cityCfg.Workspace.Includes) > 0 {
@@ -173,15 +178,6 @@ func Apply(cityPath string, opts Options) (*Report, error) {
 		packChanged = true
 	}
 
-	if len(cityCfg.Workspace.DefaultRigIncludes) > 0 {
-		if packCfg.Defaults.Rig.Imports == nil {
-			packCfg.Defaults.Rig.Imports = make(map[string]config.Import)
-		}
-		addImports(packCfg.Defaults.Rig.Imports, cityCfg.Workspace.DefaultRigIncludes, cityCfg.Packs)
-		cityCfg.Workspace.DefaultRigIncludes = nil
-		packChanged = true
-	}
-
 	cityContent, err := cityCfg.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshal city.toml: %w", err)
@@ -190,7 +186,7 @@ func Apply(cityPath string, opts Options) (*Report, error) {
 		return nil, err
 	}
 
-	if packChanged || packExists || len(selectedAgents) > 0 {
+	if packChanged {
 		packContent, err := marshalPackFile(packCfg)
 		if err != nil {
 			return nil, fmt.Errorf("marshal pack.toml: %w", err)
@@ -224,10 +220,34 @@ func loadPackFile(path string) (packFile, bool, error) {
 		return packFile{}, false, fmt.Errorf("migrate %q: %w", path, err)
 	}
 	var cfg packFile
-	if _, err := toml.Decode(string(data), &cfg); err != nil {
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
 		return packFile{}, true, fmt.Errorf("migrate %q: %w", path, err)
 	}
+	if warnings := config.CheckUndecodedKeys(md, path); len(warnings) > 0 {
+		return packFile{}, true, fmt.Errorf("migrate %q: %s", path, strings.Join(warnings, "; "))
+	}
+	cfg.defaultRigImportOrder = packDefaultRigImportOrder(md)
 	return cfg, true, nil
+}
+
+func packDefaultRigImportOrder(md toml.MetaData) []string {
+	var order []string
+	seen := make(map[string]bool)
+	for _, key := range md.Keys() {
+		if len(key) != 4 ||
+			key[0] != "defaults" ||
+			key[1] != "rig" ||
+			key[2] != "imports" {
+			continue
+		}
+		if seen[key[3]] {
+			continue
+		}
+		seen[key[3]] = true
+		order = append(order, key[3])
+	}
+	return order
 }
 
 func selectAgents(packAgents, cityAgents []config.Agent) ([]agentEntry, []string) {
@@ -377,16 +397,20 @@ func migrateAgentAssets(cityPath string, entry agentEntry, usage usageCounts, re
 	return nil
 }
 
-func ensurePackMeta(packCfg *packFile, cityCfg *config.City, cityPath string) {
+func ensurePackMeta(packCfg *packFile, cityCfg *config.City, cityPath string) bool {
+	changed := false
 	if packCfg.Pack.Name == "" {
 		packCfg.Pack.Name = strings.TrimSpace(cityCfg.Workspace.Name)
 		if packCfg.Pack.Name == "" {
 			packCfg.Pack.Name = filepath.Base(cityPath)
 		}
+		changed = true
 	}
 	if packCfg.Pack.Schema == 0 {
 		packCfg.Pack.Schema = 1
+		changed = true
 	}
+	return changed
 }
 
 func addImports(target map[string]config.Import, includes []string, packs map[string]config.PackSource) {
@@ -606,7 +630,84 @@ func pruneEmptyParents(dir, stopDir string) {
 }
 
 func marshalPackFile(cfg packFile) ([]byte, error) {
-	return encodeTOML(cfg)
+	defaultRigImports := cfg.Defaults.Rig.Imports
+	cfg.Defaults.Rig.Imports = nil
+
+	data, err := encodeTOML(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(defaultRigImports) == 0 {
+		return data, nil
+	}
+
+	var buf bytes.Buffer
+	buf.Write(data)
+	if buf.Len() > 0 && !bytes.HasSuffix(buf.Bytes(), []byte("\n")) {
+		buf.WriteByte('\n')
+	}
+	if buf.Len() > 0 && !bytes.HasSuffix(buf.Bytes(), []byte("\n\n")) {
+		buf.WriteByte('\n')
+	}
+
+	names := orderedPackDefaultRigImportNames(defaultRigImports, cfg.defaultRigImportOrder)
+	for i, name := range names {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		fmt.Fprintf(&buf, "[defaults.rig.imports.%s]\n", tomlKey(name))
+		importData, err := encodeTOML(defaultRigImports[name])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(importData)
+		if !bytes.HasSuffix(importData, []byte("\n")) {
+			buf.WriteByte('\n')
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func orderedPackDefaultRigImportNames(imports map[string]config.Import, order []string) []string {
+	names := make([]string, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, name := range order {
+		if _, ok := imports[name]; !ok || seen[name] {
+			continue
+		}
+		names = append(names, name)
+		seen[name] = true
+	}
+
+	var remaining []string
+	for name := range imports {
+		if !seen[name] {
+			remaining = append(remaining, name)
+		}
+	}
+	sort.Strings(remaining)
+	return append(names, remaining...)
+}
+
+func tomlKey(key string) string {
+	if key != "" {
+		bare := true
+		for _, r := range key {
+			if (r >= 'A' && r <= 'Z') ||
+				(r >= 'a' && r <= 'z') ||
+				(r >= '0' && r <= '9') ||
+				r == '_' ||
+				r == '-' {
+				continue
+			}
+			bare = false
+			break
+		}
+		if bare {
+			return key
+		}
+	}
+	return strconv.Quote(key)
 }
 
 func marshalAgentFile(cfg agentFile) ([]byte, error) {

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 func TestMigrateCityCommonCase(t *testing.T) {
@@ -18,7 +19,7 @@ func TestMigrateCityCommonCase(t *testing.T) {
 [workspace]
 name = "legacy-city"
 includes = ["../packs/gastown", "../packs/qa-team"]
-default_rig_includes = ["../packs/default rig"]
+default_rig_includes = ["../packs/z-pack", "../packs/a-pack"]
 
 [[agent]]
 name = "mayor"
@@ -60,19 +61,19 @@ prompt_template = "prompts/worker.md"
 	if !strings.Contains(packToml, "source = \"../packs/gastown\"") {
 		t.Fatalf("pack.toml missing gastown source:\n%s", packToml)
 	}
-	if !strings.Contains(packToml, "[defaults.rig.imports.default-rig]") {
-		t.Fatalf("pack.toml missing default rig import:\n%s", packToml)
+	if strings.Contains(packToml, "[defaults.rig.imports") {
+		t.Fatalf("pack.toml should not move ordered default_rig_includes into map-shaped defaults:\n%s", packToml)
 	}
 
 	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
 	if strings.Contains(cityToml, "[[agent]]") {
 		t.Fatalf("city.toml still contains [[agent]]:\n%s", cityToml)
 	}
-	if strings.Contains(cityToml, "includes =") {
+	if strings.Contains(cityToml, "\nincludes =") {
 		t.Fatalf("city.toml still contains workspace.includes:\n%s", cityToml)
 	}
-	if strings.Contains(cityToml, "default_rig_includes") {
-		t.Fatalf("city.toml still contains workspace.default_rig_includes:\n%s", cityToml)
+	if !strings.Contains(cityToml, `default_rig_includes = ["../packs/z-pack", "../packs/a-pack"]`) {
+		t.Fatalf("city.toml should preserve ordered workspace.default_rig_includes:\n%s", cityToml)
 	}
 
 	mayorAgentToml := readFile(t, filepath.Join(cityDir, "agents", "mayor", "agent.toml"))
@@ -116,6 +117,139 @@ prompt_template = "prompts/worker.md"
 	}
 	if _, err := os.Stat(filepath.Join(cityDir, "namepools", "mayor.txt")); !os.IsNotExist(err) {
 		t.Fatalf("expected namepool source to be removed, err=%v", err)
+	}
+}
+
+func TestMigrateDefaultRigIncludesLoadAfterMigration(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+default_rig_includes = ["../packs/z-pack", "../packs/a-pack"]
+`)
+
+	if _, err := Apply(cityDir, Options{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes after migration: %v", err)
+	}
+	if len(cfg.Workspace.DefaultRigIncludes) != 2 {
+		t.Fatalf("len(DefaultRigIncludes) = %d, want 2", len(cfg.Workspace.DefaultRigIncludes))
+	}
+	if cfg.Workspace.DefaultRigIncludes[0] != "../packs/z-pack" {
+		t.Fatalf("DefaultRigIncludes[0] = %q, want %q", cfg.Workspace.DefaultRigIncludes[0], "../packs/z-pack")
+	}
+	if cfg.Workspace.DefaultRigIncludes[1] != "../packs/a-pack" {
+		t.Fatalf("DefaultRigIncludes[1] = %q, want %q", cfg.Workspace.DefaultRigIncludes[1], "../packs/a-pack")
+	}
+}
+
+func TestMigrateRejectsUnknownExistingPackTomlFields(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/gastown"]
+`)
+	writeFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+description = "silently dropped before strict migration validation"
+`)
+
+	beforeCity := readFile(t, filepath.Join(cityDir, "city.toml"))
+	beforePack := readFile(t, filepath.Join(cityDir, "pack.toml"))
+
+	_, err := Apply(cityDir, Options{})
+	if err == nil {
+		t.Fatal("expected Apply to reject unknown pack.toml field")
+	}
+	if !strings.Contains(err.Error(), `unknown field "pack.description"`) {
+		t.Fatalf("error = %v, want unknown field detail for pack.description", err)
+	}
+	if got := readFile(t, filepath.Join(cityDir, "city.toml")); got != beforeCity {
+		t.Fatalf("city.toml changed after validation failure:\n%s", got)
+	}
+	if got := readFile(t, filepath.Join(cityDir, "pack.toml")); got != beforePack {
+		t.Fatalf("pack.toml changed after validation failure:\n%s", got)
+	}
+}
+
+func TestMigratePreservesExistingRootDefaultRigImportOrder(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/new-pack"]
+`)
+	writeFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+
+[defaults.rig.imports.z-pack]
+source = "../packs/z-pack"
+
+[defaults.rig.imports.a-pack]
+source = "../packs/a-pack"
+`)
+
+	if _, err := Apply(cityDir, Options{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	packToml := readFile(t, filepath.Join(cityDir, "pack.toml"))
+	if !strings.Contains(packToml, "[imports.new-pack]") {
+		t.Fatalf("pack.toml missing migrated workspace include:\n%s", packToml)
+	}
+	zIndex := strings.Index(packToml, "[defaults.rig.imports.z-pack]")
+	aIndex := strings.Index(packToml, "[defaults.rig.imports.a-pack]")
+	if zIndex < 0 || aIndex < 0 {
+		t.Fatalf("pack.toml missing root default rig imports:\n%s", packToml)
+	}
+	if zIndex > aIndex {
+		t.Fatalf("pack.toml reordered default rig imports:\n%s", packToml)
+	}
+}
+
+func TestMigrateDoesNotRewriteExistingPackWithoutPackChanges(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+default_rig_includes = ["../packs/z-pack", "../packs/a-pack"]
+`)
+	writeFile(t, cityDir, "pack.toml", `
+# existing formatting must survive no-op pack migration
+[pack]
+name = "legacy-city"
+schema = 2
+
+[defaults.rig.imports.z-pack]
+source = "../packs/z-pack"
+
+[defaults.rig.imports.a-pack]
+source = "../packs/a-pack"
+`)
+
+	beforePack := readFile(t, filepath.Join(cityDir, "pack.toml"))
+	if _, err := Apply(cityDir, Options{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := readFile(t, filepath.Join(cityDir, "pack.toml")); got != beforePack {
+		t.Fatalf("pack.toml changed without pack migration changes:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #894 and preserves @julianknutsen's original fix for rejecting unknown `pack.toml` fields.
- Adds maintainer fixups for migration/default-rig interactions found during adoption review: ordered `workspace.default_rig_includes` remains in `city.toml`, root `[defaults.rig.imports]` loads in declaration order, `gc rig add` honors root + city defaults without persisting derived values, and migration rejects unknown existing `pack.toml` fields before any rewrite.
- Preserves existing root default rig import order when migration must rewrite `pack.toml`, and skips no-op `pack.toml` rewrites when there are no pack-side migration changes.

Supersedes #894.
Closes #783.
Credit: Original fix by @julianknutsen; the contributor commit is preserved with original authorship.

## Testing

- [x] `go test ./internal/config ./internal/migrate ./cmd/gc -run 'TestLoadWithIncludes_RootPackDefaultRigImportsPreserveOrder|TestMigrateCityCommonCase|TestMigrateDefaultRigIncludesLoadAfterMigration|TestMigrateRejectsUnknownExistingPackTomlFields|TestMigratePreservesExistingRootDefaultRigImportOrder|TestMigrateDoesNotRewriteExistingPackWithoutPackChanges|TestDoRigAdd_RootPackDefaultRigIncludes|TestDoRigAdd_DefaultRigIncludes|TestDoRigAdd_ExplicitIncludeOverridesDefault|TestLoadWithIncludes_RejectsUnknownRootPackTomlFields|TestExpandPacks_RejectsUnknownPackTomlFields|TestImportMigrateScript|TestV2DeprecationChecksWarnOnLegacyPatterns|TestV2DeprecationChecksGoQuietAfterMigration' -count=1`
- [x] `go vet ./...`
- [ ] `make check` not run directly; `go test ./...` was attempted and failed in broad `cmd/gc` coverage with `TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure` plus a 10-minute package timeout while `TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase` was running. Scoped adoption tests passed.
- [ ] `make check-docs` not run; no docs/navigation/link changes.
- [ ] `make test-integration` not run; no integration-only runtime path changed.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes, or not needed
- [x] Called out breaking changes or migration notes

Breaking changes: none. Migration note: existing root default rig import order is preserved across migration rewrites; no-op pack migrations leave `pack.toml` untouched.
