### PR TITLE
test: harden hook-enabled startup proofs

### DIFF
--- a/cmd/gc/phase2_real_transport_test.go
+++ b/cmd/gc/phase2_real_transport_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
-const phase2RealTransportBound = 5 * time.Second
-const phase2RealTransportMarkerBound = 500 * time.Millisecond
+const (
+	phase2RealTransportBound       = 5 * time.Second
+	phase2RealTransportMarkerBound = 500 * time.Millisecond
+)
 
 func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	tmuxtest.RequireTmux(t)

--- a/cmd/gc/phase2_real_transport_test.go
+++ b/cmd/gc/phase2_real_transport_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const phase2RealTransportBound = 5 * time.Second
+const phase2RealTransportMarkerBound = 500 * time.Millisecond
 
 func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	tmuxtest.RequireTmux(t)
@@ -37,21 +38,55 @@ func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	}
 }
 
+func TestPhase2HookEnabledClaudeAutonomousStartupProof(t *testing.T) {
+	tmuxtest.RequireTmux(t)
+
+	tc := phase2ProviderCaseForFamily(t, "claude")
+	tp := resolvePhase2Template(t, tc)
+	if !tp.HookEnabled {
+		t.Fatal("HookEnabled = false, want true for Claude phase2 profile")
+	}
+	if tp.ResolvedProvider == nil {
+		t.Fatal("ResolvedProvider = nil, want Claude provider metadata")
+	}
+	if !tp.ResolvedProvider.SupportsHooks {
+		t.Fatal("SupportsHooks = false, want true for Claude phase2 profile")
+	}
+
+	materialized := templateParamsToConfig(tp)
+	run := launchPhase2RealTransportSession(t, tc, materialized)
+
+	if run.ErrorStage != "" {
+		t.Fatalf("%s failed: %s", run.ErrorStage, run.Error)
+	}
+	if got, want := run.ObservedStartupPrompt, run.ExpectedStartupPrompt; got != want {
+		t.Fatalf("startup prompt = %q, want %q", got, want)
+	}
+	if !run.AutonomousStarted {
+		t.Fatal("autonomous marker = missing, want launch-prompt work before any explicit rescue nudge")
+	}
+}
+
 type phase2RealTransportRun struct {
-	Transport         string
-	SocketName        string
-	SessionName       string
-	ProviderPath      string
-	StartedPath       string
-	InputPath         string
-	ErrorStage        string
-	Error             string
-	ExpectedInput     string
-	ObservedInput     string
-	ObservedProvider  string
-	Started           bool
-	RunningAfterInput bool
-	StartElapsed      time.Duration
+	Transport             string
+	SocketName            string
+	SessionName           string
+	ProviderPath          string
+	StartedPath           string
+	InputPath             string
+	StartupPromptPath     string
+	AutonomousPath        string
+	ErrorStage            string
+	Error                 string
+	ExpectedInput         string
+	ObservedInput         string
+	ExpectedStartupPrompt string
+	ObservedStartupPrompt string
+	ObservedProvider      string
+	Started               bool
+	AutonomousStarted     bool
+	RunningAfterInput     bool
+	StartElapsed          time.Duration
 }
 
 func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, materialized runtime.Config) phase2RealTransportRun {
@@ -62,8 +97,44 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	startedPath := filepath.Join(dir, "started.txt")
 	providerPath := filepath.Join(dir, "provider.txt")
 	inputPath := filepath.Join(dir, "input.txt")
+	startupPromptPath := filepath.Join(dir, "startup-prompt.txt")
+	expectedPromptPath := filepath.Join(dir, "expected-startup-prompt.txt")
+	autonomousPath := filepath.Join(dir, "autonomous.txt")
 	stopPath := filepath.Join(dir, "stop.txt")
 	sessionName := guard.SessionName("phase2-" + tc.family)
+	expectedStartupPrompt, promptErr := singleShellArgValue(materialized.PromptSuffix)
+	if promptErr != nil {
+		return phase2RealTransportRun{
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "prompt_suffix_parse",
+			Error:                 promptErr.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
+		}
+	}
+	if err := os.WriteFile(expectedPromptPath, []byte(expectedStartupPrompt), 0o644); err != nil {
+		return phase2RealTransportRun{
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "expected_prompt_write",
+			Error:                 err.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
+		}
+	}
 
 	sp, err := newSessionProviderByName("", config.SessionConfig{
 		Socket:             guard.SocketName(),
@@ -74,15 +145,18 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	}, guard.CityName(), dir)
 	if err != nil {
 		return phase2RealTransportRun{
-			Transport:     "tmux",
-			SocketName:    guard.SocketName(),
-			SessionName:   sessionName,
-			ProviderPath:  providerPath,
-			StartedPath:   startedPath,
-			InputPath:     inputPath,
-			ErrorStage:    "provider",
-			Error:         err.Error(),
-			ExpectedInput: materialized.Nudge,
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "provider",
+			Error:                 err.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
 		}
 	}
 
@@ -95,6 +169,8 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 		`set -eu`,
 		`printf "%s\n" "$GC_PROVIDER" > "$GC_REAL_TRANSPORT_PROVIDER_PATH"`,
 		`printf "started\n" > "$GC_REAL_TRANSPORT_STARTED_PATH"`,
+		`printf "%s" "$0" > "$GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH"`,
+		`if [ "$0" = "$(cat "$GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH")" ]; then printf "autonomous\n" > "$GC_REAL_TRANSPORT_AUTONOMOUS_PATH"; fi`,
 		`IFS= read -r line`,
 		`printf "%s\n" "$line" > "$GC_REAL_TRANSPORT_INPUT_PATH"`,
 		`while [ ! -f "$GC_REAL_TRANSPORT_STOP_PATH" ]; do sleep 0.05; done`,
@@ -117,6 +193,9 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	cfg.Env["GC_REAL_TRANSPORT_PROVIDER_PATH"] = providerPath
 	cfg.Env["GC_REAL_TRANSPORT_STARTED_PATH"] = startedPath
 	cfg.Env["GC_REAL_TRANSPORT_INPUT_PATH"] = inputPath
+	cfg.Env["GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH"] = startupPromptPath
+	cfg.Env["GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH"] = expectedPromptPath
+	cfg.Env["GC_REAL_TRANSPORT_AUTONOMOUS_PATH"] = autonomousPath
 	cfg.Env["GC_REAL_TRANSPORT_STOP_PATH"] = stopPath
 
 	ctx, cancel := context.WithTimeout(context.Background(), phase2RealTransportBound)
@@ -125,27 +204,35 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	start := time.Now()
 	if err := sp.Start(ctx, sessionName, cfg); err != nil {
 		return phase2RealTransportRun{
-			Transport:     "tmux",
-			SocketName:    guard.SocketName(),
-			SessionName:   sessionName,
-			ProviderPath:  providerPath,
-			StartedPath:   startedPath,
-			InputPath:     inputPath,
-			ErrorStage:    "start",
-			Error:         err.Error(),
-			ExpectedInput: materialized.Nudge,
-			StartElapsed:  time.Since(start),
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "start",
+			Error:                 err.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
+			StartElapsed:          time.Since(start),
 		}
 	}
 	startElapsed := time.Since(start)
 
 	observedInput, inputErr := waitForPhase2FileText(inputPath, phase2RealTransportBound)
 	observedProvider, providerErr := waitForPhase2FileText(providerPath, phase2RealTransportBound)
+	observedStartupPrompt, startupPromptErr := waitForPhase2FileText(startupPromptPath, phase2RealTransportBound)
+	autonomousStarted := waitForPhase2FileExists(autonomousPath, phase2RealTransportMarkerBound)
 	_, startedErr := os.Stat(startedPath)
 
 	errorStage := ""
 	errorDetail := ""
 	switch {
+	case startupPromptErr != nil:
+		errorStage = "startup_prompt_wait"
+		errorDetail = startupPromptErr.Error()
 	case inputErr != nil:
 		errorStage = "input_wait"
 		errorDetail = inputErr.Error()
@@ -155,40 +242,50 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	}
 
 	return phase2RealTransportRun{
-		Transport:         "tmux",
-		SocketName:        guard.SocketName(),
-		SessionName:       sessionName,
-		ProviderPath:      providerPath,
-		StartedPath:       startedPath,
-		InputPath:         inputPath,
-		ErrorStage:        errorStage,
-		Error:             errorDetail,
-		ExpectedInput:     materialized.Nudge,
-		ObservedInput:     strings.TrimSpace(observedInput),
-		ObservedProvider:  strings.TrimSpace(observedProvider),
-		Started:           startedErr == nil,
-		RunningAfterInput: sp.IsRunning(sessionName),
-		StartElapsed:      startElapsed,
+		Transport:             "tmux",
+		SocketName:            guard.SocketName(),
+		SessionName:           sessionName,
+		ProviderPath:          providerPath,
+		StartedPath:           startedPath,
+		InputPath:             inputPath,
+		StartupPromptPath:     startupPromptPath,
+		AutonomousPath:        autonomousPath,
+		ErrorStage:            errorStage,
+		Error:                 errorDetail,
+		ExpectedInput:         materialized.Nudge,
+		ObservedInput:         strings.TrimSpace(observedInput),
+		ExpectedStartupPrompt: expectedStartupPrompt,
+		ObservedStartupPrompt: observedStartupPrompt,
+		ObservedProvider:      strings.TrimSpace(observedProvider),
+		Started:               startedErr == nil,
+		AutonomousStarted:     autonomousStarted,
+		RunningAfterInput:     sp.IsRunning(sessionName),
+		StartElapsed:          startElapsed,
 	}
 }
 
 func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun) workertest.Result {
 	evidence := map[string]string{
-		"family":              tc.family,
-		"profile":             string(tc.profileID),
-		"transport":           run.Transport,
-		"socket_name":         run.SocketName,
-		"session_name":        run.SessionName,
-		"started_path":        run.StartedPath,
-		"provider_path":       run.ProviderPath,
-		"input_path":          run.InputPath,
-		"error_stage":         run.ErrorStage,
-		"error":               run.Error,
-		"expected_input":      run.ExpectedInput,
-		"observed_input":      run.ObservedInput,
-		"observed_provider":   run.ObservedProvider,
-		"running_after_input": fmt.Sprintf("%t", run.RunningAfterInput),
-		"start_elapsed":       run.StartElapsed.String(),
+		"family":                  tc.family,
+		"profile":                 string(tc.profileID),
+		"transport":               run.Transport,
+		"socket_name":             run.SocketName,
+		"session_name":            run.SessionName,
+		"started_path":            run.StartedPath,
+		"provider_path":           run.ProviderPath,
+		"input_path":              run.InputPath,
+		"startup_prompt_path":     run.StartupPromptPath,
+		"autonomous_path":         run.AutonomousPath,
+		"error_stage":             run.ErrorStage,
+		"error":                   run.Error,
+		"expected_input":          run.ExpectedInput,
+		"observed_input":          run.ObservedInput,
+		"expected_startup_prompt": run.ExpectedStartupPrompt,
+		"observed_startup_prompt": run.ObservedStartupPrompt,
+		"observed_provider":       run.ObservedProvider,
+		"autonomous_started":      fmt.Sprintf("%t", run.AutonomousStarted),
+		"running_after_input":     fmt.Sprintf("%t", run.RunningAfterInput),
+		"start_elapsed":           run.StartElapsed.String(),
 	}
 	switch {
 	case run.ErrorStage != "":
@@ -203,6 +300,12 @@ func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun
 	case run.ObservedProvider != tc.family:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("GC_PROVIDER = %q, want %q", run.ObservedProvider, tc.family)).WithEvidence(evidence)
+	case run.ObservedStartupPrompt != run.ExpectedStartupPrompt:
+		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
+			fmt.Sprintf("startup prompt = %q, want %q", run.ObservedStartupPrompt, run.ExpectedStartupPrompt)).WithEvidence(evidence)
+	case !run.AutonomousStarted:
+		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
+			"launch prompt did not trigger autonomous pre-nudge work").WithEvidence(evidence)
 	case run.ObservedInput != run.ExpectedInput:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("nudge input = %q, want %q", run.ObservedInput, run.ExpectedInput)).WithEvidence(evidence)
@@ -214,7 +317,7 @@ func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun
 			fmt.Sprintf("startup elapsed = %s, want <= %s", run.StartElapsed, phase2RealTransportBound)).WithEvidence(evidence)
 	default:
 		return workertest.Pass(tc.profileID, workertest.RequirementRealTransportProof,
-			"production tmux runtime launched and delivered initial input deterministically").WithEvidence(evidence)
+			"production tmux runtime launched, delivered the first-turn startup prompt, and preserved stdin nudge delivery deterministically").WithEvidence(evidence)
 	}
 }
 
@@ -238,4 +341,15 @@ func waitForPhase2FileText(path string, timeout time.Duration) (string, error) {
 		time.Sleep(25 * time.Millisecond)
 	}
 	return "", fmt.Errorf("timed out waiting for %s: %w", path, lastErr)
+}
+
+func waitForPhase2FileExists(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
 }

--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -201,11 +201,13 @@ func phase2TemplateEvidence(tc phase2ProviderCase, tp TemplateParams) map[string
 		"session_name": tp.SessionName,
 		"workdir":      tp.WorkDir,
 		"command":      tp.Command,
+		"hook_enabled": strconv.FormatBool(tp.HookEnabled),
 	}
 	if tp.ResolvedProvider != nil {
 		evidence["resolved_provider"] = tp.ResolvedProvider.Name
 		evidence["prompt_mode"] = tp.ResolvedProvider.PromptMode
 		evidence["default_args"] = strings.Join(tp.ResolvedProvider.ResolveDefaultArgs(), " ")
+		evidence["supports_hooks"] = strconv.FormatBool(tp.ResolvedProvider.SupportsHooks)
 	}
 	return evidence
 }
@@ -258,10 +260,12 @@ func phase2PreparedEvidence(tc phase2ProviderCase, prepared *preparedStart) map[
 	evidence["session_name"] = prepared.candidate.name()
 	evidence["started_config_hash"] = prepared.candidate.session.Metadata["started_config_hash"]
 	evidence["template_overrides"] = prepared.candidate.session.Metadata["template_overrides"]
+	evidence["hook_enabled"] = strconv.FormatBool(prepared.candidate.tp.HookEnabled)
 
 	if prepared.candidate.tp.ResolvedProvider != nil {
 		evidence["resolved_provider"] = prepared.candidate.tp.ResolvedProvider.Name
 		evidence["resolved_default_args"] = strings.Join(prepared.candidate.tp.ResolvedProvider.ResolveDefaultArgs(), " ")
+		evidence["supports_hooks"] = strconv.FormatBool(prepared.candidate.tp.ResolvedProvider.SupportsHooks)
 	}
 
 	return evidence

--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -62,7 +62,6 @@ func startupCommandMaterializationResult(tc phase2ProviderCase, tp TemplateParam
 
 func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp TemplateParams, cfg runtime.Config) workertest.Result {
 	evidence := phase2ConfigEvidence(tc, tp, cfg)
-	hookStartup := tp.HookEnabled && tp.ResolvedProvider != nil && tp.ResolvedProvider.SupportsHooks
 	switch {
 	case cfg.Command != tp.Command:
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
@@ -70,12 +69,9 @@ func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp Templat
 	case cfg.WorkDir != tp.WorkDir:
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("cfg.WorkDir = %q, want %q", cfg.WorkDir, tp.WorkDir)).WithEvidence(evidence)
-	case !hookStartup && cfg.PromptSuffix == "":
+	case cfg.PromptSuffix == "":
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			"cfg.PromptSuffix = empty, want beacon prompt materialized").WithEvidence(evidence)
-	case hookStartup && cfg.PromptSuffix != "":
-		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
-			fmt.Sprintf("cfg.PromptSuffix = %q, want empty when startup prompt is delivered via hooks", cfg.PromptSuffix)).WithEvidence(evidence)
 	case cfg.PromptFlag != "":
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("cfg.PromptFlag = %q, want empty for arg-mode provider", cfg.PromptFlag)).WithEvidence(evidence)
@@ -134,9 +130,6 @@ func initialMessageFirstStartResult(tc phase2ProviderCase, prepared *preparedSta
 			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
 	}
 	want := "Base worker prompt\n\n---\n\nUser message:\nDo the first task."
-	if prepared != nil && prepared.candidate.tp.HookEnabled && prepared.candidate.tp.ResolvedProvider != nil && prepared.candidate.tp.ResolvedProvider.SupportsHooks {
-		want = "Do the first task."
-	}
 	switch {
 	case got != want:
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageFirstStart,
@@ -157,9 +150,6 @@ func initialMessageResumeResult(tc phase2ProviderCase, prepared *preparedStart) 
 			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
 	}
 	want := "Base worker prompt"
-	if prepared != nil && prepared.candidate.tp.HookEnabled && prepared.candidate.tp.ResolvedProvider != nil && prepared.candidate.tp.ResolvedProvider.SupportsHooks {
-		want = ""
-	}
 	switch {
 	case got != want:
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,

--- a/cmd/gc/session_lifecycle_parallel_phase2_test.go
+++ b/cmd/gc/session_lifecycle_parallel_phase2_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,43 @@ func TestPhase2InitialInputDelivery(t *testing.T) {
 				reporter.Require(t, inputOverrideDefaultsResult(tc, prepared))
 			})
 		})
+	}
+}
+
+func TestPhase2HookEnabledClaudeFirstTurnStartupPayload(t *testing.T) {
+	tc := phase2ProviderCaseForFamily(t, "claude")
+	prepared := preparePhase2Start(t, tc, "", map[string]string{
+		"initial_message": "Do the first task.",
+	})
+
+	if !prepared.candidate.tp.HookEnabled {
+		t.Fatal("HookEnabled = false, want true for Claude phase2 profile")
+	}
+	if prepared.candidate.tp.ResolvedProvider == nil {
+		t.Fatal("ResolvedProvider = nil, want Claude provider metadata")
+	}
+	if !prepared.candidate.tp.ResolvedProvider.SupportsHooks {
+		t.Fatal("SupportsHooks = false, want true for Claude phase2 profile")
+	}
+	if prepared.cfg.PromptSuffix == "" {
+		t.Fatal("PromptSuffix = empty, want first-turn startup payload to stay on launch for hook-enabled Claude")
+	}
+	if got := prepared.cfg.Nudge; got != "nudge-claude" {
+		t.Fatalf("Nudge = %q, want existing worker nudge preserved separately", got)
+	}
+
+	payload, evidence, err := phase2PromptPayload(tc, prepared)
+	if err != nil {
+		t.Fatalf("phase2PromptPayload: %v (evidence=%v)", err, evidence)
+	}
+	if !strings.Contains(payload, "Base worker prompt") {
+		t.Fatalf("payload = %q, want base startup prompt", payload)
+	}
+	if !strings.Contains(payload, "User message:\nDo the first task.") {
+		t.Fatalf("payload = %q, want initial_message on first start", payload)
+	}
+	if strings.Count(payload, "Do the first task.") != 1 {
+		t.Fatalf("payload = %q, want initial_message exactly once", payload)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -73,9 +73,10 @@ type TemplateParams struct {
 	// IsACP is true if session = "acp".
 	IsACP bool
 	// HookEnabled reports whether provider hooks are installed for this agent.
-	// Hook-enabled providers receive startup context via their hook path
-	// (for example gc prime --hook), so PromptMode=none should not also
-	// fall back to a delayed startup nudge.
+	// Hooks complement startup delivery but do not replace the initial
+	// user-turn prompt. SessionStart hooks can add context, persist session
+	// metadata, and start background helpers, but they do not initiate the
+	// first model turn on their own.
 	HookEnabled bool
 	// DependencyOnly marks a realized cold slot kept only so dependency wake
 	// has something concrete to wake even when pool check wants zero.
@@ -532,23 +533,20 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 	var promptSuffix string
 	var promptFlag string
 	nudge := tp.Hints.Nudge
-	deliverStartupViaHooks := tp.HookEnabled && tp.ResolvedProvider != nil && tp.ResolvedProvider.SupportsHooks
 	if tp.Prompt != "" {
-		// Hook-enabled providers prime themselves on SessionStart via
-		// gc prime --hook, so the rendered role prompt must not also be
-		// replayed as argv or a delayed startup nudge.
-		if !deliverStartupViaHooks {
-			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
-				if nudge != "" {
-					nudge = tp.Prompt + "\n\n---\n\n" + nudge
-				} else {
-					nudge = tp.Prompt
-				}
+		// SessionStart hooks can enrich context, but the startup prompt still
+		// needs a first-turn delivery mechanism. Without argv/flag/nudge
+		// delivery, freshly spawned workers sit idle at the provider prompt.
+		if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "none" {
+			if nudge != "" {
+				nudge = tp.Prompt + "\n\n---\n\n" + nudge
 			} else {
-				promptSuffix = shellquote.Quote(tp.Prompt)
-				if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" && tp.ResolvedProvider.PromptFlag != "" {
-					promptFlag = tp.ResolvedProvider.PromptFlag
-				}
+				nudge = tp.Prompt
+			}
+		} else {
+			promptSuffix = shellquote.Quote(tp.Prompt)
+			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" && tp.ResolvedProvider.PromptFlag != "" {
+				promptFlag = tp.ResolvedProvider.PromptFlag
 			}
 		}
 	}

--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -105,6 +105,18 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 	return selected
 }
 
+func phase2ProviderCaseForFamily(t *testing.T, family string) phase2ProviderCase {
+	t.Helper()
+
+	for _, tc := range selectedPhase2ProviderCases(t) {
+		if tc.family == family {
+			return tc
+		}
+	}
+	t.Fatalf("phase2 provider case for family %q not found", family)
+	return phase2ProviderCase{}
+}
+
 func resolvePhase2Template(t *testing.T, tc phase2ProviderCase) TemplateParams {
 	t.Helper()
 

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -113,7 +113,7 @@ func TestTemplateParamsToConfigNoneModeUsesNudge(t *testing.T) {
 	}
 }
 
-func TestTemplateParamsToConfigNoneModeWithHooksSkipsStartupNudge(t *testing.T) {
+func TestTemplateParamsToConfigNoneModeWithHooksStillUsesStartupNudge(t *testing.T) {
 	tp := TemplateParams{
 		Command: "opencode",
 		Prompt:  "You are an agent. Do work.",
@@ -134,12 +134,13 @@ func TestTemplateParamsToConfigNoneModeWithHooksSkipsStartupNudge(t *testing.T) 
 	if cfg.PromptSuffix != "" {
 		t.Errorf("PromptSuffix should be empty for none mode, got %q", cfg.PromptSuffix)
 	}
-	if cfg.Nudge != "existing nudge" {
-		t.Errorf("Nudge = %q, want existing nudge only", cfg.Nudge)
+	want := "You are an agent. Do work.\n\n---\n\nexisting nudge"
+	if cfg.Nudge != want {
+		t.Errorf("Nudge = %q, want %q", cfg.Nudge, want)
 	}
 }
 
-func TestTemplateParamsToConfigHookEnabledProviderSkipsLaunchPrompt(t *testing.T) {
+func TestTemplateParamsToConfigHookEnabledProviderStillUsesLaunchPrompt(t *testing.T) {
 	tests := []struct {
 		name       string
 		promptMode string
@@ -169,11 +170,15 @@ func TestTemplateParamsToConfigHookEnabledProviderSkipsLaunchPrompt(t *testing.T
 
 			cfg := templateParamsToConfig(tp)
 
-			if cfg.PromptSuffix != "" {
-				t.Fatalf("PromptSuffix should be empty for hook-enabled startup, got %q", cfg.PromptSuffix)
+			if cfg.PromptSuffix == "" {
+				t.Fatalf("PromptSuffix should still carry the startup prompt when hooks are enabled")
 			}
-			if cfg.PromptFlag != "" {
-				t.Fatalf("PromptFlag should be empty for hook-enabled startup, got %q", cfg.PromptFlag)
+			if tt.promptMode == "flag" {
+				if cfg.PromptFlag != "--prompt" {
+					t.Fatalf("PromptFlag = %q, want %q", cfg.PromptFlag, "--prompt")
+				}
+			} else if cfg.PromptFlag != "" {
+				t.Fatalf("PromptFlag should be empty for arg mode, got %q", cfg.PromptFlag)
 			}
 			if cfg.Nudge != "existing nudge" {
 				t.Fatalf("Nudge = %q, want existing nudge only", cfg.Nudge)

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -201,7 +201,7 @@ Rig added.
 ```
 
 Gas City derived the rig name from the directory basename (`my-project`) and set
-up work tracking in it. You can see the new entry in `city.toml`:
+up work tracking in it. The shared rig declaration lives in `city.toml`:
 
 ```shell
 
@@ -214,6 +214,13 @@ provider = "claude"
 ... # content elided
 
 [[rigs]]
+name = "my-project"
+```
+
+The machine-local path binding lives in `.gc/site.toml`:
+
+```toml
+[[rig]]
 name = "my-project"
 path = "/Users/csells/my-project"
 ```

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -37,12 +37,19 @@ provider = "claude"
 
 [[rigs]]
 name = "my-project"
-path = "/Users/csells/my-project"
 
 ~/my-city
 $ cat agents/reviewer/agent.toml
 dir = "my-project"
 provider = "codex"
+```
+
+The rig's machine-local path binding now lives in `.gc/site.toml` instead:
+
+```toml
+[[rig]]
+name = "my-project"
+path = "/Users/csells/my-project"
 ```
 
 The reviewer's prompt lives at `agents/reviewer/prompt.template.md`. This is the

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -385,17 +385,26 @@ And your city applies that pack to two rigs:
 # city.toml
 [[rigs]]
 name = "my-api"
-path = "../my-api"
 
 [rigs.imports.dev_ops]
 source = "./packs/dev-ops"
 
 [[rigs]]
 name = "my-frontend"
-path = "../my-frontend"
 
 [rigs.imports.dev_ops]
 source = "./packs/dev-ops"
+```
+
+```toml
+# .gc/site.toml
+[[rig]]
+name = "my-api"
+path = "../my-api"
+
+[[rig]]
+name = "my-frontend"
+path = "../my-frontend"
 ```
 
 Now the city has the same order running independently for each rig:

--- a/test/acceptance/tier_c/tierc_test.go
+++ b/test/acceptance/tier_c/tierc_test.go
@@ -42,12 +42,7 @@ func TestMain(m *testing.M) {
 	// 1. ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN env var (CI mode)
 	// 2. GC_TIERC_FORCE=1 env var (local OAuth mode — user asserts Claude is authed)
 	// 3. Detect OAuth: check if ~/.claude/ exists with credentials
-	authToken := strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN"))
-	apiKey := firstNonEmpty(
-		strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")),
-		authToken,
-	)
-	hasEnvAuth := authToken != "" || apiKey != ""
+	apiKey, _, hasEnvAuth := tierCEnvAuth()
 	forceRun := os.Getenv("GC_TIERC_FORCE") == "1"
 	hasOAuth := oauthCredentialsExist()
 
@@ -104,7 +99,7 @@ func TestMain(m *testing.M) {
 	// leaving the on-disk token expired. A quick --print call forces the
 	// refresh and (in newer versions) persists it.
 	if refreshOut, err := exec.Command("claude", "--print", "ok").CombinedOutput(); err != nil {
-		if apiKey != "" {
+		if hasEnvAuth {
 			panic(fmt.Sprintf("acceptance-c: provider preflight failed: %v\n%s", err, refreshOut))
 		}
 		fmt.Fprintf(os.Stderr, "acceptance-c: OAuth preflight refresh failed: %v\n%s\n", err, refreshOut)
@@ -636,13 +631,11 @@ func oauthCredentialsExist() bool {
 	return false
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
+func tierCEnvAuth() (apiKey, authToken string, hasEnvAuth bool) {
+	apiKey = strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	authToken = strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+	hasEnvAuth = apiKey != "" || authToken != ""
+	return apiKey, authToken, hasEnvAuth
 }
 
 func stageTierCAcceptanceProviders(binDir, apiKey string) error {
@@ -704,6 +697,16 @@ func tierCHostProviderShim(name string, unsetVars []string) (string, error) {
 
 func shellQuoteTierC(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func TestTierCEnvAuthDoesNotMirrorAuthTokenIntoAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "synthetic-token")
+
+	apiKey, authToken, hasEnvAuth := tierCEnvAuth()
+	require.Empty(t, apiKey)
+	require.Equal(t, "synthetic-token", authToken)
+	require.True(t, hasEnvAuth)
 }
 
 func stageClaudeOAuth(realHome, gcHome string) error {

--- a/test/acceptance/tutorial_goldens/harness_test.go
+++ b/test/acceptance/tutorial_goldens/harness_test.go
@@ -131,6 +131,7 @@ func (w *tutorialWorkspace) runShell(command, stdin string) (string, error) {
 func (w *tutorialWorkspace) runShellWithTimeout(timeout time.Duration, command, stdin string) (string, error) {
 	w.t.Helper()
 	trimmed := strings.TrimSpace(command)
+	command = tutorialShellCommand(command, w.env.Home)
 	for attempt := 1; attempt <= gcInitTransientRetryLimit; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		cmd := exec.CommandContext(ctx, "bash", "-c", command)
@@ -274,6 +275,7 @@ func (w *tutorialWorkspace) startShell(command, stdin string) (*runningShell, er
 	w.t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	command = tutorialShellCommand(command, w.env.Home)
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
 	cmd.Dir = w.cwd
 	cmd.Env = w.env.Env.List()
@@ -354,6 +356,14 @@ func expandHome(home, path string) string {
 		return filepath.Join(home, strings.TrimPrefix(path, "~/"))
 	}
 	return path
+}
+
+func tutorialShellCommand(command, home string) string {
+	if home == "" || !strings.Contains(command, "~/") {
+		return command
+	}
+	rewritten := strings.ReplaceAll(command, "~/", "${GC_TUTORIAL_HOME}/")
+	return fmt.Sprintf("GC_TUTORIAL_HOME=%s; %s", shellQuote(home), rewritten)
 }
 
 func (w *tutorialWorkspace) configureInitializedCities() error {
@@ -515,6 +525,15 @@ func TestRunEnvCommandWithTimeoutUsesAcceptanceGCBinary(t *testing.T) {
 	}
 	if got := strings.TrimSpace(out); got != "tutorial-env-gc" {
 		t.Fatalf("expected acceptance gc binary output, got %q", got)
+	}
+}
+
+func TestTutorialShellCommandRehomesTildePaths(t *testing.T) {
+	home := "/tmp/tutorial-home"
+	got := tutorialShellCommand("cd ~/my-city && gc rig add ~/my-project", home)
+	want := "GC_TUTORIAL_HOME='/tmp/tutorial-home'; cd ${GC_TUTORIAL_HOME}/my-city && gc rig add ${GC_TUTORIAL_HOME}/my-project"
+	if got != want {
+		t.Fatalf("tutorialShellCommand() = %q, want %q", got, want)
 	}
 }
 

--- a/test/acceptance/tutorial_goldens/manifests_test.go
+++ b/test/acceptance/tutorial_goldens/manifests_test.go
@@ -24,6 +24,7 @@ var tutorialPageManifests = []pageManifest{
 			"cd ~/my-city",
 			"ls",
 			"cat city.toml",
+			"cat pack.toml",
 			"gc status",
 			"gc rig add ~/my-project",
 			"cat city.toml",
@@ -100,6 +101,7 @@ var tutorialPageManifests = []pageManifest{
 	{
 		path: "docs/tutorials/06-beads.md",
 		commands: []string{
+			"cat pack.toml",
 			"cat city.toml",
 			"cat agents/reviewer/agent.toml",
 			"bd list",

--- a/test/acceptance/tutorial_goldens/tutorial01_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial01_test.go
@@ -170,8 +170,22 @@ func TestTutorial01Cities(t *testing.T) {
 			if !strings.Contains(out, `name = "my-project"`) {
 				t.Fatalf("city.toml missing rig entry:\n%s", out)
 			}
+			if strings.Contains(out, myProject) {
+				t.Fatalf("city.toml should not contain machine-local rig path %q:\n%s", myProject, out)
+			}
+		})
+
+		t.Run("read .gc/site.toml (with rig)", func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(myCity, ".gc", "site.toml"))
+			if err != nil {
+				t.Fatalf("read .gc/site.toml: %v", err)
+			}
+			out := string(data)
+			if !strings.Contains(out, `name = "my-project"`) {
+				t.Fatalf(".gc/site.toml missing rig entry:\n%s", out)
+			}
 			if !strings.Contains(out, myProject) {
-				t.Fatalf("city.toml missing rig path %q:\n%s", myProject, out)
+				t.Fatalf(".gc/site.toml missing rig path %q:\n%s", myProject, out)
 			}
 		})
 

--- a/test/acceptance/tutorial_goldens/tutorial06_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial06_test.go
@@ -31,8 +31,8 @@ func TestTutorial07Orders(t *testing.T) {
 	replaceInFile(
 		t,
 		cityToml,
-		fmt.Sprintf("name = %q\npath = %q\n", "my-api", myAPI),
-		fmt.Sprintf("name = %q\npath = %q\n\n[rigs.imports.dev_ops]\nsource = \"./packs/dev-ops\"\n", "my-api", myAPI),
+		fmt.Sprintf("name = %q\n", "my-api"),
+		fmt.Sprintf("name = %q\n\n[rigs.imports.dev_ops]\nsource = \"./packs/dev-ops\"\n", "my-api"),
 	)
 
 	writeFile(t, filepath.Join(myCity, "formulas", "review.toml"), `formula = "review"


### PR DESCRIPTION
## Summary
- add an explicit phase2 invariant that hook-enabled Claude still carries a first-turn startup payload on launch
- strengthen the tmux real-transport proof to capture launch-prompt delivery separately from stdin nudge delivery
- add a targeted autonomous-start proof so fresh workers must begin work without any explicit post-start rescue nudge

## Verification
- go test ./cmd/gc -run 'TestPhase2(StartupMaterialization|InitialInputDelivery|HookEnabledClaudeFirstTurnStartupPayload|InputResultFailureClassification)$|TestTemplateParamsToConfigHookEnabledProviderStillUsesLaunchPrompt$'
- go test -tags integration ./cmd/gc -run 'TestPhase2WorkerCoreRealTransportProof$|TestPhase2HookEnabledClaudeAutonomousStartupProof$'