### PR TITLE
fix(doctor): handle absolute paths in config-refs check

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -157,6 +157,22 @@ func NewConfigRefsCheck(cfg *config.City, cityPath string) *ConfigRefsCheck {
 // Name returns the check identifier.
 func (c *ConfigRefsCheck) Name() string { return "config-refs" }
 
+// resolvePathRef returns the absolute filesystem path for a config
+// reference. Absolute refs pass through unchanged — PackV2's agents/
+// loader and adjustFragmentPath both store convention-derived paths in
+// absolute form. Relative refs are resolved against cityPath.
+//
+// filepath.Join(cityPath, "/abs/path") on Unix produces
+// cityPath + "/" + "/abs/path", which Clean collapses to a nonsense
+// path like "/Users/x/.gc/ws-city/Users/x/.gc/ws-city/...". This
+// helper avoids that by short-circuiting on absolute inputs.
+func resolvePathRef(cityPath, ref string) string {
+	if filepath.IsAbs(ref) {
+		return ref
+	}
+	return filepath.Join(cityPath, ref)
+}
+
 // Run validates that referenced paths exist and provider names are defined.
 func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
@@ -165,19 +181,19 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 	for _, a := range c.cfg.Agents {
 		qn := a.QualifiedName()
 		if a.PromptTemplate != "" {
-			path := filepath.Join(c.cityPath, a.PromptTemplate)
+			path := resolvePathRef(c.cityPath, a.PromptTemplate)
 			if _, err := os.Stat(path); err != nil {
 				issues = append(issues, fmt.Sprintf("agent %q: prompt_template %q not found", qn, a.PromptTemplate))
 			}
 		}
 		if a.SessionSetupScript != "" {
-			path := filepath.Join(c.cityPath, a.SessionSetupScript)
+			path := resolvePathRef(c.cityPath, a.SessionSetupScript)
 			if _, err := os.Stat(path); err != nil {
 				issues = append(issues, fmt.Sprintf("agent %q: session_setup_script %q not found", qn, a.SessionSetupScript))
 			}
 		}
 		if a.OverlayDir != "" {
-			path := filepath.Join(c.cityPath, a.OverlayDir)
+			path := resolvePathRef(c.cityPath, a.OverlayDir)
 			if fi, err := os.Stat(path); err != nil {
 				issues = append(issues, fmt.Sprintf("agent %q: overlay_dir %q not found", qn, a.OverlayDir))
 			} else if !fi.IsDir() {

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -269,6 +269,77 @@ func TestConfigRefsCheck_MultipleIssues(t *testing.T) {
 	}
 }
 
+// TestConfigRefsCheck_AbsolutePaths verifies that agent refs stored as
+// absolute paths (which PackV2's agents/ loader and adjustFragmentPath
+// produce for convention-derived paths) are checked against the filesystem
+// as-is, not joined to cityPath. filepath.Join(cityPath, absPath) on Unix
+// produces a nonsense path like "cityPath/abs/path" that would always fail
+// os.Stat — so without this handling every PackV2 agent shows as "not found".
+func TestConfigRefsCheck_AbsolutePaths(t *testing.T) {
+	cityDir := t.TempDir()
+	// The actual files live somewhere unrelated to cityDir — simulating a
+	// pack that was resolved to an absolute path pointing inside the city
+	// (or anywhere else the loader might have absolutized to).
+	packDir := t.TempDir()
+	agentDir := filepath.Join(packDir, "agents", "mayor")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptPath := filepath.Join(agentDir, "prompt.template.md")
+	if err := os.WriteFile(promptPath, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overlayPath := filepath.Join(agentDir, "overlay")
+	if err := os.MkdirAll(overlayPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(packDir, "scripts", "setup.sh")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:               "mayor",
+				PromptTemplate:     promptPath,   // absolute
+				OverlayDir:         overlayPath,  // absolute
+				SessionSetupScript: scriptPath,   // absolute
+			},
+		},
+	}
+	c := NewConfigRefsCheck(cfg, cityDir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
+// TestConfigRefsCheck_AbsolutePathMissing verifies that when an absolute
+// ref genuinely does not exist, the check still reports it — ensuring the
+// absolute-path short-circuit doesn't accidentally mask real misconfigs.
+func TestConfigRefsCheck_AbsolutePathMissing(t *testing.T) {
+	cityDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "prompt.template.md")
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "mayor", PromptTemplate: missing},
+		},
+	}
+	c := NewConfigRefsCheck(cfg, cityDir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if len(r.Details) != 1 {
+		t.Errorf("expected 1 issue, got %d: %v", len(r.Details), r.Details)
+	}
+}
+
 // --- BuiltinPackFamilyCheck ---
 
 func TestBuiltinPackFamilyCheck_Unmodified(t *testing.T) {


### PR DESCRIPTION
## Summary

`ConfigRefsCheck` assumes `PromptTemplate`, `OverlayDir`, and `SessionSetupScript` are all city-root-relative and runs them through `filepath.Join(cityPath, ref)`. That silently produces a nonsense path for PackV2-derived agents, whose values end up absolute (via `adjustFragmentPath`'s preserve-absolute-as-is branch and the `agents/<name>/` convention loader). Every PackV2 agent therefore gets a false-positive *"not found"* warning at the exact path the error prints.

Observed on a `worksite` pack migrated to PackV2 — 6 false-positive warnings across `mayor`, `polecat`, and `dog`. `gc prime`, `gc config show`, and runtime session launch all resolve the same paths correctly; only the doctor check is wrong.

## What changed

- Added a small `resolvePathRef(cityPath, ref)` helper in `internal/doctor/checks.go` that short-circuits absolute refs and only joins relative ones against `cityPath`.
- Updated all three call sites (`PromptTemplate`, `SessionSetupScript`, `OverlayDir`).

## Tests

Two new subtests in `internal/doctor/checks_test.go`:

- `TestConfigRefsCheck_AbsolutePaths` — existing absolute refs pass.
- `TestConfigRefsCheck_AbsolutePathMissing` — absent absolute refs still report *"not found"*, so the short-circuit doesn't mask real misconfigs.

All 9 `TestConfigRefsCheck_*` subtests pass; full `go test ./internal/doctor/` pass; `go vet ./internal/doctor/` clean.

## Test plan

- [ ] `go test ./internal/doctor/` passes
- [ ] `go vet ./internal/doctor/` clean
- [ ] Manual: on a PackV2 city, `gc doctor -v` no longer reports `config-refs` warnings for agents whose `prompt_template` / `overlay_dir` files exist at the paths shown

## Out of scope (separate issue candidate)

The auto-created pool agents (`claude`, `<rig>/claude`) use `prompt_template = "prompts/pool-worker.md"`, a file that `gc init` doesn't materialize into the city. After this patch those warnings remain as legitimate *"file missing"*. Happy to file separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #942
