### PR TITLE
fix: harden API blocking parameter parsing

### DIFF
--- a/internal/api/blocking.go
+++ b/internal/api/blocking.go
@@ -26,8 +26,10 @@ type BlockingParams struct {
 func parseBlockingParams(r *http.Request) BlockingParams {
 	bp := BlockingParams{Wait: defaultWait}
 	if v := r.URL.Query().Get("index"); v != "" {
-		bp.Index, _ = strconv.ParseUint(v, 10, 64)
-		bp.HasIndex = true
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+			bp.Index = n
+			bp.HasIndex = true
+		}
 	}
 	if v := r.URL.Query().Get("wait"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {

--- a/internal/api/blocking_test.go
+++ b/internal/api/blocking_test.go
@@ -45,6 +45,21 @@ func TestParseBlockingParamsMaxWait(t *testing.T) {
 	}
 }
 
+func TestParseBlockingParamsInvalidIndexDoesNotBlock(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v0/city/test-city/agents?index=not-a-number", nil)
+	bp := parseBlockingParams(req)
+
+	if bp.HasIndex {
+		t.Error("HasIndex = true, want false for malformed index")
+	}
+	if bp.isBlocking() {
+		t.Error("isBlocking() = true, want false for malformed index")
+	}
+	if bp.Index != 0 {
+		t.Errorf("Index = %d, want 0 for malformed index", bp.Index)
+	}
+}
+
 func TestWaitForChangeImmediate(t *testing.T) {
 	ep := events.NewFake()
 	// Record an event so LatestSeq > 0.


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `API Core Infrastructure`.

This change hardens legacy blocking-query parsing so malformed `index` values no longer silently degrade into unintended blocking waits on index `0`. It adds a regression test first, then applies the minimal fix in `internal/api/blocking.go`.

## Scope

Owned scope for this module:

- `internal/api/blocking.go`
- `internal/api/client.go`
- `internal/api/envelope.go`
- `internal/api/idempotency.go`
- `internal/api/logwatcher.go`
- `internal/api/middleware.go`
- `internal/api/pagination.go`
- `internal/api/response_cache.go`
- `internal/api/server.go`
- `internal/api/sse.go`
- `internal/api/state.go`
- `cmd/gc/api_state.go`
- `cmd/gc/apiroute.go`

No boundary exception was needed.

## Implementer Score Summary

Initial:

- `TDD` 78
- `DRY` 79
- `Separation of Concerns` 79
- `Single Responsibility` 79
- `Clear Abstractions` 82
- `Low Coupling, High Cohesion` 82
- `KISS` 77
- `YAGNI` 81
- `Prefer Non-Nullable` 82
- `Prefer Async Notifications` 84
- `Eliminate Race Conditions` 84
- `Errors Are Not Optional` 76
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 82

Final:

- `TDD` 85
- `DRY` 80
- `Separation of Concerns` 80
- `Single Responsibility` 80
- `Clear Abstractions` 83
- `Low Coupling, High Cohesion` 84
- `KISS` 84
- `YAGNI` 82
- `Prefer Non-Nullable` 82
- `Prefer Async Notifications` 84
- `Eliminate Race Conditions` 84
- `Errors Are Not Optional` 84
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 84

`N/A` rows: none

## Blind Verifier Score Summary

- `TDD` 86
- `DRY` 84
- `Separation of Concerns` 88
- `Single Responsibility` 86
- `Clear Abstractions` 84
- `Low Coupling, High Cohesion` 83
- `KISS` 82
- `YAGNI` 84
- `Prefer Non-Nullable` 83
- `Prefer Async Notifications` 90
- `Eliminate Race Conditions` 84
- `Errors Are Not Optional` 88
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 87

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added failing regression test first: `TestParseBlockingParamsInvalidIndexDoesNotBlock`
- Verified with:
  - `TMPDIR=$PWD/.tmp-go GOCACHE=$PWD/.cache-go go test ./internal/api -run 'TestParseBlockingParams|TestWaitForChange'`
  - `TMPDIR=$PWD/.tmp-go GOCACHE=$PWD/.cache-go go test ./internal/api/...`
  - `TMPDIR=$PWD/.tmp-go GOCACHE=$PWD/.cache-go go test ./cmd/gc -run TestControllerStateReadAccess`

## Notes

- `bd dolt push` remains unhealthy in this environment due a divergent/panicking Dolt state and was not forced.
