### PR TITLE
Fix noisy status after new city init

### DIFF
--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -216,16 +216,17 @@ func controllerStatusForCity(cityPath string) ControllerJSON {
 				ctrl.Status = status
 				return ctrl
 			}
-		}
-		if ctrl.PID == 0 {
-			return ctrl
+			if supervisorAliveHook() != 0 {
+				ctrl.Status = "unknown"
+				return ctrl
+			}
 		}
 	}
 	if pid := controllerAlive(cityPath); pid != 0 {
 		return ControllerJSON{Running: true, PID: pid, Mode: "standalone"}
 	}
 	if err == nil && registered {
-		return ControllerJSON{Mode: "supervisor", PID: supervisorAliveHook()}
+		return ControllerJSON{Mode: "supervisor"}
 	}
 	return ControllerJSON{}
 }
@@ -297,7 +298,7 @@ func controllerStatusGuidance(ctrl ControllerJSON, cityPath string) []string {
 		if ctrl.Running {
 			return lines
 		}
-		if ctrl.Status == "" {
+		if ctrl.Status == "" || ctrl.Status == "unknown" {
 			return append(lines, "Next: "+startCommand+" to ask the supervisor to start this city")
 		}
 		if ctrl.Status == "init_failed" {

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -206,9 +206,6 @@ func doCityStatusJSON(
 }
 
 func controllerStatusForCity(cityPath string) ControllerJSON {
-	if pid := controllerAlive(cityPath); pid != 0 {
-		return ControllerJSON{Running: true, PID: pid, Mode: "standalone"}
-	}
 	_, registered, err := registeredCityEntry(cityPath)
 	if err == nil && registered {
 		ctrl := ControllerJSON{Mode: "supervisor"}
@@ -217,9 +214,18 @@ func controllerStatusForCity(cityPath string) ControllerJSON {
 			if running, status, known := supervisorCityRunningHook(cityPath); known {
 				ctrl.Running = running
 				ctrl.Status = status
+				return ctrl
 			}
 		}
-		return ctrl
+		if ctrl.PID == 0 {
+			return ctrl
+		}
+	}
+	if pid := controllerAlive(cityPath); pid != 0 {
+		return ControllerJSON{Running: true, PID: pid, Mode: "standalone"}
+	}
+	if err == nil && registered {
+		return ControllerJSON{Mode: "supervisor", PID: supervisorAliveHook()}
 	}
 	return ControllerJSON{}
 }

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -496,11 +497,13 @@ func TestControllerStatusForCityPrefersRegisteredSupervisorState(t *testing.T) {
 		_ = lis.Close()
 		_ = os.Remove(sockPath)
 	})
+	accepted := make(chan struct{}, 1)
 	go func() {
 		conn, acceptErr := lis.Accept()
 		if acceptErr != nil {
 			return
 		}
+		accepted <- struct{}{}
 		defer conn.Close() //nolint:errcheck // test cleanup
 		_, _ = conn.Write([]byte("1234\n"))
 	}()
@@ -517,6 +520,153 @@ func TestControllerStatusForCityPrefersRegisteredSupervisorState(t *testing.T) {
 	got := controllerStatusForCity(cityPath)
 	if got.Mode != "supervisor" || !got.Running || got.PID != 4321 {
 		t.Fatalf("controllerStatusForCity = %+v, want running supervisor PID 4321", got)
+	}
+	select {
+	case <-accepted:
+		t.Fatal("controllerStatusForCity consulted standalone socket for supervisor-managed city")
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+func TestControllerStatusForCityFallsBackToStandaloneWhenRegisteredSupervisorDown(t *testing.T) {
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "gc-home"))
+
+	root := shortSocketTempDir(t, "gc-status-")
+	cityPath := filepath.Join(root, "bright-lights")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("register city: %v", err)
+	}
+
+	sockPath := filepath.Join(cityPath, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockPath)
+	})
+	go func() {
+		conn, acceptErr := lis.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		_, _ = conn.Write([]byte("2468\n"))
+	}()
+
+	oldAlive := supervisorAliveHook
+	oldRunning := supervisorCityRunningHook
+	supervisorAliveHook = func() int { return 0 }
+	supervisorCityRunningHook = func(string) (bool, string, bool) {
+		t.Fatal("supervisorCityRunningHook should not be called when supervisor is down")
+		return false, "", false
+	}
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorCityRunningHook = oldRunning
+	})
+
+	got := controllerStatusForCity(cityPath)
+	if got.Mode != "standalone" || !got.Running || got.PID != 2468 {
+		t.Fatalf("controllerStatusForCity = %+v, want running standalone PID 2468", got)
+	}
+}
+
+func TestControllerStatusForCityReusesSupervisorPIDWhenCityStateUnknown(t *testing.T) {
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "gc-home"))
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("register city: %v", err)
+	}
+
+	oldAlive := supervisorAliveHook
+	oldRunning := supervisorCityRunningHook
+	calls := 0
+	supervisorAliveHook = func() int {
+		calls++
+		if calls <= 2 {
+			return 4321
+		}
+		return 0
+	}
+	supervisorCityRunningHook = func(string) (bool, string, bool) { return false, "", false }
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorCityRunningHook = oldRunning
+	})
+
+	got := controllerStatusForCity(cityPath)
+	if got.Mode != "supervisor" || got.Running || got.PID != 4321 || got.Status != "unknown" {
+		t.Fatalf("controllerStatusForCity = %+v, want unknown supervisor PID 4321", got)
+	}
+	if line := controllerStatusLine(got); line != "supervisor-managed (PID 4321, unknown)" {
+		t.Fatalf("controllerStatusLine(%+v) = %q, want unknown supervisor status", got, line)
+	}
+	if calls != 2 {
+		t.Fatalf("supervisorAliveHook calls = %d, want 2", calls)
+	}
+}
+
+func TestControllerStatusForCityFallsBackToStandaloneWhenSupervisorVanishesDuringUnknownProbe(t *testing.T) {
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "gc-home"))
+
+	root := shortSocketTempDir(t, "gc-status-")
+	cityPath := filepath.Join(root, "bright-lights")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("register city: %v", err)
+	}
+
+	sockPath := filepath.Join(cityPath, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockPath)
+	})
+	go func() {
+		conn, acceptErr := lis.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		_, _ = conn.Write([]byte("2468\n"))
+	}()
+
+	oldAlive := supervisorAliveHook
+	oldRunning := supervisorCityRunningHook
+	calls := 0
+	supervisorAliveHook = func() int {
+		calls++
+		if calls == 1 {
+			return 4321
+		}
+		return 0
+	}
+	supervisorCityRunningHook = func(string) (bool, string, bool) { return false, "", false }
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorCityRunningHook = oldRunning
+	})
+
+	got := controllerStatusForCity(cityPath)
+	if got.Mode != "standalone" || !got.Running || got.PID != 2468 {
+		t.Fatalf("controllerStatusForCity = %+v, want running standalone PID 2468", got)
+	}
+	if calls != 2 {
+		t.Fatalf("supervisorAliveHook calls = %d, want 2", calls)
 	}
 }
 
@@ -553,6 +703,14 @@ func TestControllerStatusGuidance(t *testing.T) {
 		{
 			name: "supervisor city stopped",
 			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321},
+			want: []string{
+				"Authority: supervisor process PID 4321",
+				"Next: gc start /tmp/city to ask the supervisor to start this city",
+			},
+		},
+		{
+			name: "supervisor city unknown",
+			ctrl: ControllerJSON{Mode: "supervisor", PID: 4321, Status: "unknown"},
 			want: []string{
 				"Authority: supervisor process PID 4321",
 				"Next: gc start /tmp/city to ask the supervisor to start this city",

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/worker"
 )
 
@@ -468,6 +472,51 @@ func TestControllerStatusLine(t *testing.T) {
 				t.Fatalf("controllerStatusLine(%+v) = %q, want %q", tt.ctrl, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestControllerStatusForCityPrefersRegisteredSupervisorState(t *testing.T) {
+	t.Setenv("GC_HOME", filepath.Join(t.TempDir(), "gc-home"))
+
+	root := shortSocketTempDir(t, "gc-status-")
+	cityPath := filepath.Join(root, "bright-lights")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("register city: %v", err)
+	}
+
+	sockPath := filepath.Join(cityPath, ".gc", "controller.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockPath)
+	})
+	go func() {
+		conn, acceptErr := lis.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		_, _ = conn.Write([]byte("1234\n"))
+	}()
+
+	oldAlive := supervisorAliveHook
+	oldRunning := supervisorCityRunningHook
+	supervisorAliveHook = func() int { return 4321 }
+	supervisorCityRunningHook = func(string) (bool, string, bool) { return true, "", true }
+	t.Cleanup(func() {
+		supervisorAliveHook = oldAlive
+		supervisorCityRunningHook = oldRunning
+	})
+
+	got := controllerStatusForCity(cityPath)
+	if got.Mode != "supervisor" || !got.Running || got.PID != 4321 {
+		t.Fatalf("controllerStatusForCity = %+v, want running supervisor PID 4321", got)
 	}
 }
 

--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"strconv"
@@ -197,7 +198,7 @@ func (f *tmuxFetcher) FetchRunning(ctx context.Context) (map[string]bool, error)
 
 // isNoServerError checks if the error is a "no server running" error.
 func isNoServerError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "no server running")
+	return errors.Is(err, ErrNoServer) || (err != nil && strings.Contains(err.Error(), "no server running"))
 }
 
 // cacheTTLFromEnv reads GC_TMUX_CACHE_TTL from the environment and parses

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -330,3 +330,9 @@ func TestStateCache_RefreshLogIsOptInViaEnvVar(t *testing.T) {
 		}
 	})
 }
+
+func TestIsNoServerErrorRecognizesSentinel(t *testing.T) {
+	if !isNoServerError(ErrNoServer) {
+		t.Fatal("isNoServerError(ErrNoServer) = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Treat tmux ErrNoServer as an empty session list so gc status does not log refresh failures when no tmux server exists.
- Prefer known supervisor registry/API state over the per-city controller socket when rendering gc status for registered cities.
- Add regressions for both status behaviors.

Fixes #1013

## Verification
- go test ./internal/runtime/tmux -run TestIsNoServerErrorRecognizesSentinel
- go test ./cmd/gc -run TestControllerStatusForCityPrefersRegisteredSupervisorState
- Isolated CLI repro with fresh GC_HOME: gc init followed by gc status now emits no tmux cache errors and reports supervisor-managed.