### PR TITLE
fix(doctor): v2-scripts-layout ignores pack-resolved symlinks (#1018)

### DIFF
--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -247,10 +247,57 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	if err != nil || !info.IsDir() {
 		return okCheck("v2-scripts-layout", "no top-level scripts/ directory found")
 	}
+	// ResolveScripts (script_resolve.go) auto-materializes top-level scripts/
+	// as symlinks into .gc/system/packs/*/scripts/ on every start/reload. Those
+	// are expected PackV2 runtime artifacts — only user-authored real files
+	// represent the deprecated V1 layout worth warning about.
+	realFiles, walkErr := legacyTopLevelScripts(path)
+	if walkErr != nil {
+		return warnCheck("v2-scripts-layout",
+			fmt.Sprintf("inspecting top-level scripts/: %v", walkErr),
+			"resolve filesystem errors and rerun gc doctor",
+			[]string{"scripts/"})
+	}
+	if len(realFiles) == 0 {
+		return okCheck("v2-scripts-layout", "no top-level scripts/ directory found")
+	}
 	return warnCheck("v2-scripts-layout",
-		"top-level scripts/ is deprecated; move scripts to commands/ or assets/",
+		"top-level scripts/ contains legacy real files; move scripts to commands/ or assets/",
 		"move entrypoint scripts next to commands/doctor entries or under assets/",
-		[]string{"scripts/"})
+		realFiles)
+}
+
+// legacyTopLevelScripts returns relative paths (under "scripts/") of real
+// (non-symlink) files in the top-level scripts directory. Symlinks are
+// ignored — they are created by ResolveScripts from pack layers.
+func legacyTopLevelScripts(dir string) ([]string, error) {
+	var real []string
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, lErr := os.Lstat(p)
+		if lErr != nil {
+			return nil
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, rErr := filepath.Rel(dir, p)
+		if rErr != nil {
+			return nil
+		}
+		real = append(real, filepath.Join("scripts", rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(real)
+	return real, nil
 }
 
 type v2WorkspaceNameCheck struct{}

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -37,9 +37,10 @@ name = "helper"
 scope = "city"
 `)
 	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
-	if err := os.MkdirAll(filepath.Join(cityDir, "scripts"), 0o755); err != nil {
-		t.Fatalf("MkdirAll(scripts): %v", err)
-	}
+	// Legacy V1 scripts: user-authored real file at top-level scripts/.
+	// Symlinks (added by ResolveScripts in V2) must not trigger this check;
+	// only real files do. See TestV2ScriptsLayoutPassesForSymlinkOnlyDir.
+	writeDoctorFile(t, cityDir, "scripts/legacy.sh", "#!/bin/sh\necho legacy\n")
 
 	var buf bytes.Buffer
 	d := &doctor.Doctor{}
@@ -71,6 +72,75 @@ scope = "city"
 	}
 	if !strings.Contains(out, ".template.md") {
 		t.Fatalf("doctor output missing .template.md guidance:\n%s", out)
+	}
+}
+
+func TestV2ScriptsLayoutPassesForSymlinkOnlyDir(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	// Source file the symlink will point to — outside the scripts dir,
+	// matching how ResolveScripts links into .gc/system/packs/*/scripts/.
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(srcFile, filepath.Join(scriptsDir, "helper.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("symlink-only scripts/ should pass; got status=%v message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+}
+
+func TestV2ScriptsLayoutWarnsOnRealFilesAlongsideSymlinks(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "resolved.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(srcFile, filepath.Join(scriptsDir, "resolved.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "legacy.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(legacy): %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("mixed scripts/ should warn; got status=%v", res.Status)
+	}
+	var hasLegacy, hasResolved bool
+	for _, d := range res.Details {
+		if strings.Contains(d, "legacy.sh") {
+			hasLegacy = true
+		}
+		if strings.Contains(d, "resolved.sh") {
+			hasResolved = true
+		}
+	}
+	if !hasLegacy {
+		t.Errorf("warning should cite legacy.sh; details=%v", res.Details)
+	}
+	if hasResolved {
+		t.Errorf("warning should not cite symlinked resolved.sh; details=%v", res.Details)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Resolves the contradiction described in #1018: `gc doctor` warned about top-level `scripts/` while `gc start` / `gc init` / config reload regenerated it on every invocation.
- `v2ScriptsLayoutCheck` now walks the directory and warns only when at least one **real (non-symlink) file** is present. The pack-resolved symlinks that `ResolveScripts` (script_resolve.go) materializes into `scripts/` pass through cleanly as expected PackV2 runtime artifacts.
- `ResolveScripts` already explicitly refuses to overwrite real files (`script_resolve.go:66-68`), so the real-file/symlink split is a well-defined semantic.

## Changes

- `cmd/gc/doctor_v2_checks.go` — `v2ScriptsLayoutCheck.Run` gains a `legacyTopLevelScripts` walker that returns only real file paths; empty and symlink-only directories return `okCheck`.
- `cmd/gc/doctor_v2_checks_test.go`:
  - Updated `TestV2DeprecationChecksWarnOnLegacyPatterns` to seed a real `scripts/legacy.sh` (the original test relied implicitly on the old "any scripts/ dir warns" behavior).
  - Added `TestV2ScriptsLayoutPassesForSymlinkOnlyDir` — confirms symlink-only directories pass.
  - Added `TestV2ScriptsLayoutWarnsOnRealFilesAlongsideSymlinks` — confirms mixed directories warn and cite only the real files.

## Test plan

- [x] `go test ./cmd/gc/ -run "V2Scripts|V2Deprecation" -count=1` (9/9 pass)
- [x] `go test ./cmd/gc/ -run "Doctor|doctor" -count=1` (pass, ~5s)
- [x] `go vet ./cmd/gc/` clean
- [x] End-to-end on a real city: rebuilt `gc`, ran `gc doctor` against a workspace whose `scripts/` is populated by `resolveConfiguredScripts` with 17 symlinks into `.gc/system/packs/*/scripts/` — `v2-scripts-layout` now passes.

Fixes #1018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)