### PR TITLE
fix: gc session logs --tail N returns last N entries, not first N

### DIFF
--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -28,10 +28,19 @@ Reads the session log, resolves the conversation DAG, and prints
 messages in chronological order. Searches default paths (~/.claude/projects/)
 and any extra paths from [daemon] observe_paths in city.toml.
 
-Use --tail to print only the last N log entries (0 = all). Semantics match
-Unix 'tail -n': '--tail 5' prints the final 5 entries, not the first 5.
+Use --tail to print only the last N transcript entries (0 = all).
+Semantics match Unix 'tail -n': '--tail 5' prints the final 5 entries,
+not the first 5. A single assistant turn with multiple tool-use blocks
+still counts as one entry. Compact-boundary dividers count as entries
+when they fall inside the final window.
+
+Compatibility note: before 1.0, --tail mapped to compaction segments.
+As of 1.0, --tail trims the displayed transcript entry window instead.
+The HTTP API's tail query parameter still uses compaction-segment
+semantics.
 Use -f to follow new messages as they arrive.`,
 		Example: `  gc session logs mayor
+  gc session logs mayor --tail 2
   gc session logs gc-123 --tail 20
   gc session logs gc-123 --tail 0
   gc session logs s-gc-123 -f`,
@@ -44,7 +53,7 @@ Use -f to follow new messages as they arrive.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow new messages as they arrive")
-	cmd.Flags().IntVar(&tail, "tail", 10, "Number of most recent log entries to show (0 = all)")
+	cmd.Flags().IntVar(&tail, "tail", 10, "Number of most recent transcript entries to show (0 = all; compact dividers count as entries)")
 	return cmd
 }
 
@@ -232,9 +241,15 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 		return 1
 	}
 
+	return runSessionLogs(factory, provider, path, follow, tail, stdout, stderr, time.Sleep, readSessionFile)
+}
+
+type sessionLogsReader func(factory *worker.Factory, provider, path string) (*worker.TranscriptSession, error)
+
+func runSessionLogs(factory *worker.Factory, provider, path string, follow bool, tail int, stdout, stderr io.Writer, sleep func(time.Duration), read sessionLogsReader) int {
 	// Always read the full session; apply tail trimming locally so semantics
 	// are a true "last N entries" window regardless of compaction boundaries.
-	sess, readErr := readSessionFile(factory, provider, path, 0)
+	sess, readErr := read(factory, provider, path)
 	if readErr != nil {
 		fmt.Fprintf(stderr, "gc session logs: %v\n", readErr) //nolint:errcheck // best-effort stderr
 		return 1
@@ -262,9 +277,9 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 	const maxConsecErrors = 5
 	consecErrors := 0
 	for {
-		time.Sleep(2 * time.Second)
+		sleep(2 * time.Second)
 
-		sess, readErr = readSessionFile(factory, provider, path, 0)
+		sess, readErr = read(factory, provider, path)
 		if readErr != nil {
 			consecErrors++
 			if consecErrors >= maxConsecErrors {
@@ -285,11 +300,11 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 	}
 }
 
-func readSessionFile(factory *worker.Factory, provider, path string, tail int) (*worker.TranscriptSession, error) {
+func readSessionFile(factory *worker.Factory, provider, path string) (*worker.TranscriptSession, error) {
 	result, err := factory.ReadTranscript(worker.TranscriptRequest{
 		Provider:        provider,
 		TranscriptPath:  path,
-		TailCompactions: tail,
+		TailCompactions: 0,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -28,9 +28,11 @@ Reads the session log, resolves the conversation DAG, and prints
 messages in chronological order. Searches default paths (~/.claude/projects/)
 and any extra paths from [daemon] observe_paths in city.toml.
 
-Use --tail to control how many compaction segments to show (0 = all).
+Use --tail to print only the last N log entries (0 = all). Semantics match
+Unix 'tail -n': '--tail 5' prints the final 5 entries, not the first 5.
 Use -f to follow new messages as they arrive.`,
 		Example: `  gc session logs mayor
+  gc session logs gc-123 --tail 20
   gc session logs gc-123 --tail 0
   gc session logs s-gc-123 -f`,
 		Args: cobra.ExactArgs(1),
@@ -42,7 +44,7 @@ Use -f to follow new messages as they arrive.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow new messages as they arrive")
-	cmd.Flags().IntVar(&tail, "tail", 1, "Number of compaction segments to show (0 = all)")
+	cmd.Flags().IntVar(&tail, "tail", 10, "Number of most recent log entries to show (0 = all)")
 	return cmd
 }
 
@@ -215,6 +217,10 @@ func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, ident
 
 // doSessionLogs reads the session file and prints messages. If follow is true,
 // it polls for new messages every 2 seconds.
+//
+// The tail parameter specifies how many of the most recent log entries to
+// print (0 = all). Semantics match the conventional Unix `tail -n` flag:
+// `--tail 5` prints the LAST 5 entries of the transcript, not the first 5.
 func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr io.Writer) int {
 	if tail < 0 {
 		fmt.Fprintln(stderr, "gc session logs: --tail must be >= 0") //nolint:errcheck // best-effort stderr
@@ -226,32 +232,28 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 		return 1
 	}
 
-	sess, readErr := readSessionFile(factory, provider, path, tail)
+	// Always read the full session; apply tail trimming locally so semantics
+	// are a true "last N entries" window regardless of compaction boundaries.
+	sess, readErr := readSessionFile(factory, provider, path, 0)
 	if readErr != nil {
 		fmt.Fprintf(stderr, "gc session logs: %v\n", readErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	seen := make(map[string]bool)
+	// Seed 'seen' with ALL existing messages so that any entries trimmed by
+	// --tail do not get replayed on subsequent follow-mode re-reads, and so
+	// follow-mode only surfaces entries that arrive AFTER the initial snapshot.
 	for _, msg := range sess.Messages {
-		printLogEntry(stdout, msg)
 		seen[msg.UUID] = true
+	}
+
+	for _, msg := range tailMessages(sess.Messages, tail) {
+		printLogEntry(stdout, msg)
 	}
 
 	if !follow {
 		return 0
-	}
-
-	// Seed 'seen' with ALL existing messages so the tail=0 re-reads in the
-	// follow loop don't replay messages that were intentionally excluded by
-	// the initial tail window.
-	if tail > 0 {
-		full, err := readSessionFile(factory, provider, path, 0)
-		if err == nil {
-			for _, msg := range full.Messages {
-				seen[msg.UUID] = true
-			}
-		}
 	}
 
 	// Follow mode: poll every 2 seconds for new messages.
@@ -293,6 +295,17 @@ func readSessionFile(factory *worker.Factory, provider, path string, tail int) (
 		return nil, err
 	}
 	return result.Session, nil
+}
+
+// tailMessages returns the last n entries of msgs. When n <= 0 the full slice
+// is returned unchanged. When n >= len(msgs) the full slice is also returned.
+// Implements the --tail semantics: "last N log entries" (matches Unix
+// `tail -n` rather than "N compaction segments").
+func tailMessages(msgs []*worker.TranscriptEntry, n int) []*worker.TranscriptEntry {
+	if n <= 0 || n >= len(msgs) {
+		return msgs
+	}
+	return msgs[len(msgs)-n:]
 }
 
 // resolveMessage handles both message formats found in Claude JSONL files:

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -79,11 +79,63 @@ func TestDoSessionLogsBasic(t *testing.T) {
 	}
 }
 
-func TestDoSessionLogsCompactBoundary(t *testing.T) {
+// TestDoSessionLogsTailReturnsLastNEntries verifies the user-facing `--tail N`
+// semantics: print the LAST N displayable log entries (matching Unix `tail -n`),
+// not the FIRST N, and regardless of compaction boundaries in the transcript.
+func TestDoSessionLogsTailReturnsLastNEntries(t *testing.T) {
 	searchBase := t.TempDir()
 	workDir := t.TempDir()
 
-	// Two compact boundaries so tail=1 returns only the last segment.
+	// Six distinct user/assistant entries with no compaction boundaries at all.
+	// This mirrors the Gas City 1.0 tutorial case where a fresh mayor session
+	// has no compactions yet. Prior behavior ("N compaction segments") returned
+	// every entry, printing the FIRST N visible on screen; the corrected
+	// semantics must return the LAST N.
+	writeTestSession(t, searchBase, workDir,
+		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"first"},"timestamp":"2025-01-01T00:00:00Z"}`,
+		`{"uuid":"2","parentUuid":"1","type":"assistant","message":{"role":"assistant","content":"reply-1"},"timestamp":"2025-01-01T00:00:01Z"}`,
+		`{"uuid":"3","parentUuid":"2","type":"user","message":{"role":"user","content":"second"},"timestamp":"2025-01-01T00:00:02Z"}`,
+		`{"uuid":"4","parentUuid":"3","type":"assistant","message":{"role":"assistant","content":"reply-2"},"timestamp":"2025-01-01T00:00:03Z"}`,
+		`{"uuid":"5","parentUuid":"4","type":"user","message":{"role":"user","content":"third"},"timestamp":"2025-01-01T00:00:04Z"}`,
+		`{"uuid":"6","parentUuid":"5","type":"assistant","message":{"role":"assistant","content":"reply-3"},"timestamp":"2025-01-01T00:00:05Z"}`,
+	)
+
+	path := sessionlog.FindSessionFile([]string{searchBase}, workDir)
+	if path == "" {
+		t.Fatal("session file not found")
+	}
+
+	// --tail 2 must return the LAST 2 entries: "third" + "reply-3".
+	var stdout, stderr bytes.Buffer
+	code := doSessionLogs(path, "", false, 2, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "third") {
+		t.Errorf("tail=2 should include the penultimate entry 'third', got: %s", out)
+	}
+	if !strings.Contains(out, "reply-3") {
+		t.Errorf("tail=2 should include the last entry 'reply-3', got: %s", out)
+	}
+	// Everything before the last 2 must be absent. In particular, the FIRST
+	// entry must not leak through — that was the bug the user reported.
+	forbidden := []string{"first", "reply-1", "second", "reply-2"}
+	for _, s := range forbidden {
+		if strings.Contains(out, s) {
+			t.Errorf("tail=2 should not include earlier entry %q (would be 'first N' behavior), got: %s", s, out)
+		}
+	}
+}
+
+// TestDoSessionLogsTailIgnoresCompactBoundaries confirms that `--tail N` counts
+// displayable log entries, not compaction segments: a transcript with several
+// compact boundaries must still yield exactly N trailing entries.
+func TestDoSessionLogsTailIgnoresCompactBoundaries(t *testing.T) {
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+
 	writeTestSession(t, searchBase, workDir,
 		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"first"},"timestamp":"2025-01-01T00:00:00Z"}`,
 		`{"uuid":"2","parentUuid":"1","type":"assistant","message":{"role":"assistant","content":"reply"},"timestamp":"2025-01-01T00:00:01Z"}`,
@@ -100,7 +152,8 @@ func TestDoSessionLogsCompactBoundary(t *testing.T) {
 		t.Fatal("session file not found")
 	}
 
-	// tail=1 should show only from the last compact boundary.
+	// --tail 1 should print exactly the last entry ("reply2"), not "the last
+	// compaction segment."
 	var stdout, stderr bytes.Buffer
 	code := doSessionLogs(path, "", false, 1, &stdout, &stderr)
 	if code != 0 {
@@ -108,14 +161,29 @@ func TestDoSessionLogsCompactBoundary(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if strings.Contains(out, "first") {
-		t.Errorf("tail=1 should not include messages before compact boundary, got: %s", out)
+	if !strings.Contains(out, "reply2") {
+		t.Errorf("tail=1 should include final assistant 'reply2', got: %s", out)
 	}
-	if !strings.Contains(out, "context compacted") {
-		t.Errorf("output should contain compact divider, got: %s", out)
+	for _, forbidden := range []string{"first", "middle", "second"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("tail=1 should not include earlier entry %q, got: %s", forbidden, out)
+		}
 	}
-	if !strings.Contains(out, "second") {
-		t.Errorf("output should contain 'second', got: %s", out)
+
+	// --tail 0 should print everything, including the two compact boundary
+	// dividers.
+	stdout.Reset()
+	stderr.Reset()
+	code = doSessionLogs(path, "", false, 0, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("tail=0 code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out = stdout.String()
+	if !strings.Contains(out, "first") || !strings.Contains(out, "second") {
+		t.Errorf("tail=0 should include all entries, got: %s", out)
+	}
+	if strings.Count(out, "context compacted") != 2 {
+		t.Errorf("tail=0 should render both compact dividers, got: %s", out)
 	}
 }
 

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sessionlog"
+	"github.com/gastownhall/gascity/internal/worker"
 )
 
 func writeTestSession(t *testing.T, searchBase, workDir string, lines ...string) {
@@ -390,75 +393,104 @@ func TestDoSessionLogsNegativeTail(t *testing.T) {
 	}
 }
 
-// TestDoSessionLogsFollowSeeding verifies that follow mode seeds the 'seen' map
-// with ALL existing messages (not just the tail window) before entering the
-// poll loop. Without this, switching from tail=N to tail=0 re-reads would
-// replay messages from before the compaction boundary.
-func TestDoSessionLogsFollowSeeding(t *testing.T) {
-	searchBase := t.TempDir()
-	workDir := t.TempDir()
+// TestDoSessionLogsFollowTailShowsOnlyNewMessagesOnReadErrorExit exercises the
+// real follow path with an initial tail window and exits via the existing
+// consecutive-read-error threshold. Older pre-tail entries must be marked seen
+// from the initial snapshot so that follow-mode re-reads only emit messages
+// that arrived after the command started watching.
+func TestDoSessionLogsFollowTailShowsOnlyNewMessagesOnReadErrorExit(t *testing.T) {
+	initial := &sessionlog.Session{
+		Messages: []*sessionlog.Entry{
+			{
+				UUID:      "1",
+				Type:      "user",
+				Message:   jsonMessage(t, "user", "old msg"),
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				UUID:      "2",
+				Type:      "system",
+				Subtype:   "compact_boundary",
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 1, 0, time.UTC),
+			},
+			{
+				UUID:      "3",
+				Type:      "user",
+				Message:   jsonMessage(t, "user", "middle msg"),
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 2, 0, time.UTC),
+			},
+			{
+				UUID:      "4",
+				Type:      "system",
+				Subtype:   "compact_boundary",
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 3, 0, time.UTC),
+			},
+			{
+				UUID:      "5",
+				Type:      "user",
+				Message:   jsonMessage(t, "user", "recent msg"),
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 4, 0, time.UTC),
+			},
+		},
+	}
+	withNew := &sessionlog.Session{
+		Messages: append(append([]*sessionlog.Entry{}, initial.Messages...),
+			&sessionlog.Entry{
+				UUID:      "6",
+				Type:      "assistant",
+				Message:   jsonMessage(t, "assistant", "fresh msg"),
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 5, 0, time.UTC),
+			},
+		),
+	}
 
-	// Session with two compact boundaries: tail=1 shows only the last segment.
-	// Need 2 boundaries so sliceAtCompactBoundaries actually trims.
-	writeTestSession(t, searchBase, workDir,
-		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"old msg"},"timestamp":"2025-01-01T00:00:00Z"}`,
-		`{"uuid":"2","parentUuid":"1","type":"system","subtype":"compact_boundary","message":{"role":"system","content":"compacted 1"},"timestamp":"2025-01-01T00:00:01Z"}`,
-		`{"uuid":"3","parentUuid":"2","type":"user","message":{"role":"user","content":"middle msg"},"timestamp":"2025-01-01T00:00:02Z"}`,
-		`{"uuid":"4","parentUuid":"3","type":"system","subtype":"compact_boundary","message":{"role":"system","content":"compacted 2"},"timestamp":"2025-01-01T00:00:03Z"}`,
-		`{"uuid":"5","parentUuid":"4","type":"user","message":{"role":"user","content":"recent msg"},"timestamp":"2025-01-01T00:00:04Z"}`,
+	var stdout, stderr bytes.Buffer
+	readCount := 0
+	code := runSessionLogs(
+		nil,
+		"",
+		"/ignored",
+		true,
+		1,
+		&stdout,
+		&stderr,
+		func(time.Duration) {},
+		func(_ *worker.Factory, _ string, _ string) (*worker.TranscriptSession, error) {
+			readCount++
+			switch readCount {
+			case 1:
+				return initial, nil
+			case 2:
+				return withNew, nil
+			default:
+				return nil, fmt.Errorf("boom %d", readCount)
+			}
+		},
 	)
-
-	path := sessionlog.FindSessionFile([]string{searchBase}, workDir)
-	if path == "" {
-		t.Fatal("session file not found")
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 after injected consecutive read failures", code)
 	}
 
-	// Simulate what doSessionLogs does: initial tail=1 read, then seed seen
-	// map with tail=0. Verify "old msg" uuid is in seen even though it
-	// wasn't printed.
-	sess, err := sessionlog.ReadFile(path, 1)
-	if err != nil {
-		t.Fatal(err)
+	out := stdout.String()
+	if !strings.Contains(out, "recent msg") {
+		t.Fatalf("initial tail window should print the most recent existing entry, got: %s", out)
 	}
-
-	seen := make(map[string]bool)
-	for _, msg := range sess.Messages {
-		seen[msg.UUID] = true
+	if !strings.Contains(out, "fresh msg") {
+		t.Fatalf("follow mode should print the new message from the reread, got: %s", out)
 	}
-
-	// At this point, seen should NOT contain uuid "1" (it's before the boundary).
-	if seen["1"] {
-		t.Fatal("tail=1 should not include pre-boundary messages")
-	}
-
-	// Now simulate the seeding step (what doSessionLogs does before follow loop).
-	full, err := sessionlog.ReadFile(path, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, msg := range full.Messages {
-		seen[msg.UUID] = true
-	}
-
-	// After seeding, "1" should be in seen — preventing replay on re-read.
-	if !seen["1"] {
-		t.Error("after follow-mode seeding, pre-boundary message UUID should be in seen")
-	}
-
-	// Simulate a follow-mode re-read: no unseen messages should exist.
-	reread, err := sessionlog.ReadFile(path, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var unseen []string
-	for _, msg := range reread.Messages {
-		if !seen[msg.UUID] {
-			unseen = append(unseen, msg.UUID)
+	for _, forbidden := range []string{"old msg", "middle msg"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("follow mode should not replay pre-tail entry %q, got: %s", forbidden, out)
 		}
 	}
-	if len(unseen) > 0 {
-		t.Errorf("follow-mode re-read found unseen messages (would be replayed): %v", unseen)
+	if !strings.Contains(stderr.String(), "5 consecutive read errors") {
+		t.Fatalf("stderr should report the injected termination condition, got: %s", stderr.String())
 	}
+}
+
+func jsonMessage(t *testing.T, role, content string) []byte {
+	t.Helper()
+	return []byte(fmt.Sprintf(`{"role":%q,"content":%q}`, role, content))
 }
 
 func TestPrintLogEntryTimestamp(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2013,7 +2013,16 @@ Reads the session log, resolves the conversation DAG, and prints
 messages in chronological order. Searches default paths (~/.claude/projects/)
 and any extra paths from [daemon] observe_paths in city.toml.
 
-Use --tail to control how many compaction segments to show (0 = all).
+Use --tail to print only the last N transcript entries (0 = all).
+Semantics match Unix 'tail -n': '--tail 5' prints the final 5 entries,
+not the first 5. A single assistant turn with multiple tool-use blocks
+still counts as one entry. Compact-boundary dividers count as entries
+when they fall inside the final window.
+
+Compatibility note: before 1.0, --tail mapped to compaction segments.
+As of 1.0, --tail trims the displayed transcript entry window instead.
+The HTTP API's tail query parameter still uses compaction-segment
+semantics.
 Use -f to follow new messages as they arrive.
 
 ```
@@ -2024,6 +2033,8 @@ gc session logs <session> [flags]
 
 ```
 gc session logs mayor
+  gc session logs mayor --tail 2
+  gc session logs gc-123 --tail 20
   gc session logs gc-123 --tail 0
   gc session logs s-gc-123 -f
 ```
@@ -2031,7 +2042,7 @@ gc session logs mayor
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-f`, `--follow` | bool |  | Follow new messages as they arrive |
-| `--tail` | int | `1` | Number of compaction segments to show (0 = all) |
+| `--tail` | int | `10` | Number of most recent transcript entries to show (0 = all; compact dividers count as entries) |
 
 ## gc session new
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -7205,12 +7205,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },
@@ -7656,12 +7656,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },
@@ -15188,12 +15188,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -7205,12 +7205,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },
@@ -7656,12 +7656,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },
@@ -15188,12 +15188,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -253,9 +253,13 @@ mc-wisp-8t8 is a review request for the auth module. I've routed it to
 my-project/reviewer.
 ```
 
-`--tail N` prints the last N log entries (same convention as `tail -n`), so
-`--tail 2` above shows the most recent user prompt and the mayor's reply.
-Use `--tail 0` to print the whole conversation. Follow live output with `-f`:
+`--tail N` prints the last N transcript entries (same convention as `tail -n`),
+so `--tail 2` above shows the most recent user prompt and the mayor's reply.
+Compact-boundary dividers count as entries if one lands inside that final
+window. Use `--tail 0` to print the whole conversation. Compatibility note:
+before 1.0, `--tail` counted compaction segments; as of 1.0 it counts
+displayed transcript entries instead. The HTTP API's `tail` query parameter
+still counts compaction segments. Follow live output with `-f`:
 
 ```shell
 ~/my-city

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -244,7 +244,7 @@ conversation history:
 
 ```shell
 ~/my-city
-$ gc session logs mayor --tail 1
+$ gc session logs mayor --tail 2
 07:22:29 [USER] [my-city] mayor • 2026-04-08T00:22:24
 Check the status of mc-wisp-8t8
 
@@ -253,9 +253,9 @@ mc-wisp-8t8 is a review request for the auth module. I've routed it to
 my-project/reviewer.
 ```
 
-Note that `--tail` here counts compaction _segments_, not lines — `--tail 1`
-shows the most recent segment, `--tail 0` shows all of them. Follow live output
-with `-f`:
+`--tail N` prints the last N log entries (same convention as `tail -n`), so
+`--tail 2` above shows the most recent user prompt and the mayor's reply.
+Use `--tail 0` to print the whole conversation. Follow live output with `-f`:
 
 ```shell
 ~/my-city

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2621,7 +2621,7 @@ type WorkspaceResponse struct {
 
 // GetV0CityByCityNameAgentByBaseOutputParams defines parameters for GetV0CityByCityNameAgentByBaseOutput.
 type GetV0CityByCityNameAgentByBaseOutputParams struct {
-	// Tail Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N.
+	// Tail Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N.
 	Tail *string `form:"tail,omitempty" json:"tail,omitempty"`
 
 	// Before Message UUID cursor for loading older messages.
@@ -2633,7 +2633,7 @@ type PostV0CityByCityNameAgentByBaseByActionParamsAction string
 
 // GetV0CityByCityNameAgentByDirByBaseOutputParams defines parameters for GetV0CityByCityNameAgentByDirByBaseOutput.
 type GetV0CityByCityNameAgentByDirByBaseOutputParams struct {
-	// Tail Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N.
+	// Tail Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N.
 	Tail *string `form:"tail,omitempty" json:"tail,omitempty"`
 
 	// Before Message UUID cursor for loading older messages.
@@ -3029,7 +3029,7 @@ type StreamSessionParams struct {
 
 // GetV0CityByCityNameSessionByIdTranscriptParams defines parameters for GetV0CityByCityNameSessionByIdTranscript.
 type GetV0CityByCityNameSessionByIdTranscriptParams struct {
-	// Tail Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N.
+	// Tail Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N.
 	Tail *string `form:"tail,omitempty" json:"tail,omitempty"`
 
 	// Format Transcript format: conversation (default) or raw.

--- a/internal/api/huma_types.go
+++ b/internal/api/huma_types.go
@@ -84,6 +84,9 @@ type WaitParam struct {
 
 // TailParam is an embeddable input mixin for transcript/agent-output
 // endpoints that use the sessionlog "tail N compaction segments" shape.
+// These API parameters intentionally retain compaction-segment semantics
+// even though the gc session logs CLI now counts displayed transcript
+// entries instead.
 //
 // tail stays typed as a string on the wire so three request states are
 // distinguishable:
@@ -97,7 +100,7 @@ type WaitParam struct {
 // Resolve method validates non-negative integer format and returns 422
 // for garbage.
 type TailParam struct {
-	Tail string `query:"tail" required:"false" doc:"Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N."`
+	Tail string `query:"tail" required:"false" doc:"Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N>0 returns the last N."`
 }
 
 // Resolve validates Tail. Huma calls this during binding.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -7205,12 +7205,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },
@@ -7656,12 +7656,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },
@@ -15188,12 +15188,12 @@
             }
           },
           {
-            "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+            "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
             "explode": false,
             "in": "query",
             "name": "tail",
             "schema": {
-              "description": "Number of recent compaction segments to return. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
+              "description": "Number of recent compaction segments to return. This API parameter keeps compaction-segment semantics even though gc session logs --tail counts displayed transcript entries. Omit for the endpoint default (usually 1); 0 returns all segments; N\u003e0 returns the last N.",
               "type": "string"
             }
           },

--- a/test/acceptance/tutorial_goldens/TODO.md
+++ b/test/acceptance/tutorial_goldens/TODO.md
@@ -22,7 +22,7 @@ tutorial prose are merged together.
   page renders them later without first establishing the helper agent or those
   sessions.
 - Tutorial 03: page driver waits for `mayor` to become peekable and for
-  `gc session logs mayor --tail 1` to become readable before the visible
+  `gc session logs mayor --tail 2` to become readable before the visible
   peek/log steps because native Claude transcript files can lag session start.
 - Tutorial 04: page driver nudges the mayor after `gc mail send` so the visible
   `gc session peek mayor --lines 6` step can exercise the communication path in

--- a/test/acceptance/tutorial_goldens/manifests_test.go
+++ b/test/acceptance/tutorial_goldens/manifests_test.go
@@ -62,7 +62,7 @@ var tutorialPageManifests = []pageManifest{
 			"gc session attach mayor",
 			`gc session nudge mayor "What's the current city status?"`,
 			"gc session list",
-			"gc session logs mayor --tail 1",
+			"gc session logs mayor --tail 2",
 			"gc session logs mayor -f",
 			`gc session nudge mayor "What's the current city status?"`,
 		},

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/03-sessions.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/03-sessions.md
@@ -231,7 +231,7 @@ conversation history:
 
 ```shell
 ~/my-city
-$ gc session logs mayor --tail 1
+$ gc session logs mayor --tail 2
 07:22:29 [USER] [my-city] mayor • 2026-04-08T00:22:24
 Check the status of mc-wisp-8t8
 
@@ -240,9 +240,13 @@ mc-wisp-8t8 is a review request for the auth module. I've routed it to
 my-project/reviewer.
 ```
 
-Note that `--tail` here counts compaction _segments_, not lines — `--tail 1`
-shows the most recent segment, `--tail 0` shows all of them. Follow live output
-with `-f`:
+`--tail N` prints the last N transcript entries (same convention as `tail -n`),
+so `--tail 2` above shows the most recent user prompt and the mayor's reply.
+Compact-boundary dividers count as entries if one lands inside that final
+window. Use `--tail 0` to print the whole conversation. Compatibility note:
+before 1.0, `--tail` counted compaction segments; as of 1.0 it counts
+displayed transcript entries instead. The HTTP API's `tail` query parameter
+still counts compaction segments. Follow live output with `-f`:
 
 ```shell
 ~/my-city

--- a/test/acceptance/tutorial_goldens/tutorial03_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial03_test.go
@@ -289,7 +289,7 @@ func TestTutorial03Sessions(t *testing.T) {
 
 	ws.noteWarning("tutorial 03 runtime workaround: named mayor sessions can take a restart cycle before their alias-based transcript path becomes readable, so the page driver first waits for the visible log command as-is and only then nudges the runtime through supported session commands")
 	mayorLogsReadable := func() bool {
-		out, err := ws.runShell("gc session logs mayor --tail 1", "")
+		out, err := ws.runShell("gc session logs mayor --tail 2", "")
 		if err != nil || strings.TrimSpace(out) == "" {
 			return false
 		}
@@ -316,13 +316,13 @@ func TestTutorial03Sessions(t *testing.T) {
 		t.Fatalf("mayor transcript never became readable through alias mayor:\n%s", out)
 	}
 
-	t.Run("gc session logs mayor --tail 1", func(t *testing.T) {
-		out, err := ws.runShell("gc session logs mayor --tail 1", "")
+	t.Run("gc session logs mayor --tail 2", func(t *testing.T) {
+		out, err := ws.runShell("gc session logs mayor --tail 2", "")
 		if err != nil {
-			t.Fatalf("gc session logs mayor --tail 1: %v\n%s", err, out)
+			t.Fatalf("gc session logs mayor --tail 2: %v\n%s", err, out)
 		}
 		if strings.TrimSpace(out) == "" {
-			t.Fatal("session logs --tail 1 output is empty")
+			t.Fatal("session logs --tail 2 output is empty")
 		}
 	})
 


### PR DESCRIPTION
## Summary

`gc session logs <target> --tail N` used to return the first N entries of a
transcript instead of the last N. Root cause: the flag was wired through the
transcript reader as `TailCompactions` ("show the last N compaction segments"),
and `sliceAtCompactBoundaries` returns the full transcript unchanged when the
session has fewer than N compact boundaries. For a freshly-started mayor (the
tutorial's exact scenario), that means `--tail 5` dumps the entire transcript
starting with the initial priming USER message — which renders on screen as
"the first 5 entries", not the expected last 5.

This PR changes the CLI semantics of `--tail` to match the Unix `tail -n`
convention users already expect:

- `--tail 5` prints the **last** 5 log entries.
- `--tail 0` still prints the whole session.
- Default bumped to `10` (matching GNU `tail`) now that the unit is individual
  log entries rather than compaction segments.
- `--tail` negative still errors out, as before.

Internally, `doSessionLogs` now reads the full session (`TailCompactions=0`)
and trims locally via a small `tailMessages(msgs, n)` helper. The API-facing
compaction-based pagination in `internal/sessionlog` is unchanged — only the
CLI surface is corrected.

Found while walking through tutorial 03 for the 1.0 ship; tutorial text and
example updated to match the corrected semantics.

/cc @csells @julianknutsen — please add milestone **1.0** and add yourselves
as reviewers (I don't have permission to set those from the PR form).

## Test plan

- [x] `go build ./cmd/gc/` clean.
- [x] `go vet ./cmd/gc/...` clean.
- [x] New `TestDoSessionLogsTailReturnsLastNEntries` asserts `--tail 2` on a
      6-entry boundary-free transcript returns only the last 2 entries and
      **rejects** any of the earlier entries leaking through.
- [x] New `TestDoSessionLogsTailIgnoresCompactBoundaries` asserts `--tail 1`
      returns only the final entry regardless of multiple compact boundaries
      in the transcript, and that `--tail 0` still returns everything
      including both compact dividers.
- [x] All existing session-logs unit tests in `cmd/gc/` pass
      (`go test ./cmd/gc/ -run 'SessionLogs|session_logs|ResolveSessionLog|...' -count=1`).
- [x] Built binary `gc session logs --help` shows the corrected flag docs and
      updated default.

Closes the empirical "tutorial returned first 5 instead of last 5" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)