### PR TITLE
Add gc reload command

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -65,8 +65,10 @@ type CityRuntime struct {
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
 	convergenceReqCh    chan convergenceRequest  // receives CLI commands from controller.sock
+	reloadReqCh         chan reloadRequest       // receives structured reload requests from controller.sock
 	pokeCh              chan struct{}            // non-blocking signal to trigger immediate reconciler tick
 	controlDispatcherCh chan struct{}            // non-blocking signal for control-dispatcher-only reconcile
+	activeReload        *reloadRequest
 	onStarted           func()
 	onStatus            func(string)
 
@@ -99,6 +101,7 @@ type CityRuntimeParams struct {
 	PoolDeathHandlers map[string]poolDeathInfo
 
 	ConvergenceReqCh    chan convergenceRequest // may be nil
+	ReloadReqCh         chan reloadRequest      // may be nil; receives structured reload commands
 	PokeCh              chan struct{}           // may be nil; triggers immediate tick
 	ControlDispatcherCh chan struct{}           // may be nil; triggers control-dispatcher-only reconcile
 	OnStarted           func()                  // called after initial reconciliation succeeds
@@ -176,6 +179,12 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		poolDeathHandlers:       p.PoolDeathHandlers,
 		suspendedNames:          suspendedNames,
 		convergenceReqCh:        p.ConvergenceReqCh,
+		reloadReqCh: func() chan reloadRequest {
+			if p.ReloadReqCh != nil {
+				return p.ReloadReqCh
+			}
+			return make(chan reloadRequest)
+		}(),
 		pokeCh: func() chan struct{} {
 			if p.PokeCh != nil {
 				return p.PokeCh
@@ -392,6 +401,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, "poke")
 		case <-cr.controlDispatcherCh:
 			cr.controlDispatcherTick(ctx)
+		case req := <-cr.reloadReqCh:
+			cr.handleReloadRequest(&req)
 		case req := <-cr.convergenceReqCh:
 			// Low-latency path: process convergence commands between ticks.
 			// processConvergenceRequests() in tick() drains any that arrived
@@ -419,7 +430,13 @@ func (cr *CityRuntime) tick(
 	trigger string,
 ) {
 	sessionBeads := cr.loadSessionBeadSnapshot()
-	trace := cr.beginTraceCycle(trigger, "controller_tick", sessionBeads)
+	traceTrigger := trigger
+	traceDetail := "controller_tick"
+	if cr.activeReload != nil {
+		traceTrigger = string(TraceTickTriggerPoke)
+		traceDetail = "manual_reload"
+	}
+	trace := cr.beginTraceCycle(traceTrigger, traceDetail, sessionBeads)
 	// Detect pool instance deaths since last tick.
 	if len(cr.poolDeathHandlers) > 0 {
 		currentRunning, _ := cr.sp.ListRunning("")
@@ -445,7 +462,15 @@ func (cr *CityRuntime) tick(
 	}
 
 	if dirty.Swap(false) {
-		cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace)
+		source := reloadSourceWatch
+		if cr.activeReload != nil {
+			source = reloadSourceManual
+		}
+		reply := cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace, source)
+		if cr.activeReload != nil {
+			cr.activeReload.doneCh <- reply
+			cr.activeReload = nil
+		}
 	}
 
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
@@ -521,6 +546,31 @@ func (cr *CityRuntime) tick(
 	}
 }
 
+func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {
+	if req == nil {
+		return
+	}
+	if cr.activeReload != nil {
+		req.acceptedCh <- reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because another reload is already in progress.",
+		}
+		return
+	}
+	cr.activeReload = req
+	if cr.configDirty != nil {
+		cr.configDirty.Store(true)
+	}
+	select {
+	case cr.pokeCh <- struct{}{}:
+	default:
+	}
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+}
+
 // reloadConfig attempts to reload city.toml and update all internal
 // components. On error, the old config is kept.
 func (cr *CityRuntime) reloadConfig(
@@ -528,7 +578,7 @@ func (cr *CityRuntime) reloadConfig(
 	lastProviderName *string,
 	cityRoot string,
 ) {
-	cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, nil)
+	cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, nil, reloadSourceWatch)
 }
 
 func (cr *CityRuntime) reloadConfigTraced(
@@ -536,21 +586,40 @@ func (cr *CityRuntime) reloadConfigTraced(
 	lastProviderName *string,
 	cityRoot string,
 	trace *sessionReconcilerTraceCycle,
-) {
+	source reloadSource,
+) reloadControlReply {
+	var warnings []string
+	appendWarning := func(message string) {
+		warnings = append(warnings, message)
+		fmt.Fprintf(cr.stderr, "%s: %s\n", cr.logPrefix, message) //nolint:errcheck // best-effort stderr
+	}
+
 	result, err := tryReloadConfig(cr.tomlPath, cr.cityName, cityRoot, cr.stderr)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: config reload: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
-		telemetry.RecordConfigReload(ctx, "", err)
+		telemetry.RecordConfigReload(ctx, "", string(source), string(reloadOutcomeFailed), len(warnings), err)
 		if trace != nil {
-			trace.RecordConfigReload("", "", TraceOutcomeFailed, nil, nil, false, err)
+			trace.RecordConfigReload("", "", TraceOutcomeFailed, source, nil, nil, false, warnings, err)
 		}
-		return
+		return reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   err.Error(),
+		}
+	}
+	for _, warning := range result.Warnings {
+		appendWarning(warning)
 	}
 	if cr.configRev != "" && result.Revision == cr.configRev {
 		if trace != nil {
-			trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeNoChange, nil, nil, false, nil)
+			trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeNoChange, source, nil, nil, false, warnings, nil)
 		}
-		return
+		telemetry.RecordConfigReload(ctx, result.Revision, string(source), string(reloadOutcomeNoChange), len(warnings), nil)
+		return reloadControlReply{
+			Outcome:  reloadOutcomeNoChange,
+			Message:  "No config changes detected.",
+			Revision: result.Revision,
+			Warnings: warnings,
+		}
 	}
 
 	oldAgentCount := len(cr.cfg.Agents)
@@ -570,8 +639,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	if newProviderName != *lastProviderName {
 		newSp, spErr := newSessionProviderByName(newProviderName, nextCfg.Session, cr.cityName, cr.cityPath)
 		if spErr != nil {
-			fmt.Fprintf(cr.stderr, "%s: new session provider %q: %v (keeping old provider)\n", //nolint:errcheck
-				cr.logPrefix, newProviderName, spErr)
+			appendWarning(fmt.Sprintf("new session provider %q: %v (keeping old provider)", newProviderName, spErr))
 		} else {
 			providerChanged = true
 			nextSp = newSp
@@ -584,23 +652,18 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// gc-beads-bd ships inside the bd pack's assets/scripts/ and is
 	// materialized alongside the rest of the pack content.
 	if err := MaterializeBuiltinPacks(cityRoot); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: config reload: materializing builtin packs: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+		appendWarning(fmt.Sprintf("config reload: materializing builtin packs: %v", err))
 	}
 	if err := config.ValidateRigs(nextCfg.Rigs, config.EffectiveHQPrefix(nextCfg)); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: config reload: %v\n", cr.logPrefix, err) //nolint:errcheck
+		appendWarning(fmt.Sprintf("config reload: %v", err))
 	}
 	resolveRigPaths(cityRoot, nextCfg.Rigs)
 	if err := cityRuntimeStartBeadsLifecycle(cityRoot, cr.cityName, nextCfg, cr.stderr); err != nil {
-		fmt.Fprintf(cr.stderr, "%s: config reload: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck
-		telemetry.RecordConfigReload(ctx, "", err)
-		if trace != nil {
-			trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeFailed, nil, nil, false, err)
-		}
-		return
+		appendWarning(fmt.Sprintf("config reload: %v", err))
 	}
 	if len(nextCfg.FormulaLayers.City) > 0 {
 		if err := ResolveFormulas(cityRoot, nextCfg.FormulaLayers.City); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: config reload: city formulas: %v\n", cr.logPrefix, err) //nolint:errcheck
+			appendWarning(fmt.Sprintf("config reload: city formulas: %v", err))
 		}
 	}
 	for _, r := range nextCfg.Rigs {
@@ -610,7 +673,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		}
 		if len(layers) > 0 {
 			if err := ResolveFormulas(r.Path, layers); err != nil {
-				fmt.Fprintf(cr.stderr, "%s: config reload: rig %q formulas: %v\n", cr.logPrefix, r.Name, err) //nolint:errcheck
+				appendWarning(fmt.Sprintf("config reload: rig %q formulas: %v", r.Name, err))
 			}
 		}
 	}
@@ -618,13 +681,13 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// Resolve script symlinks for newly activated packs.
 	if len(nextCfg.ScriptLayers.City) > 0 {
 		if err := ResolveScripts(cityRoot, nextCfg.ScriptLayers.City); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: config reload: city scripts: %v\n", cr.logPrefix, err) //nolint:errcheck
+			appendWarning(fmt.Sprintf("config reload: city scripts: %v", err))
 		}
 	}
 	for _, r := range nextCfg.Rigs {
 		if layers, ok := nextCfg.ScriptLayers.Rigs[r.Name]; ok && len(layers) > 0 {
 			if err := ResolveScripts(r.Path, layers); err != nil {
-				fmt.Fprintf(cr.stderr, "%s: config reload: rig %q scripts: %v\n", cr.logPrefix, r.Name, err) //nolint:errcheck
+				appendWarning(fmt.Sprintf("config reload: rig %q scripts: %v", r.Name, err))
 			}
 		}
 	}
@@ -693,7 +756,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	}
 	if cr.svc != nil {
 		if err := cr.svc.Reload(); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: service reload: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+			appendWarning(fmt.Sprintf("service reload: %v", err))
 		}
 	}
 
@@ -702,7 +765,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 		// Also recovers from nil → non-nil when bd becomes available after startup.
 		if s, err := openCityStoreAt(cityRoot); err != nil {
 			if cr.standaloneCityStore != nil {
-				fmt.Fprintf(cr.stderr, "%s: city bead store reload: %v\n", cr.logPrefix, err) //nolint:errcheck
+				appendWarning(fmt.Sprintf("city bead store reload: %v", err))
 			}
 		} else {
 			cr.standaloneCityStore = s
@@ -720,12 +783,19 @@ func (cr *CityRuntime) reloadConfigTraced(
 		trace.syncArms(time.Now().UTC(), nextCfg)
 	}
 
-	fmt.Fprintf(cr.stdout, "Config reloaded: %s (rev %s)\n", //nolint:errcheck
+	message := fmt.Sprintf("Config reloaded: %s (rev %s)",
 		configReloadSummary(oldAgentCount, oldRigCount, len(nextCfg.Agents), len(nextCfg.Rigs)),
 		shortRev(result.Revision))
-	telemetry.RecordConfigReload(ctx, result.Revision, nil)
+	fmt.Fprintln(cr.stdout, message) //nolint:errcheck // best-effort stdout
+	telemetry.RecordConfigReload(ctx, result.Revision, string(source), string(reloadOutcomeApplied), len(warnings), nil)
 	if trace != nil {
-		trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeApplied, nil, nil, providerChanged, nil)
+		trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeApplied, source, nil, nil, providerChanged, warnings, nil)
+	}
+	return reloadControlReply{
+		Outcome:  reloadOutcomeApplied,
+		Message:  message,
+		Revision: result.Revision,
+		Warnings: warnings,
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -231,6 +231,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	dirty := cr.configDirty
 	if dirty == nil {
 		dirty = &atomic.Bool{}
+		cr.configDirty = dirty
 	}
 
 	if cr.tomlPath != "" {
@@ -413,6 +414,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			reply := cr.safeHandleConvergenceRequest(ctx, req)
 			req.replyCh <- reply
 		case <-ctx.Done():
+			cr.failActiveReload("Reload canceled because the controller is shutting down.")
 			return
 		}
 	}
@@ -433,7 +435,6 @@ func (cr *CityRuntime) tick(
 	traceTrigger := trigger
 	traceDetail := "controller_tick"
 	if cr.activeReload != nil {
-		traceTrigger = string(TraceTickTriggerPoke)
 		traceDetail = "manual_reload"
 	}
 	trace := cr.beginTraceCycle(traceTrigger, traceDetail, sessionBeads)
@@ -461,16 +462,15 @@ func (cr *CityRuntime) tick(
 		}
 	}
 
+	var manualReload *reloadRequest
+	var manualReply reloadControlReply
 	if dirty.Swap(false) {
 		source := reloadSourceWatch
 		if cr.activeReload != nil {
 			source = reloadSourceManual
+			manualReload = cr.activeReload
 		}
-		reply := cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace, source)
-		if cr.activeReload != nil {
-			cr.activeReload.doneCh <- reply
-			cr.activeReload = nil
-		}
+		manualReply = cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace, source)
 	}
 
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
@@ -541,8 +541,15 @@ func (cr *CityRuntime) tick(
 
 	// Convergence tick: process active convergence loops.
 	cr.convergenceTick(ctx)
+	if manualReload != nil {
+		select {
+		case manualReload.doneCh <- manualReply:
+		default:
+		}
+		cr.activeReload = nil
+	}
 	if trace != nil {
-		trace.end(TraceCompletionCompleted, traceRecordPayload{"phase": "tick", "trigger": trigger})
+		trace.end(TraceCompletionCompleted, traceRecordPayload{"phase": "tick", "trigger": traceTrigger})
 	}
 }
 
@@ -558,9 +565,10 @@ func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {
 		return
 	}
 	cr.activeReload = req
-	if cr.configDirty != nil {
-		cr.configDirty.Store(true)
+	if cr.configDirty == nil {
+		cr.configDirty = &atomic.Bool{}
 	}
+	cr.configDirty.Store(true)
 	select {
 	case cr.pokeCh <- struct{}{}:
 	default:
@@ -569,6 +577,20 @@ func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {
 		Outcome: reloadOutcomeAccepted,
 		Message: "Reload requested.",
 	}
+}
+
+func (cr *CityRuntime) failActiveReload(message string) {
+	if cr.activeReload == nil {
+		return
+	}
+	select {
+	case cr.activeReload.doneCh <- reloadControlReply{
+		Outcome: reloadOutcomeFailed,
+		Error:   message,
+	}:
+	default:
+	}
+	cr.activeReload = nil
 }
 
 // reloadConfig attempts to reload city.toml and update all internal
@@ -591,19 +613,29 @@ func (cr *CityRuntime) reloadConfigTraced(
 	var warnings []string
 	appendWarning := func(message string) {
 		warnings = append(warnings, message)
-		fmt.Fprintf(cr.stderr, "%s: %s\n", cr.logPrefix, message) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(cr.stderr, "%s: warning: %s\n", cr.logPrefix, message) //nolint:errcheck // best-effort stderr
 	}
 
-	result, err := tryReloadConfig(cr.tomlPath, cr.cityName, cityRoot, cr.stderr)
+	result, err := tryReloadConfig(cr.tomlPath, cr.cityName, cityRoot)
 	if err != nil {
+		if result != nil {
+			for _, warning := range result.Warnings {
+				appendWarning(warning)
+			}
+		} else {
+			for _, warning := range reloadWarningsFromError(err) {
+				appendWarning(warning)
+			}
+		}
 		fmt.Fprintf(cr.stderr, "%s: config reload: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 		telemetry.RecordConfigReload(ctx, "", string(source), string(reloadOutcomeFailed), len(warnings), err)
 		if trace != nil {
 			trace.RecordConfigReload("", "", TraceOutcomeFailed, source, nil, nil, false, warnings, err)
 		}
 		return reloadControlReply{
-			Outcome: reloadOutcomeFailed,
-			Error:   err.Error(),
+			Outcome:  reloadOutcomeFailed,
+			Error:    err.Error(),
+			Warnings: warnings,
 		}
 	}
 	for _, warning := range result.Warnings {
@@ -659,7 +691,17 @@ func (cr *CityRuntime) reloadConfigTraced(
 	}
 	resolveRigPaths(cityRoot, nextCfg.Rigs)
 	if err := cityRuntimeStartBeadsLifecycle(cityRoot, cr.cityName, nextCfg, cr.stderr); err != nil {
-		appendWarning(fmt.Sprintf("config reload: %v", err))
+		err := fmt.Errorf("config reload: %w", err)
+		fmt.Fprintf(cr.stderr, "%s: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+		telemetry.RecordConfigReload(ctx, "", string(source), string(reloadOutcomeFailed), len(warnings), err)
+		if trace != nil {
+			trace.RecordConfigReload(oldRevision, result.Revision, TraceOutcomeFailed, source, nil, nil, false, warnings, err)
+		}
+		return reloadControlReply{
+			Outcome:  reloadOutcomeFailed,
+			Error:    err.Error(),
+			Warnings: warnings,
+		}
 	}
 	if len(nextCfg.FormulaLayers.City) > 0 {
 		if err := ResolveFormulas(cityRoot, nextCfg.FormulaLayers.City); err != nil {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1209,7 +1209,7 @@ func TestCityRuntimeReloadProviderSwapPreservesDrainTracker(t *testing.T) {
 	}
 }
 
-func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
+func TestCityRuntimeReloadLifecycleFailureWarnsAndAppliesConfig(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -1254,30 +1254,36 @@ func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
 		cityRuntimeStartBeadsLifecycle = prev
 	})
 
-	writeCityRuntimeConfig(t, tomlPath, "fail")
+	data := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n\n[daemon]\nshutdown_timeout = \"1s\"\n")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 	lastProviderName := "fake"
 	cr.reloadConfig(context.Background(), &lastProviderName, cityPath)
 
-	if cr.cfg != oldCfg {
-		t.Fatal("cfg changed after lifecycle reload failure")
+	if cr.cfg == oldCfg {
+		t.Fatal("cfg did not change after lifecycle reload warning")
 	}
 	if cr.sp != oldSP {
-		t.Fatal("provider changed after lifecycle reload failure")
+		t.Fatal("provider changed after lifecycle reload warning")
 	}
 	if cr.dops != oldDops {
-		t.Fatal("drain ops changed after lifecycle reload failure")
+		t.Fatal("drain ops changed after lifecycle reload warning")
 	}
-	if cr.configRev != oldRev {
-		t.Fatalf("configRev = %q, want %q", cr.configRev, oldRev)
+	if cr.configRev == oldRev {
+		t.Fatalf("configRev = %q, want it to change", cr.configRev)
 	}
 	if lastProviderName != "fake" {
 		t.Fatalf("lastProviderName = %q, want fake", lastProviderName)
 	}
-	if !strings.Contains(stderr.String(), "keeping old config") {
-		t.Fatalf("stderr = %q, want keeping old config message", stderr.String())
+	if !strings.Contains(stderr.String(), "config reload: boom") {
+		t.Fatalf("stderr = %q, want lifecycle warning", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Session provider swapped") {
 		t.Fatalf("stdout = %q, want no provider swap message", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Config reloaded:") {
+		t.Fatalf("stdout = %q, want reload success message", stdout.String())
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1209,7 +1209,7 @@ func TestCityRuntimeReloadProviderSwapPreservesDrainTracker(t *testing.T) {
 	}
 }
 
-func TestCityRuntimeReloadLifecycleFailureWarnsAndAppliesConfig(t *testing.T) {
+func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -1222,11 +1222,12 @@ func TestCityRuntimeReloadLifecycleFailureWarnsAndAppliesConfig(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cr := newCityRuntime(CityRuntimeParams{
-		CityPath: cityPath,
-		CityName: "test-city",
-		TomlPath: tomlPath,
-		Cfg:      cfg,
-		SP:       sp,
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		LogPrefix: "gc reload",
+		Cfg:       cfg,
+		SP:        sp,
 		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
 			return DesiredStateResult{State: map[string]TemplateParams{}}
 		},
@@ -1259,31 +1260,244 @@ func TestCityRuntimeReloadLifecycleFailureWarnsAndAppliesConfig(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 	lastProviderName := "fake"
-	cr.reloadConfig(context.Background(), &lastProviderName, cityPath)
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
 
-	if cr.cfg == oldCfg {
-		t.Fatal("cfg did not change after lifecycle reload warning")
+	if reply.Outcome != reloadOutcomeFailed {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeFailed)
+	}
+	if !strings.Contains(reply.Error, "config reload: boom") {
+		t.Fatalf("reply.Error = %q, want lifecycle error", reply.Error)
+	}
+	if cr.cfg != oldCfg {
+		t.Fatal("cfg changed after lifecycle reload failure")
 	}
 	if cr.sp != oldSP {
-		t.Fatal("provider changed after lifecycle reload warning")
+		t.Fatal("provider changed after lifecycle reload failure")
 	}
 	if cr.dops != oldDops {
-		t.Fatal("drain ops changed after lifecycle reload warning")
+		t.Fatal("drain ops changed after lifecycle reload failure")
 	}
-	if cr.configRev == oldRev {
-		t.Fatalf("configRev = %q, want it to change", cr.configRev)
+	if cr.configRev != oldRev {
+		t.Fatalf("configRev = %q, want %q", cr.configRev, oldRev)
 	}
 	if lastProviderName != "fake" {
 		t.Fatalf("lastProviderName = %q, want fake", lastProviderName)
 	}
-	if !strings.Contains(stderr.String(), "config reload: boom") {
-		t.Fatalf("stderr = %q, want lifecycle warning", stderr.String())
+	if !strings.Contains(stderr.String(), "config reload: boom (keeping old config)") {
+		t.Fatalf("stderr = %q, want lifecycle failure", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "Session provider swapped") {
 		t.Fatalf("stdout = %q, want no provider swap message", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "Config reloaded:") {
-		t.Fatalf("stdout = %q, want reload success message", stdout.String())
+	if strings.Contains(stdout.String(), "Config reloaded:") {
+		t.Fatalf("stdout = %q, want no reload success message", stdout.String())
+	}
+}
+
+func TestCityRuntimeReloadStrictWarningsReturnedOnFailure(t *testing.T) {
+	oldStrict := strictMode
+	strictMode = true
+	t.Cleanup(func() { strictMode = oldStrict })
+
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	sp := runtime.NewFake()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		LogPrefix: "gc reload",
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	if err := os.WriteFile(tomlPath, []byte(`include = ["override.toml"]
+
+[workspace]
+name = "test-city"
+install_agent_hooks = ["claude"]
+
+[session]
+provider = "fake"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "override.toml"), []byte(`[workspace]
+install_agent_hooks = ["codex"]
+`), 0o644); err != nil {
+		t.Fatalf("write override.toml: %v", err)
+	}
+
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+
+	if reply.Outcome != reloadOutcomeFailed {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeFailed)
+	}
+	if !strings.Contains(reply.Error, "strict mode: 1 collision warning(s)") {
+		t.Fatalf("reply.Error = %q", reply.Error)
+	}
+	if !warningsContain(reply.Warnings, "workspace.install_agent_hooks redefined") {
+		t.Fatalf("reply.Warnings = %v, want collision warning", reply.Warnings)
+	}
+	if !warningsContain(reply.Warnings, reloadStrictWarningHint) {
+		t.Fatalf("reply.Warnings = %v, want strict recovery hint", reply.Warnings)
+	}
+	if !strings.Contains(stderr.String(), "gc reload: warning: workspace.install_agent_hooks redefined") {
+		t.Fatalf("stderr = %q, want warning details", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gc reload: warning: "+reloadStrictWarningHint) {
+		t.Fatalf("stderr = %q, want strict recovery hint", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "gc start:") {
+		t.Fatalf("stderr = %q, want reload-specific prefix without gc start", stderr.String())
+	}
+}
+
+func TestCityRuntimeReloadNonStrictWarningsReturnedOnValidationFailure(t *testing.T) {
+	oldStrict := strictMode
+	strictMode = false
+	t.Cleanup(func() { strictMode = oldStrict })
+
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	sp := runtime.NewFake()
+	var stderr bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		LogPrefix: "gc reload",
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: &stderr,
+	})
+	oldCfg := cr.cfg
+
+	if err := os.WriteFile(tomlPath, []byte(`include = ["override.toml"]
+
+[workspace]
+name = "test-city"
+install_agent_hooks = ["claude"]
+
+[session]
+provider = "fake"
+
+[[agent]]
+name = "bad name"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "override.toml"), []byte(`[workspace]
+install_agent_hooks = ["codex"]
+`), 0o644); err != nil {
+		t.Fatalf("write override.toml: %v", err)
+	}
+
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+
+	if reply.Outcome != reloadOutcomeFailed {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeFailed)
+	}
+	if !strings.Contains(reply.Error, "validating agents") {
+		t.Fatalf("reply.Error = %q, want validation failure", reply.Error)
+	}
+	if !warningsContain(reply.Warnings, "workspace.install_agent_hooks redefined") {
+		t.Fatalf("reply.Warnings = %v, want composition warning", reply.Warnings)
+	}
+	if !strings.Contains(stderr.String(), "gc reload: warning: workspace.install_agent_hooks redefined") {
+		t.Fatalf("stderr = %q, want warning details", stderr.String())
+	}
+	if cr.cfg != oldCfg {
+		t.Fatal("cfg changed after validation reload failure")
+	}
+}
+
+func TestCityRuntimeFailActiveReloadRepliesAndClears(t *testing.T) {
+	doneCh := make(chan reloadControlReply, 1)
+	cr := &CityRuntime{
+		activeReload: &reloadRequest{doneCh: doneCh},
+	}
+
+	cr.failActiveReload("Reload canceled because the controller is shutting down.")
+
+	if cr.activeReload != nil {
+		t.Fatal("activeReload was not cleared")
+	}
+	select {
+	case reply := <-doneCh:
+		if reply.Outcome != reloadOutcomeFailed {
+			t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeFailed)
+		}
+		if !strings.Contains(reply.Error, "shutting down") {
+			t.Fatalf("reply.Error = %q, want shutdown reason", reply.Error)
+		}
+	default:
+		t.Fatal("active reload did not receive cancellation reply")
+	}
+}
+
+func TestCityRuntimeHandleReloadRequestInitializesConfigDirty(t *testing.T) {
+	acceptedCh := make(chan reloadControlReply, 1)
+	req := &reloadRequest{
+		acceptedCh: acceptedCh,
+		doneCh:     make(chan reloadControlReply, 1),
+	}
+	cr := &CityRuntime{
+		pokeCh: make(chan struct{}, 1),
+	}
+
+	cr.handleReloadRequest(req)
+
+	if cr.configDirty == nil {
+		t.Fatal("configDirty was not initialized")
+	}
+	if !cr.configDirty.Load() {
+		t.Fatal("configDirty = false, want reload request to mark dirty")
+	}
+	if cr.activeReload != req {
+		t.Fatal("activeReload was not recorded")
+	}
+	select {
+	case <-cr.pokeCh:
+	default:
+		t.Fatal("reload request did not enqueue poke")
+	}
+	select {
+	case reply := <-acceptedCh:
+		if reply.Outcome != reloadOutcomeAccepted {
+			t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeAccepted)
+		}
+	default:
+		t.Fatal("reload request did not receive accepted reply")
 	}
 }
 
@@ -1331,6 +1545,62 @@ func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty for same-revision reload", stdout.String())
+	}
+}
+
+func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	doneCh := make(chan reloadControlReply, 1)
+	dirty := &atomic.Bool{}
+	dirty.Store(true)
+	sp := runtime.NewFake()
+	var stdout bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:    cityPath,
+		CityName:    "test-city",
+		TomlPath:    tomlPath,
+		ConfigRev:   configRev,
+		ConfigDirty: dirty,
+		Cfg:         cfg,
+		SP:          sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			select {
+			case reply := <-doneCh:
+				t.Fatalf("manual reload replied before desired-state rebuild: %+v", reply)
+			default:
+			}
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: io.Discard,
+	})
+	cr.activeReload = &reloadRequest{doneCh: doneCh}
+	lastProviderName := "fake"
+	var prevPoolRunning map[string]bool
+
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "poke")
+
+	select {
+	case reply := <-doneCh:
+		if reply.Outcome != reloadOutcomeNoChange {
+			t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeNoChange)
+		}
+	default:
+		t.Fatal("manual reload did not reply after tick completion")
+	}
+	if cr.activeReload != nil {
+		t.Fatal("activeReload was not cleared")
 	}
 }
 
@@ -1443,4 +1713,13 @@ func writeCityRuntimeConfig(t *testing.T, tomlPath, provider string) {
 	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+}
+
+func warningsContain(warnings []string, substr string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, substr) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/spf13/cobra"
+)
+
+type reloadOutcome string
+
+const (
+	reloadOutcomeApplied  reloadOutcome = "applied"
+	reloadOutcomeNoChange reloadOutcome = "no_change"
+	reloadOutcomeAccepted reloadOutcome = "accepted"
+	reloadOutcomeFailed   reloadOutcome = "failed"
+	reloadOutcomeBusy     reloadOutcome = "busy"
+	reloadOutcomeTimeout  reloadOutcome = "timeout"
+)
+
+type reloadSource string
+
+const (
+	reloadSourceWatch  reloadSource = "watch"
+	reloadSourceManual reloadSource = "manual"
+)
+
+var (
+	controllerReloadAcceptTimeout = 5 * time.Second
+	sendReloadControlRequestHook  = sendReloadControlRequest
+	reloadUnavailableMessageHook  = reloadUnavailableMessage
+	supervisorAPIBaseURLHook      = supervisorAPIBaseURL
+)
+
+type reloadControlRequest struct {
+	Wait    bool   `json:"wait"`
+	Timeout string `json:"timeout,omitempty"`
+}
+
+type reloadControlReply struct {
+	Outcome  reloadOutcome `json:"outcome,omitempty"`
+	Message  string        `json:"message,omitempty"`
+	Revision string        `json:"revision,omitempty"`
+	Warnings []string      `json:"warnings,omitempty"`
+	Error    string        `json:"error,omitempty"`
+}
+
+type reloadRequest struct {
+	wait       bool
+	timeout    time.Duration
+	acceptedCh chan reloadControlReply
+	doneCh     chan reloadControlReply
+}
+
+func newReloadCmd(stdout, stderr io.Writer) *cobra.Command {
+	var async bool
+	var timeoutValue string
+	cmd := &cobra.Command{
+		Use:   "reload [path]",
+		Short: "Reload the current city's config without restarting the city/controller",
+		Long: `Force the current city controller to re-read effective config and
+process one reload tick without restarting the city/controller.
+
+Reload may fetch configured remote packs before recomputing effective
+config. Existing per-session restarts may still happen if normal config
+drift rules require them.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			timeoutChanged := cmd.Flags().Changed("timeout")
+			if cmdReload(args, async, timeoutValue, timeoutChanged, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&async, "async", false, "Return after the controller accepts the reload request")
+	cmd.Flags().StringVar(&timeoutValue, "timeout", "5m", "How long to wait for reload completion")
+	return cmd
+}
+
+func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCommandCity(args)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	if async && timeoutChanged {
+		fmt.Fprintln(stderr, "gc reload: --async and --timeout cannot be used together") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	req := reloadControlRequest{Wait: !async}
+	if !async {
+		timeout, err := time.ParseDuration(timeoutValue)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc reload: invalid --timeout %q: %v\n", timeoutValue, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if timeout <= 0 {
+			fmt.Fprintln(stderr, "gc reload: --timeout must be greater than 0") //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		req.Timeout = timeout.String()
+	}
+
+	reply, err := sendReloadControlRequestHook(cityPath, req)
+	if err != nil {
+		if isControllerUnavailableError(err) {
+			if msg := reloadUnavailableMessageHook(cityPath); msg != "" {
+				fmt.Fprintf(stderr, "gc reload: %s\n", msg) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
+		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	switch reply.Outcome {
+	case reloadOutcomeAccepted, reloadOutcomeApplied, reloadOutcomeNoChange:
+		if strings.TrimSpace(reply.Message) != "" {
+			fmt.Fprintln(stdout, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stdout
+		}
+		for _, warning := range reply.Warnings {
+			fmt.Fprintf(stderr, "gc reload: warning: %s\n", warning) //nolint:errcheck // best-effort stderr
+		}
+		return 0
+	case reloadOutcomeFailed:
+		switch {
+		case strings.TrimSpace(reply.Error) != "":
+			fmt.Fprintln(stderr, strings.TrimSpace(reply.Error)) //nolint:errcheck // best-effort stderr
+		case strings.TrimSpace(reply.Message) != "":
+			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
+		default:
+			fmt.Fprintln(stderr, "gc reload: reload failed") //nolint:errcheck // best-effort stderr
+		}
+		return 1
+	case reloadOutcomeBusy, reloadOutcomeTimeout:
+		if strings.TrimSpace(reply.Message) != "" {
+			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
+		} else {
+			fmt.Fprintf(stderr, "gc reload: %s\n", reply.Outcome) //nolint:errcheck // best-effort stderr
+		}
+		return 1
+	default:
+		fmt.Fprintf(stderr, "gc reload: unexpected controller outcome %q\n", reply.Outcome) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+}
+
+func isControllerUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "connecting to controller:")
+}
+
+func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return reloadControlReply{}, fmt.Errorf("marshaling request: %w", err)
+	}
+	readTimeout := 15 * time.Second
+	if req.Wait && req.Timeout != "" {
+		timeout, err := time.ParseDuration(req.Timeout)
+		if err != nil {
+			return reloadControlReply{}, fmt.Errorf("parsing request timeout: %w", err)
+		}
+		readTimeout = controllerReloadAcceptTimeout + timeout + 10*time.Second
+	}
+	resp, err := sendControllerCommandWithReadTimeout(cityPath, "reload:"+string(data), readTimeout)
+	if err != nil {
+		return reloadControlReply{}, err
+	}
+	var reply reloadControlReply
+	if err := json.Unmarshal(resp, &reply); err != nil {
+		return reloadControlReply{}, fmt.Errorf("parsing response: %w", err)
+	}
+	return reply, nil
+}
+
+func reloadUnavailableMessage(cityPath string) string {
+	info, ok := supervisorCityInfo(cityPath)
+	if !ok {
+		return ""
+	}
+	switch {
+	case info.Running:
+		return "controller is running but not responding"
+	case info.Status == "init_failed" && strings.TrimSpace(info.Error) != "":
+		return fmt.Sprintf("city failed to start under supervisor: %s", strings.TrimSpace(info.Error))
+	case info.Status == "init_failed":
+		return "city failed to start under supervisor"
+	case strings.TrimSpace(info.Status) != "":
+		return fmt.Sprintf("city is still starting under supervisor (%s)", controllerSupervisorStatusText(info.Status))
+	default:
+		return "city controller is not running"
+	}
+}
+
+func supervisorCityInfo(cityPath string) (api.CityInfo, bool) {
+	entry, registered, err := registeredCityEntry(cityPath)
+	if err != nil || !registered || supervisorAliveHook() == 0 {
+		return api.CityInfo{}, false
+	}
+	baseURL, err := supervisorAPIBaseURLHook()
+	if err != nil {
+		return api.CityInfo{}, false
+	}
+	client := api.NewClient(baseURL)
+	cities, err := client.ListCities()
+	if err != nil {
+		return api.CityInfo{}, false
+	}
+	for _, city := range cities {
+		if samePath(city.Path, entry.Path) {
+			return city, true
+		}
+	}
+	return api.CityInfo{}, false
+}
+
+func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout time.Duration) ([]byte, error) {
+	sockPath := controllerSocketPath(cityPath)
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to controller: %w (is the controller running?)", err)
+	}
+	defer conn.Close()                                     //nolint:errcheck
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	conn.SetReadDeadline(time.Now().Add(readTimeout))      //nolint:errcheck
+	if _, err := conn.Write([]byte(command + "\n")); err != nil {
+		return nil, fmt.Errorf("sending command: %w", err)
+	}
+	var data []byte
+	buf := make([]byte, 64*1024)
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			data = append(data, buf[:n]...)
+			if strings.Contains(string(data), "\n") {
+				break
+			}
+		}
+		if err != nil {
+			if len(data) > 0 && strings.Contains(string(data), "\n") {
+				break
+			}
+			return nil, fmt.Errorf("reading response: %w", err)
+		}
+	}
+	return []byte(strings.TrimSpace(string(data))), nil
+}

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"net"
 	"strings"
 	"time"
 
@@ -113,7 +113,7 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 	if err != nil {
 		if isControllerUnavailableError(err) {
 			if msg := reloadUnavailableMessageHook(cityPath); msg != "" {
-				fmt.Fprintf(stderr, "gc reload: %s\n", msg) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "gc reload: %s: %v\n", msg, err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 		}
@@ -131,6 +131,9 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 		}
 		return 0
 	case reloadOutcomeFailed:
+		for _, warning := range reply.Warnings {
+			fmt.Fprintf(stderr, "gc reload: warning: %s\n", warning) //nolint:errcheck // best-effort stderr
+		}
 		switch {
 		case strings.TrimSpace(reply.Error) != "":
 			fmt.Fprintln(stderr, strings.TrimSpace(reply.Error)) //nolint:errcheck // best-effort stderr
@@ -157,7 +160,7 @@ func isControllerUnavailableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "connecting to controller:")
+	return errors.Is(err, errControllerUnavailable) || errors.Is(err, errControllerUnresponsive)
 }
 
 func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
@@ -223,36 +226,4 @@ func supervisorCityInfo(cityPath string) (api.CityInfo, bool) {
 		}
 	}
 	return api.CityInfo{}, false
-}
-
-func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout time.Duration) ([]byte, error) {
-	sockPath := controllerSocketPath(cityPath)
-	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
-	if err != nil {
-		return nil, fmt.Errorf("connecting to controller: %w (is the controller running?)", err)
-	}
-	defer conn.Close()                                     //nolint:errcheck
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
-	conn.SetReadDeadline(time.Now().Add(readTimeout))      //nolint:errcheck
-	if _, err := conn.Write([]byte(command + "\n")); err != nil {
-		return nil, fmt.Errorf("sending command: %w", err)
-	}
-	var data []byte
-	buf := make([]byte, 64*1024)
-	for {
-		n, err := conn.Read(buf)
-		if n > 0 {
-			data = append(data, buf[:n]...)
-			if strings.Contains(string(data), "\n") {
-				break
-			}
-		}
-		if err != nil {
-			if len(data) > 0 && strings.Contains(string(data), "\n") {
-				break
-			}
-			return nil, fmt.Errorf("reading response: %w", err)
-		}
-	}
-	return []byte(strings.TrimSpace(string(data))), nil
 }

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -87,7 +87,12 @@ func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
 	})
 
 	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
-		return reloadControlReply{}, errors.New("connecting to controller: dial failed")
+		return reloadControlReply{}, controllerCommandError{
+			op:           "connecting to controller",
+			err:          errors.New("dial failed"),
+			unavailable:  true,
+			unresponsive: false,
+		}
 	}
 	reloadUnavailableMessageHook = func(string) string {
 		return "city failed to start under supervisor: fetching packs: auth denied"
@@ -97,7 +102,38 @@ func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
 	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
-	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied" {
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied: connecting to controller: dial failed" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestCmdReloadControllerUnresponsiveUsesRicherMessage(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-unresponsive-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{}, controllerCommandError{
+			op:           "reading response",
+			err:          errors.New("i/o timeout"),
+			unresponsive: true,
+		}
+	}
+	reloadUnavailableMessageHook = func(string) string {
+		return "controller is running but not responding"
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: controller is running but not responding: reading response: i/o timeout" {
 		t.Fatalf("stderr = %q", got)
 	}
 }
@@ -129,6 +165,41 @@ func TestCmdReloadPreservesProtocolErrors(t *testing.T) {
 	}
 }
 
+func TestCmdReloadFailedReplyPrintsWarnings(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-failed-warnings-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Warnings: []string{
+				`workspace.install_agent_hooks redefined by "override.toml"`,
+			},
+			Error: "strict mode: 1 collision warning(s)",
+		}, nil
+	}
+	reloadUnavailableMessageHook = func(string) string { return "" }
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	got := stderr.String()
+	if !strings.Contains(got, `gc reload: warning: workspace.install_agent_hooks redefined by "override.toml"`) {
+		t.Fatalf("stderr = %q, want warning detail", got)
+	}
+	if !strings.Contains(got, "strict mode: 1 collision warning(s)") {
+		t.Fatalf("stderr = %q, want strict error", got)
+	}
+}
+
 func TestHandleReloadSocketCmdAsyncAccepted(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close() //nolint:errcheck
@@ -155,6 +226,42 @@ func TestHandleReloadSocketCmdAsyncAccepted(t *testing.T) {
 	}
 	if reply.Message != "Reload requested." {
 		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestHandleReloadSocketCmdAsyncIgnoresInvalidTimeout(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false,"timeout":"bad"}`, reloadReqCh)
+		close(done)
+	}()
+
+	req := <-reloadReqCh
+	if req.wait {
+		t.Fatal("req.wait = true, want false")
+	}
+	if req.timeout != 0 {
+		t.Fatalf("req.timeout = %s, want 0 for async request", req.timeout)
+	}
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeAccepted {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeAccepted)
 	}
 
 	client.Close() //nolint:errcheck
@@ -229,6 +336,42 @@ func TestHandleReloadSocketCmdBusyOnAcceptTimeout(t *testing.T) {
 	case req := <-reloadReqCh:
 		t.Fatalf("unexpected queued reload request after busy reply: %+v", req)
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestHandleReloadSocketCmdWaitsForAcceptedAfterHandoff(t *testing.T) {
+	oldAccept := controllerReloadAcceptTimeout
+	controllerReloadAcceptTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { controllerReloadAcceptTimeout = oldAccept })
+
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false}`, reloadReqCh)
+		close(done)
+	}()
+
+	time.Sleep(180 * time.Millisecond)
+	req := <-reloadReqCh
+	time.Sleep(50 * time.Millisecond)
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeAccepted {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeAccepted)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
 	}
 }
 

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/api"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/supervisor"
+)
+
+func TestCmdReloadApplied(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-cli-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+		if cityPath != canonicalTestPath(dir) {
+			t.Fatalf("cityPath = %q, want %q", cityPath, canonicalTestPath(dir))
+		}
+		if !req.Wait || req.Timeout != "30s" {
+			t.Fatalf("req = %+v, want wait=true timeout=30s", req)
+		}
+		return reloadControlReply{
+			Outcome:  reloadOutcomeApplied,
+			Message:  "Config reloaded: 1 agents, 0 rigs (rev abc123def456)",
+			Revision: "abc123def4567890",
+			Warnings: []string{"service reload: boom"},
+		}, nil
+	}
+	reloadUnavailableMessageHook = func(string) string { return "" }
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "30s", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "Config reloaded: 1 agents, 0 rigs (rev abc123def456)" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: warning: service reload: boom" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestCmdReloadAsyncExplicitTimeoutInvalid(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-flags-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, true, "30s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "--async and --timeout cannot be used together") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-unavail-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{}, errors.New("connecting to controller: dial failed")
+	}
+	reloadUnavailableMessageHook = func(string) string {
+		return "city failed to start under supervisor: fetching packs: auth denied"
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestCmdReloadPreservesProtocolErrors(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-protocol-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(string, reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{}, errors.New("parsing response: invalid character 'o' in literal null")
+	}
+	reloadUnavailableMessageHook = func(string) string {
+		return "city is still starting under supervisor"
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+		t.Fatalf("cmdReload = %d, want 1", code)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "gc reload: parsing response: invalid character 'o' in literal null" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestHandleReloadSocketCmdAsyncAccepted(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false}`, reloadReqCh)
+		close(done)
+	}()
+
+	req := <-reloadReqCh
+	if req.wait {
+		t.Fatal("req.wait = true, want false")
+	}
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeAccepted {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeAccepted)
+	}
+	if reply.Message != "Reload requested." {
+		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestHandleReloadSocketCmdSyncTimeout(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":true,"timeout":"20ms"}`, reloadReqCh)
+		close(done)
+	}()
+
+	req := <-reloadReqCh
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeTimeout {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeTimeout)
+	}
+	if !strings.Contains(reply.Message, "may still complete later") {
+		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestHandleReloadSocketCmdBusyOnAcceptTimeout(t *testing.T) {
+	oldAccept := controllerReloadAcceptTimeout
+	controllerReloadAcceptTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { controllerReloadAcceptTimeout = oldAccept })
+
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest)
+
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false}`, reloadReqCh)
+		close(done)
+	}()
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeBusy {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeBusy)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+	select {
+	case req := <-reloadReqCh:
+		t.Fatalf("unexpected queued reload request after busy reply: %+v", req)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSendReloadControlRequestNoChange(t *testing.T) {
+	sp := runtime.NewFake()
+
+	var reconcileCount atomic.Int32
+	buildFn := func(c *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		reconcileCount.Add(1)
+		ds := make(map[string]TemplateParams)
+		for _, a := range c.Agents {
+			if a.Implicit {
+				continue
+			}
+			ds[a.Name] = TemplateParams{SessionName: a.Name, TemplateName: a.Name, Command: "echo hello"}
+		}
+		return DesiredStateResult{State: ds}
+	}
+
+	dir := shortSocketTempDir(t, "gc-reload-no-change-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := writeCityTOML(t, dir, "test", "mayor")
+	cfg, prov, err := config.LoadWithIncludes(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configRev := config.Revision(osFS{}, prov, cfg, dir)
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, tomlPath, cfg, configRev, buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &stdout, &stderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		tryStopController(dir, &bytes.Buffer{})
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForController(t, dir)
+	deadline := time.After(5 * time.Second)
+	for reconcileCount.Load() < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for initial reconcile")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	reply, err := sendReloadControlRequest(dir, reloadControlRequest{Wait: true, Timeout: "1s"})
+	if err != nil {
+		t.Fatalf("sendReloadControlRequest: %v", err)
+	}
+	if reply.Outcome != reloadOutcomeNoChange {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeNoChange)
+	}
+	if reply.Message != "No config changes detected." {
+		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+	if len(reply.Warnings) != 0 {
+		t.Fatalf("reply.Warnings = %v, want none", reply.Warnings)
+	}
+}
+
+func TestSendReloadControlRequestInvalidConfig(t *testing.T) {
+	sp := runtime.NewFake()
+
+	var reconcileCount atomic.Int32
+	buildFn := func(c *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		reconcileCount.Add(1)
+		ds := make(map[string]TemplateParams)
+		for _, a := range c.Agents {
+			if a.Implicit {
+				continue
+			}
+			ds[a.Name] = TemplateParams{SessionName: a.Name, TemplateName: a.Name, Command: "echo hello"}
+		}
+		return DesiredStateResult{State: ds}
+	}
+
+	dir := shortSocketTempDir(t, "gc-reload-invalid-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := writeCityTOML(t, dir, "test", "mayor")
+	cfg, prov, err := config.LoadWithIncludes(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configRev := config.Revision(osFS{}, prov, cfg, dir)
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, tomlPath, cfg, configRev, buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &stdout, &stderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		tryStopController(dir, &bytes.Buffer{})
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForController(t, dir)
+	deadline := time.After(5 * time.Second)
+	for reconcileCount.Load() < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for initial reconcile")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if err := os.WriteFile(tomlPath, []byte("[[[ bad toml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reply, err := sendReloadControlRequest(dir, reloadControlRequest{Wait: true, Timeout: "1s"})
+	if err != nil {
+		t.Fatalf("sendReloadControlRequest: %v", err)
+	}
+	if reply.Outcome != reloadOutcomeFailed {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeFailed)
+	}
+	if !strings.Contains(reply.Error, "parsing city.toml") {
+		t.Fatalf("reply.Error = %q", reply.Error)
+	}
+	if strings.Contains(stdout.String(), "Config reloaded:") {
+		t.Fatalf("stdout unexpectedly contains reload success: %q", stdout.String())
+	}
+}
+
+func readReloadSocketReply(t *testing.T, conn net.Conn) reloadControlReply {
+	t.Helper()
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			t.Fatalf("read reply: %v", err)
+		}
+		t.Fatal("read reply: connection closed")
+	}
+	var reply reloadControlReply
+	if err := json.Unmarshal(scanner.Bytes(), &reply); err != nil {
+		t.Fatalf("decode reply: %v", err)
+	}
+	return reply
+}
+
+func TestSupervisorCityInfoMatchesNormalizedPath(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	realDir := shortSocketTempDir(t, "gc-reload-supervisor-real-")
+	linkDir := filepath.Join(t.TempDir(), "city-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(supervisor.RegistryPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(realDir, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/cities" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		payload := map[string]any{
+			"items": []api.CityInfo{{
+				Name:   "test",
+				Path:   linkDir,
+				Status: "starting_agents",
+			}},
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Fatalf("encode cities: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	oldAlive := supervisorAliveHook
+	oldBaseURL := supervisorAPIBaseURLHook
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorAPIBaseURLHook = oldBaseURL
+	})
+	supervisorAliveHook = func() int { return 4242 }
+	supervisorAPIBaseURLHook = func() (string, error) { return server.URL, nil }
+
+	info, ok := supervisorCityInfo(realDir)
+	if !ok {
+		t.Fatal("supervisorCityInfo returned ok=false")
+	}
+	if info.Path != linkDir {
+		t.Fatalf("info.Path = %q, want %q", info.Path, linkDir)
+	}
+}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1220,6 +1220,7 @@ func reconcileCities(
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, path)
 		pokeCh := make(chan struct{}, 1)
 		configDirty := &atomic.Bool{}
+		reloadReqCh := make(chan reloadRequest)
 		cityCtx, cityCancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
 		mc := &managedCity{name: cityName, cancel: cityCancel, done: done, closer: fr}
@@ -1245,6 +1246,7 @@ func reconcileCities(
 				Rec:                     rec,
 				PoolSessions:            poolSessions,
 				PoolDeathHandlers:       poolDeathHandlers,
+				ReloadReqCh:             reloadReqCh,
 				ConvergenceReqCh:        convergenceReqCh,
 				PokeCh:                  pokeCh,
 				ControlDispatcherCh:     controlDispatcherCh,
@@ -1339,7 +1341,7 @@ func reconcileCities(
 		// Start controller socket AFTER the alreadyRunning check so we
 		// never destroy a live city's socket or leak a listener.
 		sockPath := filepath.Join(path, ".gc", "controller.sock")
-		lis, lisErr := startControllerSocket(path, cityCancel, configDirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+		lis, lisErr := startControllerSocket(path, cityCancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		if lisErr != nil {
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': controller socket: %v\n", cityName, lisErr) //nolint:errcheck
 			lock.Close()                                                                               //nolint:errcheck // no socket to race with

--- a/cmd/gc/cmd_trace_test.go
+++ b/cmd/gc/cmd_trace_test.go
@@ -150,7 +150,7 @@ func TestTraceControllerSocketInvalidRequestDoesNotPoke(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 
@@ -228,7 +228,7 @@ func sendTraceSocketCommand(t *testing.T, cityDir, command string, req traceCont
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 
@@ -259,7 +259,7 @@ func sendTraceStatusSocketCommand(t *testing.T, cityDir string, pokeCh chan stru
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -32,7 +32,40 @@ import (
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
-var errControllerAlreadyRunning = errors.New("controller already running")
+var (
+	errControllerAlreadyRunning = errors.New("controller already running")
+	errControllerUnavailable    = errors.New("controller unavailable")
+	errControllerUnresponsive   = errors.New("controller unresponsive")
+)
+
+type controllerCommandError struct {
+	op           string
+	err          error
+	unavailable  bool
+	unresponsive bool
+}
+
+func (e controllerCommandError) Error() string {
+	if e.op == "" {
+		if e.err == nil {
+			return "controller command failed"
+		}
+		return e.err.Error()
+	}
+	if e.err == nil {
+		return e.op
+	}
+	return fmt.Sprintf("%s: %v", e.op, e.err)
+}
+
+func (e controllerCommandError) Unwrap() error {
+	return e.err
+}
+
+func (e controllerCommandError) Is(target error) bool {
+	return (target == errControllerUnavailable && e.unavailable) ||
+		(target == errControllerUnresponsive && e.unresponsive)
+}
 
 const controllerSocketPathLimit = 100
 
@@ -194,26 +227,28 @@ func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest)
 	}
 
 	var timeout time.Duration
-	if wire.Timeout != "" {
-		parsed, err := time.ParseDuration(wire.Timeout)
-		if err != nil {
+	if wire.Wait {
+		if wire.Timeout != "" {
+			parsed, err := time.ParseDuration(wire.Timeout)
+			if err != nil {
+				writeJSONLine(conn, reloadControlReply{
+					Outcome: reloadOutcomeFailed,
+					Error:   fmt.Sprintf("invalid reload timeout %q: %v", wire.Timeout, err),
+				})
+				return
+			}
+			timeout = parsed
+		}
+		if timeout <= 0 {
 			writeJSONLine(conn, reloadControlReply{
 				Outcome: reloadOutcomeFailed,
-				Error:   fmt.Sprintf("invalid reload timeout %q: %v", wire.Timeout, err),
+				Error:   "reload timeout must be greater than 0",
 			})
 			return
 		}
-		timeout = parsed
-	}
-	if wire.Wait && timeout <= 0 {
-		writeJSONLine(conn, reloadControlReply{
-			Outcome: reloadOutcomeFailed,
-			Error:   "reload timeout must be greater than 0",
-		})
-		return
 	}
 
-	totalDeadline := controllerReloadAcceptTimeout + 5*time.Second
+	totalDeadline := 2*controllerReloadAcceptTimeout + 5*time.Second
 	if wire.Wait {
 		totalDeadline += timeout
 	}
@@ -269,11 +304,11 @@ func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest)
 		return
 	}
 
-	reply, ok := waitFor(req.acceptedCh, remaining())
+	reply, ok := waitFor(req.acceptedCh, controllerReloadAcceptTimeout)
 	if !ok {
 		writeJSONLine(conn, reloadControlReply{
-			Outcome: reloadOutcomeBusy,
-			Message: "Reload request could not be accepted because the controller is busy.",
+			Outcome: reloadOutcomeFailed,
+			Message: "Reload request was handed to the controller but was not acknowledged in time.",
 		})
 		return
 	}
@@ -337,6 +372,41 @@ func writeJSONLine(w net.Conn, v any) {
 // route through the controller.
 func sendControllerCommand(cityPath, command string) ([]byte, error) {
 	return sendControllerCommandWithReadTimeout(cityPath, command, 95*time.Second)
+}
+
+func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout time.Duration) ([]byte, error) {
+	sockPath := controllerSocketPath(cityPath)
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		return nil, controllerCommandError{
+			op:          "connecting to controller",
+			err:         fmt.Errorf("%w (is the controller running?)", err),
+			unavailable: true,
+		}
+	}
+	defer conn.Close()                                     //nolint:errcheck
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	conn.SetReadDeadline(time.Now().Add(readTimeout))      //nolint:errcheck
+	if _, err := conn.Write([]byte(command + "\n")); err != nil {
+		return nil, fmt.Errorf("sending command: %w", err)
+	}
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, controllerCommandError{
+				op:           "reading response",
+				err:          err,
+				unresponsive: true,
+			}
+		}
+		return nil, controllerCommandError{
+			op:           "reading response",
+			err:          io.ErrUnexpectedEOF,
+			unresponsive: true,
+		}
+	}
+	return []byte(strings.TrimSpace(scanner.Text())), nil
 }
 
 // controllerAlive checks whether a controller is running by connecting
@@ -455,12 +525,44 @@ type reloadResult struct {
 	Warnings []string
 }
 
+type reloadWarningError struct {
+	err      error
+	warnings []string
+}
+
+func (e reloadWarningError) Error() string {
+	return e.err.Error()
+}
+
+func (e reloadWarningError) Unwrap() error {
+	return e.err
+}
+
+func (e reloadWarningError) ReloadWarnings() []string {
+	return append([]string(nil), e.warnings...)
+}
+
+type reloadWarningCarrier interface {
+	ReloadWarnings() []string
+}
+
+const reloadStrictWarningHint = "use --no-strict to disable strict checking"
+
+func reloadWarningsFromError(err error) []string {
+	var carrier reloadWarningCarrier
+	if errors.As(err, &carrier) {
+		return carrier.ReloadWarnings()
+	}
+	return nil
+}
+
 // tryReloadConfig attempts to reload city.toml with includes and patches.
 // Returns the new config, provenance, revision, and non-fatal warnings on
 // success, or an error on failure (parse error, validation error, cityName
-// changed). Callers should keep the old config on error. Strict mode
-// (default) makes composition warnings fatal — use --no-strict to disable.
-func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer) (*reloadResult, error) {
+// changed). Some failures after composition also return warning metadata via
+// the result and error; callers should report those details while keeping the
+// old config. Strict mode (default) makes composition warnings fatal.
+func tryReloadConfig(tomlPath, lockedCityName, cityRoot string) (*reloadResult, error) {
 	// Auto-fetch remote packs before full config load (mirrors cmd_start).
 	if quickCfg, qErr := config.Load(fsys.OSFS{}, tomlPath); qErr == nil && len(quickCfg.Packs) > 0 {
 		if fErr := config.FetchPacks(quickCfg.Packs, cityRoot); fErr != nil {
@@ -473,31 +575,49 @@ func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer
 		return nil, fmt.Errorf("parsing city.toml: %w", err)
 	}
 	applyFeatureFlags(newCfg)
-	if strictMode && len(prov.Warnings) > 0 {
-		for _, w := range prov.Warnings {
-			fmt.Fprintf(stderr, "gc start: strict: %s\n", w) //nolint:errcheck // best-effort stderr
+	reloadWarnings := append([]string(nil), prov.Warnings...)
+	resultWithWarnings := func(warnings []string) *reloadResult {
+		return &reloadResult{
+			Cfg:      newCfg,
+			Prov:     prov,
+			Warnings: append([]string(nil), warnings...),
 		}
-		fmt.Fprintln(stderr, "gc start: use --no-strict to disable strict checking") //nolint:errcheck // best-effort stderr
-		return nil, fmt.Errorf("strict mode: %d collision warning(s)", len(prov.Warnings))
+	}
+	failWithWarnings := func(err error) (*reloadResult, error) {
+		if len(reloadWarnings) == 0 {
+			return nil, err
+		}
+		return resultWithWarnings(reloadWarnings), reloadWarningError{
+			err:      err,
+			warnings: reloadWarnings,
+		}
+	}
+	if strictMode && len(prov.Warnings) > 0 {
+		warnings := append(append([]string(nil), reloadWarnings...), reloadStrictWarningHint)
+		result := resultWithWarnings(warnings)
+		return result, reloadWarningError{
+			err:      fmt.Errorf("strict mode: %d collision warning(s)", len(prov.Warnings)),
+			warnings: warnings,
+		}
 	}
 	if err := config.ValidateAgents(newCfg.Agents); err != nil {
-		return nil, fmt.Errorf("validating agents: %w", err)
+		return failWithWarnings(fmt.Errorf("validating agents: %w", err))
 	}
 	if err := config.ValidateServices(newCfg.Services); err != nil {
-		return nil, fmt.Errorf("validating services: %w", err)
+		return failWithWarnings(fmt.Errorf("validating services: %w", err))
 	}
 	if err := workspacesvc.ValidateRuntimeSupport(newCfg.Services); err != nil {
-		return nil, fmt.Errorf("validating services: %w", err)
+		return failWithWarnings(fmt.Errorf("validating services: %w", err))
 	}
 	newName := newCfg.Workspace.Name
 	if newName == "" {
 		newName = filepath.Base(filepath.Dir(tomlPath))
 	}
 	if newName != lockedCityName {
-		return nil, fmt.Errorf("workspace.name changed from %q to %q (restart controller to apply)", lockedCityName, newName)
+		return failWithWarnings(fmt.Errorf("workspace.name changed from %q to %q (restart controller to apply)", lockedCityName, newName))
 	}
 	rev := config.Revision(fsys.OSFS{}, prov, newCfg, cityRoot)
-	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev, Warnings: prov.Warnings}, nil
+	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev, Warnings: reloadWarnings}, nil
 }
 
 // gracefulStopAll performs two-pass graceful shutdown:

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -75,6 +75,7 @@ func startControllerSocket(
 	cityPath string,
 	cancelFn context.CancelFunc,
 	dirty *atomic.Bool,
+	reloadReqCh chan reloadRequest,
 	convergenceReqCh chan convergenceRequest,
 	pokeCh chan struct{},
 	controlDispatcherCh chan struct{},
@@ -95,7 +96,7 @@ func startControllerSocket(
 			if err != nil {
 				return // listener closed
 			}
-			go handleControllerConn(conn, cityPath, cancelFn, dirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+			go handleControllerConn(conn, cityPath, cancelFn, dirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		}
 	}()
 	return lis, nil
@@ -109,6 +110,7 @@ func handleControllerConn(
 	cityPath string,
 	cancelFn context.CancelFunc,
 	dirty *atomic.Bool,
+	reloadReqCh chan reloadRequest,
 	convergenceReqCh chan convergenceRequest,
 	pokeCh chan struct{},
 	controlDispatcherCh chan struct{},
@@ -143,6 +145,8 @@ func handleControllerConn(
 			default:
 			}
 			conn.Write([]byte("ok\n")) //nolint:errcheck // best-effort ack
+		case strings.HasPrefix(line, "reload:"):
+			handleReloadSocketCmd(conn, line[len("reload:"):], reloadReqCh)
 		case line == "control-dispatcher":
 			select {
 			case controlDispatcherCh <- struct{}{}:
@@ -169,6 +173,128 @@ func handleControllerConn(
 			handleTraceStatusSocketCmd(conn, cityPath)
 		}
 	}
+}
+
+func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest) {
+	if ch == nil {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   "reload control unavailable",
+		})
+		return
+	}
+
+	var wire reloadControlRequest
+	if err := json.Unmarshal([]byte(payload), &wire); err != nil {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   fmt.Sprintf("invalid reload request: %v", err),
+		})
+		return
+	}
+
+	var timeout time.Duration
+	if wire.Timeout != "" {
+		parsed, err := time.ParseDuration(wire.Timeout)
+		if err != nil {
+			writeJSONLine(conn, reloadControlReply{
+				Outcome: reloadOutcomeFailed,
+				Error:   fmt.Sprintf("invalid reload timeout %q: %v", wire.Timeout, err),
+			})
+			return
+		}
+		timeout = parsed
+	}
+	if wire.Wait && timeout <= 0 {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   "reload timeout must be greater than 0",
+		})
+		return
+	}
+
+	totalDeadline := controllerReloadAcceptTimeout + 5*time.Second
+	if wire.Wait {
+		totalDeadline += timeout
+	}
+	conn.SetDeadline(time.Now().Add(totalDeadline)) //nolint:errcheck // command-specific override
+
+	req := reloadRequest{
+		wait:       wire.Wait,
+		timeout:    timeout,
+		acceptedCh: make(chan reloadControlReply, 1),
+		doneCh:     make(chan reloadControlReply, 1),
+	}
+
+	deadline := time.Now().Add(controllerReloadAcceptTimeout)
+	remaining := func() time.Duration {
+		d := time.Until(deadline)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+
+	waitFor := func(ch <-chan reloadControlReply, timeout time.Duration) (reloadControlReply, bool) {
+		if timeout <= 0 {
+			return reloadControlReply{}, false
+		}
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case reply := <-ch:
+			return reply, true
+		case <-timer.C:
+			return reloadControlReply{}, false
+		}
+	}
+
+	acceptTimeout := remaining()
+	if acceptTimeout <= 0 {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because the controller is busy.",
+		})
+		return
+	}
+	timer := time.NewTimer(acceptTimeout)
+	defer timer.Stop()
+	select {
+	case ch <- req:
+	case <-timer.C:
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because the controller is busy.",
+		})
+		return
+	}
+
+	reply, ok := waitFor(req.acceptedCh, remaining())
+	if !ok {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeBusy,
+			Message: "Reload request could not be accepted because the controller is busy.",
+		})
+		return
+	}
+	if reply.Outcome != reloadOutcomeAccepted {
+		writeJSONLine(conn, reply)
+		return
+	}
+	if !req.wait {
+		writeJSONLine(conn, reply)
+		return
+	}
+
+	finalReply, ok := waitFor(req.doneCh, req.timeout)
+	if !ok {
+		writeJSONLine(conn, reloadControlReply{
+			Outcome: reloadOutcomeTimeout,
+			Message: "Reload did not finish before timeout; it may still complete later.",
+		})
+		return
+	}
+	writeJSONLine(conn, finalReply)
 }
 
 // handleConvergeSocketCmd parses a convergence JSON request, enqueues it
@@ -210,26 +336,7 @@ func writeJSONLine(w net.Conn, v any) {
 // returns the raw response bytes. Used by CLI commands that need to
 // route through the controller.
 func sendControllerCommand(cityPath, command string) ([]byte, error) {
-	sockPath := controllerSocketPath(cityPath)
-	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
-	if err != nil {
-		return nil, fmt.Errorf("connecting to controller: %w (is the controller running?)", err)
-	}
-	defer conn.Close()                                     //nolint:errcheck
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
-	conn.SetReadDeadline(time.Now().Add(95 * time.Second)) //nolint:errcheck // Must exceed server-side 30s enqueue + 60s reply
-	if _, err := conn.Write([]byte(command + "\n")); err != nil {
-		return nil, fmt.Errorf("sending command: %w", err)
-	}
-	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("reading response: %w", err)
-		}
-		return nil, fmt.Errorf("reading response: connection closed")
-	}
-	return scanner.Bytes(), nil
+	return sendControllerCommandWithReadTimeout(cityPath, command, 95*time.Second)
 }
 
 // controllerAlive checks whether a controller is running by connecting
@@ -345,13 +452,14 @@ type reloadResult struct {
 	Cfg      *config.City
 	Prov     *config.Provenance
 	Revision string
+	Warnings []string
 }
 
 // tryReloadConfig attempts to reload city.toml with includes and patches.
-// Returns the new config, provenance, and revision on success, or an error
-// on failure (parse error, validation error, cityName changed). Callers
-// should keep the old config on error. Warnings are written to stderr;
-// strict mode (default) makes them fatal — use --no-strict to disable.
+// Returns the new config, provenance, revision, and non-fatal warnings on
+// success, or an error on failure (parse error, validation error, cityName
+// changed). Callers should keep the old config on error. Strict mode
+// (default) makes composition warnings fatal — use --no-strict to disable.
 func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer) (*reloadResult, error) {
 	// Auto-fetch remote packs before full config load (mirrors cmd_start).
 	if quickCfg, qErr := config.Load(fsys.OSFS{}, tomlPath); qErr == nil && len(quickCfg.Packs) > 0 {
@@ -372,9 +480,6 @@ func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer
 		fmt.Fprintln(stderr, "gc start: use --no-strict to disable strict checking") //nolint:errcheck // best-effort stderr
 		return nil, fmt.Errorf("strict mode: %d collision warning(s)", len(prov.Warnings))
 	}
-	for _, w := range prov.Warnings {
-		fmt.Fprintf(stderr, "gc start: warning: %s\n", w) //nolint:errcheck // best-effort stderr
-	}
 	if err := config.ValidateAgents(newCfg.Agents); err != nil {
 		return nil, fmt.Errorf("validating agents: %w", err)
 	}
@@ -392,7 +497,7 @@ func tryReloadConfig(tomlPath, lockedCityName, cityRoot string, stderr io.Writer
 		return nil, fmt.Errorf("workspace.name changed from %q to %q (restart controller to apply)", lockedCityName, newName)
 	}
 	rev := config.Revision(fsys.OSFS{}, prov, newCfg, cityRoot)
-	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev}, nil
+	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev, Warnings: prov.Warnings}, nil
 }
 
 // gracefulStopAll performs two-pass graceful shutdown:
@@ -639,12 +744,13 @@ func runController(
 	}()
 
 	convergenceReqCh := make(chan convergenceRequest, 16)
+	reloadReqCh := make(chan reloadRequest)
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}
 
 	sockPath := controllerSocketPath(cityPath)
-	lis, err := startControllerSocket(cityPath, cancel, configDirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+	lis, err := startControllerSocket(cityPath, cancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -694,6 +800,7 @@ func runController(
 		Rec:                     rec,
 		PoolSessions:            poolSessions,
 		PoolDeathHandlers:       poolDeathHandlers,
+		ReloadReqCh:             reloadReqCh,
 		ConvergenceReqCh:        convergenceReqCh,
 		PokeCh:                  pokeCh,
 		ControlDispatcherCh:     controlDispatcherCh,

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -209,7 +209,7 @@ func TestControllerSocketFallbackUsesShortPathForLongCityPath(t *testing.T) {
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}
-	lis, err := startControllerSocket(cityPath, cancel, configDirty, convergenceReqCh, pokeCh, controlDispatcherCh)
+	lis, err := startControllerSocket(cityPath, cancel, configDirty, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
 		t.Fatalf("startControllerSocket: %v", err)
 	}
@@ -819,7 +819,7 @@ func TestHandleControllerConnControlDispatcher(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityPath, func() {}, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityPath, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -509,10 +509,9 @@ func TestControllerReloadsConventionDiscoveredAgentOnWatchEvent(t *testing.T) {
 		t.Fatalf("WriteFile(prompt.template.md): %v", err)
 	}
 
-	var stderr bytes.Buffer
-	result, err := tryReloadConfig(tomlPath, "test", dir, &stderr)
+	result, err := tryReloadConfig(tomlPath, "test", dir)
 	if err != nil {
-		t.Fatalf("tryReloadConfig() error = %v, stderr = %s", err, stderr.String())
+		t.Fatalf("tryReloadConfig() error = %v", err)
 	}
 	if result.Revision == initialRev {
 		t.Fatalf("revision did not change after convention-discovered agent was added: %s", result.Revision)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -145,6 +145,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root.AddCommand(
 		newStartCmd(stdout, stderr),
 		newInitCmd(stdout, stderr),
+		newReloadCmd(stdout, stderr),
 		newStopCmd(stdout, stderr),
 		newRestartCmd(stdout, stderr),
 		newStatusCmd(stdout, stderr),

--- a/cmd/gc/session_reconciler_trace_collector.go
+++ b/cmd/gc/session_reconciler_trace_collector.go
@@ -552,16 +552,20 @@ func buildTraceDetailScopes(cfg *config.City, arms []TraceArm) map[string]TraceS
 	return scopes
 }
 
-func (c *SessionReconcilerTraceCycle) RecordConfigReload(previousRev, newRev string, outcome TraceOutcomeCode, added, removed []string, providerChanged bool, err error) {
+func (c *SessionReconcilerTraceCycle) RecordConfigReload(previousRev, newRev string, outcome TraceOutcomeCode, source reloadSource, added, removed []string, providerChanged bool, warnings []string, err error) {
 	if c == nil {
 		return
 	}
 	fields := map[string]any{
 		"previous_config_revision": previousRev,
 		"new_config_revision":      newRev,
+		"source":                   string(source),
 		"added_templates":          added,
 		"removed_templates":        removed,
 		"provider_changed":         providerChanged,
+	}
+	if len(warnings) > 0 {
+		fields["warnings"] = warnings
 	}
 	if err != nil {
 		fields["error"] = err.Error()

--- a/docs/guides/gc-reload-design.md
+++ b/docs/guides/gc-reload-design.md
@@ -96,6 +96,7 @@ Reload failure is defined at the config-load boundary:
 - parse/load
 - validation
 - `workspace.name` mismatch
+- required bead lifecycle setup for the newly loaded config
 
 If any of those fail, reload returns non-zero and the old live config
 stays active.
@@ -104,10 +105,18 @@ After a config is successfully applied, subsequent runtime-execution
 issues are warnings rather than rollback triggers. Examples include:
 
 - provider swap setup failures
-- rig validation or bead lifecycle refresh errors
+- rig validation errors
 - formula or script resolution errors
 - service reload errors
 - standalone city bead-store refresh errors
+
+An `applied` reply with warnings means the new effective config is live,
+but one or more post-apply runtime updates could not fully converge. For
+example, if a session provider swap fails, the reload may still succeed
+while the old provider remains active. Operators and scripts that need
+to distinguish full convergence from degraded success must inspect the
+`warnings` array in the structured reply or stderr warning lines in the
+CLI projection.
 
 ### Existing Runtime Behavior Preserved
 
@@ -288,8 +297,8 @@ Rules:
   already dirty from watcher activity
 - the resulting reload is still a single reload attempt, not a watcher
   reload followed by a separate manual replay
-- tick trigger stays `poke`; manual reload is distinguished with
-  `trigger_detail="manual_reload"`
+- tick trigger records the actual tick source; manual reload is
+  distinguished with `trigger_detail="manual_reload"`
 
 ### Telemetry
 

--- a/docs/guides/gc-reload-design.md
+++ b/docs/guides/gc-reload-design.md
@@ -1,0 +1,363 @@
+# `gc reload` Design
+
+Status: working design for GitHub issue `#787`
+
+## Problem
+
+Gas City has no user-facing command that forces the current city to
+re-read effective config without restarting the city. When file watching
+misses a config or pack edit, the only documented recovery path is
+`gc restart`, which tears down active sessions and disrupts in-flight
+work.
+
+## Goals
+
+- Add a user-facing `gc reload [path]` command for the current city.
+- Work for both standalone and supervisor-managed cities.
+- Reuse the existing config-dirty reload path instead of introducing a
+  second reload implementation.
+- Default to synchronous behavior so the user knows whether one reload
+  tick completed successfully.
+- Preserve existing runtime semantics after config apply, including
+  per-session restarts caused by normal config drift rules.
+- Surface structured outcomes and warnings so CLI behavior, tests, and
+  trace data are stable.
+
+## Non-Goals
+
+- No top-level `gc poke`.
+- No new HTTP API mutation such as `POST /v0/city/reload`.
+- No lockfile update during reload-time remote pack fetches.
+- No special transactional rollback for post-apply runtime side effects.
+- No new troubleshooting guide in this change.
+
+## User-Facing Contract
+
+### Command
+
+```text
+gc reload [path] [--async] [--timeout <duration>]
+```
+
+- `[path]` is optional and follows existing city-command resolution.
+- `--async` returns after the current city controller accepts the reload
+  request.
+- `--timeout` applies only to synchronous mode, must be strictly
+  positive, and defaults to `5m`.
+- `--async --timeout ...` is invalid when `--timeout` is explicitly set.
+  Implementation uses Cobra flag-change detection so the default `5m`
+  does not make a plain `gc reload --async` invalid.
+
+### Scope
+
+- `gc reload` targets exactly one city: the resolved current city.
+- It works whether that city is running standalone or under the
+  supervisor, because both topologies expose the same per-city
+  controller socket.
+- It is a live runtime operation. If the city controller is not running,
+  the command fails.
+
+### Success and Failure Semantics
+
+Sync mode waits for the first reload-processing tick only.
+
+| Outcome | Exit | Stdout/Stderr contract |
+| --- | --- | --- |
+| `applied` | `0` | stdout: `Config reloaded: ... (rev <short>)` |
+| `no_change` | `0` | stdout: `No config changes detected.` |
+| `accepted` (`--async`) | `0` | stdout: `Reload requested.` |
+| `failed` | `1` | stderr: specific config/load/fetch error |
+| `busy` | `1` | stderr: controller too busy to accept reload |
+| `timeout` | `1` | stderr: wait budget expired; reload may still finish later |
+
+Warnings are non-fatal post-apply problems. On sync success with
+warnings:
+
+- stdout prints the main success line
+- stderr prints one line per warning as
+  `gc reload: warning: ...`
+
+Rationale for exit codes:
+
+- `gc reload` keeps the existing `gc` CLI convention of `0` for success
+  and `1` for failure conditions.
+- Finer-grained outcome differentiation lives in the structured
+  controller reply and in trace/telemetry, not in a new CLI exit-code
+  taxonomy for this feature.
+- Scripts must not parse the human `message` text; they should branch on
+  success vs failure at the CLI layer or use the controller protocol in
+  future machine-facing integrations.
+
+### Config Boundary
+
+Reload failure is defined at the config-load boundary:
+
+- remote pack fetch
+- parse/load
+- validation
+- `workspace.name` mismatch
+
+If any of those fail, reload returns non-zero and the old live config
+stays active.
+
+After a config is successfully applied, subsequent runtime-execution
+issues are warnings rather than rollback triggers. Examples include:
+
+- provider swap setup failures
+- rig validation or bead lifecycle refresh errors
+- formula or script resolution errors
+- service reload errors
+- standalone city bead-store refresh errors
+
+### Existing Runtime Behavior Preserved
+
+`gc reload`:
+
+- does not restart the city/controller
+- may still cause normal per-session restarts if the reconciler detects
+  config drift under the existing rules
+- preserves existing service-manager reload behavior
+- works while the city is suspended, as long as the controller is still
+  running
+
+### Remote Pack Behavior
+
+Reload recomputes effective config using the same full-load semantics as
+existing controller reload and startup paths:
+
+- configured remote packs may be fetched before config load
+- fetch failures are hard reload failures
+- `pack.lock` is not modified
+
+## Architecture
+
+## CLI Layer
+
+Add a top-level `reload` command in `cmd/gc`:
+
+- resolve city with existing city-command rules
+- validate `--async`/`--timeout`
+- send a structured `reload` request to the per-city controller socket
+- format reply message and warnings for human output
+- on controller-connect failure, attempt to surface richer
+  supervisor-known state when available:
+  - city still starting under supervisor, including current phase
+  - city failed to start and is in backoff, including last error
+  - city not running
+  - generic controller unavailable fallback when no richer state exists
+
+## Controller Socket Protocol
+
+The controller already has a fire-and-forget `reload` socket command
+that marks config dirty and pokes the event loop. This feature upgrades
+reload control by adding a structured variant:
+
+```text
+reload:<json>
+```
+
+### Request
+
+```json
+{
+  "wait": true,
+  "timeout": "5m"
+}
+```
+
+Semantics:
+
+- `wait=true` means sync mode
+- `wait=false` means async mode
+- `timeout` is required for sync mode, ignored internally for async mode
+
+### Reply
+
+```json
+{
+  "outcome": "applied|no_change|accepted|failed|busy|timeout",
+  "message": "human readable summary",
+  "revision": "full-config-revision-when-known",
+  "warnings": ["normalized warning", "..."],
+  "error": "specific failure string when outcome=failed"
+}
+```
+
+Notes:
+
+- `message` is controller-authored canonical wording; the CLI mainly
+  relays it.
+- `revision` is included for `applied` and `no_change`.
+- `accepted` is used only for async acceptance.
+- `busy` may be returned in both sync and async mode if the controller
+  cannot register the request within the acceptance window.
+- `warnings` are normalized, user-facing strings in encounter order.
+
+The existing bare `reload` command remains as a compatibility
+fire-and-forget path for internal callers and tests. `gc reload` uses
+the structured `reload:<json>` command.
+
+## Event-Loop Integration
+
+Manual reload reuses the existing config-dirty tick path.
+
+Implementation shape:
+
+1. Add an unbuffered `reloadReqCh` to the controller/runtime plumbing so
+   a request is handed directly to the event loop or rejected within the
+   acceptance timeout.
+2. The socket handler validates and attempts to enqueue a reload request
+   to `reloadReqCh`.
+3. Acceptance is defined as event-loop registration, not mere channel
+   enqueue.
+4. The socket handler waits up to `5s` for the event loop to receive and
+   register the request.
+5. When the event loop consumes a request:
+   - if another manual reload is already active, it replies `busy`
+   - otherwise it records the request as the active manual reload
+   - then it sets `dirty=true`
+   - then it pokes the reconciler loop
+   - then it acks the request as accepted
+6. The next tick after registration processes reload through the same
+   `dirty`-gated config reload path already used by file watching.
+7. When that tick resolves the reload outcome, it completes the active
+   manual request and clears the slot.
+
+Critical ordering rules:
+
+- An accepted manual reload is never attached to an already-running tick.
+- Registration of the active manual request happens-before
+  `dirty=true`, which happens-before the poke.
+- The reload result is bound to the first tick that starts after manual
+  registration.
+- If the event loop cannot register the request within `5s`, the caller
+  gets `busy`.
+
+Queueing rules:
+
+- one manual reload request may be active at a time
+- no manual-request piggybacking/coalescing contract is added
+- a concurrent manual request may receive `busy`
+- a manual request may coalesce with preexisting watcher dirtiness so
+  the system performs one reload attempt, attributed as `manual`
+
+Timeout rules:
+
+- enqueue timeout (`5s`) and wait timeout (`--timeout`, default `5m`)
+  remain distinct
+- `timeout` means the caller stopped waiting; the reload may still
+  complete later
+
+## Runtime Result Capture
+
+The current reload path prints directly to stdout/stderr and records only
+coarse telemetry. To support `gc reload`, factor it to produce a
+structured result in addition to existing logging behavior.
+
+Proposed internal result shape:
+
+- outcome: `applied`, `no_change`, or `failed`
+- revision
+- message
+- warnings
+- provider-changed marker
+- error
+
+This result is consumed by:
+
+- the active manual reload request
+- trace recording
+- telemetry recording
+
+Watcher-driven reloads continue using the same reload implementation but
+without a waiting CLI caller.
+
+## Observability
+
+### Trace
+
+Extend config-reload trace records to include:
+
+- `source`: `manual` or `watch`
+- `warnings[]`
+
+Rules:
+
+- source is recorded for every actual reload attempt outcome
+- manual wins if a manual reload request is accepted while config is
+  already dirty from watcher activity
+- the resulting reload is still a single reload attempt, not a watcher
+  reload followed by a separate manual replay
+- tick trigger stays `poke`; manual reload is distinguished with
+  `trigger_detail="manual_reload"`
+
+### Telemetry
+
+Keep metrics/logging low-cardinality. Extend `RecordConfigReload` to
+record:
+
+- `status`: `ok` or `error`
+- `source`: `manual` or `watch`
+- `outcome`: `applied`, `no_change`, or `failed`
+- `warning_count`
+
+Full warning strings stay out of telemetry and live in trace plus CLI
+stderr.
+
+## Out-of-Scope Machine Interface
+
+This feature does not add `gc reload --json` or a public HTTP reload
+mutation.
+
+Reasons:
+
+- mutation commands in this CLI generally stay human-oriented
+- the structured controller reply already provides the typed contract
+  needed for the implementation and tests
+- adding a CLI JSON contract or remote API surface would expand scope
+  beyond issue `#787`
+
+## Documentation
+
+Update command help and generated CLI reference to state that:
+
+- `gc reload` reloads the current city without restarting the
+  city/controller
+- it may fetch configured remote packs before recomputing effective
+  config
+- existing per-session restarts may still happen if config drift or
+  provider changes require them
+
+Do not add a separate troubleshooting guide in this feature.
+
+## Testing
+
+Minimum coverage:
+
+- standalone city: sync reload applied
+- supervisor-managed city: sync reload applied
+- sync no-change
+- sync invalid config keeps old config
+- async accepted without waiting
+- busy
+- timeout
+- controller unavailable / richer supervisor-state error surfaces
+- remote pack fetch failure
+- manual source attribution, including manual winning over preexisting
+  watcher dirty state
+- warnings surfaced in controller reply, CLI stderr, and trace
+- `--async --timeout` validation only when the user explicitly sets
+  `--timeout`
+- stable `0`/`1` exit-code behavior for the documented success/failure
+  groups
+
+## Implementation Notes
+
+- Add a new top-level command file for `gc reload`.
+- Add controller request/reply types and socket handling for `reload`.
+- Thread `reloadReqCh` through controller startup in standalone and
+  supervisor-managed cities.
+- Refactor runtime reload so it can return structured outcomes and
+  warnings while preserving the existing watcher-driven behavior.
+- Update telemetry and trace recorders plus their tests.
+- Regenerate CLI reference docs after command help lands.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,6 +45,7 @@ gc [flags]
 | [gc pack](#gc-pack) | Manage remote pack sources |
 | [gc prime](#gc-prime) | Output the behavioral prompt for an agent |
 | [gc register](#gc-register) | Register a city with the machine-wide supervisor |
+| [gc reload](#gc-reload) | Reload the current city's config without restarting the city/controller |
 | [gc restart](#gc-restart) | Restart all agent sessions in the city |
 | [gc resume](#gc-resume) | Resume a suspended city |
 | [gc rig](#gc-rig) | Manage rigs (projects) |
@@ -1517,6 +1518,24 @@ gc register [path] [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--name` | string |  | machine-local alias for this city registration |
+
+## gc reload
+
+Force the current city controller to re-read effective config and
+process one reload tick without restarting the city/controller.
+
+Reload may fetch configured remote packs before recomputing effective
+config. Existing per-session restarts may still happen if normal config
+drift rules require them.
+
+```
+gc reload [path] [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--async` | bool |  | Return after the controller accepts the reload request |
+| `--timeout` | string | `5m` | How long to wait for reload completion |
 
 ## gc restart
 

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -308,15 +308,22 @@ func RecordNudge(ctx context.Context, target string, err error) {
 }
 
 // RecordConfigReload records a config reload attempt (metrics + log event).
-func RecordConfigReload(ctx context.Context, revision string, err error) {
+func RecordConfigReload(ctx context.Context, revision, source, outcome string, warningCount int, err error) {
 	initInstruments()
 	status := statusStr(err)
 	inst.configReloadTotal.Add(ctx, 1,
-		metric.WithAttributes(attribute.String("status", status)),
+		metric.WithAttributes(
+			attribute.String("status", status),
+			attribute.String("source", source),
+			attribute.String("outcome", outcome),
+		),
 	)
 	emit(ctx, "config.reload", severity(err),
 		otellog.String("revision", revision),
 		otellog.String("status", status),
+		otellog.String("source", source),
+		otellog.String("outcome", outcome),
+		otellog.Int("warning_count", warningCount),
 		errKV(err),
 	)
 }

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -139,8 +139,8 @@ func TestRecordConfigReload(t *testing.T) {
 	resetInstruments(t)
 	ctx := context.Background()
 
-	RecordConfigReload(ctx, "abc123", nil)
-	RecordConfigReload(ctx, "", errors.New("parse error"))
+	RecordConfigReload(ctx, "abc123", "manual", "applied", 0, nil)
+	RecordConfigReload(ctx, "", "watch", "failed", 1, errors.New("parse error"))
 }
 
 func TestRecordControllerLifecycle(t *testing.T) {


### PR DESCRIPTION
## Summary

Supersedes #905.

Closes #787.

Credit: Original fix by @julianknutsen. The contributor work has been preserved as the first commit with original authorship, followed by maintainer review fixups.

- add a top-level `gc reload [path]` command with sync-by-default behavior, `--async`, and `--timeout`
- route reload through structured controller request/reply handling with explicit outcomes, warning propagation, and supervisor-aware unavailable errors
- harden reload failure semantics so invalid/lifecycle-failing config reloads keep the old runtime config and surface warnings to the CLI
- extend reload trace/telemetry coverage, focused tests, and `docs/guides/gc-reload-design.md`

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Additional local verification run during adoption:

- `go test ./cmd/gc -run 'TestCmdReload|TestHandleReloadSocketCmd|TestSendReloadControlRequest|TestSupervisorCityInfoMatchesNormalizedPath|TestControllerReloadCommandReloadsConfigImmediately|TestCityRuntimeReloadLifecycleFailureKeepsOldConfig|TestCityRuntimeReloadStrictWarningsReturnedOnFailure|TestCityRuntimeReloadNonStrictWarningsReturnedOnValidationFailure|TestCityRuntimeHandleReloadRequestInitializesConfigDirty|TestCityRuntimeFailActiveReloadRepliesAndClears|TestCityRuntimeManualReloadReplyWaitsForTickCompletion' -count=1`
- `go test ./internal/telemetry -count=1`
- `go vet ./...`
- `git diff --check`
- `go test ./cmd/gc -run 'TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure' -count=1`

`go test ./...` was attempted and did not pass because `cmd/gc` timed out in pre-existing/unrelated Dolt/controller coverage. It also hit `TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure` during the broad run, which passed when rerun alone.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No breaking changes expected.
