### PR TITLE
quality: Wave 1 controller city runtime

### DIFF
--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -414,20 +414,11 @@ func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout 
 // to the controller.sock and sending a "ping". Returns the PID if alive,
 // or 0 if not reachable.
 func controllerAlive(cityPath string) int {
-	sockPath := controllerSocketPath(cityPath)
-	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
+	resp, err := sendControllerCommandWithReadTimeout(cityPath, "ping", 2*time.Second)
 	if err != nil {
 		return 0
 	}
-	defer conn.Close()                                    //nolint:errcheck // best-effort
-	conn.Write([]byte("ping\n"))                          //nolint:errcheck // best-effort
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // best-effort
-	buf := make([]byte, 64)
-	n, err := conn.Read(buf)
-	if err != nil || n == 0 {
-		return 0
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(resp)))
 	if err != nil {
 		return 0
 	}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -250,6 +250,56 @@ func TestControllerSocketFallbackUsesShortPathForLongCityPath(t *testing.T) {
 	}
 }
 
+func TestSendControllerCommandWithReadTimeout(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-controller-command-")
+	sockPath := controllerSocketPath(dir)
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+
+		buf := make([]byte, 16)
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Errorf("read command: %v", err)
+			return
+		}
+		if got := strings.TrimSpace(string(buf[:n])); got != "ping" {
+			t.Errorf("command = %q, want ping", got)
+			return
+		}
+		if _, err := conn.Write([]byte("123\n")); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}()
+
+	resp, err := sendControllerCommandWithReadTimeout(dir, "ping", time.Second)
+	if err != nil {
+		t.Fatalf("sendControllerCommandWithReadTimeout: %v", err)
+	}
+	if got := strings.TrimSpace(string(resp)); got != "123" {
+		t.Fatalf("response = %q, want 123", got)
+	}
+	<-done
+}
+
 // writeCityTOML is a test helper that writes a city.toml with the given agents.
 func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...string) string {
 	t.Helper()

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,8 +17,8 @@ type wispGC interface {
 
 	// runGC lists closed molecules, deletes those older than TTL, and returns
 	// the count of purged entries. Errors from individual deletes are
-	// best-effort (logged but not fatal); the returned error is for list
-	// failures.
+	// best-effort and surfaced without stopping the purge; the returned error
+	// also covers list failures.
 	runGC(store beads.Store, now time.Time) (int, error)
 }
 
@@ -56,26 +57,30 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 	}
 
 	cutoff := now.Add(-m.ttl)
-	purged := purgeExpiredBeads(store, entries, cutoff)
+	purged, deleteErr := purgeExpiredBeads(store, entries, cutoff)
 
 	trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking})
 	if trackErr == nil {
-		purged += purgeExpiredBeads(store, trackEntries, cutoff)
+		trackPurged, trackDeleteErr := purgeExpiredBeads(store, trackEntries, cutoff)
+		purged += trackPurged
+		deleteErr = errors.Join(deleteErr, trackDeleteErr)
 	}
 
-	return purged, nil
+	return purged, deleteErr
 }
 
-func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time) int {
+func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
 	purged := 0
+	var deleteErr error
 	for _, entry := range entries {
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
 		if err := store.Delete(entry.ID); err != nil {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting expired bead %q: %w", entry.ID, err))
 			continue
 		}
 		purged++
 	}
-	return purged
+	return purged, deleteErr
 }

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,7 +96,7 @@ func TestWispGC_EmptyList(t *testing.T) {
 	}
 }
 
-func TestWispGC_DeleteErrorContinues(t *testing.T) {
+func TestWispGC_DeleteErrorIsSurfacedAndContinues(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
@@ -105,11 +106,14 @@ func TestWispGC_DeleteErrorContinues(t *testing.T) {
 
 	wg := newWispGC(5*time.Minute, time.Hour)
 	purged, err := wg.runGC(store, now)
-	if err != nil {
-		t.Fatalf("runGC: %v", err)
+	if err == nil {
+		t.Fatal("expected delete error to be surfaced")
 	}
 	if purged != 1 {
 		t.Fatalf("purged = %d, want 1", purged)
+	}
+	if !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err = %v, want delete failure to be included", err)
 	}
 	assertDeletedIDs(t, store.deletedIDs, "mol-2")
 }


### PR DESCRIPTION
## Summary

Wave 1 architectural-principles pass for `Controller & City Runtime`.

This PR finishes the Wave 1 pass for the controller/runtime slice in two small steps:

- refactors controller liveness checks to use the shared controller socket transport instead of open-coding a separate ping path
- fixes a concrete observability gap in `wisp_gc`: individual delete failures are now surfaced non-fatally instead of disappearing silently

## Scope

Owned scope for this module:

- `cmd/gc/{controller.go,city_runtime.go,gc_permissions.go,wisp_gc.go}`

Files touched in this PR:

- `cmd/gc/controller.go`
- `cmd/gc/controller_test.go`
- `cmd/gc/wisp_gc.go`
- `cmd/gc/wisp_gc_test.go`

## Implementer Trajectory

- Initial audit found a narrow controller transport cleanup: `controllerAlive()` was still duplicating its own socket ping path instead of using the shared controller command transport.
- Added focused regression coverage for `sendControllerCommandWithReadTimeout()` and switched the liveness path to the shared transport.
- Blind verification then correctly blocked the module on `Errors Are Not Optional`: `wisp_gc` still claimed delete failures were surfaced, but actually dropped them silently.
- Added a red test first for that path, then changed `wisp_gc` to keep purging while returning non-fatal joined delete errors so `city_runtime` can log them at the runtime boundary.

## Blind Verifier Score Summary

- `TDD` 92
- `DRY` 84
- `Separation of Concerns` 83
- `Single Responsibility` 82
- `Clear Abstractions` 83
- `Low Coupling, High Cohesion` 84
- `KISS` 81
- `YAGNI` 80
- `Prefer Non-Nullable` 80
- `Prefer Async Notifications` 85
- `Eliminate Race Conditions` 87
- `Errors Are Not Optional` 90
- `Idiomatic Project Layout` 83
- `Write for Maintainability` 84

No `N/A` rows.

Verifier verdict: pass for Wave 1 PR creation.

## Tests

- Added direct regression coverage for shared controller socket transport reads.
- Added direct regression coverage for surfaced non-fatal `wisp_gc` delete failures.
- Verified with:
  - `go test ./cmd/gc -run '^(TestWispGC|TestControllerSocketFallbackUsesShortPathForLongCityPath|TestSendControllerCommandWithReadTimeout|TestEnforceGCPermissions|TestControllerReloadsConfig|TestControllerReloadsConfigImmediatelyOnWatchEvent|TestControllerLoopCancel|TestControllerLoopTick|TestControllerShutdown)$' -count=1`
  - blind verifier pass:
    - `go test ./cmd/gc -run 'TestWispGC_(DeleteErrorIsSurfacedAndContinues|ListErrorFailsRun|PurgesExpiredMolecules|PurgesExpiredTrackingBeads|TrackingListErrorIsBestEffort|DisabledReturnsNil|ShouldRunRespectsInterval)|TestEnforceGCPermissions_(TightensLooseDir|NoErrorWhenMissing|AlreadyCorrect)|TestController(LockExclusion|Shutdown|LoopCancel|LoopTick|SocketFallbackUsesShortPathForLongCityPath)' -count=1`
    - `go test ./cmd/gc -run '^TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce$' -count=1`

## Notes

- The first blind verifier finding on `wisp_gc` was accepted as valid and fixed on the same branch before reopening verification.
- No boundary exception or shared-foundation PR was needed.
