### PR TITLE
Fix Dolt health probe dropped database artifacts

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -305,6 +305,12 @@ func normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase s
 	if strings.TrimSpace(doltDatabase) == "" {
 		doltDatabase = canonicalScopeDoltDatabase(cityPath, dir, prefix)
 	}
+	if isReservedManagedDoltDatabase(doltDatabase) {
+		// Preserve legacy probe metadata during startup normalization so old
+		// scopes can still boot and migrate deliberately. New init paths still
+		// reject this reserved name when it is not already pinned in metadata.
+		return ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase)
+	}
 	return enforceCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase)
 }
 
@@ -471,7 +477,11 @@ func finalizeCanonicalBdScopeInit(cityPath, dir, prefix, doltDatabase string) er
 	if strings.TrimSpace(doltDatabase) == "" {
 		doltDatabase = defaultScopeDoltDatabase(cityPath, dir, prefix)
 	}
-	if err := enforceCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase); err != nil {
+	if isReservedManagedDoltDatabase(doltDatabase) {
+		if err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase); err != nil {
+			return err
+		}
+	} else if err := enforceCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase); err != nil {
 		return err
 	}
 	store, err := openStoreAtForCity(dir, cityPath)
@@ -874,6 +884,7 @@ func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, pr
 	return err
 }
 
+//nolint:unparam // keep fs seam for future testable FS injection
 func ensureCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase string) error {
 	return ensureCanonicalScopeMetadata(fs, scopeRoot, doltDatabase, true)
 }

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -283,6 +283,10 @@ func defaultScopeDoltDatabase(cityPath, dir, prefix string) string {
 	return prefix
 }
 
+func isReservedManagedDoltDatabase(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), managedDoltProbeDatabase)
+}
+
 func canonicalScopeDoltDatabase(cityPath, dir, prefix string) string {
 	return readDeferredManagedDoltDatabase(filepath.Join(dir, ".beads", "metadata.json"), defaultScopeDoltDatabase(cityPath, dir, prefix))
 }
@@ -825,26 +829,47 @@ func removeScopeLocalDoltServerArtifacts(dir string) error {
 	return nil
 }
 
+func validateManagedDoltDatabaseName(path, doltDatabase string) (string, error) {
+	doltDatabase = strings.TrimSpace(doltDatabase)
+	if doltDatabase == "" {
+		return "", fmt.Errorf("missing pinned dolt_database for %s", path)
+	}
+	if isReservedManagedDoltDatabase(doltDatabase) {
+		return "", fmt.Errorf("reserved pinned dolt_database %q for %s: used internally by managed Dolt health probes; choose a different dolt_database in metadata.json and rename or move the bead database before retrying", doltDatabase, path)
+	}
+	return doltDatabase, nil
+}
+
 func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, preserveExisting bool) error {
 	path := filepath.Join(scopeRoot, ".beads", "metadata.json")
+	preserveReservedExisting := false
 	if preserveExisting {
 		if existing, ok, err := contract.ReadDoltDatabase(fs, path); err != nil {
 			return err
 		} else if ok && strings.TrimSpace(existing) != "" {
 			doltDatabase = strings.TrimSpace(existing)
+			if isReservedManagedDoltDatabase(doltDatabase) {
+				// New init paths reject this reserved name, but existing metadata
+				// may predate the reservation. Preserve it during startup
+				// normalization so operators can migrate the scope deliberately.
+				preserveReservedExisting = true
+			}
 		}
 	}
-	if strings.TrimSpace(doltDatabase) == "" {
-		return fmt.Errorf("missing pinned dolt_database for %s", path)
+	var err error
+	if !preserveReservedExisting {
+		if doltDatabase, err = validateManagedDoltDatabaseName(path, doltDatabase); err != nil {
+			return err
+		}
 	}
 	if err := ensureBeadsDir(fs, filepath.Dir(path)); err != nil {
 		return err
 	}
-	_, err := contract.EnsureCanonicalMetadata(fs, path, contract.MetadataState{
+	_, err = contract.EnsureCanonicalMetadata(fs, path, contract.MetadataState{
 		Database:     "dolt",
 		Backend:      "dolt",
 		DoltMode:     "server",
-		DoltDatabase: strings.TrimSpace(doltDatabase),
+		DoltDatabase: doltDatabase,
 	})
 	return err
 }

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -201,6 +201,37 @@ func TestNormalizeCanonicalBdScopeFilesPreservesExistingManagedProbeDatabase(t *
 	}
 }
 
+func TestNormalizeCanonicalBdScopeFilesForInitPreservesExistingManagedProbeDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	metadataPath := filepath.Join(cityPath, ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, metadataPath, contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: strings.ToUpper(managedDoltProbeDatabase),
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte("issue_prefix: gc\nissue-prefix: gc\ndolt.auto-start: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := normalizeCanonicalBdScopeFilesForInit(cityPath, cityPath, "gc", strings.ToUpper(managedDoltProbeDatabase)); err != nil {
+		t.Fatalf("normalizeCanonicalBdScopeFilesForInit: %v", err)
+	}
+
+	got, ok, err := contract.ReadDoltDatabase(fsys.OSFS{}, metadataPath)
+	if err != nil {
+		t.Fatalf("ReadDoltDatabase: %v", err)
+	}
+	if !ok || got != strings.ToUpper(managedDoltProbeDatabase) {
+		t.Fatalf("dolt_database = %q, ok=%v; want existing reserved name preserved", got, ok)
+	}
+}
+
 func TestGcBeadsBdCleanupStaleLocksBoundsLsof(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
@@ -4037,6 +4068,151 @@ esac
 	}
 	metaText := string(metaData)
 	if !strings.Contains(metaText, `"dolt_database": "gascity"`) || !strings.Contains(metaText, `"project_id": "backfilled-project-id"`) {
+		t.Fatalf("metadata = %s", metaText)
+	}
+}
+
+func TestGcBeadsBdInitFastPathPreservesExistingManagedProbeDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(cityPath, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: strings.ToUpper(managedDoltProbeDatabase),
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+capture_dir=%q
+record_db() {
+  python3 -c 'import json, pathlib, sys; meta = json.loads(pathlib.Path(sys.argv[1]).read_text()); log = pathlib.Path(sys.argv[2]); db = meta.get("dolt_database", ""); prefix = log.read_text() if log.exists() else ""; log.write_text(prefix + db + "\n")' "$1" "$2"
+}
+case "${1:-}" in
+  config)
+    record_db "$PWD/.beads/metadata.json" "$capture_dir/config-db.log"
+    exit 0
+    ;;
+  migrate)
+    record_db "$PWD/.beads/metadata.json" "$capture_dir/migrate-db.log"
+    python3 -c 'import json, pathlib, sys; path = pathlib.Path(sys.argv[1]); meta = json.loads(path.read_text()); meta["project_id"] = "backfilled-project-id"; path.write_text(json.dumps(meta, indent=2) + "\n")' "$PWD/.beads/metadata.json"
+    exit 0
+    ;;
+  list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, captureDir)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeGC := filepath.Join(binDir, "gc-helper")
+	fakeGCScript := `#!/bin/sh
+set -eu
+subcmd="$1 $2"
+shift 2
+case "$subcmd" in
+  "dolt-config normalize-scope")
+    dir=""
+    database=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city)
+          shift 2
+          ;;
+        --dir)
+          dir="$2"
+          shift 2
+          ;;
+        --prefix)
+          shift 2
+          ;;
+        --dolt-database)
+          database="$2"
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    python3 -c 'import json, pathlib, sys; meta_path = pathlib.Path(sys.argv[1]); database = sys.argv[2]; meta = json.loads(meta_path.read_text()); meta["database"] = "dolt"; meta["backend"] = "dolt"; meta["dolt_mode"] = "server"; meta["dolt_database"] = database; [meta.pop(key, None) for key in ["dolt_host", "dolt_user", "dolt_password", "dolt_server_host", "dolt_server_port", "dolt_server_user", "dolt_port"]]; meta_path.write_text(json.dumps(meta, indent=2) + "\n")' "$dir/.beads/metadata.json" "$database"
+    exit 0
+    ;;
+  "dolt-state ensure-project-id")
+    exit 0
+    ;;
+  *)
+    echo "unexpected gc helper args: $subcmd $*" >&2
+    exit 64
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeGC, []byte(fakeGCScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", strings.ToUpper(managedDoltProbeDatabase))
+	cmd.Env = sanitizedBaseEnv(
+		"GC_CITY_PATH="+cityPath,
+		"GC_BIN="+fakeGC,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	for _, name := range []string{"config-db.log", "migrate-db.log"} {
+		data, err := os.ReadFile(filepath.Join(captureDir, name))
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", name, err)
+		}
+		lines := strings.Fields(string(data))
+		if len(lines) == 0 {
+			t.Fatalf("%s empty", name)
+		}
+		for _, line := range lines {
+			if line != strings.ToUpper(managedDoltProbeDatabase) {
+				t.Fatalf("%s line = %q, want %s", name, line, strings.ToUpper(managedDoltProbeDatabase))
+			}
+		}
+	}
+
+	metaData, err := os.ReadFile(filepath.Join(cityPath, ".beads", "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	metaText := string(metaData)
+	if !strings.Contains(metaText, `"dolt_database": "`+strings.ToUpper(managedDoltProbeDatabase)+`"`) || !strings.Contains(metaText, `"project_id": "backfilled-project-id"`) {
 		t.Fatalf("metadata = %s", metaText)
 	}
 }

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -115,6 +115,92 @@ func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	}
 }
 
+func TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	script := string(scriptData)
+	assertNoManagedDoltProbeDrop(t, "gc-beads-bd read-only fallback", script)
+	if !strings.Contains(script, "CREATE TABLE IF NOT EXISTS __gc_probe.__probe") {
+		t.Fatalf("gc-beads-bd read-only fallback missing qualified persistent probe table")
+	}
+	assertManagedDoltProbeWrites(t, "gc-beads-bd read-only fallback", script)
+}
+
+func TestGcBeadsBdInitRejectsManagedProbeDatabaseName(t *testing.T) {
+	for _, dbName := range []string{managedDoltProbeDatabase, strings.ToUpper(managedDoltProbeDatabase), " " + managedDoltProbeDatabase + " "} {
+		t.Run(dbName, func(t *testing.T) {
+			cityPath := t.TempDir()
+			scopePath := filepath.Join(cityPath, "rigs", "frontend")
+			if err := os.MkdirAll(filepath.Join(scopePath, ".beads"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := MaterializeBuiltinPacks(cityPath); err != nil {
+				t.Fatalf("MaterializeBuiltinPacks: %v", err)
+			}
+			cmd := exec.Command(gcBeadsBdScriptPath(cityPath), "init", scopePath, "fe", dbName)
+			cmd.Env = sanitizedBaseEnv(
+				"GC_CITY_PATH="+cityPath,
+				"PATH="+os.Getenv("PATH"),
+			)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("gc-beads-bd init unexpectedly accepted %s:\n%s", dbName, out)
+			}
+			if !strings.Contains(string(out), "reserved dolt database name: "+dbName) {
+				t.Fatalf("gc-beads-bd init output = %s, want reserved database error", out)
+			}
+		})
+	}
+}
+
+func TestEnsureCanonicalScopeMetadataRejectsManagedProbeDatabase(t *testing.T) {
+	scopePath := t.TempDir()
+	err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, scopePath, managedDoltProbeDatabase)
+	if err == nil {
+		t.Fatalf("ensureCanonicalScopeMetadataForInit unexpectedly accepted %s", managedDoltProbeDatabase)
+	}
+	if !strings.Contains(err.Error(), "reserved pinned dolt_database") || !strings.Contains(err.Error(), "choose a different dolt_database") {
+		t.Fatalf("ensureCanonicalScopeMetadataForInit error = %v, want reserved database remediation", err)
+	}
+}
+
+func TestNormalizeCanonicalBdScopeFilesPreservesExistingManagedProbeDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	metadataPath := filepath.Join(cityPath, ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, metadataPath, contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: strings.ToUpper(managedDoltProbeDatabase),
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte("issue_prefix: hq\nissue-prefix: hq\ndolt.auto-start: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "dogfood-city"}}
+	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg); err != nil {
+		t.Fatalf("normalizeCanonicalBdScopeFiles: %v", err)
+	}
+	got, ok, err := contract.ReadDoltDatabase(fsys.OSFS{}, metadataPath)
+	if err != nil {
+		t.Fatalf("ReadDoltDatabase: %v", err)
+	}
+	if !ok || got != strings.ToUpper(managedDoltProbeDatabase) {
+		t.Fatalf("dolt_database = %q, ok=%v; want existing reserved name preserved", got, ok)
+	}
+}
+
 func TestGcBeadsBdCleanupStaleLocksBoundsLsof(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {

--- a/cmd/gc/cmd_dolt_state.go
+++ b/cmd/gc/cmd_dolt_state.go
@@ -34,6 +34,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		userText      string
 		checkReadOnly bool
 		checkDeleted  bool
+		forceReset    bool
 		logLevel      string
 		timeoutMS     int
 	)
@@ -270,6 +271,30 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 	readOnlyCheck.Flags().StringVar(&userText, "user", "", "Dolt user")
 	_ = readOnlyCheck.MarkFlagRequired("port")
 	cmd.AddCommand(readOnlyCheck)
+
+	resetProbe := &cobra.Command{
+		Use:    "reset-probe",
+		Short:  "Drop the managed Dolt health probe database",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if !forceReset {
+				fmt.Fprintf(stderr, "gc dolt-state reset-probe: refusing to drop %s without --force; this database may contain a legacy bead store in old metadata\n", managedDoltProbeDatabase) //nolint:errcheck
+				return errExit
+			}
+			if err := managedDoltResetProbe(hostText, portText, userText); err != nil {
+				fmt.Fprintf(stderr, "gc dolt-state reset-probe: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			return nil
+		},
+	}
+	resetProbe.Flags().StringVar(&hostText, "host", "", "Dolt host")
+	resetProbe.Flags().StringVar(&portText, "port", "", "Dolt port")
+	resetProbe.Flags().StringVar(&userText, "user", "", "Dolt user")
+	resetProbe.Flags().BoolVar(&forceReset, "force", false, "acknowledge dropping the managed probe database")
+	_ = resetProbe.MarkFlagRequired("port")
+	cmd.AddCommand(resetProbe)
 
 	healthCheck := &cobra.Command{
 		Use:    "health-check",

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1406,6 +1406,12 @@ exit 1
 	if code != 0 {
 		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
 	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	assertNoManagedDoltProbeDrop(t, "read-only-check invocation", string(invocation))
+	assertManagedDoltProbeWrites(t, "read-only-check invocation", string(invocation))
 }
 
 func TestDoltStateReadOnlyCheckCmdReturnsErrExitWhenWritable(t *testing.T) {
@@ -1426,6 +1432,82 @@ exit 0
 	}
 }
 
+func TestDoltStateResetProbeCmdDropsManagedProbeDatabase(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+exit 0
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "reset-probe", "--host", "127.0.0.1", "--port", "3311", "--user", "root", "--force"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	text := string(invocation)
+	if !strings.Contains(text, "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase) {
+		t.Fatalf("reset-probe invocation = %s, want managed probe drop", text)
+	}
+}
+
+func TestDoltStateResetProbeCmdRequiresForce(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "reset-probe", "--host", "127.0.0.1", "--port", "3311", "--user", "root"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run() = %d, want 1; stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "refusing to drop "+managedDoltProbeDatabase+" without --force") ||
+		!strings.Contains(stderr.String(), "legacy bead store") {
+		t.Fatalf("stderr = %q, want force warning with legacy bead store context", stderr.String())
+	}
+}
+
+func TestDoltStateResetProbeCmdUsesDirectConnectionWithPassword(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+exit 42
+`)
+	t.Setenv("GC_DOLT_PASSWORD", "secret")
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldResetDirect := managedDoltResetProbeDirectFn
+	called := false
+	managedDoltResetProbeDirectFn = func(host, port, user string) error {
+		called = true
+		if host != "127.0.0.1" || port != "3311" || user != "root" {
+			t.Fatalf("managedDoltResetProbeDirectFn(%q, %q, %q), want requested connection", host, port, user)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		managedDoltResetProbeDirectFn = oldResetDirect
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "reset-probe", "--host", "127.0.0.1", "--port", "3311", "--user", "root", "--force"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	if !called {
+		t.Fatalf("managedDoltResetProbeDirectFn was not called")
+	}
+	if _, err := os.Stat(invocationFile); !os.IsNotExist(err) {
+		t.Fatalf("dolt CLI invocation file exists after password reset path: err=%v", err)
+	}
+}
+
 func TestDoltStateHealthCheckCmdReportsReadOnlyAndConnectionCount(t *testing.T) {
 	binDir := t.TempDir()
 	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
@@ -1436,7 +1518,7 @@ case "$*" in
   *"sql -q SELECT active_branch()"*)
     exit 0
     ;;
-  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; USE __gc_probe; CREATE TABLE IF NOT EXISTS __probe (k INT PRIMARY KEY); REPLACE INTO __probe VALUES (1); DROP TABLE __probe; DROP DATABASE __gc_probe;"*)
+  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);"*)
     echo 'database is read only' >&2
     exit 1
     ;;
@@ -1473,6 +1555,8 @@ esac
 		t.Fatalf("ReadFile(invocation): %v", err)
 	}
 	text := string(invocation)
+	assertNoManagedDoltProbeDrop(t, "health-check read-only probe", text)
+	assertManagedDoltProbeWrites(t, "health-check read-only probe", text)
 	for _, want := range []string{"--host 127.0.0.1", "--port 3311", "--user root", "SELECT active_branch()", "information_schema.PROCESSLIST"} {
 		if strings.Contains(text, want) == false {
 			t.Fatalf("dolt invocation missing %q: %s", want, text)
@@ -1558,7 +1642,7 @@ case "$*" in
   *"sql -q SELECT active_branch()"*)
     exit 0
     ;;
-  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; USE __gc_probe; CREATE TABLE IF NOT EXISTS __probe (k INT PRIMARY KEY); REPLACE INTO __probe VALUES (1); DROP TABLE __probe; DROP DATABASE __gc_probe;"*)
+  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);"*)
     echo 'probe exploded' >&2
     exit 1
     ;;

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -298,7 +298,7 @@ func ensureCanonicalScopeMetadataIfPresent(fs fsys.FS, scopeRoot string) error {
 		Database:     "dolt",
 		Backend:      "dolt",
 		DoltMode:     "server",
-		DoltDatabase: strings.TrimSpace(doltDatabase),
+		DoltDatabase: doltDatabase,
 	})
 	return err
 }

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -92,6 +92,32 @@ func TestDoRigSetEndpointInheritWritesManagedInheritedRigConfig(t *testing.T) {
 	}
 }
 
+func TestEnsureCanonicalScopeMetadataIfPresentPreservesExistingManagedProbeDatabase(t *testing.T) {
+	scopeDir := t.TempDir()
+	metadataPath := filepath.Join(scopeDir, ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, metadataPath, contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: strings.ToUpper(managedDoltProbeDatabase),
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if err := ensureCanonicalScopeMetadataIfPresent(fsys.OSFS{}, scopeDir); err != nil {
+		t.Fatalf("ensureCanonicalScopeMetadataIfPresent: %v", err)
+	}
+	got, ok, err := contract.ReadDoltDatabase(fsys.OSFS{}, metadataPath)
+	if err != nil {
+		t.Fatalf("ReadDoltDatabase: %v", err)
+	}
+	if !ok || got != strings.ToUpper(managedDoltProbeDatabase) {
+		t.Fatalf("dolt_database = %q, ok=%v; want existing reserved name preserved", got, ok)
+	}
+}
+
 func TestDoRigSetEndpointInheritMirrorsExternalCity(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -1034,12 +1034,7 @@ func TestCmdStopSupervisorManagedCityReliesOnSupervisorCleanup(t *testing.T) {
 	}
 
 	ops := readOpLog(t, logFile)
-	if len(ops) != 1 {
-		t.Fatalf("expected bead provider stop, got %v", ops)
-	}
-	if !strings.HasPrefix(ops[0], "stop") {
-		t.Fatalf("unexpected bead provider op: %v", ops)
-	}
+	assertSingleStopWithBenignNoise(t, ops)
 }
 
 func TestReconcileCitiesNameDriftStopsBeadsProvider(t *testing.T) {
@@ -1097,12 +1092,7 @@ func TestReconcileCitiesNameDriftStopsBeadsProvider(t *testing.T) {
 	reconcileCities(reg, registry, supervisor.PublicationConfig{}, &stdout, &stderr)
 
 	ops := readOpLog(t, logFile)
-	if len(ops) != 1 {
-		t.Fatalf("expected bead provider stop during name-drift restart, got %v", ops)
-	}
-	if !strings.HasPrefix(ops[0], "stop") {
-		t.Fatalf("unexpected bead provider op: %v", ops)
-	}
+	assertSingleStopWithBenignNoise(t, ops)
 }
 
 func TestSupervisorCreatesControllerSocketForManagedCity(t *testing.T) {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -2268,12 +2268,7 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	}
 
 	ops := readOpLog(t, logFile)
-	if len(ops) != 1 {
-		t.Fatalf("expected bead provider stop, got %v", ops)
-	}
-	if !strings.HasPrefix(ops[0], "stop") {
-		t.Fatalf("unexpected bead provider op: %v", ops)
-	}
+	assertSingleStopWithBenignNoise(t, ops)
 }
 
 func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
@@ -2320,12 +2315,7 @@ func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 	}
 
 	ops := readOpLog(t, logFile)
-	if len(ops) != 1 {
-		t.Fatalf("expected bead provider stop, got %v", ops)
-	}
-	if !strings.HasPrefix(ops[0], "stop") {
-		t.Fatalf("unexpected bead provider op: %v", ops)
-	}
+	assertSingleStopWithBenignNoise(t, ops)
 }
 
 // TestStopSupervisorWithWaitBlocksUntilSocketStops exercises the --wait

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -19,12 +19,26 @@ type managedDoltSQLHealthReport struct {
 	ConnectionCount string
 }
 
+const managedDoltProbeDatabase = "__gc_probe"
+
 var (
 	managedDoltQueryProbeDirectFn      = managedDoltQueryProbeDirect
 	managedDoltReadOnlyStateDirectFn   = managedDoltReadOnlyStateDirect
 	managedDoltConnectionCountDirectFn = managedDoltConnectionCountDirect
+	managedDoltResetProbeDirectFn      = managedDoltResetProbeDirect
 	managedDoltSQLCommandTimeout       = 5 * time.Second
 )
+
+// The probe database is intentionally persistent. Dropping Dolt databases leaves
+// .dolt_dropped_databases backups, so the health check keeps a stable table and
+// rewrites a single row to test writability.
+var managedDoltReadOnlyProbeStatements = [...]string{
+	"CREATE DATABASE IF NOT EXISTS " + managedDoltProbeDatabase,
+	"CREATE TABLE IF NOT EXISTS " + managedDoltProbeDatabase + ".__probe (k INT PRIMARY KEY)",
+	"REPLACE INTO " + managedDoltProbeDatabase + ".__probe VALUES (1)",
+}
+
+var managedDoltReadOnlyProbeSQL = strings.Join(managedDoltReadOnlyProbeStatements[:], "; ") + ";"
 
 func managedDoltQueryProbe(host, port, user string) error {
 	if managedDoltPassword() != "" {
@@ -44,7 +58,7 @@ func managedDoltReadOnlyState(host, port, user string) (string, error) {
 	if managedDoltPassword() != "" {
 		return managedDoltReadOnlyStateDirectFn(host, port, user)
 	}
-	_, err := runManagedDoltSQL(host, port, user, "-q", "CREATE DATABASE IF NOT EXISTS __gc_probe; USE __gc_probe; CREATE TABLE IF NOT EXISTS __probe (k INT PRIMARY KEY); REPLACE INTO __probe VALUES (1); DROP TABLE __probe; DROP DATABASE __gc_probe;")
+	_, err := runManagedDoltSQL(host, port, user, "-q", managedDoltReadOnlyProbeSQL)
 	if err == nil {
 		return "false", nil
 	}
@@ -173,14 +187,7 @@ func managedDoltReadOnlyStateDirect(host, port, user string) (string, error) {
 	}
 	defer conn.Close() //nolint:errcheck
 
-	queries := []string{
-		"CREATE DATABASE IF NOT EXISTS __gc_probe",
-		"CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY)",
-		"REPLACE INTO __gc_probe.__probe VALUES (1)",
-		"DROP TABLE __gc_probe.__probe",
-		"DROP DATABASE __gc_probe",
-	}
-	for _, query := range queries {
+	for _, query := range managedDoltReadOnlyProbeStatements {
 		if _, err := conn.ExecContext(ctx, query); err != nil {
 			msg := strings.ToLower(err.Error())
 			if strings.Contains(msg, "read only") || strings.Contains(msg, "read-only") {
@@ -209,6 +216,30 @@ func managedDoltConnectionCountDirect(host, port, user string) (string, error) {
 		return "", err
 	}
 	return strconv.Itoa(count), nil
+}
+
+func managedDoltResetProbe(host, port, user string) error {
+	if managedDoltPassword() != "" {
+		return managedDoltResetProbeDirectFn(host, port, user)
+	}
+	_, err := runManagedDoltSQL(host, port, user, "-q", "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase)
+	return err
+}
+
+func managedDoltResetProbeDirect(host, port, user string) error {
+	db, err := managedDoltOpenDB(host, port, user)
+	if err != nil {
+		return err
+	}
+	defer db.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase)
+	return err
 }
 
 func runManagedDoltSQL(host, port, user string, args ...string) (string, error) {

--- a/cmd/gc/dolt_sql_health_test.go
+++ b/cmd/gc/dolt_sql_health_test.go
@@ -4,10 +4,46 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestManagedDoltReadOnlyProbeDoesNotDropProbeDatabase(t *testing.T) {
+	for _, query := range append(append([]string{}, managedDoltReadOnlyProbeStatements[:]...), managedDoltReadOnlyProbeSQL) {
+		assertNoManagedDoltProbeDrop(t, "read-only probe", query)
+	}
+	assertManagedDoltProbeWrites(t, "joined read-only probe", managedDoltReadOnlyProbeSQL)
+	foundWriteStatement := false
+	for _, query := range managedDoltReadOnlyProbeStatements {
+		if strings.Contains(query, "REPLACE INTO __gc_probe.__probe VALUES (1)") {
+			foundWriteStatement = true
+		}
+	}
+	if !foundWriteStatement {
+		t.Fatal("read-only probe statements must include a write to __gc_probe.__probe")
+	}
+}
+
+func assertNoManagedDoltProbeDrop(t *testing.T, label, text string) {
+	t.Helper()
+	dropProbeDatabase := regexp.MustCompile("(?i)\\bDROP\\s+DATABASE\\s+(IF\\s+EXISTS\\s+)?`?__gc_probe`?")
+	dropProbeTable := regexp.MustCompile("(?i)\\bDROP\\s+TABLE\\s+(IF\\s+EXISTS\\s+)?(`?__gc_probe`?\\.)?`?__probe`?")
+	if dropProbeDatabase.MatchString(text) {
+		t.Fatalf("%s must not drop __gc_probe: %s", label, text)
+	}
+	if dropProbeTable.MatchString(text) {
+		t.Fatalf("%s must keep __gc_probe.__probe stable: %s", label, text)
+	}
+}
+
+func assertManagedDoltProbeWrites(t *testing.T, label, text string) {
+	t.Helper()
+	if !strings.Contains(text, "REPLACE INTO __gc_probe.__probe VALUES (1)") {
+		t.Fatalf("%s must write to __gc_probe.__probe: %s", label, text)
+	}
+}
 
 func TestManagedDoltHealthCheckWithPasswordUsesDirectHelpers(t *testing.T) {
 	binDir := t.TempDir()

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -100,6 +101,60 @@ func TestMaterializeBuiltinPacks(t *testing.T) {
 	info, err := os.Stat(bdToml)
 	if err == nil && info.Mode()&0o111 != 0 {
 		t.Errorf("pack.toml should not be executable: mode %v", info.Mode())
+	}
+}
+
+func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	for _, tt := range []struct {
+		pack     string
+		rel      string
+		needle   string
+		minCount int
+	}{
+		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), "^dolt_cluster$\\|^__gc_probe$", 1},
+		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), "^dolt_cluster$\\|^__gc_probe$", 1},
+		{"dolt", filepath.Join("commands", "list", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 1},
+		{"dolt", filepath.Join("commands", "cleanup", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 1},
+		{"dolt", filepath.Join("commands", "health", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 2},
+		{"dolt", filepath.Join("commands", "sync", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 2},
+		{"dolt", filepath.Join("formulas", "mol-dog-stale-db.toml"), "__gc_probe", 1},
+		{"dolt", filepath.Join("formulas", "mol-dog-doctor.toml"), "__gc_probe", 1},
+	} {
+		path := filepath.Join(dir, citylayout.SystemPacksRoot, tt.pack, tt.rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s/%s): %v", tt.pack, tt.rel, err)
+		}
+		if got := strings.Count(string(data), tt.needle); got < tt.minCount {
+			t.Fatalf("%s/%s database enumeration must contain %q at least %d time(s), got %d", tt.pack, tt.rel, tt.needle, tt.minCount, got)
+		}
+	}
+}
+
+func TestDoltSyncRejectsManagedProbeDatabaseFilter(t *testing.T) {
+	for _, dbName := range []string{managedDoltProbeDatabase, strings.ToUpper(managedDoltProbeDatabase), " " + managedDoltProbeDatabase + " "} {
+		t.Run(dbName, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := MaterializeBuiltinPacks(dir); err != nil {
+				t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+			}
+			packDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt")
+			script := filepath.Join(packDir, "commands", "sync", "run.sh")
+			cmd := exec.Command(script, "--db", dbName)
+			cmd.Env = sanitizedBaseEnv("GC_CITY_PATH="+dir, "GC_PACK_DIR="+packDir)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("gc dolt sync unexpectedly accepted %s:\n%s", dbName, out)
+			}
+			if !strings.Contains(string(out), "reserved Dolt database name: "+managedDoltProbeDatabase) {
+				t.Fatalf("gc dolt sync output = %s, want reserved database error", out)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -56,6 +56,55 @@ func readOpLog(t *testing.T, logFile string) []string {
 	return strings.Split(raw, "\n")
 }
 
+// assertOpSubsequence verifies that ops contains entries with the given
+// prefixes in order. The lifecycle tests care about sequencing of the
+// current operation, not unrelated trailing health checks from background
+// activity elsewhere in the process.
+func assertOpSubsequence(t *testing.T, ops []string, want ...string) {
+	t.Helper()
+	if len(want) == 0 {
+		t.Fatalf("assertOpSubsequence requires at least one prefix")
+	}
+	if len(ops) == 0 {
+		t.Fatalf("expected ops containing %v, got none", want)
+	}
+	index := 0
+	for _, op := range ops {
+		if strings.HasPrefix(op, want[index]) {
+			index++
+			if index == len(want) {
+				return
+			}
+		}
+	}
+	t.Fatalf("expected op subsequence %v in %v", want, ops)
+}
+
+// assertSingleStopWithBenignNoise verifies a single stop call while tolerating
+// unrelated background health/probe checks from other goroutines in the test
+// process.
+func assertSingleStopWithBenignNoise(t *testing.T, ops []string) {
+	t.Helper()
+	if len(ops) == 0 {
+		t.Fatalf("expected stop op, got none")
+	}
+
+	stopCount := 0
+	for _, op := range ops {
+		switch {
+		case strings.HasPrefix(op, "stop"):
+			stopCount++
+		case strings.HasPrefix(op, "health"), strings.HasPrefix(op, "probe"):
+			continue
+		default:
+			t.Fatalf("unexpected lifecycle op in stop sequence: %v", ops)
+		}
+	}
+	if stopCount != 1 {
+		t.Fatalf("expected exactly one stop op with optional health/probe noise, got %v", ops)
+	}
+}
+
 // assertHooksExist checks that all bead hooks exist at the given directory.
 func assertHooksExist(t *testing.T, dir, context string) {
 	t.Helper()
@@ -106,19 +155,8 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 	}
 
 	ops := readOpLog(t, logFile)
-	// probe + start + init
-	if len(ops) != 3 {
-		t.Fatalf("expected 3 ops after city init, got %d: %v", len(ops), ops)
-	}
-	if !strings.HasPrefix(ops[0], "probe") {
-		t.Fatalf("expected probe first, got: %s", ops[0])
-	}
-	if !strings.HasPrefix(ops[1], "start") {
-		t.Fatalf("expected start second, got: %s", ops[1])
-	}
-	if !strings.HasPrefix(ops[2], "init "+cityPath) {
-		t.Fatalf("expected init op for city, got: %s", ops[2])
-	}
+	assertOpSubsequence(t, ops, "probe", "start", "init "+cityPath)
+	cityInitOps := len(ops)
 	assertHooksExist(t, cityPath, "after city init")
 
 	// Phase 2: gc rig add — initDirIfReady for rig.
@@ -132,13 +170,11 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 	}
 
 	ops = readOpLog(t, logFile)
-	// +probe + start + init (6 total)
-	if len(ops) != 6 {
-		t.Fatalf("expected 6 ops after rig add, got %d: %v", len(ops), ops)
+	if len(ops) <= cityInitOps {
+		t.Fatalf("expected rig add to append ops beyond %d entries, got %d: %v", cityInitOps, len(ops), ops)
 	}
-	if !strings.HasPrefix(ops[5], "init "+rigPath) {
-		t.Fatalf("expected init op for rig, got: %s", ops[5])
-	}
+	assertOpSubsequence(t, ops[cityInitOps:], "probe", "start", "init "+rigPath)
+	rigInitOps := len(ops)
 	assertHooksExist(t, rigPath, "after rig add")
 
 	// Phase 3: Simulate hook wipe (bd init recreates .beads/).
@@ -158,10 +194,10 @@ func TestLifecycleCoordination_InitRigAddStart(t *testing.T) {
 	}
 
 	ops = readOpLog(t, logFile)
-	// +start + init(city) + init(rig) = 9 total
-	if len(ops) != 9 {
-		t.Fatalf("expected 9 ops total, got %d: %v", len(ops), ops)
+	if len(ops) <= rigInitOps {
+		t.Fatalf("expected start to append ops beyond %d entries, got %d: %v", rigInitOps, len(ops), ops)
 	}
+	assertOpSubsequence(t, ops[rigInitOps:], "start", "init "+cityPath, "init "+rigPath)
 
 	// Verify hooks reinstalled at both paths after start.
 	assertHooksExist(t, cityPath, "after start")
@@ -230,12 +266,7 @@ func TestLifecycleCoordination_StopOrder(t *testing.T) {
 	}
 
 	ops := readOpLog(t, logFile)
-	if len(ops) != 1 {
-		t.Fatalf("expected 1 op, got %d: %v", len(ops), ops)
-	}
-	if !strings.HasPrefix(ops[0], "stop") {
-		t.Fatalf("expected stop op, got: %s", ops[0])
-	}
+	assertSingleStopWithBenignNoise(t, ops)
 }
 
 // TestLifecycleCoordination_InitDirIfReady_BdDeferred verifies that the bd

--- a/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
+++ b/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
@@ -449,7 +449,7 @@ orphan_count=0
 for d in "$data_dir"/*/; do
   [ ! -d "$d/.dolt" ] && continue
   name="$(basename "$d")"
-  case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+  case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
   case "$referenced" in *" $name "*) continue ;; esac
   size_bytes=$(du -sb "$d" 2>/dev/null | cut -f1 || echo 0)
   size="${size_bytes} B"
@@ -589,6 +589,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" = "__gc_probe" ]; then
+  echo "gc dolt sync: reserved Dolt database name: __gc_probe (used internally by gc)" >&2
+  exit 1
+fi
+
 is_running() {
   [ -n "${GC_DOLT_PORT:-}" ] || return 1
   lsof -i :"$GC_DOLT_PORT" -sTCP:LISTEN >/dev/null 2>&1
@@ -631,7 +636,7 @@ if [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
 
     remote=""

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1590,8 +1590,18 @@ op_init() {
     local dir="$1"
     local prefix="$2"
     local dolt_database="${3:-}"
+    local metadata_path="$dir/.beads/metadata.json"
+    local existing_db=""
+    local allow_reserved_existing=false
     if [ -z "$dir" ] || [ -z "$prefix" ]; then
         die "usage: gc-beads-bd init <dir> <prefix> [dolt_database]"
+    fi
+
+    if [ -f "$metadata_path" ]; then
+        existing_db=$(read_existing_dolt_database "$metadata_path")
+        if [ -n "$existing_db" ] && is_reserved_dolt_database_name "$existing_db"; then
+            allow_reserved_existing=true
+        fi
     fi
 
     # Validate prefix before SQL interpolation (upstream 38f7b380).
@@ -1600,7 +1610,11 @@ op_init() {
     fi
     if [ -n "$dolt_database" ]; then
         if is_reserved_dolt_database_name "$dolt_database"; then
-            die "reserved dolt database name: $dolt_database (used internally by gc)"
+            if [ "$allow_reserved_existing" = true ]; then
+                dolt_database="$existing_db"
+            else
+                die "reserved dolt database name: $dolt_database (used internally by gc)"
+            fi
         fi
         if ! valid_sql_name "$dolt_database"; then
             die "invalid dolt database name: $dolt_database (must be alphanumeric, hyphens, underscores)"
@@ -1616,21 +1630,26 @@ op_init() {
     if [ -z "$dolt_database" ]; then
         # Compatibility fallback for direct gc-beads-bd invocations.
         # GC's canonical path passes dolt_database explicitly.
-        local existing_db
-        existing_db=$(read_existing_dolt_database "$dir/.beads/metadata.json")
         if [ -n "$existing_db" ]; then
             if is_reserved_dolt_database_name "$existing_db"; then
-                die "reserved dolt database name: $existing_db (used internally by gc)"
-            fi
-            if ! valid_sql_name "$existing_db"; then
+                if [ "$allow_reserved_existing" = true ]; then
+                    # Preserve legacy probe metadata for already-initialized
+                    # scopes so startup can recover them into the canonical
+                    # migration flow. Fresh init still rejects this name.
+                    dolt_database="$existing_db"
+                else
+                    die "reserved dolt database name: $existing_db (used internally by gc)"
+                fi
+            elif ! valid_sql_name "$existing_db"; then
                 die "invalid existing dolt database name: $existing_db"
+            else
+                dolt_database="$existing_db"
             fi
-            dolt_database="$existing_db"
         else
             dolt_database="$prefix"
         fi
     fi
-    if is_reserved_dolt_database_name "$dolt_database"; then
+    if is_reserved_dolt_database_name "$dolt_database" && [ "$allow_reserved_existing" != true ]; then
         die "reserved dolt database name: $dolt_database (used internally by gc)"
     fi
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -764,7 +764,9 @@ check_read_only() {
         esac
     fi
     local output
-    output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls         sql -q "CREATE DATABASE IF NOT EXISTS __gc_probe; USE __gc_probe; CREATE TABLE IF NOT EXISTS __probe (k INT PRIMARY KEY); REPLACE INTO __probe VALUES (1); DROP TABLE __probe; DROP DATABASE __gc_probe;" 2>&1) || true
+    # Keep __gc_probe stable. Dropping Dolt databases leaves
+    # .dolt_dropped_databases backups behind.
+    output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls         sql -q "CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);" 2>&1) || true
     case "$output" in
         *"read only"*|*"READ ONLY"*|*"Read-only"*)
             return 0  # Is read-only.
@@ -1189,6 +1191,13 @@ valid_sql_name() {
     return 0
 }
 
+is_reserved_dolt_database_name() {
+    case "$(printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" in
+        __gc_probe) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # clean_stale_sockets removes stale Unix domain sockets left by a crashed
 # dolt server. Without cleanup, "unix socket set up failed: file already in
 # use" prevents clean restarts (upstream 2e058fa1).
@@ -1589,8 +1598,13 @@ op_init() {
     if ! valid_sql_name "$prefix"; then
         die "invalid beads prefix: $prefix (must be alphanumeric, hyphens, underscores)"
     fi
-    if [ -n "$dolt_database" ] && ! valid_sql_name "$dolt_database"; then
-        die "invalid dolt database name: $dolt_database (must be alphanumeric, hyphens, underscores)"
+    if [ -n "$dolt_database" ]; then
+        if is_reserved_dolt_database_name "$dolt_database"; then
+            die "reserved dolt database name: $dolt_database (used internally by gc)"
+        fi
+        if ! valid_sql_name "$dolt_database"; then
+            die "invalid dolt database name: $dolt_database (must be alphanumeric, hyphens, underscores)"
+        fi
     fi
     # Filter BEADS_DIR from inherited environment to prevent bd from
     # finding a parent directory's .beads/ database (upstream parity).
@@ -1604,11 +1618,20 @@ op_init() {
         # GC's canonical path passes dolt_database explicitly.
         local existing_db
         existing_db=$(read_existing_dolt_database "$dir/.beads/metadata.json")
-        if [ -n "$existing_db" ] && valid_sql_name "$existing_db"; then
+        if [ -n "$existing_db" ]; then
+            if is_reserved_dolt_database_name "$existing_db"; then
+                die "reserved dolt database name: $existing_db (used internally by gc)"
+            fi
+            if ! valid_sql_name "$existing_db"; then
+                die "invalid existing dolt database name: $existing_db"
+            fi
             dolt_database="$existing_db"
         else
             dolt_database="$prefix"
         fi
+    fi
+    if is_reserved_dolt_database_name "$dolt_database"; then
+        die "reserved dolt database name: $dolt_database (used internally by gc)"
     fi
 
     # Custom bead types for bd (extracted from beads core in v0.46.0).

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -82,7 +82,7 @@ orphan_count=0
 for d in "$data_dir"/*/; do
   [ ! -d "$d/.dolt" ] && continue
   name="$(basename "$d")"
-  case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+  case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
   case "$referenced" in
     *" $name "*) continue ;; # referenced, not orphan
   esac

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -122,7 +122,7 @@ if [ -d "$data_dir" ] && [ "$server_reachable" = true ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
     # Reject names with anything outside [A-Za-z0-9_] before interpolating
     # into the SQL identifier. Dolt permits directory names that shell
     # basename happily returns (e.g. backticks, semicolons) but which
@@ -197,7 +197,7 @@ if [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
     case "$referenced" in *" $name "*) continue ;; esac
     size_bytes=$(du -sb "$d" 2>/dev/null | cut -f1 || echo 0)
     if [ "$size_bytes" -ge 1048576 ]; then

--- a/examples/dolt/commands/list/run.sh
+++ b/examples/dolt/commands/list/run.sh
@@ -20,8 +20,8 @@ for d in "$data_dir"/*/; do
   [ ! -d "$d/.dolt" ] && continue
   name="$(basename "$d")"
   # Skip system databases.
-  case "$name" in
-    information_schema|mysql|dolt_cluster) continue ;;
+  case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in
+    information_schema|mysql|dolt_cluster|__gc_probe) continue ;;
   esac
   printf "%s\t%s\n" "$name" "$d"
   found=$((found + 1))

--- a/examples/dolt/commands/recover/run.sh
+++ b/examples/dolt/commands/recover/run.sh
@@ -32,6 +32,8 @@ fi
 # is wrapped in run_bounded so an unresponsive server — the very
 # failure mode `gc dolt recover` exists to handle — cannot hang the
 # script indefinitely. Mirrors the patterns established in health/run.sh.
+# This table-only probe intentionally avoids DROP DATABASE; explicit
+# managed probe recovery is available through `gc dolt-state reset-probe`.
 check_read_only() {
   host="${GC_DOLT_HOST:-127.0.0.1}"
   args="--host $host --port $GC_DOLT_PORT --user $GC_DOLT_USER --no-tls"

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -41,6 +41,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" = "__gc_probe" ]; then
+  echo "gc dolt sync: reserved Dolt database name: __gc_probe (used internally by gc)" >&2
+  exit 1
+fi
+
 # Check if server is running.
 is_running() {
   lsof -i :"$GC_DOLT_PORT" -sTCP:LISTEN >/dev/null 2>&1
@@ -77,7 +82,7 @@ if [ "$do_gc" = true ] && [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
     beads_dir=""
     # Find the .beads directory for this database.
@@ -115,7 +120,7 @@ if [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$name" in information_schema|mysql|dolt_cluster) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
 
     # Check for remote.

--- a/examples/dolt/formulas/mol-dog-doctor.toml
+++ b/examples/dolt/formulas/mol-dog-doctor.toml
@@ -95,6 +95,7 @@ Check data directory size. Warn if exceeding configured threshold.
 SHOW DATABASES;
 ```
 Count databases matching orphan patterns: testdb_*, beads_t*, beads_pt*, doctest_*.
+Ignore Dolt internals: information_schema, mysql, dolt_cluster, __gc_probe.
 If orphan count > threshold, recommend cleanup:
 ```bash
 gc dolt cleanup

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -59,7 +59,8 @@ Query the Dolt server and identify orphaned databases.
 ```sql
 SHOW DATABASES;
 ```
-Filter out Dolt internals (information_schema, mysql).
+Filter out Dolt internals (information_schema, mysql, dolt_cluster,
+__gc_probe).
 
 **2. Classify each database:**
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -31,8 +31,9 @@ if [ ! -e "$STATE_FILE" ] && [ -e "$LEGACY_STATE_FILE" ]; then
 fi
 mkdir -p "$(dirname "$STATE_FILE")"
 
-# Discover databases.
-DATABASES=$(dolt sql -P "$DOLT_PORT" -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -v '^information_schema$\|^mysql$' || true)
+# Discover databases. Exclude Dolt/MySQL system schemas and Gas City's internal
+# health-probe database; the remaining databases are expected to be bead stores.
+DATABASES=$(dolt sql -P "$DOLT_PORT" -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -vi '^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$' || true)
 if [ -z "$DATABASES" ]; then
     exit 0
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -31,8 +31,9 @@ PURGE_AGE_H=$(duration_to_hours "$PURGE_AGE")
 STALE_AGE_H=$(duration_to_hours "$STALE_ISSUE_AGE")
 MAIL_AGE_H=$(duration_to_hours "$MAIL_DELETE_AGE")
 
-# Discover databases from Dolt server.
-DATABASES=$(dolt sql -P "$DOLT_PORT" -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -v '^information_schema$\|^mysql$' || true)
+# Discover databases from Dolt server. Exclude Dolt/MySQL system schemas and
+# Gas City's internal health-probe database; remaining DBs are bead stores.
+DATABASES=$(dolt sql -P "$DOLT_PORT" -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -vi '^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$' || true)
 if [ -z "$DATABASES" ]; then
     # No databases accessible — nothing to do.
     exit 0


### PR DESCRIPTION
Fixes #946.

## Summary
- Change managed Dolt read-only probes to keep a persistent `__gc_probe.__probe` table and `REPLACE` one row instead of dropping `__gc_probe` on every health check.
- Update the `gc-beads-bd` shell fallback to use the same non-dropping probe.
- Reserve `__gc_probe` for new managed bead databases while preserving pre-existing metadata so startup/endpoint normalization does not brick legacy scopes.
- Hide `__gc_probe` from Dolt list, health, cleanup, sync, JSONL export, and reaper database enumeration.
- Add hidden `gc dolt-state reset-probe --force` for explicit operator recovery; password-backed connections use the direct SQL path instead of exposing `GC_DOLT_PASSWORD` in process args.

## Notes
- Existing `.dolt_dropped_databases/__gc_probe*` artifacts created by older builds are not auto-removed by this PR. The change stops creating new artifacts during health checks.
- A legacy bead store already named `__gc_probe` is preserved by Go normalization, but new init paths reject that name. Operators should rename/move that bead database before using `reset-probe --force`.

## Validation
- `go test ./cmd/gc -run 'TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase|TestDoltSyncRejectsManagedProbeDatabaseFilter|TestGcBeadsBd(ReadOnlyFallbackDoesNotDropProbeDatabase|InitRejectsManagedProbeDatabaseName)|TestEnsureCanonicalScopeMetadataRejectsManagedProbeDatabase|TestEnsureCanonicalScopeMetadataIfPresentPreservesExistingManagedProbeDatabase|TestNormalizeCanonicalBdScopeFilesPreservesExistingManagedProbeDatabase|TestManagedDoltReadOnlyProbeDoesNotDropProbeDatabase|TestDoltState(ReadOnlyCheckCmd|ResetProbeCmd|HealthCheckCmd)' -count=1`
- `go test ./cmd/gc -count=1 -timeout 15m`
- Live Dolt smoke with three `gc dolt-state health-check --check-read-only` calls: `dropped_before=0`, `dropped_after=0`, `probe_rows=1`
- `$review-pr --skip-gemini` dual-model review, Claude + Codex: synthesized decision `approve`; no blockers or majors. Gemini was skipped because earlier triple-model attempts hit Gemini API rate limiting.
