### PR TITLE
runtime: cache stable demand snapshots

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -256,6 +256,7 @@ func (cs *controllerState) applyBeadEventToStores(evt events.Event) {
 			cached.ApplyEvent(evt.Type, evt.Payload)
 		}
 	}
+	cs.Poke()
 }
 
 // update replaces the config, session provider, and reopens stores.

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -696,6 +697,44 @@ func TestControllerStateMutationErrorDoesNotPokeController(t *testing.T) {
 	select {
 	case <-cs.pokeCh:
 		t.Fatal("failed mutation should not poke reconciler")
+	default:
+	}
+}
+
+func TestControllerStateApplyBeadEventPokesController(t *testing.T) {
+	cs := &controllerState{
+		pokeCh: make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadUpdated,
+		Actor:   "agent-runtime",
+		Subject: "bd-123",
+		Payload: json.RawMessage(`{"id":"bd-123"}`),
+	})
+
+	select {
+	case <-cs.pokeCh:
+	default:
+		t.Fatal("expected bead event to poke controller")
+	}
+}
+
+func TestControllerStateApplyCacheReconcileEventDoesNotPokeController(t *testing.T) {
+	cs := &controllerState{
+		pokeCh: make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadUpdated,
+		Actor:   "cache-reconcile",
+		Subject: "bd-123",
+		Payload: json.RawMessage(`{"id":"bd-123"}`),
+	})
+
+	select {
+	case <-cs.pokeCh:
+		t.Fatal("cache-reconcile event should not poke controller")
 	default:
 	}
 }

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -26,7 +26,9 @@ type DesiredStateResult struct {
 	State             map[string]TemplateParams
 	BaseState         map[string]TemplateParams
 	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
-	AssignedWorkBeads []beads.Bead   // actionable assigned work: in_progress or ready+assigned
+	PoolDesiredCounts map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
+	WorkSet           map[string]bool
+	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -64,7 +66,8 @@ type CityRuntime struct {
 	standaloneRigStores map[string]beads.Store
 
 	// Bead-driven reconciler state (Phase 2f).
-	sessionDrains *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	sessionDrains  *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	demandSnapshot *runtimeDemandSnapshot
 
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
@@ -79,6 +82,14 @@ type CityRuntime struct {
 	shutdownOnce   sync.Once
 	logPrefix      string // "gc start" or "gc supervisor"
 	stdout, stderr io.Writer
+}
+
+const runtimeDemandSnapshotMaxAge = 30 * time.Second
+
+type runtimeDemandSnapshot struct {
+	createdAt          time.Time
+	sessionFingerprint string
+	result             DesiredStateResult
 }
 
 // CityRuntimeParams holds the caller-provided parameters for creating a
@@ -617,7 +628,8 @@ func (cr *CityRuntime) tick(
 		cr.sendReloadReply(manualReload.doneCh, reply)
 		cr.activeReload = nil
 	}()
-	if dirty.Swap(false) {
+	configChanged := dirty.Swap(false)
+	if configChanged {
 		dirtyCleared = true
 		source := reloadSourceWatch
 		if cr.activeReload != nil {
@@ -634,7 +646,8 @@ func (cr *CityRuntime) tick(
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
 	// corrects bead state, and the pre-reconcile sync is sufficient for
 	// the reconciler to read/write hashes during reconciliation.
-	result := cr.buildDesiredState(sessionBeads, trace)
+	demand := cr.loadDemandSnapshot(sessionBeads, trace, trigger, configChanged)
+	result := demand.result
 	sessionBeads = cr.loadSessionBeadSnapshot()
 	result = refreshDesiredStateWithSessionBeads(
 		result,
@@ -1101,8 +1114,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// same scale_check counts that buildDesiredState already computed (no
 	// duplicate shell-outs). Resume tier from cross-referenced assigned
 	// work beads + new tier from scale_check + min fill.
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-		cr.cfg, assignedWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
+	poolDesired := result.PoolDesiredCounts
+	if poolDesired == nil {
+		poolDesired = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
+			cr.cfg, assignedWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
+	}
 	// Merge named-session assignee demand so on-demand named sessions with
 	// direct work (Assignee match, no gc.routed_to) stay config-eligible.
 	if poolDesired == nil {
@@ -1146,7 +1162,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// workSet: defense-in-depth wake signal from work_query. When work_query
 	// detects pending work but scale_check hasn't caught up yet, workSet
 	// ensures at least one session wakes without waiting for the next tick.
-	workSet := computeWorkSet(cr.cfg, shellScaleCheck, cityName, cr.cityPath, store, sessionBeads, cr.stderr)
+	workSet := result.WorkSet
+	if workSet == nil {
+		workSet = computeWorkSet(cr.cfg, shellScaleCheck, cityName, cr.cityPath, store, sessionBeads, cr.stderr)
+	}
 	if trace != nil {
 		templateNames := make(map[string]struct{})
 		openCounts := make(map[string]int)
@@ -1537,6 +1556,93 @@ func (cr *CityRuntime) buildDesiredState(sessionBeads *sessionBeadSnapshot, trac
 		return cr.buildFnWithSessionBeads(cr.cfg, cr.sp, store, rigStores, sessionBeads, trace)
 	}
 	return cr.buildFn(cr.cfg, cr.sp, store)
+}
+
+func (cr *CityRuntime) loadDemandSnapshot(
+	sessionBeads *sessionBeadSnapshot,
+	trace *sessionReconcilerTraceCycle,
+	trigger string,
+	configChanged bool,
+) runtimeDemandSnapshot {
+	sessionFingerprint := sessionBeadSnapshotFingerprint(sessionBeads)
+	if cr.shouldRefreshDemandSnapshot(trigger, configChanged, sessionFingerprint) {
+		result := cr.buildDesiredState(sessionBeads, trace)
+		var openSessionBeads []beads.Bead
+		if sessionBeads != nil {
+			openSessionBeads = sessionBeads.Open()
+		}
+		result.PoolDesiredCounts = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
+			cr.cfg, result.AssignedWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace))
+		if result.PoolDesiredCounts == nil {
+			result.PoolDesiredCounts = make(map[string]int)
+		}
+		mergeNamedSessionDemand(result.PoolDesiredCounts, result.NamedSessionDemand, cr.cfg)
+		result.WorkSet = computeWorkSet(cr.cfg, shellScaleCheck, cr.cityName, cr.cityPath, cr.cityBeadStore(), sessionBeads, cr.stderr)
+		cr.demandSnapshot = &runtimeDemandSnapshot{
+			createdAt:          time.Now(),
+			sessionFingerprint: sessionFingerprint,
+			result:             result,
+		}
+	}
+	if cr.demandSnapshot == nil {
+		return runtimeDemandSnapshot{}
+	}
+	return *cr.demandSnapshot
+}
+
+func (cr *CityRuntime) shouldRefreshDemandSnapshot(
+	trigger string,
+	configChanged bool,
+	sessionFingerprint string,
+) bool {
+	if !cr.demandSnapshotsEnabled() {
+		return true
+	}
+	if configChanged || trigger != "patrol" {
+		return true
+	}
+	if cr.demandSnapshot == nil {
+		return true
+	}
+	if cr.demandSnapshot.sessionFingerprint != sessionFingerprint {
+		return true
+	}
+	return time.Since(cr.demandSnapshot.createdAt) >= runtimeDemandSnapshotMaxAge
+}
+
+func (cr *CityRuntime) demandSnapshotsEnabled() bool {
+	return cr.cs != nil && cr.cs.EventProvider() != nil
+}
+
+func sessionBeadSnapshotFingerprint(snapshot *sessionBeadSnapshot) string {
+	if snapshot == nil {
+		return ""
+	}
+	open := snapshot.Open()
+	sort.Slice(open, func(i, j int) bool {
+		return open[i].ID < open[j].ID
+	})
+	h := fnv.New64a()
+	for _, bead := range open {
+		_, _ = io.WriteString(h, bead.ID)
+		_, _ = io.WriteString(h, "\x00")
+		_, _ = io.WriteString(h, bead.Status)
+		_, _ = io.WriteString(h, "\x00")
+		_, _ = io.WriteString(h, bead.Assignee)
+		_, _ = io.WriteString(h, "\x00")
+		keys := make([]string, 0, len(bead.Metadata))
+		for key := range bead.Metadata {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			_, _ = io.WriteString(h, key)
+			_, _ = io.WriteString(h, "\x00")
+			_, _ = io.WriteString(h, bead.Metadata[key])
+			_, _ = io.WriteString(h, "\x00")
+		}
+	}
+	return fmt.Sprintf("%x", h.Sum64())
 }
 
 func buildStandaloneRigStores(cfg *config.City, cityPath string, stderr io.Writer) map[string]beads.Store {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -95,6 +95,69 @@ func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
+	buildCalls := 0
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+		},
+		cs: &controllerState{
+			eventProv: events.NewFake(),
+		},
+		stderr: io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		buildCalls++
+		return DesiredStateResult{
+			State: map[string]TemplateParams{
+				"worker-bd-1": {SessionName: "worker-bd-1"},
+			},
+		}
+	}
+
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "bead-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-bd-1",
+			"template":     "worker",
+			"state":        "active",
+		},
+	}})
+
+	first := cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	second := cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+
+	if buildCalls != 1 {
+		t.Fatalf("buildDesiredState call count = %d, want 1 for stable patrol reuse", buildCalls)
+	}
+	if len(first.result.State) != 1 || len(second.result.State) != 1 {
+		t.Fatalf("cached demand snapshot lost desired state: first=%d second=%d", len(first.result.State), len(second.result.State))
+	}
+
+	changedSessionBeads := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "bead-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-1",
+			"template":             "worker",
+			"state":                "active",
+			"pending_create_claim": "true",
+		},
+	}})
+	_ = cr.loadDemandSnapshot(changedSessionBeads, nil, "patrol", false)
+	if buildCalls != 2 {
+		t.Fatalf("buildDesiredState call count after session change = %d, want 2", buildCalls)
+	}
+
+	_ = cr.loadDemandSnapshot(changedSessionBeads, nil, "poke", false)
+	if buildCalls != 3 {
+		t.Fatalf("buildDesiredState call count after poke = %d, want 3", buildCalls)
+	}
+}
+
 // Pool session beads in the "creating" window (tmux not yet up, work not yet
 // assigned) must not be swept. Otherwise the sweep runs on the same tick the
 // pool creates the bead, observes zero assigned work, and closes it — the


### PR DESCRIPTION
## Summary

Shared-foundation PR for the Wave 1 `Session Reconcile Engine` blocker.

This change moves demand freshness ownership into `city_runtime` so steady-state patrol ticks can reuse a bounded cached demand snapshot instead of recomputing all demand inputs every cycle. It also makes non-controller bead events poke the runtime immediately, so store-driven demand changes invalidate that snapshot without waiting for the next patrol.

## Why This Exists

The frozen `Session Reconcile Engine` module was blocked on `Prefer Async Notifications`. Its wake/demand logic was still being driven by unconditional patrol-tick recomputation from the runtime trigger layer.

This PR is the shared-foundation seam that reduces that polling pressure without smearing the change into the module PR:

- `city_runtime` now owns the demand snapshot and refresh policy
- stable patrol ticks can reuse recent demand inputs when session state has not changed
- bead-event updates now poke the controller so runtime demand refresh happens on mutation, not only on patrol cadence
- the reconciler consumes cached `poolDesired` / `workSet` inputs when the runtime has already refreshed them

## Scope

Files touched:

- `cmd/gc/city_runtime.go`
- `cmd/gc/build_desired_state.go`
- `cmd/gc/api_state.go`
- `cmd/gc/city_runtime_test.go`
- `cmd/gc/api_state_test.go`

This is an explicit `shared-foundation` artifact, not a frozen-module PR.

## Behavior Change

- Added a runtime-owned demand snapshot keyed by current session-bead fingerprint.
- Stable `patrol` ticks reuse the snapshot for up to `30s` when:
  - event-backed invalidation is available
  - config did not change
  - session bead state is unchanged
- `poke` ticks and config changes always refresh the snapshot immediately.
- Non-`cache-reconcile` bead events now call `controllerState.Poke()` after updating caching stores.
- `beadReconcileTick` now consumes cached `PoolDesiredCounts` / `WorkSet` when present, instead of recomputing them unconditionally.

## Tests

- Added failing tests first for:
  - stable patrol-demand reuse and invalidation on session change / poke
  - bead-event-triggered controller pokes
  - cache-reconcile events remaining non-poking
- Verified with:
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./cmd/gc -run 'TestCityRuntimeDemandSnapshotReusesStablePatrolDemand|TestControllerStateApplyBeadEventPokesController|TestControllerStateApplyCacheReconcileEventDoesNotPokeController' -count=1`
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./cmd/gc -run 'TestCityRuntime|TestControllerState(ReadAccess|MutationsPokeController|MutationErrorDoesNotPokeController|ApplyBeadEventPokesController|ApplyCacheReconcileEventDoesNotPokeController)' -count=1`

## Follow-Up

- Rebase `quality/w1/session-reconcile-engine` on top of this PR once merged.
- Re-run the blind verifier for `Session Reconcile Engine`.
