### PR TITLE
feat(doctor): support pack-contributed fix scripts in [[doctor]] entries

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -230,6 +230,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			d.Register(&doctor.PackScriptCheck{
 				CheckName: entry.PackName + ":" + entry.Name,
 				Script:    entry.RunScript,
+				FixScript: entry.FixScript,
 				PackDir:   entry.PackDir,
 				PackName:  entry.PackName,
 			})

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -190,7 +190,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		if err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
 		}
-		packDoctors = append(packDoctors, legacyPackDoctors(pc.Doctor, cityRoot, pc.Pack.Name)...)
+		legacyDoctors, err := legacyPackDoctors(fs, pc.Doctor, cityRoot, pc.Pack.Name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
+		}
+		packDoctors = append(packDoctors, legacyDoctors...)
 		if len(packDoctors) > 0 {
 			root.PackDoctors = appendDiscoveredDoctors(root.PackDoctors, packDoctors...)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -665,6 +665,13 @@ type PackDoctorEntry struct {
 	Script string `toml:"script" jsonschema:"required"`
 	// Description is an optional human-readable description of the check.
 	Description string `toml:"description,omitempty"`
+	// Fix is an optional path to a remediation script, relative to the
+	// pack directory. When set, the check opts into `gc doctor --fix`
+	// auto-remediation: the fix script is dispatched with the same
+	// environment contract as Script (GC_CITY_PATH, GC_PACK_DIR, pack
+	// runtime env). Exit 0 indicates successful remediation; non-zero
+	// exit is surfaced as a fix error and the check remains failed.
+	Fix string `toml:"fix,omitempty"`
 }
 
 // PackCommandEntry declares a CLI subcommand provided by a pack.

--- a/internal/config/doctor_discovery.go
+++ b/internal/config/doctor_discovery.go
@@ -16,7 +16,7 @@ type DiscoveredDoctor struct {
 	RunScript   string
 	// FixScript is the optional remediation script. When non-empty the
 	// check opts into `gc doctor --fix`. Empty means check is diagnostic-
-	// only (the pre-existing behaviour).
+	// only (the pre-existing behavior).
 	FixScript   string
 	HelpFile    string
 	SourceDir   string
@@ -31,12 +31,12 @@ type doctorManifest struct {
 	Fix         string `toml:"fix"`
 }
 
-func resolveContainedDoctorRunPath(packDir, checkDir, runRel string) (string, error) {
-	if filepath.IsAbs(runRel) {
-		return "", fmt.Errorf("run path %q must stay within the pack directory", runRel)
+func resolveContainedDoctorPath(kind, packDir, checkDir, relPath string) (string, error) {
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("%s path %q must stay within the pack directory", kind, relPath)
 	}
 
-	candidate := filepath.Clean(filepath.Join(checkDir, runRel))
+	candidate := filepath.Clean(filepath.Join(checkDir, relPath))
 	absPackDir, err := filepath.Abs(packDir)
 	if err != nil {
 		return "", err
@@ -50,9 +50,17 @@ func resolveContainedDoctorRunPath(packDir, checkDir, runRel string) (string, er
 		return "", err
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("run path %q escapes the pack directory", runRel)
+		return "", fmt.Errorf("%s path %q escapes the pack directory", kind, relPath)
 	}
 	return candidate, nil
+}
+
+func resolveContainedDoctorRunPath(packDir, checkDir, runRel string) (string, error) {
+	return resolveContainedDoctorPath("run", packDir, checkDir, runRel)
+}
+
+func resolveContainedDoctorFixPath(packDir, checkDir, fixRel string) (string, error) {
+	return resolveContainedDoctorPath("fix", packDir, checkDir, fixRel)
 }
 
 // DiscoverPackDoctors scans a pack's doctor/ directory and returns
@@ -118,23 +126,20 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 
 	fixPath := ""
 	if fixRel != "" {
-		resolved, err := resolveContainedDoctorRunPath(packDir, checkDir, fixRel)
+		resolved, err := resolveContainedDoctorFixPath(packDir, checkDir, fixRel)
 		if err != nil {
 			return DiscoveredDoctor{}, false, fmt.Errorf("doctor/%s fix: %w", name, err)
 		}
 		if _, err := fs.Stat(resolved); err == nil {
 			fixPath = resolved
+		} else {
+			return DiscoveredDoctor{}, false, fmt.Errorf("doctor/%s fix %q: %w", name, fixRel, err)
 		}
-		// If the fix script is declared but missing on disk, fall back
-		// to diagnostic-only — matches existing behaviour for run.sh
-		// when the file is absent (the check is silently skipped).
 	} else {
 		// Sibling-convention auto-discovery: if a fix script named
-		// `fix.sh` (or matching the `<runBase>.fix.<ext>` sibling of
-		// a custom `run` script) exists next to the check script, the
-		// check opts into `gc doctor --fix` without needing a manifest.
-		// This mirrors how `run.sh` is the default when no manifest is
-		// provided.
+		// `fix.sh` exists next to the check script, the check opts into
+		// `gc doctor --fix` without needing a manifest. This mirrors how
+		// `run.sh` is the default when no manifest is provided.
 		candidate := filepath.Join(checkDir, "fix.sh")
 		if _, err := fs.Stat(candidate); err == nil {
 			fixPath = candidate

--- a/internal/config/doctor_discovery.go
+++ b/internal/config/doctor_discovery.go
@@ -14,6 +14,10 @@ type DiscoveredDoctor struct {
 	Name        string
 	Description string
 	RunScript   string
+	// FixScript is the optional remediation script. When non-empty the
+	// check opts into `gc doctor --fix`. Empty means check is diagnostic-
+	// only (the pre-existing behaviour).
+	FixScript   string
 	HelpFile    string
 	SourceDir   string
 	PackDir     string
@@ -24,6 +28,7 @@ type DiscoveredDoctor struct {
 type doctorManifest struct {
 	Description string `toml:"description"`
 	Run         string `toml:"run"`
+	Fix         string `toml:"fix"`
 }
 
 func resolveContainedDoctorRunPath(packDir, checkDir, runRel string) (string, error) {
@@ -86,6 +91,7 @@ func DiscoverPackDoctors(fs fsys.FS, packDir, packName string) ([]DiscoveredDoct
 func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName string) (DiscoveredDoctor, bool, error) {
 	runRel := "run.sh"
 	description := ""
+	fixRel := ""
 
 	manifestPath := filepath.Join(checkDir, "doctor.toml")
 	if data, err := fs.ReadFile(manifestPath); err == nil {
@@ -97,6 +103,9 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 		if manifest.Run != "" {
 			runRel = manifest.Run
 		}
+		if manifest.Fix != "" {
+			fixRel = manifest.Fix
+		}
 	}
 
 	runPath, err := resolveContainedDoctorRunPath(packDir, checkDir, runRel)
@@ -105,6 +114,31 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 	}
 	if _, err := fs.Stat(runPath); err != nil {
 		return DiscoveredDoctor{}, false, nil
+	}
+
+	fixPath := ""
+	if fixRel != "" {
+		resolved, err := resolveContainedDoctorRunPath(packDir, checkDir, fixRel)
+		if err != nil {
+			return DiscoveredDoctor{}, false, fmt.Errorf("doctor/%s fix: %w", name, err)
+		}
+		if _, err := fs.Stat(resolved); err == nil {
+			fixPath = resolved
+		}
+		// If the fix script is declared but missing on disk, fall back
+		// to diagnostic-only — matches existing behaviour for run.sh
+		// when the file is absent (the check is silently skipped).
+	} else {
+		// Sibling-convention auto-discovery: if a fix script named
+		// `fix.sh` (or matching the `<runBase>.fix.<ext>` sibling of
+		// a custom `run` script) exists next to the check script, the
+		// check opts into `gc doctor --fix` without needing a manifest.
+		// This mirrors how `run.sh` is the default when no manifest is
+		// provided.
+		candidate := filepath.Join(checkDir, "fix.sh")
+		if _, err := fs.Stat(candidate); err == nil {
+			fixPath = candidate
+		}
 	}
 
 	helpPath := filepath.Join(checkDir, "help.md")
@@ -117,6 +151,7 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 		Name:        name,
 		Description: description,
 		RunScript:   runPath,
+		FixScript:   fixPath,
 		HelpFile:    helpFile,
 		SourceDir:   checkDir,
 		PackDir:     packDir,

--- a/internal/config/doctor_discovery_test.go
+++ b/internal/config/doctor_discovery_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -220,24 +221,18 @@ func TestDiscoverPackDoctors_FixScriptMissingOnDisk(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "mypk")
 
-	// fix declared but the fix script does not exist — fall back to
-	// diagnostic-only (FixScript empty) rather than failing discovery.
-	// Matches the pre-existing treatment of a missing run.sh file.
 	writeTestFile(t, packDir, "doctor/binaries/doctor.toml", `
 run = "check.sh"
 fix = "fix.sh"
 `)
 	writeTestFile(t, packDir, "doctor/binaries/check.sh", "#!/bin/sh\nexit 0\n")
 
-	got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
-	if err != nil {
-		t.Fatalf("DiscoverPackDoctors: %v", err)
+	_, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err == nil {
+		t.Fatal("DiscoverPackDoctors error = nil, want missing fix script error")
 	}
-	if len(got) != 1 {
-		t.Fatalf("got %d checks, want 1", len(got))
-	}
-	if got[0].FixScript != "" {
-		t.Fatalf("FixScript = %q, want empty when file missing", got[0].FixScript)
+	if !strings.Contains(err.Error(), "doctor/binaries fix") {
+		t.Fatalf("DiscoverPackDoctors error = %v, want doctor fix context", err)
 	}
 }
 

--- a/internal/config/doctor_discovery_test.go
+++ b/internal/config/doctor_discovery_test.go
@@ -126,6 +126,137 @@ func TestDiscoverPackDoctors_BadManifest(t *testing.T) {
 	}
 }
 
+func TestDiscoverPackDoctors_SiblingFixScriptAutoDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "mypk")
+
+	// Pure convention: run.sh + sibling fix.sh, no doctor.toml.
+	writeTestFile(t, packDir, "doctor/binaries/run.sh", "#!/bin/sh\nexit 0\n")
+	writeTestFile(t, packDir, "doctor/binaries/fix.sh", "#!/bin/sh\nexit 0\n")
+
+	got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err != nil {
+		t.Fatalf("DiscoverPackDoctors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d checks, want 1", len(got))
+	}
+	wantFix := filepath.Join(packDir, "doctor", "binaries", "fix.sh")
+	if got[0].FixScript != wantFix {
+		t.Fatalf("FixScript = %q, want %q (sibling convention)",
+			got[0].FixScript, wantFix)
+	}
+}
+
+func TestDiscoverPackDoctors_NoSiblingFixScript(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "mypk")
+
+	// Only run.sh — no sibling fix.sh and no manifest.
+	writeTestFile(t, packDir, "doctor/binaries/run.sh", "#!/bin/sh\nexit 0\n")
+
+	got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err != nil {
+		t.Fatalf("DiscoverPackDoctors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d checks, want 1", len(got))
+	}
+	if got[0].FixScript != "" {
+		t.Fatalf("FixScript = %q, want empty (no sibling fix.sh)",
+			got[0].FixScript)
+	}
+}
+
+func TestDiscoverPackDoctors_ManifestFixScript(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "mypk")
+
+	writeTestFile(t, packDir, "doctor/binaries/doctor.toml", `
+description = "Check required binaries"
+run = "check.sh"
+fix = "fix.sh"
+`)
+	writeTestFile(t, packDir, "doctor/binaries/check.sh", "#!/bin/sh\nexit 0\n")
+	writeTestFile(t, packDir, "doctor/binaries/fix.sh", "#!/bin/sh\nexit 0\n")
+
+	got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err != nil {
+		t.Fatalf("DiscoverPackDoctors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d checks, want 1", len(got))
+	}
+	wantFix := filepath.Join(packDir, "doctor", "binaries", "fix.sh")
+	if got[0].FixScript != wantFix {
+		t.Fatalf("FixScript = %q, want %q", got[0].FixScript, wantFix)
+	}
+}
+
+func TestDiscoverPackDoctors_FixScriptAbsentWhenNotDeclared(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "mypk")
+
+	// doctor.toml with only run — no fix declared.
+	writeTestFile(t, packDir, "doctor/binaries/doctor.toml", `
+description = "Diagnostic only"
+run = "check.sh"
+`)
+	writeTestFile(t, packDir, "doctor/binaries/check.sh", "#!/bin/sh\nexit 0\n")
+
+	got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err != nil {
+		t.Fatalf("DiscoverPackDoctors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d checks, want 1", len(got))
+	}
+	if got[0].FixScript != "" {
+		t.Fatalf("FixScript = %q, want empty (no fix declared)", got[0].FixScript)
+	}
+}
+
+func TestDiscoverPackDoctors_FixScriptMissingOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "mypk")
+
+	// fix declared but the fix script does not exist — fall back to
+	// diagnostic-only (FixScript empty) rather than failing discovery.
+	// Matches the pre-existing treatment of a missing run.sh file.
+	writeTestFile(t, packDir, "doctor/binaries/doctor.toml", `
+run = "check.sh"
+fix = "fix.sh"
+`)
+	writeTestFile(t, packDir, "doctor/binaries/check.sh", "#!/bin/sh\nexit 0\n")
+
+	got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err != nil {
+		t.Fatalf("DiscoverPackDoctors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d checks, want 1", len(got))
+	}
+	if got[0].FixScript != "" {
+		t.Fatalf("FixScript = %q, want empty when file missing", got[0].FixScript)
+	}
+}
+
+func TestDiscoverPackDoctors_RejectsFixPathEscape(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "mypk")
+
+	writeTestFile(t, packDir, "doctor/binaries/doctor.toml", `
+run = "check.sh"
+fix = "../../../outside.sh"
+`)
+	writeTestFile(t, packDir, "doctor/binaries/check.sh", "#!/bin/sh\nexit 0\n")
+
+	_, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+	if err == nil {
+		t.Fatal("DiscoverPackDoctors error = nil, want containment error for fix")
+	}
+}
+
 func TestDiscoverPackDoctors_PreservesPackDir(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "mypk")

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1324,7 +1324,11 @@ func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName s
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
-	doctors = append(doctors, legacyPackDoctors(tc.Doctor, topoDir, tc.Pack.Name)...)
+	legacyDoctors, err := legacyPackDoctors(fs, tc.Doctor, topoDir, tc.Pack.Name)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, err
+	}
+	doctors = append(doctors, legacyDoctors...)
 	skills, err := DiscoverPackSkills(fs, topoDir, tc.Pack.Name)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
@@ -2044,7 +2048,7 @@ func legacyPackCommands(entries []PackCommandEntry, packDir, packName string) []
 	return out
 }
 
-func legacyPackDoctors(entries []PackDoctorEntry, packDir, packName string) []DiscoveredDoctor {
+func legacyPackDoctors(fs fsys.FS, entries []PackDoctorEntry, packDir, packName string) ([]DiscoveredDoctor, error) {
 	out := make([]DiscoveredDoctor, 0, len(entries))
 	for _, entry := range entries {
 		runScript := entry.Script
@@ -2053,8 +2057,15 @@ func legacyPackDoctors(entries []PackDoctorEntry, packDir, packName string) []Di
 		}
 
 		fixScript := entry.Fix
-		if fixScript != "" && !filepath.IsAbs(fixScript) {
-			fixScript = filepath.Join(packDir, fixScript)
+		if fixScript != "" {
+			resolved, err := resolveContainedDoctorFixPath(packDir, packDir, fixScript)
+			if err != nil {
+				return nil, fmt.Errorf("doctor %s fix: %w", entry.Name, err)
+			}
+			if _, err := fs.Stat(resolved); err != nil {
+				return nil, fmt.Errorf("doctor %s fix %q: %w", entry.Name, fixScript, err)
+			}
+			fixScript = resolved
 		}
 
 		out = append(out, DiscoveredDoctor{
@@ -2067,7 +2078,7 @@ func legacyPackDoctors(entries []PackDoctorEntry, packDir, packName string) []Di
 			PackName:    packName,
 		})
 	}
-	return out
+	return out, nil
 }
 
 // applyPackGlobals appends [global].session_live commands from packs

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1902,17 +1902,28 @@ func appendDiscoveredCommands(dst []DiscoveredCommand, src ...DiscoveredCommand)
 
 func appendDiscoveredDoctors(dst []DiscoveredDoctor, src ...DiscoveredDoctor) []DiscoveredDoctor {
 	for _, check := range src {
-		duplicate := false
-		for _, existing := range dst {
+		duplicateIdx := -1
+		for i, existing := range dst {
 			if existing.Name == check.Name &&
 				existing.BindingName == check.BindingName &&
 				existing.RunScript == check.RunScript {
-				duplicate = true
+				duplicateIdx = i
 				break
 			}
 		}
-		if !duplicate {
+		if duplicateIdx < 0 {
 			dst = append(dst, check)
+			continue
+		}
+		// Duplicate detected (same Name + BindingName + RunScript). Merge
+		// complementary metadata so a richer source doesn't lose out to an
+		// earlier-appended sparse one. Specifically: a convention-discovered
+		// entry that lacks an explicit `fix` manifest still wins on Name
+		// dedup against a legacy [[doctor]] TOML entry for the same check
+		// that declares `fix = "..."`. Without this merge, CanFix would
+		// spuriously return false on the winning entry.
+		if dst[duplicateIdx].FixScript == "" && check.FixScript != "" {
+			dst[duplicateIdx].FixScript = check.FixScript
 		}
 	}
 	return dst
@@ -2041,10 +2052,16 @@ func legacyPackDoctors(entries []PackDoctorEntry, packDir, packName string) []Di
 			runScript = filepath.Join(packDir, runScript)
 		}
 
+		fixScript := entry.Fix
+		if fixScript != "" && !filepath.IsAbs(fixScript) {
+			fixScript = filepath.Join(packDir, fixScript)
+		}
+
 		out = append(out, DiscoveredDoctor{
 			Name:        entry.Name,
 			Description: entry.Description,
 			RunScript:   runScript,
+			FixScript:   fixScript,
 			SourceDir:   packDir,
 			PackDir:     packDir,
 			PackName:    packName,

--- a/internal/config/pack_doctor_merge_test.go
+++ b/internal/config/pack_doctor_merge_test.go
@@ -1,0 +1,100 @@
+package config
+
+import "testing"
+
+// Tests for appendDiscoveredDoctors merge semantics.
+//
+// The merge matters because two discovery paths can produce entries for
+// the same check: convention-based (doctor/<name>/run.sh) and legacy TOML
+// ([[doctor]] with script = "..."). When both fire for the same pack, the
+// earlier-appended one wins the dedup. The merge preserves FixScript from
+// the suppressed duplicate so CanFix does not spuriously return false on
+// the winning entry.
+
+func TestAppendDiscoveredDoctors_AppendsNew(t *testing.T) {
+	a := DiscoveredDoctor{Name: "check-a", RunScript: "/a.sh"}
+	b := DiscoveredDoctor{Name: "check-b", RunScript: "/b.sh"}
+
+	got := appendDiscoveredDoctors(nil, a, b)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+}
+
+func TestAppendDiscoveredDoctors_DedupesOnNameAndRunScript(t *testing.T) {
+	first := DiscoveredDoctor{Name: "same", RunScript: "/path.sh"}
+	second := DiscoveredDoctor{Name: "same", RunScript: "/path.sh"}
+
+	got := appendDiscoveredDoctors(nil, first, second)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1 (dedup)", len(got))
+	}
+}
+
+func TestAppendDiscoveredDoctors_MergesFixScriptFromDuplicate(t *testing.T) {
+	// Convention-discovered entry appends first without a fix script…
+	convention := DiscoveredDoctor{
+		Name:      "same",
+		RunScript: "/path.sh",
+		FixScript: "",
+	}
+	// …then the legacy TOML entry for the same check with fix declared.
+	legacy := DiscoveredDoctor{
+		Name:      "same",
+		RunScript: "/path.sh",
+		FixScript: "/legacy-fix.sh",
+	}
+
+	got := appendDiscoveredDoctors(nil, convention, legacy)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1 (dedup)", len(got))
+	}
+	if got[0].FixScript != "/legacy-fix.sh" {
+		t.Fatalf("FixScript = %q, want %q (merge from suppressed duplicate)",
+			got[0].FixScript, "/legacy-fix.sh")
+	}
+}
+
+func TestAppendDiscoveredDoctors_PreservesExistingFixScript(t *testing.T) {
+	// If the winning entry already has a fix, don't let a sparse
+	// duplicate clear it.
+	winner := DiscoveredDoctor{
+		Name:      "same",
+		RunScript: "/path.sh",
+		FixScript: "/keep.sh",
+	}
+	sparse := DiscoveredDoctor{
+		Name:      "same",
+		RunScript: "/path.sh",
+		FixScript: "",
+	}
+
+	got := appendDiscoveredDoctors(nil, winner, sparse)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].FixScript != "/keep.sh" {
+		t.Fatalf("FixScript = %q, want %q (should not be cleared)",
+			got[0].FixScript, "/keep.sh")
+	}
+}
+
+func TestAppendDiscoveredDoctors_DistinguishesByBindingName(t *testing.T) {
+	// Same Name + RunScript but different BindingName = two distinct
+	// checks (same pack reachable under two imports).
+	a := DiscoveredDoctor{
+		Name:        "same",
+		RunScript:   "/path.sh",
+		BindingName: "alpha",
+	}
+	b := DiscoveredDoctor{
+		Name:        "same",
+		RunScript:   "/path.sh",
+		BindingName: "beta",
+	}
+
+	got := appendDiscoveredDoctors(nil, a, b)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2 (distinct binding names)", len(got))
+	}
+}

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3381,6 +3381,52 @@ script = "doctor/check2.sh"
 	}
 }
 
+func TestLegacyPackDoctorsRejectsEscapingFixPaths(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name string
+		fix  string
+	}{
+		{name: "absolute", fix: filepath.Join(dir, "outside.sh")},
+		{name: "relative escape", fix: "../../../outside.sh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := legacyPackDoctors(fsys.OSFS{}, []PackDoctorEntry{{
+				Name:   "check",
+				Script: "doctor/check.sh",
+				Fix:    tt.fix,
+			}}, filepath.Join(dir, "pack"), "pack")
+			if err == nil {
+				t.Fatal("legacyPackDoctors error = nil, want containment error")
+			}
+			if !strings.Contains(err.Error(), "doctor check fix") {
+				t.Fatalf("legacyPackDoctors error = %v, want check fix context", err)
+			}
+		})
+	}
+}
+
+func TestLegacyPackDoctorsRejectsMissingFixScript(t *testing.T) {
+	packDir := filepath.Join(t.TempDir(), "pack")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := legacyPackDoctors(fsys.OSFS{}, []PackDoctorEntry{{
+		Name:   "check",
+		Script: "doctor/check.sh",
+		Fix:    "doctor/missing-fix.sh",
+	}}, packDir, "pack")
+	if err == nil {
+		t.Fatal("legacyPackDoctors error = nil, want missing fix script error")
+	}
+	if !strings.Contains(err.Error(), "doctor check fix") {
+		t.Fatalf("legacyPackDoctors error = %v, want check fix context", err)
+	}
+}
+
 func TestPackDoctorEntriesDeduplicatesDirs(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "pack.toml", `

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3343,6 +3343,42 @@ name = "worker"
 	if entries[1].Entry.Description != "" {
 		t.Errorf("second Entry.Description = %q, want empty", entries[1].Entry.Description)
 	}
+
+	// Fix field defaults to empty when not declared (diagnostic-only check).
+	if entries[0].Entry.Fix != "" {
+		t.Errorf("Entry.Fix = %q, want empty when not declared", entries[0].Entry.Fix)
+	}
+}
+
+func TestPackDoctorEntriesParsesFixField(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pack.toml", `
+[pack]
+name = "fixable"
+schema = 1
+
+[[doctor]]
+name = "check-with-fix"
+script = "doctor/check.sh"
+fix = "doctor/fix.sh"
+description = "Check that opts into auto-remediation"
+
+[[doctor]]
+name = "check-no-fix"
+script = "doctor/check2.sh"
+`)
+
+	entries := LoadPackDoctorEntries(fsys.OSFS{}, []string{dir})
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+
+	if entries[0].Entry.Fix != "doctor/fix.sh" {
+		t.Errorf("Entry.Fix = %q, want %q", entries[0].Entry.Fix, "doctor/fix.sh")
+	}
+	if entries[1].Entry.Fix != "" {
+		t.Errorf("Entry.Fix without fix field = %q, want empty", entries[1].Entry.Fix)
+	}
 }
 
 func TestPackDoctorEntriesDeduplicatesDirs(t *testing.T) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -42,7 +42,12 @@ func (d *Doctor) Run(ctx *CheckContext, w io.Writer, fix bool) *Report {
 				result = c.Run(ctx)
 				if result.Status == StatusOK {
 					result.Fixed = true
+				} else {
+					result.FixAttempted = true
 				}
+			} else {
+				result.FixError = err.Error()
+				result.FixAttempted = true
 			}
 		}
 
@@ -86,6 +91,11 @@ func printResult(w io.Writer, r *CheckResult, verbose bool) {
 		for _, d := range r.Details {
 			fmt.Fprintf(w, "      %s\n", d) //nolint:errcheck // best-effort output
 		}
+	}
+	if r.FixError != "" && r.Status != StatusOK && !r.Fixed {
+		fmt.Fprintf(w, "      fix failed: %s\n", r.FixError) //nolint:errcheck // best-effort output
+	} else if r.FixAttempted && r.Status != StatusOK && !r.Fixed {
+		fmt.Fprintf(w, "      fix attempted; check still failing\n") //nolint:errcheck // best-effort output
 	}
 	if r.FixHint != "" && r.Status != StatusOK && !r.Fixed {
 		fmt.Fprintf(w, "      hint: %s\n", r.FixHint) //nolint:errcheck // best-effort output

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -137,6 +137,27 @@ func TestDoctor_FixFails(t *testing.T) {
 	if r.Failed != 1 {
 		t.Errorf("Failed = %d, want 1", r.Failed)
 	}
+	if !strings.Contains(buf.String(), "fix failed: fix failed") {
+		t.Errorf("output missing fix error: %q", buf.String())
+	}
+}
+
+func TestDoctor_FixSucceedsButCheckStillFails(t *testing.T) {
+	d := &Doctor{}
+	d.Register(&unchangedFixCheck{})
+
+	var buf bytes.Buffer
+	r := d.Run(&CheckContext{CityPath: "/tmp"}, &buf, true)
+
+	if r.Fixed != 0 {
+		t.Errorf("Fixed = %d, want 0", r.Fixed)
+	}
+	if r.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", r.Failed)
+	}
+	if !strings.Contains(buf.String(), "fix attempted; check still failing") {
+		t.Errorf("output missing fix-attempt signal: %q", buf.String())
+	}
 }
 
 func TestDoctor_NoChecks(t *testing.T) {
@@ -241,3 +262,16 @@ func (c *hintCheck) Run(_ *CheckContext) *CheckResult {
 }
 func (c *hintCheck) CanFix() bool              { return false }
 func (c *hintCheck) Fix(_ *CheckContext) error { return nil }
+
+type unchangedFixCheck struct{}
+
+func (c *unchangedFixCheck) Name() string { return "unchanged-fix" }
+func (c *unchangedFixCheck) Run(_ *CheckContext) *CheckResult {
+	return &CheckResult{
+		Name:    "unchanged-fix",
+		Status:  StatusError,
+		Message: "still bad",
+	}
+}
+func (c *unchangedFixCheck) CanFix() bool              { return true }
+func (c *unchangedFixCheck) Fix(_ *CheckContext) error { return nil }

--- a/internal/doctor/pack_checks.go
+++ b/internal/doctor/pack_checks.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -19,11 +20,23 @@ import (
 //
 //	GC_CITY_PATH    — absolute path to the city root
 //	GC_PACK_DIR — absolute path to the pack directory
+//
+// When FixScript is non-empty, the check also supports `gc doctor --fix`:
+// the fix script is dispatched with the same environment contract as
+// Script. Exit 0 = remediation succeeded (Fix returns nil); non-zero
+// exit surfaces as a fix error (Fix returns an error carrying the
+// exit code and captured output). Packs opt into auto-remediation by
+// declaring `fix = "..."` in their pack.toml [[doctor]] entry (or in a
+// convention-discovered doctor/<name>/doctor.toml manifest).
 type PackScriptCheck struct {
 	// CheckName is the fully-qualified name, e.g. "maintenance:check-binaries".
 	CheckName string
 	// Script is the absolute path to the check script.
 	Script string
+	// FixScript is the absolute path to the remediation script, or
+	// empty when the check is diagnostic-only. When set, CanFix returns
+	// true and Fix dispatches to this script.
+	FixScript string
 	// PackDir is the absolute pack directory path.
 	PackDir string
 	// PackName is the logical pack name used for runtime env injection.
@@ -33,11 +46,42 @@ type PackScriptCheck struct {
 // Name returns the check's fully-qualified name.
 func (c *PackScriptCheck) Name() string { return c.CheckName }
 
-// CanFix reports that pack script checks do not support auto-fix.
-func (c *PackScriptCheck) CanFix() bool { return false }
+// CanFix reports whether the pack declared a fix script for this check.
+// When true, `gc doctor --fix` will dispatch to FixScript after the
+// check returns a non-OK status.
+func (c *PackScriptCheck) CanFix() bool { return c.FixScript != "" }
 
-// Fix is a no-op (pack script checks do not support auto-fix).
-func (c *PackScriptCheck) Fix(_ *CheckContext) error { return nil }
+// Fix runs the pack's fix script with the same environment contract as
+// Run. Returns nil on exit 0 (remediation succeeded); returns an error
+// carrying the exit code and any captured output on non-zero exit or
+// if the script cannot be executed. When FixScript is empty this is a
+// no-op and returns nil — callers should gate on CanFix first.
+func (c *PackScriptCheck) Fix(ctx *CheckContext) error {
+	if c.FixScript == "" {
+		return nil
+	}
+
+	cmd := exec.Command(c.FixScript) //nolint:gosec // path from pack config
+	cmd.Dir = c.PackDir
+	cmd.Env = append(cmd.Environ(), citylayout.PackRuntimeEnv(ctx.CityPath, c.PackName)...)
+	cmd.Env = append(cmd.Env,
+		"GC_PACK_DIR="+c.PackDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			output := strings.TrimSpace(string(out))
+			if output == "" {
+				return fmt.Errorf("fix script exited with status %d", exitErr.ExitCode())
+			}
+			return fmt.Errorf("fix script exited with status %d: %s", exitErr.ExitCode(), output)
+		}
+		return fmt.Errorf("fix script error: %w", err)
+	}
+	return nil
+}
 
 // Run executes the pack script and interprets its output.
 func (c *PackScriptCheck) Run(ctx *CheckContext) *CheckResult {

--- a/internal/doctor/pack_checks_test.go
+++ b/internal/doctor/pack_checks_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -270,6 +271,34 @@ func TestPackScriptCheckFixFailure(t *testing.T) {
 	}
 	if !strings.Contains(msg, "remediation failed") {
 		t.Errorf("error missing captured output: %q", msg)
+	}
+}
+
+func TestDoctorRunPackScriptCheckReportsFixFailure(t *testing.T) {
+	dir := t.TempDir()
+	check := writeCheckScript(t, dir, "#!/bin/sh\necho 'marker missing'\nexit 2\n")
+	fix := writeFixScript(t, dir, "#!/bin/sh\necho 'cannot create marker'\nexit 5\n")
+	d := &Doctor{}
+	d.Register(&PackScriptCheck{
+		CheckName: "topo:fix-fail",
+		Script:    check,
+		FixScript: fix,
+		PackDir:   dir,
+		PackName:  "topo",
+	})
+
+	var buf bytes.Buffer
+	report := d.Run(&CheckContext{CityPath: t.TempDir()}, &buf, true)
+
+	if report.Fixed != 0 {
+		t.Errorf("Fixed = %d, want 0", report.Fixed)
+	}
+	if report.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", report.Failed)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "fix failed: fix script exited with status 5: cannot create marker") {
+		t.Errorf("output missing fix script failure: %q", out)
 	}
 }
 

--- a/internal/doctor/pack_checks_test.go
+++ b/internal/doctor/pack_checks_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -178,6 +179,112 @@ func TestPackScriptCheckEnvVars(t *testing.T) {
 		" state=" + filepath.Join(cityPath, ".gc", "runtime", "packs", "topo")
 	if result.Message != expected {
 		t.Errorf("Message = %q, want %q", result.Message, expected)
+	}
+}
+
+func writeFixScript(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "fix.sh")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestPackScriptCheckCanFixWithoutScript(t *testing.T) {
+	c := &PackScriptCheck{
+		CheckName: "topo:diag-only",
+		Script:    "/irrelevant",
+		PackDir:   t.TempDir(),
+		PackName:  "topo",
+	}
+	if c.CanFix() {
+		t.Error("CanFix() = true without FixScript, want false")
+	}
+	if err := c.Fix(&CheckContext{CityPath: t.TempDir()}); err != nil {
+		t.Errorf("Fix() on diagnostic-only check returned error: %v", err)
+	}
+}
+
+func TestPackScriptCheckCanFixWithScript(t *testing.T) {
+	dir := t.TempDir()
+	fix := writeFixScript(t, dir, "#!/bin/sh\nexit 0\n")
+	c := &PackScriptCheck{
+		CheckName: "topo:fixable",
+		Script:    "/irrelevant",
+		FixScript: fix,
+		PackDir:   dir,
+		PackName:  "topo",
+	}
+	if !c.CanFix() {
+		t.Error("CanFix() = false with FixScript set, want true")
+	}
+}
+
+func TestPackScriptCheckFixSuccess(t *testing.T) {
+	dir := t.TempDir()
+	city := t.TempDir()
+	// Fix script: create a marker at $GC_CITY_PATH/.marker. Exit 0.
+	fix := writeFixScript(t, dir,
+		"#!/bin/sh\nset -e\necho hello\necho 'pack='$GC_PACK_DIR\n: > \"$GC_CITY_PATH/.marker\"\nexit 0\n")
+	c := &PackScriptCheck{
+		CheckName: "topo:fix-ok",
+		Script:    "/irrelevant",
+		FixScript: fix,
+		PackDir:   dir,
+		PackName:  "topo",
+	}
+
+	if err := c.Fix(&CheckContext{CityPath: city}); err != nil {
+		t.Fatalf("Fix() returned unexpected error: %v", err)
+	}
+	// Marker file confirms (a) the fix executed, (b) GC_CITY_PATH env
+	// var was delivered, and (c) the script had write access to the
+	// city directory.
+	marker := filepath.Join(city, ".marker")
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("marker not created by fix script: %v", err)
+	}
+}
+
+func TestPackScriptCheckFixFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Fix script prints details and exits non-zero.
+	fix := writeFixScript(t, dir,
+		"#!/bin/sh\necho 'remediation failed'\necho 'reason: disk full'\nexit 5\n")
+	c := &PackScriptCheck{
+		CheckName: "topo:fix-fail",
+		Script:    "/irrelevant",
+		FixScript: fix,
+		PackDir:   dir,
+		PackName:  "topo",
+	}
+
+	err := c.Fix(&CheckContext{CityPath: t.TempDir()})
+	if err == nil {
+		t.Fatal("Fix() returned nil, want error for non-zero exit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "status 5") {
+		t.Errorf("error missing exit code: %q", msg)
+	}
+	if !strings.Contains(msg, "remediation failed") {
+		t.Errorf("error missing captured output: %q", msg)
+	}
+}
+
+func TestPackScriptCheckFixMissingScript(t *testing.T) {
+	c := &PackScriptCheck{
+		CheckName: "topo:fix-missing",
+		Script:    "/irrelevant",
+		FixScript: "/nonexistent/fix.sh",
+		PackDir:   t.TempDir(),
+		PackName:  "topo",
+	}
+
+	err := c.Fix(&CheckContext{CityPath: t.TempDir()})
+	if err == nil {
+		t.Fatal("Fix() returned nil for missing script, want error")
 	}
 }
 

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -49,6 +49,11 @@ type CheckResult struct {
 	Details []string
 	// FixHint is a suggestion shown when the check fails and cannot auto-fix.
 	FixHint string
+	// FixError describes why an attempted automatic remediation failed.
+	FixError string
+	// FixAttempted is true when automatic remediation ran but did not
+	// leave the check passing.
+	FixAttempted bool
 	// Fixed is true when --fix successfully remediated the issue.
 	Fixed bool
 }


### PR DESCRIPTION
## Summary

Pack doctor checks can declare a diagnostic `script` today, but `PackScriptCheck.CanFix()` returns `false` and `Fix()` is a no-op by design ([`internal/doctor/pack_checks.go:36-40`](https://github.com/gastownhall/gascity/blob/main/internal/doctor/pack_checks.go#L36-L40) on main). Packs have no way to plug into `gc doctor --fix`. This PR adds that plug point.

A pack opts into auto-fix by declaring a `fix` script alongside its `script`, either via the `[[doctor]]` TOML entry or a convention-discovered sibling:

```toml
# pack.toml — legacy [[doctor]] form
[[doctor]]
name = "marker-present"
script = "doctor/marker-present/run.sh"
fix    = "doctor/marker-present/fix.sh"
```

```
# or convention-discovered
my-pack/
└── doctor/
    └── marker-present/
        ├── run.sh
        └── fix.sh          # picked up automatically
```

`doctor.toml` manifest can override with an explicit `fix = "..."` when needed (same containment rules as `run`).

The fix script runs with the same environment contract as the check (`GC_CITY_PATH`, `GC_PACK_DIR`, pack runtime env). Exit 0 = remediation succeeded; non-zero = fix error carrying exit code and captured output. The existing doctor runner then re-runs the check and marks it `(fixed)` if the follow-up returns `StatusOK`.

## Motivation

Packs that do first-time dev-environment setup naturally want a single `gc doctor --fix` flow: "check what state the pack expects; if missing, establish it." Today that requires either a separate pack-contributed command or an out-of-tree bootstrap script. Adding fix-script support closes the gap with minimal new surface area and full backward compatibility.

## Changes

**Schema**
- `PackDoctorEntry` gains optional `Fix string` field (`toml:"fix,omitempty"`).
- `doctorManifest` gains optional `Fix string` field.
- `DiscoveredDoctor` gains `FixScript string`, populated by both loaders.

**Discovery**
- `discoveredDoctorFromDir`: resolves `manifest.Fix` when declared; otherwise auto-discovers a sibling `fix.sh` next to `run.sh`. Applies the same `resolveContainedDoctorRunPath` containment check.
- `legacyPackDoctors`: resolves `entry.Fix` to an absolute path under the pack dir.

**Dedup merge**
- `appendDiscoveredDoctors` now merges `FixScript` from suppressed duplicates: when a convention-discovered entry and a `[[doctor]]` entry both describe the same check, whichever gets appended first wins on identity (Name + BindingName + RunScript), but a non-empty `FixScript` from the suppressed entry is copied onto the winner. Without this, `CanFix` could spuriously return `false`.

**Runtime**
- `PackScriptCheck` gains `FixScript string`. `CanFix()` returns `c.FixScript != ""`. `Fix()` execs the fix script with the full env contract, wrapping non-zero exits in an error that includes exit code and captured output.
- `cmd/gc/cmd_doctor.go` threads `FixScript` through when registering checks.

## Backward compatibility

100%. The new field is optional in every layer. Packs without `fix` declarations keep the pre-PR behavior (`CanFix() == false`, `Fix()` is a no-op).

## Empirical before/after

Verified on v0.15.2 against a minimal test pack with a diagnostic + fix pair.

**Before (main):**
\`\`\`
\$ gc doctor
  ⚠ demo:marker-present — marker missing; fix script can create it

\$ gc doctor --fix
  ⚠ demo:marker-present — marker missing; fix script can create it
# marker NOT created — fix script ignored
\`\`\`

**After (this PR):**
\`\`\`
\$ gc doctor --fix
  ✓ demo:marker-present — marker present at <city>/.marker (fixed)
# marker file created on disk; re-run check returns StatusOK
\`\`\`

## Tests

New tests cover:

- \`PackScriptCheck.Fix\` success, failure (non-zero exit), missing fix script, \`CanFix()\` toggling on \`FixScript\` presence.
- \`PackDoctorEntry.Fix\` parsing from \`[[doctor]]\` TOML, default-empty when not declared.
- \`DiscoverPackDoctors\`: manifest-declared \`fix\`, sibling-convention \`fix.sh\` auto-discovery, absent \`fix.sh\` case, and containment-escape rejection for \`fix\` paths.
- \`appendDiscoveredDoctors\`: appending new entries, dedup on (Name, BindingName, RunScript), merge of \`FixScript\` from suppressed duplicates, preservation of existing \`FixScript\` when duplicate is sparse, distinct \`BindingName\` treated as separate checks.

All tests in the two touched packages pass locally. Pre-existing failing tests in \`internal/config/\` (GPG-signing and pack-cache environmental dependencies) are unchanged by this PR.

## Test plan

- [ ] Reviewer can reproduce before/after by creating a minimal pack with a \`[[doctor]]\` entry declaring \`fix\`, and running \`gc doctor --fix\` on v0.15.2 vs this branch.
- [ ] \`go test ./internal/doctor/ ./internal/config/ -run "PackScriptCheck|PackDoctor|DiscoverPackDoctors|AppendDiscoveredDoctors"\` passes.
- [ ] No existing pack behavior changes (verified by running against gastown + maintenance + bd + dolt system packs — all pre-existing checks continue to register and run with \`CanFix() == false\`).

---

Closes #958