### PR TITLE
fix: allow bare and qualified session identifiers to coexist (#1005)

### DIFF
--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -348,9 +348,10 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 		}
 		// Historical aliases are compatibility-only input and do not reserve
 		// namespace for new session-name claims.
-		// This collision check is intentionally one-way. Explicit names cannot
-		// reuse a live short identifier, but later template/common-name sessions
-		// may still coexist and are resolved second to the exact session_name.
+		// Identifier collisions are exact-match only: a bare name like
+		// "control-dispatcher" does not collide with a qualified sibling like
+		// "<rig>/control-dispatcher", since configured multi-rig dispatchers
+		// occupy distinct namespaces by design.
 		if sessionNameConflictsWithExistingIdentifier(b, name) {
 			if continuityIneligibleConfiguredOwner(b, selfOwner) {
 				continue

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -380,9 +380,6 @@ func sessionNameConflictsWithExistingIdentifier(b beads.Bead, name string) bool 
 		if field == name {
 			return true
 		}
-		if !strings.Contains(name, "/") && strings.HasSuffix(field, "/"+name) {
-			return true
-		}
 	}
 	return false
 }

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -176,6 +176,37 @@ func TestEnsureSessionNameAvailable_AllowsBareVsQualifiedCoexistence(t *testing.
 	}
 }
 
+// Same multi-rig scenario via the production entry point
+// EnsureSessionNameAvailableWithConfigForOwner — the reconciler calls this path
+// (cmd/gc/session_beads.go, cmd/gc/session_template_start.go), so regression
+// coverage must include it alongside the helper-level test above.
+func TestEnsureSessionNameAvailableWithConfigForOwner_AllowsBareVsQualifiedCoexistence(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{
+			{Template: "control-dispatcher"},
+		},
+	}
+
+	for _, rig := range []string{"codeprobe", "geo"} {
+		if _, err := store.Create(beads.Bead{
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"agent_name":   rig + "/control-dispatcher",
+				"template":     rig + "/control-dispatcher",
+				"session_name": rig + "--control-dispatcher",
+			},
+		}); err != nil {
+			t.Fatalf("Create(%s dispatcher): %v", rig, err)
+		}
+	}
+
+	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "control-dispatcher", "", "control-dispatcher"); err != nil {
+		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(bare vs qualified) = %v, want nil", err)
+	}
+}
+
 func TestEnsureSessionNameAvailable_RejectsLiveAliasCollisions(t *testing.T) {
 	store := beads.NewMemStore()
 	_, err := store.Create(beads.Bead{

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -111,7 +111,7 @@ func TestEnsureSessionNameAvailable_RejectsOpenIdentifierCollisions(t *testing.T
 		Type:   BeadType,
 		Labels: []string{LabelSession},
 		Metadata: map[string]string{
-			"template": "myrig/worker",
+			"template": "worker",
 		},
 	})
 	if err != nil {
@@ -127,6 +127,52 @@ func TestEnsureSessionNameAvailable_RejectsOpenIdentifierCollisions(t *testing.T
 	}
 	if err := ensureSessionNameAvailable(store, "worker"); err != nil {
 		t.Fatalf("ensureSessionNameAvailable(closed collision) = %v, want nil", err)
+	}
+}
+
+// Bare names and qualified identifiers occupy distinct namespaces. A city-scoped
+// control-dispatcher with bare session_name="control-dispatcher" must coexist
+// with rig-scoped dispatchers whose agent_name is "<rig>/control-dispatcher".
+// Regression for the multi-rig collision fixed by dropping the bare-vs-qualified
+// suffix match in sessionNameConflictsWithExistingIdentifier.
+func TestEnsureSessionNameAvailable_AllowsBareVsQualifiedCoexistence(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Two rig-scoped dispatchers already registered with qualified identifiers.
+	// Matches the production shape where tp.SessionName = "<rig>--control-dispatcher"
+	// and agent_name/template carry the qualified "<rig>/control-dispatcher" form.
+	for _, rig := range []string{"codeprobe", "geo"} {
+		if _, err := store.Create(beads.Bead{
+			Type:   BeadType,
+			Labels: []string{LabelSession},
+			Metadata: map[string]string{
+				"agent_name":   rig + "/control-dispatcher",
+				"template":     rig + "/control-dispatcher",
+				"session_name": rig + "--control-dispatcher",
+			},
+		}); err != nil {
+			t.Fatalf("Create(%s dispatcher): %v", rig, err)
+		}
+	}
+
+	// City-scoped dispatcher with bare session_name must still be able to claim
+	// "control-dispatcher" despite the qualified identifiers above.
+	if err := ensureSessionNameAvailable(store, "control-dispatcher"); err != nil {
+		t.Fatalf("ensureSessionNameAvailable(bare vs qualified) = %v, want nil", err)
+	}
+
+	// Exact-match on template must still collide (guard that the narrower check holds).
+	if _, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"template": "control-dispatcher",
+		},
+	}); err != nil {
+		t.Fatalf("Create(bare template): %v", err)
+	}
+	if err := ensureSessionNameAvailable(store, "control-dispatcher"); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("ensureSessionNameAvailable(bare exact-match) error = %v, want %v", err, ErrSessionNameExists)
 	}
 }
 


### PR DESCRIPTION
Closes #1005.

## Summary

`sessionNameConflictsWithExistingIdentifier` had a suffix-match branch that treated a bare
name like `control-dispatcher` as colliding with any qualified identifier ending in
`/control-dispatcher`. This broke multi-rig control-dispatcher injection: the city-scoped
dispatcher (bare `session_name`) could never coexist with per-rig dispatchers whose
`agent_name` is `<rig>/control-dispatcher`, so only the first dispatcher to register ever
worked. Every other rig logged `session name already exists` on every wake, bead
registration failed, and the dispatcher pane sat at the SessionStart banner routing no
work.

Delete the suffix branch (`internal/session/names.go:383-385`). The exact-match guard at
L380 plus the alias check at L343 already prevent real collisions; the suffix rule was a
pre-multi-rig assumption that bare names must not alias any qualified suffix.

## Relation to #909 / #1001

Distinct from #909 (pool-managed bead squatting on a named-session name) and #1001's
`configuredOwnerCanReusePoolIdentifier` bypass. That bypass only triggers when the
blocking bead has `pool_managed: "true"` or `pool_slot`; rig-scoped control-dispatchers
are configured named sessions, not pool-managed, so they do not match and this bug would
remain after #1001.

## Review

- Ran `/gascity-ship` pipeline (simplify → multi-model review → contributor check).
- Stage 2 multi-model review (Claude + Codex gpt-5.4 + Copilot gpt-5.3-codex), 2 iterations:
  - Iteration 1: Codex flagged a stale comment at `internal/session/names.go:349-353`
    (\"Explicit names cannot reuse a live short identifier\" described the deleted
    suffix-match rule) as a **major**, plus a minor coverage gap — the test exercised the
    helper-level predicate but not the production entry point
    `EnsureSessionNameAvailableWithConfigForOwner` called by the reconciler.
  - Fixed both in `e1c79b9f`: rewrote the comment to describe exact-match-only semantics,
    and added `TestEnsureSessionNameAvailableWithConfigForOwner_AllowsBareVsQualifiedCoexistence`.
  - Iteration 2: all three models approve, no blockers or majors.
- Stage 3 contributor check: `make build`, fmt, lint, vet, tests all pass. 29-rule audit
  all PASS or n/a. No docs touched.

## Tests

- New `TestEnsureSessionNameAvailable_AllowsBareVsQualifiedCoexistence` at the helper
  level: seeds two rig-scoped dispatchers (`codeprobe`, `geo`) with qualified
  `agent_name`/`template` metadata; verifies bare `control-dispatcher` can still be
  claimed; then adds a bead with bare template `control-dispatcher` and verifies the
  exact-match path still blocks.
- New `TestEnsureSessionNameAvailableWithConfigForOwner_AllowsBareVsQualifiedCoexistence`
  at the production entry point: same shape, exercised via
  `EnsureSessionNameAvailableWithConfigForOwner` with
  `cfg.NamedSessions: [{Template: "control-dispatcher"}]` and
  `selfOwner=\"control-dispatcher\"`.
- Existing `TestEnsureSessionNameAvailable_RejectsOpenIdentifierCollisions` retargeted to
  use bare template `worker` so it still exercises the exact-match path after the suffix
  branch is gone.
- `go test -race ./internal/session/... ./internal/dispatch/...` passes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/session/... ./internal/dispatch/...`
- [x] `go test ./cmd/gc/...` (pre-existing cmd/gc timeout flakiness reproduces on clean
  main — not caused by this change; targeted session tests are stable 5×)
- [ ] Manual verification in a multi-rig workspace: all rig control-dispatchers prime and
  route work after applying the fix