### PR TITLE
fix: stabilize managed Dolt lifecycle probes

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -95,6 +96,65 @@ func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	}
 	if got := env["GC_BIN"]; got != "/opt/gc/bin/gc" {
 		t.Fatalf("providerLifecycleProcessEnv()[GC_BIN] = %q, want %q", got, "/opt/gc/bin/gc")
+	}
+}
+
+func TestGcBeadsBdCleanupStaleLocksBoundsLsof(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	prelude, _, ok := strings.Cut(string(scriptData), "# --- Main ---")
+	if !ok {
+		t.Fatal("gc-beads-bd script missing main marker")
+	}
+
+	dataDir := filepath.Join(cityPath, ".beads", "dolt")
+	lockFile := filepath.Join(dataDir, "hq", ".dolt", "noms", "LOCK")
+	if err := os.MkdirAll(filepath.Dir(lockFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockFile, []byte("lock\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "lsof"), []byte("#!/bin/sh\nexec sleep 2\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(lsof): %v", err)
+	}
+	harness := filepath.Join(t.TempDir(), "cleanup-locks.sh")
+	body := prelude + fmt.Sprintf(`
+DATA_DIR=%q
+cleanup_stale_locks
+`, dataDir)
+	if err := os.WriteFile(harness, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", harness)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GC_LSOF_TIMEOUT_SECONDS=0.1",
+	)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("cleanup_stale_locks timed out after %s\n%s", time.Since(start), out)
+	}
+	if err != nil {
+		t.Fatalf("cleanup_stale_locks failed: %v\n%s", err, out)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("cleanup_stale_locks took %s, want bounded lsof timeout", elapsed)
+	}
+	if _, err := os.Stat(lockFile); err != nil {
+		t.Fatalf("LOCK stat err = %v, want preserved when lsof times out", err)
 	}
 }
 
@@ -4818,12 +4878,18 @@ case "${1:-}" in
       prev="$arg"
     done
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
-    exec python3 - "$port" <<'INNERPY'
+    data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
+    exec python3 - "$port" "$data_dir" <<'INNERPY'
+import os
 import signal
 import socket
 import sys
 import time
 port = int(sys.argv[1])
+data_dir = sys.argv[2]
+if data_dir:
+    os.makedirs(data_dir, exist_ok=True)
+    os.chdir(data_dir)
 sock = socket.socket()
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 sock.bind(("0.0.0.0", port))
@@ -4886,12 +4952,18 @@ case "${1:-}" in
       prev="$arg"
     done
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
-    exec python3 - "$port" <<'INNERPY'
+    data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
+    exec python3 - "$port" "$data_dir" <<'INNERPY'
+import os
 import signal
 import socket
 import sys
 import time
 port = int(sys.argv[1])
+data_dir = sys.argv[2]
+if data_dir:
+    os.makedirs(data_dir, exist_ok=True)
+    os.chdir(data_dir)
 sock = socket.socket()
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 sock.bind(("0.0.0.0", port))
@@ -5483,12 +5555,18 @@ case "${1:-}" in
       prev="$arg"
     done
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
-    exec python3 - "$port" <<'INNERPY'
+    data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
+    exec python3 - "$port" "$data_dir" <<'INNERPY'
+import os
 import signal
 import socket
 import sys
 import time
 port = int(sys.argv[1])
+data_dir = sys.argv[2]
+if data_dir:
+    os.makedirs(data_dir, exist_ok=True)
+    os.chdir(data_dir)
 sock = socket.socket()
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 sock.bind(("0.0.0.0", port))
@@ -5565,6 +5643,19 @@ func readManagedDoltConfigForTest(t *testing.T, path string) managedDoltConfigFo
 	return cfg
 }
 
+func readDoltStartCountForTest(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read start count: %v", err)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse start count %q: %v", strings.TrimSpace(string(data)), err)
+	}
+	return count
+}
+
 func TestGcBeadsBdStartIsIdempotentWhenAlreadyRunning(t *testing.T) {
 	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
@@ -5608,12 +5699,18 @@ case "${1:-}" in
       prev="$arg"
     done
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
-    exec python3 - "$port" <<'INNERPY'
+    data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
+    exec python3 - "$port" "$data_dir" <<'INNERPY'
+import os
 import signal
 import socket
 import sys
 import time
 port = int(sys.argv[1])
+data_dir = sys.argv[2]
+if data_dir:
+    os.makedirs(data_dir, exist_ok=True)
+    os.chdir(data_dir)
 sock = socket.socket()
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 sock.bind(("0.0.0.0", port))
@@ -5665,6 +5762,7 @@ esac
 	if firstPID == "" {
 		t.Fatal("first pid file is empty")
 	}
+	initialStartCount := readDoltStartCountForTest(t, countFile)
 
 	runStart()
 
@@ -5677,12 +5775,8 @@ esac
 		t.Fatalf("repeated start changed pid from %q to %q", firstPID, secondPID)
 	}
 
-	countData, err := os.ReadFile(countFile)
-	if err != nil {
-		t.Fatalf("read start count: %v", err)
-	}
-	if got := strings.TrimSpace(string(countData)); got != "1" {
-		t.Fatalf("dolt sql-server launch count = %q, want 1", got)
+	if got := readDoltStartCountForTest(t, countFile); got != initialStartCount {
+		t.Fatalf("dolt sql-server launch count = %d, want unchanged from initial %d", got, initialStartCount)
 	}
 
 	state, err := os.ReadFile(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt-provider-state.json"))
@@ -5712,6 +5806,7 @@ func TestGcBeadsBdStartRestartsServerHoldingDeletedDataInodes(t *testing.T) {
 	}
 
 	countFile := filepath.Join(t.TempDir(), "dolt-start-count")
+	deletedMarkerFile := filepath.Join(t.TempDir(), "deleted-inode-held")
 	fakeDolt := filepath.Join(binDir, "dolt")
 	fakeScript := fmt.Sprintf(`#!/bin/sh
 set -eu
@@ -5738,7 +5833,7 @@ case "${1:-}" in
       prev="$arg"
     done
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
-    exec python3 - "$port" "$data_dir" "$count" <<'INNERPY'
+    exec python3 - "$port" "$data_dir" %q <<'INNERPY'
 import os
 import signal
 import socket
@@ -5746,19 +5841,22 @@ import sys
 import time
 port = int(sys.argv[1])
 data_dir = sys.argv[2]
-count = int(sys.argv[3])
+marker_path = sys.argv[3]
 os.makedirs(data_dir, exist_ok=True)
+os.chdir(data_dir)
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("0.0.0.0", port))
+sock.listen(5)
 open_file = None
-if count == 1:
+if not os.path.exists(marker_path):
+    with open(marker_path, "w") as marker:
+        marker.write("held")
     stale = os.path.join(data_dir, "stale-open.txt")
     open_file = open(stale, "w+")
     open_file.write("stale")
     open_file.flush()
     os.unlink(stale)
-sock = socket.socket()
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-sock.bind(("0.0.0.0", port))
-sock.listen(5)
 def _stop(*_args):
     raise SystemExit(0)
 signal.signal(signal.SIGTERM, _stop)
@@ -5771,7 +5869,7 @@ INNERPY
     exit 0
     ;;
 esac
-`, countFile, filepath.Join(cityPath, ".beads", "dolt"))
+`, countFile, filepath.Join(cityPath, ".beads", "dolt"), deletedMarkerFile)
 	if err := os.WriteFile(fakeDolt, []byte(fakeScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -5806,6 +5904,7 @@ esac
 	if firstPID == "" {
 		t.Fatal("first pid file is empty")
 	}
+	initialStartCount := readDoltStartCountForTest(t, countFile)
 
 	runStart()
 
@@ -5818,12 +5917,8 @@ esac
 		t.Fatal("second pid file is empty")
 	}
 
-	countData, err := os.ReadFile(countFile)
-	if err != nil {
-		t.Fatalf("read start count: %v", err)
-	}
-	if got := strings.TrimSpace(string(countData)); got != "2" {
-		t.Fatalf("dolt sql-server launch count = %q, want 2", got)
+	if got := readDoltStartCountForTest(t, countFile); got <= initialStartCount {
+		t.Fatalf("dolt sql-server launch count = %d, want greater than initial %d", got, initialStartCount)
 	}
 }
 
@@ -5928,6 +6023,7 @@ esac
 	if firstPID == "" {
 		t.Fatal("first pid file is empty")
 	}
+	initialStartCount := readDoltStartCountForTest(t, countFile)
 
 	realNC, err := exec.LookPath("nc")
 	if err != nil {
@@ -5969,12 +6065,8 @@ exec "$real_nc" "$@"
 		t.Fatalf("ensure-ready changed pid from %q to %q after transient tcp probe failure", firstPID, secondPID)
 	}
 
-	countData, err := os.ReadFile(countFile)
-	if err != nil {
-		t.Fatalf("read start count: %v", err)
-	}
-	if got := strings.TrimSpace(string(countData)); got != "1" {
-		t.Fatalf("dolt sql-server launch count = %q, want 1", got)
+	if got := readDoltStartCountForTest(t, countFile); got != initialStartCount {
+		t.Fatalf("dolt sql-server launch count = %d, want unchanged from initial %d", got, initialStartCount)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1081,6 +1081,12 @@ while True:
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start listener process in %s: %v", dir, err)
 	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 200*time.Millisecond)

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -1,16 +1,22 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
 var managedDoltPreflightCleanupFn = preflightManagedDoltCleanup
+
+const managedDoltLsofTimeout = 500 * time.Millisecond
 
 func preflightManagedDoltCleanup(cityPath string) error {
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
@@ -182,10 +188,30 @@ func removeStaleManagedDoltLocks(dataDir string) error {
 }
 
 func fileOpenedByAnyProcess(path string) (bool, error) {
+	if open, checked := fileOpenedByAnyProcessFromProc(path); checked {
+		return open, nil
+	}
 	if _, err := exec.LookPath("lsof"); err != nil {
 		return false, errManagedDoltOpenStateUnknown
 	}
-	out, err := exec.Command("lsof", path).CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), managedDoltLsofTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "lsof", path)
+	cmd.WaitDelay = 100 * time.Millisecond
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			return err
+		}
+		return nil
+	}
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return false, errManagedDoltOpenStateUnknown
+	}
 	if err == nil {
 		return true, nil
 	}
@@ -194,4 +220,62 @@ func fileOpenedByAnyProcess(path string) (bool, error) {
 		return false, nil
 	}
 	return false, fmt.Errorf("lsof %s: %w: %s", path, err, strings.TrimSpace(string(out)))
+}
+
+func fileOpenedByAnyProcessFromProc(path string) (bool, bool) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return false, false
+	}
+	socketInodes, _ := unixSocketInodesForPath(path)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		fdDir := filepath.Join("/proc", entry.Name(), "fd")
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			target, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+			if err != nil {
+				continue
+			}
+			target = strings.TrimSuffix(target, " (deleted)")
+			if samePath(target, path) {
+				return true, true
+			}
+			if len(socketInodes) > 0 && strings.HasPrefix(target, "socket:[") && strings.HasSuffix(target, "]") {
+				inode := strings.TrimSuffix(strings.TrimPrefix(target, "socket:["), "]")
+				if _, ok := socketInodes[inode]; ok {
+					return true, true
+				}
+			}
+		}
+	}
+	return false, true
+}
+
+func unixSocketInodesForPath(path string) (map[string]struct{}, bool) {
+	data, err := os.ReadFile("/proc/net/unix")
+	if err != nil {
+		return nil, false
+	}
+	inodes := map[string]struct{}{}
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 8 {
+			continue
+		}
+		if !samePath(fields[len(fields)-1], path) {
+			continue
+		}
+		inodes[fields[6]] = struct{}{}
+	}
+	return inodes, true
 }

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStaleManagedDoltSocketPathsExcludesMysqlSock(t *testing.T) {
@@ -42,22 +43,46 @@ func TestStaleManagedDoltSocketPathsExcludesMysqlSock(t *testing.T) {
 	}
 }
 
-func TestFileOpenedByAnyProcessWithoutLsofReturnsUnknown(t *testing.T) {
+func TestFileOpenedByAnyProcessWithoutLsofReturnsClosedOrUnknown(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "LOCK")
 	if err := os.WriteFile(path, []byte("stale\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing-bin"))
 	open, err := fileOpenedByAnyProcess(path)
-	if !errors.Is(err, errManagedDoltOpenStateUnknown) {
-		t.Fatalf("fileOpenedByAnyProcess() error = %v, want errManagedDoltOpenStateUnknown", err)
+	if err != nil && !errors.Is(err, errManagedDoltOpenStateUnknown) {
+		t.Fatalf("fileOpenedByAnyProcess() error = %v, want nil or errManagedDoltOpenStateUnknown", err)
 	}
 	if open {
 		t.Fatal("fileOpenedByAnyProcess() = true, want false when lsof is unavailable")
 	}
 }
 
-func TestRemoveStaleManagedDoltLocksWithoutLsofKeepsLock(t *testing.T) {
+func TestFileOpenedByAnyProcessBoundsLsof(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "LOCK")
+	if err := os.WriteFile(path, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "lsof"), []byte("#!/bin/sh\nexec sleep 2\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(lsof): %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	start := time.Now()
+	open, err := fileOpenedByAnyProcess(path)
+	if err != nil && !errors.Is(err, errManagedDoltOpenStateUnknown) {
+		t.Fatalf("fileOpenedByAnyProcess() error = %v, want nil or errManagedDoltOpenStateUnknown", err)
+	}
+	if open {
+		t.Fatal("fileOpenedByAnyProcess() = true, want false when lsof times out")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("fileOpenedByAnyProcess() took %s, want bounded timeout", elapsed)
+	}
+}
+
+func TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState(t *testing.T) {
 	dataDir := t.TempDir()
 	lockFile := filepath.Join(dataDir, "hq", ".dolt", "noms", "LOCK")
 	if err := os.MkdirAll(filepath.Dir(lockFile), 0o755); err != nil {
@@ -67,11 +92,16 @@ func TestRemoveStaleManagedDoltLocksWithoutLsofKeepsLock(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", filepath.Join(t.TempDir(), "missing-bin"))
+	_, procChecked := fileOpenedByAnyProcessFromProc(lockFile)
 	if err := removeStaleManagedDoltLocks(dataDir); err != nil {
 		t.Fatalf("removeStaleManagedDoltLocks() error = %v", err)
 	}
-	if _, err := os.Stat(lockFile); err != nil {
-		t.Fatalf("LOCK stat err = %v, want preserved when lsof unavailable", err)
+	if _, err := os.Stat(lockFile); procChecked {
+		if !os.IsNotExist(err) {
+			t.Fatalf("LOCK stat err = %v, want stale lock removed when proc state is available", err)
+		}
+	} else if err != nil {
+		t.Fatalf("LOCK stat err = %v, want preserved when open-file state is unknown", err)
 	}
 }
 

--- a/cmd/gc/dolt_process_inspection.go
+++ b/cmd/gc/dolt_process_inspection.go
@@ -9,8 +9,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
+
+const processArgsPSTimeout = time.Second
 
 type managedDoltProcessInspection struct {
 	ManagedPID              int
@@ -69,15 +72,35 @@ func managedPIDFromPIDFile(pidFile string) int {
 }
 
 func findPortHolderPID(port string) int {
-	if strings.TrimSpace(port) == "" {
+	port = strings.TrimSpace(port)
+	if port == "" {
 		return 0
 	}
+	if pid, checked := findPortHolderPIDFromProc(port); checked {
+		return pid
+	}
+	return findPortHolderPIDFromLsof(port)
+}
+
+func findPortHolderPIDFromLsof(port string) int {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		return 0
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "lsof", "-nP", "-iTCP:"+strings.TrimSpace(port), "-sTCP:LISTEN", "-t").Output()
+	cmd := exec.CommandContext(ctx, "lsof", "-nP", "-iTCP:"+port, "-sTCP:LISTEN", "-t")
+	cmd.WaitDelay = 100 * time.Millisecond
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			return err
+		}
+		return nil
+	}
+	out, err := cmd.Output()
 	if err != nil {
 		return 0
 	}
@@ -91,6 +114,82 @@ func findPortHolderPID(port string) int {
 		return 0
 	}
 	return pid
+}
+
+func findPortHolderPIDFromProc(port string) (int, bool) {
+	portNum, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, true
+	}
+	inodes, checked := listeningSocketInodesFromProc(uint16(portNum))
+	if !checked {
+		return 0, false
+	}
+	if len(inodes) == 0 {
+		return 0, true
+	}
+	return processWithSocketInodes(inodes), true
+}
+
+func listeningSocketInodesFromProc(port uint16) (map[string]struct{}, bool) {
+	inodes := map[string]struct{}{}
+	checked := false
+	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		checked = true
+		scanner := bufio.NewScanner(strings.NewReader(string(data)))
+		for scanner.Scan() {
+			fields := strings.Fields(scanner.Text())
+			if len(fields) < 10 || fields[3] != "0A" {
+				continue
+			}
+			_, portHex, ok := strings.Cut(fields[1], ":")
+			if !ok {
+				continue
+			}
+			gotPort, err := strconv.ParseUint(portHex, 16, 16)
+			if err != nil || uint16(gotPort) != port {
+				continue
+			}
+			inodes[fields[9]] = struct{}{}
+		}
+	}
+	return inodes, checked
+}
+
+func processWithSocketInodes(inodes map[string]struct{}) int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || !pidAlive(pid) {
+			continue
+		}
+		fdDir := filepath.Join("/proc", entry.Name(), "fd")
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			target, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+			if err != nil || !strings.HasPrefix(target, "socket:[") || !strings.HasSuffix(target, "]") {
+				continue
+			}
+			inode := strings.TrimSuffix(strings.TrimPrefix(target, "socket:["), "]")
+			if _, ok := inodes[inode]; ok {
+				return pid
+			}
+		}
+	}
+	return 0
 }
 
 func managedPIDFromPSByConfig(configFile string) int {
@@ -205,7 +304,53 @@ func loadDoltRuntimeStateDataDir(path string) string {
 }
 
 func processArgs(pid int) (string, error) {
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
+	if args, err := processArgsFromProc(pid); err == nil && args != "" {
+		return args, nil
+	}
+	return processArgsFromPS(pid, processArgsPSTimeout)
+}
+
+func processArgsFromProc(pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("invalid pid %d", pid)
+	}
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return "", err
+	}
+	args := strings.TrimSpace(strings.ReplaceAll(string(data), "\x00", " "))
+	if args == "" {
+		return "", fmt.Errorf("empty cmdline for pid %d", pid)
+	}
+	return args, nil
+}
+
+func processArgsFromPS(pid int, timeout time.Duration) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("invalid pid %d", pid)
+	}
+	if timeout <= 0 {
+		timeout = processArgsPSTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "args=")
+	cmd.WaitDelay = 100 * time.Millisecond
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			return err
+		}
+		return nil
+	}
+	out, err := cmd.Output()
+	if ctx.Err() != nil {
+		return "", fmt.Errorf("ps args for pid %d: %w", pid, ctx.Err())
+	}
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/dolt_process_inspection_test.go
+++ b/cmd/gc/dolt_process_inspection_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProcessArgsFromPSReturnsWhenPSHangs(t *testing.T) {
+	binDir := t.TempDir()
+	psPath := filepath.Join(binDir, "ps")
+	if err := os.WriteFile(psPath, []byte("#!/bin/sh\nexec sleep 10\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(ps): %v", err)
+	}
+	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
+
+	start := time.Now()
+	_, err := processArgsFromPS(os.Getpid(), 100*time.Millisecond)
+	if err == nil {
+		t.Fatalf("processArgsFromPS succeeded with a hanging ps")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("processArgsFromPS took %s, want bounded timeout", elapsed)
+	}
+}
+
+func TestFindPortHolderPIDUsesProcBeforeLsof(t *testing.T) {
+	listener := listenOnRandomPort(t)
+	defer func() { _ = listener.Close() }()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	binDir := t.TempDir()
+	psPath := filepath.Join(binDir, "lsof")
+	if err := os.WriteFile(psPath, []byte("#!/bin/sh\nexec sleep 2\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(lsof): %v", err)
+	}
+	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
+
+	start := time.Now()
+	pid := findPortHolderPID(strconv.Itoa(port))
+	if pid != os.Getpid() {
+		t.Fatalf("findPortHolderPID(%d) = %d, want current pid %d", port, pid, os.Getpid())
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("findPortHolderPID took %s, want /proc path before lsof", elapsed)
+	}
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -26,6 +26,7 @@ DOLT_HOST="${GC_DOLT_HOST:-0.0.0.0}"
 DOLT_USER="${GC_DOLT_USER:-root}"
 DOLT_PASSWORD="${GC_DOLT_PASSWORD:-}"
 DOLT_LOGLEVEL="${GC_DOLT_LOGLEVEL:-warning}"
+LSOF_TIMEOUT_SECONDS="${GC_LSOF_TIMEOUT_SECONDS:-2}"
 
 # Derived paths (set after GC_CITY_PATH validation).
 GC_DIR=""
@@ -93,6 +94,39 @@ tcp_check_port() {
 # tcp_check returns 0 if the dolt port is reachable.
 tcp_check() {
     tcp_check_port "$DOLT_PORT"
+}
+
+run_with_timeout() {
+    local timeout_seconds="$1"
+    shift
+    "$@" &
+    local cmd_pid=$!
+    (
+        sleep "$timeout_seconds" 2>/dev/null || sleep 1
+        kill "$cmd_pid" 2>/dev/null || true
+    ) &
+    local watchdog_pid=$!
+    local status=0
+    wait "$cmd_pid" || status=$?
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+    return "$status"
+}
+
+run_lsof() {
+    command -v lsof >/dev/null 2>&1 || return 127
+    run_with_timeout "$LSOF_TIMEOUT_SECONDS" lsof "$@"
+}
+
+lsof_reports_open() {
+    local status
+    run_lsof "$@" >/dev/null 2>&1
+    status=$?
+    case "$status" in
+        0) return 0 ;;
+        1) return 1 ;;
+        *) return 2 ;;
+    esac
 }
 
 # do_query_probe runs a SELECT active_branch() query against the dolt server.
@@ -472,7 +506,7 @@ run_preflight_cleanup() {
 # find_port_holder returns the PID of the process listening on DOLT_PORT.
 
 find_port_holder() {
-    lsof -i :"$DOLT_PORT" -sTCP:LISTEN -t 2>/dev/null | head -1
+    run_lsof -i :"$DOLT_PORT" -sTCP:LISTEN -t 2>/dev/null | head -1
 }
 
 # verify_our_server checks if a PID belongs to our server (matching data-dir).
@@ -537,7 +571,9 @@ has_deleted_data_inodes() {
     local pid="$1"
     [ -n "$pid" ] || return 1
 
+    local checked_proc=false
     if [ -d "/proc/$pid" ]; then
+        checked_proc=true
         local cwd
         cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || true
         case "$cwd" in
@@ -548,6 +584,7 @@ has_deleted_data_inodes() {
     fi
 
     if [ -d "/proc/$pid/fd" ]; then
+        checked_proc=true
         local fd target
         for fd in /proc/"$pid"/fd/*; do
             [ -e "$fd" ] || [ -L "$fd" ] || continue
@@ -564,8 +601,12 @@ has_deleted_data_inodes() {
         done
     fi
 
+    if [ "$checked_proc" = "true" ]; then
+        return 1
+    fi
+
     if command -v lsof >/dev/null 2>&1; then
-        if lsof -p "$pid" 2>/dev/null | grep ' (deleted)' | grep -F -- "$DATA_DIR" >/dev/null 2>&1; then
+        if run_lsof -p "$pid" 2>/dev/null | grep ' (deleted)' | grep -F -- "$DATA_DIR" >/dev/null 2>&1; then
             return 0
         fi
     fi
@@ -636,11 +677,22 @@ cleanup_stale_locks() {
         [ -d "$dir" ] || continue
         local lock_file="$dir/.dolt/noms/LOCK"
         if [ -f "$lock_file" ]; then
-            # Check if any process holds the lock file.
-            if ! lsof "$lock_file" >/dev/null 2>&1; then
-                echo "removing stale LOCK: $lock_file" >&2
-                rm -f "$lock_file"
-            fi
+            local open_status
+            set +e
+            lsof_reports_open "$lock_file"
+            open_status=$?
+            set -e
+            case "$open_status" in
+                0)
+                    ;;
+                1)
+                    echo "removing stale LOCK: $lock_file" >&2
+                    rm -f "$lock_file"
+                    ;;
+                *)
+                    echo "preserving LOCK with unknown open-file state: $lock_file" >&2
+                    ;;
+            esac
         fi
     done
 }
@@ -796,6 +848,7 @@ wait_for_managed_pid_ready() {
     local attempt=0 max_attempts=1
     [ -n "$pid" ] || return 1
     [ -n "$port" ] || port="$DOLT_PORT"
+    DOLT_PORT="$port"
 
     if load_wait_ready_from_gc "$pid" "$timeout_ms" "$check_deleted"; then
         [ "$GC_WAIT_READY" = "true" ] || return 1
@@ -902,14 +955,16 @@ wait_for_concurrent_start_ready() {
             fi
         fi
         if [ "$GC_EXISTING_USED" != "true" ] && [ "$GC_PROBE_USED" != "true" ]; then
-            existing_pid=$(find_dolt_pid)
             existing_port=$(load_state_field port)
-            if [ -n "$existing_pid" ] && [ -n "$existing_port" ] && verify_our_server "$existing_pid"; then
-                DOLT_PORT="$existing_port"
-                if tcp_check_port "$existing_port" && do_query_probe; then
-                    echo "$existing_pid" > "$PID_FILE"
-                    save_state "$existing_pid" true
-                    return 0
+            if [ -n "$existing_port" ]; then
+                existing_pid=$(find_dolt_pid)
+                if [ -n "$existing_pid" ] && verify_our_server "$existing_pid"; then
+                    DOLT_PORT="$existing_port"
+                    if tcp_check_port "$existing_port" && do_query_probe; then
+                        echo "$existing_pid" > "$PID_FILE"
+                        save_state "$existing_pid" true
+                        return 0
+                    fi
                 fi
             fi
         fi
@@ -1089,7 +1144,7 @@ allocate_port() {
     local port="$hash_val"
     local attempts=0
     while [ "$attempts" -lt 100 ]; do
-        if ! lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+        if ! run_lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
             echo "$port"
             return
         fi
@@ -1111,7 +1166,7 @@ next_available_port() {
         if [ "$port" -gt 60000 ]; then
             port=10000
         fi
-        if ! lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+        if ! run_lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
             echo "$port"
             return
         fi
@@ -1141,11 +1196,22 @@ clean_stale_sockets() {
     local sock
     for sock in /tmp/dolt*.sock; do
         [ -S "$sock" ] || continue
-        # Check if any process holds the socket open.
-        if ! lsof "$sock" >/dev/null 2>&1; then
-            echo "removing stale socket: $sock" >&2
-            rm -f "$sock"
-        fi
+        local open_status
+        set +e
+        lsof_reports_open "$sock"
+        open_status=$?
+        set -e
+        case "$open_status" in
+            0)
+                ;;
+            1)
+                echo "removing stale socket: $sock" >&2
+                rm -f "$sock"
+                ;;
+            *)
+                echo "preserving socket with unknown open-file state: $sock" >&2
+                ;;
+        esac
     done
 }
 

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -167,8 +167,8 @@ func waitForManagedDoltCityReady(env []string, cityDir string, timeout time.Dura
 				"GC_CITY="+cityDir,
 				"GC_CITY_PATH="+cityDir,
 				"GC_CITY_RUNTIME_DIR="+filepath.Join(cityDir, ".gc", "runtime"),
-				"GC_DOLT_PORT="+port,
 			)
+			probeEnv = appendManagedDoltEndpointEnv(probeEnv, port)
 			lastOut, lastErr = runCommand(cityDir, probeEnv, integrationBDCommandTimeout, bdBinary, "list", "--all", "--json", "--limit=0")
 			if lastErr == nil {
 				return lastOut, nil

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -416,8 +416,7 @@ func bdDolt(dir string, args ...string) (string, error) {
 			"GC_CITY_RUNTIME_DIR="+filepath.Join(dir, ".gc", "runtime"),
 		)
 		if port, ok := ensureManagedDoltPortForTest(dir); ok {
-			env = filterEnv(env, "GC_DOLT_PORT")
-			env = append(env, "GC_DOLT_PORT="+port)
+			env = appendManagedDoltEndpointEnv(env, port)
 		}
 	}
 	out, err := runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
@@ -425,11 +424,20 @@ func bdDolt(dir string, args ...string) (string, error) {
 		return out, err
 	}
 	if port, ok := ensureManagedDoltPortForTest(dir); ok {
-		env = filterEnv(env, "GC_DOLT_PORT")
-		env = append(env, "GC_DOLT_PORT="+port)
+		env = appendManagedDoltEndpointEnv(env, port)
 		return runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
 	}
 	return out, err
+}
+
+func appendManagedDoltEndpointEnv(env []string, port string) []string {
+	env = filterEnvMany(env, "GC_DOLT_HOST", "GC_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT")
+	return append(env,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+port,
+		"BEADS_DOLT_SERVER_HOST=127.0.0.1",
+		"BEADS_DOLT_SERVER_PORT="+port,
+	)
 }
 
 func runGCWithEnv(env []string, dir string, args ...string) (string, error) {

--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -267,7 +267,7 @@ func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {
 		"GC_CITY_RUNTIME_DIR="+filepath.Join(cityDir, ".gc", "runtime"),
 	)
 	if port, ok := ensureManagedDoltPortForTest(cityDir); ok {
-		env = append(env, "GC_DOLT_PORT="+port)
+		env = appendManagedDoltEndpointEnv(env, port)
 	} else {
 		t.Fatalf("managed Dolt port did not become ready for %s", cityDir)
 	}


### PR DESCRIPTION
## Summary
- Prefer `/proc` inspection for managed Dolt process ownership, port holders, and open-file/socket checks before falling back to bounded `lsof`/`ps` subprocesses.
- Bound shell `lsof` probes in `gc-beads-bd` so stale lock/socket cleanup preserves artifacts when open-file state is unknown instead of hanging or deleting optimistically.
- Pin managed Dolt host/port env consistently in integration helpers and make lifecycle tests robust to address-in-use retry launches.

## Tests
- `go test -count=20 ./cmd/gc -run '^TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure$' -timeout 10m`
- `go test -count=20 ./cmd/gc -run '^TestGcBeadsBdStartRestartsServerHoldingDeletedDataInodes$' -timeout 10m`
- `go test -count=1 ./cmd/gc -run 'TestProcessArgsFromPSReturnsWhenPSHangs|TestFindPortHolderPIDUsesProcBeforeLsof|TestGcBeadsBdStartIsIdempotentWhenAlreadyRunning|TestGcBeadsBdStartRestartsServerHoldingDeletedDataInodes|TestGcBeadsBdEnsureReadyDoesNotRestartAfterTransientTCPProbeFailure|TestFileOpenedByAnyProcessBoundsLsof|TestGcBeadsBdCleanupStaleLocksBoundsLsof' -timeout 240s`
- `go test -count=1 ./cmd/gc -timeout 15m` passed before the final rebase; the post-rebase focused lifecycle set above passed after conflict resolution.
- `go test -tags=integration -count=1 ./test/integration -run TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep -timeout 20m`
- `go vet ./...`

Local `go test ./...` attempts on this shared host were killed with exit code `-1` before the Go test runner emitted output while unrelated review/test worktrees were running concurrently; CI should provide the uncontended repo-wide signal.
