### PR TITLE
fix: limit live in-progress bead queries

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -523,7 +523,7 @@ func collectAssignedWorkBeadsWithStores(
 	for _, s := range stores {
 		seen := make(map[string]struct{})
 		// In-progress beads with an assignee (active work).
-		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress"}); err == nil {
+		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
 			appendAssignedUnique(&result, &resultStores, inProgress, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -375,7 +375,7 @@ func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallb
 	}
 	empty := ""
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status})
+		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: status == "in_progress"})
 		if err != nil {
 			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", sessionID, err) //nolint:errcheck
 			continue
@@ -403,7 +403,7 @@ func reassignWorkAssignedToRetiredSessionBead(store beads.Store, oldSessionID, n
 		stderr = io.Discard
 	}
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status})
+		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status, Live: status == "in_progress"})
 		if err != nil {
 			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", oldSessionID, err) //nolint:errcheck
 			continue

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1143,7 +1143,7 @@ func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (b
 				continue
 			}
 			seen[key] = struct{}{}
-			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status})
+			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: status == "in_progress"})
 			if err != nil {
 				return false, err
 			}
@@ -1498,6 +1498,7 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		assigned, err := store.List(beads.ListQuery{
 			Assignee: assignee,
 			Status:   "in_progress",
+			Live:     true,
 			Sort:     beads.SortCreatedDesc,
 		})
 		if err != nil {

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -235,6 +235,7 @@ func (s *Server) findActiveBeadForAssignees(rig string, assignees ...string) str
 			matches, err := stores[rn].List(beads.ListQuery{
 				Assignee: assignee,
 				Status:   "in_progress",
+				Live:     true,
 				Limit:    1,
 				Sort:     beads.SortCreatedDesc,
 			})

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -203,7 +203,7 @@ func reassignOpenWorkAssignedToSession(store beads.Store, oldID, newID string) e
 		return nil
 	}
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldID, Status: status})
+		work, err := store.List(beads.ListQuery{Assignee: oldID, Status: status, Live: status == "in_progress"})
 		if err != nil {
 			return fmt.Errorf("listing work assigned to retired session %s: %w", oldID, err)
 		}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -41,7 +41,7 @@ func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
 	}
 }
 
-func TestCachingStoreListInProgressUsesBackingStore(t *testing.T) {
+func TestCachingStoreListInProgressUsesCacheByDefault(t *testing.T) {
 	t.Parallel()
 
 	backing := NewMemStore()
@@ -67,8 +67,39 @@ func TestCachingStoreListInProgressUsesBackingStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
+	if len(got) != 0 {
+		t.Fatalf("List(in_progress) = %+v, want cached result before reconcile", got)
+	}
+}
+
+func TestCachingStoreListLiveBypassesCache(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{
+		Title:    "claimed work",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "in_progress"
+	if err := backing.Update(bead.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	got, err := cache.List(ListQuery{Status: "in_progress", Live: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
 	if len(got) != 1 || got[0].ID != bead.ID {
-		t.Fatalf("List(in_progress) = %+v, want %s from backing store", got, bead.ID)
+		t.Fatalf("List(in_progress, Live) = %+v, want %s from backing store", got, bead.ID)
 	}
 }
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -14,7 +14,7 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
 	}
-	if query.Status == "in_progress" {
+	if query.Live {
 		return c.backing.List(query)
 	}
 

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -36,7 +36,10 @@ type ListQuery struct {
 	Limit         int
 	IncludeClosed bool
 	AllowScan     bool
-	Sort          SortOrder
+	// Live bypasses CachingStore and reads from the backing store. Use it only
+	// for lifecycle gates that must observe external mutations immediately.
+	Live bool
+	Sort SortOrder
 }
 
 // HasFilter reports whether the query includes at least one indexed selector.


### PR DESCRIPTION
## Summary

- add an explicit `ListQuery.Live` opt-in for cache bypasses
- restore default cached behavior for `Status: "in_progress"` queries
- mark only lifecycle/ownership call paths live where stale data can stop or reassign active sessions incorrectly

## Rationale

PR #1020 fixed the observed review-formulas failure by making every in-progress list query bypass the cache. That was correct for the stale claimed-work bug, but broader than needed. The actual risk is limited to paths that make realtime lifecycle decisions from active work: desired-state collection, session close/drain gates, task workdir continuity, retired-session reassignment, and API active-bead/session reassignment lookups.

This keeps cheap cached reads as the default and requires call sites to opt into backing-store freshness when they are about to make an expensive or mutating decision.

## Tests

- `go test ./internal/beads/...`
- `go test ./cmd/gc -run 'Test(CollectAssignedWork|SessionHasOpenAssignedWork|ResolveTaskWorkDir|FindActiveBead)'`
- `go test ./internal/api/...`
- `make fmt-check`
- `make lint`

Note: `go test ./cmd/gc ./internal/beads/... ./internal/api/...` hit the repo's 10-minute timeout in unrelated long-running `cmd/gc` controller/session tests; the targeted changed-path tests and API/beads package tests passed.
