### PR TITLE
Fix molecule step cleanup during wisp GC

### DIFF
--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -72,10 +72,97 @@ func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
-		if err := store.Delete(entry.ID); err != nil {
+		if err := deleteExpiredBeadClosure(store, entry.ID); err != nil {
 			continue
 		}
 		purged++
 	}
 	return purged
+}
+
+func deleteExpiredBeadClosure(store beads.Store, rootID string) error {
+	ids, err := collectExpiredBeadClosure(store, rootID)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := deleteWorkflowBead(store, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, error) {
+	if store == nil {
+		return nil, fmt.Errorf("bead store unavailable")
+	}
+	rootOwned := make([]string, 0, 4)
+	related, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": rootID},
+		IncludeClosed: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list workflow-owned beads for %s: %w", rootID, err)
+	}
+	for _, bead := range related {
+		if bead.ID != "" && bead.ID != rootID {
+			rootOwned = append(rootOwned, bead.ID)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(rootOwned)+1)
+	ids := make([]string, 0, len(rootOwned)+1)
+	var visit func(string) error
+	visit = func(id string) error {
+		if id == "" {
+			return nil
+		}
+		if _, ok := seen[id]; ok {
+			return nil
+		}
+		seen[id] = struct{}{}
+
+		if id == rootID {
+			for _, relatedID := range rootOwned {
+				if err := visit(relatedID); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Treat structural parentage as workflow ownership. Some molecule step
+		// beads are linked only by ParentID / parent-child deps and do not carry
+		// gc.root_bead_id metadata, so GC must follow those ownership edges while
+		// still ignoring non-ownership deps such as blocks or waits-for.
+		children, err := store.Children(id, beads.IncludeClosed)
+		if err != nil {
+			return fmt.Errorf("list children for %s: %w", id, err)
+		}
+		for _, child := range children {
+			if err := visit(child.ID); err != nil {
+				return err
+			}
+		}
+
+		upDeps, err := store.DepList(id, "up")
+		if err != nil {
+			return fmt.Errorf("list dependents for %s: %w", id, err)
+		}
+		for _, dep := range upDeps {
+			if dep.Type != "parent-child" || dep.IssueID == "" {
+				continue
+			}
+			if err := visit(dep.IssueID); err != nil {
+				return err
+			}
+		}
+
+		ids = append(ids, id)
+		return nil
+	}
+	if err := visit(rootID); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -56,23 +56,31 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 	}
 
 	cutoff := now.Add(-m.ttl)
-	purged := purgeExpiredBeads(store, entries, cutoff)
+	purged := purgeExpiredBeadClosures(store, entries, cutoff)
 
 	trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking})
 	if trackErr == nil {
-		purged += purgeExpiredBeads(store, trackEntries, cutoff)
+		purged += purgeExpiredBeadRoots(store, trackEntries, cutoff)
 	}
 
 	return purged, nil
 }
 
-func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time) int {
+func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time) int {
+	return purgeExpiredBeads(store, entries, cutoff, deleteExpiredBeadClosure)
+}
+
+func purgeExpiredBeadRoots(store beads.Store, entries []beads.Bead, cutoff time.Time) int {
+	return purgeExpiredBeads(store, entries, cutoff, deleteWorkflowBead)
+}
+
+func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, deleteFn func(beads.Store, string) error) int {
 	purged := 0
 	for _, entry := range entries {
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
-		if err := deleteExpiredBeadClosure(store, entry.ID); err != nil {
+		if err := deleteFn(store, entry.ID); err != nil {
 			continue
 		}
 		purged++
@@ -81,6 +89,9 @@ func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time
 }
 
 func deleteExpiredBeadClosure(store beads.Store, rootID string) error {
+	// deleteWorkflowBead removes every dependency attached to each closure
+	// member before deleting the bead. Only use the closure deleter for roots
+	// whose full ownership tree is safe to collect.
 	ids, err := collectExpiredBeadClosure(store, rootID)
 	if err != nil {
 		return err

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -114,6 +114,224 @@ func TestWispGC_DeleteErrorContinues(t *testing.T) {
 	assertDeletedIDs(t, store.deletedIDs, "mol-2")
 }
 
+func TestWispGC_PurgesExpiredMoleculeChildrenWithRoot(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		{
+			ID:        "mol-1.2",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1.1",
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.2", "mol-1.1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.2->mol-1.1): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 root purge accounting", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-1.1", "mol-1.2")
+	for _, id := range []string{"mol-1", "mol-1.1", "mol-1.2"} {
+		if _, err := store.Get(id); err == nil {
+			t.Fatalf("Get(%s) succeeded after GC delete", id)
+		}
+	}
+}
+
+func TestWispGC_DoesNotDeleteExternalDependents(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		makeGCBead("external-1", now.Add(-2*time.Hour), "open", "task"),
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("external-1", "mol-1.1", "blocks"); err != nil {
+		t.Fatalf("DepAdd(external-1->mol-1.1): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-1.1")
+	if _, err := store.Get("external-1"); err != nil {
+		t.Fatalf("external dependent was deleted: %v", err)
+	}
+}
+
+func TestWispGC_PurgesParentChildOwnedDependentsWithoutMetadata(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		{
+			ID:        "mol-1.2",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.2", "mol-1.1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.2->mol-1.1): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-1.1", "mol-1.2")
+}
+
+func TestWispGC_LeavesRootWhenChildDeleteFails(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	store.deleteErrors["mol-1.1"] = fmt.Errorf("delete failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0 when child delete fails", purged)
+	}
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted = %v, want none", store.deletedIDs)
+	}
+	if _, err := store.Get("mol-1"); err != nil {
+		t.Fatalf("root deleted after child failure: %v", err)
+	}
+	if _, err := store.Get("mol-1.1"); err != nil {
+		t.Fatalf("child unexpectedly deleted after failure: %v", err)
+	}
+}
+
+func TestWispGC_PartialChildDeleteRemainsRetryable(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		{
+			ID:        "mol-1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+		{
+			ID:        "mol-1.1.1",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1.1",
+		},
+		{
+			ID:        "mol-1.2",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "mol-1",
+		},
+	})
+	if err := store.DepAdd("mol-1.1", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1->mol-1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.1.1", "mol-1.1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.1.1->mol-1.1): %v", err)
+	}
+	if err := store.DepAdd("mol-1.2", "mol-1", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(mol-1.2->mol-1): %v", err)
+	}
+	store.deleteErrors["mol-1.2"] = fmt.Errorf("delete failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC first pass: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("first purged = %d, want 0", purged)
+	}
+	if _, err := store.Get("mol-1"); err != nil {
+		t.Fatalf("root deleted after partial child failure: %v", err)
+	}
+	if _, err := store.Get("mol-1.2"); err != nil {
+		t.Fatalf("failing child deleted unexpectedly: %v", err)
+	}
+	if _, err := store.Get("mol-1.1"); err == nil {
+		t.Fatalf("expected an earlier child to be deleted before downstream failure")
+	}
+
+	delete(store.deleteErrors, "mol-1.2")
+	purged, err = wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC second pass: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("second purged = %d, want 1", purged)
+	}
+	for _, id := range []string{"mol-1", "mol-1.2"} {
+		if _, err := store.Get(id); err == nil {
+			t.Fatalf("Get(%s) succeeded after retry cleanup", id)
+		}
+	}
+}
+
 func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -316,6 +316,7 @@ func TestWispGC_PartialChildDeleteRemainsRetryable(t *testing.T) {
 	if _, err := store.Get("mol-1.1"); err == nil {
 		t.Fatalf("expected an earlier child to be deleted before downstream failure")
 	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1.1.1", "mol-1.1")
 
 	delete(store.deleteErrors, "mol-1.2")
 	purged, err = wg.runGC(store, now)
@@ -350,6 +351,36 @@ func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 		t.Fatalf("purged = %d, want 2", purged)
 	}
 	assertDeletedIDs(t, store.deletedIDs, "mol-1", "track-old")
+}
+
+func TestWispGC_TrackingBeadsDoNotDeleteParentChildDescendants(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBeadWithLabels("track-old", now.Add(-3*time.Hour), "closed", "task", labelOrderTracking),
+		{
+			ID:        "track-child",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-3 * time.Hour),
+			ParentID:  "track-old",
+		},
+	})
+	if err := store.DepAdd("track-child", "track-old", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(track-child->track-old): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "track-old")
+	if _, err := store.Get("track-child"); err != nil {
+		t.Fatalf("tracking child was deleted: %v", err)
+	}
 }
 
 func TestWispGC_TrackingListErrorIsBestEffort(t *testing.T) {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -751,6 +751,12 @@ func (s *BdStore) Ready() ([]Bead, error) {
 
 // DepAdd records a dependency via bd dep add.
 func (s *BdStore) DepAdd(issueID, dependsOnID, depType string) error {
+	if depType == "parent-child" {
+		bead, err := s.Get(issueID)
+		if err == nil && bead.ParentID == dependsOnID {
+			return nil
+		}
+	}
 	_, err := s.runner(s.dir, "bd", "dep", "add", issueID, dependsOnID, "--type", depType)
 	if err != nil {
 		return fmt.Errorf("adding dep %s→%s: %w", issueID, dependsOnID, err)

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -861,6 +861,28 @@ func TestBdStoreCreateWithParentID(t *testing.T) {
 	}
 }
 
+func TestBdStoreDepAddParentChildAlreadyParentedIsNoop(t *testing.T) {
+	calls := make([]string, 0, 1)
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		call := name + " " + strings.Join(args, " ")
+		calls = append(calls, call)
+		switch call {
+		case "bd show --json bd-child":
+			return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","parent":"bd-parent"}]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %s", call)
+		}
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	if err := s.DepAdd("bd-child", "bd-parent", "parent-child"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %v, want only bd show", calls)
+	}
+}
+
 func TestBdStoreCreateNoLabelsNoParent(t *testing.T) {
 	var gotArgs []string
 	runner := func(_, _ string, args ...string) ([]byte, error) {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -386,8 +386,11 @@ func (m *MemStore) DepAdd(issueID, dependsOnID, depType string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for i, d := range m.deps {
-		if d.IssueID == issueID && d.DependsOnID == dependsOnID {
-			m.deps[i].Type = depType // update type on re-add
+		if d.IssueID == issueID && d.DependsOnID == dependsOnID && d.Type == depType {
+			return nil
+		}
+		if d.IssueID == issueID && d.DependsOnID == dependsOnID && d.Type != "parent-child" && depType != "parent-child" {
+			m.deps[i].Type = depType
 			return nil
 		}
 	}

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -423,6 +423,33 @@ func TestMemStoreReadyRespectsBlockingDeps(t *testing.T) {
 	}
 }
 
+func TestMemStoreReadyIgnoresParentChildDeps(t *testing.T) {
+	s := beads.NewMemStore()
+
+	parent, err := s.Create(beads.Bead{Title: "parent", Type: "molecule"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := s.Create(beads.Bead{Title: "child", Type: "task", ParentID: parent.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DepAdd(child.ID, parent.ID, "parent-child"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Ready()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Ready() returned %d beads, want 1", len(got))
+	}
+	if got[0].ID != child.ID {
+		t.Fatalf("Ready()[0].ID = %s, want %s", got[0].ID, child.ID)
+	}
+}
+
 func TestMemStoreDepListDefaultDirection(t *testing.T) {
 	s := beads.NewMemStore()
 	_ = s.DepAdd("a", "b", "blocks")

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -450,6 +450,46 @@ func TestMemStoreReadyIgnoresParentChildDeps(t *testing.T) {
 	}
 }
 
+func TestMemStoreReadyPreservesBlocksWhenParentChildSharesPair(t *testing.T) {
+	s := beads.NewMemStore()
+
+	parent, err := s.Create(beads.Bead{Title: "parent", Type: "molecule"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := s.Create(beads.Bead{Title: "child", Type: "task", ParentID: parent.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DepAdd(child.ID, parent.ID, "blocks"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DepAdd(child.ID, parent.ID, "parent-child"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Ready()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bead := range got {
+		if bead.ID == child.ID {
+			t.Fatalf("child is ready while parent blocker is still open; ready=%v", got)
+		}
+	}
+
+	if err := s.Close(parent.ID); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.Ready()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != child.ID {
+		t.Fatalf("Ready() after closing parent = %v, want only child", got)
+	}
+}
+
 func TestMemStoreDepListDefaultDirection(t *testing.T) {
 	s := beads.NewMemStore()
 	_ = s.DepAdd("a", "b", "blocks")

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -521,6 +521,9 @@ func appendRalphRetryGraphEdges(plan *beads.GraphApplyPlan, store beads.Store, o
 		return err
 	}
 	for _, dep := range deps {
+		if dep.Type == "parent-child" {
+			continue
+		}
 		edge := beads.GraphApplyEdge{
 			FromKey: oldID,
 			Type:    dep.Type,

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -896,6 +896,33 @@ func TestAppendRalphRetryDefersAssigneesUntilDepsAreWired(t *testing.T) {
 	}
 }
 
+func TestAppendRalphRetryGraphEdgesSkipsParentChildDeps(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	parent := mustCreateWorkflowBead(t, store, beads.Bead{Title: "parent", Type: "task"})
+	child := mustCreateWorkflowBead(t, store, beads.Bead{Title: "child", Type: "task", ParentID: parent.ID})
+	blocker := mustCreateWorkflowBead(t, store, beads.Bead{Title: "blocker", Type: "task"})
+	mustDepAdd(t, store, child.ID, parent.ID, "parent-child")
+	mustDepAdd(t, store, child.ID, blocker.ID, "blocks")
+
+	plan := &beads.GraphApplyPlan{}
+	if err := appendRalphRetryGraphEdges(plan, store, child.ID, map[string]bool{
+		parent.ID:  true,
+		blocker.ID: true,
+	}); err != nil {
+		t.Fatalf("appendRalphRetryGraphEdges: %v", err)
+	}
+
+	if len(plan.Edges) != 1 {
+		t.Fatalf("edges = %+v, want only the blocking edge", plan.Edges)
+	}
+	edge := plan.Edges[0]
+	if edge.Type != "blocks" || edge.FromKey != child.ID || edge.ToKey != blocker.ID {
+		t.Fatalf("edge = %+v, want blocks edge to blocker", edge)
+	}
+}
+
 func TestAppendRalphRetryClearsPoolAssignee(t *testing.T) {
 	t.Parallel()
 

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -388,6 +388,7 @@ func setNodeParentRef(nodes []beads.GraphApplyNode, stepID, parentKey, parentID 
 		}
 		if parentKey != "" {
 			nodes[i].ParentKey = parentKey
+			nodes[i].ParentID = ""
 		}
 		if parentID != "" {
 			nodes[i].ParentID = parentID

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -276,16 +276,11 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 		priorityOverride = clonePriority(root.Priority)
 	}
 	vars := applyVarDefaults(opts.Vars, recipe.Vars)
-	externalDepsByStep := make(map[string][]ExternalDep)
-	for _, dep := range opts.ExternalDeps {
-		if dep.StepID == "" || dep.DependsOnID == "" {
-			continue
-		}
-		if dep.Type == "" {
-			dep.Type = "blocks"
-		}
-		externalDepsByStep[dep.StepID] = append(externalDepsByStep[dep.StepID], dep)
+	externalDepsByStep, err := groupExternalDeps(opts.ExternalDeps)
+	if err != nil {
+		return nil, err
 	}
+	recipeParentByStep := recipeParentDeps(recipe.Deps)
 
 	plan := &beads.GraphApplyPlan{
 		CommitMessage: fmt.Sprintf("gc: instantiate fragment into %s", opts.RootID),
@@ -319,6 +314,9 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 			node.AssignAfterCreate = true
 		}
 		for _, dep := range externalDepsByStep[step.ID] {
+			if dep.Type == "parent-child" && recipeParentByStep[step.ID] != "" {
+				continue
+			}
 			if dep.Type == "parent-child" {
 				node.ParentID = dep.DependsOnID
 			}

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -503,10 +503,6 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if !fromOK || !toOK {
 				continue // step was filtered out (RootOnly or condition)
 			}
-			// Skip parent-child deps — already handled via ParentID field.
-			if dep.Type == "parent-child" {
-				continue
-			}
 			if embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] {
 				continue
 			}
@@ -622,6 +618,20 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 				b.Needs = append(b.Needs, dep.Type+":"+dep.DependsOnID)
 			}
 		}
+		for _, dep := range recipe.Deps {
+			if dep.StepID == step.ID && dep.Type == "parent-child" {
+				if parentBeadID, ok := idMapping[dep.DependsOnID]; ok {
+					b.ParentID = parentBeadID
+					break
+				}
+			}
+		}
+		for _, dep := range externalDepsByStep[step.ID] {
+			if b.ParentID == "" && dep.Type == "parent-child" && dep.DependsOnID != "" {
+				b.ParentID = dep.DependsOnID
+				break
+			}
+		}
 
 		if b.Metadata == nil {
 			b.Metadata = make(map[string]string, 2)
@@ -665,7 +675,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 	for _, dep := range recipe.Deps {
 		fromID, fromOK := idMapping[dep.StepID]
 		toID, toOK := idMapping[dep.DependsOnID]
-		if !fromOK || !toOK || dep.Type == "parent-child" {
+		if !fromOK || !toOK {
 			continue
 		}
 		if embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -375,6 +375,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 
 	// Build the list of beads to create.
 	idMapping := make(map[string]string, len(recipe.Steps))
+	createdParentByStep := make(map[string]string, len(recipe.Steps))
 	var createdIDs []string
 	embeddedDeps := make(map[string]bool)
 	pendingAssignees := make(map[string]string)
@@ -491,6 +492,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 		}
 
 		idMapping[step.ID] = created.ID
+		createdParentByStep[step.ID] = created.ParentID
 		createdIDs = append(createdIDs, created.ID)
 
 	}
@@ -505,6 +507,14 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			}
 			if embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] {
 				continue
+			}
+			if dep.Type == "parent-child" && createdParentByStep[dep.StepID] != toID {
+				parentID := toID
+				if err := store.Update(fromID, beads.UpdateOpts{ParentID: &parentID}); err != nil {
+					markFailed(store, createdIDs)
+					return nil, fmt.Errorf("setting parent for dep %s->%s: %w", dep.StepID, dep.DependsOnID, err)
+				}
+				createdParentByStep[dep.StepID] = toID
 			}
 			if err := store.DepAdd(fromID, toID, dep.Type); err != nil {
 				markFailed(store, createdIDs)
@@ -575,22 +585,18 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 	vars := applyVarDefaults(opts.Vars, recipe.Vars)
 	idMapping := make(map[string]string, len(recipe.Steps))
 	var createdIDs []string
+	createdParentByStep := make(map[string]string, len(recipe.Steps))
 	embeddedDeps := make(map[string]bool)
 	pendingAssignees := make(map[string]string)
 	existingLogicalBeadIDs, err := existingLogicalBeadIDIndex(store, opts.RootID)
 	if err != nil {
 		return nil, fmt.Errorf("indexing existing logical beads: %w", err)
 	}
-	externalDepsByStep := make(map[string][]ExternalDep)
-	for _, dep := range opts.ExternalDeps {
-		if dep.StepID == "" || dep.DependsOnID == "" {
-			continue
-		}
-		if dep.Type == "" {
-			dep.Type = "blocks"
-		}
-		externalDepsByStep[dep.StepID] = append(externalDepsByStep[dep.StepID], dep)
+	externalDepsByStep, err := groupExternalDeps(opts.ExternalDeps)
+	if err != nil {
+		return nil, err
 	}
+	recipeParentByStep := recipeParentDeps(recipe.Deps)
 
 	for _, step := range recipe.Steps {
 		b := stepToBead(step, vars, priorityOverride)
@@ -612,6 +618,9 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 			embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] = true
 		}
 		for _, dep := range externalDepsByStep[step.ID] {
+			if dep.Type == "parent-child" {
+				continue
+			}
 			if dep.Type == "blocks" {
 				b.Needs = append(b.Needs, dep.DependsOnID)
 			} else {
@@ -627,7 +636,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 			}
 		}
 		for _, dep := range externalDepsByStep[step.ID] {
-			if b.ParentID == "" && dep.Type == "parent-child" && dep.DependsOnID != "" {
+			if b.ParentID == "" && recipeParentByStep[step.ID] == "" && dep.Type == "parent-child" && dep.DependsOnID != "" {
 				b.ParentID = dep.DependsOnID
 				break
 			}
@@ -669,6 +678,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 			return nil, fmt.Errorf("creating fragment bead for step %q: %w", step.ID, err)
 		}
 		idMapping[step.ID] = created.ID
+		createdParentByStep[step.ID] = created.ParentID
 		createdIDs = append(createdIDs, created.ID)
 	}
 
@@ -681,9 +691,35 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 		if embeddedDeps[dep.StepID+"|"+dep.DependsOnID+"|"+dep.Type] {
 			continue
 		}
+		if dep.Type == "parent-child" && createdParentByStep[dep.StepID] != toID {
+			parentID := toID
+			if err := store.Update(fromID, beads.UpdateOpts{ParentID: &parentID}); err != nil {
+				markFailed(store, createdIDs)
+				return nil, fmt.Errorf("setting fragment parent for dep %s->%s: %w", dep.StepID, dep.DependsOnID, err)
+			}
+			createdParentByStep[dep.StepID] = toID
+		}
 		if err := store.DepAdd(fromID, toID, dep.Type); err != nil {
 			markFailed(store, createdIDs)
 			return nil, fmt.Errorf("wiring fragment dep %s->%s: %w", dep.StepID, dep.DependsOnID, err)
+		}
+	}
+	for stepID, deps := range externalDepsByStep {
+		if recipeParentByStep[stepID] != "" {
+			continue
+		}
+		fromID, fromOK := idMapping[stepID]
+		if !fromOK {
+			continue
+		}
+		for _, dep := range deps {
+			if dep.Type != "parent-child" {
+				continue
+			}
+			if err := store.DepAdd(fromID, dep.DependsOnID, dep.Type); err != nil {
+				markFailed(store, createdIDs)
+				return nil, fmt.Errorf("wiring external fragment dep %s->%s: %w", stepID, dep.DependsOnID, err)
+			}
 		}
 	}
 
@@ -705,6 +741,37 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 		IDMapping: idMapping,
 		Created:   len(createdIDs),
 	}, nil
+}
+
+func recipeParentDeps(deps []formula.RecipeDep) map[string]string {
+	parents := make(map[string]string)
+	for _, dep := range deps {
+		if dep.Type == "parent-child" && dep.StepID != "" && dep.DependsOnID != "" && parents[dep.StepID] == "" {
+			parents[dep.StepID] = dep.DependsOnID
+		}
+	}
+	return parents
+}
+
+func groupExternalDeps(deps []ExternalDep) (map[string][]ExternalDep, error) {
+	byStep := make(map[string][]ExternalDep)
+	parentByStep := make(map[string]string)
+	for _, dep := range deps {
+		if dep.StepID == "" || dep.DependsOnID == "" {
+			continue
+		}
+		if dep.Type == "" {
+			dep.Type = "blocks"
+		}
+		if dep.Type == "parent-child" {
+			if parentByStep[dep.StepID] != "" {
+				return nil, fmt.Errorf("step %q has multiple external parent-child deps", dep.StepID)
+			}
+			parentByStep[dep.StepID] = dep.DependsOnID
+		}
+		byStep[dep.StepID] = append(byStep[dep.StepID], dep)
+	}
+	return byStep, nil
 }
 
 // stepToBead converts a RecipeStep to a Bead with variable substitution.

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -251,6 +251,21 @@ func TestInstantiateSimple(t *testing.T) {
 	if stepB.ParentID != result.RootID {
 		t.Errorf("step-b.ParentID = %q, want %q", stepB.ParentID, result.RootID)
 	}
+
+	deps, err := store.DepList(stepBID, "down")
+	if err != nil {
+		t.Fatalf("DepList(step-b): %v", err)
+	}
+	foundParent := false
+	for _, dep := range deps {
+		if dep.Type == "parent-child" && dep.DependsOnID == result.RootID {
+			foundParent = true
+			break
+		}
+	}
+	if !foundParent {
+		t.Fatalf("step-b missing parent-child dependency to root; deps=%v", deps)
+	}
 }
 
 func TestInstantiateUsesGraphApplyStoreWhenAvailable(t *testing.T) {
@@ -886,6 +901,175 @@ func TestInstantiateFragmentInheritsRootPriority(t *testing.T) {
 		if bead.Priority == nil || *bead.Priority != 1 {
 			t.Fatalf("fragment bead %s priority = %v, want 1", bead.ID, bead.Priority)
 		}
+	}
+}
+
+func TestInstantiateFragmentRecordsParentChildDeps(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{RootID: root.ID})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+
+	childID := result.IDMapping["frag.scope.child"]
+	parentID := result.IDMapping["frag.scope"]
+	if childID == "" || parentID == "" {
+		t.Fatalf("fragment IDs = %#v, want parent and child IDs", result.IDMapping)
+	}
+	child, err := store.Get(childID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if child.ParentID != parentID {
+		t.Fatalf("child.ParentID = %q, want %q", child.ParentID, parentID)
+	}
+	deps, err := store.DepList(childID, "down")
+	if err != nil {
+		t.Fatalf("DepList(child): %v", err)
+	}
+	found := false
+	for _, dep := range deps {
+		if dep.Type == "parent-child" && dep.DependsOnID == parentID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("child missing parent-child dependency on scope bead; deps=%v", deps)
+	}
+}
+
+func TestInstantiateFragmentPrefersRecipeParentOverExternalParent(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	externalParent, err := store.Create(beads.Bead{
+		Title: "External parent",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create external parent: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{
+				StepID:      "frag.scope.child",
+				DependsOnID: externalParent.ID,
+				Type:        "parent-child",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+
+	child, err := store.Get(result.IDMapping["frag.scope.child"])
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if child.ParentID != result.IDMapping["frag.scope"] {
+		t.Fatalf("child.ParentID = %q, want recipe parent %q", child.ParentID, result.IDMapping["frag.scope"])
+	}
+}
+
+func TestInstantiateFragmentGraphApplyPrefersRecipeParentOverExternalParent(t *testing.T) {
+	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	externalParent, err := store.Create(beads.Bead{
+		Title: "External parent",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create external parent: %v", err)
+	}
+
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(true)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	if _, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{
+				StepID:      "frag.scope.child",
+				DependsOnID: externalParent.ID,
+				Type:        "parent-child",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+	if store.plan == nil {
+		t.Fatal("ApplyGraphPlan was not called")
+	}
+
+	nodesByKey := make(map[string]beads.GraphApplyNode, len(store.plan.Nodes))
+	for _, node := range store.plan.Nodes {
+		nodesByKey[node.Key] = node
+	}
+	child := nodesByKey["frag.scope.child"]
+	if child.ParentKey != "frag.scope" {
+		t.Fatalf("child.ParentKey = %q, want frag.scope", child.ParentKey)
+	}
+	if child.ParentID != "" {
+		t.Fatalf("child.ParentID = %q, want empty when recipe parent wins", child.ParentID)
 	}
 }
 

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1009,6 +1009,98 @@ func TestInstantiateFragmentPrefersRecipeParentOverExternalParent(t *testing.T) 
 	if child.ParentID != result.IDMapping["frag.scope"] {
 		t.Fatalf("child.ParentID = %q, want recipe parent %q", child.ParentID, result.IDMapping["frag.scope"])
 	}
+	deps, err := store.DepList(child.ID, "down")
+	if err != nil {
+		t.Fatalf("DepList(child): %v", err)
+	}
+	for _, dep := range deps {
+		if dep.Type == "parent-child" && dep.DependsOnID == externalParent.ID {
+			t.Fatalf("child has external parent-child dep %q despite recipe parent winning; deps=%v", externalParent.ID, deps)
+		}
+	}
+}
+
+func TestInstantiateFragmentPrefersRecipeParentWhenChildPrecedesParent(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Priority: priorityPtr(1),
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	externalParent, err := store.Create(beads.Bead{
+		Title: "External parent",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create external parent: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+			{ID: "frag.scope", Title: "Scope", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.scope.child", DependsOnID: "frag.scope", Type: "parent-child"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{
+				StepID:      "frag.scope.child",
+				DependsOnID: externalParent.ID,
+				Type:        "parent-child",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+
+	child, err := store.Get(result.IDMapping["frag.scope.child"])
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if child.ParentID != result.IDMapping["frag.scope"] {
+		t.Fatalf("child.ParentID = %q, want recipe parent %q", child.ParentID, result.IDMapping["frag.scope"])
+	}
+}
+
+func TestInstantiateFragmentRejectsDuplicateExternalParents(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title: "Workflow root",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			{ID: "frag.scope.child", Title: "Child", Type: "task"},
+		},
+	}
+
+	_, err = InstantiateFragment(context.Background(), store, recipe, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{StepID: "frag.scope.child", DependsOnID: "external-1", Type: "parent-child"},
+			{StepID: "frag.scope.child", DependsOnID: "external-2", Type: "parent-child"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate external parent-child deps to fail")
+	}
+	if !strings.Contains(err.Error(), "multiple external parent-child") {
+		t.Fatalf("error = %q, want duplicate external parent-child message", err)
+	}
 }
 
 func TestInstantiateFragmentGraphApplyPrefersRecipeParentOverExternalParent(t *testing.T) {
@@ -1070,6 +1162,11 @@ func TestInstantiateFragmentGraphApplyPrefersRecipeParentOverExternalParent(t *t
 	}
 	if child.ParentID != "" {
 		t.Fatalf("child.ParentID = %q, want empty when recipe parent wins", child.ParentID)
+	}
+	for _, edge := range store.plan.Edges {
+		if edge.Type == "parent-child" && edge.FromKey == "frag.scope.child" && edge.ToID == externalParent.ID {
+			t.Fatalf("graph plan kept external parent-child edge despite recipe parent winning: %+v", edge)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #952 by @julianknutsen and preserves the original fix with contributor authorship.
- Closes #932 by ensuring workflow-owned molecule closures are cleaned child-first instead of leaving open step beads behind.
- Adds maintainer fixups for BdStore parent-child idempotence, fragment recipe-parent precedence, MemStore same-pair dependency coexistence, Ralph retry graph replay, and tracking-bead GC scope.

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test ./internal/beads ./internal/molecule ./internal/dispatch`
- [x] `go test ./cmd/gc -run 'TestWispGC_'`
- [x] `go vet ./...`

Note: a broader `go test ./cmd/gc ./internal/beads ./internal/molecule ./internal/dispatch` attempt timed out in unrelated `TestDoltStateRecoverManagedCmdFailsWhenPostStartHealthFails`; the focused regression packages above pass on this branch.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No user-facing docs or migration notes are needed; this fixes persistence and cleanup behavior for existing molecule/wisp workflows.

Supersedes #952.
Closes #932.