### PR TITLE
fix: bootstrap remote [imports] cache via gc pack fetch (#805)

### DIFF
--- a/cmd/gc/cmd_pack.go
+++ b/cmd/gc/cmd_pack.go
@@ -32,12 +32,16 @@ can be pinned to specific git refs.`,
 func newPackFetchCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "fetch",
-		Short: "Clone missing and update existing remote packs",
-		Long: `Clone missing and update existing remote pack caches.
+		Short: "Clone missing and update existing remote packs and imports",
+		Long: `Clone missing and update existing remote pack and import caches.
 
-Fetches all configured pack sources from their git repositories,
-updates the local cache, and writes a lockfile with commit hashes
-for reproducibility. Automatically called during "gc start".`,
+Populates the include cache for each remote [imports] entry declared in
+pack.toml, then fetches any legacy [packs] entries from city.toml. This
+is the bootstrap path for a fresh PackV2 city whose config references
+remote imports — without it, loaders cannot read the composed config.
+
+The [packs] fetch is automatically invoked during "gc start"; remote
+[imports] must currently be bootstrapped explicitly via this command.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if doPackFetch(stdout, stderr) != 0 {
@@ -56,6 +60,28 @@ func doPackFetch(stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Bootstrap declared [imports] BEFORE loading the config: a fresh
+	// PackV2 city with remote imports cannot successfully loadCityConfig
+	// until the include-cache is populated (issue #805).
+	manifest, err := loadCityPackManifestFS(fsys.OSFS{}, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc pack fetch: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	remoteImports := 0
+	for _, imp := range manifest.Imports {
+		if isRemoteImportSource(imp.Source) {
+			remoteImports++
+		}
+	}
+	if remoteImports > 0 {
+		fmt.Fprintf(stdout, "Fetching %d import(s)...\n", remoteImports) //nolint:errcheck
+		if err := config.FetchImports(manifest.Imports, cityPath); err != nil {
+			fmt.Fprintf(stderr, "gc pack fetch: %v\n", err) //nolint:errcheck
+			return 1
+		}
+	}
+
 	cfg, err := loadCityConfig(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack fetch: %v\n", err) //nolint:errcheck
@@ -63,7 +89,9 @@ func doPackFetch(stdout, stderr io.Writer) int {
 	}
 
 	if len(cfg.Packs) == 0 {
-		fmt.Fprintln(stdout, "No remote packs configured.") //nolint:errcheck
+		if remoteImports == 0 {
+			fmt.Fprintln(stdout, "No remote packs or remote imports configured.") //nolint:errcheck
+		}
 		return 0
 	}
 

--- a/cmd/gc/cmd_pack_test.go
+++ b/cmd/gc/cmd_pack_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestDoPackFetch_BootstrapsDeclaredImports is the regression test for
+// issue #805: a fresh PackV2 city with a remote [imports.X] entry has
+// no CLI bootstrap path. `gc pack fetch` must populate the include-cache
+// BEFORE calling config.Load, otherwise loadCityConfig dies on the
+// same cache-miss the user was trying to resolve.
+func TestDoPackFetch_BootstrapsDeclaredImports(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	repo := initImportBarePackRepo(t, "flywheel", "", `
+[pack]
+name = "flywheel"
+schema = 1
+
+[[agent]]
+name = "cass"
+scope = "city"
+`)
+	source := "file://" + repo
+
+	cityDir := filepath.Join(dir, "city")
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.cass]
+source = "`+source+`"
+`)
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := doPackFetch(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doPackFetch code = %d\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	// The whole point of the bug: after `gc pack fetch`, a subsequent
+	// config.Load must succeed. Before #805's fix this failed with
+	// "remote include ... is not cached at ...".
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes after bootstrap: %v", err)
+	}
+	found := false
+	for _, a := range cfg.Agents {
+		if a.Name == "cass" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		names := make([]string, 0, len(cfg.Agents))
+		for _, a := range cfg.Agents {
+			names = append(names, a.QualifiedName())
+		}
+		t.Errorf("expected imported agent named cass after bootstrap; got %v", names)
+	}
+}
+
+func TestDoPackFetch_NoImportsOrPacksReportsClean(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := doPackFetch(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doPackFetch code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No remote packs or remote imports configured") {
+		t.Errorf("stdout = %q, want mention of empty config", stdout.String())
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1474,16 +1474,20 @@ gc pack
 
 | Subcommand | Description |
 |------------|-------------|
-| [gc pack fetch](#gc-pack-fetch) | Clone missing and update existing remote packs |
+| [gc pack fetch](#gc-pack-fetch) | Clone missing and update existing remote packs and imports |
 | [gc pack list](#gc-pack-list) | Show remote pack sources and cache status |
 
 ## gc pack fetch
 
-Clone missing and update existing remote pack caches.
+Clone missing and update existing remote pack and import caches.
 
-Fetches all configured pack sources from their git repositories,
-updates the local cache, and writes a lockfile with commit hashes
-for reproducibility. Automatically called during "gc start".
+Populates the include cache for each remote [imports] entry declared in
+pack.toml, then fetches any legacy [packs] entries from city.toml. This
+is the bootstrap path for a fresh PackV2 city whose config references
+remote imports — without it, loaders cannot read the composed config.
+
+The [packs] fetch is automatically invoked during "gc start"; remote
+[imports] must currently be bootstrapped explicitly via this command.
 
 ```
 gc pack fetch

--- a/internal/config/pack_fetch.go
+++ b/internal/config/pack_fetch.go
@@ -29,6 +29,76 @@ type LockedPack struct {
 	Hash   string `toml:"hash"`
 }
 
+// FetchImports clones or updates each declared remote import into the
+// include-cache under <cityRoot>/.gc/cache/includes/<slug-hash>/. Local
+// path imports are skipped. The cache key matches what the loader's
+// fetchRemoteInclude reads so a subsequent config.Load resolves imports
+// from the same directory.
+//
+// FetchImports is the bootstrap path for remote [imports] — loaders are
+// pure readers (see design issue #583), so a fresh PackV2 city with
+// declared remote imports needs a CLI step to populate the cache before
+// any command that performs config.Load can succeed.
+func FetchImports(imports map[string]Import, cityRoot string) error {
+	cacheRoot := filepath.Join(cityRoot, includeCacheDir)
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		return fmt.Errorf("creating include cache root: %w", err)
+	}
+
+	names := make([]string, 0, len(imports))
+	for name := range imports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		imp := imports[name]
+		if !isRemoteRef(imp.Source) {
+			continue
+		}
+		cacheKey, cloneURL, ref := importCloneTarget(imp.Source)
+		cacheDir := filepath.Join(cacheRoot, includeCacheName(cacheKey))
+
+		if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err == nil {
+			if err := updatePack(cacheDir, ref); err != nil {
+				return fmt.Errorf("import %q: %w", name, err)
+			}
+			continue
+		}
+		if err := clonePack(cloneURL, cacheDir, ref); err != nil {
+			return fmt.Errorf("import %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// importCloneTarget parses an import source into three related strings:
+//   - cacheKey: the exact string passed to includeCacheName on the loader
+//     side (fetchRemoteInclude), used to compute the cache directory
+//   - cloneURL: a git-cloneable URL (scheme-prefixed), used for `git clone`
+//   - ref: the git ref (branch/tag) if specified
+//
+// The loader does not normalize bare `github.com/...` sources before
+// hashing (see pack_include.go fetchRemoteInclude), so the bootstrap
+// must use the same raw source for the cache key — otherwise the clone
+// lands at a different hash than the loader will read.
+func importCloneTarget(source string) (cacheKey, cloneURL, ref string) {
+	switch {
+	case isGitHubTreeURL(source):
+		clone, _, r := parseGitHubTreeURL(source)
+		return clone, clone, r
+	case isRemoteInclude(source):
+		parsed, _, r := parseRemoteInclude(source)
+		clone := parsed
+		if strings.HasPrefix(clone, "github.com/") {
+			clone = "https://" + clone
+		}
+		return parsed, clone, r
+	default:
+		return source, source, ""
+	}
+}
+
 // FetchPacks ensures all remote packs are cached locally.
 // Clones missing repos and updates existing ones to match the declared ref.
 func FetchPacks(packs map[string]PackSource, cityRoot string) error {

--- a/internal/config/pack_fetch.go
+++ b/internal/config/pack_fetch.go
@@ -59,14 +59,17 @@ func FetchImports(imports map[string]Import, cityRoot string) error {
 		cacheKey, cloneURL, ref := importCloneTarget(imp.Source)
 		cacheDir := filepath.Join(cacheRoot, includeCacheName(cacheKey))
 
-		if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err == nil {
+		switch _, err := os.Stat(filepath.Join(cacheDir, ".git")); {
+		case err == nil:
 			if err := updatePack(cacheDir, ref); err != nil {
 				return fmt.Errorf("import %q: %w", name, err)
 			}
-			continue
-		}
-		if err := clonePack(cloneURL, cacheDir, ref); err != nil {
-			return fmt.Errorf("import %q: %w", name, err)
+		case os.IsNotExist(err):
+			if err := clonePack(cloneURL, cacheDir, ref); err != nil {
+				return fmt.Errorf("import %q: %w", name, err)
+			}
+		default:
+			return fmt.Errorf("import %q: checking cache at %s: %w", name, cacheDir, err)
 		}
 	}
 	return nil

--- a/internal/config/pack_fetch_test.go
+++ b/internal/config/pack_fetch_test.go
@@ -606,6 +606,219 @@ func TestFetchRemoteInclude_MissingCache(t *testing.T) {
 	if !strings.Contains(err.Error(), "not cached") {
 		t.Fatalf("error = %v, want not cached", err)
 	}
+	// The error must point users at the bootstrap command; otherwise a
+	// fresh PackV2 city with declared [imports] has no discoverable way
+	// to populate the cache (issue #805).
+	if !strings.Contains(err.Error(), "gc pack fetch") {
+		t.Fatalf("error = %v, want mention of `gc pack fetch` bootstrap command", err)
+	}
+}
+
+func TestImportCloneTarget_CacheKeyMatchesLoader(t *testing.T) {
+	// fetchRemoteInclude computes its cache directory from the string
+	// that resolvePackRef passes to it. The bootstrap must use the same
+	// key, otherwise `gc pack fetch` writes the cache at a different
+	// hash than `gc config show` will read from (issue #805).
+	tests := []struct {
+		name             string
+		source           string
+		wantLoaderSource string // value resolvePackRef passes to fetchRemoteInclude
+		wantClone        string
+		wantRef          string
+	}{
+		{
+			name:             "github tree URL",
+			source:           "https://github.com/org/repo/tree/main/sub",
+			wantLoaderSource: "https://github.com/org/repo.git",
+			wantClone:        "https://github.com/org/repo.git",
+			wantRef:          "main",
+		},
+		{
+			name:             "https remote include with ref",
+			source:           "https://example.com/repo.git#v1.0",
+			wantLoaderSource: "https://example.com/repo.git",
+			wantClone:        "https://example.com/repo.git",
+			wantRef:          "v1.0",
+		},
+		{
+			name:             "ssh remote include",
+			source:           "git@github.com:org/repo.git",
+			wantLoaderSource: "git@github.com:org/repo.git",
+			wantClone:        "git@github.com:org/repo.git",
+			wantRef:          "",
+		},
+		{
+			name:             "bare github shorthand",
+			source:           "github.com/org/repo",
+			wantLoaderSource: "github.com/org/repo",
+			wantClone:        "https://github.com/org/repo",
+			wantRef:          "",
+		},
+		{
+			name:             "file URL with subpath and ref",
+			source:           "file:///tmp/repo.git//pack#dev",
+			wantLoaderSource: "file:///tmp/repo.git",
+			wantClone:        "file:///tmp/repo.git",
+			wantRef:          "dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cacheKey, clone, ref := importCloneTarget(tt.source)
+			if cacheKey != tt.wantLoaderSource {
+				t.Errorf("cacheKey = %q, want %q (loader source)", cacheKey, tt.wantLoaderSource)
+			}
+			if clone != tt.wantClone {
+				t.Errorf("cloneURL = %q, want %q", clone, tt.wantClone)
+			}
+			if ref != tt.wantRef {
+				t.Errorf("ref = %q, want %q", ref, tt.wantRef)
+			}
+			if includeCacheName(cacheKey) != includeCacheName(tt.wantLoaderSource) {
+				t.Errorf("include cache name diverges: got %q, want %q",
+					includeCacheName(cacheKey), includeCacheName(tt.wantLoaderSource))
+			}
+		})
+	}
+}
+
+func TestFetchImports_ClonesRemoteImport(t *testing.T) {
+	bare := initBareRepo(t, "imp-clones")
+	cityRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityRoot, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	imports := map[string]Import{
+		"cass": {Source: "file://" + bare},
+	}
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("FetchImports: %v", err)
+	}
+
+	cacheName := includeCacheName("file://" + bare)
+	cacheDir := filepath.Join(cityRoot, ".gc", "cache", "includes", cacheName)
+	if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
+		t.Fatalf("expected cache clone at %s: %v", cacheDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "pack.toml")); err != nil {
+		t.Errorf("pack.toml missing from cache: %v", err)
+	}
+}
+
+func TestFetchImports_SkipsLocalPathImport(t *testing.T) {
+	cityRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityRoot, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	imports := map[string]Import{
+		"local": {Source: "./assets/imports/gastown"},
+	}
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("FetchImports on local path: %v", err)
+	}
+
+	cacheRoot := filepath.Join(cityRoot, ".gc", "cache", "includes")
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("reading cache dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("cache should stay empty for local imports, got %d entries", len(entries))
+	}
+}
+
+func TestFetchImports_Idempotent(t *testing.T) {
+	bare := initBareRepo(t, "imp-idempotent")
+	cityRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityRoot, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	imports := map[string]Import{
+		"cass": {Source: "file://" + bare},
+	}
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("first FetchImports: %v", err)
+	}
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("second FetchImports: %v", err)
+	}
+}
+
+func TestFetchImports_LoaderReadsBootstrappedCache(t *testing.T) {
+	// The loader's fetchRemoteInclude must find the cache at the same
+	// path FetchImports writes to. If these two diverge, `gc config
+	// show` will cache-miss even after a successful `gc pack fetch`
+	// (issue #805).
+	bare := initBareRepo(t, "imp-loader")
+	cityRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityRoot, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	imports := map[string]Import{
+		"cass": {Source: "file://" + bare},
+	}
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("FetchImports: %v", err)
+	}
+
+	cacheDir, err := fetchRemoteInclude("file://"+bare, "", cityRoot)
+	if err != nil {
+		t.Fatalf("loader cannot find bootstrap cache: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "pack.toml")); err != nil {
+		t.Errorf("pack.toml missing from loader-visible cache: %v", err)
+	}
+}
+
+func TestFetchImports_UpdatesExistingCache(t *testing.T) {
+	// Second run must pick up upstream commits, not stall on stale cache.
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "imp-update.git")
+	mustGit(t, "", "init", "--initial-branch=main", workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "pack.toml"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, workDir, "add", "-A")
+	mustGit(t, workDir, "commit", "-m", "v1")
+	mustGit(t, workDir, "clone", "--bare", workDir, bareDir)
+
+	cityRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityRoot, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	imports := map[string]Import{"cass": {Source: "file://" + bareDir}}
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("initial FetchImports: %v", err)
+	}
+
+	pushDir := filepath.Join(dir, "push")
+	mustGit(t, "", "clone", bareDir, pushDir)
+	if err := os.WriteFile(filepath.Join(pushDir, "pack.toml"), []byte("v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, pushDir, "add", "-A")
+	mustGit(t, pushDir, "commit", "-m", "v2")
+	mustGit(t, pushDir, "push")
+
+	if err := FetchImports(imports, cityRoot); err != nil {
+		t.Fatalf("second FetchImports: %v", err)
+	}
+
+	cacheName := includeCacheName("file://" + bareDir)
+	data, err := os.ReadFile(filepath.Join(cityRoot, ".gc", "cache", "includes", cacheName, "pack.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "v2" {
+		t.Errorf("cache not updated: got %q, want v2", string(data))
+	}
 }
 
 func TestLoadPack_RemoteInclude(t *testing.T) {

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -210,7 +210,7 @@ func resolveLockedRemoteImport(source, cityRoot string) (string, bool, error) {
 	cacheDir := filepath.Join(home, ".gc", "cache", "repos", RepoCacheKey(source, entry.Commit))
 	if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
 		if os.IsNotExist(err) {
-			return "", false, fmt.Errorf("remote import %s is locked but not cached at %s", source, cacheDir)
+			return "", false, fmt.Errorf("remote import %s is locked but not cached at %s (run `gc import install` to populate the cache)", source, cacheDir)
 		}
 		return "", false, fmt.Errorf("checking cached import %s: %w", source, err)
 	}
@@ -254,9 +254,9 @@ func fetchRemoteInclude(source, ref, cityRoot string) (string, error) {
 	if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
 		if os.IsNotExist(err) {
 			if ref != "" {
-				return "", fmt.Errorf("remote include %s#%s is not cached at %s", source, ref, cacheDir)
+				return "", fmt.Errorf("remote include %s#%s is not cached at %s (run `gc pack fetch` to populate the cache)", source, ref, cacheDir)
 			}
-			return "", fmt.Errorf("remote include %s is not cached at %s", source, cacheDir)
+			return "", fmt.Errorf("remote include %s is not cached at %s (run `gc pack fetch` to populate the cache)", source, cacheDir)
 		}
 		return "", fmt.Errorf("checking cached include %s: %w", source, err)
 	}


### PR DESCRIPTION
## Summary

Closes #805. A fresh PackV2 city with a remote `[imports.X]` entry had no CLI bootstrap path — `gc config show`, `gc pack fetch`, and `gc import install` all dead-ended on an empty include cache, leaving manual `git clone` into `.gc/cache/includes/` as the only workaround.

- `config.FetchImports` clones each declared remote import into `<cityRoot>/.gc/cache/includes/<slug-hash>/` using the same cache key the loader's `fetchRemoteInclude` reads from.
- `gc pack fetch` now reads `pack.toml` directly and runs `FetchImports` **before** `loadCityConfig`, sidestepping the chicken-and-egg where config loading fails on the same cache miss the user is trying to resolve.
- Cache-miss error messages point users at the bootstrap command — `fetchRemoteInclude` → `gc pack fetch`, sibling `resolveLockedRemoteImport` → `gc import install`.
- Help text updated; `docs/reference/cli.md` regenerated.

Honors design issue #583: loaders remain pure readers, `packs.lock` stays in `gc import`'s lane, non-semver remote sources are populated without being written to `packs.lock`.

## Test plan

- [x] `TestImportCloneTarget_CacheKeyMatchesLoader` — table-driven, 5 input forms (tree URL, https with ref, ssh, bare `github.com/`, `file://` with subpath+ref). Asserts cache key parity with what the loader's `fetchRemoteInclude` computes. Prevents the bare-github divergence caught in review.
- [x] `TestFetchImports_LoaderReadsBootstrappedCache` — end-to-end parity: bootstrap clones, loader reads from the same directory.
- [x] `TestFetchImports_ClonesRemoteImport` / `_SkipsLocalPathImport` / `_Idempotent` / `_UpdatesExistingCache` — behavior coverage.
- [x] `TestDoPackFetch_BootstrapsDeclaredImports` — reporter's exact repro: fresh city → `pack.toml` with `[imports.X] source = "file://..."` → `doPackFetch` → `config.LoadWithIncludes` finds the imported agent.
- [x] `TestDoPackFetch_NoImportsOrPacksReportsClean` — clean empty-city message.
- [x] `TestFetchRemoteInclude_MissingCache` — error now mentions `gc pack fetch`.
- [x] `make build`, `make check`, `make check-docs` all green.

## Review coverage

Multi-model review (Claude quartet + Codex + Copilot) surfaced one critical correctness bug — cache-key divergence for bare `github.com/org/repo` sources — which is now fixed by separating `cacheKey` (matches loader) from `cloneURL` (scheme-prefixed for git). Contributor-check's 29-rule audit flagged two polish items (help text accuracy, symmetric sibling error message) which are both addressed in this commit.

## Known follow-ups (out of scope)

- `gc start`, `gc config show`, and controller reload still call `FetchPacks` but not `FetchImports`; a fresh city with remote imports requires an explicit `gc pack fetch` first. The new error message makes this discoverable but the auto-fetch sites should eventually be extended. Happy to file a follow-up issue if desired.