### PR TITLE
quality: Wave 1 supervisor daemon registry lifecycle

### DIFF
--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -259,6 +259,49 @@ func (sm *SupervisorMux) buildMultiplexer() *events.Multiplexer {
 	return mux
 }
 
+func (sm *SupervisorMux) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	cities := sm.resolver.ListCities()
+	var running int
+	// Prefer a running city for startup info so the supervisor health
+	// surface reflects live lifecycle state in multi-city deployments.
+	var startup map[string]any
+	var fallback map[string]any
+	for _, c := range cities {
+		if c.Running {
+			running++
+			if startup == nil {
+				startup = map[string]any{
+					"ready":            true,
+					"phase":            "running",
+					"phases_completed": allStartupPhases(),
+				}
+			}
+			continue
+		}
+		if fallback == nil {
+			fallback = map[string]any{
+				"ready":            false,
+				"phase":            c.Status,
+				"phases_completed": c.PhasesCompleted,
+			}
+		}
+	}
+	if startup == nil {
+		startup = fallback
+	}
+	resp := map[string]any{
+		"status":         "ok",
+		"version":        sm.version,
+		"uptime_sec":     int(time.Since(sm.startedAt).Seconds()),
+		"cities_total":   len(cities),
+		"cities_running": running,
+	}
+	if startup != nil {
+		resp["startup"] = startup
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // allStartupPhases returns the ordered list of all startup phases.
 func allStartupPhases() []string {
 	return []string{

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -262,32 +262,27 @@ func (sm *SupervisorMux) buildMultiplexer() *events.Multiplexer {
 func (sm *SupervisorMux) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	cities := sm.resolver.ListCities()
 	var running int
-	// Prefer a running city for startup info so the supervisor health
-	// surface reflects live lifecycle state in multi-city deployments.
+	// Use the first city for startup info (single-city deployments).
 	var startup map[string]any
-	var fallback map[string]any
 	for _, c := range cities {
 		if c.Running {
 			running++
-			if startup == nil {
+		}
+		if startup == nil {
+			if c.Running {
 				startup = map[string]any{
 					"ready":            true,
 					"phase":            "running",
 					"phases_completed": allStartupPhases(),
 				}
-			}
-			continue
-		}
-		if fallback == nil {
-			fallback = map[string]any{
-				"ready":            false,
-				"phase":            c.Status,
-				"phases_completed": c.PhasesCompleted,
+			} else {
+				startup = map[string]any{
+					"ready":            false,
+					"phase":            c.Status,
+					"phases_completed": c.PhasesCompleted,
+				}
 			}
 		}
-	}
-	if startup == nil {
-		startup = fallback
 	}
 	resp := map[string]any{
 		"status":         "ok",

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -42,6 +42,19 @@ func (f *fakeCityResolver) CityState(name string) State {
 	return nil
 }
 
+type healthCityResolver struct {
+	cities []CityInfo
+	states map[string]*fakeState
+}
+
+func (h *healthCityResolver) ListCities() []CityInfo {
+	return h.cities
+}
+
+func (h *healthCityResolver) CityState(name string) State {
+	return h.states[name]
+}
+
 func newTestSupervisorMux(t *testing.T, cities map[string]*fakeState) *SupervisorMux {
 	t.Helper()
 	resolver := &fakeCityResolver{cities: cities}
@@ -331,6 +344,48 @@ func TestSupervisorHealth(t *testing.T) {
 	}
 	if resp["cities_running"] != float64(1) {
 		t.Errorf("cities_running = %v, want 1", resp["cities_running"])
+	}
+}
+
+func TestSupervisorHealthPrefersRunningCityForStartupPhase(t *testing.T) {
+	stopped := newFakeState(t)
+	stopped.cityName = "alpha"
+	running := newFakeState(t)
+	running.cityName = "beta"
+
+	resolver := &healthCityResolver{
+		cities: []CityInfo{
+			{Name: "alpha", Path: stopped.CityPath(), Running: false, Status: "starting_bead_store"},
+			{Name: "beta", Path: running.CityPath(), Running: true},
+		},
+		states: map[string]*fakeState{
+			"alpha": stopped,
+			"beta":  running,
+		},
+	}
+
+	sm := NewSupervisorMux(resolver, false, "test", time.Now())
+	req := httptest.NewRequest("GET", "/health", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	startup, ok := resp["startup"].(map[string]any)
+	if !ok {
+		t.Fatalf("startup = %#v, want object", resp["startup"])
+	}
+	if got := startup["phase"]; got != "running" {
+		t.Fatalf("startup.phase = %v, want running", got)
+	}
+	if got := startup["ready"]; got != true {
+		t.Fatalf("startup.ready = %v, want true", got)
 	}
 }
 

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -42,19 +42,6 @@ func (f *fakeCityResolver) CityState(name string) State {
 	return nil
 }
 
-type healthCityResolver struct {
-	cities []CityInfo
-	states map[string]*fakeState
-}
-
-func (h *healthCityResolver) ListCities() []CityInfo {
-	return h.cities
-}
-
-func (h *healthCityResolver) CityState(name string) State {
-	return h.states[name]
-}
-
 func newTestSupervisorMux(t *testing.T, cities map[string]*fakeState) *SupervisorMux {
 	t.Helper()
 	resolver := &fakeCityResolver{cities: cities}
@@ -344,48 +331,6 @@ func TestSupervisorHealth(t *testing.T) {
 	}
 	if resp["cities_running"] != float64(1) {
 		t.Errorf("cities_running = %v, want 1", resp["cities_running"])
-	}
-}
-
-func TestSupervisorHealthPrefersRunningCityForStartupPhase(t *testing.T) {
-	stopped := newFakeState(t)
-	stopped.cityName = "alpha"
-	running := newFakeState(t)
-	running.cityName = "beta"
-
-	resolver := &healthCityResolver{
-		cities: []CityInfo{
-			{Name: "alpha", Path: stopped.CityPath(), Running: false, Status: "starting_bead_store"},
-			{Name: "beta", Path: running.CityPath(), Running: true},
-		},
-		states: map[string]*fakeState{
-			"alpha": stopped,
-			"beta":  running,
-		},
-	}
-
-	sm := NewSupervisorMux(resolver, false, "test", time.Now())
-	req := httptest.NewRequest("GET", "/health", nil)
-	rec := httptest.NewRecorder()
-	sm.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
-	}
-
-	var resp map[string]any
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	startup, ok := resp["startup"].(map[string]any)
-	if !ok {
-		t.Fatalf("startup = %#v, want object", resp["startup"])
-	}
-	if got := startup["phase"]; got != "running" {
-		t.Fatalf("startup.phase = %v, want running", got)
-	}
-	if got := startup["ready"]; got != true {
-		t.Fatalf("startup.ready = %v, want true", got)
 	}
 }
 

--- a/internal/supervisor/registry.go
+++ b/internal/supervisor/registry.go
@@ -59,6 +59,18 @@ func NewRegistry(path string) *Registry {
 	return &Registry{path: path}
 }
 
+func (r *Registry) refuseHostRegistryDuringTests() {
+	if !isTestBinary() {
+		return
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		hostRegistry := filepath.Join(home, ".gc")
+		if strings.HasPrefix(r.path, hostRegistry+string(filepath.Separator)) || r.path == hostRegistry {
+			panic("supervisor.Registry: refusing to write to host registry during tests")
+		}
+	}
+}
+
 // List returns all registered cities. Returns an empty slice (not nil)
 // if the file doesn't exist or is empty.
 func (r *Registry) List() ([]CityEntry, error) {
@@ -74,15 +86,7 @@ func (r *Registry) List() ([]CityEntry, error) {
 // a different city with the same effective name is already registered.
 // Uses file-level locking for cross-process safety.
 func (r *Registry) Register(cityPath, effectiveName string) error {
-	// Guard: refuse to write to the host registry during tests.
-	if isTestBinary() {
-		if home, err := os.UserHomeDir(); err == nil {
-			hostRegistry := filepath.Join(home, ".gc")
-			if strings.HasPrefix(r.path, hostRegistry+string(filepath.Separator)) || r.path == hostRegistry {
-				panic("supervisor.Registry.Register: refusing to write to host registry during tests")
-			}
-		}
-	}
+	r.refuseHostRegistryDuringTests()
 
 	abs, err := filepath.Abs(cityPath)
 	if err != nil {
@@ -140,6 +144,8 @@ func (r *Registry) Register(cityPath, effectiveName string) error {
 // error if the city is not registered. The path is resolved to
 // absolute before comparison. Uses file-level locking for cross-process safety.
 func (r *Registry) Unregister(cityPath string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := filepath.Abs(cityPath)
 	if err != nil {
 		return fmt.Errorf("resolving path: %w", err)
@@ -287,6 +293,8 @@ func (r *Registry) ListRigs() ([]RigEntry, error) {
 // already exists, the entry is updated. Uses file-level locking for
 // cross-process safety.
 func (r *Registry) RegisterRig(rigPath, name, defaultCity string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := resolveAbsPath(rigPath)
 	if err != nil {
 		return err
@@ -345,6 +353,8 @@ func (r *Registry) RegisterRig(rigPath, name, defaultCity string) error {
 // UnregisterRig removes a rig from the registry by path. Returns an error
 // if the rig is not registered. Uses file-level locking for cross-process safety.
 func (r *Registry) UnregisterRig(rigPath string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := resolveAbsPath(rigPath)
 	if err != nil {
 		return err
@@ -430,6 +440,8 @@ func (r *Registry) LookupRigByName(name string) (RigEntry, bool) {
 // SetRigDefault sets the default city for a rig. The rig must already be
 // registered. Uses file-level locking for cross-process safety.
 func (r *Registry) SetRigDefault(rigPath, defaultCity string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := resolveAbsPath(rigPath)
 	if err != nil {
 		return err
@@ -464,6 +476,8 @@ func (r *Registry) SetRigDefault(rigPath, defaultCity string) error {
 // default_city if the referenced city no longer contains the rig. Removes
 // rig entries that no longer belong to any city.
 func (r *Registry) ReconcileRigs(rigCityMap []RigCityMapping) error {
+	r.refuseHostRegistryDuringTests()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/internal/supervisor/registry_test.go
+++ b/internal/supervisor/registry_test.go
@@ -364,6 +364,71 @@ func TestRigUnregisterNotFound(t *testing.T) {
 	}
 }
 
+func TestRegistryMutatorsRefuseHostRegistryDuringTests(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hostRegistry := filepath.Join(home, ".gc", "cities.toml")
+	r := NewRegistry(hostRegistry)
+
+	tests := []struct {
+		name string
+		call func(*Registry)
+	}{
+		{
+			name: "Register",
+			call: func(r *Registry) {
+				_ = r.Register(filepath.Join(home, "cities", "alpha"), "alpha")
+			},
+		},
+		{
+			name: "Unregister",
+			call: func(r *Registry) {
+				_ = r.Unregister(filepath.Join(home, "cities", "alpha"))
+			},
+		},
+		{
+			name: "RegisterRig",
+			call: func(r *Registry) {
+				_ = r.RegisterRig(filepath.Join(home, "rigs", "alpha"), "alpha", "")
+			},
+		},
+		{
+			name: "UnregisterRig",
+			call: func(r *Registry) {
+				_ = r.UnregisterRig(filepath.Join(home, "rigs", "alpha"))
+			},
+		},
+		{
+			name: "SetRigDefault",
+			call: func(r *Registry) {
+				_ = r.SetRigDefault(filepath.Join(home, "rigs", "alpha"), filepath.Join(home, "cities", "alpha"))
+			},
+		},
+		{
+			name: "ReconcileRigs",
+			call: func(r *Registry) {
+				_ = r.ReconcileRigs([]RigCityMapping{{
+					RigPath:  filepath.Join(home, "rigs", "alpha"),
+					RigName:  "alpha",
+					CityPath: filepath.Join(home, "cities", "alpha"),
+				}})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered == nil {
+					t.Fatalf("expected panic for %s against host registry path", tc.name)
+				}
+			}()
+			tc.call(r)
+		})
+	}
+}
+
 func TestRigLookupByPath(t *testing.T) {
 	dir := t.TempDir()
 	r := NewRegistry(filepath.Join(dir, "cities.toml"))


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Supervisor, Daemon & Registry Lifecycle`.

This PR hardens the supervisor registry mutation surface by applying the existing test-only host-registry guard to every mutating path instead of only `Register`. That closes a real isolation gap in the owned registry lifecycle while keeping production behavior unchanged.

## Scope

Owned scope for this module:

- `cmd/gc/{cmd_supervisor.go,cmd_supervisor_city.go,cmd_supervisor_lifecycle.go,cmd_daemon_unix.go,cmd_daemon_windows.go,city_context.go,city_registry.go}`
- `internal/supervisor/*`
- `internal/api/{handler_status.go,supervisor.go}`

Files touched in this PR:

- `internal/supervisor/registry.go`
- `internal/supervisor/registry_test.go`
- `internal/api/supervisor.go`
- `internal/api/supervisor_test.go`

## Implementer Trajectory

- Initial audit found the weakest architectural row in the registry mutators: only `Register` refused to touch the host `~/.gc` registry during tests, while other mutating paths could still leak to host state.
- Extracted the guard into a shared helper and applied it consistently across the registry mutators.
- Added focused coverage proving each mutating path refuses the host registry during tests.
- The speculative supervisor health-path tweak was trimmed back so the final branch keeps the stable health behavior while preserving the registry hardening.

## Blind Verifier Score Summary

- `TDD` 84
- `DRY` 88
- `Separation of Concerns` 85
- `Single Responsibility` 84
- `Clear Abstractions` 84
- `Low Coupling, High Cohesion` 84
- `KISS` 82
- `YAGNI` 82
- `Prefer Non-Nullable` 84
- `Prefer Async Notifications` 81
- `Eliminate Race Conditions` 92
- `Errors Are Not Optional` 86
- `Idiomatic Project Layout` 92
- `Write for Maintainability` 86

No `N/A` rows.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added focused coverage for registry mutators refusing the host registry during tests.
- Verified with:
  - `go test ./internal/supervisor -run '^(TestLoadConfig|TestLoadCityPublicationRefs|TestRegistry.*|TestRig.*|TestDefaultHome.*|TestRuntimeDir.*|TestUsesIsolatedGCHomeOverride.*)$' -count=1`
  - `go test ./internal/api -run '^(TestSupervisorHealth|TestSupervisorCitiesList|TestSupervisorProviderReadinessRoute|TestSupervisorPerCityEventStream|TestSupervisorEmptyCityName)$' -count=1`
  - `go test ./cmd/gc -run '^(TestDoSupervisorLogsNoFile|TestSupervisorAliveFallsBackToDefaultHomeSocket|TestSupervisorAliveIgnoresSharedXDGSocketForIsolatedGCHome|TestReloadSupervisorFallsBackToDefaultHomeSocket|TestRegisterCityWithSupervisorKeepsRegistrationWhenCityNeverBecomesReady|TestRegisterCityWithSupervisorRetriesControllerLockInitFailure|TestRegisterCityWithSupervisorKeepsRegistrationWhenReloadFails|TestRegisterCityWithSupervisorFailsFastWhenSupervisorStopsDuringWait|TestCityRegistry.*)$' -count=1`

## Notes

- The final branch keeps the existing single-city-first startup metadata behavior on the supervisor health surface; no shared-foundation or boundary exception was needed for this Wave 1 pass.
