### PR TITLE
Fix worker runtime reconstruction follow-ups

### DIFF
--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -323,13 +323,17 @@ func resolvedWorkerRuntimeWithConfig(cityPath string, cfg *config.City, info ses
 		return nil
 	}
 
-	command := resolved.CommandString()
-	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
-		command = command + " " + shellquote.Join(defaultArgs)
+	command := strings.TrimSpace(info.Command)
+	if command == "" {
+		command = resolved.CommandString()
+		if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
+			command = strings.TrimSpace(command + " " + shellquote.Join(defaultArgs))
+		}
+		if sa := settingsArgs(cityPath, resolved.Name); sa != "" {
+			command = strings.TrimSpace(command + " " + sa)
+		}
 	}
-	if sa := settingsArgs(cityPath, resolved.Name); sa != "" {
-		command = command + " " + sa
-	}
+	command = firstNonEmptyGCString(command, resolved.Name, info.Provider)
 
 	workDir := strings.TrimSpace(info.WorkDir)
 	if workDir == "" {
@@ -338,7 +342,7 @@ func resolvedWorkerRuntimeWithConfig(cityPath string, cfg *config.City, info ses
 	return &worker.ResolvedRuntime{
 		Command:    command,
 		WorkDir:    workDir,
-		Provider:   resolved.Name,
+		Provider:   firstNonEmptyGCString(info.Provider, resolved.Name),
 		SessionEnv: resolved.Env,
 		Hints: runtime.Config{
 			WorkDir:                workDir,
@@ -348,9 +352,9 @@ func resolvedWorkerRuntimeWithConfig(cityPath string, cfg *config.City, info ses
 			EmitsPermissionWarning: resolved.EmitsPermissionWarning,
 		},
 		Resume: session.ProviderResume{
-			ResumeFlag:    resolved.ResumeFlag,
-			ResumeStyle:   resolved.ResumeStyle,
-			ResumeCommand: resolved.ResumeCommand,
+			ResumeFlag:    firstNonEmptyGCString(info.ResumeFlag, resolved.ResumeFlag),
+			ResumeStyle:   firstNonEmptyGCString(info.ResumeStyle, resolved.ResumeStyle),
+			ResumeCommand: firstNonEmptyGCString(info.ResumeCommand, resolved.ResumeCommand),
 			SessionIDFlag: resolved.SessionIDFlag,
 		},
 	}
@@ -394,4 +398,13 @@ func workerNudgeDeliveryForMode(mode nudgeDeliveryMode) (worker.NudgeDelivery, b
 	default:
 		return "", false
 	}
+}
+
+func firstNonEmptyGCString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -459,7 +459,7 @@ ready_delay_ms = 250
 	}
 }
 
-func TestWorkerSessionRuntimeResolverWithConfigReturnsErrorForInvalidResolvedRuntime(t *testing.T) {
+func TestWorkerSessionRuntimeResolverWithConfigFallsBackToProviderNameWhenResolvedCommandMissing(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{{
@@ -476,8 +476,83 @@ func TestWorkerSessionRuntimeResolverWithConfigReturnsErrorForInvalidResolvedRun
 		t.Fatal("workerSessionRuntimeResolverWithConfig() = nil")
 	}
 
-	_, err := resolver(session.Info{Template: "worker"}, "")
-	if err == nil {
-		t.Fatal("resolver error = nil, want invalid resolved runtime error")
+	runtimeCfg, err := resolver(session.Info{Template: "worker"}, "")
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolver() = nil")
+	}
+	if got, want := runtimeCfg.Command, "stub"; got != want {
+		t.Fatalf("Command = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Provider, "stub"; got != want {
+		t.Fatalf("Provider = %q, want %q", got, want)
+	}
+}
+
+func TestWorkerSessionRuntimeResolverWithConfigFallsBackToPersistedRuntimeOnIncompleteResolvedConfig(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:     "worker",
+			Provider: "stub",
+		}},
+		Providers: map[string]config.ProviderSpec{
+			"stub": {
+				ReadyPromptPrefix: "resolved-ready>",
+				ReadyDelayMs:      321,
+			},
+		},
+	}
+
+	resolver := workerSessionRuntimeResolverWithConfig(t.TempDir(), cfg)
+	if resolver == nil {
+		t.Fatal("workerSessionRuntimeResolverWithConfig() = nil")
+	}
+
+	info := session.Info{
+		Template:      "worker",
+		Command:       "persisted-worker --dangerously-skip-permissions",
+		Provider:      "persisted-provider",
+		WorkDir:       "/tmp/persisted-workdir",
+		ResumeFlag:    "--resume-persisted",
+		ResumeStyle:   "subcommand",
+		ResumeCommand: "persisted resume {{.SessionKey}}",
+	}
+
+	runtimeCfg, err := resolver(info, "")
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolver() = nil")
+	}
+	if got, want := runtimeCfg.Command, info.Command; got != want {
+		t.Fatalf("Command = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Provider, info.Provider; got != want {
+		t.Fatalf("Provider = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.WorkDir, info.WorkDir; got != want {
+		t.Fatalf("WorkDir = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.ResumeFlag, info.ResumeFlag; got != want {
+		t.Fatalf("Resume.ResumeFlag = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.ResumeStyle, info.ResumeStyle; got != want {
+		t.Fatalf("Resume.ResumeStyle = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.ResumeCommand, info.ResumeCommand; got != want {
+		t.Fatalf("Resume.ResumeCommand = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Hints.WorkDir, info.WorkDir; got != want {
+		t.Fatalf("Hints.WorkDir = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Hints.ReadyPromptPrefix, "resolved-ready>"; got != want {
+		t.Fatalf("Hints.ReadyPromptPrefix = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Hints.ReadyDelayMs, 321; got != want {
+		t.Fatalf("Hints.ReadyDelayMs = %d, want %d", got, want)
 	}
 }

--- a/internal/api/handler_session_stream.go
+++ b/internal/api/handler_session_stream.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2/sse"
+	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sessionlog"
 	"github.com/gastownhall/gascity/internal/worker"
@@ -38,6 +39,16 @@ type SessionStreamRawMessageEvent struct {
 }
 
 var sessionStreamPendingStallTimeout = 5 * time.Second
+
+func runtimePendingInteraction(pending *worker.PendingInteraction) runtime.PendingInteraction {
+	return runtime.PendingInteraction{
+		RequestID: pending.RequestID,
+		Kind:      pending.Kind,
+		Prompt:    pending.Prompt,
+		Options:   append([]string(nil), pending.Options...),
+		Metadata:  cloneStringMap(pending.Metadata),
+	}
+}
 
 func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	store := s.state.CityBeadStore()
@@ -726,7 +737,7 @@ func (s *Server) streamSessionTranscriptLogRawHuma(ctx context.Context, send sse
 		}
 		lastPendingID = pending.RequestID
 		seq++
-		_ = send(sse.Message{ID: seq, Data: *pending})
+		_ = send(sse.Message{ID: seq, Data: runtimePendingInteraction(pending)})
 		return true
 	}
 
@@ -928,7 +939,7 @@ func (s *Server) streamSessionPeekRawHuma(ctx context.Context, send sse.Sender, 
 		if err == nil && pending != nil && pending.RequestID != lastPendingID {
 			lastPendingID = pending.RequestID
 			seq++
-			_ = send(sse.Message{ID: seq, Data: *pending})
+			_ = send(sse.Message{ID: seq, Data: runtimePendingInteraction(pending)})
 		} else if pending == nil && lastPendingID != "" {
 			lastPendingID = ""
 		}

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -3049,6 +3049,66 @@ func TestHandleSessionStreamRawStallEmitsPendingWithoutTranscriptGrowth(t *testi
 	}
 }
 
+func TestHandleSessionStreamRawStallEmitsPendingEventOnCityRoute(t *testing.T) {
+	fs := newSessionFakeState(t)
+	searchBase := t.TempDir()
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+	srv.sessionLogSearchPaths = []string{searchBase}
+
+	prevStallTimeout := sessionStreamPendingStallTimeout
+	sessionStreamPendingStallTimeout = 50 * time.Millisecond
+	defer func() {
+		sessionStreamPendingStallTimeout = prevStallTimeout
+	}()
+
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	resume := session.ProviderResume{
+		ResumeFlag:    "--resume",
+		ResumeStyle:   "flag",
+		SessionIDFlag: "--session-id",
+	}
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "myrig/worker", "Chat", "claude", workDir, "claude", nil, resume, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	writeNamedSessionJSONL(t, searchBase, workDir, info.SessionKey+".jsonl",
+		`{"uuid":"1","parentUuid":"","type":"user","message":"{\"role\":\"user\",\"content\":\"hello\"}","timestamp":"2025-01-01T00:00:00Z"}`,
+		`{"uuid":"2","parentUuid":"1","type":"assistant","message":"{\"role\":\"assistant\",\"content\":\"world\"}","timestamp":"2025-01-01T00:00:01Z"}`,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID+"/stream?format=raw", nil).WithContext(ctx)
+	rec := newSyncResponseRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	if body := waitForRecorderSubstring(t, rec, "hello", time.Second); !strings.Contains(body, "hello") {
+		t.Fatalf("raw stream body missing initial transcript: %s", body)
+	}
+
+	fs.sp.SetPendingInteraction(info.SessionName, &runtime.PendingInteraction{
+		RequestID: "req-1",
+		Kind:      "approval",
+		Prompt:    "Proceed?",
+	})
+
+	body := waitForRecorderSubstring(t, rec, "req-1", time.Second)
+
+	cancel()
+	<-done
+
+	if !strings.Contains(body, "event: pending") {
+		t.Fatalf("raw stream body missing pending SSE event name: %s", body)
+	}
+}
+
 func TestHandleSessionStreamTranscriptWriteWakesWithoutPolling(t *testing.T) {
 	fs := newSessionFakeState(t)
 	searchBase := t.TempDir()

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -131,15 +131,15 @@ func (s *Server) resolveWorkerSessionRuntime(info session.Info, _ string) (*work
 		return nil, nil
 	}
 	runtimeCfg, err := worker.NormalizeResolvedRuntime(worker.ResolvedRuntime{
-		Command:    firstNonEmptyString(resolved.CommandString(), info.Command, resolved.Name),
-		WorkDir:    firstNonEmptyString(workDir, info.WorkDir),
-		Provider:   firstNonEmptyString(resolved.Name, info.Provider),
+		Command:    firstNonEmptyString(info.Command, resolved.CommandString(), info.Provider, resolved.Name),
+		WorkDir:    firstNonEmptyString(info.WorkDir, workDir),
+		Provider:   firstNonEmptyString(info.Provider, resolved.Name),
 		SessionEnv: resolved.Env,
 		Hints:      sessionResumeHints(resolved, firstNonEmptyString(workDir, info.WorkDir)),
 		Resume: session.ProviderResume{
-			ResumeFlag:    resolved.ResumeFlag,
-			ResumeStyle:   resolved.ResumeStyle,
-			ResumeCommand: resolved.ResumeCommand,
+			ResumeFlag:    firstNonEmptyString(info.ResumeFlag, resolved.ResumeFlag),
+			ResumeStyle:   firstNonEmptyString(info.ResumeStyle, resolved.ResumeStyle),
+			ResumeCommand: firstNonEmptyString(info.ResumeCommand, resolved.ResumeCommand),
 			SessionIDFlag: resolved.SessionIDFlag,
 		},
 	})

--- a/internal/api/worker_factory_test.go
+++ b/internal/api/worker_factory_test.go
@@ -11,6 +11,68 @@ import (
 	"github.com/gastownhall/gascity/internal/worker"
 )
 
+func TestResolveWorkerSessionRuntimePreservesPersistedRuntimeFieldsAndBackfillsSessionIDFlag(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents[0].Provider = "resolved-worker"
+	fs.cfg.Providers["resolved-worker"] = config.ProviderSpec{
+		DisplayName:       "Resolved Worker",
+		Command:           "/bin/echo",
+		ReadyPromptPrefix: "resolved-ready>",
+		ReadyDelayMs:      321,
+		ResumeFlag:        "--resume-resolved",
+		ResumeStyle:       "flag",
+		ResumeCommand:     "resolved resume {{.SessionKey}}",
+		SessionIDFlag:     "--session-id-resolved",
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:            "sess-1",
+		Template:      "myrig/worker",
+		Command:       "persisted-worker --dangerously-skip-permissions",
+		Provider:      "persisted-provider",
+		WorkDir:       t.TempDir(),
+		ResumeFlag:    "--resume-persisted",
+		ResumeStyle:   "subcommand",
+		ResumeCommand: "persisted resume {{.SessionKey}}",
+	}
+
+	runtimeCfg, err := srv.resolveWorkerSessionRuntime(info, "")
+	if err != nil {
+		t.Fatalf("resolveWorkerSessionRuntime: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolveWorkerSessionRuntime() = nil")
+	}
+	if got, want := runtimeCfg.Command, info.Command; got != want {
+		t.Fatalf("Command = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Provider, info.Provider; got != want {
+		t.Fatalf("Provider = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.WorkDir, info.WorkDir; got != want {
+		t.Fatalf("WorkDir = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.ResumeFlag, info.ResumeFlag; got != want {
+		t.Fatalf("Resume.ResumeFlag = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.ResumeStyle, info.ResumeStyle; got != want {
+		t.Fatalf("Resume.ResumeStyle = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.ResumeCommand, info.ResumeCommand; got != want {
+		t.Fatalf("Resume.ResumeCommand = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Resume.SessionIDFlag, "--session-id-resolved"; got != want {
+		t.Fatalf("Resume.SessionIDFlag = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Hints.ReadyPromptPrefix, "resolved-ready>"; got != want {
+		t.Fatalf("Hints.ReadyPromptPrefix = %q, want %q", got, want)
+	}
+	if got, want := runtimeCfg.Hints.ReadyDelayMs, 321; got != want {
+		t.Fatalf("Hints.ReadyDelayMs = %d, want %d", got, want)
+	}
+}
+
 func TestWorkerFactorySessionByIDUsesResolvedTemplateRuntime(t *testing.T) {
 	fs := newSessionFakeState(t)
 	fs.cfg.Agents[0].Provider = "resolved-worker"


### PR DESCRIPTION
## Summary
- preserve persisted command/provider/resume metadata when rebuilding worker runtime details from current config, while still backfilling SessionIDFlag and live hints
- emit Huma raw session-stream pending interactions as runtime pending events so clients receive `event: pending`
- keep the gc worker-handle resolver resilient to partial config drift by falling back to persisted runtime fields instead of failing closed

## Validation
- go test ./internal/api
- go test ./cmd/gc -run "TestWorkerSessionRuntimeResolverWithConfig(FallsBackToProviderNameWhenResolvedCommandMissing|FallsBackToPersistedRuntimeOnIncompleteResolvedConfig)"

## Notes
- the earlier SessionIDFlag reconstruction concern was already covered on current `main`; this PR addresses the remaining regressions that still reproduced locally.