### PR TITLE
fix: route gc formula cook and show to rig store (#1014)

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -106,7 +106,25 @@ Examples:
 
 			compileVars := vars
 
-			recipe, err := formula.Compile(cmd.Context(), name, cityFormulaSearchPaths(stderr), compileVars)
+			cityPath, err := resolveCity()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadCityConfig(cityPath, stderr)
+			if err != nil {
+				return err
+			}
+			rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, rigFlag)
+			if err != nil {
+				return err
+			}
+			rigName := ""
+			if rig != nil {
+				rigName = rig.Name
+			}
+			searchPaths := cfg.FormulaLayers.SearchPaths(rigName)
+
+			recipe, err := formula.Compile(cmd.Context(), name, searchPaths, compileVars)
 			if err != nil {
 				return err
 			}
@@ -345,20 +363,6 @@ func parseMetadataArgs(items []string) (map[string]string, error) {
 		out[key] = value
 	}
 	return out, nil
-}
-
-// cityFormulaSearchPaths returns the city-level formula search paths.
-// Best-effort: returns nil if no city is loaded.
-func cityFormulaSearchPaths(warningWriter ...io.Writer) []string {
-	cityPath, err := resolveCity()
-	if err != nil {
-		return nil
-	}
-	cfg, err := loadCityConfig(cityPath, warningWriter...)
-	if err != nil {
-		return nil
-	}
-	return cfg.FormulaLayers.City
 }
 
 // allFormulaSearchPaths returns the deduplicated union of formula search

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -229,15 +229,33 @@ bead into a sub-workflow at runtime.`,
 			if err != nil {
 				return err
 			}
-			store, err := openStoreAtForCity(cityPath, cityPath)
+
+			// Resolve target store scope: explicit --rig flag wins, else cwd,
+			// else city. Matches the pattern used by gc bd and gc sling so
+			// cooking a formula from a rig directory writes beads with the
+			// rig's prefix into the rig's store.
+			rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, rigFlag)
+			if err != nil {
+				return err
+			}
+			storeDir := cityPath
+			rigName := ""
+			if rig != nil {
+				storeDir = resolveStoreScopeRoot(cityPath, rig.Path)
+				rigName = rig.Name
+			}
+
+			store, err := openStoreAtForCity(storeDir, cityPath)
 			if err != nil {
 				return err
 			}
 
+			searchPaths := cfg.FormulaLayers.SearchPaths(rigName)
+
 			cookVars := parseFormulaVars(vars)
 
 			if attach != "" {
-				recipe, err := formula.Compile(cmd.Context(), args[0], cfg.FormulaLayers.City, cookVars)
+				recipe, err := formula.Compile(cmd.Context(), args[0], searchPaths, cookVars)
 				if err != nil {
 					return fmt.Errorf("compile: %w", err)
 				}
@@ -259,7 +277,7 @@ bead into a sub-workflow at runtime.`,
 				return nil
 			}
 
-			result, err := molecule.Cook(cmd.Context(), store, args[0], cfg.FormulaLayers.City, molecule.Options{
+			result, err := molecule.Cook(cmd.Context(), store, args[0], searchPaths, molecule.Options{
 				Title: title,
 				Vars:  cookVars,
 			})

--- a/cmd/gc/rig_scope_resolution.go
+++ b/cmd/gc/rig_scope_resolution.go
@@ -9,6 +9,40 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+// resolveRigScopeFromFlagOrCwd returns the rig a command should target,
+// preferring an explicit --rig flag value over cwd-based detection. A nil
+// result means no rig was resolved (caller should fall back to city scope).
+//
+// This is the shared primitive for commands whose only rig signals are the
+// --rig flag and the working directory (e.g. gc formula cook).
+//
+// Commands that can also discover a rig from other signals — such as gc bd
+// (bead-ID prefix in args) or gc sling (agent target, bead prefix) — have
+// their own richer resolvers. They may delegate the flag/cwd leg here if
+// their precedence rules permit it, but those with intermediate signals
+// (like bd's bead-ID sniffing between flag and cwd) must layer their own
+// logic explicitly.
+func resolveRigScopeFromFlagOrCwd(cfg *config.City, cityPath, rigName string) (*config.Rig, error) {
+	if strings.TrimSpace(rigName) != "" {
+		rig, ok := rigByName(cfg, rigName)
+		if !ok {
+			return nil, fmt.Errorf("rig %q not found", rigName)
+		}
+		if strings.TrimSpace(rig.Path) == "" {
+			return nil, fmt.Errorf("rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it", rig.Name, rig.Name)
+		}
+		return &rig, nil
+	}
+	rig, ok, err := bdRigFromCwd(cfg, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return &rig, nil
+}
+
 func rigForDir(cfg *config.City, cityPath, dir string) (config.Rig, bool) {
 	rig, ok, _ := resolveRigForDir(cfg, cityPath, dir)
 	return rig, ok

--- a/cmd/gc/rig_scope_resolution_test.go
+++ b/cmd/gc/rig_scope_resolution_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestResolveRigScopeFromFlagOrCwd(t *testing.T) {
+	cityPath := t.TempDir()
+	rigA := filepath.Join(cityPath, "rig-a")
+	rigB := filepath.Join(cityPath, "rig-b")
+	for _, d := range []string{rigA, rigB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "rig-a", Path: rigA},
+			{Name: "rig-b", Path: rigB},
+			{Name: "unbound"}, // declared but no path binding
+		},
+	}
+
+	t.Run("explicit flag selects named rig", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "rig-a")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig == nil || rig.Name != "rig-a" {
+			t.Fatalf("rig = %+v, want rig-a", rig)
+		}
+	})
+
+	t.Run("explicit flag wins over cwd", func(t *testing.T) {
+		t.Chdir(rigA)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "rig-b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig == nil || rig.Name != "rig-b" {
+			t.Fatalf("rig = %+v, want rig-b (flag should override cwd)", rig)
+		}
+	})
+
+	t.Run("unknown rig flag returns error", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "nope")
+		if err == nil {
+			t.Fatalf("want error, got rig=%+v", rig)
+		}
+		if !strings.Contains(err.Error(), `"nope" not found`) {
+			t.Fatalf("error = %v, want 'not found' for unknown rig", err)
+		}
+	})
+
+	t.Run("unbound rig flag returns error", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "unbound")
+		if err == nil {
+			t.Fatalf("want error, got rig=%+v", rig)
+		}
+		if !strings.Contains(err.Error(), "no path binding") {
+			t.Fatalf("error = %v, want 'no path binding' guidance", err)
+		}
+	})
+
+	t.Run("cwd in rig dir resolves to that rig", func(t *testing.T) {
+		t.Chdir(rigB)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig == nil || rig.Name != "rig-b" {
+			t.Fatalf("rig = %+v, want rig-b from cwd", rig)
+		}
+	})
+
+	t.Run("cwd outside rigs returns nil (city scope)", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig != nil {
+			t.Fatalf("rig = %+v, want nil (city scope)", rig)
+		}
+	})
+
+	t.Run("whitespace-only flag treated as no flag", func(t *testing.T) {
+		t.Chdir(cityPath)
+		rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, "   ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rig != nil {
+			t.Fatalf("rig = %+v, want nil (whitespace flag should not select a rig)", rig)
+		}
+	})
+}

--- a/cmd/gc/rig_scope_resolution_test.go
+++ b/cmd/gc/rig_scope_resolution_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -104,4 +105,63 @@ func TestResolveRigScopeFromFlagOrCwd(t *testing.T) {
 			t.Fatalf("rig = %+v, want nil (whitespace flag should not select a rig)", rig)
 		}
 	})
+}
+
+// TestRigScopeDrivesFormulaSearchPaths locks in the integration between
+// resolveRigScopeFromFlagOrCwd and FormulaLayers.SearchPaths used by both
+// `gc formula cook` and `gc formula show`. The #1004 bug had two halves:
+// a wrong store root AND wrong search paths; asserting the search-path
+// half here prevents regression even if the store half is correct.
+func TestRigScopeDrivesFormulaSearchPaths(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cityLayers := []string{"/city/formulas"}
+	rigLayers := []string{"/city/formulas", "/rigs/my-project/formulas"}
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "my-project", Path: rigPath}},
+		FormulaLayers: config.FormulaLayers{
+			City: cityLayers,
+			Rigs: map[string][]string{"my-project": rigLayers},
+		},
+	}
+
+	cases := []struct {
+		name    string
+		cwd     string
+		flag    string
+		wantRig string
+		want    []string
+	}{
+		{"cwd in rig yields rig layers", rigPath, "", "my-project", rigLayers},
+		{"flag yields rig layers", cityPath, "my-project", "my-project", rigLayers},
+		{"city scope yields city layers", cityPath, "", "", cityLayers},
+	}
+
+	prev := rigFlag
+	t.Cleanup(func() { rigFlag = prev })
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(tc.cwd)
+			rig, err := resolveRigScopeFromFlagOrCwd(cfg, cityPath, tc.flag)
+			if err != nil {
+				t.Fatalf("resolveRigScopeFromFlagOrCwd: %v", err)
+			}
+			rigName := ""
+			if rig != nil {
+				rigName = rig.Name
+			}
+			if rigName != tc.wantRig {
+				t.Errorf("rigName = %q, want %q", rigName, tc.wantRig)
+			}
+			got := cfg.FormulaLayers.SearchPaths(rigName)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("searchPaths = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Closes #1004 — `gc formula cook` (and `gc formula show`) hardcoded the city store / city-only search paths, so invoking from a rig cwd (or with `--rig`) silently created city-prefixed beads and failed to find rig-layer formulas.

**Fix**:
- New shared primitive `resolveRigScopeFromFlagOrCwd` in `cmd/gc/rig_scope_resolution.go` (canonical home for this family). Returns `*config.Rig` — nil means city scope. Precedence: `--rig` flag > cwd > city.
- `newFormulaCookCmd` and `newFormulaShowCmd` both consume the primitive, pick `storeDir = resolveStoreScopeRoot(cityPath, rig.Path)`, and use `cfg.FormulaLayers.SearchPaths(rigName)` so rig-layer formulas shadow city-layer ones.
- Both cook branches (default and `--attach`) and show share the same scope → same behavior.
- Deletes the now-dead `cityFormulaSearchPaths` helper (its name lied about its job; after the show fix, zero callers).

Helper doc comment explicitly lays out how `gc bd` and `gc sling` (which layer extra signals like bead-ID sniffing) can adopt the primitive in a follow-up.

## Verification

Manual repro from #1004:

```
# Before: mc-* (city prefix) from rig cwd — wrong
# After:
cd ~/my-project && gc formula cook pancakes        # mp-* ✓ (cwd)
gc --rig my-project formula cook pancakes          # mp-* ✓ (flag)
gc formula cook pancakes                           # mc-* ✓ (city fallback unchanged)
gc formula show rig-specific-formula               # finds rig layer ✓ (cwd)
gc --rig my-project formula show rig-formula       # finds rig layer ✓ (flag)
```

## Tests

10 new unit tests across `cmd/gc/rig_scope_resolution_test.go`:

**Primitive (`TestResolveRigScopeFromFlagOrCwd`, 7 cases):**
- `explicit flag selects named rig`
- `explicit flag wins over cwd`
- `unknown rig flag returns error`
- `unbound rig flag returns error` (with actionable `gc rig add` guidance)
- `cwd in rig dir resolves to that rig`
- `cwd outside rigs returns nil (city scope)`
- `whitespace-only flag treated as no flag`

**Scope → search paths integration (`TestRigScopeDrivesFormulaSearchPaths`, 3 cases):**
- `cwd in rig yields rig layers`
- `flag yields rig layers`
- `city scope yields city layers`

This last test explicitly asserts `cfg.FormulaLayers.SearchPaths(rigName)` — defense against the "searchPaths wrong even when storeRoot is right" half of the #1004 bug class.

## Testing

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/gc -run "TestResolveRigScope|TestRigScopeDrivesFormulaSearchPaths|TestFormula"` — all pass
- [x] `go test ./internal/formula/... ./internal/molecule/...` — clean
- [x] Manual repro of all three cases in #1004 — fixed for both cook and show
- [ ] `make test-integration` — not run locally; fork CI gated at `action_required` pending maintainer approval. Change is localized to CLI scope resolution; no store/runtime behavior altered.

## Notes

This PR supersedes my earlier #1011 (single-commit `fix/formula-cook-rig-scope` branch). Extended here to also fix the symmetric bug in `gc formula show` (same root cause: helper returned only `FormulaLayers.City`) and to delete the now-dead helper.

Related PR #1010 from @sjarmak targets the same issue with a formula-subsystem-internal `resolveFormulaScope`. This PR instead extracts the primitive into `rig_scope_resolution.go` where it can be reused by `gc bd` / `gc sling` / any future rig-aware command, and documents that extension path in the helper's doc comment.
