### PR TITLE
quality: Wave 1 pack/provider/workspace

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -917,18 +917,9 @@ func (cr *CityRuntime) reloadConfigTraced(
 	}
 
 	// Resolve script symlinks for newly activated packs.
-	if len(nextCfg.ScriptLayers.City) > 0 {
-		if err := ResolveScripts(cityRoot, nextCfg.ScriptLayers.City); err != nil {
-			appendWarning(fmt.Sprintf("config reload: city scripts: %v", err))
-		}
-	}
-	for _, r := range nextCfg.Rigs {
-		if layers, ok := nextCfg.ScriptLayers.Rigs[r.Name]; ok && len(layers) > 0 {
-			if err := ResolveScripts(r.Path, layers); err != nil {
-				appendWarning(fmt.Sprintf("config reload: rig %q scripts: %v", r.Name, err))
-			}
-		}
-	}
+	resolveConfiguredScripts(cityRoot, nextCfg, func(scope string, err error) {
+		appendWarning(fmt.Sprintf("config reload: %s scripts: %v", scope, err))
+	})
 
 	if providerChanged {
 		if running, lErr := cr.sp.ListRunning(""); lErr == nil && len(running) > 0 {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -1227,10 +1227,10 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 			fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
 		}
 	}
-	if loadErr == nil && len(expandedCfg.ScriptLayers.City) > 0 {
-		if rsErr := ResolveScripts(cityPath, expandedCfg.ScriptLayers.City); rsErr != nil {
-			fmt.Fprintf(stderr, "gc init: resolving scripts: %v\n", rsErr) //nolint:errcheck // best-effort stderr
-		}
+	if loadErr == nil {
+		resolveConfiguredScripts(cityPath, expandedCfg, func(scope string, err error) {
+			fmt.Fprintf(stderr, "gc init: resolving %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
+		})
 	}
 
 	fmt.Fprintln(stdout, "Welcome to Gas City!")                                           //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -477,18 +477,9 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	}
 
 	// Materialize script symlinks before agent startup.
-	if len(cfg.ScriptLayers.City) > 0 {
-		if err := ResolveScripts(cityPath, cfg.ScriptLayers.City); err != nil {
-			fmt.Fprintf(stderr, "gc start: city scripts: %v\n", err) //nolint:errcheck // best-effort stderr
-		}
-	}
-	for _, r := range cfg.Rigs {
-		if layers, ok := cfg.ScriptLayers.Rigs[r.Name]; ok && len(layers) > 0 {
-			if err := ResolveScripts(r.Path, layers); err != nil {
-				fmt.Fprintf(stderr, "gc start: rig %q scripts: %v\n", r.Name, err) //nolint:errcheck // best-effort stderr
-			}
-		}
-	}
+	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		fmt.Fprintf(stderr, "gc start: %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
+	})
 
 	// Validate agents.
 	if err := config.ValidateAgents(cfg.Agents); err != nil {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1653,6 +1653,14 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 		}
 	}
 
+	// Resolve script symlinks, including empty layer sets so stale links are pruned.
+	if progress != nil {
+		progress("resolving_scripts")
+	}
+	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		fmt.Fprintf(stderr, "gc supervisor: city '%s': %s scripts: %v\n", cityName, scope, err) //nolint:errcheck
+	})
+
 	// Validate agents.
 	if err := runStep("validating_agents", func() error {
 		return config.ValidateAgents(cfg.Agents)

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -17,10 +17,6 @@ import (
 // and symlinks for scripts no longer in any layer are removed. Real files
 // (non-symlinks) in the target directory are never overwritten.
 func ResolveScripts(targetDir string, layers []string) error {
-	if len(layers) == 0 {
-		return nil
-	}
-
 	// Build winner map: relative path → absolute source path.
 	// Later layers overwrite earlier ones (higher priority).
 	winners := make(map[string]string)

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // ResolveScripts computes per-relative-path winners from layered script
@@ -81,6 +84,24 @@ func ResolveScripts(targetDir string, layers []string) error {
 	}
 
 	return cleanStaleScriptSymlinks(symlinkDir, winners)
+}
+
+func resolveConfiguredScripts(cityPath string, cfg *config.City, handleErr func(scope string, err error)) {
+	if err := ResolveScripts(cityPath, cfg.ScriptLayers.City); err != nil {
+		handleErr("city", err)
+	}
+	for _, r := range cfg.Rigs {
+		rigPath := strings.TrimSpace(r.Path)
+		if rigPath == "" {
+			continue
+		}
+		if !filepath.IsAbs(rigPath) {
+			rigPath = filepath.Join(cityPath, rigPath)
+		}
+		if err := ResolveScripts(rigPath, cfg.ScriptLayers.Rigs[r.Name]); err != nil {
+			handleErr(fmt.Sprintf("rig %q", r.Name), err)
+		}
+	}
 }
 
 // cleanStaleScriptSymlinks removes symlinks in symlinkDir that are not in

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -238,6 +238,29 @@ func TestResolveScripts_EmptyLayers(t *testing.T) {
 	}
 }
 
+func TestResolveScripts_EmptyLayersCleanStaleSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	layer := filepath.Join(dir, "pack", "scripts")
+	writeScriptFile(t, layer, "setup.sh", "setup")
+
+	target := filepath.Join(dir, "city")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll target: %v", err)
+	}
+
+	if err := ResolveScripts(target, []string{layer}); err != nil {
+		t.Fatalf("first ResolveScripts: %v", err)
+	}
+
+	if err := ResolveScripts(target, nil); err != nil {
+		t.Fatalf("second ResolveScripts: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(target, "scripts", "setup.sh")); !os.IsNotExist(err) {
+		t.Fatalf("setup.sh should have been removed after empty-layer cleanup, err=%v", err)
+	}
+}
+
 func TestResolveScripts_MissingLayerDir(t *testing.T) {
 	dir := t.TempDir()
 	layer := filepath.Join(dir, "pack", "scripts")

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func writeScriptFile(t *testing.T, dir, relPath, content string) {
@@ -230,10 +233,11 @@ func TestResolveScripts_RealFileNotOverwritten(t *testing.T) {
 }
 
 func TestResolveScripts_EmptyLayers(t *testing.T) {
-	if err := ResolveScripts("/tmp/nonexistent", nil); err != nil {
+	target := filepath.Join(t.TempDir(), "city")
+	if err := ResolveScripts(target, nil); err != nil {
 		t.Errorf("nil layers should be no-op: %v", err)
 	}
-	if err := ResolveScripts("/tmp/nonexistent", []string{}); err != nil {
+	if err := ResolveScripts(target, []string{}); err != nil {
 		t.Errorf("empty layers should be no-op: %v", err)
 	}
 }
@@ -303,5 +307,110 @@ func TestResolveScripts_EmptySubdirCleanup(t *testing.T) {
 	checksDir := filepath.Join(target, "scripts", "checks")
 	if _, err := os.Stat(checksDir); !os.IsNotExist(err) {
 		t.Errorf("empty checks/ subdir should have been removed, err=%v", err)
+	}
+}
+
+func TestResolveConfiguredScripts_CleansCityAndRigWhenLayersDisappear(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cityLayer := filepath.Join(dir, "pack", "scripts")
+	rigLayer := filepath.Join(dir, "rig-pack", "scripts")
+	writeScriptFile(t, cityLayer, "city.sh", "city")
+	writeScriptFile(t, rigLayer, "rig.sh", "rig")
+
+	cityPath := filepath.Join(dir, "city")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll city: %v", err)
+	}
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll rig: %v", err)
+	}
+	cwdStale := filepath.Join(dir, "scripts", "stale.sh")
+	if err := os.MkdirAll(filepath.Dir(cwdStale), 0o755); err != nil {
+		t.Fatalf("MkdirAll cwd scripts: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "unbound.sh"), cwdStale); err != nil {
+		t.Fatalf("cwd stale symlink: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "app", Path: "rig"},
+			{Name: "unbound"},
+		},
+		ScriptLayers: config.ScriptLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{"app": {cityLayer, rigLayer}},
+		},
+	}
+	var warnings []string
+	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		warnings = append(warnings, scope+": "+err.Error())
+	})
+	if len(warnings) > 0 {
+		t.Fatalf("resolveConfiguredScripts warnings: %v", warnings)
+	}
+
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("city script should exist: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
+		t.Fatalf("rig script should exist: %v", err)
+	}
+
+	cfg.ScriptLayers = config.ScriptLayers{Rigs: map[string][]string{}}
+	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		warnings = append(warnings, scope+": "+err.Error())
+	})
+	if len(warnings) > 0 {
+		t.Fatalf("resolveConfiguredScripts cleanup warnings: %v", warnings)
+	}
+
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); !os.IsNotExist(err) {
+		t.Fatalf("city script should be cleaned after layers disappear, err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); !os.IsNotExist(err) {
+		t.Fatalf("rig script should be cleaned after layers disappear, err=%v", err)
+	}
+	if _, err := os.Lstat(cwdStale); err != nil {
+		t.Fatalf("blank rig path should not clean cwd scripts, err=%v", err)
+	}
+}
+
+func TestPrepareCityForSupervisorCleansScriptsWhenLayersDisappear(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	rigPath := filepath.Join(dir, "rig")
+	if err := os.MkdirAll(filepath.Join(cityPath, "scripts"), 0o755); err != nil {
+		t.Fatalf("MkdirAll city scripts: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, "scripts"), 0o755); err != nil {
+		t.Fatalf("MkdirAll rig scripts: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "old-city.sh"), filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("city symlink: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "old-rig.sh"), filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
+		t.Fatalf("rig symlink: %v", err)
+	}
+
+	logFile := filepath.Join(t.TempDir(), "beads.log")
+	t.Setenv("GC_BEADS", "exec:"+writeSpyScript(t, logFile))
+
+	cfg := config.DefaultCity("bright-lights")
+	cfg.Rigs = []config.Rig{{Name: "app", Path: rigPath}}
+	cfg.ScriptLayers = config.ScriptLayers{Rigs: map[string][]string{}}
+
+	if err := prepareCityForSupervisor(cityPath, "bright-lights", &cfg, io.Discard, nil); err != nil {
+		t.Fatalf("prepareCityForSupervisor: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); !os.IsNotExist(err) {
+		t.Fatalf("city script should be cleaned by supervisor start path, err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); !os.IsNotExist(err) {
+		t.Fatalf("rig script should be cleaned by supervisor start path, err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Supersedes #965.

This carries forward @julianknutsen's fix for stale script symlink cleanup when the final script layer disappears, and adds maintainer fixups from the adoption review so the cleanup reaches the production entry points.

Credit: Original fix by @julianknutsen. The original contributor commit is preserved with its authorship.

## Changes

- Allows `ResolveScripts` to prune stale symlinks when called with empty script layers.
- Routes city and rig script materialization through a shared helper for init, reload, standalone start, and supervisor-backed start.
- Normalizes relative rig paths under the city root before script cleanup.
- Skips blank rig paths so unbound rigs cannot clean or write `./scripts` under the current working directory.
- Adds regressions for empty-layer cleanup, city/rig cleanup, supervisor start cleanup, relative rig paths, and blank rig path safety.

## Tests

- `go test ./cmd/gc -run 'TestResolveConfiguredScripts_CleansCityAndRigWhenLayersDisappear|TestPrepareCityForSupervisorCleansScriptsWhenLayersDisappear|TestResolveScripts_(EmptyLayers|EmptyLayersCleanStaleSymlinks|StaleCleanup|EmptySubdirCleanup)' -count=1`
- `GC_FAST_UNIT=1 go test ./cmd/gc -short -count=1 -timeout 300s`
- `go vet ./cmd/gc`