### PR TITLE
fix: harden post-security follow-up checks

### DIFF
--- a/cmd/gc/dashboard/web/README.md
+++ b/cmd/gc/dashboard/web/README.md
@@ -9,7 +9,7 @@ The Go service exists only to serve the compiled static bundle.
 
 ## Dev workflow
 
-Requires Node 20+ and npm.
+Requires Node 20, 22, or 24+ and npm.
 
 ```bash
 npm install          # one-time
@@ -19,14 +19,18 @@ npm run build        # Vite production build → dist/
 npm run dev          # Vite dev server with HMR on :5173
 ```
 
+`npm run test`, `npm run typecheck`, `npm run build`, and `npm run dev`
+all regenerate `src/generated/` first so they work from a clean checkout.
+
 `dist/` is git-ignored. It is built fresh by CI and by the pre-commit
 hook (see `.githooks/pre-commit`). Run `npm run build` before handing
 a branch to a reviewer if they don't have Node available — or let the
 hook do it.
 
-`src/generated/` is also git-ignored. `npm run gen` must be run after
-any change to `internal/api/openapi.json`. The pre-commit hook does
-this automatically when the spec regenerates.
+`src/generated/` is also git-ignored. Run `npm run gen` after any change
+to `internal/api/openapi.json`, or rely on the lifecycle hooks baked into
+the main scripts above. The pre-commit hook also regenerates these files
+when the spec changes.
 
 ## Layout
 

--- a/cmd/gc/dashboard/web/README.md
+++ b/cmd/gc/dashboard/web/README.md
@@ -22,10 +22,10 @@ npm run dev          # Vite dev server with HMR on :5173
 `npm run test`, `npm run typecheck`, `npm run build`, and `npm run dev`
 all regenerate `src/generated/` first so they work from a clean checkout.
 
-`dist/` is git-ignored. It is built fresh by CI and by the pre-commit
-hook (see `.githooks/pre-commit`). Run `npm run build` before handing
-a branch to a reviewer if they don't have Node available — or let the
-hook do it.
+`dist/` is committed because the Go binary embeds the built SPA bundle.
+It is rebuilt by CI and by the pre-commit hook (see
+`.githooks/pre-commit`). Run `npm run build` before handing a branch to
+a reviewer if they don't have Node available — or let the hook do it.
 
 `src/generated/` is also git-ignored. Run `npm run gen` after any change
 to `internal/api/openapi.json`, or rely on the lifecycle hooks baked into

--- a/cmd/gc/dashboard/web/package-lock.json
+++ b/cmd/gc/dashboard/web/package-lock.json
@@ -18,6 +18,9 @@
         "typescript": "^5.6.3",
         "vite": "^6.4.2",
         "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/cmd/gc/dashboard/web/package.json
+++ b/cmd/gc/dashboard/web/package.json
@@ -4,14 +4,18 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
   },
   "description": "Gas City dashboard SPA. Typed against the supervisor OpenAPI spec.",
   "scripts": {
     "gen": "openapi-ts && openapi-typescript ../../../../internal/api/openapi.json -o src/generated/schema.d.ts",
+    "pretest": "npm run gen --silent",
     "test": "vitest run --environment jsdom",
+    "pretypecheck": "npm run gen --silent",
     "typecheck": "tsc --noEmit",
+    "prebuild": "npm run gen --silent",
     "build": "vite build",
+    "predev": "npm run gen --silent",
     "dev": "vite",
     "preview": "vite preview"
   },

--- a/internal/extmsg/helpers.go
+++ b/internal/extmsg/helpers.go
@@ -109,13 +109,15 @@ func copyMetadata(in map[string]string) map[string]string {
 	return out
 }
 
-func encodeMetadataFields(meta map[string]string, fields map[string]string) map[string]string {
-	capHint := len(fields)
-	if len(meta) > 0 && capHint <= math.MaxInt-len(meta) {
-		// Preserve the prior sizing intent without risking overflow in the hint.
-		capHint += len(meta)
+func encodedMetadataFieldCapacity(fieldCount, metaCount int) int {
+	if metaCount > 0 && fieldCount <= math.MaxInt-metaCount {
+		return fieldCount + metaCount
 	}
-	out := make(map[string]string, capHint)
+	return fieldCount
+}
+
+func encodeMetadataFields(meta map[string]string, fields map[string]string) map[string]string {
+	out := make(map[string]string, encodedMetadataFieldCapacity(len(fields), len(meta)))
 	for k, v := range fields {
 		if strings.TrimSpace(k) == "" {
 			continue

--- a/internal/extmsg/helpers.go
+++ b/internal/extmsg/helpers.go
@@ -3,6 +3,7 @@ package extmsg
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -109,7 +110,12 @@ func copyMetadata(in map[string]string) map[string]string {
 }
 
 func encodeMetadataFields(meta map[string]string, fields map[string]string) map[string]string {
-	out := make(map[string]string, len(fields))
+	capHint := len(fields)
+	if len(meta) > 0 && capHint <= math.MaxInt-len(meta) {
+		// Preserve the prior sizing intent without risking overflow in the hint.
+		capHint += len(meta)
+	}
+	out := make(map[string]string, capHint)
 	for k, v := range fields {
 		if strings.TrimSpace(k) == "" {
 			continue

--- a/internal/extmsg/helpers_test.go
+++ b/internal/extmsg/helpers_test.go
@@ -1,6 +1,38 @@
 package extmsg
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
+
+func TestEncodedMetadataFieldCapacity(t *testing.T) {
+	tests := []struct {
+		name       string
+		fieldCount int
+		metaCount  int
+		want       int
+	}{
+		{
+			name:       "adds safe metadata capacity",
+			fieldCount: 2,
+			metaCount:  3,
+			want:       5,
+		},
+		{
+			name:       "skips addition when it would overflow",
+			fieldCount: math.MaxInt,
+			metaCount:  1,
+			want:       math.MaxInt,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := encodedMetadataFieldCapacity(tt.fieldCount, tt.metaCount); got != tt.want {
+				t.Fatalf("encodedMetadataFieldCapacity(%d, %d) = %d, want %d", tt.fieldCount, tt.metaCount, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestEncodeMetadataFieldsPrefixesMetadataAndSkipsBlankFieldKeys(t *testing.T) {
 	meta := map[string]string{

--- a/internal/extmsg/helpers_test.go
+++ b/internal/extmsg/helpers_test.go
@@ -19,6 +19,24 @@ func TestEncodedMetadataFieldCapacity(t *testing.T) {
 			want:       5,
 		},
 		{
+			name:       "adds metadata when fields are empty",
+			fieldCount: 0,
+			metaCount:  3,
+			want:       3,
+		},
+		{
+			name:       "keeps fields when metadata is empty",
+			fieldCount: 4,
+			metaCount:  0,
+			want:       4,
+		},
+		{
+			name:       "uses exact boundary when addition is safe",
+			fieldCount: math.MaxInt - 1,
+			metaCount:  1,
+			want:       math.MaxInt,
+		},
+		{
 			name:       "skips addition when it would overflow",
 			fieldCount: math.MaxInt,
 			metaCount:  1,


### PR DESCRIPTION
## Summary
Follow-up hardening for the already-merged security alert PR #987.

This PR does not reopen the dependency upgrades themselves. It tightens the supporting contract and evidence around that merged change by:
- keeping the `internal/extmsg` capacity hint fix overflow-safe while preserving the original sizing intent
- adding direct unit coverage for the capacity helper boundary cases
- making the dashboard `test` / `typecheck` / `build` / `dev` scripts regenerate `src/generated/` so clean checkouts work without a hidden manual `npm run gen`
- syncing `package-lock.json` with the tightened `engines.node` contract
- correcting the dashboard README to document that `dist/` is committed because the Go binary embeds it

## Verification
- `go test ./internal/telemetry ./internal/extmsg`
- in `cmd/gc/dashboard/web` after `npm ci --silent` and `rm -rf src/generated`:
  - `npm test`
  - `npm run typecheck`
  - `npm run build`
- `git diff --check`

## Review Notes
- latest local `review-pr` codex pass on this follow-up branch reported no new findings after the lockfile sync
- the only major raised in the previous synthesis was missing clean-environment evidence for the dashboard script fix; that evidence is included above
