### PR TITLE
fix: allow pack description metadata

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -618,6 +618,8 @@ type PackMeta struct {
 	Schema int `toml:"schema" jsonschema:"required"`
 	// RequiresGC is an optional minimum gc version requirement.
 	RequiresGC string `toml:"requires_gc,omitempty"`
+	// Description is an optional human-readable summary of the pack.
+	Description string `toml:"description,omitempty"`
 	// Includes lists other packs to compose into this one (V1 mechanism).
 	// Each entry is a local relative path (e.g. "../maintenance") or a
 	// remote git URL (SSH or HTTPS) with optional //subpath and #ref.

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -409,6 +409,29 @@ scheam = 1
 	}
 }
 
+func TestExpandPacks_AcceptsPackDescription(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/described/pack.toml", `
+[pack]
+name = "described"
+schema = 2
+description = "Human-readable pack summary"
+
+[[agent]]
+name = "worker"
+`)
+
+	cfg := &City{
+		Rigs: []Rig{
+			{Name: "hw", Path: "/hw", Includes: []string{"packs/described"}},
+		},
+	}
+
+	if err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil); err != nil {
+		t.Fatalf("ExpandPacks rejected [pack].description: %v", err)
+	}
+}
+
 func TestExpandPacks_RejectsUnknownPackImportFields(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/helper/pack.toml", `


### PR DESCRIPTION
## Summary
- allow `[pack].description` in `pack.toml` by adding it to `PackMeta`
- add a regression test that keeps strict unknown-field rejection while accepting documented pack descriptions

## Tracking
- Fixes bead `ga-jbspq`

## Tests
- `go test ./internal/config -run 'TestExpandPacks_(AcceptsPackDescription|RejectsUnknownPackTomlFields|RejectsUnknownPackImportFields)'`\n- `go test ./internal/config`\n- `go test ./internal/config ./internal/packman`\n- `go test ./cmd/gc -run 'Test.*(Pack|Import)'`\n\nNote: `go test ./...` was stopped after roughly seven minutes without output; the PR CI matrix will run the full repository gates.