### PR TITLE
fix: recover reconciler panics to prevent full-city cascade (#663)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -277,24 +277,68 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
+	retryDelay := cr.cfg.Daemon.PatrolIntervalDuration()
+	startupRetryLimit := cr.cfg.Daemon.MaxRestartsOrDefault()
+	waitForRetry := func() bool {
+		timer := time.NewTimer(retryDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	retryStartupStep := func(trigger string, complete func() bool, run func()) bool {
+		for attempt := 1; !complete(); attempt++ {
+			panicked := cr.safeTick(run, trigger)
+			if ctx.Err() != nil {
+				return false
+			}
+			if complete() {
+				return true
+			}
+			if !panicked {
+				fmt.Fprintf(cr.stderr, "%s: %s did not complete without panic; stopping city runtime\n", //nolint:errcheck
+					cr.logPrefix, trigger)
+				return false
+			}
+			if startupRetryLimit > 0 && attempt >= startupRetryLimit {
+				fmt.Fprintf(cr.stderr, "%s: %s did not complete after %d attempt(s); stopping city runtime\n", //nolint:errcheck
+					cr.logPrefix, trigger, attempt)
+				return false
+			}
+			if !waitForRetry() {
+				return false
+			}
+		}
+		return true
+	}
+
 	// Adoption barrier: ensure every running session has a bead.
 	// Runs on every startup (rerunnable, crash-safe).
-	if cr.onStatus != nil {
-		cr.onStatus("adopting_sessions")
-	}
-	if cr.cityBeadStore() != nil {
-		result, passed := runAdoptionBarrier(cr.cityBeadStore(), cr.sp, cr.cfg, cr.cityName, clock.Real{}, cr.stderr, false)
-		if result.Adopted > 0 {
-			fmt.Fprintf(cr.stdout, "Adopted %d running session(s) into bead store.\n", result.Adopted) //nolint:errcheck
+	adoptionComplete := false
+	if !retryStartupStep("adoption-barrier", func() bool { return adoptionComplete }, func() {
+		if cr.onStatus != nil {
+			cr.onStatus("adopting_sessions")
 		}
-		if !passed {
-			// Sessions that fail adoption AND have no matching agent are
-			// invisible to the bead reconciler (which only processes beaded
-			// sessions). They will be cleaned up when they naturally exit.
-			// Sessions with matching agents get beads via syncSessionBeads
-			// on the next tick.
-			fmt.Fprintf(cr.stderr, "%s: adoption barrier: %d session(s) failed bead creation\n", cr.logPrefix, result.Skipped) //nolint:errcheck
+		if cr.cityBeadStore() != nil {
+			result, passed := runAdoptionBarrier(cr.cityBeadStore(), cr.sp, cr.cfg, cr.cityName, clock.Real{}, cr.stderr, false)
+			if result.Adopted > 0 {
+				fmt.Fprintf(cr.stdout, "Adopted %d running session(s) into bead store.\n", result.Adopted) //nolint:errcheck
+			}
+			if !passed {
+				// Sessions that fail adoption AND have no matching agent are
+				// invisible to the bead reconciler (which only processes beaded
+				// sessions). They will be cleaned up when they naturally exit.
+				// Sessions with matching agents get beads via syncSessionBeads
+				// on the next tick.
+				fmt.Fprintf(cr.stderr, "%s: adoption barrier: %d session(s) failed bead creation\n", cr.logPrefix, result.Skipped) //nolint:errcheck
+			}
 		}
+		adoptionComplete = true
+	}) {
+		return
 	}
 	if ctx.Err() != nil {
 		return
@@ -316,7 +360,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// into cityRuntime.shutdown(). See issue #663. The trace cycle is
 	// ended inside the closure via defer so it's closed out on panic,
 	// ctx cancellation, or normal completion alike.
-	cr.safeTick(func() {
+	startupComplete := false
+	if !retryStartupStep("startup", func() bool { return startupComplete }, func() {
 		sessionBeads := cr.loadSessionBeadSnapshot()
 		startupTrace := cr.beginTraceCycle("startup", "initial_reconcile", sessionBeads)
 		completion := TraceCompletionAborted
@@ -353,21 +398,14 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			return
 		}
 
-		// Mark city as started. Convergence startup reconciliation runs on
-		// the first tick (it calls List() which waits for the full async prime).
-		if cr.onStatus != nil {
-			cr.onStatus("starting_agents")
-		}
-		if cr.onStarted != nil {
-			cr.onStarted()
-		}
-		fmt.Fprintln(cr.stdout, "City started.") //nolint:errcheck // best-effort stdout
-
 		if cr.sessionDrains != nil {
 			cr.beadReconcileTick(ctx, result, sessionBeads, startupTrace)
 		}
 		completion = TraceCompletionCompleted
-	}, "startup")
+		startupComplete = true
+	}) {
+		return
+	}
 	if ctx.Err() != nil {
 		return
 	}
@@ -379,11 +417,31 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	//
 	// Wrapped in safeTick so a panic during convergence recovery (same
 	// class of transient store failure as #663) doesn't cascade to
-	// cityRuntime.shutdown(). The next patrol tick will re-drain any
-	// still-pending convergence beads.
-	cr.safeTick(func() {
+	// cityRuntime.shutdown(). Startup does not advance until the active
+	// convergence index is populated, so later patrols can drain pending
+	// convergence beads.
+	convergenceStartupDone := convergenceStartupComplete(cr)
+	if !retryStartupStep("convergence-startup", func() bool { return convergenceStartupDone }, func() {
 		cr.convergenceStartupReconcile(ctx)
-	}, "convergence-startup")
+		convergenceStartupDone = true
+	}) {
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Mark city as started only after all retry-critical startup work has
+	// completed. Publishing readiness before bead reconciliation or
+	// convergence index population would let API callers observe a started
+	// city whose one-shot startup state is still incomplete.
+	if cr.onStatus != nil {
+		cr.onStatus("starting_agents")
+	}
+	if cr.onStarted != nil {
+		cr.onStarted()
+	}
+	fmt.Fprintln(cr.stdout, "City started.") //nolint:errcheck // best-effort stdout
 	if ctx.Err() != nil {
 		return
 	}
@@ -419,7 +477,9 @@ func (cr *CityRuntime) run(ctx context.Context) {
 				cr.controlDispatcherTick(ctx)
 			}, "control-dispatcher")
 		case req := <-cr.reloadReqCh:
-			cr.handleReloadRequest(&req)
+			cr.safeTick(func() {
+				cr.handleReloadRequest(&req)
+			}, "reload-request")
 		case req := <-cr.convergenceReqCh:
 			// Low-latency path: process convergence commands between ticks.
 			// processConvergenceRequests() in tick() drains any that arrived
@@ -427,8 +487,10 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			// are atomic, so each request is processed exactly once.
 			// Note: ordering relative to convergenceTick is non-deterministic
 			// via this path, but handlers are idempotent so interleaving is safe.
-			reply := cr.safeHandleConvergenceRequest(ctx, req)
-			req.replyCh <- reply
+			cr.safeTick(func() {
+				reply := cr.safeHandleConvergenceRequest(ctx, req)
+				req.replyCh <- reply
+			}, "convergence-request")
 		case <-ctx.Done():
 			cr.failActiveReload("Reload canceled because the controller is shutting down.")
 			return
@@ -452,13 +514,16 @@ func (cr *CityRuntime) run(ctx context.Context) {
 // strictly better than the prior behavior of one panic killing every
 // session in the city with no log of what triggered it. Operators
 // should treat repeated "reconciler tick panicked" lines as a bug
-// report, not a steady-state condition.
+// report, not a steady-state condition. The panic signal is intentionally
+// stderr-only because recovery must not depend on event-bus availability
+// during store or controller failures.
 //
 // Trigger identifies which tick site fired so operators can correlate
 // the log with the cause.
-func (cr *CityRuntime) safeTick(fn func(), trigger string) {
+func (cr *CityRuntime) safeTick(fn func(), trigger string) (panicked bool) {
 	defer func() {
 		if r := recover(); r != nil {
+			panicked = true
 			// Include the recovered type and a stack trace so a latent
 			// invariant bug (e.g. nil deref) is diagnosable from the log
 			// alone — crucial because safeTick intentionally swallows
@@ -468,6 +533,14 @@ func (cr *CityRuntime) safeTick(fn func(), trigger string) {
 		}
 	}()
 	fn()
+	return false
+}
+
+func convergenceStartupComplete(cr *CityRuntime) bool {
+	return cr.convHandler == nil ||
+		cr.convergenceReqCh == nil ||
+		cr.convStoreAdapter == nil ||
+		cr.convStoreAdapter.activeIndex != nil
 }
 
 // tick performs one reconciliation tick: pool death detection, config
@@ -523,13 +596,38 @@ func (cr *CityRuntime) tick(
 
 	var manualReload *reloadRequest
 	var manualReply reloadControlReply
+	manualReloadCompleted := false
+	manualReloadReplied := false
+	dirtyCleared := false
+	tickCompleted := false
+	defer func() {
+		if dirtyCleared && !tickCompleted && manualReload == nil {
+			dirty.Store(true)
+		}
+		if manualReload == nil || manualReloadReplied {
+			return
+		}
+		reply := reloadControlReply{
+			Outcome: reloadOutcomeFailed,
+			Error:   fmt.Sprintf("Reload failed because reconciliation tick %q panicked before completion.", trigger),
+		}
+		if manualReloadCompleted {
+			reply = manualReply
+		}
+		cr.sendReloadReply(manualReload.doneCh, reply)
+		cr.activeReload = nil
+	}()
 	if dirty.Swap(false) {
+		dirtyCleared = true
 		source := reloadSourceWatch
 		if cr.activeReload != nil {
 			source = reloadSourceManual
 			manualReload = cr.activeReload
 		}
 		manualReply = cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, trace, source)
+		if manualReload != nil {
+			manualReloadCompleted = true
+		}
 	}
 
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
@@ -601,13 +699,12 @@ func (cr *CityRuntime) tick(
 	// Convergence tick: process active convergence loops.
 	cr.convergenceTick(ctx)
 	if manualReload != nil {
-		select {
-		case manualReload.doneCh <- manualReply:
-		default:
-		}
+		cr.sendReloadReply(manualReload.doneCh, manualReply)
+		manualReloadReplied = true
 		cr.activeReload = nil
 	}
 	completion = TraceCompletionCompleted
+	tickCompleted = true
 }
 
 func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {
@@ -640,14 +737,24 @@ func (cr *CityRuntime) failActiveReload(message string) {
 	if cr.activeReload == nil {
 		return
 	}
-	select {
-	case cr.activeReload.doneCh <- reloadControlReply{
+	cr.sendReloadReply(cr.activeReload.doneCh, reloadControlReply{
 		Outcome: reloadOutcomeFailed,
 		Error:   message,
-	}:
+	})
+	cr.activeReload = nil
+}
+
+func (cr *CityRuntime) sendReloadReply(ch chan<- reloadControlReply, reply reloadControlReply) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(cr.stderr, "%s: reload reply panicked: %v (type=%T)\n%s\n", //nolint:errcheck // best-effort stderr
+				cr.logPrefix, r, r, debug.Stack())
+		}
+	}()
+	select {
+	case ch <- reply:
 	default:
 	}
-	cr.activeReload = nil
 }
 
 // reloadConfig attempts to reload city.toml and update all internal

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -308,54 +309,65 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).
-	sessionBeads := cr.loadSessionBeadSnapshot()
-	startupTrace := cr.beginTraceCycle("startup", "initial_reconcile", sessionBeads)
-	result := cr.buildDesiredState(sessionBeads, startupTrace)
-	sessionBeads = cr.loadSessionBeadSnapshot()
-	result = refreshDesiredStateWithSessionBeads(
-		result,
-		cr.cityName,
-		cr.cityPath,
-		cr.cfg,
-		cr.sp,
-		cr.cityBeadStore(),
-		sessionBeads,
-		cr.stderr,
-	)
-	sessionBeads = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
-	result = refreshDesiredStateWithSessionBeads(
-		result,
-		cr.cityName,
-		cr.cityPath,
-		cr.cfg,
-		cr.sp,
-		cr.cityBeadStore(),
-		sessionBeads,
-		cr.stderr,
-	)
-	if ctx.Err() != nil {
-		if startupTrace != nil {
-			startupTrace.end(TraceCompletionAborted, traceRecordPayload{"phase": "startup"})
+	//
+	// Wrapped in safeTick so a panic during startup reconciliation (e.g.
+	// a transient bead-store failure triggering a downstream nil deref)
+	// does not propagate to the supervisor's panic recovery and cascade
+	// into cityRuntime.shutdown(). See issue #663. The trace cycle is
+	// ended inside the closure via defer so it's closed out on panic,
+	// ctx cancellation, or normal completion alike.
+	cr.safeTick(func() {
+		sessionBeads := cr.loadSessionBeadSnapshot()
+		startupTrace := cr.beginTraceCycle("startup", "initial_reconcile", sessionBeads)
+		completion := TraceCompletionAborted
+		defer func() {
+			if startupTrace != nil {
+				startupTrace.end(completion, traceRecordPayload{"phase": "startup"})
+			}
+		}()
+
+		result := cr.buildDesiredState(sessionBeads, startupTrace)
+		sessionBeads = cr.loadSessionBeadSnapshot()
+		result = refreshDesiredStateWithSessionBeads(
+			result,
+			cr.cityName,
+			cr.cityPath,
+			cr.cfg,
+			cr.sp,
+			cr.cityBeadStore(),
+			sessionBeads,
+			cr.stderr,
+		)
+		sessionBeads = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
+		result = refreshDesiredStateWithSessionBeads(
+			result,
+			cr.cityName,
+			cr.cityPath,
+			cr.cfg,
+			cr.sp,
+			cr.cityBeadStore(),
+			sessionBeads,
+			cr.stderr,
+		)
+		if ctx.Err() != nil {
+			return
 		}
-		return
-	}
 
-	// Mark city as started. Convergence startup reconciliation runs on
-	// the first tick (it calls List() which waits for the full async prime).
-	if cr.onStatus != nil {
-		cr.onStatus("starting_agents")
-	}
-	if cr.onStarted != nil {
-		cr.onStarted()
-	}
-	fmt.Fprintln(cr.stdout, "City started.") //nolint:errcheck // best-effort stdout
+		// Mark city as started. Convergence startup reconciliation runs on
+		// the first tick (it calls List() which waits for the full async prime).
+		if cr.onStatus != nil {
+			cr.onStatus("starting_agents")
+		}
+		if cr.onStarted != nil {
+			cr.onStarted()
+		}
+		fmt.Fprintln(cr.stdout, "City started.") //nolint:errcheck // best-effort stdout
 
-	if cr.sessionDrains != nil {
-		cr.beadReconcileTick(ctx, result, sessionBeads, startupTrace)
-	}
-	if startupTrace != nil {
-		startupTrace.end(TraceCompletionCompleted, traceRecordPayload{"phase": "startup"})
-	}
+		if cr.sessionDrains != nil {
+			cr.beadReconcileTick(ctx, result, sessionBeads, startupTrace)
+		}
+		completion = TraceCompletionCompleted
+	}, "startup")
 	if ctx.Err() != nil {
 		return
 	}
@@ -364,14 +376,26 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// beads that were interrupted by a controller crash. Runs after "City
 	// started" so it doesn't block readiness. List() waits for the full
 	// CachingStore prime, then serves from memory.
-	cr.convergenceStartupReconcile(ctx)
+	//
+	// Wrapped in safeTick so a panic during convergence recovery (same
+	// class of transient store failure as #663) doesn't cascade to
+	// cityRuntime.shutdown(). The next patrol tick will re-drain any
+	// still-pending convergence beads.
+	cr.safeTick(func() {
+		cr.convergenceStartupReconcile(ctx)
+	}, "convergence-startup")
 	if ctx.Err() != nil {
 		return
 	}
 	// Track pool instance liveness for death detection.
 	var prevPoolRunning map[string]bool
+	runTick := func(trigger string) {
+		cr.safeTick(func() {
+			cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, trigger)
+		}, trigger)
+	}
 	if dirty.Load() {
-		cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, "startup-poke")
+		runTick("startup-poke")
 		if ctx.Err() != nil {
 			return
 		}
@@ -384,14 +408,16 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, "patrol")
+			runTick("patrol")
 		case <-cr.pokeCh:
 			// Event-driven wake path: sling or API assigned work to a sleeping
 			// session. Trigger an immediate tick so the reconciler sees the new
 			// work via workSet/poolDesired and wakes the target promptly.
-			cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, "poke")
+			runTick("poke")
 		case <-cr.controlDispatcherCh:
-			cr.controlDispatcherTick(ctx)
+			cr.safeTick(func() {
+				cr.controlDispatcherTick(ctx)
+			}, "control-dispatcher")
 		case req := <-cr.reloadReqCh:
 			cr.handleReloadRequest(&req)
 		case req := <-cr.convergenceReqCh:
@@ -408,6 +434,40 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			return
 		}
 	}
+}
+
+// safeTick runs fn with panic recovery. A panic inside fn is logged to
+// stderr and swallowed so the reconciler loop can continue to the next
+// tick. Without this wrapper, a panic in the reconciliation body
+// propagates to cmd_supervisor.go's per-city goroutine recovery, which
+// escalates to cityRuntime.shutdown() -> gracefulStopAll for every
+// session in the city. Transient bead-store failures (e.g. Dolt EOF on
+// a single metadata write) must not cascade into a full-city restart:
+// the next tick is idempotent and will retry the failed work.
+//
+// This intentionally swallows ALL panics, including non-transient bugs
+// (e.g. nil derefs from broken invariants). That tradeoff is explicit:
+// a latent invariant bug that panics every tick will log visibly on
+// each patrol interval, surfacing the bug via repetition, which is
+// strictly better than the prior behavior of one panic killing every
+// session in the city with no log of what triggered it. Operators
+// should treat repeated "reconciler tick panicked" lines as a bug
+// report, not a steady-state condition.
+//
+// Trigger identifies which tick site fired so operators can correlate
+// the log with the cause.
+func (cr *CityRuntime) safeTick(fn func(), trigger string) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Include the recovered type and a stack trace so a latent
+			// invariant bug (e.g. nil deref) is diagnosable from the log
+			// alone — crucial because safeTick intentionally swallows
+			// the panic and the bug may only surface via repetition.
+			fmt.Fprintf(cr.stderr, "%s: reconciler tick panicked (trigger=%s): %v (type=%T)\n%s\n", //nolint:errcheck // best-effort stderr
+				cr.logPrefix, trigger, r, r, debug.Stack())
+		}
+	}()
+	fn()
 }
 
 // tick performs one reconciliation tick: pool death detection, config
@@ -428,6 +488,15 @@ func (cr *CityRuntime) tick(
 		traceDetail = "manual_reload"
 	}
 	trace := cr.beginTraceCycle(traceTrigger, traceDetail, sessionBeads)
+	// End the trace via defer so a panic recovered by safeTick still
+	// closes the cycle (aborted). completion flips to Completed at the
+	// normal end of the tick body below.
+	completion := TraceCompletionAborted
+	defer func() {
+		if trace != nil {
+			trace.end(completion, traceRecordPayload{"phase": "tick", "trigger": traceTrigger})
+		}
+	}()
 	// Detect pool instance deaths since last tick.
 	if len(cr.poolDeathHandlers) > 0 {
 		currentRunning, _ := cr.sp.ListRunning("")
@@ -538,9 +607,7 @@ func (cr *CityRuntime) tick(
 		}
 		cr.activeReload = nil
 	}
-	if trace != nil {
-		trace.end(TraceCompletionCompleted, traceRecordPayload{"phase": "tick", "trigger": traceTrigger})
-	}
+	completion = TraceCompletionCompleted
 }
 
 func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1783,6 +1783,141 @@ func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T)
 	}
 }
 
+// safeTick must swallow panics so a transient failure in the reconciler
+// tick body (e.g. Dolt EOF triggering a downstream nil deref) does not
+// cascade through the supervisor's per-city panic recovery into
+// cityRuntime.shutdown() -> gracefulStopAll (issue #663).
+func TestCityRuntimeSafeTick_RecoversFromPanicAndLogsTrigger(t *testing.T) {
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityName:  "test-city",
+		logPrefix: "test-city",
+		stderr:    &stderr,
+	}
+
+	called := false
+	cr.safeTick(func() {
+		called = true
+		panic("simulated dolt eof cascade")
+	}, "patrol")
+
+	if !called {
+		t.Fatal("tick body was not invoked")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "panicked") {
+		t.Errorf("stderr = %q, want to contain 'panicked'", got)
+	}
+	if !strings.Contains(got, "trigger=patrol") {
+		t.Errorf("stderr = %q, want to contain 'trigger=patrol'", got)
+	}
+	if !strings.Contains(got, "simulated dolt eof cascade") {
+		t.Errorf("stderr = %q, want to contain panic payload", got)
+	}
+	if !strings.Contains(got, "type=string") {
+		t.Errorf("stderr = %q, want to contain panic value type (helps distinguish errors from strings)", got)
+	}
+	if !strings.Contains(got, "goroutine ") {
+		t.Errorf("stderr = %q, want to contain a stack trace so latent bugs stay diagnosable", got)
+	}
+}
+
+// safeTick must forward normal (non-panicking) returns unchanged so the
+// wrapper is transparent in the common case.
+func TestCityRuntimeSafeTick_PassesThroughWhenNoPanic(t *testing.T) {
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityName:  "test-city",
+		logPrefix: "test-city",
+		stderr:    &stderr,
+	}
+	called := false
+	cr.safeTick(func() { called = true }, "poke")
+	if !called {
+		t.Fatal("tick body was not invoked")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty on clean tick", stderr.String())
+	}
+}
+
+// A panic during startup reconciliation must NOT cause run() to exit
+// or call shutdown(): the supervisor loop must survive a transient
+// bead-store failure (or the nil deref it would trigger) without
+// restarting the whole city. Regression for #663.
+//
+// Sequence: first BuildFn call fires inside the startup safeTick
+// closure and panics — safeTick recovers, trace ends Aborted via
+// defer. Because configDirty is still true, the post-startup
+// startup-poke branch invokes cr.tick(), which calls BuildFn a second
+// time; that call cancels ctx and run() exits cleanly.
+func TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	sp := runtime.NewFake()
+	var stdout, stderr bytes.Buffer
+
+	var buildCalls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			n := buildCalls.Add(1)
+			if n == 1 {
+				panic("simulated dolt eof nil deref")
+			}
+			cancel()
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = beads.NewMemStore()
+	cr.setControllerState(cs)
+
+	// Prime configDirty so the post-startup startup-poke branch fires
+	// cr.tick() and drives a second BuildFn call that cancels ctx.
+	var dirty atomic.Bool
+	dirty.Store(true)
+	cr.configDirty = &dirty
+
+	done := make(chan struct{})
+	go func() {
+		cr.run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("run did not return within 5s after panic+cancel")
+	}
+
+	if buildCalls.Load() < 2 {
+		t.Fatalf("BuildFn invoked %d time(s), want >= 2 (startup panic + startup-poke recovery)", buildCalls.Load())
+	}
+	if !strings.Contains(stderr.String(), "panicked") {
+		t.Errorf("stderr = %q, want to contain 'panicked' (safeTick must log)", stderr.String())
+	}
+}
+
 func TestCityRuntimeRunShutsDownSessionsOnContextCancel(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1738,6 +1738,108 @@ func TestCityRuntimeReloadRestartsConfigWatcherWithNewPackTargets(t *testing.T) 
 	}
 }
 
+func TestCityRuntimeManualReloadPanicAfterReloadKeepsReloadReplyAndClears(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	doneCh := make(chan reloadControlReply, 1)
+	dirty := &atomic.Bool{}
+	dirty.Store(true)
+	sp := runtime.NewFake()
+	var stderr bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:    cityPath,
+		CityName:    "test-city",
+		TomlPath:    tomlPath,
+		ConfigRev:   configRev,
+		ConfigDirty: dirty,
+		Cfg:         cfg,
+		SP:          sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			panic("manual reload boom")
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: &stderr,
+	})
+	cr.activeReload = &reloadRequest{doneCh: doneCh}
+	lastProviderName := "fake"
+	var prevPoolRunning map[string]bool
+
+	cr.safeTick(func() {
+		cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "poke")
+	}, "poke")
+
+	if cr.activeReload != nil {
+		t.Fatal("activeReload was not cleared after recovered panic")
+	}
+	select {
+	case reply := <-doneCh:
+		if reply.Outcome != reloadOutcomeNoChange {
+			t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeNoChange)
+		}
+	default:
+		t.Fatal("manual reload did not receive reload reply after recovered panic")
+	}
+	if !strings.Contains(stderr.String(), "manual reload boom") {
+		t.Fatalf("stderr = %q, want recovered panic log", stderr.String())
+	}
+}
+
+func TestCityRuntimeWatchReloadPanicRestoresDirty(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	dirty := &atomic.Bool{}
+	dirty.Store(true)
+	sp := runtime.NewFake()
+	var stderr bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:    cityPath,
+		CityName:    "test-city",
+		TomlPath:    tomlPath,
+		ConfigRev:   configRev,
+		ConfigDirty: dirty,
+		Cfg:         cfg,
+		SP:          sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			panic("watch reload boom")
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: &stderr,
+	})
+	lastProviderName := "fake"
+	var prevPoolRunning map[string]bool
+
+	cr.safeTick(func() {
+		cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "patrol")
+	}, "patrol")
+
+	if !dirty.Load() {
+		t.Fatal("dirty flag was not restored after recovered watch reload panic")
+	}
+	if !strings.Contains(stderr.String(), "watch reload boom") {
+		t.Fatalf("stderr = %q, want recovered panic log", stderr.String())
+	}
+}
+
 func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
@@ -1860,6 +1962,7 @@ func TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
+	cfg.Daemon.PatrolInterval = "1ms"
 	sp := runtime.NewFake()
 	var stdout, stderr bytes.Buffer
 
@@ -1915,6 +2018,233 @@ func TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "panicked") {
 		t.Errorf("stderr = %q, want to contain 'panicked' (safeTick must log)", stderr.String())
+	}
+}
+
+func TestCityRuntimeRun_RetriesStartupAfterRecoveredPanicBeforeStarted(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Daemon.PatrolInterval = "1ms"
+	sp := runtime.NewFake()
+	var stdout, stderr bytes.Buffer
+
+	var buildCalls atomic.Int32
+	var started atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			n := buildCalls.Add(1)
+			if n == 1 {
+				panic("simulated startup panic")
+			}
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops: newDrainOps(sp),
+		Rec:  events.Discard,
+		OnStarted: func() {
+			started.Store(true)
+			cancel()
+		},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = beads.NewMemStore()
+	cr.setControllerState(cs)
+
+	done := make(chan struct{})
+	go func() {
+		cr.run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("run did not return within 5s after startup retry")
+	}
+
+	if buildCalls.Load() < 2 {
+		t.Fatalf("BuildFn invoked %d time(s), want startup retry after recovered panic", buildCalls.Load())
+	}
+	if !started.Load() {
+		t.Fatal("OnStarted was not called after successful startup retry")
+	}
+	if !strings.Contains(stdout.String(), "City started.") {
+		t.Fatalf("stdout = %q, want started banner after retry", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "simulated startup panic") {
+		t.Fatalf("stderr = %q, want recovered startup panic log", stderr.String())
+	}
+}
+
+type panicOnceConvergenceListStore struct {
+	beads.Store
+	panicked atomic.Bool
+}
+
+func (s *panicOnceConvergenceListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Type == "convergence" && !s.panicked.Swap(true) {
+		panic("convergence startup list boom")
+	}
+	return s.Store.List(query)
+}
+
+type errorConvergenceListStore struct {
+	beads.Store
+}
+
+func (s *errorConvergenceListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Type == "convergence" {
+		return nil, fmt.Errorf("convergence list unavailable")
+	}
+	return s.Store.List(query)
+}
+
+func TestCityRuntimeRun_ConvergenceStartupErrorDoesNotBlockStarted(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Daemon.PatrolInterval = "1ms"
+	sp := runtime.NewFake()
+	store := &errorConvergenceListStore{Store: beads.NewMemStore()}
+	var stderr bytes.Buffer
+	var started atomic.Bool
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:             newDrainOps(sp),
+		Rec:              events.Discard,
+		ConvergenceReqCh: make(chan convergenceRequest, 1),
+		OnStarted: func() {
+			started.Store(true)
+			cancel()
+		},
+		Stdout: io.Discard,
+		Stderr: &stderr,
+	})
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = store
+	cr.setControllerState(cs)
+
+	done := make(chan struct{})
+	go func() {
+		cr.run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("run did not return after convergence startup list error")
+	}
+	if !started.Load() {
+		t.Fatal("OnStarted was not called after non-panic convergence startup error")
+	}
+	if !strings.Contains(stderr.String(), "convergence list unavailable") {
+		t.Fatalf("stderr = %q, want convergence list error", stderr.String())
+	}
+}
+
+func TestCityRuntimeRun_RetriesConvergenceStartupUntilIndexPopulated(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.Daemon.PatrolInterval = "1ms"
+	sp := runtime.NewFake()
+	store := &panicOnceConvergenceListStore{Store: beads.NewMemStore()}
+	var stderr bytes.Buffer
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		TomlPath: tomlPath,
+		Cfg:      cfg,
+		SP:       sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:             newDrainOps(sp),
+		Rec:              events.Discard,
+		ConvergenceReqCh: make(chan convergenceRequest, 1),
+		Stdout:           io.Discard,
+		Stderr:           &stderr,
+	})
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = store
+	cr.setControllerState(cs)
+
+	done := make(chan struct{})
+	go func() {
+		cr.run(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if cr.convStoreAdapter != nil && cr.convStoreAdapter.activeIndex != nil {
+			cancel()
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("convergence active index was not populated after retry")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not stop after convergence retry test cancellation")
+	}
+	if !store.panicked.Load() {
+		t.Fatal("test store did not inject convergence startup panic")
+	}
+	if !strings.Contains(stderr.String(), "convergence startup list boom") {
+		t.Fatalf("stderr = %q, want recovered convergence startup panic log", stderr.String())
 	}
 }
 


### PR DESCRIPTION
Closes #663.

## Summary
- Add `cr.safeTick(fn, trigger)` panic-recovery wrapper around reconciliation tick bodies in `cmd/gc/city_runtime.go`.
- Wrap all reconciliation entry points from `CityRuntime.run()`: startup reconcile block, convergence-startup recovery, post-startup `startup-poke`, and the main `patrol` / `poke` / `control-dispatcher` select arms.
- Restructure the startup reconcile block with a deferred `trace.end(completion)` sentinel so the trace cycle is closed on panic, ctx cancel, or normal completion alike.

## Background
A transient bead-store failure during a reconciliation tick — observed as `[mysql] packets.go:58 unexpected EOF` followed by `connect: connection refused` — could panic in the tick body. Before this fix, that panic propagated out of `CityRuntime.run()`, triggering its own `defer cr.shutdown()` AND the supervisor's per-city goroutine recovery at `cmd/gc/cmd_supervisor.go:1418-1427`, which called `cityRuntime.shutdown()` → `gracefulStopAll` with `op=interrupt wave=0` for every managed session. The reporter observed 73 such cascades in 37 hours, each a ~65s full-city outage.

`safeTick` catches the panic at the tick boundary, logs the trigger + payload, and lets the next tick retry the failed work idempotently.

## Intentional tradeoff
`safeTick` swallows ALL panics, including non-transient programmer bugs. A latent invariant bug will log `reconciler tick panicked (trigger=<x>): <payload>` on each patrol, surfacing the bug via repetition — strictly better than the prior behavior of killing every session in the city with no log of what caused it. Documented on the method.

## Test plan
- [x] Unit: `TestCityRuntimeSafeTick_RecoversFromPanicAndLogsTrigger` — panic caught, stderr contains `panicked` + `trigger=patrol` + payload.
- [x] Unit: `TestCityRuntimeSafeTick_PassesThroughWhenNoPanic` — wrapper is transparent when no panic; stderr stays empty.
- [x] Integration: `TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity` — a panic during startup reconciliation does not propagate out of `run()`; the post-startup tick reaches BuildFn and `run()` exits cleanly on `ctx.Done()`.
- [x] Full `make check` passes.

## Review highlights
Multi-model review (Anthropic + Codex GPT-5 + Copilot GPT-5.3-Codex) flagged two items, both addressed:
1. Test was originally mislabeled — panic fires in startup reconcile, not the tick loop; redundant pokeCh setup removed and test renamed.
2. `safeTick` suppresses all panics — tradeoff now documented on the method.

Contributor check (29-rule audit) surfaced one B23 scope-completeness note: `convergenceStartupReconcile` was an unwrapped sibling reconciliation path in the same `run()` body. Wrapped in the same commit.

## Not changed
- Bd transport retry already exists at `cmd/gc/bd_env.go:bdCommandRunnerWithManagedRetry` with the correct error classifier (`connection refused`, `unexpected EOF`, `broken pipe`, etc.). The cascade was via panic propagation, not via error return, so no new retry layer was needed.