### PR TITLE
test: isolate provider readiness flake spy

### DIFF
--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -752,14 +752,6 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_DOLT", "")
-	spyDir := t.TempDir()
-	callLog := filepath.Join(spyDir, "gc-beads-bd.calls")
-	spy := filepath.Join(spyDir, "gc-beads-bd")
-	scriptBody := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\nexit 0\n", callLog)
-	if err := os.WriteFile(spy, []byte(scriptBody), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("GC_BEADS", "exec:"+spy)
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
@@ -770,6 +762,15 @@ func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
+
+	spyDir := t.TempDir()
+	callLog := filepath.Join(spyDir, "gc-beads-bd.calls")
+	spy := filepath.Join(spyDir, "gc-beads-bd")
+	scriptBody := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\nexit 0\n", callLog)
+	if err := os.WriteFile(spy, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "exec:"+spy)
 
 	oldProbe := initProbeProvidersReadiness
 	initProbeProvidersReadiness = func(_ context.Context, _ []string, fresh bool) (map[string]api.ReadinessItem, error) {


### PR DESCRIPTION
Follow-up to #923 and bead ga-lw467.

This narrows `TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock` so the `GC_BEADS=exec:<spy>` provider is installed only after `doInit` completes and immediately before the blocked `finalizeInit` phase. That keeps setup-time scaffold work from being recorded in the spy log and misread as readiness-block leakage.

No production behavior changes.

Verification:
- `GC_FAST_UNIT=1 go test ./cmd/gc -run '^TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock$' -count=1 -v`\n- `GC_FAST_UNIT=1 go test -timeout 8m -coverprofile=/tmp/pr-923-cmd-gc-coverage.txt ./cmd/gc -count=1`\n- `make test`\n- `go vet ./...`\n- `go build ./...`\n- `git diff --check`