### PR TITLE
quality: Wave 1 session identity

### DIFF
--- a/internal/sessionlog/agents.go
+++ b/internal/sessionlog/agents.go
@@ -119,9 +119,12 @@ func FindAgentMappings(parentLogPath string) ([]AgentMapping, error) {
 	var mappings []AgentMapping
 	for _, path := range agentPaths {
 		agentID := agentIDFromPath(path)
-		toolUseID := extractParentToolUseID(path)
 		if agentID == "" {
 			continue
+		}
+		toolUseID, err := extractParentToolUseID(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading agent %q mapping: %w", agentID, err)
 		}
 		mappings = append(mappings, AgentMapping{
 			AgentID:         agentID,
@@ -193,10 +196,10 @@ func agentIDFromPath(path string) string {
 // extractParentToolUseID reads the first few lines of an agent JSONL file
 // and looks for the parentToolUseId field. Claude Code writes this on
 // the first entry of every subagent session.
-func extractParentToolUseID(path string) string {
+func extractParentToolUseID(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("opening transcript: %w", err)
 	}
 	defer f.Close() //nolint:errcheck // read-only
 
@@ -216,10 +219,13 @@ func extractParentToolUseID(path string) string {
 			continue
 		}
 		if entry.ParentToolUseID != "" {
-			return entry.ParentToolUseID
+			return entry.ParentToolUseID, nil
 		}
 	}
-	return ""
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scanning transcript: %w", err)
+	}
+	return "", nil
 }
 
 // inferAgentStatus determines the agent's status from its message history.

--- a/internal/sessionlog/agents_test.go
+++ b/internal/sessionlog/agents_test.go
@@ -134,7 +134,10 @@ func TestExtractParentToolUseID(t *testing.T) {
 		`{"uuid":"u2","type":"user","message":{"role":"user","content":"hello"}}` + "\n"
 	writeTestFile(t, path, content)
 
-	got := extractParentToolUseID(path)
+	got, err := extractParentToolUseID(path)
+	if err != nil {
+		t.Fatalf("extractParentToolUseID: %v", err)
+	}
 	if got != "toolu_abc123" {
 		t.Errorf("extractParentToolUseID = %q, want %q", got, "toolu_abc123")
 	}
@@ -145,7 +148,10 @@ func TestExtractParentToolUseID_Missing(t *testing.T) {
 	path := filepath.Join(dir, "agent-test.jsonl")
 	writeTestFile(t, path, `{"uuid":"u1","type":"user"}`+"\n")
 
-	got := extractParentToolUseID(path)
+	got, err := extractParentToolUseID(path)
+	if err != nil {
+		t.Fatalf("extractParentToolUseID: %v", err)
+	}
 	if got != "" {
 		t.Errorf("extractParentToolUseID = %q, want empty", got)
 	}
@@ -177,6 +183,22 @@ func TestFindAgentMappings(t *testing.T) {
 	}
 	if found["ghi"] != "toolu_222" {
 		t.Errorf("agent ghi: want toolu_222, got %q", found["ghi"])
+	}
+}
+
+func TestFindAgentMappings_PropagatesReadErrors(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, subDir := makeSessionDir(t, dir, "session-abc")
+
+	brokenTarget := filepath.Join(subDir, "missing-target.jsonl")
+	brokenPath := filepath.Join(subDir, "agent-broken.jsonl")
+	if err := os.Symlink(brokenTarget, brokenPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := FindAgentMappings(parentPath)
+	if err == nil {
+		t.Fatal("expected error when reading a broken agent transcript")
 	}
 }
 


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Session Identity, Resolution & Transcript Access`.

This PR fixes a correctness and observability gap in subagent transcript discovery: broken agent transcript files now surface an error instead of being silently dropped as empty mappings.

## Scope

Owned scope for this module:

- `internal/session/{alias.go,manager.go,names.go,overlay.go,resolve.go}`
- `internal/sessionlog/*`
- `internal/worker/{sessionlog_adapter.go,types.go}`
- `cmd/gc/{cmd_session.go,cmd_session_logs.go,named_sessions.go,session_bead_snapshot.go,session_beads.go,session_index.go,session_keys.go,session_manager.go,session_name_lookup.go,session_resolve.go,session_state_helpers.go,session_target.go,session_types.go}`
- `internal/api/{handler_sessions.go,session_manager.go,session_resolution.go,title_generate.go}`

Files touched in this PR:

- `internal/sessionlog/agents.go`
- `internal/sessionlog/agents_test.go`

## Implementer Trajectory

- Initial audit found a silent-failure path in `FindAgentMappings`: unreadable/broken agent transcript files were reduced to empty mappings instead of surfacing the read failure.
- Added a regression test first for a broken agent transcript symlink.
- Changed the low-level helper to return read/scanner errors and propagate them through `FindAgentMappings`.

## Blind Verifier Score Summary

- `TDD` 92
- `DRY` 86
- `Separation of Concerns` 90
- `Single Responsibility` 85
- `Clear Abstractions` 88
- `Low Coupling, High Cohesion` 88
- `KISS` 93
- `YAGNI` 94
- `Prefer Non-Nullable` 88
- `Prefer Async Notifications` `N/A`
- `Eliminate Race Conditions` 85
- `Errors Are Not Optional` 94
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 91

`N/A` rows:

- `Prefer Async Notifications` — accepted because the touched module-owned change is synchronous transcript parsing/lookup rather than notification coordination.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added regression coverage for broken subagent transcript reads.
- Verified with:
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/sessionlog -run 'Test(FindAgentMappings|ExtractParentToolUseID)' -count=1`
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/sessionlog ./internal/worker -count=1`

## Notes

- A prior blind-verifier attempt was rejected because it mixed in unrelated main-worktree files outside the isolated module branch. The accepted verifier result was rerun against the isolated worktree only.
