### PR TITLE
fix: route gc formula cook to rig store (#1011)

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -229,15 +229,33 @@ bead into a sub-workflow at runtime.`,
 			if err != nil {
 				return err
 			}
-			store, err := openStoreAtForCity(cityPath, cityPath)
+
+			// Resolve target store scope: explicit --rig flag wins, else cwd,
+			// else city. Matches the pattern used by gc bd and gc sling so
+			// cooking a formula from a rig directory writes beads with the
+			// rig's prefix into the rig's store.
+			rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, rigFlag)
+			if err != nil {
+				return err
+			}
+			storeDir := cityPath
+			rigName := ""
+			if rig != nil {
+				storeDir = resolveStoreScopeRoot(cityPath, rig.Path)
+				rigName = rig.Name
+			}
+
+			store, err := openStoreAtForCity(storeDir, cityPath)
 			if err != nil {
 				return err
 			}
 
+			searchPaths := cfg.FormulaLayers.SearchPaths(rigName)
+
 			cookVars := parseFormulaVars(vars)
 
 			if attach != "" {
-				recipe, err := formula.Compile(cmd.Context(), args[0], cfg.FormulaLayers.City, cookVars)
+				recipe, err := formula.Compile(cmd.Context(), args[0], searchPaths, cookVars)
 				if err != nil {
 					return fmt.Errorf("compile: %w", err)
 				}
@@ -259,7 +277,7 @@ bead into a sub-workflow at runtime.`,
 				return nil
 			}
 
-			result, err := molecule.Cook(cmd.Context(), store, args[0], cfg.FormulaLayers.City, molecule.Options{
+			result, err := molecule.Cook(cmd.Context(), store, args[0], searchPaths, molecule.Options{
 				Title: title,
 				Vars:  cookVars,
 			})

--- a/cmd/gc/rig_scope_resolution.go
+++ b/cmd/gc/rig_scope_resolution.go
@@ -9,6 +9,40 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+// resolveRigScopeFromFlagOrCwd returns the rig a command should target,
+// preferring an explicit --rig flag value over cwd-based detection. A nil
+// result means no rig was resolved (caller should fall back to city scope).
+//
+// This is the shared primitive for commands whose only rig signals are the
+// --rig flag and the working directory (e.g. gc formula cook).
+//
+// Commands that can also discover a rig from other signals — such as gc bd
+// (bead-ID prefix in args) or gc sling (agent target, bead prefix) — have
+// their own richer resolvers. They may delegate the flag/cwd leg here if
+// their precedence rules permit it, but those with intermediate signals
+// (like bd's bead-ID sniffing between flag and cwd) must layer their own
+// logic explicitly.
+func resolveRigScopeFromFlagOrCwd(cfg *config.City, cityPath, rigName string) (*config.Rig, error) {
+	if strings.TrimSpace(rigName) != "" {
+		rig, ok := rigByName(cfg, rigName)
+		if !ok {
+			return nil, fmt.Errorf("rig %q not found", rigName)
+		}
+		if strings.TrimSpace(rig.Path) == "" {
+			return nil, fmt.Errorf("rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it", rig.Name, rig.Name)
+		}
+		return &rig, nil
+	}
+	rig, ok, err := bdRigFromCwd(cfg, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return &rig, nil
+}
+
 func rigForDir(cfg *config.City, cityPath, dir string) (config.Rig, bool) {
 	rig, ok, _ := resolveRigForDir(cfg, cityPath, dir)
 	return rig, ok

--- a/cmd/gc/rig_scope_resolution_test.go
+++ b/cmd/gc/rig_scope_resolution_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestResolveRigScopeFromFlagOrCwd(t *testing.T) {
+	cityPath := t.TempDir()
+	rigA := filepath.Join(cityPath, "rig-a")
+	rigB := filepath.Join(cityPath, "rig-b")
+	for _, d := range []string{rigA, rigB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "rig-a", Path: rigA},
+			{Name: "rig-b", Path: rigB},
+			{Name: "unbound"}, // declared but no path binding
+		},
+	}
+
+	t.Run("explicit flag selects named rig", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "rig-a")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig == nil || rig.Name != "rig-a" {
+			t.Fatalf("rig = %+v, want rig-a", rig)
+		}
+	})
+
+	t.Run("explicit flag wins over cwd", func(t *testing.T) {
+		t.Chdir(rigA)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "rig-b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig == nil || rig.Name != "rig-b" {
+			t.Fatalf("rig = %+v, want rig-b (flag should override cwd)", rig)
+		}
+	})
+
+	t.Run("unknown rig flag returns error", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "nope")
+		if err == nil {
+			t.Fatalf("want error, got rig=%+v", rig)
+		}
+		if !strings.Contains(err.Error(), `"nope" not found`) {
+			t.Fatalf("error = %v, want 'not found' for unknown rig", err)
+		}
+	})
+
+	t.Run("unbound rig flag returns error", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "unbound")
+		if err == nil {
+			t.Fatalf("want error, got rig=%+v", rig)
+		}
+		if !strings.Contains(err.Error(), "no path binding") {
+			t.Fatalf("error = %v, want 'no path binding' guidance", err)
+		}
+	})
+
+	t.Run("cwd in rig dir resolves to that rig", func(t *testing.T) {
+		t.Chdir(rigB)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig == nil || rig.Name != "rig-b" {
+			t.Fatalf("rig = %+v, want rig-b from cwd", rig)
+		}
+	})
+
+	t.Run("cwd outside rigs returns nil (city scope)", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig != nil {
+			t.Fatalf("rig = %+v, want nil (city scope)", rig)
+		}
+	})
+
+	t.Run("whitespace-only flag treated as no flag", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "   ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig != nil {
+			t.Fatalf("rig = %+v, want nil (whitespace flag should not select a rig)", rig)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1004 — `gc formula cook` hardcoded `openStoreAtForCity(cityPath, cityPath)`, so cooking from a rig cwd (or with `--rig`) silently created beads in the city store with the city prefix instead of the rig prefix. The tutorial contract (`cd` into rig, cook, get rig-prefixed beads) was broken.

**Fix**:
- Extract the shared `--rig` flag / cwd resolution into `resolveRigScopeFromFlagOrCwd` in `rig_scope_resolution.go` (the existing home for scope-resolution primitives). Returns `(*config.Rig, error)` — nil means city scope.
- `newFormulaCookCmd` now calls the helper to pick the right `storeDir` and uses `cfg.FormulaLayers.SearchPaths(rigName)` so rig-layer formulas can shadow city-layer ones when scoped to a rig.
- Both the default cook branch and the `--attach` branch pick up the fix since they share the same `store` variable.

**Not touched in this PR** (can be follow-ups):
- `gc bd` (`resolveBdScopeTarget`) has bead-ID sniffing between its flag and cwd legs, so it keeps its richer resolver. Helper is designed to compose in later.
- `gc sling` has its own resolver keyed on agent target and bead prefix, no cwd signal — different precedence, out of scope.

## Verification

Manual repro from #1004:

```
# Before: mc-* (city prefix) from rig cwd — wrong
# After:
cd ~/my-project && gc formula cook pancakes        # mp-0if ✓ (cwd)
gc --rig my-project formula cook pancakes          # mp-6dd ✓ (flag)
gc formula cook pancakes                           # mc-o6q ✓ (city fallback unchanged)
```

Unit tests in `rig_scope_resolution_test.go` cover: flag selects rig, flag wins over cwd, unknown rig errors, unbound rig errors (with actionable message pointing to `gc rig add`), cwd-in-rig resolves, cwd-outside-rigs returns nil, whitespace-only flag treated as no flag. All 7 pass.

## Testing

- [x] `make build` — clean
- [x] `go test ./cmd/gc/ -run "TestResolveRigScope|TestFormula|TestCook|TestInitTutorial"` — pass
- [x] `golangci-lint run ./cmd/gc/...` — 0 issues
- [x] `go vet ./cmd/gc/...` — clean
- [x] Manual repro of all three cases in #1004 — fixed
- [ ] `make check` — ran; new/changed tests pass. Pre-existing unrelated failures on my macOS env: `internal/runtime/k8s` (base64 help mismatch), `internal/supervisor` symlink canonicalization (`/private/var` vs `/var`), `internal/worker/workertest` tmux timing. None touch cmd/gc or anything in this change. Happy to investigate separately if maintainers see them in CI too.
- [ ] `make check-docs` — not run; no docs changed.
- [ ] `make test-integration` — not run; change is localized to CLI store selection. Let me know if you want the integration pass.

## Checklist

- [x] Linked issue: #1004
- [x] Added tests for behavior changes
- [ ] Updated docs for user-facing changes — no docs change needed; the fix restores the documented tutorial contract rather than changing it. Happy to add a note under `docs/tutorials/05-formulas` if the maintainers think it's worth calling out.
- [ ] Breaking changes / migration notes — none. Behavior change is strictly additive: previously-broken scope now works; city-scope fallback is unchanged.