### PR TITLE
fix: gc init --provider emits pack-first scaffold matching docs

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -589,14 +589,6 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 		)
 		cityCfg.Workspace.Includes = nil
 	}
-	if len(cfg.Workspace.GlobalFragments) > 0 {
-		packCfg.AgentDefaults.AppendFragments = appendUniqueStrings(
-			append([]string(nil), packCfg.AgentDefaults.AppendFragments...),
-			cfg.Workspace.GlobalFragments...,
-		)
-		cityCfg.Workspace.GlobalFragments = nil
-	}
-
 	if len(cfg.DefaultRigImports) > 0 {
 		defaults := packDefaults{
 			Rig: packRigDefaults{
@@ -1069,7 +1061,8 @@ func cmdInitFromDirWithOptions(fromDir string, args []string, nameOverride strin
 }
 
 // doInitFromDir copies an example city directory to a new city path,
-// updates workspace.name, creates .gc/, and installs hooks.
+// writes machine-local workspace identity to .gc/site.toml, and
+// installs the standard runtime scaffold.
 func doInitFromDir(srcDir, cityPath string, stdout, stderr io.Writer) int {
 	return doInitFromDirWithOptions(srcDir, cityPath, "", stdout, stderr, false)
 }
@@ -1093,95 +1086,20 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 	}
 
 	copiedToml := filepath.Join(cityPath, "city.toml")
-	data, err := os.ReadFile(copiedToml)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: reading copied city.toml: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cfg, err := config.Parse(data)
+	cfg, cityName, cityPrefix, persistSiteIdentity, err := rewriteCopiedInitFromIdentity(fs, cityPath, nameOverride)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	cityName := resolveCityName(nameOverride, cfg.Workspace.Name, cityPath)
-	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
-	cfg.Workspace.Name = cityName
-	cfg.Workspace.Prefix = cityPrefix
-	content, err := cfg.Marshal()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if err := persistInitWorkspaceIdentity(fs, cityPath, copiedToml, cfg, cityName, cityPrefix); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	return doInitFromDirWithOptions(srcDir, cityPath, nameOverride, stdout, stderr, skipProviderReadiness)
-}
-
-func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
-	fs := fsys.OSFS{}
-	// Validate source has city.toml.
-	srcToml := filepath.Join(srcDir, "city.toml")
-	if _, err := os.Stat(srcToml); err != nil {
-		fmt.Fprintf(stderr, "gc init --from: source %q has no city.toml\n", srcDir) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-
-	// Check target not already initialized.
-	if cityAlreadyInitializedFS(fs, cityPath) {
-		return initAlreadyInitialized(stderr)
-	}
-
-	// Create target directory if needed.
-	if err := fs.MkdirAll(cityPath, 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-
-	// Copy directory tree (skip .gc/ and *_test.go).
-	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkip, stderr); err != nil {
-		fmt.Fprintf(stderr, "gc init --from: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-
-	copiedToml := filepath.Join(cityPath, "city.toml")
-	data, err := os.ReadFile(copiedToml)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: reading copied city.toml: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cfg, err := config.Parse(data)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	cityName := resolveCityName(nameOverride, "", cityPath)
-	cfg.Workspace.Name = cityName
-	content, err := cfg.Marshal()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if err := persistInitWorkspaceIdentity(fs, cityPath, copiedToml, cfg, cityName, strings.TrimSpace(cfg.Workspace.Prefix)); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+	if persistSiteIdentity {
+		if err := persistInitWorkspaceIdentity(fs, cityPath, copiedToml, cfg, cityName, cityPrefix); err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	// Create runtime scaffold.
-	if err := ensureCityScaffold(cityPath); err != nil {
+	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -1222,6 +1140,246 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 		skipProviderReadiness: skipProviderReadiness,
 		commandName:           "gc init",
 	})
+}
+
+func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+	return doInitFromDirWithOptionsFS(fsys.OSFS{}, srcDir, cityPath, nameOverride, stdout, stderr, skipProviderReadiness)
+}
+
+func rewriteCopiedInitFromIdentity(fs fsys.FS, cityPath, nameOverride string) (*config.City, string, string, bool, error) {
+	copiedToml := filepath.Join(cityPath, "city.toml")
+	data, err := fs.ReadFile(copiedToml)
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("reading copied city.toml: %w", err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		return nil, "", "", false, err
+	}
+
+	cityName := resolveCityName(nameOverride, "", cityPath)
+	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	packPath := filepath.Join(cityPath, "pack.toml")
+	if _, err := fs.Stat(packPath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, "", "", false, err
+		}
+		cfg.Workspace.Name = cityName
+		content, err := cfg.Marshal()
+		if err != nil {
+			return nil, "", "", false, err
+		}
+		if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
+			return nil, "", "", false, err
+		}
+		return cfg, cityName, cityPrefix, false, nil
+	}
+	cfg.Workspace.Name = ""
+	cfg.Workspace.Prefix = ""
+
+	content, err := cfg.Marshal()
+	if err != nil {
+		return nil, "", "", false, err
+	}
+	if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
+		return nil, "", "", false, err
+	}
+	if err := rewriteCopiedInitPackName(fs, cityPath, cityName); err != nil {
+		return nil, "", "", false, err
+	}
+	return cfg, cityName, cityPrefix, true, nil
+}
+
+func rewriteCopiedInitPackName(fs fsys.FS, cityPath, cityName string) error {
+	packPath := filepath.Join(cityPath, "pack.toml")
+	data, err := fs.ReadFile(packPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading copied pack.toml: %w", err)
+	}
+
+	updated, err := rewritePackNameInCopiedPackToml(data, cityName)
+	if err != nil {
+		return fmt.Errorf("updating copied pack.toml: %w", err)
+	}
+	if err := fsys.WriteFileAtomic(fs, packPath, updated, 0o644); err != nil {
+		return fmt.Errorf("writing copied pack.toml: %w", err)
+	}
+	return nil
+}
+
+func rewritePackNameInCopiedPackToml(data []byte, cityName string) ([]byte, error) {
+	lines := splitPreserveNewlines(string(data))
+	lineEnding := "\n"
+	for _, line := range lines {
+		if strings.HasSuffix(line, "\n") {
+			lineEnding = "\n"
+			break
+		}
+	}
+
+	inPackTable := false
+	sawPackTable := false
+	multilineDelimiter := ""
+	for i, line := range lines {
+		if multilineDelimiter != "" {
+			if multilineStringEndsOnLine(line, multilineDelimiter) {
+				multilineDelimiter = ""
+			}
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if isTOMLTableHeader(trimmed) {
+			if inPackTable {
+				lines = insertPackNameLine(lines, i, cityName, lineEnding)
+				return []byte(strings.Join(lines, "")), nil
+			}
+			inPackTable = isPackTableHeader(trimmed)
+			if inPackTable {
+				sawPackTable = true
+			}
+			continue
+		}
+		if !inPackTable {
+			continue
+		}
+		key, _, hasAssignment := strings.Cut(stripTOMLInlineComment(trimmed), "=")
+		if hasAssignment && strings.TrimSpace(key) == "name" {
+			lines[i] = rewritePackNameLine(line, cityName)
+			return []byte(strings.Join(lines, "")), nil
+		}
+		if delimiter := startsUnterminatedTOMLMultilineString(line); delimiter != "" {
+			multilineDelimiter = delimiter
+		}
+	}
+
+	if !sawPackTable {
+		return nil, fmt.Errorf("pack.toml missing [pack] table")
+	}
+	lines = insertPackNameLine(lines, len(lines), cityName, lineEnding)
+	return []byte(strings.Join(lines, "")), nil
+}
+
+func splitPreserveNewlines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	var lines []string
+	start := 0
+	for i, r := range text {
+		if r != '\n' {
+			continue
+		}
+		lines = append(lines, text[start:i+1])
+		start = i + 1
+	}
+	if start < len(text) {
+		lines = append(lines, text[start:])
+	}
+	return lines
+}
+
+func isTOMLTableHeader(line string) bool {
+	return strings.HasPrefix(line, "[")
+}
+
+func isPackTableHeader(line string) bool {
+	if !strings.HasPrefix(line, "[") {
+		return false
+	}
+	end := strings.Index(line, "]")
+	if end == -1 {
+		return false
+	}
+	return strings.TrimSpace(line[1:end]) == "pack"
+}
+
+func insertPackNameLine(lines []string, idx int, cityName, lineEnding string) []string {
+	inserted := "name = " + strconv.Quote(cityName) + lineEnding
+	lines = append(lines, "")
+	copy(lines[idx+1:], lines[idx:])
+	lines[idx] = inserted
+	return lines
+}
+
+func rewritePackNameLine(line, cityName string) string {
+	indentLen := len(line) - len(strings.TrimLeft(line, " \t"))
+	indent := line[:indentLen]
+	lineEnding := ""
+	if strings.HasSuffix(line, "\n") {
+		lineEnding = "\n"
+	}
+	comment := ""
+	if suffix := tomlInlineCommentSuffix(strings.TrimRight(line, "\n")); suffix != "" {
+		comment = " " + suffix
+	}
+	return indent + "name = " + strconv.Quote(cityName) + comment + lineEnding
+}
+
+func startsUnterminatedTOMLMultilineString(line string) string {
+	code := stripTOMLInlineComment(line)
+	for _, delimiter := range []string{`"""`, `'''`} {
+		if strings.Count(code, delimiter)%2 == 1 {
+			return delimiter
+		}
+	}
+	return ""
+}
+
+func multilineStringEndsOnLine(line, delimiter string) bool {
+	return strings.Count(line, delimiter)%2 == 1
+}
+
+func stripTOMLInlineComment(line string) string {
+	if suffix := tomlInlineCommentSuffix(line); suffix != "" {
+		return strings.TrimSuffix(line, suffix)
+	}
+	return line
+}
+
+func tomlInlineCommentSuffix(line string) string {
+	inBasic := false
+	inLiteral := false
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch {
+		case inBasic:
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inBasic = false
+			}
+		case inLiteral:
+			if ch == '\'' {
+				inLiteral = false
+			}
+		default:
+			switch ch {
+			case '#':
+				return line[i:]
+			case '"':
+				if strings.HasPrefix(line[i:], `"""`) {
+					return ""
+				}
+				inBasic = true
+			case '\'':
+				if strings.HasPrefix(line[i:], `'''`) {
+					return ""
+				}
+				inLiteral = true
+			}
+		}
+	}
+	return ""
 }
 
 func persistInitWorkspaceIdentity(fs fsys.FS, cityPath, cityTomlPath string, cfg *config.City, cityName, cityPrefix string) error {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -524,6 +524,17 @@ func newInitPackConfig(cityName string) initPackConfig {
 	}
 }
 
+// splitInitConfig separates a composed init template City into its
+// portable pack-first shape and the machine-local city runtime shape:
+//
+//   - pack.toml owns the portable definition: [pack], [[agent]],
+//     [[named_session]], [imports.*], [providers.*], agent/service
+//     patches, formulas, and agent_defaults.
+//   - city.toml keeps only runtime-local deployment settings (e.g.
+//     workspace.provider, workspace.start_command, api, daemon, beads).
+//   - workspace.name and workspace.prefix migrate to .gc/site.toml via
+//     persistInitWorkspaceIdentity, so they are cleared here to avoid
+//     duplicating the city's machine-local identity in city.toml.
 func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.City) {
 	packCfg := newInitPackConfig(cityName)
 	if cfg == nil {
@@ -531,13 +542,61 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 	}
 
 	cityCfg := *cfg
+	cityCfg.Agents = nil
+	cityCfg.NamedSessions = nil
+	cityCfg.Imports = nil
+	cityCfg.Providers = nil
+	cityCfg.Services = nil
+	cityCfg.Formulas = config.FormulasConfig{}
+	cityCfg.Patches = config.Patches{}
+	cityCfg.AgentDefaults = config.AgentDefaults{}
+	cityCfg.AgentsDefaults = config.AgentDefaults{}
+	cityCfg.Workspace.Name = ""
+	cityCfg.Workspace.Prefix = ""
+
+	packCfg.Agents = append([]config.Agent(nil), cfg.Agents...)
+	packCfg.NamedSessions = append([]config.NamedSession(nil), cfg.NamedSessions...)
 	if len(cfg.Imports) > 0 {
 		packCfg.Imports = make(map[string]config.Import, len(cfg.Imports))
 		for name, imp := range cfg.Imports {
 			packCfg.Imports[name] = imp
 		}
-		cityCfg.Imports = nil
 	}
+	if len(cfg.Providers) > 0 {
+		packCfg.Providers = make(map[string]config.ProviderSpec, len(cfg.Providers))
+		for name, spec := range cfg.Providers {
+			packCfg.Providers[name] = spec
+		}
+	}
+	packCfg.AgentDefaults = cfg.AgentDefaults
+	if isZeroValue(packCfg.AgentDefaults) && !isZeroValue(cfg.AgentsDefaults) {
+		packCfg.AgentDefaults = cfg.AgentsDefaults
+	}
+	packCfg.Formulas = cfg.Formulas
+	packCfg.Patches = cfg.Patches
+	for _, svc := range cfg.Services {
+		if svc.PublishMode == "direct" {
+			cityCfg.Services = append(cityCfg.Services, svc)
+			continue
+		}
+		packCfg.Services = append(packCfg.Services, svc)
+	}
+
+	if len(cfg.Workspace.Includes) > 0 {
+		packCfg.Pack.Includes = appendUniqueStrings(
+			append([]string(nil), packCfg.Pack.Includes...),
+			cfg.Workspace.Includes...,
+		)
+		cityCfg.Workspace.Includes = nil
+	}
+	if len(cfg.Workspace.GlobalFragments) > 0 {
+		packCfg.AgentDefaults.AppendFragments = appendUniqueStrings(
+			append([]string(nil), packCfg.AgentDefaults.AppendFragments...),
+			cfg.Workspace.GlobalFragments...,
+		)
+		cityCfg.Workspace.GlobalFragments = nil
+	}
+
 	if len(cfg.DefaultRigImports) > 0 {
 		defaults := packDefaults{
 			Rig: packRigDefaults{
@@ -673,6 +732,10 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	if code := writeDefaultFormulas(fs, cityPath, stderr); code != 0 {
 		return code
 	}
+	// Rewrite legacy prompt paths on the composed config before splitting so
+	// the pack-owned [[agent]] entries pick up the V2 agents/<name>/
+	// prompt.template.md paths we actually scaffold.
+	rewriteInitPromptTemplates(cfg)
 	packCfg, cityCfg := splitInitConfig(cityName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
 	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
@@ -684,10 +747,6 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	if rfErr := ResolveFormulas(cityPath, []string{formulasInitDir}); rfErr != nil {
 		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
 	}
-
-	// Rewrite legacy prompt paths only after we've copied the embedded prompt
-	// scaffolds that still live under prompts/.
-	rewriteInitPromptTemplates(&cityCfg)
 
 	// Re-marshal so the name and rewritten prompt paths are updated.
 	content, err := cityCfg.Marshal()
@@ -812,8 +871,11 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	// Write city.toml — wizard path gets one agent + provider/startCommand;
 	// --provider path gets the same city shape non-interactively;
 	// custom path gets one mayor + no provider (user configures manually).
+	// Rewrite legacy prompt paths on the composed config before splitting so
+	// the pack-owned [[agent]] entries pick up the V2 agents/<name>/
+	// prompt.template.md paths we actually scaffold.
+	rewriteInitPromptTemplates(&cfg)
 	packCfg, cityCfg := splitInitConfig(cityName, &cfg)
-	rewriteInitPromptTemplates(&cityCfg)
 	content, err := cityCfg.Marshal()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/init_identity_failure_test.go
+++ b/cmd/gc/init_identity_failure_test.go
@@ -102,6 +102,9 @@ func TestDoInitFromDirRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testing
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"), srcData, 0o644); err != nil {
 		t.Fatalf("write source city.toml: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"), []byte("[pack]\nname = \"declared-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write source pack.toml: %v", err)
+	}
 
 	cityPath := filepath.Join(t.TempDir(), "target-city")
 	fs := &failSiteBindingRenameFS{target: filepath.Join(cityPath, ".gc", "site.toml")}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -8,10 +8,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/citylayout"
@@ -1536,6 +1538,20 @@ func TestDoInitGastownWritesCanonicalPackV2Shape(t *testing.T) {
 	if !strings.Contains(packToml, "[defaults.rig.imports.gastown]") {
 		t.Fatalf("pack.toml missing canonical default-rig import:\n%s", packToml)
 	}
+	if strings.Contains(packToml, `append_fragments = ["command-glossary", "operational-awareness"]`) {
+		t.Fatalf("pack.toml should not rewrite workspace.global_fragments into append_fragments:\n%s", packToml)
+	}
+	if !strings.Contains(cityToml, `global_fragments = ["command-glossary", "operational-awareness"]`) {
+		t.Fatalf("city.toml should preserve gastown workspace.global_fragments:\n%s", cityToml)
+	}
+
+	cfg, err := config.Parse([]byte(cityToml))
+	if err != nil {
+		t.Fatalf("parsing written city.toml: %v", err)
+	}
+	if got := cfg.Workspace.GlobalFragments; !reflect.DeepEqual(got, []string{"command-glossary", "operational-awareness"}) {
+		t.Fatalf("Workspace.GlobalFragments = %v, want %v", got, []string{"command-glossary", "operational-awareness"})
+	}
 }
 
 func TestDoInitAlreadyInitialized(t *testing.T) {
@@ -2502,6 +2518,10 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
+		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -2528,20 +2548,40 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 		t.Errorf("stdout missing city name: %q", out)
 	}
 
-	// Verify city.toml was copied and name updated.
+	// Verify city.toml keeps runtime-local settings only; machine-local
+	// identity lives in .gc/site.toml and pack.toml adopts the target name.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
 	}
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
+	if raw.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty", raw.Workspace.Name)
 	}
-	if cfg.Workspace.Provider != "claude" {
-		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
+	if raw.Workspace.Provider != "claude" {
+		t.Errorf("Workspace.Provider = %q, want %q", raw.Workspace.Provider, "claude")
+	}
+
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
+	}
+	if cfg.ResolvedWorkspaceName != "bright-lights" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "bright-lights")
+	}
+
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	if !strings.Contains(string(packData), `name = "bright-lights"`) {
+		t.Errorf("pack.toml should keep init name aligned with site workspace name, got:\n%s", string(packData))
+	}
+	if strings.Contains(string(packData), `name = "template"`) {
+		t.Errorf("pack.toml should not keep copied source name, got:\n%s", string(packData))
 	}
 
 	// Verify files were copied.
@@ -2594,6 +2634,10 @@ func TestInitNameFlagWithFrom(t *testing.T) {
 		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
+		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -2610,12 +2654,26 @@ func TestInitNameFlagWithFrom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
 	}
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.Workspace.Name != "my-custom-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-custom-name")
+	if raw.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty", raw.Workspace.Name)
+	}
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.ResolvedWorkspaceName != "my-custom-name" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "my-custom-name")
+	}
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	if !strings.Contains(string(packData), `name = "my-custom-name"`) {
+		t.Errorf("pack.toml should keep init name aligned with site workspace name, got:\n%s", string(packData))
 	}
 }
 
@@ -2702,6 +2760,10 @@ func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
+		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -2718,12 +2780,242 @@ func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
 	}
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.Workspace.Name != "my-new-city" {
-		t.Errorf("Workspace.Name = %q, want %q (--from should default to target dir basename)", cfg.Workspace.Name, "my-new-city")
+	if raw.Workspace.Name != "" {
+		t.Errorf("Workspace.Name = %q, want empty", raw.Workspace.Name)
+	}
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.ResolvedWorkspaceName != "my-new-city" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q (--from should default to target dir basename)", cfg.ResolvedWorkspaceName, "my-new-city")
+	}
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	if !strings.Contains(string(packData), `name = "my-new-city"`) {
+		t.Errorf("pack.toml should keep init name aligned with site workspace name, got:\n%s", string(packData))
+	}
+	if strings.Contains(string(packData), `name = "template"`) {
+		t.Errorf("pack.toml should not keep copied source name, got:\n%s", string(packData))
+	}
+}
+
+func TestInitFromPreservesCopiedPackDefaultRigImportOrder(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nprovider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"), []byte(`[pack]
+name = "template"
+schema = 2
+
+[defaults.rig.imports.zeta]
+source = "./packs/zeta"
+
+[defaults.rig.imports.alpha]
+source = "./packs/alpha"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDirWithOptions(srcDir, cityPath, "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	packText := string(packData)
+	zetaIdx := strings.Index(packText, "[defaults.rig.imports.zeta]")
+	alphaIdx := strings.Index(packText, "[defaults.rig.imports.alpha]")
+	if zetaIdx == -1 || alphaIdx == -1 {
+		t.Fatalf("pack.toml missing copied default rig imports:\n%s", packText)
+	}
+	if zetaIdx > alphaIdx {
+		t.Fatalf("pack.toml reordered copied default rig imports:\n%s", packText)
+	}
+
+	defaultRigImports, err := config.LoadRootPackDefaultRigImports(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadRootPackDefaultRigImports: %v", err)
+	}
+	if len(defaultRigImports) != 2 {
+		t.Fatalf("LoadRootPackDefaultRigImports len = %d, want 2", len(defaultRigImports))
+	}
+	if defaultRigImports[0].Binding != "zeta" || defaultRigImports[1].Binding != "alpha" {
+		t.Fatalf("LoadRootPackDefaultRigImports = %v, want [zeta alpha]", []string{
+			defaultRigImports[0].Binding,
+			defaultRigImports[1].Binding,
+		})
+	}
+}
+
+func TestInitFromPreservesCopiedPackLegacyAgentDefaultsAlias(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nprovider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"), []byte(`[pack]
+name = "template"
+schema = 2
+
+[agents]
+append_fragments = ["legacy-footer"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDirWithOptions(srcDir, cityPath, "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	if err != nil {
+		t.Fatalf("reading pack.toml: %v", err)
+	}
+	packText := string(packData)
+	if !strings.Contains(packText, "[agents]") {
+		t.Fatalf("pack.toml dropped copied [agents] alias:\n%s", packText)
+	}
+
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
+	}
+	if got := cfg.AgentDefaults.AppendFragments; len(got) != 1 || got[0] != "legacy-footer" {
+		t.Fatalf("AgentDefaults.AppendFragments = %v, want [legacy-footer]", got)
+	}
+}
+
+func TestInitFromWithoutPackTomlPreservesLegacyWorkspaceIdentity(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDirWithOptions(srcDir, cityPath, "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	raw, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("parsing city.toml: %v", err)
+	}
+	if raw.Workspace.Name != "bright-lights" {
+		t.Fatalf("Workspace.Name = %q, want %q", raw.Workspace.Name, "bright-lights")
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("pack.toml should not be created for legacy --from templates without a pack manifest")
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, ".gc", "site.toml")); !os.IsNotExist(err) {
+		t.Fatalf(".gc/site.toml should not be written for legacy --from templates without a pack manifest")
+	}
+}
+
+func TestRewritePackNameInCopiedPackTomlPreservesInlineComment(t *testing.T) {
+	out, err := rewritePackNameInCopiedPackToml([]byte(`[pack]
+name = "template" # keep me
+schema = 2
+`), "bright-lights")
+	if err != nil {
+		t.Fatalf("rewritePackNameInCopiedPackToml: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `name = "bright-lights" # keep me`) {
+		t.Fatalf("rewritePackNameInCopiedPackToml should preserve inline comments, got:\n%s", got)
+	}
+
+	var cfg initPackConfig
+	if _, err := toml.Decode(got, &cfg); err != nil {
+		t.Fatalf("toml.Decode(rewritten pack.toml): %v", err)
+	}
+	if cfg.Pack.Name != "bright-lights" {
+		t.Fatalf("Pack.Name = %q, want %q", cfg.Pack.Name, "bright-lights")
+	}
+}
+
+func TestRewritePackNameInCopiedPackTomlIgnoresTableLikeLinesInsideMultilineString(t *testing.T) {
+	out, err := rewritePackNameInCopiedPackToml([]byte(`[pack]
+description = """
+[not-a-table]
+still description
+"""
+schema = 2
+
+[agents]
+append_fragments = ["legacy-footer"]
+`), "bright-lights")
+	if err != nil {
+		t.Fatalf("rewritePackNameInCopiedPackToml: %v", err)
+	}
+	got := string(out)
+	nameIdx := strings.Index(got, `name = "bright-lights"`)
+	if nameIdx == -1 {
+		t.Fatalf("rewritten pack.toml missing name:\n%s", got)
+	}
+	if nameIdx < strings.LastIndex(got, `"""`) {
+		t.Fatalf("rewritePackNameInCopiedPackToml inserted name inside multiline string:\n%s", got)
+	}
+	if agentsIdx := strings.Index(got, "[agents]"); agentsIdx == -1 || nameIdx > agentsIdx {
+		t.Fatalf("rewritePackNameInCopiedPackToml inserted name after [agents]:\n%s", got)
+	}
+
+	var cfg initPackConfig
+	if _, err := toml.Decode(got, &cfg); err != nil {
+		t.Fatalf("toml.Decode(rewritten pack.toml): %v", err)
+	}
+	if cfg.Pack.Name != "bright-lights" {
+		t.Fatalf("Pack.Name = %q, want %q", cfg.Pack.Name, "bright-lights")
+	}
+	if cfg.Pack.Description != "[not-a-table]\nstill description\n" {
+		t.Fatalf("Pack.Description = %q, want multiline description preserved", cfg.Pack.Description)
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1455,23 +1455,25 @@ func TestDoInitSuccess(t *testing.T) {
 		t.Errorf("pack.toml missing schema 2:\n%s", packToml)
 	}
 
-	// Verify written config parses correctly.
-	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
-	cfg, err := config.Parse(data)
+	// Verify the composed config loads correctly from pack.toml + city.toml.
+	// agents + named_session live in pack.toml (pack-first); workspace name
+	// lives in .gc/site.toml as the machine-local binding.
+	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
 	if err != nil {
-		t.Fatalf("parsing written config: %v", err)
+		t.Fatalf("loading written config: %v", err)
 	}
-	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "bright-lights")
+	if cfg.ResolvedWorkspaceName != "bright-lights" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "bright-lights")
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	explicit := explicitAgents(cfg.Agents)
+	if len(explicit) != 1 {
+		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
 	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
+	if explicit[0].Name != "mayor" {
+		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
+		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
 	}
 }
 
@@ -1484,9 +1486,21 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
+	// city.toml keeps only the runtime-local [workspace] (empty in the
+	// default mayor-only path). workspace.name lives in .gc/site.toml.
 	got := string(f.Files[filepath.Join("/bright-lights", "city.toml")])
 	want := `[workspace]
+`
+	if got != want {
+		t.Errorf("city.toml content:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+
+	// pack.toml owns the portable definition: [pack] + [[agent]] mayor +
+	// [[named_session]] mayor (pack-first scaffold from tutorial 01).
+	packGot := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
+	packWant := `[pack]
 name = "bright-lights"
+schema = 2
 
 [[agent]]
 name = "mayor"
@@ -1495,15 +1509,6 @@ prompt_template = "agents/mayor/prompt.template.md"
 [[named_session]]
 template = "mayor"
 mode = "always"
-`
-	if got != want {
-		t.Errorf("city.toml content:\ngot:\n%s\nwant:\n%s", got, want)
-	}
-
-	packGot := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
-	packWant := `[pack]
-name = "bright-lights"
-schema = 2
 `
 	if packGot != packWant {
 		t.Errorf("pack.toml content:\ngot:\n%s\nwant:\n%s", packGot, packWant)
@@ -2003,23 +2008,30 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 		t.Errorf("stdout missing wizard message: %q", out)
 	}
 
-	// Verify written config has one agent and provider.
+	// Verify written raw city.toml keeps the provider (runtime-local) and
+	// the composed config (city.toml + pack.toml) surfaces the mayor agent
+	// from the pack-first scaffold.
 	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Provider != "claude" {
-		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
+	if raw.Workspace.Provider != "claude" {
+		t.Errorf("Workspace.Provider = %q, want %q", raw.Workspace.Provider, "claude")
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
 	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
+	explicit := explicitAgents(cfg.Agents)
+	if len(explicit) != 1 {
+		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if explicit[0].Name != "mayor" {
+		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
+	}
+	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
+		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
 	}
 	// Verify provider appears in TOML.
 	if !strings.Contains(string(data), `provider = "claude"`) {
@@ -2041,20 +2053,25 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	// Verify written config has start_command and no provider.
+	// Verify raw city.toml carries start_command and no provider; the
+	// composed config then surfaces the mayor agent from pack.toml.
 	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.StartCommand != "my-agent --auto" {
-		t.Errorf("Workspace.StartCommand = %q, want %q", cfg.Workspace.StartCommand, "my-agent --auto")
+	if raw.Workspace.StartCommand != "my-agent --auto" {
+		t.Errorf("Workspace.StartCommand = %q, want %q", raw.Workspace.StartCommand, "my-agent --auto")
 	}
-	if cfg.Workspace.Provider != "" {
-		t.Errorf("Workspace.Provider = %q, want empty", cfg.Workspace.Provider)
+	if raw.Workspace.Provider != "" {
+		t.Errorf("Workspace.Provider = %q, want empty", raw.Workspace.Provider)
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
+	}
+	if len(explicitAgents(cfg.Agents)) != 1 {
+		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicitAgents(cfg.Agents)))
 	}
 }
 
@@ -2120,20 +2137,26 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	// Custom template → DefaultCity (one mayor, no provider).
+	// Custom template → DefaultCity (one mayor, no provider). The mayor
+	// agent lives in pack.toml after the pack-first scaffold split.
 	data := f.Files[filepath.Join("/my-city", "city.toml")]
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("len(Agents) = %d, want 1", len(cfg.Agents))
+	if raw.Workspace.Provider != "" {
+		t.Errorf("Workspace.Provider = %q, want empty", raw.Workspace.Provider)
 	}
-	if cfg.Agents[0].Name != "mayor" {
-		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "mayor")
+	cfg, err := loadCityConfigFS(f, filepath.Join("/my-city", "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
 	}
-	if cfg.Workspace.Provider != "" {
-		t.Errorf("Workspace.Provider = %q, want empty", cfg.Workspace.Provider)
+	explicit := explicitAgents(cfg.Agents)
+	if len(explicit) != 1 {
+		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
+	}
+	if explicit[0].Name != "mayor" {
+		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
 	}
 }
 
@@ -2304,35 +2327,41 @@ scale_check = "echo 3"
 		t.Errorf("stdout missing source filename: %q", out)
 	}
 
-	// Verify city.toml was written with updated name.
+	// Verify city.toml was written and the composed config carries the
+	// expected provider + pack-first agents.
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatalf("reading city.toml: %v", err)
 	}
-	cfg, err := config.Parse(data)
+	raw, err := config.Parse(data)
 	if err != nil {
 		t.Fatalf("parsing written config: %v", err)
 	}
-	if cfg.Workspace.Name != "bright-lights" {
-		t.Errorf("Workspace.Name = %q, want %q (should be overridden)", cfg.Workspace.Name, "bright-lights")
+	if raw.Workspace.Provider != "claude" {
+		t.Errorf("Workspace.Provider = %q, want %q", raw.Workspace.Provider, "claude")
 	}
-	if cfg.Workspace.Provider != "claude" {
-		t.Errorf("Workspace.Provider = %q, want %q", cfg.Workspace.Provider, "claude")
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("loading written config: %v", err)
 	}
-	if len(cfg.Agents) != 2 {
-		t.Fatalf("len(Agents) = %d, want 2", len(cfg.Agents))
+	if cfg.ResolvedWorkspaceName != "bright-lights" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q (should be overridden)", cfg.ResolvedWorkspaceName, "bright-lights")
 	}
-	if cfg.Agents[1].Name != "worker" {
-		t.Errorf("Agents[1].Name = %q, want %q", cfg.Agents[1].Name, "worker")
+	explicit := explicitAgents(cfg.Agents)
+	if len(explicit) != 2 {
+		t.Fatalf("len(explicitAgents) = %d, want 2", len(explicit))
 	}
-	if cfg.Agents[1].MaxActiveSessions == nil {
-		t.Fatal("Agents[1].MaxActiveSessions is nil, want non-nil")
+	if explicit[1].Name != "worker" {
+		t.Errorf("explicitAgents[1].Name = %q, want %q", explicit[1].Name, "worker")
 	}
-	if *cfg.Agents[1].MaxActiveSessions != 5 {
-		t.Errorf("Agents[1].MaxActiveSessions = %d, want 5", *cfg.Agents[1].MaxActiveSessions)
+	if explicit[1].MaxActiveSessions == nil {
+		t.Fatal("explicitAgents[1].MaxActiveSessions is nil, want non-nil")
 	}
-	if cfg.Agents[0].PromptTemplate != "agents/mayor/prompt.template.md" {
-		t.Errorf("Agents[0].PromptTemplate = %q, want %q", cfg.Agents[0].PromptTemplate, "agents/mayor/prompt.template.md")
+	if *explicit[1].MaxActiveSessions != 5 {
+		t.Errorf("explicitAgents[1].MaxActiveSessions = %d, want 5", *explicit[1].MaxActiveSessions)
+	}
+	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
+		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
 	}
 
 	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
@@ -2611,16 +2640,14 @@ func TestInitNameFlagWithFile(t *testing.T) {
 		t.Fatalf("cmdInitFromFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	// Workspace name now lives in .gc/site.toml (pack-first scaffold), so
+	// the effective identity comes from the composed site binding.
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
-		t.Fatalf("reading city.toml: %v", err)
+		t.Fatalf("loading config: %v", err)
 	}
-	cfg, err := config.Parse(data)
-	if err != nil {
-		t.Fatalf("parsing config: %v", err)
-	}
-	if cfg.Workspace.Name != "my-file-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-file-name")
+	if cfg.ResolvedWorkspaceName != "my-file-name" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "my-file-name")
 	}
 }
 
@@ -2641,23 +2668,21 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	// Workspace name lives in .gc/site.toml (pack-first scaffold). The
+	// resolved identity derives from site binding.
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
-		t.Fatalf("reading city.toml: %v", err)
+		t.Fatalf("loading config: %v", err)
 	}
-	cfg, err := config.Parse(data)
-	if err != nil {
-		t.Fatalf("parsing config: %v", err)
-	}
-	if cfg.Workspace.Name != "my-bare-name" {
-		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "my-bare-name")
+	if cfg.ResolvedWorkspaceName != "my-bare-name" {
+		t.Errorf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "my-bare-name")
 	}
 	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
 	if err != nil {
 		t.Fatalf("reading pack.toml: %v", err)
 	}
 	if !strings.Contains(string(packData), `name = "my-bare-name"`) {
-		t.Errorf("pack.toml should keep init name aligned with workspace.name, got:\n%s", string(packData))
+		t.Errorf("pack.toml should keep init name aligned with site workspace name, got:\n%s", string(packData))
 	}
 }
 

--- a/cmd/gc/testdata/init-from-dir.txtar
+++ b/cmd/gc/testdata/init-from-dir.txtar
@@ -10,9 +10,12 @@ stdout 'Welcome to Gas City!'
 stdout 'Initialized city'
 stdout 'my-city'
 
-# Verify city.toml exists and name was updated to target dir.
+# Verify city.toml exists but machine-local identity moved to .gc/site.toml.
 exists $WORK/my-city/city.toml
-exec grep 'my-city' $WORK/my-city/city.toml
+! exec grep 'name = "my-city"' $WORK/my-city/city.toml
+exec grep 'workspace_name = "my-city"' $WORK/my-city/.gc/site.toml
+exec grep 'name = "my-city"' $WORK/my-city/pack.toml
+! exec grep 'name = "template"' $WORK/my-city/pack.toml
 
 # Verify prompts were copied.
 exists $WORK/my-city/prompts/mayor.md
@@ -30,13 +33,17 @@ exists $WORK/my-city/.gc
 exec gc init --from $WORK/template --name custom-name $WORK/named-city
 stdout 'custom-name'
 exists $WORK/named-city/city.toml
-exec grep 'custom-name' $WORK/named-city/city.toml
+! exec grep 'name = "custom-name"' $WORK/named-city/city.toml
+exec grep 'workspace_name = "custom-name"' $WORK/named-city/.gc/site.toml
+exec grep 'name = "custom-name"' $WORK/named-city/pack.toml
 
 # gc init --from uses the target dir basename unless --name overrides it,
 # even when the source template already has an explicit workspace.name.
 exec gc init --from $WORK/named-template $WORK/other-basename
-exec grep 'name = "other-basename"' $WORK/other-basename/city.toml
-! exec grep 'name = "mining"' $WORK/other-basename/city.toml
+! exec grep 'name = "other-basename"' $WORK/other-basename/city.toml
+exec grep 'workspace_name = "other-basename"' $WORK/other-basename/.gc/site.toml
+exec grep 'name = "other-basename"' $WORK/other-basename/pack.toml
+! exec grep 'name = "mining"' $WORK/other-basename/pack.toml
 
 # gc init --from rejects already-initialized city.
 ! exec gc init --from $WORK/template $WORK/my-city
@@ -57,6 +64,11 @@ provider = "claude"
 name = "mayor"
 prompt_template = "prompts/mayor.md"
 
+-- template/pack.toml --
+[pack]
+name = "template"
+schema = 2
+
 -- template/prompts/mayor.md --
 You are the mayor.
 
@@ -74,6 +86,11 @@ provider = "claude"
 [[agent]]
 name = "mayor"
 prompt_template = "prompts/mayor.md"
+
+-- named-template/pack.toml --
+[pack]
+name = "mining"
+schema = 2
 
 -- named-template/prompts/mayor.md --
 You are the mayor.

--- a/cmd/gc/testdata/init-from-file.txtar
+++ b/cmd/gc/testdata/init-from-file.txtar
@@ -22,8 +22,9 @@ stdout 'worker'
 stdout 'max_active_sessions = 5'
 
 # gc init --file uses the target dir basename unless --name overrides it.
-exec grep 'name = "my-city"' $WORK/my-city/city.toml
-! exec grep 'name = "placeholder"' $WORK/my-city/city.toml
+exec grep 'name = "my-city"' $WORK/my-city/pack.toml
+! exec grep 'name = "placeholder"' $WORK/my-city/pack.toml
+exec grep 'workspace_name = "my-city"' $WORK/my-city/.gc/site.toml
 
 # gc init --file rejects already-initialized city.
 ! exec gc init --file $WORK/configs/08-agent-pools.toml $WORK/my-city

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -582,7 +582,7 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `name` | string | **yes** |  | Name is the human-readable name for this city. |
+| `name` | string |  |  | Name is the legacy checked-in city name. Runtime identity now resolves from site binding (.gc/site.toml workspace_name), declared config, and basename precedence instead; gc init writes the machine-local name to site.toml and omits it from city.toml. |
 | `prefix` | string |  |  | Prefix overrides the auto-derived HQ bead ID prefix. When empty, the prefix is derived from the city Name via DeriveBeadsPrefix. |
 | `provider` | string |  |  | Provider is the default provider name used by agents that don't specify one. |
 | `start_command` | string |  |  | StartCommand overrides the provider's command for all agents. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1966,7 +1966,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name is the human-readable name for this city."
+          "description": "Name is the legacy checked-in city name. Runtime identity now resolves\nfrom site binding (.gc/site.toml workspace_name), declared config, and\nbasename precedence instead; gc init writes the machine-local name to\nsite.toml and omits it from city.toml."
         },
         "prefix": {
           "type": "string",
@@ -2023,9 +2023,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "name"
-      ],
       "description": "Workspace holds city-level metadata and optional defaults that apply to all agents unless overridden per-agent."
     }
   },

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1966,7 +1966,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name is the human-readable name for this city."
+          "description": "Name is the legacy checked-in city name. Runtime identity now resolves\nfrom site binding (.gc/site.toml workspace_name), declared config, and\nbasename precedence instead; gc init writes the machine-local name to\nsite.toml and omits it from city.toml."
         },
         "prefix": {
           "type": "string",
@@ -2023,9 +2023,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "name"
-      ],
       "description": "Workspace holds city-level metadata and optional defaults that apply to all agents unless overridden per-agent."
     }
   },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -792,8 +792,11 @@ func splitCompoundWord(word string) []string {
 // Workspace holds city-level metadata and optional defaults that apply
 // to all agents unless overridden per-agent.
 type Workspace struct {
-	// Name is the human-readable name for this city.
-	Name string `toml:"name" jsonschema:"required"`
+	// Name is the legacy checked-in city name. Runtime identity now resolves
+	// from site binding (.gc/site.toml workspace_name), declared config, and
+	// basename precedence instead; gc init writes the machine-local name to
+	// site.toml and omits it from city.toml.
+	Name string `toml:"name,omitempty"`
 	// Prefix overrides the auto-derived HQ bead ID prefix. When empty,
 	// the prefix is derived from the city Name via DeriveBeadsPrefix.
 	Prefix string `toml:"prefix,omitempty"`


### PR DESCRIPTION
## Summary

- Restores the pack-first `splitInitConfig` behavior established by PR #892 (merged Apr 19) that PR #949 inadvertently reverted, so `gc init --provider claude` writes the scaffold documented in tutorial 01 (`docs/tutorials/01-cities-and-rigs.md`).
- Clears `workspace.name` / `workspace.prefix` from `city.toml` during init; the machine-local city name already lives in `.gc/site.toml` via `persistInitWorkspaceIdentity`.
- Re-marks `Workspace.Name` as `toml:"name,omitempty"` so the now-blank field is actually omitted on marshal, instead of emitting `name = ""`.

## Why

Tutorial 01 is the Gas City 1.0 onboarding contract:

```
# pack.toml
[pack]
name = "my-city"
schema = 2

[[agent]]
name = "mayor"
prompt_template = "agents/mayor/prompt.template.md"

[[named_session]]
template = "mayor"
mode = "always"

# city.toml
[workspace]
provider = "claude"

# .gc/site.toml
workspace_name = "my-city"
```

On `main` (c22cf324) pre-fix, `gc init --provider claude ~/my-city` produced:
- `pack.toml`: `[pack]` only (no agents, no named_session)
- `city.toml`: `[workspace] name = "my-city" provider = "claude"` plus `[[agent]] mayor` and `[[named_session]] mayor`
- `.gc/site.toml`: `workspace_name = "my-city"` (already correct)

i.e., the `--provider` path emitted the pre-pack-first city-first scaffold, contradicting both the docs and PR #892's intent.

## Root cause

`cmd/gc/cmd_init.go` `splitInitConfig` had been reduced in PR #949 to moving only `Imports` and `DefaultRigImports` into `packCfg`, while leaving `Agents`, `NamedSessions`, `Providers`, `Services`, `Formulas`, `Patches`, `AgentDefaults`, and `Workspace.Name/Prefix` on the `cityCfg` side. That same PR reverted the `Workspace.Name` TOML tag from `toml:"name,omitempty"` back to `toml:"name" jsonschema:"required"`, forcing the name to serialize even if cleared.

This PR restores the full pack-first split (matching PR #892), moves the `rewriteInitPromptTemplates` call to run on the composed config before the split so pack-owned `[[agent]]` entries pick up V2 `agents/<name>/prompt.template.md` paths, and flips the workspace name tag back to `omitempty`.

## Test plan

- [x] `go build ./cmd/gc/` — clean
- [x] `go test ./cmd/gc/ -run 'Init|Scaffold|PackFirst' -count=1` — passing
- [x] `go test ./internal/config/ -count=1` — passing
- [x] Build binary + `gc init --provider claude /tmp/<fresh>/my-city --skip-provider-readiness` — produces exactly the tutorial 01 contract (pack.toml with agent/named_session, city.toml with only `provider = \"claude\"`, site.toml with workspace_name)

## Context

- Fixes divergence from #892 ("fix: make gc init emit a pack-first scaffold") introduced by #949 ("Finish gc import launch backlog")
- Contract reference: `docs/tutorials/01-cities-and-rigs.md`
- Gas City 1.0 ships tomorrow; this is a tutorial-facing regression

/cc @csells @julianknutsen