### PR TITLE
fix: gc mail send from shell shows FROM=human (was: FROM=recipient)

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -921,6 +921,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 		}
 	}
 
+	senderExplicit := from != ""
 	sender := from
 	if sender == "" {
 		if store != nil {
@@ -938,11 +939,6 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-	}
-
-	var nf nudgeFunc
-	if notify && store != nil {
-		nf = newMailNudgeFunc(sender)
 	}
 
 	// When --to is set, prepend it to args so doMailSend sees [to, body].
@@ -972,6 +968,21 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 		if validRecipients != nil {
 			validRecipients[canonicalTo] = true
 		}
+	}
+
+	// A sender derived from inherited session env vars that exactly matches
+	// the recipient almost always indicates a human running gc from a shell
+	// attached to (or inside) the recipient's session, not the recipient
+	// agent mailing itself. Fall back to "human" so inbox attribution matches
+	// the tutorial's documented behaviour. Agents that legitimately want to
+	// send mail to themselves can opt in explicitly with --from.
+	if !senderExplicit && !all && len(args) > 0 && sender == args[0] {
+		sender = "human"
+	}
+
+	var nf nudgeFunc
+	if notify && store != nil {
+		nf = newMailNudgeFunc(sender)
 	}
 
 	if all {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -465,6 +465,146 @@ func TestCmdMailSendDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *testi
 	}
 }
 
+// TestCmdMailSendHumanFallbackWhenEnvDerivedSenderEqualsRecipient guards the
+// tutorial-04 behaviour: when a human runs `gc mail send mayor ...` from a
+// shell that has inherited session env vars for that same mailbox (e.g. the
+// user is physically inside the mayor's tmux session), the env-derived sender
+// would otherwise resolve to the recipient itself and produce FROM=mayor.
+// Without --from set, we fall back to "human" so inbox attribution matches the
+// intuitive (and documented) "this came from a human" shape.
+func TestCmdMailSendHumanFallbackWhenEnvDerivedSenderEqualsRecipient(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "mayor",
+			"session_name": "mayor-gc-42",
+		},
+	}); err != nil {
+		t.Fatalf("Create mayor session: %v", err)
+	}
+
+	// Simulate a human running `gc mail send mayor` from a shell that has
+	// inherited the mayor session's runtime env vars. Without the fallback
+	// this would attribute the sender as "mayor" — the bug reported in
+	// tutorial 04.
+	t.Setenv("GC_SESSION_ID", "mayor-gc-42")
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_AGENT", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend([]string{"mayor", "note from human"}, false, false, "", "", "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	storeAfter, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt after send: %v", err)
+	}
+	all, err := storeAfter.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	var msg beads.Bead
+	found := false
+	for _, b := range all {
+		if b.Type == "message" {
+			msg = b
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("message bead not found; beads=%#v", all)
+	}
+	if msg.Assignee != "mayor" {
+		t.Fatalf("message Assignee = %q, want mayor", msg.Assignee)
+	}
+	if msg.From == msg.Assignee {
+		t.Fatalf("message From (%q) must not equal Assignee (%q); inbox would show FROM=recipient", msg.From, msg.Assignee)
+	}
+	if msg.From != "human" {
+		t.Fatalf("message From = %q, want human", msg.From)
+	}
+}
+
+// TestCmdMailSendExplicitFromIsRespectedEvenWhenMatchingRecipient ensures the
+// human-fallback heuristic only applies when the caller did *not* pass --from.
+// An agent legitimately mailing itself can opt in via --from <self>.
+func TestCmdMailSendExplicitFromIsRespectedEvenWhenMatchingRecipient(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "mayor",
+			"session_name": "mayor-gc-42",
+		},
+	}); err != nil {
+		t.Fatalf("Create mayor session: %v", err)
+	}
+
+	_ = os.Unsetenv("GC_SESSION_ID")
+	_ = os.Unsetenv("GC_ALIAS")
+	_ = os.Unsetenv("GC_AGENT")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailSend([]string{"mayor", "note to self"}, false, false, "mayor", "", "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	storeAfter, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt after send: %v", err)
+	}
+	all, err := storeAfter.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	var msg beads.Bead
+	found := false
+	for _, b := range all {
+		if b.Type == "message" {
+			msg = b
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("message bead not found; beads=%#v", all)
+	}
+	if msg.From != "mayor" {
+		t.Fatalf("message From = %q, want mayor (explicit --from must not be rewritten)", msg.From)
+	}
+}
+
 func TestResolveDefaultMailTargetsForCommand_HumanDefaultWhenNoEnv(t *testing.T) {
 	t.Setenv("GC_MAIL", "fake")
 	_ = os.Unsetenv("GC_ALIAS")


### PR DESCRIPTION
## Summary

When a human runs `gc mail send mayor ...` from a shell that has inherited the mayor session's runtime env vars (`GC_SESSION_ID` / `GC_ALIAS` / `GC_AGENT`), the env-derived default sender resolves to `"mayor"` — the recipient — so `gc mail inbox mayor` renders `FROM=mayor` instead of the tutorial-documented `FROM=human`.

- This is the tutorial-04 walkthrough scenario ([`docs/tutorials/04-communication.md`](docs/tutorials/04-communication.md) line 73-74: `FROM=human`).
- The acceptance golden test (`test/acceptance/tutorial_goldens/tutorial04_communication_test.go`) does not catch it because the tutorial harness filters env to a minimal allowlist (see `test/acceptance/helpers/env.go`) that omits the `GC_SESSION_*` / `GC_ALIAS` / `GC_AGENT` vars, so default sender resolution always hits the `"human"` path there.

## Fix

In `cmdMailSend`, after resolving both the default sender and the canonical recipient, fall back to `"human"` when `--from` was not explicitly supplied and the derived sender equals the recipient. A sender == recipient via env-var defaulting almost always indicates a human running `gc` from a shell attached to the recipient's session, not the recipient agent mailing itself. Agents that legitimately want to self-mail can opt in with `--from <self>`.

Narrowly scoped:
- Only triggers when `--from` is empty (explicit `--from` is untouched).
- Only triggers when the resolved sender exactly equals the canonical recipient.
- Only applies to `gc mail send <to>` (not `--all` broadcasts).

## Test plan

- [x] `go build ./cmd/gc/` is clean
- [x] Added regression test `TestCmdMailSendHumanFallbackWhenEnvDerivedSenderEqualsRecipient` — without the fix it fails with `message From ("mayor") must not equal Assignee ("mayor"); inbox would show FROM=recipient`; with the fix it passes.
- [x] Added guard test `TestCmdMailSendExplicitFromIsRespectedEvenWhenMatchingRecipient` — asserts `--from mayor` is not rewritten by the fallback.
- [x] All existing `TestMailSend*` / `TestCmdMailSend*` tests still pass.
- [x] `./internal/mail/...` tests still pass.

cc @csells @julianknutsen — flagged for milestone 1.0 cutline. Please label `1.0-cutline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)