### PR TITLE
fix(tmux): eliminate silent inline fallback for large prompts

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/overlay"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
 // Provider adapts [Tmux] to the [runtime.Provider] interface.
@@ -837,6 +838,7 @@ const maxInlinePromptLen = 1024
 
 func ensureFreshSession(ops startOps, name string, cfg runtime.Config) error {
 	fullCommand := cfg.Command
+	promptFile := ""
 	if cfg.PromptSuffix != "" {
 		if len(cfg.PromptSuffix) > maxInlinePromptLen {
 			// Large prompt — write to temp file and use $(cat ...) expansion
@@ -844,7 +846,8 @@ func ensureFreshSession(ops startOps, name string, cfg runtime.Config) error {
 			// prevent the quoted prompt from leaking into the exec command
 			// line (which triggers ENAMETOOLONG / exit 126 when the total
 			// command overflows kernel argv/exec buffers).
-			promptFile, err := writePromptFile(cfg.WorkDir, name, cfg.PromptSuffix)
+			var err error
+			promptFile, err = writePromptFile(cfg.WorkDir, name, cfg.PromptSuffix)
 			if err != nil {
 				// No silent fallback: the inline path would produce the
 				// "File name too long" tmux pane death that this helper
@@ -852,13 +855,7 @@ func ensureFreshSession(ops startOps, name string, cfg runtime.Config) error {
 				// records it and the operator can diagnose the cause.
 				return fmt.Errorf("writing prompt temp file for session %q: %w", name, err)
 			}
-			if cfg.PromptFlag != "" {
-				fullCommand = fmt.Sprintf(`sh -c 'exec %s %s "$(cat %q)" && rm -f %q'`,
-					cfg.Command, cfg.PromptFlag, promptFile, promptFile)
-			} else {
-				fullCommand = fmt.Sprintf(`sh -c 'exec %s "$(cat %q)" && rm -f %q'`,
-					cfg.Command, promptFile, promptFile)
-			}
+			fullCommand = longPromptCommand(cfg.Command, cfg.PromptFlag, promptFile)
 		} else {
 			if cfg.PromptFlag != "" {
 				fullCommand = fullCommand + " " + cfg.PromptFlag + " " + cfg.PromptSuffix
@@ -879,17 +876,17 @@ func ensureFreshSession(ops startOps, name string, cfg runtime.Config) error {
 		}
 	}
 	if !errors.Is(err, ErrSessionExists) {
-		return fmt.Errorf("creating session: %w", err)
+		return cleanupPromptFileOnError(promptFile, fmt.Errorf("creating session: %w", err))
 	}
 
 	// Session exists but the pane is already dead (e.g. remain-on-exit corpse).
 	// Safe to recycle even when ProcessNames are unavailable.
 	if !ops.isSessionRunning(name) {
 		if err := ops.killSession(name); err != nil {
-			return fmt.Errorf("killing dead session: %w", err)
+			return cleanupPromptFileOnError(promptFile, fmt.Errorf("killing dead session: %w", err))
 		}
-		if err := recreateSessionAfterCleanup(ops, name, cfg.WorkDir, fullCommand, cfg.Env); err != nil {
-			return fmt.Errorf("creating session after dead-session cleanup: %w", err)
+		if err := recreateSessionAfterCleanup(ops, name, cfg.WorkDir, fullCommand, cfg.Env, promptFile); err != nil {
+			return cleanupPromptFileOnError(promptFile, fmt.Errorf("creating session after dead-session cleanup: %w", err))
 		}
 		return nil
 	}
@@ -897,31 +894,65 @@ func ensureFreshSession(ops startOps, name string, cfg runtime.Config) error {
 	// Session exists — without process names we can't distinguish a zombie
 	// from a healthy session, so treat it as a duplicate.
 	if len(cfg.ProcessNames) == 0 {
-		return fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name)
+		return cleanupPromptFileOnError(promptFile, fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name))
 	}
 
 	// We have process names — check if the agent is alive.
 	if ops.isRuntimeRunning(name, cfg.ProcessNames) {
-		return fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name)
+		return cleanupPromptFileOnError(promptFile, fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name))
 	}
 
 	// Zombie: tmux alive but agent dead. Kill and recreate.
 	if err := ops.killSession(name); err != nil {
-		return fmt.Errorf("killing zombie session: %w", err)
+		return cleanupPromptFileOnError(promptFile, fmt.Errorf("killing zombie session: %w", err))
 	}
-	if err := recreateSessionAfterCleanup(ops, name, cfg.WorkDir, fullCommand, cfg.Env); err != nil {
-		return fmt.Errorf("creating session after zombie cleanup: %w", err)
+	if err := recreateSessionAfterCleanup(ops, name, cfg.WorkDir, fullCommand, cfg.Env, promptFile); err != nil {
+		return cleanupPromptFileOnError(promptFile, fmt.Errorf("creating session after zombie cleanup: %w", err))
 	}
 	return nil
 }
 
-func recreateSessionAfterCleanup(ops startOps, name, workDir, command string, env map[string]string) error {
+func longPromptCommand(command, promptFlag, promptFile string) string {
+	quotedPromptFile := shellquote.Quote(promptFile)
+	var script string
+	if promptFlag != "" {
+		script = fmt.Sprintf(`__gc_prompt="$(cat %s && printf .)"; __gc_status=$?; rm -f %s; [ "$__gc_status" -eq 0 ] || exit "$__gc_status"; __gc_prompt="${__gc_prompt%%.}"; exec %s %s "$__gc_prompt"`,
+			quotedPromptFile, quotedPromptFile, command, promptFlag)
+	} else {
+		script = fmt.Sprintf(`__gc_prompt="$(cat %s && printf .)"; __gc_status=$?; rm -f %s; [ "$__gc_status" -eq 0 ] || exit "$__gc_status"; __gc_prompt="${__gc_prompt%%.}"; exec %s "$__gc_prompt"`,
+			quotedPromptFile, quotedPromptFile, command)
+	}
+	return "sh -c " + shellquote.Quote(script)
+}
+
+func removePromptFile(promptFile string) error {
+	if promptFile == "" {
+		return nil
+	}
+	if err := os.Remove(promptFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing prompt temp file %q: %w", promptFile, err)
+	}
+	return nil
+}
+
+func cleanupPromptFileOnError(promptFile string, err error) error {
+	if promptFile == "" || err == nil {
+		return err
+	}
+	if removeErr := removePromptFile(promptFile); removeErr != nil {
+		return errors.Join(err, removeErr)
+	}
+	return err
+}
+
+func recreateSessionAfterCleanup(ops startOps, name, workDir, command string, env map[string]string, promptFile string) error {
 	err := ops.createSession(name, workDir, command, env)
 	if errors.Is(err, ErrNoServer) {
 		time.Sleep(50 * time.Millisecond)
 		err = ops.createSession(name, workDir, command, env)
 	}
 	if errors.Is(err, ErrSessionExists) {
+		_ = removePromptFile(promptFile)
 		return nil // race: another process created it
 	}
 	return err
@@ -933,11 +964,12 @@ func recreateSessionAfterCleanup(ops startOps, name, workDir, command string, en
 // element.
 //
 // Preferred location is <workDir>/.gc/tmp (visible from inside the worktree
-// and cleaned up with the agent's scratch space). If that path is unusable
-// — workDir is empty, doesn't exist yet (pre_start hasn't materialized the
-// worktree), or is read-only — falls back to os.TempDir(). The fallback is
-// load-bearing: without it a failed MkdirAll used to trigger a silent
-// "inline the prompt into the tmux command line" path that produced
+// and cleaned up with the agent's scratch space). A non-empty WorkDir must
+// exist and be a directory, because tmux may otherwise start the pane in the
+// wrong checkout. If WorkDir is empty, or WorkDir exists but its .gc/tmp path
+// is unusable, this falls back to a gc-scoped directory under os.TempDir().
+// The fallback is load-bearing: without it a failed MkdirAll used to trigger
+// a silent "inline the prompt into the tmux command line" path that produced
 // "cannot execute: File name too long" pane deaths for large prompts.
 func writePromptFile(workDir, agentName, shellQuotedPrompt string) (string, error) {
 	// Strip surrounding single quotes from shell-quoted string.
@@ -952,18 +984,26 @@ func writePromptFile(workDir, agentName, shellQuotedPrompt string) (string, erro
 	// want a valid argv-via-file path to avoid the inline fallback.
 	var candidateErrs []error
 	if workDir != "" {
-		dir := filepath.Join(workDir, ".gc", "tmp")
-		if path, err := writePromptToDir(dir, agentName, raw); err == nil {
-			return path, nil
-		} else {
-			candidateErrs = append(candidateErrs, fmt.Errorf("workdir tmp: %w", err))
+		info, err := os.Stat(workDir)
+		if err != nil {
+			return "", fmt.Errorf("workdir unavailable: %w", err)
 		}
+		if !info.IsDir() {
+			return "", fmt.Errorf("workdir %q is not a directory", workDir)
+		}
+		dir := filepath.Join(workDir, ".gc", "tmp")
+		path, err := writePromptToDir(dir, agentName, raw)
+		if err == nil {
+			return path, nil
+		}
+		candidateErrs = append(candidateErrs, fmt.Errorf("workdir tmp: %w", err))
 	}
-	if path, err := writePromptToDir(os.TempDir(), agentName, raw); err == nil {
+	osTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf(".gc-%d", os.Getuid()), "tmux-prompts")
+	path, err := writePromptToDir(osTmpDir, agentName, raw)
+	if err == nil {
 		return path, nil
-	} else {
-		candidateErrs = append(candidateErrs, fmt.Errorf("os tmp: %w", err))
 	}
+	candidateErrs = append(candidateErrs, fmt.Errorf("os tmp: %w", err))
 	return "", errors.Join(candidateErrs...)
 }
 

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -838,25 +838,26 @@ const maxInlinePromptLen = 1024
 func ensureFreshSession(ops startOps, name string, cfg runtime.Config) error {
 	fullCommand := cfg.Command
 	if cfg.PromptSuffix != "" {
-		if len(cfg.PromptSuffix) > maxInlinePromptLen && cfg.WorkDir != "" {
+		if len(cfg.PromptSuffix) > maxInlinePromptLen {
 			// Large prompt — write to temp file and use $(cat ...) expansion
-			// inside the tmux session's shell to avoid the protocol limit.
+			// inside the tmux session's shell to avoid the protocol limit and
+			// prevent the quoted prompt from leaking into the exec command
+			// line (which triggers ENAMETOOLONG / exit 126 when the total
+			// command overflows kernel argv/exec buffers).
 			promptFile, err := writePromptFile(cfg.WorkDir, name, cfg.PromptSuffix)
-			if err == nil {
-				if cfg.PromptFlag != "" {
-					fullCommand = fmt.Sprintf(`sh -c 'exec %s %s "$(cat %q)" && rm -f %q'`,
-						cfg.Command, cfg.PromptFlag, promptFile, promptFile)
-				} else {
-					fullCommand = fmt.Sprintf(`sh -c 'exec %s "$(cat %q)" && rm -f %q'`,
-						cfg.Command, promptFile, promptFile)
-				}
+			if err != nil {
+				// No silent fallback: the inline path would produce the
+				// "File name too long" tmux pane death that this helper
+				// exists to prevent. Surface the failure so the reconciler
+				// records it and the operator can diagnose the cause.
+				return fmt.Errorf("writing prompt temp file for session %q: %w", name, err)
+			}
+			if cfg.PromptFlag != "" {
+				fullCommand = fmt.Sprintf(`sh -c 'exec %s %s "$(cat %q)" && rm -f %q'`,
+					cfg.Command, cfg.PromptFlag, promptFile, promptFile)
 			} else {
-				// Fall back to inline (will likely fail, but preserves old behavior).
-				if cfg.PromptFlag != "" {
-					fullCommand = fullCommand + " " + cfg.PromptFlag + " " + cfg.PromptSuffix
-				} else {
-					fullCommand = fullCommand + " " + cfg.PromptSuffix
-				}
+				fullCommand = fmt.Sprintf(`sh -c 'exec %s "$(cat %q)" && rm -f %q'`,
+					cfg.Command, promptFile, promptFile)
 			}
 		} else {
 			if cfg.PromptFlag != "" {
@@ -926,10 +927,18 @@ func recreateSessionAfterCleanup(ops startOps, name, workDir, command string, en
 	return err
 }
 
-// writePromptFile writes a shell-quoted prompt string to a temp file in
-// the agent's working directory. The file contains the raw prompt text
-// (unquoted) so it can be read back via $(cat ...) inside the shell.
-// Returns the file path on success.
+// writePromptFile writes a shell-quoted prompt string to a temp file for
+// the tmux session's shell to read back via $(cat ...). The file contains
+// the raw prompt text (unquoted) so shell expansion yields a single argv
+// element.
+//
+// Preferred location is <workDir>/.gc/tmp (visible from inside the worktree
+// and cleaned up with the agent's scratch space). If that path is unusable
+// — workDir is empty, doesn't exist yet (pre_start hasn't materialized the
+// worktree), or is read-only — falls back to os.TempDir(). The fallback is
+// load-bearing: without it a failed MkdirAll used to trigger a silent
+// "inline the prompt into the tmux command line" path that produced
+// "cannot execute: File name too long" pane deaths for large prompts.
 func writePromptFile(workDir, agentName, shellQuotedPrompt string) (string, error) {
 	// Strip surrounding single quotes from shell-quoted string.
 	raw := shellQuotedPrompt
@@ -937,7 +946,30 @@ func writePromptFile(workDir, agentName, shellQuotedPrompt string) (string, erro
 		raw = raw[1 : len(raw)-1]
 		raw = strings.ReplaceAll(raw, `'\''`, `'`)
 	}
-	dir := filepath.Join(workDir, ".gc", "tmp")
+
+	// Try workDir-scoped path first so the prompt file sits next to the
+	// session's scratch state. An unusable workDir is not fatal; we still
+	// want a valid argv-via-file path to avoid the inline fallback.
+	var candidateErrs []error
+	if workDir != "" {
+		dir := filepath.Join(workDir, ".gc", "tmp")
+		if path, err := writePromptToDir(dir, agentName, raw); err == nil {
+			return path, nil
+		} else {
+			candidateErrs = append(candidateErrs, fmt.Errorf("workdir tmp: %w", err))
+		}
+	}
+	if path, err := writePromptToDir(os.TempDir(), agentName, raw); err == nil {
+		return path, nil
+	} else {
+		candidateErrs = append(candidateErrs, fmt.Errorf("os tmp: %w", err))
+	}
+	return "", errors.Join(candidateErrs...)
+}
+
+// writePromptToDir creates the target directory and writes the prompt to
+// a new temp file inside it. Returns the temp file path on success.
+func writePromptToDir(dir, agentName, raw string) (string, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -3,15 +3,22 @@ package tmux
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/shellquote"
 )
+
+func fallbackPromptDir(tmpRoot string) string {
+	return filepath.Join(tmpRoot, fmt.Sprintf(".gc-%d", os.Getuid()), "tmux-prompts")
+}
 
 // startCall records a single invocation on fakeStartOps with full arguments.
 type startCall struct {
@@ -1362,21 +1369,173 @@ func TestEnsureFreshSession_LongPromptWithFlagUsesFileExpansion(t *testing.T) {
 	if !strings.HasPrefix(c.command, "sh -c '") {
 		t.Fatalf("long prompt should use sh -c wrapper, got %q", c.command)
 	}
-	// The flag must appear as a separate token before $(cat ...).
-	if !strings.Contains(c.command, "--prompt \"$(cat ") {
-		t.Errorf("flag-mode long prompt should include --prompt before $(cat ...), got %q", c.command)
+	// The flag must appear as a separate token before the loaded prompt.
+	if !strings.Contains(c.command, `--prompt "$__gc_prompt"`) {
+		t.Errorf("flag-mode long prompt should pass the loaded prompt after --prompt, got %q", c.command)
 	}
 }
 
-// TestEnsureFreshSession_LongPromptUnusableWorkDirFallsBackToOSTemp verifies
-// that when WorkDir points at a path that can't be materialized (e.g. the
-// polecat worktree pre_start hasn't run yet, leaving the worktree missing),
-// the prompt still lands in a temp file and the tmux command still uses
-// file-expansion. Regression for gc-yha: PackV2 polecat spawns died with
-// "cannot execute: File name too long" because writePromptFile failed on
-// the missing workdir and the silent fallback embedded the raw prompt in
-// the tmux command string.
-func TestEnsureFreshSession_LongPromptUnusableWorkDirFallsBackToOSTemp(t *testing.T) {
+func longPromptScriptFromCommand(t *testing.T, command string) string {
+	t.Helper()
+	args := shellquote.Split(command)
+	if len(args) != 3 || args[0] != "sh" || args[1] != "-c" {
+		t.Fatalf("long-prompt command should be sh -c <script>, got args %#v from %q", args, command)
+	}
+	return args[2]
+}
+
+func promptFileFromLongPromptCommand(t *testing.T, command string) string {
+	t.Helper()
+	script := longPromptScriptFromCommand(t, command)
+	const marker = `$(cat `
+	start := strings.Index(script, marker)
+	if start < 0 {
+		t.Fatalf("long-prompt script missing cat expansion: %q", script)
+	}
+	start += len(marker)
+	end := strings.Index(script[start:], ` && printf .)`)
+	if end < 0 {
+		t.Fatalf("long-prompt script has unterminated prompt path: %q", script)
+	}
+	args := shellquote.Split(script[start : start+end])
+	if len(args) != 1 {
+		t.Fatalf("long-prompt script has invalid prompt path expression %q parsed as %#v", script[start:start+end], args)
+	}
+	return args[0]
+}
+
+func TestEnsureFreshSession_LongPromptRemovesPromptFileBeforeExec(t *testing.T) {
+	ops := &fakeStartOps{}
+
+	longPrompt := "'" + strings.Repeat("x", maxInlinePromptLen+100) + "'"
+	cfg := runtime.Config{
+		WorkDir:      t.TempDir(),
+		Command:      "claude --dangerously-skip-permissions",
+		PromptSuffix: longPrompt,
+	}
+	if err := ensureFreshSession(ops, "gc-test-clean-before-exec", cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := ops.calls[0]
+	script := longPromptScriptFromCommand(t, c.command)
+	readIdx := strings.Index(script, "$(cat ")
+	rmIdx := strings.Index(script, "rm -f ")
+	execIdx := strings.Index(script, "exec ")
+	if readIdx < 0 || rmIdx < 0 || execIdx < 0 {
+		t.Fatalf("long-prompt script missing read/remove/exec sequence: %q", script)
+	}
+	if readIdx >= rmIdx || rmIdx >= execIdx {
+		t.Fatalf("prompt file must be read and removed before exec replaces the shell, got %q", script)
+	}
+}
+
+func TestLongPromptCommandPreservesTrailingNewlines(t *testing.T) {
+	tmp := t.TempDir()
+	promptDir := filepath.Join(tmp, "dir$HOME")
+	if err := os.MkdirAll(promptDir, 0o700); err != nil {
+		t.Fatalf("create prompt dir: %v", err)
+	}
+	promptFile := filepath.Join(promptDir, "prompt.txt")
+	outFile := filepath.Join(tmp, "out.txt")
+	rawPrompt := "first line\nsecond line\n\n"
+	if err := os.WriteFile(promptFile, []byte(rawPrompt), 0o600); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	receiver := "sh -c " + shellquote.Quote(`printf %s "$1" > "$0"`) + " " + shellquote.Quote(outFile)
+	command := longPromptCommand(receiver, "", promptFile)
+	cmd := exec.Command("sh", "-c", command)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("running long prompt command: %v\n%s", err, output)
+	}
+
+	got, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(got) != rawPrompt {
+		t.Fatalf("prompt payload mismatch:\ngot  %q\nwant %q", string(got), rawPrompt)
+	}
+	if _, err := os.Stat(promptFile); !os.IsNotExist(err) {
+		t.Fatalf("prompt file should be removed by wrapper, stat err = %v", err)
+	}
+}
+
+func TestEnsureFreshSession_LongPromptShellWrapperQuotesScript(t *testing.T) {
+	ops := &fakeStartOps{}
+
+	tmpRoot := filepath.Join(t.TempDir(), "o'brien")
+	if err := os.MkdirAll(tmpRoot, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Setenv("TMPDIR", tmpRoot)
+
+	cfg := runtime.Config{
+		WorkDir:      "",
+		Command:      "claude",
+		PromptSuffix: "'" + strings.Repeat("x", maxInlinePromptLen+100) + "'",
+	}
+	if err := ensureFreshSession(ops, "gc-test-quoted-tempdir", cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	promptFile := promptFileFromLongPromptCommand(t, ops.calls[0].command)
+	if !strings.HasPrefix(promptFile, tmpRoot+string(os.PathSeparator)) {
+		t.Fatalf("quoted wrapper should preserve temp path prefix %q, got %q", tmpRoot, promptFile)
+	}
+}
+
+func TestEnsureFreshSession_CreateSessionFailureRemovesPromptFile(t *testing.T) {
+	ops := &fakeStartOps{createErrs: []error{errors.New("tmux create failed")}}
+
+	workDir := t.TempDir()
+	longPrompt := "'" + strings.Repeat("x", maxInlinePromptLen+100) + "'"
+	cfg := runtime.Config{
+		WorkDir:      workDir,
+		Command:      "claude",
+		PromptSuffix: longPrompt,
+	}
+	err := ensureFreshSession(ops, "gc-test-create-fails", cfg)
+	if err == nil {
+		t.Fatal("expected createSession error")
+	}
+
+	promptFile := promptFileFromLongPromptCommand(t, ops.calls[0].command)
+	if _, statErr := os.Stat(promptFile); !os.IsNotExist(statErr) {
+		t.Fatalf("prompt file should be removed after createSession failure, stat err = %v", statErr)
+	}
+}
+
+func TestEnsureFreshSession_RecreateRaceRemovesUnusedPromptFile(t *testing.T) {
+	running := true
+	ops := &fakeStartOps{
+		isSessionRunningResult: &running,
+		createErrs:             []error{ErrSessionExists, ErrSessionExists},
+		isRuntimeRunningResult: false,
+	}
+
+	cfg := runtime.Config{
+		WorkDir:      t.TempDir(),
+		Command:      "claude",
+		PromptSuffix: "'" + strings.Repeat("x", maxInlinePromptLen+100) + "'",
+		ProcessNames: []string{"claude"},
+	}
+	if err := ensureFreshSession(ops, "gc-test-recreate-race", cfg); err != nil {
+		t.Fatalf("unexpected error: %v (race should be tolerated)", err)
+	}
+
+	promptFile := promptFileFromLongPromptCommand(t, ops.calls[0].command)
+	if _, statErr := os.Stat(promptFile); !os.IsNotExist(statErr) {
+		t.Fatalf("unused prompt file should be removed after tolerated recreate race, stat err = %v", statErr)
+	}
+}
+
+// TestEnsureFreshSession_LongPromptUnusableWorkDirReturnsError verifies that
+// a non-empty invalid WorkDir remains fatal. Falling back to OS temp for the
+// prompt file would let real tmux start the pane in its default directory,
+// which can put agents in the wrong checkout.
+func TestEnsureFreshSession_LongPromptUnusableWorkDirReturnsError(t *testing.T) {
 	ops := &fakeStartOps{}
 
 	// A deep path whose ancestors can't be created (os.MkdirAll fails on a
@@ -1396,23 +1555,45 @@ func TestEnsureFreshSession_LongPromptUnusableWorkDirFallsBackToOSTemp(t *testin
 		PromptSuffix: longPrompt,
 	}
 	err := ensureFreshSession(ops, "gc-test-unusable-workdir", cfg)
-	if err != nil {
+	if err == nil {
+		t.Fatal("expected invalid workdir error")
+	}
+	if !strings.Contains(err.Error(), "workdir unavailable") {
+		t.Fatalf("expected workdir unavailable error, got %v", err)
+	}
+	if len(ops.calls) != 0 {
+		t.Fatalf("createSession should not be called for invalid WorkDir, calls = %#v", ops.calls)
+	}
+}
+
+func TestEnsureFreshSession_LongPromptValidWorkDirUnusableTmpFallsBackToOSTemp(t *testing.T) {
+	ops := &fakeStartOps{}
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, ".gc"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	longPromptRaw := strings.Repeat("x", maxInlinePromptLen+100)
+	cfg := runtime.Config{
+		WorkDir:      workDir,
+		Command:      "claude --dangerously-skip-permissions",
+		PromptSuffix: "'" + longPromptRaw + "'",
+	}
+	if err := ensureFreshSession(ops, "gc-test-workdir-tmp-fallback", cfg); err != nil {
 		t.Fatalf("expected OS temp dir fallback, got error: %v", err)
 	}
 
 	c := ops.calls[0]
-	// Must use file-expansion, NOT inline.
-	if !strings.HasPrefix(c.command, "sh -c '") {
-		t.Fatalf("long prompt with unusable workdir should still use sh -c wrapper, got %q", c.command)
-	}
-	if !strings.Contains(c.command, "$(cat ") {
-		t.Errorf("expected $(cat ...) expansion, got %q", c.command)
-	}
-	// The raw prompt MUST NOT appear verbatim in the command — that is the
-	// failure mode that produced "cannot execute: File name too long" in
-	// the tmux pane for PackV2 polecat spawns.
 	if strings.Contains(c.command, longPromptRaw) {
-		t.Errorf("raw prompt leaked into tmux command (this is the regression), command = %q", c.command)
+		t.Errorf("raw prompt leaked into tmux command, command = %q", c.command)
+	}
+	promptFile := promptFileFromLongPromptCommand(t, c.command)
+	expectedDir := fallbackPromptDir(tmpRoot)
+	if !strings.HasPrefix(promptFile, expectedDir+string(os.PathSeparator)) {
+		t.Errorf("expected OS fallback prompt under %q, got %q", expectedDir, promptFile)
 	}
 }
 
@@ -1421,6 +1602,8 @@ func TestEnsureFreshSession_LongPromptUnusableWorkDirFallsBackToOSTemp(t *testin
 // instead of silently falling back to inline embedding.
 func TestEnsureFreshSession_LongPromptEmptyWorkDirFallsBackToOSTemp(t *testing.T) {
 	ops := &fakeStartOps{}
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
 
 	longPromptRaw := strings.Repeat("y", maxInlinePromptLen+100)
 	longPrompt := "'" + longPromptRaw + "'"
@@ -1440,6 +1623,35 @@ func TestEnsureFreshSession_LongPromptEmptyWorkDirFallsBackToOSTemp(t *testing.T
 	}
 	if strings.Contains(c.command, longPromptRaw) {
 		t.Errorf("raw prompt leaked into tmux command, command = %q", c.command)
+	}
+	promptFile := promptFileFromLongPromptCommand(t, c.command)
+	expectedDir := fallbackPromptDir(tmpRoot)
+	if !strings.HasPrefix(promptFile, expectedDir+string(os.PathSeparator)) {
+		t.Errorf("expected OS fallback prompt under %q, got %q", expectedDir, promptFile)
+	}
+}
+
+func TestEnsureFreshSession_LongPromptFileWriteFailureDoesNotCreateSession(t *testing.T) {
+	ops := &fakeStartOps{}
+
+	tmp := t.TempDir()
+	regularFile := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(regularFile, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Setenv("TMPDIR", regularFile)
+
+	cfg := runtime.Config{
+		WorkDir:      filepath.Join(regularFile, "worktree-that-cannot-exist"),
+		Command:      "claude",
+		PromptSuffix: "'" + strings.Repeat("x", maxInlinePromptLen+100) + "'",
+	}
+	err := ensureFreshSession(ops, "gc-test-no-prompt-file", cfg)
+	if err == nil {
+		t.Fatal("expected prompt file write failure")
+	}
+	if len(ops.calls) != 0 {
+		t.Fatalf("createSession should not be called when prompt file creation fails, calls = %#v", ops.calls)
 	}
 }
 

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -1368,6 +1368,109 @@ func TestEnsureFreshSession_LongPromptWithFlagUsesFileExpansion(t *testing.T) {
 	}
 }
 
+// TestEnsureFreshSession_LongPromptUnusableWorkDirFallsBackToOSTemp verifies
+// that when WorkDir points at a path that can't be materialized (e.g. the
+// polecat worktree pre_start hasn't run yet, leaving the worktree missing),
+// the prompt still lands in a temp file and the tmux command still uses
+// file-expansion. Regression for gc-yha: PackV2 polecat spawns died with
+// "cannot execute: File name too long" because writePromptFile failed on
+// the missing workdir and the silent fallback embedded the raw prompt in
+// the tmux command string.
+func TestEnsureFreshSession_LongPromptUnusableWorkDirFallsBackToOSTemp(t *testing.T) {
+	ops := &fakeStartOps{}
+
+	// A deep path whose ancestors can't be created (os.MkdirAll fails on a
+	// path that descends into a regular file).
+	tmp := t.TempDir()
+	regularFile := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(regularFile, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	unusableWorkDir := filepath.Join(regularFile, "worktree-that-cannot-exist")
+
+	longPromptRaw := strings.Repeat("x", maxInlinePromptLen+100)
+	longPrompt := "'" + longPromptRaw + "'"
+	cfg := runtime.Config{
+		WorkDir:      unusableWorkDir,
+		Command:      "claude --dangerously-skip-permissions",
+		PromptSuffix: longPrompt,
+	}
+	err := ensureFreshSession(ops, "gc-test-unusable-workdir", cfg)
+	if err != nil {
+		t.Fatalf("expected OS temp dir fallback, got error: %v", err)
+	}
+
+	c := ops.calls[0]
+	// Must use file-expansion, NOT inline.
+	if !strings.HasPrefix(c.command, "sh -c '") {
+		t.Fatalf("long prompt with unusable workdir should still use sh -c wrapper, got %q", c.command)
+	}
+	if !strings.Contains(c.command, "$(cat ") {
+		t.Errorf("expected $(cat ...) expansion, got %q", c.command)
+	}
+	// The raw prompt MUST NOT appear verbatim in the command — that is the
+	// failure mode that produced "cannot execute: File name too long" in
+	// the tmux pane for PackV2 polecat spawns.
+	if strings.Contains(c.command, longPromptRaw) {
+		t.Errorf("raw prompt leaked into tmux command (this is the regression), command = %q", c.command)
+	}
+}
+
+// TestEnsureFreshSession_LongPromptEmptyWorkDirFallsBackToOSTemp verifies
+// that when WorkDir is empty the long-prompt path still writes to OS temp
+// instead of silently falling back to inline embedding.
+func TestEnsureFreshSession_LongPromptEmptyWorkDirFallsBackToOSTemp(t *testing.T) {
+	ops := &fakeStartOps{}
+
+	longPromptRaw := strings.Repeat("y", maxInlinePromptLen+100)
+	longPrompt := "'" + longPromptRaw + "'"
+	cfg := runtime.Config{
+		WorkDir:      "",
+		Command:      "claude",
+		PromptSuffix: longPrompt,
+	}
+	err := ensureFreshSession(ops, "gc-test-empty-workdir", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := ops.calls[0]
+	if !strings.HasPrefix(c.command, "sh -c '") {
+		t.Fatalf("long prompt with empty workdir should use sh -c wrapper, got %q", c.command)
+	}
+	if strings.Contains(c.command, longPromptRaw) {
+		t.Errorf("raw prompt leaked into tmux command, command = %q", c.command)
+	}
+}
+
+// TestEnsureFreshSession_LongPromptWorkDirPreferredOverOSTemp verifies that
+// when the configured WorkDir is usable, the prompt file lands inside it
+// (not OS temp). This preserves the session-scoped lifetime of the file so
+// it gets cleaned up alongside the session.
+func TestEnsureFreshSession_LongPromptWorkDirPreferredOverOSTemp(t *testing.T) {
+	ops := &fakeStartOps{}
+
+	workDir := t.TempDir()
+	longPrompt := "'" + strings.Repeat("z", maxInlinePromptLen+100) + "'"
+	cfg := runtime.Config{
+		WorkDir:      workDir,
+		Command:      "claude",
+		PromptSuffix: longPrompt,
+	}
+	err := ensureFreshSession(ops, "gc-test-prefer-workdir", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := ops.calls[0]
+	// The prompt file path appears inside the sh -c wrapper. It should be
+	// rooted at workDir/.gc/tmp rather than os.TempDir.
+	expectedDir := filepath.Join(workDir, ".gc", "tmp")
+	if !strings.Contains(c.command, expectedDir) {
+		t.Errorf("expected prompt file under %q, got command %q", expectedDir, c.command)
+	}
+}
+
 func TestTmuxStartOpsRunSetupCommandUsesGC_DIRAsWorkingDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	ops := &tmuxStartOps{tm: &Tmux{cfg: DefaultConfig()}}


### PR DESCRIPTION
## Summary

- Large polecat spawns under PackV2 were dying in tmux with `cannot execute: File name too long` (exit 126), with the full prompt echoed into the pane
- Root cause: when `writePromptFile` failed (e.g. worktree dir didn't yet exist because `pre_start` had not run), `ensureFreshSession` silently fell back to embedding the quoted prompt directly in the tmux command string — a path labeled "will likely fail" and duly did
- Two fixes:
  - `writePromptFile` now tries `workDir/.gc/tmp` first, then falls back to `os.TempDir()`. An unusable workdir no longer forces the inline path.
  - `ensureFreshSession` uses the file-expansion path for every prompt over `maxInlinePromptLen` regardless of workdir, and returns an error if `writePromptFile` still fails instead of silently falling back to the known-broken inline path.

## Impact

P0 regression: blocked all new polecat spawns across rigs using PackV2 providers. Cascaded into ordered dispatches (mol-dog-backup, etc.) hanging, slung work queuing indefinitely, and contributing to Dolt-flap symptoms.

## Test plan

- [x] Three regression tests added in `internal/runtime/tmux/startup_test.go` covering: unusable `WorkDir` (MkdirAll fails), empty `WorkDir`, and healthy path preferring workdir over OS temp
- [x] Local `make install` + smoke test
- [ ] CI green
- [ ] Post-merge: verify `gc session new <rig>/claude-opus-high` succeeds; tmux pane boots agent normally instead of exit-126

Ref: gc-yha (parent), gc-yha.1 (fix bead, closed on merge of 32c0353f locally)