### PR TITLE
quality: Wave 1 controller city runtime

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -699,8 +699,14 @@ func (cr *CityRuntime) tick(
 	if store := cr.cityBeadStore(); cr.wg != nil && store != nil && cr.wg.shouldRun(time.Now()) {
 		purged, gcErr := cr.wg.runGC(store, time.Now())
 		if gcErr != nil {
-			fmt.Fprintf(cr.stderr, "%s: wisp gc: %v\n", cr.logPrefix, gcErr) //nolint:errcheck // best-effort stderr
-		} else if purged > 0 {
+			for _, line := range strings.Split(gcErr.Error(), "\n") {
+				if line == "" {
+					continue
+				}
+				fmt.Fprintf(cr.stderr, "%s: wisp gc: %s\n", cr.logPrefix, line) //nolint:errcheck // best-effort stderr
+			}
+		}
+		if purged > 0 {
 			fmt.Fprintf(cr.stdout, "Bead GC: purged %d expired bead(s)\n", purged) //nolint:errcheck // best-effort stdout
 		}
 	}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -964,6 +964,89 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 	}
 }
 
+func TestCityRuntimeTick_LogsWispGCPurgeCountWithNonFatalError(t *testing.T) {
+	store := beads.NewMemStore()
+	var stdout, stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "test-city",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		wg:                  fixedWispGC{purged: 2, err: fmt.Errorf("delete failed")},
+		rec:                 events.Discard,
+		logPrefix:           "test-city",
+		stdout:              &stdout,
+		stderr:              &stderr,
+		buildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	var dirty atomic.Bool
+	var lastProviderName string
+	var prevPoolRunning map[string]bool
+	cr.tick(context.Background(), &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "test")
+
+	if !strings.Contains(stderr.String(), "test-city: wisp gc: delete failed") {
+		t.Fatalf("stderr = %q, want wisp gc error", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Bead GC: purged 2 expired bead(s)") {
+		t.Fatalf("stdout = %q, want purge count despite non-fatal error", stdout.String())
+	}
+}
+
+func TestCityRuntimeTick_PrefixesEachJoinedWispGCErrorLine(t *testing.T) {
+	store := beads.NewMemStore()
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "test-city",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		wg: fixedWispGC{err: fmt.Errorf("%s\n%s",
+			"deleting expired bead \"mol-1\": delete failed",
+			"listing closed order-tracking beads: list failed",
+		)},
+		rec:       events.Discard,
+		logPrefix: "test-city",
+		stdout:    io.Discard,
+		stderr:    &stderr,
+		buildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	var dirty atomic.Bool
+	var lastProviderName string
+	var prevPoolRunning map[string]bool
+	cr.tick(context.Background(), &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "test")
+
+	got := stderr.String()
+	for _, want := range []string{
+		"test-city: wisp gc: deleting expired bead \"mol-1\": delete failed\n",
+		"test-city: wisp gc: listing closed order-tracking beads: list failed\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr = %q, want line %q", got, want)
+		}
+	}
+}
+
+type fixedWispGC struct {
+	purged int
+	err    error
+}
+
+func (f fixedWispGC) shouldRun(time.Time) bool {
+	return true
+}
+
+func (f fixedWispGC) runGC(beads.Store, time.Time) (int, error) {
+	return f.purged, f.err
+}
+
 func TestCityRuntimeBeadReconcileTick_KeepsAssignedPoolWorkerAwake(t *testing.T) {
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -414,20 +414,11 @@ func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout 
 // to the controller.sock and sending a "ping". Returns the PID if alive,
 // or 0 if not reachable.
 func controllerAlive(cityPath string) int {
-	sockPath := controllerSocketPath(cityPath)
-	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
+	resp, err := sendControllerCommandWithReadTimeout(cityPath, "ping", 2*time.Second)
 	if err != nil {
 		return 0
 	}
-	defer conn.Close()                                    //nolint:errcheck // best-effort
-	conn.Write([]byte("ping\n"))                          //nolint:errcheck // best-effort
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // best-effort
-	buf := make([]byte, 64)
-	n, err := conn.Read(buf)
-	if err != nil || n == 0 {
-		return 0
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(resp)))
 	if err != nil {
 		return 0
 	}

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -376,8 +376,12 @@ func sendControllerCommand(cityPath, command string) ([]byte, error) {
 }
 
 func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout time.Duration) ([]byte, error) {
+	return sendControllerCommandWithTimeouts(cityPath, command, 2*time.Second, 5*time.Second, readTimeout)
+}
+
+func sendControllerCommandWithTimeouts(cityPath, command string, dialTimeout, writeTimeout, readTimeout time.Duration) ([]byte, error) {
 	sockPath := controllerSocketPath(cityPath)
-	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	conn, err := net.DialTimeout("unix", sockPath, dialTimeout)
 	if err != nil {
 		return nil, controllerCommandError{
 			op:          "connecting to controller",
@@ -385,9 +389,9 @@ func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout 
 			unavailable: true,
 		}
 	}
-	defer conn.Close()                                     //nolint:errcheck
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
-	conn.SetReadDeadline(time.Now().Add(readTimeout))      //nolint:errcheck
+	defer conn.Close()                                  //nolint:errcheck
+	conn.SetWriteDeadline(time.Now().Add(writeTimeout)) //nolint:errcheck
+	conn.SetReadDeadline(time.Now().Add(readTimeout))   //nolint:errcheck
 	if _, err := conn.Write([]byte(command + "\n")); err != nil {
 		return nil, fmt.Errorf("sending command: %w", err)
 	}
@@ -414,7 +418,7 @@ func sendControllerCommandWithReadTimeout(cityPath, command string, readTimeout 
 // to the controller.sock and sending a "ping". Returns the PID if alive,
 // or 0 if not reachable.
 func controllerAlive(cityPath string) int {
-	resp, err := sendControllerCommandWithReadTimeout(cityPath, "ping", 2*time.Second)
+	resp, err := sendControllerCommandWithTimeouts(cityPath, "ping", 500*time.Millisecond, 500*time.Millisecond, 2*time.Second)
 	if err != nil {
 		return 0
 	}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -300,6 +300,50 @@ func TestSendControllerCommandWithReadTimeout(t *testing.T) {
 	<-done
 }
 
+func TestSendControllerCommandWithTimeoutsTimesOutOnRead(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-controller-command-timeout-")
+	sockPath := controllerSocketPath(dir)
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+
+		buf := make([]byte, 16)
+		if _, err := conn.Read(buf); err != nil {
+			t.Errorf("read command: %v", err)
+			return
+		}
+		<-time.After(200 * time.Millisecond)
+	}()
+
+	start := time.Now()
+	_, err = sendControllerCommandWithTimeouts(dir, "ping", time.Second, time.Second, 25*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected read timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 150*time.Millisecond {
+		t.Fatalf("timeout took %s, want short read deadline", elapsed)
+	}
+	<-done
+}
+
 // writeCityTOML is a test helper that writes a city.toml with the given agents.
 func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...string) string {
 	t.Helper()

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -250,6 +250,56 @@ func TestControllerSocketFallbackUsesShortPathForLongCityPath(t *testing.T) {
 	}
 }
 
+func TestSendControllerCommandWithReadTimeout(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-controller-command-")
+	sockPath := controllerSocketPath(dir)
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+
+		buf := make([]byte, 16)
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Errorf("read command: %v", err)
+			return
+		}
+		if got := strings.TrimSpace(string(buf[:n])); got != "ping" {
+			t.Errorf("command = %q, want ping", got)
+			return
+		}
+		if _, err := conn.Write([]byte("123\n")); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}()
+
+	resp, err := sendControllerCommandWithReadTimeout(dir, "ping", time.Second)
+	if err != nil {
+		t.Fatalf("sendControllerCommandWithReadTimeout: %v", err)
+	}
+	if got := strings.TrimSpace(string(resp)); got != "123" {
+		t.Fatalf("response = %q, want 123", got)
+	}
+	<-done
+}
+
 // writeCityTOML is a test helper that writes a city.toml with the given agents.
 func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...string) string {
 	t.Helper()

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -64,6 +64,8 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 		trackPurged, trackDeleteErr := purgeExpiredBeadRoots(store, trackEntries, cutoff)
 		purged += trackPurged
 		deleteErr = errors.Join(deleteErr, trackDeleteErr)
+	} else {
+		deleteErr = errors.Join(deleteErr, fmt.Errorf("listing closed order-tracking beads: %w", trackErr))
 	}
 
 	return purged, deleteErr

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,8 +17,8 @@ type wispGC interface {
 
 	// runGC lists closed molecules, deletes those older than TTL, and returns
 	// the count of purged entries. Errors from individual deletes are
-	// best-effort (logged but not fatal); the returned error is for list
-	// failures.
+	// best-effort and surfaced without stopping the purge; the returned error
+	// also covers list failures.
 	runGC(store beads.Store, now time.Time) (int, error)
 }
 
@@ -56,36 +57,40 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 	}
 
 	cutoff := now.Add(-m.ttl)
-	purged := purgeExpiredBeadClosures(store, entries, cutoff)
+	purged, deleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
 
 	trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking})
 	if trackErr == nil {
-		purged += purgeExpiredBeadRoots(store, trackEntries, cutoff)
+		trackPurged, trackDeleteErr := purgeExpiredBeadRoots(store, trackEntries, cutoff)
+		purged += trackPurged
+		deleteErr = errors.Join(deleteErr, trackDeleteErr)
 	}
 
-	return purged, nil
+	return purged, deleteErr
 }
 
-func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time) int {
+func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
 	return purgeExpiredBeads(store, entries, cutoff, deleteExpiredBeadClosure)
 }
 
-func purgeExpiredBeadRoots(store beads.Store, entries []beads.Bead, cutoff time.Time) int {
+func purgeExpiredBeadRoots(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
 	return purgeExpiredBeads(store, entries, cutoff, deleteWorkflowBead)
 }
 
-func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, deleteFn func(beads.Store, string) error) int {
+func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, deleteFn func(beads.Store, string) error) (int, error) {
 	purged := 0
+	var deleteErr error
 	for _, entry := range entries {
 		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
 			continue
 		}
 		if err := deleteFn(store, entry.ID); err != nil {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting expired bead %q: %w", entry.ID, err))
 			continue
 		}
 		purged++
 	}
-	return purged
+	return purged, deleteErr
 }
 
 func deleteExpiredBeadClosure(store beads.Store, rootID string) error {

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -363,6 +363,28 @@ func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 	assertDeletedIDs(t, store.deletedIDs, "mol-1", "track-old")
 }
 
+func TestWispGC_TrackingListErrorIsSurfacedAndMoleculePurgeContinues(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		makeGCBeadWithLabels("track-old", now.Add(-3*time.Hour), "closed", "task", labelOrderTracking),
+	})
+	store.listErrors[gcQueryKey{Status: "closed", Label: labelOrderTracking}] = fmt.Errorf("tracking list failed")
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err == nil {
+		t.Fatal("expected tracking list error to be surfaced")
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	if !strings.Contains(err.Error(), "tracking list failed") {
+		t.Fatalf("err = %v, want tracking list failure to be included", err)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "mol-1")
+}
+
 func TestWispGC_TrackingBeadsDoNotDeleteParentChildDescendants(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
@@ -391,25 +413,6 @@ func TestWispGC_TrackingBeadsDoNotDeleteParentChildDescendants(t *testing.T) {
 	if _, err := store.Get("track-child"); err != nil {
 		t.Fatalf("tracking child was deleted: %v", err)
 	}
-}
-
-func TestWispGC_TrackingListErrorIsBestEffort(t *testing.T) {
-	now := time.Now()
-	store := newGCStore([]beads.Bead{
-		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
-		makeGCBeadWithLabels("track-old", now.Add(-3*time.Hour), "closed", "task", labelOrderTracking),
-	})
-	store.listErrors[gcQueryKey{Status: "closed", Label: labelOrderTracking}] = fmt.Errorf("tracking list failed")
-
-	wg := newWispGC(5*time.Minute, time.Hour)
-	purged, err := wg.runGC(store, now)
-	if err != nil {
-		t.Fatalf("runGC: %v", err)
-	}
-	if purged != 1 {
-		t.Fatalf("purged = %d, want 1", purged)
-	}
-	assertDeletedIDs(t, store.deletedIDs, "mol-1")
 }
 
 func TestWispGC_ListErrorFailsRun(t *testing.T) {

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,7 +96,7 @@ func TestWispGC_EmptyList(t *testing.T) {
 	}
 }
 
-func TestWispGC_DeleteErrorContinues(t *testing.T) {
+func TestWispGC_DeleteErrorIsSurfacedAndContinues(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
@@ -105,11 +106,14 @@ func TestWispGC_DeleteErrorContinues(t *testing.T) {
 
 	wg := newWispGC(5*time.Minute, time.Hour)
 	purged, err := wg.runGC(store, now)
-	if err != nil {
-		t.Fatalf("runGC: %v", err)
+	if err == nil {
+		t.Fatal("expected delete error to be surfaced")
 	}
 	if purged != 1 {
 		t.Fatalf("purged = %d, want 1", purged)
+	}
+	if !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err = %v, want delete failure to be included", err)
 	}
 	assertDeletedIDs(t, store.deletedIDs, "mol-2")
 }
@@ -245,8 +249,11 @@ func TestWispGC_LeavesRootWhenChildDeleteFails(t *testing.T) {
 
 	wg := newWispGC(5*time.Minute, time.Hour)
 	purged, err := wg.runGC(store, now)
-	if err != nil {
-		t.Fatalf("runGC: %v", err)
+	if err == nil {
+		t.Fatal("expected child delete error")
+	}
+	if !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err = %v, want delete failure to be included", err)
 	}
 	if purged != 0 {
 		t.Fatalf("purged = %d, want 0 when child delete fails", purged)
@@ -301,8 +308,11 @@ func TestWispGC_PartialChildDeleteRemainsRetryable(t *testing.T) {
 
 	wg := newWispGC(5*time.Minute, time.Hour)
 	purged, err := wg.runGC(store, now)
-	if err != nil {
-		t.Fatalf("runGC first pass: %v", err)
+	if err == nil {
+		t.Fatal("expected first pass child delete error")
+	}
+	if !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("first pass err = %v, want delete failure to be included", err)
 	}
 	if purged != 0 {
 		t.Fatalf("first purged = %d, want 0", purged)


### PR DESCRIPTION
## Summary

- Supersedes #973, which became conflicted after `main` moved through the newer wisp GC ownership cleanup work.
- Preserves @julianknutsen's original controller/runtime quality pass as the first commit, with authorship preserved.
- Adapts the wisp GC delete-error surfacing to the current parent-child ownership cleanup code.
- Adds maintainer review fixups for tracking-list error surfacing, partial-success GC logging, joined-error line context, and liveness-specific controller command timeouts.

Credit: Original fix by @julianknutsen; the contributor commit is preserved with original authorship.

## Testing

- [x] `go test -timeout 20m ./...`
- [x] `go vet ./...`
- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed: supersedes #973; no separate issue is needed for this adoption follow-up.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes: none
