### PR TITLE
fix(rig): require --adopt to attach existing .beads/ store

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -279,15 +279,43 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	}
 
 	if existingPrefix, ok := readBeadsPrefix(fs, rigPath); ok && existingPrefix != prefix {
-		if reAdd {
-			_, _ = fmt.Fprintf(stderr, "gc rig add: rig %q has bead prefix %q but city.toml has %q; edit city.toml to set prefix = %q, or remove %s/.beads to reinitialize\n",
+		switch {
+		case reAdd:
+			// On re-add, --prefix is ignored (we use the existing rig's
+			// configured prefix). Direct the user to edit city.toml.
+			fmt.Fprintf(stderr, "gc rig add: rig %q has bead prefix %q but city.toml has %q; "+ //nolint:errcheck // best-effort stderr
+				"edit city.toml to set prefix = %q, or remove %s/.beads to reinitialize\n",
 				name, existingPrefix, prefix, existingPrefix, rigPath)
-		} else {
-			_, _ = fmt.Fprintf(stderr, "gc rig add: rig %q already has bead prefix %q (requested %q); use --prefix %s to match, or remove %s/.beads to reinitialize\n",
+		case adopt:
+			// On --adopt, the user explicitly wants the existing store.
+			// "Remove .beads to reinitialize" is the wrong recovery here:
+			// nudge them toward matching the existing prefix instead.
+			fmt.Fprintf(stderr, "gc rig add: --adopt: rig %q already has bead prefix %q (requested %q); "+ //nolint:errcheck // best-effort stderr
+				"use --prefix %s (or omit --prefix) to match the existing store\n",
+				name, existingPrefix, prefix, existingPrefix)
+		default:
+			fmt.Fprintf(stderr, "gc rig add: rig %q already has bead prefix %q (requested %q); "+ //nolint:errcheck // best-effort stderr
+				"use --prefix %s to match, or remove %s/.beads to reinitialize\n",
 				name, existingPrefix, prefix, existingPrefix, rigPath)
 		}
 		return 1
 	}
+
+	// Guard: on a fresh add (not a re-add) without --adopt, refuse to run
+	// if .beads/ is already present. Without this, doRigAdd falls through
+	// to bd init against an existing Dolt store and typically dies with
+	// "bd init: signal: killed" after the probe times out — an unhelpful
+	// failure mode for the common "register existing store" workflow.
+	if !reAdd && !adopt {
+		if fi, err := fs.Stat(filepath.Join(rigPath, ".beads")); err == nil && fi.IsDir() {
+			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
+				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
+				rigPath, rigPath)
+			return 1
+		}
+	}
+
+	// --- Phase 1: Infrastructure (all fallible, before touching city.toml) ---
 
 	w := func(s string) { fmt.Fprintln(stdout, s) } //nolint:errcheck // best-effort stdout
 	if reAdd {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -307,7 +307,13 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	// "bd init: signal: killed" after the probe times out — an unhelpful
 	// failure mode for the common "register existing store" workflow.
 	if !reAdd && !adopt {
-		if fi, err := fs.Stat(filepath.Join(rigPath, ".beads")); err == nil && fi.IsDir() {
+		beadsPath := filepath.Join(rigPath, ".beads")
+		fi, err := fs.Stat(beadsPath)
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if err == nil && fi.IsDir() {
 			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
 				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
 				rigPath, rigPath)

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1567,8 +1567,11 @@ func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 	}
 }
 
-// Matching prefix (explicit or derived) succeeds even when .beads exists.
-func TestDoRigAdd_MatchingPrefixSucceeds(t *testing.T) {
+// A fresh "gc rig add" against a pre-existing .beads/ directory must fail
+// fast and point the user at --adopt — even when the existing prefix would
+// have matched the derived one. Falling through to bd init on a populated
+// Dolt store produces confusing "signal: killed" failures (see fo-5zeij).
+func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1578,7 +1581,9 @@ func TestDoRigAdd_MatchingPrefixSucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Rig "alpha-beta" derives prefix "ab", and .beads already has "ab".
+	// Rig "alpha-beta" derives prefix "ab", and .beads already has "ab"
+	// — so the prefix-conflict guard does not trip and we reach the new
+	// "exists without --adopt" guard.
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
 	beadsDir := filepath.Join(rigPath, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
@@ -1594,8 +1599,15 @@ func TestDoRigAdd_MatchingPrefixSucceeds(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("expected success for matching prefix, got code %d; stderr: %s", code, stderr.String())
+	if code != 1 {
+		t.Fatalf("expected failure for pre-existing .beads/ without --adopt, got code %d; stdout: %s", code, stdout.String())
+	}
+	errMsg := stderr.String()
+	if !strings.Contains(errMsg, ".beads already exists") {
+		t.Errorf("stderr should mention pre-existing .beads/: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "--adopt") {
+		t.Errorf("stderr should hint at --adopt: %s", errMsg)
 	}
 }
 

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1611,6 +1611,34 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	}
 }
 
+func TestDoRigAdd_ExistingBeadsStatErrorFailsClosed(t *testing.T) {
+	f := fsys.NewFake()
+	cityPath := "/city"
+	rigPath := "/alpha-beta"
+	beadsPath := filepath.Join(rigPath, ".beads")
+
+	f.Dirs[filepath.Join(cityPath, ".gc")] = true
+	f.Dirs[rigPath] = true
+	f.Files[filepath.Join(cityPath, "city.toml")] = []byte("[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n")
+	f.Errors[beadsPath] = os.ErrPermission
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(f, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected failure for .beads stat error, got code %d; stdout: %s", code, stdout.String())
+	}
+	errMsg := stderr.String()
+	if !strings.Contains(errMsg, "checking "+beadsPath) {
+		t.Fatalf("stderr should identify the .beads stat failure, got: %s", errMsg)
+	}
+	if _, ok := f.Files[filepath.Join(cityPath, "city.toml")]; !ok {
+		t.Fatal("city.toml missing from fake filesystem")
+	}
+}
+
 func TestReadBeadsPrefix(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Addresses foundations bead fo-5zeij. `gc rig add` previously ran `bd init` unconditionally, clobbering existing `.beads/` stores — blocking registration of rigs whose directory already had a populated store (e.g. symlinked project stores). This PR makes `gc rig add` refuse to re-init when `.beads/` already exists; use the new `--adopt` flag to attach the existing store instead. New test: `TestDoRigAdd_ExistingBeadsRequiresAdopt`. Verified with make check.