### PR TITLE
Move workspace identity into site binding

### DIFF
--- a/cmd/gc/apiroute.go
+++ b/cmd/gc/apiroute.go
@@ -47,15 +47,11 @@ func apiClient(cityPath string) *api.Client {
 	return supervisorCityAPIClient(cityPath)
 }
 
-// standaloneControllerCityName resolves the city name for a standalone
-// controller API client. In standalone mode the controller serves exactly
-// one city; we prefer cfg.Workspace.Name when set, falling back to the
-// resolved name from the city directory path.
+// standaloneControllerCityName resolves the effective city name for a
+// standalone controller API client. In standalone mode the controller serves
+// exactly one city, so the client must match the runtime identity.
 func standaloneControllerCityName(cfg *config.City, cityPath string) string {
-	if cfg != nil && cfg.Workspace.Name != "" {
-		return cfg.Workspace.Name
-	}
-	return resolveCityName("", "", cityPath)
+	return loadedCityName(cfg, cityPath)
 }
 
 // resolveAgentForAPI resolves a bare agent name (e.g., "worker") to its

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1012,10 +1012,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 }
 
 func lockedConfigName(cfg *config.City, cityPath string) string {
-	if cfg != nil && cfg.Workspace.Name != "" {
-		return cfg.Workspace.Name
-	}
-	return filepath.Base(cityPath)
+	return loadedCityName(cfg, cityPath)
 }
 
 func (cr *CityRuntime) configWatcherTargets() []config.WatchTarget {

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -123,10 +122,7 @@ func doCityStatus(
 		}
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 
 	// Header: city name and path.
 	fmt.Fprintf(stdout, "%s  %s\n", cityName, cityPath) //nolint:errcheck // best-effort stdout
@@ -296,10 +292,7 @@ func doCityStatusJSON(
 		}
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 
 	// Build suspended rig lookup.
 	suspendedRigs := make(map[string]bool)

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -178,7 +178,7 @@ func tryDiscoveredCommandFallback(args []string, cfg *config.City, cityPath stri
 		return true
 	}
 
-	cityName := cfg.Workspace.Name
+	cityName := loadedCityName(cfg, cityPath)
 	sort.SliceStable(matching, func(i, j int) bool {
 		return len(matching[i].Command) > len(matching[j].Command)
 	})

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -140,7 +140,7 @@ func runControlDispatcher(beadID string, stdout, stderr io.Writer) error {
 		case "check", "fanout":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)
 			opts.PrepareFragment = func(fragment *formula.FragmentRecipe, source beads.Bead) error {
-				return decorateDynamicFragmentRecipe(fragment, source, store, cfg.Workspace.Name, cityPath, cfg)
+				return decorateDynamicFragmentRecipe(fragment, source, store, loadedCityName(cfg, cityPath), cityPath, cfg)
 			}
 		case "retry-eval":
 			sp := dispatchControlSessionProvider()
@@ -641,7 +641,7 @@ func resolveSourceWorkflowTarget(cfg *config.City, cityPath, sourceBeadID string
 	}
 	target.storeView = view
 	target.sourceBead = bead
-	target.storeRef = workflowStoreRefForDir(view.path, cityPath, cfg.Workspace.Name, cfg)
+	target.storeRef = workflowStoreRefForDir(view.path, cityPath, loadedCityName(cfg, cityPath), cfg)
 	return target, nil
 }
 
@@ -666,9 +666,9 @@ func openSourceWorkflowStoreRef(cfg *config.City, cityPath, storeRef string) (co
 		if err != nil {
 			return convoyStoreView{}, "", fmt.Errorf("opening city store: %w", err)
 		}
-		cityName := "city"
-		if cfg != nil && strings.TrimSpace(cfg.Workspace.Name) != "" {
-			cityName = cfg.Workspace.Name
+		cityName := loadedCityName(cfg, cityPath)
+		if cityName == "" {
+			cityName = "city"
 		}
 		return convoyStoreView{path: cityPath, store: store}, "city:" + cityName, nil
 	case strings.HasPrefix(storeRef, "city:"):
@@ -1051,7 +1051,7 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 	}
 	matches := make([]sourceWorkflowStoreMatch, 0, len(stores))
 	for _, info := range stores {
-		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cfg.Workspace.Name, cfg)
+		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, loadedCityName(cfg, cityPath), cfg)
 		roots, err := sourceworkflow.ListLiveRoots(info.store, sourceBeadID, sourceStoreRef, rootStoreRef)
 		if err != nil {
 			return nil, skips, err

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -169,10 +169,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	d.Register(doctor.NewControllerCheck(cityPath, controllerRunning))
 
 	if cfgErr == nil && !controllerRunning {
-		cityName := cfg.Workspace.Name
-		if cityName == "" {
-			cityName = filepath.Base(cityPath)
-		}
+		cityName := loadedCityName(cfg, cityPath)
 		st := cfg.Workspace.SessionTemplate
 		sp := newSessionProvider()
 

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -231,13 +231,7 @@ func resolveEventsScope(apiURLOverride string) (eventsAPIScope, error) {
 }
 
 func resolvedEventsCityName(cityPath string, cfg *config.City) string {
-	if cfg != nil && strings.TrimSpace(cfg.Workspace.Name) != "" {
-		return strings.TrimSpace(cfg.Workspace.Name)
-	}
-	if strings.TrimSpace(cityPath) == "" {
-		return ""
-	}
-	return resolveCityName("", "", cityPath)
+	return loadedCityName(cfg, cityPath)
 }
 
 func validateEventsCursor(scope eventsAPIScope, afterSeq uint64, afterCursor string) error {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -124,11 +124,12 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		return 1
 	}
 
+	cityName := loadedCityName(cfg, cityPath)
 	workQuery := a.EffectiveWorkQuery()
 	// Expand {{.Rig}}/{{.AgentBase}} in user-supplied work_query so agent-side
 	// hook invocation sees the same rig substitution as the controller-side
 	// probes in build_desired_state.go / session_reconcile.go. #793.
-	workQuery = expandAgentCommandTemplate(cityPath, cfg.Workspace.Name, &a, cfg.Rigs, "work_query", workQuery, stderr)
+	workQuery = expandAgentCommandTemplate(cityPath, cityName, &a, cfg.Rigs, "work_query", workQuery, stderr)
 	workDir := agentCommandDir(cityPath, &a, cfg.Rigs)
 
 	// Build the work query subprocess environment. Rig-backed agents get
@@ -139,7 +140,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	// names; named-session context preserves the runtime-supplied owner
 	// env while selecting the backing config through GC_TEMPLATE.
 	resolvedAgentName := a.QualifiedName()
-	resolvedSessionName := cliSessionName(cityPath, cfg.Workspace.Name, resolvedAgentName, cfg.Workspace.SessionTemplate)
+	resolvedSessionName := cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
 	agentForQuery := resolvedAgentName
 	sessionForQuery := resolvedSessionName
 	if sessionTemplateContext {

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -721,12 +721,7 @@ func normalizeCityPackManifestAgentDefaultsAlias(manifest *cityPackManifest, met
 func defaultCityPackName(fs fsys.FS, cityPath string) string {
 	cfg, err := config.Load(fs, filepath.Join(cityPath, "city.toml"))
 	if err == nil {
-		if cfg.Workspace.Name != "" {
-			return cfg.Workspace.Name
-		}
-		if cfg.ResolvedWorkspaceName != "" {
-			return cfg.ResolvedWorkspaceName
-		}
+		return config.EffectiveCityName(cfg, filepath.Base(cityPath))
 	}
 	return filepath.Base(cityPath)
 }

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -281,7 +281,7 @@ non-interactively, or --file to initialize from an existing TOML config file.`,
 	}
 	cmd.Flags().StringVar(&fileFlag, "file", "", "path to a TOML file to use as city.toml")
 	cmd.Flags().StringVar(&fromFlag, "from", "", "path to an example city directory to copy")
-	cmd.Flags().StringVar(&nameFlag, "name", "", "workspace name (default: source template's workspace.name if set, else target directory basename)")
+	cmd.Flags().StringVar(&nameFlag, "name", "", "machine-local city name (default: source template's workspace.name if set, else source pack.name if set, else target directory basename)")
 	cmd.Flags().StringVar(&providerFlag, "provider", "", "built-in workspace provider to use for the default mayor config")
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
@@ -537,8 +537,8 @@ func newInitPackConfig(cityName string) initPackConfig {
 	}
 }
 
-func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.City) {
-	packCfg := newInitPackConfig(cityName)
+func splitInitConfig(packName string, cfg *config.City) (initPackConfig, config.City) {
+	packCfg := newInitPackConfig(packName)
 	if cfg == nil {
 		return packCfg, config.City{}
 	}
@@ -553,6 +553,8 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 	cityCfg.Patches = config.Patches{}
 	cityCfg.AgentDefaults = config.AgentDefaults{}
 	cityCfg.AgentsDefaults = config.AgentDefaults{}
+	cityCfg.Workspace.Name = ""
+	cityCfg.Workspace.Prefix = ""
 
 	packCfg.Agents = append([]config.Agent(nil), cfg.Agents...)
 	packCfg.NamedSessions = append([]config.NamedSession(nil), cfg.NamedSessions...)
@@ -600,14 +602,14 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 	return packCfg, cityCfg
 }
 
-func decodeInitPackTemplate(data []byte, cityName string) (initPackConfig, error) {
-	cfg := newInitPackConfig(cityName)
+func decodeInitPackTemplate(data []byte, packName string) (initPackConfig, error) {
+	cfg := newInitPackConfig(packName)
 	if _, err := toml.Decode(string(data), &cfg); err != nil {
 		return initPackConfig{}, fmt.Errorf("parse pack template: %w", err)
 	}
 	// Fresh init always materializes a city-scoped root pack, so the target
-	// city name and current schema override any template header identity.
-	cfg.Pack.Name = cityName
+	// pack identity and current schema override any template header identity.
+	cfg.Pack.Name = packName
 	cfg.Pack.Schema = initPackSchemaVersion
 	return cfg, nil
 }
@@ -683,15 +685,18 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return 1
 	}
 
-	// --file creates a new city from a template. Preserve the source's
-	// workspace.name if set; otherwise fall back to the target dir basename.
-	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, cityPath)
-	templatePack, err := decodeInitPackTemplate(data, cityName)
+	// --file creates a new city from a template. Preserve explicit source
+	// identity when present, but write the machine-local result to
+	// .gc/site.toml instead of checked-in city.toml.
+	sourcePackName := parseInitPackName(data)
+	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, sourcePackName, cityPath)
+	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	packName := resolvePackName(sourcePackName, cityName)
+	templatePack, err := decodeInitPackTemplate(data, packName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cfg.Workspace.Name = cityName
 
 	// Create directory structure.
 	if cityAlreadyInitializedFS(fs, cityPath) {
@@ -719,7 +724,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	// Rewrite legacy prompt paths only after we've copied the embedded prompt
 	// scaffolds that still live under prompts/.
 	rewriteInitPromptTemplates(cfg)
-	packCfg, cityCfg := splitInitConfig(cityName, cfg)
+	packCfg, cityCfg := splitInitConfig(packName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
 
 	// Re-marshal so the name and rewritten prompt paths are updated.
@@ -736,6 +741,10 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 
 	// Write city.toml.
 	if err := fs.WriteFile(filepath.Join(cityPath, "city.toml"), content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := config.PersistWorkspaceSiteBinding(fs, cityPath, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -796,22 +805,10 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 				return code
 			}
 		}
-		// Preserve the persisted workspace.name when no --name override
-		// was supplied, so the bootstrap message reports the real city
-		// name rather than the target dir basename.
-		var persistedName string
-		if trimmedNameOverride == "" {
-			if data, err := fs.ReadFile(tomlPath); err != nil {
-				fmt.Fprintf(stderr, "gc init: warning: reading persisted workspace name from %q: %v\n", tomlPath, err) //nolint:errcheck // best-effort stderr
-			} else {
-				if existing, perr := config.Parse(data); perr == nil {
-					persistedName = existing.Workspace.Name
-				} else {
-					fmt.Fprintf(stderr, "gc init: warning: parsing persisted workspace name from %q: %v\n", tomlPath, perr) //nolint:errcheck // best-effort stderr
-				}
-			}
+		cityName := trimmedNameOverride
+		if cityName == "" {
+			cityName = loadExistingCityNameForInit(fs, tomlPath, stderr)
 		}
-		cityName := resolveCityName(trimmedNameOverride, persistedName, cityPath)
 		fmt.Fprintln(stdout, "Welcome to Gas City!")                              //nolint:errcheck // best-effort stdout
 		fmt.Fprintf(stdout, "Bootstrapped city %q runtime scaffold.\n", cityName) //nolint:errcheck // best-effort stdout
 		return 0
@@ -836,7 +833,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	// Build the initial city shape before writing prompt scaffolds so init
 	// only creates convention-discoverable prompt files for the agents the
 	// chosen city template actually declares.
-	cityName := resolveCityName(nameOverride, "", cityPath)
+	cityName := resolveCityName(nameOverride, "", "", cityPath)
 	var cfg config.City
 	switch {
 	case wiz.configName == "custom":
@@ -863,6 +860,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	// state. We intentionally retain current compatibility fields such as
 	// workspace.provider in city.toml until the runtime cutover is complete.
 	rewriteInitPromptTemplates(&cfg)
+	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
 	packCfg, cityCfg := splitInitConfig(cityName, &cfg)
 	content, err := cityCfg.Marshal()
 	if err != nil {
@@ -876,6 +874,10 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	}
 	logInitProgress(stdout, 5, "Writing city configuration")
 	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := config.PersistWorkspaceSiteBinding(fs, cityPath, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -1004,15 +1006,19 @@ func initFromSkip(relPath string, isDir bool) bool {
 	return false
 }
 
-// overrideCityName reads an existing city.toml, updates workspace.name, and writes it back.
+// overrideCityName stores a machine-local workspace name override in
+// .gc/site.toml while preserving any existing site-bound prefix.
 func overrideCityName(f fsys.FS, tomlPath, name string, stderr io.Writer) int {
-	cfg, err := loadCityConfigForEditFS(f, tomlPath)
+	cfg, err := config.Load(f, tomlPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cfg.Workspace.Name = name
-	if err := writeCityConfigForEditFS(f, tomlPath, cfg); err != nil {
+	prefix := strings.TrimSpace(cfg.ResolvedWorkspacePrefix)
+	if prefix == "" {
+		prefix = strings.TrimSpace(cfg.Workspace.Prefix)
+	}
+	if err := config.PersistWorkspaceSiteBinding(f, filepath.Dir(tomlPath), name, prefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -1020,21 +1026,67 @@ func overrideCityName(f fsys.FS, tomlPath, name string, stderr io.Writer) int {
 }
 
 // resolveCityName returns the workspace name to use during init.
-// Priority: explicit --name flag > name set on the source/template config > target directory basename.
-// sourceName is the workspace.name already present in a template TOML (for
-// `gc init --file` and `gc init --from`); pass "" at call sites that have no
-// such source, and the fallback becomes the target dir basename.
+// Priority: explicit --name flag > source/template workspace.name >
+// source/template pack.name > target directory basename.
 // Matches runtime config.EffectiveCityName by trimming whitespace on all
 // inputs so a name with stray spaces resolves the same way at init time
 // and at runtime.
-func resolveCityName(nameOverride, sourceName, cityPath string) string {
+func resolveCityName(nameOverride, sourceName, sourcePackName, cityPath string) string {
 	if n := strings.TrimSpace(nameOverride); n != "" {
 		return n
 	}
 	if n := strings.TrimSpace(sourceName); n != "" {
 		return n
 	}
+	if n := strings.TrimSpace(sourcePackName); n != "" {
+		return n
+	}
 	return strings.TrimSpace(filepath.Base(cityPath))
+}
+
+func resolvePackName(sourcePackName, cityName string) string {
+	if n := strings.TrimSpace(sourcePackName); n != "" {
+		return n
+	}
+	return strings.TrimSpace(cityName)
+}
+
+func parseInitPackName(data []byte) string {
+	var meta struct {
+		Pack struct {
+			Name string `toml:"name"`
+		} `toml:"pack"`
+	}
+	if _, err := toml.Decode(string(data), &meta); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(meta.Pack.Name)
+}
+
+func readInitSourcePackName(fs fsys.FS, srcDir string) string {
+	data, err := fs.ReadFile(filepath.Join(srcDir, "pack.toml"))
+	if err != nil {
+		return ""
+	}
+	return parseInitPackName(data)
+}
+
+func loadExistingCityNameForInit(fs fsys.FS, tomlPath string, stderr io.Writer) string {
+	data, err := fs.ReadFile(tomlPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc init: warning: reading persisted workspace identity from %q: %v\n", tomlPath, err) //nolint:errcheck // best-effort stderr
+		return strings.TrimSpace(filepath.Base(filepath.Dir(tomlPath)))
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc init: warning: parsing persisted workspace identity from %q: %v\n", tomlPath, err) //nolint:errcheck // best-effort stderr
+		return strings.TrimSpace(filepath.Base(filepath.Dir(tomlPath)))
+	}
+	if err := config.ResolveWorkspaceIdentity(fs, filepath.Dir(tomlPath), cfg); err != nil {
+		fmt.Fprintf(stderr, "gc init: warning: resolving persisted workspace identity from %q: %v\n", tomlPath, err) //nolint:errcheck // best-effort stderr
+		return strings.TrimSpace(filepath.Base(filepath.Dir(tomlPath)))
+	}
+	return config.EffectiveCityName(cfg, filepath.Base(filepath.Dir(tomlPath)))
 }
 
 func cmdInitFromDirWithOptions(fromDir string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
@@ -1065,7 +1117,7 @@ func cmdInitFromDirWithOptions(fromDir string, args []string, nameOverride strin
 }
 
 // doInitFromDir copies an example city directory to a new city path,
-// updates workspace.name, creates .gc/, and installs hooks.
+// writes the local city identity to .gc/site.toml, creates .gc/, and installs hooks.
 func doInitFromDir(srcDir, cityPath string, stdout, stderr io.Writer) int {
 	return doInitFromDirWithOptions(srcDir, cityPath, "", stdout, stderr, false)
 }
@@ -1108,16 +1160,23 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	// --from copies a template city; preserve its workspace.name if set,
-	// otherwise fall back to the target dir basename.
-	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, cityPath)
-	cfg.Workspace.Name = cityName
+	// --from copies a template city; preserve explicit source identity when
+	// present, but write the machine-local result to .gc/site.toml.
+	sourcePackName := readInitSourcePackName(fs, srcDir)
+	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, sourcePackName, cityPath)
+	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	cfg.Workspace.Name = ""
+	cfg.Workspace.Prefix = ""
 	content, err := cfg.Marshal()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := config.PersistWorkspaceSiteBinding(fs, cityPath, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -426,10 +425,7 @@ func configuredMailboxAddressWithConfig(cityPath string, cfg *config.City, ident
 	if identifier == "" || identifier == "human" || cfg == nil {
 		return "", false
 	}
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	spec, ok, err := findNamedSessionSpecForTarget(cfg, cityName, identifier)
 	if err != nil || !ok {
 		return "", false

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -624,10 +624,7 @@ func resolveNudgeTarget(identifier string, warningWriter ...io.Writer) (nudgeTar
 }
 
 func resolveNudgeTargetFromSessionBead(cityPath string, cfg *config.City, b beads.Bead) nudgeTarget {
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	sessionName := strings.TrimSpace(b.Metadata["session_name"])
 	if sessionName == "" {
 		sessionName = sessionNameFromBeadID(b.ID)

--- a/cmd/gc/cmd_pack_commands.go
+++ b/cmd/gc/cmd_pack_commands.go
@@ -42,7 +42,7 @@ func registerPackCommands(root *cobra.Command, stdout, stderr io.Writer) {
 		return
 	}
 
-	addDiscoveredCommandsToRoot(root, cfg.PackCommands, cityPath, cfg.Workspace.Name, stdout, stderr, false)
+	addDiscoveredCommandsToRoot(root, cfg.PackCommands, cityPath, loadedCityName(cfg, cityPath), stdout, stderr, false)
 }
 
 // coreCommandNames returns the set of built-in command names that packs

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -134,10 +134,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		return 0 // empty output; hooks call this
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 
 	// Look up agent in config. First try qualified identity resolution
 	// (handles "rig/agent" and rig-context matching), then fall back to

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/supervisor"
@@ -25,8 +24,9 @@ func newRegisterCmd(stdout, stderr io.Writer) *cobra.Command {
 If no path is given, registers the current city (discovered from cwd).
 Use --name to set the machine-local registration alias. The alias is stored
 in the machine-local supervisor registry and never written back to city.toml.
-When --name is omitted, workspace.name is used if present, otherwise
-[pack].name is used — in either case city.toml is not modified.
+When --name is omitted, the current effective city identity is used
+(site-bound workspace name if present, otherwise legacy workspace.name,
+otherwise the directory basename) — in every case city.toml is not modified.
 Registration is idempotent — registering the same city twice is a no-op.
 The supervisor is started if needed and immediately reconciles the city.`,
 		Args: cobra.MaximumNArgs(1),
@@ -83,30 +83,7 @@ func resolveRegistrationName(cityPath, nameOverride string) (string, error) {
 	if alias := strings.TrimSpace(nameOverride); alias != "" {
 		return alias, nil
 	}
-	if current := strings.TrimSpace(cfg.Workspace.Name); current != "" {
-		return current, nil
-	}
-
-	return readPackName(filepath.Join(cityPath, "pack.toml"))
-}
-
-func readPackName(packTomlPath string) (string, error) {
-	data, err := os.ReadFile(packTomlPath)
-	if err != nil {
-		return "", fmt.Errorf("reading %q: %w", packTomlPath, err)
-	}
-	var meta struct {
-		Pack struct {
-			Name string `toml:"name"`
-		} `toml:"pack"`
-	}
-	if _, err := toml.Decode(string(data), &meta); err != nil {
-		return "", fmt.Errorf("parsing %q: %w", packTomlPath, err)
-	}
-	if strings.TrimSpace(meta.Pack.Name) == "" {
-		return "", fmt.Errorf("%s: missing [pack].name for registration fallback", packTomlPath)
-	}
-	return meta.Pack.Name, nil
+	return config.EffectiveCityName(cfg, filepath.Base(filepath.Clean(cityPath))), nil
 }
 
 func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -200,7 +200,44 @@ func TestDoRegisterWithoutNameStillUsesWorkspaceName(t *testing.T) {
 	}
 }
 
-func TestDoRegisterWithoutNameFallsBackToPackNameWithoutMutatingCityToml(t *testing.T) {
+func TestDoRegisterWithoutNameUsesSiteBoundWorkspaceName(t *testing.T) {
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = nil
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".gc", "site.toml"), []byte("workspace_name = \"site-name\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegister([]string{cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", code, stderr.String())
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %v", entries)
+	}
+	if entries[0].Name != "site-name" {
+		t.Fatalf("registry name = %q, want %q", entries[0].Name, "site-name")
+	}
+}
+
+func TestDoRegisterWithoutNameFallsBackToDirBasenameWithoutMutatingCityToml(t *testing.T) {
 	oldRegister := registerCityWithSupervisorTestHook
 	registerCityWithSupervisorTestHook = nil
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
@@ -233,8 +270,8 @@ func TestDoRegisterWithoutNameFallsBackToPackNameWithoutMutatingCityToml(t *test
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %v", entries)
 	}
-	if entries[0].Name != "pack-name" {
-		t.Fatalf("registry name = %q, want %q", entries[0].Name, "pack-name")
+	if entries[0].Name != "my-city" {
+		t.Fatalf("registry name = %q, want %q", entries[0].Name, "my-city")
 	}
 
 	gotCityToml, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
@@ -246,7 +283,7 @@ func TestDoRegisterWithoutNameFallsBackToPackNameWithoutMutatingCityToml(t *test
 	}
 }
 
-func TestDoRegisterWithoutNameErrorsWhenWorkspaceAndPackNameMissing(t *testing.T) {
+func TestDoRegisterWithoutNameUsesDirBasenameWhenWorkspaceAndPackNameMissing(t *testing.T) {
 	oldRegister := registerCityWithSupervisorTestHook
 	registerCityWithSupervisorTestHook = nil
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
@@ -266,11 +303,20 @@ func TestDoRegisterWithoutNameErrorsWhenWorkspaceAndPackNameMissing(t *testing.T
 
 	var stdout, stderr bytes.Buffer
 	code := doRegister([]string{cityPath}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("expected exit 1, got %d", code)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "missing [pack].name") {
-		t.Fatalf("stderr = %q, want missing [pack].name", stderr.String())
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	entries, err := reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %v", entries)
+	}
+	if entries[0].Name != "my-city" {
+		t.Fatalf("registry name = %q, want %q", entries[0].Name, "my-city")
 	}
 }
 
@@ -422,11 +468,11 @@ func TestDoRegister_Regression602_DoesNotMutateCityToml(t *testing.T) {
 			wantRegName:  "machine-alias",
 		},
 		{
-			name:         "no --name, workspace.name empty, pack.name fallback — city.toml unchanged",
+			name:         "no --name, workspace.name empty, basename fallback — city.toml unchanged",
 			cityToml:     "[workspace]\n",
 			packToml:     "[pack]\nname = \"pack-name\"\nschema = 2\n",
 			nameOverride: "",
-			wantRegName:  "pack-name",
+			wantRegName:  "my-city",
 		},
 	}
 

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -124,10 +123,7 @@ func cmdRigRestart(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	sp := newSessionProvider()
 	rec := openCityRecorder(stderr)
 	store, _ := openCityStoreAt(cityPath)

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -657,10 +657,7 @@ func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.W
 
 	// HQ rig (the city itself).
 	hqBeads := rigBeadsStatus(fs, cityPath)
-	displayName := cfg.Workspace.Name
-	if displayName == "" {
-		displayName = filepath.Base(cityPath)
-	}
+	displayName := loadedCityName(cfg, cityPath)
 	w("")
 	w(fmt.Sprintf("  %s (HQ):", displayName))
 	w(fmt.Sprintf("    Prefix: %s", hqPrefix))
@@ -1052,10 +1049,7 @@ func cmdRigDefault(rigNameOrPath, cityNameOrPath string, stdout, stderr io.Write
 		fmt.Fprintf(stderr, "gc rig default: warning: writing routes: %v\n", err) //nolint:errcheck // best-effort stderr
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	fmt.Fprintf(stdout, "Set default city for rig '%s' to '%s'\n", entry.Name, cityName) //nolint:errcheck // best-effort stdout
 	return 0
 }

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -1487,10 +1486,7 @@ func resolveWorkDir(cityPath string, cfg *config.City, agent *config.Agent) (str
 }
 
 func resolveWorkDirForQualifiedName(cityPath string, cfg *config.City, agent *config.Agent, qualifiedName string) (string, error) {
-	cityName := filepath.Base(cityPath)
-	if cfg != nil && cfg.Workspace.Name != "" {
-		cityName = cfg.Workspace.Name
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	var rigs []config.Rig
 	if cfg != nil {
 		rigs = cfg.Rigs

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -191,10 +190,7 @@ func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, ident
 	if identifier == "" {
 		return "", false
 	}
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	if spec, ok, _ := findNamedSessionSpecForTarget(cfg, cityName, identifier); ok && spec.Agent != nil {
 		workDirQualifiedName := workdirutil.SessionQualifiedName(cityPath, *spec.Agent, cfg.Rigs, spec.Identity, "")
 		workDir, err := resolveWorkDirForQualifiedName(cityPath, cfg, spec.Agent, workDirQualifiedName)

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -246,10 +246,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	}
 
 	sp := newSessionProvider()
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 
 	storeDir := resolveSlingStoreRoot(cfg, cityPath, beadOrFormula, a)
 	store, err := openStoreAtForCity(storeDir, cityPath)
@@ -257,7 +254,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		fmt.Fprintf(stderr, "gc sling: opening store %s: %v\n", storeDir, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	storeRef := workflowStoreRefForDir(storeDir, cityPath, cfg.Workspace.Name, cfg)
+	storeRef := workflowStoreRefForDir(storeDir, cityPath, cityName, cfg)
 	storeEnv := slingStoreEnv(cfg, cityPath, storeDir)
 
 	// Inline text mode: if the argument doesn't look like a bead ID

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -414,10 +414,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc start: warning: %s\n", w) //nolint:errcheck // best-effort stderr
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 
 	// Validate rigs (prefix collisions, missing fields).
 	if err := config.ValidateRigs(cfg.Rigs, config.EffectiveHQPrefix(cfg)); err != nil {

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -75,10 +74,7 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	sp := newSessionProvider()
 	dops := newDrainOps(sp)
 	return doRigStatus(sp, dops, rig, rigAgents, cityPath, cityName, cfg.Workspace.SessionTemplate, stdout, stderr)

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -54,10 +54,7 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 
 	if handled, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc stop"); handled {
 		if code != 0 {

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -65,16 +65,12 @@ func fetchCityPacksIfNeeded(cityPath string) error {
 }
 
 func effectiveCityName(cityPath string) (string, error) {
-	name := filepath.Base(cityPath)
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
 	if err != nil {
 		return "", err
 	}
-	if cfg.Workspace.Name != "" {
-		name = cfg.Workspace.Name
-	}
-	return name, nil
+	return config.EffectiveCityName(cfg, filepath.Base(filepath.Clean(cityPath))), nil
 }
 
 func registeredCityName(cityPath, nameOverride string) (string, error) {

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -392,6 +392,27 @@ func TestRegisterCityWithSupervisorFetchesRemotePacksBeforeLoadingIncludes(t *te
 	}
 }
 
+func TestEffectiveCityNameUsesWorkspaceSiteBinding(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "target-basename")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".gc", "site.toml"), []byte("workspace_name = \"site-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := effectiveCityName(cityPath)
+	if err != nil {
+		t.Fatalf("effectiveCityName returned error: %v", err)
+	}
+	if name != "site-city" {
+		t.Fatalf("effectiveCityName = %q, want %q", name, "site-city")
+	}
+}
+
 func TestRegisterCityWithSupervisorRejectsStandaloneController(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -820,10 +820,7 @@ func tryReloadConfig(tomlPath, lockedWorkspaceName, cityRoot string) (*reloadRes
 	if err := workspacesvc.ValidateRuntimeSupport(newCfg.Services); err != nil {
 		return failWithWarnings(fmt.Errorf("validating services: %w", err))
 	}
-	newName := newCfg.Workspace.Name
-	if newName == "" {
-		newName = filepath.Base(filepath.Dir(tomlPath))
-	}
+	newName := loadedCityName(newCfg, filepath.Dir(tomlPath))
 	if newName != lockedWorkspaceName {
 		return failWithWarnings(fmt.Errorf("workspace.name changed from %q to %q (restart controller to apply)", lockedWorkspaceName, newName))
 	}
@@ -1107,10 +1104,7 @@ func runController(
 	}
 	defer convergence.RemoveToken(cityPath) //nolint:errcheck // best-effort cleanup
 
-	cityName := cfg.Workspace.Name
-	if cityName == "" {
-		cityName = filepath.Base(cityPath)
-	}
+	cityName := loadedCityName(cfg, cityPath)
 	rec.Record(events.Event{Type: events.ControllerStarted, Actor: "gc"})
 	telemetry.RecordControllerLifecycle(context.Background(), "started")
 	fmt.Fprintln(stdout, "Controller started.") //nolint:errcheck // best-effort stdout

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -169,7 +169,7 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	// Expand {{.Rig}}/{{.AgentBase}} once so the long-poll drain reuses the
 	// rig-scoped command instead of passing the literal template to the shell
 	// on every iteration. #793.
-	workQuery := expandAgentCommandTemplate(cityPath, cfg.Workspace.Name, &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
+	workQuery := expandAgentCommandTemplate(cityPath, loadedCityName(cfg, cityPath), &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
 		return drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -300,18 +300,81 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 
 type v2WorkspaceNameCheck struct{}
 
-func (v2WorkspaceNameCheck) Name() string                     { return "v2-workspace-name" }
-func (v2WorkspaceNameCheck) CanFix() bool                     { return false }
-func (v2WorkspaceNameCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2WorkspaceNameCheck) Name() string { return "v2-workspace-name" }
+func (v2WorkspaceNameCheck) CanFix() bool { return true }
+func (v2WorkspaceNameCheck) Fix(ctx *doctor.CheckContext) error {
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(ctx.CityPath, "city.toml"))
+	if err != nil {
+		return err
+	}
+	binding, err := config.LoadSiteBinding(fsys.OSFS{}, ctx.CityPath)
+	if err != nil {
+		return err
+	}
+
+	rawName := strings.TrimSpace(cfg.Workspace.Name)
+	rawPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	siteName := strings.TrimSpace(binding.WorkspaceName)
+	sitePrefix := strings.TrimSpace(binding.WorkspacePrefix)
+
+	var conflicts []string
+	if rawName != "" && siteName != "" && rawName != siteName {
+		conflicts = append(conflicts, fmt.Sprintf("workspace.name=%q .gc/site.toml workspace_name=%q", rawName, siteName))
+	}
+	if rawPrefix != "" && sitePrefix != "" && rawPrefix != sitePrefix {
+		conflicts = append(conflicts, fmt.Sprintf("workspace.prefix=%q .gc/site.toml workspace_prefix=%q", rawPrefix, sitePrefix))
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return fmt.Errorf("refusing to migrate workspace identity — city.toml and .gc/site.toml disagree; resolve manually and re-run `gc doctor --fix`:\n  %s",
+			strings.Join(conflicts, "\n  "))
+	}
+
+	name := siteName
+	if name == "" {
+		name = rawName
+	}
+	prefix := sitePrefix
+	if prefix == "" {
+		prefix = rawPrefix
+	}
+
+	// Write the site binding first. If the city.toml rewrite fails
+	// afterwards, runtime identity remains stable and `gc doctor` will
+	// continue warning about the still-present legacy fields rather than
+	// silently losing the chosen name/prefix.
+	if err := config.PersistWorkspaceSiteBinding(fsys.OSFS{}, ctx.CityPath, name, prefix); err != nil {
+		return err
+	}
+	cfg.Workspace.Name = ""
+	cfg.Workspace.Prefix = ""
+	content, err := cfg.MarshalForWrite()
+	if err != nil {
+		return err
+	}
+	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, filepath.Join(ctx.CityPath, "city.toml"), content, 0o644)
+}
 func (v2WorkspaceNameCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
-	if !ok || strings.TrimSpace(cfg.Workspace.Name) == "" {
-		return okCheck("v2-workspace-name", "workspace.name already absent")
+	if !ok {
+		return okCheck("v2-workspace-name", "workspace identity migration skipped until city.toml parses")
+	}
+	rawName := strings.TrimSpace(cfg.Workspace.Name)
+	rawPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	if rawName == "" && rawPrefix == "" {
+		return okCheck("v2-workspace-name", "workspace identity already absent from city.toml")
+	}
+	var details []string
+	if rawName != "" {
+		details = append(details, "workspace.name="+rawName)
+	}
+	if rawPrefix != "" {
+		details = append(details, "workspace.prefix="+rawPrefix)
 	}
 	return warnCheck("v2-workspace-name",
-		"workspace.name will move to .gc/ in a future release",
-		"review site-binding migration guidance before the hard cutover",
-		[]string{cfg.Workspace.Name})
+		"workspace identity still lives in city.toml",
+		"run `gc doctor --fix` to migrate workspace.name/workspace.prefix into .gc/site.toml",
+		details)
 }
 
 type v2PromptTemplateSuffixCheck struct{}

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -159,6 +159,56 @@ path = "/tmp/frontend"
 	}
 }
 
+func TestV2DeprecationChecksWarnAndFixLegacyWorkspaceIdentity(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+prefix = "lc"
+`)
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	registerV2DeprecationChecks(d)
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, false)
+
+	out := buf.String()
+	if !strings.Contains(out, "v2-workspace-name") {
+		t.Fatalf("doctor output missing workspace identity warning:\n%s", out)
+	}
+	if !strings.Contains(out, ".gc/site.toml") {
+		t.Fatalf("doctor output missing site binding guidance:\n%s", out)
+	}
+
+	buf.Reset()
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
+
+	rawData, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(city.toml): %v", err)
+	}
+	if strings.Contains(string(rawData), `name = "legacy-city"`) || strings.Contains(string(rawData), `prefix = "lc"`) {
+		t.Fatalf("city.toml should no longer store workspace identity:\n%s", rawData)
+	}
+
+	binding, err := config.LoadSiteBinding(fsys.OSFS{}, cityDir)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if binding.WorkspaceName != "legacy-city" || binding.WorkspacePrefix != "lc" {
+		t.Fatalf("binding = %+v, want workspace_name=legacy-city workspace_prefix=lc", binding)
+	}
+
+	buf.Reset()
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, false)
+	out = buf.String()
+	if strings.Contains(out, "⚠ v2-workspace-name") {
+		t.Fatalf("workspace identity warning should clear after fix:\n%s", out)
+	}
+}
+
 func TestV2DeprecationChecksWarnOnLegacyTemplateSuffix(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gc/effective_identity.go
+++ b/cmd/gc/effective_identity.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func loadedCityName(cfg *config.City, cityPath string) string {
+	fallback := ""
+	if cityPath != "" {
+		fallback = filepath.Base(filepath.Clean(cityPath))
+	}
+	return config.EffectiveCityName(cfg, fallback)
+}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -62,6 +62,15 @@ func configureIsolatedRuntimeEnv(t *testing.T) {
 	}
 }
 
+func mustLoadSiteBinding(t *testing.T, fs fsys.FS, cityPath string) *config.SiteBinding {
+	t.Helper()
+	binding, err := config.LoadSiteBinding(fs, cityPath)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding(%q): %v", cityPath, err)
+	}
+	return binding
+}
+
 func configureSupervisorHooksForTests() {
 	ensureSupervisorRunningHook = func(_, _ io.Writer) int { return 0 }
 	reloadSupervisorHook = func(_, _ io.Writer) int { return 0 }
@@ -1650,8 +1659,8 @@ func TestDoInitSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loading written config: %v", err)
 	}
-	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
+	if got := config.EffectiveCityName(cfg, ""); got != "bright-lights" {
+		t.Errorf("EffectiveCityName = %q, want %q", got, "bright-lights")
 	}
 	if len(cfg.Agents) != 1 {
 		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
@@ -1681,10 +1690,13 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 
 	got := string(f.Files[filepath.Join("/bright-lights", "city.toml")])
 	want := `[workspace]
-name = "bright-lights"
 `
 	if got != want {
 		t.Errorf("city.toml content:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+	binding := mustLoadSiteBinding(t, f, "/bright-lights")
+	if binding.WorkspaceName != "bright-lights" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "bright-lights")
 	}
 
 	packGot := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
@@ -1792,6 +1804,12 @@ func TestSplitInitConfigMovesPackOwnedFields(t *testing.T) {
 	}
 	if !cityCfg.Patches.IsEmpty() {
 		t.Fatalf("cityCfg.Patches should be empty, got %#v", cityCfg.Patches)
+	}
+	if cityCfg.Workspace.Name != "" {
+		t.Fatalf("cityCfg.Workspace.Name = %q, want empty", cityCfg.Workspace.Name)
+	}
+	if cityCfg.Workspace.Prefix != "" {
+		t.Fatalf("cityCfg.Workspace.Prefix = %q, want empty", cityCfg.Workspace.Prefix)
 	}
 	if len(cityCfg.Workspace.Includes) != 0 {
 		t.Fatalf("cityCfg.Workspace.Includes = %v, want empty", cityCfg.Workspace.Includes)
@@ -1921,9 +1939,9 @@ func TestDoInitBootstrapsExistingCityToml(t *testing.T) {
 	}
 }
 
-// When bootstrapping an existing city.toml with no --name override, the
-// "Bootstrapped city" stdout line must report the persisted workspace.name
-// rather than the target directory basename (the two can diverge).
+// When bootstrapping an existing city with no --name override, the
+// "Bootstrapped city" stdout line must report the persisted effective city
+// identity rather than the target directory basename (the two can diverge).
 func TestDoInitBootstrapPreservesPersistedName(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files[filepath.Join("/target-basename", "city.toml")] = []byte("[workspace]\nname = \"mining\"\n")
@@ -1950,7 +1968,7 @@ func TestDoInitBootstrapWarnsWhenPersistedNameCannotBeParsed(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "warning: parsing persisted workspace name") {
+	if !strings.Contains(stderr.String(), "warning: parsing persisted workspace identity") {
 		t.Errorf("stderr = %q, want parse warning", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), `"target-basename"`) {
@@ -1975,8 +1993,12 @@ func TestDoInitBootstrapWithNameOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing updated city.toml: %v", err)
 	}
-	if cfg.Workspace.Name != "new-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "new-name")
+	if cfg.Workspace.Name != "old-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "old-name")
+	}
+	binding := mustLoadSiteBinding(t, f, "/city")
+	if binding.WorkspaceName != "new-name" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "new-name")
 	}
 }
 
@@ -1997,8 +2019,12 @@ func TestDoInitBootstrapTrimsNameOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing updated city.toml: %v", err)
 	}
-	if cfg.Workspace.Name != "new-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "new-name")
+	if cfg.Workspace.Name != "old-name" {
+		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "old-name")
+	}
+	binding := mustLoadSiteBinding(t, f, "/city")
+	if binding.WorkspaceName != "new-name" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "new-name")
 	}
 }
 
@@ -2818,8 +2844,8 @@ scale_check = "echo 3"
 		t.Errorf("stdout missing source filename: %q", out)
 	}
 
-	// Verify city.toml was written with the basename fallback since the
-	// source had no explicit workspace.name.
+	// Verify city.toml keeps only shared config while the chosen local name
+	// is written to .gc/site.toml.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
@@ -2828,8 +2854,8 @@ scale_check = "echo 3"
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q (dir basename fallback)", cfg.Workspace.Name, "bright-lights")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
 	}
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
@@ -2837,10 +2863,17 @@ scale_check = "echo 3"
 	if len(cfg.Agents) != 0 {
 		t.Fatalf("len(raw city Agents) = %d, want 0", len(cfg.Agents))
 	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "bright-lights" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "bright-lights")
+	}
 
 	composed, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("loading composed config: %v", err)
+	}
+	if got := config.EffectiveCityName(composed, ""); got != "bright-lights" {
+		t.Fatalf("EffectiveCityName = %q, want %q", got, "bright-lights")
 	}
 	explicit := explicitAgents(composed.Agents)
 	if len(explicit) != 2 {
@@ -3077,9 +3110,9 @@ func TestCmdInitFromTOMLFileAlreadyInitializedByCityToml(t *testing.T) {
 	}
 }
 
-// Regression for #795: gc init --file must preserve workspace.name from the
-// source template rather than silently replacing it with the target dir
-// basename. The --name override still wins over the source.
+// Regression for #795: gc init --file must preserve the source template's
+// intended identity as the initial site-bound city name, and the --name
+// override still wins over that source default.
 func TestCmdInitFromTOMLFileNamePriority(t *testing.T) {
 	tomlWithName := []byte(`[workspace]
 name = "mining"
@@ -3139,8 +3172,12 @@ prompt_template = "prompts/mayor.md"
 			if err != nil {
 				t.Fatalf("parsing written config: %v", err)
 			}
-			if cfg.Workspace.Name != tt.wantName {
-				t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, tt.wantName)
+			if cfg.Workspace.Name != "" {
+				t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
+			}
+			binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+			if binding.WorkspaceName != tt.wantName {
+				t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, tt.wantName)
 			}
 
 			if tt.checkPack {
@@ -3203,7 +3240,8 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 		t.Errorf("stdout missing city name: %q", out)
 	}
 
-	// Verify city.toml was copied and basename fallback applied.
+	// Verify city.toml was copied with shared config only, while the local
+	// identity is written to .gc/site.toml using the basename fallback.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
@@ -3212,11 +3250,15 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q (dir basename fallback)", cfg.Workspace.Name, "bright-lights")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
 	}
 	if cfg.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
+	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "bright-lights" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "bright-lights")
 	}
 
 	// Verify files were copied.
@@ -3231,8 +3273,8 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 }
 
 // Regression for the #795 parallel-sibling: gc init --from must preserve an
-// explicit workspace.name set on the template city.toml rather than silently
-// replacing it with the target directory basename.
+// explicit source name as the initial site-bound city identity rather than
+// silently replacing it with the target directory basename.
 func TestDoInitFromDirPreservesSourceName(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
@@ -3268,8 +3310,12 @@ func TestDoInitFromDirPreservesSourceName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Name != "mining" {
-		t.Errorf("Workspace.Name = %q, want %q (source name must be preserved)", cfg.Workspace.Name, "mining")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
+	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "mining" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "mining")
 	}
 }
 
@@ -3278,26 +3324,29 @@ func TestResolveCityName(t *testing.T) {
 		name         string
 		nameOverride string
 		sourceName   string
+		sourcePack   string
 		cityPath     string
 		want         string
 	}{
-		{"override wins over source and dir", "custom", "template", "/path/to/dir", "custom"},
-		{"override wins over dir when no source", "custom", "", "/path/to/dir", "custom"},
-		{"source preserved when no override", "", "template", "/path/to/dir", "template"},
-		{"dir basename used as fallback when both empty", "", "", "/path/to/dir", "dir"},
+		{"override wins over source and dir", "custom", "template", "", "/path/to/dir", "custom"},
+		{"override wins over dir when no source", "custom", "", "", "/path/to/dir", "custom"},
+		{"source preserved when no override", "", "template", "pack-template", "/path/to/dir", "template"},
+		{"source pack used when workspace name absent", "", "", "pack-template", "/path/to/dir", "pack-template"},
+		{"dir basename used as fallback when both empty", "", "", "", "/path/to/dir", "dir"},
 		// Whitespace trimming matches runtime config.EffectiveCityName so
 		// that a stray-space name resolves identically at init and runtime.
-		{"override trims whitespace", "  custom  ", "template", "/path/to/dir", "custom"},
-		{"source trims whitespace", "", "  mining  ", "/path/to/dir", "mining"},
-		{"whitespace-only override falls through to source", "   ", "template", "/path/to/dir", "template"},
-		{"whitespace-only source falls through to basename", "", "   ", "/path/to/dir", "dir"},
+		{"override trims whitespace", "  custom  ", "template", "", "/path/to/dir", "custom"},
+		{"source trims whitespace", "", "  mining  ", "", "/path/to/dir", "mining"},
+		{"whitespace-only override falls through to source", "   ", "template", "", "/path/to/dir", "template"},
+		{"whitespace-only source falls through to pack name", "", "   ", "pack-template", "/path/to/dir", "pack-template"},
+		{"whitespace-only source pack falls through to basename", "", "   ", "   ", "/path/to/dir", "dir"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveCityName(tt.nameOverride, tt.sourceName, tt.cityPath)
+			got := resolveCityName(tt.nameOverride, tt.sourceName, tt.sourcePack, tt.cityPath)
 			if got != tt.want {
-				t.Errorf("resolveCityName(%q, %q, %q) = %q, want %q",
-					tt.nameOverride, tt.sourceName, tt.cityPath, got, tt.want)
+				t.Errorf("resolveCityName(%q, %q, %q, %q) = %q, want %q",
+					tt.nameOverride, tt.sourceName, tt.sourcePack, tt.cityPath, got, tt.want)
 			}
 		})
 	}
@@ -3339,8 +3388,12 @@ func TestInitNameFlagWithFrom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.Workspace.Name != "my-custom-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-custom-name")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
+	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "my-custom-name" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "my-custom-name")
 	}
 }
 
@@ -3405,8 +3458,12 @@ func TestInitNameFlagWithFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.Workspace.Name != "my-file-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-file-name")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
+	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "my-file-name" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "my-file-name")
 	}
 }
 
@@ -3435,15 +3492,19 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.Workspace.Name != "my-bare-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-bare-name")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
 	}
 	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
 	if err != nil {
 		t.Fatalf("reading pack.toml: %v", err)
 	}
 	if !strings.Contains(string(packData), `name = "my-bare-name"`) {
-		t.Errorf("pack.toml should keep init name aligned with workspace.name, got:\n%s", string(packData))
+		t.Errorf("pack.toml should keep init name aligned with bare-init name, got:\n%s", string(packData))
+	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "my-bare-name" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "my-bare-name")
 	}
 }
 
@@ -3486,8 +3547,12 @@ func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.Workspace.Name != "my-new-city" {
-		t.Errorf("Workspace.Name = %q, want %q (--from should default to target dir basename)", cfg.Workspace.Name, "my-new-city")
+	if cfg.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty in city.toml", cfg.Workspace.Name)
+	}
+	binding := mustLoadSiteBinding(t, fsys.OSFS{}, cityPath)
+	if binding.WorkspaceName != "my-new-city" {
+		t.Fatalf("binding.WorkspaceName = %q, want %q", binding.WorkspaceName, "my-new-city")
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -103,7 +103,7 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 		stderr:     stderr,
 		maxTimeout: cfg.Orders.MaxTimeoutDuration(),
 		cfg:        cfg,
-		cityName:   cfg.Workspace.Name,
+		cityName:   loadedCityName(cfg, cityPath),
 	}
 }
 

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -61,10 +61,7 @@ func sessionProviderContextForCity(cfg *config.City, cityPath, providerOverride 
 		return ctx
 	}
 	ctx.sc = cfg.Session
-	ctx.cityName = cfg.Workspace.Name
-	if ctx.cityName == "" {
-		ctx.cityName = filepath.Base(cityPath)
-	}
+	ctx.cityName = loadedCityName(cfg, cityPath)
 	ctx.agents = cfg.Agents
 	ctx.sessionTemplate = cfg.Workspace.SessionTemplate
 	if ctx.providerName == "" {

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -604,16 +604,17 @@ schema, plus the qualified rows that matter most during migration.
 
 > **Current rollout note:** Some rows below describe the target PackV2
 > destination rather than the exact state of every in-flight branch. In
-> release v0.15.0, `workspace.name` still lives in `city.toml`.
-> Phase A rig-binding work removes machine-local `rigs.path` from newly
-> written city configs, but `rigs.prefix` and `rigs.suspended` remain in
-> `city.toml` as of release v0.15.0.
+> the current 15.0 wave, machine-local workspace identity (`workspace.name`,
+> `workspace.prefix`) and `rigs.path` now live in `.gc/site.toml` for newly
+> written or migrated cities. `rigs.prefix` and `rigs.suspended` remain in
+> `city.toml` in this release.
 
 | 0.14.0 element | What it did | New home or action |
 |---|---|---|
 | `include` | Merged extra config fragments into `city.toml` before load | Remove as part of migration. Move real composition to imports and move remaining config to `pack.toml`, `city.toml`, or discovered directories. |
 | `[workspace]` | Held city metadata and pack composition in one place | Split across the root `pack.toml`, `city.toml`, and `.gc/`. |
-| `workspace.name` | Workspace identity | As of release v0.15.0, this remains transitional. Keep it in `city.toml` for the current migration slice. Fresh `gc init` keeps it aligned with `pack.name`; `gc register` uses it when present, otherwise falls back to `pack.name`, and stores the selected registration name in the machine-local supervisor registry without backfilling `city.toml`. Full removal from `city.toml` still waits for the broader site-binding cutover; track [#602](https://github.com/gastownhall/gascity/issues/602). |
+| `workspace.name` | Workspace identity | Move to `.gc/site.toml` as `workspace_name`. Runtime identity resolves from registered alias (supervisor-managed flows), then site binding / legacy config, then directory basename. `pack.name` remains the portable definition identity and init-time default only. |
+| `workspace.prefix` | Workspace bead prefix | Move to `.gc/site.toml` as `workspace_prefix`. Runtime/API surfaces use the effective site-bound prefix when present and otherwise derive from the effective city name. |
 | `workspace.includes` | City-level pack composition | Move to `[imports.*]` in the root city `pack.toml`. |
 | `workspace.default_rig_includes` | Default pack composition for newly added rigs | Move to `[defaults.rig.imports]` in the root city `pack.toml`. This is the target shape, but loader-backed support is still tracked in [#360](https://github.com/gastownhall/gascity/issues/360). |
 | `[providers.*]` | Named provider presets | Usually move to `[providers.*]` in the root city `pack.toml`, unless the setting is truly deployment-only. |

--- a/docs/packv2/doc-conformance-matrix.md
+++ b/docs/packv2/doc-conformance-matrix.md
@@ -75,7 +75,7 @@ These are settled enough, and implemented enough, to block CI now.
 | Commands discovery | The default `commands/<name>/run.sh` discovery path works; final manifest shape remains non-gating | Unit + testscript | `internal/config/command_discovery.go` |
 | Doctor discovery | The default `doctor/<name>/run.sh` discovery path works | Unit + testscript | `internal/config/doctor_discovery.go` |
 | Legacy migration rewrite | `gc doctor` inventories legacy Pack/City v1 usage and `gc doctor --fix` performs the safe mechanical rewrites for agent directories, prompt/overlay/namepool moves, and import-oriented composition. Legacy remote `workspace.includes` is a hard-break migration issue, not a runtime compatibility target. | Testscript | `cmd/gc/doctor_v2_checks.go`, migration fix path TBD |
-| Registration naming | `gc register --name` stores the chosen machine-local alias in the supervisor registry without mutating `city.toml`; plain `gc register` uses `workspace.name` if present, otherwise `pack.name`, and stores that value in the registry without backfilling `workspace.name` | Unit | `cmd/gc/cmd_register.go`, `cmd/gc/cmd_supervisor_city.go`, `internal/supervisor/registry.go` |
+| Registration naming | `gc register --name` stores the chosen machine-local alias in the supervisor registry without mutating `city.toml`; plain `gc register` uses the effective city identity (site binding / legacy config / basename) and stores that value in the registry without backfilling `city.toml` | Unit | `cmd/gc/cmd_register.go`, `cmd/gc/cmd_supervisor_city.go`, `internal/supervisor/registry.go` |
 
 ## Add To CI When Warning Plumbing Lands
 
@@ -91,7 +91,7 @@ warning surface is implemented end to end.
 | Legacy prompt injection | `global_fragments`, `inject_fragments`, and `inject_fragments_append` emit deprecation warnings toward `append_fragments` or explicit `{{ template }}` | Testscript + unit |
 | Legacy fallback model | `fallback` emits a loud warning and is not part of the v.next authoring surface | Testscript |
 | Legacy path wiring | `prompt_template`, `overlay_dir`, and `namepool` on legacy agent definitions warn during migration-facing flows | Testscript |
-| Workspace soft deprecations | `workspace.start_command`, `workspace.name`, `workspace.prefix`, and any future workspace-surface migration warnings must not imply that runtime precedence already matches a later design | Testscript |
+| Workspace soft deprecations | `workspace.provider`, `workspace.start_command`, and `workspace.install_agent_hooks` warn with the documented replacement path; `workspace.name` and `workspace.prefix` now have an active site-binding migration path via `gc doctor --fix` | Testscript |
 | Formula directory path | `[formulas].dir = "formulas"` soft-warns; any other value is rejected | Unit + testscript |
 | Rig override naming | `rig.overrides` is accepted with a soft warning in favor of `rig.patches` | Unit + testscript |
 | Fragment-only include | top-level `include` stays fragment-only and rejects pack-composition content such as `[imports]`, include-based composition, or `pack.toml` references | Unit + testscript |
@@ -108,7 +108,7 @@ unsettled to be reliable release gates.
 | `patches/` directory convention for imported prompt replacements | documented in v.next docs, not implemented | Current implementation still relies on explicit patch fields rather than full loader-discovered patch files |
 | Pack `skills/` discovery | documented, not implemented | First slice is current-city-pack only with list-only visibility; imported-pack catalogs are later |
 | `mcp/` TOML abstraction | documented, not implemented | Same first-slice scope as skills: current-city-pack only, list-only visibility first, provider projection later |
-| `.gc/site.toml` rig-path split (`#588`) | implemented for `rig.path` | Loader overlays `.gc/site.toml`, commands write site bindings, and `gc doctor --fix` migrates legacy `rig.path`; `rig.prefix` / `rig.suspended` remain in `city.toml` in Phase A |
+| `.gc/site.toml` site-binding split | implemented for workspace identity + `rig.path` | Loader overlays `.gc/site.toml`, commands write site bindings, and `gc doctor --fix` migrates legacy `workspace.name`, `workspace.prefix`, and `rig.path`; `rig.prefix` / `rig.suspended` remain in `city.toml` in this phase |
 | Final doctor manifest symmetry/shape | still under-specified | Discovery is testable now, but the final manifest shape should not be frozen by the first-pass suite |
 | Command collision rules and final command/doctor manifest shape | still under-specified | The docs still use "current preferred direction" language rather than frozen contract language |
 | Legacy cleanup surfaces | e.g. stale `.order.` / `.formula.` references in old docs/examples or dismantling `[workspace]` | Keep as handoff cleanup, but do not treat it as a current-wave ship gate |

--- a/docs/packv2/doc-pack-v2.md
+++ b/docs/packv2/doc-pack-v2.md
@@ -136,9 +136,9 @@ Everything else — agents, named sessions, providers, formulas, prompts, script
 
 #### Names, prefixes, and generation
 
-`gc init` and `gc rig add` generate names and prefixes by default. Users can override with `--name` and `--prefix` (typically to resolve conflicts). In this rollout, `gc init --name` keeps definition and runtime identity aligned by writing the chosen name to both `pack.toml` and `city.toml`.
+`gc init` and `gc rig add` generate names and prefixes by default. Users can override with `--name` and `--prefix` (typically to resolve conflicts). `gc init` now writes the chosen machine-local workspace name/prefix to `.gc/site.toml`; `pack.toml` keeps the portable definition identity.
 
-`gc register` accepts `--name` to set the city's registration name explicitly. The chosen name is stored in the machine-local supervisor registry and is not written back to `city.toml`. When `--name` is omitted, `gc register` uses `workspace.name` if present; otherwise it falls back to `pack.name` and stores that value in the registry. `gc register` does not rewrite `city.toml` or `pack.toml`. ([#602](https://github.com/gastownhall/gascity/issues/602))
+`gc register` accepts `--name` to set the city's registration name explicitly. The chosen name is stored in the machine-local supervisor registry and is not written back to `city.toml`. When `--name` is omitted, `gc register` uses the current effective city identity (site-bound workspace name if present, otherwise legacy `workspace.name`, otherwise the directory basename) and stores that value in the registry. `gc register` does not rewrite `city.toml` or `pack.toml`. ([#602](https://github.com/gastownhall/gascity/issues/602))
 
 Names and prefixes are both managed by `gc`, but the current Phase A rollout only moves the machine-local rig path into `.gc/`. Rig names, prefixes, and suspended flags still live in `city.toml` for now. Names are human-facing labels; prefixes are derived from names and baked into bead IDs. Neither should be casually changed after creation.
 
@@ -152,9 +152,9 @@ If `gc` detects a mismatch between a rig name in city.toml and its managed state
 
 `pack.name` is the identity of the definition — "this pack is called gastown." It lives in `pack.toml`, is portable, and travels with the pack when imported.
 
-`workspace.name` is still a transitional runtime identity surface in this rollout. `gc init` keeps fresh cities stable by writing the same chosen name to both `pack.toml` and `city.toml`. `gc register` now treats the supervisor registry as the machine-local source of truth for registration identity: an explicit `--name` alias can differ from committed `workspace.name`, and fallback from `pack.name` is stored only in the registry.
+`workspace.name` and `workspace.prefix` are now legacy compatibility fields. Fresh `gc init` writes machine-local identity to `.gc/site.toml`, and `gc doctor --fix` migrates legacy values out of `city.toml`. `gc register` treats the supervisor registry as the machine-local source of truth for registration identity: an explicit `--name` alias can differ from site-bound or legacy workspace identity, and runtime supervisor-managed flows prefer that registered alias.
 
-The long-term direction remains the same: remove `workspace.name` from `city.toml`, derive portable identity from `pack.name`, and keep machine-local naming in site binding. This PR does not complete that cutover.
+The long-term direction remains the same: keep portable identity in `pack.name`, deployment plan in `city.toml`, and machine-local naming/bindings in site binding under `.gc/`.
 
 The full field-by-field migration is in the appendix.
 
@@ -404,7 +404,7 @@ Per-machine state lives in `.gc/` and is managed by `gc` commands:
 
 The rule: **if it's in a checked-in TOML file, it's definition or deployment. If it's in `.gc/`, it's site binding.** No gray area.
 
-> **Current rollout ([#588](https://github.com/gastownhall/gascity/issues/588)):** `rig.path` now lives in `.gc/site.toml`. The loader overlays site binding onto `city.toml` at load time, ignores legacy `rig.path` entries for runtime use, and `gc doctor --fix` migrates the legacy path into `.gc/site.toml`. Phase A only moves `rig.path`: `rig.prefix` and `rig.suspended` remain in `city.toml` for now.
+> **Current rollout:** workspace identity (`workspace.name`, `workspace.prefix`) and `rig.path` now live in `.gc/site.toml`. The loader overlays site binding onto `city.toml` at load time, legacy authored values still read during migration, and `gc doctor --fix` migrates the legacy fields into `.gc/site.toml`. `rig.prefix` and `rig.suspended` remain in `city.toml` for now.
 
 See also [doc-rig-binding-phases.md](doc-rig-binding-phases.md) for the current
 Phase A / Phase B split between path extraction and post-15.0 multi-city rig

--- a/docs/packv2/skew-analysis.md
+++ b/docs/packv2/skew-analysis.md
@@ -91,9 +91,9 @@
 
 | Status | Field | As-built | Current rollout disposition | Later destination |
 |--------|-------|----------|--------------------|-----------------------|
-| 🟡 | `name` | Required string | **Optional.** As of release v0.15.0, this remains a transitional runtime identity field. Fresh `gc init` keeps it aligned with `pack.name`; `gc register` reads it when present but stores registration aliases in the machine-local supervisor registry without backfilling `city.toml`. Soft warning: full site-binding cutover remains later. | `.gc/` site binding (#600) |
-| 🟡 | `prefix` | String | **Optional.** As of release v0.15.0, this gets the same treatment as `name`. Soft warning. | `.gc/` site binding (#600) |
-| 🟢 | `provider` | String | **Keep.** As of release v0.15.0, this is still the current runtime default-provider field. Corresponding `[agent_defaults].provider` is still unsupported and emits a migration warning — see `doc-conformance-matrix.md`. | Later default-provider redesign, not part of this rollout |
+| 🟢 | `name` | Optional string | **Migrated.** Fresh `gc init` writes machine-local identity to `.gc/site.toml`; `gc doctor --fix` migrates legacy values out of `city.toml`; runtime resolves registered alias (supervisor-managed flows), then site binding / legacy config, then basename. | `.gc/` site binding (#600) |
+| 🟢 | `prefix` | String | **Migrated.** Fresh `gc init` writes machine-local prefix to `.gc/site.toml`; `gc doctor --fix` migrates legacy values out of `city.toml`. | `.gc/` site binding (#600) |
+| 🟡 | `provider` | String | **Soft warning.** "Use `[agent_defaults] provider = ...` instead." | `[agent_defaults]` in pack.toml |
 | 🟡 | `start_command` | String | **Soft warning.** "Use per-agent `start_command` in `agent.toml` instead." | Per-agent `agent.toml` |
 | 🟡 | `suspended` | Boolean | **Soft warning.** "Use `gc suspend`/`gc resume` instead." | `.gc/` site binding |
 | 🟢 | `max_active_sessions` | Integer | **Keep as-is.** Deployment capacity. | Top-level city.toml field when `[workspace]` is dismantled |
@@ -259,11 +259,11 @@ All Import fields match spec. No changes needed.
 | 🟢 | `orders/` top-level discovery | doc-directory-conventions | `discoverFlatFiles` in orders/discovery.go |
 | 🟢 | `commands/` convention discovery | doc-commands | `DiscoverPackCommands` in command_discovery.go |
 | 🔴 | `[defaults.rig.imports]` loader support | doc-pack-v2 | Migrate tool writes it, loader ignores it |
-| 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented. The current rollout stores the chosen registration name in the machine-local supervisor registry without rewriting `city.toml`; no-flag registration uses `workspace.name` first, then `pack.name`, and stores the selected name only in the registry. |
+| 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented. The current rollout stores the chosen registration name in the machine-local supervisor registry without rewriting `city.toml`; no-flag registration uses the effective city identity (site binding / legacy config / basename) and stores the selected name only in the registry. |
 | 🔴 | `patches/` directory convention | doc-agent-v2 | Not implemented |
 | 🔴 | `skills/` pack discovery | doc-agent-v2 | First slice is current-city-pack only with list-only visibility; imported-pack catalogs are later |
 | 🔴 | `mcp/` TOML abstraction | doc-agent-v2 | First slice is current-city-pack only with list-only visibility; provider projection is later |
-| 🟢 | `.gc/site.toml` for rig path bindings | doc-pack-v2 | Implemented in #588 Phase A (`rig.path` only) |
+| 🟢 | `.gc/site.toml` for workspace identity + rig path bindings | doc-pack-v2 | Implemented. `workspace.name`, `workspace.prefix`, and `rig.path` now migrate into site binding state. |
 | 🔵 | Pack/Deployment/SiteBinding struct separation | doc-loader-v2 | Loader composes into one City struct |
 | 🔵 | Pack-defined `[[service]]` | — | #657 |
 | 🔵 | Expansion of `[agent_defaults]` to all agent fields | — | later wave |
@@ -274,6 +274,6 @@ All Import fields match spec. No changes needed.
 
 1. **Deprecation warning infrastructure** — implement loud and soft warnings for all V1 fields listed above.
 2. **Loud warnings for schema 2 cities** using `[[agent]]`, `workspace.includes`, `workspace.default_rig_includes`, `[packs]`, `rigs.includes`, `rigs.formulas_dir`, `fallback`, `inject_fragments`.
-3. **Soft warnings** for `workspace.name`, `workspace.prefix`, `workspace.provider`, `workspace.start_command`, `workspace.suspended`, `workspace.install_agent_hooks`, `workspace.global_fragments`, `rigs.overrides`, `[formulas].dir`.
+3. **Soft warnings** for `workspace.provider`, `workspace.start_command`, `workspace.suspended`, `workspace.install_agent_hooks`, `workspace.global_fragments`, `rigs.overrides`, `[formulas].dir`.
 4. **Hard error** for `[formulas].dir` set to anything other than `"formulas"`.
 5. **Hard error** for `include` fragments that contain `[imports]`, `includes`, or reference `pack.toml`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1120,7 +1120,7 @@ gc init
 | `--bootstrap-profile` | string |  | bootstrap profile to apply for hosted/container defaults |
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
-| `--name` | string |  | workspace name (default: source template's workspace.name if set, else target directory basename) |
+| `--name` | string |  | machine-local city name (default: source template's workspace.name if set, else source pack.name if set, else target directory basename) |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
 | `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
 
@@ -1530,8 +1530,9 @@ Register a city directory with the machine-wide supervisor.
 If no path is given, registers the current city (discovered from cwd).
 Use --name to set the machine-local registration alias. The alias is stored
 in the machine-local supervisor registry and never written back to city.toml.
-When --name is omitted, workspace.name is used if present, otherwise
-[pack].name is used — in either case city.toml is not modified.
+When --name is omitted, the current effective city identity is used
+(site-bound workspace name if present, otherwise legacy workspace.name,
+otherwise the directory basename) — in every case city.toml is not modified.
 Registration is idempotent — registering the same city twice is a no-op.
 The supervisor is started if needed and immediately reconciles the city.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -555,7 +555,7 @@ SessionConfig holds session provider settings.
 | `debounce_ms` | integer |  | `500` | DebounceMs is the default debounce interval in milliseconds for send-keys. Defaults to 500. |
 | `display_ms` | integer |  | `5000` | DisplayMs is the default display duration in milliseconds for status messages. Defaults to 5000. |
 | `startup_timeout` | string |  | `60s` | StartupTimeout is how long to wait for each agent's Start() call before treating it as failed. Duration string (e.g., "60s", "2m"). Defaults to "60s". |
-| `socket` | string |  |  | Socket specifies the tmux socket name for per-city isolation. When set, all tmux commands use "tmux -L &lt;socket&gt;" to connect to a dedicated server. When empty, defaults to the city name (workspace.name) — giving every city its own tmux server automatically. Set explicitly to override. |
+| `socket` | string |  |  | Socket specifies the tmux socket name for per-city isolation. When set, all tmux commands use "tmux -L &lt;socket&gt;" to connect to a dedicated server. When empty, defaults to the effective city name (site binding, legacy config, or basename) — giving every city its own tmux server automatically. Set explicitly to override. |
 | `remote_match` | string |  |  | RemoteMatch is a substring pattern for the hybrid provider to route sessions to the remote (K8s) backend. Sessions whose names contain this pattern go to K8s; all others stay local (tmux). Overridden by the GC_HYBRID_REMOTE_MATCH env var if set. |
 
 ## SessionSleepConfig
@@ -574,7 +574,7 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `name` | string | **yes** |  | Name is the human-readable name for this city. |
+| `name` | string |  |  | Name is the legacy checked-in city name. Runtime identity now resolves from site binding, legacy config, and basename precedence instead. |
 | `prefix` | string |  |  | Prefix overrides the auto-derived HQ bead ID prefix. When empty, the prefix is derived from the city Name via DeriveBeadsPrefix. |
 | `provider` | string |  |  | Provider is the default provider name used by agents that don't specify one. |
 | `start_command` | string |  |  | StartCommand overrides the provider's command for all agents. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1889,7 +1889,7 @@
         },
         "socket": {
           "type": "string",
-          "description": "Socket specifies the tmux socket name for per-city isolation.\nWhen set, all tmux commands use \"tmux -L \u003csocket\u003e\" to connect to\na dedicated server. When empty, defaults to the city name\n(workspace.name) — giving every city its own tmux server\nautomatically. Set explicitly to override."
+          "description": "Socket specifies the tmux socket name for per-city isolation.\nWhen set, all tmux commands use \"tmux -L \u003csocket\u003e\" to connect to\na dedicated server. When empty, defaults to the effective city name\n(site binding, legacy config, or basename) — giving every city its own tmux server\nautomatically. Set explicitly to override."
         },
         "remote_match": {
           "type": "string",
@@ -1923,7 +1923,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name is the human-readable name for this city."
+          "description": "Name is the legacy checked-in city name. Runtime identity now resolves\nfrom site binding, legacy config, and basename precedence instead."
         },
         "prefix": {
           "type": "string",
@@ -1980,9 +1980,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "name"
-      ],
       "description": "Workspace holds city-level metadata and optional defaults that apply to all agents unless overridden per-agent."
     }
   },

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1889,7 +1889,7 @@
         },
         "socket": {
           "type": "string",
-          "description": "Socket specifies the tmux socket name for per-city isolation.\nWhen set, all tmux commands use \"tmux -L \u003csocket\u003e\" to connect to\na dedicated server. When empty, defaults to the city name\n(workspace.name) — giving every city its own tmux server\nautomatically. Set explicitly to override."
+          "description": "Socket specifies the tmux socket name for per-city isolation.\nWhen set, all tmux commands use \"tmux -L \u003csocket\u003e\" to connect to\na dedicated server. When empty, defaults to the effective city name\n(site binding, legacy config, or basename) — giving every city its own tmux server\nautomatically. Set explicitly to override."
         },
         "remote_match": {
           "type": "string",
@@ -1923,7 +1923,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name is the human-readable name for this city."
+          "description": "Name is the legacy checked-in city name. Runtime identity now resolves\nfrom site binding, legacy config, and basename precedence instead."
         },
         "prefix": {
           "type": "string",
@@ -1980,9 +1980,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "name"
-      ],
       "description": "Workspace holds city-level metadata and optional defaults that apply to all agents unless overridden per-agent."
     }
   },

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -6716,7 +6716,16 @@
       "WorkspaceResponse": {
         "additionalProperties": false,
         "properties": {
+          "declared_name": {
+            "type": "string"
+          },
+          "declared_prefix": {
+            "type": "string"
+          },
           "name": {
+            "type": "string"
+          },
+          "prefix": {
             "type": "string"
           },
           "provider": {

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -6716,7 +6716,16 @@
       "WorkspaceResponse": {
         "additionalProperties": false,
         "properties": {
+          "declared_name": {
+            "type": "string"
+          },
+          "declared_prefix": {
+            "type": "string"
+          },
           "name": {
+            "type": "string"
+          },
+          "prefix": {
             "type": "string"
           },
           "provider": {

--- a/engdocs/proposals/workspace-identity-site-binding-implementation-plan.md
+++ b/engdocs/proposals/workspace-identity-site-binding-implementation-plan.md
@@ -1,0 +1,169 @@
+---
+title: "Workspace Identity Site Binding — Implementation Plan"
+---
+
+Companion to GitHub issue `#600` and beads issue `ga-h6h43`.
+
+This plan finishes the PackV2 identity cutover that earlier work only started:
+
+- `#850` moved `rig.path` into `.gc/site.toml`
+- `#923` made registration aliases machine-local
+- `#853` preserved template `workspace.name` during `gc init`
+
+The remaining work is to move workspace identity and prefix into site binding,
+resolve effective identity early, and make runtime/API/doctor surfaces use the
+effective values rather than raw `city.toml` fields.
+
+## Decisions
+
+- Runtime name precedence:
+  1. registered alias when the city is running under the supervisor
+  2. site-bound workspace name from `.gc/site.toml`
+  3. directory basename fallback
+- `pack.name` is not a runtime identity source; it is only an init-time default
+- Prefix moves in the same slice as name
+- Operational config/API surfaces expose effective identity by default
+- Raw declared values remain available only where migration/debugging needs them
+
+## Acceptance
+
+- `city.toml` can omit `workspace.name` and `workspace.prefix` after migration
+- `gc doctor` is clean for migrated PackV2 cities
+- runtime naming, session naming, `GC_CITY_NAME`, and HQ prefix use effective identity
+- `gc init*` writes machine-local identity into `.gc/site.toml`
+- `gc doctor --fix` migrates legacy workspace name/prefix into `.gc/site.toml`
+- legacy configs remain readable during the migration window
+
+## Phase 1: Site Binding Foundation
+
+### 1A. Extend `.gc/site.toml` schema
+**Files:** `internal/config/site_binding.go`, `internal/config/site_binding_test.go`, `docs/packv2/doc-loader-v2.md`
+
+**Scope:**
+- add workspace name/prefix fields to `SiteBinding`
+- add helpers to apply workspace identity from site binding
+- keep rig binding behavior unchanged
+
+**Verification:**
+- unit tests for load/apply/persist of workspace name/prefix
+
+### 1B. Resolve effective identity in config load
+**Files:** `internal/config/config.go`, `internal/config/named_sessions.go`, `internal/config/compose.go`, relevant tests
+
+**Scope:**
+- formalize helpers for effective city name and effective HQ prefix
+- set effective identity from site binding before named-session validation
+- preserve basename fallback when no site-bound name exists
+
+**Verification:**
+- unit tests proving named-session validation uses site-bound name
+- unit tests proving prefix resolution uses site-bound prefix
+
+## Phase 2: Runtime and CLI Cutover
+
+### 2A. Replace raw workspace-name consumers
+**Files:** runtime/CLI callers currently reading `cfg.Workspace.Name` or `cfg.Workspace.Prefix`
+
+**Primary surfaces:**
+- `cmd/gc/providers.go`
+- `cmd/gc/cmd_hook.go`
+- `cmd/gc/cmd_status.go`
+- `cmd/gc/cmd_events.go`
+- `cmd/gc/cmd_mail.go`
+- `cmd/gc/cmd_prime.go`
+- `cmd/gc/order_dispatch.go`
+- `internal/workdir/workdir.go`
+- other session/runtime name helpers discovered during implementation
+
+**Scope:**
+- switch these paths to effective identity helpers
+- keep raw config access only where editing/migration needs it
+
+**Verification:**
+- targeted unit tests for session names, `GC_CITY_NAME`, workdir expansion, and prefix consumers
+
+### 2B. Align standalone controller/runtime behavior
+**Files:** `cmd/gc/controller.go`, `cmd/gc/city_runtime.go`, `cmd/gc/cmd_supervisor.go`, tests
+
+**Scope:**
+- make reload/name-lock logic compare effective identity, not only `workspace.name`
+- keep supervisor registered alias authoritative when present
+- ensure standalone runtime uses site-bound/basename identity consistently
+
+**Verification:**
+- controller reload tests
+- supervisor initialization tests
+
+## Phase 3: Init, Migration, and Doctor
+
+### 3A. Write site-bound identity on init
+**Files:** `cmd/gc/cmd_init.go`, `cmd/gc/main_test.go`, init txtar fixtures
+
+**Scope:**
+- `gc init`, `gc init --file`, and `gc init --from` write workspace name/prefix to `.gc/site.toml`
+- `pack.name` remains the init-time default only
+- new writes stop persisting workspace name/prefix into `city.toml`
+
+**Verification:**
+- targeted init tests
+- txtar coverage for fresh init, file-based init, and template init
+
+### 3B. Migrate legacy workspace identity out of `city.toml`
+**Files:** `cmd/gc/doctor_v2_checks.go`, `cmd/gc/doctor_v2_checks_test.go`, `internal/configedit/...`
+
+**Scope:**
+- add a `gc doctor --fix` migration for `workspace.name` and `workspace.prefix`
+- keep legacy read fallback until migration completes
+- define conflict handling when site binding and legacy fields disagree
+
+**Verification:**
+- migration tests for happy path, conflict path, and idempotent rerun
+
+### 3C. Make doctor clean for migrated cities
+**Files:** `internal/doctor/checks.go`, `cmd/gc/doctor_v2_checks.go`, tests
+
+**Scope:**
+- stop warning just because `workspace.name` is absent
+- retire or rewrite the `v2-workspace-name` warning
+- report healthy state when effective identity is site-bound or basename-derived
+
+**Verification:**
+- doctor tests proving migrated cities are warning-free
+
+## Phase 4: API, Docs, and Schema
+
+### 4A. Expose effective identity in API/config surfaces
+**Files:** `internal/api/huma_handlers_config.go`, config/status handlers, related tests
+
+**Scope:**
+- `/v0/config` and related operational endpoints return effective name/prefix
+- if needed, expose raw declared values only in explain/debug surfaces
+
+**Verification:**
+- API response tests for effective name/prefix
+
+### 4B. Update docs and schema
+**Files:** `docs/reference/config.md`, `docs/packv2/doc-pack-v2.md`, `docs/packv2/skew-analysis.md`, `docs/guides/migrating-to-pack-vnext.md`, schema/reference outputs
+
+**Scope:**
+- document `.gc/site.toml` as the home of machine-local workspace identity
+- remove stale claims that `workspace.name` is the required runtime identity
+- document `pack.name` as init-only default
+
+**Verification:**
+- doc/schema regeneration checks used by the repo
+
+## Execution Order
+
+1. Phase 1A
+2. Phase 1B
+3. Phase 2A
+4. Phase 2B
+5. Phase 3A
+6. Phase 3B
+7. Phase 3C
+8. Phase 4A
+9. Phase 4B
+
+Each phase should keep the repo building and the targeted tests green before
+moving on.

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2582,7 +2582,10 @@ type WorkflowSnapshotResponse struct {
 
 // WorkspaceResponse defines model for WorkspaceResponse.
 type WorkspaceResponse struct {
+	DeclaredName    *string `json:"declared_name,omitempty"`
+	DeclaredPrefix  *string `json:"declared_prefix,omitempty"`
 	Name            string  `json:"name"`
+	Prefix          *string `json:"prefix,omitempty"`
 	Provider        *string `json:"provider,omitempty"`
 	SessionTemplate *string `json:"session_template,omitempty"`
 	Suspended       bool    `json:"suspended"`

--- a/internal/api/handler_config.go
+++ b/internal/api/handler_config.go
@@ -18,6 +18,9 @@ type configResponse struct {
 
 type workspaceResponse struct {
 	Name            string `json:"name"`
+	Prefix          string `json:"prefix,omitempty"`
+	DeclaredName    string `json:"declared_name,omitempty"`
+	DeclaredPrefix  string `json:"declared_prefix,omitempty"`
 	Provider        string `json:"provider,omitempty"`
 	Suspended       bool   `json:"suspended"`
 	SessionTemplate string `json:"session_template,omitempty"`

--- a/internal/api/handler_config_test.go
+++ b/internal/api/handler_config_test.go
@@ -34,6 +34,9 @@ func TestHandleConfigGet(t *testing.T) {
 	if resp.Workspace.Name != "test-city" {
 		t.Errorf("workspace.name = %q, want %q", resp.Workspace.Name, "test-city")
 	}
+	if resp.Workspace.Prefix != "tc" {
+		t.Errorf("workspace.prefix = %q, want %q", resp.Workspace.Prefix, "tc")
+	}
 	if resp.Workspace.Provider != "claude" {
 		t.Errorf("workspace.provider = %q, want %q", resp.Workspace.Provider, "claude")
 	}
@@ -48,6 +51,38 @@ func TestHandleConfigGet(t *testing.T) {
 	}
 	if _, ok := resp.Providers["custom"]; !ok {
 		t.Error("expected 'custom' in providers")
+	}
+}
+
+func TestHandleConfigGet_UsesEffectiveWorkspaceIdentity(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityName = "machine-alias"
+	fs.cfg.Workspace.Name = "declared-city"
+	fs.cfg.Workspace.Prefix = "dc"
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/config"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp configResponse
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+
+	if resp.Workspace.Name != "machine-alias" {
+		t.Errorf("workspace.name = %q, want %q", resp.Workspace.Name, "machine-alias")
+	}
+	if resp.Workspace.Prefix != "dc" {
+		t.Errorf("workspace.prefix = %q, want %q", resp.Workspace.Prefix, "dc")
+	}
+	if resp.Workspace.DeclaredName != "declared-city" {
+		t.Errorf("workspace.declared_name = %q, want %q", resp.Workspace.DeclaredName, "declared-city")
+	}
+	if resp.Workspace.DeclaredPrefix != "dc" {
+		t.Errorf("workspace.declared_prefix = %q, want %q", resp.Workspace.DeclaredPrefix, "dc")
 	}
 }
 

--- a/internal/api/huma_handlers_config.go
+++ b/internal/api/huma_handlers_config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -10,6 +11,11 @@ import (
 // humaHandleConfigGet is the Huma-typed handler for GET /v0/config.
 func (s *Server) humaHandleConfigGet(_ context.Context, _ *ConfigGetInput) (*IndexOutput[configResponse], error) {
 	cfg := s.state.Config()
+	name := strings.TrimSpace(s.state.CityName())
+	if name == "" {
+		name = config.EffectiveCityName(cfg, "")
+	}
+	prefix := effectiveWorkspacePrefix(cfg, name)
 
 	agents := make([]configAgentResponse, 0, len(cfg.Agents))
 	for _, a := range cfg.Agents {
@@ -48,7 +54,10 @@ func (s *Server) humaHandleConfigGet(_ context.Context, _ *ConfigGetInput) (*Ind
 
 	resp := configResponse{
 		Workspace: workspaceResponse{
-			Name:            cfg.Workspace.Name,
+			Name:            name,
+			Prefix:          prefix,
+			DeclaredName:    strings.TrimSpace(cfg.Workspace.Name),
+			DeclaredPrefix:  strings.TrimSpace(cfg.Workspace.Prefix),
 			Provider:        cfg.Workspace.Provider,
 			Suspended:       cfg.Workspace.Suspended,
 			SessionTemplate: cfg.Workspace.SessionTemplate,
@@ -70,6 +79,19 @@ func (s *Server) humaHandleConfigGet(_ context.Context, _ *ConfigGetInput) (*Ind
 		Index: s.latestIndex(),
 		Body:  resp,
 	}, nil
+}
+
+func effectiveWorkspacePrefix(cfg *config.City, name string) string {
+	if cfg == nil {
+		return config.DeriveBeadsPrefix(name)
+	}
+	if prefix := strings.TrimSpace(cfg.ResolvedWorkspacePrefix); prefix != "" {
+		return prefix
+	}
+	if prefix := strings.TrimSpace(cfg.Workspace.Prefix); prefix != "" {
+		return prefix
+	}
+	return config.DeriveBeadsPrefix(name)
 }
 
 // humaHandleConfigExplain is the Huma-typed handler for GET /v0/config/explain.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -6716,7 +6716,16 @@
       "WorkspaceResponse": {
         "additionalProperties": false,
         "properties": {
+          "declared_name": {
+            "type": "string"
+          },
+          "declared_prefix": {
+            "type": "string"
+          },
           "name": {
+            "type": "string"
+          },
+          "prefix": {
             "type": "string"
           },
           "provider": {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -63,7 +63,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	cityRoot := filepath.Dir(path)
 	prov := newProvenance(path)
 	prov.Warnings = append(prov.Warnings, rootWarnings...)
-	root.ResolvedWorkspaceName = filepath.Base(cityRoot)
 	cityAgentsForProvenance := root.Agents
 
 	// V2: if a pack.toml exists alongside city.toml, it is the city's
@@ -449,8 +448,15 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// layers have been applied so runtime consumers can trust the values.
 	NormalizeSessionSleepFields(root)
 
-	// Validate named session declarations after pack expansion so stamped
-	// identities and referenced templates are final.
+	siteBindingWarnings, err := ApplySiteBindings(fs, cityRoot, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	prov.Warnings = append(prov.Warnings, siteBindingWarnings...)
+
+	// Validate named session declarations after pack expansion and site
+	// binding resolution so stamped identities and deterministic runtime
+	// names reflect the effective workspace identity.
 	if err := ValidateNamedSessions(root); err != nil {
 		return nil, nil, err
 	}
@@ -476,12 +482,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	if warning := WarnDeprecatedAttachmentFields(root); warning != "" {
 		prov.Warnings = append(prov.Warnings, warning)
 	}
-
-	siteBindingWarnings, err := ApplySiteBindings(fs, cityRoot, root)
-	if err != nil {
-		return nil, nil, err
-	}
-	prov.Warnings = append(prov.Warnings, siteBindingWarnings...)
 
 	// v0.15.1: enrich every agent with its convention-discovered
 	// agent-local asset paths (agents/<name>/skills/, agents/<name>/mcp/).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,9 +183,12 @@ type City struct {
 	// imported packs so LoadWithIncludes can surface them through provenance.
 	// Runtime-only — not persisted to TOML or JSON.
 	LoadWarnings []string `toml:"-" json:"-"`
-	// ResolvedWorkspaceName is the effective city name derived from the
-	// config file path when workspace.name is omitted. Runtime-only.
+	// ResolvedWorkspaceName is the effective city name after applying site
+	// binding, declared config, and basename fallback rules. Runtime-only.
 	ResolvedWorkspaceName string `toml:"-" json:"-"`
+	// ResolvedWorkspacePrefix is the effective HQ prefix after applying site
+	// binding and declared config. Runtime-only.
+	ResolvedWorkspacePrefix string `toml:"-" json:"-"`
 
 	// FormulaLayers holds the resolved formula directories per scope.
 	// Populated during pack expansion in LoadWithIncludes. Not from TOML.
@@ -704,18 +707,19 @@ func (r *Rig) EffectivePrefix() string {
 }
 
 // EffectiveHQPrefix returns the bead ID prefix for the city's HQ store.
-// Uses the explicit workspace Prefix if set, otherwise derives one from
-// the city name (falling back to ResolvedWorkspaceName when the TOML
-// name field is omitted).
+// Uses the effective site-bound prefix first, then the declared workspace
+// Prefix, then derives one from the effective city name.
 func EffectiveHQPrefix(cfg *City) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.ResolvedWorkspacePrefix != "" {
+		return cfg.ResolvedWorkspacePrefix
+	}
 	if cfg.Workspace.Prefix != "" {
 		return cfg.Workspace.Prefix
 	}
-	name := cfg.Workspace.Name
-	if name == "" {
-		name = cfg.ResolvedWorkspaceName
-	}
-	return DeriveBeadsPrefix(name)
+	return DeriveBeadsPrefix(cfg.EffectiveCityName())
 }
 
 // DeriveBeadsPrefix computes a short bead ID prefix from a rig/city name.
@@ -781,8 +785,9 @@ func splitCompoundWord(word string) []string {
 // Workspace holds city-level metadata and optional defaults that apply
 // to all agents unless overridden per-agent.
 type Workspace struct {
-	// Name is the human-readable name for this city.
-	Name string `toml:"name" jsonschema:"required"`
+	// Name is the legacy checked-in city name. Runtime identity now resolves
+	// from site binding, legacy config, and basename precedence instead.
+	Name string `toml:"name,omitempty"`
 	// Prefix overrides the auto-derived HQ bead ID prefix. When empty,
 	// the prefix is derived from the city Name via DeriveBeadsPrefix.
 	Prefix string `toml:"prefix,omitempty"`
@@ -862,8 +867,8 @@ type SessionConfig struct {
 	StartupTimeout string `toml:"startup_timeout,omitempty" jsonschema:"default=60s"`
 	// Socket specifies the tmux socket name for per-city isolation.
 	// When set, all tmux commands use "tmux -L <socket>" to connect to
-	// a dedicated server. When empty, defaults to the city name
-	// (workspace.name) — giving every city its own tmux server
+	// a dedicated server. When empty, defaults to the effective city name
+	// (site binding, legacy config, or basename) — giving every city its own tmux server
 	// automatically. Set explicitly to override.
 	Socket string `toml:"socket,omitempty"`
 	// RemoteMatch is a substring pattern for the hybrid provider to route
@@ -2702,7 +2707,9 @@ func Load(fs fsys.FS, path string) (*City, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg.ResolvedWorkspaceName = filepath.Base(filepath.Dir(path))
+	if err := ResolveWorkspaceIdentity(fs, filepath.Dir(path), cfg); err != nil {
+		return nil, err
+	}
 	// Load intentionally skips include and pack expansion, so validate the
 	// direct named-session declarations without requiring pack-provided
 	// backing templates to be present yet.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2706,6 +2706,17 @@ func TestEffectiveHQPrefix_ExplicitPrefixOverridesAll(t *testing.T) {
 	}
 }
 
+func TestEffectiveHQPrefix_ResolvedPrefixOverridesDeclaredPrefix(t *testing.T) {
+	cfg := &City{
+		Workspace:               Workspace{Name: "declared-city", Prefix: "declared"},
+		ResolvedWorkspaceName:   "site-city",
+		ResolvedWorkspacePrefix: "sc",
+	}
+	if got := EffectiveHQPrefix(cfg); got != "sc" {
+		t.Errorf("EffectiveHQPrefix() = %q, want %q", got, "sc")
+	}
+}
+
 // --- Suspended field tests ---
 
 func TestParseSuspended(t *testing.T) {

--- a/internal/config/named_sessions.go
+++ b/internal/config/named_sessions.go
@@ -58,14 +58,15 @@ func FindAgent(cfg *City, identity string) *Agent {
 }
 
 // EffectiveCityName returns the name used for deterministic runtime naming.
-// When workspace.name is omitted, callers may pass a fallback derived from the
-// city path; loaded configs also carry ResolvedWorkspaceName for this purpose.
+// Loaded configs should populate ResolvedWorkspaceName with the effective
+// site-bound/declared/basename result; raw parsed configs may still rely on
+// workspace.name or the provided fallback.
 func EffectiveCityName(cfg *City, fallback string) string {
 	if cfg != nil {
-		if name := strings.TrimSpace(cfg.Workspace.Name); name != "" {
+		if name := strings.TrimSpace(cfg.ResolvedWorkspaceName); name != "" {
 			return name
 		}
-		if name := strings.TrimSpace(cfg.ResolvedWorkspaceName); name != "" {
+		if name := strings.TrimSpace(cfg.Workspace.Name); name != "" {
 			return name
 		}
 	}
@@ -73,8 +74,8 @@ func EffectiveCityName(cfg *City, fallback string) string {
 }
 
 // EffectiveCityName returns the effective deterministic naming prefix for the
-// loaded config. It is empty only when neither workspace.name nor a derived
-// city-root fallback is available.
+// loaded config. It is empty only when neither site-bound/legacy workspace
+// identity nor a derived city-root fallback is available.
 func (c *City) EffectiveCityName() string {
 	return EffectiveCityName(c, "")
 }

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -20,7 +20,9 @@ func SiteBindingPath(cityRoot string) string {
 
 // SiteBinding stores machine-local rig bindings for a city.
 type SiteBinding struct {
-	Rigs []RigSiteBinding `toml:"rig,omitempty"`
+	WorkspaceName   string           `toml:"workspace_name,omitempty"`
+	WorkspacePrefix string           `toml:"workspace_prefix,omitempty"`
+	Rigs            []RigSiteBinding `toml:"rig,omitempty"`
 }
 
 // RigSiteBinding binds a declared rig name to a machine-local path.
@@ -68,6 +70,7 @@ func applySiteBindings(fs fsys.FS, cityRoot string, cfg *City, keepLegacy bool) 
 	if err != nil {
 		return nil, err
 	}
+	applyWorkspaceIdentityBinding(cityRoot, binding, cfg)
 	paths := make(map[string]string, len(binding.Rigs))
 	for _, rig := range binding.Rigs {
 		name := strings.TrimSpace(rig.Name)
@@ -112,10 +115,58 @@ func applySiteBindings(fs fsys.FS, cityRoot string, cfg *City, keepLegacy bool) 
 	return warnings, nil
 }
 
+// ResolveWorkspaceIdentity applies workspace identity from site binding when
+// present, otherwise falls back to declared config and finally directory
+// basename. Callers that need the effective city identity without mutating raw
+// workspace fields should use this helper.
+func ResolveWorkspaceIdentity(fs fsys.FS, cityRoot string, cfg *City) error {
+	if cfg == nil {
+		return nil
+	}
+	binding, err := LoadSiteBinding(fs, cityRoot)
+	if err != nil {
+		return err
+	}
+	applyWorkspaceIdentityBinding(cityRoot, binding, cfg)
+	return nil
+}
+
+func applyWorkspaceIdentityBinding(cityRoot string, binding *SiteBinding, cfg *City) {
+	if cfg == nil {
+		return
+	}
+	name := strings.TrimSpace(filepath.Base(filepath.Clean(cityRoot)))
+	if raw := strings.TrimSpace(cfg.Workspace.Name); raw != "" {
+		name = raw
+	}
+	if binding != nil {
+		if site := strings.TrimSpace(binding.WorkspaceName); site != "" {
+			name = site
+		}
+	}
+	cfg.ResolvedWorkspaceName = name
+
+	prefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	if binding != nil {
+		if site := strings.TrimSpace(binding.WorkspacePrefix); site != "" {
+			prefix = site
+		}
+	}
+	cfg.ResolvedWorkspacePrefix = prefix
+}
+
 // PersistRigSiteBindings writes the current machine-local rig bindings to
 // .gc/site.toml. Rigs without paths are left unbound and omitted.
 func PersistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig) error {
-	binding := SiteBinding{Rigs: make([]RigSiteBinding, 0, len(rigs))}
+	existing, err := LoadSiteBinding(fs, cityRoot)
+	if err != nil {
+		return err
+	}
+	binding := SiteBinding{
+		WorkspaceName:   strings.TrimSpace(existing.WorkspaceName),
+		WorkspacePrefix: strings.TrimSpace(existing.WorkspacePrefix),
+		Rigs:            make([]RigSiteBinding, 0, len(rigs)),
+	}
 	for _, rig := range rigs {
 		name := strings.TrimSpace(rig.Name)
 		path := strings.TrimSpace(rig.Path)
@@ -128,8 +179,27 @@ func PersistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig) error {
 		return binding.Rigs[i].Name < binding.Rigs[j].Name
 	})
 
+	return persistSiteBinding(fs, cityRoot, binding)
+}
+
+// PersistWorkspaceSiteBinding writes machine-local workspace identity to
+// .gc/site.toml while preserving any existing rig bindings.
+func PersistWorkspaceSiteBinding(fs fsys.FS, cityRoot, name, prefix string) error {
+	existing, err := LoadSiteBinding(fs, cityRoot)
+	if err != nil {
+		return err
+	}
+	binding := SiteBinding{
+		WorkspaceName:   strings.TrimSpace(name),
+		WorkspacePrefix: strings.TrimSpace(prefix),
+		Rigs:            append([]RigSiteBinding(nil), existing.Rigs...),
+	}
+	return persistSiteBinding(fs, cityRoot, binding)
+}
+
+func persistSiteBinding(fs fsys.FS, cityRoot string, binding SiteBinding) error {
 	path := SiteBindingPath(cityRoot)
-	if len(binding.Rigs) == 0 {
+	if len(binding.Rigs) == 0 && binding.WorkspaceName == "" && binding.WorkspacePrefix == "" {
 		if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing site binding %q: %w", path, err)
 		}

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -52,6 +52,33 @@ func TestPersistRigSiteBindings(t *testing.T) {
 	}
 }
 
+func TestPersistRigSiteBindings_PreservesWorkspaceIdentity(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+workspace_name = "site-city"
+workspace_prefix = "sc"
+`)
+	cfg := []Rig{{Name: "frontend", Path: "/tmp/frontend"}}
+
+	if err := PersistRigSiteBindings(fs, "/city", cfg); err != nil {
+		t.Fatalf("PersistRigSiteBindings: %v", err)
+	}
+
+	binding, err := LoadSiteBinding(fs, "/city")
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if binding.WorkspaceName != "site-city" {
+		t.Fatalf("WorkspaceName = %q, want %q", binding.WorkspaceName, "site-city")
+	}
+	if binding.WorkspacePrefix != "sc" {
+		t.Fatalf("WorkspacePrefix = %q, want %q", binding.WorkspacePrefix, "sc")
+	}
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Name != "frontend" {
+		t.Fatalf("binding.Rigs = %+v, want preserved workspace identity plus frontend rig", binding.Rigs)
+	}
+}
+
 func TestApplySiteBindingsForEdit_KeepsLegacyPath(t *testing.T) {
 	fs := fsys.NewFake()
 	cfg := &City{
@@ -93,6 +120,45 @@ path = "/site/frontend"
 	}
 	if cfg.Rigs[0].Path != "/site/frontend" {
 		t.Fatalf("Path = %q, want site binding path", cfg.Rigs[0].Path)
+	}
+	if len(prov.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", prov.Warnings)
+	}
+}
+
+func TestLoadWithIncludes_AppliesWorkspaceIdentitySiteBinding(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "declared-city"
+prefix = "declared"
+`)
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+workspace_name = "site-city"
+workspace_prefix = "sc"
+`)
+
+	cfg, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if cfg.Workspace.Name != "declared-city" {
+		t.Fatalf("Workspace.Name = %q, want raw declared value preserved", cfg.Workspace.Name)
+	}
+	if cfg.Workspace.Prefix != "declared" {
+		t.Fatalf("Workspace.Prefix = %q, want raw declared value preserved", cfg.Workspace.Prefix)
+	}
+	if cfg.ResolvedWorkspaceName != "site-city" {
+		t.Fatalf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "site-city")
+	}
+	if cfg.ResolvedWorkspacePrefix != "sc" {
+		t.Fatalf("ResolvedWorkspacePrefix = %q, want %q", cfg.ResolvedWorkspacePrefix, "sc")
+	}
+	if got := cfg.EffectiveCityName(); got != "site-city" {
+		t.Fatalf("EffectiveCityName() = %q, want %q", got, "site-city")
+	}
+	if got := EffectiveHQPrefix(cfg); got != "sc" {
+		t.Fatalf("EffectiveHQPrefix() = %q, want %q", got, "sc")
 	}
 	if len(prov.Warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", prov.Warnings)
@@ -165,5 +231,31 @@ path = "/legacy/frontend"
 	}
 	if len(prov.Warnings) != 1 || !strings.Contains(prov.Warnings[0], ".gc/site.toml") {
 		t.Fatalf("warnings = %v, want legacy site binding guidance", prov.Warnings)
+	}
+}
+
+func TestLoad_AppliesWorkspaceIdentitySiteBinding(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "declared-city"
+`)
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+workspace_name = "site-city"
+workspace_prefix = "sc"
+`)
+
+	cfg, err := Load(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ResolvedWorkspaceName != "site-city" {
+		t.Fatalf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "site-city")
+	}
+	if cfg.ResolvedWorkspacePrefix != "sc" {
+		t.Fatalf("ResolvedWorkspacePrefix = %q, want %q", cfg.ResolvedWorkspacePrefix, "sc")
+	}
+	if got := cfg.EffectiveCityName(); got != "site-city" {
+		t.Fatalf("EffectiveCityName() = %q, want %q", got, "site-city")
 	}
 }

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -60,13 +60,14 @@ func (c *CityStructureCheck) CanFix() bool { return false }
 // Fix is a no-op.
 func (c *CityStructureCheck) Fix(_ *CheckContext) error { return nil }
 
-// CityConfigCheck verifies city.toml parses and workspace.name is set.
+// CityConfigCheck verifies city.toml parses and an effective workspace name can
+// be resolved.
 type CityConfigCheck struct{}
 
 // Name returns the check identifier.
 func (c *CityConfigCheck) Name() string { return "city-config" }
 
-// Run parses city.toml and checks workspace.name.
+// Run parses city.toml and checks effective workspace identity.
 func (c *CityConfigCheck) Run(ctx *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(ctx.CityPath, "city.toml"))
@@ -80,12 +81,7 @@ func (c *CityConfigCheck) Run(ctx *CheckContext) *CheckResult {
 		r.Message = "workspace.name not set (and could not derive from path)"
 		return r
 	}
-	summary := fmt.Sprintf("city.toml loaded (%d agents, %d rigs)", len(cfg.Agents), len(cfg.Rigs))
-	if cfg.Workspace.Name == "" {
-		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("workspace.name not set (using derived name %q); %s", cfg.ResolvedWorkspaceName, summary)
-		return r
-	}
+	summary := fmt.Sprintf("city.toml loaded (%d agents, %d rigs); effective city name %q", len(cfg.Agents), len(cfg.Rigs), cfg.ResolvedWorkspaceName)
 	r.Status = StatusOK
 	r.Message = summary
 	return r

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -91,10 +91,20 @@ func TestCityConfigCheck_NoName(t *testing.T) {
 	dir := setupCity(t, "[workspace]\n")
 	c := &CityConfigCheck{}
 	r := c.Run(&CheckContext{CityPath: dir})
-	// Empty workspace.name with a derived ResolvedWorkspaceName is a warning,
-	// not an error — EffectiveHQPrefix falls back to the derived name.
-	if r.Status != StatusWarning {
-		t.Errorf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestCityConfigCheck_SiteBoundName(t *testing.T) {
+	dir := setupCity(t, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, ".gc", "site.toml"), []byte("workspace_name = \"site-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := &CityConfigCheck{}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
 }
 

--- a/internal/workdir/workdir.go
+++ b/internal/workdir/workdir.go
@@ -21,13 +21,9 @@ type PathContext struct {
 	CityName  string
 }
 
-// CityName returns the configured workspace name, or the city directory basename
-// when workspace.name is unset.
+// CityName returns the effective workspace name for workdir/template expansion.
 func CityName(cityPath string, cfg *config.City) string {
-	if cfg != nil && cfg.Workspace.Name != "" {
-		return cfg.Workspace.Name
-	}
-	return filepath.Base(filepath.Clean(cityPath))
+	return config.EffectiveCityName(cfg, filepath.Base(filepath.Clean(cityPath)))
 }
 
 // ResolveDirPath returns an absolute path for dir, resolving relative paths


### PR DESCRIPTION
Fixes #600.

## Summary
- move workspace name and prefix into `.gc/site.toml` while preserving existing rig bindings
- resolve effective city identity early in config load and use it across runtime, controller, session, API, and CLI flows
- update `gc init`, `gc init --file`, `gc init --from`, bootstrap overrides, `gc register`, and `gc doctor --fix` for the site-binding model
- return effective identity from `/v0/config` while still exposing declared legacy identity fields for migration/debugging
- update generated docs/schema/OpenAPI artifacts and add regression coverage for the cutover

## Behavior changes
- runtime identity precedence is now: registered alias (supervisor-managed flows) > site-bound / legacy workspace identity > directory basename
- `pack.name` remains the portable definition identity and init-time default only
- fresh init writes machine-local workspace identity to `.gc/site.toml` instead of checked-in `city.toml`
- `gc doctor --fix` migrates legacy `workspace.name` / `workspace.prefix` into `.gc/site.toml`
- migrated cities can omit checked-in workspace identity and still load cleanly / report cleanly

## Testing
- `go test ./cmd/gc -run 'Test(DoRegister|RegisteredCityName|RestartRegistrationName|CmdInitFromTOMLFile|DoInit|ResolveCityName|InitNameFlag|InitFromDefaultsToTargetDirBasename|V2DeprecationChecks|EffectiveCityNameUsesWorkspaceSiteBinding)'`
- `go test ./internal/config ./internal/doctor`
- `go test ./internal/api -run TestOpenAPISpecInSync`
- `go test ./internal/api/genclient -run TestGeneratedClientInSync`
