### PR TITLE
Fix named session reservation with pool beads

### DIFF
--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3300,6 +3300,173 @@ func TestReconcileSessionBeads_FileStoreAlwaysNamedRecoversWithLeakedDuplicateOp
 	}
 }
 
+func TestReconcileSessionBeads_FreshAlwaysNamedWithPoolDemandMaterializesNamedDespitePoolBead(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", StartCommand: "true", ScaleCheck: "printf 1", MaxActiveSessions: intPtr(3)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+
+	var stdout, stderr bytes.Buffer
+	dsResult, sessions, woken := reconcileConfiguredSessionsOnce(t, cityPath, store, cfg, sp, clk, &stdout, &stderr)
+
+	if _, ok := dsResult.State[sessionName]; !ok {
+		t.Fatalf("desired state missing canonical named session %q; keys=%v", sessionName, mapKeys(dsResult.State))
+	}
+	if woken != 2 {
+		t.Fatalf("woken = %d, want 2; sessions=%v stderr:\n%s", woken, sessionBeadDebug(sessions), stderr.String())
+	}
+	if !sp.IsRunning(sessionName) {
+		t.Fatalf("canonical named session %q was not started; stderr:\n%s", sessionName, stderr.String())
+	}
+	if _, ok := findTestSessionBeadByName(sessions, sessionName); !ok {
+		t.Fatalf("canonical named session bead %q was not materialized; sessions=%v stderr:\n%s", sessionName, sessionBeadDebug(sessions), stderr.String())
+	}
+	if !testHasRunningPoolSessionForTemplate(sessions, sp, "mayor") {
+		t.Fatalf("same-template pool session was not started; sessions=%v stderr:\n%s", sessionBeadDebug(sessions), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "session_name \"mayor\"") {
+		t.Fatalf("unexpected named-session reservation conflict:\n%s", stderr.String())
+	}
+}
+
+func TestReconcileSessionBeads_ExistingAlwaysNamedStillAllowsSameTemplatePoolDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor", StartCommand: "true", ScaleCheck: "printf 1", MaxActiveSessions: intPtr(3)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "mayor",
+			"template":                   "mayor",
+			"agent_name":                 "mayor",
+			"state":                      "asleep",
+			"generation":                 "1",
+			"continuation_epoch":         "1",
+			"instance_token":             "canonical-token",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "always",
+		},
+	}); err != nil {
+		t.Fatalf("Create(canonical): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_, sessions, woken := reconcileConfiguredSessionsOnce(t, cityPath, store, cfg, sp, clk, &stdout, &stderr)
+
+	if woken != 2 {
+		t.Fatalf("woken = %d, want 2; sessions=%v stderr:\n%s", woken, sessionBeadDebug(sessions), stderr.String())
+	}
+	if !sp.IsRunning(sessionName) {
+		t.Fatalf("canonical named session %q was not started; stderr:\n%s", sessionName, stderr.String())
+	}
+	if !testHasRunningPoolSessionForTemplate(sessions, sp, "mayor") {
+		t.Fatalf("same-template pool session was not started; sessions=%v stderr:\n%s", sessionBeadDebug(sessions), stderr.String())
+	}
+}
+
+func reconcileConfiguredSessionsOnce(
+	t *testing.T,
+	cityPath string,
+	store beads.Store,
+	cfg *config.City,
+	sp *runtime.Fake,
+	clk *clock.Fake,
+	stdout, stderr *bytes.Buffer,
+) (DesiredStateResult, []beads.Bead, int) {
+	t.Helper()
+
+	dsResult := buildDesiredState(cfg.EffectiveCityName(), cityPath, clk.Now().UTC(), cfg, sp, store, stderr)
+	cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
+	syncSessionBeads(cityPath, store, dsResult.State, sp, cfgNames, cfg, clk, stderr, true)
+
+	sessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessions, dsResult.ScaleCheckCounts))
+	if poolDesired == nil {
+		poolDesired = make(map[string]int)
+	}
+	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+
+	woken := reconcileSessionBeads(
+		context.Background(), sessions, dsResult.State, cfgNames, cfg, sp,
+		store, nil, dsResult.AssignedWorkBeads, nil, newDrainTracker(), poolDesired,
+		dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+		nil, clk, events.Discard, 0, 0, stdout, stderr,
+	)
+
+	sessions, err = loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads after reconcile: %v", err)
+	}
+	return dsResult, sessions, woken
+}
+
+func findTestSessionBeadByName(sessions []beads.Bead, sessionName string) (beads.Bead, bool) {
+	for _, sessionBead := range sessions {
+		if sessionBead.Metadata["session_name"] == sessionName {
+			return sessionBead, true
+		}
+	}
+	return beads.Bead{}, false
+}
+
+func testHasRunningPoolSessionForTemplate(sessions []beads.Bead, sp *runtime.Fake, template string) bool {
+	for _, sessionBead := range sessions {
+		if sessionBead.Metadata["template"] != template || !isPoolManagedSessionBead(sessionBead) {
+			continue
+		}
+		sessionName := sessionBead.Metadata["session_name"]
+		if sessionName != "" && sp.IsRunning(sessionName) {
+			return true
+		}
+	}
+	return false
+}
+
+func sessionBeadDebug(sessions []beads.Bead) []string {
+	out := make([]string, 0, len(sessions))
+	for _, sessionBead := range sessions {
+		out = append(out, fmt.Sprintf("%s:name=%s template=%s named=%t pool=%t state=%s status=%s",
+			sessionBead.ID,
+			sessionBead.Metadata["session_name"],
+			sessionBead.Metadata["template"],
+			isNamedSessionBead(sessionBead),
+			isPoolManagedSessionBead(sessionBead),
+			sessionBead.Metadata["state"],
+			sessionBead.Status,
+		))
+	}
+	return out
+}
+
 // TestReconcileSessionBeads_PoolRecoveryAfterClosedBead verifies the full
 // recovery cycle for a managed pool session after its bead is closed.
 // When a pool session's bead is closed (crash, drain, quota exhaustion),

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -353,6 +353,11 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 		// "<rig>/control-dispatcher", since configured multi-rig dispatchers
 		// occupy distinct namespaces by design.
 		if sessionNameConflictsWithExistingIdentifier(b, name) {
+			// Configured named sessions reserve their exact runtime name in
+			// config, so a pool-managed backing-template bead must not squat it.
+			if configuredOwnerCanReusePoolIdentifier(b, name, selfOwner) {
+				continue
+			}
 			if continuityIneligibleConfiguredOwner(b, selfOwner) {
 				continue
 			}
@@ -383,6 +388,21 @@ func sessionNameConflictsWithExistingIdentifier(b beads.Bead, name string) bool 
 		}
 	}
 	return false
+}
+
+func configuredOwnerCanReusePoolIdentifier(b beads.Bead, name, selfOwner string) bool {
+	name = strings.TrimSpace(name)
+	selfOwner = strings.TrimSpace(selfOwner)
+	if name == "" || selfOwner == "" {
+		return false
+	}
+	if name != selfOwner && !strings.HasSuffix(selfOwner, "/"+name) {
+		return false
+	}
+	if strings.TrimSpace(b.Metadata["pool_managed"]) == "true" {
+		return true
+	}
+	return strings.TrimSpace(b.Metadata["pool_slot"]) != ""
 }
 
 func configuredNamedSessionOwnerForBead(b beads.Bead, reserved string) string {
@@ -425,7 +445,7 @@ func ensureConfiguredSessionNameAvailable(store beads.Store, cfg *config.City, n
 		if !isConfiguredNamedSessionRuntimeName(cfg, name, selfOwner) {
 			return err
 		}
-		if !noLiveSessionNameCollisions(store, name, selfID) {
+		if !noLiveSessionNameCollisions(store, name, selfID, selfOwner) {
 			return err
 		}
 		// All holders are closed and the name belongs to a configured named
@@ -475,7 +495,7 @@ func isConfiguredNamedSessionRuntimeName(cfg *config.City, name, owner string) b
 // fields. This mirrors the full collision check in
 // ensureSessionNameAvailableForSelf so the legacy-bypass path cannot
 // suppress rejections from live alias or identifier collisions.
-func noLiveSessionNameCollisions(store beads.Store, name, selfID string) bool {
+func noLiveSessionNameCollisions(store beads.Store, name, selfID, selfOwner string) bool {
 	all, err := store.List(beads.ListQuery{
 		Label:         LabelSession,
 		IncludeClosed: true,
@@ -502,6 +522,9 @@ func noLiveSessionNameCollisions(store beads.Store, name, selfID string) bool {
 		// namespace for new session-name claims.
 		// Live identifier collision blocks.
 		if sessionNameConflictsWithExistingIdentifier(b, name) {
+			if configuredOwnerCanReusePoolIdentifier(b, name, selfOwner) {
+				continue
+			}
 			return false
 		}
 	}

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -911,6 +911,39 @@ func TestEnsureConfiguredSessionNameAvailable_RejectsLiveIdentifierCollisionDesp
 	}
 }
 
+func TestEnsureSessionNameAvailableWithConfigForOwner_AllowsPoolManagedIdentifierCollision(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "mayor"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor"},
+		},
+	}
+
+	if _, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "mayor-gc-1",
+			"agent_name":   "mayor",
+			"template":     "mayor",
+			"pool_managed": "true",
+		},
+	}); err != nil {
+		t.Fatalf("Create pool managed: %v", err)
+	}
+
+	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "mayor"); err != nil {
+		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(pool identifier collision) = %v, want nil", err)
+	}
+	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "foreman"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(wrong owner) = %v, want ErrSessionNameExists", err)
+	}
+}
+
 func TestWithCitySessionLocks_EmptyCityPathSharesIdentifierNamespace(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})


### PR DESCRIPTION
## Summary
- Fixes #909 by allowing a configured named session to claim its reserved runtime name when the only collision is a pool-managed bead's backing template identifier.
- Preserves same-template named-session + pool-session coexistence; this avoids the broad suppression behavior from #920.
- Adds regression coverage for fresh materialization with pool demand, existing canonical named-session coexistence, and low-level wrong-owner rejection.

## Review
- Ran `$review-pr` local branch review.
- Claude + Codex synthesis decision: approve, with no blocker or major findings.
- Gemini preflight passed, but the Gemini review invocation returned a 429 `rateLimitExceeded` transport failure, so synthesis was completed in dual-model mode.

## Tests
- `go test ./internal/session -count=1`
- `go test ./cmd/gc -run 'TestReconcileSessionBeads_FreshAlwaysNamedWithPoolDemandMaterializesNamedDespitePoolBead|TestReconcileSessionBeads_ExistingAlwaysNamedStillAllowsSameTemplatePoolDemand' -count=1` passed before rebasing; after rebasing onto current `origin/main`, `cmd/gc` no longer compiles because base `cmd/gc/main_test.go` references undefined `mustLoadSiteBinding`.
- `go test ./internal/session ./cmd/gc -run 'TestEnsureConfiguredSessionNameAvailable_RejectsLiveIdentifierCollisionDespiteLegacyBypass|TestEnsureSessionNameAvailableWithConfigForOwner_AllowsPoolManagedIdentifierCollision|TestReconcileSessionBeads_FreshAlwaysNamedWithPoolDemandMaterializesNamedDespitePoolBead|TestReconcileSessionBeads_ExistingAlwaysNamedStillAllowsSameTemplatePoolDemand' -count=1` passed before rebase.
- Full `go test ./internal/session ./cmd/gc -count=1` hit the existing `cmd/gc` 10 minute timeout path in `TestCmdSessionWait_AllowsRigDependencyBeads` before rebase.

Bead: ga-8mo9d
