### PR TITLE
Fix mail recipient session materialization

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -378,23 +378,6 @@ func resolveMailRecipientIdentity(cityPath string, cfg *config.City, store beads
 	if identifier == "" || identifier == "human" {
 		return "human", nil
 	}
-	if store != nil && cfg != nil {
-		sessionID, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, identifier)
-		if err == nil {
-			b, err := store.Get(sessionID)
-			if err != nil {
-				return "", err
-			}
-			address := sessionMailboxAddress(b)
-			if address == "" {
-				return "", fmt.Errorf("session %q has no mailbox identity", identifier)
-			}
-			return address, nil
-		}
-		if !errors.Is(err, session.ErrSessionNotFound) {
-			return "", err
-		}
-	}
 	if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
 		return "", targetErr
 	} else if matched {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -807,6 +807,87 @@ func TestResolveMailRecipientIdentity_RejectsTemplatePrefixOnSessionSurface(t *t
 	}
 }
 
+func TestResolveMailRecipientIdentity_BareNamedSessionUsesConfiguredMailboxWithoutMaterializing(t *testing.T) {
+	t.Setenv("GC_SESSION", "fake")
+
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "always",
+		}},
+	}
+
+	address, err := resolveMailRecipientIdentity(t.TempDir(), cfg, store, "mayor")
+	if err != nil {
+		t.Fatalf("resolveMailRecipientIdentity(mayor): %v", err)
+	}
+	if address != "mayor" {
+		t.Fatalf("address = %q, want configured mailbox mayor", address)
+	}
+
+	all, err := store.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("session bead count = %d, want 0", len(all))
+	}
+}
+
+func TestResolveMailRecipientIdentity_BareNamedSessionUsesExistingLiveMailboxWithoutMaterializing(t *testing.T) {
+	t.Setenv("GC_SESSION", "fake")
+
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "always",
+		}},
+	}
+	existing, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "mayor",
+			"session_name": "mayor",
+			"template":     "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(existing session): %v", err)
+	}
+
+	address, err := resolveMailRecipientIdentity(t.TempDir(), cfg, store, "mayor")
+	if err != nil {
+		t.Fatalf("resolveMailRecipientIdentity(mayor): %v", err)
+	}
+	if address != "mayor" {
+		t.Fatalf("address = %q, want existing live mailbox mayor", address)
+	}
+
+	all, err := store.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(all))
+	}
+	if all[0].ID != existing.ID {
+		t.Fatalf("session bead ID = %q, want existing %q", all[0].ID, existing.ID)
+	}
+}
+
 func TestResolveMailRecipientIdentity_BareRigScopedNamedUsesUniqueLiveConfiguredNamedSession(t *testing.T) {
 	t.Setenv("GC_SESSION", "fake")
 

--- a/cmd/gc/testdata/events.txtar
+++ b/cmd/gc/testdata/events.txtar
@@ -24,11 +24,11 @@ stdout 'Closed bead: gc-1'
 # --- Send mail → should emit mail.sent ---
 
 exec gc mail send mayor 'hey there'
-stdout 'Sent message gc-3 to mayor'
+stdout 'Sent message gc-2 to mayor'
 
 # --- Read mail → should emit mail.read ---
 
-exec gc mail read gc-3
+exec gc mail read gc-2
 stdout 'Body:     hey there'
 
 # --- Event-producing commands append to the local city log ---

--- a/cmd/gc/testdata/gastown-events.txtar
+++ b/cmd/gc/testdata/gastown-events.txtar
@@ -23,22 +23,22 @@ exec grep 'gc-1' .gc/events.jsonl
 # --- 2. Mail operations emit events ---
 
 exec gc mail send mayor 'Deploy status?'
-exec gc mail read gc-3
+exec gc mail read gc-2
 
 exec grep 'mail.sent' .gc/events.jsonl
 exec grep 'mail.read' .gc/events.jsonl
-exec grep 'gc-3' .gc/events.jsonl
+exec grep 'gc-2' .gc/events.jsonl
 
 # --- 3. Convoy operations emit events ---
 
 exec bd create 'Task A'
-exec gc convoy create 'Sprint' gc-4
+exec gc convoy create 'Sprint' gc-3
 exec grep 'convoy.created' .gc/events.jsonl
-exec grep 'gc-5' .gc/events.jsonl
+exec grep 'gc-4' .gc/events.jsonl
 
-exec gc convoy close gc-5
+exec gc convoy close gc-4
 exec grep 'convoy.closed' .gc/events.jsonl
-exec grep 'gc-5' .gc/events.jsonl
+exec grep 'gc-4' .gc/events.jsonl
 
 # --- 4. Custom events via gc event emit ---
 

--- a/cmd/gc/testdata/gastown-mail.txtar
+++ b/cmd/gc/testdata/gastown-mail.txtar
@@ -14,7 +14,7 @@ cd $WORK/mailtown
 # --- 1. Mayor sends mail to deacon ---
 
 exec gc mail send deacon 'Start patrol loop'
-stdout 'Sent message gc-2 to deacon'
+stdout 'Sent message gc-1 to deacon'
 
 # --- 2. Deacon checks inbox ---
 
@@ -34,7 +34,7 @@ exec gc mail check deacon
 
 env GC_ALIAS=deacon
 exec gc mail send mayor 'Patrol complete, 3 issues found'
-stdout 'Sent message gc-4 to mayor'
+stdout 'Sent message gc-2 to mayor'
 
 # --- 5. Mayor reads deacon's message ---
 
@@ -43,7 +43,7 @@ exec gc mail inbox mayor
 stdout 'deacon'
 stdout 'Patrol complete'
 
-exec gc mail read gc-4
+exec gc mail read gc-2
 stdout 'From:     deacon'
 stdout 'To:       mayor'
 
@@ -51,32 +51,32 @@ stdout 'To:       mayor'
 
 # Mayor sends work to witness
 exec gc mail send witness 'Check rig health'
-stdout 'Sent message gc-6 to witness'
+stdout 'Sent message gc-3 to witness'
 
 # Witness reads and replies
 env GC_ALIAS=witness
-exec gc mail read gc-6
+exec gc mail read gc-3
 stdout 'From:     human'
 stdout 'Body:     Check rig health'
 
 exec gc mail send mayor 'Rig healthy, 2 polecats active'
-stdout 'Sent message gc-7 to mayor'
+stdout 'Sent message gc-4 to mayor'
 
 # --- 7. Mail archive removes from inbox ---
 
 env GC_ALIAS=
 exec gc mail inbox mayor
-stdout 'gc-7'
+stdout 'gc-4'
 
-exec gc mail archive gc-7
-stdout 'Archived message gc-7'
+exec gc mail archive gc-4
+stdout 'Archived message gc-4'
 
 exec gc mail inbox mayor
-! stdout 'gc-7'
+! stdout 'gc-4'
 
 # --- 8. Read message still accessible via peek ---
 
-exec gc mail peek gc-4
+exec gc mail peek gc-2
 stdout 'From:     deacon'
 
 # --- 9. Multiple messages to same agent ---

--- a/cmd/gc/testdata/mail.txtar
+++ b/cmd/gc/testdata/mail.txtar
@@ -14,7 +14,7 @@ cd $WORK/bright-lights
 # --- Human sends a message to the mayor ---
 
 exec gc mail send mayor 'hey, are you still there?'
-stdout 'Sent message gc-2 to mayor'
+stdout 'Sent message gc-1 to mayor'
 
 # --- Mayor checks inbox ---
 
@@ -24,7 +24,7 @@ stdout 'hey, are you still there?'
 
 # --- Mayor reads the message ---
 
-exec gc mail read gc-2
+exec gc mail read gc-1
 stdout 'From:     human'
 stdout 'To:       mayor'
 stdout 'Body:     hey, are you still there?'
@@ -36,14 +36,14 @@ stdout 'No unread messages for mayor'
 
 # --- But message is still accessible via peek ---
 
-exec gc mail peek gc-2
+exec gc mail peek gc-1
 stdout 'Body:     hey, are you still there?'
 
 # --- Mayor replies (agent perspective) ---
 
 env GC_ALIAS=mayor
 exec gc mail send human 'yes, working on gc-4'
-stdout 'Sent message gc-3 to human'
+stdout 'Sent message gc-2 to human'
 
 # --- Human checks their inbox ---
 
@@ -54,29 +54,29 @@ stdout 'yes, working on gc-4'
 
 # --- Human reads the reply ---
 
-exec gc mail read gc-3
+exec gc mail read gc-2
 stdout 'From:     mayor'
 stdout 'To:       human'
 stdout 'Body:     yes, working on gc-4'
 
 # --- Reading again still works (already read) ---
 
-exec gc mail read gc-3
+exec gc mail read gc-2
 stdout 'Body:     yes, working on gc-4'
 
 # --- Messages are beads: they appear in bead list ---
 
 exec bd list
+stdout 'gc-1'
 stdout 'gc-2'
-stdout 'gc-3'
 
 # --- Archive a new message ---
 
 exec gc mail send mayor 'archive me'
-stdout 'Sent message gc-4 to mayor'
+stdout 'Sent message gc-3 to mayor'
 
-exec gc mail archive gc-4
-stdout 'Archived message gc-4'
+exec gc mail archive gc-3
+stdout 'Archived message gc-3'
 
 # --- Archived message no longer appears in inbox ---
 
@@ -85,30 +85,30 @@ stdout 'No unread messages for mayor'
 
 # --- Archiving already-archived message is idempotent ---
 
-exec gc mail archive gc-4
-stdout 'Already archived gc-4'
+exec gc mail archive gc-3
+stdout 'Already archived gc-3'
 
 # --- Mark read / mark unread ---
 
 exec gc mail send mayor 'toggle me'
-stdout 'Sent message gc-5 to mayor'
+stdout 'Sent message gc-4 to mayor'
 
-exec gc mail mark-read gc-5
-stdout 'Marked gc-5 as read'
+exec gc mail mark-read gc-4
+stdout 'Marked gc-4 as read'
 
 exec gc mail inbox mayor
 stdout 'No unread messages for mayor'
 
-exec gc mail mark-unread gc-5
-stdout 'Marked gc-5 as unread'
+exec gc mail mark-unread gc-4
+stdout 'Marked gc-4 as unread'
 
 exec gc mail inbox mayor
 stdout 'toggle me'
 
 # --- Delete ---
 
-exec gc mail delete gc-5
-stdout 'Deleted message gc-5'
+exec gc mail delete gc-4
+stdout 'Deleted message gc-4'
 
 exec gc mail inbox mayor
 stdout 'No unread messages for mayor'

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -82,7 +82,30 @@ func (s *Server) resolveMailSendRecipientWithContext(ctx context.Context, recipi
 		}
 		return resolved, nil
 	}
-	return s.resolveSessionIDMaterializingNamedWithContext(ctx, store, recipient)
+	if target, matched, err := s.resolveLiveConfiguredNamedMailTarget(store, recipient); err != nil {
+		return "", err
+	} else if matched {
+		return target.display, nil
+	}
+	if id, err := s.resolveSessionTargetIDWithContext(ctx, store, recipient, apiSessionResolveOptions{}); err == nil {
+		bead, getErr := store.Get(id)
+		if getErr != nil {
+			return "", getErr
+		}
+		address := apiSessionMailboxAddress(bead)
+		if address == "" {
+			return "", fmt.Errorf("session %q has no mailbox identity", recipient)
+		}
+		return address, nil
+	} else if !errors.Is(err, session.ErrSessionNotFound) {
+		return "", err
+	}
+	if address, ok, err := s.configuredMailRecipientAddress(store, recipient); err != nil {
+		return "", err
+	} else if ok {
+		return address, nil
+	}
+	return "", apiSessionTargetNotFound(recipient)
 }
 
 func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, recipient string) []string {
@@ -142,6 +165,106 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 	}
 	sort.Strings(recipients)
 	return recipients, nil
+}
+
+type apiResolvedMailTarget struct {
+	display    string
+	recipients []string
+}
+
+func apiSessionMailboxAddress(b beads.Bead) string {
+	if alias := strings.TrimSpace(b.Metadata["alias"]); alias != "" {
+		return alias
+	}
+	if b.ID != "" {
+		return b.ID
+	}
+	return strings.TrimSpace(b.Metadata["session_name"])
+}
+
+func apiSessionMailboxAddresses(b beads.Bead) []string {
+	seen := map[string]bool{}
+	var addresses []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			return
+		}
+		seen[value] = true
+		addresses = append(addresses, value)
+	}
+	add(apiSessionMailboxAddress(b))
+	add(b.ID)
+	for _, alias := range session.AliasHistory(b.Metadata) {
+		add(alias)
+	}
+	if len(addresses) == 0 {
+		add(strings.TrimSpace(b.Metadata["session_name"]))
+	}
+	return addresses
+}
+
+func (s *Server) resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) (apiResolvedMailTarget, bool, error) {
+	identifier = apiNormalizeSessionTarget(identifier)
+	if store == nil || identifier == "" || identifier == "human" || strings.Contains(identifier, "/") {
+		return apiResolvedMailTarget{}, false, nil
+	}
+	all, err := store.List(beads.ListQuery{
+		Label: session.LabelSession,
+	})
+	if err != nil {
+		return apiResolvedMailTarget{}, false, err
+	}
+
+	matches := make(map[string]apiResolvedMailTarget)
+	order := make([]string, 0, 2)
+	for _, b := range all {
+		if !session.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
+			continue
+		}
+		identity := strings.TrimSpace(b.Metadata[apiNamedSessionIdentityKey])
+		if identity == "" || session.TargetBasename(identity) != identifier {
+			continue
+		}
+		addresses := apiSessionMailboxAddresses(b)
+		if len(addresses) == 0 {
+			continue
+		}
+		display := apiSessionMailboxAddress(b)
+		if display == "" {
+			display = addresses[0]
+		}
+		if _, ok := matches[display]; ok {
+			continue
+		}
+		matches[display] = apiResolvedMailTarget{
+			display:    display,
+			recipients: addresses,
+		}
+		order = append(order, display)
+	}
+
+	switch len(order) {
+	case 0:
+		return apiResolvedMailTarget{}, false, nil
+	case 1:
+		return matches[order[0]], true, nil
+	default:
+		sort.Strings(order)
+		return apiResolvedMailTarget{}, false, fmt.Errorf("%w: %q matches multiple configured named session mailboxes: %s", session.ErrAmbiguous, identifier, strings.Join(order, ", "))
+	}
+}
+
+func (s *Server) configuredMailRecipientAddress(store beads.Store, identifier string) (string, bool, error) {
+	identifier = apiNormalizeSessionTarget(identifier)
+	if identifier == "" || identifier == "human" {
+		return "", false, nil
+	}
+	spec, ok, err := s.findNamedSessionSpecForTarget(store, identifier)
+	if err != nil || !ok {
+		return "", false, err
+	}
+	return spec.Identity, true, nil
 }
 
 func mailInboxForRecipients(mp mail.Provider, recipients []string) ([]mail.Message, error) {

--- a/internal/api/session_model_phase0_interface_spec_test.go
+++ b/internal/api/session_model_phase0_interface_spec_test.go
@@ -171,6 +171,75 @@ func TestPhase0APIMailSend_BareConfigNameDoesNotResolveAsRecipient(t *testing.T)
 	}
 }
 
+func TestPhase0APIMailSend_BareNamedSessionUsesConfiguredMailboxWithoutMaterializing(t *testing.T) {
+	fs := newPhase0APINamedWorkerState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	body := `{"from":"human","to":"worker","subject":"hello","body":"test"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(fs, "/mail"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /v0/mail status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	msgs, err := fs.cityMailProv.Inbox("myrig/worker")
+	if err != nil {
+		t.Fatalf("Inbox(myrig/worker): %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("configured named mailbox got %d message(s), want 1", len(msgs))
+	}
+	if got := msgs[0].To; got != "myrig/worker" {
+		t.Fatalf("message To = %q, want configured mailbox identity myrig/worker", got)
+	}
+	if count := phase0APISessionCount(t, fs.cityBeadStore); count != 0 {
+		t.Fatalf("POST /v0/mail materialized %d session(s) for configured named recipient", count)
+	}
+}
+
+func TestPhase0APIMailSend_BareNamedSessionUsesExistingLiveMailboxWithoutMaterializing(t *testing.T) {
+	fs := newPhase0APINamedWorkerState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+	live, err := fs.cityBeadStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			apiNamedSessionMetadataKey: "true",
+			apiNamedSessionIdentityKey: "myrig/worker",
+			apiNamedSessionModeKey:     "always",
+			"alias":                    "live-worker",
+			"session_name":             "s-gc-test-city-worker",
+			"state":                    "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live named session: %v", err)
+	}
+
+	body := `{"from":"human","to":"worker","subject":"hello","body":"test"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(fs, "/mail"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /v0/mail status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	msgs, err := fs.cityMailProv.Inbox("live-worker")
+	if err != nil {
+		t.Fatalf("Inbox(live-worker): %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("live named mailbox got %d message(s), want 1", len(msgs))
+	}
+	if got := msgs[0].To; got != "live-worker" {
+		t.Fatalf("message To = %q, want existing live mailbox live-worker", got)
+	}
+	if count := phase0APISessionCount(t, fs.cityBeadStore); count != 1 {
+		t.Fatalf("POST /v0/mail left %d session(s), want only existing live session %s", count, live.ID)
+	}
+}
+
 func TestPhase0APIResolver_BareConfigNameDoesNotMaterializeOrdinarySession(t *testing.T) {
 	fs := newPhase0APIOrdinaryWorkerState(t)
 	srv := New(fs)
@@ -193,6 +262,32 @@ func newPhase0APIOrdinaryWorkerState(t *testing.T) *fakeState {
 			Name:              "worker",
 			Provider:          "test-agent",
 			MaxActiveSessions: intPtr(1),
+		}},
+		Providers: map[string]config.ProviderSpec{
+			"test-agent": {DisplayName: "Test Agent"},
+		},
+	}
+	return fs
+}
+
+func newPhase0APINamedWorkerState(t *testing.T) *fakeState {
+	t.Helper()
+	fs := newSessionFakeState(t)
+	fs.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "myrig",
+			Provider:          "test-agent",
+			MaxActiveSessions: intPtr(1),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Dir:      "myrig",
+		}},
+		Rigs: []config.Rig{{
+			Name: "myrig",
+			Path: "/tmp/myrig",
 		}},
 		Providers: map[string]config.ProviderSpec{
 			"test-agent": {DisplayName: "Test Agent"},


### PR DESCRIPTION
## Summary
- Stop bare configured named-session mail recipients from materializing session beads in both CLI and API mail send paths.
- Preserve delivery to existing live configured named mailboxes when one exists.
- Add API regression coverage for no-live-session and existing-live-session cases.

Supersedes #974.
Credit: Original CLI fix by @julianknutsen; the original commit is preserved with its authorship.

## Verification
- `go test ./cmd/gc -run 'TestResolveMailRecipientIdentity_(BareNamedSessionUsesConfiguredMailboxWithoutMaterializing|BareNamedSessionUsesExistingLiveMailboxWithoutMaterializing|RejectsTemplatePrefixOnSessionSurface|BareRigScopedNamed)' -count=1`
- `go test ./cmd/gc -run TestTutorial01 -count=1 -timeout=3m`
- `GC_FAST_UNIT=1 go test ./cmd/gc -count=1 -timeout=5m`
- `go test ./internal/api -run 'TestPhase0APIMailSend|TestMailLifecycle' -count=1`
- `go vet ./...`

Note: `go test ./...` ran most packages green but the `cmd/gc` package reached its 10-minute timeout in unrelated long-running tests. The focused `cmd/gc` fast package gate above passed on the final branch.

Closes ga-f4i5b.
