### PR TITLE
quality: Wave 1 orders and dispatch runtime

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -405,36 +405,6 @@ func doOrderShow(aa []orders.Order, name, rig string, stdout, stderr io.Writer) 
 
 // --- gc order run ---
 
-func openCityOrderStore(stderr io.Writer, cmdName string) (beads.Store, int) {
-	cityPath, err := resolveCity()
-	if err != nil {
-		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
-	}
-	store, err := openStoreAtForCity(cityPath, cityPath)
-	if err != nil {
-		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
-		return nil, 1
-	}
-	return store, 0
-}
-
-func openOrderStoreForOrder(cityPath string, cfg *config.City, a orders.Order, stderr io.Writer, cmdName string) (beads.Store, int) {
-	target, err := resolveOrderStoreTarget(cityPath, cfg, a)
-	if err != nil {
-		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
-	}
-	store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
-	if err != nil {
-		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
-		return nil, 1
-	}
-	return store, 0
-}
-
 func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order run")
 	if code != 0 {
@@ -620,28 +590,6 @@ func orderLastRunFn(store beads.Store) orders.LastRunFunc {
 	}
 }
 
-func orderLastRunFnAcrossStores(stores ...beads.Store) orders.LastRunFunc {
-	fns := make([]orders.LastRunFunc, 0, len(stores))
-	for _, store := range stores {
-		if store != nil {
-			fns = append(fns, orderLastRunFn(store))
-		}
-	}
-	return func(name string) (time.Time, error) {
-		var latest time.Time
-		for _, fn := range fns {
-			t, err := fn(name)
-			if err != nil {
-				return time.Time{}, err
-			}
-			if t.After(latest) {
-				latest = t
-			}
-		}
-		return latest, nil
-	}
-}
-
 // doOrderCheck evaluates triggers for all orders and prints a table.
 // Returns 0 if any are due, 1 if none are due.
 func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc, stdout io.Writer) int {
@@ -681,94 +629,6 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 	return 1
 }
 
-type (
-	orderStoreResolver  func(orders.Order) (beads.Store, error)
-	orderStoresResolver func(orders.Order) ([]beads.Store, error)
-)
-
-func cachedOrderStoresResolver(cityPath string, cfg *config.City) orderStoresResolver {
-	stores := make(map[string]beads.Store)
-	openCached := func(target execStoreTarget) (beads.Store, error) {
-		key := orderStoreTargetKey(target)
-		if store, ok := stores[key]; ok {
-			return store, nil
-		}
-		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
-		if err != nil {
-			return nil, err
-		}
-		stores[key] = store
-		return store, nil
-	}
-	return func(a orders.Order) ([]beads.Store, error) {
-		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
-		if err != nil {
-			return nil, err
-		}
-		primary, err := openCached(target)
-		if err != nil {
-			return nil, err
-		}
-		out := []beads.Store{primary}
-		if legacyOrderCityFallbackNeeded(cityPath, target) {
-			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, legacy)
-		}
-		return out, nil
-	}
-}
-
-func cachedOrderHistoryStoresResolver(cityPath string, cfg *config.City, stderr io.Writer) orderStoresResolver {
-	stores := make(map[string]beads.Store)
-	openCached := func(target execStoreTarget) (beads.Store, error) {
-		key := orderStoreTargetKey(target)
-		if store, ok := stores[key]; ok {
-			return store, nil
-		}
-		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
-		if err != nil {
-			return nil, err
-		}
-		stores[key] = store
-		return store, nil
-	}
-	return func(a orders.Order) ([]beads.Store, error) {
-		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
-		if err != nil {
-			return nil, err
-		}
-		primary, err := openCached(target)
-		if err != nil {
-			return nil, err
-		}
-		out := []beads.Store{primary}
-		if legacyOrderCityFallbackNeeded(cityPath, target) {
-			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
-			if err != nil {
-				fmt.Fprintf(stderr, "gc order history: legacy city fallback unavailable for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
-				return out, nil
-			}
-			out = append(out, legacy)
-		}
-		return out, nil
-	}
-}
-
-func legacyOrderCityFallbackNeeded(cityPath string, target execStoreTarget) bool {
-	return target.ScopeKind == "rig" && filepath.Clean(target.ScopeRoot) != filepath.Clean(cityPath)
-}
-
-func legacyOrderCityTarget(cityPath string, cfg *config.City) execStoreTarget {
-	prefix := ""
-	if cfg != nil {
-		prefix = config.EffectiveHQPrefix(cfg)
-	}
-	return execStoreTarget{ScopeRoot: cityPath, ScopeKind: "city", Prefix: prefix}
-}
-
 func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
 	if len(aa) == 0 {
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
@@ -788,7 +648,7 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		baseLastRunFn := orderLastRunFnAcrossStores(stores...)
+		baseLastRunFn := orders.LastRunAcrossStores(stores...)
 		var lastRunErr error
 		lastRunFn := func(orderName string) (time.Time, error) {
 			last, err := baseLastRunFn(orderName)
@@ -797,7 +657,7 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 			}
 			return last, err
 		}
-		cursorFn := bdCursorFuncAcrossStores(stores...)
+		cursorFn := orders.CursorAcrossStores(stores...)
 		if a.Trigger == "event" {
 			cursor, err := bdCursorAcrossStores(a.ScopedName(), stores...)
 			if err != nil {
@@ -979,18 +839,6 @@ func findOrder(aa []orders.Order, name, rig string) (orders.Order, bool) {
 	return orders.Order{}, false
 }
 
-// bdCursorFunc returns a CursorFunc that queries BdStore for the max seq
-// label on wisps labeled order:<name>.
-func bdCursorFunc(store beads.Store) orders.CursorFunc {
-	return func(orderName string) uint64 {
-		seq, err := bdCursor(store, orderName)
-		if err != nil {
-			return 0
-		}
-		return seq
-	}
-}
-
 func bdCursor(store beads.Store, orderName string) (uint64, error) {
 	beadList, err := store.List(beads.ListQuery{
 		Label:         "order:" + orderName,
@@ -1005,24 +853,6 @@ func bdCursor(store beads.Store, orderName string) (uint64, error) {
 		labelSets[i] = b.Labels
 	}
 	return orders.MaxSeqFromLabels(labelSets), nil
-}
-
-func bdCursorFuncAcrossStores(stores ...beads.Store) orders.CursorFunc {
-	fns := make([]orders.CursorFunc, 0, len(stores))
-	for _, store := range stores {
-		if store != nil {
-			fns = append(fns, bdCursorFunc(store))
-		}
-	}
-	return func(orderName string) uint64 {
-		var maxSeq uint64
-		for _, fn := range fns {
-			if seq := fn(orderName); seq > maxSeq {
-				maxSeq = seq
-			}
-		}
-		return maxSeq
-	}
 }
 
 func bdCursorAcrossStores(orderName string, stores ...beads.Store) (uint64, error) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -58,6 +58,15 @@ func configureIsolatedRuntimeEnv(t *testing.T) {
 	}
 }
 
+func mustLoadSiteBinding(t *testing.T, fs fsys.FS, cityPath string) *config.SiteBinding {
+	t.Helper()
+	binding, err := config.LoadSiteBinding(fs, cityPath)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding(%q): %v", cityPath, err)
+	}
+	return binding
+}
+
 func configureSupervisorHooksForTests() {
 	ensureSupervisorRunningHook = func(_, _ io.Writer) int { return 0 }
 	reloadSupervisorHook = func(_, _ io.Writer) int { return 0 }

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
@@ -43,6 +42,14 @@ func shellExecRunner(ctx context.Context, command, dir string, env []string) ([]
 	return cmd.CombinedOutput()
 }
 
+func logDispatchError(stderr io.Writer, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	log.Print(msg)
+	if stderr != nil {
+		fmt.Fprintln(stderr, msg) //nolint:errcheck // best-effort stderr
+	}
+}
+
 type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
@@ -65,12 +72,12 @@ type memoryOrderDispatcher struct {
 func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) orderDispatcher {
 	allAA, err := scanAllOrders(cityPath, cfg, stderr, "gc start: order scan")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: order scan: %v\n", err) //nolint:errcheck // best-effort stderr
+		logDispatchError(stderr, "gc start: order scan: %v", err)
 		return nil
 	}
 	if len(cfg.Orders.Overrides) > 0 {
 		if err := orders.ApplyOverrides(allAA, convertOverrides(cfg.Orders.Overrides)); err != nil {
-			fmt.Fprintf(stderr, "gc start: order overrides: %v\n", err) //nolint:errcheck // best-effort stderr
+			logDispatchError(stderr, "gc start: order overrides: %v", err)
 		}
 	}
 
@@ -123,7 +130,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 		target, err := resolveOrderStoreTarget(cityPath, m.cfg, a)
 		if err != nil {
-			fmt.Fprintf(m.stderr, "gc: order dispatch: resolving target for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+			logDispatchError(m.stderr, "gc: order dispatch: resolving target for %s: %v", a.ScopedName(), err)
 			continue
 		}
 
@@ -132,7 +139,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if !ok {
 			store, err = m.storeFn(target)
 			if err != nil {
-				fmt.Fprintf(m.stderr, "gc: order dispatch: opening %s store for %s: %v\n", target.ScopeKind, a.ScopedName(), err) //nolint:errcheck
+				logDispatchError(m.stderr, "gc: order dispatch: opening %s store for %s: %v", target.ScopeKind, a.ScopedName(), err)
 				continue
 			}
 			stores[storeKey] = store
@@ -146,7 +153,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if legacyStore != nil {
 			storesForGate = append(storesForGate, legacyStore)
 		}
-		baseLastRunFn := orderLastRunFnAcrossStores(storesForGate...)
+		baseLastRunFn := orders.LastRunAcrossStores(storesForGate...)
 		var lastRunErr error
 		lastRunFn := func(orderName string) (time.Time, error) {
 			last, err := baseLastRunFn(orderName)
@@ -155,11 +162,11 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			}
 			return last, err
 		}
-		cursorFn := bdCursorFuncAcrossStores(storesForGate...)
+		cursorFn := orders.CursorAcrossStores(storesForGate...)
 		if a.Trigger == "event" {
 			cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
 			if err != nil {
-				fmt.Fprintf(m.stderr, "gc: order dispatch: reading event cursor for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+				logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
 				continue
 			}
 			cursorFn = func(string) uint64 {
@@ -168,7 +175,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		}
 		result := orders.CheckTrigger(a, now, lastRunFn, m.ep, cursorFn)
 		if lastRunErr != nil {
-			fmt.Fprintf(m.stderr, "gc: order dispatch: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck
+			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
 			continue
 		}
 		if !result.Due {
@@ -179,7 +186,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		scoped := a.ScopedName()
 		hasOpenWork, err := m.hasOpenWorkInStoresStrict(storesForGate, scoped)
 		if err != nil {
-			fmt.Fprintf(m.stderr, "gc: order dispatch: checking open work for %s: %v\n", scoped, err) //nolint:errcheck
+			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
 			continue
 		}
 		if hasOpenWork {
@@ -193,7 +200,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			Labels: []string{"order-run:" + scoped, labelOrderTracking},
 		})
 		if err != nil {
-			fmt.Fprintf(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v\n", scoped, err) //nolint:errcheck
+			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
 			continue
 		}
 
@@ -214,7 +221,7 @@ func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target
 	}
 	store, err := m.storeFn(legacyTarget)
 	if err != nil {
-		fmt.Fprintf(m.stderr, "gc: order dispatch: opening legacy city store for rig order fallback: %v\n", err) //nolint:errcheck
+		logDispatchError(m.stderr, "gc: order dispatch: opening legacy city store for rig order fallback: %v", err)
 		return nil, false
 	}
 	stores[key] = store
@@ -254,9 +261,9 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.St
 	output, err := m.execRun(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
 		labels = append(labels, "exec-failed")
-		fmt.Fprintf(m.stderr, "gc: order exec %s failed: %v\n", scoped, err) //nolint:errcheck
+		logDispatchError(m.stderr, "gc: order exec %s failed: %v", scoped, err)
 		if len(output) > 0 {
-			fmt.Fprintf(m.stderr, "gc: order exec %s output: %s\n", scoped, output) //nolint:errcheck
+			logDispatchError(m.stderr, "gc: order exec %s output: %s", scoped, output)
 		}
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
@@ -274,76 +281,6 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.St
 
 	// Label tracking bead with outcome via store (not CLI).
 	store.Update(trackingID, beads.UpdateOpts{Labels: labels}) //nolint:errcheck // best-effort
-}
-
-func resolveOrderStoreTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
-	if strings.TrimSpace(a.Rig) == "" {
-		prefix := ""
-		if cfg != nil {
-			prefix = config.EffectiveHQPrefix(cfg)
-		}
-		return execStoreTarget{ScopeRoot: cityPath, ScopeKind: "city", Prefix: prefix}, nil
-	}
-	if cfg == nil {
-		return execStoreTarget{}, fmt.Errorf("rig-scoped order %q requires city config", a.ScopedName())
-	}
-	resolveRigPaths(cityPath, cfg.Rigs)
-	rig, ok := rigByName(cfg, a.Rig)
-	if !ok {
-		return execStoreTarget{}, fmt.Errorf("rig %q not found in %s", a.Rig, filepath.Join(cityPath, "city.toml"))
-	}
-	if strings.TrimSpace(rig.Path) == "" {
-		return execStoreTarget{}, fmt.Errorf("rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it before dispatching rig-scoped orders", rig.Name, rig.Name)
-	}
-	return execStoreTarget{
-		ScopeRoot: rig.Path,
-		ScopeKind: "rig",
-		Prefix:    rig.EffectivePrefix(),
-		RigName:   rig.Name,
-	}, nil
-}
-
-func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
-	return resolveOrderStoreTarget(cityPath, cfg, a)
-}
-
-func orderStoreTargetKey(target execStoreTarget) string {
-	return target.ScopeKind + "\x00" + filepath.Clean(target.ScopeRoot)
-}
-
-func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) []string {
-	var env map[string]string
-	if target.ScopeKind == "rig" {
-		env = bdRuntimeEnvForRig(cityPath, cfg, target.ScopeRoot)
-	} else {
-		env = bdRuntimeEnv(cityPath)
-		env["BEADS_DIR"] = filepath.Join(target.ScopeRoot, ".beads")
-	}
-	env["GC_STORE_ROOT"] = target.ScopeRoot
-	env["GC_STORE_SCOPE"] = target.ScopeKind
-	env["GC_BEADS_PREFIX"] = target.Prefix
-	if target.ScopeKind == "rig" {
-		env["GC_RIG"] = target.RigName
-		env["GC_RIG_ROOT"] = target.ScopeRoot
-	} else {
-		env["GC_RIG"] = ""
-		env["GC_RIG_ROOT"] = ""
-	}
-	if a.Source != "" {
-		env["ORDER_DIR"] = filepath.Dir(a.Source)
-	}
-	if a.FormulaLayer != "" {
-		packDir := filepath.Dir(a.FormulaLayer)
-		env["PACK_DIR"] = packDir
-		env["GC_PACK_DIR"] = packDir
-
-		packName := filepath.Base(packDir)
-		if packName != "." && packName != string(filepath.Separator) {
-			env["GC_PACK_NAME"] = packName
-			env["GC_PACK_STATE_DIR"] = citylayout.PackStateDir(cityPath, packName)
-		}
-	}
-	return mergeRuntimeEnv(nil, env)
 }
 
 // dispatchWisp instantiates a wisp from the order's formula.
@@ -388,7 +325,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if a.Pool != "" {
 		pool := qualifyPool(a.Pool, a.Rig)
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", "", store, m.cityName, cityPath, m.cfg); err != nil {
-			fmt.Fprintf(m.stderr, "gc: order %s: routing decoration failed: %v\n", scoped, err) //nolint:errcheck
+			logDispatchError(m.stderr, "gc: order %s: routing decoration failed: %v", scoped, err)
 			// Non-fatal — molecule still works, just without step-level routing.
 		}
 	}
@@ -422,7 +359,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if err := store.Update(rootID, update); err != nil {
 		// Label failure is critical for duplicate-dispatch prevention.
 		// Log and emit an event so operators can investigate.
-		fmt.Fprintf(m.stderr, "gc: order %s: failed to label wisp %s: %v\n", scoped, rootID, err) //nolint:errcheck
+		logDispatchError(m.stderr, "gc: order %s: failed to label wisp %s: %v", scoped, rootID, err)
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
 			Actor:   "controller",

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -265,6 +265,13 @@ func TestOrderDispatchExecFailure(t *testing.T) {
 	store := beads.NewMemStore()
 	var rec memRecorder
 	var stderr bytes.Buffer
+	tracking, err := store.Create(beads.Bead{
+		Title:  "order:fail-exec",
+		Labels: []string{"order-run:fail-exec", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
 		return []byte("error output\n"), fmt.Errorf("exit status 1")
@@ -280,8 +287,9 @@ func TestOrderDispatchExecFailure(t *testing.T) {
 	mad := ad.(*memoryOrderDispatcher)
 	mad.stderr = &stderr
 
-	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(100 * time.Millisecond)
+	logs := captureCmdOrderLogs(t, func() {
+		mad.dispatchExec(context.Background(), store, execStoreTarget{ScopeRoot: t.TempDir()}, aa[0], t.TempDir(), tracking.ID)
+	})
 
 	// Check tracking bead has exec-failed label.
 	all := trackingBeads(t, store, "order-run:fail-exec")
@@ -300,6 +308,9 @@ func TestOrderDispatchExecFailure(t *testing.T) {
 	// Check order.failed event.
 	if !rec.hasType(events.OrderFailed) {
 		t.Error("missing order.failed event")
+	}
+	if !strings.Contains(logs, "order exec fail-exec failed") {
+		t.Fatalf("logs = %q, want exec failure warning", logs)
 	}
 }
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+type (
+	orderStoreResolver  func(orders.Order) (beads.Store, error)
+	orderStoresResolver func(orders.Order) ([]beads.Store, error)
+)
+
+func openCityOrderStore(stderr io.Writer, cmdName string) (beads.Store, int) {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	store, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	return store, 0
+}
+
+func openOrderStoreForOrder(cityPath string, cfg *config.City, a orders.Order, stderr io.Writer, cmdName string) (beads.Store, int) {
+	target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		return nil, 1
+	}
+	return store, 0
+}
+
+func resolveOrderStoreTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
+	if strings.TrimSpace(a.Rig) == "" {
+		prefix := ""
+		if cfg != nil {
+			prefix = config.EffectiveHQPrefix(cfg)
+		}
+		return execStoreTarget{ScopeRoot: cityPath, ScopeKind: "city", Prefix: prefix}, nil
+	}
+	if cfg == nil {
+		return execStoreTarget{}, fmt.Errorf("rig-scoped order %q requires city config", a.ScopedName())
+	}
+	resolveRigPaths(cityPath, cfg.Rigs)
+	rig, ok := rigByName(cfg, a.Rig)
+	if !ok {
+		return execStoreTarget{}, fmt.Errorf("rig %q not found in %s", a.Rig, filepath.Join(cityPath, "city.toml"))
+	}
+	if strings.TrimSpace(rig.Path) == "" {
+		return execStoreTarget{}, fmt.Errorf("rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it before dispatching rig-scoped orders", rig.Name, rig.Name)
+	}
+	return execStoreTarget{
+		ScopeRoot: rig.Path,
+		ScopeKind: "rig",
+		Prefix:    rig.EffectivePrefix(),
+		RigName:   rig.Name,
+	}, nil
+}
+
+func resolveOrderExecTarget(cityPath string, cfg *config.City, a orders.Order) (execStoreTarget, error) {
+	return resolveOrderStoreTarget(cityPath, cfg, a)
+}
+
+func orderStoreTargetKey(target execStoreTarget) string {
+	return target.ScopeKind + "\x00" + filepath.Clean(target.ScopeRoot)
+}
+
+func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) []string {
+	var env map[string]string
+	if target.ScopeKind == "rig" {
+		env = bdRuntimeEnvForRig(cityPath, cfg, target.ScopeRoot)
+	} else {
+		env = bdRuntimeEnv(cityPath)
+		env["BEADS_DIR"] = filepath.Join(target.ScopeRoot, ".beads")
+	}
+	env["GC_STORE_ROOT"] = target.ScopeRoot
+	env["GC_STORE_SCOPE"] = target.ScopeKind
+	env["GC_BEADS_PREFIX"] = target.Prefix
+	if target.ScopeKind == "rig" {
+		env["GC_RIG"] = target.RigName
+		env["GC_RIG_ROOT"] = target.ScopeRoot
+	} else {
+		env["GC_RIG"] = ""
+		env["GC_RIG_ROOT"] = ""
+	}
+	if a.Source != "" {
+		env["ORDER_DIR"] = filepath.Dir(a.Source)
+	}
+	if a.FormulaLayer != "" {
+		packDir := filepath.Dir(a.FormulaLayer)
+		env["PACK_DIR"] = packDir
+		env["GC_PACK_DIR"] = packDir
+
+		packName := filepath.Base(packDir)
+		if packName != "." && packName != string(filepath.Separator) {
+			env["GC_PACK_NAME"] = packName
+			env["GC_PACK_STATE_DIR"] = citylayout.PackStateDir(cityPath, packName)
+		}
+	}
+	if a.Rig != "" && target.RigName == "" {
+		env["GC_RIG"] = a.Rig
+	}
+	return mergeRuntimeEnv(nil, env)
+}
+
+func cachedOrderStoresResolver(cityPath string, cfg *config.City) orderStoresResolver {
+	stores := make(map[string]beads.Store)
+	openCached := func(target execStoreTarget) (beads.Store, error) {
+		key := orderStoreTargetKey(target)
+		if store, ok := stores[key]; ok {
+			return store, nil
+		}
+		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+		if err != nil {
+			return nil, err
+		}
+		stores[key] = store
+		return store, nil
+	}
+	return func(a orders.Order) ([]beads.Store, error) {
+		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+		if err != nil {
+			return nil, err
+		}
+		primary, err := openCached(target)
+		if err != nil {
+			return nil, err
+		}
+		out := []beads.Store{primary}
+		if legacyOrderCityFallbackNeeded(cityPath, target) {
+			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, legacy)
+		}
+		return out, nil
+	}
+}
+
+func cachedOrderHistoryStoresResolver(cityPath string, cfg *config.City, stderr io.Writer) orderStoresResolver {
+	stores := make(map[string]beads.Store)
+	openCached := func(target execStoreTarget) (beads.Store, error) {
+		key := orderStoreTargetKey(target)
+		if store, ok := stores[key]; ok {
+			return store, nil
+		}
+		store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
+		if err != nil {
+			return nil, err
+		}
+		stores[key] = store
+		return store, nil
+	}
+	return func(a orders.Order) ([]beads.Store, error) {
+		target, err := resolveOrderStoreTarget(cityPath, cfg, a)
+		if err != nil {
+			return nil, err
+		}
+		primary, err := openCached(target)
+		if err != nil {
+			return nil, err
+		}
+		out := []beads.Store{primary}
+		if legacyOrderCityFallbackNeeded(cityPath, target) {
+			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
+			if err != nil {
+				fmt.Fprintf(stderr, "gc order history: legacy city fallback unavailable for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+				return out, nil
+			}
+			out = append(out, legacy)
+		}
+		return out, nil
+	}
+}
+
+func legacyOrderCityFallbackNeeded(cityPath string, target execStoreTarget) bool {
+	return target.ScopeKind == "rig" && filepath.Clean(target.ScopeRoot) != filepath.Clean(cityPath)
+}
+
+func legacyOrderCityTarget(cityPath string, cfg *config.City) execStoreTarget {
+	prefix := ""
+	if cfg != nil {
+		prefix = config.EffectiveHQPrefix(cfg)
+	}
+	return execStoreTarget{ScopeRoot: cityPath, ScopeKind: "city", Prefix: prefix}
+}

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -3716,6 +3716,9 @@
           "status": {
             "type": "string"
           },
+          "store_ref": {
+            "type": "string"
+          },
           "target": {
             "type": "string"
           },
@@ -3873,10 +3876,14 @@
           },
           "output": {
             "type": "string"
+          },
+          "store_ref": {
+            "type": "string"
           }
         },
         "required": [
           "bead_id",
+          "store_ref",
           "created_at",
           "labels",
           "output"
@@ -3928,12 +3935,16 @@
           "signal": {
             "type": "string"
           },
+          "store_ref": {
+            "type": "string"
+          },
           "wisp_root_id": {
             "type": "string"
           }
         },
         "required": [
           "bead_id",
+          "store_ref",
           "name",
           "scoped_name",
           "created_at",
@@ -11905,6 +11916,16 @@
             "required": true,
             "schema": {
               "description": "Bead ID for the order run.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Store reference for disambiguating store-local bead IDs.",
+            "explode": false,
+            "in": "query",
+            "name": "store_ref",
+            "schema": {
+              "description": "Store reference for disambiguating store-local bead IDs.",
               "type": "string"
             }
           }

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -3716,6 +3716,9 @@
           "status": {
             "type": "string"
           },
+          "store_ref": {
+            "type": "string"
+          },
           "target": {
             "type": "string"
           },
@@ -3873,10 +3876,14 @@
           },
           "output": {
             "type": "string"
+          },
+          "store_ref": {
+            "type": "string"
           }
         },
         "required": [
           "bead_id",
+          "store_ref",
           "created_at",
           "labels",
           "output"
@@ -3928,12 +3935,16 @@
           "signal": {
             "type": "string"
           },
+          "store_ref": {
+            "type": "string"
+          },
           "wisp_root_id": {
             "type": "string"
           }
         },
         "required": [
           "bead_id",
+          "store_ref",
           "name",
           "scoped_name",
           "created_at",
@@ -11905,6 +11916,16 @@
             "required": true,
             "schema": {
               "description": "Bead ID for the order run.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Store reference for disambiguating store-local bead IDs.",
+            "explode": false,
+            "in": "query",
+            "name": "store_ref",
+            "schema": {
+              "description": "Store reference for disambiguating store-local bead IDs.",
               "type": "string"
             }
           }

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -1511,6 +1511,7 @@ type MonitorFeedItemResponse struct {
 	ScopeRef           string  `json:"scope_ref"`
 	StartedAt          string  `json:"started_at"`
 	Status             string  `json:"status"`
+	StoreRef           *string `json:"store_ref,omitempty"`
 	Target             string  `json:"target"`
 	Title              string  `json:"title"`
 	Type               string  `json:"type"`
@@ -1565,6 +1566,7 @@ type OrderHistoryDetailResponse struct {
 	CreatedAt string    `json:"created_at"`
 	Labels    *[]string `json:"labels"`
 	Output    string    `json:"output"`
+	StoreRef  string    `json:"store_ref"`
 }
 
 // OrderHistoryEntry defines model for OrderHistoryEntry.
@@ -1581,6 +1583,7 @@ type OrderHistoryEntry struct {
 	Rig           *string   `json:"rig,omitempty"`
 	ScopedName    string    `json:"scoped_name"`
 	Signal        *string   `json:"signal,omitempty"`
+	StoreRef      string    `json:"store_ref"`
 	WispRootId    *string   `json:"wisp_root_id,omitempty"`
 }
 
@@ -2938,6 +2941,12 @@ type ReplyMailParams struct {
 	Rig *string `form:"rig,omitempty" json:"rig,omitempty"`
 }
 
+// GetV0CityByCityNameOrderHistoryByBeadIdParams defines parameters for GetV0CityByCityNameOrderHistoryByBeadId.
+type GetV0CityByCityNameOrderHistoryByBeadIdParams struct {
+	// StoreRef Store reference for disambiguating store-local bead IDs.
+	StoreRef *string `form:"store_ref,omitempty" json:"store_ref,omitempty"`
+}
+
 // GetV0CityByCityNameOrdersFeedParams defines parameters for GetV0CityByCityNameOrdersFeed.
 type GetV0CityByCityNameOrdersFeedParams struct {
 	// ScopeKind Scope kind (city or rig).
@@ -3862,7 +3871,7 @@ type ClientInterface interface {
 	ReplyMail(ctx context.Context, cityName string, id string, params *ReplyMailParams, body ReplyMailJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetV0CityByCityNameOrderHistoryByBeadId request
-	GetV0CityByCityNameOrderHistoryByBeadId(ctx context.Context, cityName string, beadId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetV0CityByCityNameOrderHistoryByBeadId(ctx context.Context, cityName string, beadId string, params *GetV0CityByCityNameOrderHistoryByBeadIdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetV0CityByCityNameOrderByName request
 	GetV0CityByCityNameOrderByName(ctx context.Context, cityName string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5312,8 +5321,8 @@ func (c *Client) ReplyMail(ctx context.Context, cityName string, id string, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetV0CityByCityNameOrderHistoryByBeadId(ctx context.Context, cityName string, beadId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetV0CityByCityNameOrderHistoryByBeadIdRequest(c.Server, cityName, beadId)
+func (c *Client) GetV0CityByCityNameOrderHistoryByBeadId(ctx context.Context, cityName string, beadId string, params *GetV0CityByCityNameOrderHistoryByBeadIdParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetV0CityByCityNameOrderHistoryByBeadIdRequest(c.Server, cityName, beadId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -10883,7 +10892,7 @@ func NewReplyMailRequestWithBody(server string, cityName string, id string, para
 }
 
 // NewGetV0CityByCityNameOrderHistoryByBeadIdRequest generates requests for GetV0CityByCityNameOrderHistoryByBeadId
-func NewGetV0CityByCityNameOrderHistoryByBeadIdRequest(server string, cityName string, beadId string) (*http.Request, error) {
+func NewGetV0CityByCityNameOrderHistoryByBeadIdRequest(server string, cityName string, beadId string, params *GetV0CityByCityNameOrderHistoryByBeadIdParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10913,6 +10922,28 @@ func NewGetV0CityByCityNameOrderHistoryByBeadIdRequest(server string, cityName s
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.StoreRef != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "store_ref", *params.StoreRef, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -14680,7 +14711,7 @@ type ClientWithResponsesInterface interface {
 	ReplyMailWithResponse(ctx context.Context, cityName string, id string, params *ReplyMailParams, body ReplyMailJSONRequestBody, reqEditors ...RequestEditorFn) (*ReplyMailResponse, error)
 
 	// GetV0CityByCityNameOrderHistoryByBeadIdWithResponse request
-	GetV0CityByCityNameOrderHistoryByBeadIdWithResponse(ctx context.Context, cityName string, beadId string, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrderHistoryByBeadIdResponse, error)
+	GetV0CityByCityNameOrderHistoryByBeadIdWithResponse(ctx context.Context, cityName string, beadId string, params *GetV0CityByCityNameOrderHistoryByBeadIdParams, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrderHistoryByBeadIdResponse, error)
 
 	// GetV0CityByCityNameOrderByNameWithResponse request
 	GetV0CityByCityNameOrderByNameWithResponse(ctx context.Context, cityName string, name string, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrderByNameResponse, error)
@@ -19060,8 +19091,8 @@ func (c *ClientWithResponses) ReplyMailWithResponse(ctx context.Context, cityNam
 }
 
 // GetV0CityByCityNameOrderHistoryByBeadIdWithResponse request returning *GetV0CityByCityNameOrderHistoryByBeadIdResponse
-func (c *ClientWithResponses) GetV0CityByCityNameOrderHistoryByBeadIdWithResponse(ctx context.Context, cityName string, beadId string, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrderHistoryByBeadIdResponse, error) {
-	rsp, err := c.GetV0CityByCityNameOrderHistoryByBeadId(ctx, cityName, beadId, reqEditors...)
+func (c *ClientWithResponses) GetV0CityByCityNameOrderHistoryByBeadIdWithResponse(ctx context.Context, cityName string, beadId string, params *GetV0CityByCityNameOrderHistoryByBeadIdParams, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrderHistoryByBeadIdResponse, error) {
+	rsp, err := c.GetV0CityByCityNameOrderHistoryByBeadId(ctx, cityName, beadId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handler_orders.go
+++ b/internal/api/handler_orders.go
@@ -4,9 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
-	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -91,28 +89,6 @@ func toOrderResponse(a orders.Order) orderResponse {
 		Enabled:       a.IsEnabled(),
 		Rig:           a.Rig,
 		CaptureOutput: a.IsExec(), // exec orders capture output
-	}
-}
-
-func beadLastRunFunc(store beads.Store) orders.LastRunFunc {
-	return func(name string) (time.Time, error) {
-		if store == nil {
-			return time.Time{}, nil
-		}
-		label := "order-run:" + name
-		results, err := store.List(beads.ListQuery{
-			Label:         label,
-			Limit:         1,
-			IncludeClosed: true,
-			Sort:          beads.SortCreatedDesc,
-		})
-		if err != nil {
-			return time.Time{}, err
-		}
-		if len(results) == 0 {
-			return time.Time{}, nil
-		}
-		return results[0].CreatedAt, nil
 	}
 }
 

--- a/internal/api/handler_orders.go
+++ b/internal/api/handler_orders.go
@@ -14,6 +14,7 @@ import (
 var (
 	errOrderNotFound  = errors.New("order not found")
 	errOrderAmbiguous = errors.New("ambiguous order name")
+	errNoOrderStores  = errors.New("order bead stores unavailable")
 )
 
 type orderResponse struct {

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -585,6 +585,220 @@ func TestHandleOrdersFeedCityScopeReportsPartialRigFailures(t *testing.T) {
 	}
 }
 
+func TestHandleOrdersFeedIncludesRigStoreTrackingBeads(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Trigger: "cron", Interval: "24h", Pool: "reviewers", Rig: "myrig"},
+	}
+
+	tracking, err := rigStore.Create(beads.Bead{
+		Title:  "order:nightly-review:rig:myrig",
+		Status: "closed",
+		Labels: []string{"order-tracking", "order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create tracking bead: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	_, err = rigStore.Create(beads.Bead{
+		Title:  "nightly-review wisp",
+		Type:   "wisp",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create wisp bead: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/feed?scope_kind=rig&scope_ref=myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Items []monitorFeedItemResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(resp.Items))
+	}
+	item := resp.Items[0]
+	if item.BeadID != tracking.ID {
+		t.Fatalf("bead_id = %q, want %q", item.BeadID, tracking.ID)
+	}
+	if item.ScopeKind != "rig" || item.ScopeRef != "myrig" {
+		t.Fatalf("scope = %s/%s, want rig/myrig", item.ScopeKind, item.ScopeRef)
+	}
+	if item.Target != "myrig/reviewers" {
+		t.Fatalf("target = %q, want myrig/reviewers", item.Target)
+	}
+	if item.UpdatedAt == item.StartedAt {
+		t.Fatalf("updated_at = %q, started_at = %q, want updated_at to reflect newer run activity", item.UpdatedAt, item.StartedAt)
+	}
+}
+
+func TestHandleOrderCheckUsesRigStoreLastRunState(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Trigger: "cooldown", Interval: "24h", Rig: "myrig"},
+	}
+
+	if _, err := rigStore.Create(beads.Bead{
+		Title:  "nightly-review wisp",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	}); err != nil {
+		t.Fatalf("create rig run: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Checks []struct {
+			Name           string  `json:"name"`
+			ScopedName     string  `json:"scoped_name"`
+			Due            bool    `json:"due"`
+			LastRunOutcome *string `json:"last_run_outcome"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(resp.Checks))
+	}
+	check := resp.Checks[0]
+	if check.ScopedName != "nightly-review:rig:myrig" {
+		t.Fatalf("scoped_name = %q, want nightly-review:rig:myrig", check.ScopedName)
+	}
+	if check.Due {
+		t.Fatalf("due = true, want false when rig store has a recent run")
+	}
+	if check.LastRunOutcome == nil || *check.LastRunOutcome != "success" {
+		t.Fatalf("last_run_outcome = %v, want success", check.LastRunOutcome)
+	}
+}
+
+func TestHandleOrderHistoryUsesRigStore(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Rig: "myrig"},
+	}
+
+	run, err := rigStore.Create(beads.Bead{
+		Title:  "nightly-review wisp",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create rig history bead: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review:rig:myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID     string `json:"bead_id"`
+			ScopedName string `json:"scoped_name"`
+			Rig        string `json:"rig"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(resp.Entries))
+	}
+	if resp.Entries[0].BeadID != run.ID {
+		t.Fatalf("bead_id = %q, want %q", resp.Entries[0].BeadID, run.ID)
+	}
+	if resp.Entries[0].ScopedName != "nightly-review:rig:myrig" {
+		t.Fatalf("scoped_name = %q, want nightly-review:rig:myrig", resp.Entries[0].ScopedName)
+	}
+	if resp.Entries[0].Rig != "myrig" {
+		t.Fatalf("rig = %q, want myrig", resp.Entries[0].Rig)
+	}
+}
+
+func TestHandleOrderHistoryDetailUsesRigStore(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+
+	run, err := rigStore.Create(beads.Bead{
+		Title:  "nightly-review wisp",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+		Metadata: map[string]string{
+			"convergence.gate_stdout": "done",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create rig history bead: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/order/history/"+run.ID), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		BeadID string `json:"bead_id"`
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.BeadID != run.ID {
+		t.Fatalf("bead_id = %q, want %q", resp.BeadID, run.ID)
+	}
+	if resp.Output != "done" {
+		t.Fatalf("output = %q, want done", resp.Output)
+	}
+}
+
 func TestHandleOrderGet_Ambiguous(t *testing.T) {
 	fs := newFakeState(t)
 	fs.autos = []orders.Order{

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -637,6 +637,12 @@ func TestHandleOrdersFeedIncludesRigStoreTrackingBeads(t *testing.T) {
 	if item.BeadID != tracking.ID {
 		t.Fatalf("bead_id = %q, want %q", item.BeadID, tracking.ID)
 	}
+	if item.StoreRef != "rig:myrig" {
+		t.Fatalf("store_ref = %q, want rig:myrig", item.StoreRef)
+	}
+	if item.ID != "order:rig:myrig:"+tracking.ID {
+		t.Fatalf("id = %q, want store-qualified order id", item.ID)
+	}
 	if item.ScopeKind != "rig" || item.ScopeRef != "myrig" {
 		t.Fatalf("scope = %s/%s, want rig/myrig", item.ScopeKind, item.ScopeRef)
 	}
@@ -645,6 +651,29 @@ func TestHandleOrdersFeedIncludesRigStoreTrackingBeads(t *testing.T) {
 	}
 	if item.UpdatedAt == item.StartedAt {
 		t.Fatalf("updated_at = %q, started_at = %q, want updated_at to reflect newer run activity", item.UpdatedAt, item.StartedAt)
+	}
+}
+
+func TestHandleOrdersFeedRigScopeReturnsRequestedStoreFailure(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	fs.stores["myrig"] = failListStore{Store: fs.stores["myrig"]}
+
+	if _, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "legacy rig tracking",
+		Status: "closed",
+		Labels: []string{"order-tracking", "order-run:nightly-review:rig:myrig", "wisp"},
+	}); err != nil {
+		t.Fatalf("create legacy tracking bead: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/feed?scope_kind=rig&scope_ref=myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusInternalServerError, w.Body.String())
 	}
 }
 
@@ -702,6 +731,35 @@ func TestHandleOrderCheckUsesRigStoreLastRunState(t *testing.T) {
 	}
 }
 
+func TestHandleOrderCheckSkipsUnavailableRigStore(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	delete(fs.stores, "missing")
+	fs.autos = []orders.Order{
+		{Name: "city-review", Formula: "mol-adopt-pr-v2", Trigger: "manual"},
+		{Name: "rig-review", Formula: "mol-adopt-pr-v2", Trigger: "manual", Rig: "missing"},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Checks []orderCheckResponse `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Checks) != 2 {
+		t.Fatalf("len(checks) = %d, want 2", len(resp.Checks))
+	}
+}
+
 func TestHandleOrderHistoryUsesRigStore(t *testing.T) {
 	fs := newFakeState(t)
 	fs.cityBeadStore = beads.NewMemStore()
@@ -755,6 +813,260 @@ func TestHandleOrderHistoryUsesRigStore(t *testing.T) {
 	}
 }
 
+func TestHandleOrderHistoryIncludesStoreRefForCollidingIDs(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Rig: "myrig"},
+	}
+
+	cityRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "legacy city nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create city history bead: %v", err)
+	}
+	rigRun, err := rigStore.Create(beads.Bead{
+		Title:  "rig nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create rig history bead: %v", err)
+	}
+	if cityRun.ID != rigRun.ID {
+		t.Fatalf("test requires colliding IDs, got city=%q rig=%q", cityRun.ID, rigRun.ID)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review:rig:myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID   string `json:"bead_id"`
+			StoreRef string `json:"store_ref"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2: %+v", len(resp.Entries), resp.Entries)
+	}
+	got := map[string]bool{}
+	for _, entry := range resp.Entries {
+		if entry.BeadID != cityRun.ID {
+			t.Fatalf("bead_id = %q, want colliding id %q", entry.BeadID, cityRun.ID)
+		}
+		got[entry.StoreRef] = true
+	}
+	for _, want := range []string{"city:test-city", "rig:myrig"} {
+		if !got[want] {
+			t.Fatalf("entries missing store_ref %q: %+v", want, resp.Entries)
+		}
+	}
+}
+
+func TestHandleOrderHistoryBeforeUsesBufferedBoundedFetch(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2"},
+	}
+
+	oldRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "old nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create old run: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	midRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "middle nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create middle run: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if _, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "new nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review", "wisp"},
+	}); err != nil {
+		t.Fatalf("create new run: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	before := midRun.CreatedAt.Format(time.RFC3339Nano)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+before), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID string `json:"bead_id"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1: %+v", len(resp.Entries), resp.Entries)
+	}
+	if resp.Entries[0].BeadID != oldRun.ID {
+		t.Fatalf("bead_id = %q, want older run %q", resp.Entries[0].BeadID, oldRun.ID)
+	}
+}
+
+func TestHandleOrderHistoryBeforeFiltersBeforeStoreLimit(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2"},
+	}
+
+	oldRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "old nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create old run: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	cursorRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "cursor nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create cursor run: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	for i := 0; i < 4; i++ {
+		if _, err := fs.cityBeadStore.Create(beads.Bead{
+			Title:  "newer nightly-review",
+			Status: "closed",
+			Labels: []string{"order-run:nightly-review", "wisp"},
+		}); err != nil {
+			t.Fatalf("create newer run %d: %v", i, err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	h := newTestCityHandler(t, fs)
+	before := cursorRun.CreatedAt.Format(time.RFC3339Nano)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+before), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID string `json:"bead_id"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1: %+v", len(resp.Entries), resp.Entries)
+	}
+	if resp.Entries[0].BeadID != oldRun.ID {
+		t.Fatalf("bead_id = %q, want older run %q", resp.Entries[0].BeadID, oldRun.ID)
+	}
+}
+
+func TestHandleOrderHistoryBeforeFiltersBeforeMergedLimit(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Rig: "myrig"},
+	}
+
+	oldRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "legacy older nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create old city run: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	cursorRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "cursor nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create cursor run: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	for i := 0; i < 3; i++ {
+		if _, err := rigStore.Create(beads.Bead{
+			Title:  "newer rig nightly-review",
+			Status: "closed",
+			Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+		}); err != nil {
+			t.Fatalf("create newer rig run %d: %v", i, err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	h := newTestCityHandler(t, fs)
+	before := cursorRun.CreatedAt.Format(time.RFC3339Nano)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review:rig:myrig&limit=1&before="+before), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID   string `json:"bead_id"`
+			StoreRef string `json:"store_ref"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1: %+v", len(resp.Entries), resp.Entries)
+	}
+	if resp.Entries[0].BeadID != oldRun.ID || resp.Entries[0].StoreRef != "city:test-city" {
+		t.Fatalf("entry = %+v, want old city run %q", resp.Entries[0], oldRun.ID)
+	}
+}
+
 func TestHandleOrderHistoryDetailUsesRigStore(t *testing.T) {
 	fs := newFakeState(t)
 	fs.cityBeadStore = beads.NewMemStore()
@@ -796,6 +1108,80 @@ func TestHandleOrderHistoryDetailUsesRigStore(t *testing.T) {
 	}
 	if resp.Output != "done" {
 		t.Fatalf("output = %q, want done", resp.Output)
+	}
+}
+
+func TestHandleOrderHistoryDetailUsesStoreRefForCollidingIDs(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	rigStore := fs.stores["myrig"]
+	if rigStore == nil {
+		t.Fatal("expected rig store")
+	}
+
+	cityRun, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "legacy city nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+		Metadata: map[string]string{
+			"convergence.gate_stdout": "city output",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create city history bead: %v", err)
+	}
+	rigRun, err := rigStore.Create(beads.Bead{
+		Title:  "rig nightly-review",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review:rig:myrig", "wisp"},
+		Metadata: map[string]string{
+			"convergence.gate_stdout": "rig output",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create rig history bead: %v", err)
+	}
+	if cityRun.ID != rigRun.ID {
+		t.Fatalf("test requires colliding IDs, got city=%q rig=%q", cityRun.ID, rigRun.ID)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/order/history/"+rigRun.ID+"?store_ref=rig:myrig"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		BeadID   string `json:"bead_id"`
+		StoreRef string `json:"store_ref"`
+		Output   string `json:"output"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.StoreRef != "rig:myrig" {
+		t.Fatalf("store_ref = %q, want rig:myrig", resp.StoreRef)
+	}
+	if resp.Output != "rig output" {
+		t.Fatalf("output = %q, want rig output", resp.Output)
+	}
+}
+
+func TestHandleOrderHistoryNoStoresReturnsServiceUnavailable(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = nil
+	fs.stores = map[string]beads.Store{}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusServiceUnavailable, w.Body.String())
 	}
 }
 

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -66,35 +66,16 @@ type OrderCheckListOutput struct {
 func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*OrderCheckListOutput, error) {
 	aa := s.state.Orders()
 
-	store := s.state.CityBeadStore()
-	lastRunFn := beadLastRunFunc(store)
 	ep := s.state.EventProvider()
-
-	var cursorFn orders.CursorFunc
-	if store != nil {
-		cursorFn = func(name string) uint64 {
-			label := "order-run:" + name
-			results, err := store.List(beads.ListQuery{
-				Label:         label,
-				Limit:         10,
-				IncludeClosed: true,
-				Sort:          beads.SortCreatedDesc,
-			})
-			if err != nil || len(results) == 0 {
-				return 0
-			}
-			var labelSets [][]string
-			for _, b := range results {
-				labelSets = append(labelSets, b.Labels)
-			}
-			return orders.MaxSeqFromLabels(labelSets)
-		}
-	}
 
 	now := time.Now()
 	checks := make([]orderCheckResponse, 0, len(aa))
 	for _, a := range aa {
-		result := orders.CheckTrigger(a, now, lastRunFn, ep, cursorFn)
+		stores, err := orders.StoresForState(s.state, a)
+		if err != nil {
+			return nil, huma.Error500InternalServerError(err.Error())
+		}
+		result := orders.CheckTrigger(a, now, orders.LastRunAcrossStores(stores...), ep, orders.CursorAcrossStores(stores...))
 		cr := orderCheckResponse{
 			Name:       a.Name,
 			ScopedName: a.ScopedName(),
@@ -106,18 +87,10 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 			ts := result.LastRun.Format(time.RFC3339)
 			cr.LastRun = &ts
 		}
-		if store != nil {
-			label := "order-run:" + a.ScopedName()
-			if results, err := store.List(beads.ListQuery{
-				Label:         label,
-				Limit:         1,
-				IncludeClosed: true,
-				Sort:          beads.SortCreatedDesc,
-			}); err == nil && len(results) > 0 {
-				outcome := lastRunOutcomeFromLabels(results[0].Labels)
-				if outcome != "" {
-					cr.LastRunOutcome = &outcome
-				}
+		if results, err := orders.HistoryBeadsAcrossStores(stores, a.ScopedName()); err == nil && len(results) > 0 {
+			outcome := lastRunOutcomeFromLabels(results[0].Labels)
+			if outcome != "" {
+				cr.LastRunOutcome = &outcome
 			}
 		}
 		checks = append(checks, cr)
@@ -155,11 +128,6 @@ type OrderHistoryListOutput struct {
 
 // humaHandleOrderHistory is the Huma-typed handler for GET /v0/orders/history.
 func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryInput) (*OrderHistoryListOutput, error) {
-	store := s.state.CityBeadStore()
-	if store == nil {
-		return nil, huma.Error503ServiceUnavailable("no bead store configured")
-	}
-
 	scopedName := input.ScopedName
 	if scopedName == "" {
 		return nil, huma.Error400BadRequest("scoped_name is required")
@@ -181,24 +149,27 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 
 	aa := s.state.Orders()
 	var auto *orders.Order
+	var orderDef orders.Order
 	for i, a := range aa {
 		if a.ScopedName() == scopedName {
 			auto = &aa[i]
+			orderDef = aa[i]
 			break
 		}
 	}
-
-	label := "order-run:" + scopedName
-	fetchLimit := limit
-	if !beforeTime.IsZero() {
-		fetchLimit = limit * 3
+	if auto == nil {
+		orderDef = orders.Order{Name: scopedName}
+		if idx := strings.Index(scopedName, ":rig:"); idx >= 0 {
+			orderDef.Name = scopedName[:idx]
+			orderDef.Rig = scopedName[idx+5:]
+		}
 	}
-	results, err := store.List(beads.ListQuery{
-		Label:         label,
-		Limit:         fetchLimit,
-		IncludeClosed: true,
-		Sort:          beads.SortCreatedDesc,
-	})
+	stores, err := orders.StoresForState(s.state, orderDef)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(err.Error())
+	}
+
+	results, err := orders.HistoryBeadsAcrossStores(stores, scopedName)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
@@ -273,12 +244,14 @@ func (s *Server) humaHandleOrderHistoryDetail(_ context.Context, input *OrderHis
 	Body orderHistoryDetailResponse
 }, error,
 ) {
-	store := s.state.CityBeadStore()
-	if store == nil {
-		return nil, huma.Error503ServiceUnavailable("no bead store configured")
+	storeInfos := workflowStores(s.state)
+	stores := make([]beads.Store, 0, len(storeInfos))
+	for _, info := range storeInfos {
+		if info.store != nil {
+			stores = append(stores, info.store)
+		}
 	}
-
-	b, err := store.Get(input.BeadID)
+	b, err := orders.HistoryBeadAcrossStores(stores, input.BeadID)
 	if err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
 			return nil, huma.Error404NotFound("bead not found")
@@ -363,11 +336,11 @@ func (s *Server) humaHandleOrdersFeed(_ context.Context, input *OrdersFeedInput)
 		return nil, huma.Error500InternalServerError("order feed failed")
 	}
 
-	items := make([]monitorFeedItemResponse, 0, len(workflowRuns.Items)+len(orderRuns))
+	items := make([]monitorFeedItemResponse, 0, len(workflowRuns.Items)+len(orderRuns.Items))
 	for _, run := range workflowRuns.Items {
 		items = append(items, workflowRunProjectionFeedItem(run))
 	}
-	items = append(items, orderRuns...)
+	items = append(items, orderRuns.Items...)
 
 	sort.SliceStable(items, func(i, j int) bool {
 		iRank := monitorStatusRank(items[i].Status)
@@ -394,17 +367,31 @@ func (s *Server) humaHandleOrdersFeed(_ context.Context, input *OrdersFeedInput)
 
 	body := ordersFeedBody{
 		Items:   items,
-		Partial: workflowRuns.Partial,
+		Partial: workflowRuns.Partial || orderRuns.Partial,
 	}
-	if len(workflowRuns.PartialErrors) > 0 {
-		body.PartialErrors = workflowRuns.PartialErrors
-	}
+	body.PartialErrors = appendUniqueStrings(body.PartialErrors, workflowRuns.PartialErrors...)
+	body.PartialErrors = appendUniqueStrings(body.PartialErrors, orderRuns.PartialErrors...)
 
 	s.storeResponse(cacheKey, index, body)
 
 	return &struct {
 		Body ordersFeedBody
 	}{Body: body}, nil
+}
+
+func appendUniqueStrings(dst []string, values ...string) []string {
+	seen := make(map[string]bool, len(dst))
+	for _, value := range dst {
+		seen[value] = true
+	}
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		dst = append(dst, value)
+	}
+	return dst
 }
 
 func (s *Server) setOrderEnabledHuma(name string, enabled bool) (*OKResponse, error) {

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -71,10 +72,11 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 	now := time.Now()
 	checks := make([]orderCheckResponse, 0, len(aa))
 	for _, a := range aa {
-		stores, err := orders.StoresForState(s.state, a)
+		storeInfos, err := orderStoreInfosForState(s.state, a)
 		if err != nil {
-			return nil, huma.Error500InternalServerError(err.Error())
+			storeInfos = nil
 		}
+		stores := storesFromWorkflowInfos(storeInfos)
 		result := orders.CheckTrigger(a, now, orders.LastRunAcrossStores(stores...), ep, orders.CursorAcrossStores(stores...))
 		cr := orderCheckResponse{
 			Name:       a.Name,
@@ -87,8 +89,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 			ts := result.LastRun.Format(time.RFC3339)
 			cr.LastRun = &ts
 		}
-		if results, err := orders.HistoryBeadsAcrossStores(stores, a.ScopedName()); err == nil && len(results) > 0 {
-			outcome := lastRunOutcomeFromLabels(results[0].Labels)
+		if results, err := orderHistoryBeadsAcrossStoreInfos(storeInfos, a.ScopedName(), 1, time.Time{}); err == nil && len(results) > 0 {
+			outcome := lastRunOutcomeFromLabels(results[0].bead.Labels)
 			if outcome != "" {
 				cr.LastRunOutcome = &outcome
 			}
@@ -164,22 +166,22 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 			orderDef.Rig = scopedName[idx+5:]
 		}
 	}
-	stores, err := orders.StoresForState(s.state, orderDef)
+	storeInfos, err := orderStoreInfosForState(s.state, orderDef)
 	if err != nil {
+		if errors.Is(err, errNoOrderStores) {
+			return nil, huma.Error503ServiceUnavailable(err.Error())
+		}
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
-	results, err := orders.HistoryBeadsAcrossStores(stores, scopedName)
+	results, err := orderHistoryBeadsAcrossStoreInfos(storeInfos, scopedName, limit, beforeTime)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
 	entries := make([]orderHistoryEntry, 0, len(results))
-	for _, b := range results {
-		if !beforeTime.IsZero() && !b.CreatedAt.Before(beforeTime) {
-			continue
-		}
-
+	for _, result := range results {
+		b := result.bead
 		name := scopedName
 		rig := ""
 		if auto != nil {
@@ -192,6 +194,7 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 
 		entry := orderHistoryEntry{
 			BeadID:        b.ID,
+			StoreRef:      result.storeRef,
 			Name:          name,
 			ScopedName:    scopedName,
 			Rig:           rig,
@@ -225,6 +228,7 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 // orderHistoryEntry is a single entry in the order history response.
 type orderHistoryEntry struct {
 	BeadID        string   `json:"bead_id"`
+	StoreRef      string   `json:"store_ref"`
 	Name          string   `json:"name"`
 	ScopedName    string   `json:"scoped_name"`
 	Rig           string   `json:"rig,omitempty"`
@@ -245,19 +249,24 @@ func (s *Server) humaHandleOrderHistoryDetail(_ context.Context, input *OrderHis
 }, error,
 ) {
 	storeInfos := workflowStores(s.state)
-	stores := make([]beads.Store, 0, len(storeInfos))
-	for _, info := range storeInfos {
-		if info.store != nil {
-			stores = append(stores, info.store)
+	if input.StoreRef != "" {
+		info, ok := workflowStoreByRef(s.state, input.StoreRef)
+		if !ok {
+			return nil, huma.Error404NotFound("store not found")
 		}
+		storeInfos = []workflowStoreInfo{info}
 	}
-	b, err := orders.HistoryBeadAcrossStores(stores, input.BeadID)
+	result, err := orderHistoryBeadAcrossStoreInfos(storeInfos, input.BeadID)
 	if err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
 			return nil, huma.Error404NotFound("bead not found")
 		}
+		if errors.Is(err, errNoOrderStores) {
+			return nil, huma.Error503ServiceUnavailable(err.Error())
+		}
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
+	b := result.bead
 
 	output := ""
 	if b.Metadata != nil {
@@ -276,6 +285,7 @@ func (s *Server) humaHandleOrderHistoryDetail(_ context.Context, input *OrderHis
 		Body orderHistoryDetailResponse
 	}{Body: orderHistoryDetailResponse{
 		BeadID:    b.ID,
+		StoreRef:  result.storeRef,
 		CreatedAt: b.CreatedAt.Format(time.RFC3339),
 		Labels:    b.Labels,
 		Output:    output,
@@ -285,9 +295,127 @@ func (s *Server) humaHandleOrderHistoryDetail(_ context.Context, input *OrderHis
 // orderHistoryDetailResponse is the response for GET /v0/order/history/{bead_id}.
 type orderHistoryDetailResponse struct {
 	BeadID    string   `json:"bead_id"`
+	StoreRef  string   `json:"store_ref"`
 	CreatedAt string   `json:"created_at"`
 	Labels    []string `json:"labels"`
 	Output    string   `json:"output"`
+}
+
+type orderHistoryStoreBead struct {
+	storeRef string
+	bead     beads.Bead
+}
+
+func orderStoreInfosForState(state State, a orders.Order) ([]workflowStoreInfo, error) {
+	cityName := workflowCityScopeRef(state.CityName())
+	infos := make([]workflowStoreInfo, 0, 2)
+	if strings.TrimSpace(a.Rig) != "" {
+		if rigStore := state.BeadStore(a.Rig); rigStore != nil {
+			infos = append(infos, workflowStoreInfo{
+				ref:       "rig:" + a.Rig,
+				scopeKind: "rig",
+				scopeRef:  a.Rig,
+				store:     rigStore,
+			})
+		}
+	}
+
+	if cityStore := state.CityBeadStore(); cityStore != nil {
+		infos = append(infos, workflowStoreInfo{
+			ref:       "city:" + cityName,
+			scopeKind: "city",
+			scopeRef:  cityName,
+			store:     cityStore,
+		})
+	}
+
+	if len(infos) == 0 {
+		return nil, errNoOrderStores
+	}
+	return infos, nil
+}
+
+func storesFromWorkflowInfos(infos []workflowStoreInfo) []beads.Store {
+	stores := make([]beads.Store, 0, len(infos))
+	for _, info := range infos {
+		if info.store != nil {
+			stores = append(stores, info.store)
+		}
+	}
+	return stores
+}
+
+func orderHistoryBeadsAcrossStoreInfos(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time) ([]orderHistoryStoreBead, error) {
+	if len(infos) == 0 {
+		return nil, errNoOrderStores
+	}
+
+	label := "order-run:" + scopedName
+	seen := make(map[string]bool)
+	results := make([]orderHistoryStoreBead, 0)
+	for i, info := range infos {
+		if info.store == nil {
+			continue
+		}
+		rows, err := info.store.List(beads.ListQuery{
+			Label:         label,
+			CreatedBefore: beforeTime,
+			Limit:         limit,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, err
+			}
+			log.Printf("api: order history list failed for %s: %v", info.ref, err)
+			continue
+		}
+		for _, row := range rows {
+			if !beforeTime.IsZero() && !row.CreatedAt.Before(beforeTime) {
+				continue
+			}
+			key := info.ref + "\x00" + row.ID
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			results = append(results, orderHistoryStoreBead{storeRef: info.ref, bead: row})
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].bead.CreatedAt.After(results[j].bead.CreatedAt)
+	})
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+
+func orderHistoryBeadAcrossStoreInfos(infos []workflowStoreInfo, beadID string) (orderHistoryStoreBead, error) {
+	if len(infos) == 0 {
+		return orderHistoryStoreBead{}, errNoOrderStores
+	}
+
+	var lastErr error
+	for _, info := range infos {
+		if info.store == nil {
+			continue
+		}
+		bead, err := info.store.Get(beadID)
+		if err == nil {
+			return orderHistoryStoreBead{storeRef: info.ref, bead: bead}, nil
+		}
+		if errors.Is(err, beads.ErrNotFound) {
+			continue
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return orderHistoryStoreBead{}, lastErr
+	}
+	return orderHistoryStoreBead{}, beads.ErrNotFound
 }
 
 // humaHandleOrderEnable is the Huma-typed handler for POST /v0/order/{name}/enable.

--- a/internal/api/huma_types_orders.go
+++ b/internal/api/huma_types_orders.go
@@ -44,7 +44,8 @@ type OrderHistoryInput struct {
 // OrderHistoryDetailInput is the Huma input for GET /v0/city/{cityName}/order/history/{bead_id}.
 type OrderHistoryDetailInput struct {
 	CityScope
-	BeadID string `path:"bead_id" doc:"Bead ID for the order run."`
+	BeadID   string `path:"bead_id" doc:"Bead ID for the order run."`
+	StoreRef string `query:"store_ref" required:"false" doc:"Store reference for disambiguating store-local bead IDs."`
 }
 
 // OrderEnableInput is the Huma input for POST /v0/city/{cityName}/order/{name}/enable.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -3716,6 +3716,9 @@
           "status": {
             "type": "string"
           },
+          "store_ref": {
+            "type": "string"
+          },
           "target": {
             "type": "string"
           },
@@ -3873,10 +3876,14 @@
           },
           "output": {
             "type": "string"
+          },
+          "store_ref": {
+            "type": "string"
           }
         },
         "required": [
           "bead_id",
+          "store_ref",
           "created_at",
           "labels",
           "output"
@@ -3928,12 +3935,16 @@
           "signal": {
             "type": "string"
           },
+          "store_ref": {
+            "type": "string"
+          },
           "wisp_root_id": {
             "type": "string"
           }
         },
         "required": [
           "bead_id",
+          "store_ref",
           "name",
           "scoped_name",
           "created_at",
@@ -11905,6 +11916,16 @@
             "required": true,
             "schema": {
               "description": "Bead ID for the order run.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Store reference for disambiguating store-local bead IDs.",
+            "explode": false,
+            "in": "query",
+            "name": "store_ref",
+            "schema": {
+              "description": "Store reference for disambiguating store-local bead IDs.",
               "type": "string"
             }
           }

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -13,6 +13,8 @@ import (
 
 const maxOrdersFeedLimit = 500
 
+var orderFeedLogf = log.Printf
+
 type monitorFeedItemResponse struct {
 	ID                 string `json:"id"`
 	Type               string `json:"type"`
@@ -50,6 +52,12 @@ type workflowRunProjection struct {
 
 type workflowRunProjectionResult struct {
 	Items         []workflowRunProjection
+	Partial       bool
+	PartialErrors []string
+}
+
+type orderRunFeedResult struct {
+	Items         []monitorFeedItemResponse
 	Partial       bool
 	PartialErrors []string
 }
@@ -281,20 +289,8 @@ func listActiveWorkflowProjectionBeads(store beads.Store) ([]beads.Bead, error) 
 	return store.List(beads.ListQuery{AllowScan: true})
 }
 
-func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef string) ([]monitorFeedItemResponse, error) {
-	store := state.CityBeadStore()
-	if store == nil {
-		return []monitorFeedItemResponse{}, nil
-	}
-
-	results, err := store.List(beads.ListQuery{
-		Label: "order-tracking",
-		Sort:  beads.SortCreatedDesc,
-	})
-	if err != nil {
-		return nil, err
-	}
-
+func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef string) (orderRunFeedResult, error) {
+	stores := workflowStores(state)
 	orderByScopedName := make(map[string]orders.Order, len(state.Orders()))
 	for _, order := range state.Orders() {
 		orderByScopedName[order.ScopedName()] = order
@@ -302,46 +298,71 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 
 	cityScopeRef := workflowCityScopeRef(state.CityName())
 	includeAllForCity := requestedScopeKind == "city" && requestedScopeRef == cityScopeRef
-	items := make([]monitorFeedItemResponse, 0, len(results))
-	updatedAtByScopedName := make(map[string]time.Time, len(results))
-	for _, bead := range results {
-		scopedName := orderTrackingScopedName(bead)
-		if scopedName == "" {
+	items := make([]monitorFeedItemResponse, 0)
+	partialErrors := make([]string, 0)
+	var requestedScopeErr error
+	for _, info := range stores {
+		if info.store == nil {
 			continue
 		}
-		scopeKind, scopeRef := orderTrackingScope(scopedName, cityScopeRef)
-		if !includeAllForCity && (scopeKind != requestedScopeKind || scopeRef != requestedScopeRef) {
+		results, err := info.store.List(beads.ListQuery{
+			Label: "order-tracking",
+			Sort:  beads.SortCreatedDesc,
+		})
+		if err != nil {
+			if requestedScopeErr == nil && info.scopeKind == requestedScopeKind && info.scopeRef == requestedScopeRef {
+				requestedScopeErr = err
+			}
+			if includeAllForCity {
+				msg := info.ref + " store unavailable"
+				log.Printf("api: order feed list failed for %s: %v", info.ref, err)
+				partialErrors = append(partialErrors, msg)
+			}
 			continue
 		}
 
-		updatedAt := updatedAtByScopedName[scopedName]
-		if updatedAt.IsZero() {
-			updatedAt = orderTrackingUpdatedAt(store, bead, scopedName)
-			updatedAtByScopedName[scopedName] = updatedAt
-		}
+		for _, bead := range results {
+			scopedName := orderTrackingScopedName(bead)
+			if scopedName == "" {
+				continue
+			}
+			scopeKind, scopeRef := orderTrackingScope(scopedName, cityScopeRef)
+			if !includeAllForCity && (scopeKind != requestedScopeKind || scopeRef != requestedScopeRef) {
+				continue
+			}
 
-		orderDef, ok := orderByScopedName[scopedName]
-		title := orderTrackingTitle(scopedName, orderDef, ok)
-		target := orderTrackingTarget(orderDef, ok, bead)
-		itemType := orderTrackingType(orderDef, ok, bead)
-		item := monitorFeedItemResponse{
-			ID:                 "order:" + bead.ID,
-			Type:               itemType,
-			Status:             normalizeMonitorStatus(orderTrackingStatus(bead)),
-			Title:              title,
-			ScopeKind:          scopeKind,
-			ScopeRef:           scopeRef,
-			Target:             target,
-			StartedAt:          bead.CreatedAt.Format(time.RFC3339Nano),
-			UpdatedAt:          updatedAt.Format(time.RFC3339Nano),
-			BeadID:             bead.ID,
-			DetailAvailable:    ok && orderDef.IsExec(),
-			RunDetailAvailable: ok && orderDef.IsExec(),
+			updatedAt := orderTrackingUpdatedAt(info.store, bead, scopedName)
+			orderDef, ok := orderByScopedName[scopedName]
+			title := orderTrackingTitle(scopedName, orderDef, ok)
+			target := orderTrackingTarget(orderDef, ok, bead)
+			itemType := orderTrackingType(orderDef, ok, bead)
+			item := monitorFeedItemResponse{
+				ID:                 "order:" + bead.ID,
+				Type:               itemType,
+				Status:             normalizeMonitorStatus(orderTrackingStatus(bead)),
+				Title:              title,
+				ScopeKind:          scopeKind,
+				ScopeRef:           scopeRef,
+				Target:             target,
+				StartedAt:          bead.CreatedAt.Format(time.RFC3339Nano),
+				UpdatedAt:          updatedAt.Format(time.RFC3339Nano),
+				BeadID:             bead.ID,
+				DetailAvailable:    ok && orderDef.IsExec(),
+				RunDetailAvailable: ok && orderDef.IsExec(),
+			}
+			items = append(items, item)
 		}
-		items = append(items, item)
 	}
 
-	return items, nil
+	if len(items) == 0 && requestedScopeErr != nil && !includeAllForCity {
+		return orderRunFeedResult{}, requestedScopeErr
+	}
+
+	return orderRunFeedResult{
+		Items:         items,
+		Partial:       len(partialErrors) > 0,
+		PartialErrors: partialErrors,
+	}, nil
 }
 
 func orderTrackingUpdatedAt(store beads.Store, tracking beads.Bead, scopedName string) time.Time {
@@ -356,6 +377,7 @@ func orderTrackingUpdatedAt(store beads.Store, tracking beads.Bead, scopedName s
 		Sort:  beads.SortCreatedDesc,
 	})
 	if err != nil {
+		orderFeedLogf("api: order feed update lookup failed for %s bead %s: %v", scopedName, tracking.ID, err)
 		return updatedAt
 	}
 	if len(runs) > 0 && runs[0].CreatedAt.After(updatedAt) {

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -30,6 +30,7 @@ type monitorFeedItemResponse struct {
 	WorkflowID         string `json:"workflow_id,omitempty"`
 	RootBeadID         string `json:"root_bead_id,omitempty"`
 	RootStoreRef       string `json:"root_store_ref,omitempty"`
+	StoreRef           string `json:"store_ref,omitempty"`
 	AttachedBeadID     string `json:"attached_bead_id,omitempty"`
 	LogicalBeadID      string `json:"logical_bead_id,omitempty"`
 	RunDetailAvailable bool   `json:"run_detail_available,omitempty"`
@@ -337,7 +338,7 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 			target := orderTrackingTarget(orderDef, ok, bead)
 			itemType := orderTrackingType(orderDef, ok, bead)
 			item := monitorFeedItemResponse{
-				ID:                 "order:" + bead.ID,
+				ID:                 "order:" + info.ref + ":" + bead.ID,
 				Type:               itemType,
 				Status:             normalizeMonitorStatus(orderTrackingStatus(bead)),
 				Title:              title,
@@ -347,6 +348,7 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 				StartedAt:          bead.CreatedAt.Format(time.RFC3339Nano),
 				UpdatedAt:          updatedAt.Format(time.RFC3339Nano),
 				BeadID:             bead.ID,
+				StoreRef:           info.ref,
 				DetailAvailable:    ok && orderDef.IsExec(),
 				RunDetailAvailable: ok && orderDef.IsExec(),
 			}
@@ -354,7 +356,7 @@ func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef s
 		}
 	}
 
-	if len(items) == 0 && requestedScopeErr != nil && !includeAllForCity {
+	if requestedScopeErr != nil && !includeAllForCity {
 		return orderRunFeedResult{}, requestedScopeErr
 	}
 

--- a/internal/api/orders_feed_test.go
+++ b/internal/api/orders_feed_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,8 +101,46 @@ func TestBuildWorkflowRunProjectionsKeepsInProgressChildrenOnHistoryFailure(t *t
 	}
 }
 
+func TestOrderTrackingUpdatedAtLogsLookupFailure(t *testing.T) {
+	store := labelFailListStore{
+		Store:     beads.NewMemStore(),
+		failLabel: "order-run:digest",
+	}
+	tracking := beads.Bead{
+		CreatedAt: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+	}
+
+	var logs strings.Builder
+	origLogf := orderFeedLogf
+	orderFeedLogf = func(format string, args ...any) {
+		logs.WriteString(strings.TrimSpace(fmt.Sprintf(format, args...)))
+		logs.WriteByte('\n')
+	}
+	defer func() { orderFeedLogf = origLogf }()
+
+	got := orderTrackingUpdatedAt(store, tracking, "digest")
+	if !got.Equal(tracking.CreatedAt) {
+		t.Fatalf("updatedAt = %s, want %s", got, tracking.CreatedAt)
+	}
+	if !strings.Contains(logs.String(), "order feed update lookup failed") {
+		t.Fatalf("logs = %q, want update lookup failure warning", logs.String())
+	}
+}
+
 type workflowProjectionStore struct {
 	*beads.MemStore
+}
+
+type labelFailListStore struct {
+	beads.Store
+	failLabel string
+}
+
+func (s labelFailListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == s.failLabel {
+		return nil, errors.New("list failed")
+	}
+	return s.Store.List(query)
 }
 
 func (s *workflowProjectionStore) List(query beads.ListQuery) ([]beads.Bead, error) {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -650,6 +650,9 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if query.IncludeClosed || query.Status == "closed" {
 		args = append(args, "--all")
 	}
+	if !query.CreatedBefore.IsZero() {
+		args = append(args, "--created-before", query.CreatedBefore.Format(time.RFC3339Nano))
+	}
 	args = append(args, "--include-infra", "--include-gates", "--limit", fmt.Sprintf("%d", limit))
 	if query.ParentID != "" {
 		args = append(args, "--parent", query.ParentID)

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -1000,6 +1001,34 @@ func TestBdStoreListByLabel(t *testing.T) {
 	}
 	if len(got[0].Labels) != 1 || got[0].Labels[0] != "order-run:digest" {
 		t.Errorf("got[0].Labels = %v, want [order-run:digest]", got[0].Labels)
+	}
+}
+
+func TestBdStoreListCreatedBeforeForwardsFilter(t *testing.T) {
+	before := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	wantCmd := `bd list --json --label=order-run:digest --all --created-before ` +
+		before.Format(time.RFC3339Nano) + ` --include-infra --include-gates --limit 1`
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		wantCmd: {
+			out: []byte(`[{"id":"bd-old","title":"digest wisp","status":"closed","issue_type":"task","created_at":"2026-04-20T11:59:00Z","labels":["order-run:digest"]}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{
+		Label:         "order-run:digest",
+		CreatedBefore: before,
+		Limit:         1,
+		IncludeClosed: true,
+		Sort:          beads.SortCreatedDesc,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "bd-old" {
+		t.Fatalf("List returned %+v, want bd-old", got)
 	}
 }
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1,6 +1,9 @@
 package beads
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestIsContainerType(t *testing.T) {
 	tests := []struct {
@@ -64,5 +67,30 @@ func TestIsReadyExcludedType(t *testing.T) {
 		if got := IsReadyExcludedType(tt.typ); got != tt.want {
 			t.Errorf("IsReadyExcludedType(%q) = %v, want %v", tt.typ, got, tt.want)
 		}
+	}
+}
+
+func TestListQueryCreatedBeforeFiltersBeforeLimit(t *testing.T) {
+	base := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	items := []Bead{
+		{ID: "newer-2", Title: "newer 2", Status: "closed", CreatedAt: base.Add(2 * time.Minute), Labels: []string{"order-run:digest"}},
+		{ID: "newer-1", Title: "newer 1", Status: "closed", CreatedAt: base.Add(time.Minute), Labels: []string{"order-run:digest"}},
+		{ID: "older-2", Title: "older 2", Status: "closed", CreatedAt: base.Add(-2 * time.Minute), Labels: []string{"order-run:digest"}},
+		{ID: "older-1", Title: "older 1", Status: "closed", CreatedAt: base.Add(-time.Minute), Labels: []string{"order-run:digest"}},
+	}
+
+	got := ApplyListQuery(items, ListQuery{
+		Label:         "order-run:digest",
+		CreatedBefore: base,
+		Limit:         1,
+		IncludeClosed: true,
+		Sort:          SortCreatedDesc,
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ID != "older-1" {
+		t.Fatalf("got[0].ID = %q, want older-1", got[0].ID)
 	}
 }

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -295,7 +295,7 @@ func (s *Store) List(query beads.ListQuery) ([]beads.Bead, error) {
 		if query.Type != "" {
 			args = append(args, "--type="+query.Type)
 		}
-		if query.Limit > 0 {
+		if query.Limit > 0 && query.CreatedBefore.IsZero() {
 			args = append(args, "--limit="+strconv.Itoa(query.Limit))
 		}
 		out, err = s.run(nil, args...)

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -1001,3 +1001,41 @@ esac
 		}
 	}
 }
+
+func TestListWithCreatedBeforeDoesNotForwardLimitBeforeClientFilter(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	script := writeScript(t, dir, `
+op="$1"
+shift
+case "$op" in
+  list)
+    printf '%s
+' "$*" > "`+argsFile+`"
+    echo '[]'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	s := NewStore(script)
+
+	_, err := s.List(beads.ListQuery{
+		Type:          "task",
+		CreatedBefore: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		Limit:         7,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	argsData, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("ReadFile(args): %v", err)
+	}
+	argsText := string(argsData)
+	if strings.Contains(argsText, "--limit=7") {
+		t.Fatalf("list args should not limit before created-before filtering: %s", argsText)
+	}
+	if !strings.Contains(argsText, "--type=task") {
+		t.Fatalf("list args missing type filter: %s", argsText)
+	}
+}

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"errors"
 	"sort"
+	"time"
 )
 
 // ErrQueryRequiresScan reports that a query would require an explicit scan.
@@ -31,6 +32,7 @@ type ListQuery struct {
 	Assignee      string
 	ParentID      string
 	Metadata      map[string]string
+	CreatedBefore time.Time
 	Limit         int
 	IncludeClosed bool
 	AllowScan     bool
@@ -44,7 +46,8 @@ func (q ListQuery) HasFilter() bool {
 		q.Label != "" ||
 		q.Assignee != "" ||
 		q.ParentID != "" ||
-		len(q.Metadata) > 0
+		len(q.Metadata) > 0 ||
+		!q.CreatedBefore.IsZero()
 }
 
 // IncludesClosed reports whether the query may return closed beads.
@@ -74,6 +77,9 @@ func (q ListQuery) Matches(b Bead) bool {
 		return false
 	}
 	if len(q.Metadata) > 0 && !matchesMetadata(b, q.Metadata) {
+		return false
+	}
+	if !q.CreatedBefore.IsZero() && !b.CreatedAt.Before(q.CreatedBefore) {
 		return false
 	}
 	return true

--- a/internal/orders/discovery.go
+++ b/internal/orders/discovery.go
@@ -1,8 +1,10 @@
 package orders
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -72,7 +74,10 @@ func warnDeprecatedPath(opts ScanOptions, format string, args ...any) {
 func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error, opts ScanOptions) error {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading order root %s: %w", dir, err)
 	}
 	// Two-pass scan: canonical .toml files win over legacy .order.toml files
 	// regardless of ReadDir ordering. A legacy file is only consumed if no
@@ -98,6 +103,9 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 			source := filepath.Join(dir, fileName)
 			data, err := fs.ReadFile(source)
 			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					warnUnreadablePath(opts, "warning: unreadable order path %s: %v", source, err)
+				}
 				continue
 			}
 			if legacy {
@@ -118,7 +126,10 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error) error {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading order root %s: %w", dir, err)
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -131,6 +142,9 @@ func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, 
 		source := filepath.Join(dir, name, orderFileName)
 		data, err := fs.ReadFile(source)
 		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				warnUnreadablePath(ScanOptions{}, "warning: unreadable order path %s: %v", source, err)
+			}
 			continue
 		}
 		if err := add(name, source, data); err != nil {
@@ -138,6 +152,13 @@ func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, 
 		}
 	}
 	return nil
+}
+
+func warnUnreadablePath(opts ScanOptions, format string, args ...any) {
+	if opts.SuppressDeprecatedPathWarnings {
+		return
+	}
+	log.Printf(format, args...)
 }
 
 func legacyOrdersDir(formulaLayer string) string {

--- a/internal/orders/discovery.go
+++ b/internal/orders/discovery.go
@@ -43,7 +43,7 @@ func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Ord
 	if err := discoverSubdirectoryOrders(fs, root.Dir, found, func(name, source string, data []byte) error {
 		warnDeprecatedPath(opts, "warning: deprecated order path %s; rename to orders/%s.toml", source, name)
 		return add(name, source, data)
-	}); err != nil {
+	}, opts); err != nil {
 		return nil, err
 	}
 
@@ -52,7 +52,7 @@ func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Ord
 		if err := discoverSubdirectoryOrders(fs, legacyDir, found, func(name, source string, data []byte) error {
 			warnDeprecatedPath(opts, "warning: deprecated order path %s; move to orders/%s.toml", source, name)
 			return add(name, source, data)
-		}); err != nil {
+		}, opts); err != nil {
 			return nil, err
 		}
 	}
@@ -123,7 +123,7 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 	return scan(true)
 }
 
-func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error) error {
+func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error, opts ScanOptions) error {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -143,7 +143,7 @@ func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, 
 		data, err := fs.ReadFile(source)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				warnUnreadablePath(ScanOptions{}, "warning: unreadable order path %s: %v", source, err)
+				warnUnreadablePath(opts, "warning: unreadable order path %s: %v", source, err)
 			}
 			continue
 		}
@@ -154,10 +154,7 @@ func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, 
 	return nil
 }
 
-func warnUnreadablePath(opts ScanOptions, format string, args ...any) {
-	if opts.SuppressDeprecatedPathWarnings {
-		return
-	}
+func warnUnreadablePath(_ ScanOptions, format string, args ...any) {
 	log.Printf(format, args...)
 }
 

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -119,15 +119,36 @@ schedule = "*/5 * * * *"
 `)
 	fs.Errors["/pack/orders/health-check.toml"] = errors.New("boom")
 
-	orders, err := discoverRoot(fs, ScanRoot{
+	logs := captureOrderLogs(t, func() {
+		orders, err := discoverRoot(fs, ScanRoot{
+			Dir:          "/pack/orders",
+			FormulaLayer: "/pack/formulas",
+		})
+		if err != nil {
+			t.Fatalf("discoverRoot: %v", err)
+		}
+		if len(orders) != 0 {
+			t.Fatalf("got %d orders, want 0", len(orders))
+		}
+	})
+	if !strings.Contains(logs, "unreadable order path") {
+		t.Fatalf("logs = %q, want unreadable order path warning", logs)
+	}
+}
+
+func TestDiscoverRootReturnsUnreadableRootError(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Errors["/pack/orders"] = errors.New("permission denied")
+
+	_, err := discoverRoot(fs, ScanRoot{
 		Dir:          "/pack/orders",
 		FormulaLayer: "/pack/formulas",
 	})
-	if err != nil {
-		t.Fatalf("discoverRoot: %v", err)
+	if err == nil {
+		t.Fatal("discoverRoot returned nil error for unreadable root")
 	}
-	if len(orders) != 0 {
-		t.Fatalf("got %d orders, want 0", len(orders))
+	if !strings.Contains(err.Error(), "reading order root") {
+		t.Fatalf("error = %v, want readable root context", err)
 	}
 }
 

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -136,6 +136,33 @@ schedule = "*/5 * * * *"
 	}
 }
 
+func TestDiscoverRootLogsUnreadablePathWhenDeprecatedWarningsSuppressed(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/pack/orders/health-check.toml"] = []byte(`
+[order]
+formula = "health-check"
+trigger = "cron"
+schedule = "*/5 * * * *"
+`)
+	fs.Errors["/pack/orders/health-check.toml"] = errors.New("boom")
+
+	logs := captureOrderLogs(t, func() {
+		orders, err := discoverRootWithOptions(fs, ScanRoot{
+			Dir:          "/pack/orders",
+			FormulaLayer: "/pack/formulas",
+		}, ScanOptions{SuppressDeprecatedPathWarnings: true})
+		if err != nil {
+			t.Fatalf("discoverRootWithOptions: %v", err)
+		}
+		if len(orders) != 0 {
+			t.Fatalf("got %d orders, want 0", len(orders))
+		}
+	})
+	if !strings.Contains(logs, "unreadable order path") {
+		t.Fatalf("logs = %q, want unreadable order path warning", logs)
+	}
+}
+
 func TestDiscoverRootReturnsUnreadableRootError(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Errors["/pack/orders"] = errors.New("permission denied")

--- a/internal/orders/runtime_helpers.go
+++ b/internal/orders/runtime_helpers.go
@@ -1,0 +1,187 @@
+package orders
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// StoreState captures the bead-store accessors needed to resolve order history
+// and run-state across city and rig scopes.
+type StoreState interface {
+	CityBeadStore() beads.Store
+	BeadStore(rig string) beads.Store
+}
+
+// StoresForState returns the primary store for an order plus the city store
+// fallback when available. Rig-scoped orders read rig first so the current
+// store wins over any legacy city fallback.
+func StoresForState(state StoreState, a Order) ([]beads.Store, error) {
+	stores := make([]beads.Store, 0, 2)
+	if strings.TrimSpace(a.Rig) == "" {
+		store := state.CityBeadStore()
+		if store == nil {
+			return nil, fmt.Errorf("city bead store is unavailable")
+		}
+		return []beads.Store{store}, nil
+	}
+
+	rigStore := state.BeadStore(a.Rig)
+	if rigStore == nil {
+		return nil, fmt.Errorf("rig %q bead store is unavailable", a.Rig)
+	}
+	stores = append(stores, rigStore)
+
+	if cityStore := state.CityBeadStore(); cityStore != nil {
+		stores = append(stores, cityStore)
+	}
+	return stores, nil
+}
+
+// LastRunFuncForStore returns the latest order-run bead time for one store.
+func LastRunFuncForStore(store beads.Store) LastRunFunc {
+	return func(name string) (time.Time, error) {
+		if store == nil {
+			return time.Time{}, nil
+		}
+		label := "order-run:" + name
+		results, err := store.List(beads.ListQuery{
+			Label:         label,
+			Limit:         1,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+		})
+		if err != nil {
+			return time.Time{}, err
+		}
+		if len(results) == 0 {
+			return time.Time{}, nil
+		}
+		return results[0].CreatedAt, nil
+	}
+}
+
+// LastRunAcrossStores returns the most recent run time across a set of stores
+// for a single order name.
+func LastRunAcrossStores(stores ...beads.Store) LastRunFunc {
+	return func(name string) (time.Time, error) {
+		var latest time.Time
+		for _, store := range stores {
+			if store == nil {
+				continue
+			}
+			last, err := LastRunFuncForStore(store)(name)
+			if err != nil {
+				return time.Time{}, err
+			}
+			if last.After(latest) {
+				latest = last
+			}
+		}
+		return latest, nil
+	}
+}
+
+// CursorFuncForStore returns the max order-run seq for one store.
+func CursorFuncForStore(store beads.Store) CursorFunc {
+	return func(name string) uint64 {
+		label := "order-run:" + name
+		results, err := store.List(beads.ListQuery{
+			Label:         label,
+			Limit:         10,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+		})
+		if err != nil || len(results) == 0 {
+			return 0
+		}
+		labelSets := make([][]string, 0, len(results))
+		for _, b := range results {
+			labelSets = append(labelSets, b.Labels)
+		}
+		return MaxSeqFromLabels(labelSets)
+	}
+}
+
+// CursorAcrossStores merges seq cursors from multiple stores.
+func CursorAcrossStores(stores ...beads.Store) CursorFunc {
+	fns := make([]CursorFunc, 0, len(stores))
+	for _, store := range stores {
+		if store != nil {
+			fns = append(fns, CursorFuncForStore(store))
+		}
+	}
+	return func(name string) uint64 {
+		var latest uint64
+		for _, fn := range fns {
+			if seq := fn(name); seq > latest {
+				latest = seq
+			}
+		}
+		return latest
+	}
+}
+
+// HistoryBeadsAcrossStores merges order history rows from a primary store and
+// its fallback stores while preserving recency ordering.
+func HistoryBeadsAcrossStores(stores []beads.Store, scopedName string) ([]beads.Bead, error) {
+	label := "order-run:" + scopedName
+	seen := make(map[string]bool)
+	results := make([]beads.Bead, 0)
+
+	for i, store := range stores {
+		if store == nil {
+			continue
+		}
+		rows, err := store.List(beads.ListQuery{
+			Label:         label,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+		})
+		if err != nil {
+			if i == 0 {
+				return nil, err
+			}
+			continue
+		}
+		for _, row := range rows {
+			if seen[row.ID] {
+				continue
+			}
+			seen[row.ID] = true
+			results = append(results, row)
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].CreatedAt.After(results[j].CreatedAt)
+	})
+	return results, nil
+}
+
+// HistoryBeadAcrossStores finds a bead by ID across a primary store and its
+// fallbacks.
+func HistoryBeadAcrossStores(stores []beads.Store, beadID string) (beads.Bead, error) {
+	var lastErr error
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		bead, err := store.Get(beadID)
+		if err == nil {
+			return bead, nil
+		}
+		if errors.Is(err, beads.ErrNotFound) {
+			continue
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return beads.Bead{}, lastErr
+	}
+	return beads.Bead{}, beads.ErrNotFound
+}

--- a/internal/orders/runtime_helpers.go
+++ b/internal/orders/runtime_helpers.go
@@ -1,46 +1,10 @@
 package orders
 
 import (
-	"errors"
-	"fmt"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
-
-// StoreState captures the bead-store accessors needed to resolve order history
-// and run-state across city and rig scopes.
-type StoreState interface {
-	CityBeadStore() beads.Store
-	BeadStore(rig string) beads.Store
-}
-
-// StoresForState returns the primary store for an order plus the city store
-// fallback when available. Rig-scoped orders read rig first so the current
-// store wins over any legacy city fallback.
-func StoresForState(state StoreState, a Order) ([]beads.Store, error) {
-	stores := make([]beads.Store, 0, 2)
-	if strings.TrimSpace(a.Rig) == "" {
-		store := state.CityBeadStore()
-		if store == nil {
-			return nil, fmt.Errorf("city bead store is unavailable")
-		}
-		return []beads.Store{store}, nil
-	}
-
-	rigStore := state.BeadStore(a.Rig)
-	if rigStore == nil {
-		return nil, fmt.Errorf("rig %q bead store is unavailable", a.Rig)
-	}
-	stores = append(stores, rigStore)
-
-	if cityStore := state.CityBeadStore(); cityStore != nil {
-		stores = append(stores, cityStore)
-	}
-	return stores, nil
-}
 
 // LastRunFuncForStore returns the latest order-run bead time for one store.
 func LastRunFuncForStore(store beads.Store) LastRunFunc {
@@ -124,64 +88,4 @@ func CursorAcrossStores(stores ...beads.Store) CursorFunc {
 		}
 		return latest
 	}
-}
-
-// HistoryBeadsAcrossStores merges order history rows from a primary store and
-// its fallback stores while preserving recency ordering.
-func HistoryBeadsAcrossStores(stores []beads.Store, scopedName string) ([]beads.Bead, error) {
-	label := "order-run:" + scopedName
-	seen := make(map[string]bool)
-	results := make([]beads.Bead, 0)
-
-	for i, store := range stores {
-		if store == nil {
-			continue
-		}
-		rows, err := store.List(beads.ListQuery{
-			Label:         label,
-			IncludeClosed: true,
-			Sort:          beads.SortCreatedDesc,
-		})
-		if err != nil {
-			if i == 0 {
-				return nil, err
-			}
-			continue
-		}
-		for _, row := range rows {
-			if seen[row.ID] {
-				continue
-			}
-			seen[row.ID] = true
-			results = append(results, row)
-		}
-	}
-
-	sort.SliceStable(results, func(i, j int) bool {
-		return results[i].CreatedAt.After(results[j].CreatedAt)
-	})
-	return results, nil
-}
-
-// HistoryBeadAcrossStores finds a bead by ID across a primary store and its
-// fallbacks.
-func HistoryBeadAcrossStores(stores []beads.Store, beadID string) (beads.Bead, error) {
-	var lastErr error
-	for _, store := range stores {
-		if store == nil {
-			continue
-		}
-		bead, err := store.Get(beadID)
-		if err == nil {
-			return bead, nil
-		}
-		if errors.Is(err, beads.ErrNotFound) {
-			continue
-		}
-		lastErr = err
-	}
-	if lastErr != nil {
-		return beads.Bead{}, lastErr
-	}
-	return beads.Bead{}, beads.ErrNotFound
 }


### PR DESCRIPTION
Path C replacement for #998 because the original PR has maintainer edits disabled and maintainer fixups were required.

Supersedes #998.

Contributor credit is preserved:
- `7623927d` squashes the two original contributor commits from #998 with author `julianknutsen <julianknutsen@users.noreply.github.com>`.
- `37dcb5da` contains the maintainer fixes found during adoption review.

Review synthesis:
- Dual-model review completed with Claude + Codex. Gemini was skipped after quota failures.
- Decision: approve.
- No blocker or major findings remain.
- Remaining review notes are minor/nit only.

Verification:
- `go test ./internal/beads ./internal/beads/exec ./internal/api ./internal/orders ./internal/api/genclient ./internal/dispatch -count=1`
- `go test ./cmd/gc -run 'TestOrder(CheckWithStoresResolver|HistoryWithStoresResolver|DispatchExec)|Test(Graph|Order|CmdOrder|OpenRigAwareStore|ServiceRuntimeBeadStoreUsesProviderAwareRigStore|ConvoyStoreCandidatesUseRigStoresForScopedFileProvider|DoConvoyAutocloseUsesProviderAwareStore|DoConvoyAutocloseUsesBeadsDirStoreRoot|DoWispAutocloseUsesBeadsDirStoreRoot)' -count=1`
- `go vet ./internal/beads ./internal/beads/exec ./internal/orders ./internal/api ./cmd/gc ./internal/dispatch`

Full-suite note:
- `go test ./...` was attempted on the replacement branch. It reached `cmd/gc` and failed by the package's 10-minute test timeout in long-running controller/bd tests; affected packages and focused `cmd/gc` coverage passed.

Path C guardrails:
- Core stable patch ID excluding the base-drift test-helper restore matches the adopted branch: `024423daaf584a5271a23ed825bfdc83ac18a3c6`.
- Replacement branch has exactly two commits on current `origin/main`.
- The extra `cmd/gc/main_test.go` change restores `mustLoadSiteBinding`, which current `origin/main` references but no longer defines.
