### PR TITLE
fix: detect legacy bd split stores in doctor

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -185,6 +185,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 
 	// Data checks.
 	if cfgErr == nil {
+		d.Register(doctor.NewBDSplitStoreCheck(cityPath))
 		d.Register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
 		d.Register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
@@ -208,6 +209,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			}
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
+			d.Register(doctor.NewRigBDSplitStoreCheck(rig))
 			d.Register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
 			d.Register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || os.Getenv("GC_DOLT") == "skip"))
 			// Custom types check — rig store.

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -209,7 +209,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			}
 			d.Register(doctor.NewRigPathCheck(rig))
 			d.Register(doctor.NewRigGitCheck(rig))
-			d.Register(doctor.NewRigBDSplitStoreCheck(rig))
+			d.Register(doctor.NewRigBDSplitStoreCheck(cityPath, rig))
 			d.Register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
 			d.Register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || os.Getenv("GC_DOLT") == "skip"))
 			// Custom types check — rig store.

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -177,6 +177,40 @@ dolt_port = "3308"
 	}
 }
 
+func TestDoDoctorReportsLegacyBDSplitStore(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{
+		filepath.Join(cityDir, ".beads", "dolt", "hq", ".dolt"),
+		filepath.Join(cityDir, ".beads", "embeddeddolt", "legacy", ".dolt"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("GC_BEADS", "file")
+	origCityFlag := cityFlag
+	cityFlag = cityDir
+	t.Cleanup(func() { cityFlag = origCityFlag })
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, false, &stdout, &stderr)
+	out := stdout.String() + stderr.String()
+	if !strings.Contains(out, "bd-split-store") {
+		t.Fatalf("doctor output missing bd-split-store check:\n%s", out)
+	}
+	if !strings.Contains(out, "legacy split store") {
+		t.Fatalf("doctor output missing split-store warning:\n%s", out)
+	}
+}
+
 func TestCollectPackDirsEmpty(t *testing.T) {
 	cfg := &config.City{}
 	dirs := collectPackDirs(cfg)

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1,11 +1,13 @@
 package doctor
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -673,6 +675,167 @@ func (c *BeadsStoreCheck) CanFix() bool { return false }
 
 // Fix is a no-op.
 func (c *BeadsStoreCheck) Fix(_ *CheckContext) error { return nil }
+
+// BDSplitStoreCheck warns when legacy bd embedded/server store directories
+// coexist and the inactive store still contains Dolt data.
+type BDSplitStoreCheck struct {
+	name      string
+	scopePath string
+}
+
+// NewBDSplitStoreCheck creates a city-level split-store check.
+func NewBDSplitStoreCheck(scopePath string) *BDSplitStoreCheck {
+	return &BDSplitStoreCheck{name: "bd-split-store", scopePath: scopePath}
+}
+
+// NewRigBDSplitStoreCheck creates a rig-level split-store check.
+func NewRigBDSplitStoreCheck(rig config.Rig) *BDSplitStoreCheck {
+	return &BDSplitStoreCheck{name: "rig:" + rig.Name + ":bd-split-store", scopePath: rig.Path}
+}
+
+func (c *BDSplitStoreCheck) Name() string { return c.name }
+
+func (c *BDSplitStoreCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	beadsDir := filepath.Join(c.scopePath, ".beads")
+	serverDir := filepath.Join(beadsDir, "dolt")
+	embeddedDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	serverExists := splitStoreDirExists(serverDir)
+	embeddedExists := splitStoreDirExists(embeddedDir)
+	if !serverExists || !embeddedExists {
+		r.Status = StatusOK
+		r.Message = "no legacy split store detected"
+		return r
+	}
+
+	serverRepos, serverErr := doltReposUnder(serverDir)
+	embeddedRepos, embeddedErr := doltReposUnder(embeddedDir)
+	if serverErr != nil || embeddedErr != nil {
+		r.Status = StatusWarning
+		r.Message = "could not inspect legacy bd split store directories"
+		r.FixHint = "inspect .beads/dolt and .beads/embeddeddolt manually before deleting either directory"
+		if serverErr != nil {
+			r.Details = append(r.Details, fmt.Sprintf("scan .beads/dolt: %v", serverErr))
+		}
+		if embeddedErr != nil {
+			r.Details = append(r.Details, fmt.Sprintf("scan .beads/embeddeddolt: %v", embeddedErr))
+		}
+		return r
+	}
+
+	mode, activeStore := activeBDStoreFromMetadata(filepath.Join(beadsDir, "metadata.json"))
+	if activeStore == "" {
+		if len(serverRepos)+len(embeddedRepos) == 0 {
+			r.Status = StatusOK
+			r.Message = "legacy split store directories present but no Dolt repos found"
+			return r
+		}
+		r.Status = StatusWarning
+		r.Message = "legacy split store detected: both .beads/dolt and .beads/embeddeddolt contain or may contain data, but metadata.json does not declare an active store"
+		r.Details = splitStoreDetails("unknown", mode, serverRepos, embeddedRepos)
+		r.FixHint = splitStoreFixHint()
+		return r
+	}
+
+	inactiveStore := "embeddeddolt"
+	inactiveRepos := embeddedRepos
+	if activeStore == "embeddeddolt" {
+		inactiveStore = "dolt"
+		inactiveRepos = serverRepos
+	}
+	if len(inactiveRepos) == 0 {
+		r.Status = StatusOK
+		r.Message = "legacy split store directories present but inactive store is empty"
+		return r
+	}
+
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("legacy split store detected: active .beads/%s (metadata.json dolt_mode=%s), inactive .beads/%s contains %d Dolt repo(s)", activeStore, mode, inactiveStore, len(inactiveRepos))
+	r.Details = splitStoreDetails(activeStore, mode, serverRepos, embeddedRepos)
+	r.FixHint = splitStoreFixHint()
+	return r
+}
+
+func (c *BDSplitStoreCheck) CanFix() bool { return false }
+
+func (c *BDSplitStoreCheck) Fix(_ *CheckContext) error { return nil }
+
+func activeBDStoreFromMetadata(path string) (string, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", ""
+	}
+	var meta struct {
+		DoltMode string `json:"dolt_mode"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", ""
+	}
+	mode := strings.ToLower(strings.TrimSpace(meta.DoltMode))
+	switch mode {
+	case "server":
+		return mode, "dolt"
+	case "embedded", "local":
+		return mode, "embeddeddolt"
+	default:
+		return mode, ""
+	}
+}
+
+func splitStoreDetails(activeStore, mode string, serverRepos, embeddedRepos []string) []string {
+	activeLine := "active store: unknown"
+	if activeStore != "unknown" && activeStore != "" {
+		activeLine = fmt.Sprintf("active store: .beads/%s (metadata.json dolt_mode=%s)", activeStore, mode)
+	}
+	details := []string{
+		activeLine,
+		fmt.Sprintf(".beads/dolt repositories: %s", describeRepoList(serverRepos)),
+		fmt.Sprintf(".beads/embeddeddolt repositories: %s", describeRepoList(embeddedRepos)),
+		"recovery: export from a copy of the inactive store, review with bd import --dry-run, then import into the active store",
+	}
+	return details
+}
+
+func splitStoreFixHint() string {
+	return "export from the inactive store into a backup JSONL, review with bd import --dry-run, then import into the active store; keep both directories until reconciled"
+}
+
+func describeRepoList(repos []string) string {
+	if len(repos) == 0 {
+		return "(none)"
+	}
+	return strings.Join(repos, ", ")
+}
+
+func doltReposUnder(root string) ([]string, error) {
+	var repos []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if d.Name() != ".dolt" {
+			return nil
+		}
+		parent := filepath.Dir(path)
+		rel, err := filepath.Rel(root, parent)
+		if err != nil || rel == "." {
+			rel = filepath.Base(parent)
+		}
+		repos = append(repos, filepath.ToSlash(rel))
+		return filepath.SkipDir
+	})
+	sort.Strings(repos)
+	return repos, err
+}
+
+func splitStoreDirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
 
 func validateBDStoreTarget(cityPath, scopeRoot string) (contract.DoltConnectionTarget, string, bool, error) {
 	if !usesBDDoltStore(cityPath) {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -679,22 +679,25 @@ func (c *BeadsStoreCheck) Fix(_ *CheckContext) error { return nil }
 // BDSplitStoreCheck warns when legacy bd embedded/server store directories
 // coexist and the inactive store still contains Dolt data.
 type BDSplitStoreCheck struct {
+	cityPath  string
 	name      string
 	scopePath string
 }
 
 // NewBDSplitStoreCheck creates a city-level split-store check.
 func NewBDSplitStoreCheck(scopePath string) *BDSplitStoreCheck {
-	return &BDSplitStoreCheck{name: "bd-split-store", scopePath: scopePath}
+	return &BDSplitStoreCheck{cityPath: scopePath, name: "bd-split-store", scopePath: scopePath}
 }
 
 // NewRigBDSplitStoreCheck creates a rig-level split-store check.
-func NewRigBDSplitStoreCheck(rig config.Rig) *BDSplitStoreCheck {
-	return &BDSplitStoreCheck{name: "rig:" + rig.Name + ":bd-split-store", scopePath: rig.Path}
+func NewRigBDSplitStoreCheck(cityPath string, rig config.Rig) *BDSplitStoreCheck {
+	return &BDSplitStoreCheck{cityPath: cityPath, name: "rig:" + rig.Name + ":bd-split-store", scopePath: rig.Path}
 }
 
+// Name returns the check identifier.
 func (c *BDSplitStoreCheck) Name() string { return c.name }
 
+// Run detects legacy split bd store directories and reports inactive Dolt repos.
 func (c *BDSplitStoreCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	beadsDir := filepath.Join(c.scopePath, ".beads")
@@ -724,7 +727,7 @@ func (c *BDSplitStoreCheck) Run(_ *CheckContext) *CheckResult {
 		return r
 	}
 
-	mode, activeStore := activeBDStoreFromMetadata(filepath.Join(beadsDir, "metadata.json"))
+	activeSource, activeStore := c.activeBDStore(beadsDir)
 	if activeStore == "" {
 		if len(serverRepos)+len(embeddedRepos) == 0 {
 			r.Status = StatusOK
@@ -732,9 +735,9 @@ func (c *BDSplitStoreCheck) Run(_ *CheckContext) *CheckResult {
 			return r
 		}
 		r.Status = StatusWarning
-		r.Message = "legacy split store detected: both .beads/dolt and .beads/embeddeddolt contain or may contain data, but metadata.json does not declare an active store"
-		r.Details = splitStoreDetails("unknown", mode, serverRepos, embeddedRepos)
-		r.FixHint = splitStoreFixHint()
+		r.Message = "legacy split store detected: both .beads/dolt and .beads/embeddeddolt contain or may contain data, but no active local store was identified"
+		r.Details = splitStoreDetails("unknown", activeSource, serverRepos, embeddedRepos)
+		r.FixHint = splitStoreFixHint("unknown")
 		return r
 	}
 
@@ -751,15 +754,78 @@ func (c *BDSplitStoreCheck) Run(_ *CheckContext) *CheckResult {
 	}
 
 	r.Status = StatusWarning
-	r.Message = fmt.Sprintf("legacy split store detected: active .beads/%s (metadata.json dolt_mode=%s), inactive .beads/%s contains %d Dolt repo(s)", activeStore, mode, inactiveStore, len(inactiveRepos))
-	r.Details = splitStoreDetails(activeStore, mode, serverRepos, embeddedRepos)
-	r.FixHint = splitStoreFixHint()
+	r.Message = fmt.Sprintf("legacy split store detected: active .beads/%s (%s), inactive .beads/%s contains %d Dolt repo(s)", activeStore, activeSource, inactiveStore, len(inactiveRepos))
+	r.Details = splitStoreDetails(activeStore, activeSource, serverRepos, embeddedRepos)
+	r.FixHint = splitStoreFixHint(activeStore)
 	return r
 }
 
+// CanFix returns false; reconciliation requires explicit user review.
 func (c *BDSplitStoreCheck) CanFix() bool { return false }
 
+// Fix is a no-op.
 func (c *BDSplitStoreCheck) Fix(_ *CheckContext) error { return nil }
+
+func (c *BDSplitStoreCheck) activeBDStore(beadsDir string) (string, string) {
+	activeSource, activeStore := activeBDStoreFromMetadata(filepath.Join(beadsDir, "metadata.json"))
+	if c.cityPath == "" {
+		return activeSource, activeStore
+	}
+	if !scopeUsesBDDoltStore(c.cityPath, c.scopePath) {
+		return activeSource, ""
+	}
+	resolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, c.cityPath, c.scopePath, "")
+	if err != nil {
+		if source, ok := c.rawNonLocalEndpointSource(); ok {
+			return source, ""
+		}
+		if source, ok := c.rawCityNonLocalEndpointSource(); ok {
+			return source, ""
+		}
+		return activeSource, activeStore
+	}
+	if resolved.Kind != contract.ScopeConfigAuthoritative {
+		if source, ok := c.rawCityNonLocalEndpointSource(); ok {
+			return source, ""
+		}
+		return activeSource, activeStore
+	}
+	switch resolved.State.EndpointOrigin {
+	case contract.EndpointOriginManagedCity:
+		if sameDoctorScope(c.cityPath, c.scopePath) {
+			return "canonical endpoint_origin=" + string(resolved.State.EndpointOrigin), "dolt"
+		}
+		return "canonical endpoint_origin=" + string(resolved.State.EndpointOrigin), ""
+	case contract.EndpointOriginCityCanonical, contract.EndpointOriginExplicit, contract.EndpointOriginInheritedCity:
+		return "canonical endpoint_origin=" + string(resolved.State.EndpointOrigin), ""
+	default:
+		return activeSource, activeStore
+	}
+}
+
+func (c *BDSplitStoreCheck) rawNonLocalEndpointSource() (string, bool) {
+	return rawNonLocalEndpointSource(c.scopePath)
+}
+
+func (c *BDSplitStoreCheck) rawCityNonLocalEndpointSource() (string, bool) {
+	if sameDoctorScope(c.cityPath, c.scopePath) {
+		return "", false
+	}
+	return rawNonLocalEndpointSource(c.cityPath)
+}
+
+func rawNonLocalEndpointSource(scopePath string) (string, bool) {
+	cfg, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(scopePath, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		return "", false
+	}
+	switch cfg.EndpointOrigin {
+	case contract.EndpointOriginCityCanonical, contract.EndpointOriginExplicit, contract.EndpointOriginInheritedCity:
+		return "canonical endpoint_origin=" + string(cfg.EndpointOrigin), true
+	default:
+		return "", false
+	}
+}
 
 func activeBDStoreFromMetadata(path string) (string, string) {
 	data, err := os.ReadFile(path)
@@ -767,37 +833,55 @@ func activeBDStoreFromMetadata(path string) (string, string) {
 		return "", ""
 	}
 	var meta struct {
+		Database string `json:"database"`
+		Backend  string `json:"backend"`
 		DoltMode string `json:"dolt_mode"`
 	}
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return "", ""
 	}
 	mode := strings.ToLower(strings.TrimSpace(meta.DoltMode))
+	database := strings.ToLower(strings.TrimSpace(meta.Database))
+	backend := strings.ToLower(strings.TrimSpace(meta.Backend))
+	declaresNonDoltStore := (database != "" && database != "dolt") || (backend != "" && backend != "dolt")
+	declaresDoltStore := database == "dolt" || backend == "dolt"
+	if mode != "" && declaresNonDoltStore && !declaresDoltStore {
+		return mode, ""
+	}
 	switch mode {
 	case "server":
-		return mode, "dolt"
+		return "metadata.json dolt_mode=" + mode, "dolt"
 	case "embedded", "local":
-		return mode, "embeddeddolt"
+		return "metadata.json dolt_mode=" + mode, "embeddeddolt"
 	default:
 		return mode, ""
 	}
 }
 
-func splitStoreDetails(activeStore, mode string, serverRepos, embeddedRepos []string) []string {
+func sameDoctorScope(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func splitStoreDetails(activeStore, activeSource string, serverRepos, embeddedRepos []string) []string {
 	activeLine := "active store: unknown"
+	recoveryLine := "recovery: export from copies of the legacy stores, review with bd import --dry-run, then import into the current or intended active store"
 	if activeStore != "unknown" && activeStore != "" {
-		activeLine = fmt.Sprintf("active store: .beads/%s (metadata.json dolt_mode=%s)", activeStore, mode)
+		activeLine = fmt.Sprintf("active store: .beads/%s (%s)", activeStore, activeSource)
+		recoveryLine = "recovery: export from a copy of the inactive store, review with bd import --dry-run, then import into the active store"
 	}
 	details := []string{
 		activeLine,
 		fmt.Sprintf(".beads/dolt repositories: %s", describeRepoList(serverRepos)),
 		fmt.Sprintf(".beads/embeddeddolt repositories: %s", describeRepoList(embeddedRepos)),
-		"recovery: export from a copy of the inactive store, review with bd import --dry-run, then import into the active store",
+		recoveryLine,
 	}
 	return details
 }
 
-func splitStoreFixHint() string {
+func splitStoreFixHint(activeStore string) string {
+	if activeStore == "" || activeStore == "unknown" {
+		return "export from each legacy store into backup JSONL, review with bd import --dry-run, then import into the current or intended active store; keep both directories until reconciled"
+	}
 	return "export from the inactive store into a backup JSONL, review with bd import --dry-run, then import into the active store; keep both directories until reconciled"
 }
 
@@ -817,13 +901,15 @@ func doltReposUnder(root string) ([]string, error) {
 		if !d.IsDir() {
 			return nil
 		}
-		if d.Name() != ".dolt" {
+		if d.Name() == ".dolt" {
+			return filepath.SkipDir
+		}
+		if !splitStoreDirExists(filepath.Join(path, ".dolt")) {
 			return nil
 		}
-		parent := filepath.Dir(path)
-		rel, err := filepath.Rel(root, parent)
+		rel, err := filepath.Rel(root, path)
 		if err != nil || rel == "." {
-			rel = filepath.Base(parent)
+			rel = filepath.Base(path)
 		}
 		repos = append(repos, filepath.ToSlash(rel))
 		return filepath.SkipDir
@@ -838,7 +924,7 @@ func splitStoreDirExists(path string) bool {
 }
 
 func validateBDStoreTarget(cityPath, scopeRoot string) (contract.DoltConnectionTarget, string, bool, error) {
-	if !usesBDDoltStore(cityPath) {
+	if !scopeUsesBDDoltStore(cityPath, scopeRoot) {
 		return contract.DoltConnectionTarget{}, "", false, nil
 	}
 	resolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, scopeRoot, "")
@@ -873,16 +959,25 @@ func providerUsesBDDoltStore(provider string) bool {
 	if provider == "" || provider == "bd" {
 		return true
 	}
-	if strings.HasPrefix(provider, "exec:") && filepath.Base(strings.TrimPrefix(provider, "exec:")) == "gc-beads-bd" {
+	if strings.HasPrefix(provider, "exec:") && doctorExecProviderBase(provider) == "gc-beads-bd" {
 		return true
 	}
 	return false
+}
+
+func doctorExecProviderBase(provider string) string {
+	script := strings.TrimSpace(strings.TrimPrefix(provider, "exec:"))
+	return strings.TrimSuffix(filepath.Base(script), ".sh")
 }
 
 func effectiveDoctorBeadsProvider(cityPath string) string {
 	if v := strings.TrimSpace(os.Getenv("GC_BEADS")); v != "" {
 		return v
 	}
+	return configuredDoctorBeadsProvider(cityPath)
+}
+
+func configuredDoctorBeadsProvider(cityPath string) string {
 	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		return "bd"
@@ -890,8 +985,67 @@ func effectiveDoctorBeadsProvider(cityPath string) string {
 	return cfg.Beads.Provider
 }
 
-func usesBDDoltStore(cityPath string) bool {
-	return providerUsesBDDoltStore(effectiveDoctorBeadsProvider(cityPath))
+func scopeUsesBDDoltStore(cityPath, scopePath string) bool {
+	resolvedScope := resolveDoctorScopePath(cityPath, scopePath)
+	if explicit, ok := scopedDoctorBeadsProviderOverride(cityPath, resolvedScope); ok {
+		return providerUsesBDDoltStore(explicit)
+	}
+	provider := effectiveDoctorBeadsProvider(cityPath)
+	if strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT")) != "" {
+		provider = configuredDoctorBeadsProvider(cityPath)
+	}
+	if sameDoctorScope(resolvedScope, cityPath) {
+		return providerUsesBDDoltStore(provider)
+	}
+	if strings.HasPrefix(strings.TrimSpace(provider), "exec:") && !providerUsesBDDoltStore(provider) {
+		return false
+	}
+	if doctorScopeHasBDMetadata(resolvedScope) {
+		return true
+	}
+	if doctorScopeHasFileStoreMarker(resolvedScope) {
+		return false
+	}
+	return providerUsesBDDoltStore(provider)
+}
+
+func scopedDoctorBeadsProviderOverride(cityPath, scopePath string) (string, bool) {
+	provider := strings.TrimSpace(os.Getenv("GC_BEADS"))
+	if provider == "" {
+		return "", false
+	}
+	scopedRoot := strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT"))
+	if scopedRoot == "" {
+		return provider, true
+	}
+	if sameDoctorScope(resolveDoctorScopePath(cityPath, scopedRoot), scopePath) {
+		return provider, true
+	}
+	return "", false
+}
+
+func resolveDoctorScopePath(cityPath, scopePath string) string {
+	scopePath = strings.TrimSpace(scopePath)
+	if scopePath == "" {
+		scopePath = cityPath
+	}
+	if !filepath.IsAbs(scopePath) {
+		scopePath = filepath.Join(cityPath, scopePath)
+	}
+	return filepath.Clean(scopePath)
+}
+
+func doctorScopeHasBDMetadata(scopePath string) bool {
+	info, err := os.Stat(filepath.Join(scopePath, ".beads", "metadata.json"))
+	return err == nil && !info.IsDir()
+}
+
+func doctorScopeHasFileStoreMarker(scopePath string) bool {
+	if doctorScopeHasBDMetadata(scopePath) {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(scopePath, ".gc", "beads.json"))
+	return err == nil && !info.IsDir()
 }
 
 // DoltServerCheck verifies the dolt server is running and reachable.

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -803,6 +803,83 @@ func TestBeadsStoreCheck_FileProviderSkipsDoltPreflight(t *testing.T) {
 	}
 }
 
+// --- BDSplitStoreCheck ---
+
+func TestBDSplitStoreCheck_ServerActiveWarnsWhenEmbeddedStoreHasRepos(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	for _, want := range []string{"legacy split store", ".beads/embeddeddolt", "1 Dolt repo"} {
+		if !strings.Contains(r.Message, want) {
+			t.Fatalf("message = %q, want %q", r.Message, want)
+		}
+	}
+	if !strings.Contains(r.FixHint, "bd import --dry-run") {
+		t.Fatalf("fix hint = %q, want import dry-run guidance", r.FixHint)
+	}
+}
+
+func TestBDSplitStoreCheck_EmbeddedActiveWarnsWhenServerStoreHasRepos(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"legacy"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "embeddeddolt", "legacy"))
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "dolt", "hq"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	for _, want := range []string{"legacy split store", ".beads/dolt", "metadata.json dolt_mode=embedded"} {
+		if !strings.Contains(r.Message, want) {
+			t.Fatalf("message = %q, want %q", r.Message, want)
+		}
+	}
+}
+
+func TestBDSplitStoreCheck_BothDirsButInactiveEmptyIsOK(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	if err := os.MkdirAll(filepath.Join(dir, ".beads", "embeddeddolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func writeDoltRepoMarker(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".dolt", "noms"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // spyPingStore is a minimal Store that records Ping calls.
 type spyPingStore struct {
 	beads.MemStore

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -873,6 +873,293 @@ func TestBDSplitStoreCheck_BothDirsButInactiveEmptyIsOK(t *testing.T) {
 	}
 }
 
+func TestBDSplitStoreCheck_ExternalCityTreatsLocalReposAsLegacy(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginCityCanonical,
+		EndpointStatus: contract.EndpointStatusVerified,
+		DoltHost:       "db.example.com",
+		DoltPort:       "3307",
+	})
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	if err := os.MkdirAll(filepath.Join(dir, ".beads", "embeddeddolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no active local store") {
+		t.Fatalf("message = %q, want no active local store warning", r.Message)
+	}
+}
+
+func TestBDSplitStoreCheck_InvalidExternalCityConfigUsesNeutralGuidance(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginCityCanonical,
+		EndpointStatus: contract.EndpointStatusVerified,
+		DoltHost:       "db.example.com",
+	})
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no active local store") {
+		t.Fatalf("message = %q, want no active local store warning", r.Message)
+	}
+	if strings.Contains(r.Message, "active .beads/dolt") {
+		t.Fatalf("message = %q, should not trust metadata when canonical external config is invalid", r.Message)
+	}
+	if strings.Contains(r.FixHint, "inactive store") {
+		t.Fatalf("fix hint = %q, should not reference inactive store when active local store is unknown", r.FixHint)
+	}
+}
+
+func TestBDSplitStoreCheck_FileProviderUsesNeutralRecoveryGuidance(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no active local store") {
+		t.Fatalf("message = %q, want no active local store warning", r.Message)
+	}
+	if strings.Contains(r.FixHint, "inactive store") {
+		t.Fatalf("fix hint = %q, should not reference inactive store under file provider", r.FixHint)
+	}
+}
+
+func TestBDSplitStoreCheck_ManagedCityUsesCanonicalSourceInMessage(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginManagedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(dir, ".beads", "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if strings.Contains(r.Message, "metadata.json dolt_mode=managed_city") {
+		t.Fatalf("message = %q, should not label endpoint origin as metadata dolt_mode", r.Message)
+	}
+	if !strings.Contains(r.Message, "canonical endpoint_origin=managed_city") {
+		t.Fatalf("message = %q, want canonical endpoint source", r.Message)
+	}
+}
+
+func TestRigBDSplitStoreCheck_InheritedRigTreatsLocalReposAsLegacy(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "demo")
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, cityDir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginManagedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, cityDir, "hq")
+	writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+		IssuePrefix:    "de",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+	writeDoltRepoMarker(t, filepath.Join(rigDir, ".beads", "dolt", "de"))
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads", "embeddeddolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewRigBDSplitStoreCheck(cityDir, config.Rig{Name: "demo", Path: rigDir})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no active local store") {
+		t.Fatalf("message = %q, want no active local store warning", r.Message)
+	}
+}
+
+func TestRigBDSplitStoreCheck_BDBackedRigUnderFileCityUsesRigMetadata(t *testing.T) {
+	cityDir := setupCity(t, `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`)
+	rigDir := filepath.Join(cityDir, "demo")
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+	writeDoltRepoMarker(t, filepath.Join(rigDir, ".beads", "dolt", "de"))
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads", "embeddeddolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewRigBDSplitStoreCheck(cityDir, config.Rig{Name: "demo", Path: rigDir})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+	if !strings.Contains(r.Message, "inactive store is empty") {
+		t.Fatalf("message = %q, want inactive-store-empty OK", r.Message)
+	}
+}
+
+func TestRigBDSplitStoreCheck_ManagedExecProviderScriptUsesBDStore(t *testing.T) {
+	cityDir := setupCity(t, `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`)
+	t.Setenv("GC_BEADS", "exec:"+filepath.Join(cityDir, ".gc", "system", "packs", "bd", "assets", "scripts", "gc-beads-bd.sh"))
+	rigDir := filepath.Join(cityDir, "demo")
+	fs := fsys.OSFS{}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+	writeDoltRepoMarker(t, filepath.Join(rigDir, ".beads", "dolt", "de"))
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads", "embeddeddolt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewRigBDSplitStoreCheck(cityDir, config.Rig{Name: "demo", Path: rigDir})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+	if !strings.Contains(r.Message, "inactive store is empty") {
+		t.Fatalf("message = %q, want inactive-store-empty OK", r.Message)
+	}
+}
+
+func TestRigBDSplitStoreCheck_InvalidExternalCityConfigUsesNeutralGuidance(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "demo")
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, cityDir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginCityCanonical,
+		EndpointStatus: contract.EndpointStatusVerified,
+		DoltHost:       "db.example.com",
+	})
+	writeDoctorCanonicalMetadata(t, fs, cityDir, "hq")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+	writeDoltRepoMarker(t, filepath.Join(rigDir, ".beads", "dolt", "de"))
+	writeDoltRepoMarker(t, filepath.Join(rigDir, ".beads", "embeddeddolt", "legacy"))
+
+	c := NewRigBDSplitStoreCheck(cityDir, config.Rig{Name: "demo", Path: rigDir})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no active local store") {
+		t.Fatalf("message = %q, want no active local store warning", r.Message)
+	}
+	if strings.Contains(r.Message, "active .beads/dolt") {
+		t.Fatalf("message = %q, should not trust rig metadata when city external config is invalid", r.Message)
+	}
+	if strings.Contains(r.FixHint, "inactive store") {
+		t.Fatalf("fix hint = %q, should not reference inactive store when active local store is unknown", r.FixHint)
+	}
+}
+
+func TestBDSplitStoreCheck_UnknownActiveUsesNeutralRecoveryGuidance(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if strings.Contains(r.FixHint, "inactive store") {
+		t.Fatalf("fix hint = %q, should not reference an inactive store when active store is unknown", r.FixHint)
+	}
+	if !strings.Contains(r.FixHint, "current or intended active store") {
+		t.Fatalf("fix hint = %q, want neutral active-store guidance", r.FixHint)
+	}
+}
+
+func TestBDSplitStoreCheck_NonDoltLocalModeUsesNeutralRecoveryGuidance(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"database":"sqlite","backend":"sqlite","dolt_mode":"local"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "dolt", "hq"))
+	writeDoltRepoMarker(t, filepath.Join(beadsDir, "embeddeddolt", "legacy"))
+
+	c := NewBDSplitStoreCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if strings.Contains(r.Message, "active .beads/embeddeddolt") {
+		t.Fatalf("message = %q, should not treat non-Dolt local mode as active embeddeddolt", r.Message)
+	}
+	if strings.Contains(r.FixHint, "inactive store") {
+		t.Fatalf("fix hint = %q, should not reference inactive store for non-Dolt local mode", r.FixHint)
+	}
+}
+
+func TestDoltReposUnderSkipsDetectedRepoWorktree(t *testing.T) {
+	root := t.TempDir()
+	writeDoltRepoMarker(t, filepath.Join(root, "hq"))
+	writeDoltRepoMarker(t, filepath.Join(root, "hq", "nested"))
+
+	repos, err := doltReposUnder(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(repos, ","), "hq"; got != want {
+		t.Fatalf("repos = %q, want %q", got, want)
+	}
+}
+
 func writeDoltRepoMarker(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(dir, ".dolt", "noms"), 0o700); err != nil {


### PR DESCRIPTION
## Summary

- Supersedes #898 and preserves the original contributor fix by @julianknutsen.
- Adds a warning-only `gc doctor` check for legacy `.beads/dolt` plus `.beads/embeddeddolt` split stores at both city and rig scope.
- Hardens active-store detection so external, inherited, file-provider, invalid canonical, and non-Dolt metadata cases use neutral recovery guidance instead of trusting stale local metadata.
- Counts detected Dolt worktrees once when scanning legacy store directories, so nested `.dolt` directories do not inflate warnings.

Closes #633

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

## Testing

- [ ] `make check` (not run; targeted checks below passed, and full `go test ./...` previously timed out in existing `cmd/gc` managed bd lifecycle coverage unrelated to this doctor check)
- [ ] `make check-docs` if docs, navigation, or links changed (not applicable)
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed (not applicable)

Targeted checks run on the rebased branch:

- `git diff --check origin/main...HEAD`
- `go test ./internal/doctor -run 'Test(RigBDSplitStoreCheck|BDSplitStoreCheck|DoltReposUnder)' -count=1`
- `go test ./cmd/gc -run 'Test(DoDoctorReportsLegacyBDSplitStore|DoctorSkipsDoltChecksTreatsExecGcBeadsBdAsBdContract|DoctorSkipsSuspendedRigChecks|DoltTopologyCheck)' -count=1 -timeout 5m`
- `go vet ./internal/doctor ./cmd/gc`

Review gates:

- Claude approved current head `146f3f81` before replay onto `origin/main`.
- Codex approved current head `146f3f81` before replay onto `origin/main`.
- Replay onto `origin/main` was clean; rebased branch head is `3cbffac7` with the same logical changes.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes (not applicable; diagnostic output only)
- [x] Called out breaking changes or migration notes (none)
