### PR TITLE
test: harden hook-enabled startup proofs

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -50,6 +50,12 @@ type primeHookInput struct {
 	Source    string `json:"source"`
 }
 
+type primeHookContext struct {
+	SessionID     string
+	Source        string
+	HookEventName string
+}
+
 // newPrimeCmd creates the "gc prime [agent-name]" command.
 func newPrimeCmd(stdout, stderr io.Writer) *cobra.Command {
 	var hookMode bool
@@ -140,6 +146,12 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		agentName = args[0]
 	}
 
+	hookContext := primeHookContext{}
+	suppressHookPrompt := false
+	if hookMode {
+		hookContext = readPrimeHookContext()
+		suppressHookPrompt = managedSessionHookPromptAlreadyDelivered(hookContext)
+	}
 	// In non-strict mode, hook side effects fire eagerly (existing behavior).
 	// In strict mode, we defer them until after strict checks pass so that a
 	// failing --strict invocation does not persist a session-id for failed
@@ -148,7 +160,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		if !hookMode {
 			return
 		}
-		if sessionID, _ := readPrimeHookContext(); sessionID != "" {
+		if sessionID := hookContext.SessionID; sessionID != "" {
 			persistPrimeHookSessionID(sessionID)
 		}
 		persistPrimeHookProviderSessionKey()
@@ -272,7 +284,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
 				cfg.PackDirs, fragments, nil)
 			if prompt != "" {
-				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat)
+				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt)
 				return 0
 			}
 			// File is present but rendered empty. Treat as a legitimate
@@ -293,7 +305,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			}
 			if promptFile != "" {
 				if content, fErr := os.ReadFile(filepath.Join(cityPath, promptFile)); fErr == nil {
-					writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, string(content), hookMode, hookFormat)
+					writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, string(content), hookMode, hookFormat, suppressHookPrompt)
 					return 0
 				}
 			}
@@ -363,7 +375,22 @@ func prependHookBeacon(cityName, agentName, prompt string) string {
 	return beacon + "\n\n" + prompt
 }
 
-func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt string, hookMode bool, hookFormat string) {
+func managedSessionHookPromptAlreadyDelivered(ctx primeHookContext) bool {
+	if strings.TrimSpace(os.Getenv(startupPromptDeliveredEnv)) != "1" {
+		return false
+	}
+	if strings.TrimSpace(os.Getenv(managedSessionHookEnv)) != "1" {
+		return false
+	}
+	return strings.TrimSpace(ctx.HookEventName) == "SessionStart"
+}
+
+func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt string, hookMode bool, hookFormat string, suppressPrompt bool) {
+	if hookMode && suppressPrompt {
+		// Managed sessions receive the rendered startup prompt through the
+		// launch payload or nudge path. SessionStart hooks add context only.
+		prompt = ""
+	}
 	if hookMode {
 		prompt = prependHookBeacon(cityName, agentName, prompt)
 	}
@@ -374,23 +401,31 @@ func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt st
 	fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout
 }
 
-func readPrimeHookContext() (sessionID, source string) {
-	source = os.Getenv("GC_HOOK_SOURCE")
-	if id := os.Getenv("GC_SESSION_ID"); id != "" {
-		return id, source
+func readPrimeHookContext() primeHookContext {
+	ctx := primeHookContext{
+		Source:        strings.TrimSpace(os.Getenv("GC_HOOK_SOURCE")),
+		HookEventName: strings.TrimSpace(os.Getenv("GC_HOOK_EVENT_NAME")),
 	}
-	if id := os.Getenv("CLAUDE_SESSION_ID"); id != "" {
-		return id, source
-	}
-	if input := readPrimeHookStdin(); input != nil {
-		if input.Source != "" {
-			source = input.Source
-		}
-		if input.SessionID != "" {
-			return input.SessionID, source
+	if shouldReadPrimeHookStdin() {
+		if input := readPrimeHookStdin(); input != nil {
+			if source := strings.TrimSpace(input.Source); source != "" {
+				ctx.Source = source
+			}
+			ctx.SessionID = strings.TrimSpace(input.SessionID)
 		}
 	}
-	return "", source
+	if id := strings.TrimSpace(os.Getenv("GC_SESSION_ID")); id != "" {
+		ctx.SessionID = id
+	} else if id := strings.TrimSpace(os.Getenv("CLAUDE_SESSION_ID")); id != "" {
+		ctx.SessionID = id
+	}
+	return ctx
+}
+
+func shouldReadPrimeHookStdin() bool {
+	hasEnvSessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID")) != "" ||
+		strings.TrimSpace(os.Getenv("CLAUDE_SESSION_ID")) != ""
+	return !hasEnvSessionID
 }
 
 func readPrimeHookStdin() *primeHookInput {

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -264,4 +265,189 @@ prompt_template = "prompts/polecat.template.md"
 	if strings.Contains(out, "# Gas City Agent") {
 		t.Fatalf("stdout = %q, want resolved hook prompt, not generic fallback", out)
 	}
+}
+
+func TestDoPrimeWithHook_StartupPromptDeliveryEnvControlsPromptSuppression(t *testing.T) {
+	cityDir := t.TempDir()
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	const promptContent = "launch-only startup prompt\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "worker.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name             string
+		delivered        string
+		managedHook      string
+		envHookSource    string
+		envHookEvent     string
+		wantPromptInHook bool
+	}{
+		{
+			name:             "startup hook delivered",
+			delivered:        "1",
+			managedHook:      "1",
+			envHookSource:    "startup",
+			envHookEvent:     "SessionStart",
+			wantPromptInHook: false,
+		},
+		{
+			name:             "resume hook delivered",
+			delivered:        "1",
+			managedHook:      "1",
+			envHookSource:    "resume",
+			envHookEvent:     "SessionStart",
+			wantPromptInHook: false,
+		},
+		{name: "manual command with inherited marker", delivered: "1", wantPromptInHook: true},
+		{
+			name:             "unmanaged session start keeps prompt",
+			delivered:        "1",
+			envHookEvent:     "SessionStart",
+			wantPromptInHook: true,
+		},
+		{
+			name:             "startup hook not delivered",
+			managedHook:      "1",
+			envHookSource:    "startup",
+			envHookEvent:     "SessionStart",
+			wantPromptInHook: true,
+		},
+		{
+			name:             "non startup event keeps prompt",
+			delivered:        "1",
+			envHookSource:    "startup",
+			envHookEvent:     "UserPromptSubmit",
+			wantPromptInHook: true,
+		},
+		{
+			name:             "session start ignores source value",
+			delivered:        "1",
+			managedHook:      "1",
+			envHookSource:    "manual",
+			envHookEvent:     "SessionStart",
+			wantPromptInHook: false,
+		},
+		{name: "unset source not delivered", wantPromptInHook: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withPrimeHookStdin(t, nil)
+			t.Setenv("GC_CITY", cityDir)
+			t.Setenv("GC_AGENT", "worker")
+			t.Setenv("GC_ALIAS", "worker")
+			t.Setenv("GC_TEMPLATE", "worker")
+			t.Setenv("GC_SESSION_NAME", "gastown--worker")
+			t.Setenv("GC_SESSION_ID", "sess-777")
+			t.Setenv(managedSessionHookEnv, tc.managedHook)
+			t.Setenv("GC_HOOK_SOURCE", tc.envHookSource)
+			t.Setenv("GC_HOOK_EVENT_NAME", tc.envHookEvent)
+			t.Setenv(startupPromptDeliveredEnv, tc.delivered)
+
+			var stdout, stderr bytes.Buffer
+			code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
+			if code != 0 {
+				t.Fatalf("doPrimeWithMode() = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			out := stdout.String()
+			if got := strings.Contains(out, promptContent); got != tc.wantPromptInHook {
+				t.Fatalf("stdout = %q, prompt present = %v, want %v", out, got, tc.wantPromptInHook)
+			}
+			if !strings.Contains(out, "[gastown] worker") {
+				t.Fatalf("stdout = %q, want hook beacon", out)
+			}
+		})
+	}
+}
+
+func TestDoPrimeWithHook_DeliveredStartupPromptJSONHookFormat(t *testing.T) {
+	cityDir := t.TempDir()
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	const promptContent = "launch-only startup prompt\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "worker.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_AGENT", "worker")
+	t.Setenv("GC_ALIAS", "worker")
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_SESSION_NAME", "gastown--worker")
+	t.Setenv("GC_SESSION_ID", "sess-777")
+	t.Setenv(managedSessionHookEnv, "1")
+	t.Setenv("GC_HOOK_SOURCE", "startup")
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+	t.Setenv(startupPromptDeliveredEnv, "1")
+	withPrimeHookStdin(t, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatGemini, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var got struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
+	}
+	context := got.HookSpecificOutput.AdditionalContext
+	if strings.Contains(context, promptContent) {
+		t.Fatalf("additionalContext = %q, want no repeated startup prompt", context)
+	}
+	if !strings.Contains(context, "[gastown] worker") {
+		t.Fatalf("additionalContext = %q, want hook beacon", context)
+	}
+}
+
+func withPrimeHookStdin(t *testing.T, payload map[string]string) {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload != nil {
+		if err := json.NewEncoder(writer).Encode(payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPrimeStdin := primeStdin
+	primeStdin = func() *os.File { return reader }
+	t.Cleanup(func() {
+		primeStdin = oldPrimeStdin
+		_ = reader.Close()
+	})
 }

--- a/cmd/gc/phase2_real_transport_test.go
+++ b/cmd/gc/phase2_real_transport_test.go
@@ -40,7 +40,7 @@ func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	}
 }
 
-func TestPhase2HookEnabledClaudeAutonomousStartupProof(t *testing.T) {
+func TestPhase2HookEnabledClaudeLaunchPromptDeliveryProof(t *testing.T) {
 	tmuxtest.RequireTmux(t)
 
 	tc := phase2ProviderCaseForFamily(t, "claude")
@@ -65,30 +65,36 @@ func TestPhase2HookEnabledClaudeAutonomousStartupProof(t *testing.T) {
 		t.Fatalf("startup prompt = %q, want %q", got, want)
 	}
 	if !run.AutonomousStarted {
-		t.Fatal("autonomous marker = missing, want launch-prompt work before any explicit rescue nudge")
+		t.Fatal("launch prompt marker = missing, want command-line startup prompt matched before any explicit rescue nudge")
 	}
 }
 
 type phase2RealTransportRun struct {
-	Transport             string
-	SocketName            string
-	SessionName           string
-	ProviderPath          string
-	StartedPath           string
-	InputPath             string
-	StartupPromptPath     string
-	AutonomousPath        string
-	ErrorStage            string
-	Error                 string
-	ExpectedInput         string
-	ObservedInput         string
-	ExpectedStartupPrompt string
-	ObservedStartupPrompt string
-	ObservedProvider      string
-	Started               bool
-	AutonomousStarted     bool
-	RunningAfterInput     bool
-	StartElapsed          time.Duration
+	Transport                string
+	SocketName               string
+	SessionName              string
+	ProviderPath             string
+	StartedPath              string
+	InputPath                string
+	SessionOriginPath        string
+	StartupDeliveredPath     string
+	StartupPromptPath        string
+	AutonomousPath           string
+	ErrorStage               string
+	Error                    string
+	ExpectedInput            string
+	ObservedInput            string
+	ExpectedSessionOrigin    string
+	ObservedSessionOrigin    string
+	ExpectedStartupDelivered string
+	ObservedStartupDelivered string
+	ExpectedStartupPrompt    string
+	ObservedStartupPrompt    string
+	ObservedProvider         string
+	Started                  bool
+	AutonomousStarted        bool
+	RunningAfterInput        bool
+	StartElapsed             time.Duration
 }
 
 func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, materialized runtime.Config) phase2RealTransportRun {
@@ -99,6 +105,8 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	startedPath := filepath.Join(dir, "started.txt")
 	providerPath := filepath.Join(dir, "provider.txt")
 	inputPath := filepath.Join(dir, "input.txt")
+	sessionOriginPath := filepath.Join(dir, "session-origin.txt")
+	startupDeliveredPath := filepath.Join(dir, "startup-delivered.txt")
 	startupPromptPath := filepath.Join(dir, "startup-prompt.txt")
 	expectedPromptPath := filepath.Join(dir, "expected-startup-prompt.txt")
 	autonomousPath := filepath.Join(dir, "autonomous.txt")
@@ -107,34 +115,42 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	expectedStartupPrompt, promptErr := singleShellArgValue(materialized.PromptSuffix)
 	if promptErr != nil {
 		return phase2RealTransportRun{
-			Transport:             "tmux",
-			SocketName:            guard.SocketName(),
-			SessionName:           sessionName,
-			ProviderPath:          providerPath,
-			StartedPath:           startedPath,
-			InputPath:             inputPath,
-			StartupPromptPath:     startupPromptPath,
-			AutonomousPath:        autonomousPath,
-			ErrorStage:            "prompt_suffix_parse",
-			Error:                 promptErr.Error(),
-			ExpectedInput:         materialized.Nudge,
-			ExpectedStartupPrompt: expectedStartupPrompt,
+			Transport:                "tmux",
+			SocketName:               guard.SocketName(),
+			SessionName:              sessionName,
+			ProviderPath:             providerPath,
+			StartedPath:              startedPath,
+			InputPath:                inputPath,
+			SessionOriginPath:        sessionOriginPath,
+			StartupDeliveredPath:     startupDeliveredPath,
+			StartupPromptPath:        startupPromptPath,
+			AutonomousPath:           autonomousPath,
+			ErrorStage:               "prompt_suffix_parse",
+			Error:                    promptErr.Error(),
+			ExpectedInput:            materialized.Nudge,
+			ExpectedSessionOrigin:    materialized.Env["GC_SESSION_ORIGIN"],
+			ExpectedStartupDelivered: materialized.Env[startupPromptDeliveredEnv],
+			ExpectedStartupPrompt:    expectedStartupPrompt,
 		}
 	}
 	if err := os.WriteFile(expectedPromptPath, []byte(expectedStartupPrompt), 0o644); err != nil {
 		return phase2RealTransportRun{
-			Transport:             "tmux",
-			SocketName:            guard.SocketName(),
-			SessionName:           sessionName,
-			ProviderPath:          providerPath,
-			StartedPath:           startedPath,
-			InputPath:             inputPath,
-			StartupPromptPath:     startupPromptPath,
-			AutonomousPath:        autonomousPath,
-			ErrorStage:            "expected_prompt_write",
-			Error:                 err.Error(),
-			ExpectedInput:         materialized.Nudge,
-			ExpectedStartupPrompt: expectedStartupPrompt,
+			Transport:                "tmux",
+			SocketName:               guard.SocketName(),
+			SessionName:              sessionName,
+			ProviderPath:             providerPath,
+			StartedPath:              startedPath,
+			InputPath:                inputPath,
+			SessionOriginPath:        sessionOriginPath,
+			StartupDeliveredPath:     startupDeliveredPath,
+			StartupPromptPath:        startupPromptPath,
+			AutonomousPath:           autonomousPath,
+			ErrorStage:               "expected_prompt_write",
+			Error:                    err.Error(),
+			ExpectedInput:            materialized.Nudge,
+			ExpectedSessionOrigin:    materialized.Env["GC_SESSION_ORIGIN"],
+			ExpectedStartupDelivered: materialized.Env[startupPromptDeliveredEnv],
+			ExpectedStartupPrompt:    expectedStartupPrompt,
 		}
 	}
 
@@ -147,18 +163,22 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	}, guard.CityName(), dir)
 	if err != nil {
 		return phase2RealTransportRun{
-			Transport:             "tmux",
-			SocketName:            guard.SocketName(),
-			SessionName:           sessionName,
-			ProviderPath:          providerPath,
-			StartedPath:           startedPath,
-			InputPath:             inputPath,
-			StartupPromptPath:     startupPromptPath,
-			AutonomousPath:        autonomousPath,
-			ErrorStage:            "provider",
-			Error:                 err.Error(),
-			ExpectedInput:         materialized.Nudge,
-			ExpectedStartupPrompt: expectedStartupPrompt,
+			Transport:                "tmux",
+			SocketName:               guard.SocketName(),
+			SessionName:              sessionName,
+			ProviderPath:             providerPath,
+			StartedPath:              startedPath,
+			InputPath:                inputPath,
+			SessionOriginPath:        sessionOriginPath,
+			StartupDeliveredPath:     startupDeliveredPath,
+			StartupPromptPath:        startupPromptPath,
+			AutonomousPath:           autonomousPath,
+			ErrorStage:               "provider",
+			Error:                    err.Error(),
+			ExpectedInput:            materialized.Nudge,
+			ExpectedSessionOrigin:    materialized.Env["GC_SESSION_ORIGIN"],
+			ExpectedStartupDelivered: materialized.Env[startupPromptDeliveredEnv],
+			ExpectedStartupPrompt:    expectedStartupPrompt,
 		}
 	}
 
@@ -170,9 +190,11 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	script := strings.Join([]string{
 		`set -eu`,
 		`printf "%s\n" "$GC_PROVIDER" > "$GC_REAL_TRANSPORT_PROVIDER_PATH"`,
+		`printf "%s" "${GC_SESSION_ORIGIN:-}" > "$GC_REAL_TRANSPORT_SESSION_ORIGIN_PATH"`,
+		`printf "%s" "${GC_STARTUP_PROMPT_DELIVERED:-}" > "$GC_REAL_TRANSPORT_STARTUP_DELIVERED_PATH"`,
 		`printf "started\n" > "$GC_REAL_TRANSPORT_STARTED_PATH"`,
 		`printf "%s" "$0" > "$GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH"`,
-		`if [ "$0" = "$(cat "$GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH")" ]; then printf "autonomous\n" > "$GC_REAL_TRANSPORT_AUTONOMOUS_PATH"; fi`,
+		`if cmp -s "$GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH" "$GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH"; then printf "launch-prompt\n" > "$GC_REAL_TRANSPORT_AUTONOMOUS_PATH"; fi`,
 		`IFS= read -r line`,
 		`printf "%s\n" "$line" > "$GC_REAL_TRANSPORT_INPUT_PATH"`,
 		`while [ ! -f "$GC_REAL_TRANSPORT_STOP_PATH" ]; do sleep 0.05; done`,
@@ -195,6 +217,8 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	cfg.Env["GC_REAL_TRANSPORT_PROVIDER_PATH"] = providerPath
 	cfg.Env["GC_REAL_TRANSPORT_STARTED_PATH"] = startedPath
 	cfg.Env["GC_REAL_TRANSPORT_INPUT_PATH"] = inputPath
+	cfg.Env["GC_REAL_TRANSPORT_SESSION_ORIGIN_PATH"] = sessionOriginPath
+	cfg.Env["GC_REAL_TRANSPORT_STARTUP_DELIVERED_PATH"] = startupDeliveredPath
 	cfg.Env["GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH"] = startupPromptPath
 	cfg.Env["GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH"] = expectedPromptPath
 	cfg.Env["GC_REAL_TRANSPORT_AUTONOMOUS_PATH"] = autonomousPath
@@ -206,27 +230,33 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	start := time.Now()
 	if err := sp.Start(ctx, sessionName, cfg); err != nil {
 		return phase2RealTransportRun{
-			Transport:             "tmux",
-			SocketName:            guard.SocketName(),
-			SessionName:           sessionName,
-			ProviderPath:          providerPath,
-			StartedPath:           startedPath,
-			InputPath:             inputPath,
-			StartupPromptPath:     startupPromptPath,
-			AutonomousPath:        autonomousPath,
-			ErrorStage:            "start",
-			Error:                 err.Error(),
-			ExpectedInput:         materialized.Nudge,
-			ExpectedStartupPrompt: expectedStartupPrompt,
-			StartElapsed:          time.Since(start),
+			Transport:                "tmux",
+			SocketName:               guard.SocketName(),
+			SessionName:              sessionName,
+			ProviderPath:             providerPath,
+			StartedPath:              startedPath,
+			InputPath:                inputPath,
+			SessionOriginPath:        sessionOriginPath,
+			StartupDeliveredPath:     startupDeliveredPath,
+			StartupPromptPath:        startupPromptPath,
+			AutonomousPath:           autonomousPath,
+			ErrorStage:               "start",
+			Error:                    err.Error(),
+			ExpectedInput:            materialized.Nudge,
+			ExpectedSessionOrigin:    materialized.Env["GC_SESSION_ORIGIN"],
+			ExpectedStartupDelivered: materialized.Env[startupPromptDeliveredEnv],
+			ExpectedStartupPrompt:    expectedStartupPrompt,
+			StartElapsed:             time.Since(start),
 		}
 	}
 	startElapsed := time.Since(start)
 
-	observedInput, inputErr := waitForPhase2FileText(inputPath, phase2RealTransportBound)
-	observedProvider, providerErr := waitForPhase2FileText(providerPath, phase2RealTransportBound)
 	observedStartupPrompt, startupPromptErr := waitForPhase2FileText(startupPromptPath, phase2RealTransportBound)
 	autonomousStarted := waitForPhase2FileExists(autonomousPath, phase2RealTransportMarkerBound)
+	observedInput, inputErr := waitForPhase2FileText(inputPath, phase2RealTransportBound)
+	observedProvider, providerErr := waitForPhase2FileText(providerPath, phase2RealTransportBound)
+	observedSessionOrigin, sessionOriginErr := waitForPhase2FileText(sessionOriginPath, phase2RealTransportBound)
+	observedStartupDelivered, startupDeliveredErr := waitForPhase2FileText(startupDeliveredPath, phase2RealTransportBound)
 	_, startedErr := os.Stat(startedPath)
 
 	errorStage := ""
@@ -241,53 +271,71 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	case providerErr != nil:
 		errorStage = "provider_marker_wait"
 		errorDetail = providerErr.Error()
+	case sessionOriginErr != nil:
+		errorStage = "session_origin_wait"
+		errorDetail = sessionOriginErr.Error()
+	case startupDeliveredErr != nil:
+		errorStage = "startup_delivered_wait"
+		errorDetail = startupDeliveredErr.Error()
 	}
 
 	return phase2RealTransportRun{
-		Transport:             "tmux",
-		SocketName:            guard.SocketName(),
-		SessionName:           sessionName,
-		ProviderPath:          providerPath,
-		StartedPath:           startedPath,
-		InputPath:             inputPath,
-		StartupPromptPath:     startupPromptPath,
-		AutonomousPath:        autonomousPath,
-		ErrorStage:            errorStage,
-		Error:                 errorDetail,
-		ExpectedInput:         materialized.Nudge,
-		ObservedInput:         strings.TrimSpace(observedInput),
-		ExpectedStartupPrompt: expectedStartupPrompt,
-		ObservedStartupPrompt: observedStartupPrompt,
-		ObservedProvider:      strings.TrimSpace(observedProvider),
-		Started:               startedErr == nil,
-		AutonomousStarted:     autonomousStarted,
-		RunningAfterInput:     sp.IsRunning(sessionName),
-		StartElapsed:          startElapsed,
+		Transport:                "tmux",
+		SocketName:               guard.SocketName(),
+		SessionName:              sessionName,
+		ProviderPath:             providerPath,
+		StartedPath:              startedPath,
+		InputPath:                inputPath,
+		SessionOriginPath:        sessionOriginPath,
+		StartupDeliveredPath:     startupDeliveredPath,
+		StartupPromptPath:        startupPromptPath,
+		AutonomousPath:           autonomousPath,
+		ErrorStage:               errorStage,
+		Error:                    errorDetail,
+		ExpectedInput:            materialized.Nudge,
+		ObservedInput:            strings.TrimSpace(observedInput),
+		ExpectedSessionOrigin:    materialized.Env["GC_SESSION_ORIGIN"],
+		ObservedSessionOrigin:    strings.TrimSpace(observedSessionOrigin),
+		ExpectedStartupDelivered: materialized.Env[startupPromptDeliveredEnv],
+		ObservedStartupDelivered: strings.TrimSpace(observedStartupDelivered),
+		ExpectedStartupPrompt:    expectedStartupPrompt,
+		ObservedStartupPrompt:    observedStartupPrompt,
+		ObservedProvider:         strings.TrimSpace(observedProvider),
+		Started:                  startedErr == nil,
+		AutonomousStarted:        autonomousStarted,
+		RunningAfterInput:        sp.IsRunning(sessionName),
+		StartElapsed:             startElapsed,
 	}
 }
 
 func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun) workertest.Result {
 	evidence := map[string]string{
-		"family":                  tc.family,
-		"profile":                 string(tc.profileID),
-		"transport":               run.Transport,
-		"socket_name":             run.SocketName,
-		"session_name":            run.SessionName,
-		"started_path":            run.StartedPath,
-		"provider_path":           run.ProviderPath,
-		"input_path":              run.InputPath,
-		"startup_prompt_path":     run.StartupPromptPath,
-		"autonomous_path":         run.AutonomousPath,
-		"error_stage":             run.ErrorStage,
-		"error":                   run.Error,
-		"expected_input":          run.ExpectedInput,
-		"observed_input":          run.ObservedInput,
-		"expected_startup_prompt": run.ExpectedStartupPrompt,
-		"observed_startup_prompt": run.ObservedStartupPrompt,
-		"observed_provider":       run.ObservedProvider,
-		"autonomous_started":      fmt.Sprintf("%t", run.AutonomousStarted),
-		"running_after_input":     fmt.Sprintf("%t", run.RunningAfterInput),
-		"start_elapsed":           run.StartElapsed.String(),
+		"family":                     tc.family,
+		"profile":                    string(tc.profileID),
+		"transport":                  run.Transport,
+		"socket_name":                run.SocketName,
+		"session_name":               run.SessionName,
+		"started_path":               run.StartedPath,
+		"provider_path":              run.ProviderPath,
+		"input_path":                 run.InputPath,
+		"session_origin_path":        run.SessionOriginPath,
+		"startup_delivered_path":     run.StartupDeliveredPath,
+		"startup_prompt_path":        run.StartupPromptPath,
+		"autonomous_path":            run.AutonomousPath,
+		"error_stage":                run.ErrorStage,
+		"error":                      run.Error,
+		"expected_input":             run.ExpectedInput,
+		"observed_input":             run.ObservedInput,
+		"expected_session_origin":    run.ExpectedSessionOrigin,
+		"observed_session_origin":    run.ObservedSessionOrigin,
+		"expected_startup_delivered": run.ExpectedStartupDelivered,
+		"observed_startup_delivered": run.ObservedStartupDelivered,
+		"expected_startup_prompt":    run.ExpectedStartupPrompt,
+		"observed_startup_prompt":    run.ObservedStartupPrompt,
+		"observed_provider":          run.ObservedProvider,
+		"autonomous_started":         fmt.Sprintf("%t", run.AutonomousStarted),
+		"running_after_input":        fmt.Sprintf("%t", run.RunningAfterInput),
+		"start_elapsed":              run.StartElapsed.String(),
 	}
 	switch {
 	case run.ErrorStage != "":
@@ -302,12 +350,18 @@ func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun
 	case run.ObservedProvider != tc.family:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("GC_PROVIDER = %q, want %q", run.ObservedProvider, tc.family)).WithEvidence(evidence)
+	case run.ExpectedSessionOrigin != "" && run.ObservedSessionOrigin != run.ExpectedSessionOrigin:
+		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
+			fmt.Sprintf("GC_SESSION_ORIGIN = %q, want %q", run.ObservedSessionOrigin, run.ExpectedSessionOrigin)).WithEvidence(evidence)
+	case run.ExpectedStartupDelivered != "" && run.ObservedStartupDelivered != run.ExpectedStartupDelivered:
+		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
+			fmt.Sprintf("%s = %q, want %q", startupPromptDeliveredEnv, run.ObservedStartupDelivered, run.ExpectedStartupDelivered)).WithEvidence(evidence)
 	case run.ObservedStartupPrompt != run.ExpectedStartupPrompt:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("startup prompt = %q, want %q", run.ObservedStartupPrompt, run.ExpectedStartupPrompt)).WithEvidence(evidence)
 	case !run.AutonomousStarted:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
-			"launch prompt did not trigger autonomous pre-nudge work").WithEvidence(evidence)
+			"command-line startup prompt did not match expected payload before nudge").WithEvidence(evidence)
 	case run.ObservedInput != run.ExpectedInput:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("nudge input = %q, want %q", run.ObservedInput, run.ExpectedInput)).WithEvidence(evidence)
@@ -319,7 +373,7 @@ func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun
 			fmt.Sprintf("startup elapsed = %s, want <= %s", run.StartElapsed, phase2RealTransportBound)).WithEvidence(evidence)
 	default:
 		return workertest.Pass(tc.profileID, workertest.RequirementRealTransportProof,
-			"production tmux runtime launched, delivered the first-turn startup prompt, and preserved stdin nudge delivery deterministically").WithEvidence(evidence)
+			"production tmux runtime launched, delivered the command-line startup prompt, and preserved stdin nudge delivery deterministically").WithEvidence(evidence)
 	}
 }
 

--- a/cmd/gc/phase2_real_transport_test.go
+++ b/cmd/gc/phase2_real_transport_test.go
@@ -18,7 +18,10 @@ import (
 	"github.com/gastownhall/gascity/test/tmuxtest"
 )
 
-const phase2RealTransportBound = 5 * time.Second
+const (
+	phase2RealTransportBound       = 5 * time.Second
+	phase2RealTransportMarkerBound = 500 * time.Millisecond
+)
 
 func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	tmuxtest.RequireTmux(t)
@@ -37,21 +40,55 @@ func TestPhase2WorkerCoreRealTransportProof(t *testing.T) {
 	}
 }
 
+func TestPhase2HookEnabledClaudeAutonomousStartupProof(t *testing.T) {
+	tmuxtest.RequireTmux(t)
+
+	tc := phase2ProviderCaseForFamily(t, "claude")
+	tp := resolvePhase2Template(t, tc)
+	if !tp.HookEnabled {
+		t.Fatal("HookEnabled = false, want true for Claude phase2 profile")
+	}
+	if tp.ResolvedProvider == nil {
+		t.Fatal("ResolvedProvider = nil, want Claude provider metadata")
+	}
+	if !tp.ResolvedProvider.SupportsHooks {
+		t.Fatal("SupportsHooks = false, want true for Claude phase2 profile")
+	}
+
+	materialized := templateParamsToConfig(tp)
+	run := launchPhase2RealTransportSession(t, tc, materialized)
+
+	if run.ErrorStage != "" {
+		t.Fatalf("%s failed: %s", run.ErrorStage, run.Error)
+	}
+	if got, want := run.ObservedStartupPrompt, run.ExpectedStartupPrompt; got != want {
+		t.Fatalf("startup prompt = %q, want %q", got, want)
+	}
+	if !run.AutonomousStarted {
+		t.Fatal("autonomous marker = missing, want launch-prompt work before any explicit rescue nudge")
+	}
+}
+
 type phase2RealTransportRun struct {
-	Transport         string
-	SocketName        string
-	SessionName       string
-	ProviderPath      string
-	StartedPath       string
-	InputPath         string
-	ErrorStage        string
-	Error             string
-	ExpectedInput     string
-	ObservedInput     string
-	ObservedProvider  string
-	Started           bool
-	RunningAfterInput bool
-	StartElapsed      time.Duration
+	Transport             string
+	SocketName            string
+	SessionName           string
+	ProviderPath          string
+	StartedPath           string
+	InputPath             string
+	StartupPromptPath     string
+	AutonomousPath        string
+	ErrorStage            string
+	Error                 string
+	ExpectedInput         string
+	ObservedInput         string
+	ExpectedStartupPrompt string
+	ObservedStartupPrompt string
+	ObservedProvider      string
+	Started               bool
+	AutonomousStarted     bool
+	RunningAfterInput     bool
+	StartElapsed          time.Duration
 }
 
 func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, materialized runtime.Config) phase2RealTransportRun {
@@ -62,8 +99,44 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	startedPath := filepath.Join(dir, "started.txt")
 	providerPath := filepath.Join(dir, "provider.txt")
 	inputPath := filepath.Join(dir, "input.txt")
+	startupPromptPath := filepath.Join(dir, "startup-prompt.txt")
+	expectedPromptPath := filepath.Join(dir, "expected-startup-prompt.txt")
+	autonomousPath := filepath.Join(dir, "autonomous.txt")
 	stopPath := filepath.Join(dir, "stop.txt")
 	sessionName := guard.SessionName("phase2-" + tc.family)
+	expectedStartupPrompt, promptErr := singleShellArgValue(materialized.PromptSuffix)
+	if promptErr != nil {
+		return phase2RealTransportRun{
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "prompt_suffix_parse",
+			Error:                 promptErr.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
+		}
+	}
+	if err := os.WriteFile(expectedPromptPath, []byte(expectedStartupPrompt), 0o644); err != nil {
+		return phase2RealTransportRun{
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "expected_prompt_write",
+			Error:                 err.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
+		}
+	}
 
 	sp, err := newSessionProviderByName("", config.SessionConfig{
 		Socket:             guard.SocketName(),
@@ -74,15 +147,18 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	}, guard.CityName(), dir)
 	if err != nil {
 		return phase2RealTransportRun{
-			Transport:     "tmux",
-			SocketName:    guard.SocketName(),
-			SessionName:   sessionName,
-			ProviderPath:  providerPath,
-			StartedPath:   startedPath,
-			InputPath:     inputPath,
-			ErrorStage:    "provider",
-			Error:         err.Error(),
-			ExpectedInput: materialized.Nudge,
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "provider",
+			Error:                 err.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
 		}
 	}
 
@@ -95,6 +171,8 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 		`set -eu`,
 		`printf "%s\n" "$GC_PROVIDER" > "$GC_REAL_TRANSPORT_PROVIDER_PATH"`,
 		`printf "started\n" > "$GC_REAL_TRANSPORT_STARTED_PATH"`,
+		`printf "%s" "$0" > "$GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH"`,
+		`if [ "$0" = "$(cat "$GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH")" ]; then printf "autonomous\n" > "$GC_REAL_TRANSPORT_AUTONOMOUS_PATH"; fi`,
 		`IFS= read -r line`,
 		`printf "%s\n" "$line" > "$GC_REAL_TRANSPORT_INPUT_PATH"`,
 		`while [ ! -f "$GC_REAL_TRANSPORT_STOP_PATH" ]; do sleep 0.05; done`,
@@ -117,6 +195,9 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	cfg.Env["GC_REAL_TRANSPORT_PROVIDER_PATH"] = providerPath
 	cfg.Env["GC_REAL_TRANSPORT_STARTED_PATH"] = startedPath
 	cfg.Env["GC_REAL_TRANSPORT_INPUT_PATH"] = inputPath
+	cfg.Env["GC_REAL_TRANSPORT_STARTUP_PROMPT_PATH"] = startupPromptPath
+	cfg.Env["GC_REAL_TRANSPORT_EXPECTED_PROMPT_PATH"] = expectedPromptPath
+	cfg.Env["GC_REAL_TRANSPORT_AUTONOMOUS_PATH"] = autonomousPath
 	cfg.Env["GC_REAL_TRANSPORT_STOP_PATH"] = stopPath
 
 	ctx, cancel := context.WithTimeout(context.Background(), phase2RealTransportBound)
@@ -125,27 +206,35 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	start := time.Now()
 	if err := sp.Start(ctx, sessionName, cfg); err != nil {
 		return phase2RealTransportRun{
-			Transport:     "tmux",
-			SocketName:    guard.SocketName(),
-			SessionName:   sessionName,
-			ProviderPath:  providerPath,
-			StartedPath:   startedPath,
-			InputPath:     inputPath,
-			ErrorStage:    "start",
-			Error:         err.Error(),
-			ExpectedInput: materialized.Nudge,
-			StartElapsed:  time.Since(start),
+			Transport:             "tmux",
+			SocketName:            guard.SocketName(),
+			SessionName:           sessionName,
+			ProviderPath:          providerPath,
+			StartedPath:           startedPath,
+			InputPath:             inputPath,
+			StartupPromptPath:     startupPromptPath,
+			AutonomousPath:        autonomousPath,
+			ErrorStage:            "start",
+			Error:                 err.Error(),
+			ExpectedInput:         materialized.Nudge,
+			ExpectedStartupPrompt: expectedStartupPrompt,
+			StartElapsed:          time.Since(start),
 		}
 	}
 	startElapsed := time.Since(start)
 
 	observedInput, inputErr := waitForPhase2FileText(inputPath, phase2RealTransportBound)
 	observedProvider, providerErr := waitForPhase2FileText(providerPath, phase2RealTransportBound)
+	observedStartupPrompt, startupPromptErr := waitForPhase2FileText(startupPromptPath, phase2RealTransportBound)
+	autonomousStarted := waitForPhase2FileExists(autonomousPath, phase2RealTransportMarkerBound)
 	_, startedErr := os.Stat(startedPath)
 
 	errorStage := ""
 	errorDetail := ""
 	switch {
+	case startupPromptErr != nil:
+		errorStage = "startup_prompt_wait"
+		errorDetail = startupPromptErr.Error()
 	case inputErr != nil:
 		errorStage = "input_wait"
 		errorDetail = inputErr.Error()
@@ -155,40 +244,50 @@ func launchPhase2RealTransportSession(t *testing.T, tc phase2ProviderCase, mater
 	}
 
 	return phase2RealTransportRun{
-		Transport:         "tmux",
-		SocketName:        guard.SocketName(),
-		SessionName:       sessionName,
-		ProviderPath:      providerPath,
-		StartedPath:       startedPath,
-		InputPath:         inputPath,
-		ErrorStage:        errorStage,
-		Error:             errorDetail,
-		ExpectedInput:     materialized.Nudge,
-		ObservedInput:     strings.TrimSpace(observedInput),
-		ObservedProvider:  strings.TrimSpace(observedProvider),
-		Started:           startedErr == nil,
-		RunningAfterInput: sp.IsRunning(sessionName),
-		StartElapsed:      startElapsed,
+		Transport:             "tmux",
+		SocketName:            guard.SocketName(),
+		SessionName:           sessionName,
+		ProviderPath:          providerPath,
+		StartedPath:           startedPath,
+		InputPath:             inputPath,
+		StartupPromptPath:     startupPromptPath,
+		AutonomousPath:        autonomousPath,
+		ErrorStage:            errorStage,
+		Error:                 errorDetail,
+		ExpectedInput:         materialized.Nudge,
+		ObservedInput:         strings.TrimSpace(observedInput),
+		ExpectedStartupPrompt: expectedStartupPrompt,
+		ObservedStartupPrompt: observedStartupPrompt,
+		ObservedProvider:      strings.TrimSpace(observedProvider),
+		Started:               startedErr == nil,
+		AutonomousStarted:     autonomousStarted,
+		RunningAfterInput:     sp.IsRunning(sessionName),
+		StartElapsed:          startElapsed,
 	}
 }
 
 func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun) workertest.Result {
 	evidence := map[string]string{
-		"family":              tc.family,
-		"profile":             string(tc.profileID),
-		"transport":           run.Transport,
-		"socket_name":         run.SocketName,
-		"session_name":        run.SessionName,
-		"started_path":        run.StartedPath,
-		"provider_path":       run.ProviderPath,
-		"input_path":          run.InputPath,
-		"error_stage":         run.ErrorStage,
-		"error":               run.Error,
-		"expected_input":      run.ExpectedInput,
-		"observed_input":      run.ObservedInput,
-		"observed_provider":   run.ObservedProvider,
-		"running_after_input": fmt.Sprintf("%t", run.RunningAfterInput),
-		"start_elapsed":       run.StartElapsed.String(),
+		"family":                  tc.family,
+		"profile":                 string(tc.profileID),
+		"transport":               run.Transport,
+		"socket_name":             run.SocketName,
+		"session_name":            run.SessionName,
+		"started_path":            run.StartedPath,
+		"provider_path":           run.ProviderPath,
+		"input_path":              run.InputPath,
+		"startup_prompt_path":     run.StartupPromptPath,
+		"autonomous_path":         run.AutonomousPath,
+		"error_stage":             run.ErrorStage,
+		"error":                   run.Error,
+		"expected_input":          run.ExpectedInput,
+		"observed_input":          run.ObservedInput,
+		"expected_startup_prompt": run.ExpectedStartupPrompt,
+		"observed_startup_prompt": run.ObservedStartupPrompt,
+		"observed_provider":       run.ObservedProvider,
+		"autonomous_started":      fmt.Sprintf("%t", run.AutonomousStarted),
+		"running_after_input":     fmt.Sprintf("%t", run.RunningAfterInput),
+		"start_elapsed":           run.StartElapsed.String(),
 	}
 	switch {
 	case run.ErrorStage != "":
@@ -203,6 +302,12 @@ func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun
 	case run.ObservedProvider != tc.family:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("GC_PROVIDER = %q, want %q", run.ObservedProvider, tc.family)).WithEvidence(evidence)
+	case run.ObservedStartupPrompt != run.ExpectedStartupPrompt:
+		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
+			fmt.Sprintf("startup prompt = %q, want %q", run.ObservedStartupPrompt, run.ExpectedStartupPrompt)).WithEvidence(evidence)
+	case !run.AutonomousStarted:
+		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
+			"launch prompt did not trigger autonomous pre-nudge work").WithEvidence(evidence)
 	case run.ObservedInput != run.ExpectedInput:
 		return workertest.Fail(tc.profileID, workertest.RequirementRealTransportProof,
 			fmt.Sprintf("nudge input = %q, want %q", run.ObservedInput, run.ExpectedInput)).WithEvidence(evidence)
@@ -214,7 +319,7 @@ func phase2RealTransportResult(tc phase2ProviderCase, run phase2RealTransportRun
 			fmt.Sprintf("startup elapsed = %s, want <= %s", run.StartElapsed, phase2RealTransportBound)).WithEvidence(evidence)
 	default:
 		return workertest.Pass(tc.profileID, workertest.RequirementRealTransportProof,
-			"production tmux runtime launched and delivered initial input deterministically").WithEvidence(evidence)
+			"production tmux runtime launched, delivered the first-turn startup prompt, and preserved stdin nudge delivery deterministically").WithEvidence(evidence)
 	}
 }
 
@@ -238,4 +343,15 @@ func waitForPhase2FileText(path string, timeout time.Duration) (string, error) {
 		time.Sleep(25 * time.Millisecond)
 	}
 	return "", fmt.Errorf("timed out waiting for %s: %w", path, lastErr)
+}
+
+func waitForPhase2FileExists(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
 }

--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -201,11 +201,13 @@ func phase2TemplateEvidence(tc phase2ProviderCase, tp TemplateParams) map[string
 		"session_name": tp.SessionName,
 		"workdir":      tp.WorkDir,
 		"command":      tp.Command,
+		"hook_enabled": strconv.FormatBool(tp.HookEnabled),
 	}
 	if tp.ResolvedProvider != nil {
 		evidence["resolved_provider"] = tp.ResolvedProvider.Name
 		evidence["prompt_mode"] = tp.ResolvedProvider.PromptMode
 		evidence["default_args"] = strings.Join(tp.ResolvedProvider.ResolveDefaultArgs(), " ")
+		evidence["supports_hooks"] = strconv.FormatBool(tp.ResolvedProvider.SupportsHooks)
 	}
 	return evidence
 }
@@ -258,10 +260,12 @@ func phase2PreparedEvidence(tc phase2ProviderCase, prepared *preparedStart) map[
 	evidence["session_name"] = prepared.candidate.name()
 	evidence["started_config_hash"] = prepared.candidate.session.Metadata["started_config_hash"]
 	evidence["template_overrides"] = prepared.candidate.session.Metadata["template_overrides"]
+	evidence["hook_enabled"] = strconv.FormatBool(prepared.candidate.tp.HookEnabled)
 
 	if prepared.candidate.tp.ResolvedProvider != nil {
 		evidence["resolved_provider"] = prepared.candidate.tp.ResolvedProvider.Name
 		evidence["resolved_default_args"] = strings.Join(prepared.candidate.tp.ResolvedProvider.ResolveDefaultArgs(), " ")
+		evidence["supports_hooks"] = strconv.FormatBool(prepared.candidate.tp.ResolvedProvider.SupportsHooks)
 	}
 
 	return evidence

--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -84,6 +84,9 @@ func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp Templat
 	case cfg.Env["GC_SESSION_NAME"] != tp.SessionName:
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("GC_SESSION_NAME = %q, want %q", cfg.Env["GC_SESSION_NAME"], tp.SessionName)).WithEvidence(evidence)
+	case tp.Prompt != "" && cfg.Env[startupPromptDeliveredEnv] != "1":
+		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
+			fmt.Sprintf("%s = %q, want 1", startupPromptDeliveredEnv, cfg.Env[startupPromptDeliveredEnv])).WithEvidence(evidence)
 	case cfg.Env["WORKER_CORE_MARKER"] != tc.family:
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("WORKER_CORE_MARKER = %q, want %q", cfg.Env["WORKER_CORE_MARKER"], tc.family)).WithEvidence(evidence)
@@ -149,17 +152,19 @@ func initialMessageResumeResult(tc phase2ProviderCase, prepared *preparedStart) 
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
 			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
 	}
-	want := "Base worker prompt"
 	switch {
-	case got != want:
+	case got != "":
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
-			fmt.Sprintf("PromptSuffix payload = %q, want %q", got, want)).WithEvidence(evidence)
+			fmt.Sprintf("PromptSuffix payload = %q, want no startup user-turn on resume", got)).WithEvidence(evidence)
 	case strings.Contains(got, "Do the first task."):
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
 			fmt.Sprintf("PromptSuffix payload = %q, want no replayed initial message", got)).WithEvidence(evidence)
+	case prepared.cfg.Env[startupPromptDeliveredEnv] != "":
+		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
+			fmt.Sprintf("%s = %q, want unset on resume", startupPromptDeliveredEnv, prepared.cfg.Env[startupPromptDeliveredEnv])).WithEvidence(evidence)
 	default:
 		return workertest.Pass(tc.profileID, workertest.RequirementInputInitialMessageResume,
-			"resumed sessions do not replay the initial_message after first start").WithEvidence(evidence)
+			"resumed sessions do not replay startup prompt material as a new user turn").WithEvidence(evidence)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -345,6 +345,16 @@ func buildPreparedStart(
 		forceFresh := session.Metadata["wake_mode"] == "fresh"
 		agentCfg.Command = resolveSessionCommand(agentCfg.Command, sk, tp.ResolvedProvider, firstStart, forceFresh)
 	}
+	firstStart := session.Metadata["started_config_hash"] == ""
+	forceFresh := session.Metadata["wake_mode"] == "fresh"
+	if !firstStart && !forceFresh {
+		agentCfg.PromptSuffix = ""
+		agentCfg.PromptFlag = ""
+		agentCfg.Nudge = tp.Hints.Nudge
+		if agentCfg.Env != nil {
+			delete(agentCfg.Env, startupPromptDeliveredEnv)
+		}
+	}
 	// Initial message: append to prompt on first start only.
 	// Schema overrides were already applied in the block above (before coreHash).
 	// resolveSessionCommand only adds --resume/--session-id which are not schema

--- a/cmd/gc/session_lifecycle_parallel_phase2_test.go
+++ b/cmd/gc/session_lifecycle_parallel_phase2_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,43 @@ func TestPhase2InitialInputDelivery(t *testing.T) {
 				reporter.Require(t, inputOverrideDefaultsResult(tc, prepared))
 			})
 		})
+	}
+}
+
+func TestPhase2HookEnabledClaudeFirstTurnStartupPayload(t *testing.T) {
+	tc := phase2ProviderCaseForFamily(t, "claude")
+	prepared := preparePhase2Start(t, tc, "", map[string]string{
+		"initial_message": "Do the first task.",
+	})
+
+	if !prepared.candidate.tp.HookEnabled {
+		t.Fatal("HookEnabled = false, want true for Claude phase2 profile")
+	}
+	if prepared.candidate.tp.ResolvedProvider == nil {
+		t.Fatal("ResolvedProvider = nil, want Claude provider metadata")
+	}
+	if !prepared.candidate.tp.ResolvedProvider.SupportsHooks {
+		t.Fatal("SupportsHooks = false, want true for Claude phase2 profile")
+	}
+	if prepared.cfg.PromptSuffix == "" {
+		t.Fatal("PromptSuffix = empty, want first-turn startup payload to stay on launch for hook-enabled Claude")
+	}
+	if got := prepared.cfg.Nudge; got != "nudge-claude" {
+		t.Fatalf("Nudge = %q, want existing worker nudge preserved separately", got)
+	}
+
+	payload, evidence, err := phase2PromptPayload(tc, prepared)
+	if err != nil {
+		t.Fatalf("phase2PromptPayload: %v (evidence=%v)", err, evidence)
+	}
+	if !strings.Contains(payload, "Base worker prompt") {
+		t.Fatalf("payload = %q, want base startup prompt", payload)
+	}
+	if !strings.Contains(payload, "User message:\nDo the first task.") {
+		t.Fatalf("payload = %q, want initial_message on first start", payload)
+	}
+	if strings.Count(payload, "Do the first task.") != 1 {
+		t.Fatalf("payload = %q, want initial_message exactly once", payload)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -31,6 +32,11 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
+)
+
+const (
+	startupPromptDeliveredEnv = "GC_STARTUP_PROMPT_DELIVERED"
+	managedSessionHookEnv     = "GC_MANAGED_SESSION_HOOK"
 )
 
 // TemplateParams holds all resolved values needed to start a session.
@@ -516,13 +522,15 @@ func sessionDoltEnv(cityPath, rigRoot string, rigs []config.Rig) map[string]stri
 }
 
 // templateParamsToConfig converts TemplateParams to the runtime.Config
-// needed by Provider.Start. This mirrors managed.SessionConfig() at
-// internal/agent/agent.go:292-315 — for the same inputs, both must
-// produce identical output.
+// needed by Provider.Start. When it materializes the rendered prompt into the
+// launch or nudge path, it marks the runtime env so SessionStart hooks can add
+// context without repeating the full startup prompt.
 func templateParamsToConfig(tp TemplateParams) runtime.Config {
 	var promptSuffix string
 	var promptFlag string
 	nudge := tp.Hints.Nudge
+	env := maps.Clone(tp.Env)
+	startupPromptDelivered := false
 	if tp.Prompt != "" {
 		// SessionStart hooks can enrich context, but the startup prompt still
 		// needs a first-turn delivery mechanism. Without argv/flag/nudge
@@ -533,18 +541,30 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 			} else {
 				nudge = tp.Prompt
 			}
+			startupPromptDelivered = true
 		} else {
 			promptSuffix = shellquote.Quote(tp.Prompt)
-			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" && tp.ResolvedProvider.PromptFlag != "" {
-				promptFlag = tp.ResolvedProvider.PromptFlag
+			startupPromptDelivered = promptSuffix != ""
+			if tp.ResolvedProvider != nil && tp.ResolvedProvider.PromptMode == "flag" {
+				if tp.ResolvedProvider.PromptFlag != "" {
+					promptFlag = tp.ResolvedProvider.PromptFlag
+				} else {
+					startupPromptDelivered = false
+				}
 			}
 		}
+	}
+	if startupPromptDelivered {
+		if env == nil {
+			env = map[string]string{}
+		}
+		env[startupPromptDeliveredEnv] = "1"
 	}
 	return runtime.Config{
 		Command:                tp.Command,
 		PromptSuffix:           promptSuffix,
 		PromptFlag:             promptFlag,
-		Env:                    tp.Env,
+		Env:                    env,
 		WorkDir:                tp.WorkDir,
 		ReadyPromptPrefix:      tp.Hints.ReadyPromptPrefix,
 		ReadyDelayMs:           tp.Hints.ReadyDelayMs,

--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -105,6 +105,18 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 	return selected
 }
 
+func phase2ProviderCaseForFamily(t *testing.T, family string) phase2ProviderCase {
+	t.Helper()
+
+	for _, tc := range selectedPhase2ProviderCases(t) {
+		if tc.family == family {
+			return tc
+		}
+	}
+	t.Fatalf("phase2 provider case for family %q not found", family)
+	return phase2ProviderCase{}
+}
+
 func resolvePhase2Template(t *testing.T, tc phase2ProviderCase) TemplateParams {
 	t.Helper()
 

--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -108,6 +108,9 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 func phase2ProviderCaseForFamily(t *testing.T, family string) phase2ProviderCase {
 	t.Helper()
 
+	if filter := strings.TrimSpace(os.Getenv("PROFILE")); filter != "" && filter != family && !strings.HasPrefix(filter, family+"/") {
+		t.Skipf("PROFILE=%q excludes %s phase2 provider case", filter, family)
+	}
 	for _, tc := range selectedPhase2ProviderCases(t) {
 		if tc.family == family {
 			return tc

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -90,6 +90,30 @@ func TestTemplateParamsToConfigFlagModePrependsFlag(t *testing.T) {
 	}
 }
 
+func TestTemplateParamsToConfigFlagModeMissingFlagDoesNotMarkPromptDelivered(t *testing.T) {
+	tp := TemplateParams{
+		Command: "myprovider",
+		Prompt:  "You are an agent.",
+		ResolvedProvider: &config.ResolvedProvider{
+			Name:       "myprovider",
+			Command:    "myprovider",
+			PromptMode: "flag",
+		},
+	}
+
+	cfg := templateParamsToConfig(tp)
+
+	if cfg.PromptSuffix == "" {
+		t.Fatal("PromptSuffix should preserve the rendered prompt for diagnostics")
+	}
+	if cfg.PromptFlag != "" {
+		t.Fatalf("PromptFlag = %q, want empty when provider metadata has no prompt flag", cfg.PromptFlag)
+	}
+	if cfg.Env != nil && cfg.Env[startupPromptDeliveredEnv] == "1" {
+		t.Fatalf("%s marked despite missing flag delivery metadata", startupPromptDeliveredEnv)
+	}
+}
+
 // TestTemplateParamsToConfigNoneModeUsesNudge verifies that when PromptMode is
 // "none" and hooks are not available, startup instructions are delivered via
 // runtime.Config.Nudge instead of PromptSuffix.

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook"
           }
         ]
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -358,5 +358,6 @@ func claudeFileNeedsUpgrade(existing []byte) bool {
 		return false
 	}
 	stale := strings.Replace(string(current), `gc handoff \"context cycle\"`, `gc prime --hook`, 1)
-	return string(existing) == stale
+	previousSessionStart := strings.Replace(string(current), `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
+	return string(existing) == stale || string(existing) == previousSessionStart
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -95,8 +95,15 @@ func TestInstallClaude(t *testing.T) {
 	if !strings.Contains(s, "SessionStart") {
 		t.Error("claude settings should contain SessionStart hook")
 	}
-	if !strings.Contains(claudeHookCommand(t, runtimeData, "SessionStart"), "gc prime --hook") {
+	sessionStartCommand := claudeHookCommand(t, runtimeData, "SessionStart")
+	if !strings.Contains(sessionStartCommand, "gc prime --hook") {
 		t.Error("claude SessionStart hook should contain gc prime --hook")
+	}
+	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
+		t.Error("claude SessionStart hook should mark managed hook event")
+	}
+	if !strings.Contains(sessionStartCommand, "GC_MANAGED_SESSION_HOOK=1") {
+		t.Error("claude SessionStart hook should mark managed hook invocation")
 	}
 	if !strings.Contains(claudeHookCommand(t, runtimeData, "PreCompact"), `gc handoff "context cycle"`) {
 		t.Error("claude PreCompact hook should use gc handoff (not gc prime) to avoid context accumulation on compaction")
@@ -139,6 +146,37 @@ func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
 	runtimeData := fs.Files["/city/.gc/settings.json"]
 	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff "context cycle"`) {
 		t.Fatalf("upgraded claude hook missing gc handoff:\n%s", string(hookData))
+	}
+	if string(runtimeData) != string(hookData) {
+		t.Fatalf("runtime Claude settings should mirror upgraded hook settings:\n%s", string(runtimeData))
+	}
+}
+
+func TestInstallClaudeUpgradesGeneratedFileMissingManagedSessionMarkers(t *testing.T) {
+	fs := fsys.NewFake()
+	current, err := readEmbedded("config/claude.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	stale := strings.Replace(string(current), `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
+	if stale == string(current) {
+		t.Fatal("stale fixture did not diverge from current embedded config — check SessionStart marker pattern")
+	}
+	fs.Files["/city/hooks/claude.json"] = []byte(stale)
+	fs.Files["/city/.gc/settings.json"] = []byte(stale)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	hookData := fs.Files["/city/hooks/claude.json"]
+	runtimeData := fs.Files["/city/.gc/settings.json"]
+	sessionStartCommand := claudeHookCommand(t, hookData, "SessionStart")
+	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
+		t.Fatalf("upgraded SessionStart missing event marker: %s", sessionStartCommand)
+	}
+	if !strings.Contains(sessionStartCommand, "GC_MANAGED_SESSION_HOOK=1") {
+		t.Fatalf("upgraded SessionStart missing managed marker: %s", sessionStartCommand)
 	}
 	if string(runtimeData) != string(hookData) {
 		t.Fatalf("runtime Claude settings should mirror upgraded hook settings:\n%s", string(runtimeData))


### PR DESCRIPTION
## Summary

- Supersedes #960.
- Credit: Original startup proof hardening by @julianknutsen; the contributor change is preserved as the first commit in this branch.
- Adds the hook-enabled startup proofs from #960 and maintainer follow-ups that restore startup prompt delivery without duplicating SessionStart hook context.
- Prevents resumed sessions from replaying the startup prompt as a new user turn.
- Upgrades previously generated Claude settings that are missing the managed SessionStart hook markers.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Additional verification run locally:

- `go test ./internal/hooks ./cmd/gc -run 'TestInstallClaude|TestPhase2(StartupMaterialization|InitialInputDelivery|HookEnabledClaudeFirstTurnStartupPayload|InputResultFailureClassification)$|TestTemplateParamsToConfigHookEnabledProviderStillUsesLaunchPrompt|TestDoPrimeWithHook_StartupPromptDeliveryEnvControlsPromptSuppression'`
- `go test ./cmd/gc -run '^TestCmdSessionWake_ManagedBdPokesControllerAndMovesSuspendedToAsleep$' -count=1 -timeout 3m`
- `go test ./cmd/gc -timeout 20m`
- `go vet ./...`

`go test ./...` was also run; all non-`cmd/gc` packages passed, and `cmd/gc` hit the default 10-minute package timeout. The isolated timed-out test passed, and the full `cmd/gc` package passed with `-timeout 20m`.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No breaking changes expected. Existing generated Claude settings are upgraded when they match known generated stale shapes.
