### PR TITLE
Add PackV2 import state validation

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -125,6 +125,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	d.Register(&doctor.CityConfigCheck{})
 	registerV2DeprecationChecks(d)
 	d.Register(&doctor.ImplicitImportCacheCheck{})
+	d.Register(newImportStateDoctorCheck(cityPath))
 	d.Register(&doctor.DeprecatedAttachmentFieldsCheck{})
 
 	// Load config for deeper checks. If it fails, we still run the core

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -125,7 +125,6 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	d.Register(&doctor.CityConfigCheck{})
 	registerV2DeprecationChecks(d)
 	d.Register(&doctor.ImplicitImportCacheCheck{})
-	d.Register(newImportStateDoctorCheck(cityPath))
 	d.Register(&doctor.DeprecatedAttachmentFieldsCheck{})
 
 	// Load config for deeper checks. If it fails, we still run the core
@@ -144,6 +143,9 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		d.Register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))
 		d.Register(newMCPSharedTargetDoctorCheck(cityPath, cfg, exec.LookPath))
+	}
+	if _, rawCfgErr := loadCityConfigForEditFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); rawCfgErr == nil {
+		d.Register(newImportStateDoctorCheck(cityPath))
 	}
 
 	// System formulas/orders now ship via the core bootstrap pack; pack

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -23,6 +23,7 @@ var (
 	syncImports             = packman.SyncLock
 	syncImportsSelective    = packman.SyncLockSelectiveUpgrade
 	installLockedImports    = packman.InstallLocked
+	checkInstalledImports   = packman.CheckInstalled
 	readImportLockfile      = packman.ReadLockfile
 	writeImportLockfile     = packman.WriteLockfile
 	resolveImportVersion    = packman.ResolveVersion
@@ -84,6 +85,7 @@ func newImportCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(
 		newImportAddCmd(stdout, stderr),
 		newImportRemoveCmd(stdout, stderr),
+		newImportCheckCmd(stdout, stderr),
 		newImportInstallCmd(stdout, stderr),
 		newImportUpgradeCmd(stdout, stderr),
 		newImportListCmd(stdout, stderr),
@@ -128,6 +130,25 @@ func newImportRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if doImportRemove(fsys.OSFS{}, cityPath, args[0], stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+}
+
+func newImportCheckCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Short: "Validate installed pack import state",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cityPath, err := resolveImportRoot()
+			if err != nil {
+				fmt.Fprintf(stderr, "gc import check: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			if doImportCheck(cityPath, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -530,6 +551,52 @@ func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "Installed %d remote import(s)\n", len(lock.Packs)) //nolint:errcheck
 	return 0
+}
+
+func doImportCheck(cityPath string, stdout, stderr io.Writer) int {
+	allImports, err := collectAllImportsFS(fsys.OSFS{}, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import check: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	report, err := checkInstalledImports(cityPath, allImports)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import check: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if !report.HasIssues() {
+		fmt.Fprintf(stdout, "Import state OK: %d remote import(s) checked\n", report.CheckedSources) //nolint:errcheck
+		return 0
+	}
+
+	fmt.Fprintf(stdout, "Import state has %d issue(s):\n", len(report.Issues)) //nolint:errcheck
+	writeImportCheckIssues(stdout, report.Issues)
+	return 1
+}
+
+func writeImportCheckIssues(w io.Writer, issues []packman.CheckIssue) {
+	for _, issue := range issues {
+		fmt.Fprintf(w, "  [%s] %s", issue.Severity, issue.Code) //nolint:errcheck
+		if issue.ImportName != "" {
+			fmt.Fprintf(w, " %s", issue.ImportName) //nolint:errcheck
+		}
+		if issue.Source != "" {
+			fmt.Fprintf(w, " (%s)", issue.Source) //nolint:errcheck
+		}
+		fmt.Fprintf(w, "\n") //nolint:errcheck
+		if issue.Message != "" {
+			fmt.Fprintf(w, "      issue: %s\n", issue.Message) //nolint:errcheck
+		}
+		if issue.Commit != "" {
+			fmt.Fprintf(w, "      commit: %s\n", issue.Commit) //nolint:errcheck
+		}
+		if issue.Path != "" {
+			fmt.Fprintf(w, "      path: %s\n", issue.Path) //nolint:errcheck
+		}
+		if issue.RepairHint != "" {
+			fmt.Fprintf(w, "      repair: %s\n", issue.RepairHint) //nolint:errcheck
+		}
+	}
 }
 
 func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -307,6 +308,10 @@ func (s *importScopeState) syntheticKey(name string) string {
 	return s.syntheticTag + name
 }
 
+func (s *importScopeState) isRootPackScope() bool {
+	return s != nil && s.syntheticTag == "pack:"
+}
+
 func loadImportScopeFS(fs fsys.FS, cityPath string) (*importScopeState, error) {
 	targetRig := strings.TrimSpace(rigFlag)
 	if targetRig == "" {
@@ -363,6 +368,15 @@ func collectAllImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import,
 	for name, imp := range packManifest.Imports {
 		all["pack:"+name] = imp
 	}
+	if len(packManifest.Defaults.Rig.Imports) > 0 {
+		defaults, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, bound := range defaults {
+			all["default-rig:"+bound.Binding] = bound.Import
+		}
+	}
 
 	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
 		if os.IsNotExist(err) {
@@ -381,6 +395,39 @@ func collectAllImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import,
 		}
 	}
 	return all, nil
+}
+
+func collectInspectableImportsFS(fs fsys.FS, cityPath string, scope *importScopeState) (map[string]config.Import, error) {
+	imports := make(map[string]config.Import, len(scope.imports))
+	for name, imp := range scope.imports {
+		imports[name] = imp
+	}
+	if !scope.isRootPackScope() {
+		return imports, nil
+	}
+	defaults, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, bound := range defaults {
+		key := "default-rig:" + bound.Binding
+		if _, exists := imports[key]; exists {
+			return nil, fmt.Errorf("import %q conflicts with reserved default-rig inspection key", key)
+		}
+		imports[key] = bound.Import
+	}
+	return imports, nil
+}
+
+func lookupInspectableImport(target string, imports map[string]config.Import) (config.Import, bool) {
+	if imp, ok := imports[target]; ok {
+		return imp, true
+	}
+	if !strings.Contains(target, ":") {
+		imp, ok := imports["default-rig:"+target]
+		return imp, ok
+	}
+	return config.Import{}, false
 }
 
 func loadCityImportManifestFS(fs fsys.FS, cityPath string) (*config.City, error) {
@@ -442,6 +489,10 @@ func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string,
 		fmt.Fprintln(stderr, "gc import add: could not derive import name; use --name") //nolint:errcheck
 		return 1
 	}
+	if strings.HasPrefix(name, "default-rig:") {
+		fmt.Fprintf(stderr, "gc import add: import name %q uses reserved prefix \"default-rig:\"\n", name) //nolint:errcheck
+		return 1
+	}
 	if _, exists := scope.imports[name]; exists {
 		fmt.Fprintf(stderr, "gc import add: import %q already exists\n", name) //nolint:errcheck
 		return 1
@@ -500,10 +551,18 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 		return 1
 	}
 	if _, exists := scope.imports[name]; !exists {
-		fmt.Fprintf(stderr, "gc import remove: import %q not found\n", name) //nolint:errcheck
-		return 1
+		removed, err := removeRootDefaultRigImportFS(fs, cityPath, scope, name)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		if !removed {
+			fmt.Fprintf(stderr, "gc import remove: import %q not found\n", name) //nolint:errcheck
+			return 1
+		}
+	} else {
+		delete(scope.imports, name)
 	}
-	delete(scope.imports, name)
 
 	allImports, err := collectAllImportsFS(fs, cityPath)
 	if err != nil {
@@ -511,6 +570,7 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 		return 1
 	}
 	delete(allImports, scope.syntheticKey(name))
+	delete(allImports, "default-rig:"+strings.TrimPrefix(name, "default-rig:"))
 	lock, err := syncImports(cityPath, allImports, packman.InstallResolveIfNeeded)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc import remove %q: %v\n", name, err) //nolint:errcheck
@@ -526,6 +586,25 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 	}
 	fmt.Fprintf(stdout, "Removed import %q\n", name) //nolint:errcheck
 	return 0
+}
+
+func removeRootDefaultRigImportFS(fs fsys.FS, cityPath string, scope *importScopeState, name string) (bool, error) {
+	if !scope.isRootPackScope() {
+		return false, nil
+	}
+	defaultName := strings.TrimPrefix(name, "default-rig:")
+	manifest, err := loadCityPackManifestFS(fs, cityPath)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := manifest.Defaults.Rig.Imports[defaultName]; !ok {
+		return false, nil
+	}
+	delete(manifest.Defaults.Rig.Imports, defaultName)
+	scope.save = func() error {
+		return writeCityPackManifest(fs, cityPath, manifest)
+	}
+	return true, nil
 }
 
 func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
@@ -616,7 +695,12 @@ func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {
 	if target == "" {
 		lock, err = syncImports(cityPath, allImports, packman.InstallUpgrade)
 	} else {
-		targetImp, ok := scope.imports[target]
+		inspectImports, inspectErr := collectInspectableImportsFS(fsys.OSFS{}, cityPath, scope)
+		if inspectErr != nil {
+			fmt.Fprintf(stderr, "gc import upgrade: %v\n", inspectErr) //nolint:errcheck
+			return 1
+		}
+		targetImp, ok := lookupInspectableImport(target, inspectImports)
 		if !ok {
 			fmt.Fprintf(stderr, "gc import upgrade: import %q not found\n", target) //nolint:errcheck
 			return 1
@@ -660,13 +744,18 @@ func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	inspectImports, err := collectInspectableImportsFS(fsys.OSFS{}, cityPath, scope)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+		return 1
+	}
 	var directNames []string
-	for name := range scope.imports {
+	for name := range inspectImports {
 		directNames = append(directNames, name)
 	}
 	sort.Strings(directNames)
 	if tree {
-		if err := writeImportTree(stdout, scope.imports, lock); err != nil {
+		if err := writeImportTree(stdout, inspectImports, lock); err != nil {
 			fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
 			return 1
 		}
@@ -678,9 +767,9 @@ func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	allowLockOnlyFallback := len(allImports) == len(scope.imports)
+	allowLockOnlyFallback := len(allImports) == len(inspectImports)
 
-	graph, graphErr := buildImportGraph(scope.imports, lock)
+	graph, graphErr := buildImportGraph(inspectImports, lock)
 	if graphErr != nil && !allowLockOnlyFallback {
 		fmt.Fprintf(stderr, "gc import list: %v\n", graphErr) //nolint:errcheck
 		return 1
@@ -688,7 +777,7 @@ func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 
 	directSources := make(map[string]bool)
 	for _, name := range directNames {
-		imp := scope.imports[name]
+		imp := inspectImports[name]
 		if !isRemoteImportSource(imp.Source) {
 			fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", name, imp.Source, imp.Version, "(path)") //nolint:errcheck
 			continue
@@ -733,7 +822,12 @@ func doImportWhy(cityPath, target string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	graph, err := buildImportGraph(scope.imports, lock)
+	inspectImports, err := collectInspectableImportsFS(fsys.OSFS{}, cityPath, scope)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	graph, err := buildImportGraph(inspectImports, lock)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
 		return 1
@@ -924,7 +1018,7 @@ func findImportWhyMatches(nodes []*importGraphNode, target string) ([][]*importG
 		if node.Import.Source == target {
 			sourceMatches = append(sourceMatches, append([]*importGraphNode(nil), path...))
 		}
-		if node.Name == target {
+		if node.Name == target || importDisplayName(node.Name) == target {
 			nameMatches = append(nameMatches, append([]*importGraphNode(nil), path...))
 		}
 		for _, child := range node.Children {
@@ -957,6 +1051,13 @@ func findImportWhyMatches(nodes []*importGraphNode, target string) ([][]*importG
 	}
 
 	return nameMatches, nil
+}
+
+func importDisplayName(name string) string {
+	if rest, ok := strings.CutPrefix(name, "default-rig:"); ok {
+		return rest
+	}
+	return name
 }
 
 func writeImportWhy(stdout io.Writer, target string, matches [][]*importGraphNode) error {
@@ -1121,7 +1222,7 @@ func writeOrderedDefaultRigImports(buf *bytes.Buffer, manifest *cityPackManifest
 
 	for _, name := range names {
 		imp := manifest.Defaults.Rig.Imports[name]
-		fmt.Fprintf(buf, "\n[defaults.rig.imports.%s]\n", name) //nolint:errcheck
+		fmt.Fprintf(buf, "\n[defaults.rig.imports.%s]\n", strconv.Quote(name)) //nolint:errcheck
 		if err := toml.NewEncoder(buf).Encode(imp); err != nil {
 			return fmt.Errorf("encoding defaults.rig.imports.%s: %w", name, err)
 		}

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -670,6 +670,103 @@ func TestDoImportInstallWithNoImportsSucceeds(t *testing.T) {
 	}
 }
 
+func TestDoImportCheckReportsOKForInstalledImports(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, `
+[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+
+[rigs.imports.ui]
+source = "https://example.com/ui.git"
+version = "^2.0"
+`)
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() { checkInstalledImports = prevCheck })
+	checkInstalledImports = func(cityRoot string, imports map[string]config.Import) (*packman.CheckReport, error) {
+		if cityRoot != dir {
+			t.Fatalf("cityRoot = %q, want %q", cityRoot, dir)
+		}
+		for _, name := range []string{"pack:tools", "rig:frontend:ui"} {
+			if _, ok := imports[name]; !ok {
+				t.Fatalf("imports = %#v, want %s", imports, name)
+			}
+		}
+		return &packman.CheckReport{CheckedSources: 2}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportCheck(dir, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Import state OK: 2 remote import(s) checked") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDoImportCheckPrintsIssueDetails(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() { checkInstalledImports = prevCheck })
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		return &packman.CheckReport{
+			CheckedSources: 1,
+			Issues: []packman.CheckIssue{{
+				Severity:   packman.CheckSeverityError,
+				Code:       "missing-cache",
+				ImportName: "pack:tools",
+				Source:     "https://example.com/tools.git",
+				Commit:     "abc123",
+				Path:       filepath.Join(dir, ".gc", "cache", "repos", "abc"),
+				Message:    "locked import is missing from the local repo cache",
+				RepairHint: `run "gc import install"`,
+			}},
+		}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportCheck(dir, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Import state has 1 issue(s):",
+		"[error] missing-cache pack:tools",
+		"locked import is missing from the local repo cache",
+		`repair: run "gc import install"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s\nstderr:\n%s", want, out, stderr.String())
+		}
+	}
+}
+
 func TestDoImportUpgradeTargetedMergesPreservedImports(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -214,13 +214,60 @@ source = "./packs/gastown"
 	}
 	text := string(data)
 	for _, want := range []string{
-		`[defaults.rig.imports.gastown]`,
+		`[defaults.rig.imports."gastown"]`,
 		`source = "./packs/gastown"`,
 		`[imports.tools]`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("pack.toml missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestDoImportAddPreservesQuotedRootPackDefaultRigImportBinding(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[defaults.rig.imports."foo.bar"]
+source = "./packs/foo"
+`)
+
+	prevResolve := resolveImportVersion
+	prevConstraint := defaultImportConstraint
+	prevSync := syncImports
+	t.Cleanup(func() {
+		resolveImportVersion = prevResolve
+		defaultImportConstraint = prevConstraint
+		syncImports = prevSync
+	})
+	resolveImportVersion = func(_, _ string) (packman.ResolvedVersion, error) {
+		return packman.ResolvedVersion{Version: "1.4.2", Commit: "abc123"}, nil
+	}
+	defaultImportConstraint = func(_ string) (string, error) { return "^1.4", nil }
+	syncImports = func(_ string, _ map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		return &packman.Lockfile{Schema: packman.LockfileSchema, Packs: map[string]packman.LockedPack{}}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportAdd(fsys.OSFS{}, dir, "https://github.com/example/tools.git", "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "pack.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(pack.toml): %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `[defaults.rig.imports."foo.bar"]`) {
+		t.Fatalf("pack.toml did not preserve quoted default-rig binding:\n%s", text)
+	}
+	if strings.Contains(text, "[defaults.rig.imports.foo.bar]") {
+		t.Fatalf("pack.toml split quoted default-rig binding:\n%s", text)
 	}
 }
 
@@ -447,7 +494,7 @@ source = "./packs/gastown"
 		t.Fatalf("pack.toml still contains removed import:\n%s", text)
 	}
 	for _, want := range []string{
-		`[defaults.rig.imports.gastown]`,
+		`[defaults.rig.imports."gastown"]`,
 		`source = "./packs/gastown"`,
 	} {
 		if !strings.Contains(text, want) {
@@ -692,6 +739,11 @@ schema = 1
 [imports.tools]
 source = "https://example.com/tools.git"
 version = "^1.0"
+
+[defaults.rig.imports.worker]
+source = "https://example.com/worker.git"
+version = "^3.0"
+transitive = false
 `)
 
 	prevCheck := checkInstalledImports
@@ -700,12 +752,12 @@ version = "^1.0"
 		if cityRoot != dir {
 			t.Fatalf("cityRoot = %q, want %q", cityRoot, dir)
 		}
-		for _, name := range []string{"pack:tools", "rig:frontend:ui"} {
+		for _, name := range []string{"pack:tools", "default-rig:worker", "rig:frontend:ui"} {
 			if _, ok := imports[name]; !ok {
 				t.Fatalf("imports = %#v, want %s", imports, name)
 			}
 		}
-		return &packman.CheckReport{CheckedSources: 2}, nil
+		return &packman.CheckReport{CheckedSources: 3}, nil
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -713,7 +765,7 @@ version = "^1.0"
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Import state OK: 2 remote import(s) checked") {
+	if !strings.Contains(stdout.String(), "Import state OK: 3 remote import(s) checked") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
 }
@@ -922,6 +974,102 @@ source = "../packs/local"
 	}
 }
 
+func TestDoImportUpgradeTargetsDefaultRigImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[defaults.rig.imports.worker]
+source = "https://example.com/worker.git"
+version = "^3.0"
+transitive = false
+`)
+
+	prevSelective := syncImportsSelective
+	t.Cleanup(func() { syncImportsSelective = prevSelective })
+	syncImportsSelective = func(_ string, imports map[string]config.Import, upgradeSources map[string]struct{}) (*packman.Lockfile, error) {
+		if _, ok := imports["default-rig:worker"]; !ok {
+			t.Fatalf("imports = %#v, want default-rig:worker", imports)
+		}
+		if len(upgradeSources) != 1 {
+			t.Fatalf("len(upgradeSources) = %d, want 1", len(upgradeSources))
+		}
+		if _, ok := upgradeSources["https://example.com/worker.git"]; !ok {
+			t.Fatalf("upgradeSources = %#v, want worker.git", upgradeSources)
+		}
+		return &packman.Lockfile{
+			Schema: packman.LockfileSchema,
+			Packs: map[string]packman.LockedPack{
+				"https://example.com/worker.git": {Version: "3.2.0", Commit: "worker"},
+			},
+		}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportUpgrade(dir, "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `Upgraded import "worker"`) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDoImportRemoveTargetsDefaultRigImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[defaults.rig.imports.worker]
+source = "https://example.com/worker.git"
+version = "^3.0"
+`)
+
+	prevSync := syncImports
+	t.Cleanup(func() { syncImports = prevSync })
+	syncImports = func(_ string, imports map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		if _, ok := imports["default-rig:worker"]; ok {
+			t.Fatalf("imports = %#v, did not expect default-rig:worker", imports)
+		}
+		return &packman.Lockfile{Schema: packman.LockfileSchema, Packs: map[string]packman.LockedPack{}}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportRemove(fsys.OSFS{}, dir, "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	defaults, err := config.LoadRootPackDefaultRigImports(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("LoadRootPackDefaultRigImports: %v", err)
+	}
+	if len(defaults) != 0 {
+		t.Fatalf("defaults = %#v, want empty", defaults)
+	}
+}
+
+func TestDoImportAddRejectsReservedDefaultRigPrefix(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, "[pack]\nname = \"demo\"\nschema = 1\n")
+
+	var stdout, stderr bytes.Buffer
+	code := doImportAdd(fsys.OSFS{}, dir, "https://example.com/worker.git", "default-rig:worker", "^1.0", &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected reserved prefix import add to fail")
+	}
+	if !strings.Contains(stderr.String(), "reserved prefix") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestDoImportListShowsDirectAndTransitive(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()
@@ -979,11 +1127,44 @@ source = "../packs/local"
 	}
 }
 
+func TestDoImportListShowsDefaultRigImports(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[defaults.rig.imports.worker]
+source = "https://example.com/worker.git"
+version = "^3.0"
+transitive = false
+`)
+	if err := packman.WriteLockfile(fsys.OSFS{}, dir, &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			"https://example.com/worker.git": {Version: "3.1.0", Commit: "worker"},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportList(dir, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "default-rig:worker\thttps://example.com/worker.git\t^3.0\t3.1.0") {
+		t.Fatalf("missing default-rig import line:\n%s", stdout.String())
+	}
+}
+
 func TestDoImportListTreeShowsDependencyGraph(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")
 	t.Setenv("HOME", home)
+	stubCmdCachedPackGit(t)
 
 	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
 	writePackToml(t, dir, `[pack]
@@ -1226,6 +1407,7 @@ func TestDoImportListWithRigShowsOnlyRigScopedClosure(t *testing.T) {
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")
 	t.Setenv("HOME", home)
+	stubCmdCachedPackGit(t)
 
 	writeCityToml(t, dir, `
 [workspace]
@@ -1428,6 +1610,7 @@ func TestDoImportWhyExplainsTransitiveImport(t *testing.T) {
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")
 	t.Setenv("HOME", home)
+	stubCmdCachedPackGit(t)
 
 	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
 	writePackToml(t, dir, `
@@ -1477,6 +1660,39 @@ schema = 1
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in output:\n%s", want, out)
 		}
+	}
+}
+
+func TestDoImportWhyShowsDefaultRigImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, dir, `[pack]
+name = "demo"
+schema = 1
+
+[defaults.rig.imports.worker]
+source = "https://example.com/worker.git"
+version = "^3.0"
+transitive = false
+`)
+	if err := packman.WriteLockfile(fsys.OSFS{}, dir, &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			"https://example.com/worker.git": {Version: "3.1.0", Commit: "worker"},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportWhy(dir, "worker", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "worker is a direct import") || !strings.Contains(out, "https://example.com/worker.git") {
+		t.Fatalf("unexpected why output:\n%s", out)
 	}
 }
 
@@ -2069,9 +2285,58 @@ func stageCmdCachedPack(t *testing.T, source, commit, packToml string) {
 	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(path, ".packman-test-commit"), []byte(commit), 0o644); err != nil {
+		t.Fatalf("WriteFile(.packman-test-commit): %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte(packToml), 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
 	}
+}
+
+func stubCmdCachedPackGit(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+set -eu
+dir="$PWD"
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-C)
+			dir="$2"
+			shift 2
+			;;
+		-c)
+			shift 2
+			;;
+		*)
+			break
+			;;
+	esac
+done
+case "${1:-}" in
+	rev-parse)
+		if [ "${2:-}" = "HEAD" ]; then
+			cat "$dir/.packman-test-commit"
+			exit 0
+		fi
+		;;
+	status)
+		if [ "${2:-}" = "--porcelain" ]; then
+			if [ -f "$dir/.packman-test-dirty" ]; then
+				printf '%s\n' ' M pack.toml'
+			fi
+			exit 0
+		fi
+		;;
+esac
+printf 'unexpected git command: %s\n' "$*" >&2
+exit 1
+`
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake git): %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func mustGitImport(t *testing.T, dir string, args ...string) {

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -216,31 +216,39 @@ func TestScanAllOrdersRemoteImportedFlatPackOrders(t *testing.T) {
 
 	cityDir := t.TempDir()
 	source := "https://github.com/example/orders-pack.git"
-	commit := "abc123def456"
-	cacheDir := filepath.Join(home, ".gc", "cache", "repos", config.RepoCacheKey(source, commit))
-	if err := os.MkdirAll(filepath.Join(cacheDir, ".git"), 0o755); err != nil {
+	repoDir := filepath.Join(home, "orders-pack-work")
+	if err := os.MkdirAll(filepath.Join(repoDir, "formulas"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(cacheDir, "formulas"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(cacheDir, "orders"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(repoDir, "orders"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(cacheDir, "pack.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(repoDir, "pack.toml"), []byte(`
 [pack]
 name = "ops"
 schema = 1
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cacheDir, "orders", "health-check.order.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(repoDir, "orders", "health-check.order.toml"), []byte(`
 [order]
 formula = "health-check"
 trigger = "cron"
 schedule = "*/5 * * * *"
 `), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGitImport(t, repoDir, "init")
+	mustGitImport(t, repoDir, "add", ".")
+	mustGitImport(t, repoDir, "commit", "-m", "initial")
+	commit := gitOutputImport(t, repoDir, "rev-parse", "HEAD")
+
+	cacheDir := filepath.Join(home, ".gc", "cache", "repos", config.RepoCacheKey(source, commit))
+	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(repoDir, cacheDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -266,7 +274,7 @@ schema = 1
 
 [packs."https://github.com/example/orders-pack.git"]
 version = "1.2.3"
-commit = "abc123def456"
+commit = "`+commit+`"
 fetched = "2026-04-10T00:00:00Z"
 `), 0o644); err != nil {
 		t.Fatal(err)

--- a/cmd/gc/import_state_doctor_check.go
+++ b/cmd/gc/import_state_doctor_check.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+type importStateDoctorCheck struct {
+	cityPath string
+}
+
+func newImportStateDoctorCheck(cityPath string) *importStateDoctorCheck {
+	return &importStateDoctorCheck{cityPath: cityPath}
+}
+
+func (c *importStateDoctorCheck) Name() string { return "packv2-import-state" }
+
+func (c *importStateDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	r := &doctor.CheckResult{Name: c.Name()}
+
+	imports, err := collectAllImportsFS(fsys.OSFS{}, c.cityPath)
+	if err != nil {
+		r.Status = doctor.StatusError
+		r.Message = fmt.Sprintf("reading declared imports: %v", err)
+		return r
+	}
+	report, err := checkInstalledImports(c.cityPath, imports)
+	if err != nil {
+		r.Status = doctor.StatusError
+		r.Message = fmt.Sprintf("checking import state: %v", err)
+		r.FixHint = `run "gc import install"`
+		return r
+	}
+	if !report.HasIssues() {
+		r.Status = doctor.StatusOK
+		r.Message = fmt.Sprintf("%d remote import(s) installed", report.CheckedSources)
+		return r
+	}
+
+	r.Status = doctor.StatusError
+	r.Message = fmt.Sprintf("%d import state issue(s)", len(report.Issues))
+	r.FixHint = `run "gc import install"`
+	for _, issue := range report.Issues {
+		r.Details = append(r.Details, formatImportStateDoctorDetail(issue))
+	}
+	return r
+}
+
+func (c *importStateDoctorCheck) CanFix() bool { return false }
+
+func (c *importStateDoctorCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func formatImportStateDoctorDetail(issue packman.CheckIssue) string {
+	parts := []string{issue.Code}
+	if issue.ImportName != "" {
+		parts = append(parts, issue.ImportName)
+	}
+	if issue.Source != "" {
+		parts = append(parts, issue.Source)
+	}
+	if issue.Commit != "" {
+		parts = append(parts, "commit="+issue.Commit)
+	}
+	if issue.Path != "" {
+		parts = append(parts, "path="+issue.Path)
+	}
+	if issue.Message != "" {
+		parts = append(parts, issue.Message)
+	}
+	return strings.Join(parts, " | ")
+}

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+func TestImportStateDoctorCheckReportsOK(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() { checkInstalledImports = prevCheck })
+	checkInstalledImports = func(_ string, imports map[string]config.Import) (*packman.CheckReport, error) {
+		if _, ok := imports["pack:tools"]; !ok {
+			t.Fatalf("imports = %#v, want pack:tools", imports)
+		}
+		return &packman.CheckReport{CheckedSources: 1}, nil
+	}
+
+	result := newImportStateDoctorCheck(cityDir).Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want OK; result=%#v", result.Status, result)
+	}
+	if !strings.Contains(result.Message, "1 remote import(s) installed") {
+		t.Fatalf("message = %q", result.Message)
+	}
+}
+
+func TestImportStateDoctorCheckReportsInstallHint(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() { checkInstalledImports = prevCheck })
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		return &packman.CheckReport{
+			CheckedSources: 1,
+			Issues: []packman.CheckIssue{{
+				Severity:   packman.CheckSeverityError,
+				Code:       "missing-cache",
+				ImportName: "pack:tools",
+				Source:     "https://example.com/tools.git",
+				Commit:     "abc123",
+				Path:       filepath.Join(cityDir, ".gc", "cache", "repos", "abc"),
+				Message:    "locked import is missing from the local repo cache",
+				RepairHint: `run "gc import install"`,
+			}},
+		}, nil
+	}
+
+	check := newImportStateDoctorCheck(cityDir)
+	result := check.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want Error; result=%#v", result.Status, result)
+	}
+	if check.CanFix() || result.FixHint != `run "gc import install"` {
+		t.Fatalf("result = %#v, want non-fixable install hint", result)
+	}
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "missing-cache") {
+		t.Fatalf("details = %#v", result.Details)
+	}
+}
+
+func TestDoDoctorRegistersImportStateCheck(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevCityFlag := cityFlag
+	prevCheck := checkInstalledImports
+	prevCityDoltCheck := newDoctorDoltServerCheck
+	prevRigDoltCheck := newDoctorRigDoltServerCheck
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		checkInstalledImports = prevCheck
+		newDoctorDoltServerCheck = prevCityDoltCheck
+		newDoctorRigDoltServerCheck = prevRigDoltCheck
+	})
+	cityFlag = cityDir
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		return &packman.CheckReport{
+			Issues: []packman.CheckIssue{{
+				Severity:   packman.CheckSeverityError,
+				Code:       "missing-lockfile",
+				RepairHint: `run "gc import install"`,
+			}},
+		}, nil
+	}
+	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
+		return doctor.NewDoltServerCheck(cityPath, true)
+	}
+	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
+		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, true, &stdout, &stderr)
+	out := stdout.String() + stderr.String()
+	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, `run "gc import install"`) {
+		t.Fatalf("doctor output missing import state check:\n%s", out)
+	}
+}

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -137,3 +137,79 @@ version = "^1.0"
 		t.Fatalf("doctor output missing import state check:\n%s", out)
 	}
 }
+
+func TestDoDoctorRunsImportStateCheckWhenImportInstallStateBroken(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevCityFlag := cityFlag
+	prevCityDoltCheck := newDoctorDoltServerCheck
+	prevRigDoltCheck := newDoctorRigDoltServerCheck
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		newDoctorDoltServerCheck = prevCityDoltCheck
+		newDoctorRigDoltServerCheck = prevRigDoltCheck
+	})
+	cityFlag = cityDir
+	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
+		return doctor.NewDoltServerCheck(cityPath, true)
+	}
+	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
+		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, true, &stdout, &stderr)
+	out := stdout.String() + stderr.String()
+	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, "missing-lockfile") {
+		t.Fatalf("doctor output missing import-state failure for broken install state:\n%s", out)
+	}
+	if !strings.Contains(out, `run "gc import install"`) {
+		t.Fatalf("doctor output missing install hint:\n%s", out)
+	}
+}
+
+func TestDoDoctorSkipsImportStateCheckWhenCityConfigInvalid(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prevCityFlag := cityFlag
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		checkInstalledImports = prevCheck
+	})
+	cityFlag = cityDir
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		t.Fatal("import state check should not run when city.toml cannot load")
+		return nil, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, true, &stdout, &stderr)
+	out := stdout.String() + stderr.String()
+	if strings.Contains(out, "packv2-import-state") {
+		t.Fatalf("doctor output included import state check for invalid config:\n%s", out)
+	}
+	if !strings.Contains(out, "city-config") {
+		t.Fatalf("doctor output missing city config failure:\n%s", out)
+	}
+}

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -173,6 +173,12 @@ source = "../shared/gastown"
 Use the city pack's `pack.toml` for city-wide imports. Use rig-scoped
 imports in `city.toml` when a pack should compose only into one rig.
 
+For remote imports, run `gc import install` after the import declarations
+are in place. That writes or repairs `packs.lock` and materializes the
+cache. Use `gc import check` when you want a read-only validation pass:
+it reports missing or stale lock/cache state and points back to
+`gc import install` for repair.
+
 Rigs are the main thing that remain in `city.toml`. As you migrate, the
 usual pattern is:
 

--- a/docs/packv2/doc-pack-v2.md
+++ b/docs/packv2/doc-pack-v2.md
@@ -269,6 +269,7 @@ Four distinct operations, currently partially conflated:
 | Operation | Verb | What it does |
 |---|---|---|
 | Define a city's contents | `gc init` (creates files), or hand-edit | Creates pack.toml, city.toml, directory structure |
+| Validate installed imports | `gc import check` | Checks declared imports, `packs.lock`, and local cache state without fetching or mutating |
 | Install a city's packs | `gc import install` | Bootstraps or repairs `packs.lock` and materializes all imports into the cache |
 | Register a city with the controller | `gc register` | Binds the city to `.gc/`; tells the controller it exists |
 | Start the city's runtime | `gc start` | Controller activates the registered city |

--- a/docs/packv2/doc-packman.md
+++ b/docs/packv2/doc-packman.md
@@ -25,6 +25,8 @@ The launch contract for PackV2 imports is now:
 - Normal load, start, and config flows are pure readers of declared
   imports, `packs.lock`, and the local cache. They do not fetch or
   self-heal.
+- `gc import check` is the read-only validation surface for declared
+  imports, lock state, and local cache state.
 - `gc import install` is the single remediation command. It bootstraps
   `packs.lock` from declared imports when needed and restores cache
   state from `packs.lock` when possible.
@@ -187,6 +189,13 @@ hint to run `gc import install`.
 - provide the one remediation path used by fresh clones, broken caches,
   and offline-preparation workflows
 
+### `gc import check`
+
+- validate declared imports against `packs.lock` without fetching
+- validate the locked cache entries and cached pack roots already exist
+- report stale lock/cache drift with `gc import install` as the repair
+  path
+
 ### `gc import upgrade [<binding>]`
 
 - re-resolve one binding or the whole graph within the declared
@@ -218,6 +227,13 @@ Run `gc import install`. It resolves the declared imports, writes
 ### Normal load/start/config with missing import state
 
 Fail fast and tell the user to run `gc import install`.
+
+### Checking import state without mutation
+
+Run `gc import check`. It does not resolve versions, fetch, clone, or
+rewrite files. It reports missing lock entries, missing cache entries,
+cache checkout drift, missing cached `pack.toml` files, and stale lock
+entries. Run `gc import install` to repair the lock/cache state.
 
 ### Offline execution
 

--- a/docs/packv2/doc-packman.md
+++ b/docs/packv2/doc-packman.md
@@ -188,6 +188,9 @@ hint to run `gc import install`.
 - restore cache state from `packs.lock` when possible
 - provide the one remediation path used by fresh clones, broken caches,
   and offline-preparation workflows
+- repair managed repo-cache entries in place when they drift from
+  `packs.lock`; this may discard local edits or untracked files inside
+  `$HOME/.gc/cache/repos/<key>` because that directory is machine-managed
 
 ### `gc import check`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1028,6 +1028,7 @@ gc import
 | Subcommand | Description |
 |------------|-------------|
 | [gc import add](#gc-import-add) | Add a pack import |
+| [gc import check](#gc-import-check) | Validate installed pack import state |
 | [gc import install](#gc-import-install) | Install imports from pack.toml and packs.lock |
 | [gc import list](#gc-import-list) | List imported packs |
 | [gc import migrate](#gc-import-migrate) | Migrate a V1 city layout to the V2 pack shape |
@@ -1047,6 +1048,14 @@ gc import add <source> [flags]
 |------|------|---------|-------------|
 | `--name` | string |  | Local binding name override |
 | `--version` | string |  | Version constraint for git-backed imports |
+
+## gc import check
+
+Validate installed pack import state
+
+```
+gc import check
+```
 
 ## gc import install
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -109,7 +109,8 @@ func EnsureBootstrapForCity(gcHome string, userImports map[string]config.Import)
 	}
 
 	if len(BootstrapPacks) > 0 {
-		if err := os.MkdirAll(filepath.Join(gcHome, "cache", "repos"), 0o755); err != nil {
+		cacheRoot := filepath.Join(gcHome, "cache", "repos")
+		if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
 			return fmt.Errorf("creating bootstrap cache root: %w", err)
 		}
 		for _, entry := range BootstrapPacks {
@@ -119,10 +120,15 @@ func EnsureBootstrapForCity(gcHome string, userImports map[string]config.Import)
 			}
 
 			cacheDir := config.GlobalRepoCachePath(gcHome, entry.Source, commit)
-			if _, err := os.Stat(filepath.Join(cacheDir, "pack.toml")); err != nil {
-				if err := materializeBootstrapPack(cacheDir, entry); err != nil {
-					return fmt.Errorf("bootstrapping %q: %w", entry.Name, err)
+			if _, err := config.WithRepoCacheWriteLock(cacheRoot, func() (string, error) {
+				if _, err := os.Stat(filepath.Join(cacheDir, "pack.toml")); err != nil {
+					if err := materializeBootstrapPack(cacheDir, entry); err != nil {
+						return "", err
+					}
 				}
+				return cacheDir, nil
+			}); err != nil {
+				return fmt.Errorf("bootstrapping %q: %w", entry.Name, err)
 			}
 
 			next := implicitImport{

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -6,8 +6,10 @@ package config
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,6 +31,21 @@ func writeTestFile(t *testing.T, dir, name, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func stubCleanRepoCacheGit(t *testing.T, commit string) {
+	t.Helper()
+	prev := runRepoCacheGit
+	runRepoCacheGit = func(dir string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD" {
+			return commit, nil
+		}
+		if len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
+			return "", nil
+		}
+		return prev(dir, args...)
+	}
+	t.Cleanup(func() { runRepoCacheGit = prev })
 }
 
 //nolint:unparam // test helper keeps the permission explicit at each call site.
@@ -631,6 +648,7 @@ func TestImport_RootPackRemoteImportFromLockfileCache(t *testing.T) {
 
 	source := "https://github.com/example/gastown.git"
 	commit := "abc123def456"
+	stubCleanRepoCacheGit(t, commit)
 	cacheKey := fmt.Sprintf("%x", sha256.Sum256([]byte(source+commit)))
 	cacheDir := filepath.Join(home, ".gc", "cache", "repos", cacheKey)
 	mustMkdirAll(t, filepath.Join(cacheDir, ".git"), 0o755)
@@ -681,6 +699,84 @@ scope = "city"
 	}
 }
 
+func TestImport_RootPackRemoteImportDirtySharedCacheFails(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+
+	cityDir := filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+
+	source := "https://github.com/example/gastown.git"
+	cacheRoot := filepath.Join(home, ".gc", "cache", "repos")
+	seedDir := filepath.Join(dir, "seed")
+	mustMkdirAll(t, seedDir, 0o755)
+	writeTestFile(t, seedDir, "pack.toml", `
+[pack]
+name = "gastown"
+schema = 1
+
+[[agent]]
+name = "polecat"
+scope = "city"
+`)
+	if _, err := runRepoCacheGit(seedDir, "init"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if _, err := runRepoCacheGit(seedDir, "add", "pack.toml"); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if _, err := runRepoCacheGit(seedDir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	commit, err := runRepoCacheGit(seedDir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, commit))
+	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(seedDir, cacheDir); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, cacheDir, "pack.toml", `
+[pack]
+name = "tampered"
+schema = 1
+`)
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeTestFile(t, cityDir, "pack.toml", `
+[pack]
+name = "test"
+schema = 1
+
+[imports.gastown]
+source = "https://github.com/example/gastown.git"
+version = "^1.2"
+`)
+	writeTestFile(t, cityDir, "packs.lock", fmt.Sprintf(`
+schema = 1
+
+[packs."https://github.com/example/gastown.git"]
+version = "1.2.3"
+commit = "%s"
+fetched = "2026-04-10T00:00:00Z"
+`, commit))
+
+	_, _, err = LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected dirty shared cache error")
+	}
+	if !strings.Contains(err.Error(), "local worktree changes") || !strings.Contains(err.Error(), `run "gc import install"`) {
+		t.Fatalf("error = %v, want dirty-cache install hint", err)
+	}
+}
+
 func TestImport_RootPackRemoteImportMissingSharedCacheFails(t *testing.T) {
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")
@@ -717,6 +813,76 @@ fetched = "2026-04-10T00:00:00Z"
 	}
 	if !strings.Contains(err.Error(), "locked but not cached") || !strings.Contains(err.Error(), `run "gc import install"`) {
 		t.Fatalf("error = %v, want locked-but-not-cached install hint", err)
+	}
+}
+
+func TestImport_RootPackRemoteImportMissingCacheHeadFails(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+
+	cityDir := filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+
+	source := "https://github.com/example/gastown.git"
+	commit := "abc123def456"
+	cacheDir := filepath.Join(home, ".gc", "cache", "repos", RepoCacheKey(source, commit))
+	mustMkdirAll(t, filepath.Join(cacheDir, ".git"), 0o755)
+	writeTestFile(t, cacheDir, "pack.toml", `
+[pack]
+name = "gastown"
+schema = 1
+`)
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeTestFile(t, cityDir, "pack.toml", `
+[pack]
+name = "test"
+schema = 1
+
+[imports.gastown]
+source = "https://github.com/example/gastown.git"
+version = "^1.2"
+`)
+	writeTestFile(t, cityDir, "packs.lock", `
+schema = 1
+
+[packs."https://github.com/example/gastown.git"]
+version = "1.2.3"
+commit = "abc123def456"
+fetched = "2026-04-10T00:00:00Z"
+`)
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected missing cache HEAD error")
+	}
+	if !strings.Contains(err.Error(), "reading cached import") || !strings.Contains(err.Error(), "HEAD") {
+		t.Fatalf("error = %v, want cached import HEAD error", err)
+	}
+}
+
+func TestValidateLockedRemoteCacheRequiresGit(t *testing.T) {
+	cacheDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cacheDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := runRepoCacheGit
+	runRepoCacheGit = func(_ string, _ ...string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	t.Cleanup(func() { runRepoCacheGit = prev })
+
+	err := validateLockedRemoteCache("https://example.com/tools.git", cacheDir, "abc123")
+	if err == nil {
+		t.Fatal("validateLockedRemoteCache succeeded without git")
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("validateLockedRemoteCache error = %v, want exec.ErrNotFound", err)
 	}
 }
 
@@ -760,6 +926,7 @@ func TestImport_RootPackRemoteSubpathImportFromLockfileCache(t *testing.T) {
 	mustMkdirAll(t, cityDir, 0o755)
 
 	commit := "abc123def456"
+	stubCleanRepoCacheGit(t, commit)
 	cacheKey := fmt.Sprintf("%x", sha256.Sum256([]byte("file:///tmp/repo.git"+commit)))
 	cacheDir := filepath.Join(home, ".gc", "cache", "repos", cacheKey)
 	mustMkdirAll(t, filepath.Join(cacheDir, ".git"), 0o755)
@@ -820,6 +987,7 @@ func TestImport_RootPackGitHubTreeImportFromLockfileCache(t *testing.T) {
 	mustMkdirAll(t, cityDir, 0o755)
 
 	commit := "abc123def456"
+	stubCleanRepoCacheGit(t, commit)
 	cacheKey := fmt.Sprintf("%x", sha256.Sum256([]byte("https://github.com/example/repo.git"+commit)))
 	cacheDir := filepath.Join(home, ".gc", "cache", "repos", cacheKey)
 	mustMkdirAll(t, filepath.Join(cacheDir, ".git"), 0o755)

--- a/internal/config/loader_coverage_test.go
+++ b/internal/config/loader_coverage_test.go
@@ -53,6 +53,22 @@ mode = "on_demand"
 	}
 }
 
+func TestLoadWithIncludesLocalOnlyDoesNotRequireHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("home", "")
+
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test"
+`)
+
+	if _, _, err := LoadWithIncludes(fs, "/city/city.toml"); err != nil {
+		t.Fatalf("LoadWithIncludes local-only config: %v", err)
+	}
+}
+
 func TestLoadWithIncludes_ConcatServices(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1089,6 +1089,23 @@ func loadPackWithCache(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, 
 }
 
 func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
+	var agents []Agent
+	var namedSessions []NamedSession
+	var providers map[string]ProviderSpec
+	var services []Service
+	var topoDirs []string
+	var requirements []PackRequirement
+	var globals []ResolvedPackGlobal
+	err := withRepoCacheReadLockForPath(topoDir, func() error {
+		var loadErr error
+		agents, namedSessions, providers, services, topoDirs, requirements, globals, loadErr = loadPackWithCacheOptionsLocked(
+			fs, topoPath, topoDir, cityRoot, rigName, seen, cache, opts)
+		return loadErr
+	})
+	return agents, namedSessions, providers, services, topoDirs, requirements, globals, err
+}
+
+func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
 	// Initialize seen set on first call.
 	if seen == nil {
 		seen = make(map[string]bool)

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -4,12 +4,15 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 )
+
+var runRepoCacheGit = defaultRunRepoCacheGit
 
 // includeCacheDir is the subdirectory under .gc/cache/includes/ where
 // remote pack includes are cached.
@@ -207,12 +210,21 @@ func resolveLockedRemoteImport(source, cityRoot string) (string, bool, error) {
 		return "", false, fmt.Errorf("resolving home dir: %w", err)
 	}
 
-	cacheDir := filepath.Join(home, ".gc", "cache", "repos", RepoCacheKey(source, entry.Commit))
-	if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
-		if os.IsNotExist(err) {
-			return "", false, fmt.Errorf("remote import %s is locked but not cached at %s; run \"gc import install\"", source, cacheDir)
+	cacheRoot := filepath.Join(home, ".gc", "cache", "repos")
+	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, entry.Commit))
+	if err := WithRepoCacheReadLock(cacheRoot, func() error {
+		if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("remote import %s is locked but not cached at %s; run \"gc import install\"", source, cacheDir)
+			}
+			return fmt.Errorf("checking cached import %s: %w", source, err)
 		}
-		return "", false, fmt.Errorf("checking cached import %s: %w", source, err)
+		if err := validateLockedRemoteCache(source, cacheDir, entry.Commit); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return "", false, err
 	}
 	return cacheDir, true, nil
 }
@@ -241,14 +253,94 @@ func resolveInstalledRemoteImport(source, cityRoot string) (string, error) {
 		return "", fmt.Errorf("resolving home dir: %w", err)
 	}
 
-	cacheDir := filepath.Join(home, ".gc", "cache", "repos", RepoCacheKey(source, entry.Commit))
-	if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("remote import %s is locked but not cached at %s; run \"gc import install\"", source, cacheDir)
+	cacheRoot := filepath.Join(home, ".gc", "cache", "repos")
+	cacheDir := filepath.Join(cacheRoot, RepoCacheKey(source, entry.Commit))
+	if err := WithRepoCacheReadLock(cacheRoot, func() error {
+		if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("remote import %s is locked but not cached at %s; run \"gc import install\"", source, cacheDir)
+			}
+			return fmt.Errorf("checking cached import %s: %w", source, err)
 		}
-		return "", fmt.Errorf("checking cached import %s: %w", source, err)
+		if err := validateLockedRemoteCache(source, cacheDir, entry.Commit); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return "", err
 	}
 	return cacheDir, nil
+}
+
+func validateLockedRemoteCache(source, cacheDir, commit string) error {
+	head, err := runRepoCacheGit(cacheDir, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("reading cached import %s HEAD: %w", source, err)
+	}
+	if !sameRepoCacheCommit(head, commit) {
+		return fmt.Errorf("cached import %s is checked out at %s, expected %s; run \"gc import install\"", source, strings.TrimSpace(head), commit)
+	}
+	status, err := runRepoCacheGit(cacheDir, "status", "--porcelain", "--ignored")
+	if err != nil {
+		return fmt.Errorf("checking cached import %s worktree status: %w", source, err)
+	}
+	if strings.TrimSpace(status) != "" {
+		return fmt.Errorf("cached import %s has local worktree changes; run \"gc import install\"", source)
+	}
+	return nil
+}
+
+func sameRepoCacheCommit(actual, expected string) bool {
+	actual = strings.TrimSpace(actual)
+	expected = strings.TrimSpace(expected)
+	if actual == "" || expected == "" {
+		return false
+	}
+	if strings.EqualFold(actual, expected) {
+		return true
+	}
+	return len(expected) >= 7 && len(expected) < len(actual) && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected))
+}
+
+func defaultRunRepoCacheGit(dir string, args ...string) (string, error) {
+	cmdArgs := append([]string{
+		"-c", "core.fsmonitor=false",
+		"-c", "core.hooksPath=/dev/null",
+		"-c", "core.untrackedCache=false",
+	}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	cmd.Dir = dir
+	for _, e := range os.Environ() {
+		if k, _, ok := strings.Cut(e, "="); ok && repoCacheGitEnvBlacklist[k] {
+			continue
+		}
+		cmd.Env = append(cmd.Env, e)
+	}
+	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+var repoCacheGitEnvBlacklist = map[string]bool{
+	"GIT_DIR":                          true,
+	"GIT_WORK_TREE":                    true,
+	"GIT_INDEX_FILE":                   true,
+	"GIT_OBJECT_DIRECTORY":             true,
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
+	"GIT_COMMON_DIR":                   true,
+	"GIT_CEILING_DIRECTORIES":          true,
+	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
+	"GIT_NAMESPACE":                    true,
+	"GIT_CONFIG":                       true,
+	"GIT_CONFIG_GLOBAL":                true,
+	"GIT_CONFIG_SYSTEM":                true,
+	"GIT_CONFIG_NOSYSTEM":              true,
+	"GIT_CONFIG_COUNT":                 true,
+	"GIT_EXEC_PATH":                    true,
+	"GIT_PAGER":                        true,
 }
 
 // RepoCacheKey computes the sha256 cache key for a remote source+commit pair.

--- a/internal/config/repo_cache_lock.go
+++ b/internal/config/repo_cache_lock.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const repoCacheLockName = ".packman-cache.lock"
+
+// WithRepoCacheReadLock runs fn while holding the shared repo-cache lock if
+// the cache root exists. It does not create cache files or directories.
+func WithRepoCacheReadLock(root string, fn func() error) error {
+	return withRepoCacheLock(root, repoCacheLockShared, false, fn)
+}
+
+// WithRepoCacheWriteLock runs fn while holding the exclusive repo-cache lock.
+func WithRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
+	var result string
+	err := withRepoCacheLock(root, repoCacheLockExclusive, true, func() error {
+		var fnErr error
+		result, fnErr = fn()
+		return fnErr
+	})
+	return result, err
+}
+
+func withRepoCacheReadLockForPath(path string, fn func() error) error {
+	root, ok := repoCacheRootForPath(path)
+	if !ok {
+		return fn()
+	}
+	return WithRepoCacheReadLock(root, fn)
+}
+
+func repoCacheRootForPath(path string) (string, bool) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	for _, root := range repoCacheRootCandidates() {
+		if pathWithinDir(abs, root) {
+			return root, true
+		}
+	}
+	return "", false
+}
+
+func repoCacheRootCandidates() []string {
+	var roots []string
+	add := func(root string) {
+		if root == "" {
+			return
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			abs = root
+		}
+		for _, existing := range roots {
+			if existing == abs {
+				return
+			}
+		}
+		roots = append(roots, abs)
+	}
+	if gcHome := ImplicitGCHome(); gcHome != "" {
+		add(filepath.Join(gcHome, "cache", "repos"))
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		add(filepath.Join(home, ".gc", "cache", "repos"))
+	}
+	return roots
+}
+
+func pathWithinDir(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!filepath.IsAbs(rel) && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}

--- a/internal/config/repo_cache_lock_test.go
+++ b/internal/config/repo_cache_lock_test.go
@@ -1,0 +1,122 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWithRepoCacheReadLockDoesNotCreateMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	called := false
+	if err := WithRepoCacheReadLock(root, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("WithRepoCacheReadLock: %v", err)
+	}
+	if !called {
+		t.Fatal("read lock callback was not called")
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("root stat err = %v, want not exist", err)
+	}
+}
+
+func TestWithRepoCacheReadLockCreatesLockFileForExistingRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := WithRepoCacheReadLock(root, func() error { return nil }); err != nil {
+		t.Fatalf("WithRepoCacheReadLock: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, repoCacheLockName)); err != nil {
+		t.Fatalf("lock file stat: %v", err)
+	}
+}
+
+func TestRepoCacheRootForPathUsesKnownCacheRootsOnly(t *testing.T) {
+	home := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	t.Setenv("HOME", home)
+	t.Setenv("GC_HOME", gcHome)
+
+	homeRoot := filepath.Join(home, ".gc", "cache", "repos")
+	gcHomeRoot := filepath.Join(gcHome, "cache", "repos")
+	for _, tc := range []struct {
+		name string
+		path string
+		root string
+		ok   bool
+	}{
+		{
+			name: "home cache child",
+			path: filepath.Join(homeRoot, "abc123", "pack.toml"),
+			root: homeRoot,
+			ok:   true,
+		},
+		{
+			name: "gc home cache child",
+			path: filepath.Join(gcHomeRoot, "def456", "pack.toml"),
+			root: gcHomeRoot,
+			ok:   true,
+		},
+		{
+			name: "unrelated cache repos substring",
+			path: filepath.Join(t.TempDir(), "cache", "repos", "project", "pack.toml"),
+			ok:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := repoCacheRootForPath(tc.path)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (root %q)", ok, tc.ok, got)
+			}
+			if ok && got != tc.root {
+				t.Fatalf("root = %q, want %q", got, tc.root)
+			}
+		})
+	}
+}
+
+func TestWithRepoCacheReadLockWaitsOnCacheRoot(t *testing.T) {
+	root := t.TempDir()
+	lockPath := filepath.Join(root, repoCacheLockName)
+	lockDir, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("Open(root): %v", err)
+	}
+	defer lockDir.Close() //nolint:errcheck
+	if err := syscall.Flock(int(lockDir.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("Flock(exclusive): %v", err)
+	}
+
+	entered := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- WithRepoCacheReadLock(root, func() error {
+			close(entered)
+			return nil
+		})
+	}()
+
+	select {
+	case <-entered:
+		t.Fatal("read lock entered while exclusive lock was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := syscall.Flock(int(lockDir.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("Flock(unlock): %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("read lock did not enter after exclusive lock released")
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("WithRepoCacheReadLock: %v", err)
+	}
+}

--- a/internal/config/repo_cache_lock_unix.go
+++ b/internal/config/repo_cache_lock_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const (
+	repoCacheLockShared    = syscall.LOCK_SH
+	repoCacheLockExclusive = syscall.LOCK_EX
+)
+
+func withRepoCacheLock(root string, mode int, createRoot bool, fn func() error) error {
+	if createRoot {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return fmt.Errorf("creating repo cache root: %w", err)
+		}
+	} else if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return fn()
+		}
+		return fmt.Errorf("checking repo cache root: %w", err)
+	}
+	lockPath := root + string(os.PathSeparator) + repoCacheLockName
+	flags := os.O_RDWR | os.O_CREATE
+	lockFile, err := os.OpenFile(lockPath, flags, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening repo cache lock file: %w", err)
+	}
+	defer lockFile.Close() //nolint:errcheck
+	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+		return fmt.Errorf("locking repo cache: %w", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+	return fn()
+}

--- a/internal/config/repo_cache_lock_windows.go
+++ b/internal/config/repo_cache_lock_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	repoCacheLockShared    = 0
+	repoCacheLockExclusive = 1
+)
+
+func withRepoCacheLock(root string, mode int, createRoot bool, fn func() error) error {
+	if createRoot {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return fmt.Errorf("creating repo cache root: %w", err)
+		}
+	}
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) && !createRoot {
+			return fn()
+		}
+		return fmt.Errorf("opening repo cache lock root: %w", err)
+	}
+	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening repo cache lock: %w", err)
+	}
+	defer lockFile.Close() //nolint:errcheck
+
+	var flags uint32
+	if mode == repoCacheLockExclusive {
+		flags = windows.LOCKFILE_EXCLUSIVE_LOCK
+	}
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(windows.Handle(lockFile.Fd()), flags, 0, 1, 0, &overlapped); err != nil {
+		return fmt.Errorf("locking repo cache: %w", err)
+	}
+	defer windows.UnlockFileEx(windows.Handle(lockFile.Fd()), 0, 1, 0, &overlapped) //nolint:errcheck
+	return fn()
+}

--- a/internal/materialize/skills.go
+++ b/internal/materialize/skills.go
@@ -690,18 +690,24 @@ func bootstrapSkillDirs() ([]namedSkillsDir, error) {
 		return nil, nil
 	}
 	out := make([]namedSkillsDir, 0, len(imports))
-	for name, imp := range imports {
-		if _, ok := bootstrapNames[name]; !ok {
-			continue
+	cacheRoot := filepath.Join(gcHome, "cache", "repos")
+	if err := config.WithRepoCacheReadLock(cacheRoot, func() error {
+		for name, imp := range imports {
+			if _, ok := bootstrapNames[name]; !ok {
+				continue
+			}
+			if imp.Commit == "" {
+				continue
+			}
+			skillsDir := filepath.Join(config.GlobalRepoCachePath(gcHome, imp.Source, imp.Commit), "skills")
+			if info, err := os.Stat(skillsDir); err != nil || !info.IsDir() {
+				continue
+			}
+			out = append(out, namedSkillsDir{Name: name, Dir: skillsDir})
 		}
-		if imp.Commit == "" {
-			continue
-		}
-		skillsDir := filepath.Join(config.GlobalRepoCachePath(gcHome, imp.Source, imp.Commit), "skills")
-		if info, err := os.Stat(skillsDir); err != nil || !info.IsDir() {
-			continue
-		}
-		out = append(out, namedSkillsDir{Name: name, Dir: skillsDir})
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -2,11 +2,13 @@
 package packman
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -38,23 +40,49 @@ func RepoCachePath(source, commit string) (string, error) {
 	return filepath.Join(root, RepoCacheKey(source, commit)), nil
 }
 
-// EnsureRepoInCache clones and checks out the requested commit when absent.
+// EnsureRepoInCache clones and checks out the requested commit when absent,
+// or repairs an existing cache whose checkout has drifted from the lock entry.
 func EnsureRepoInCache(source, commit string) (string, error) {
 	parsed := normalizeRemoteSource(source)
 	cachePath, err := RepoCachePath(source, commit)
 	if err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(filepath.Join(cachePath, ".git")); err == nil {
-		return cachePath, nil
-	}
-
 	root, err := RepoCacheRoot()
 	if err != nil {
 		return "", err
 	}
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return "", fmt.Errorf("creating repo cache root: %w", err)
+	}
+	return withRepoCacheWriteLock(root, func() (string, error) {
+		return ensureRepoInCacheLocked(source, commit, parsed, cachePath)
+	})
+}
+
+func ensureRepoInCacheLocked(source, commit string, parsed remoteSource, cachePath string) (string, error) {
+	if _, err := os.Stat(filepath.Join(cachePath, ".git")); err == nil {
+		if err := checkoutExistingCache(cachePath, commit); err == nil {
+			if err := validateCachedPackRoot(source, cachePath); err != nil {
+				if removeErr := os.RemoveAll(cachePath); removeErr != nil {
+					return "", fmt.Errorf("removing invalid repo cache %q after %v: %w", cachePath, err, removeErr)
+				}
+			} else {
+				return cachePath, nil
+			}
+		} else if err := os.RemoveAll(cachePath); err != nil {
+			return "", fmt.Errorf("removing stale repo cache %q: %w", cachePath, err)
+		}
+	} else if os.IsNotExist(err) || errors.Is(err, syscall.ENOTDIR) {
+		if _, statErr := os.Stat(cachePath); statErr == nil {
+			if removeErr := os.RemoveAll(cachePath); removeErr != nil {
+				return "", fmt.Errorf("removing invalid repo cache %q: %w", cachePath, removeErr)
+			}
+		} else if statErr != nil && !os.IsNotExist(statErr) {
+			return "", fmt.Errorf("checking repo cache %q: %w", cachePath, statErr)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("checking repo cache %q: %w", cachePath, err)
 	}
 
 	if _, err := runGit("", "clone", "--quiet", parsed.CloneURL, cachePath); err != nil {
@@ -63,7 +91,78 @@ func EnsureRepoInCache(source, commit string) (string, error) {
 	if _, err := runGit(cachePath, "checkout", "--quiet", commit); err != nil {
 		return "", fmt.Errorf("checking out %q: %w", commit, err)
 	}
+	if err := validateCachedPackRoot(source, cachePath); err != nil {
+		return "", err
+	}
 	return cachePath, nil
+}
+
+const repoCacheLockName = ".packman-cache.lock"
+
+func withRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
+	return withRepoCacheLock(root, syscall.LOCK_EX, fn)
+}
+
+func withRepoCacheReadLock(fn func() error) error {
+	root, err := RepoCacheRoot()
+	if err != nil {
+		return err
+	}
+	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_RDONLY, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fn()
+		}
+		return fmt.Errorf("opening repo cache lock: %w", err)
+	}
+	defer lockFile.Close() //nolint:errcheck
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_SH); err != nil {
+		return fmt.Errorf("locking repo cache: %w", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+	return fn()
+}
+
+func withRepoCacheLock(root string, mode int, fn func() (string, error)) (string, error) {
+	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("opening repo cache lock: %w", err)
+	}
+	defer lockFile.Close() //nolint:errcheck
+	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+		return "", fmt.Errorf("locking repo cache: %w", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+	return fn()
+}
+
+func checkoutExistingCache(cachePath, commit string) error {
+	head, headErr := runGit(cachePath, "rev-parse", "HEAD")
+	if headErr == nil && sameCommit(head, commit) {
+		return nil
+	}
+	if _, err := runGit(cachePath, "checkout", "--quiet", commit); err != nil {
+		if headErr != nil {
+			return fmt.Errorf("reading cached repo HEAD: %w; checking out %q: %v", headErr, commit, err)
+		}
+		return fmt.Errorf("checking out %q in cached repo: %w", commit, err)
+	}
+	return nil
+}
+
+func validateCachedPackRoot(source, cachePath string) error {
+	packPath := filepath.Join(cachedPackDir(source, cachePath), "pack.toml")
+	st, err := os.Stat(packPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("cached pack %q is missing pack.toml at %s", source, packPath)
+		}
+		return fmt.Errorf("checking cached pack %q at %s: %w", source, packPath, err)
+	}
+	if st.IsDir() {
+		return fmt.Errorf("cached pack %q has directory where pack.toml is expected at %s", source, packPath)
+	}
+	return nil
 }
 
 type remoteSource struct {

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -55,7 +55,7 @@ func EnsureRepoInCache(source, commit string) (string, error) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return "", fmt.Errorf("creating repo cache root: %w", err)
 	}
-	return withRepoCacheWriteLock(root, func() (string, error) {
+	return config.WithRepoCacheWriteLock(root, func() (string, error) {
 		return ensureRepoInCacheLocked(source, commit, parsed, cachePath)
 	})
 }
@@ -65,7 +65,7 @@ func ensureRepoInCacheLocked(source, commit string, parsed remoteSource, cachePa
 		if err := checkoutExistingCache(cachePath, commit); err == nil {
 			if err := validateCachedPackRoot(source, cachePath); err != nil {
 				if removeErr := os.RemoveAll(cachePath); removeErr != nil {
-					return "", fmt.Errorf("removing invalid repo cache %q after %v: %w", cachePath, err, removeErr)
+					return "", fmt.Errorf("removing invalid repo cache %q after %w: %w", cachePath, err, removeErr)
 				}
 			} else {
 				return cachePath, nil
@@ -92,15 +92,12 @@ func ensureRepoInCacheLocked(source, commit string, parsed remoteSource, cachePa
 		return "", fmt.Errorf("checking out %q: %w", commit, err)
 	}
 	if err := validateCachedPackRoot(source, cachePath); err != nil {
+		if removeErr := os.RemoveAll(cachePath); removeErr != nil {
+			return "", fmt.Errorf("removing invalid repo cache %q after %w: %w", cachePath, err, removeErr)
+		}
 		return "", err
 	}
 	return cachePath, nil
-}
-
-const repoCacheLockName = ".packman-cache.lock"
-
-func withRepoCacheWriteLock(root string, fn func() (string, error)) (string, error) {
-	return withRepoCacheLock(root, syscall.LOCK_EX, fn)
 }
 
 func withRepoCacheReadLock(fn func() error) error {
@@ -108,44 +105,62 @@ func withRepoCacheReadLock(fn func() error) error {
 	if err != nil {
 		return err
 	}
-	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_RDONLY, 0)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fn()
-		}
-		return fmt.Errorf("opening repo cache lock: %w", err)
-	}
-	defer lockFile.Close() //nolint:errcheck
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_SH); err != nil {
-		return fmt.Errorf("locking repo cache: %w", err)
-	}
-	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
-	return fn()
-}
-
-func withRepoCacheLock(root string, mode int, fn func() (string, error)) (string, error) {
-	lockFile, err := os.OpenFile(filepath.Join(root, repoCacheLockName), os.O_CREATE|os.O_RDWR, 0o644)
-	if err != nil {
-		return "", fmt.Errorf("opening repo cache lock: %w", err)
-	}
-	defer lockFile.Close() //nolint:errcheck
-	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
-		return "", fmt.Errorf("locking repo cache: %w", err)
-	}
-	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
-	return fn()
+	return config.WithRepoCacheReadLock(root, fn)
 }
 
 func checkoutExistingCache(cachePath, commit string) error {
 	head, headErr := runGit(cachePath, "rev-parse", "HEAD")
 	if headErr == nil && sameCommit(head, commit) {
-		return nil
+		dirty, err := cachedRepoDirty(cachePath)
+		if err != nil {
+			return err
+		}
+		if !dirty {
+			return nil
+		}
+		return resetCachedRepo(cachePath, commit)
 	}
 	if _, err := runGit(cachePath, "checkout", "--quiet", commit); err != nil {
 		if headErr != nil {
-			return fmt.Errorf("reading cached repo HEAD: %w; checking out %q: %v", headErr, commit, err)
+			return fmt.Errorf("reading cached repo HEAD: %w; checking out %q: %w", headErr, commit, err)
 		}
 		return fmt.Errorf("checking out %q in cached repo: %w", commit, err)
+	}
+	return resetCachedRepo(cachePath, commit)
+}
+
+func cachedRepoDirty(cachePath string) (bool, error) {
+	status, err := runGit(cachePath, "status", "--porcelain", "--ignored")
+	if err != nil {
+		return false, fmt.Errorf("checking cached repo worktree status: %w", err)
+	}
+	return strings.TrimSpace(status) != "", nil
+}
+
+func validateCachedRepoCheckout(cachePath, commit string) error {
+	head, err := runGit(cachePath, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("reading cached repo HEAD: %w", err)
+	}
+	if !sameCommit(head, commit) {
+		return fmt.Errorf("cached repository is checked out at %s, expected %s", strings.TrimSpace(head), commit)
+	}
+	dirty, err := cachedRepoDirty(cachePath)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("cached repository has local worktree changes")
+	}
+	return nil
+}
+
+func resetCachedRepo(cachePath, commit string) error {
+	if _, err := runGit(cachePath, "reset", "--hard", "--quiet", commit); err != nil {
+		return fmt.Errorf("resetting cached repo to %q: %w", commit, err)
+	}
+	if _, err := runGit(cachePath, "clean", "-ffdx", "--quiet"); err != nil {
+		return fmt.Errorf("cleaning cached repo: %w", err)
 	}
 	return nil
 }
@@ -219,7 +234,12 @@ func parseGitHubTreeSource(source string) remoteSource {
 }
 
 func defaultRunGit(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmdArgs := append([]string{
+		"-c", "core.fsmonitor=false",
+		"-c", "core.hooksPath=/dev/null",
+		"-c", "core.untrackedCache=false",
+	}, args...)
+	cmd := exec.Command("git", cmdArgs...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -229,6 +249,7 @@ func defaultRunGit(dir string, args ...string) (string, error) {
 		}
 		cmd.Env = append(cmd.Env, e)
 	}
+	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
@@ -242,4 +263,15 @@ var fetchGitEnvBlacklist = map[string]bool{
 	"GIT_INDEX_FILE":                   true,
 	"GIT_OBJECT_DIRECTORY":             true,
 	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
+	"GIT_COMMON_DIR":                   true,
+	"GIT_CEILING_DIRECTORIES":          true,
+	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
+	"GIT_NAMESPACE":                    true,
+	"GIT_CONFIG":                       true,
+	"GIT_CONFIG_GLOBAL":                true,
+	"GIT_CONFIG_SYSTEM":                true,
+	"GIT_CONFIG_NOSYSTEM":              true,
+	"GIT_CONFIG_COUNT":                 true,
+	"GIT_EXEC_PATH":                    true,
+	"GIT_PAGER":                        true,
 }

--- a/internal/packman/cache_test.go
+++ b/internal/packman/cache_test.go
@@ -1,8 +1,10 @@
 package packman
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -47,7 +49,7 @@ func TestRepoCacheKeyNormalizesGitHubShortcut(t *testing.T) {
 	}
 }
 
-func TestEnsureRepoInCacheSkipsExistingClone(t *testing.T) {
+func TestEnsureRepoInCacheUsesExistingCloneWhenCheckoutMatches(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
@@ -57,12 +59,18 @@ func TestEnsureRepoInCacheSkipsExistingClone(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte("[pack]\nname = \"repo\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
 
-	called := false
+	var calls [][]string
 	prev := runGit
-	runGit = func(_ string, _ ...string) (string, error) {
-		called = true
-		return "", nil
+	runGit = func(_ string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if reflect.DeepEqual(args, []string{"rev-parse", "HEAD"}) {
+			return "abc123", nil
+		}
+		return "", fmt.Errorf("unexpected git call: %v", args)
 	}
 	t.Cleanup(func() { runGit = prev })
 
@@ -73,7 +81,205 @@ func TestEnsureRepoInCacheSkipsExistingClone(t *testing.T) {
 	if got != path {
 		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
 	}
-	if called {
-		t.Fatal("runGit called for existing cache")
+	if len(calls) != 1 || !reflect.DeepEqual(calls[0], []string{"rev-parse", "HEAD"}) {
+		t.Fatalf("git calls = %#v, want rev-parse only", calls)
+	}
+}
+
+func TestEnsureRepoInCacheRepairsExistingCloneCheckout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte("[pack]\nname = \"repo\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+
+	var calls [][]string
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch args[0] {
+		case "rev-parse":
+			return "def456", nil
+		case "checkout":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected git call: %v", args)
+		}
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	got, err := EnsureRepoInCache("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("EnsureRepoInCache: %v", err)
+	}
+	if got != path {
+		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
+	}
+	want := [][]string{
+		{"rev-parse", "HEAD"},
+		{"checkout", "--quiet", "abc123"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("git calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestEnsureRepoInCacheReclonesInvalidExistingCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	var calls [][]string
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch args[0] {
+		case "rev-parse":
+			return "abc123", nil
+		case "clone":
+			target := args[len(args)-1]
+			if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(filepath.Join(target, "pack.toml"), []byte("[pack]\nname = \"repo\"\nschema = 1\n"), 0o644); err != nil {
+				return "", err
+			}
+			return "", nil
+		case "checkout":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected git call: %v", args)
+		}
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	got, err := EnsureRepoInCache("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("EnsureRepoInCache: %v", err)
+	}
+	if got != path {
+		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
+	}
+	want := [][]string{
+		{"rev-parse", "HEAD"},
+		{"clone", "--quiet", "https://github.com/example/repo", path},
+		{"checkout", "--quiet", "abc123"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("git calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestEnsureRepoInCacheReclonesCacheDirWithoutGit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "leftover.txt"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("WriteFile(leftover): %v", err)
+	}
+
+	var calls [][]string
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch args[0] {
+		case "clone":
+			target := args[len(args)-1]
+			if _, err := os.Stat(filepath.Join(target, "leftover.txt")); !os.IsNotExist(err) {
+				return "", fmt.Errorf("stale cache directory was not removed before clone")
+			}
+			if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(filepath.Join(target, "pack.toml"), []byte("[pack]\nname = \"repo\"\nschema = 1\n"), 0o644); err != nil {
+				return "", err
+			}
+			return "", nil
+		case "checkout":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected git call: %v", args)
+		}
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	got, err := EnsureRepoInCache("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("EnsureRepoInCache: %v", err)
+	}
+	if got != path {
+		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
+	}
+	want := [][]string{
+		{"clone", "--quiet", "https://github.com/example/repo", path},
+		{"checkout", "--quiet", "abc123"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("git calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestEnsureRepoInCacheReclonesCacheFileWithoutGit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("WriteFile(cachePath): %v", err)
+	}
+
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		switch args[0] {
+		case "clone":
+			target := args[len(args)-1]
+			if _, err := os.Stat(target); !os.IsNotExist(err) {
+				return "", fmt.Errorf("stale cache file was not removed before clone")
+			}
+			if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(filepath.Join(target, "pack.toml"), []byte("[pack]\nname = \"repo\"\nschema = 1\n"), 0o644); err != nil {
+				return "", err
+			}
+			return "", nil
+		case "checkout":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected git call: %v", args)
+		}
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	got, err := EnsureRepoInCache("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("EnsureRepoInCache: %v", err)
+	}
+	if got != path {
+		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
 	}
 }

--- a/internal/packman/cache_test.go
+++ b/internal/packman/cache_test.go
@@ -70,6 +70,9 @@ func TestEnsureRepoInCacheUsesExistingCloneWhenCheckoutMatches(t *testing.T) {
 		if reflect.DeepEqual(args, []string{"rev-parse", "HEAD"}) {
 			return "abc123", nil
 		}
+		if reflect.DeepEqual(args, []string{"status", "--porcelain", "--ignored"}) {
+			return "", nil
+		}
 		return "", fmt.Errorf("unexpected git call: %v", args)
 	}
 	t.Cleanup(func() { runGit = prev })
@@ -81,8 +84,66 @@ func TestEnsureRepoInCacheUsesExistingCloneWhenCheckoutMatches(t *testing.T) {
 	if got != path {
 		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
 	}
-	if len(calls) != 1 || !reflect.DeepEqual(calls[0], []string{"rev-parse", "HEAD"}) {
-		t.Fatalf("git calls = %#v, want rev-parse only", calls)
+	want := [][]string{
+		{"rev-parse", "HEAD"},
+		{"status", "--porcelain", "--ignored"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("git calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestEnsureRepoInCacheRepairsDirtyMatchingCheckout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte("not toml"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+
+	var calls [][]string
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch args[0] {
+		case "rev-parse":
+			return "abc123", nil
+		case "status":
+			return " M pack.toml", nil
+		case "reset":
+			if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte("[pack]\nname = \"repo\"\nschema = 1\n"), 0o644); err != nil {
+				return "", err
+			}
+			return "", nil
+		case "clean":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected git call: %v", args)
+		}
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	got, err := EnsureRepoInCache("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("EnsureRepoInCache: %v", err)
+	}
+	if got != path {
+		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
+	}
+	want := [][]string{
+		{"rev-parse", "HEAD"},
+		{"status", "--porcelain", "--ignored"},
+		{"reset", "--hard", "--quiet", "abc123"},
+		{"clean", "-ffdx", "--quiet"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("git calls = %#v, want %#v", calls, want)
 	}
 }
 
@@ -109,6 +170,10 @@ func TestEnsureRepoInCacheRepairsExistingCloneCheckout(t *testing.T) {
 			return "def456", nil
 		case "checkout":
 			return "", nil
+		case "reset":
+			return "", nil
+		case "clean":
+			return "", nil
 		default:
 			return "", fmt.Errorf("unexpected git call: %v", args)
 		}
@@ -125,6 +190,8 @@ func TestEnsureRepoInCacheRepairsExistingCloneCheckout(t *testing.T) {
 	want := [][]string{
 		{"rev-parse", "HEAD"},
 		{"checkout", "--quiet", "abc123"},
+		{"reset", "--hard", "--quiet", "abc123"},
+		{"clean", "-ffdx", "--quiet"},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("git calls = %#v, want %#v", calls, want)
@@ -149,6 +216,8 @@ func TestEnsureRepoInCacheReclonesInvalidExistingCache(t *testing.T) {
 		switch args[0] {
 		case "rev-parse":
 			return "abc123", nil
+		case "status":
+			return "", nil
 		case "clone":
 			target := args[len(args)-1]
 			if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
@@ -175,11 +244,45 @@ func TestEnsureRepoInCacheReclonesInvalidExistingCache(t *testing.T) {
 	}
 	want := [][]string{
 		{"rev-parse", "HEAD"},
+		{"status", "--porcelain", "--ignored"},
 		{"clone", "--quiet", "https://github.com/example/repo", path},
 		{"checkout", "--quiet", "abc123"},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("git calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestEnsureRepoInCacheCleansFreshCloneAfterPackValidationFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := RepoCachePath("https://github.com/example/repo", "abc123")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+
+	prev := runGit
+	runGit = func(_ string, args ...string) (string, error) {
+		switch args[0] {
+		case "clone":
+			target := args[len(args)-1]
+			if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			return "", nil
+		case "checkout":
+			return "", nil
+		default:
+			return "", fmt.Errorf("unexpected git call: %v", args)
+		}
+	}
+	t.Cleanup(func() { runGit = prev })
+
+	if _, err := EnsureRepoInCache("https://github.com/example/repo", "abc123"); err == nil {
+		t.Fatal("EnsureRepoInCache succeeded, want pack validation error")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("cache path still exists after validation failure: %v", err)
 	}
 }
 

--- a/internal/packman/check.go
+++ b/internal/packman/check.go
@@ -1,0 +1,423 @@
+package packman
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// CheckSeverity classifies an import state validation issue.
+type CheckSeverity string
+
+const (
+	// CheckSeverityError means the import state is not usable as-is.
+	CheckSeverityError CheckSeverity = "error"
+)
+
+// CheckIssue describes one read-only import state validation finding.
+type CheckIssue struct {
+	Severity   CheckSeverity
+	Code       string
+	ImportName string
+	Source     string
+	Commit     string
+	Path       string
+	Message    string
+	RepairHint string
+}
+
+// CheckReport summarizes the read-only validation of a city's import state.
+type CheckReport struct {
+	CheckedSources int
+	Issues         []CheckIssue
+}
+
+// ErrorCount returns the number of error-severity issues in the report.
+func (r *CheckReport) ErrorCount() int {
+	if r == nil {
+		return 0
+	}
+	count := 0
+	for _, issue := range r.Issues {
+		if issue.Severity == CheckSeverityError {
+			count++
+		}
+	}
+	return count
+}
+
+// HasIssues reports whether validation found any issue.
+func (r *CheckReport) HasIssues() bool {
+	return r != nil && len(r.Issues) > 0
+}
+
+// CheckInstalled validates that declared remote imports are represented by
+// packs.lock and by already-materialized local cache entries. It does not
+// resolve versions, clone repositories, fetch, or mutate disk state.
+func CheckInstalled(cityRoot string, imports map[string]config.Import) (*CheckReport, error) {
+	report := &CheckReport{}
+
+	lockExists, err := lockfileExists(cityRoot)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := ReadLockfile(fsys.OSFS{}, cityRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if !lockExists && countRemoteImports(imports) > 0 {
+		report.addIssue(CheckIssue{
+			Code:       "missing-lockfile",
+			Path:       filepath.Join(cityRoot, LockfileName),
+			Message:    fmt.Sprintf("%s is missing for declared remote imports", LockfileName),
+			RepairHint: `run "gc import install"`,
+		})
+		return report, nil
+	}
+
+	if countRemoteImports(imports) > 0 || len(lock.Packs) > 0 {
+		if err := withRepoCacheReadLock(func() error {
+			checkLockedImports(report, lock, imports)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	} else {
+		checkLockedImports(report, lock, imports)
+	}
+	return report, nil
+}
+
+func checkLockedImports(report *CheckReport, lock *Lockfile, imports map[string]config.Import) {
+	state := &importCheckState{
+		lock:              lock,
+		report:            report,
+		constraints:       make(map[string]string),
+		reachable:         make(map[string]struct{}),
+		seen:              make(map[string]bool),
+		reportedIssueKeys: make(map[string]struct{}),
+	}
+
+	names := sortedImportNames(imports)
+	for _, name := range names {
+		state.walkImport(name, imports[name])
+	}
+
+	state.reportStaleLockEntries()
+}
+
+type importCheckState struct {
+	lock              *Lockfile
+	report            *CheckReport
+	constraints       map[string]string
+	reachable         map[string]struct{}
+	seen              map[string]bool
+	reportedIssueKeys map[string]struct{}
+	closureIncomplete bool
+}
+
+func (s *importCheckState) walkImport(name string, imp config.Import) {
+	if !isRemoteSource(imp.Source) {
+		return
+	}
+
+	mergedConstraint, err := mergeConstraints(s.constraints[imp.Source], imp.Version)
+	if err != nil {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "conflicting-constraints",
+			ImportName: name,
+			Source:     imp.Source,
+			Message:    fmt.Sprintf("import constraints cannot be merged: %v", err),
+			RepairHint: "edit imports to use compatible version constraints",
+		})
+		return
+	}
+	s.constraints[imp.Source] = mergedConstraint
+	if _, ok := s.reachable[imp.Source]; !ok {
+		s.report.CheckedSources++
+	}
+	s.reachable[imp.Source] = struct{}{}
+
+	locked, ok := s.lock.Packs[imp.Source]
+	if !ok {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "missing-lock-entry",
+			ImportName: name,
+			Source:     imp.Source,
+			Message:    "declared remote import is not present in packs.lock",
+			RepairHint: `run "gc import install"`,
+		})
+		return
+	}
+	if strings.TrimSpace(locked.Commit) == "" {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "missing-lock-commit",
+			ImportName: name,
+			Source:     imp.Source,
+			Message:    "packs.lock entry is missing a commit",
+			RepairHint: `run "gc import install"`,
+		})
+		return
+	}
+	if !matchesExisting(locked, mergedConstraint) {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "lock-constraint-mismatch",
+			ImportName: name,
+			Source:     imp.Source,
+			Commit:     locked.Commit,
+			Message:    fmt.Sprintf("packs.lock entry version %q does not satisfy constraint %q", locked.Version, mergedConstraint),
+			RepairHint: `run "gc import install"`,
+		})
+		return
+	}
+
+	packDir, ok := s.validateCachedPack(name, imp.Source, locked.Commit)
+	if !ok || !imp.ImportIsTransitive() {
+		return
+	}
+	if s.seen[imp.Source] {
+		return
+	}
+	s.seen[imp.Source] = true
+	nested, err := readPackImports(packDir)
+	if err != nil {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "invalid-cached-pack",
+			ImportName: name,
+			Source:     imp.Source,
+			Commit:     locked.Commit,
+			Path:       filepath.Join(packDir, "pack.toml"),
+			Message:    err.Error(),
+			RepairHint: `run "gc import install"`,
+		})
+		return
+	}
+	for _, nestedName := range sortedImportNames(nested) {
+		s.walkImport(name+"/"+nestedName, nested[nestedName])
+	}
+}
+
+func (s *importCheckState) validateCachedPack(name, source, commit string) (string, bool) {
+	cachePath, err := RepoCachePath(source, commit)
+	if err != nil {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "invalid-cache-path",
+			ImportName: name,
+			Source:     source,
+			Commit:     commit,
+			Message:    err.Error(),
+			RepairHint: `run "gc import install"`,
+		})
+		return "", false
+	}
+
+	gitPath := filepath.Join(cachePath, ".git")
+	if st, err := os.Stat(gitPath); err != nil {
+		if os.IsNotExist(err) {
+			s.closureIncomplete = true
+			s.addIssue(CheckIssue{
+				Code:       "missing-cache",
+				ImportName: name,
+				Source:     source,
+				Commit:     commit,
+				Path:       cachePath,
+				Message:    "locked import is missing from the local repo cache",
+				RepairHint: `run "gc import install"`,
+			})
+			return "", false
+		}
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "unreadable-cache",
+			ImportName: name,
+			Source:     source,
+			Commit:     commit,
+			Path:       gitPath,
+			Message:    fmt.Sprintf("cannot inspect cached repository: %v", err),
+			RepairHint: `run "gc import install"`,
+		})
+		return "", false
+	} else if st.IsDir() || st.Mode().IsRegular() {
+		head, err := runGit(cachePath, "rev-parse", "HEAD")
+		if err != nil {
+			s.closureIncomplete = true
+			s.addIssue(CheckIssue{
+				Code:       "unreadable-cache-git",
+				ImportName: name,
+				Source:     source,
+				Commit:     commit,
+				Path:       cachePath,
+				Message:    fmt.Sprintf("cannot read cached repository HEAD: %v", err),
+				RepairHint: `run "gc import install"`,
+			})
+			return "", false
+		}
+		if !sameCommit(head, commit) {
+			s.closureIncomplete = true
+			s.addIssue(CheckIssue{
+				Code:       "cache-checkout-mismatch",
+				ImportName: name,
+				Source:     source,
+				Commit:     commit,
+				Path:       cachePath,
+				Message:    fmt.Sprintf("cached repository is checked out at %s, expected %s", strings.TrimSpace(head), commit),
+				RepairHint: `run "gc import install"`,
+			})
+			return "", false
+		}
+	} else {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "invalid-cache",
+			ImportName: name,
+			Source:     source,
+			Commit:     commit,
+			Path:       gitPath,
+			Message:    "cached repository .git entry is not a file or directory",
+			RepairHint: `run "gc import install"`,
+		})
+		return "", false
+	}
+
+	packDir := cachedPackDir(source, cachePath)
+	if st, err := os.Stat(filepath.Join(packDir, "pack.toml")); err != nil {
+		if os.IsNotExist(err) {
+			s.closureIncomplete = true
+			s.addIssue(CheckIssue{
+				Code:       "missing-cached-pack",
+				ImportName: name,
+				Source:     source,
+				Commit:     commit,
+				Path:       filepath.Join(packDir, "pack.toml"),
+				Message:    "cached import is missing pack.toml",
+				RepairHint: `run "gc import install"`,
+			})
+			return "", false
+		}
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "unreadable-cached-pack",
+			ImportName: name,
+			Source:     source,
+			Commit:     commit,
+			Path:       filepath.Join(packDir, "pack.toml"),
+			Message:    fmt.Sprintf("cannot inspect cached pack.toml: %v", err),
+			RepairHint: `run "gc import install"`,
+		})
+		return "", false
+	} else if st.IsDir() {
+		s.closureIncomplete = true
+		s.addIssue(CheckIssue{
+			Code:       "invalid-cached-pack",
+			ImportName: name,
+			Source:     source,
+			Commit:     commit,
+			Path:       filepath.Join(packDir, "pack.toml"),
+			Message:    "cached pack.toml is a directory",
+			RepairHint: `run "gc import install"`,
+		})
+		return "", false
+	}
+
+	return packDir, true
+}
+
+func (s *importCheckState) reportStaleLockEntries() {
+	if s.closureIncomplete {
+		return
+	}
+	sources := make([]string, 0, len(s.lock.Packs))
+	for source := range s.lock.Packs {
+		if _, ok := s.reachable[source]; !ok {
+			sources = append(sources, source)
+		}
+	}
+	sort.Strings(sources)
+	for _, source := range sources {
+		pack := s.lock.Packs[source]
+		s.addIssue(CheckIssue{
+			Code:       "stale-lock-entry",
+			Source:     source,
+			Commit:     pack.Commit,
+			Message:    "packs.lock contains a source that is not reachable from declared imports",
+			RepairHint: `run "gc import install"`,
+		})
+	}
+}
+
+func (s *importCheckState) addIssue(issue CheckIssue) {
+	key := issue.Code + "\x00" + issue.Source + "\x00" + issue.Commit + "\x00" + issue.Path
+	if _, ok := s.reportedIssueKeys[key]; ok {
+		return
+	}
+	s.reportedIssueKeys[key] = struct{}{}
+	s.report.addIssue(issue)
+}
+
+func (r *CheckReport) addIssue(issue CheckIssue) {
+	if issue.Severity == "" {
+		issue.Severity = CheckSeverityError
+	}
+	r.Issues = append(r.Issues, issue)
+}
+
+func lockfileExists(cityRoot string) (bool, error) {
+	_, err := os.Stat(filepath.Join(cityRoot, LockfileName))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking %s: %w", LockfileName, err)
+}
+
+func countRemoteImports(imports map[string]config.Import) int {
+	count := 0
+	for _, imp := range imports {
+		if isRemoteSource(imp.Source) {
+			count++
+		}
+	}
+	return count
+}
+
+func sortedImportNames(imports map[string]config.Import) []string {
+	names := make([]string, 0, len(imports))
+	for name := range imports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func cachedPackDir(source, cachePath string) string {
+	if subpath := normalizeRemoteSource(source).Subpath; subpath != "" {
+		return filepath.Join(cachePath, subpath)
+	}
+	return cachePath
+}
+
+func sameCommit(actual, expected string) bool {
+	actual = strings.TrimSpace(actual)
+	expected = strings.TrimSpace(expected)
+	if actual == "" || expected == "" {
+		return false
+	}
+	if strings.EqualFold(actual, expected) {
+		return true
+	}
+	return len(expected) < len(actual) && strings.HasPrefix(strings.ToLower(actual), strings.ToLower(expected))
+}

--- a/internal/packman/check.go
+++ b/internal/packman/check.go
@@ -182,13 +182,9 @@ func (s *importCheckState) walkImport(name string, imp config.Import) {
 	}
 
 	packDir, ok := s.validateCachedPack(name, imp.Source, locked.Commit)
-	if !ok || !imp.ImportIsTransitive() {
+	if !ok {
 		return
 	}
-	if s.seen[imp.Source] {
-		return
-	}
-	s.seen[imp.Source] = true
 	nested, err := readPackImports(packDir)
 	if err != nil {
 		s.closureIncomplete = true
@@ -203,6 +199,13 @@ func (s *importCheckState) walkImport(name string, imp config.Import) {
 		})
 		return
 	}
+	if !imp.ImportIsTransitive() {
+		return
+	}
+	if s.seen[imp.Source] {
+		return
+	}
+	s.seen[imp.Source] = true
 	for _, nestedName := range sortedImportNames(nested) {
 		s.walkImport(name+"/"+nestedName, nested[nestedName])
 	}
@@ -273,6 +276,33 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       cachePath,
 				Message:    fmt.Sprintf("cached repository is checked out at %s, expected %s", strings.TrimSpace(head), commit),
+				RepairHint: `run "gc import install"`,
+			})
+			return "", false
+		}
+		dirty, err := cachedRepoDirty(cachePath)
+		if err != nil {
+			s.closureIncomplete = true
+			s.addIssue(CheckIssue{
+				Code:       "unreadable-cache-git",
+				ImportName: name,
+				Source:     source,
+				Commit:     commit,
+				Path:       cachePath,
+				Message:    fmt.Sprintf("cannot read cached repository status: %v", err),
+				RepairHint: `run "gc import install"`,
+			})
+			return "", false
+		}
+		if dirty {
+			s.closureIncomplete = true
+			s.addIssue(CheckIssue{
+				Code:       "cache-worktree-dirty",
+				ImportName: name,
+				Source:     source,
+				Commit:     commit,
+				Path:       cachePath,
+				Message:    "cached repository has local worktree changes",
 				RepairHint: `run "gc import install"`,
 			})
 			return "", false

--- a/internal/packman/check_test.go
+++ b/internal/packman/check_test.go
@@ -1,0 +1,372 @@
+package packman
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestCheckInstalledNoRemoteImportsMissingLockOK(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"local": {Source: "./packs/local"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	if report.HasIssues() {
+		t.Fatalf("issues = %#v, want none", report.Issues)
+	}
+	if report.CheckedSources != 0 {
+		t.Fatalf("CheckedSources = %d, want 0", report.CheckedSources)
+	}
+}
+
+func TestCheckInstalledReportsMissingLockfile(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-lockfile")
+}
+
+func TestCheckInstalledReportsMissingCache(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-cache")
+}
+
+func TestCheckInstalledMissingCacheDoesNotCreateCacheRoot(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-cache")
+	if _, err := os.Stat(filepath.Join(home, ".gc", "cache", "repos")); !os.IsNotExist(err) {
+		t.Fatalf("repo cache root stat err = %v, want not exist", err)
+	}
+}
+
+func TestCheckInstalledDeduplicatesRepeatedSourceIssues(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools":         {Source: "https://example.com/tools.git", Version: "^1.0"},
+		"rig:frontend:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-cache")
+	if report.CheckedSources != 1 {
+		t.Fatalf("CheckedSources = %d, want 1", report.CheckedSources)
+	}
+}
+
+func TestCheckInstalledSkipsStaleLockEntriesWhenClosureIncomplete(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/a.git": {Version: "1.0.0", Commit: "aaaa"},
+		"https://example.com/b.git": {Version: "1.0.0", Commit: "bbbb"},
+	})
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:a": {Source: "https://example.com/a.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-cache")
+}
+
+func TestCheckInstalledReportsConstraintMismatch(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^2.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "lock-constraint-mismatch")
+}
+
+func TestCheckInstalledWalksTransitiveClosureAndReportsStaleLockEntry(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/a.git":     {Version: "1.0.0", Commit: "aaaa"},
+		"https://example.com/b.git":     {Version: "1.0.0", Commit: "bbbb"},
+		"https://example.com/stale.git": {Version: "1.0.0", Commit: "cccc"},
+	})
+	stageCachedPack(t, "https://example.com/a.git", "aaaa", `
+[pack]
+name = "a"
+schema = 1
+
+[imports.b]
+source = "https://example.com/b.git"
+version = "^1.0"
+`)
+	stageCachedPack(t, "https://example.com/b.git", "bbbb", `
+[pack]
+name = "b"
+schema = 1
+`)
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:a": {Source: "https://example.com/a.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "stale-lock-entry")
+	if report.CheckedSources != 2 {
+		t.Fatalf("CheckedSources = %d, want 2", report.CheckedSources)
+	}
+}
+
+func TestCheckInstalledReportsMissingTransitiveLockEntry(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/a.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+	stageCachedPack(t, "https://example.com/a.git", "aaaa", `
+[pack]
+name = "a"
+schema = 1
+
+[imports.b]
+source = "https://example.com/b.git"
+version = "^1.0"
+`)
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:a": {Source: "https://example.com/a.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-lock-entry")
+}
+
+func TestCheckInstalledExpandsRepeatedSourceWhenAnyImportIsTransitive(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/shared.git": {Version: "1.0.0", Commit: "aaaa"},
+		"https://example.com/inner.git":  {Version: "1.0.0", Commit: "bbbb"},
+	})
+	stageCachedPack(t, "https://example.com/shared.git", "aaaa", `
+[pack]
+name = "shared"
+schema = 1
+
+[imports.inner]
+source = "https://example.com/inner.git"
+version = "^1.0"
+`)
+	stageCachedPack(t, "https://example.com/inner.git", "bbbb", `
+[pack]
+name = "inner"
+schema = 1
+`)
+
+	transitiveFalse := false
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:a": {Source: "https://example.com/shared.git", Version: "^1.0", Transitive: &transitiveFalse},
+		"pack:z": {Source: "https://example.com/shared.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	if report.HasIssues() {
+		t.Fatalf("issues = %#v, want none", report.Issues)
+	}
+	if report.CheckedSources != 2 {
+		t.Fatalf("CheckedSources = %d, want 2", report.CheckedSources)
+	}
+}
+
+func TestCheckInstalledReportsCacheCheckoutMismatch(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+	stageCachedPackAtCommit(t, "https://example.com/tools.git", "aaaa", "bbbb", `
+[pack]
+name = "tools"
+schema = 1
+`)
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "cache-checkout-mismatch")
+}
+
+func TestCheckInstalledUsesRemoteSubpath(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	source := "file:///tmp/repo.git//packs/base"
+	writeTestLockfile(t, city, map[string]LockedPack{
+		source: {Version: "1.0.0", Commit: "aaaa"},
+	})
+	path, err := RepoCachePath(source, "aaaa")
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+	writeCachedPackCommit(t, path, "aaaa")
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:base": {Source: source, Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "missing-cached-pack")
+}
+
+func assertSingleIssue(t *testing.T, report *CheckReport, code string) {
+	t.Helper()
+	if report == nil {
+		t.Fatal("report is nil")
+	}
+	if len(report.Issues) != 1 {
+		t.Fatalf("len(Issues) = %d, want 1: %#v", len(report.Issues), report.Issues)
+	}
+	if report.Issues[0].Code != code {
+		t.Fatalf("issue code = %q, want %q; issue=%#v", report.Issues[0].Code, code, report.Issues[0])
+	}
+	if report.Issues[0].Severity != CheckSeverityError {
+		t.Fatalf("issue severity = %q, want error", report.Issues[0].Severity)
+	}
+	if report.ErrorCount() != 1 {
+		t.Fatalf("ErrorCount = %d, want 1", report.ErrorCount())
+	}
+}
+
+func writeTestLockfile(t *testing.T, city string, packs map[string]LockedPack) {
+	t.Helper()
+	for source, pack := range packs {
+		if pack.Fetched.IsZero() {
+			pack.Fetched = time.Unix(10, 0).UTC()
+			packs[source] = pack
+		}
+	}
+	if err := WriteLockfile(fsys.OSFS{}, city, &Lockfile{
+		Schema: LockfileSchema,
+		Packs:  packs,
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+}
+
+func stubCachedPackGit(t *testing.T) {
+	t.Helper()
+	prev := runGit
+	runGit = func(dir string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD" {
+			data, err := os.ReadFile(filepath.Join(dir, ".packman-test-commit"))
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		}
+		if len(args) >= 1 && args[0] == "checkout" {
+			if dir == "" {
+				return "", fmt.Errorf("checkout requires dir")
+			}
+			writeCachedPackCommit(t, dir, args[len(args)-1])
+			return "", nil
+		}
+		return prev(dir, args...)
+	}
+	t.Cleanup(func() { runGit = prev })
+}
+
+func stageCachedPackAtCommit(t *testing.T, source, cacheCommit, headCommit, packToml string) {
+	t.Helper()
+	path, err := RepoCachePath(source, cacheCommit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeCachedPackCommit(t, path, headCommit)
+	if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+}
+
+func writeCachedPackCommit(t *testing.T, cachePath, commit string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(cachePath, ".packman-test-commit"), []byte(commit), 0o644); err != nil {
+		t.Fatalf("WriteFile(.packman-test-commit): %v", err)
+	}
+}

--- a/internal/packman/check_test.go
+++ b/internal/packman/check_test.go
@@ -61,23 +61,29 @@ func TestCheckInstalledReportsMissingCache(t *testing.T) {
 	assertSingleIssue(t, report, "missing-cache")
 }
 
-func TestCheckInstalledMissingCacheDoesNotCreateCacheRoot(t *testing.T) {
+func TestCheckInstalledMissingCacheDoesNotCreateCacheEntry(t *testing.T) {
 	home := t.TempDir()
 	city := t.TempDir()
 	t.Setenv("HOME", home)
+	source := "https://example.com/tools.git"
+	commit := "aaaa"
 	writeTestLockfile(t, city, map[string]LockedPack{
-		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+		source: {Version: "1.0.0", Commit: commit},
 	})
 
 	report, err := CheckInstalled(city, map[string]config.Import{
-		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+		"pack:tools": {Source: source, Version: "^1.0"},
 	})
 	if err != nil {
 		t.Fatalf("CheckInstalled: %v", err)
 	}
 	assertSingleIssue(t, report, "missing-cache")
-	if _, err := os.Stat(filepath.Join(home, ".gc", "cache", "repos")); !os.IsNotExist(err) {
-		t.Fatalf("repo cache root stat err = %v, want not exist", err)
+	cachePath, err := RepoCachePath(source, commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Fatalf("repo cache entry stat err = %v, want not exist", err)
 	}
 }
 
@@ -241,6 +247,30 @@ schema = 1
 	}
 }
 
+func TestCheckInstalledParsesNonTransitiveCachedPack(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+	stageCachedPack(t, "https://example.com/tools.git", "aaaa", `
+[pack
+name = "tools"
+schema = 1
+`)
+
+	transitiveFalse := false
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0", Transitive: &transitiveFalse},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "invalid-cached-pack")
+}
+
 func TestCheckInstalledReportsCacheCheckoutMismatch(t *testing.T) {
 	home := t.TempDir()
 	city := t.TempDir()
@@ -262,6 +292,30 @@ schema = 1
 		t.Fatalf("CheckInstalled: %v", err)
 	}
 	assertSingleIssue(t, report, "cache-checkout-mismatch")
+}
+
+func TestCheckInstalledReportsDirtyCacheWorktree(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+	writeTestLockfile(t, city, map[string]LockedPack{
+		"https://example.com/tools.git": {Version: "1.0.0", Commit: "aaaa"},
+	})
+	stageCachedPackAtCommit(t, "https://example.com/tools.git", "aaaa", "aaaa", `
+[pack]
+name = "tools"
+schema = 1
+`)
+	markCachedPackDirty(t, "https://example.com/tools.git", "aaaa")
+
+	report, err := CheckInstalled(city, map[string]config.Import{
+		"pack:tools": {Source: "https://example.com/tools.git", Version: "^1.0"},
+	})
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	assertSingleIssue(t, report, "cache-worktree-dirty")
 }
 
 func TestCheckInstalledUsesRemoteSubpath(t *testing.T) {
@@ -337,6 +391,14 @@ func stubCachedPackGit(t *testing.T) {
 			}
 			return string(data), nil
 		}
+		if len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
+			if _, err := os.Stat(filepath.Join(dir, ".packman-test-dirty")); err == nil {
+				return " M pack.toml", nil
+			} else if err != nil && !os.IsNotExist(err) {
+				return "", err
+			}
+			return "", nil
+		}
 		if len(args) >= 1 && args[0] == "checkout" {
 			if dir == "" {
 				return "", fmt.Errorf("checkout requires dir")
@@ -368,5 +430,16 @@ func writeCachedPackCommit(t *testing.T, cachePath, commit string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(cachePath, ".packman-test-commit"), []byte(commit), 0o644); err != nil {
 		t.Fatalf("WriteFile(.packman-test-commit): %v", err)
+	}
+}
+
+func markCachedPackDirty(t *testing.T, source, commit string) {
+	t.Helper()
+	path, err := RepoCachePath(source, commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ".packman-test-dirty"), []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("WriteFile(.packman-test-dirty): %v", err)
 	}
 }

--- a/internal/packman/install.go
+++ b/internal/packman/install.go
@@ -223,10 +223,9 @@ func (s *syncState) walkImport(_ string, imp config.Import, constraints map[stri
 	if !ok || !matchesExisting(chosen, mergedConstraint) {
 		*dirty = true
 	}
-	if seen[imp.Source] || !ok {
+	if !ok {
 		return nil
 	}
-	seen[imp.Source] = true
 
 	cachePath, err := s.cachedPackPath(imp.Source, chosen.Commit)
 	if err != nil {
@@ -235,6 +234,10 @@ func (s *syncState) walkImport(_ string, imp config.Import, constraints map[stri
 	if !imp.ImportIsTransitive() {
 		return nil
 	}
+	if seen[imp.Source] {
+		return nil
+	}
+	seen[imp.Source] = true
 
 	nested, err := readPackImports(cachePath)
 	if err != nil {

--- a/internal/packman/install.go
+++ b/internal/packman/install.go
@@ -33,10 +33,26 @@ func ReadCachedPackImports(source, commit string) (map[string]config.Import, err
 	if err != nil {
 		return nil, err
 	}
+	packPath := cachePath
 	if subpath := normalizeRemoteSource(source).Subpath; subpath != "" {
-		cachePath = filepath.Join(cachePath, subpath)
+		packPath = filepath.Join(packPath, subpath)
 	}
-	return readPackImports(cachePath)
+	root, err := RepoCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+	var imports map[string]config.Import
+	if err := config.WithRepoCacheReadLock(root, func() error {
+		if err := validateCachedRepoCheckout(cachePath, commit); err != nil {
+			return err
+		}
+		var readErr error
+		imports, readErr = readPackImports(packPath)
+		return readErr
+	}); err != nil {
+		return nil, err
+	}
+	return imports, nil
 }
 
 // InstallLocked restores every entry recorded in packs.lock into the shared cache.
@@ -227,8 +243,7 @@ func (s *syncState) walkImport(_ string, imp config.Import, constraints map[stri
 		return nil
 	}
 
-	cachePath, err := s.cachedPackPath(imp.Source, chosen.Commit)
-	if err != nil {
+	if _, err := s.cachedPackPath(imp.Source, chosen.Commit); err != nil {
 		return err
 	}
 	if !imp.ImportIsTransitive() {
@@ -239,7 +254,7 @@ func (s *syncState) walkImport(_ string, imp config.Import, constraints map[stri
 	}
 	seen[imp.Source] = true
 
-	nested, err := readPackImports(cachePath)
+	nested, err := ReadCachedPackImports(imp.Source, chosen.Commit)
 	if err != nil {
 		return err
 	}

--- a/internal/packman/install_test.go
+++ b/internal/packman/install_test.go
@@ -16,6 +16,7 @@ func TestSyncLockFromLockWalksTransitiveImports(t *testing.T) {
 	home := t.TempDir()
 	city := t.TempDir()
 	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
 
 	lock := &Lockfile{
 		Packs: map[string]LockedPack{
@@ -57,6 +58,7 @@ func TestSyncLockHonorsTransitiveFalse(t *testing.T) {
 	home := t.TempDir()
 	city := t.TempDir()
 	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
 
 	lock := &Lockfile{
 		Packs: map[string]LockedPack{
@@ -91,6 +93,49 @@ schema = 1
 	}
 	if len(got.Packs) != 1 {
 		t.Fatalf("len(Packs) = %d, want 1", len(got.Packs))
+	}
+}
+
+func TestSyncLockExpandsRepeatedSourceWhenAnyImportIsTransitive(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
+
+	lock := &Lockfile{
+		Packs: map[string]LockedPack{
+			"https://example.com/shared.git": {Version: "1.0.0", Commit: "aaaa", Fetched: time.Unix(10, 0).UTC()},
+			"https://example.com/inner.git":  {Version: "1.0.0", Commit: "bbbb", Fetched: time.Unix(20, 0).UTC()},
+		},
+	}
+	if err := WriteLockfile(fsys.OSFS{}, city, lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	stageCachedPack(t, "https://example.com/shared.git", "aaaa", `
+[pack]
+name = "shared"
+schema = 1
+
+[imports.inner]
+source = "https://example.com/inner.git"
+version = "^1.0"
+`)
+	stageCachedPack(t, "https://example.com/inner.git", "bbbb", `
+[pack]
+name = "inner"
+schema = 1
+`)
+
+	transitiveFalse := false
+	got, err := SyncLock(city, map[string]config.Import{
+		"a": {Source: "https://example.com/shared.git", Version: "^1.0", Transitive: &transitiveFalse},
+		"z": {Source: "https://example.com/shared.git", Version: "^1.0"},
+	}, InstallFromLock)
+	if err != nil {
+		t.Fatalf("SyncLock: %v", err)
+	}
+	if len(got.Packs) != 2 {
+		t.Fatalf("len(Packs) = %d, want 2", len(got.Packs))
 	}
 }
 
@@ -158,6 +203,9 @@ func TestInstallLockedEnsuresEveryLockedRepo(t *testing.T) {
 		case "clone":
 			target := args[len(args)-1]
 			if err := os.MkdirAll(filepath.Join(target, ".git"), 0o755); err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(filepath.Join(target, "pack.toml"), []byte("[pack]\nname = \"cached\"\nschema = 1\n"), 0o644); err != nil {
 				return "", err
 			}
 			seen = append(seen, args[len(args)-2])
@@ -321,6 +369,7 @@ func TestSyncLockMergesDirectAndTransitiveConstraintsBeforeResolution(t *testing
 	home := t.TempDir()
 	city := t.TempDir()
 	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
 
 	if err := WriteLockfile(fsys.OSFS{}, city, &Lockfile{
 		Schema: LockfileSchema,
@@ -435,6 +484,7 @@ func TestSyncLockConvergesForDeepTransitiveChains(t *testing.T) {
 	home := t.TempDir()
 	city := t.TempDir()
 	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
 
 	lock := &Lockfile{
 		Schema: LockfileSchema,
@@ -538,6 +588,7 @@ func stageCachedPack(t *testing.T, source, commit, packToml string) {
 	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
+	writeCachedPackCommit(t, path, commit)
 	if err := os.WriteFile(filepath.Join(path, "pack.toml"), []byte(packToml), 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
 	}

--- a/internal/packman/install_test.go
+++ b/internal/packman/install_test.go
@@ -145,7 +145,7 @@ func TestSyncLockResolveIfNeededResolvesAndCaches(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	prev := runGit
-	runGit = func(_ string, args ...string) (string, error) {
+	runGit = func(dir string, args ...string) (string, error) {
 		switch args[0] {
 		case "ls-remote":
 			return "aaaa\trefs/tags/v1.0.0\n", nil
@@ -159,6 +159,15 @@ func TestSyncLockResolveIfNeededResolvesAndCaches(t *testing.T) {
 			}
 			return "", nil
 		case "checkout":
+			writeCachedPackCommit(t, dir, args[len(args)-1])
+			return "", nil
+		case "rev-parse":
+			data, err := os.ReadFile(filepath.Join(dir, ".packman-test-commit"))
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		case "status":
 			return "", nil
 		default:
 			return "", nil
@@ -233,6 +242,7 @@ func TestInstallLockedEnsuresEveryLockedRepo(t *testing.T) {
 func TestReadCachedPackImportsUsesSubpath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	stubCachedPackGit(t)
 
 	source := "file:///tmp/repo.git//packs/base"
 	commit := "abc123"
@@ -243,6 +253,7 @@ func TestReadCachedPackImportsUsesSubpath(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.git): %v", err)
 	}
+	writeCachedPackCommit(t, path, commit)
 	if err := os.MkdirAll(filepath.Join(path, "packs", "base"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(subpath): %v", err)
 	}
@@ -263,6 +274,35 @@ source = "https://example.com/inner.git"
 	}
 	if _, ok := imports["inner"]; !ok {
 		t.Fatalf("missing nested import from subpath pack: %#v", imports)
+	}
+}
+
+func TestReadCachedPackImportsRejectsMissingGitHead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	source := "file:///tmp/repo.git//packs/base"
+	commit := "abc123"
+	path, err := RepoCachePath(source, commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, "packs", "base"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(subpath): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "packs", "base", "pack.toml"), []byte("[pack]\nname = \"base\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+
+	_, err = ReadCachedPackImports(source, commit)
+	if err == nil {
+		t.Fatal("ReadCachedPackImports succeeded for cache with missing .git/HEAD")
+	}
+	if !strings.Contains(err.Error(), "reading cached repo HEAD") {
+		t.Fatalf("error = %v, want cached repo HEAD failure", err)
 	}
 }
 
@@ -289,7 +329,7 @@ func TestSyncLockMergesCompatibleDirectConstraints(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	prev := runGit
-	runGit = func(_ string, args ...string) (string, error) {
+	runGit = func(dir string, args ...string) (string, error) {
 		switch args[0] {
 		case "ls-remote":
 			return "aaaa\trefs/tags/v2.0.0\nbbbb\trefs/tags/v1.5.0\n", nil
@@ -303,6 +343,15 @@ func TestSyncLockMergesCompatibleDirectConstraints(t *testing.T) {
 			}
 			return "", nil
 		case "checkout":
+			writeCachedPackCommit(t, dir, args[len(args)-1])
+			return "", nil
+		case "rev-parse":
+			data, err := os.ReadFile(filepath.Join(dir, ".packman-test-commit"))
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		case "status":
 			return "", nil
 		default:
 			return "", nil
@@ -329,7 +378,7 @@ func TestSyncLockSelectiveUpgradeMergesSameSourceConstraints(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	prev := runGit
-	runGit = func(_ string, args ...string) (string, error) {
+	runGit = func(dir string, args ...string) (string, error) {
 		switch args[0] {
 		case "ls-remote":
 			return "cccc\trefs/tags/v2.0.0\nbbbb\trefs/tags/v1.5.0\n", nil
@@ -343,6 +392,15 @@ func TestSyncLockSelectiveUpgradeMergesSameSourceConstraints(t *testing.T) {
 			}
 			return "", nil
 		case "checkout":
+			writeCachedPackCommit(t, dir, args[len(args)-1])
+			return "", nil
+		case "rev-parse":
+			data, err := os.ReadFile(filepath.Join(dir, ".packman-test-commit"))
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		case "status":
 			return "", nil
 		default:
 			return "", nil
@@ -448,8 +506,9 @@ source = "https://example.com/shared.git"
 version = "<2.0"
 `)
 
+	stubCachedPackGit(t)
 	prev := runGit
-	runGit = func(_ string, args ...string) (string, error) {
+	runGit = func(dir string, args ...string) (string, error) {
 		switch args[0] {
 		case "ls-remote":
 			switch args[len(args)-1] {
@@ -461,7 +520,7 @@ version = "<2.0"
 				return "", nil
 			}
 		default:
-			return "", nil
+			return prev(dir, args...)
 		}
 	}
 	t.Cleanup(func() { runGit = prev })
@@ -527,7 +586,7 @@ func TestSyncLockAllowsMultipleSubpathsFromSameRepoWithSharedClone(t *testing.T)
 
 	cloneCount := 0
 	prev := runGit
-	runGit = func(_ string, args ...string) (string, error) {
+	runGit = func(dir string, args ...string) (string, error) {
 		switch args[0] {
 		case "ls-remote":
 			return "aaaa\trefs/tags/v1.2.3\n", nil
@@ -551,6 +610,15 @@ func TestSyncLockAllowsMultipleSubpathsFromSameRepoWithSharedClone(t *testing.T)
 			}
 			return "", nil
 		case "checkout":
+			writeCachedPackCommit(t, dir, args[len(args)-1])
+			return "", nil
+		case "rev-parse":
+			data, err := os.ReadFile(filepath.Join(dir, ".packman-test-commit"))
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		case "status":
 			return "", nil
 		default:
 			return "", nil


### PR DESCRIPTION
## Summary
- Add read-only `gc import check` validation for PackV2 declared imports, `packs.lock`, cache checkout drift, cached `pack.toml`, subpaths, transitive closure, and stale lock entries.
- Wire the same validation into `gc doctor` with `gc import install` as the repair hint.
- Harden `gc import install` cache materialization so stale/corrupt existing cache checkouts are repaired under a shared cache lock.
- Update PackV2 docs and migration guidance for the check/install split.

## Review
- Ran `/review-pr` in dual-model mode after Gemini returned quota/rate-limit errors.
- Fixed all blocker/major findings from the review iterations, including stale-lock false positives, duplicate issue reporting, cache repair edge cases, cache read/write races, read-only check mutation, and repeated same-source transitive expansion.
- Final Codex blocker/major recheck returned: `No blockers or majors.`
- Claude could not be rerun for the final recheck because this environment hit the Claude limit until Apr 23, 2026; the earlier Claude major finding was fixed before the final Codex recheck.

## Tests
- `go test ./internal/config ./internal/packman -count=1`
- `go test ./cmd/gc -run 'TestDoImport(Check|Install|Upgrade|List|Why)|TestImportStateDoctorCheck|TestDoDoctorRegistersImportStateCheck' -count=1`
- `go test ./test/docsync -count=1`
- `git diff HEAD --check`

Closes #842
Closes #575
