### PR TITLE
quality: Wave 1 session reconcile engine

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -10,6 +10,44 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+// awakeSessionBeadFromBead projects a stored session bead into the awake-set
+// model used by ComputeAwakeSet. It keeps the reconciliation bridge focused on
+// transport while the projection rules live in one place.
+func awakeSessionBeadFromBead(b beads.Bead, clk time.Time) (AwakeSessionBead, bool) {
+	if b.Status == "closed" {
+		return AwakeSessionBead{}, false
+	}
+	name := strings.TrimSpace(b.Metadata["session_name"])
+	if name == "" {
+		return AwakeSessionBead{}, false
+	}
+	lifecycle := session.ProjectLifecycle(session.LifecycleInput{
+		Status:   b.Status,
+		Metadata: b.Metadata,
+		Now:      clk,
+	})
+	bead := AwakeSessionBead{
+		ID:             b.ID,
+		SessionName:    name,
+		Template:       b.Metadata["template"],
+		State:          string(lifecycle.CompatState),
+		SleepReason:    b.Metadata["sleep_reason"],
+		ManualSession:  isManualSessionBead(b),
+		PendingCreate:  lifecycle.HasWakeCause(session.WakeCausePendingCreate),
+		DependencyOnly: b.Metadata["dependency_only"] == "true",
+		NamedIdentity:  lifecycle.NamedIdentity,
+		Pinned:         lifecycle.HasWakeCause(session.WakeCausePinned),
+		Drained:        lifecycle.BaseState == session.BaseStateDrained,
+		WaitHold:       b.Metadata["wait_hold"] == "true",
+	}
+	bead.HeldUntil = lifecycle.HeldUntil
+	bead.QuarantinedUntil = lifecycle.QuarantinedUntil
+	if t, err := time.Parse(time.RFC3339, b.Metadata["detached_at"]); err == nil && !t.IsZero() {
+		bead.IdleSince = t
+	}
+	return bead, true
+}
+
 // buildAwakeInputFromReconciler constructs AwakeInput from the reconciler's
 // existing data. Runtime liveness is populated from the already-computed
 // wakeTargets; attachment and pending interactions come from provider
@@ -72,37 +110,9 @@ func buildAwakeInputFromReconciler(
 
 	// Session beads
 	for i := range sessionBeads {
-		b := &sessionBeads[i]
-		if b.Status == "closed" {
+		bead, ok := awakeSessionBeadFromBead(sessionBeads[i], clk)
+		if !ok {
 			continue
-		}
-		name := strings.TrimSpace(b.Metadata["session_name"])
-		if name == "" {
-			continue
-		}
-		lifecycle := session.ProjectLifecycle(session.LifecycleInput{
-			Status:   b.Status,
-			Metadata: b.Metadata,
-			Now:      clk,
-		})
-		bead := AwakeSessionBead{
-			ID:             b.ID,
-			SessionName:    name,
-			Template:       b.Metadata["template"],
-			State:          string(lifecycle.CompatState),
-			SleepReason:    b.Metadata["sleep_reason"],
-			ManualSession:  isManualSessionBead(*b),
-			PendingCreate:  lifecycle.HasWakeCause(session.WakeCausePendingCreate),
-			DependencyOnly: b.Metadata["dependency_only"] == "true",
-			NamedIdentity:  lifecycle.NamedIdentity,
-			Pinned:         lifecycle.HasWakeCause(session.WakeCausePinned),
-			Drained:        lifecycle.BaseState == session.BaseStateDrained,
-			WaitHold:       b.Metadata["wait_hold"] == "true",
-		}
-		bead.HeldUntil = lifecycle.HeldUntil
-		bead.QuarantinedUntil = lifecycle.QuarantinedUntil
-		if t, err := time.Parse(time.RFC3339, b.Metadata["detached_at"]); err == nil && !t.IsZero() {
-			bead.IdleSince = t
 		}
 		input.SessionBeads = append(input.SessionBeads, bead)
 	}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -9,6 +9,66 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+func TestAwakeSessionBeadFromBeadProjectsLifecycleAndSkipsIrrelevantBeads(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("projects trimmed session metadata", func(t *testing.T) {
+		bead, ok := awakeSessionBeadFromBead(beads.Bead{
+			ID:     "mc-session-1",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"state":        "stopped",
+				"session_name": "  s-worker  ",
+				"template":     "worker",
+				"wait_hold":    "true",
+			},
+		}, now)
+		if !ok {
+			t.Fatal("awakeSessionBeadFromBead returned false, want true")
+		}
+		if bead.SessionName != "s-worker" {
+			t.Fatalf("SessionName = %q, want trimmed s-worker", bead.SessionName)
+		}
+		if bead.State != "asleep" {
+			t.Fatalf("State = %q, want asleep-compatible projection", bead.State)
+		}
+		if !bead.WaitHold {
+			t.Fatal("WaitHold = false, want true")
+		}
+		if bead.Template != "worker" {
+			t.Fatalf("Template = %q, want worker", bead.Template)
+		}
+	})
+
+	t.Run("skips closed beads", func(t *testing.T) {
+		if _, ok := awakeSessionBeadFromBead(beads.Bead{
+			ID:     "mc-session-2",
+			Status: "closed",
+			Type:   "session",
+			Metadata: map[string]string{
+				"session_name": "s-worker",
+				"template":     "worker",
+			},
+		}, now); ok {
+			t.Fatal("awakeSessionBeadFromBead returned true for closed bead")
+		}
+	})
+
+	t.Run("skips beads without session name", func(t *testing.T) {
+		if _, ok := awakeSessionBeadFromBead(beads.Bead{
+			ID:     "mc-session-3",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"template": "worker",
+			},
+		}, now); ok {
+			t.Fatal("awakeSessionBeadFromBead returned true for bead without session_name")
+		}
+	})
+}
+
 func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilityStates(t *testing.T) {
 	now := time.Now().UTC()
 	input := buildAwakeInputFromReconciler(

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -428,6 +428,9 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 			defer func() { <-sem }()
 			out, err := runner(probes[idx].wq, probes[idx].dir, probes[idx].env)
 			if err != nil {
+				if stderr != nil {
+					fmt.Fprintf(stderr, "session reconcile: work_query %s: %v\n", probes[idx].qn, err) //nolint:errcheck // best-effort stderr
+				}
 				return // command failed — treat as no work
 			}
 			if workQueryHasReadyWork(strings.TrimSpace(out)) {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -705,6 +706,31 @@ func TestComputeWorkSet_UsesConfiguredRigRoot(t *testing.T) {
 	work := computeWorkSet(cfg, runner, "test-city", cityDir, nil, nil, nil)
 	if !work["myrig/polecat"] {
 		t.Error("expected myrig/polecat to have work when rig root is configured externally")
+	}
+}
+
+func TestComputeWorkSet_LogsProbeErrors(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	runner := func(_ string, _ string, _ map[string]string) (string, error) {
+		return "", fmt.Errorf("probe exploded")
+	}
+
+	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, &stderr)
+	if work["worker"] {
+		t.Fatal("worker should not be marked ready when work_query fails")
+	}
+	if !strings.Contains(stderr.String(), "work_query worker") {
+		t.Fatalf("stderr = %q, want work_query failure log", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "probe exploded") {
+		t.Fatalf("stderr = %q, want probe error detail", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Session Reconcile Engine`.

This PR finishes the session-reconcile slice by keeping the awake-bridge refactor, depending on the shared runtime demand-freshness seam from `#961`, and closing the last observability gap in `computeWorkSet` so probe failures are logged instead of being silently downgraded to “no work”.

## Dependency

This PR is stacked on top of `#961` (`runtime: cache stable demand snapshots`).

The initial Wave 1 verifier correctly blocked this module on `Prefer Async Notifications` because the runtime trigger layer was still forcing unconditional patrol-tick demand recomputation. `#961` moves that freshness responsibility into `city_runtime`; this PR carries the module-owned reconcile/bridge changes on top.

## Scope

Owned scope for this module:

- `cmd/gc/build_desired_state.go`
- `cmd/gc/compute_awake_bridge.go`
- `cmd/gc/compute_awake_set.go`
- `cmd/gc/session_reconcile.go`
- `cmd/gc/session_reconciler.go`
- `cmd/gc/pool_desired_state.go`

Files touched in this PR branch relative to `main`:

- `cmd/gc/build_desired_state.go`
- `cmd/gc/compute_awake_bridge.go`
- `cmd/gc/compute_awake_bridge_test.go`
- `cmd/gc/session_reconcile.go`
- `cmd/gc/session_reconcile_test.go`
- plus the shared-foundation dependency files in `#961`

No boundary exception was needed inside the module PR itself; the runtime seam lives in the explicit shared-foundation dependency.

## Implementer Trajectory

- Initial Wave 1 verification failed on `Prefer Async Notifications` because the module was still being driven by unconditional patrol-tick demand refresh from outside its ownership boundary.
- Shared-foundation PR `#961` introduced runtime-owned demand freshness and event-triggered invalidation so the session module no longer owns that cadence concern.
- Final stacked loop fixed the last owned regression by logging `work_query` probe failures in `computeWorkSet`, with a regression test proving the error is surfaced.

## Blind Verifier Score Summary

- `TDD` 88
- `DRY` 84
- `Separation of Concerns` 91
- `Single Responsibility` 82
- `Clear Abstractions` 85
- `Low Coupling, High Cohesion` 84
- `KISS` 81
- `YAGNI` 80
- `Prefer Non-Nullable` 84
- `Prefer Async Notifications` `N/A`
- `Eliminate Race Conditions` 86
- `Errors Are Not Optional` 84
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 86

`N/A` rows:

- `Prefer Async Notifications` — accepted by the blind verifier because the module now consumes reconciliation/runtime inputs rather than owning a push/watch notification subsystem after the shared-foundation split.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added focused regression coverage for:
  - awake-bridge lifecycle projection
  - compatibility-state projection into `BuildAwakeInputFromReconciler`
  - pending-interaction population
  - `computeWorkSet` probe-error logging
- Verified with:
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./cmd/gc -run 'TestCityRuntime|TestControllerState(ReadAccess|MutationsPokeController|MutationErrorDoesNotPokeController|ApplyBeadEventPokesController|ApplyCacheReconcileEventDoesNotPokeController)|Test(AwakeSessionBeadFromBeadProjectsLifecycleAndSkipsIrrelevantBeads|BuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilityStates|BuildAwakeInputFromReconcilerPopulatesPendingInteractions|ComputeWorkSet_|BuildDesiredState_|ComputePoolDesiredStates_|ReconcileSessionBeads_)' -count=1`
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./cmd/gc -run 'TestComputeWorkSet_(LogsProbeErrors|RunsWorkQuery|ResolvesRigDir|UsesConfiguredRigRoot|ExplicitRigWorkQueryUsesRigPassword)' -count=1`

## Notes

- The only post-shared-foundation fix needed inside the owned module was surfacing `computeWorkSet` runner failures to stderr.
- `bd dolt push` remains unhealthy in this environment due lock/panic/divergent-history issues and was not forced.
