### PR TITLE
fix: rig-scope gc formula cook and show (#1004)

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/spf13/cobra"
@@ -106,7 +107,11 @@ Examples:
 
 			compileVars := vars
 
-			recipe, err := formula.Compile(cmd.Context(), name, cityFormulaSearchPaths(stderr), compileVars)
+			searchPaths, err := formulaSearchPathsForScope(stderr)
+			if err != nil {
+				return err
+			}
+			recipe, err := formula.Compile(cmd.Context(), name, searchPaths, compileVars)
 			if err != nil {
 				return err
 			}
@@ -229,7 +234,11 @@ bead into a sub-workflow at runtime.`,
 			if err != nil {
 				return err
 			}
-			store, err := openStoreAtForCity(cityPath, cityPath)
+			scope, err := resolveFormulaScope(cfg, cityPath)
+			if err != nil {
+				return err
+			}
+			store, err := openStoreAtForCity(scope.storeRoot, cityPath)
 			if err != nil {
 				return err
 			}
@@ -237,7 +246,7 @@ bead into a sub-workflow at runtime.`,
 			cookVars := parseFormulaVars(vars)
 
 			if attach != "" {
-				recipe, err := formula.Compile(cmd.Context(), args[0], cfg.FormulaLayers.City, cookVars)
+				recipe, err := formula.Compile(cmd.Context(), args[0], scope.searchPaths, cookVars)
 				if err != nil {
 					return fmt.Errorf("compile: %w", err)
 				}
@@ -259,7 +268,7 @@ bead into a sub-workflow at runtime.`,
 				return nil
 			}
 
-			result, err := molecule.Cook(cmd.Context(), store, args[0], cfg.FormulaLayers.City, molecule.Options{
+			result, err := molecule.Cook(cmd.Context(), store, args[0], scope.searchPaths, molecule.Options{
 				Title: title,
 				Vars:  cookVars,
 			})
@@ -329,18 +338,70 @@ func parseMetadataArgs(items []string) (map[string]string, error) {
 	return out, nil
 }
 
-// cityFormulaSearchPaths returns the city-level formula search paths.
-// Best-effort: returns nil if no city is loaded.
-func cityFormulaSearchPaths(warningWriter ...io.Writer) []string {
+// formulaScope is the resolved rig/city context for a formula invocation.
+// searchPaths falls back to city-level layers when the rig has no
+// rig-specific entry (see FormulaLayers.SearchPaths).
+type formulaScope struct {
+	storeRoot   string
+	searchPaths []string
+}
+
+// resolveFormulaScope determines the rig (if any) under which a formula
+// invocation should run. Priority: --rig flag > enclosing rig from cwd >
+// city.
+func resolveFormulaScope(cfg *config.City, cityPath string) (formulaScope, error) {
+	if name := strings.TrimSpace(rigFlag); name != "" {
+		rig, ok := rigByName(cfg, name)
+		if !ok {
+			return formulaScope{}, fmt.Errorf("rig %q not found", name)
+		}
+		if strings.TrimSpace(rig.Path) == "" {
+			return formulaScope{}, fmt.Errorf("rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it", rig.Name, rig.Name)
+		}
+		return rigFormulaScope(cfg, cityPath, rig), nil
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		// resolveRigForDir already filters unbound rigs (see
+		// rig_scope_resolution.go), so a true return guarantees rig.Path is
+		// non-empty.
+		if rig, ok, rerr := resolveRigForDir(cfg, cityPath, cwd); rerr != nil {
+			return formulaScope{}, rerr
+		} else if ok {
+			return rigFormulaScope(cfg, cityPath, rig), nil
+		}
+	}
+
+	return formulaScope{
+		storeRoot:   cityPath,
+		searchPaths: cfg.FormulaLayers.City,
+	}, nil
+}
+
+func rigFormulaScope(cfg *config.City, cityPath string, rig config.Rig) formulaScope {
+	return formulaScope{
+		storeRoot:   resolveStoreScopeRoot(cityPath, rig.Path),
+		searchPaths: cfg.FormulaLayers.SearchPaths(rig.Name),
+	}
+}
+
+// formulaSearchPathsForScope resolves the active formula scope (honoring
+// --rig and cwd) and returns its search paths. Used by read-only commands
+// like `gc formula show` that don't need to open a store.
+func formulaSearchPathsForScope(warningWriter ...io.Writer) ([]string, error) {
 	cityPath, err := resolveCity()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	cfg, err := loadCityConfig(cityPath, warningWriter...)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return cfg.FormulaLayers.City
+	scope, err := resolveFormulaScope(cfg, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	return scope.searchPaths, nil
 }
 
 // allFormulaSearchPaths returns the deduplicated union of formula search

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestResolveFormulaScope_RigFlagWins verifies that an explicit --rig flag
+// takes priority over the cwd, and that the rig's FormulaLayers are used.
+func TestResolveFormulaScope_RigFlagWins(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	otherPath := filepath.Join(cityPath, "other-rig")
+	for _, p := range []string{rigPath, otherPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "my-project", Path: rigPath},
+			{Name: "other-rig", Path: otherPath},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"my-project": {"/city/formulas", "/rigs/my-project/formulas"},
+				"other-rig":  {"/city/formulas", "/rigs/other-rig/formulas"},
+			},
+		},
+	}
+
+	t.Chdir(otherPath) // cwd would otherwise resolve to other-rig
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = "my-project"
+
+	scope, err := resolveFormulaScope(cfg, cityPath)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigPath {
+		t.Errorf("storeRoot = %q, want %q", scope.storeRoot, rigPath)
+	}
+	want := []string{"/city/formulas", "/rigs/my-project/formulas"}
+	if !reflect.DeepEqual(scope.searchPaths, want) {
+		t.Errorf("searchPaths = %v, want %v", scope.searchPaths, want)
+	}
+}
+
+// TestResolveFormulaScope_CwdInsideRig falls back to cwd when --rig is unset.
+// Asserts searchPaths too — the core bug in #1004 was search paths dropping
+// back to city layers even when storeRoot was rig-correct.
+func TestResolveFormulaScope_CwdInsideRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "my-project", Path: rigPath},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"my-project": {"/city/formulas", "/rigs/my-project/formulas"},
+			},
+		},
+	}
+
+	t.Chdir(rigPath)
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = ""
+
+	scope, err := resolveFormulaScope(cfg, cityPath)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigPath {
+		t.Errorf("storeRoot = %q, want %q", scope.storeRoot, rigPath)
+	}
+	want := []string{"/city/formulas", "/rigs/my-project/formulas"}
+	if !reflect.DeepEqual(scope.searchPaths, want) {
+		t.Errorf("searchPaths = %v, want %v", scope.searchPaths, want)
+	}
+}
+
+// TestResolveFormulaScope_CityScopeWhenNoRig returns city defaults when the
+// cwd is inside the city root but outside any declared rig and --rig is unset.
+func TestResolveFormulaScope_CityScopeWhenNoRig(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+		},
+	}
+
+	t.Chdir(cityPath)
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = ""
+
+	scope, err := resolveFormulaScope(cfg, cityPath)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != cityPath {
+		t.Errorf("storeRoot = %q, want %q", scope.storeRoot, cityPath)
+	}
+	want := []string{"/city/formulas"}
+	if !reflect.DeepEqual(scope.searchPaths, want) {
+		t.Errorf("searchPaths = %v, want %v", scope.searchPaths, want)
+	}
+}
+
+// TestResolveFormulaScope_UnknownRigErrors surfaces a clear error when the
+// user passes a --rig name that doesn't exist.
+func TestResolveFormulaScope_UnknownRigErrors(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "real", Path: filepath.Join(cityPath, "real")}},
+	}
+
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = "ghost"
+
+	_, err := resolveFormulaScope(cfg, cityPath)
+	if err == nil {
+		t.Fatal("expected error for unknown rig, got nil")
+	}
+	if !strings.Contains(err.Error(), `rig "ghost" not found`) {
+		t.Errorf("error = %v, want substring 'rig \"ghost\" not found'", err)
+	}
+}
+
+// TestResolveFormulaScope_UnboundRigErrors rejects a declared rig that has
+// no path binding — matching the gc bd error semantics.
+func TestResolveFormulaScope_UnboundRigErrors(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "unbound", Path: ""}},
+	}
+
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = "unbound"
+
+	_, err := resolveFormulaScope(cfg, cityPath)
+	if err == nil {
+		t.Fatal("expected error for unbound rig, got nil")
+	}
+	if !strings.Contains(err.Error(), "no path binding") {
+		t.Errorf("error = %v, want substring 'no path binding'", err)
+	}
+}
+
+// TestResolveFormulaScope_RigFallsBackToCityLayers covers the case where a
+// rig is resolved but has no rig-specific FormulaLayers entry; SearchPaths
+// should fall back to city layers.
+func TestResolveFormulaScope_RigFallsBackToCityLayers(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "bare-rig")
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "bare-rig", Path: rigPath}},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+		},
+	}
+
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+	rigFlag = "bare-rig"
+
+	scope, err := resolveFormulaScope(cfg, cityPath)
+	if err != nil {
+		t.Fatalf("resolveFormulaScope: %v", err)
+	}
+	if scope.storeRoot != rigPath {
+		t.Errorf("storeRoot = %q, want %q", scope.storeRoot, rigPath)
+	}
+	want := []string{"/city/formulas"}
+	if !reflect.DeepEqual(scope.searchPaths, want) {
+		t.Errorf("searchPaths = %v, want %v (city fallback)", scope.searchPaths, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `gc formula cook` and `gc formula show` hardcoded `openStoreAtForCity(cityPath, cityPath)` + `cfg.FormulaLayers.City`, ignoring both `--rig` and enclosing-rig-from-cwd. Running `gc formula cook pancakes` from inside a rig wrote `mc-*` beads into the city store instead of `mp-*` beads into the rig store.
- Introduces `resolveFormulaScope` (priority: `--rig` > cwd > city) returning a `{storeRoot, searchPaths}` pair threaded through both cook branches (default and `--attach`) and through show.
- Store opening uses the existing `openStoreAtForCity(scope.storeRoot, cityPath)` entry point, which already routes rig-scoped providers through `bdRuntimeEnvForRig` for correct `GC_RIG` / `GC_RIG_ROOT` / Dolt env projection.
- Search paths use `FormulaLayers.SearchPaths(rigName)` (falls back to city layers when the rig has no rig-specific entry).

Mirrors the shape of the recently-merged [PR #906](https://github.com/gastownhall/gascity/pull/906) (`resolveOrderStoreTarget`). Deletes the now-dead `cityFormulaSearchPaths` helper.

Closes #1004.

## Root cause

`cmd/gc/cmd_formula.go:232` (`newFormulaCookCmd.RunE`) — hardcoded city store plus `cfg.FormulaLayers.City`, no rig resolution. `newFormulaShowCmd.RunE` had the same class of bug at line 109 via `cityFormulaSearchPaths(stderr)`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New unit tests in `cmd/gc/cmd_formula_test.go` (6 cases):
  - `RigFlagWins` — `--rig` overrides cwd; rig-specific search paths used
  - `CwdInsideRig` — cwd fallback resolves rig; **asserts both storeRoot AND searchPaths** (closes B32 gap — the search-path half of the bug would otherwise go undetected)
  - `CityScopeWhenNoRig` — cwd inside city, no rig match → city defaults
  - `UnknownRigErrors` — `--rig ghost` → clear error
  - `UnboundRigErrors` — `--rig <declared-but-no-path-binding>` → clear error
  - `RigFallsBackToCityLayers` — rig resolved but no rig-specific `FormulaLayers` entry → falls back to city layers per `SearchPaths` semantics
- [x] `go test ./cmd/gc -race` clean (pre-existing `TestCityRuntimeWatchReloadPanicRestoresDirty` flake unrelated — passes in isolation 3/3)
- [x] Existing `tutorial04_test.go:168` acceptance test already exercises `gc formula cook pancakes` from a rig cwd and will now correctly produce `mp-*` prefixes

## Review results

Pre-push multi-model review (Claude + Codex/GPT-5.4 + Copilot/GPT-5.3-codex) — 0 blockers, 0 majors. Two known-minors, both pre-existing codebase-wide patterns:

- `os.Getwd()` failure in the cwd branch falls through to city scope silently (same pattern as the rest of `cmd/gc`).
- `--rig <path>` is advertised as "name or path" on the root flag (`main.go:145`), but `resolveFormulaScope` uses name-only `rigByName`. This matches the existing behavior of `cmd_bd.go:197`, `order_store.go:62`, `cmd_rig_endpoint.go:97`, and `work_query_probe.go:64`. A codebase-wide follow-up would be a separate issue.

Contributor check (29-rule audit): all in-scope rules pass. `B23` (fix-scope completeness) verified — `formula show`'s sibling bug is fixed in this PR; other `cfg.FormulaLayers.City` callers (`cmd_start`, `cmd_supervisor`, `cmd_init`, `cmd_order`, `convergence_tick`) are legitimate city-wide scan/resolve operations, not rig-scoped command entry points.

## Out-of-scope follow-ups

- Extract a shared `resolveRigScopeTarget` across bd / orders / formula to eliminate the three parallel implementations of the `--rig > cwd > city` resolution ladder. Would also be the right place to add `--rig <path>` support across the board.
- Clearer error when `--rig foo --attach mc-cityBead` is used with a cross-scope bead. Current behavior returns `attach bead mc-cityBead: not found` (a real failure, not silent wrong-store creation) but doesn't explain the scope mismatch.