### PR TITLE
quality: Wave 1 supervisor daemon registry lifecycle

### DIFF
--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -259,44 +259,6 @@ func (sm *SupervisorMux) buildMultiplexer() *events.Multiplexer {
 	return mux
 }
 
-func (sm *SupervisorMux) handleHealth(w http.ResponseWriter, _ *http.Request) {
-	cities := sm.resolver.ListCities()
-	var running int
-	// Use the first city for startup info (single-city deployments).
-	var startup map[string]any
-	for _, c := range cities {
-		if c.Running {
-			running++
-		}
-		if startup == nil {
-			if c.Running {
-				startup = map[string]any{
-					"ready":            true,
-					"phase":            "running",
-					"phases_completed": allStartupPhases(),
-				}
-			} else {
-				startup = map[string]any{
-					"ready":            false,
-					"phase":            c.Status,
-					"phases_completed": c.PhasesCompleted,
-				}
-			}
-		}
-	}
-	resp := map[string]any{
-		"status":         "ok",
-		"version":        sm.version,
-		"uptime_sec":     int(time.Since(sm.startedAt).Seconds()),
-		"cities_total":   len(cities),
-		"cities_running": running,
-	}
-	if startup != nil {
-		resp["startup"] = startup
-	}
-	writeJSON(w, http.StatusOK, resp)
-}
-
 // allStartupPhases returns the ordered list of all startup phases.
 func allStartupPhases() []string {
 	return []string{

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -259,6 +259,44 @@ func (sm *SupervisorMux) buildMultiplexer() *events.Multiplexer {
 	return mux
 }
 
+func (sm *SupervisorMux) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	cities := sm.resolver.ListCities()
+	var running int
+	// Use the first city for startup info (single-city deployments).
+	var startup map[string]any
+	for _, c := range cities {
+		if c.Running {
+			running++
+		}
+		if startup == nil {
+			if c.Running {
+				startup = map[string]any{
+					"ready":            true,
+					"phase":            "running",
+					"phases_completed": allStartupPhases(),
+				}
+			} else {
+				startup = map[string]any{
+					"ready":            false,
+					"phase":            c.Status,
+					"phases_completed": c.PhasesCompleted,
+				}
+			}
+		}
+	}
+	resp := map[string]any{
+		"status":         "ok",
+		"version":        sm.version,
+		"uptime_sec":     int(time.Since(sm.startedAt).Seconds()),
+		"cities_total":   len(cities),
+		"cities_running": running,
+	}
+	if startup != nil {
+		resp["startup"] = startup
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // allStartupPhases returns the ordered list of all startup phases.
 func allStartupPhases() []string {
 	return []string{

--- a/internal/supervisor/registry.go
+++ b/internal/supervisor/registry.go
@@ -59,6 +59,18 @@ func NewRegistry(path string) *Registry {
 	return &Registry{path: path}
 }
 
+func (r *Registry) refuseHostRegistryDuringTests() {
+	if !isTestBinary() {
+		return
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		hostRegistry := filepath.Join(home, ".gc")
+		if strings.HasPrefix(r.path, hostRegistry+string(filepath.Separator)) || r.path == hostRegistry {
+			panic("supervisor.Registry: refusing to write to host registry during tests")
+		}
+	}
+}
+
 // List returns all registered cities. Returns an empty slice (not nil)
 // if the file doesn't exist or is empty.
 func (r *Registry) List() ([]CityEntry, error) {
@@ -74,15 +86,7 @@ func (r *Registry) List() ([]CityEntry, error) {
 // a different city with the same effective name is already registered.
 // Uses file-level locking for cross-process safety.
 func (r *Registry) Register(cityPath, effectiveName string) error {
-	// Guard: refuse to write to the host registry during tests.
-	if isTestBinary() {
-		if home, err := os.UserHomeDir(); err == nil {
-			hostRegistry := filepath.Join(home, ".gc")
-			if strings.HasPrefix(r.path, hostRegistry+string(filepath.Separator)) || r.path == hostRegistry {
-				panic("supervisor.Registry.Register: refusing to write to host registry during tests")
-			}
-		}
-	}
+	r.refuseHostRegistryDuringTests()
 
 	abs, err := filepath.Abs(cityPath)
 	if err != nil {
@@ -140,6 +144,8 @@ func (r *Registry) Register(cityPath, effectiveName string) error {
 // error if the city is not registered. The path is resolved to
 // absolute before comparison. Uses file-level locking for cross-process safety.
 func (r *Registry) Unregister(cityPath string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := filepath.Abs(cityPath)
 	if err != nil {
 		return fmt.Errorf("resolving path: %w", err)
@@ -287,6 +293,8 @@ func (r *Registry) ListRigs() ([]RigEntry, error) {
 // already exists, the entry is updated. Uses file-level locking for
 // cross-process safety.
 func (r *Registry) RegisterRig(rigPath, name, defaultCity string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := resolveAbsPath(rigPath)
 	if err != nil {
 		return err
@@ -345,6 +353,8 @@ func (r *Registry) RegisterRig(rigPath, name, defaultCity string) error {
 // UnregisterRig removes a rig from the registry by path. Returns an error
 // if the rig is not registered. Uses file-level locking for cross-process safety.
 func (r *Registry) UnregisterRig(rigPath string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := resolveAbsPath(rigPath)
 	if err != nil {
 		return err
@@ -430,6 +440,8 @@ func (r *Registry) LookupRigByName(name string) (RigEntry, bool) {
 // SetRigDefault sets the default city for a rig. The rig must already be
 // registered. Uses file-level locking for cross-process safety.
 func (r *Registry) SetRigDefault(rigPath, defaultCity string) error {
+	r.refuseHostRegistryDuringTests()
+
 	abs, err := resolveAbsPath(rigPath)
 	if err != nil {
 		return err
@@ -464,6 +476,8 @@ func (r *Registry) SetRigDefault(rigPath, defaultCity string) error {
 // default_city if the referenced city no longer contains the rig. Removes
 // rig entries that no longer belong to any city.
 func (r *Registry) ReconcileRigs(rigCityMap []RigCityMapping) error {
+	r.refuseHostRegistryDuringTests()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/internal/supervisor/registry_test.go
+++ b/internal/supervisor/registry_test.go
@@ -364,6 +364,71 @@ func TestRigUnregisterNotFound(t *testing.T) {
 	}
 }
 
+func TestRegistryMutatorsRefuseHostRegistryDuringTests(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hostRegistry := filepath.Join(home, ".gc", "cities.toml")
+	r := NewRegistry(hostRegistry)
+
+	tests := []struct {
+		name string
+		call func(*Registry)
+	}{
+		{
+			name: "Register",
+			call: func(r *Registry) {
+				_ = r.Register(filepath.Join(home, "cities", "alpha"), "alpha")
+			},
+		},
+		{
+			name: "Unregister",
+			call: func(r *Registry) {
+				_ = r.Unregister(filepath.Join(home, "cities", "alpha"))
+			},
+		},
+		{
+			name: "RegisterRig",
+			call: func(r *Registry) {
+				_ = r.RegisterRig(filepath.Join(home, "rigs", "alpha"), "alpha", "")
+			},
+		},
+		{
+			name: "UnregisterRig",
+			call: func(r *Registry) {
+				_ = r.UnregisterRig(filepath.Join(home, "rigs", "alpha"))
+			},
+		},
+		{
+			name: "SetRigDefault",
+			call: func(r *Registry) {
+				_ = r.SetRigDefault(filepath.Join(home, "rigs", "alpha"), filepath.Join(home, "cities", "alpha"))
+			},
+		},
+		{
+			name: "ReconcileRigs",
+			call: func(r *Registry) {
+				_ = r.ReconcileRigs([]RigCityMapping{{
+					RigPath:  filepath.Join(home, "rigs", "alpha"),
+					RigName:  "alpha",
+					CityPath: filepath.Join(home, "cities", "alpha"),
+				}})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered == nil {
+					t.Fatalf("expected panic for %s against host registry path", tc.name)
+				}
+			}()
+			tc.call(r)
+		})
+	}
+}
+
 func TestRigLookupByPath(t *testing.T) {
 	dir := t.TempDir()
 	r := NewRegistry(filepath.Join(dir, "cities.toml"))


### PR DESCRIPTION
## Summary

Supersedes #970.

This keeps the original supervisor registry hardening from #970 and adds the maintainer review fixup from the adoption review:

- applies the test-only host-registry guard consistently to every supervisor registry mutator
- keeps production behavior unchanged by making the guard test-binary-only
- removes the dead untyped supervisor health handler that was left in the original branch, keeping `/health` exclusively on the existing typed Huma handler

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

## Review

Adoption review found one minor architecture issue: the original PR still contained an unused raw `handleHealth` method using `map[string]any`/`writeJSON`, while the active `/health` route is already served by the typed Huma handler. This branch removes that dead code and leaves the final diff scoped to `internal/supervisor/registry.go` and `internal/supervisor/registry_test.go`.

## Tests

- `go test ./internal/supervisor -run 'TestRegistryMutatorsRefuseHostRegistryDuringTests|TestRegistry|TestRig' -count=1`
- `go test ./internal/api -run 'TestSupervisorHealth|TestSupervisorCitiesList|TestSupervisorProviderReadinessRoute|TestSupervisorPerCityEventStream|TestSupervisorEmptyCityName' -count=1`
- `go vet ./...`
- `go test ./cmd/gc -count=1 -timeout 20m`
- `go test ./...` was also run; all packages passed except `cmd/gc` exceeded the default 10m package timeout. The isolated `cmd/gc` rerun passed with a 20m timeout (`754.536s`).
