### PR TITLE
quality: Wave 1 session reconcile engine

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -10,6 +10,44 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+// awakeSessionBeadFromBead projects a stored session bead into the awake-set
+// model used by ComputeAwakeSet. It keeps the reconciliation bridge focused on
+// transport while the projection rules live in one place.
+func awakeSessionBeadFromBead(b beads.Bead, clk time.Time) (AwakeSessionBead, bool) {
+	if b.Status == "closed" {
+		return AwakeSessionBead{}, false
+	}
+	name := strings.TrimSpace(b.Metadata["session_name"])
+	if name == "" {
+		return AwakeSessionBead{}, false
+	}
+	lifecycle := session.ProjectLifecycle(session.LifecycleInput{
+		Status:   b.Status,
+		Metadata: b.Metadata,
+		Now:      clk,
+	})
+	bead := AwakeSessionBead{
+		ID:             b.ID,
+		SessionName:    name,
+		Template:       b.Metadata["template"],
+		State:          string(lifecycle.CompatState),
+		SleepReason:    b.Metadata["sleep_reason"],
+		ManualSession:  isManualSessionBead(b),
+		PendingCreate:  lifecycle.HasWakeCause(session.WakeCausePendingCreate),
+		DependencyOnly: b.Metadata["dependency_only"] == "true",
+		NamedIdentity:  lifecycle.NamedIdentity,
+		Pinned:         lifecycle.HasWakeCause(session.WakeCausePinned),
+		Drained:        lifecycle.BaseState == session.BaseStateDrained,
+		WaitHold:       b.Metadata["wait_hold"] == "true",
+	}
+	bead.HeldUntil = lifecycle.HeldUntil
+	bead.QuarantinedUntil = lifecycle.QuarantinedUntil
+	if t, err := time.Parse(time.RFC3339, b.Metadata["detached_at"]); err == nil && !t.IsZero() {
+		bead.IdleSince = t
+	}
+	return bead, true
+}
+
 // buildAwakeInputFromReconciler constructs AwakeInput from the reconciler's
 // existing data. Runtime liveness is populated from the already-computed
 // wakeTargets; attachment and pending interactions come from provider
@@ -72,37 +110,9 @@ func buildAwakeInputFromReconciler(
 
 	// Session beads
 	for i := range sessionBeads {
-		b := &sessionBeads[i]
-		if b.Status == "closed" {
+		bead, ok := awakeSessionBeadFromBead(sessionBeads[i], clk)
+		if !ok {
 			continue
-		}
-		name := strings.TrimSpace(b.Metadata["session_name"])
-		if name == "" {
-			continue
-		}
-		lifecycle := session.ProjectLifecycle(session.LifecycleInput{
-			Status:   b.Status,
-			Metadata: b.Metadata,
-			Now:      clk,
-		})
-		bead := AwakeSessionBead{
-			ID:             b.ID,
-			SessionName:    name,
-			Template:       b.Metadata["template"],
-			State:          string(lifecycle.CompatState),
-			SleepReason:    b.Metadata["sleep_reason"],
-			ManualSession:  isManualSessionBead(*b),
-			PendingCreate:  lifecycle.HasWakeCause(session.WakeCausePendingCreate),
-			DependencyOnly: b.Metadata["dependency_only"] == "true",
-			NamedIdentity:  lifecycle.NamedIdentity,
-			Pinned:         lifecycle.HasWakeCause(session.WakeCausePinned),
-			Drained:        lifecycle.BaseState == session.BaseStateDrained,
-			WaitHold:       b.Metadata["wait_hold"] == "true",
-		}
-		bead.HeldUntil = lifecycle.HeldUntil
-		bead.QuarantinedUntil = lifecycle.QuarantinedUntil
-		if t, err := time.Parse(time.RFC3339, b.Metadata["detached_at"]); err == nil && !t.IsZero() {
-			bead.IdleSince = t
 		}
 		input.SessionBeads = append(input.SessionBeads, bead)
 	}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -9,6 +9,66 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+func TestAwakeSessionBeadFromBeadProjectsLifecycleAndSkipsIrrelevantBeads(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("projects trimmed session metadata", func(t *testing.T) {
+		bead, ok := awakeSessionBeadFromBead(beads.Bead{
+			ID:     "mc-session-1",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"state":        "stopped",
+				"session_name": "  s-worker  ",
+				"template":     "worker",
+				"wait_hold":    "true",
+			},
+		}, now)
+		if !ok {
+			t.Fatal("awakeSessionBeadFromBead returned false, want true")
+		}
+		if bead.SessionName != "s-worker" {
+			t.Fatalf("SessionName = %q, want trimmed s-worker", bead.SessionName)
+		}
+		if bead.State != "asleep" {
+			t.Fatalf("State = %q, want asleep-compatible projection", bead.State)
+		}
+		if !bead.WaitHold {
+			t.Fatal("WaitHold = false, want true")
+		}
+		if bead.Template != "worker" {
+			t.Fatalf("Template = %q, want worker", bead.Template)
+		}
+	})
+
+	t.Run("skips closed beads", func(t *testing.T) {
+		if _, ok := awakeSessionBeadFromBead(beads.Bead{
+			ID:     "mc-session-2",
+			Status: "closed",
+			Type:   "session",
+			Metadata: map[string]string{
+				"session_name": "s-worker",
+				"template":     "worker",
+			},
+		}, now); ok {
+			t.Fatal("awakeSessionBeadFromBead returned true for closed bead")
+		}
+	})
+
+	t.Run("skips beads without session name", func(t *testing.T) {
+		if _, ok := awakeSessionBeadFromBead(beads.Bead{
+			ID:     "mc-session-3",
+			Status: "open",
+			Type:   "session",
+			Metadata: map[string]string{
+				"template": "worker",
+			},
+		}, now); ok {
+			t.Fatal("awakeSessionBeadFromBead returned true for bead without session_name")
+		}
+	})
+}
+
 func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilityStates(t *testing.T) {
 	now := time.Now().UTC()
 	input := buildAwakeInputFromReconciler(

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -419,6 +419,7 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 
 	sem := make(chan struct{}, cfg.Daemon.ProbeConcurrencyOrDefault())
 	results := make([]bool, len(probes))
+	errorLogs := make([]string, len(probes))
 	var wg sync.WaitGroup
 	for i := range probes {
 		wg.Add(1)
@@ -428,9 +429,7 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 			defer func() { <-sem }()
 			out, err := runner(probes[idx].wq, probes[idx].dir, probes[idx].env)
 			if err != nil {
-				if stderr != nil {
-					fmt.Fprintf(stderr, "session reconcile: work_query %s: %v\n", probes[idx].qn, err) //nolint:errcheck // best-effort stderr
-				}
+				errorLogs[idx] = fmt.Sprintf("session reconcile: work_query %s: %v\n", probes[idx].qn, err)
 				return // command failed — treat as no work
 			}
 			if workQueryHasReadyWork(strings.TrimSpace(out)) {
@@ -441,6 +440,9 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	wg.Wait()
 
 	for i, p := range probes {
+		if stderr != nil && errorLogs[i] != "" {
+			fmt.Fprint(stderr, errorLogs[i]) //nolint:errcheck // best-effort stderr
+		}
 		if results[i] {
 			work[p.qn] = true
 		}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -428,6 +428,9 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 			defer func() { <-sem }()
 			out, err := runner(probes[idx].wq, probes[idx].dir, probes[idx].env)
 			if err != nil {
+				if stderr != nil {
+					fmt.Fprintf(stderr, "session reconcile: work_query %s: %v\n", probes[idx].qn, err) //nolint:errcheck // best-effort stderr
+				}
 				return // command failed — treat as no work
 			}
 			if workQueryHasReadyWork(strings.TrimSpace(out)) {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -734,6 +734,82 @@ func TestComputeWorkSet_LogsProbeErrors(t *testing.T) {
 	}
 }
 
+type overlapDetectingWriter struct {
+	mu       sync.Mutex
+	active   int
+	overlap  bool
+	contents bytes.Buffer
+}
+
+func (w *overlapDetectingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	if w.active > 0 {
+		w.overlap = true
+	}
+	w.active++
+	w.mu.Unlock()
+
+	time.Sleep(10 * time.Millisecond)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.active--
+	return w.contents.Write(p)
+}
+
+func (w *overlapDetectingWriter) Overlapped() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.overlap
+}
+
+func (w *overlapDetectingWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.contents.String()
+}
+
+func TestComputeWorkSet_LogsProbeErrorsAfterConcurrentProbesComplete(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Daemon:    config.DaemonConfig{ProbeConcurrency: intPtr(2)},
+		Agents: []config.Agent{
+			{Name: "worker"},
+			{Name: "reviewer"},
+		},
+	}
+
+	var stderr overlapDetectingWriter
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	runner := func(_ string, _ string, _ map[string]string) (string, error) {
+		started <- struct{}{}
+		<-release
+		return "", fmt.Errorf("probe exploded")
+	}
+
+	done := make(chan map[string]bool, 1)
+	go func() {
+		done <- computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, &stderr)
+	}()
+
+	for range 2 {
+		<-started
+	}
+	close(release)
+
+	work := <-done
+	if work["worker"] || work["reviewer"] {
+		t.Fatalf("failed probes should not be marked ready: %v", work)
+	}
+	if stderr.Overlapped() {
+		t.Fatalf("stderr writes overlapped; output = %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "work_query worker") || !strings.Contains(stderr.String(), "work_query reviewer") {
+		t.Fatalf("stderr = %q, want both probe failure logs", stderr.String())
+	}
+}
+
 func TestComputeWorkSet_ExplicitRigWorkQueryUsesRigPassword(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT_USER", "")

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -705,6 +706,31 @@ func TestComputeWorkSet_UsesConfiguredRigRoot(t *testing.T) {
 	work := computeWorkSet(cfg, runner, "test-city", cityDir, nil, nil, nil)
 	if !work["myrig/polecat"] {
 		t.Error("expected myrig/polecat to have work when rig root is configured externally")
+	}
+}
+
+func TestComputeWorkSet_LogsProbeErrors(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	runner := func(_ string, _ string, _ map[string]string) (string, error) {
+		return "", fmt.Errorf("probe exploded")
+	}
+
+	work := computeWorkSet(cfg, runner, "test-city", "/tmp", nil, nil, &stderr)
+	if work["worker"] {
+		t.Fatal("worker should not be marked ready when work_query fails")
+	}
+	if !strings.Contains(stderr.String(), "work_query worker") {
+		t.Fatalf("stderr = %q, want work_query failure log", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "probe exploded") {
+		t.Fatalf("stderr = %q, want probe error detail", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #962.
- Carries the original Wave 1 session reconcile engine changes from @julianknutsen, including the awake-bridge projection refactor and `computeWorkSet` probe-error observability.
- Adds a maintainer fixup from adoption review: `computeWorkSet` now records work_query error log lines per probe and emits them after concurrent probes complete, so callers can pass a generic non-concurrency-safe `io.Writer` without overlapping writes.

Credit: Original fix by @julianknutsen. The original contribution is preserved as the first commit on this branch with original authorship.

No linked issue; this is a stacked quality/adoption PR for the session reconcile engine work.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Verified during adoption:

- `TMPDIR=/tmp/gascity-pr962-gotmp GOCACHE=/tmp/gascity-pr962-gocache GOTMPDIR=/tmp/gascity-pr962-gotmp go test ./cmd/gc -run 'TestCityRuntime|TestControllerState(ReadAccess|MutationsPokeController|MutationErrorDoesNotPokeController|ApplyBeadEventPokesController|ApplyCacheReconcileEventDoesNotPokeController)|Test(AwakeSessionBeadFromBeadProjectsLifecycleAndSkipsIrrelevantBeads|BuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilityStates|BuildAwakeInputFromReconcilerPopulatesPendingInteractions|ComputeWorkSet_|BuildDesiredState_|ComputePoolDesiredStates_|ReconcileSessionBeads_)' -count=1`
- `TMPDIR=/tmp/gascity-pr962-gotmp GOCACHE=/tmp/gascity-pr962-gocache GOTMPDIR=/tmp/gascity-pr962-gotmp go test ./cmd/gc -run 'TestComputeWorkSet_(LogsProbeErrors|LogsProbeErrorsAfterConcurrentProbesComplete|RunsWorkQuery|ResolvesRigDir|UsesConfiguredRigRoot|ExplicitRigWorkQueryUsesRigPassword)' -count=1`
- `TMPDIR=/tmp/gascity-pr962-gotmp GOCACHE=/tmp/gascity-pr962-gocache GOTMPDIR=/tmp/gascity-pr962-gotmp go vet ./...`

Attempted:

- `TMPDIR=$PWD/.gotmp GOCACHE=$PWD/.gocache GOTMPDIR=$PWD/.gotmp go test ./...` failed because repo-local temp/cache directories were visible to repository-walking tests and because managed bd tests emitted extra MySQL timeout text into JSON output. The focused PR test set and vet passed with temp/cache outside the repo.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No user-facing docs changes or breaking changes.
