### PR TITLE
quality: Wave 1 session identity

### DIFF
--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"log"
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -309,6 +310,7 @@ func (s *Server) humaHandleSessionAgentList(_ context.Context, input *SessionIDI
 
 	mappings, err := sessionlog.FindAgentMappings(logPath)
 	if err != nil {
+		log.Printf("gc api: session %s agent mapping failed for %s: %v", id, logPath, err)
 		return nil, huma.Error500InternalServerError("failed to list agents")
 	}
 	if mappings == nil {

--- a/internal/sessionlog/agents.go
+++ b/internal/sessionlog/agents.go
@@ -13,6 +13,8 @@ import (
 // ErrAgentNotFound is returned when a subagent file does not exist.
 var ErrAgentNotFound = errors.New("agent not found")
 
+const agentMappingScannerMaxTokenSize = 8 * 1024 * 1024
+
 // AgentMapping links a subagent to the parent Task tool_use that spawned it.
 type AgentMapping struct {
 	AgentID         string `json:"agent_id"`
@@ -106,7 +108,9 @@ func FindAgentFiles(parentLogPath string) ([]string, error) {
 }
 
 // FindAgentMappings scans agent-*.jsonl files alongside the parent session
-// and extracts the parent_tool_use_id from each agent's first entry.
+// and extracts the parent_tool_use_id from each agent's first entry. It
+// returns an error without partial mappings if any agent transcript cannot be
+// read.
 func FindAgentMappings(parentLogPath string) ([]AgentMapping, error) {
 	agentPaths, err := FindAgentFiles(parentLogPath)
 	if err != nil {
@@ -204,7 +208,9 @@ func extractParentToolUseID(path string) (string, error) {
 	defer f.Close() //nolint:errcheck // read-only
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	// Claude Code transcript entries may contain large tool results, but the
+	// parentToolUseId is expected near the top of the file.
+	scanner.Buffer(make([]byte, 0, 256*1024), agentMappingScannerMaxTokenSize)
 
 	// Check first 5 lines — the field is usually on line 1.
 	for i := 0; i < 5 && scanner.Scan(); i++ {

--- a/internal/sessionlog/agents.go
+++ b/internal/sessionlog/agents.go
@@ -119,9 +119,12 @@ func FindAgentMappings(parentLogPath string) ([]AgentMapping, error) {
 	var mappings []AgentMapping
 	for _, path := range agentPaths {
 		agentID := agentIDFromPath(path)
-		toolUseID := extractParentToolUseID(path)
 		if agentID == "" {
 			continue
+		}
+		toolUseID, err := extractParentToolUseID(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading agent %q mapping: %w", agentID, err)
 		}
 		mappings = append(mappings, AgentMapping{
 			AgentID:         agentID,
@@ -193,10 +196,10 @@ func agentIDFromPath(path string) string {
 // extractParentToolUseID reads the first few lines of an agent JSONL file
 // and looks for the parentToolUseId field. Claude Code writes this on
 // the first entry of every subagent session.
-func extractParentToolUseID(path string) string {
+func extractParentToolUseID(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("opening transcript: %w", err)
 	}
 	defer f.Close() //nolint:errcheck // read-only
 
@@ -216,10 +219,13 @@ func extractParentToolUseID(path string) string {
 			continue
 		}
 		if entry.ParentToolUseID != "" {
-			return entry.ParentToolUseID
+			return entry.ParentToolUseID, nil
 		}
 	}
-	return ""
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scanning transcript: %w", err)
+	}
+	return "", nil
 }
 
 // inferAgentStatus determines the agent's status from its message history.

--- a/internal/sessionlog/agents_test.go
+++ b/internal/sessionlog/agents_test.go
@@ -134,7 +134,10 @@ func TestExtractParentToolUseID(t *testing.T) {
 		`{"uuid":"u2","type":"user","message":{"role":"user","content":"hello"}}` + "\n"
 	writeTestFile(t, path, content)
 
-	got := extractParentToolUseID(path)
+	got, err := extractParentToolUseID(path)
+	if err != nil {
+		t.Fatalf("extractParentToolUseID: %v", err)
+	}
 	if got != "toolu_abc123" {
 		t.Errorf("extractParentToolUseID = %q, want %q", got, "toolu_abc123")
 	}
@@ -145,7 +148,10 @@ func TestExtractParentToolUseID_Missing(t *testing.T) {
 	path := filepath.Join(dir, "agent-test.jsonl")
 	writeTestFile(t, path, `{"uuid":"u1","type":"user"}`+"\n")
 
-	got := extractParentToolUseID(path)
+	got, err := extractParentToolUseID(path)
+	if err != nil {
+		t.Fatalf("extractParentToolUseID: %v", err)
+	}
 	if got != "" {
 		t.Errorf("extractParentToolUseID = %q, want empty", got)
 	}
@@ -177,6 +183,22 @@ func TestFindAgentMappings(t *testing.T) {
 	}
 	if found["ghi"] != "toolu_222" {
 		t.Errorf("agent ghi: want toolu_222, got %q", found["ghi"])
+	}
+}
+
+func TestFindAgentMappings_PropagatesReadErrors(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, subDir := makeSessionDir(t, dir, "session-abc")
+
+	brokenTarget := filepath.Join(subDir, "missing-target.jsonl")
+	brokenPath := filepath.Join(subDir, "agent-broken.jsonl")
+	if err := os.Symlink(brokenTarget, brokenPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := FindAgentMappings(parentPath)
+	if err == nil {
+		t.Fatal("expected error when reading a broken agent transcript")
 	}
 }
 

--- a/internal/sessionlog/agents_test.go
+++ b/internal/sessionlog/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -190,15 +191,36 @@ func TestFindAgentMappings_PropagatesReadErrors(t *testing.T) {
 	dir := t.TempDir()
 	parentPath, subDir := makeSessionDir(t, dir, "session-abc")
 
-	brokenTarget := filepath.Join(subDir, "missing-target.jsonl")
 	brokenPath := filepath.Join(subDir, "agent-broken.jsonl")
-	if err := os.Symlink(brokenTarget, brokenPath); err != nil {
-		t.Skipf("symlink not supported: %v", err)
+	writeTestFile(t, brokenPath, `{"uuid":"a1","type":"system"}`+"\n")
+	if err := os.Chmod(brokenPath, 0); err != nil {
+		t.Fatalf("chmod broken agent transcript: %v", err)
 	}
+	t.Cleanup(func() { _ = os.Chmod(brokenPath, 0o644) })
 
 	_, err := FindAgentMappings(parentPath)
 	if err == nil {
 		t.Fatal("expected error when reading a broken agent transcript")
+	}
+	if !strings.Contains(err.Error(), `reading agent "broken" mapping`) {
+		t.Fatalf("FindAgentMappings error = %q, want agent context", err)
+	}
+	if !strings.Contains(err.Error(), "opening transcript") {
+		t.Fatalf("FindAgentMappings error = %q, want open context", err)
+	}
+}
+
+func TestExtractParentToolUseID_PropagatesScannerErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent-test.jsonl")
+	writeTestFile(t, path, strings.Repeat("x", agentMappingScannerMaxTokenSize+1)+"\n")
+
+	_, err := extractParentToolUseID(path)
+	if err == nil {
+		t.Fatal("expected scanner error for oversized transcript line")
+	}
+	if !strings.Contains(err.Error(), "scanning transcript") {
+		t.Fatalf("extractParentToolUseID error = %q, want scanner context", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #966.
- Preserves the original fix by @julianknutsen for subagent transcript discovery: broken agent transcript files now surface read/scanner errors instead of being silently reduced to empty mappings.
- Adds maintainer review fixups from the adoption review:
  - logs wrapped agent mapping errors at the Huma session-agent-list boundary before returning the stable client-facing 500
  - documents the all-or-nothing `FindAgentMappings` error contract
  - tightens regression coverage for wrapped error context and scanner failures
  - uses an 8 MiB mapping scanner cap with an explicit rationale

Credit: Original fix by @julianknutsen. The original contributor commit is preserved with original authorship.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Verified targeted adoption gates:

- [x] `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/sessionlog -run 'Test(FindAgentMappings|ExtractParentToolUseID)' -count=1`
- [x] `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./internal/sessionlog ./internal/worker ./internal/api -count=1`

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No separate issue is needed; this is a superseding adoption PR for #966.

Behavior note: `FindAgentMappings` now returns an error without partial mappings if any agent transcript cannot be read. This is intentional so corrupted/broken transcript discovery is visible instead of silently incomplete.
