### PR TITLE
quality: Wave 1 pack/provider/workspace

### DIFF
--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -17,10 +17,6 @@ import (
 // and symlinks for scripts no longer in any layer are removed. Real files
 // (non-symlinks) in the target directory are never overwritten.
 func ResolveScripts(targetDir string, layers []string) error {
-	if len(layers) == 0 {
-		return nil
-	}
-
 	// Build winner map: relative path → absolute source path.
 	// Later layers overwrite earlier ones (higher priority).
 	winners := make(map[string]string)

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -238,6 +238,29 @@ func TestResolveScripts_EmptyLayers(t *testing.T) {
 	}
 }
 
+func TestResolveScripts_EmptyLayersCleanStaleSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	layer := filepath.Join(dir, "pack", "scripts")
+	writeScriptFile(t, layer, "setup.sh", "setup")
+
+	target := filepath.Join(dir, "city")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll target: %v", err)
+	}
+
+	if err := ResolveScripts(target, []string{layer}); err != nil {
+		t.Fatalf("first ResolveScripts: %v", err)
+	}
+
+	if err := ResolveScripts(target, nil); err != nil {
+		t.Fatalf("second ResolveScripts: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(target, "scripts", "setup.sh")); !os.IsNotExist(err) {
+		t.Fatalf("setup.sh should have been removed after empty-layer cleanup, err=%v", err)
+	}
+}
+
 func TestResolveScripts_MissingLayerDir(t *testing.T) {
 	dir := t.TempDir()
 	layer := filepath.Join(dir, "pack", "scripts")


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Pack, Provider Resolution & Workspace Layout`.

This PR fixes a concrete cleanup regression in the script-layer resolver: when the last script layer disappears, stale symlinks under `city/scripts/` now get removed instead of being left behind indefinitely.

## Scope

Owned scope for this module:

- `internal/config/{compose.go,pack.go,pack_fetch.go,pack_include.go,provider.go,resolve.go}`
- `internal/citylayout/*`
- `internal/workdir/*`
- `internal/api/{handler_city.go,handler_city_create.go,handler_packs.go,handler_provider_crud.go,handler_providers.go}`
- `cmd/gc/{city_layout.go,template_resolve.go,script_resolve.go}`

Files touched in this PR:

- `cmd/gc/script_resolve.go`
- `cmd/gc/script_resolve_test.go`

## Implementer Trajectory

- Initial audit found a correctness gap in `ResolveScripts`: `len(layers) == 0` returned early, so stale symlinks were never cleaned after the last layer disappeared.
- Added a regression test first for empty-layer stale-symlink cleanup.
- Removed the early return so empty-layer runs still flow through stale cleanup.

## Blind Verifier Score Summary

- `TDD` 90
- `DRY` 83
- `Separation of Concerns` 84
- `Single Responsibility` 81
- `Clear Abstractions` 87
- `Low Coupling, High Cohesion` 86
- `KISS` 81
- `YAGNI` 84
- `Prefer Non-Nullable` 83
- `Prefer Async Notifications` `N/A`
- `Eliminate Race Conditions` `N/A`
- `Errors Are Not Optional` 92
- `Idiomatic Project Layout` 89
- `Write for Maintainability` 88

`N/A` rows:

- `Prefer Async Notifications` — the module does not own notification or polling coordination.
- `Eliminate Race Conditions` — the owned scope does not contain shared concurrent state.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added focused regression coverage for empty-layer stale symlink cleanup.
- Verified with:
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./cmd/gc -run 'TestResolveScripts_(EmptyLayers|EmptyLayersCleanStaleSymlinks|StaleCleanup|EmptySubdirCleanup)' -count=1`
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/config ./internal/citylayout ./internal/workdir -count=1`

## Notes

- The fix stays fully inside owned scope; no boundary exception or shared-foundation dependency was needed.
