### PR TITLE
test: recover review check fixture bd transport failures

### DIFF
--- a/test/integration/review_check_scripts_test.go
+++ b/test/integration/review_check_scripts_test.go
@@ -232,7 +232,7 @@ func setupReviewCheckScriptCity(t *testing.T) string {
 func createJSONBead(t *testing.T, cityDir, title string) string {
 	t.Helper()
 
-	out, err := bd(cityDir, "create", "--json", title)
+	out, err := reviewCheckBD(t, cityDir, "create", "--json", title)
 	if err != nil {
 		t.Fatalf("bd create failed: %v\noutput: %s", err, out)
 	}
@@ -250,10 +250,20 @@ func updateBeadMetadata(t *testing.T, cityDir, beadID string, pairs ...string) {
 	for _, pair := range pairs {
 		args = append(args, "--set-metadata", pair)
 	}
-	out, err := bd(cityDir, args...)
+	out, err := reviewCheckBD(t, cityDir, args...)
 	if err != nil {
 		t.Fatalf("bd update %s failed: %v\noutput: %s", beadID, err, out)
 	}
+}
+
+func reviewCheckBD(t *testing.T, cityDir string, args ...string) (string, error) {
+	t.Helper()
+
+	out, err := bd(cityDir, args...)
+	if err == nil || !managedDoltTransportRetryable(out) {
+		return out, err
+	}
+	return bdDolt(cityDir, args...)
 }
 
 func checkScriptEnv(t *testing.T, cityDir, beadID string) []string {


### PR DESCRIPTION
## Summary

Harden the review-check integration fixture against transient managed-Dolt transport failures during setup writes.

The failed `Integration / rest-full` job on PR #929 died in `TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep/code_review` while setting bead metadata:

```text
bd update rcst-e6k failed: failed to open database: Dolt server unreachable at 127.0.0.1:0
```

The fixture already has a Dolt-aware helper (`bdDolt`) that refreshes the managed endpoint and retries retryable transport failures, but `createJSONBead` and `updateBeadMetadata` were still calling the plain `bd` helper. This keeps the normal fast path, then falls back to `bdDolt` only when the `bd` output matches the managed-Dolt transport failure markers.

## Changes

- Route review-check fixture bead creation through `reviewCheckBD`.
- Route review-check fixture metadata updates through `reviewCheckBD`.
- Add `reviewCheckBD` as a narrow fallback wrapper: plain `bd` first, `bdDolt` only for retryable managed-Dolt transport errors.

## Test plan

- [x] `go test -tags integration ./test/integration -run TestReviewCheckScriptsPreferNewestVerdictAcrossRalphStep/code_review -count=1 -v -timeout 20m`
- [x] `go test -tags integration ./test/integration -run 'TestReviewCheckScripts' -count=1 -v -timeout 25m`

Fixes the CI failure mode observed while adopting #929.
