### PR TITLE
fix: scrub GC_*/BEADS_* env vars when running gc-beads-bd in tests

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5897,9 +5897,15 @@ esac
 		t.Fatal(err)
 	}
 
-	baseEnv := append(os.Environ(),
+	// Must use sanitizedBaseEnv, not append(os.Environ(), ...). Raw
+	// inheritance leaks GC_CITY_RUNTIME_DIR / GC_PACK_STATE_DIR /
+	// GC_DOLT_STATE_FILE from the user's shell into this script, aiming
+	// dolt-provider-state.json at the user's real registered city
+	// instead of this test's t.TempDir() — confirmed in the wild on a
+	// dev workstation where a previous run of this test clobbered a
+	// live city. Regression guard for gastownhall/gascity#938.
+	baseEnv := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
-		"GC_BIN=",
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
 

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2412,7 +2412,14 @@ func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scriptEnv := append(os.Environ(),
+	poisonRuntimeDir := filepath.Join(t.TempDir(), "poison-runtime")
+	poisonPackStateDir := filepath.Join(poisonRuntimeDir, "packs", "dolt")
+	poisonStateFile := filepath.Join(poisonPackStateDir, "dolt-provider-state.json")
+	t.Setenv("GC_CITY_RUNTIME_DIR", poisonRuntimeDir)
+	t.Setenv("GC_PACK_STATE_DIR", poisonPackStateDir)
+	t.Setenv("GC_DOLT_STATE_FILE", poisonStateFile)
+
+	scriptEnv := sanitizedBaseEnv(
 		"HOME="+homeDir,
 		"GIT_CONFIG_GLOBAL="+gitConfig,
 		"GC_CITY_PATH="+cityPath,
@@ -2454,6 +2461,9 @@ func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(cityPath, ".beads", "dolt-server.port")); !os.IsNotExist(err) {
 		t.Fatalf("dolt-server.port should not be written by shell start, stat err = %v", err)
+	}
+	if _, err := os.Stat(poisonStateFile); !os.IsNotExist(err) {
+		t.Fatalf("start leaked ambient GC_* state to %q, stat err = %v", poisonStateFile, err)
 	}
 }
 
@@ -3153,7 +3163,7 @@ esac
 			}
 
 			cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-			cmd.Env = append(os.Environ(),
+			cmd.Env = sanitizedBaseEnv(
 				"GC_CITY_PATH="+cityPath,
 				"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 			)
@@ -3237,7 +3247,7 @@ exec %q "$@"
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -3425,7 +3435,7 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+currentGCBinaryForTests(t),
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -3555,7 +3565,7 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -3644,7 +3654,7 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+currentGCBinaryForTests(t),
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -3708,7 +3718,7 @@ exit 0
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -3834,7 +3844,7 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -4014,7 +4024,7 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -4380,7 +4390,7 @@ esac
 		t.Fatalf("write compat port file: %v", err)
 	}
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -4936,7 +4946,7 @@ while [ ! -f "$release_file" ]; do
   sleep 0.1
  done
 `, "sh", layout.LockFile, readyFile, releaseFile)
-	holder.Env = append(os.Environ(), "PATH="+os.Getenv("PATH"))
+	holder.Env = sanitizedBaseEnv("PATH=" + os.Getenv("PATH"))
 	if err := holder.Start(); err != nil {
 		t.Fatalf("start lock holder: %v", err)
 	}
@@ -4983,7 +4993,7 @@ while [ ! -f "$release_file" ]; do
 	}
 	beforeInode := inodeFor(layout.LockFile)
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_DOLT_PORT=3311",
 		"GC_FAKE_DOLT_INVOCATION_FILE="+invocationFile,
@@ -5214,7 +5224,7 @@ sleep 4
 printf 'ready\n' > "$started_file"
 sleep 1
 `, "sh", layout.LockFile, readyFile, startedFile)
-	holder.Env = append(os.Environ(), "PATH="+os.Getenv("PATH"))
+	holder.Env = sanitizedBaseEnv("PATH=" + os.Getenv("PATH"))
 	if err := holder.Start(); err != nil {
 		t.Fatalf("start lock holder: %v", err)
 	}
@@ -5233,7 +5243,7 @@ sleep 1
 		time.Sleep(25 * time.Millisecond)
 	}
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_DOLT_PORT=3311",
 		"GC_BIN="+fakeGC,
@@ -5277,7 +5287,7 @@ func TestGcBeadsBdStartUsesGCBinManagedConfigWriter(t *testing.T) {
 	fakeGC := writeFakeManagedConfigWriterGC(t, binDir, invocationFile)
 	writeFakeManagedConfigWriterDolt(t, binDir)
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -5352,7 +5362,7 @@ func TestGcBeadsBdStopUsesGCBinStopManagedHelperWhenAvailable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -5391,7 +5401,7 @@ func TestGcBeadsBdRecoverUsesGCBinRecoverManagedHelperWhenAvailable(t *testing.T
 	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
 	fakeGC := writeFakeManagedConfigWriterGC(t, binDir, invocationFile)
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -5430,7 +5440,7 @@ func TestGcBeadsBdRecoverHelperPreservesReadOnlyWarning(t *testing.T) {
 	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
 	fakeGC := writeFakeManagedConfigWriterGC(t, binDir, invocationFile)
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"GC_FAKE_RECOVER_DIAGNOSED_READ_ONLY=true",
@@ -5509,7 +5519,7 @@ esac
 	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_DOLT_PORT=3311",
 		"GC_DOLT_LOGLEVEL=info",
@@ -5635,7 +5645,7 @@ esac
 		t.Fatal(err)
 	}
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -5776,7 +5786,7 @@ esac
 		t.Fatal(err)
 	}
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -5904,8 +5914,15 @@ esac
 	// instead of this test's t.TempDir() — confirmed in the wild on a
 	// dev workstation where a previous run of this test clobbered a
 	// live city. Regression guard for gastownhall/gascity#938.
+	poisonRuntimeDir := filepath.Join(t.TempDir(), "poison-runtime")
+	poisonPackStateDir := filepath.Join(poisonRuntimeDir, "packs", "dolt")
+	poisonStateFile := filepath.Join(poisonPackStateDir, "dolt-provider-state.json")
+	t.Setenv("GC_CITY_RUNTIME_DIR", poisonRuntimeDir)
+	t.Setenv("GC_PACK_STATE_DIR", poisonPackStateDir)
+	t.Setenv("GC_DOLT_STATE_FILE", poisonStateFile)
 	baseEnv := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
+		"GC_BIN=",
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
 
@@ -5958,7 +5975,7 @@ exec "$real_nc" "$@"
 	if err := os.WriteFile(shimPath, []byte(shim), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	envWithShim := append(os.Environ(),
+	envWithShim := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN=",
 		"PATH="+strings.Join([]string{shimDir, binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -5981,6 +5998,9 @@ exec "$real_nc" "$@"
 	}
 	if got := strings.TrimSpace(string(countData)); got != "1" {
 		t.Fatalf("dolt sql-server launch count = %q, want 1", got)
+	}
+	if _, err := os.Stat(poisonStateFile); !os.IsNotExist(err) {
+		t.Fatalf("ensure-ready leaked ambient GC_* state to %q, stat err = %v", poisonStateFile, err)
 	}
 }
 
@@ -6683,7 +6703,7 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", rigPath, "fe", "fe")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+currentGCBinaryForTests(t),
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
@@ -6811,7 +6831,7 @@ func TestGcBeadsBdStartFallsBackToShellManagedConfigWriterWhenGCBinUnset(t *test
 	_ = writeFakeManagedConfigWriterGC(t, binDir, invocationFile)
 	writeFakeManagedConfigWriterDolt(t, binDir)
 
-	env := append(os.Environ(),
+	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1068,7 +1068,14 @@ func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T
 		t.Fatal(err)
 	}
 
-	scriptEnv := append(os.Environ(),
+	poisonRuntimeDir := filepath.Join(t.TempDir(), "poison-runtime")
+	poisonPackStateDir := filepath.Join(poisonRuntimeDir, "packs", "dolt")
+	poisonStateFile := filepath.Join(poisonPackStateDir, "dolt-provider-state.json")
+	t.Setenv("GC_CITY_RUNTIME_DIR", poisonRuntimeDir)
+	t.Setenv("GC_PACK_STATE_DIR", poisonPackStateDir)
+	t.Setenv("GC_DOLT_STATE_FILE", poisonStateFile)
+
+	scriptEnv := sanitizedBaseEnv(
 		"HOME="+homeDir,
 		"GIT_CONFIG_GLOBAL="+gitConfig,
 		"GC_CITY_PATH="+cityDir,
@@ -1092,6 +1099,9 @@ func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T
 	})
 
 	runScript("start")
+	if _, err := os.Stat(poisonStateFile); !os.IsNotExist(err) {
+		t.Fatalf("start leaked ambient GC_* state to %q, stat err = %v", poisonStateFile, err)
+	}
 	if err := publishManagedDoltRuntimeState(cityDir); err != nil {
 		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
 	}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -37,7 +37,7 @@ var (
 
 func waitTestEnv(overrides map[string]string) []string {
 	env := map[string]string{}
-	for _, entry := range os.Environ() {
+	for _, entry := range sanitizedBaseEnv() {
 		key, value, ok := strings.Cut(entry, "=")
 		if !ok {
 			continue
@@ -1215,10 +1215,20 @@ func setupManagedBdWaitTestCity(t *testing.T) (string, string) {
 		t.Fatalf("MaterializeBuiltinPacks: %v", err)
 	}
 	script := gcBeadsBdScriptPath(cityPath)
+	poisonRuntimeDir := filepath.Join(t.TempDir(), "poison-runtime")
+	poisonPackStateDir := filepath.Join(poisonRuntimeDir, "packs", "dolt")
+	poisonStateFile := filepath.Join(poisonPackStateDir, "dolt-provider-state.json")
+	t.Setenv("GC_CITY_RUNTIME_DIR", poisonRuntimeDir)
+	t.Setenv("GC_PACK_STATE_DIR", poisonPackStateDir)
+	t.Setenv("GC_DOLT_STATE_FILE", poisonStateFile)
+	scriptEnv := sanitizedBaseEnv(
+		"GC_CITY="+cityPath,
+		"GC_CITY_PATH="+cityPath,
+	)
 	runScript := func(args ...string) {
 		t.Helper()
 		cmd := exec.Command(script, args...)
-		cmd.Env = os.Environ()
+		cmd.Env = scriptEnv
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("%s: %v\n%s", strings.Join(args, " "), err, out)
@@ -1226,11 +1236,14 @@ func setupManagedBdWaitTestCity(t *testing.T) (string, string) {
 	}
 	t.Cleanup(func() {
 		cmd := exec.Command(script, "stop")
-		cmd.Env = os.Environ()
+		cmd.Env = scriptEnv
 		_, _ = cmd.CombinedOutput()
 	})
 
 	runScript("start")
+	if _, err := os.Stat(poisonStateFile); !os.IsNotExist(err) {
+		t.Fatalf("start leaked ambient GC_* state to %q, stat err = %v", poisonStateFile, err)
+	}
 	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
 		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
 	}

--- a/cmd/gc/fast_loop_helpers_env_test.go
+++ b/cmd/gc/fast_loop_helpers_env_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Regression for gastownhall/gascity#938:
+// beads_provider_lifecycle_test.go test cases that run the real
+// gc-beads-bd shell script did `append(os.Environ(), ...)` to build
+// their subprocess env. That inherited any GC_*/BEADS_* vars the user
+// had in their shell — crucially GC_CITY_RUNTIME_DIR, which makes the
+// dolt runtime layout resolver write dolt-provider-state.json into the
+// *real* user city rather than the test's t.TempDir(). Confirmed in a
+// dev city: `.gc/runtime/packs/dolt/dolt-provider-state.json.corrupt-bak`
+// contained a data_dir pointing at a deleted test tempdir.
+//
+// sanitizedBaseEnv is the escape hatch: it strips every GC_*/BEADS_*
+// entry from os.Environ() before appending the test's own overrides, so
+// even a shell where the user had been `gc session`'d into a real city
+// can't leak into a lifecycle-test run.
+
+func TestSanitizedBaseEnv_StripsGCPrefixed(t *testing.T) {
+	t.Setenv("GC_CITY_RUNTIME_DIR", "/pretend/real/city/.gc/runtime")
+	t.Setenv("GC_DOLT_STATE_FILE", "/pretend/real/city/.gc/runtime/packs/dolt/dolt-provider-state.json")
+	t.Setenv("GC_PACK_STATE_DIR", "/pretend/real/city/.gc/runtime/packs/dolt")
+
+	env := sanitizedBaseEnv()
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GC_") {
+			t.Errorf("sanitizedBaseEnv leaked GC_* var: %q", kv)
+		}
+	}
+}
+
+func TestSanitizedBaseEnv_StripsBEADSPrefixed(t *testing.T) {
+	// BEADS_DIR / BEADS_DOLT_* get set by gc when it spawns agent shells.
+	// A test running from inside such a shell would inherit them.
+	t.Setenv("BEADS_DIR", "/pretend/real/city/.beads")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "28231")
+
+	env := sanitizedBaseEnv()
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "BEADS_") {
+			t.Errorf("sanitizedBaseEnv leaked BEADS_* var: %q", kv)
+		}
+	}
+}
+
+func TestSanitizedBaseEnv_PreservesUnrelatedVars(t *testing.T) {
+	// The child process typically still needs HOME, PATH, USER, etc.
+	// We only filter the namespaces that drive gc path resolution.
+	t.Setenv("MCDCLIENT_GASCITY_MARKER_FOR_TEST", "keepme")
+
+	env := sanitizedBaseEnv()
+
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "MCDCLIENT_GASCITY_MARKER_FOR_TEST=") {
+			if kv != "MCDCLIENT_GASCITY_MARKER_FOR_TEST=keepme" {
+				t.Errorf("unrelated var corrupted: %q", kv)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("sanitizedBaseEnv stripped an unrelated var; expected to keep MCDCLIENT_GASCITY_MARKER_FOR_TEST")
+	}
+}
+
+func TestSanitizedBaseEnv_AppendsExtras(t *testing.T) {
+	// Also: extras that happen to start with GC_/BEADS_ are allowed — this
+	// is the mechanism the caller uses to set GC_CITY_PATH=<tempdir>.
+	env := sanitizedBaseEnv(
+		"GC_CITY_PATH=/tmp/explicit/city",
+		"PATH=/opt/bin:/usr/bin",
+	)
+
+	gotCity := ""
+	gotPath := ""
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "GC_CITY_PATH="):
+			gotCity = kv
+		case strings.HasPrefix(kv, "PATH="):
+			gotPath = kv
+		}
+	}
+	if gotCity != "GC_CITY_PATH=/tmp/explicit/city" {
+		t.Errorf("GC_CITY_PATH extra not appended: got %q", gotCity)
+	}
+	if gotPath != "PATH=/opt/bin:/usr/bin" {
+		t.Errorf("PATH extra not appended: got %q", gotPath)
+	}
+}
+
+func TestSanitizedBaseEnv_ExtrasOverrideInheritedLastWins(t *testing.T) {
+	// If the helper ever regresses to NOT filter a var and the extras
+	// also set it, POSIX "last wins" must resolve in the extras' favor —
+	// otherwise the leak reappears silently.
+	t.Setenv("SOMETHING_UNFILTERED", "inherited")
+	env := sanitizedBaseEnv("SOMETHING_UNFILTERED=override")
+
+	// Find the last occurrence — that's what execve sees.
+	last := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "SOMETHING_UNFILTERED=") {
+			last = kv
+		}
+	}
+	if last != "SOMETHING_UNFILTERED=override" {
+		t.Errorf("last-wins violated; got final %q, want SOMETHING_UNFILTERED=override", last)
+	}
+}
+
+// Sanity: the filter matches the prefixes we actually care about and
+// nothing else. Guards against a future refactor that tightens the
+// matcher too far.
+func TestSanitizedBaseEnv_MatchesExactlyGCAndBEADSPrefixes(t *testing.T) {
+	for _, kv := range []string{
+		"GC_=empty_key",
+		"GC_FOO=1",
+		"BEADS_=empty_key",
+		"BEADS_BAR=2",
+	} {
+		eqIdx := strings.Index(kv, "=")
+		key := kv[:eqIdx]
+		val := kv[eqIdx+1:]
+		t.Setenv(key, val)
+	}
+
+	env := sanitizedBaseEnv()
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GC_") || strings.HasPrefix(kv, "BEADS_") {
+			t.Errorf("sanitizedBaseEnv kept %q; both GC_* and BEADS_* must be filtered", kv)
+		}
+	}
+
+	// Defensive: a var that merely contains "GC_" mid-name must pass through.
+	t.Setenv("HMM_GC_LIKE", "mid-token-not-a-prefix")
+	env = sanitizedBaseEnv()
+	found := false
+	for _, kv := range env {
+		if kv == "HMM_GC_LIKE=mid-token-not-a-prefix" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("sanitizedBaseEnv stripped a var whose key merely contained GC_ as a substring")
+	}
+	_ = os.Environ // reminder that we're reading from the process env
+}

--- a/cmd/gc/fast_loop_helpers_env_test.go
+++ b/cmd/gc/fast_loop_helpers_env_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
@@ -100,12 +99,13 @@ func TestSanitizedBaseEnv_AppendsExtras(t *testing.T) {
 
 func TestSanitizedBaseEnv_ExtrasOverrideInheritedLastWins(t *testing.T) {
 	// If the helper ever regresses to NOT filter a var and the extras
-	// also set it, POSIX "last wins" must resolve in the extras' favor —
-	// otherwise the leak reappears silently.
+	// also set it, the caller still hands exec.Cmd an env slice whose last
+	// entry is the intended override. Otherwise the leak reappears silently.
 	t.Setenv("SOMETHING_UNFILTERED", "inherited")
 	env := sanitizedBaseEnv("SOMETHING_UNFILTERED=override")
 
-	// Find the last occurrence — that's what execve sees.
+	// Find the last occurrence — this test only verifies the helper's
+	// slice ordering, not child-process environment lookup semantics.
 	last := ""
 	for _, kv := range env {
 		if strings.HasPrefix(kv, "SOMETHING_UNFILTERED=") {
@@ -113,7 +113,23 @@ func TestSanitizedBaseEnv_ExtrasOverrideInheritedLastWins(t *testing.T) {
 		}
 	}
 	if last != "SOMETHING_UNFILTERED=override" {
-		t.Errorf("last-wins violated; got final %q, want SOMETHING_UNFILTERED=override", last)
+		t.Errorf("override ordering violated; got final %q, want SOMETHING_UNFILTERED=override", last)
+	}
+}
+
+func TestSanitizedBaseEnv_AllowsExplicitEmptyFilteredOverride(t *testing.T) {
+	t.Setenv("GC_BIN", "/pretend/inherited/gc")
+
+	env := sanitizedBaseEnv("GC_BIN=")
+
+	got := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GC_BIN=") {
+			got = kv
+		}
+	}
+	if got != "GC_BIN=" {
+		t.Fatalf("explicit empty GC_BIN override missing: got %q", got)
 	}
 }
 
@@ -127,9 +143,10 @@ func TestSanitizedBaseEnv_MatchesExactlyGCAndBEADSPrefixes(t *testing.T) {
 		"BEADS_=empty_key",
 		"BEADS_BAR=2",
 	} {
-		eqIdx := strings.Index(kv, "=")
-		key := kv[:eqIdx]
-		val := kv[eqIdx+1:]
+		key, val, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("malformed test env entry %q", kv)
+		}
 		t.Setenv(key, val)
 	}
 
@@ -153,5 +170,4 @@ func TestSanitizedBaseEnv_MatchesExactlyGCAndBEADSPrefixes(t *testing.T) {
 	if !found {
 		t.Error("sanitizedBaseEnv stripped a var whose key merely contained GC_ as a substring")
 	}
-	_ = os.Environ // reminder that we're reading from the process env
 }

--- a/cmd/gc/fast_loop_helpers_test.go
+++ b/cmd/gc/fast_loop_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -16,6 +17,25 @@ func skipSlowCmdGCTest(t *testing.T, reason string) {
 	if os.Getenv("GC_FAST_UNIT") == "1" || testing.Short() {
 		t.Skip(reason)
 	}
+}
+
+// sanitizedBaseEnv returns os.Environ() with every GC_*/BEADS_* entry
+// filtered out, followed by the given extras. Use this to build the
+// `Env` for any exec.Cmd that runs the real gc-beads-bd lifecycle script
+// or gc subcommands — inheriting os.Environ() raw lets GC_CITY_RUNTIME_DIR,
+// GC_PACK_STATE_DIR, GC_DOLT_STATE_FILE, and friends point the child at
+// the user's real registered city instead of the test's t.TempDir(),
+// which silently overwrites user state on every run.
+// Regression for gastownhall/gascity#938.
+func sanitizedBaseEnv(extra ...string) []string {
+	filtered := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "GC_") || strings.HasPrefix(kv, "BEADS_") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return append(filtered, extra...)
 }
 
 // writeTestScript creates a shell script that exits with the given code.


### PR DESCRIPTION
## Summary
- Fixes #938: `TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure` inherited `os.Environ()` raw into its subprocess env, leaking `GC_CITY_RUNTIME_DIR` / `GC_PACK_STATE_DIR` / `GC_DOLT_STATE_FILE` from a gc-managed shell into the lifecycle script. Result: the test rewrote `dolt-provider-state.json` in the user's real registered city, aiming it at a t.TempDir() that Go cleaned up at end-of-test.
- Adds `sanitizedBaseEnv(extra ...string)` in `fast_loop_helpers_test.go` that filters `GC_*` and `BEADS_*` from `os.Environ()` before appending caller overrides, and switches the leaking test to use it.

## Why
On a dev workstation today, `gc start` on a real city failed with `init city beads: exec beads init: signal: killed`. The `.corrupt-bak` the recovery path wrote showed the state file's `data_dir` pointed at `/tmp/TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFail…/001/.beads/dolt` — a tempdir name belonging to this exact test, dated 2026-04-18. The tempdir had been reaped by `t.TempDir()` cleanup, but the provider-state.json referencing it survived because it was written to a path *outside* the tempdir.

Tests that run the real `gc-beads-bd` script need to scrub inherited namespace env vars, not trust them. `sanitizedBaseEnv` is the escape hatch.

Only the one test with a confirmed leak is migrated here; eleven other `append(os.Environ(), ...)` sites in `beads_provider_lifecycle_test.go` are candidates for the same treatment in a follow-up — called out in the commit body. No existing behaviour depends on the leak; this is strictly additive on the failure surface.

## Test plan
- [x] 6 unit tests in `fast_loop_helpers_env_test.go` covering: GC_* stripping, BEADS_* stripping, unrelated vars pass through, extras append correctly (including GC_* extras the caller wants to set, e.g. `GC_CITY_PATH=<tempdir>`), POSIX last-wins semantics for unfiltered keys, exact-prefix matching (`HMM_GC_LIKE` passes through). All 6 fail on main (undefined symbol), pass after the helper lands.
- [x] The migrated `TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure` still passes end-to-end: `go test ./cmd/gc/ -run 'TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure$' -count=1 -timeout 120s` → `ok … 5.571s`
- [x] `go build ./cmd/gc/` clean, `go vet ./cmd/gc/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)