### PR TITLE
quality: Wave 1 beads storage core

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -310,26 +310,37 @@ type bdIssue struct {
 // parseIssuesTolerant unmarshals a JSON array of bdIssue objects, skipping
 // any entries that fail to parse (e.g. corrupt metadata with non-string values).
 // This prevents a single bad bead from breaking all list operations.
-func parseIssuesTolerant(data []byte) []bdIssue {
+func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
 	var raw []json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil
+		return nil, fmt.Errorf("parsing JSON: %w", err)
 	}
 	result := make([]bdIssue, 0, len(raw))
+	var parseErr error
 	for _, r := range raw {
 		var issue bdIssue
 		if err := json.Unmarshal(r, &issue); err != nil {
-			// Skip corrupt entry — log the ID if we can extract it.
 			var peek struct {
 				ID string `json:"id"`
 			}
 			_ = json.Unmarshal(r, &peek)
-			fmt.Fprintf(os.Stderr, "beads: skipping corrupt bead %q: %v\n", peek.ID, err)
+			if peek.ID == "" {
+				peek.ID = "<unknown>"
+			}
+			parseErr = errors.Join(parseErr, fmt.Errorf("%s: %w", peek.ID, err))
 			continue
 		}
 		result = append(result, issue)
 	}
-	return result
+	if parseErr != nil {
+		skipped := len(raw) - len(result)
+		beadNoun := "beads"
+		if skipped == 1 {
+			beadNoun = "bead"
+		}
+		return result, fmt.Errorf("skipped %d corrupt %s: %w", skipped, beadNoun, parseErr)
+	}
+	return result, nil
 }
 
 // toBead converts a bdIssue to a Gas City Bead. CreatedAt is truncated to
@@ -526,6 +537,9 @@ func (s *BdStore) SetMetadata(id, key, value string) error {
 	_, err := s.runner(s.dir, "bd", "update", "--json", id,
 		"--set-metadata", key+"="+value)
 	if err != nil {
+		if isBdNotFound(err) {
+			return fmt.Errorf("setting metadata on %q: %w", id, ErrNotFound)
+		}
 		return fmt.Errorf("setting metadata on %q: %w", id, err)
 	}
 	return nil
@@ -549,6 +563,9 @@ func (s *BdStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	}
 	_, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
+		if isBdNotFound(err) {
+			return fmt.Errorf("setting metadata on %q: %w", id, ErrNotFound)
+		}
 		return fmt.Errorf("setting metadata on %q: %w", id, err)
 	}
 	return nil
@@ -574,7 +591,9 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 	// prevent metadata writes on closed beads).
 	for _, id := range ids {
 		if len(metadata) > 0 {
-			_ = s.SetMetadataBatch(id, metadata)
+			if err := s.SetMetadataBatch(id, metadata); err != nil {
+				return 0, err
+			}
 		}
 	}
 
@@ -584,12 +603,15 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 	if err != nil {
 		// Fall back to individual closes on batch failure.
 		closed := 0
+		fallbackErr := fmt.Errorf("bd close batch: %w", err)
 		for _, id := range ids {
 			if closeErr := s.Close(id); closeErr == nil {
 				closed++
+			} else {
+				fallbackErr = errors.Join(fallbackErr, closeErr)
 			}
 		}
-		return closed, nil
+		return closed, fallbackErr
 	}
 	return len(ids), nil
 }
@@ -672,12 +694,16 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bd list: %w", err)
 	}
-	issues := parseIssuesTolerant(extractJSON(out))
+	issues, parseErr := parseIssuesTolerant(extractJSON(out))
 	result := make([]Bead, len(issues))
 	for i := range issues {
 		result[i] = issues[i].toBead()
 	}
-	return applyListQuery(result, query), nil
+	filtered := applyListQuery(result, query)
+	if parseErr != nil {
+		return filtered, fmt.Errorf("bd list: %w", parseErr)
+	}
+	return filtered, nil
 }
 
 // ListOpen returns non-closed beads via bd list. Pass a status to filter further.
@@ -740,7 +766,7 @@ func (s *BdStore) Ready() ([]Bead, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bd ready: %w", err)
 	}
-	issues := parseIssuesTolerant(extractJSON(out))
+	issues, parseErr := parseIssuesTolerant(extractJSON(out))
 	result := make([]Bead, 0, len(issues))
 	for i := range issues {
 		bead := issues[i].toBead()
@@ -748,6 +774,9 @@ func (s *BdStore) Ready() ([]Bead, error) {
 			continue
 		}
 		result = append(result, bead)
+	}
+	if parseErr != nil {
+		return result, fmt.Errorf("bd ready: %w", parseErr)
 	}
 	return result, nil
 }

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -311,6 +311,9 @@ type bdIssue struct {
 // any entries that fail to parse (e.g. corrupt metadata with non-string values).
 // This prevents a single bad bead from breaking all list operations.
 func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, nil
+	}
 	var raw []json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parsing JSON: %w", err)
@@ -603,7 +606,7 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 	if err != nil {
 		// Fall back to individual closes on batch failure.
 		closed := 0
-		fallbackErr := fmt.Errorf("bd close batch: %w", err)
+		var fallbackErr error
 		for _, id := range ids {
 			if closeErr := s.Close(id); closeErr == nil {
 				closed++
@@ -611,7 +614,10 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 				fallbackErr = errors.Join(fallbackErr, closeErr)
 			}
 		}
-		return closed, fallbackErr
+		if fallbackErr != nil {
+			return closed, errors.Join(fmt.Errorf("bd close batch: %w", err), fallbackErr)
+		}
+		return closed, nil
 	}
 	return len(ids), nil
 }
@@ -701,6 +707,9 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	}
 	filtered := applyListQuery(result, query)
 	if parseErr != nil {
+		if len(filtered) > 0 {
+			return filtered, nil
+		}
 		return filtered, fmt.Errorf("bd list: %w", parseErr)
 	}
 	return filtered, nil
@@ -776,6 +785,9 @@ func (s *BdStore) Ready() ([]Bead, error) {
 		result = append(result, bead)
 	}
 	if parseErr != nil {
+		if len(result) > 0 {
+			return result, nil
+		}
 		return result, fmt.Errorf("bd ready: %w", parseErr)
 	}
 	return result, nil

--- a/internal/beads/bdstore_graph_apply.go
+++ b/internal/beads/bdstore_graph_apply.go
@@ -49,8 +49,8 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 	if err := json.Unmarshal(extractJSON(out), &result); err != nil {
 		return nil, fmt.Errorf("bd create --graph: parsing JSON: %w", err)
 	}
-	if len(result.IDs) == 0 {
-		return nil, fmt.Errorf("bd create --graph: empty result")
+	if err := ValidateGraphApplyResult(plan, &result); err != nil {
+		return nil, fmt.Errorf("bd create --graph: %w", err)
 	}
 	return &result, nil
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -422,6 +422,76 @@ func TestBdStoreCloseCLIError(t *testing.T) {
 	}
 }
 
+func TestBdStoreCloseAllReturnsMetadataWriteFailure(t *testing.T) {
+	metadataErr := errors.New("metadata write failed")
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd update --json bd-abc-123 --set-metadata source=wave1`: {
+			err: metadataErr,
+		},
+		`bd close --json bd-abc-123`: {
+			out: []byte(`[{"id":"bd-abc-123","title":"test","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	closed, err := s.CloseAll([]string{"bd-abc-123"}, map[string]string{"source": "wave1"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if !strings.Contains(err.Error(), `setting metadata on "bd-abc-123"`) {
+		t.Fatalf("error = %q, want metadata context", err)
+	}
+	if !errors.Is(err, metadataErr) {
+		t.Fatalf("error = %v, want wrapped metadata error", err)
+	}
+}
+
+func TestBdStoreCloseAllReturnsPartialCountAndErrorOnFallbackFailure(t *testing.T) {
+	batchErr := errors.New("batch close failed")
+	individualErr := errors.New("single close failed")
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd close --json bd-1 bd-2`: {
+			err: batchErr,
+		},
+		`bd close --json bd-1`: {
+			out: []byte(`[{"id":"bd-1","title":"one","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+		`bd close --json bd-2`: {
+			err: individualErr,
+		},
+		`bd show --json bd-2`: {
+			out: []byte(`[{"id":"bd-2","title":"two","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	closed, err := s.CloseAll([]string{"bd-1", "bd-2"}, nil)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, batchErr) {
+		t.Fatalf("error = %v, want wrapped batch error", err)
+	}
+	if !errors.Is(err, individualErr) {
+		t.Fatalf("error = %v, want wrapped individual error", err)
+	}
+	if !strings.Contains(err.Error(), `closing bead "bd-2"`) {
+		t.Fatalf("error = %q, want failing bead context", err)
+	}
+}
+
 // --- List ---
 
 func TestBdStoreList(t *testing.T) {
@@ -477,6 +547,35 @@ func TestBdStoreListError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bd list") {
 		t.Errorf("error = %q, want to contain 'bd list'", err)
+	}
+}
+
+func TestBdStoreListReturnsPartialResultsAndErrorOnCorruptEntries(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --include-infra --include-gates --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-good","title":"good","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time"}
+			]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ListOpen()
+	if len(got) != 1 || got[0].ID != "bd-good" {
+		t.Fatalf("ListOpen() = %v, want only bd-good", got)
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "skipped 1 corrupt bead") {
+		t.Fatalf("error = %q, want skipped-entry summary", err)
+	}
+	if !strings.Contains(err.Error(), "bd-bad") {
+		t.Fatalf("error = %q, want corrupt bead id", err)
 	}
 }
 
@@ -572,6 +671,26 @@ func TestBdStoreReadyError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bd ready") {
 		t.Errorf("error = %q, want to contain 'bd ready'", err)
+	}
+}
+
+func TestBdStoreReadyReturnsParseErrorOnMalformedJSON(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --limit 0`: {
+			out: []byte(`{not json`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	_, err := s.Ready()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "parsing JSON") {
+		t.Fatalf("error = %q, want parsing JSON context", err)
 	}
 }
 
@@ -974,6 +1093,34 @@ func TestBdStoreSetMetadataError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "setting metadata") {
 		t.Errorf("error = %q, want to contain 'setting metadata'", err)
+	}
+}
+
+func TestBdStoreSetMetadataCLINotFound(t *testing.T) {
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1: Error updating x: issue not found: bd-42")
+	}
+	s := beads.NewBdStore("/city", runner)
+	err := s.SetMetadata("bd-42", "key", "value")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestBdStoreSetMetadataBatchCLINotFound(t *testing.T) {
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1: Error updating x: no issue found matching \"bd-42\"")
+	}
+	s := beads.NewBdStore("/city", runner)
+	err := s.SetMetadataBatch("bd-42", map[string]string{"key": "value"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
 	}
 }
 
@@ -1383,5 +1530,26 @@ func TestBdStoreApplyGraphPlan(t *testing.T) {
 	}
 	if matches, _ := filepath.Glob(filepath.Join(dir, ".gc", "tmp", "graph-apply-*.json")); len(matches) != 0 {
 		t.Fatalf("temp graph apply files were not cleaned up: %v", matches)
+	}
+}
+
+func TestBdStoreApplyGraphPlanRejectsMissingIDs(t *testing.T) {
+	dir := t.TempDir()
+	runner := func(string, string, ...string) ([]byte, error) {
+		return []byte(`{"ids":{"mol.root":"bd-1"}}`), nil
+	}
+
+	s := beads.NewBdStore(dir, runner)
+	_, err := s.ApplyGraphPlan(t.Context(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "mol.root", Title: "Root"},
+			{Key: "mol.step", Title: "Step"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "missing IDs for keys: mol.step") {
+		t.Fatalf("error = %q, want missing key detail", err)
 	}
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -492,6 +492,33 @@ func TestBdStoreCloseAllReturnsPartialCountAndErrorOnFallbackFailure(t *testing.
 	}
 }
 
+func TestBdStoreCloseAllFallbackSuccessReturnsNil(t *testing.T) {
+	batchErr := errors.New("batch close failed")
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd close --json bd-1 bd-2`: {
+			err: batchErr,
+		},
+		`bd close --json bd-1`: {
+			out: []byte(`[{"id":"bd-1","title":"one","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+		`bd close --json bd-2`: {
+			out: []byte(`[{"id":"bd-2","title":"two","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	closed, err := s.CloseAll([]string{"bd-1", "bd-2"}, nil)
+	if err != nil {
+		t.Fatalf("CloseAll returned error after successful fallback: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want 2", closed)
+	}
+}
+
 // --- List ---
 
 func TestBdStoreList(t *testing.T) {
@@ -536,6 +563,23 @@ func TestBdStoreListEmpty(t *testing.T) {
 	}
 }
 
+func TestBdStoreListEmptyOutputMeansNoBeads(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --include-infra --include-gates --limit 0`: {out: []byte(" \n\t")},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ListOpen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List() returned %d beads, want 0", len(got))
+	}
+}
+
 func TestBdStoreListError(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1")
@@ -550,7 +594,7 @@ func TestBdStoreListError(t *testing.T) {
 	}
 }
 
-func TestBdStoreListReturnsPartialResultsAndErrorOnCorruptEntries(t *testing.T) {
+func TestBdStoreListReturnsPartialResultsOnCorruptEntries(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte
 		err error
@@ -568,14 +612,8 @@ func TestBdStoreListReturnsPartialResultsAndErrorOnCorruptEntries(t *testing.T) 
 	if len(got) != 1 || got[0].ID != "bd-good" {
 		t.Fatalf("ListOpen() = %v, want only bd-good", got)
 	}
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "skipped 1 corrupt bead") {
-		t.Fatalf("error = %q, want skipped-entry summary", err)
-	}
-	if !strings.Contains(err.Error(), "bd-bad") {
-		t.Fatalf("error = %q, want corrupt bead id", err)
+	if err != nil {
+		t.Fatalf("ListOpen() error = %v, want nil with usable partial results", err)
 	}
 }
 

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -3,10 +3,8 @@ package beads
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
-	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,57 +15,58 @@ import (
 // through to the backing store and update the cache on success.
 //
 // External writes (agents running bd directly) are picked up via the
-// bd hook → gc event emit → event bus path. Call ApplyEvent when the
-// event bus delivers bead.created/updated/closed events. A background
-// reconciler periodically syncs as a safety net.
+// bd hook -> gc event emit -> event bus path. Call ApplyEvent when the
+// event bus delivers bead.created/updated/closed events. The background
+// reconciler acts as a watchdog and only performs a full scan once the
+// cache has gone stale or degraded.
 //
 // Only wraps BdStore because the event hook path requires dolt/bd.
 type CachingStore struct {
 	backing Store // runtime: always *BdStore; tests may use MemStore
 
-	mu       sync.RWMutex
-	beads    map[string]Bead
-	deps     map[string][]Dep
-	state    cacheState
-	syncedAt time.Time
-
-	// primeReady is closed when Prime completes (success or failure).
-	// Full-scan reads (List) block on this instead of falling through
-	// to a bd subprocess, preventing stampedes during startup.
-	primeReady chan struct{}
-	primeErr   error // set if Prime fails; readers fall through to backing
+	mu          sync.RWMutex
+	beads       map[string]Bead
+	deps        map[string][]Dep
+	state       cacheState
+	lastFreshAt time.Time
 
 	reconciling  atomic.Bool
 	syncFailures int
 	stats        CacheStats
 	onChange     func(eventType, beadID string, payload json.RawMessage)
 	cancelFn     context.CancelFunc
+	problemf     func(string)
 }
 
 type cacheState int
 
 const (
 	cacheUninitialized cacheState = iota
-	cachePartial                  // PrimeActive loaded active beads; filtered active queries hit cache immediately
+	cachePartial                  // PrimeActive loaded active beads; active queries can use the cache immediately.
 	cacheLive
 	cacheDegraded
 )
 
-// CacheStats exposes reconciliation metrics for observability.
+// CacheStats exposes cache freshness, reconciliation, and problem state.
 type CacheStats struct {
 	TotalBeads      int
 	TotalDeps       int
+	LastFreshAt     time.Time
 	LastReconcileAt time.Time
 	LastReconcileMs float64
 	Adds            int64
 	Removes         int64
 	Updates         int64
 	SyncFailures    int
+	ProblemCount    int64
+	LastProblemAt   time.Time
+	LastProblem     string
 	State           string
 }
 
 const (
 	maxCacheSyncFailures         = 5
+	cacheReconcilePollInterval   = 5 * time.Second
 	cacheReconcileIntervalSmall  = 30 * time.Second
 	cacheReconcileIntervalMedium = 60 * time.Second
 	cacheReconcileIntervalLarge  = 120 * time.Second
@@ -75,11 +74,11 @@ const (
 
 // NewCachingStore wraps a BdStore with an in-memory read cache.
 // Call Prime() before serving reads, then StartReconciler() for
-// background sync. The onChange callback (optional) is called for
+// watchdog reconciliation. The onChange callback (optional) is called for
 // each detected external change with event type and bead JSON.
 //
-// Only BdStore is supported because the event hook path (bd hooks →
-// gc event emit → event bus → ApplyEvent) requires dolt infrastructure.
+// Only BdStore is supported because the event hook path (bd hooks ->
+// gc event emit -> event bus -> ApplyEvent) requires dolt infrastructure.
 func NewCachingStore(backing *BdStore, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return newCachingStore(backing, onChange)
 }
@@ -92,19 +91,20 @@ func NewCachingStoreForTest(backing Store, onChange func(eventType, beadID strin
 
 func newCachingStore(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
-		backing:    backing,
-		beads:      make(map[string]Bead),
-		deps:       make(map[string][]Dep),
-		onChange:   onChange,
-		primeReady: make(chan struct{}),
+		backing:  backing,
+		beads:    make(map[string]Bead),
+		deps:     make(map[string][]Dep),
+		onChange: onChange,
+		problemf: func(msg string) {
+			log.Printf("beads cache: %s", msg)
+		},
 	}
 }
 
 // PrimeActive loads all non-closed beads (open + in_progress) into the
-// cache. These are fast indexed queries (~1-2s total) that populate
-// enough data for the startup path (adoption, session snapshot, desired
-// state) without waiting for the full Prime. The cache enters
-// cachePartial state: filtered List queries and Get hit cache for primed
+// cache. These are fast indexed queries that populate enough data for
+// startup paths without waiting for a full scan. The cache enters
+// cachePartial state: filtered active queries and Get hit cache for primed
 // beads, while closed-bead queries still delegate to the backing store.
 func (c *CachingStore) PrimeActive() error {
 	var all []Bead
@@ -124,12 +124,12 @@ func (c *CachingStore) PrimeActive() error {
 	if c.state == cacheUninitialized {
 		c.state = cachePartial
 	}
-	log.Printf("caching-store: pre-primed %d active beads", len(all))
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
 	return nil
 }
 
 // Prime loads all active beads and deps from the backing store into memory.
-// Closes the primeReady channel on completion so blocked callers can proceed.
 // Retries up to 3 times on failure since bd list can time out under
 // concurrent dolt load.
 func (c *CachingStore) Prime(_ context.Context) error {
@@ -140,14 +140,12 @@ func (c *CachingStore) Prime(_ context.Context) error {
 		if err == nil {
 			break
 		}
-		log.Printf("caching-store: prime attempt %d/3 failed: %v", attempt, err)
+		c.recordProblem(fmt.Sprintf("prime cache attempt %d/3", attempt), err)
 		if attempt < 3 {
 			time.Sleep(time.Duration(attempt*5) * time.Second)
 		}
 	}
 	if err != nil {
-		c.primeErr = err
-		c.signalPrimeReady()
 		return fmt.Errorf("prime list: %w", err)
 	}
 
@@ -155,44 +153,26 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	for _, b := range all {
 		beadMap[b.ID] = cloneBead(b)
 	}
-	// Batch-fetch deps in one subprocess call (if backing is BdStore).
-	depMap := make(map[string][]Dep)
-	if bdStore, ok := c.backing.(*BdStore); ok && len(beadMap) > 0 {
-		ids := make([]string, 0, len(beadMap))
-		for id := range beadMap {
-			ids = append(ids, id)
-		}
-		if batchDeps, err := bdStore.DepListBatch(ids); err == nil {
-			for id, deps := range batchDeps {
-				depMap[id] = slices.Clone(deps)
-			}
-		}
+
+	depMap, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
+	if depErr != nil {
+		c.recordProblem("prime dep cache", depErr)
 	}
 
+	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.beads = beadMap
 	c.deps = depMap
 	c.state = cacheLive
-	c.syncedAt = time.Now()
 	c.syncFailures = 0
+	c.stats.SyncFailures = 0
+	c.markFreshLocked(now)
 	c.updateStatsLocked()
-	log.Printf("caching-store: primed %d beads, %d dep entries", len(beadMap), len(depMap))
-	c.signalPrimeReady()
 	return nil
 }
 
-// signalPrimeReady closes the primeReady channel exactly once.
-func (c *CachingStore) signalPrimeReady() {
-	select {
-	case <-c.primeReady:
-		// Already closed (from a previous Prime call).
-	default:
-		close(c.primeReady)
-	}
-}
-
-// StartReconciler launches background periodic sync. Cancel ctx to stop.
+// StartReconciler launches watchdog reconciliation. Cancel ctx to stop.
 func (c *CachingStore) StartReconciler(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancelFn = cancel
@@ -210,8 +190,11 @@ func (c *CachingStore) StopReconciler() {
 func (c *CachingStore) Stats() CacheStats {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+
 	s := c.stats
 	switch c.state {
+	case cachePartial:
+		s.State = "partial"
 	case cacheLive:
 		s.State = "live"
 	case cacheDegraded:
@@ -232,621 +215,31 @@ func (c *CachingStore) IsLive() bool {
 // Backing returns the underlying store.
 func (c *CachingStore) Backing() Store { return c.backing }
 
-// ApplyEvent updates the cache from a bd hook event. Call this when the
-// event bus delivers a bead.created, bead.updated, or bead.closed event
-// with the full bead JSON payload. This provides sub-second cache
-// freshness for agent-initiated bd mutations without waiting for
-// reconciliation.
-func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
-	if len(payload) == 0 {
-		return
-	}
-	var b Bead
-	if err := json.Unmarshal(payload, &b); err != nil {
-		return
-	}
-	if b.ID == "" {
-		return
-	}
-	// bd hook payloads use "issue_type" while Bead uses "type". If Type
-	// wasn't populated from "type", check for the bd field name.
-	if b.Type == "" {
-		var bdCompat struct {
-			IssueType string `json:"issue_type"`
-		}
-		if err := json.Unmarshal(payload, &bdCompat); err == nil && bdCompat.IssueType != "" {
-			b.Type = bdCompat.IssueType
-		}
-	}
+func (c *CachingStore) markFreshLocked(now time.Time) {
+	c.lastFreshAt = now
+	c.stats.LastFreshAt = now
+}
 
+func (c *CachingStore) recordProblem(op string, err error) {
+	if err == nil {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.state != cacheLive {
+	c.recordProblemLocked(op, err)
+}
+
+func (c *CachingStore) recordProblemLocked(op string, err error) {
+	if err == nil {
 		return
 	}
-
-	switch eventType {
-	case "bead.created":
-		if _, exists := c.beads[b.ID]; !exists {
-			c.beads[b.ID] = cloneBead(b)
-			c.updateStatsLocked()
-		}
-	case "bead.updated":
-		c.beads[b.ID] = cloneBead(b)
-	case "bead.closed":
-		if existing, ok := c.beads[b.ID]; ok {
-			existing.Status = "closed"
-			// Merge metadata from the event — close events often carry
-			// gc.outcome and other fields set in the same bd update.
-			for k, v := range b.Metadata {
-				if existing.Metadata == nil {
-					existing.Metadata = make(map[string]string)
-				}
-				existing.Metadata[k] = v
-			}
-			c.beads[b.ID] = existing
-		} else {
-			// Bead not in cache yet — store the closed version.
-			c.beads[b.ID] = cloneBead(b)
-			c.updateStatsLocked()
-		}
+	msg := fmt.Sprintf("%s: %v", op, err)
+	c.stats.ProblemCount++
+	c.stats.LastProblemAt = time.Now()
+	c.stats.LastProblem = msg
+	if c.problemf != nil {
+		c.problemf(msg)
 	}
-}
-
-// ApplyDepEvent updates the dep cache for a bead. Call after dep
-// mutations are detected via events or write-through.
-func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.state != cacheLive {
-		return
-	}
-	c.deps[beadID] = slices.Clone(deps)
-}
-
-// ── Read methods (cache when live, fallback to backing) ─────────────
-
-// List returns beads matching the query. Active-bead queries are served from
-// cache when available. IncludeClosed queries merge cached active results with
-// backing-store history when possible so callers keep the old best-effort
-// behavior from ListByLabel/ListByMetadata during transient bd failures.
-func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
-	if !query.HasFilter() && !query.AllowScan {
-		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
-	}
-
-	c.mu.RLock()
-	state := c.state
-	if state == cacheLive || state == cachePartial {
-		// PrimeActive loads the full active set (open + in_progress), so
-		// active-only queries are complete even before the history prime finishes.
-		cached := make([]Bead, 0, len(c.beads))
-		for _, b := range c.beads {
-			if !query.Matches(b) {
-				continue
-			}
-			cached = append(cached, cloneBead(b))
-		}
-		c.mu.RUnlock()
-
-		finish := func(items []Bead) ([]Bead, error) {
-			sortBeadsForQuery(items, query.Sort)
-			if query.Limit > 0 && len(items) > query.Limit {
-				items = items[:query.Limit]
-			}
-			return items, nil
-		}
-
-		if !query.IncludesClosed() {
-			return finish(cached)
-		}
-
-		// The cache never has a complete closed-only or parent-history view, so
-		// preserve the old backing-store behavior for those query shapes.
-		if query.Status == "closed" || query.ParentID != "" {
-			return c.backing.List(query)
-		}
-
-		all, err := c.backing.List(query)
-		if err != nil {
-			return finish(cached)
-		}
-
-		seen := make(map[string]bool, len(cached))
-		for _, b := range cached {
-			seen[b.ID] = true
-		}
-		for _, b := range all {
-			if seen[b.ID] {
-				continue
-			}
-			cached = append(cached, b)
-			seen[b.ID] = true
-		}
-		return finish(cached)
-	}
-	c.mu.RUnlock()
-	return c.backing.List(query)
-}
-
-// ListOpen returns all cached beads, optionally filtered by status.
-func (c *CachingStore) ListOpen(status ...string) ([]Bead, error) {
-	query := ListQuery{AllowScan: true}
-	if len(status) > 0 {
-		query.Status = status[0]
-	}
-	return c.List(query)
-}
-
-// Get returns a single bead by ID from the cache or backing store.
-func (c *CachingStore) Get(id string) (Bead, error) {
-	c.mu.RLock()
-	if c.state == cacheLive || c.state == cachePartial {
-		if b, ok := c.beads[id]; ok {
-			c.mu.RUnlock()
-			return cloneBead(b), nil
-		}
-		c.mu.RUnlock()
-		return c.backing.Get(id)
-	}
-	c.mu.RUnlock()
-	return c.backing.Get(id)
-}
-
-// Ready returns open beads whose blocking deps are all closed.
-func (c *CachingStore) Ready() ([]Bead, error) {
-	c.mu.RLock()
-	if c.state == cacheLive {
-		statusByID := make(map[string]string, len(c.beads))
-		depsByID := make(map[string][]Dep, len(c.deps))
-		openBeads := make([]Bead, 0, len(c.beads))
-		missingDepIDs := make(map[string]struct{})
-		for _, b := range c.beads {
-			statusByID[b.ID] = b.Status
-			if b.Status == "open" && !IsReadyExcludedType(b.Type) {
-				openBeads = append(openBeads, cloneBead(b))
-			}
-		}
-		for _, b := range openBeads {
-			deps := slices.Clone(c.deps[b.ID])
-			depsByID[b.ID] = deps
-			for _, dep := range deps {
-				switch dep.Type {
-				case "blocks", "waits-for", "conditional-blocks":
-				default:
-					continue
-				}
-				if _, ok := statusByID[dep.DependsOnID]; !ok {
-					missingDepIDs[dep.DependsOnID] = struct{}{}
-				}
-			}
-		}
-		c.mu.RUnlock()
-
-		for depID := range missingDepIDs {
-			dep, err := c.backing.Get(depID)
-			if err != nil {
-				if errors.Is(err, ErrNotFound) {
-					continue
-				}
-				return nil, err
-			}
-			statusByID[depID] = dep.Status
-		}
-
-		var result []Bead
-		for _, b := range openBeads {
-			blocked := false
-			for _, dep := range depsByID[b.ID] {
-				switch dep.Type {
-				case "blocks", "waits-for", "conditional-blocks":
-				default:
-					continue
-				}
-				if statusByID[dep.DependsOnID] != "closed" {
-					blocked = true
-					break
-				}
-			}
-			if !blocked {
-				result = append(result, cloneBead(b))
-			}
-		}
-		return result, nil
-	}
-	c.mu.RUnlock()
-	return c.backing.Ready()
-}
-
-// Children returns beads with the given parent ID.
-func (c *CachingStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
-	return c.List(ListQuery{
-		ParentID:      parentID,
-		IncludeClosed: HasOpt(opts, IncludeClosed),
-		Sort:          SortCreatedAsc,
-	})
-}
-
-// ListByLabel returns beads matching the given label. By default, serves from
-// cache only (non-closed beads). Pass IncludeClosed to also query the backing
-// store for closed beads and merge results.
-func (c *CachingStore) ListByLabel(label string, limit int, opts ...QueryOpt) ([]Bead, error) {
-	return c.List(ListQuery{
-		Label:         label,
-		Limit:         limit,
-		IncludeClosed: HasOpt(opts, IncludeClosed),
-		Sort:          SortCreatedDesc,
-	})
-}
-
-// ListByAssignee returns beads assigned to the given agent with matching status.
-func (c *CachingStore) ListByAssignee(assignee, status string, limit int) ([]Bead, error) {
-	return c.List(ListQuery{
-		Assignee: assignee,
-		Status:   status,
-		Limit:    limit,
-		Sort:     SortCreatedDesc,
-	})
-}
-
-// ListByMetadata filters beads by metadata key-value pairs. By default, serves
-// from cache only (non-closed beads). Pass IncludeClosed to also query the
-// backing store for closed beads and merge results.
-func (c *CachingStore) ListByMetadata(filters map[string]string, limit int, opts ...QueryOpt) ([]Bead, error) {
-	return c.List(ListQuery{
-		Metadata:      filters,
-		Limit:         limit,
-		IncludeClosed: HasOpt(opts, IncludeClosed),
-		Sort:          SortCreatedDesc,
-	})
-}
-
-func matchesMetadata(b Bead, filters map[string]string) bool {
-	for k, v := range filters {
-		if b.Metadata[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
-// DepList returns dependencies for a bead in the given direction.
-func (c *CachingStore) DepList(id, direction string) ([]Dep, error) {
-	c.mu.RLock()
-	if c.state == cacheLive {
-		if direction == "down" || direction == "" {
-			if deps, ok := c.deps[id]; ok {
-				c.mu.RUnlock()
-				return slices.Clone(deps), nil
-			}
-			// Dep not cached yet — fetch from backing and cache it.
-			c.mu.RUnlock()
-			deps, err := c.backing.DepList(id, direction)
-			if err != nil {
-				return nil, err
-			}
-			c.mu.Lock()
-			c.deps[id] = slices.Clone(deps)
-			c.mu.Unlock()
-			return deps, nil
-		}
-		// "up" — reverse lookup (best-effort from cache, fall through for uncached)
-		var result []Dep
-		for _, deps := range c.deps {
-			for _, d := range deps {
-				if d.DependsOnID == id {
-					result = append(result, d)
-				}
-			}
-		}
-		c.mu.RUnlock()
-		if len(result) > 0 {
-			return result, nil
-		}
-		// Cache might be incomplete for "up" — fall through.
-		return c.backing.DepList(id, direction)
-	}
-	c.mu.RUnlock()
-	return c.backing.DepList(id, direction)
-}
-
-// Ping delegates to the backing store.
-func (c *CachingStore) Ping() error {
-	return c.backing.Ping()
-}
-
-// ── Write methods (pass through + update cache) ─────────────────────
-
-// Create passes through to the backing store and updates the cache.
-func (c *CachingStore) Create(b Bead) (Bead, error) {
-	created, err := c.backing.Create(b)
-	if err != nil {
-		return created, err
-	}
-	c.mu.Lock()
-	c.beads[created.ID] = cloneBead(created)
-	c.mu.Unlock()
-	c.notifyChange("bead.created", created)
-	return created, nil
-}
-
-// Update passes through to the backing store and refreshes the cache.
-func (c *CachingStore) Update(id string, opts UpdateOpts) error {
-	if err := c.backing.Update(id, opts); err != nil {
-		return err
-	}
-	// Re-fetch from backing to get the authoritative state.
-	if fresh, err := c.backing.Get(id); err == nil {
-		c.mu.Lock()
-		c.beads[id] = cloneBead(fresh)
-		c.mu.Unlock()
-		c.notifyChange("bead.updated", fresh)
-	}
-	return nil
-}
-
-// Close marks a bead as closed in the backing store and cache.
-func (c *CachingStore) Close(id string) error {
-	if err := c.backing.Close(id); err != nil {
-		return err
-	}
-	c.mu.Lock()
-	if b, ok := c.beads[id]; ok {
-		b.Status = "closed"
-		c.beads[id] = b
-		c.mu.Unlock()
-		c.notifyChange("bead.closed", b)
-	} else {
-		c.mu.Unlock()
-	}
-	return nil
-}
-
-// CloseAll closes multiple beads and sets metadata on each.
-func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
-	n, err := c.backing.CloseAll(ids, metadata)
-	if err != nil {
-		return n, err
-	}
-	c.mu.Lock()
-	for _, id := range ids {
-		if b, ok := c.beads[id]; ok {
-			b.Status = "closed"
-			if b.Metadata == nil {
-				b.Metadata = make(map[string]string, len(metadata))
-			}
-			for k, v := range metadata {
-				b.Metadata[k] = v
-			}
-			c.beads[id] = b
-		}
-	}
-	c.mu.Unlock()
-	return n, nil
-}
-
-// SetMetadata sets a single metadata key-value on a bead.
-func (c *CachingStore) SetMetadata(id, key, value string) error {
-	if err := c.backing.SetMetadata(id, key, value); err != nil {
-		return err
-	}
-	c.mu.Lock()
-	if b, ok := c.beads[id]; ok {
-		if b.Metadata == nil {
-			b.Metadata = make(map[string]string)
-		}
-		b.Metadata[key] = value
-		c.beads[id] = b
-	}
-	c.mu.Unlock()
-	return nil
-}
-
-// SetMetadataBatch sets multiple metadata key-values on a bead.
-func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error {
-	if err := c.backing.SetMetadataBatch(id, kvs); err != nil {
-		return err
-	}
-	c.mu.Lock()
-	if b, ok := c.beads[id]; ok {
-		if b.Metadata == nil {
-			b.Metadata = make(map[string]string, len(kvs))
-		}
-		for k, v := range kvs {
-			b.Metadata[k] = v
-		}
-		c.beads[id] = b
-	}
-	c.mu.Unlock()
-	return nil
-}
-
-// DepAdd adds a dependency and updates the cache.
-func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
-	if err := c.backing.DepAdd(issueID, dependsOnID, depType); err != nil {
-		return err
-	}
-	c.mu.Lock()
-	deps := c.deps[issueID]
-	for i, d := range deps {
-		if d.DependsOnID == dependsOnID {
-			deps[i].Type = depType
-			c.deps[issueID] = deps
-			c.mu.Unlock()
-			return nil
-		}
-	}
-	c.deps[issueID] = append(deps, Dep{IssueID: issueID, DependsOnID: dependsOnID, Type: depType})
-	c.mu.Unlock()
-	return nil
-}
-
-// DepRemove removes a dependency and updates the cache.
-func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
-	if err := c.backing.DepRemove(issueID, dependsOnID); err != nil {
-		return err
-	}
-	c.mu.Lock()
-	deps := c.deps[issueID]
-	for i, d := range deps {
-		if d.DependsOnID == dependsOnID {
-			c.deps[issueID] = append(deps[:i], deps[i+1:]...)
-			break
-		}
-	}
-	c.mu.Unlock()
-	return nil
-}
-
-// ── Background reconciler ───────────────────────────────────────────
-
-func (c *CachingStore) reconcileLoop(ctx context.Context) {
-	timer := time.NewTimer(5 * time.Second)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-		}
-
-		if c.reconciling.CompareAndSwap(false, true) {
-			c.runReconciliation()
-			c.reconciling.Store(false)
-		}
-
-		timer.Reset(c.adaptiveInterval())
-	}
-}
-
-func (c *CachingStore) adaptiveInterval() time.Duration {
-	c.mu.RLock()
-	total := len(c.beads)
-	c.mu.RUnlock()
-	switch {
-	case total >= 5000:
-		return cacheReconcileIntervalLarge
-	case total >= 1000:
-		return cacheReconcileIntervalMedium
-	default:
-		return cacheReconcileIntervalSmall
-	}
-}
-
-func (c *CachingStore) runReconciliation() {
-	start := time.Now()
-	fresh, err := c.backing.List(ListQuery{AllowScan: true})
-	if err != nil {
-		c.mu.Lock()
-		c.syncFailures++
-		if c.syncFailures >= maxCacheSyncFailures && c.state == cacheLive {
-			c.state = cacheDegraded
-			log.Printf("caching-store: degraded after %d consecutive failures", c.syncFailures)
-		}
-		c.mu.Unlock()
-		log.Printf("caching-store: reconcile failed: %v", err)
-		return
-	}
-
-	freshByID := make(map[string]Bead, len(fresh))
-	for _, b := range fresh {
-		freshByID[b.ID] = b
-	}
-
-	c.mu.Lock()
-
-	var adds, removes, updates int64
-	var changedIDs []string
-
-	// Detect new and updated
-	for id, fb := range freshByID {
-		old, exists := c.beads[id]
-		if !exists {
-			c.beads[id] = cloneBead(fb)
-			adds++
-			changedIDs = append(changedIDs, id)
-			c.notifyChangeLocked("bead.created", fb)
-		} else if beadChanged(old, fb) {
-			c.beads[id] = cloneBead(fb)
-			updates++
-			changedIDs = append(changedIDs, id)
-			c.notifyChangeLocked("bead.updated", fb)
-		}
-	}
-
-	// Detect removed
-	for id, old := range c.beads {
-		if _, exists := freshByID[id]; !exists {
-			delete(c.beads, id)
-			delete(c.deps, id)
-			removes++
-			c.notifyChangeLocked("bead.closed", old)
-		}
-	}
-
-	c.syncFailures = 0
-	c.syncedAt = time.Now()
-	if c.state == cacheDegraded {
-		c.state = cacheLive
-		log.Printf("caching-store: recovered to live")
-	}
-
-	durMs := float64(time.Since(start).Microseconds()) / 1000.0
-	c.stats.LastReconcileAt = time.Now()
-	c.stats.LastReconcileMs = durMs
-	c.stats.Adds += adds
-	c.stats.Removes += removes
-	c.stats.Updates += updates
-	c.stats.SyncFailures = c.syncFailures
-	c.updateStatsLocked()
-	c.mu.Unlock()
-
-	// Batch-refresh deps for changed beads (one subprocess call).
-	if len(changedIDs) > 0 {
-		if bdStore, ok := c.backing.(*BdStore); ok {
-			if depMap, err := bdStore.DepListBatch(changedIDs); err == nil {
-				c.mu.Lock()
-				for id, deps := range depMap {
-					c.deps[id] = slices.Clone(deps)
-				}
-				c.mu.Unlock()
-			}
-		} else {
-			// Non-BdStore fallback: per-ID dep fetch.
-			for _, id := range changedIDs {
-				if deps, err := c.backing.DepList(id, "down"); err == nil {
-					c.mu.Lock()
-					c.deps[id] = slices.Clone(deps)
-					c.mu.Unlock()
-				}
-			}
-		}
-	}
-
-	if adds > 0 || removes > 0 || updates > 0 {
-		log.Printf("caching-store: reconciled in %.0fms (+%d -%d ~%d, %d total)",
-			durMs, adds, removes, updates, len(c.beads))
-	}
-}
-
-func (c *CachingStore) notifyChange(eventType string, b Bead) {
-	if c.onChange == nil {
-		return
-	}
-	payload, _ := json.Marshal(b)
-	c.onChange(eventType, b.ID, payload)
-}
-
-func (c *CachingStore) notifyChangeLocked(eventType string, b Bead) {
-	if c.onChange == nil {
-		return
-	}
-	payload, _ := json.Marshal(b)
-	// Unlock before callback to avoid holding the lock during event recording.
-	c.mu.Unlock()
-	c.onChange(eventType, b.ID, payload)
-	c.mu.Lock()
 }
 
 func (c *CachingStore) updateStatsLocked() {
@@ -856,40 +249,49 @@ func (c *CachingStore) updateStatsLocked() {
 		totalDeps += len(deps)
 	}
 	c.stats.TotalDeps = totalDeps
+	c.stats.SyncFailures = c.syncFailures
 }
 
-func beadChanged(old, fresh Bead) bool {
-	if old.Status != fresh.Status {
-		return true
+func beadIDs(beadMap map[string]Bead) []string {
+	ids := make([]string, 0, len(beadMap))
+	for id := range beadMap {
+		ids = append(ids, id)
 	}
-	if old.Title != fresh.Title {
-		return true
+	return ids
+}
+
+func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, error) {
+	depMap := make(map[string][]Dep)
+	if len(ids) == 0 {
+		return depMap, nil
 	}
-	if old.Assignee != fresh.Assignee {
-		return true
-	}
-	if old.Description != fresh.Description {
-		return true
-	}
-	if len(old.Metadata) != len(fresh.Metadata) {
-		return true
-	}
-	for k, v := range old.Metadata {
-		if fresh.Metadata[k] != v {
-			return true
+
+	if bdStore, ok := c.backing.(*BdStore); ok {
+		batchDeps, err := bdStore.DepListBatch(ids)
+		if err != nil {
+			return depMap, err
 		}
+		for id, deps := range batchDeps {
+			depMap[id] = cloneDeps(deps)
+		}
+		return depMap, nil
 	}
-	return len(old.Labels) != len(fresh.Labels)
+
+	for _, id := range ids {
+		deps, err := c.backing.DepList(id, "down")
+		if err != nil {
+			return depMap, fmt.Errorf("listing deps for %s: %w", id, err)
+		}
+		depMap[id] = cloneDeps(deps)
+	}
+	return depMap, nil
 }
 
-// Delete passes through to the backing store and removes from cache.
-func (c *CachingStore) Delete(id string) error {
-	if err := c.backing.Delete(id); err != nil {
-		return err
+func cloneDeps(deps []Dep) []Dep {
+	if len(deps) == 0 {
+		return nil
 	}
-	c.mu.Lock()
-	delete(c.beads, id)
-	delete(c.deps, id)
-	c.mu.Unlock()
-	return nil
+	cloned := make([]Dep, len(deps))
+	copy(cloned, deps)
+	return cloned
 }

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -27,6 +27,7 @@ type CachingStore struct {
 	mu          sync.RWMutex
 	beads       map[string]Bead
 	deps        map[string][]Dep
+	dirty       map[string]struct{}
 	state       cacheState
 	lastFreshAt time.Time
 
@@ -94,6 +95,7 @@ func newCachingStore(backing Store, onChange func(eventType, beadID string, payl
 		backing:  backing,
 		beads:    make(map[string]Bead),
 		deps:     make(map[string][]Dep),
+		dirty:    make(map[string]struct{}),
 		onChange: onChange,
 		problemf: func(msg string) {
 			log.Printf("beads cache: %s", msg)
@@ -164,6 +166,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	defer c.mu.Unlock()
 	c.beads = beadMap
 	c.deps = depMap
+	c.dirty = make(map[string]struct{})
 	c.state = cacheLive
 	c.syncFailures = 0
 	c.stats.SyncFailures = 0

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -1,0 +1,148 @@
+package beads
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+)
+
+// ApplyEvent updates the cache from a bd hook event. Call this when the
+// event bus delivers a bead.created, bead.updated, or bead.closed event
+// with the full bead JSON payload. This keeps the cache fresh without
+// waiting for reconciliation.
+func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
+	if len(payload) == 0 {
+		return
+	}
+
+	b, err := decodeCacheEvent(payload)
+	if err != nil {
+		c.recordProblem(fmt.Sprintf("apply %s event", eventType), err)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != cacheLive {
+		return
+	}
+
+	switch eventType {
+	case "bead.created":
+		if _, exists := c.beads[b.ID]; !exists {
+			c.beads[b.ID] = cloneBead(b)
+			c.updateStatsLocked()
+		}
+	case "bead.updated":
+		c.beads[b.ID] = cloneBead(b)
+	case "bead.closed":
+		if _, exists := c.beads[b.ID]; !exists {
+			c.updateStatsLocked()
+		}
+		c.beads[b.ID] = cloneBead(b)
+	default:
+		return
+	}
+
+	c.markFreshLocked(time.Now())
+}
+
+// ApplyDepEvent updates the dep cache for a bead. Call after dep
+// mutations are detected via events or write-through.
+func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != cacheLive {
+		return
+	}
+	c.deps[beadID] = cloneDeps(deps)
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+}
+
+func decodeCacheEvent(payload json.RawMessage) (Bead, error) {
+	var b Bead
+	if err := json.Unmarshal(payload, &b); err != nil {
+		return Bead{}, err
+	}
+	if b.ID == "" {
+		return Bead{}, fmt.Errorf("missing bead id")
+	}
+	// bd hook payloads use "issue_type" while Bead uses "type". If Type
+	// wasn't populated from "type", check for the bd field name.
+	if b.Type == "" {
+		var bdCompat struct {
+			IssueType string `json:"issue_type"`
+		}
+		if err := json.Unmarshal(payload, &bdCompat); err == nil && bdCompat.IssueType != "" {
+			b.Type = bdCompat.IssueType
+		}
+	}
+	return b, nil
+}
+
+func (c *CachingStore) notifyChange(eventType string, b Bead) {
+	if c.onChange == nil {
+		return
+	}
+	payload, err := json.Marshal(b)
+	if err != nil {
+		c.recordProblem(fmt.Sprintf("marshal %s notification", eventType), err)
+		return
+	}
+	c.onChange(eventType, b.ID, payload)
+}
+
+type cacheNotification struct {
+	eventType string
+	bead      Bead
+}
+
+func (c *CachingStore) notifyChanges(notifications []cacheNotification) {
+	for _, notification := range notifications {
+		c.notifyChange(notification.eventType, notification.bead)
+	}
+}
+
+func beadChanged(old, fresh Bead) bool {
+	if old.ID != fresh.ID ||
+		old.Title != fresh.Title ||
+		old.Status != fresh.Status ||
+		old.Type != fresh.Type ||
+		!intPtrEqual(old.Priority, fresh.Priority) ||
+		!old.CreatedAt.Equal(fresh.CreatedAt) ||
+		old.Assignee != fresh.Assignee ||
+		old.From != fresh.From ||
+		old.ParentID != fresh.ParentID ||
+		old.Ref != fresh.Ref ||
+		old.Description != fresh.Description {
+		return true
+	}
+	if !maps.Equal(old.Metadata, fresh.Metadata) {
+		return true
+	}
+	if !slices.Equal(old.Labels, fresh.Labels) {
+		return true
+	}
+	if !slices.Equal(old.Needs, fresh.Needs) {
+		return true
+	}
+	return !slices.Equal(old.Dependencies, fresh.Dependencies)
+}
+
+func depsChanged(old, fresh []Dep) bool {
+	return !slices.Equal(old, fresh)
+}
+
+func intPtrEqual(left, right *int) bool {
+	switch {
+	case left == nil && right == nil:
+		return true
+	case left == nil || right == nil:
+		return false
+	default:
+		return *left == *right
+	}
+}

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -33,15 +33,18 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	case "bead.created":
 		if _, exists := c.beads[b.ID]; !exists {
 			c.beads[b.ID] = cloneBead(b)
+			delete(c.dirty, b.ID)
 			c.updateStatsLocked()
 		}
 	case "bead.updated":
 		c.beads[b.ID] = cloneBead(b)
+		delete(c.dirty, b.ID)
 	case "bead.closed":
 		if _, exists := c.beads[b.ID]; !exists {
 			c.updateStatsLocked()
 		}
 		c.beads[b.ID] = cloneBead(b)
+		delete(c.dirty, b.ID)
 	default:
 		return
 	}
@@ -58,6 +61,7 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 		return
 	}
 	c.deps[beadID] = cloneDeps(deps)
+	delete(c.dirty, beadID)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 }

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -41,6 +41,37 @@ func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
 	}
 }
 
+func TestCachingStoreListInProgressUsesBackingStore(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{
+		Title:    "claimed work",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "in_progress"
+	if err := backing.Update(bead.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	got, err := cache.List(ListQuery{Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != bead.ID {
+		t.Fatalf("List(in_progress) = %+v, want %s from backing store", got, bead.ID)
+	}
+}
+
 func TestCachingStoreRunReconciliationDetectsPriorityChanges(t *testing.T) {
 	t.Parallel()
 
@@ -569,10 +600,10 @@ func (s *partialCloseAllStore) CloseAll(ids []string, metadata map[string]string
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	if err := s.Store.SetMetadataBatch(ids[0], metadata); err != nil {
+	if err := s.SetMetadataBatch(ids[0], metadata); err != nil {
 		return 0, err
 	}
-	if err := s.Store.Close(ids[0]); err != nil {
+	if err := s.Close(ids[0]); err != nil {
 		return 0, err
 	}
 	return 1, nil
@@ -586,10 +617,10 @@ func (s *partialCloseAllErrorStore) CloseAll(ids []string, metadata map[string]s
 	if len(ids) == 0 {
 		return 0, errors.New("no ids")
 	}
-	if err := s.Store.SetMetadataBatch(ids[0], metadata); err != nil {
+	if err := s.SetMetadataBatch(ids[0], metadata); err != nil {
 		return 0, err
 	}
-	if err := s.Store.Close(ids[0]); err != nil {
+	if err := s.Close(ids[0]); err != nil {
 		return 0, err
 	}
 	return 1, errors.New("second close failed")
@@ -603,10 +634,10 @@ func (s *nonPrefixCloseAllErrorStore) CloseAll(ids []string, metadata map[string
 	if len(ids) < 2 {
 		return 0, errors.New("need two ids")
 	}
-	if err := s.Store.SetMetadataBatch(ids[1], metadata); err != nil {
+	if err := s.SetMetadataBatch(ids[1], metadata); err != nil {
 		return 0, err
 	}
-	if err := s.Store.Close(ids[1]); err != nil {
+	if err := s.Close(ids[1]); err != nil {
 		return 0, err
 	}
 	return 1, errors.New("first close failed")
@@ -626,11 +657,11 @@ func (s *closeAllRefreshFailingStore) Get(id string) (Bead, error) {
 	return s.Store.Get(id)
 }
 
-func (s *closeAllRefreshFailingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+func (s *closeAllRefreshFailingStore) CloseAll(ids []string, _ map[string]string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	if err := s.Store.Close(ids[0]); err != nil {
+	if err := s.Close(ids[0]); err != nil {
 		return 0, err
 	}
 	return 1, nil

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1,0 +1,454 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "Task", Labels: []string{"old"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := backing.Update(bead.ID, UpdateOpts{
+		Labels:       []string{"new"},
+		RemoveLabels: []string{"old"},
+	}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	cache.runReconciliation()
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get after reconcile: %v", err)
+	}
+	if len(got.Labels) != 1 || got.Labels[0] != "new" {
+		t.Fatalf("Labels = %v, want [new]", got.Labels)
+	}
+}
+
+func TestCachingStoreRunReconciliationDetectsPriorityChanges(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	initialPriority := 1
+	bead, err := backing.Create(Bead{Title: "Task", Priority: &initialPriority})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	updatedPriority := 2
+	if err := backing.Update(bead.ID, UpdateOpts{Priority: &updatedPriority}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	cache.runReconciliation()
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get after reconcile: %v", err)
+	}
+	if got.Priority == nil || *got.Priority != updatedPriority {
+		t.Fatalf("Priority = %v, want %d", got.Priority, updatedPriority)
+	}
+}
+
+func TestCachingStoreRunReconciliationDetectsDepOnlyChangesAndNotifies(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	bead, err := backing.Create(Bead{Title: "Task"})
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	deps, err := cache.DepList(bead.ID, "down")
+	if err != nil {
+		t.Fatalf("DepList before dep add: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("initial deps = %v, want empty", deps)
+	}
+
+	if err := backing.DepAdd(bead.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd backing: %v", err)
+	}
+
+	cache.runReconciliation()
+
+	deps, err = cache.DepList(bead.ID, "down")
+	if err != nil {
+		t.Fatalf("DepList after reconcile: %v", err)
+	}
+	if len(deps) != 1 || deps[0].DependsOnID != blocker.ID {
+		t.Fatalf("deps after reconcile = %v, want blocker %s", deps, blocker.ID)
+	}
+	if len(events) != 1 || events[0] != "bead.updated:"+bead.ID {
+		t.Fatalf("events = %v, want [bead.updated:%s]", events, bead.ID)
+	}
+}
+
+func TestCachingStoreRunReconciliationPublishesCallbacksAfterDepsCommitted(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	bead, err := backing.Create(Bead{Title: "Task"})
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+
+	var observedDeps int
+	var cache *CachingStore
+	cache = NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		if eventType != "bead.updated" || beadID != bead.ID {
+			return
+		}
+		deps, err := cache.DepList(beadID, "down")
+		if err != nil {
+			t.Fatalf("DepList during callback: %v", err)
+		}
+		observedDeps = len(deps)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if _, err := cache.DepList(bead.ID, "down"); err != nil {
+		t.Fatalf("DepList before changes: %v", err)
+	}
+
+	title := "Task updated"
+	if err := backing.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+	if err := backing.DepAdd(bead.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd backing: %v", err)
+	}
+
+	cache.runReconciliation()
+
+	if observedDeps != 1 {
+		t.Fatalf("observed deps during callback = %d, want 1", observedDeps)
+	}
+}
+
+func TestCachingStoreUpdateInvalidatesStaleCacheWhenRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	backing := &refreshFailingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "before"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	title := "after"
+	backing.failNextGet = true
+	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+	if got.Title != "after" {
+		t.Fatalf("Title = %q, want after", got.Title)
+	}
+
+	stats := cache.Stats()
+	if stats.ProblemCount != 1 {
+		t.Fatalf("ProblemCount = %d, want 1", stats.ProblemCount)
+	}
+	if !strings.Contains(stats.LastProblem, "refresh bead after update") {
+		t.Fatalf("LastProblem = %q, want refresh context", stats.LastProblem)
+	}
+	if stats.LastProblemAt.IsZero() {
+		t.Fatal("LastProblemAt should be set")
+	}
+}
+
+func TestCachingStoreUpdateLogsRefreshFailure(t *testing.T) {
+	backing := &refreshFailingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "before"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	var logged []string
+	cache.problemf = func(msg string) {
+		logged = append(logged, msg)
+	}
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	title := "after"
+	backing.failNextGet = true
+	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if len(logged) != 1 {
+		t.Fatalf("logged = %v, want single refresh failure", logged)
+	}
+	if !strings.Contains(logged[0], "refresh bead after update") {
+		t.Fatalf("logged[0] = %q, want refresh context", logged[0])
+	}
+	if !strings.Contains(logged[0], bead.ID) {
+		t.Fatalf("logged[0] = %q, want bead id", logged[0])
+	}
+}
+
+func TestCachingStoreDepListUpFallsThroughToBackingTruth(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	root, err := backing.Create(Bead{Title: "root"})
+	if err != nil {
+		t.Fatalf("Create root: %v", err)
+	}
+	left, err := backing.Create(Bead{Title: "left"})
+	if err != nil {
+		t.Fatalf("Create left: %v", err)
+	}
+	right, err := backing.Create(Bead{Title: "right"})
+	if err != nil {
+		t.Fatalf("Create right: %v", err)
+	}
+	if err := backing.DepAdd(left.ID, root.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd left: %v", err)
+	}
+	if err := backing.DepAdd(right.ID, root.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd right: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Populate only one downward dep entry in the cache, leaving reverse lookups
+	// incomplete unless they fall through to the backing store.
+	if _, err := cache.DepList(left.ID, "down"); err != nil {
+		t.Fatalf("DepList left down: %v", err)
+	}
+
+	deps, err := cache.DepList(root.ID, "up")
+	if err != nil {
+		t.Fatalf("DepList root up: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("DepList(root, up) = %d deps, want 2", len(deps))
+	}
+}
+
+func TestCachingStoreApplyEventRecordsProblemOnMalformedPayload(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCachingStoreForTest(NewMemStore(), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{`))
+
+	stats := cache.Stats()
+	if stats.ProblemCount != 1 {
+		t.Fatalf("ProblemCount = %d, want 1", stats.ProblemCount)
+	}
+	if !strings.Contains(stats.LastProblem, "apply bead.updated event") {
+		t.Fatalf("LastProblem = %q, want apply-event context", stats.LastProblem)
+	}
+	if stats.LastProblemAt.IsZero() {
+		t.Fatal("LastProblemAt should be set")
+	}
+}
+
+func TestCachingStoreRunReconciliationRecordsProblemAndDegrades(t *testing.T) {
+	t.Parallel()
+
+	backing := &listFailingStore{Store: NewMemStore()}
+	if _, err := backing.Create(Bead{Title: "Task"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.failList = true
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cache.runReconciliation()
+	}
+
+	if cache.state != cacheDegraded {
+		t.Fatalf("state = %v, want degraded", cache.state)
+	}
+
+	stats := cache.Stats()
+	if stats.SyncFailures != maxCacheSyncFailures {
+		t.Fatalf("SyncFailures = %d, want %d", stats.SyncFailures, maxCacheSyncFailures)
+	}
+	if stats.ProblemCount != int64(maxCacheSyncFailures) {
+		t.Fatalf("ProblemCount = %d, want %d", stats.ProblemCount, maxCacheSyncFailures)
+	}
+	if !strings.Contains(stats.LastProblem, "reconcile cache") {
+		t.Fatalf("LastProblem = %q, want reconcile context", stats.LastProblem)
+	}
+}
+
+func TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCachingStoreForTest(NewMemStore(), nil)
+	cache.state = cacheLive
+	cache.lastFreshAt = time.Unix(100, 0)
+
+	if got := cache.nextReconcileDelay(time.Unix(110, 0)); got != 20*time.Second {
+		t.Fatalf("nextReconcileDelay(fresh) = %s, want 20s", got)
+	}
+
+	cache.lastFreshAt = time.Unix(70, 0)
+	if got := cache.nextReconcileDelay(time.Unix(110, 0)); got != 0 {
+		t.Fatalf("nextReconcileDelay(stale) = %s, want immediate reconcile", got)
+	}
+
+	cache.state = cacheDegraded
+	cache.lastFreshAt = time.Unix(109, 0)
+	if got := cache.nextReconcileDelay(time.Unix(110, 0)); got != 0 {
+		t.Fatalf("nextReconcileDelay(degraded) = %s, want immediate reconcile", got)
+	}
+}
+
+func TestCachingStoreCloseAllRefreshesOnlyActuallyClosedBeads(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialCloseAllStore{Store: NewMemStore()}
+	first, err := backing.Create(Bead{Title: "first"})
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	second, err := backing.Create(Bead{Title: "second"})
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	closed, err := cache.CloseAll([]string{first.ID, second.ID}, map[string]string{"source": "wave1"})
+	if err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	gotFirst, err := cache.Get(first.ID)
+	if err != nil {
+		t.Fatalf("Get first: %v", err)
+	}
+	if gotFirst.Status != "closed" {
+		t.Fatalf("first status = %q, want closed", gotFirst.Status)
+	}
+	if gotFirst.Metadata["source"] != "wave1" {
+		t.Fatalf("first metadata = %v, want source=wave1", gotFirst.Metadata)
+	}
+
+	gotSecond, err := cache.Get(second.ID)
+	if err != nil {
+		t.Fatalf("Get second: %v", err)
+	}
+	if gotSecond.Status != "open" {
+		t.Fatalf("second status = %q, want open", gotSecond.Status)
+	}
+	if gotSecond.Metadata["source"] != "" {
+		t.Fatalf("second metadata = %v, want no source metadata", gotSecond.Metadata)
+	}
+}
+
+type refreshFailingStore struct {
+	Store
+	failNextGet bool
+}
+
+func (s *refreshFailingStore) Get(id string) (Bead, error) {
+	if s.failNextGet {
+		s.failNextGet = false
+		return Bead{}, errors.New("transient get failure")
+	}
+	return s.Store.Get(id)
+}
+
+type listFailingStore struct {
+	Store
+	failList bool
+}
+
+func (s *listFailingStore) List(query ListQuery) ([]Bead, error) {
+	if s.failList {
+		return nil, errors.New("transient list failure")
+	}
+	return s.Store.List(query)
+}
+
+type partialCloseAllStore struct {
+	Store
+}
+
+func (s *partialCloseAllStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if err := s.Store.SetMetadataBatch(ids[0], metadata); err != nil {
+		return 0, err
+	}
+	if err := s.Store.Close(ids[0]); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -350,6 +350,13 @@ func TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog(t *testing.T) {
 		t.Fatalf("nextReconcileDelay(fresh) = %s, want 20s", got)
 	}
 
+	cache.stats.LastReconcileAt = time.Unix(70, 0)
+	cache.lastFreshAt = time.Unix(109, 0)
+	if got := cache.nextReconcileDelay(time.Unix(110, 0)); got != 0 {
+		t.Fatalf("nextReconcileDelay(stale full scan with fresh writes) = %s, want immediate reconcile", got)
+	}
+
+	cache.stats.LastReconcileAt = time.Time{}
 	cache.lastFreshAt = time.Unix(70, 0)
 	if got := cache.nextReconcileDelay(time.Unix(110, 0)); got != 0 {
 		t.Fatalf("nextReconcileDelay(stale) = %s, want immediate reconcile", got)
@@ -411,6 +418,124 @@ func TestCachingStoreCloseAllRefreshesOnlyActuallyClosedBeads(t *testing.T) {
 	}
 }
 
+func TestCachingStoreCloseAllRefreshesPartialSuccessBeforeReturningError(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialCloseAllErrorStore{Store: NewMemStore()}
+	first, err := backing.Create(Bead{Title: "first"})
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	second, err := backing.Create(Bead{Title: "second"})
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	closed, err := cache.CloseAll([]string{first.ID, second.ID}, map[string]string{"source": "wave1"})
+	if err == nil {
+		t.Fatal("expected CloseAll error")
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	gotFirst, err := cache.Get(first.ID)
+	if err != nil {
+		t.Fatalf("Get first: %v", err)
+	}
+	if gotFirst.Status != "closed" {
+		t.Fatalf("first status = %q, want closed", gotFirst.Status)
+	}
+	if gotFirst.Metadata["source"] != "wave1" {
+		t.Fatalf("first metadata = %v, want source=wave1", gotFirst.Metadata)
+	}
+	stats := cache.Stats()
+	if stats.State != "live" {
+		t.Fatalf("cache state = %q, want live", stats.State)
+	}
+}
+
+func TestCachingStoreCloseAllRefreshesNonPrefixPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	backing := &nonPrefixCloseAllErrorStore{Store: NewMemStore()}
+	first, err := backing.Create(Bead{Title: "first"})
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	second, err := backing.Create(Bead{Title: "second"})
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	closed, err := cache.CloseAll([]string{first.ID, second.ID}, map[string]string{"source": "wave1"})
+	if err == nil {
+		t.Fatal("expected CloseAll error")
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	gotFirst, err := cache.Get(first.ID)
+	if err != nil {
+		t.Fatalf("Get first: %v", err)
+	}
+	if gotFirst.Status != "open" {
+		t.Fatalf("first status = %q, want open", gotFirst.Status)
+	}
+	gotSecond, err := cache.Get(second.ID)
+	if err != nil {
+		t.Fatalf("Get second: %v", err)
+	}
+	if gotSecond.Status != "closed" {
+		t.Fatalf("second status = %q, want closed", gotSecond.Status)
+	}
+	if gotSecond.Metadata["source"] != "wave1" {
+		t.Fatalf("second metadata = %v, want source=wave1", gotSecond.Metadata)
+	}
+}
+
+func TestCachingStoreCloseAllMarksRefreshFailuresDirty(t *testing.T) {
+	t.Parallel()
+
+	backing := &closeAllRefreshFailingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "first"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.failGetID = bead.ID
+	closed, err := cache.CloseAll([]string{bead.ID}, nil)
+	if err == nil {
+		t.Fatal("expected CloseAll refresh error")
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	if _, err := cache.List(ListQuery{AllowScan: true}); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if backing.listCalls == 0 {
+		t.Fatal("List did not fall back to backing store after dirty refresh failure")
+	}
+}
+
 type refreshFailingStore struct {
 	Store
 	failNextGet bool
@@ -451,4 +576,67 @@ func (s *partialCloseAllStore) CloseAll(ids []string, metadata map[string]string
 		return 0, err
 	}
 	return 1, nil
+}
+
+type partialCloseAllErrorStore struct {
+	Store
+}
+
+func (s *partialCloseAllErrorStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	if len(ids) == 0 {
+		return 0, errors.New("no ids")
+	}
+	if err := s.Store.SetMetadataBatch(ids[0], metadata); err != nil {
+		return 0, err
+	}
+	if err := s.Store.Close(ids[0]); err != nil {
+		return 0, err
+	}
+	return 1, errors.New("second close failed")
+}
+
+type nonPrefixCloseAllErrorStore struct {
+	Store
+}
+
+func (s *nonPrefixCloseAllErrorStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	if len(ids) < 2 {
+		return 0, errors.New("need two ids")
+	}
+	if err := s.Store.SetMetadataBatch(ids[1], metadata); err != nil {
+		return 0, err
+	}
+	if err := s.Store.Close(ids[1]); err != nil {
+		return 0, err
+	}
+	return 1, errors.New("first close failed")
+}
+
+type closeAllRefreshFailingStore struct {
+	Store
+	failGetID string
+	listCalls int
+}
+
+func (s *closeAllRefreshFailingStore) Get(id string) (Bead, error) {
+	if id == s.failGetID {
+		s.failGetID = ""
+		return Bead{}, errors.New("refresh failed")
+	}
+	return s.Store.Get(id)
+}
+
+func (s *closeAllRefreshFailingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if err := s.Store.Close(ids[0]); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
+func (s *closeAllRefreshFailingStore) List(query ListQuery) ([]Bead, error) {
+	s.listCalls++
+	return s.Store.List(query)
 }

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -1,0 +1,244 @@
+package beads
+
+import (
+	"errors"
+	"fmt"
+)
+
+// List returns beads matching the query. Active-bead queries are served from
+// cache when available. IncludeClosed queries merge cached active results with
+// backing-store history when possible so callers keep the old best-effort
+// behavior from ListByLabel/ListByMetadata during transient bd failures.
+func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
+	if !query.HasFilter() && !query.AllowScan {
+		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
+	}
+
+	c.mu.RLock()
+	state := c.state
+	if state == cacheLive || state == cachePartial {
+		// PrimeActive loads the full active set (open + in_progress), so
+		// active-only queries are complete even before the history prime finishes.
+		cached := make([]Bead, 0, len(c.beads))
+		for _, b := range c.beads {
+			if !query.Matches(b) {
+				continue
+			}
+			cached = append(cached, cloneBead(b))
+		}
+		c.mu.RUnlock()
+
+		finish := func(items []Bead) ([]Bead, error) {
+			sortBeadsForQuery(items, query.Sort)
+			if query.Limit > 0 && len(items) > query.Limit {
+				items = items[:query.Limit]
+			}
+			return items, nil
+		}
+
+		if !query.IncludesClosed() {
+			return finish(cached)
+		}
+
+		// The cache never has a complete closed-only or parent-history view, so
+		// preserve the old backing-store behavior for those query shapes.
+		if query.Status == "closed" || query.ParentID != "" {
+			return c.backing.List(query)
+		}
+
+		all, err := c.backing.List(query)
+		if err != nil {
+			return finish(cached)
+		}
+
+		seen := make(map[string]bool, len(cached))
+		for _, b := range cached {
+			seen[b.ID] = true
+		}
+		for _, b := range all {
+			if seen[b.ID] {
+				continue
+			}
+			cached = append(cached, b)
+			seen[b.ID] = true
+		}
+		return finish(cached)
+	}
+	c.mu.RUnlock()
+	return c.backing.List(query)
+}
+
+// ListOpen returns all cached beads, optionally filtered by status.
+func (c *CachingStore) ListOpen(status ...string) ([]Bead, error) {
+	query := ListQuery{AllowScan: true}
+	if len(status) > 0 {
+		query.Status = status[0]
+	}
+	return c.List(query)
+}
+
+// Get returns a single bead by ID from the cache or backing store.
+func (c *CachingStore) Get(id string) (Bead, error) {
+	c.mu.RLock()
+	if c.state == cacheLive || c.state == cachePartial {
+		if b, ok := c.beads[id]; ok {
+			c.mu.RUnlock()
+			return cloneBead(b), nil
+		}
+		c.mu.RUnlock()
+		return c.backing.Get(id)
+	}
+	c.mu.RUnlock()
+	return c.backing.Get(id)
+}
+
+// Ready returns open beads whose blocking deps are all closed.
+func (c *CachingStore) Ready() ([]Bead, error) {
+	c.mu.RLock()
+	if c.state == cacheLive {
+		statusByID := make(map[string]string, len(c.beads))
+		depsByID := make(map[string][]Dep, len(c.deps))
+		openBeads := make([]Bead, 0, len(c.beads))
+		missingDepIDs := make(map[string]struct{})
+		for _, b := range c.beads {
+			statusByID[b.ID] = b.Status
+			if b.Status == "open" && !IsReadyExcludedType(b.Type) {
+				openBeads = append(openBeads, cloneBead(b))
+			}
+		}
+		for _, b := range openBeads {
+			deps := cloneDeps(c.deps[b.ID])
+			depsByID[b.ID] = deps
+			for _, dep := range deps {
+				switch dep.Type {
+				case "blocks", "waits-for", "conditional-blocks":
+				default:
+					continue
+				}
+				if _, ok := statusByID[dep.DependsOnID]; !ok {
+					missingDepIDs[dep.DependsOnID] = struct{}{}
+				}
+			}
+		}
+		c.mu.RUnlock()
+
+		for depID := range missingDepIDs {
+			dep, err := c.backing.Get(depID)
+			if err != nil {
+				if errors.Is(err, ErrNotFound) {
+					continue
+				}
+				return nil, err
+			}
+			statusByID[depID] = dep.Status
+		}
+
+		var result []Bead
+		for _, b := range openBeads {
+			blocked := false
+			for _, dep := range depsByID[b.ID] {
+				switch dep.Type {
+				case "blocks", "waits-for", "conditional-blocks":
+				default:
+					continue
+				}
+				if statusByID[dep.DependsOnID] != "closed" {
+					blocked = true
+					break
+				}
+			}
+			if !blocked {
+				result = append(result, cloneBead(b))
+			}
+		}
+		return result, nil
+	}
+	c.mu.RUnlock()
+	return c.backing.Ready()
+}
+
+// Children returns beads with the given parent ID.
+func (c *CachingStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
+	return c.List(ListQuery{
+		ParentID:      parentID,
+		IncludeClosed: HasOpt(opts, IncludeClosed),
+		Sort:          SortCreatedAsc,
+	})
+}
+
+// ListByLabel returns beads matching the given label. By default, serves from
+// cache only (non-closed beads). Pass IncludeClosed to also query the backing
+// store for closed beads and merge results.
+func (c *CachingStore) ListByLabel(label string, limit int, opts ...QueryOpt) ([]Bead, error) {
+	return c.List(ListQuery{
+		Label:         label,
+		Limit:         limit,
+		IncludeClosed: HasOpt(opts, IncludeClosed),
+		Sort:          SortCreatedDesc,
+	})
+}
+
+// ListByAssignee returns beads assigned to the given agent with matching status.
+func (c *CachingStore) ListByAssignee(assignee, status string, limit int) ([]Bead, error) {
+	return c.List(ListQuery{
+		Assignee: assignee,
+		Status:   status,
+		Limit:    limit,
+		Sort:     SortCreatedDesc,
+	})
+}
+
+// ListByMetadata filters beads by metadata key-value pairs. By default, serves
+// from cache only (non-closed beads). Pass IncludeClosed to also query the
+// backing store for closed beads and merge results.
+func (c *CachingStore) ListByMetadata(filters map[string]string, limit int, opts ...QueryOpt) ([]Bead, error) {
+	return c.List(ListQuery{
+		Metadata:      filters,
+		Limit:         limit,
+		IncludeClosed: HasOpt(opts, IncludeClosed),
+		Sort:          SortCreatedDesc,
+	})
+}
+
+func matchesMetadata(b Bead, filters map[string]string) bool {
+	for k, v := range filters {
+		if b.Metadata[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// DepList returns dependencies for a bead in the given direction.
+func (c *CachingStore) DepList(id, direction string) ([]Dep, error) {
+	c.mu.RLock()
+	if c.state == cacheLive {
+		if direction == "down" || direction == "" {
+			if deps, ok := c.deps[id]; ok {
+				c.mu.RUnlock()
+				return cloneDeps(deps), nil
+			}
+			// Dep not cached yet - fetch from backing and cache it.
+			c.mu.RUnlock()
+			deps, err := c.backing.DepList(id, direction)
+			if err != nil {
+				return nil, err
+			}
+			c.mu.Lock()
+			c.deps[id] = cloneDeps(deps)
+			c.mu.Unlock()
+			return deps, nil
+		}
+		// Reverse lookups are only partially cached; defer to the backing
+		// store so callers do not observe incomplete results.
+		c.mu.RUnlock()
+		return c.backing.DepList(id, direction)
+	}
+	c.mu.RUnlock()
+	return c.backing.DepList(id, direction)
+}
+
+// Ping delegates to the backing store.
+func (c *CachingStore) Ping() error {
+	return c.backing.Ping()
+}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -14,6 +14,9 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
 	}
+	if query.Status == "in_progress" {
+		return c.backing.List(query)
+	}
 
 	c.mu.RLock()
 	state := c.state

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 // List returns beads matching the query. Active-bead queries are served from
@@ -17,6 +18,10 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	c.mu.RLock()
 	state := c.state
 	if state == cacheLive || state == cachePartial {
+		if len(c.dirty) > 0 {
+			c.mu.RUnlock()
+			return c.backing.List(query)
+		}
 		// PrimeActive loads the full active set (open + in_progress), so
 		// active-only queries are complete even before the history prime finishes.
 		cached := make([]Bead, 0, len(c.beads))
@@ -81,6 +86,20 @@ func (c *CachingStore) ListOpen(status ...string) ([]Bead, error) {
 func (c *CachingStore) Get(id string) (Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive || c.state == cachePartial {
+		if _, ok := c.dirty[id]; ok {
+			c.mu.RUnlock()
+			fresh, err := c.backing.Get(id)
+			if err != nil {
+				return Bead{}, err
+			}
+			c.mu.Lock()
+			c.beads[id] = cloneBead(fresh)
+			delete(c.dirty, id)
+			c.markFreshLocked(time.Now())
+			c.updateStatsLocked()
+			c.mu.Unlock()
+			return fresh, nil
+		}
 		if b, ok := c.beads[id]; ok {
 			c.mu.RUnlock()
 			return cloneBead(b), nil
@@ -96,6 +115,10 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 func (c *CachingStore) Ready() ([]Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive {
+		if len(c.dirty) > 0 {
+			c.mu.RUnlock()
+			return c.backing.Ready()
+		}
 		statusByID := make(map[string]string, len(c.beads))
 		depsByID := make(map[string][]Dep, len(c.deps))
 		openBeads := make([]Bead, 0, len(c.beads))

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -29,12 +29,6 @@ func (c *CachingStore) reconcileLoop(ctx context.Context) {
 	}
 }
 
-func (c *CachingStore) adaptiveInterval() time.Duration {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.adaptiveIntervalLocked()
-}
-
 func (c *CachingStore) adaptiveIntervalLocked() time.Duration {
 	total := len(c.beads)
 	switch {

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -1,0 +1,156 @@
+package beads
+
+import (
+	"context"
+	"time"
+)
+
+func (c *CachingStore) reconcileLoop(ctx context.Context) {
+	timer := time.NewTimer(cacheReconcilePollInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		if c.nextReconcileDelay(time.Now()) == 0 && c.reconciling.CompareAndSwap(false, true) {
+			c.runReconciliation()
+			c.reconciling.Store(false)
+		}
+
+		next := c.nextReconcileDelay(time.Now())
+		if next <= 0 || next > cacheReconcilePollInterval {
+			next = cacheReconcilePollInterval
+		}
+		timer.Reset(next)
+	}
+}
+
+func (c *CachingStore) adaptiveInterval() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.adaptiveIntervalLocked()
+}
+
+func (c *CachingStore) adaptiveIntervalLocked() time.Duration {
+	total := len(c.beads)
+	switch {
+	case total >= 5000:
+		return cacheReconcileIntervalLarge
+	case total >= 1000:
+		return cacheReconcileIntervalMedium
+	default:
+		return cacheReconcileIntervalSmall
+	}
+}
+
+func (c *CachingStore) nextReconcileDelay(now time.Time) time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state == cacheDegraded || c.lastFreshAt.IsZero() {
+		return 0
+	}
+
+	dueAt := c.lastFreshAt.Add(c.adaptiveIntervalLocked())
+	if !now.Before(dueAt) {
+		return 0
+	}
+	return dueAt.Sub(now)
+}
+
+func (c *CachingStore) runReconciliation() {
+	start := time.Now()
+	fresh, err := c.backing.List(ListQuery{AllowScan: true})
+	if err != nil {
+		c.mu.Lock()
+		c.syncFailures++
+		if c.syncFailures >= maxCacheSyncFailures && c.state == cacheLive {
+			c.state = cacheDegraded
+		}
+		c.recordProblemLocked("reconcile cache", err)
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		return
+	}
+
+	freshByID := make(map[string]Bead, len(fresh))
+	for _, b := range fresh {
+		freshByID[b.ID] = cloneBead(b)
+	}
+
+	depMap, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
+	if depErr != nil {
+		c.recordProblem("refresh dep cache during reconcile", depErr)
+	}
+
+	c.mu.Lock()
+
+	var adds, removes, updates int64
+	notifications := make([]cacheNotification, 0, len(freshByID))
+	nextDeps := make(map[string][]Dep, len(freshByID))
+
+	for id, freshBead := range freshByID {
+		if depErr == nil {
+			nextDeps[id] = cloneDeps(depMap[id])
+		} else if deps, ok := c.deps[id]; ok {
+			nextDeps[id] = cloneDeps(deps)
+		}
+
+		old, exists := c.beads[id]
+		switch {
+		case !exists:
+			adds++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.created",
+				bead:      cloneBead(freshBead),
+			})
+		case beadChanged(old, freshBead):
+			updates++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.updated",
+				bead:      cloneBead(freshBead),
+			})
+		case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+			updates++
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.updated",
+				bead:      cloneBead(freshBead),
+			})
+		}
+	}
+
+	for id, old := range c.beads {
+		if _, exists := freshByID[id]; !exists {
+			removes++
+			closed := cloneBead(old)
+			closed.Status = "closed"
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.closed",
+				bead:      closed,
+			})
+		}
+	}
+
+	c.beads = freshByID
+	c.deps = nextDeps
+	c.syncFailures = 0
+	if c.state == cacheDegraded {
+		c.state = cacheLive
+	}
+
+	now := time.Now()
+	durMs := float64(time.Since(start).Microseconds()) / 1000.0
+	c.stats.LastReconcileAt = now
+	c.stats.LastReconcileMs = durMs
+	c.stats.Adds += adds
+	c.stats.Removes += removes
+	c.stats.Updates += updates
+	c.markFreshLocked(now)
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	c.notifyChanges(notifications)
+}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -55,7 +55,11 @@ func (c *CachingStore) nextReconcileDelay(now time.Time) time.Duration {
 		return 0
 	}
 
-	dueAt := c.lastFreshAt.Add(c.adaptiveIntervalLocked())
+	lastFullScanAt := c.stats.LastReconcileAt
+	if lastFullScanAt.IsZero() {
+		lastFullScanAt = c.lastFreshAt
+	}
+	dueAt := lastFullScanAt.Add(c.adaptiveIntervalLocked())
 	if !now.Before(dueAt) {
 		return 0
 	}
@@ -137,6 +141,7 @@ func (c *CachingStore) runReconciliation() {
 
 	c.beads = freshByID
 	c.deps = nextDeps
+	c.dirty = make(map[string]struct{})
 	c.syncFailures = 0
 	if c.state == cacheDegraded {
 		c.state = cacheLive

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -291,8 +291,14 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 		t.Fatalf("metadata after update = %v, want gc.step_ref=mol.review", got.Metadata)
 	}
 
-	// Apply a close event.
-	closed := beads.Bead{ID: b1.ID, Status: "closed", Metadata: map[string]string{"gc.outcome": "pass"}}
+	// Apply a close event with the full closed bead payload.
+	closed := beads.Bead{
+		ID:       b1.ID,
+		Title:    "Closed by agent",
+		Status:   "closed",
+		Labels:   []string{"done"},
+		Metadata: map[string]string{"gc.outcome": "pass"},
+	}
 	payload, _ = json.Marshal(closed)
 	cs.ApplyEvent("bead.closed", payload)
 
@@ -300,12 +306,17 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	if got.Status != "closed" {
 		t.Fatalf("status after close event = %q, want closed", got.Status)
 	}
+	if got.Title != "Closed by agent" {
+		t.Fatalf("title after close event = %q, want Closed by agent", got.Title)
+	}
+	if len(got.Labels) != 1 || got.Labels[0] != "done" {
+		t.Fatalf("labels after close event = %v, want [done]", got.Labels)
+	}
 	if got.Metadata["gc.outcome"] != "pass" {
 		t.Fatalf("outcome = %q, want pass", got.Metadata["gc.outcome"])
 	}
-	// Original metadata should be preserved (merged, not replaced).
-	if got.Metadata["gc.step_ref"] != "mol.review" {
-		t.Fatalf("step_ref lost after close event: %v", got.Metadata)
+	if got.Metadata["gc.step_ref"] != "" {
+		t.Fatalf("close event should replace stale metadata, got %v", got.Metadata)
 	}
 }
 

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -1,0 +1,227 @@
+package beads
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Create passes through to the backing store and updates the cache.
+func (c *CachingStore) Create(b Bead) (Bead, error) {
+	created, err := c.backing.Create(b)
+	if err != nil {
+		return created, err
+	}
+
+	c.mu.Lock()
+	c.beads[created.ID] = cloneBead(created)
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+
+	c.notifyChange("bead.created", created)
+	return created, nil
+}
+
+// Update passes through to the backing store and refreshes the cache.
+func (c *CachingStore) Update(id string, opts UpdateOpts) error {
+	if err := c.backing.Update(id, opts); err != nil {
+		return err
+	}
+
+	// Re-fetch from backing to get the authoritative state.
+	fresh, err := c.backing.Get(id)
+	if err != nil {
+		c.mu.Lock()
+		delete(c.beads, id)
+		delete(c.deps, id)
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))
+		return nil
+	}
+
+	c.mu.Lock()
+	c.beads[id] = cloneBead(fresh)
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+
+	c.notifyChange("bead.updated", fresh)
+	return nil
+}
+
+// Close marks a bead as closed in the backing store and cache.
+func (c *CachingStore) Close(id string) error {
+	if err := c.backing.Close(id); err != nil {
+		return err
+	}
+
+	var closed Bead
+	var found bool
+	c.mu.Lock()
+	if b, ok := c.beads[id]; ok {
+		b.Status = "closed"
+		c.beads[id] = b
+		closed = cloneBead(b)
+		found = true
+		c.markFreshLocked(time.Now())
+		c.updateStatsLocked()
+	}
+	c.mu.Unlock()
+
+	if found {
+		c.notifyChange("bead.closed", closed)
+	}
+	return nil
+}
+
+// CloseAll closes multiple beads and sets metadata on each.
+func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	n, err := c.backing.CloseAll(ids, metadata)
+	if err != nil {
+		return n, err
+	}
+
+	type refreshedBead struct {
+		id   string
+		bead Bead
+	}
+	refreshed := make([]refreshedBead, 0, len(ids))
+	var refreshErr error
+	for _, id := range ids {
+		fresh, getErr := c.backing.Get(id)
+		if getErr != nil {
+			refreshErr = errors.Join(refreshErr, fmt.Errorf("refresh bead after close-all %s: %w", id, getErr))
+			continue
+		}
+		refreshed = append(refreshed, refreshedBead{id: id, bead: fresh})
+	}
+
+	notifications := make([]cacheNotification, 0, len(refreshed))
+	c.mu.Lock()
+	if refreshErr != nil {
+		c.state = cacheDegraded
+		c.recordProblemLocked("close-all refresh", refreshErr)
+	}
+	for _, item := range refreshed {
+		previous, hadPrevious := c.beads[item.id]
+		c.beads[item.id] = cloneBead(item.bead)
+		if item.bead.Status == "closed" {
+			delete(c.deps, item.id)
+		}
+		if hadPrevious && previous.Status != "closed" && item.bead.Status == "closed" {
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.closed",
+				bead:      cloneBead(item.bead),
+			})
+		}
+	}
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	c.notifyChanges(notifications)
+	return n, refreshErr
+}
+
+// SetMetadata sets a single metadata key-value on a bead.
+func (c *CachingStore) SetMetadata(id, key, value string) error {
+	if err := c.backing.SetMetadata(id, key, value); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	if b, ok := c.beads[id]; ok {
+		if b.Metadata == nil {
+			b.Metadata = make(map[string]string)
+		}
+		b.Metadata[key] = value
+		c.beads[id] = b
+	}
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	return nil
+}
+
+// SetMetadataBatch sets multiple metadata key-values on a bead.
+func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if err := c.backing.SetMetadataBatch(id, kvs); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	if b, ok := c.beads[id]; ok {
+		if b.Metadata == nil {
+			b.Metadata = make(map[string]string, len(kvs))
+		}
+		for k, v := range kvs {
+			b.Metadata[k] = v
+		}
+		c.beads[id] = b
+	}
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	return nil
+}
+
+// DepAdd adds a dependency and updates the cache.
+func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
+	if err := c.backing.DepAdd(issueID, dependsOnID, depType); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	deps := c.deps[issueID]
+	for i, d := range deps {
+		if d.DependsOnID == dependsOnID {
+			deps[i].Type = depType
+			c.deps[issueID] = deps
+			c.markFreshLocked(time.Now())
+			c.updateStatsLocked()
+			c.mu.Unlock()
+			return nil
+		}
+	}
+	c.deps[issueID] = append(deps, Dep{IssueID: issueID, DependsOnID: dependsOnID, Type: depType})
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	return nil
+}
+
+// DepRemove removes a dependency and updates the cache.
+func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
+	if err := c.backing.DepRemove(issueID, dependsOnID); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	deps := c.deps[issueID]
+	for i, d := range deps {
+		if d.DependsOnID == dependsOnID {
+			c.deps[issueID] = append(deps[:i], deps[i+1:]...)
+			break
+		}
+	}
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	return nil
+}
+
+// Delete passes through to the backing store and removes from cache.
+func (c *CachingStore) Delete(id string) error {
+	if err := c.backing.Delete(id); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	delete(c.beads, id)
+	delete(c.deps, id)
+	c.markFreshLocked(time.Now())
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	return nil
+}

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -15,6 +15,7 @@ func (c *CachingStore) Create(b Bead) (Bead, error) {
 
 	c.mu.Lock()
 	c.beads[created.ID] = cloneBead(created)
+	delete(c.dirty, created.ID)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -33,9 +34,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 	fresh, err := c.backing.Get(id)
 	if err != nil {
 		c.mu.Lock()
-		delete(c.beads, id)
-		delete(c.deps, id)
-		c.updateStatsLocked()
+		c.dirty[id] = struct{}{}
 		c.mu.Unlock()
 		c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))
 		return nil
@@ -43,6 +42,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 
 	c.mu.Lock()
 	c.beads[id] = cloneBead(fresh)
+	delete(c.dirty, id)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -63,6 +63,7 @@ func (c *CachingStore) Close(id string) error {
 	if b, ok := c.beads[id]; ok {
 		b.Status = "closed"
 		c.beads[id] = b
+		delete(c.dirty, id)
 		closed = cloneBead(b)
 		found = true
 		c.markFreshLocked(time.Now())
@@ -79,7 +80,7 @@ func (c *CachingStore) Close(id string) error {
 // CloseAll closes multiple beads and sets metadata on each.
 func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
 	n, err := c.backing.CloseAll(ids, metadata)
-	if err != nil {
+	if err != nil && n == 0 {
 		return n, err
 	}
 
@@ -89,9 +90,11 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 	}
 	refreshed := make([]refreshedBead, 0, len(ids))
 	var refreshErr error
+	refreshFailed := make(map[string]struct{})
 	for _, id := range ids {
 		fresh, getErr := c.backing.Get(id)
 		if getErr != nil {
+			refreshFailed[id] = struct{}{}
 			refreshErr = errors.Join(refreshErr, fmt.Errorf("refresh bead after close-all %s: %w", id, getErr))
 			continue
 		}
@@ -101,12 +104,15 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 	notifications := make([]cacheNotification, 0, len(refreshed))
 	c.mu.Lock()
 	if refreshErr != nil {
-		c.state = cacheDegraded
 		c.recordProblemLocked("close-all refresh", refreshErr)
+	}
+	for id := range refreshFailed {
+		c.dirty[id] = struct{}{}
 	}
 	for _, item := range refreshed {
 		previous, hadPrevious := c.beads[item.id]
 		c.beads[item.id] = cloneBead(item.bead)
+		delete(c.dirty, item.id)
 		if item.bead.Status == "closed" {
 			delete(c.deps, item.id)
 		}
@@ -121,7 +127,7 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 	c.updateStatsLocked()
 	c.mu.Unlock()
 	c.notifyChanges(notifications)
-	return n, refreshErr
+	return n, errors.Join(err, refreshErr)
 }
 
 // SetMetadata sets a single metadata key-value on a bead.
@@ -137,6 +143,7 @@ func (c *CachingStore) SetMetadata(id, key, value string) error {
 		}
 		b.Metadata[key] = value
 		c.beads[id] = b
+		delete(c.dirty, id)
 	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
@@ -159,6 +166,7 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 			b.Metadata[k] = v
 		}
 		c.beads[id] = b
+		delete(c.dirty, id)
 	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
@@ -178,6 +186,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 		if d.DependsOnID == dependsOnID {
 			deps[i].Type = depType
 			c.deps[issueID] = deps
+			delete(c.dirty, issueID)
 			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()
@@ -185,6 +194,7 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 		}
 	}
 	c.deps[issueID] = append(deps, Dep{IssueID: issueID, DependsOnID: dependsOnID, Type: depType})
+	delete(c.dirty, issueID)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()
@@ -202,6 +212,7 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 	for i, d := range deps {
 		if d.DependsOnID == dependsOnID {
 			c.deps[issueID] = append(deps[:i], deps[i+1:]...)
+			delete(c.dirty, issueID)
 			break
 		}
 	}
@@ -220,6 +231,7 @@ func (c *CachingStore) Delete(id string) error {
 	c.mu.Lock()
 	delete(c.beads, id)
 	delete(c.deps, id)
+	delete(c.dirty, id)
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	c.mu.Unlock()

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -37,10 +37,15 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
 
+	locker := Locker(nopLocker{})
+	if _, ok := fs.(fsys.OSFS); ok {
+		locker = NewFileFlock(path + ".lock")
+	}
+
 	data, err := fs.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &FileStore{MemStore: NewMemStore(), fs: fs, path: path, locker: nopLocker{}}, nil
+			return &FileStore{MemStore: NewMemStore(), fs: fs, path: path, locker: locker}, nil
 		}
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
@@ -49,7 +54,7 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 	if err := json.Unmarshal(data, &fd); err != nil {
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
-	return &FileStore{MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps), fs: fs, path: path, locker: nopLocker{}}, nil
+	return &FileStore{MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps), fs: fs, path: path, locker: locker}, nil
 }
 
 // SetLocker sets a cross-process Locker (typically a FileFlock). When set,
@@ -221,9 +226,38 @@ func (fs *FileStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	return nil
 }
 
+// Delete delegates to MemStore.Delete and flushes to disk.
+// If the disk flush fails, the in-memory mutation is rolled back.
+func (fs *FileStore) Delete(id string) error {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
+	snap := fs.snapshotLocked()
+	if err := fs.MemStore.Delete(id); err != nil {
+		return err
+	}
+	if err := fs.save(); err != nil {
+		fs.restoreFrom(snap.seq, snap.beads, snap.deps)
+		return err
+	}
+	return nil
+}
+
 // Ping checks that the store file is accessible.
 func (fs *FileStore) Ping() error {
-	return fs.MemStore.Ping()
+	if err := fs.MemStore.Ping(); err != nil {
+		return err
+	}
+	if _, err := fs.fs.ReadFile(fs.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("pinging file store: %w", err)
+	}
+	return nil
 }
 
 // DepAdd delegates to MemStore.DepAdd and flushes to disk.

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -1,6 +1,7 @@
 package beads_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -139,6 +140,32 @@ func TestFileStoreMetadataPersistence(t *testing.T) {
 	}
 }
 
+func TestFileStoreDeletePersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s1.Create(beads.Bead{Title: "delete-me"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s1.Delete(b.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Get(b.ID); err == nil {
+		t.Fatalf("Get(%q) after reopen should fail", b.ID)
+	} else if !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get(%q) after reopen = %v, want ErrNotFound", b.ID, err)
+	}
+}
+
 func TestFileStoreChildrenExcludeClosedByDefault(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "beads.json")
 	s, err := beads.OpenFileStore(fsys.OSFS{}, path)
@@ -273,6 +300,25 @@ func TestFileStoreOpenEmpty(t *testing.T) {
 	}
 	if b.ID != "gc-1" {
 		t.Errorf("ID = %q, want %q", b.ID, "gc-1")
+	}
+}
+
+func TestFileStorePingDetectsReadFailures(t *testing.T) {
+	path := "/city/beads.json"
+	f := fsys.NewFake()
+	f.Dirs["/city"] = true
+	f.Files[path] = []byte(`{}`)
+
+	s, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Errors[path] = fmt.Errorf("permission denied")
+	if err := s.Ping(); err == nil {
+		t.Fatal("expected ping error")
+	} else if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("Ping error = %v, want permission denied", err)
 	}
 }
 
@@ -457,6 +503,71 @@ func TestFileStoreConcurrentCreateWithFlock(t *testing.T) {
 	}
 
 	// Reopen and verify all beads survived.
+	s3 := open()
+	all, err := s3.ListOpen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != perStore*2 {
+		t.Errorf("after reopen: %d beads, want %d", len(all), perStore*2)
+	}
+}
+
+// This regression covers the default locker path for OS-backed file stores.
+// It fails on branches where callers must inject locking manually.
+func TestFileStoreConcurrentCreateUsesDefaultLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock not available on Windows")
+	}
+
+	dir := t.TempDir()
+	beadsPath := filepath.Join(dir, "beads.json")
+
+	const perStore = 20
+
+	open := func() *beads.FileStore {
+		s, err := beads.OpenFileStore(fsys.OSFS{}, beadsPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+
+	s1 := open()
+	s2 := open()
+
+	var wg sync.WaitGroup
+	ids := make(chan string, perStore*2)
+
+	createN := func(s *beads.FileStore, prefix string) {
+		defer wg.Done()
+		for i := 0; i < perStore; i++ {
+			b, err := s.Create(beads.Bead{Title: fmt.Sprintf("%s-%d", prefix, i)})
+			if err != nil {
+				t.Errorf("Create failed: %v", err)
+				return
+			}
+			ids <- b.ID
+		}
+	}
+
+	wg.Add(2)
+	go createN(s1, "s1")
+	go createN(s2, "s2")
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[string]bool)
+	for id := range ids {
+		if seen[id] {
+			t.Errorf("duplicate ID: %s", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != perStore*2 {
+		t.Errorf("got %d unique IDs, want %d", len(seen), perStore*2)
+	}
+
 	s3 := open()
 	all, err := s3.ListOpen()
 	if err != nil {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -64,6 +64,7 @@ func cloneBead(b Bead) Bead {
 	b.Metadata = maps.Clone(b.Metadata)
 	b.Labels = slices.Clone(b.Labels)
 	b.Needs = slices.Clone(b.Needs)
+	b.Dependencies = slices.Clone(b.Dependencies)
 	return b
 }
 

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -282,6 +282,38 @@ func TestMemStoreAddAndRemoveLabels(t *testing.T) {
 	}
 }
 
+func TestMemStoreGetReturnsClonedDependencies(t *testing.T) {
+	s := beads.NewMemStore()
+	created, err := s.Create(beads.Bead{
+		Title: "test",
+		Dependencies: []beads.Dep{
+			{IssueID: "gc-1", DependsOnID: "dep-1", Type: "blocks"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created.Dependencies[0].DependsOnID = "mutated"
+
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Dependencies[0].DependsOnID != "dep-1" {
+		t.Fatalf("DependsOnID after returned bead mutation = %q, want dep-1", got.Dependencies[0].DependsOnID)
+	}
+
+	got.Dependencies[0].DependsOnID = "changed-again"
+	again, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Dependencies[0].DependsOnID != "dep-1" {
+		t.Fatalf("DependsOnID after Get mutation = %q, want dep-1", again.Dependencies[0].DependsOnID)
+	}
+}
+
 // --- DepAdd / DepRemove / DepList ---
 
 func TestMemStoreDepAddAndList(t *testing.T) {


### PR DESCRIPTION
## Summary
- Supersedes #994.
- Preserves the original beads storage-core refactor and regression coverage from @julianknutsen as a single squashed contributor commit.
- Adds adoption-review fixups for cache recovery, close-all fallback semantics, watchdog reconciliation cadence, dirty-cache fallback reads, and empty `bd list` output handling.

## Module
- Module 12: `Beads Storage Core`
- Scope: `internal/beads/{bdstore.go,bdstore_graph_apply.go,beads.go,caching_store.go,filestore.go,flock.go,graph_apply.go,memstore.go}`
- Boundary exceptions: adoption-review fixups remain within `internal/beads`
- Shared-foundation dependencies: none

## Attribution
Credit: Original fix by @julianknutsen. The contributor changes are preserved as a squashed commit with original authorship.

## Adoption Review Fixups
- `BdStore.CloseAll` now returns nil when batch close fails but every individual fallback close succeeds.
- `CachingStore.CloseAll` refreshes all attempted IDs after partial success and marks refresh failures dirty so cached reads do not serve stale open beads.
- Watchdog reconciliation is scheduled from last full scan rather than generic cache freshness so steady write/event traffic cannot postpone full scans indefinitely.
- Failed post-update refreshes now mark a bead dirty and force backing reads/lists until refreshed instead of deleting it from cached results.
- Empty successful `bd list --json` output is treated as an empty bead list for fake-bd/bootstrap paths.

## Verification
- `TMPDIR=/tmp/gascity-pr994-tmp GOCACHE=/tmp/gascity-pr994-gocache go test ./internal/beads/...`
- `TMPDIR=/tmp/gascity-pr994-vet-tmp GOCACHE=/tmp/gascity-pr994-vet-cache go vet ./...`
- Targeted `cmd/gc` bd initialization tests passed after the empty-output parser fix.

## Notes
- `go test ./cmd/gc -count=1` still times out at 10 minutes in this environment in a separate wait-path test; the targeted storage and bd initialization coverage above passes.
