### PR TITLE
docs(prompt): clarify mayor's /gc-* slash commands vs bash commands

### DIFF
--- a/cmd/gc/prompts/mayor.md
+++ b/cmd/gc/prompts/mayor.md
@@ -8,6 +8,14 @@ manage rigs and agents, dispatch tasks, and monitor progress.
 Use `/gc-work`, `/gc-dispatch`, `/gc-agents`, `/gc-rigs`, `/gc-mail`,
 or `/gc-city` to load command reference for any topic.
 
+Note: those `/gc-*` entries are Claude Code slash commands (skill references),
+not bash commands — do not invent `gc mail list`, `gc city status`, etc. from
+them. For bead work use `gc bd ...`, for city-level status use `gc status`,
+and for mail use `gc mail <subcommand>` where subcommands are `inbox`, `send`,
+`check`, `read`, `peek`, `reply`, `mark-read`, `mark-unread`, `thread`,
+`count`, `archive`, `delete`. If unsure of exact subcommand shape, run
+`gc <cmd> --help` rather than guessing.
+
 ## How to work
 
 1. **Set up rigs:** `gc rig add <path>` to register project directories


### PR DESCRIPTION
## Summary

The embedded mayor prompt (`cmd/gc/prompts/mayor.md`) lists `/gc-work`, `/gc-mail`, `/gc-city`, etc. as Claude Code slash command references (skill loads). However, an LLM reading the prompt sometimes extrapolates these into invented bash subcommands, e.g. `gc mail list` (no such thing — real subcommands are `inbox`/`send`/`check`/etc.) or `gc city status` (also not a command — correct is `gc status`). Observed live via `gc session peek mayor` showing the mayor repeatedly running invented commands and getting "unknown subcommand" errors.

This PR adds a short (7-line) clarifying note in the existing `## Commands` section. It:

- Tells the mayor that `/gc-*` entries are Claude Code slash commands, not bash commands
- Names the bash shapes: `gc bd ...`, `gc status`, `gc mail <subcommand>` with the real subcommand list
- Says "run `gc <cmd> --help` rather than guessing"

No code change, no test change — just the embedded prompt markdown. `go build ./cmd/gc/` passes.

## Test plan

- [x] `go build ./cmd/gc/` (embedded prompt, pure compile check)
- [ ] Reviewer can skim the diff on `cmd/gc/prompts/mayor.md` to confirm tone/placement

## Priority

Low priority — nice-to-have prompt hardening, not a 1.0-cutline item. /cc @csells @julianknutsen in case it's worth considering for launch.