### PR TITLE
fix: repair RC gate failures from run 24640328594

### DIFF
--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -62,7 +62,6 @@ func startupCommandMaterializationResult(tc phase2ProviderCase, tp TemplateParam
 
 func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp TemplateParams, cfg runtime.Config) workertest.Result {
 	evidence := phase2ConfigEvidence(tc, tp, cfg)
-	hookStartup := tp.HookEnabled && tp.ResolvedProvider != nil && tp.ResolvedProvider.SupportsHooks
 	switch {
 	case cfg.Command != tp.Command:
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
@@ -70,12 +69,9 @@ func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp Templat
 	case cfg.WorkDir != tp.WorkDir:
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("cfg.WorkDir = %q, want %q", cfg.WorkDir, tp.WorkDir)).WithEvidence(evidence)
-	case !hookStartup && cfg.PromptSuffix == "":
+	case cfg.PromptSuffix == "":
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			"cfg.PromptSuffix = empty, want beacon prompt materialized").WithEvidence(evidence)
-	case hookStartup && cfg.PromptSuffix != "":
-		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
-			fmt.Sprintf("cfg.PromptSuffix = %q, want empty when startup prompt is delivered via hooks", cfg.PromptSuffix)).WithEvidence(evidence)
 	case cfg.PromptFlag != "":
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("cfg.PromptFlag = %q, want empty for arg-mode provider", cfg.PromptFlag)).WithEvidence(evidence)
@@ -134,9 +130,6 @@ func initialMessageFirstStartResult(tc phase2ProviderCase, prepared *preparedSta
 			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
 	}
 	want := "Base worker prompt\n\n---\n\nUser message:\nDo the first task."
-	if prepared != nil && prepared.candidate.tp.HookEnabled && prepared.candidate.tp.ResolvedProvider != nil && prepared.candidate.tp.ResolvedProvider.SupportsHooks {
-		want = "Do the first task."
-	}
 	switch {
 	case got != want:
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageFirstStart,
@@ -157,9 +150,6 @@ func initialMessageResumeResult(tc phase2ProviderCase, prepared *preparedStart) 
 			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
 	}
 	want := "Base worker prompt"
-	if prepared != nil && prepared.candidate.tp.HookEnabled && prepared.candidate.tp.ResolvedProvider != nil && prepared.candidate.tp.ResolvedProvider.SupportsHooks {
-		want = ""
-	}
 	switch {
 	case got != want:
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -73,9 +73,10 @@ type TemplateParams struct {
 	// IsACP is true if session = "acp".
 	IsACP bool
 	// HookEnabled reports whether provider hooks are installed for this agent.
-	// Hook-enabled providers receive startup context via their hook path
-	// (for example gc prime --hook), so PromptMode=none should not also
-	// fall back to a delayed startup nudge.
+	// Hooks complement startup delivery but do not replace the initial
+	// user-turn prompt. SessionStart hooks can add context, persist session
+	// metadata, and start background helpers, but they do not initiate the
+	// first model turn on their own.
 	HookEnabled bool
 	// DependencyOnly marks a realized cold slot kept only so dependency wake
 	// has something concrete to wake even when pool check wants zero.
@@ -532,23 +533,20 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 	var promptSuffix string
 	var promptFlag string
 	nudge := tp.Hints.Nudge
-	deliverStartupViaHooks := tp.HookEnabled && tp.ResolvedProvider != nil && tp.ResolvedProvider.SupportsHooks
 	if tp.Prompt != "" {
-		// Hook-enabled providers prime themselves on SessionStart via
-		// gc prime --hook, so the rendered role prompt must not also be
-		// replayed as argv or a delayed startup nudge.
-		if !deliverStartupViaHooks {
-			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
-				if nudge != "" {
-					nudge = tp.Prompt + "\n\n---\n\n" + nudge
-				} else {
-					nudge = tp.Prompt
-				}
+		// SessionStart hooks can enrich context, but the startup prompt still
+		// needs a first-turn delivery mechanism. Without argv/flag/nudge
+		// delivery, freshly spawned workers sit idle at the provider prompt.
+		if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
+			if nudge != "" {
+				nudge = tp.Prompt + "\n\n---\n\n" + nudge
 			} else {
-				promptSuffix = shellquote.Quote(tp.Prompt)
-				if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" && tp.ResolvedProvider.PromptFlag != "" {
-					promptFlag = tp.ResolvedProvider.PromptFlag
-				}
+				nudge = tp.Prompt
+			}
+		} else {
+			promptSuffix = shellquote.Quote(tp.Prompt)
+			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" && tp.ResolvedProvider.PromptFlag != "" {
+				promptFlag = tp.ResolvedProvider.PromptFlag
 			}
 		}
 	}

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -113,7 +113,7 @@ func TestTemplateParamsToConfigNoneModeUsesNudge(t *testing.T) {
 	}
 }
 
-func TestTemplateParamsToConfigNoneModeWithHooksSkipsStartupNudge(t *testing.T) {
+func TestTemplateParamsToConfigNoneModeWithHooksStillUsesStartupNudge(t *testing.T) {
 	tp := TemplateParams{
 		Command: "opencode",
 		Prompt:  "You are an agent. Do work.",
@@ -134,12 +134,13 @@ func TestTemplateParamsToConfigNoneModeWithHooksSkipsStartupNudge(t *testing.T) 
 	if cfg.PromptSuffix != "" {
 		t.Errorf("PromptSuffix should be empty for none mode, got %q", cfg.PromptSuffix)
 	}
-	if cfg.Nudge != "existing nudge" {
-		t.Errorf("Nudge = %q, want existing nudge only", cfg.Nudge)
+	want := "You are an agent. Do work.\n\n---\n\nexisting nudge"
+	if cfg.Nudge != want {
+		t.Errorf("Nudge = %q, want %q", cfg.Nudge, want)
 	}
 }
 
-func TestTemplateParamsToConfigHookEnabledProviderSkipsLaunchPrompt(t *testing.T) {
+func TestTemplateParamsToConfigHookEnabledProviderStillUsesLaunchPrompt(t *testing.T) {
 	tests := []struct {
 		name       string
 		promptMode string
@@ -169,11 +170,15 @@ func TestTemplateParamsToConfigHookEnabledProviderSkipsLaunchPrompt(t *testing.T
 
 			cfg := templateParamsToConfig(tp)
 
-			if cfg.PromptSuffix != "" {
-				t.Fatalf("PromptSuffix should be empty for hook-enabled startup, got %q", cfg.PromptSuffix)
+			if cfg.PromptSuffix == "" {
+				t.Fatalf("PromptSuffix should still carry the startup prompt when hooks are enabled")
 			}
-			if cfg.PromptFlag != "" {
-				t.Fatalf("PromptFlag should be empty for hook-enabled startup, got %q", cfg.PromptFlag)
+			if tt.promptMode == "flag" {
+				if cfg.PromptFlag != "--prompt" {
+					t.Fatalf("PromptFlag = %q, want %q", cfg.PromptFlag, "--prompt")
+				}
+			} else if cfg.PromptFlag != "" {
+				t.Fatalf("PromptFlag should be empty for arg mode, got %q", cfg.PromptFlag)
 			}
 			if cfg.Nudge != "existing nudge" {
 				t.Fatalf("Nudge = %q, want existing nudge only", cfg.Nudge)

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -201,7 +201,7 @@ Rig added.
 ```
 
 Gas City derived the rig name from the directory basename (`my-project`) and set
-up work tracking in it. You can see the new entry in `city.toml`:
+up work tracking in it. The shared rig declaration lives in `city.toml`:
 
 ```shell
 
@@ -214,6 +214,13 @@ provider = "claude"
 ... # content elided
 
 [[rigs]]
+name = "my-project"
+```
+
+The machine-local path binding lives in `.gc/site.toml`:
+
+```toml
+[[rig]]
 name = "my-project"
 path = "/Users/csells/my-project"
 ```

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -37,12 +37,19 @@ provider = "claude"
 
 [[rigs]]
 name = "my-project"
-path = "/Users/csells/my-project"
 
 ~/my-city
 $ cat agents/reviewer/agent.toml
 dir = "my-project"
 provider = "codex"
+```
+
+The rig's machine-local path binding now lives in `.gc/site.toml` instead:
+
+```toml
+[[rig]]
+name = "my-project"
+path = "/Users/csells/my-project"
 ```
 
 The reviewer's prompt lives at `agents/reviewer/prompt.template.md`. This is the

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -385,17 +385,26 @@ And your city applies that pack to two rigs:
 # city.toml
 [[rigs]]
 name = "my-api"
-path = "../my-api"
 
 [rigs.imports.dev_ops]
 source = "./packs/dev-ops"
 
 [[rigs]]
 name = "my-frontend"
-path = "../my-frontend"
 
 [rigs.imports.dev_ops]
 source = "./packs/dev-ops"
+```
+
+```toml
+# .gc/site.toml
+[[rig]]
+name = "my-api"
+path = "../my-api"
+
+[[rig]]
+name = "my-frontend"
+path = "../my-frontend"
 ```
 
 Now the city has the same order running independently for each rig:

--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -42,12 +42,7 @@ func TestMain(m *testing.M) {
 	// 1. ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN env var (CI mode)
 	// 2. GC_TIERC_FORCE=1 env var (local OAuth mode — user asserts Claude is authed)
 	// 3. Detect OAuth: check if ~/.claude/ exists with credentials
-	authToken := strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN"))
-	apiKey := firstNonEmpty(
-		strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")),
-		authToken,
-	)
-	hasEnvAuth := authToken != "" || apiKey != ""
+	apiKey, _, hasEnvAuth := tierCEnvAuth()
 	forceRun := os.Getenv("GC_TIERC_FORCE") == "1"
 	hasOAuth := oauthCredentialsExist()
 
@@ -104,7 +99,7 @@ func TestMain(m *testing.M) {
 	// leaving the on-disk token expired. A quick --print call forces the
 	// refresh and (in newer versions) persists it.
 	if refreshOut, err := exec.Command("claude", "--print", "ok").CombinedOutput(); err != nil {
-		if apiKey != "" {
+		if hasEnvAuth {
 			panic(fmt.Sprintf("acceptance-c: provider preflight failed: %v\n%s", err, refreshOut))
 		}
 		fmt.Fprintf(os.Stderr, "acceptance-c: OAuth preflight refresh failed: %v\n%s\n", err, refreshOut)
@@ -636,13 +631,11 @@ func oauthCredentialsExist() bool {
 	return false
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
+func tierCEnvAuth() (apiKey, authToken string, hasEnvAuth bool) {
+	apiKey = strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	authToken = strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+	hasEnvAuth = apiKey != "" || authToken != ""
+	return apiKey, authToken, hasEnvAuth
 }
 
 func stageTierCAcceptanceProviders(binDir, apiKey string) error {
@@ -704,6 +697,16 @@ func tierCHostProviderShim(name string, unsetVars []string) (string, error) {
 
 func shellQuoteTierC(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func TestTierCEnvAuthDoesNotMirrorAuthTokenIntoAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "synthetic-token")
+
+	apiKey, authToken, hasEnvAuth := tierCEnvAuth()
+	require.Empty(t, apiKey)
+	require.Equal(t, "synthetic-token", authToken)
+	require.True(t, hasEnvAuth)
 }
 
 func stageClaudeOAuth(realHome, gcHome string) error {

--- a/test/acceptance/tutorial_goldens/harness_test.go
+++ b/test/acceptance/tutorial_goldens/harness_test.go
@@ -131,6 +131,7 @@ func (w *tutorialWorkspace) runShell(command, stdin string) (string, error) {
 func (w *tutorialWorkspace) runShellWithTimeout(timeout time.Duration, command, stdin string) (string, error) {
 	w.t.Helper()
 	trimmed := strings.TrimSpace(command)
+	command = tutorialShellCommand(command, w.env.Home)
 	for attempt := 1; attempt <= gcInitTransientRetryLimit; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		cmd := exec.CommandContext(ctx, "bash", "-c", command)
@@ -274,6 +275,7 @@ func (w *tutorialWorkspace) startShell(command, stdin string) (*runningShell, er
 	w.t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	command = tutorialShellCommand(command, w.env.Home)
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
 	cmd.Dir = w.cwd
 	cmd.Env = w.env.Env.List()
@@ -354,6 +356,14 @@ func expandHome(home, path string) string {
 		return filepath.Join(home, strings.TrimPrefix(path, "~/"))
 	}
 	return path
+}
+
+func tutorialShellCommand(command, home string) string {
+	if home == "" || !strings.Contains(command, "~/") {
+		return command
+	}
+	rewritten := strings.ReplaceAll(command, "~/", "${GC_TUTORIAL_HOME}/")
+	return fmt.Sprintf("GC_TUTORIAL_HOME=%s; %s", shellQuote(home), rewritten)
 }
 
 func (w *tutorialWorkspace) configureInitializedCities() error {
@@ -515,6 +525,15 @@ func TestRunEnvCommandWithTimeoutUsesAcceptanceGCBinary(t *testing.T) {
 	}
 	if got := strings.TrimSpace(out); got != "tutorial-env-gc" {
 		t.Fatalf("expected acceptance gc binary output, got %q", got)
+	}
+}
+
+func TestTutorialShellCommandRehomesTildePaths(t *testing.T) {
+	home := "/tmp/tutorial-home"
+	got := tutorialShellCommand("cd ~/my-city && gc rig add ~/my-project", home)
+	want := "GC_TUTORIAL_HOME='/tmp/tutorial-home'; cd ${GC_TUTORIAL_HOME}/my-city && gc rig add ${GC_TUTORIAL_HOME}/my-project"
+	if got != want {
+		t.Fatalf("tutorialShellCommand() = %q, want %q", got, want)
 	}
 }
 

--- a/test/acceptance/tutorial_goldens/manifests_test.go
+++ b/test/acceptance/tutorial_goldens/manifests_test.go
@@ -24,6 +24,7 @@ var tutorialPageManifests = []pageManifest{
 			"cd ~/my-city",
 			"ls",
 			"cat city.toml",
+			"cat pack.toml",
 			"gc status",
 			"gc rig add ~/my-project",
 			"cat city.toml",
@@ -100,6 +101,7 @@ var tutorialPageManifests = []pageManifest{
 	{
 		path: "docs/tutorials/06-beads.md",
 		commands: []string{
+			"cat pack.toml",
 			"cat city.toml",
 			"cat agents/reviewer/agent.toml",
 			"bd list",

--- a/test/acceptance/tutorial_goldens/tutorial01_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial01_test.go
@@ -170,8 +170,22 @@ func TestTutorial01Cities(t *testing.T) {
 			if !strings.Contains(out, `name = "my-project"`) {
 				t.Fatalf("city.toml missing rig entry:\n%s", out)
 			}
+			if strings.Contains(out, myProject) {
+				t.Fatalf("city.toml should not contain machine-local rig path %q:\n%s", myProject, out)
+			}
+		})
+
+		t.Run("read .gc/site.toml (with rig)", func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(myCity, ".gc", "site.toml"))
+			if err != nil {
+				t.Fatalf("read .gc/site.toml: %v", err)
+			}
+			out := string(data)
+			if !strings.Contains(out, `name = "my-project"`) {
+				t.Fatalf(".gc/site.toml missing rig entry:\n%s", out)
+			}
 			if !strings.Contains(out, myProject) {
-				t.Fatalf("city.toml missing rig path %q:\n%s", myProject, out)
+				t.Fatalf(".gc/site.toml missing rig path %q:\n%s", myProject, out)
 			}
 		})
 

--- a/test/acceptance/tutorial_goldens/tutorial06_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial06_test.go
@@ -31,8 +31,8 @@ func TestTutorial07Orders(t *testing.T) {
 	replaceInFile(
 		t,
 		cityToml,
-		fmt.Sprintf("name = %q\npath = %q\n", "my-api", myAPI),
-		fmt.Sprintf("name = %q\npath = %q\n\n[rigs.imports.dev_ops]\nsource = \"./packs/dev-ops\"\n", "my-api", myAPI),
+		fmt.Sprintf("name = %q\n", "my-api"),
+		fmt.Sprintf("name = %q\n\n[rigs.imports.dev_ops]\nsource = \"./packs/dev-ops\"\n", "my-api"),
 	)
 
 	writeFile(t, filepath.Join(myCity, "formulas", "review.toml"), `formula = "review"


### PR DESCRIPTION
## Summary
- restore first-turn startup prompt delivery for hook-enabled workers because SessionStart hooks add context but do not initiate the first model turn
- update tutorial acceptance/docs expectations for rig path storage moving from city.toml to .gc/site.toml, and normalize ~/ paths in the tutorial harness
- fix tier-c acceptance auth detection so ANTHROPIC_AUTH_TOKEN is not mirrored into ANTHROPIC_API_KEY

## Verification
- `go test ./cmd/gc -run "TestTemplateParamsToConfig|TestResolveTemplateHookEnabledOpencodeOmitsPrimeInstruction|TestPhase2"`
- `go test ./internal/config ./internal/hooks`
- live acceptance repro after the fix shows fresh Claude pool workers now boot with the full startup prompt instead of a bare prompt

## Local Acceptance Caveat
- full end-to-end tutorial/tier-c acceptance could not be completed locally because the workstation Claude account hit the usage-limit banner during the live worker turn; CI on this PR is the final end-to-end proof for the RC gate