### PR TITLE
Fix molecule step cleanup during wisp GC

### DIFF
--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -86,69 +85,78 @@ func deleteExpiredBeadClosure(store beads.Store, rootID string) error {
 	if err != nil {
 		return err
 	}
-	_, errs := deleteWorkflowBeads(store, ids)
-	if len(errs) == 0 {
-		return nil
-	}
-	joined := make([]error, 0, len(errs))
-	for _, err := range errs {
-		if err != nil {
-			joined = append(joined, err)
+	for _, id := range ids {
+		if err := deleteWorkflowBead(store, id); err != nil {
+			return err
 		}
 	}
-	if len(joined) == 0 {
-		return nil
-	}
-	return errors.Join(joined...)
+	return nil
 }
 
 func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, error) {
 	if store == nil {
 		return nil, fmt.Errorf("bead store unavailable")
 	}
-	queue := []string{rootID}
+	rootOwned := make([]string, 0, 4)
 	if related, err := store.List(beads.ListQuery{
 		Metadata:      map[string]string{"gc.root_bead_id": rootID},
 		IncludeClosed: true,
 	}); err == nil {
 		for _, bead := range related {
-			queue = append(queue, bead.ID)
+			if bead.ID != "" && bead.ID != rootID {
+				rootOwned = append(rootOwned, bead.ID)
+			}
 		}
 	}
 
-	seen := make(map[string]struct{}, len(queue))
-	ids := make([]string, 0, len(queue))
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
+	seen := make(map[string]struct{}, len(rootOwned)+1)
+	ids := make([]string, 0, len(rootOwned)+1)
+	var visit func(string) error
+	visit = func(id string) error {
 		if id == "" {
-			continue
+			return nil
 		}
 		if _, ok := seen[id]; ok {
-			continue
+			return nil
 		}
 		seen[id] = struct{}{}
-		ids = append(ids, id)
 
-		upDeps, err := store.DepList(id, "up")
-		if err != nil {
-			return nil, fmt.Errorf("list dependents for %s: %w", id, err)
-		}
-		for _, dep := range upDeps {
-			if dep.IssueID != "" {
-				queue = append(queue, dep.IssueID)
+		if id == rootID {
+			for _, relatedID := range rootOwned {
+				if err := visit(relatedID); err != nil {
+					return err
+				}
 			}
 		}
 
 		children, err := store.Children(id, beads.IncludeClosed)
 		if err != nil {
-			return nil, fmt.Errorf("list children for %s: %w", id, err)
+			return fmt.Errorf("list children for %s: %w", id, err)
 		}
 		for _, child := range children {
-			if child.ID != "" {
-				queue = append(queue, child.ID)
+			if err := visit(child.ID); err != nil {
+				return err
 			}
 		}
+
+		upDeps, err := store.DepList(id, "up")
+		if err != nil {
+			return fmt.Errorf("list dependents for %s: %w", id, err)
+		}
+		for _, dep := range upDeps {
+			if dep.Type != "parent-child" || dep.IssueID == "" {
+				continue
+			}
+			if err := visit(dep.IssueID); err != nil {
+				return err
+			}
+		}
+
+		ids = append(ids, id)
+		return nil
+	}
+	if err := visit(rootID); err != nil {
+		return nil, err
 	}
 	return ids, nil
 }

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -72,10 +73,82 @@ func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
-		if err := store.Delete(entry.ID); err != nil {
+		if err := deleteExpiredBeadClosure(store, entry.ID); err != nil {
 			continue
 		}
 		purged++
 	}
 	return purged
+}
+
+func deleteExpiredBeadClosure(store beads.Store, rootID string) error {
+	ids, err := collectExpiredBeadClosure(store, rootID)
+	if err != nil {
+		return err
+	}
+	_, errs := deleteWorkflowBeads(store, ids)
+	if len(errs) == 0 {
+		return nil
+	}
+	joined := make([]error, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			joined = append(joined, err)
+		}
+	}
+	if len(joined) == 0 {
+		return nil
+	}
+	return errors.Join(joined...)
+}
+
+func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, error) {
+	if store == nil {
+		return nil, fmt.Errorf("bead store unavailable")
+	}
+	queue := []string{rootID}
+	if related, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": rootID},
+		IncludeClosed: true,
+	}); err == nil {
+		for _, bead := range related {
+			queue = append(queue, bead.ID)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(queue))
+	ids := make([]string, 0, len(queue))
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+
+		upDeps, err := store.DepList(id, "up")
+		if err != nil {
+			return nil, fmt.Errorf("list dependents for %s: %w", id, err)
+		}
+		for _, dep := range upDeps {
+			if dep.IssueID != "" {
+				queue = append(queue, dep.IssueID)
+			}
+		}
+
+		children, err := store.Children(id, beads.IncludeClosed)
+		if err != nil {
+			return nil, fmt.Errorf("list children for %s: %w", id, err)
+		}
+		for _, child := range children {
+			if child.ID != "" {
+				queue = append(queue, child.ID)
+			}
+		}
+	}
+	return ids, nil
 }

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -98,14 +98,16 @@ func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, erro
 		return nil, fmt.Errorf("bead store unavailable")
 	}
 	rootOwned := make([]string, 0, 4)
-	if related, err := store.List(beads.ListQuery{
+	related, err := store.List(beads.ListQuery{
 		Metadata:      map[string]string{"gc.root_bead_id": rootID},
 		IncludeClosed: true,
-	}); err == nil {
-		for _, bead := range related {
-			if bead.ID != "" && bead.ID != rootID {
-				rootOwned = append(rootOwned, bead.ID)
-			}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list workflow-owned beads for %s: %w", rootID, err)
+	}
+	for _, bead := range related {
+		if bead.ID != "" && bead.ID != rootID {
+			rootOwned = append(rootOwned, bead.ID)
 		}
 	}
 

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -131,6 +131,10 @@ func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, erro
 			}
 		}
 
+		// Treat structural parentage as workflow ownership. Some molecule step
+		// beads are linked only by ParentID / parent-child deps and do not carry
+		// gc.root_bead_id metadata, so GC must follow those ownership edges while
+		// still ignoring non-ownership deps such as blocks or waits-for.
 		children, err := store.Children(id, beads.IncludeClosed)
 		if err != nil {
 			return fmt.Errorf("list children for %s: %w", id, err)

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -156,6 +156,76 @@ func TestWispGC_PurgesExpiredMoleculeChildrenWithRoot(t *testing.T) {
 	}
 }
 
+func TestWispGC_DoesNotDeleteExternalDependents(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		makeGCBead("external-1", now.Add(-2*time.Hour), "open", "task"),
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("external-1", "mol-1.1", "blocks"); err != nil {
+		t.Fatalf("DepAdd(external-1->mol-1.1): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-1.1")
+	if _, err := store.Get("external-1"); err != nil {
+		t.Fatalf("external dependent was deleted: %v", err)
+	}
+}
+
+func TestWispGC_LeavesRootWhenChildDeleteFails(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	store.deleteErrors["mol-1.1"] = fmt.Errorf("delete failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0 when child delete fails", purged)
+	}
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted = %v, want none", store.deletedIDs)
+	}
+	if _, err := store.Get("mol-1"); err != nil {
+		t.Fatalf("root deleted after child failure: %v", err)
+	}
+	if _, err := store.Get("mol-1.1"); err != nil {
+		t.Fatalf("child unexpectedly deleted after failure: %v", err)
+	}
+}
+
 func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -114,6 +114,48 @@ func TestWispGC_DeleteErrorContinues(t *testing.T) {
 	assertDeletedIDs(t, store.deletedIDs, "mol-2")
 }
 
+func TestWispGC_PurgesExpiredMoleculeChildrenWithRoot(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		{
+			ID:        "mol-1.2",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1.1",
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.2", "mol-1.1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.2->mol-1.1): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 root purge accounting", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-1.1", "mol-1.2")
+	for _, id := range []string{"mol-1", "mol-1.1", "mol-1.2"} {
+		if _, err := store.Get(id); err == nil {
+			t.Fatalf("Get(%s) succeeded after GC delete", id)
+		}
+	}
+}
+
 func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -262,6 +262,76 @@ func TestWispGC_LeavesRootWhenChildDeleteFails(t *testing.T) {
 	}
 }
 
+func TestWispGC_PartialChildDeleteRemainsRetryable(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		{
+			ID:        "mol-1.1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1.1",
+		},
+		{
+			ID:        "mol-1.2",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.1.1", "mol-1.1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1.1->mol-1.1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.2", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.2->mol-1): %v", err)
+	}
+	store.deleteErrors["mol-1.2"] = fmt.Errorf("delete failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC first pass: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("first purged = %d, want 0", purged)
+	}
+	if _, err := store.Get("mol-1"); err != nil {
+		t.Fatalf("root deleted after partial child failure: %v", err)
+	}
+	if _, err := store.Get("mol-1.2"); err != nil {
+		t.Fatalf("failing child deleted unexpectedly: %v", err)
+	}
+	if _, err := store.Get("mol-1.1"); err == nil {
+		t.Fatalf("expected an earlier child to be deleted before downstream failure")
+	}
+
+	delete(store.deleteErrors, "mol-1.2")
+	purged, err = wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC second pass: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("second purged = %d, want 1", purged)
+	}
+	for _, id := range []string{"mol-1", "mol-1.2"} {
+		if _, err := store.Get(id); err == nil {
+			t.Fatalf("Get(%s) succeeded after retry cleanup", id)
+		}
+	}
+}
+
 func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -190,6 +190,42 @@ func TestWispGC_DoesNotDeleteExternalDependents(t *testing.T) {
 	}
 }
 
+func TestWispGC_PurgesParentChildOwnedDependentsWithoutMetadata(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		{
+			ID:        "mol-1.2",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.2", "mol-1.1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.2->mol-1.1): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-1.1", "mol-1.2")
+}
+
 func TestWispGC_LeavesRootWhenChildDeleteFails(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -423,6 +423,33 @@ func TestMemStoreReadyRespectsBlockingDeps(t *testing.T) {
 	}
 }
 
+func TestMemStoreReadyIgnoresParentChildDeps(t *testing.T) {
+	s := beads.NewMemStore()
+
+	parent, err := s.Create(beads.Bead{Title: "parent", Type: "molecule"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := s.Create(beads.Bead{Title: "child", Type: "task", ParentID: parent.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DepAdd(child.ID, parent.ID, "parent-child"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Ready()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Ready() returned %d beads, want 1", len(got))
+	}
+	if got[0].ID != child.ID {
+		t.Fatalf("Ready()[0].ID = %s, want %s", got[0].ID, child.ID)
+	}
+}
+
 func TestMemStoreDepListDefaultDirection(t *testing.T) {
 	s := beads.NewMemStore()
 	_ = s.DepAdd("a", "b", "blocks")

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -388,6 +388,7 @@ func setNodeParentRef(nodes []beads.GraphApplyNode, stepID, parentKey, parentID 
 		}
 		if parentKey != "" {
 			nodes[i].ParentKey = parentKey
+			nodes[i].ParentID = ""
 		}
 		if parentID != "" {
 			nodes[i].ParentID = parentID

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -503,10 +503,6 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if !fromOK || !toOK {
 				continue // step was filtered out (RootOnly or condition)
 			}
-			// Skip parent-child deps — already handled via ParentID field.
-			if dep.Type == "parent-child" {
-				continue
-			}
 			if embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] {
 				continue
 			}
@@ -622,6 +618,20 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 				b.Needs = append(b.Needs, dep.Type+":"+dep.DependsOnID)
 			}
 		}
+		for _, dep := range recipe.Deps {
+			if dep.StepID == step.ID && dep.Type == "parent-child" {
+				if parentBeadID, ok := idMapping[dep.DependsOnID]; ok {
+					b.ParentID = parentBeadID
+				}
+				break
+			}
+		}
+		for _, dep := range externalDepsByStep[step.ID] {
+			if dep.Type == "parent-child" && dep.DependsOnID != "" {
+				b.ParentID = dep.DependsOnID
+				break
+			}
+		}
 
 		if b.Metadata == nil {
 			b.Metadata = make(map[string]string, 2)
@@ -665,7 +675,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 	for _, dep := range recipe.Deps {
 		fromID, fromOK := idMapping[dep.StepID]
 		toID, toOK := idMapping[dep.DependsOnID]
-		if !fromOK || !toOK || dep.Type == "parent-child" {
+		if !fromOK || !toOK {
 			continue
 		}
 		if embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -622,12 +622,12 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 			if dep.StepID == step.ID && dep.Type == "parent-child" {
 				if parentBeadID, ok := idMapping[dep.DependsOnID]; ok {
 					b.ParentID = parentBeadID
+					break
 				}
-				break
 			}
 		}
 		for _, dep := range externalDepsByStep[step.ID] {
-			if dep.Type == "parent-child" && dep.DependsOnID != "" {
+			if b.ParentID == "" && dep.Type == "parent-child" && dep.DependsOnID != "" {
 				b.ParentID = dep.DependsOnID
 				break
 			}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -98,6 +98,21 @@ func TestInstantiateSimple(t *testing.T) {
 	if stepB.ParentID != result.RootID {
 		t.Errorf("step-b.ParentID = %q, want %q", stepB.ParentID, result.RootID)
 	}
+
+	deps, err := store.DepList(stepBID, "down")
+	if err != nil {
+		t.Fatalf("DepList(step-b): %v", err)
+	}
+	foundParent := false
+	for _, dep := range deps {
+		if dep.Type == "parent-child" && dep.DependsOnID == result.RootID {
+			foundParent = true
+			break
+		}
+	}
+	if !foundParent {
+		t.Fatalf("step-b missing parent-child dependency to root; deps=%v", deps)
+	}
 }
 
 func TestInstantiateUsesGraphApplyStoreWhenAvailable(t *testing.T) {
@@ -733,6 +748,61 @@ func TestInstantiateFragmentInheritsRootPriority(t *testing.T) {
 		if bead.Priority == nil || *bead.Priority != 1 {
 			t.Fatalf("fragment bead %s priority = %v, want 1", bead.ID, bead.Priority)
 		}
+	}
+}
+
+func TestInstantiateFragmentRecordsParentChildDeps(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{RootID: root.ID})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+
+	childID := result.IDMapping["frag.scope.child"]
+	parentID := result.IDMapping["frag.scope"]
+	if childID == "" || parentID == "" {
+		t.Fatalf("fragment IDs = %#v, want parent and child IDs", result.IDMapping)
+	}
+	child, err := store.Get(childID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if child.ParentID != parentID {
+		t.Fatalf("child.ParentID = %q, want %q", child.ParentID, parentID)
+	}
+	deps, err := store.DepList(childID, "down")
+	if err != nil {
+		t.Fatalf("DepList(child): %v", err)
+	}
+	found := false
+	for _, dep := range deps {
+		if dep.Type == "parent-child" && dep.DependsOnID == parentID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("child missing parent-child dependency on scope bead; deps=%v", deps)
 	}
 }
 

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -806,6 +806,58 @@ func TestInstantiateFragmentRecordsParentChildDeps(t *testing.T) {
 	}
 }
 
+func TestInstantiateFragmentPrefersRecipeParentOverExternalParent(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	externalParent, err := store.Create(beads.Bead{
+		Title: "External parent",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create external parent: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{
+				StepID:      "frag.scope.child",
+				DependsOnID: externalParent.ID,
+				Type:        "parent-child",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+
+	child, err := store.Get(result.IDMapping["frag.scope.child"])
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if child.ParentID != result.IDMapping["frag.scope"] {
+		t.Fatalf("child.ParentID = %q, want recipe parent %q", child.ParentID, result.IDMapping["frag.scope"])
+	}
+}
+
 func TestBuildFragmentApplyPlan_UsesTracksOwnershipEdges(t *testing.T) {
 	store := beads.NewMemStore()
 	root, err := store.Create(beads.Bead{

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -858,6 +858,68 @@ func TestInstantiateFragmentPrefersRecipeParentOverExternalParent(t *testing.T) 
 	}
 }
 
+func TestInstantiateFragmentGraphApplyPrefersRecipeParentOverExternalParent(t *testing.T) {
+	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	externalParent, err := store.Create(beads.Bead{
+		Title: "External parent",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create external parent: %v", err)
+	}
+
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	if _, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{
+				StepID:      "frag.scope.child",
+				DependsOnID: externalParent.ID,
+				Type:        "parent-child",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+	if store.plan == nil {
+		t.Fatal("ApplyGraphPlan was not called")
+	}
+
+	nodesByKey := make(map[string]beads.GraphApplyNode, len(store.plan.Nodes))
+	for _, node := range store.plan.Nodes {
+		nodesByKey[node.Key] = node
+	}
+	child := nodesByKey["frag.scope.child"]
+	if child.ParentKey != "frag.scope" {
+		t.Fatalf("child.ParentKey = %q, want frag.scope", child.ParentKey)
+	}
+	if child.ParentID != "" {
+		t.Fatalf("child.ParentID = %q, want empty when recipe parent wins", child.ParentID)
+	}
+}
+
 func TestBuildFragmentApplyPlan_UsesTracksOwnershipEdges(t *testing.T) {
 	store := beads.NewMemStore()
 	root, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary
- delete expired workflow-owned molecule closures child-first instead of deleting only the root bead
- persist parent-child ownership edges in sequential molecule and fragment instantiation, and align fragment parent precedence across fallback and graph-apply paths
- add regression coverage for structural ownership traversal, retryable partial GC cleanup, and the non-blocking readiness contract for parent-child deps

Closes #932.

## Testing
- go test ./cmd/gc -run 'TestWispGC_|TestDeleteWorkflowBeads'
- go test ./internal/molecule
- go test ./internal/beads -run 'TestMemStoreReadyRespectsBlockingDeps|TestMemStoreReadyIgnoresParentChildDeps'

## Review
- final focused Codex blocker/major pass returned: `No blocker or major findings.`
- Claude and Gemini review lanes were quota-blocked in this environment, so the final clean review signal came from Codex after the follow-up fixes/tests