### PR TITLE
fix: skip leaked duplicate named-session beads

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -870,6 +870,7 @@ func desiredHasConfiguredNamedTemplate(desired map[string]TemplateParams, templa
 	}
 	return false
 }
+
 func realizePoolDesiredSessions(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -656,6 +656,12 @@ func discoverSessionBeadsWithRoots(
 			continue
 		}
 		roots[template] = true
+		if !isManualSessionBead(b) && !isNamedSessionBead(b) && !isPoolManagedSessionBead(b) && desiredHasConfiguredNamedTemplate(desired, template) {
+			// A configured named session already owns this backing template in
+			// desired state. Treat any extra plain open bead as leaked state so
+			// the reconciler can close it as orphaned instead of reviving it.
+			continue
+		}
 		// Pool agents: respect the pool's scaling decision. If the main
 		// config iteration (which ran evaluatePool / scale_check) did not
 		// produce any desired entries for this template, the pool wants 0
@@ -856,6 +862,14 @@ func desiredHasTemplate(desired map[string]TemplateParams, template string) bool
 	return false
 }
 
+func desiredHasConfiguredNamedTemplate(desired map[string]TemplateParams, template string) bool {
+	for _, existing := range desired {
+		if existing.TemplateName == template && strings.TrimSpace(existing.ConfiguredNamedIdentity) != "" {
+			return true
+		}
+	}
+	return false
+}
 func realizePoolDesiredSessions(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -3180,6 +3182,121 @@ func TestReconcileSessionBeads_ClosedOnDemandBeadReopensWhenInDesiredState(t *te
 	}
 	if !sp.IsRunning(sessionName) {
 		t.Fatalf("session %q not running after reconcile — recovery did not trigger start", sessionName)
+	}
+}
+
+// Regression test for #742 follow-up: after the stale-bead reaper closes a
+// dead canonical bead, rediscovery must not also revive a leaked plain open
+// bead for the same backing template alongside the rebuilt named session.
+func TestReconcileSessionBeads_FileStoreAlwaysNamedRecoversWithLeakedDuplicateOpenBead(t *testing.T) {
+	cityPath := t.TempDir()
+	beadsPath := filepath.Join(cityPath, ".gc", "beads.json")
+	store, err := beads.OpenFileStore(fsys.OSFS{}, beadsPath)
+	if err != nil {
+		t.Fatalf("OpenFileStore: %v", err)
+	}
+	store.SetLocker(beads.NewFileFlock(beadsPath + ".lock"))
+
+	clk := &clock.Fake{Time: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", StartCommand: "true", MaxActiveSessions: intPtr(0)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+
+	_, err = store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "mayor",
+			"template":                   "mayor",
+			"agent_name":                 "mayor",
+			"state":                      "asleep",
+			"generation":                 "1",
+			"continuation_epoch":         "1",
+			"instance_token":             "canonical-token",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(canonical): %v", err)
+	}
+	leaked, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:mayor"},
+		Metadata: map[string]string{
+			"session_name":       "s-gc-leaked",
+			"template":           "mayor",
+			"agent_name":         "mayor",
+			"state":              "asleep",
+			"generation":         "1",
+			"continuation_epoch": "1",
+			"instance_token":     "leaked-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(leaked): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	dsResult := buildDesiredState(cfg.EffectiveCityName(), cityPath, clk.Now().UTC(), cfg, sp, store, &stderr)
+
+	mayorTP, ok := dsResult.State[sessionName]
+	if !ok {
+		t.Fatalf("desired state missing canonical named session %q; keys=%v", sessionName, mapKeys(dsResult.State))
+	}
+	if mayorTP.ConfiguredNamedIdentity != "mayor" {
+		t.Fatalf("ConfiguredNamedIdentity = %q, want mayor", mayorTP.ConfiguredNamedIdentity)
+	}
+	if mayorTP.SessionName != sessionName {
+		t.Fatalf("SessionName = %q, want %q", mayorTP.SessionName, sessionName)
+	}
+	if _, ok := dsResult.State[leaked.Metadata["session_name"]]; ok {
+		t.Fatalf("desired state unexpectedly included leaked duplicate bead %q; keys=%v", leaked.Metadata["session_name"], mapKeys(dsResult.State))
+	}
+
+	cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
+	syncSessionBeads(cityPath, store, dsResult.State, sp, cfgNames, cfg, clk, &stderr, true)
+
+	sessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessions, dsResult.ScaleCheckCounts))
+	if poolDesired == nil {
+		poolDesired = make(map[string]int)
+	}
+	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+
+	woken := reconcileSessionBeads(
+		context.Background(), sessions, dsResult.State, cfgNames, cfg, sp,
+		store, nil, dsResult.AssignedWorkBeads, nil, newDrainTracker(), poolDesired,
+		dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+	if !sp.IsRunning(sessionName) {
+		t.Fatalf("canonical named session %q was not started", sessionName)
+	}
+	if sp.IsRunning(leaked.Metadata["session_name"]) {
+		t.Fatalf("leaked duplicate session %q should not have been started", leaked.Metadata["session_name"])
+	}
+	if strings.Contains(stderr.String(), "session alias already exists") {
+		t.Fatalf("unexpected alias collision during recovery:\n%s", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a file-backed named-session recovery regression covering a leaked plain open bead for the same backing template
- prevent `buildDesiredState` rediscovery from re-importing that leaked plain bead when a configured named session already owns the template in desired state
- add the maintainer `gofumpt` fix required for CI in `cmd/gc/build_desired_state.go`

## Context

Supersedes #984.

Credit: Original fix by @julianknutsen.

`#752` fixed the primary dead-tmux failure by reaping stale open session beads before desired-state construction.

This follow-up covers the remaining duplicate-rediscovery hole: if a plain leaked bead is still open for the named session's backing template, `buildDesiredState` could still pull it back into desired state alongside the canonical named session. That leaves the duplicate alive instead of letting the reconciler close it as orphaned.

## Test plan

- [x] `make lint`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc -run 'TestReconcileSessionBeads_FileStoreAlwaysNamedRecoversWithLeakedDuplicateOpenBead$|TestBuildDesiredState_|TestReconcileSessionBeads_'`
- [x] `go test ./internal/api/...`
- [x] CI rerun on the superseding PR
