### PR TITLE
Fix session create command and rollback semantics

### DIFF
--- a/internal/api/handler_session_create.go
+++ b/internal/api/handler_session_create.go
@@ -128,40 +128,13 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Merge explicit options with provider effective defaults.
-	// User-specified options override defaults; unspecified options get the
-	// provider's EffectiveDefaults (e.g., permission_mode=unrestricted for claude).
-	command := firstNonEmptyString(resolved.CommandString(), resolved.Name)
-	if len(resolved.OptionsSchema) > 0 {
-		mergedOptions := make(map[string]string)
-		for k, v := range resolved.EffectiveDefaults {
-			mergedOptions[k] = v
-		}
-		for k, v := range body.Options {
-			mergedOptions[k] = v
-		}
-		if mergedArgs, err := config.ResolveExplicitOptions(resolved.OptionsSchema, mergedOptions); err == nil && len(mergedArgs) > 0 {
-			command = config.ReplaceSchemaFlags(command, resolved.OptionsSchema, mergedArgs)
-		}
-	}
+	command := sessionCreateAgentCommand(resolved)
 
 	// Build template_overrides metadata. Includes schema overrides AND
 	// the initial message (as "initial_message" key). The reconciler
 	// handles both: schema overrides map to CLI flags, initial_message
 	// is appended to the prompt on first start only.
-	allOverrides := make(map[string]string)
-	for k, v := range body.Options {
-		allOverrides[k] = v
-	}
-	if msg := strings.TrimSpace(body.Message); msg != "" {
-		allOverrides["initial_message"] = msg
-	}
-	var extraMeta map[string]string
-	if len(allOverrides) > 0 {
-		if overridesJSON, jsonErr := json.Marshal(allOverrides); jsonErr == nil {
-			extraMeta = map[string]string{"template_overrides": string(overridesJSON)}
-		}
-	}
+	extraMeta := sessionTemplateOverridesMetadata(body.Options, body.Message)
 	if extraMeta == nil {
 		extraMeta = make(map[string]string)
 	}
@@ -353,9 +326,15 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 	if msg := strings.TrimSpace(body.Message); msg != "" {
 		if _, sendErr := s.submitMessageToSession(r.Context(), store, info.ID, msg, session.SubmitIntentDefault); sendErr != nil {
 			log.Printf("session %s: initial message delivery failed: %v", info.ID, sendErr)
+			rollbackErr := s.rollbackCreatedSession(store, info.ID)
 			s.idem.unreserve(idemKey)
+			if rollbackErr != nil {
+				writeError(w, http.StatusInternalServerError, "message_delivery_failed",
+					fmt.Sprintf("initial message delivery failed: %v (rollback failed: %v)", sendErr, rollbackErr))
+				return
+			}
 			writeError(w, http.StatusInternalServerError, "message_delivery_failed",
-				fmt.Sprintf("session created but initial message failed: %v", sendErr))
+				fmt.Sprintf("initial message delivery failed: %v", sendErr))
 			return
 		}
 	}
@@ -373,6 +352,41 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 	statusCode := http.StatusCreated
 	s.idem.storeResponse(idemKey, bodyHash, statusCode, resp)
 	writeJSON(w, statusCode, resp)
+}
+
+func sessionCreateAgentCommand(resolved *config.ResolvedProvider) string {
+	return firstNonEmptyString(resolved.CommandString(), resolved.Name)
+}
+
+func sessionTemplateOverridesMetadata(options map[string]string, message string) map[string]string {
+	allOverrides := make(map[string]string, len(options)+1)
+	for k, v := range options {
+		allOverrides[k] = v
+	}
+	if msg := strings.TrimSpace(message); msg != "" {
+		allOverrides["initial_message"] = msg
+	}
+	if len(allOverrides) == 0 {
+		return nil
+	}
+	overridesJSON, err := json.Marshal(allOverrides)
+	if err != nil {
+		return nil
+	}
+	return map[string]string{"template_overrides": string(overridesJSON)}
+}
+
+func (s *Server) rollbackCreatedSession(store beads.Store, sessionID string) error {
+	if store == nil || strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	if err := s.sessionManager(store).Close(sessionID); err != nil {
+		return fmt.Errorf("close created session: %w", err)
+	}
+	if err := store.Delete(sessionID); err != nil {
+		return fmt.Errorf("delete created session bead: %w", err)
+	}
+	return nil
 }
 
 // persistSessionMeta writes option metadata and project_id to the session bead.

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -61,6 +61,21 @@ func (p *cancelStartProvider) Start(ctx context.Context, name string, cfg runtim
 	return p.Fake.Start(ctx, name, cfg)
 }
 
+type failNudgeProvider struct {
+	*runtime.Fake
+	err error
+}
+
+func (p *failNudgeProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	if err := p.Fake.Nudge(name, content); err != nil {
+		return err
+	}
+	if p.err != nil {
+		return p.err
+	}
+	return nil
+}
+
 type stateWithSessionProvider struct {
 	*fakeState
 	provider runtime.Provider
@@ -1293,6 +1308,60 @@ func TestHandleProviderSessionCreateWithMessageUsesProviderDefaultNudge(t *testi
 	}
 }
 
+func TestHandleProviderSessionCreateWithMessageRollsBackOnDeliveryFailure(t *testing.T) {
+	fs := newSessionFakeState(t)
+	provider := &failNudgeProvider{Fake: runtime.NewFake(), err: errors.New("nudge failed")}
+	wrappedState := &stateWithSessionProvider{fakeState: fs, provider: provider}
+	srv := New(wrappedState)
+	h := newTestCityHandlerWith(t, wrappedState, srv)
+
+	body := `{"kind":"provider","name":"test-agent","message":"hello","title":"Retryable"}`
+	req := newPostRequest(cityURL(fs, "/sessions"), strings.NewReader(body))
+	req.Header.Set("Idempotency-Key", "provider-create-rollback")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("first create status = %d, want %d; body: %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "initial message delivery failed") {
+		t.Fatalf("first create body = %q, want initial message delivery failure detail", rec.Body.String())
+	}
+
+	items, err := fs.cityBeadStore.ListByLabel(session.LabelSession, 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("session bead count after rollback = %d, want 0", len(items))
+	}
+	running, err := provider.ListRunning("")
+	if err != nil {
+		t.Fatalf("ListRunning: %v", err)
+	}
+	if len(running) != 0 {
+		t.Fatalf("running sessions after rollback = %v, want none", running)
+	}
+
+	provider.err = nil
+	req = newPostRequest(cityURL(fs, "/sessions"), strings.NewReader(body))
+	req.Header.Set("Idempotency-Key", "provider-create-rollback")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("retry create status = %d, want %d; body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	items, err = fs.cityBeadStore.ListByLabel(session.LabelSession, 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("ListByLabel after retry: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("session bead count after retry = %d, want 1", len(items))
+	}
+}
+
 func TestHandleSessionCreatePersistsAlias(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)
@@ -1494,7 +1563,7 @@ func newSessionFakeStateWithOptions(t *testing.T) *fakeState {
 	return fs
 }
 
-func TestHandleSessionCreateAppliesProviderDefaults(t *testing.T) {
+func TestHandleSessionCreateDoesNotApplyProviderDefaultsToAgentCommand(t *testing.T) {
 	fs := newSessionFakeStateWithOptions(t)
 	srv := New(fs)
 	h := newTestCityHandlerWith(t, fs, srv)
@@ -1519,15 +1588,15 @@ func TestHandleSessionCreateAppliesProviderDefaults(t *testing.T) {
 		t.Fatalf("get bead: %v", err)
 	}
 	cmd := b.Metadata["command"]
-	if !strings.Contains(cmd, "--skip-permissions") {
-		t.Errorf("command %q should contain --skip-permissions from provider default permission_mode=unrestricted", cmd)
+	if strings.Contains(cmd, "--skip-permissions") {
+		t.Errorf("command %q should not contain provider default flags for deferred agent create", cmd)
 	}
-	if !strings.Contains(cmd, "--effort max") {
-		t.Errorf("command %q should contain --effort max from provider default effort=max", cmd)
+	if strings.Contains(cmd, "--effort max") {
+		t.Errorf("command %q should not contain provider default effort=max for deferred agent create", cmd)
 	}
 }
 
-func TestHandleSessionCreateMergesPartialOptionsWithDefaults(t *testing.T) {
+func TestHandleSessionCreateStoresExplicitOverridesWithoutCommandRewrite(t *testing.T) {
 	fs := newSessionFakeStateWithOptions(t)
 	srv := New(fs)
 	h := newTestCityHandlerWith(t, fs, srv)
@@ -1552,18 +1621,26 @@ func TestHandleSessionCreateMergesPartialOptionsWithDefaults(t *testing.T) {
 		t.Fatalf("get bead: %v", err)
 	}
 	cmd := b.Metadata["command"]
-	if !strings.Contains(cmd, "--skip-permissions") {
-		t.Errorf("command %q should contain --skip-permissions from unspecified default permission_mode=unrestricted", cmd)
+	if strings.Contains(cmd, "--skip-permissions") || strings.Contains(cmd, "--effort high") || strings.Contains(cmd, "--effort max") {
+		t.Errorf("command %q should not be rewritten from provider defaults or explicit overrides", cmd)
 	}
-	if !strings.Contains(cmd, "--effort high") {
-		t.Errorf("command %q should contain --effort high from explicit option", cmd)
+	ovr := b.Metadata["template_overrides"]
+	if ovr == "" {
+		t.Fatal("template_overrides not set")
 	}
-	if strings.Contains(cmd, "--effort max") {
-		t.Errorf("command %q should NOT contain --effort max — user specified high", cmd)
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(ovr), &parsed); err != nil {
+		t.Fatalf("parse template_overrides: %v", err)
+	}
+	if parsed["effort"] != "high" {
+		t.Errorf("effort = %q, want %q", parsed["effort"], "high")
+	}
+	if _, ok := parsed["permission_mode"]; ok {
+		t.Errorf("permission_mode override unexpectedly present: %#v", parsed)
 	}
 }
 
-func TestHandleSessionCreateExplicitOptionsOverrideDefaults(t *testing.T) {
+func TestHandleSessionCreatePersistsExplicitOptionsInTemplateOverrides(t *testing.T) {
 	fs := newSessionFakeStateWithOptions(t)
 	srv := New(fs)
 	h := newTestCityHandlerWith(t, fs, srv)
@@ -1588,14 +1665,22 @@ func TestHandleSessionCreateExplicitOptionsOverrideDefaults(t *testing.T) {
 		t.Fatalf("get bead: %v", err)
 	}
 	cmd := b.Metadata["command"]
-	if !strings.Contains(cmd, "--permission-mode plan") {
-		t.Errorf("command %q should contain --permission-mode plan from explicit option", cmd)
+	if strings.Contains(cmd, "--permission-mode plan") || strings.Contains(cmd, "--skip-permissions") || strings.Contains(cmd, "--effort low") {
+		t.Errorf("command %q should not be rewritten from explicit overrides", cmd)
 	}
-	if strings.Contains(cmd, "--skip-permissions") {
-		t.Errorf("command %q should NOT contain --skip-permissions — user specified plan", cmd)
+	ovr := b.Metadata["template_overrides"]
+	if ovr == "" {
+		t.Fatal("template_overrides not set")
 	}
-	if !strings.Contains(cmd, "--effort low") {
-		t.Errorf("command %q should contain --effort low from explicit option", cmd)
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(ovr), &parsed); err != nil {
+		t.Fatalf("parse template_overrides: %v", err)
+	}
+	if parsed["permission_mode"] != "plan" {
+		t.Errorf("permission_mode = %q, want %q", parsed["permission_mode"], "plan")
+	}
+	if parsed["effort"] != "low" {
+		t.Errorf("effort = %q, want %q", parsed["effort"], "low")
 	}
 }
 

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -107,33 +106,8 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
-	command := resolved.CommandString()
-	if len(resolved.OptionsSchema) > 0 {
-		mergedOptions := make(map[string]string)
-		for k, v := range resolved.EffectiveDefaults {
-			mergedOptions[k] = v
-		}
-		for k, v := range body.Options {
-			mergedOptions[k] = v
-		}
-		if mergedArgs, mergeErr := config.ResolveExplicitOptions(resolved.OptionsSchema, mergedOptions); mergeErr == nil && len(mergedArgs) > 0 {
-			command = config.ReplaceSchemaFlags(command, resolved.OptionsSchema, mergedArgs)
-		}
-	}
-
-	allOverrides := make(map[string]string)
-	for k, v := range body.Options {
-		allOverrides[k] = v
-	}
-	if msg := strings.TrimSpace(body.Message); msg != "" {
-		allOverrides["initial_message"] = msg
-	}
-	var extraMeta map[string]string
-	if len(allOverrides) > 0 {
-		if overridesJSON, jsonErr := json.Marshal(allOverrides); jsonErr == nil {
-			extraMeta = map[string]string{"template_overrides": string(overridesJSON)}
-		}
-	}
+	command := sessionCreateAgentCommand(resolved)
+	extraMeta := sessionTemplateOverridesMetadata(body.Options, body.Message)
 
 	mgr := s.sessionManager(store)
 	var info session.Info
@@ -305,8 +279,12 @@ func (s *Server) humaCreateProviderSession(ctx context.Context, store beads.Stor
 	if msg := strings.TrimSpace(body.Message); msg != "" {
 		if _, sendErr := s.submitMessageToSession(ctx, store, info.ID, msg, session.SubmitIntentDefault); sendErr != nil {
 			log.Printf("session %s: initial message delivery failed: %v", info.ID, sendErr)
+			if rollbackErr := s.rollbackCreatedSession(store, info.ID); rollbackErr != nil {
+				return nil, huma.Error500InternalServerError(
+					fmt.Sprintf("initial message delivery failed: %v (rollback failed: %v)", sendErr, rollbackErr))
+			}
 			return nil, huma.Error500InternalServerError(
-				fmt.Sprintf("session created but initial message failed: %v", sendErr))
+				fmt.Sprintf("initial message delivery failed: %v", sendErr))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- stop rewriting stored agent session commands from provider defaults or explicit create-time options
- keep create-time option/message overrides in `template_overrides` for later resolution at start time
- roll back provider sessions when initial message delivery fails so idempotent retries do not duplicate sessions

## Why
These are the two medium-severity follow-ups that were found in review after the worker conformance + hardening stack merged:
1. agent session creation could persist a command mutated by provider `EffectiveDefaults` even when the request did not provide options
2. provider session creation could leave a created session behind after initial message delivery failed, so retrying could create duplicates

## Validation
- `golangci-lint run ./internal/api/...`
- `go test -count=1 ./internal/api -run 'TestHandle(SessionCreate|ProviderSessionCreate).*'`
