### PR TITLE
fix: use 'opencode acp' for ACP-native session startup

### DIFF
--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -65,13 +65,17 @@ type ServerInfo struct {
 }
 
 // InitializeParams is the params for the "initialize" request.
+// protocolVersion is required by the ACP spec (MUST be included).
+// See https://agentclientprotocol.com/protocol/initialization
 type InitializeParams struct {
-	ClientInfo ClientInfo `json:"clientInfo"`
+	ProtocolVersion int        `json:"protocolVersion"`
+	ClientInfo      ClientInfo `json:"clientInfo"`
 }
 
 // InitializeResult is the result of the "initialize" request.
 type InitializeResult struct {
-	ServerInfo ServerInfo `json:"serverInfo"`
+	ProtocolVersion int        `json:"protocolVersion"`
+	ServerInfo      ServerInfo `json:"serverInfo"`
 }
 
 // SessionNewResult is the result of the "session/new" request.
@@ -123,7 +127,8 @@ func newNotification(method string) JSONRPCMessage {
 // newInitializeRequest creates an "initialize" request.
 func newInitializeRequest() (JSONRPCMessage, int64) {
 	return newRequest("initialize", InitializeParams{
-		ClientInfo: ClientInfo{Name: "gc", Version: "1.0"},
+		ProtocolVersion: 1,
+		ClientInfo:      ClientInfo{Name: "gc", Version: "1.0"},
 	})
 }
 

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -290,9 +290,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 	"opencode": {
 		DisplayName:      "OpenCode",
 		Command:          "opencode",
-		Args:             []string{},
+		Args:             []string{"acp"},
 		PromptMode:       "none",
-		ReadyDelayMs:     8000,
 		ProcessNames:     []string{"opencode", "node", "bun"},
 		Env:              map[string]string{"OPENCODE_PERMISSION": `{"*":"allow"}`},
 		SupportsACP:      true,


### PR DESCRIPTION
## Summary

Two fixes to make OpenCode work as an ACP provider:

1. **Profile**: Change OpenCode `Args` from `[]` to `["acp"]` — OpenCode requires the explicit `acp` subcommand for ACP mode (unlike Claude Code which auto-detects JSON-RPC on stdin)
2. **Protocol**: Add `protocolVersion: 1` to the ACP `InitializeParams` — the [ACP spec requires this field](https://agentclientprotocol.com/protocol/initialization): *"The initialize request MUST include the latest protocol version the Client supports."* Without it, OpenCode rejects the handshake with `Invalid params: expected number, received undefined`

## Verification

Tested `opencode acp` handshake directly:

```
# gc's current InitializeParams (no protocolVersion) → rejected:
{"error":{"code":-32602,"message":"Invalid params","data":{"protocolVersion":{"_errors":["Invalid input: expected number, received undefined"]}}}}

# With protocolVersion: 1 → accepted:
{"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true,...},"agentInfo":{"name":"OpenCode","version":"1.14.19"}}}
```

- `go test ./internal/runtime/acp/` — 47 tests pass
- `go test ./internal/worker/builtin/` — profile tests pass
- `go test ./cmd/gc/ -run TestTemplateParamsToConfig` — prompt resolution tests pass
- `golangci-lint run ./...` — 0 issues
- End-to-end `gc session` testing in progress (debugging unrelated city config issue)

## Notes

- The `protocolVersion` omission affects ALL ACP providers, not just OpenCode — Claude Code happened to be lenient about it
- Agents using OpenCode also need `session = "acp"` in their agent definition (tmux transport is not viable for OpenCode's BubbleTea TUI — no plain-text prompt prefix for readiness detection)
- `ReadyDelayMs` removed since ACP uses JSON-RPC handshake for readiness, not prompt polling

Fixes #1008
Related: #350