### PR TITLE
runtime: cache stable demand snapshots

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -256,6 +256,7 @@ func (cs *controllerState) applyBeadEventToStores(evt events.Event) {
 			cached.ApplyEvent(evt.Type, evt.Payload)
 		}
 	}
+	cs.Poke()
 }
 
 // update replaces the config, session provider, and reopens stores.

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -696,6 +697,44 @@ func TestControllerStateMutationErrorDoesNotPokeController(t *testing.T) {
 	select {
 	case <-cs.pokeCh:
 		t.Fatal("failed mutation should not poke reconciler")
+	default:
+	}
+}
+
+func TestControllerStateApplyBeadEventPokesController(t *testing.T) {
+	cs := &controllerState{
+		pokeCh: make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadUpdated,
+		Actor:   "agent-runtime",
+		Subject: "bd-123",
+		Payload: json.RawMessage(`{"id":"bd-123"}`),
+	})
+
+	select {
+	case <-cs.pokeCh:
+	default:
+		t.Fatal("expected bead event to poke controller")
+	}
+}
+
+func TestControllerStateApplyCacheReconcileEventDoesNotPokeController(t *testing.T) {
+	cs := &controllerState{
+		pokeCh: make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadUpdated,
+		Actor:   "cache-reconcile",
+		Subject: "bd-123",
+		Payload: json.RawMessage(`{"id":"bd-123"}`),
+	})
+
+	select {
+	case <-cs.pokeCh:
+		t.Fatal("cache-reconcile event should not poke controller")
 	default:
 	}
 }

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -26,7 +26,9 @@ type DesiredStateResult struct {
 	State             map[string]TemplateParams
 	BaseState         map[string]TemplateParams
 	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
-	AssignedWorkBeads []beads.Bead   // actionable assigned work: in_progress or ready+assigned
+	PoolDesiredCounts map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
+	WorkSet           map[string]bool
+	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -1588,7 +1589,9 @@ func (cr *CityRuntime) loadDemandSnapshot(
 	if cr.demandSnapshot == nil {
 		return runtimeDemandSnapshot{}
 	}
-	return *cr.demandSnapshot
+	snapshot := *cr.demandSnapshot
+	cr.installDemandSnapshotSideEffects(snapshot.result)
+	return snapshot
 }
 
 func (cr *CityRuntime) shouldRefreshDemandSnapshot(
@@ -1612,7 +1615,32 @@ func (cr *CityRuntime) shouldRefreshDemandSnapshot(
 }
 
 func (cr *CityRuntime) demandSnapshotsEnabled() bool {
-	return cr.cs != nil && cr.cs.EventProvider() != nil
+	return cr.cs != nil && cr.cs.EventProvider() != nil && demandSnapshotDemandSourcesEventBacked(cr.cfg)
+}
+
+func demandSnapshotDemandSourcesEventBacked(cfg *config.City) bool {
+	if cfg == nil {
+		return false
+	}
+	for i := range cfg.Agents {
+		if strings.TrimSpace(cfg.Agents[i].ScaleCheck) != "" || strings.TrimSpace(cfg.Agents[i].WorkQuery) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func (cr *CityRuntime) installDemandSnapshotSideEffects(result DesiredStateResult) {
+	autoSP, ok := cr.sp.(*sessionauto.Provider)
+	if !ok {
+		return
+	}
+	for _, tp := range result.State {
+		if !tp.IsACP || strings.TrimSpace(tp.SessionName) == "" {
+			continue
+		}
+		autoSP.RouteACP(tp.SessionName)
+	}
 }
 
 func sessionBeadSnapshotFingerprint(snapshot *sessionBeadSnapshot) string {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -64,7 +66,8 @@ type CityRuntime struct {
 	standaloneRigStores map[string]beads.Store
 
 	// Bead-driven reconciler state (Phase 2f).
-	sessionDrains *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	sessionDrains  *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	demandSnapshot *runtimeDemandSnapshot
 
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
@@ -79,6 +82,14 @@ type CityRuntime struct {
 	shutdownOnce   sync.Once
 	logPrefix      string // "gc start" or "gc supervisor"
 	stdout, stderr io.Writer
+}
+
+const runtimeDemandSnapshotMaxAge = 30 * time.Second
+
+type runtimeDemandSnapshot struct {
+	createdAt          time.Time
+	sessionFingerprint string
+	result             DesiredStateResult
 }
 
 // CityRuntimeParams holds the caller-provided parameters for creating a
@@ -620,7 +631,8 @@ func (cr *CityRuntime) tick(
 		cr.sendReloadReply(manualReload.doneCh, reply)
 		cr.activeReload = nil
 	}()
-	if dirty.Swap(false) {
+	configChanged := dirty.Swap(false)
+	if configChanged {
 		dirtyCleared = true
 		source := reloadSourceWatch
 		if cr.activeReload != nil {
@@ -637,7 +649,8 @@ func (cr *CityRuntime) tick(
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
 	// corrects bead state, and the pre-reconcile sync is sufficient for
 	// the reconciler to read/write hashes during reconciliation.
-	result := cr.buildDesiredState(sessionBeads, trace)
+	demand := cr.loadDemandSnapshot(sessionBeads, trace, trigger, configChanged)
+	result := demand.result
 	sessionBeads = cr.loadSessionBeadSnapshot()
 	result = refreshDesiredStateWithSessionBeads(
 		result,
@@ -1102,8 +1115,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// same scale_check counts that buildDesiredState already computed (no
 	// duplicate shell-outs). Resume tier from cross-referenced assigned
 	// work beads + new tier from scale_check + min fill.
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-		cr.cfg, assignedWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
+	poolDesired := result.PoolDesiredCounts
+	if poolDesired == nil {
+		poolDesired = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
+			cr.cfg, assignedWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
+	}
 	// Merge named-session assignee demand so on-demand named sessions with
 	// direct work (Assignee match, no gc.routed_to) stay config-eligible.
 	if poolDesired == nil {
@@ -1147,7 +1163,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// workSet: defense-in-depth wake signal from work_query. When work_query
 	// detects pending work but scale_check hasn't caught up yet, workSet
 	// ensures at least one session wakes without waiting for the next tick.
-	workSet := computeWorkSet(cr.cfg, shellScaleCheck, cityName, cr.cityPath, store, sessionBeads, cr.stderr)
+	workSet := result.WorkSet
+	if workSet == nil {
+		workSet = computeWorkSet(cr.cfg, shellScaleCheck, cityName, cr.cityPath, store, sessionBeads, cr.stderr)
+	}
 	if trace != nil {
 		templateNames := make(map[string]struct{})
 		openCounts := make(map[string]int)
@@ -1538,6 +1557,93 @@ func (cr *CityRuntime) buildDesiredState(sessionBeads *sessionBeadSnapshot, trac
 		return cr.buildFnWithSessionBeads(cr.cfg, cr.sp, store, rigStores, sessionBeads, trace)
 	}
 	return cr.buildFn(cr.cfg, cr.sp, store)
+}
+
+func (cr *CityRuntime) loadDemandSnapshot(
+	sessionBeads *sessionBeadSnapshot,
+	trace *sessionReconcilerTraceCycle,
+	trigger string,
+	configChanged bool,
+) runtimeDemandSnapshot {
+	sessionFingerprint := sessionBeadSnapshotFingerprint(sessionBeads)
+	if cr.shouldRefreshDemandSnapshot(trigger, configChanged, sessionFingerprint) {
+		result := cr.buildDesiredState(sessionBeads, trace)
+		var openSessionBeads []beads.Bead
+		if sessionBeads != nil {
+			openSessionBeads = sessionBeads.Open()
+		}
+		result.PoolDesiredCounts = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
+			cr.cfg, result.AssignedWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace))
+		if result.PoolDesiredCounts == nil {
+			result.PoolDesiredCounts = make(map[string]int)
+		}
+		mergeNamedSessionDemand(result.PoolDesiredCounts, result.NamedSessionDemand, cr.cfg)
+		result.WorkSet = computeWorkSet(cr.cfg, shellScaleCheck, cr.cityName, cr.cityPath, cr.cityBeadStore(), sessionBeads, cr.stderr)
+		cr.demandSnapshot = &runtimeDemandSnapshot{
+			createdAt:          time.Now(),
+			sessionFingerprint: sessionFingerprint,
+			result:             result,
+		}
+	}
+	if cr.demandSnapshot == nil {
+		return runtimeDemandSnapshot{}
+	}
+	return *cr.demandSnapshot
+}
+
+func (cr *CityRuntime) shouldRefreshDemandSnapshot(
+	trigger string,
+	configChanged bool,
+	sessionFingerprint string,
+) bool {
+	if !cr.demandSnapshotsEnabled() {
+		return true
+	}
+	if configChanged || trigger != "patrol" {
+		return true
+	}
+	if cr.demandSnapshot == nil {
+		return true
+	}
+	if cr.demandSnapshot.sessionFingerprint != sessionFingerprint {
+		return true
+	}
+	return time.Since(cr.demandSnapshot.createdAt) >= runtimeDemandSnapshotMaxAge
+}
+
+func (cr *CityRuntime) demandSnapshotsEnabled() bool {
+	return cr.cs != nil && cr.cs.EventProvider() != nil
+}
+
+func sessionBeadSnapshotFingerprint(snapshot *sessionBeadSnapshot) string {
+	if snapshot == nil {
+		return ""
+	}
+	open := snapshot.Open()
+	sort.Slice(open, func(i, j int) bool {
+		return open[i].ID < open[j].ID
+	})
+	h := fnv.New64a()
+	for _, bead := range open {
+		_, _ = io.WriteString(h, bead.ID)
+		_, _ = io.WriteString(h, "\x00")
+		_, _ = io.WriteString(h, bead.Status)
+		_, _ = io.WriteString(h, "\x00")
+		_, _ = io.WriteString(h, bead.Assignee)
+		_, _ = io.WriteString(h, "\x00")
+		keys := make([]string, 0, len(bead.Metadata))
+		for key := range bead.Metadata {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			_, _ = io.WriteString(h, key)
+			_, _ = io.WriteString(h, "\x00")
+			_, _ = io.WriteString(h, bead.Metadata[key])
+			_, _ = io.WriteString(h, "\x00")
+		}
+	}
+	return fmt.Sprintf("%x", h.Sum64())
 }
 
 func buildStandaloneRigStores(cfg *config.City, cityPath string, stderr io.Writer) map[string]beads.Store {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -95,6 +95,69 @@ func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
+	buildCalls := 0
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+		},
+		cs: &controllerState{
+			eventProv: events.NewFake(),
+		},
+		stderr: io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		buildCalls++
+		return DesiredStateResult{
+			State: map[string]TemplateParams{
+				"worker-bd-1": {SessionName: "worker-bd-1"},
+			},
+		}
+	}
+
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "bead-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-bd-1",
+			"template":     "worker",
+			"state":        "active",
+		},
+	}})
+
+	first := cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	second := cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+
+	if buildCalls != 1 {
+		t.Fatalf("buildDesiredState call count = %d, want 1 for stable patrol reuse", buildCalls)
+	}
+	if len(first.result.State) != 1 || len(second.result.State) != 1 {
+		t.Fatalf("cached demand snapshot lost desired state: first=%d second=%d", len(first.result.State), len(second.result.State))
+	}
+
+	changedSessionBeads := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "bead-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-1",
+			"template":             "worker",
+			"state":                "active",
+			"pending_create_claim": "true",
+		},
+	}})
+	_ = cr.loadDemandSnapshot(changedSessionBeads, nil, "patrol", false)
+	if buildCalls != 2 {
+		t.Fatalf("buildDesiredState call count after session change = %d, want 2", buildCalls)
+	}
+
+	_ = cr.loadDemandSnapshot(changedSessionBeads, nil, "poke", false)
+	if buildCalls != 3 {
+		t.Fatalf("buildDesiredState call count after poke = %d, want 3", buildCalls)
+	}
+}
+
 // Pool session beads in the "creating" window (tmux not yet up, work not yet
 // assigned) must not be swept. Otherwise the sweep runs on the same tick the
 // pool creates the bead, observes zero assigned work, and closes it — the

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
 )
 
 func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
@@ -155,6 +156,92 @@ func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	_ = cr.loadDemandSnapshot(changedSessionBeads, nil, "poke", false)
 	if buildCalls != 3 {
 		t.Fatalf("buildDesiredState call count after poke = %d, want 3", buildCalls)
+	}
+}
+
+func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testing.T) {
+	cases := []struct {
+		name  string
+		agent config.Agent
+	}{
+		{
+			name: "custom scale_check",
+			agent: config.Agent{
+				Name:       "worker",
+				ScaleCheck: "test -f external-queue && echo 1 || echo 0",
+			},
+		},
+		{
+			name: "custom work_query",
+			agent: config.Agent{
+				Name:      "worker",
+				WorkQuery: "gh issue list --json number --limit 1",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buildCalls := 0
+			cr := &CityRuntime{
+				cityName: "test-city",
+				cityPath: t.TempDir(),
+				cfg: &config.City{
+					Workspace: config.Workspace{Name: "test-city"},
+					Agents:    []config.Agent{tc.agent},
+				},
+				cs: &controllerState{
+					eventProv: events.NewFake(),
+				},
+				stderr: io.Discard,
+			}
+			cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+				buildCalls++
+				return DesiredStateResult{State: map[string]TemplateParams{}}
+			}
+
+			sessionBeads := newSessionBeadSnapshot(nil)
+			_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+			_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+
+			if buildCalls != 2 {
+				t.Fatalf("buildDesiredState call count = %d, want 2 when demand command is not event-backed", buildCalls)
+			}
+		})
+	}
+}
+
+func TestCityRuntimeDemandSnapshotReplaysACPRoutesOnCacheHit(t *testing.T) {
+	defaultSP := runtime.NewFake()
+	acpSP := runtime.NewFake()
+	sp := sessionauto.New(defaultSP, acpSP)
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+		},
+		sp: sp,
+		cs: &controllerState{
+			eventProv: events.NewFake(),
+		},
+		demandSnapshot: &runtimeDemandSnapshot{
+			createdAt:          time.Now(),
+			sessionFingerprint: "",
+			result: DesiredStateResult{State: map[string]TemplateParams{
+				"headless-agent": {
+					SessionName: "headless-agent",
+					IsACP:       true,
+				},
+			}},
+		},
+		stderr: io.Discard,
+	}
+
+	_ = cr.loadDemandSnapshot(nil, nil, "patrol", false)
+
+	if err := sp.Attach("headless-agent"); err == nil || !strings.Contains(err.Error(), "ACP transport") {
+		t.Fatalf("Attach(headless-agent) error = %v, want ACP transport route", err)
 	}
 }
 


### PR DESCRIPTION
Supersedes #961 by @julianknutsen.

Credit: Original fix by @julianknutsen; the original patch is preserved as a commit with original authorship.

Summary:
- Cache stable runtime demand snapshots when event-backed demand inputs have not changed.
- Invalidate cached snapshots when runtime demand changes through controller events, session freshness, config changes, or explicit pokes.
- Keep snapshot reuse conservative by disabling it for custom agent `scale_check` or `work_query` commands.
- Replay ACP route side effects when serving desired state from a cached snapshot.

Maintainer changes in this superseding branch:
- Added regression coverage for custom demand commands forcing a fresh desired-state build.
- Added regression coverage for ACP route registration on cache hits.
- Added the conservative guard for user-supplied demand commands.

Verification:
- `go test ./cmd/gc -run 'TestCityRuntime|TestControllerState(ReadAccess|MutationsPokeController|MutationErrorDoesNotPokeController|ApplyBeadEventPokesController|ApplyCacheReconcileEventDoesNotPokeController)' -count=1`\n- `go vet ./cmd/gc`\n\nFull `go test ./...` was attempted during adoption, but the local batch environment produced unrelated filesystem/temp-dir and managed bd/dolt infrastructure failures. GitHub CI is the merge gate for the full suite.