### PR TITLE
fix: harden isolated supervisor service installs

### DIFF
--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/pidutil"
 )
 
 func parseDoltStateOutput(t *testing.T, out string) map[string]string {
@@ -156,6 +157,31 @@ func TestDoltStateAllocatePortCmdReusesLiveProviderState(t *testing.T) {
 	}
 	if got := strings.TrimSpace(stdout.String()); got != strconv.Itoa(port) {
 		t.Fatalf("allocate-port = %q, want %d", got, port)
+	}
+}
+
+func TestStartTCPListenerProcessInDirRegistersCleanup(t *testing.T) {
+	port := reserveRandomTCPPort(t)
+	dir := t.TempDir()
+	var proc *exec.Cmd
+
+	t.Run("listener", func(t *testing.T) {
+		proc = startTCPListenerProcessInDir(t, port, dir)
+		if !pidutil.Alive(proc.Process.Pid) {
+			t.Fatalf("listener pid %d is not alive after start", proc.Process.Pid)
+		}
+	})
+
+	if proc == nil {
+		t.Fatal("listener process handle was not captured")
+	}
+	if proc.ProcessState == nil {
+		t.Fatal("listener cleanup did not wait for process exit")
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 200*time.Millisecond)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("listener port is still reachable after cleanup")
 	}
 }
 

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -26,7 +31,10 @@ var (
 	supervisorAliveHook         = supervisorAlive
 	supervisorReadyTimeout      = 15 * time.Second
 	supervisorReadyPollInterval = 100 * time.Millisecond
-	supervisorSystemctlRun      = func(args ...string) error {
+	supervisorLaunchctlRun      = func(args ...string) error {
+		return exec.Command("launchctl", args...).Run()
+	}
+	supervisorSystemctlRun = func(args ...string) error {
 		return exec.Command("systemctl", args...).Run()
 	}
 	supervisorSystemctlActive = func(service string) bool {
@@ -188,15 +196,16 @@ func unloadSupervisorService() {
 	switch goruntime.GOOS {
 	case "darwin":
 		path := supervisorLaunchdPlistPath()
-		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-			return
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			_ = supervisorLaunchctlRun("unload", path)
 		}
-		exec.Command("launchctl", "unload", path).Run() //nolint:errcheck // best-effort
+		_ = unloadLegacySupervisorLaunchd(false)
 	case "linux":
-		if _, err := os.Stat(supervisorSystemdServicePath()); errors.Is(err, os.ErrNotExist) {
-			return
+		service := supervisorSystemdServiceName()
+		if _, err := os.Stat(supervisorSystemdServicePath()); !errors.Is(err, os.ErrNotExist) {
+			_ = supervisorSystemctlRun("--user", "stop", service)
 		}
-		exec.Command("systemctl", "--user", "stop", "gascity-supervisor.service").Run() //nolint:errcheck // best-effort
+		_ = unloadLegacySupervisorSystemd(false)
 	}
 }
 
@@ -325,6 +334,7 @@ type supervisorServiceData struct {
 	LogPath       string
 	GCHome        string
 	XDGRuntimeDir string
+	LaunchdLabel  string
 	SafeName      string
 	Path          string
 }
@@ -345,6 +355,7 @@ func buildSupervisorServiceData() (*supervisorServiceData, error) {
 		LogPath:       supervisorLogPath(),
 		GCHome:        home,
 		XDGRuntimeDir: xdgRuntimeDir,
+		LaunchdLabel:  supervisorLaunchdLabel(),
 		SafeName:      sanitizeServiceName(filepath.Base(home)),
 		Path:          searchpath.ExpandPath(homeDir, goruntime.GOOS, os.Getenv("PATH")),
 	}, nil
@@ -357,12 +368,45 @@ func sanitizeServiceName(name string) string {
 	return strings.Trim(name, "-")
 }
 
+const (
+	defaultSupervisorLaunchdLabel = "com.gascity.supervisor"
+	defaultSupervisorSystemdUnit  = "gascity-supervisor.service"
+)
+
+func supervisorServiceSuffix() string {
+	if !supervisor.UsesIsolatedGCHomeOverride() {
+		return ""
+	}
+	gcHome := isolatedSupervisorHome()
+	base := sanitizeServiceName(filepath.Base(gcHome))
+	sum := sha1.Sum([]byte(gcHome))
+	hash := hex.EncodeToString(sum[:])[:8]
+	if base == "" {
+		return "isolated-" + hash
+	}
+	return base + "-" + hash
+}
+
+func supervisorLaunchdLabel() string {
+	if suffix := supervisorServiceSuffix(); suffix != "" {
+		return defaultSupervisorLaunchdLabel + "." + suffix
+	}
+	return defaultSupervisorLaunchdLabel
+}
+
+func supervisorSystemdServiceName() string {
+	if suffix := supervisorServiceSuffix(); suffix != "" {
+		return "gascity-supervisor-" + suffix + ".service"
+	}
+	return defaultSupervisorSystemdUnit
+}
+
 const supervisorLaunchdTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.gascity.supervisor</string>
+    <string>{{xmlesc .LaunchdLabel}}</string>
     <key>ProgramArguments</key>
     <array>
         <string>{{xmlesc .GCPath}}</string>
@@ -435,12 +479,268 @@ func renderSupervisorTemplate(tmplStr string, data *supervisorServiceData) (stri
 
 func supervisorLaunchdPlistPath() string {
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, "Library", "LaunchAgents", "com.gascity.supervisor.plist")
+	return filepath.Join(home, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+}
+
+func legacySupervisorLaunchdPlistPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "LaunchAgents", defaultSupervisorLaunchdLabel+".plist")
 }
 
 func supervisorSystemdServicePath() string {
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "share", "systemd", "user", "gascity-supervisor.service")
+	return filepath.Join(home, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+}
+
+func legacySupervisorSystemdServicePath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "share", "systemd", "user", defaultSupervisorSystemdUnit)
+}
+
+func isolatedSupervisorHome() string {
+	return normalizePathForCompare(strings.TrimSpace(os.Getenv("GC_HOME")))
+}
+
+func legacySupervisorTargetsCurrentHome(path string) bool {
+	if !supervisor.UsesIsolatedGCHomeOverride() {
+		return false
+	}
+	gcHome := isolatedSupervisorHome()
+	if gcHome == "" {
+		return false
+	}
+	legacyHome, ok := legacySupervisorHome(path)
+	return ok && samePath(legacyHome, gcHome)
+}
+
+func legacySupervisorHome(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	switch filepath.Ext(path) {
+	case ".plist":
+		return launchdSupervisorHome(data)
+	case ".service":
+		return systemdSupervisorHome(data)
+	default:
+		return "", false
+	}
+}
+
+type plistValue struct {
+	text string
+	dict map[string]plistValue
+}
+
+func launchdSupervisorHome(data []byte) (string, bool) {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			return "", false
+		}
+		if err != nil {
+			return "", false
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "dict" {
+			continue
+		}
+		root, err := parsePlistDict(dec)
+		if err != nil {
+			return "", false
+		}
+		env, ok := root["EnvironmentVariables"]
+		if !ok || env.dict == nil {
+			return "", false
+		}
+		gcHome, ok := env.dict["GC_HOME"]
+		if !ok || gcHome.text == "" {
+			return "", false
+		}
+		return filepath.Clean(gcHome.text), true
+	}
+}
+
+func parsePlistDict(dec *xml.Decoder) (map[string]plistValue, error) {
+	dict := make(map[string]plistValue)
+	currentKey := ""
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch tok := tok.(type) {
+		case xml.StartElement:
+			switch tok.Name.Local {
+			case "key":
+				var key string
+				if err := dec.DecodeElement(&key, &tok); err != nil {
+					return nil, err
+				}
+				currentKey = key
+			case "string":
+				var value string
+				if err := dec.DecodeElement(&value, &tok); err != nil {
+					return nil, err
+				}
+				if currentKey != "" {
+					dict[currentKey] = plistValue{text: value}
+					currentKey = ""
+				}
+			case "dict":
+				nested, err := parsePlistDict(dec)
+				if err != nil {
+					return nil, err
+				}
+				if currentKey != "" {
+					dict[currentKey] = plistValue{dict: nested}
+					currentKey = ""
+				}
+			default:
+				if err := skipXMLElement(dec); err != nil {
+					return nil, err
+				}
+				if currentKey != "" {
+					dict[currentKey] = plistValue{}
+					currentKey = ""
+				}
+			}
+		case xml.EndElement:
+			if tok.Name.Local == "dict" {
+				return dict, nil
+			}
+		}
+	}
+}
+
+func skipXMLElement(dec *xml.Decoder) error {
+	depth := 1
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		switch tok.(type) {
+		case xml.StartElement:
+			depth++
+		case xml.EndElement:
+			depth--
+		}
+	}
+	return nil
+}
+
+func systemdSupervisorHome(data []byte) (string, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "Environment=GC_HOME=") {
+			continue
+		}
+		value := strings.TrimPrefix(line, "Environment=GC_HOME=")
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			return filepath.Clean(unquoted), true
+		}
+		return filepath.Clean(value), true
+	}
+	return "", false
+}
+
+func unloadLegacySupervisorLaunchd(remove bool) error {
+	path := legacySupervisorLaunchdPlistPath()
+	if samePath(path, supervisorLaunchdPlistPath()) || !legacySupervisorTargetsCurrentHome(path) {
+		return nil
+	}
+	_ = supervisorLaunchctlRun("unload", path)
+	if remove {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing legacy plist %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func unloadLegacySupervisorSystemd(remove bool) error {
+	path := legacySupervisorSystemdServicePath()
+	if samePath(path, supervisorSystemdServicePath()) || !legacySupervisorTargetsCurrentHome(path) {
+		return nil
+	}
+	_ = supervisorSystemctlRun("--user", "stop", defaultSupervisorSystemdUnit)
+	if remove {
+		_ = supervisorSystemctlRun("--user", "disable", defaultSupervisorSystemdUnit)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing legacy unit %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func rollbackNewSupervisorLaunchdInstall(path string, restoreLegacy bool) error {
+	var errs []error
+	_ = supervisorLaunchctlRun("unload", path)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("removing failed plist %s during rollback: %w", path, err))
+	}
+	if restoreLegacy {
+		if err := supervisorLaunchctlRun("load", legacySupervisorLaunchdPlistPath()); err != nil {
+			errs = append(errs, fmt.Errorf("restoring legacy plist %s: %w", legacySupervisorLaunchdPlistPath(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func restorePreviousSupervisorLaunchdInstall(path string, previousContent []byte) error {
+	var errs []error
+	_ = supervisorLaunchctlRun("unload", path)
+	if err := os.WriteFile(path, previousContent, 0o644); err != nil {
+		errs = append(errs, fmt.Errorf("restoring previous plist %s: %w", path, err))
+	} else if err := supervisorLaunchctlRun("load", path); err != nil {
+		errs = append(errs, fmt.Errorf("reloading previous plist %s: %w", path, err))
+	}
+	return errors.Join(errs...)
+}
+
+func rollbackNewSupervisorSystemdInstall(path, service string, restoreLegacy bool) error {
+	var errs []error
+	_ = supervisorSystemctlRun("--user", "stop", service)
+	_ = supervisorSystemctlRun("--user", "disable", service)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("removing failed unit %s during rollback: %w", path, err))
+	}
+	if err := supervisorSystemctlRun("--user", "daemon-reload"); err != nil {
+		errs = append(errs, fmt.Errorf("systemctl --user daemon-reload during rollback: %w", err))
+	}
+	if restoreLegacy {
+		if err := supervisorSystemctlRun("--user", "start", defaultSupervisorSystemdUnit); err != nil {
+			errs = append(errs, fmt.Errorf("restoring legacy unit %s: %w", defaultSupervisorSystemdUnit, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func restorePreviousSupervisorSystemdInstall(path, service string, previousContent []byte, restart bool) error {
+	var errs []error
+	if restart {
+		_ = supervisorSystemctlRun("--user", "stop", service)
+	}
+	if err := os.WriteFile(path, previousContent, 0o644); err != nil {
+		errs = append(errs, fmt.Errorf("restoring previous unit %s: %w", path, err))
+		return errors.Join(errs...)
+	}
+	if err := supervisorSystemctlRun("--user", "daemon-reload"); err != nil {
+		errs = append(errs, fmt.Errorf("systemctl --user daemon-reload during rollback: %w", err))
+	}
+	if restart {
+		if err := supervisorSystemctlRun("--user", "enable", service); err != nil {
+			errs = append(errs, fmt.Errorf("restoring previous unit enable %s: %w", service, err))
+		}
+		if err := supervisorSystemctlRun("--user", "start", service); err != nil {
+			errs = append(errs, fmt.Errorf("restoring previous unit start %s: %w", service, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Writer) int {
@@ -451,6 +751,13 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 	}
 
 	path := supervisorLaunchdPlistPath()
+	legacyPresent := legacySupervisorTargetsCurrentHome(legacySupervisorLaunchdPlistPath())
+	existing, err := os.ReadFile(path)
+	hadCurrent := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(stderr, "gc supervisor install: reading existing plist: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -459,11 +766,27 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc supervisor install: writing plist: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if err := unloadLegacySupervisorLaunchd(false); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
-	exec.Command("launchctl", "unload", path).Run() //nolint:errcheck // best-effort cleanup
-	if err := exec.Command("launchctl", "load", path).Run(); err != nil {
+	_ = supervisorLaunchctlRun("unload", path)
+	if err := supervisorLaunchctlRun("load", path); err != nil {
+		var rollbackErr error
+		if hadCurrent {
+			rollbackErr = restorePreviousSupervisorLaunchdInstall(path, existing)
+		} else {
+			rollbackErr = rollbackNewSupervisorLaunchdInstall(path, legacyPresent)
+		}
+		if rollbackErr != nil {
+			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl load failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
+		}
 		fmt.Fprintf(stderr, "gc supervisor install: launchctl load: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if err := unloadLegacySupervisorLaunchd(true); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: warning: %v\n", err) //nolint:errcheck // best-effort stderr
 	}
 
 	fmt.Fprintf(stdout, "Installed launchd service: %s\n", path) //nolint:errcheck // best-effort stdout
@@ -472,9 +795,13 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 
 func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
 	path := supervisorLaunchdPlistPath()
-	exec.Command("launchctl", "unload", path).Run() //nolint:errcheck // best-effort cleanup
+	_ = supervisorLaunchctlRun("unload", path)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(stderr, "gc supervisor uninstall: removing plist: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := unloadLegacySupervisorLaunchd(true); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	fmt.Fprintf(stdout, "Uninstalled launchd service: %s\n", path) //nolint:errcheck // best-effort stdout
@@ -489,11 +816,18 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 	}
 
 	path := supervisorSystemdServicePath()
+	service := supervisorSystemdServiceName()
+	legacyPresent := legacySupervisorTargetsCurrentHome(legacySupervisorSystemdServicePath())
+	existing, err := os.ReadFile(path)
+	hadCurrent := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(stderr, "gc supervisor install: reading existing unit: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	existing, _ := os.ReadFile(path)
 	contentChanged := string(existing) != content
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: writing unit: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -502,27 +836,62 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 
 	for _, args := range [][]string{
 		{"--user", "daemon-reload"},
-		{"--user", "enable", "gascity-supervisor.service"},
+		{"--user", "enable", service},
 	} {
 		if err := supervisorSystemctlRun(args...); err != nil {
+			var rollbackErr error
+			if hadCurrent {
+				rollbackErr = restorePreviousSupervisorSystemdInstall(path, service, existing, false)
+			} else {
+				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, false)
+			}
+			if rollbackErr != nil {
+				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+			}
 			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
+	if err := unloadLegacySupervisorSystemd(false); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
-	service := "gascity-supervisor.service"
 	if contentChanged && supervisorSystemctlActive(service) {
 		args := []string{"--user", "restart", service}
 		if err := supervisorSystemctlRun(args...); err != nil {
+			var rollbackErr error
+			if hadCurrent {
+				rollbackErr = restorePreviousSupervisorSystemdInstall(path, service, existing, true)
+			} else {
+				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, legacyPresent)
+			}
+			if rollbackErr != nil {
+				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+			}
 			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	} else if !supervisorSystemctlActive(service) {
 		args := []string{"--user", "start", service}
 		if err := supervisorSystemctlRun(args...); err != nil {
+			var rollbackErr error
+			if hadCurrent {
+				rollbackErr = restorePreviousSupervisorSystemdInstall(path, service, existing, true)
+			} else {
+				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, legacyPresent)
+			}
+			if rollbackErr != nil {
+				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+			}
 			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
+	}
+	if err := unloadLegacySupervisorSystemd(true); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: warning: %v\n", err) //nolint:errcheck // best-effort stderr
+	} else {
+		_ = supervisorSystemctlRun("--user", "daemon-reload")
 	}
 
 	fmt.Fprintf(stdout, "Installed systemd service: %s\n", path) //nolint:errcheck // best-effort stdout
@@ -531,13 +900,18 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 
 func uninstallSupervisorSystemd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
 	path := supervisorSystemdServicePath()
-	exec.Command("systemctl", "--user", "stop", "gascity-supervisor.service").Run()    //nolint:errcheck // best-effort cleanup
-	exec.Command("systemctl", "--user", "disable", "gascity-supervisor.service").Run() //nolint:errcheck // best-effort cleanup
+	service := supervisorSystemdServiceName()
+	_ = supervisorSystemctlRun("--user", "stop", service)
+	_ = supervisorSystemctlRun("--user", "disable", service)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(stderr, "gc supervisor uninstall: removing unit: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	exec.Command("systemctl", "--user", "daemon-reload").Run()     //nolint:errcheck // best-effort cleanup
+	if err := unloadLegacySupervisorSystemd(true); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	_ = supervisorSystemctlRun("--user", "daemon-reload")
 	fmt.Fprintf(stdout, "Uninstalled systemd service: %s\n", path) //nolint:errcheck // best-effort stdout
 	return 0
 }

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -77,6 +78,32 @@ func shortTempDir(t *testing.T, prefix string) string {
 	}
 	t.Cleanup(func() { os.RemoveAll(dir) }) //nolint:errcheck
 	return dir
+}
+
+func installFakeSystemctl(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "systemctl.log")
+	script := filepath.Join(binDir, "systemctl")
+	content := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$GC_TEST_SYSTEMCTL_LOG\"\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", script, err)
+	}
+	t.Setenv("GC_TEST_SYSTEMCTL_LOG", logFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logFile
+}
+
+func readCommandLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	return string(data)
 }
 
 func TestDoSupervisorLogsNoFile(t *testing.T) {
@@ -240,6 +267,7 @@ func TestRenderSupervisorLaunchdTemplate(t *testing.T) {
 		LogPath:       "/home/user/.gc/supervisor.log",
 		GCHome:        "/home/user/.gc",
 		XDGRuntimeDir: "/tmp/gc-run",
+		LaunchdLabel:  defaultSupervisorLaunchdLabel,
 		Path:          "/usr/local/bin:/usr/bin:/bin",
 	}
 
@@ -271,6 +299,7 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 		LogPath:       "/home/user/.gc/supervisor.log",
 		GCHome:        "/home/user/.gc",
 		XDGRuntimeDir: "/tmp/gc-run",
+		LaunchdLabel:  defaultSupervisorLaunchdLabel,
 		Path:          "/usr/local/bin:/usr/bin:/bin",
 	}
 
@@ -409,6 +438,191 @@ func TestBuildSupervisorServiceDataOmitsXDGRuntimeDirForIsolatedGCHome(t *testin
 	}
 }
 
+func TestBuildSupervisorServiceDataCanonicalizesIsolatedGCHome(t *testing.T) {
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(t.TempDir(), "isolated-home")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkHome := filepath.Join(t.TempDir(), "isolated-home-link")
+	if err := os.Symlink(canonicalHome, symlinkHome); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", symlinkHome)
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	if data.GCHome != normalizePathForCompare(symlinkHome) {
+		t.Fatalf("buildSupervisorServiceData GCHome = %q, want canonical %q", data.GCHome, normalizePathForCompare(symlinkHome))
+	}
+}
+
+func TestRenderSupervisorTemplateUsesCanonicalRelativeGCHome(t *testing.T) {
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(homeDir, "isolated-home")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(homeDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", "isolated-home")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	systemdContent, err := renderSupervisorTemplate(supervisorSystemdTemplate, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(systemdContent, `Environment=GC_HOME="`+canonicalHome+`"`) {
+		t.Fatalf("systemd template missing canonical GC_HOME %q:\n%s", canonicalHome, systemdContent)
+	}
+
+	launchdContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(launchdContent, "<key>GC_HOME</key>") || !strings.Contains(launchdContent, "<string>"+xmlEscape(canonicalHome)+"</string>") {
+		t.Fatalf("launchd template missing canonical GC_HOME %q:\n%s", canonicalHome, launchdContent)
+	}
+}
+
+func TestSupervisorLaunchdPlistPathUsesIsolatedLabelForIsolatedGCHome(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "isolated-home"))
+
+	label := supervisorLaunchdLabel()
+	if label == defaultSupervisorLaunchdLabel {
+		t.Fatalf("supervisorLaunchdLabel() = %q, want isolated label", label)
+	}
+	if !strings.HasPrefix(label, "com.gascity.supervisor.isolated-home-") {
+		t.Fatalf("supervisorLaunchdLabel() = %q, want isolated-home-prefixed label", label)
+	}
+	wantPath := filepath.Join(homeDir, "Library", "LaunchAgents", label+".plist")
+	if got := supervisorLaunchdPlistPath(); got != wantPath {
+		t.Fatalf("supervisorLaunchdPlistPath() = %q, want %q", got, wantPath)
+	}
+}
+
+func TestSupervisorServiceSuffixUsesFullGCHomePath(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	first := filepath.Join(t.TempDir(), "isolated-home")
+	second := filepath.Join(t.TempDir(), "isolated-home")
+
+	t.Setenv("GC_HOME", first)
+	firstName := supervisorSystemdServiceName()
+	firstLabel := supervisorLaunchdLabel()
+
+	t.Setenv("GC_HOME", second)
+	secondName := supervisorSystemdServiceName()
+	secondLabel := supervisorLaunchdLabel()
+
+	if firstName == defaultSupervisorSystemdUnit || secondName == defaultSupervisorSystemdUnit {
+		t.Fatalf("isolated service name fell back to default: first=%q second=%q", firstName, secondName)
+	}
+	if firstName == secondName {
+		t.Fatalf("supervisorSystemdServiceName() collided for distinct GC_HOME values: %q", firstName)
+	}
+	if firstLabel == secondLabel {
+		t.Fatalf("supervisorLaunchdLabel() collided for distinct GC_HOME values: %q", firstLabel)
+	}
+}
+
+func TestSupervisorServiceSuffixNormalizesEquivalentGCHomePaths(t *testing.T) {
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(t.TempDir(), "isolated-home")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkHome := filepath.Join(t.TempDir(), "isolated-home-link")
+	if err := os.Symlink(canonicalHome, symlinkHome); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	t.Setenv("GC_HOME", canonicalHome)
+	canonicalName := supervisorSystemdServiceName()
+	canonicalLabel := supervisorLaunchdLabel()
+
+	t.Setenv("GC_HOME", symlinkHome)
+	symlinkName := supervisorSystemdServiceName()
+	symlinkLabel := supervisorLaunchdLabel()
+
+	if canonicalName != symlinkName {
+		t.Fatalf("supervisorSystemdServiceName() mismatch for equivalent GC_HOME paths: canonical=%q symlink=%q", canonicalName, symlinkName)
+	}
+	if canonicalLabel != symlinkLabel {
+		t.Fatalf("supervisorLaunchdLabel() mismatch for equivalent GC_HOME paths: canonical=%q symlink=%q", canonicalLabel, symlinkLabel)
+	}
+}
+
+func TestSupervisorServiceSuffixNormalizesRelativeGCHomePaths(t *testing.T) {
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(homeDir, "isolated-home")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(homeDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	t.Setenv("HOME", homeDir)
+
+	t.Setenv("GC_HOME", canonicalHome)
+	canonicalName := supervisorSystemdServiceName()
+	canonicalLabel := supervisorLaunchdLabel()
+
+	t.Setenv("GC_HOME", "isolated-home")
+	relativeName := supervisorSystemdServiceName()
+	relativeLabel := supervisorLaunchdLabel()
+
+	if canonicalName != relativeName {
+		t.Fatalf("supervisorSystemdServiceName() mismatch for equivalent GC_HOME paths: canonical=%q relative=%q", canonicalName, relativeName)
+	}
+	if canonicalLabel != relativeLabel {
+		t.Fatalf("supervisorLaunchdLabel() mismatch for equivalent GC_HOME paths: canonical=%q relative=%q", canonicalLabel, relativeLabel)
+	}
+}
+
+func TestSupervisorServiceSuffixDoesNotFallBackWhenBasenameSanitizesEmpty(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "---"))
+
+	if got := supervisorSystemdServiceName(); got == defaultSupervisorSystemdUnit {
+		t.Fatalf("supervisorSystemdServiceName() = %q, want isolated non-default name", got)
+	}
+	if got := supervisorLaunchdLabel(); got == defaultSupervisorLaunchdLabel {
+		t.Fatalf("supervisorLaunchdLabel() = %q, want isolated non-default label", got)
+	}
+}
+
 func TestSupervisorInstallUnsupportedOS(t *testing.T) {
 	if goruntime.GOOS == "darwin" || goruntime.GOOS == "linux" {
 		t.Skip("unsupported-os test only applies outside darwin/linux")
@@ -428,6 +642,7 @@ func TestInstallSupervisorSystemdRestartsWhenUnitChangesAndServiceActive(t *test
 	}
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
 
 	data := &supervisorServiceData{
 		GCPath:        "/tmp/gc-new",
@@ -484,6 +699,7 @@ func TestInstallSupervisorSystemdStartsInactiveService(t *testing.T) {
 	}
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
 
 	data := &supervisorServiceData{
 		GCPath:        "/tmp/gc-new",
@@ -518,6 +734,955 @@ func TestInstallSupervisorSystemdStartsInactiveService(t *testing.T) {
 	}
 	if strings.Contains(joined, "--user restart gascity-supervisor.service") {
 		t.Fatalf("systemctl calls = %v, should not restart inactive service", calls)
+	}
+}
+
+func TestInstallSupervisorSystemdUsesIsolatedUnitNameForIsolatedGCHome(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	isolatedHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("GC_HOME", isolatedHome)
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(isolatedHome, "supervisor.log"),
+		GCHome:        isolatedHome,
+		XDGRuntimeDir: "",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorSystemctlActive = func(_ string) bool {
+		return false
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	wantName := supervisorSystemdServiceName()
+	if wantName == defaultSupervisorSystemdUnit {
+		t.Fatalf("supervisorSystemdServiceName() = %q, want isolated unit name", wantName)
+	}
+	if !strings.HasPrefix(wantName, "gascity-supervisor-isolated-home-") {
+		t.Fatalf("supervisorSystemdServiceName() = %q, want isolated-home-prefixed name", wantName)
+	}
+	wantPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", wantName)
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("Stat(%q): %v", wantPath, err)
+	}
+	defaultPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", "gascity-supervisor.service")
+	if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		t.Fatalf("default systemd unit %q should stay absent; err=%v", defaultPath, err)
+	}
+
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user enable " + wantName,
+		"--user start " + wantName,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+	if strings.Contains(joined, "gascity-supervisor.service") {
+		t.Fatalf("systemctl calls = %v, should not target the default unit when GC_HOME is isolated", calls)
+	}
+}
+
+func TestUnloadSupervisorServiceSkipsDefaultUnitForIsolatedGCHome(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "isolated-home"))
+	logFile := installFakeSystemctl(t)
+
+	defaultPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", "gascity-supervisor.service")
+	if err := os.MkdirAll(filepath.Dir(defaultPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(defaultPath, []byte("[Unit]\nDescription=test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	unloadSupervisorService()
+
+	if got := strings.TrimSpace(readCommandLog(t, logFile)); got != "" {
+		t.Fatalf("unloadSupervisorService invoked systemctl for default unit under isolated GC_HOME: %q", got)
+	}
+}
+
+func TestUnloadSupervisorServiceUsesIsolatedUnitWhenPresent(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "isolated-home"))
+	logFile := installFakeSystemctl(t)
+
+	unitPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("[Unit]\nDescription=test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	unloadSupervisorService()
+
+	got := strings.TrimSpace(readCommandLog(t, logFile))
+	if !strings.Contains(got, "--user stop "+supervisorSystemdServiceName()) {
+		t.Fatalf("systemctl log = %q, want isolated unit stop", got)
+	}
+	if strings.Contains(got, "--user stop gascity-supervisor.service") {
+		t.Fatalf("systemctl log = %q, should not target the default unit", got)
+	}
+}
+
+func TestUnloadSupervisorServiceStopsMatchingLegacyDefaultUnitForIsolatedGCHome(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	logFile := installFakeSystemctl(t)
+
+	legacyPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", defaultSupervisorSystemdUnit)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	unloadSupervisorService()
+
+	got := strings.TrimSpace(readCommandLog(t, logFile))
+	if !strings.Contains(got, "--user stop "+defaultSupervisorSystemdUnit) {
+		t.Fatalf("systemctl log = %q, want legacy default unit stop", got)
+	}
+}
+
+func TestLegacySupervisorTargetsCurrentHomeLaunchdDecodesEscapedGC_HOME(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated&home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !legacySupervisorTargetsCurrentHome(legacyPath) {
+		t.Fatalf("legacySupervisorTargetsCurrentHome(%q) = false, want true for escaped GC_HOME", legacyPath)
+	}
+}
+
+func TestLegacySupervisorTargetsCurrentHomeRequiresExactSystemdGC_HOMEMatch(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, &supervisorServiceData{
+		GCPath: "/tmp/gc",
+		LogPath: filepath.Join(
+			gcHome,
+			"supervisor.log",
+		),
+		GCHome: filepath.Join(filepath.Dir(gcHome), filepath.Base(gcHome)+"-other"),
+		Path:   "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if legacySupervisorTargetsCurrentHome(legacyPath) {
+		t.Fatalf("legacySupervisorTargetsCurrentHome(%q) = true, want false for non-exact GC_HOME match", legacyPath)
+	}
+}
+
+func TestLegacySupervisorTargetsCurrentHomeMatchesEquivalentSystemdHomePaths(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(t.TempDir(), "isolated-home")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkHome := filepath.Join(t.TempDir(), "isolated-home-link")
+	if err := os.Symlink(canonicalHome, symlinkHome); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", symlinkHome)
+
+	legacyPath := legacySupervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, &supervisorServiceData{
+		GCPath:   "/tmp/gc",
+		LogPath:  filepath.Join(canonicalHome, "supervisor.log"),
+		GCHome:   canonicalHome,
+		Path:     "/usr/local/bin:/usr/bin:/bin",
+		SafeName: sanitizeServiceName(filepath.Base(canonicalHome)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !legacySupervisorTargetsCurrentHome(legacyPath) {
+		t.Fatalf("legacySupervisorTargetsCurrentHome(%q) = false, want true for equivalent GC_HOME paths", legacyPath)
+	}
+}
+
+func TestInstallSupervisorSystemdRemovesMatchingLegacyDefaultUnitForIsolatedGCHome(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", defaultSupervisorSystemdUnit)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorSystemctlActive = func(_ string) bool {
+		return false
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy systemd unit %q should be removed; err=%v", legacyPath, err)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user stop " + defaultSupervisorSystemdUnit,
+		"--user disable " + defaultSupervisorSystemdUnit,
+		"--user enable " + supervisorSystemdServiceName(),
+		"--user start " + supervisorSystemdServiceName(),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorSystemdIgnoresLegacyStopDisableFailures(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	supervisorSystemctlRun = func(args ...string) error {
+		if len(args) >= 3 && args[1] == "stop" && args[2] == defaultSupervisorSystemdUnit {
+			return errors.New("legacy stop failed")
+		}
+		if len(args) >= 3 && args[1] == "disable" && args[2] == defaultSupervisorSystemdUnit {
+			return errors.New("legacy disable failed")
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(_ string) bool {
+		return false
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy systemd unit %q should be removed despite stop/disable failures; err=%v", legacyPath, err)
+	}
+}
+
+func TestInstallSupervisorSystemdKeepsLegacyUnitWhenNewServiceFails(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) >= 3 && args[1] == "start" && args[2] == supervisorSystemdServiceName() {
+			return errors.New("new unit failed to start")
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(_ string) bool {
+		return false
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	currentPath := supervisorSystemdServicePath()
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("new systemd unit %q should be removed during rollback; err=%v", currentPath, err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy systemd unit %q should remain after failed install; err=%v", legacyPath, err)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user stop " + defaultSupervisorSystemdUnit,
+		"--user start " + supervisorSystemdServiceName(),
+		"--user disable " + supervisorSystemdServiceName(),
+		"--user start " + defaultSupervisorSystemdUnit,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorSystemdRestoresPreviousCurrentUnitWhenUpdateFails(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	currentPath := supervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldContent := []byte("old isolated unit\n")
+	if err := os.WriteFile(currentPath, oldContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	startCalls := 0
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) >= 3 && args[1] == "start" && args[2] == supervisorSystemdServiceName() {
+			startCalls++
+			if startCalls == 1 {
+				return errors.New("new unit failed to start")
+			}
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(_ string) bool {
+		return false
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	gotContent, err := os.ReadFile(currentPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", currentPath, err)
+	}
+	if !bytes.Equal(gotContent, oldContent) {
+		t.Fatalf("restored systemd unit = %q, want original %q", gotContent, oldContent)
+	}
+	if startCalls != 2 {
+		t.Fatalf("systemctl start call count = %d, want 2 (failed install + rollback restore); calls=%v", startCalls, calls)
+	}
+}
+
+func TestUninstallSupervisorSystemdRemovesMatchingLegacyDefaultUnitForIsolatedGCHome(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	currentPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+	legacyPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", defaultSupervisorSystemdUnit)
+	for _, path := range []string{currentPath, legacyPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldRun := supervisorSystemctlRun
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorSystemd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	for _, path := range []string{currentPath, legacyPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("systemd unit %q should be removed; err=%v", path, err)
+		}
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user stop " + supervisorSystemdServiceName(),
+		"--user disable " + supervisorSystemdServiceName(),
+		"--user stop " + defaultSupervisorSystemdUnit,
+		"--user disable " + defaultSupervisorSystemdUnit,
+		"--user daemon-reload",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestUninstallSupervisorSystemdIgnoresLegacyStopDisableFailures(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	currentPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+	legacyPath := legacySupervisorSystemdServicePath()
+	for _, path := range []string{currentPath, legacyPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldRun := supervisorSystemctlRun
+	supervisorSystemctlRun = func(args ...string) error {
+		if len(args) >= 3 && args[1] == "stop" && args[2] == defaultSupervisorSystemdUnit {
+			return errors.New("legacy stop failed")
+		}
+		if len(args) >= 3 && args[1] == "disable" && args[2] == defaultSupervisorSystemdUnit {
+			return errors.New("legacy disable failed")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorSystemd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	for _, path := range []string{currentPath, legacyPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("systemd unit %q should be removed despite legacy stop/disable failures; err=%v", path, err)
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedGCHome(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := filepath.Join(homeDir, "Library", "LaunchAgents", defaultSupervisorLaunchdLabel+".plist")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-legacy",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy launchd plist %q should be removed; err=%v", legacyPath, err)
+	}
+	joined := strings.Join(calls, "\n")
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	for _, want := range []string{
+		"unload " + legacyPath,
+		"unload " + currentPath,
+		"load " + currentPath,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdIgnoresLegacyUnloadFailures(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-legacy",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorLaunchctlRun
+	supervisorLaunchctlRun = func(args ...string) error {
+		if len(args) == 2 && args[0] == "unload" && args[1] == legacyPath {
+			return errors.New("legacy unload failed")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy launchd plist %q should be removed despite unload failures; err=%v", legacyPath, err)
+	}
+}
+
+func TestInstallSupervisorLaunchdKeepsLegacyPlistWhenNewServiceFails(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-legacy",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) == 2 && args[0] == "load" && args[1] == currentPath {
+			return errors.New("new plist failed to load")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("new launchd plist %q should be removed during rollback; err=%v", currentPath, err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy launchd plist %q should remain after failed install; err=%v", legacyPath, err)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"unload " + legacyPath,
+		"load " + currentPath,
+		"load " + legacyPath,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdRestoresPreviousCurrentPlistWhenUpdateFails(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldContent := []byte("old isolated plist\n")
+	if err := os.WriteFile(currentPath, oldContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  supervisorLaunchdLabel(),
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	loadCalls := 0
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) == 2 && args[0] == "load" && args[1] == currentPath {
+			loadCalls++
+			if loadCalls == 1 {
+				return errors.New("new plist failed to load")
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	gotContent, err := os.ReadFile(currentPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", currentPath, err)
+	}
+	if !bytes.Equal(gotContent, oldContent) {
+		t.Fatalf("restored launchd plist = %q, want original %q", gotContent, oldContent)
+	}
+	if loadCalls != 2 {
+		t.Fatalf("launchctl load call count = %d, want 2 (failed install + rollback restore); calls=%v", loadCalls, calls)
+	}
+}
+
+func TestUninstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedGCHome(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	legacyPath := filepath.Join(homeDir, "Library", "LaunchAgents", defaultSupervisorLaunchdLabel+".plist")
+	for _, path := range []string{currentPath, legacyPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		label := supervisorLaunchdLabel()
+		if path == legacyPath {
+			label = defaultSupervisorLaunchdLabel
+		}
+		content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+			GCPath:       "/tmp/gc-legacy",
+			LogPath:      filepath.Join(gcHome, "supervisor.log"),
+			GCHome:       gcHome,
+			LaunchdLabel: label,
+			Path:         "/usr/local/bin:/usr/bin:/bin",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorLaunchd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	for _, path := range []string{currentPath, legacyPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("launchd plist %q should be removed; err=%v", path, err)
+		}
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"unload " + currentPath,
+		"unload " + legacyPath,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestUninstallSupervisorLaunchdIgnoresLegacyUnloadFailures(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	for _, path := range []string{currentPath, legacyPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		label := supervisorLaunchdLabel()
+		if path == legacyPath {
+			label = defaultSupervisorLaunchdLabel
+		}
+		content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+			GCPath:       "/tmp/gc-legacy",
+			LogPath:      filepath.Join(gcHome, "supervisor.log"),
+			GCHome:       gcHome,
+			LaunchdLabel: label,
+			Path:         "/usr/local/bin:/usr/bin:/bin",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldRun := supervisorLaunchctlRun
+	supervisorLaunchctlRun = func(args ...string) error {
+		if len(args) == 2 && args[0] == "unload" && args[1] == legacyPath {
+			return errors.New("legacy unload failed")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorLaunchd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	for _, path := range []string{currentPath, legacyPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("launchd plist %q should be removed despite legacy unload failures; err=%v", path, err)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -1164,6 +1164,85 @@ func TestInstallSupervisorSystemdKeepsLegacyUnitWhenNewServiceFails(t *testing.T
 		if !strings.Contains(joined, want) {
 			t.Fatalf("systemctl calls = %v, want %q", calls, want)
 		}
+	}
+}
+
+func TestInstallSupervisorSystemdKeepsLegacyUnitWhenEarlySetupFails(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	for _, tc := range []struct {
+		name     string
+		failVerb string
+	}{
+		{name: "daemon-reload", failVerb: "daemon-reload"},
+		{name: "enable", failVerb: "enable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			gcHome := filepath.Join(t.TempDir(), "isolated-home")
+			t.Setenv("HOME", homeDir)
+			t.Setenv("GC_HOME", gcHome)
+
+			legacyPath := legacySupervisorSystemdServicePath()
+			if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(legacyPath, []byte("Environment=GC_HOME=\""+gcHome+"\"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			data := &supervisorServiceData{
+				GCPath:        "/tmp/gc-new",
+				LogPath:       filepath.Join(gcHome, "supervisor.log"),
+				GCHome:        gcHome,
+				XDGRuntimeDir: "",
+				LaunchdLabel:  supervisorLaunchdLabel(),
+				Path:          "/usr/local/bin:/usr/bin:/bin",
+			}
+
+			oldRun := supervisorSystemctlRun
+			oldActive := supervisorSystemctlActive
+			var calls []string
+			failed := false
+			supervisorSystemctlRun = func(args ...string) error {
+				call := strings.Join(args, " ")
+				calls = append(calls, call)
+				if !failed && len(args) >= 2 && args[1] == tc.failVerb {
+					failed = true
+					return errors.New("early setup failed")
+				}
+				return nil
+			}
+			supervisorSystemctlActive = func(_ string) bool {
+				return false
+			}
+			t.Cleanup(func() {
+				supervisorSystemctlRun = oldRun
+				supervisorSystemctlActive = oldActive
+			})
+
+			var stdout, stderr bytes.Buffer
+			if code := installSupervisorSystemd(data, &stdout, &stderr); code != 1 {
+				t.Fatalf("installSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+			}
+			currentPath := supervisorSystemdServicePath()
+			if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+				t.Fatalf("new systemd unit %q should be removed during rollback; err=%v", currentPath, err)
+			}
+			if _, err := os.Stat(legacyPath); err != nil {
+				t.Fatalf("legacy systemd unit %q should remain after failed install; err=%v", legacyPath, err)
+			}
+			joined := strings.Join(calls, "\n")
+			for _, notWant := range []string{
+				"--user stop " + defaultSupervisorSystemdUnit,
+				"--user start " + defaultSupervisorSystemdUnit,
+			} {
+				if strings.Contains(joined, notWant) {
+					t.Fatalf("systemctl calls = %v, did not want %q before legacy unload", calls, notWant)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -15,8 +15,27 @@ func NormalizePathForCompare(path string) string {
 	path = filepath.Clean(path)
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		path = resolved
+	} else if resolved, ok := normalizeMissingPath(path); ok {
+		path = resolved
 	}
 	return filepath.Clean(path)
+}
+
+func normalizeMissingPath(path string) (string, bool) {
+	var missing []string
+	for current := path; ; current = filepath.Dir(current) {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return resolved, true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", false
+		}
+		missing = append(missing, filepath.Base(current))
+	}
 }
 
 // SamePath reports whether two paths refer to the same location after

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -42,6 +42,24 @@ func TestSamePathSymlink(t *testing.T) {
 	}
 }
 
+func TestNormalizePathForCompareResolvesSymlinkAncestorForMissingLeaf(t *testing.T) {
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real-parent")
+	if err := os.MkdirAll(realParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkParent := filepath.Join(root, "link-parent")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	got := NormalizePathForCompare(filepath.Join(linkParent, "missing", "gc-home"))
+	want := filepath.Join(realParent, "missing", "gc-home")
+	if got != want {
+		t.Fatalf("NormalizePathForCompare() = %q, want %q", got, want)
+	}
+}
+
 func TestSamePathDifferent(t *testing.T) {
 	a := t.TempDir()
 	b := t.TempDir()

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // isTestBinary reports whether the current process is a Go test binary.
@@ -146,7 +147,7 @@ func LoadConfig(path string) (Config, error) {
 // silent fallback to the user's real ~/.gc directory.
 func DefaultHome() string {
 	if v := os.Getenv("GC_HOME"); v != "" {
-		return v
+		return pathutil.NormalizePathForCompare(v)
 	}
 	if isTestBinary() {
 		panic("supervisor.DefaultHome: GC_HOME must be set during tests to prevent host supervisor interference")
@@ -168,7 +169,7 @@ func UsesIsolatedGCHomeOverride() bool {
 	if gcHome == "" {
 		return false
 	}
-	return filepath.Clean(gcHome) != filepath.Clean(builtinDefaultHome())
+	return pathutil.NormalizePathForCompare(gcHome) != pathutil.NormalizePathForCompare(builtinDefaultHome())
 }
 
 // RuntimeDir returns the directory for ephemeral runtime files (lock,

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -243,14 +243,14 @@ func shouldSeedIsolatedSupervisorConfig(path string) bool {
 	if gcHome == "" {
 		return false
 	}
-	if !samePath(path, ConfigPath()) {
+	if !pathutil.SamePath(path, ConfigPath()) {
 		return false
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return true
 	}
-	return !samePath(gcHome, filepath.Join(home, ".gc"))
+	return !pathutil.SamePath(gcHome, filepath.Join(home, ".gc"))
 }
 
 func reserveLoopbackPort() (int, error) {
@@ -264,23 +264,4 @@ func reserveLoopbackPort() (int, error) {
 		return 0, fmt.Errorf("unexpected supervisor listener address %T", lis.Addr())
 	}
 	return addr.Port, nil
-}
-
-func samePath(a, b string) bool {
-	a = canonicalPath(a)
-	b = canonicalPath(b)
-	return a == b
-}
-
-func canonicalPath(p string) string {
-	if p == "" {
-		return ""
-	}
-	if abs, err := filepath.Abs(p); err == nil {
-		p = abs
-	}
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
-		p = resolved
-	}
-	return filepath.Clean(p)
 }

--- a/internal/supervisor/config_test.go
+++ b/internal/supervisor/config_test.go
@@ -111,6 +111,46 @@ func TestDefaultHomeWithEnv(t *testing.T) {
 	}
 }
 
+func TestDefaultHomeCanonicalizesSymlinkOverride(t *testing.T) {
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(homeDir, "canonical-gc")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkHome := filepath.Join(homeDir, "gc-link")
+	if err := os.Symlink(canonicalHome, symlinkHome); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", symlinkHome)
+	if got := DefaultHome(); got != canonicalHome {
+		t.Fatalf("DefaultHome() = %q, want canonical %q", got, canonicalHome)
+	}
+}
+
+func TestDefaultHomeCanonicalizesRelativeOverride(t *testing.T) {
+	homeDir := t.TempDir()
+	canonicalHome := filepath.Join(homeDir, "relative-gc")
+	if err := os.MkdirAll(canonicalHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(homeDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	t.Setenv("GC_HOME", "relative-gc")
+	if got := DefaultHome(); got != canonicalHome {
+		t.Fatalf("DefaultHome() = %q, want canonical %q", got, canonicalHome)
+	}
+}
+
 func TestRuntimeDirWithXDG(t *testing.T) {
 	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
 	if got := RuntimeDir(); got != "/run/user/1000/gc" {
@@ -154,6 +194,48 @@ func TestUsesIsolatedGCHomeOverrideFalseForDefaultHome(t *testing.T) {
 	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
 	if UsesIsolatedGCHomeOverride() {
 		t.Fatal("UsesIsolatedGCHomeOverride() = true, want false")
+	}
+}
+
+func TestUsesIsolatedGCHomeOverrideFalseForSymlinkedDefaultHome(t *testing.T) {
+	homeDir := t.TempDir()
+	defaultHome := filepath.Join(homeDir, ".gc")
+	if err := os.MkdirAll(defaultHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkHome := filepath.Join(homeDir, "default-home-link")
+	if err := os.Symlink(defaultHome, symlinkHome); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", symlinkHome)
+	if UsesIsolatedGCHomeOverride() {
+		t.Fatal("UsesIsolatedGCHomeOverride() = true, want false for symlinked default home")
+	}
+}
+
+func TestUsesIsolatedGCHomeOverrideFalseForRelativeDefaultHome(t *testing.T) {
+	homeDir := t.TempDir()
+	defaultHome := filepath.Join(homeDir, ".gc")
+	if err := os.MkdirAll(defaultHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(homeDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", ".gc")
+	if UsesIsolatedGCHomeOverride() {
+		t.Fatal("UsesIsolatedGCHomeOverride() = true, want false for relative default home")
 	}
 }
 

--- a/internal/supervisor/config_test.go
+++ b/internal/supervisor/config_test.go
@@ -57,6 +57,24 @@ func TestLoadConfigSeedsIsolatedGCHomeConfig(t *testing.T) {
 	}
 }
 
+func TestShouldSeedIsolatedSupervisorConfigFalseForCanonicalDefaultUnderSymlinkedHome(t *testing.T) {
+	root := t.TempDir()
+	realHome := filepath.Join(root, "real-home")
+	if err := os.MkdirAll(realHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkHome := filepath.Join(root, "home-link")
+	if err := os.Symlink(realHome, linkHome); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	t.Setenv("HOME", linkHome)
+	t.Setenv("GC_HOME", filepath.Join(realHome, ".gc"))
+	if shouldSeedIsolatedSupervisorConfig(ConfigPath()) {
+		t.Fatal("shouldSeedIsolatedSupervisorConfig() = true, want false for canonical default GC_HOME under symlinked HOME")
+	}
+}
+
 func TestLoadConfigExplicit(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "supervisor.toml")


### PR DESCRIPTION
## Summary
- derive isolated launchd/systemd service identities from canonicalized GC_HOME values and scope legacy cleanup to the matching home only
- preserve working supervisor registrations on failed isolated installs by rolling back to the prior current service or the matching legacy default service
- add regression coverage for canonical GC_HOME handling, legacy migration, failed reinstall rollback, and listener-helper cleanup

## Testing
- go vet ./...
- go test ./internal/supervisor ./cmd/gc -count=1 -run 'Test(DefaultHome|UsesIsolatedGCHomeOverride|RuntimeDirUsesIsolatedGCHomeWhenOverrideDiffersFromDefault|RuntimeDirUsesXDGWhenGCHomeMatchesDefaultHome|BuildSupervisorServiceDataCanonicalizesIsolatedGCHome|RenderSupervisorTemplateUsesCanonicalRelativeGCHome|SupervisorLaunchdPlistPathUsesIsolatedLabelForIsolatedGCHome|SupervisorServiceSuffixUsesFullGCHomePath|SupervisorServiceSuffixNormalizesEquivalentGCHomePaths|SupervisorServiceSuffixNormalizesRelativeGCHomePaths|SupervisorServiceSuffixDoesNotFallBackWhenBasenameSanitizesEmpty|InstallSupervisorSystemdUsesIsolatedUnitNameForIsolatedGCHome|UnloadSupervisorServiceSkipsDefaultUnitForIsolatedGCHome|UnloadSupervisorServiceUsesIsolatedUnitWhenPresent|UnloadSupervisorServiceStopsMatchingLegacyDefaultUnitForIsolatedGCHome|LegacySupervisorTargetsCurrentHomeLaunchdDecodesEscapedGC_HOME|LegacySupervisorTargetsCurrentHomeRequiresExactSystemdGC_HOMEMatch|LegacySupervisorTargetsCurrentHomeMatchesEquivalentSystemdHomePaths|InstallSupervisorSystemdRemovesMatchingLegacyDefaultUnitForIsolatedGCHome|InstallSupervisorSystemdIgnoresLegacyStopDisableFailures|InstallSupervisorSystemdKeepsLegacyUnitWhenNewServiceFails|InstallSupervisorSystemdRestoresPreviousCurrentUnitWhenUpdateFails|UninstallSupervisorSystemdRemovesMatchingLegacyDefaultUnitForIsolatedGCHome|UninstallSupervisorSystemdIgnoresLegacyStopDisableFailures|InstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedGCHome|InstallSupervisorLaunchdIgnoresLegacyUnloadFailures|InstallSupervisorLaunchdKeepsLegacyPlistWhenNewServiceFails|InstallSupervisorLaunchdRestoresPreviousCurrentPlistWhenUpdateFails|UninstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedGCHome|UninstallSupervisorLaunchdIgnoresLegacyUnloadFailures|StartTCPListenerProcessInDirRegistersCleanup)'
- go test ./... -count=1 -timeout=20m

Closes #936