### PR TITLE
Fix waking drained sessions with explicit controller demand

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -17,6 +17,7 @@ import (
 func buildAwakeInputFromReconciler(
 	cfg *config.City,
 	sessionBeads []beads.Bead,
+	desiredState map[string]TemplateParams,
 	poolDesired map[string]int,
 	workSet map[string]bool,
 	readyWaitSet map[string]bool,
@@ -26,14 +27,15 @@ func buildAwakeInputFromReconciler(
 	clk time.Time,
 ) AwakeInput {
 	input := AwakeInput{
-		ScaleCheckCounts: poolDesired,
-		WorkSet:          workSet,
-		ReadyWaitSet:     readyWaitSet,
-		RunningSessions:  make(map[string]bool),
-		AttachedSessions: make(map[string]bool),
-		PendingSessions:  make(map[string]bool),
-		ChatIdleTimeout:  cfg.ChatSessions.IdleTimeoutDuration(),
-		Now:              clk,
+		ControllerDesiredSessions: make(map[string]bool),
+		ScaleCheckCounts:          poolDesired,
+		WorkSet:                   workSet,
+		ReadyWaitSet:              readyWaitSet,
+		RunningSessions:           make(map[string]bool),
+		AttachedSessions:          make(map[string]bool),
+		PendingSessions:           make(map[string]bool),
+		ChatIdleTimeout:           cfg.ChatSessions.IdleTimeoutDuration(),
+		Now:                       clk,
 	}
 
 	// Agents
@@ -48,6 +50,13 @@ func buildAwakeInputFromReconciler(
 			agent.DependsOn = a.DependsOn
 		}
 		input.Agents = append(input.Agents, agent)
+	}
+
+	for sessionName, tp := range desiredState {
+		if strings.TrimSpace(tp.ConfiguredNamedMode) == "on_demand" {
+			continue
+		}
+		input.ControllerDesiredSessions[sessionName] = true
 	}
 
 	// Named sessions

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -29,6 +29,7 @@ func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilitySta
 		nil,
 		nil,
 		nil,
+		nil,
 		now,
 	)
 
@@ -66,6 +67,7 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 		nil,
 		nil,
 		nil,
+		nil,
 		[]wakeTarget{{session: &session, alive: true}},
 		sp,
 		now,
@@ -78,5 +80,38 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 	got := decisions["s-worker"]
 	if !got.ShouldWake || got.Reason != "pending" {
 		t.Fatalf("decision = %+v, want pending wake", got)
+	}
+}
+
+func TestBuildAwakeInputFromReconcilerSkipsOnDemandNamedSessionsFromControllerDesired(t *testing.T) {
+	now := time.Now().UTC()
+	input := buildAwakeInputFromReconciler(
+		&config.City{},
+		nil,
+		map[string]TemplateParams{
+			"test-city--triage": {
+				SessionName:         "test-city--triage",
+				TemplateName:        "worker",
+				ConfiguredNamedMode: "on_demand",
+			},
+			"worker-1": {
+				SessionName:  "worker-1",
+				TemplateName: "worker",
+			},
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	if input.ControllerDesiredSessions["test-city--triage"] {
+		t.Fatal("on-demand named session should not be treated as controller-desired wake")
+	}
+	if !input.ControllerDesiredSessions["worker-1"] {
+		t.Fatal("ordinary desired session should be treated as controller-desired wake")
 	}
 }

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -16,18 +16,19 @@ const defaultOnDemandIdleTimeout = 5 * time.Minute
 // should be awake. All external I/O (shell commands, tmux checks, store
 // queries) happens before this function is called.
 type AwakeInput struct {
-	Agents           []AwakeAgent
-	NamedSessions    []AwakeNamedSession
-	SessionBeads     []AwakeSessionBead
-	WorkBeads        []AwakeWorkBead
-	ScaleCheckCounts map[string]int  // agent template → desired count
-	WorkSet          map[string]bool // agent template → work_query found pending work
-	RunningSessions  map[string]bool // session name → tmux exists
-	AttachedSessions map[string]bool // session name → user attached
-	PendingSessions  map[string]bool // session name → pending interaction
-	ReadyWaitSet     map[string]bool // session bead ID → durable wait is ready
-	ChatIdleTimeout  time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
-	Now              time.Time
+	Agents                    []AwakeAgent
+	NamedSessions             []AwakeNamedSession
+	SessionBeads              []AwakeSessionBead
+	WorkBeads                 []AwakeWorkBead
+	ControllerDesiredSessions map[string]bool // session name → desiredState wants this concrete session awake
+	ScaleCheckCounts          map[string]int  // agent template → desired count
+	WorkSet                   map[string]bool // agent template → work_query found pending work
+	RunningSessions           map[string]bool // session name → tmux exists
+	AttachedSessions          map[string]bool // session name → user attached
+	PendingSessions           map[string]bool // session name → pending interaction
+	ReadyWaitSet              map[string]bool // session bead ID → durable wait is ready
+	ChatIdleTimeout           time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	Now                       time.Time
 }
 
 // AwakeAgent represents an [[agent]] config entry.
@@ -95,17 +96,32 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	// Step 1: Build desired set.
-	// Drained and dependency_only beads are excluded from demand-driven wake.
+	// Drained beads are excluded from generic template demand, but explicit
+	// session-specific controller intent (pending create, current desiredState,
+	// named-always, assigned work, pins) may still reuse the same bead.
 	desired := make(map[string]string) // sessionName → reason
 
 	// Newly created beads that still carry a controller create claim must be
 	// launched at least once, even if the work signal that materialized them
 	// is no longer visible on the very next tick.
 	for _, bead := range input.SessionBeads {
-		if bead.Drained || !bead.PendingCreate {
+		if !bead.PendingCreate {
 			continue
 		}
 		desired[bead.SessionName] = "pending-create"
+	}
+
+	for _, bead := range input.SessionBeads {
+		if bead.State == "closed" || bead.DependencyOnly || bead.ManualSession {
+			continue
+		}
+		if !input.ControllerDesiredSessions[bead.SessionName] {
+			continue
+		}
+		if _, already := desired[bead.SessionName]; already {
+			continue
+		}
+		desired[bead.SessionName] = "controller-desired"
 	}
 
 	// Named sessions
@@ -117,7 +133,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		case "always":
 			if sn := findNamedSessionName(input.SessionBeads, ns.Identity); sn != "" {
 				bead := findBeadBySessionName(input.SessionBeads, sn)
-				if bead != nil && !bead.Drained && !bead.DependencyOnly {
+				if bead != nil && !bead.DependencyOnly {
 					desired[sn] = "named-always"
 				}
 			} else {
@@ -201,7 +217,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// accept current session_name and exact configured named identity tokens,
 	// but normal targeting surfaces write the concrete bead ID.
 	for _, bead := range input.SessionBeads {
-		if bead.State == "closed" || bead.Drained {
+		if bead.State == "closed" {
 			continue
 		}
 		if _, already := desired[bead.SessionName]; already {
@@ -276,7 +292,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// Durable pin override — wakes and keeps the session awake while
 		// still respecting hard blockers applied below.
 		pinBlockedByState := bead.State == "suspended" || bead.State == "closed"
-		if !decision.ShouldWake && bead.Pinned && !pinBlockedByState && !bead.DependencyOnly && !bead.Drained && !bead.WaitHold {
+		if !decision.ShouldWake && bead.Pinned && !pinBlockedByState && !bead.DependencyOnly && !bead.WaitHold {
 			if agent, ok := agentsByName[bead.Template]; ok && !agent.Suspended {
 				decision.ShouldWake = true
 				decision.Reason = "pin"

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -58,6 +58,43 @@ func TestNamedAlways_AsleepWakes(t *testing.T) {
 	assertAwake(t, result, "deacon")
 }
 
+func TestNamedAlways_DrainedCompatibilityStateStillWakes(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "deacon"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "deacon", Template: "deacon", Mode: "always"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:            "mc-1",
+			SessionName:   "deacon",
+			Template:      "deacon",
+			State:         "asleep",
+			NamedIdentity: "deacon",
+			Drained:       true,
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "deacon")
+	assertReason(t, result, "deacon", "named-always")
+}
+
+func TestControllerDesiredSession_DrainedCompatibilityStateStillWakes(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "deacon"}},
+		ControllerDesiredSessions: map[string]bool{
+			"deacon": true,
+		},
+		SessionBeads: []AwakeSessionBead{{
+			ID:          "mc-1",
+			SessionName: "deacon",
+			Template:    "deacon",
+			State:       "asleep",
+			Drained:     true,
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "deacon")
+	assertReason(t, result, "deacon", "controller-desired")
+}
+
 func TestNamedAlways_ActiveStaysAwake(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:          []AwakeAgent{{QualifiedName: "deacon"}},
@@ -483,6 +520,31 @@ func TestDrained_ManualNotWoken(t *testing.T) {
 		Now:          now,
 	})
 	assertAsleep(t, result, "s-mc-1")
+}
+
+func TestDrained_WithAssignedWork_Wakes(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "asleep", Drained: true},
+		},
+		WorkBeads: []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-1", Status: "in_progress"}},
+		Now:       now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "assigned-work")
+}
+
+func TestDrained_Pinned_Wakes(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "asleep", Drained: true, Pinned: true},
+		},
+		Now: now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "pin")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -855,7 +855,7 @@ func reconcileSessionBeadsTraced(
 
 	// Use ComputeAwakeSet for the wake/sleep decision.
 	awakeInput := buildAwakeInputFromReconciler(
-		cfg, ordered, poolDesired, workSet, readyWaitSet,
+		cfg, ordered, desiredState, poolDesired, workSet, readyWaitSet,
 		assignedWorkBeads, wakeTargets, sp, clk.Now(),
 	)
 	awakeDecisions := ComputeAwakeSet(awakeInput)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1343,6 +1343,103 @@ func TestReconcileSessionBeads_WakesDeadSession(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_AlwaysNamedSessionWakesFromDrainedCompatibilityState(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "asleep",
+		"sleep_reason":               "drained",
+		"continuation_reset_pending": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatalf("always named session %q should have been restarted", sessionName)
+	}
+}
+
+func TestReconcileSessionBeads_ControllerDesiredSessionWakesFromDrainedCompatibilityState(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: intPtr(1)}},
+	}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "true",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                      "asleep",
+		"sleep_reason":               "drained",
+		"continuation_reset_pending": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("controller-desired session should have been restarted from drained compatibility state")
+	}
+}
+
+func TestReconcileSessionBeads_OnDemandNamedSessionDoesNotWakeFromDesiredStatePresence(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "on_demand",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"state":                      "asleep",
+		"sleep_reason":               "drained",
+		"continuation_reset_pending": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if env.sp.IsRunning(sessionName) {
+		t.Fatalf("on-demand named session %q should remain asleep without direct demand", sessionName)
+	}
+}
+
 func TestReconcileSessionBeads_SyncsGCDirWithWorkDirOverride(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}


### PR DESCRIPTION
## Summary
- allow stale `drained` compatibility state to be overridden only when the controller still wants that exact concrete session awake
- keep generic template demand unchanged so drained pool sessions are not revived just because a template still has demand
- preserve `named_session mode = "on_demand"` behavior by excluding those entries from the controller-desired wake override
- add reconciler, bridge, and awake-set regression tests for named `always`, controller-desired concrete sessions, assigned-work/pin continuity, and the `on_demand` guard

Fixes #930.

## Testing
- `go test ./cmd/gc -run 'Test(BuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilityStates|BuildAwakeInputFromReconcilerPopulatesPendingInteractions|BuildAwakeInputFromReconcilerSkipsOnDemandNamedSessionsFromControllerDesired|NamedAlways_DrainedCompatibilityStateStillWakes|ControllerDesiredSession_DrainedCompatibilityStateStillWakes|Drained_WithAssignedWork_Wakes|Drained_Pinned_Wakes|Drained_NotWokenByDemand|WorkSet_SkipsDrained|Regression_AsleepEphemeralWithoutWork_StaysAsleep|ReconcileSessionBeads_AlwaysNamedSessionWakesFromDrainedCompatibilityState|ReconcileSessionBeads_ControllerDesiredSessionWakesFromDrainedCompatibilityState|ReconcileSessionBeads_OnDemandNamedSessionDoesNotWakeFromDesiredStatePresence)$'`
- `go test ./cmd/gc -run 'Test(Phase0NamedOnDemand_DoesNotWakeFromTemplateWorkSet|Phase0NamedOnDemand_WakesFromAssignedBeadID|Phase0NamedOnDemand_WakesFromExactConfiguredNamedIdentityAssignee|Phase0NamedOnDemand_DoesNotWakeFromBackingTemplateAssigneeToken|BuildAwakeInputFromReconcilerSkipsOnDemandNamedSessionsFromControllerDesired)$'`

## Review
- Codex blocker/major review: `No blocker/major findings.`
- Independent fallback reviewer: `No blocker/major findings.`
