### PR TITLE
fix: renumber gc init progress steps to remove duplicate [6/8]

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -218,7 +218,7 @@ func resolveAgentChoice(input string, order []string, builtins map[string]config
 	return ""
 }
 
-const initProgressSteps = 8
+const initProgressSteps = 9
 
 // initExitAlreadyInitialized is the process exit code for an init request
 // that targets an already-initialized city. The supervisor API depends on

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -225,7 +225,7 @@ func registerCityWithSupervisorNamed(cityPath, nameOverride string, stdout, stde
 	}
 	if supervisorAliveHook() != 0 {
 		if showProgress {
-			logInitProgress(stdout, 8, "Waiting for supervisor to start city")
+			logInitProgress(stdout, 9, "Waiting for supervisor to start city")
 		} else if stdout != nil {
 			fmt.Fprintln(stdout, "Waiting for supervisor to start city...") //nolint:errcheck // best-effort stdout
 		}

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -58,9 +58,9 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 
 	if opts.showProgress {
 		if opts.skipProviderReadiness {
-			logInitProgress(stdout, 6, "Skipping provider readiness checks")
+			logInitProgress(stdout, 7, "Skipping provider readiness checks")
 		} else {
-			logInitProgress(stdout, 6, "Checking provider readiness")
+			logInitProgress(stdout, 7, "Checking provider readiness")
 		}
 	}
 	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
@@ -90,7 +90,7 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		return 1
 	}
 	if opts.showProgress {
-		logInitProgress(stdout, 7, "Registering city with supervisor")
+		logInitProgress(stdout, 8, "Registering city with supervisor")
 	}
 	return registerCityWithSupervisor(cityPath, stdout, stderr, opts.commandName, opts.showProgress)
 }

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -357,7 +357,7 @@ func TestFinalizeInitWithoutProgressSkipsStepCounter(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("finalizeInit = %d, want 0: %s", code, stderr.String())
 	}
-	if strings.Contains(stdout.String(), "[8/8]") {
+	if strings.Contains(stdout.String(), "[9/9]") {
 		t.Fatalf("stdout = %q, want no progress counter", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "Waiting for supervisor to start city...") {


### PR DESCRIPTION
## Summary

\`gc init\` currently emits two \"[6/8]\" lines back-to-back — first \"Writing city configuration\" from \`cmd_init.go\`, then \"Checking/Skipping provider readiness\" from \`init_provider_readiness.go\`. The duplicate counter looks like a bug to any first-time user, and the last two lines (\`[7/8]\` registering, \`[8/8]\` waiting) compound the off-by-one feel.

## Fix

Each distinct action gets its own counter. Total bumped 8 → 9; provider readiness becomes step 7, supervisor registration step 8, \`Waiting for supervisor to start city\` step 9.

| Before | After |
|---|---|
| \`[6/8] Writing city configuration\` | \`[6/9] Writing city configuration\` |
| \`[6/8] Checking provider readiness\` | \`[7/9] Checking provider readiness\` |
| \`[7/8] Registering city with supervisor\` | \`[8/9] Registering city with supervisor\` |
| \`[8/8] Waiting for supervisor to start city\` | \`[9/9] Waiting for supervisor to start city\` |

## Test plan

- \`go build ./cmd/gc/\`
- \`go vet ./cmd/gc/\`
- \`go test ./cmd/gc/ -run 'TestCmdInit|TestFinalizeInit|TestInitProgress|TestProviderReadiness' -count=1\` — all 16 tests pass
- Updated the one existing \`[8/8]\` assertion in \`init_provider_readiness_test.go\` to \`[9/9]\`

## Follow-up

\`docs/tutorials/01-cities-and-rigs.md\` still pins the old 8-step transcript. A separate docs PR will update it along with other post-rewrite drift (e.g., \`pool\` → \`scaled\` from #959, \`gc session list\` column changes). Keeping that in a dedicated PR so this code change stays easy to review.

/cc @csells @julianknutsen

🤖 Generated with [Claude Code](https://claude.com/claude-code)