### PR TITLE
quality: Wave 1 config core and validation

### DIFF
--- a/internal/config/resolved_cache.go
+++ b/internal/config/resolved_cache.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 )
 
 // BuildResolvedProviderCache walks every custom provider's base chain,
@@ -47,7 +49,72 @@ func BuildResolvedProviderCache(cfg *City) error {
 		// Do not overwrite the existing cache on error.
 		return errors.Join(errs...)
 	}
+	if err := ValidateCustomProviderOptions(cfg.Providers); err != nil {
+		return err
+	}
 	cfg.ResolvedProviders = next
+	return nil
+}
+
+// ValidateCustomProviderOptions validates provider options after applying the
+// same structural inheritance rules the runtime uses for custom providers.
+// This catches invalid schema defaults and option_defaults before they can
+// silently degrade into missing launch flags.
+func ValidateCustomProviderOptions(providers map[string]ProviderSpec) error {
+	if len(providers) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(providers))
+	for name := range providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var errs []error
+	for _, name := range names {
+		resolved, err := resolveCustomProviderForValidation(name, providers[name], providers)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving provider %q: %w", name, err))
+			continue
+		}
+		if err := validateResolvedProviderOptions(name, resolved); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func resolveCustomProviderForValidation(name string, spec ProviderSpec, providers map[string]ProviderSpec) (ResolvedProvider, error) {
+	if spec.Base != nil {
+		if strings.TrimSpace(*spec.Base) == "" {
+			return *specToResolved(name, &spec), nil
+		}
+		return ResolveProviderChain(name, spec, providers)
+	}
+
+	builtins := BuiltinProviders()
+	if base, ok := builtins[name]; ok {
+		merged := MergeProviderOverBuiltin(base, spec)
+		return *specToResolved(name, &merged), nil
+	}
+	if base, ok := builtins[spec.Command]; ok {
+		merged := MergeProviderOverBuiltin(base, spec)
+		return *specToResolved(name, &merged), nil
+	}
+	return *specToResolved(name, &spec), nil
+}
+
+func validateResolvedProviderOptions(name string, resolved ResolvedProvider) error {
+	if err := ValidateOptionsSchema(resolved.OptionsSchema); err != nil {
+		return fmt.Errorf("provider %q options_schema: %w", name, err)
+	}
+	if err := ValidateOptionDefaults(resolved.OptionsSchema, resolved.EffectiveDefaults); err != nil {
+		return fmt.Errorf("provider %q option_defaults: %w", name, err)
+	}
 	return nil
 }
 

--- a/internal/config/resolved_cache_test.go
+++ b/internal/config/resolved_cache_test.go
@@ -95,6 +95,48 @@ func TestBuildResolvedProviderCache_ReportsAllChainErrors(t *testing.T) {
 	}
 }
 
+func TestBuildResolvedProviderCache_RejectsInvalidLegacyBuiltinOptionDefaults(t *testing.T) {
+	cfg := &City{
+		Providers: map[string]ProviderSpec{
+			"codex-fast": {
+				Command: "codex",
+				OptionDefaults: map[string]string{
+					"permission_mode": "typo",
+				},
+			},
+		},
+	}
+
+	err := BuildResolvedProviderCache(cfg)
+	if err == nil {
+		t.Fatal("expected invalid option_defaults to fail cache build")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `provider "codex-fast" option_defaults`) {
+		t.Fatalf("error = %q, want provider option_defaults context", msg)
+	}
+	if !strings.Contains(msg, `"permission_mode"`) || !strings.Contains(msg, `"typo"`) {
+		t.Fatalf("error = %q, want invalid option default details", msg)
+	}
+}
+
+func TestBuildResolvedProviderCache_AllowsValidLegacyBuiltinOptionDefaults(t *testing.T) {
+	cfg := &City{
+		Providers: map[string]ProviderSpec{
+			"codex-fast": {
+				Command: "codex",
+				OptionDefaults: map[string]string{
+					"permission_mode": "unrestricted",
+				},
+			},
+		},
+	}
+
+	if err := BuildResolvedProviderCache(cfg); err != nil {
+		t.Fatalf("unexpected error for valid legacy builtin option defaults: %v", err)
+	}
+}
+
 func TestResolvedProviderCached_DeepCopyIsolatesMutations(t *testing.T) {
 	base := "builtin:codex"
 	cfg := &City{

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -1010,5 +1010,8 @@ func validateProviders(providers map[string]config.ProviderSpec) error {
 		}
 		return fmt.Errorf("provider %q: command is required (or set base to inherit)", name)
 	}
+	if err := config.ValidateCustomProviderOptions(providers); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -1162,6 +1162,25 @@ func TestCreateProvider_NoBaseNoCommandRejected(t *testing.T) {
 	}
 }
 
+func TestCreateProvider_RejectsInvalidLegacyBuiltinOptionDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, minimalCity())
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.CreateProvider("codex-fast", config.ProviderSpec{
+		Command: "codex",
+		OptionDefaults: map[string]string{
+			"permission_mode": "typo",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected invalid option_defaults to be rejected")
+	}
+	if !strings.Contains(err.Error(), `option_defaults key "permission_mode"`) {
+		t.Fatalf("error = %v, want option_defaults validation detail", err)
+	}
+}
+
 func TestCreateProvider_Duplicate(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, cityWithProvider())


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Config Core & Validation`.

This PR closes a real config-validation gap: custom providers that inherit a built-in option schema can no longer ship invalid `option_defaults` silently. The config load/cache-build path and config-edit CRUD path now reject those bad defaults up front instead of degrading into missing launch flags later.

## Scope

Owned scope for this module:

- `internal/config/{config.go,namepool.go,named_sessions.go,options.go,patch.go,revision.go,service.go,session_sleep.go,undecoded.go,validate_durations.go,validate_semantics.go}`
- `internal/configedit/*`
- `internal/api/{handler_config.go,handler_patches.go,huma_handlers_config.go,huma_handlers_patches.go,huma_types_config.go,huma_types_patches.go}`
- `cmd/gc/{cmd_config.go,config_hash.go}`

Files touched in this PR:

- `internal/config/resolved_cache.go`
- `internal/config/resolved_cache_test.go`
- `internal/configedit/configedit.go`
- `internal/configedit/configedit_test.go`

## Implementer Trajectory

- Audit found that provider option-schema validation helpers existed but were not wired into the custom-provider load/edit paths.
- Added red tests first for the concrete failure mode: a custom provider that inherits Codex’s option schema but declares an invalid `permission_mode` default.
- Added shared structural provider-option validation that follows the same inheritance rules the runtime uses for custom providers.
- Reused that validation in both:
  - `BuildResolvedProviderCache`, so bad provider defaults fail at config load time
  - `configedit.validateProviders`, so CRUD/edit operations reject the same invalid state before write-back

## Blind Verifier Score Summary

- `TDD` 85
- `DRY` 83
- `Separation of Concerns` 82
- `Single Responsibility` 81
- `Clear Abstractions` 83
- `Low Coupling, High Cohesion` 82
- `KISS` 81
- `YAGNI` 84
- `Prefer Non-Nullable` 82
- `Prefer Async Notifications` `N/A`
- `Eliminate Race Conditions` 83
- `Errors Are Not Optional` 82
- `Idiomatic Project Layout` 90
- `Write for Maintainability` 85

`N/A` rows:

- `Prefer Async Notifications` — accepted because this module owns config composition/editing rather than notification coordination or polling behavior.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added regression coverage for invalid inherited provider `option_defaults` in both load/cache-build and config-edit CRUD paths.
- Verified with:
  - `go test ./internal/config -run 'TestBuildResolvedProviderCache_(RejectsInvalidLegacyBuiltinOptionDefaults|AllowsValidLegacyBuiltinOptionDefaults)' -count=1`
  - `go test ./internal/configedit -run 'TestCreateProvider_(RejectsInvalidLegacyBuiltinOptionDefaults|NoBaseNoCommandRejected)' -count=1`
  - `go test ./internal/config ./internal/configedit ./internal/api -run 'Test(HandleConfigValidate|BuildResolvedProviderCache|CreateProvider_)' -count=1`
  - `go test ./internal/config ./internal/configedit ./internal/api -count=1`
  - blind verifier pass: `TMPDIR=/tmp GOCACHE=$(mktemp -d) go test ./internal/config ./internal/configedit`

## Notes

- No boundary exception or shared-foundation dependency was required.
- The blind verifier attempted additional targeted `internal/api` / `cmd/gc` checks but hit environment temp/cache limits; those were not treated as code failures. The coordinator separately verified `./internal/api` in the isolated worktree before opening this PR.
