### PR TITLE
Fix orphaned rig pool assignment release

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -23,12 +23,15 @@ import (
 // can pass ScaleCheckCounts to ComputePoolDesiredStates without re-running
 // scale_check commands.
 type DesiredStateResult struct {
-	State             map[string]TemplateParams
-	BaseState         map[string]TemplateParams
-	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
-	PoolDesiredCounts map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
-	WorkSet           map[string]bool
-	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
+	State              map[string]TemplateParams
+	BaseState          map[string]TemplateParams
+	ScaleCheckCounts   map[string]int // nil when store is nil or scale_check not run
+	PoolDesiredCounts  map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
+	WorkSet            map[string]bool
+	AssignedWorkBeads  []beads.Bead // actionable assigned work: in_progress or ready+assigned
+	// AssignedWorkStores maps AssignedWorkBeads IDs to the store that produced
+	// them, so later mutation paths update rig-owned work in the right store.
+	AssignedWorkStores map[string]beads.Store
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into
@@ -238,9 +241,10 @@ func buildDesiredStateWithSessionBeads(
 	// named session on_demand wake. Hoisted out of the store block so
 	// the named session section can also use it.
 	var assignedWorkBeads []beads.Bead
+	var assignedWorkStores map[string]beads.Store
 	var storePartial bool
 	if store != nil {
-		assignedWorkBeads, storePartial = collectAssignedWorkBeads(cfg, store, rigStores, suspendedRigPaths)
+		assignedWorkBeads, assignedWorkStores, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -409,6 +413,7 @@ func buildDesiredStateWithSessionBeads(
 		BaseState:          baseDesired,
 		ScaleCheckCounts:   scaleCheckCounts,
 		AssignedWorkBeads:  assignedWorkBeads,
+		AssignedWorkStores: assignedWorkStores,
 		NamedSessionDemand: namedWorkReady,
 		StoreQueryPartial:  storePartial,
 		BeaconTime:         beaconTime,
@@ -491,6 +496,16 @@ func collectAssignedWorkBeads(
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
 ) ([]beads.Bead, bool) {
+	result, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, rigStores, suspendedRigPaths)
+	return result, partial
+}
+
+func collectAssignedWorkBeadsWithStores(
+	cfg *config.City,
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+	suspendedRigPaths map[string]bool,
+) ([]beads.Bead, map[string]beads.Store, bool) {
 	// Use CachingStore-wrapped stores. Creating raw bdStoreForCity per rig
 	// spawns bd subprocesses on every tick, saturating dolt.
 	stores := []beads.Store{cityStore}
@@ -504,12 +519,13 @@ func collectAssignedWorkBeads(
 	}
 
 	var result []beads.Bead
+	resultStores := make(map[string]beads.Store)
 	var partial bool
 	seen := make(map[string]struct{})
 	for _, s := range stores {
 		// In-progress beads with an assignee (active work).
 		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress"}); err == nil {
-			appendAssignedUnique(&result, inProgress, seen)
+			appendAssignedUnique(&result, resultStores, inProgress, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
 			partial = true
@@ -517,13 +533,13 @@ func collectAssignedWorkBeads(
 		// Ready beads with an assignee (queued direct handoff work that is
 		// actually runnable, not merely open).
 		if ready, err := s.Ready(); err == nil {
-			appendAssignedUnique(&result, ready, seen)
+			appendAssignedUnique(&result, resultStores, ready, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
 			partial = true
 		}
 	}
-	return result, partial
+	return result, resultStores, partial
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is
@@ -551,7 +567,7 @@ func mergeNamedSessionDemand(poolDesired map[string]int, namedDemand map[string]
 	}
 }
 
-func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[string]struct{}) {
+func appendAssignedUnique(dst *[]beads.Bead, stores map[string]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
@@ -569,6 +585,9 @@ func appendAssignedUnique(dst *[]beads.Bead, beadList []beads.Bead, seen map[str
 		}
 		seen[b.ID] = struct{}{}
 		*dst = append(*dst, b)
+		if stores != nil {
+			stores[b.ID] = store
+		}
 	}
 }
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -23,15 +23,16 @@ import (
 // can pass ScaleCheckCounts to ComputePoolDesiredStates without re-running
 // scale_check commands.
 type DesiredStateResult struct {
-	State              map[string]TemplateParams
-	BaseState          map[string]TemplateParams
-	ScaleCheckCounts   map[string]int // nil when store is nil or scale_check not run
-	PoolDesiredCounts  map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
-	WorkSet            map[string]bool
-	AssignedWorkBeads  []beads.Bead // actionable assigned work: in_progress or ready+assigned
-	// AssignedWorkStores maps AssignedWorkBeads IDs to the store that produced
-	// them, so later mutation paths update rig-owned work in the right store.
-	AssignedWorkStores map[string]beads.Store
+	State             map[string]TemplateParams
+	BaseState         map[string]TemplateParams
+	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
+	PoolDesiredCounts map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
+	WorkSet           map[string]bool
+	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
+	// AssignedWorkStores is aligned by index with AssignedWorkBeads, so later
+	// mutation paths update rig-owned work in the right store even when
+	// independent stores produce overlapping bead IDs.
+	AssignedWorkStores []beads.Store
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into
@@ -241,7 +242,7 @@ func buildDesiredStateWithSessionBeads(
 	// named session on_demand wake. Hoisted out of the store block so
 	// the named session section can also use it.
 	var assignedWorkBeads []beads.Bead
-	var assignedWorkStores map[string]beads.Store
+	var assignedWorkStores []beads.Store
 	var storePartial bool
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
@@ -493,10 +494,8 @@ func refreshDesiredStateWithSessionBeads(
 func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
-	rigStores map[string]beads.Store,
-	suspendedRigPaths map[string]bool,
 ) ([]beads.Bead, bool) {
-	result, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, rigStores, suspendedRigPaths)
+	result, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil)
 	return result, partial
 }
 
@@ -505,7 +504,7 @@ func collectAssignedWorkBeadsWithStores(
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
-) ([]beads.Bead, map[string]beads.Store, bool) {
+) ([]beads.Bead, []beads.Store, bool) {
 	// Use CachingStore-wrapped stores. Creating raw bdStoreForCity per rig
 	// spawns bd subprocesses on every tick, saturating dolt.
 	stores := []beads.Store{cityStore}
@@ -519,13 +518,13 @@ func collectAssignedWorkBeadsWithStores(
 	}
 
 	var result []beads.Bead
-	resultStores := make(map[string]beads.Store)
+	var resultStores []beads.Store
 	var partial bool
-	seen := make(map[string]struct{})
 	for _, s := range stores {
+		seen := make(map[string]struct{})
 		// In-progress beads with an assignee (active work).
 		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress"}); err == nil {
-			appendAssignedUnique(&result, resultStores, inProgress, seen, s)
+			appendAssignedUnique(&result, &resultStores, inProgress, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
 			partial = true
@@ -533,7 +532,7 @@ func collectAssignedWorkBeadsWithStores(
 		// Ready beads with an assignee (queued direct handoff work that is
 		// actually runnable, not merely open).
 		if ready, err := s.Ready(); err == nil {
-			appendAssignedUnique(&result, resultStores, ready, seen, s)
+			appendAssignedUnique(&result, &resultStores, ready, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
 			partial = true
@@ -567,7 +566,7 @@ func mergeNamedSessionDemand(poolDesired map[string]int, namedDemand map[string]
 	}
 }
 
-func appendAssignedUnique(dst *[]beads.Bead, stores map[string]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
+func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
@@ -586,7 +585,7 @@ func appendAssignedUnique(dst *[]beads.Bead, stores map[string]beads.Store, bead
 		seen[b.ID] = struct{}{}
 		*dst = append(*dst, b)
 		if stores != nil {
-			stores[b.ID] = store
+			*stores = append(*stores, store)
 		}
 	}
 }

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -153,6 +153,43 @@ func TestCollectAssignedWorkBeads_ExcludesSessionBeads(t *testing.T) {
 	}
 }
 
+func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "assigned rig work",
+		Type:     "task",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set rig work in_progress: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload rig work bead: %v", err)
+	}
+
+	got, stores, partial := collectAssignedWorkBeadsWithStores(
+		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
+		cityStore,
+		map[string]beads.Store{"repo": rigStore},
+		nil,
+	)
+	if partial {
+		t.Fatal("partial = true, want false")
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeadsWithStores returned %#v, want [%s]", got, work.ID)
+	}
+	if stores[work.ID] != rigStore {
+		t.Fatalf("store for %s = %#v, want rig store", work.ID, stores[work.ID])
+	}
+}
+
 func TestBuildDesiredState_UsesAgentHookOverride(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -47,7 +47,7 @@ func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T)
 		t.Fatalf("create queued bead: %v", err)
 	}
 
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 1 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1: %#v", len(got), got)
 	}
@@ -82,7 +82,7 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 		t.Fatalf("add blocking dep: %v", err)
 	}
 
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 0 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0: %#v", len(got), got)
 	}
@@ -106,7 +106,7 @@ func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *tes
 	}); err != nil {
 		t.Fatalf("create unrouted bead: %v", err)
 	}
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 0 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0", len(got))
 	}
@@ -144,7 +144,7 @@ func TestCollectAssignedWorkBeads_ExcludesSessionBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create task bead: %v", err)
 	}
-	got, _ := collectAssignedWorkBeads(&config.City{}, store, nil, nil)
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 1 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1 (task only): %#v", len(got), got)
 	}
@@ -185,8 +185,70 @@ func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
 	if len(got) != 1 || got[0].ID != work.ID {
 		t.Fatalf("collectAssignedWorkBeadsWithStores returned %#v, want [%s]", got, work.ID)
 	}
-	if stores[work.ID] != rigStore {
-		t.Fatalf("store for %s = %#v, want rig store", work.ID, stores[work.ID])
+	if len(stores) != 1 || stores[0] != rigStore {
+		t.Fatalf("stores = %#v, want [rig store]", stores)
+	}
+}
+
+func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	cityWork, err := cityStore.Create(beads.Bead{
+		Title:    "assigned city work",
+		Type:     "task",
+		Assignee: "worker-city",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create city work bead: %v", err)
+	}
+	if err := cityStore.Update(cityWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set city work in_progress: %v", err)
+	}
+	cityWork, err = cityStore.Get(cityWork.ID)
+	if err != nil {
+		t.Fatalf("reload city work bead: %v", err)
+	}
+	rigWork, err := rigStore.Create(beads.Bead{
+		Title:    "assigned rig work",
+		Type:     "task",
+		Assignee: "worker-rig",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(rigWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set rig work in_progress: %v", err)
+	}
+	rigWork, err = rigStore.Get(rigWork.ID)
+	if err != nil {
+		t.Fatalf("reload rig work bead: %v", err)
+	}
+	if cityWork.ID != rigWork.ID {
+		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
+	}
+
+	got, stores, partial := collectAssignedWorkBeadsWithStores(
+		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
+		cityStore,
+		map[string]beads.Store{"repo": rigStore},
+		nil,
+	)
+	if partial {
+		t.Fatal("partial = true, want false")
+	}
+	if len(got) != 2 {
+		t.Fatalf("collectAssignedWorkBeadsWithStores returned %d beads, want 2: %#v", len(got), got)
+	}
+	if len(stores) != len(got) {
+		t.Fatalf("stores length = %d, want %d", len(stores), len(got))
+	}
+	if got[0].ID != cityWork.ID || stores[0] != cityStore {
+		t.Fatalf("first collected work = (%s, %#v), want city work/store", got[0].ID, stores[0])
+	}
+	if got[1].ID != rigWork.ID || stores[1] != rigStore {
+		t.Fatalf("second collected work = (%s, %#v), want rig work/store", got[1].ID, stores[1])
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1103,8 +1103,9 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	if sessionBeads == nil {
 		sessionBeads = cr.loadSessionBeadSnapshot()
 	}
+	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
-	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores); len(released) > 0 {
 		releasedSet := make(map[string]struct{}, len(released))
 		for _, id := range released {
 			releasedSet[id] = struct{}{}
@@ -1146,7 +1147,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	if sweepUndesiredPoolSessionBeads(
 		store,
-		cr.rigBeadStores(),
+		rigStores,
 		sessionBeads,
 		desiredState,
 		cr.cfg,
@@ -1255,7 +1256,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	reconcileSessionBeadsTraced(
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, store,
 		cr.dops,
-		assignedWorkBeads, cr.rigBeadStores(), readyWaitSet, cr.sessionDrains, poolDesired,
+		assignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, poolDesired,
 		result.StoreQueryPartial,
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -1106,19 +1107,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
 	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores); len(released) > 0 {
-		releasedSet := make(map[string]struct{}, len(released))
-		for _, id := range released {
-			releasedSet[id] = struct{}{}
-			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", id) //nolint:errcheck
+		for _, r := range released {
+			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
-		filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
-		for _, wb := range assignedWorkBeads {
-			if _, ok := releasedSet[wb.ID]; ok {
-				continue
-			}
-			filtered = append(filtered, wb)
-		}
-		assignedWorkBeads = filtered
+		assignedWorkBeads = filterReleasedAssignedWorkBeads(assignedWorkBeads, released)
 	}
 	// poolDesired determines how many sessions should be AWAKE. Uses the
 	// same scale_check counts that buildDesiredState already computed (no
@@ -1281,6 +1273,33 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 
 	// Idle recovery: detect pool sessions stuck at the prompt after
+}
+
+func filterReleasedAssignedWorkBeads(assignedWorkBeads []beads.Bead, released []releasedPoolAssignment) []beads.Bead {
+	if len(assignedWorkBeads) == 0 || len(released) == 0 {
+		return assignedWorkBeads
+	}
+	releasedIndexes := make(map[int]struct{}, len(released))
+	for _, r := range released {
+		if r.Index >= 0 && r.Index < len(assignedWorkBeads) {
+			if assignedWorkBeads[r.Index].ID != r.ID {
+				log.Printf("filterReleasedAssignedWorkBeads: released index %d points at bead %q, want %q", r.Index, assignedWorkBeads[r.Index].ID, r.ID)
+				continue
+			}
+			releasedIndexes[r.Index] = struct{}{}
+		}
+	}
+	if len(releasedIndexes) == 0 {
+		return assignedWorkBeads
+	}
+	filtered := make([]beads.Bead, 0, len(assignedWorkBeads)-len(releasedIndexes))
+	for i, wb := range assignedWorkBeads {
+		if _, ok := releasedIndexes[i]; ok {
+			continue
+		}
+		filtered = append(filtered, wb)
+	}
+	return filtered
 }
 
 func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -68,6 +68,41 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 }
 
+func TestFilterReleasedAssignedWorkBeads_PreservesSameIDUnreleasedWork(t *testing.T) {
+	assigned := []beads.Bead{
+		{ID: "gc-1", Title: "released city work"},
+		{ID: "gc-1", Title: "live rig work"},
+		{ID: "gc-2", Title: "unrelated work"},
+	}
+
+	got := filterReleasedAssignedWorkBeads(assigned, []releasedPoolAssignment{{ID: "gc-1", Index: 0}})
+
+	if len(got) != 2 {
+		t.Fatalf("filtered length = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Title != "live rig work" || got[1].Title != "unrelated work" {
+		t.Fatalf("filtered = %#v, want live same-ID work and unrelated work", got)
+	}
+}
+
+func TestFilterReleasedAssignedWorkBeads_IgnoresMismatchedReleasedIndex(t *testing.T) {
+	assigned := []beads.Bead{
+		{ID: "gc-1", Title: "first work"},
+		{ID: "gc-2", Title: "second work"},
+	}
+
+	got := filterReleasedAssignedWorkBeads(assigned, []releasedPoolAssignment{{ID: "gc-2", Index: 0}})
+
+	if len(got) != len(assigned) {
+		t.Fatalf("filtered length = %d, want %d: %#v", len(got), len(assigned), got)
+	}
+	for i := range assigned {
+		if got[i].ID != assigned[i].ID {
+			t.Fatalf("filtered[%d] = %q, want %q", i, got[i].ID, assigned[i].ID)
+		}
+	}
+}
+
 func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	cr := &CityRuntime{
 		sessionDrains: newDrainTracker(),

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -47,6 +47,7 @@ func releaseOrphanedPoolAssignments(
 	cfg *config.City,
 	openSessionBeads []beads.Bead,
 	assignedWorkBeads []beads.Bead,
+	assignedWorkStores map[string]beads.Store,
 ) []string {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
@@ -97,15 +98,29 @@ func releaseOrphanedPoolAssignments(
 		}
 		seen[wb.ID] = struct{}{}
 
-		if err := store.Update(wb.ID, beads.UpdateOpts{
-			Assignee: stringPtr(""),
-			Status:   stringPtr("open"),
-		}); err != nil {
+		ownerStore := store
+		if assignedWorkStores != nil {
+			if s, ok := assignedWorkStores[wb.ID]; ok {
+				ownerStore = s
+			}
+		}
+		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID) {
 			continue
 		}
 		released = append(released, wb.ID)
 	}
 	return released
+}
+
+func releaseOrphanedPoolAssignment(store beads.Store, id string) bool {
+	if store == nil || id == "" {
+		return false
+	}
+	opts := beads.UpdateOpts{
+		Assignee: stringPtr(""),
+		Status:   stringPtr("open"),
+	}
+	return store.Update(id, opts) == nil
 }
 
 func assigneePreservesNamedSessionRoute(cfg *config.City, template, assignee string) bool {

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"path"
 	"strings"
 	"time"
@@ -9,6 +10,11 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
+
+type releasedPoolAssignment struct {
+	ID    string
+	Index int
+}
 
 // PoolSessionName derives the tmux session name for a pool worker session.
 // Format: {basename(template)}-{beadID} (e.g., "claude-mc-xyz").
@@ -47,10 +53,14 @@ func releaseOrphanedPoolAssignments(
 	cfg *config.City,
 	openSessionBeads []beads.Bead,
 	assignedWorkBeads []beads.Bead,
-	assignedWorkStores map[string]beads.Store,
-) []string {
+	assignedWorkStores []beads.Store,
+) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
+	}
+	storeAware := len(assignedWorkStores) > 0
+	if storeAware && len(assignedWorkStores) != len(assignedWorkBeads) {
+		log.Printf("releaseOrphanedPoolAssignments: assigned work/store length mismatch: work=%d stores=%d", len(assignedWorkBeads), len(assignedWorkStores))
 	}
 
 	openIdentifiers := make(map[string]struct{}, len(openSessionBeads)*3)
@@ -69,9 +79,8 @@ func releaseOrphanedPoolAssignments(
 		}
 	}
 
-	var released []string
-	seen := make(map[string]struct{}, len(assignedWorkBeads))
-	for _, wb := range assignedWorkBeads {
+	var released []releasedPoolAssignment
+	for i, wb := range assignedWorkBeads {
 		if wb.Status != "open" && wb.Status != "in_progress" {
 			continue
 		}
@@ -93,21 +102,19 @@ func releaseOrphanedPoolAssignments(
 		if assigneePreservesNamedSessionRoute(cfg, template, assignee) {
 			continue
 		}
-		if _, ok := seen[wb.ID]; ok {
-			continue
-		}
-		seen[wb.ID] = struct{}{}
 
 		ownerStore := store
-		if assignedWorkStores != nil {
-			if s, ok := assignedWorkStores[wb.ID]; ok {
-				ownerStore = s
+		if storeAware {
+			if i >= len(assignedWorkStores) || assignedWorkStores[i] == nil {
+				log.Printf("releaseOrphanedPoolAssignments: missing owner store for assigned work %q at index %d", wb.ID, i)
+				continue
 			}
+			ownerStore = assignedWorkStores[i]
 		}
 		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID) {
 			continue
 		}
-		released = append(released, wb.ID)
+		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	return released
 }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -164,6 +164,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		nil,
 		[]beads.Bead{work},
+		nil,
 	)
 	if len(released) != 1 || released[0] != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
@@ -172,6 +173,67 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 	got, err := store.Get(work.ID)
 	if err != nil {
 		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ReopensRigStoreMissingPoolAssignee(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	citySession, err := cityStore.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-dead",
+			"template":             "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create city session bead: %v", err)
+	}
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "orphaned rig pool work",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+	if citySession.ID != work.ID {
+		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", citySession.ID, work.ID)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		&config.City{
+			Rigs:   []config.Rig{{Name: "repo"}},
+			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		},
+		nil,
+		[]beads.Bead{work},
+		map[string]beads.Store{work.ID: rigStore},
+	)
+	if len(released) != 1 || released[0] != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
 	}
 	if got.Status != "open" {
 		t.Fatalf("status = %q, want open", got.Status)
@@ -218,6 +280,7 @@ func TestReleaseOrphanedPoolAssignments_KeepsOpenSessionOwnership(t *testing.T) 
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		[]beads.Bead{session},
 		[]beads.Bead{work},
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released = %v, want none", released)
@@ -263,7 +326,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensStaleDirectAssigneeForNamedBacked
 		ResolvedWorkspaceName: "test-city",
 	}
 
-	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work})
+	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil)
 	if len(released) != 1 || released[0] != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
 	}
@@ -308,7 +371,7 @@ func TestReleaseOrphanedPoolAssignments_PreservesCanonicalNamedIdentity(t *testi
 		ResolvedWorkspaceName: "test-city",
 	}
 
-	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work})
+	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil)
 	if len(released) != 0 {
 		t.Fatalf("released = %v, want none", released)
 	}

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -166,7 +166,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 		[]beads.Bead{work},
 		nil,
 	)
-	if len(released) != 1 || released[0] != work.ID {
+	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
 	}
 
@@ -186,9 +186,10 @@ func TestReleaseOrphanedPoolAssignments_ReopensRigStoreMissingPoolAssignee(t *te
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 	citySession, err := cityStore.Create(beads.Bead{
-		Title:  "worker session",
-		Type:   sessionBeadType,
-		Status: "open",
+		Title:    "worker session",
+		Type:     sessionBeadType,
+		Status:   "open",
+		Assignee: "worker-live",
 		Metadata: map[string]string{
 			"session_name":         "worker-dead",
 			"template":             "worker",
@@ -225,9 +226,9 @@ func TestReleaseOrphanedPoolAssignments_ReopensRigStoreMissingPoolAssignee(t *te
 		},
 		nil,
 		[]beads.Bead{work},
-		map[string]beads.Store{work.ID: rigStore},
+		[]beads.Store{rigStore},
 	)
-	if len(released) != 1 || released[0] != work.ID {
+	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
 	}
 
@@ -240,6 +241,125 @@ func TestReleaseOrphanedPoolAssignments_ReopensRigStoreMissingPoolAssignee(t *te
 	}
 	if got.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+	gotSession, err := cityStore.Get(citySession.ID)
+	if err != nil {
+		t.Fatalf("Get city session bead: %v", err)
+	}
+	if gotSession.Type != sessionBeadType {
+		t.Fatalf("city session type = %q, want %q", gotSession.Type, sessionBeadType)
+	}
+	if gotSession.Assignee != "worker-live" {
+		t.Fatalf("city session assignee = %q, want worker-live", gotSession.Assignee)
+	}
+	if gotSession.Metadata["session_name"] != "worker-dead" ||
+		gotSession.Metadata["template"] != "worker" ||
+		gotSession.Metadata[poolManagedMetadataKey] != boolMetadata(true) {
+		t.Fatalf("city session metadata changed: %#v", gotSession.Metadata)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ReopensCrossStoreIDCollisions(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	cityWork, err := cityStore.Create(beads.Bead{
+		Title:    "orphaned city pool work",
+		Assignee: "worker-city-dead",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create city work bead: %v", err)
+	}
+	if err := cityStore.Update(cityWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set city work status: %v", err)
+	}
+	cityWork, err = cityStore.Get(cityWork.ID)
+	if err != nil {
+		t.Fatalf("Reload city work bead: %v", err)
+	}
+	rigWork, err := rigStore.Create(beads.Bead{
+		Title:    "orphaned rig pool work",
+		Assignee: "worker-rig-dead",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(rigWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	rigWork, err = rigStore.Get(rigWork.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+	if cityWork.ID != rigWork.ID {
+		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		&config.City{
+			Rigs:   []config.Rig{{Name: "repo"}},
+			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		},
+		nil,
+		[]beads.Bead{cityWork, rigWork},
+		[]beads.Store{cityStore, rigStore},
+	)
+	if len(released) != 2 || released[0].ID != cityWork.ID || released[1].ID != rigWork.ID {
+		t.Fatalf("released = %v, want [%s %s]", released, cityWork.ID, rigWork.ID)
+	}
+	gotCity, err := cityStore.Get(cityWork.ID)
+	if err != nil {
+		t.Fatalf("Get city work bead: %v", err)
+	}
+	if gotCity.Status != "open" || gotCity.Assignee != "" {
+		t.Fatalf("city work = status %q assignee %q, want open/unassigned", gotCity.Status, gotCity.Assignee)
+	}
+	gotRig, err := rigStore.Get(rigWork.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if gotRig.Status != "open" || gotRig.Assignee != "" {
+		t.Fatalf("rig work = status %q assignee %q, want open/unassigned", gotRig.Status, gotRig.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsStoreAwareEntryWithoutOwnerStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "orphaned rig pool work",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{nil},
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none without owner store", released)
+	}
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-dead" {
+		t.Fatalf("rig work = status %q assignee %q, want unchanged in_progress/worker-dead", got.Status, got.Assignee)
 	}
 }
 
@@ -327,7 +447,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensStaleDirectAssigneeForNamedBacked
 	}
 
 	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil)
-	if len(released) != 1 || released[0] != work.ID {
+	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
 	}
 


### PR DESCRIPTION
## Summary

- Track the source bead store for assigned-work snapshots collected from city and rig stores.
- Reopen orphaned pool work in the store that produced the work bead, so rig-owned in-progress work no longer stays assigned to dead sessions.
- Add regression coverage for rig-store orphan release, including overlapping city/rig bead IDs.

Refs #855.

## Tests

- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeadsWithStores_TracksRigStore|TestReleaseOrphanedPoolAssignments|TestReconcileSessionBeads_OrphanDrainLogThrottled' -count=1`\n- `go test ./cmd/gc -count=1` timed out after 10m in existing `TestCmdSessionWait_AllowsRigDependencyBeads`; no failure was in the touched tests/path.