### PR TITLE
quality: Wave 1 session lifecycle

### DIFF
--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -248,7 +248,10 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 			return 1
 		}
 		if cityPath, err := resolveCity(); err == nil {
-			_ = pokeController(cityPath)
+			if err := pokeController(cityPath); err != nil {
+				fmt.Fprintf(stderr, "gc session wait: poking controller: %v\n", err) //nolint:errcheck
+				return 1
+			}
 		}
 		fmt.Fprintf(stdout, "Registered wait %s for session %s.\nSession %s draining to sleep.\n", waitBead.ID, sessionID, sessionID) //nolint:errcheck
 		return 0
@@ -382,7 +385,10 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 				return 1
 			}
 		}
-		_ = clearSessionWaitHoldIfIdle(store, b.Metadata["session_id"])
+		if err := clearSessionWaitHoldIfIdle(store, b.Metadata["session_id"]); err != nil {
+			fmt.Fprintf(stderr, "gc wait: clearing session wait hold: %v\n", err) //nolint:errcheck
+			return 1
+		}
 	}
 	fmt.Fprintf(stdout, "Updated wait %s to %s.\n", waitID, state) //nolint:errcheck
 	return 0
@@ -688,14 +694,18 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 		if err := enqueueQueuedNudgeWithStore(cityPath, store, item); err != nil {
 			return err
 		}
-		_ = store.SetMetadata(wait.ID, "nudge_id", nudgeID)
+		if err := store.SetMetadata(wait.ID, "nudge_id", nudgeID); err != nil {
+			return fmt.Errorf("setting wait nudge_id: %w", err)
+		}
 		// provider_kind is stamped from ResolvedProvider.Kind /
 		// BuiltinAncestor at session-bead creation, so wrapped codex
 		// aliases (e.g. [providers.my-wrapped-codex] base = "builtin:codex")
 		// already surface as "codex" here. The provider fallback covers
 		// sessions created before provider_kind was stamped.
 		if sessionProviderFamily(sessionBead) == "codex" {
-			_ = startNudgePoller(cityPath, waitNudgeAgent(sessionBead), sessionBead.Metadata["session_name"])
+			if err := startNudgePoller(cityPath, waitNudgeAgent(sessionBead), sessionBead.Metadata["session_name"]); err != nil {
+				return fmt.Errorf("starting wait nudge poller: %w", err)
+			}
 		}
 	}
 	return nil

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -218,11 +218,13 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 	}
 	ready, depErr := depsWaitReadyDetailedForCity(cityPath, store, waitBead)
 	if depErr != nil {
-		_ = setWaitTerminalState(store, waitBead.ID, map[string]string{
+		if err := setWaitTerminalState(store, waitBead.ID, map[string]string{
 			"state":      waitStateFailed,
 			"failed_at":  now.Format(time.RFC3339),
 			"last_error": depErr.Error(),
-		})
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc session wait: setting failed state: %v\n", err) //nolint:errcheck
+		}
 		fmt.Fprintf(stderr, "gc session wait: dependency state check: %v\n", depErr) //nolint:errcheck
 		return 1
 	}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -25,6 +25,17 @@ type waitErrorStore struct {
 	*beads.MemStore
 }
 
+type waitNudgeMetadataFailStore struct {
+	*beads.MemStore
+}
+
+func (s waitNudgeMetadataFailStore) SetMetadata(id, key, value string) error {
+	if key == "nudge_id" {
+		return errors.New("set nudge id failed")
+	}
+	return s.MemStore.SetMetadata(id, key, value)
+}
+
 var (
 	waitTestRealBDPathOnce sync.Once
 	waitTestRealBDCached   string
@@ -783,6 +794,98 @@ func TestDispatchReadyWaitNudges_StartsCodexPoller(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("startNudgePoller was not called")
+	}
+}
+
+func TestDispatchReadyWaitNudges_PropagatesNudgeIDMetadataFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := waitNudgeMetadataFailStore{MemStore: beads.NewMemStore()}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"dep_ids":          "gc-1",
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	err = dispatchReadyWaitNudges(dir, store, sp, time.Now().UTC())
+	if err == nil || !strings.Contains(err.Error(), "setting wait nudge_id") {
+		t.Fatalf("dispatchReadyWaitNudges error = %v, want nudge_id failure", err)
+	}
+}
+
+func TestDispatchReadyWaitNudges_PropagatesPollerFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "1",
+			"provider":           "codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"dep_ids":          "gc-1",
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	prev := startNudgePoller
+	startNudgePoller = func(_, _, _ string) error {
+		return errors.New("poller failed")
+	}
+	t.Cleanup(func() { startNudgePoller = prev })
+
+	err = dispatchReadyWaitNudges(dir, store, sp, time.Now().UTC())
+	if err == nil || !strings.Contains(err.Error(), "starting wait nudge poller") {
+		t.Fatalf("dispatchReadyWaitNudges error = %v, want poller failure", err)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -640,8 +640,11 @@ func commitStartResultTraced(
 			return false
 		}
 		fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck
-		_ = store.SetMetadata(session.ID, "last_woke_at", "")
-		session.Metadata["last_woke_at"] = ""
+		if err := store.SetMetadata(session.ID, "last_woke_at", ""); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: clearing last_woke_at for %s: %v\n", name, err) //nolint:errcheck
+		} else {
+			session.Metadata["last_woke_at"] = ""
+		}
 		recordWakeFailure(session, store, clk)
 		if trace != nil {
 			trace.recordOperation("reconciler.start.failed", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{

--- a/cmd/gc/session_sleep.go
+++ b/cmd/gc/session_sleep.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"strings"
 	"time"
 
@@ -143,8 +144,11 @@ func reconcileDetachedAt(
 	}
 	if policy.Class == config.SessionSleepNonInteractive || !policy.enabled() || sp == nil || !alive || policy.Capability != runtime.SessionSleepCapabilityFull {
 		if session.Metadata["detached_at"] != "" {
-			_ = store.SetMetadata(session.ID, "detached_at", "")
-			session.Metadata["detached_at"] = ""
+			if err := store.SetMetadata(session.ID, "detached_at", ""); err != nil {
+				log.Printf("session sleep: clearing detached_at for %s: %v", session.ID, err)
+			} else {
+				session.Metadata["detached_at"] = ""
+			}
 		}
 		return
 	}
@@ -155,15 +159,21 @@ func reconcileDetachedAt(
 	attached, err := workerSessionTargetAttachedWithConfig("", store, sp, nil, session.ID)
 	if err == nil && attached {
 		if session.Metadata["detached_at"] != "" {
-			_ = store.SetMetadata(session.ID, "detached_at", "")
-			session.Metadata["detached_at"] = ""
+			if err := store.SetMetadata(session.ID, "detached_at", ""); err != nil {
+				log.Printf("session sleep: clearing detached_at for %s: %v", session.ID, err)
+			} else {
+				session.Metadata["detached_at"] = ""
+			}
 		}
 		return
 	}
 	if session.Metadata["detached_at"] == "" {
 		ts := clk.Now().UTC().Format(time.RFC3339)
-		_ = store.SetMetadata(session.ID, "detached_at", ts)
-		session.Metadata["detached_at"] = ts
+		if err := store.SetMetadata(session.ID, "detached_at", ts); err != nil {
+			log.Printf("session sleep: setting detached_at for %s: %v", session.ID, err)
+		} else {
+			session.Metadata["detached_at"] = ts
+		}
 	}
 }
 

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -184,10 +184,11 @@ func setReconcilerDrainAckMetadata(sp runtime.Provider, name string, ds *drainSt
 }
 
 func clearReconcilerDrainAckMetadata(sp runtime.Provider, name string) {
-	_ = sp.RemoveMeta(name, "GC_DRAIN_ACK")
-	_ = sp.RemoveMeta(name, reconcilerDrainAckSourceKey)
-	_ = sp.RemoveMeta(name, reconcilerDrainAckReasonKey)
-	_ = sp.RemoveMeta(name, reconcilerDrainAckGenerationKey)
+	for _, key := range []string{"GC_DRAIN_ACK", reconcilerDrainAckSourceKey, reconcilerDrainAckReasonKey, reconcilerDrainAckGenerationKey} {
+		if err := sp.RemoveMeta(name, key); err != nil {
+			log.Printf("session wake: clearing reconciler drain ack metadata %s for %s: %v", key, name, err)
+		}
+	}
 }
 
 // cancelSessionDrain removes a cancelable drain if wake reasons reappeared for

--- a/internal/api/handler_session_agents_test.go
+++ b/internal/api/handler_session_agents_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/sessionlog"
+)
+
+func createTranscriptBackedSession(t *testing.T, store beads.Store, sp *runtime.Fake, workDir string) session.Info {
+	t.Helper()
+	mgr := session.NewManager(store, sp)
+	info, err := mgr.Create(
+		context.Background(),
+		"default",
+		"Transcript Backed",
+		"echo test",
+		workDir,
+		"test",
+		nil,
+		session.ProviderResume{},
+		runtime.Config{},
+	)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return info
+}
+
+func writeSessionAgentTranscriptFixture(t *testing.T, searchBase, workDir string, info session.Info) {
+	t.Helper()
+
+	slugDir := filepath.Join(searchBase, sessionlog.ProjectSlug(workDir))
+	parentPath := filepath.Join(slugDir, info.SessionKey+".jsonl")
+	subagentsDir := filepath.Join(slugDir, info.SessionKey, "subagents")
+	if err := os.MkdirAll(subagentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir subagents: %v", err)
+	}
+	parentContent := `{"uuid":"u1","type":"user","message":{"role":"user","content":"hello"}}` + "\n"
+	if err := os.WriteFile(parentPath, []byte(parentContent), 0o644); err != nil {
+		t.Fatalf("write parent transcript: %v", err)
+	}
+
+	agentPath := filepath.Join(subagentsDir, "agent-helper.jsonl")
+	agentContent := strings.Join([]string{
+		`{"uuid":"a1","type":"system","parentToolUseId":"toolu_123"}`,
+		`{"uuid":"a2","parentUuid":"a1","type":"assistant","message":{"role":"assistant","content":"working"}}`,
+		`{"uuid":"a3","parentUuid":"a2","type":"result","message":{"role":"result"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(agentPath, []byte(agentContent), 0o644); err != nil {
+		t.Fatalf("write agent transcript: %v", err)
+	}
+}
+
+type sessionAgentListTestResponse struct {
+	Agents []struct {
+		AgentID         string `json:"agent_id"`
+		ParentToolUseID string `json:"parent_tool_use_id"`
+	} `json:"agents"`
+}
+
+type sessionAgentGetTestResponse struct {
+	Messages []map[string]any `json:"messages"`
+	Status   string           `json:"status"`
+}
+
+func TestHandleSessionAgentList(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	searchBase := t.TempDir()
+	srv.sessionLogSearchPaths = []string{searchBase}
+
+	workDir := filepath.Join(t.TempDir(), "claude-project")
+	info := createTranscriptBackedSession(t, fs.cityBeadStore, fs.sp, workDir)
+	writeSessionAgentTranscriptFixture(t, searchBase, workDir, info)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/session/"+info.ID+"/agents", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp sessionAgentListTestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Agents) != 1 {
+		t.Fatalf("len(Agents) = %d, want 1", len(resp.Agents))
+	}
+	if resp.Agents[0].AgentID != "helper" {
+		t.Fatalf("Agents[0].AgentID = %q, want helper", resp.Agents[0].AgentID)
+	}
+	if resp.Agents[0].ParentToolUseID != "toolu_123" {
+		t.Fatalf("Agents[0].ParentToolUseID = %q, want toolu_123", resp.Agents[0].ParentToolUseID)
+	}
+}
+
+func TestHandleSessionAgentGet(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	searchBase := t.TempDir()
+	srv.sessionLogSearchPaths = []string{searchBase}
+
+	workDir := filepath.Join(t.TempDir(), "claude-project")
+	info := createTranscriptBackedSession(t, fs.cityBeadStore, fs.sp, workDir)
+	writeSessionAgentTranscriptFixture(t, searchBase, workDir, info)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/session/"+info.ID+"/agents/helper", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp sessionAgentGetTestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != string(sessionlog.AgentStatusCompleted) {
+		t.Fatalf("Status = %q, want %q", resp.Status, sessionlog.AgentStatusCompleted)
+	}
+	if len(resp.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(resp.Messages))
+	}
+	if got := resp.Messages[0]["parentToolUseId"]; got != "toolu_123" {
+		t.Fatalf("Messages[0][parentToolUseId] = %#v, want toolu_123", got)
+	}
+}

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -42,16 +42,23 @@ func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
 	return strings.TrimSpace(result)
 }
 
-func (m *Manager) clearStaleResumeMetadata(id string, b *beads.Bead) {
-	_ = m.store.SetMetadata(id, "session_key", "")
-	_ = m.store.SetMetadata(id, "started_config_hash", "")
-	_ = m.store.SetMetadata(id, "continuation_reset_pending", "true")
+func (m *Manager) clearStaleResumeMetadata(id string, b *beads.Bead) error {
+	if err := m.store.SetMetadata(id, "session_key", ""); err != nil {
+		return fmt.Errorf("clearing stale resume metadata session_key: %w", err)
+	}
+	if err := m.store.SetMetadata(id, "started_config_hash", ""); err != nil {
+		return fmt.Errorf("clearing stale resume metadata started_config_hash: %w", err)
+	}
+	if err := m.store.SetMetadata(id, "continuation_reset_pending", "true"); err != nil {
+		return fmt.Errorf("clearing stale resume metadata continuation_reset_pending: %w", err)
+	}
 	if b.Metadata == nil {
 		b.Metadata = make(map[string]string)
 	}
 	b.Metadata["session_key"] = ""
 	b.Metadata["started_config_hash"] = ""
 	b.Metadata["continuation_reset_pending"] = "true"
+	return nil
 }
 
 func (m *Manager) retryFreshStartAfterStaleKey(
@@ -67,7 +74,12 @@ func (m *Manager) retryFreshStartAfterStaleKey(
 		return false, nil
 	}
 	freshCmd := stripResumeFlag(resumeCommand, b.Metadata["resume_flag"], b.Metadata["session_key"])
-	m.clearStaleResumeMetadata(id, b)
+	if err := m.clearStaleResumeMetadata(id, b); err != nil {
+		if unroute != nil {
+			unroute()
+		}
+		return false, err
+	}
 	if freshCmd == resumeCommand {
 		if unroute != nil {
 			unroute()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -146,6 +146,18 @@ type waitFailStore struct {
 	*beads.MemStore
 }
 
+type failMetadataKeyStore struct {
+	*beads.MemStore
+	key string
+}
+
+func (s failMetadataKeyStore) SetMetadata(id, key, value string) error {
+	if key == s.key {
+		return errors.New("set metadata failed")
+	}
+	return s.MemStore.SetMetadata(id, key, value)
+}
+
 func (s waitFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	if query.Label == WaitBeadLabel || strings.HasPrefix(query.Label, "session:") {
 		return nil, errors.New("wait list failed")
@@ -2844,5 +2856,51 @@ func TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata(t *test
 	}
 	if b.Metadata["state"] != string(StateSuspended) {
 		t.Errorf("state should remain suspended after failed unstrippable fallback, got %q", b.Metadata["state"])
+	}
+}
+
+func TestEnsureRunning_StartupDeathClearMetadataFailurePropagates(t *testing.T) {
+	store := failMetadataKeyStore{MemStore: beads.NewMemStore(), key: "session_key"}
+	base := runtime.NewFake()
+	sp := &startupDeathProvider{Fake: base}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "worker", "", "claude --dangerously", "/tmp", "claude", nil, ProviderResume{
+		ResumeFlag:    "--resume",
+		SessionIDFlag: "--session-id",
+	}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get bead: %v", err)
+	}
+	sessionKey := b.Metadata["session_key"]
+	if sessionKey == "" {
+		t.Fatal("expected session_key in bead metadata after Create with ResumeFlag")
+	}
+
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	sp.armed = true
+	resumeCmd := "claude --dangerously --resume " + sessionKey
+	err = mgr.Send(context.Background(), info.ID, "hello", resumeCmd, runtime.Config{WorkDir: "/tmp"})
+	if err == nil {
+		t.Fatal("Send should fail when stale resume metadata cannot be cleared")
+	}
+	if !strings.Contains(err.Error(), "clearing stale resume metadata session_key") {
+		t.Fatalf("Send error = %v, want stale metadata clear failure", err)
+	}
+
+	b, err = store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get bead after failure: %v", err)
+	}
+	if b.Metadata["session_key"] == "" {
+		t.Fatal("session_key should remain set after failed metadata clear")
 	}
 }


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Session Lifecycle, Wake & Interaction Delivery`.

This PR finishes the Wave 1 pass for the session-lifecycle slice in two small steps:

- adds direct coverage for the legacy `/v0/session/{id}/agents` and `/v0/session/{id}/agents/{agentId}` handlers so the module’s session-agent delivery seam is proven through the owned HTTP surface instead of only through lower-level worker/sessionlog tests
- surfaces previously silent lifecycle cleanup failures instead of discarding them in best-effort paths

## Scope

Owned scope for this module:

- `internal/session/{chat.go,lifecycle.go,waits.go}`
- `cmd/gc/{adoption_barrier.go,cmd_handoff.go,cmd_nudge.go,cmd_wait.go,cmd_session_wake.go,session_lifecycle_parallel.go,session_overrides.go,session_sleep.go,session_template_start.go,session_wake.go}`
- `internal/api/handler_session_agents.go`

Files touched in this PR:

- `internal/api/handler_session_agents_test.go`
- `internal/session/chat.go`
- `internal/session/manager_test.go`
- `cmd/gc/cmd_wait.go`
- `cmd/gc/session_sleep.go`
- `cmd/gc/session_wake.go`
- `cmd/gc/session_lifecycle_parallel.go`

## Implementer Trajectory

- Audit first found the clearest Wave 1 gap in `TDD`: the owned legacy session-agent handlers had no direct tests.
- Added focused HTTP-level tests on the correct module branch using a real transcript fixture and the existing worker-boundary lookup path.
- Strict verification then blocked the module on `Errors Are Not Optional` because several cleanup paths were still swallowing store/provider failures.
- The final loop surfaces those failures through returned errors, `stderr`, or process logs instead of silently discarding them.

## Blind Verifier Score Summary

- `TDD` 90
- `DRY` 84
- `Separation of Concerns` 85
- `Single Responsibility` 82
- `Clear Abstractions` 88
- `Low Coupling, High Cohesion` 84
- `KISS` 85
- `YAGNI` 90
- `Prefer Non-Nullable` 88
- `Prefer Async Notifications` 85
- `Eliminate Race Conditions` 86
- `Errors Are Not Optional` 84
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 85

No `N/A` rows.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added direct coverage for:
  - `GET /v0/session/{id}/agents`
  - `GET /v0/session/{id}/agents/{agentId}`
- Added regression coverage for stale-resume cleanup failure propagation.
- Verified with:
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/api -run 'TestHandleSessionAgent(List|Get)$' -count=1`
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/session -run 'TestEnsureRunning_(StartupDeathClearMetadataFailurePropagates|StartupDeathWithoutStrippableResumeClearsMetadata|RetriesAfterStartupDeathError|StaleKeyRetryAlsoFails)' -count=1`
  - `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./cmd/gc -run 'TestDispatchReadyWaitNudges_(StartsCodexPoller|PropagatesNudgeIDMetadataFailure|PropagatesPollerFailure)|Test(PrepareStartCandidate_GeneratesMissingSessionKeyBeforeWake|ReconcileSessionBeads_BlockedCandidatesDoNotConsumeWakeBudget|ExecutePlannedStarts_FreshWakeAfterDrainRetainsStartupContext|LogLifecycleOutcome_SanitizesMultilineErrors)' -count=1`

## Notes

- An earlier worker run landed equivalent coverage on the wrong dirty branch; that output was rejected and not reused directly. This PR re-lands only the owned test coverage on the isolated module branch.
- The strict verifier’s first pass found the silent-cleanup issue; the final branch addresses that finding directly.
