### PR TITLE
fix(packv2): remove top-level scripts shim (#1018)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -931,9 +931,9 @@ func (cr *CityRuntime) reloadConfigTraced(
 		}
 	}
 
-	// Resolve script symlinks for newly activated packs.
-	resolveConfiguredScripts(cityRoot, nextCfg, func(scope string, err error) {
-		appendWarning(fmt.Sprintf("config reload: %s scripts: %v", scope, err))
+	// Prune legacy top-level scripts/ symlinks from older runtime shims.
+	pruneLegacyConfiguredScripts(cityRoot, nextCfg, func(scope string, err error) {
+		appendWarning(fmt.Sprintf("config reload: pruning legacy %s scripts: %v", scope, err))
 	})
 
 	if providerChanged {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -1177,8 +1177,8 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 		}
 	}
 	if loadErr == nil {
-		resolveConfiguredScripts(cityPath, expandedCfg, func(scope string, err error) {
-			fmt.Fprintf(stderr, "gc init: resolving %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
+		pruneLegacyConfiguredScripts(cityPath, expandedCfg, func(scope string, err error) {
+			fmt.Fprintf(stderr, "gc init: pruning legacy %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
 		})
 	}
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -976,21 +976,21 @@ func shouldSkipLegacyTopLevelScripts(srcFS fsys.FS, srcDir string) bool {
 	if sourceTemplatePackSchemaFS(srcFS, srcDir) < initPackSchemaVersion {
 		return false
 	}
-	_, ok, err := legacyShimLinks(srcDir, sourceTemplateLegacyScriptOrigins(srcDir))
+	_, ok, err := legacyShimLinks(srcDir, sourceTemplateLegacyScriptOriginsFS(srcFS, srcDir))
 	return err == nil && ok
 }
 
 func sourceTemplateLegacyScriptOrigins(srcDir string) []string {
+	return sourceTemplateLegacyScriptOriginsFS(fsys.OSFS{}, srcDir)
+}
+
+func sourceTemplateLegacyScriptOriginsFS(srcFS fsys.FS, srcDir string) []string {
 	dir := filepath.Join(srcDir, "assets", "scripts")
-	info, err := os.Stat(dir)
+	info, err := srcFS.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return nil
 	}
 	return []string{filepath.Clean(dir)}
-}
-
-func sourceTemplatePackSchema(srcDir string) int {
-	return sourceTemplatePackSchemaFS(fsys.OSFS{}, srcDir)
 }
 
 func sourceTemplatePackSchemaFS(srcFS fsys.FS, srcDir string) int {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -951,6 +951,34 @@ func initFromSkip(relPath string, isDir bool) bool {
 	return false
 }
 
+// initFromSkipForSource returns the source-aware skip policy for gc init --from.
+// PackV2 templates should not carry the deprecated top-level scripts/ shim
+// forward into the new city; legacy templates retain the historical behavior.
+func initFromSkipForSource(srcDir string) overlay.SkipFunc {
+	skipTopLevelScripts := sourceTemplatePackSchema(srcDir) >= initPackSchemaVersion
+	return func(relPath string, isDir bool) bool {
+		if skipTopLevelScripts {
+			top, _, _ := strings.Cut(relPath, string(filepath.Separator))
+			if top == "scripts" {
+				return true
+			}
+		}
+		return initFromSkip(relPath, isDir)
+	}
+}
+
+func sourceTemplatePackSchema(srcDir string) int {
+	data, err := os.ReadFile(filepath.Join(srcDir, "pack.toml"))
+	if err != nil {
+		return 0
+	}
+	var pc initPackConfig
+	if _, err := toml.Decode(string(data), &pc); err != nil {
+		return 0
+	}
+	return pc.Pack.Schema
+}
+
 // overrideCityName reads an existing city.toml, updates workspace.name, and writes it back.
 func overrideCityName(f fsys.FS, tomlPath, name string, stderr io.Writer) int {
 	cfg, err := loadCityConfigForEditFS(f, tomlPath)
@@ -1025,7 +1053,7 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkip, stderr); err != nil {
+	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkipForSource(srcDir), stderr); err != nil {
 		fmt.Fprintf(stderr, "gc init --from: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -1086,7 +1114,7 @@ func doInitFromDirWithOptions(srcDir, cityPath, nameOverride string, stdout, std
 	}
 
 	// Copy directory tree (skip .gc/ and *_test.go).
-	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkip, stderr); err != nil {
+	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkipForSource(srcDir), stderr); err != nil {
 		fmt.Fprintf(stderr, "gc init --from: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -953,9 +953,14 @@ func initFromSkip(relPath string, isDir bool) bool {
 
 // initFromSkipForSource returns the source-aware skip policy for gc init --from.
 // PackV2 templates should not carry the deprecated top-level scripts/ shim
-// forward into the new city; legacy templates retain the historical behavior.
+// forward into the new city, but real files and foreign symlink trees remain
+// user-owned and are copied through unchanged.
 func initFromSkipForSource(srcDir string) overlay.SkipFunc {
-	skipTopLevelScripts := sourceTemplatePackSchema(srcDir) >= initPackSchemaVersion
+	return initFromSkipForSourceFS(fsys.OSFS{}, srcDir)
+}
+
+func initFromSkipForSourceFS(srcFS fsys.FS, srcDir string) overlay.SkipFunc {
+	skipTopLevelScripts := shouldSkipLegacyTopLevelScripts(srcFS, srcDir)
 	return func(relPath string, isDir bool) bool {
 		if skipTopLevelScripts {
 			top, _, _ := strings.Cut(relPath, string(filepath.Separator))
@@ -967,8 +972,29 @@ func initFromSkipForSource(srcDir string) overlay.SkipFunc {
 	}
 }
 
+func shouldSkipLegacyTopLevelScripts(srcFS fsys.FS, srcDir string) bool {
+	if sourceTemplatePackSchemaFS(srcFS, srcDir) < initPackSchemaVersion {
+		return false
+	}
+	_, ok, err := legacyShimLinks(srcDir, sourceTemplateLegacyScriptOrigins(srcDir))
+	return err == nil && ok
+}
+
+func sourceTemplateLegacyScriptOrigins(srcDir string) []string {
+	dir := filepath.Join(srcDir, "assets", "scripts")
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	return []string{filepath.Clean(dir)}
+}
+
 func sourceTemplatePackSchema(srcDir string) int {
-	data, err := os.ReadFile(filepath.Join(srcDir, "pack.toml"))
+	return sourceTemplatePackSchemaFS(fsys.OSFS{}, srcDir)
+}
+
+func sourceTemplatePackSchemaFS(srcFS fsys.FS, srcDir string) int {
+	data, err := srcFS.ReadFile(filepath.Join(srcDir, "pack.toml"))
 	if err != nil {
 		return 0
 	}
@@ -1053,7 +1079,7 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkipForSource(srcDir), stderr); err != nil {
+	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkipForSourceFS(fs, srcDir), stderr); err != nil {
 		fmt.Fprintf(stderr, "gc init --from: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -1030,21 +1030,32 @@ func shouldSkipLegacyTopLevelScripts(srcFS fsys.FS, srcDir string) bool {
 	if sourceTemplatePackSchemaFS(srcFS, srcDir) < initPackSchemaVersion {
 		return false
 	}
-	_, ok, err := legacyShimLinks(srcDir, sourceTemplateLegacyScriptOriginsFS(srcFS, srcDir))
+	_, ok, err := legacyShimLinksFS(srcDir, sourceTemplateLegacyScriptOriginsFS(srcFS, srcDir), srcFS, srcDir)
 	return err == nil && ok
 }
 
-func sourceTemplateLegacyScriptOrigins(srcDir string) []string {
-	return sourceTemplateLegacyScriptOriginsFS(fsys.OSFS{}, srcDir)
-}
-
 func sourceTemplateLegacyScriptOriginsFS(srcFS fsys.FS, srcDir string) []string {
-	dir := filepath.Join(srcDir, "assets", "scripts")
-	info, err := srcFS.Stat(dir)
-	if err != nil || !info.IsDir() {
-		return nil
+	seen := make(map[string]struct{})
+	var dirs []string
+	add := func(candidates []string) {
+		for _, dir := range candidates {
+			dir = filepath.Clean(dir)
+			if _, ok := seen[dir]; ok {
+				continue
+			}
+			seen[dir] = struct{}{}
+			dirs = append(dirs, dir)
+		}
 	}
-	return []string{filepath.Clean(dir)}
+
+	add(legacyLocalScriptOriginsFS(srcFS, srcDir))
+
+	cfg, _, err := config.LoadWithIncludes(srcFS, filepath.Join(srcDir, "city.toml"))
+	if err == nil {
+		add(legacyScriptSourceDirsFS(srcFS, cfg.PackDirs))
+	}
+
+	return dirs
 }
 
 func sourceTemplatePackSchemaFS(srcFS fsys.FS, srcDir string) int {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -473,9 +473,9 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		}
 	}
 
-	// Materialize script symlinks before agent startup.
-	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
-		fmt.Fprintf(stderr, "gc start: %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
+	// Prune legacy top-level scripts/ symlinks left by pre-PackV2 runtimes.
+	pruneLegacyConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		fmt.Fprintf(stderr, "gc start: pruning legacy %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
 	})
 
 	// Validate agents.

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1650,12 +1650,12 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 		}
 	}
 
-	// Resolve script symlinks, including empty layer sets so stale links are pruned.
+	// Prune legacy top-level scripts/ symlinks left by pre-PackV2 runtimes.
 	if progress != nil {
-		progress("resolving_scripts")
+		progress("pruning_legacy_scripts")
 	}
-	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
-		fmt.Fprintf(stderr, "gc supervisor: city '%s': %s scripts: %v\n", cityName, scope, err) //nolint:errcheck
+	pruneLegacyConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		fmt.Fprintf(stderr, "gc supervisor: city '%s': pruning legacy %s scripts: %v\n", cityName, scope, err) //nolint:errcheck
 	})
 
 	// Validate agents.

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -256,9 +256,22 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	}
 	if len(realFiles) == 0 {
 		if sawSymlink {
+			legacyShim, provenanceErr := legacyTopLevelScriptsShim(ctx.CityPath)
+			if provenanceErr != nil {
+				return warnCheck("v2-scripts-layout",
+					fmt.Sprintf("inspecting top-level scripts/ provenance: %v", provenanceErr),
+					"fix the config load error or inspect scripts/ manually before rerunning gc doctor",
+					[]string{"scripts/"})
+			}
+			if legacyShim {
+				return warnCheck("v2-scripts-layout",
+					"top-level scripts/ only contains stale legacy symlinks",
+					"delete scripts/ or rerun gc start/gc supervisor so runtime pruning can remove the old shim",
+					[]string{"scripts/"})
+			}
 			return warnCheck("v2-scripts-layout",
-				"top-level scripts/ only contains stale legacy symlinks",
-				"delete scripts/ or rerun gc start/gc supervisor so runtime pruning can remove the old shim",
+				"top-level scripts/ only contains user-managed symlinks; runtime pruning will not remove them",
+				"move scripts to commands/ or assets/, or remove the user-managed symlinks manually",
 				[]string{"scripts/"})
 		}
 		return okCheck("v2-scripts-layout", "no legacy top-level scripts found")
@@ -303,6 +316,19 @@ func inspectTopLevelScripts(dir string) ([]string, bool, error) {
 	}
 	sort.Strings(real)
 	return real, sawSymlink, nil
+}
+
+func legacyTopLevelScriptsShim(cityPath string) (bool, error) {
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		return false, err
+	}
+	origins := legacyScriptSourceDirs(cfg.PackDirs)
+	if len(origins) == 0 {
+		origins = legacyScriptSourceDirs([]string{cityPath})
+	}
+	_, ok, err := legacyShimLinks(cityPath, origins)
+	return ok, err
 }
 
 type v2WorkspaceNameCheck struct{}

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -287,7 +287,7 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 // stale compatibility artifacts from the removed ResolveScripts shim, while
 // real files indicate the deprecated user-authored top-level scripts layout.
 func inspectTopLevelScripts(dir string) ([]string, bool, error) {
-	var real []string
+	var realFiles []string
 	var sawSymlink bool
 	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -308,14 +308,14 @@ func inspectTopLevelScripts(dir string) ([]string, bool, error) {
 		if rErr != nil {
 			return rErr
 		}
-		real = append(real, filepath.Join("scripts", rel))
+		realFiles = append(realFiles, filepath.Join("scripts", rel))
 		return nil
 	})
 	if err != nil {
 		return nil, false, err
 	}
-	sort.Strings(real)
-	return real, sawSymlink, nil
+	sort.Strings(realFiles)
+	return realFiles, sawSymlink, nil
 }
 
 func legacyTopLevelScriptsShim(cityPath string) (bool, error) {
@@ -323,11 +323,8 @@ func legacyTopLevelScriptsShim(cityPath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	origins := legacyScriptSourceDirs(cfg.PackDirs)
-	if len(origins) == 0 {
-		origins = legacyScriptSourceDirs([]string{cityPath})
-	}
-	_, ok, err := legacyShimLinks(cityPath, origins)
+	origins := legacyScriptOriginsForScope(cityPath, cfg.PackDirs)
+	_, ok, err := legacyShimLinks(cityPath, origins, cityPath)
 	return ok, err
 }
 

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -247,10 +247,59 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	if err != nil || !info.IsDir() {
 		return okCheck("v2-scripts-layout", "no top-level scripts/ directory found")
 	}
+	realFiles, sawSymlink, walkErr := inspectTopLevelScripts(path)
+	if walkErr != nil {
+		return warnCheck("v2-scripts-layout",
+			fmt.Sprintf("inspecting top-level scripts/: %v", walkErr),
+			"resolve filesystem errors and rerun gc doctor",
+			[]string{"scripts/"})
+	}
+	if len(realFiles) == 0 {
+		if sawSymlink {
+			return okCheck("v2-scripts-layout", "top-level scripts/ only contains pack-resolved symlinks")
+		}
+		return okCheck("v2-scripts-layout", "no legacy top-level scripts found")
+	}
 	return warnCheck("v2-scripts-layout",
-		"top-level scripts/ is deprecated; move scripts to commands/ or assets/",
+		"top-level scripts/ contains legacy real files; move scripts to commands/ or assets/",
 		"move entrypoint scripts next to commands/doctor entries or under assets/",
-		[]string{"scripts/"})
+		realFiles)
+}
+
+// inspectTopLevelScripts returns relative paths (under "scripts/") of real
+// files plus whether the tree contains any symlinks. Symlinks are treated as
+// compatibility artifacts created by ResolveScripts, while real files indicate
+// the deprecated user-authored top-level scripts layout.
+func inspectTopLevelScripts(dir string) ([]string, bool, error) {
+	var real []string
+	var sawSymlink bool
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, lErr := os.Lstat(path)
+		if lErr != nil {
+			return lErr
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			sawSymlink = true
+			return nil
+		}
+		rel, rErr := filepath.Rel(dir, path)
+		if rErr != nil {
+			return rErr
+		}
+		real = append(real, filepath.Join("scripts", rel))
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	sort.Strings(real)
+	return real, sawSymlink, nil
 }
 
 type v2WorkspaceNameCheck struct{}

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -256,7 +256,10 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	}
 	if len(realFiles) == 0 {
 		if sawSymlink {
-			return okCheck("v2-scripts-layout", "top-level scripts/ only contains pack-resolved symlinks")
+			return warnCheck("v2-scripts-layout",
+				"top-level scripts/ only contains stale legacy symlinks",
+				"delete scripts/ or rerun gc start/gc supervisor so runtime pruning can remove the old shim",
+				[]string{"scripts/"})
 		}
 		return okCheck("v2-scripts-layout", "no legacy top-level scripts found")
 	}
@@ -268,8 +271,8 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 
 // inspectTopLevelScripts returns relative paths (under "scripts/") of real
 // files plus whether the tree contains any symlinks. Symlinks are treated as
-// compatibility artifacts created by ResolveScripts, while real files indicate
-// the deprecated user-authored top-level scripts layout.
+// stale compatibility artifacts from the removed ResolveScripts shim, while
+// real files indicate the deprecated user-authored top-level scripts layout.
 func inspectTopLevelScripts(dir string) ([]string, bool, error) {
 	var real []string
 	var sawSymlink bool

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -76,8 +76,19 @@ func TestV2ScriptsLayoutWarnsForSymlinkOnlyDir(t *testing.T) {
 	t.Parallel()
 
 	cityDir := t.TempDir()
-	srcDir := t.TempDir()
-	srcFile := filepath.Join(srcDir, "helper.sh")
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "city"
+schema = 2
+`)
+	srcFile := filepath.Join(cityDir, "assets", "scripts", "helper.sh")
+	if err := os.MkdirAll(filepath.Dir(srcFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -100,12 +111,60 @@ func TestV2ScriptsLayoutWarnsForSymlinkOnlyDir(t *testing.T) {
 	}
 }
 
+func TestV2ScriptsLayoutWarnsForUserManagedSymlinkOnlyDir(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "city"
+schema = 2
+`)
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(srcFile, filepath.Join(scriptsDir, "helper.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("user-managed symlink-only scripts/ should still warn; got status=%v message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(res.Message, "user-managed symlinks") {
+		t.Fatalf("user-managed symlink-only scripts/ should report preserved symlink state, got %q", res.Message)
+	}
+}
+
 func TestV2ScriptsLayoutWarnsOnRealFilesAlongsideSymlinks(t *testing.T) {
 	t.Parallel()
 
 	cityDir := t.TempDir()
-	srcDir := t.TempDir()
-	srcFile := filepath.Join(srcDir, "resolved.sh")
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "city"
+schema = 2
+`)
+	srcFile := filepath.Join(cityDir, "assets", "scripts", "resolved.sh")
+	if err := os.MkdirAll(filepath.Dir(srcFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -148,6 +148,77 @@ schema = 2
 	}
 }
 
+func TestV2ScriptsLayoutTreatsTopLevelScriptsTargetsAsUserManaged(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "city"
+schema = 2
+`)
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(scriptsDir, "generated", "helper.sh"), filepath.Join(scriptsDir, "helper.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("top-level scripts/ symlinks should still warn; got status=%v message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(res.Message, "user-managed symlinks") {
+		t.Fatalf("top-level scripts/ symlink targets should be treated as user-managed, got %q", res.Message)
+	}
+}
+
+func TestV2ScriptsLayoutTreatsRelayoutIntoAssetsScriptsAsUserManaged(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "city"
+schema = 2
+`)
+	srcFile := filepath.Join(cityDir, "assets", "scripts", "helper.sh")
+	if err := os.MkdirAll(filepath.Dir(srcFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(srcFile, filepath.Join(scriptsDir, "custom-helper.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("relayout symlink-only scripts/ should still warn; got status=%v message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(res.Message, "user-managed symlinks") {
+		t.Fatalf("relayout symlink-only scripts/ should be treated as user-managed, got %q", res.Message)
+	}
+}
+
 func TestV2ScriptsLayoutWarnsOnRealFilesAlongsideSymlinks(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -37,9 +37,7 @@ name = "helper"
 scope = "city"
 `)
 	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
-	if err := os.MkdirAll(filepath.Join(cityDir, "scripts"), 0o755); err != nil {
-		t.Fatalf("MkdirAll(scripts): %v", err)
-	}
+	writeDoctorFile(t, cityDir, "scripts/legacy.sh", "#!/bin/sh\necho legacy\n")
 
 	var buf bytes.Buffer
 	d := &doctor.Doctor{}
@@ -71,6 +69,76 @@ scope = "city"
 	}
 	if !strings.Contains(out, ".template.md") {
 		t.Fatalf("doctor output missing .template.md guidance:\n%s", out)
+	}
+}
+
+func TestV2ScriptsLayoutPassesForSymlinkOnlyDir(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(srcFile, filepath.Join(scriptsDir, "helper.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("symlink-only scripts/ should pass; got status=%v message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(res.Message, "pack-resolved symlinks") {
+		t.Fatalf("symlink-only scripts/ should report compatibility shim state, got %q", res.Message)
+	}
+}
+
+func TestV2ScriptsLayoutWarnsOnRealFilesAlongsideSymlinks(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "resolved.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(srcFile, filepath.Join(scriptsDir, "resolved.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "legacy.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(legacy): %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("mixed scripts/ should warn; got status=%v", res.Status)
+	}
+	var hasLegacy, hasResolved bool
+	for _, d := range res.Details {
+		if strings.Contains(d, "legacy.sh") {
+			hasLegacy = true
+		}
+		if strings.Contains(d, "resolved.sh") {
+			hasResolved = true
+		}
+	}
+	if !hasLegacy {
+		t.Errorf("warning should cite legacy.sh; details=%v", res.Details)
+	}
+	if hasResolved {
+		t.Errorf("warning should not cite symlinked resolved.sh; details=%v", res.Details)
 	}
 }
 

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -72,7 +72,7 @@ scope = "city"
 	}
 }
 
-func TestV2ScriptsLayoutPassesForSymlinkOnlyDir(t *testing.T) {
+func TestV2ScriptsLayoutWarnsForSymlinkOnlyDir(t *testing.T) {
 	t.Parallel()
 
 	cityDir := t.TempDir()
@@ -91,12 +91,12 @@ func TestV2ScriptsLayoutPassesForSymlinkOnlyDir(t *testing.T) {
 	}
 
 	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
-	if res.Status != doctor.StatusOK {
-		t.Fatalf("symlink-only scripts/ should pass; got status=%v message=%q details=%v",
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("symlink-only scripts/ should warn as stale legacy state; got status=%v message=%q details=%v",
 			res.Status, res.Message, res.Details)
 	}
-	if !strings.Contains(res.Message, "pack-resolved symlinks") {
-		t.Fatalf("symlink-only scripts/ should report compatibility shim state, got %q", res.Message)
+	if !strings.Contains(res.Message, "stale legacy symlinks") {
+		t.Fatalf("symlink-only scripts/ should report stale legacy state, got %q", res.Message)
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3420,6 +3420,56 @@ func TestInitFromSkipForSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	v2ManagedDir := filepath.Join(dir, "v2-managed")
+	if err := os.MkdirAll(filepath.Join(v2ManagedDir, "assets", "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(v2ManagedDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2ManagedDir, "city.toml"),
+		[]byte("[workspace]\nname = \"modern\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2ManagedDir, "pack.toml"),
+		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	managedTarget := filepath.Join(v2ManagedDir, "assets", "scripts", "run.sh")
+	if err := os.WriteFile(managedTarget, []byte("#!/bin/sh\necho managed\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(managedTarget, filepath.Join(v2ManagedDir, "scripts", "custom-run.sh")); err != nil {
+		t.Fatal(err)
+	}
+
+	v2IncludedPackShimDir := filepath.Join(dir, "v2-include-shim")
+	if err := os.MkdirAll(filepath.Join(v2IncludedPackShimDir, "packs", "base", "assets", "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(v2IncludedPackShimDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2IncludedPackShimDir, "city.toml"),
+		[]byte("[workspace]\nname = \"modern\"\nincludes = [\"packs/base\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2IncludedPackShimDir, "pack.toml"),
+		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2IncludedPackShimDir, "packs", "base", "pack.toml"),
+		[]byte("[pack]\nname = \"base\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	includedShimTarget := filepath.Join(v2IncludedPackShimDir, "packs", "base", "assets", "scripts", "run.sh")
+	if err := os.WriteFile(includedShimTarget, []byte("#!/bin/sh\necho include\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(includedShimTarget, filepath.Join(v2IncludedPackShimDir, "scripts", "run.sh")); err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name    string
 		srcDir  string
@@ -3430,6 +3480,8 @@ func TestInitFromSkipForSource(t *testing.T) {
 		{name: "legacy keeps top-level scripts", srcDir: v1Dir, relPath: "scripts", isDir: true, want: false},
 		{name: "packv2 preserves real top-level scripts", srcDir: v2RealDir, relPath: "scripts", isDir: true, want: false},
 		{name: "packv2 skips only legacy shim scripts", srcDir: v2ShimDir, relPath: "scripts", isDir: true, want: true},
+		{name: "packv2 skips legacy shim scripts backed by included packs", srcDir: v2IncludedPackShimDir, relPath: "scripts", isDir: true, want: true},
+		{name: "packv2 preserves user-managed symlink relayout", srcDir: v2ManagedDir, relPath: "scripts", isDir: true, want: false},
 		{name: "packv2 preserves foreign symlink tree", srcDir: v2ForeignDir, relPath: "scripts", isDir: true, want: false},
 		{name: "packv2 still skips .gc", srcDir: v2ShimDir, relPath: ".gc", isDir: true, want: true},
 		{name: "packv2 still skips tests", srcDir: v2ShimDir, relPath: "helper_test.go", isDir: false, want: true},
@@ -3465,6 +3517,7 @@ func TestInitFromSkipForSourceFSUsesProvidedLegacyOrigins(t *testing.T) {
 
 	fs := fsys.NewFake()
 	fs.Files[filepath.Join(srcDir, "pack.toml")] = []byte("[pack]\nname = \"modern\"\nschema = 2\n")
+	fs.Files[filepath.Join(srcDir, "assets", "scripts", "run.sh")] = []byte("#!/bin/sh\necho shim\n")
 	fs.Dirs[filepath.Join(srcDir, "assets")] = true
 	fs.Dirs[filepath.Join(srcDir, "assets", "scripts")] = true
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2908,7 +2908,7 @@ func TestDoInitFromDirPreservesPermissionsForLegacyTopLevelScripts(t *testing.T)
 	}
 }
 
-func TestDoInitFromDirSkipsTopLevelScriptsForPackV2Template(t *testing.T) {
+func TestDoInitFromDirPreservesRealTopLevelScriptsForPackV2Template(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	configureIsolatedRuntimeEnv(t)
@@ -2943,8 +2943,58 @@ func TestDoInitFromDirSkipsTopLevelScriptsForPackV2Template(t *testing.T) {
 		t.Fatalf("doInitFromDir = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
+	info, err := os.Stat(filepath.Join(cityPath, "scripts", "run.sh"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("permissions = %o, want 755", info.Mode().Perm())
+	}
+}
+
+func TestDoInitFromDirSkipsLegacyShimScriptsForPackV2Template(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "assets", "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"src\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
+		[]byte("[pack]\nname = \"src\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assetScript := filepath.Join(srcDir, "assets", "scripts", "run.sh")
+	if err := os.WriteFile(assetScript, []byte("#!/bin/sh\necho hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(assetScript, filepath.Join(srcDir, "scripts", "run.sh")); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "dst")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDir(srcDir, cityPath, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInitFromDir = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
 	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("top-level scripts/ should be skipped for PackV2 templates, stat err=%v", err)
+		t.Fatalf("legacy top-level scripts/ shim should be skipped for PackV2 templates, stat err=%v", err)
 	}
 }
 
@@ -2981,17 +3031,75 @@ func TestInitFromSkipForSource(t *testing.T) {
 	if err := os.MkdirAll(v1Dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(v1Dir, "city.toml"),
+		[]byte("[workspace]\nname = \"legacy\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(v1Dir, "pack.toml"),
 		[]byte("[pack]\nname = \"legacy\"\nschema = 1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	v2Dir := filepath.Join(dir, "v2")
-	if err := os.MkdirAll(v2Dir, 0o755); err != nil {
+	v2RealDir := filepath.Join(dir, "v2-real")
+	if err := os.MkdirAll(filepath.Join(v2RealDir, "scripts"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(v2Dir, "pack.toml"),
+	if err := os.WriteFile(filepath.Join(v2RealDir, "city.toml"),
+		[]byte("[workspace]\nname = \"modern\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2RealDir, "pack.toml"),
 		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2RealDir, "scripts", "run.sh"),
+		[]byte("#!/bin/sh\necho hello\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	v2ShimDir := filepath.Join(dir, "v2-shim")
+	if err := os.MkdirAll(filepath.Join(v2ShimDir, "assets", "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(v2ShimDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2ShimDir, "city.toml"),
+		[]byte("[workspace]\nname = \"modern\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2ShimDir, "pack.toml"),
+		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	shimTarget := filepath.Join(v2ShimDir, "assets", "scripts", "run.sh")
+	if err := os.WriteFile(shimTarget, []byte("#!/bin/sh\necho shim\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(shimTarget, filepath.Join(v2ShimDir, "scripts", "run.sh")); err != nil {
+		t.Fatal(err)
+	}
+
+	v2ForeignDir := filepath.Join(dir, "v2-foreign")
+	if err := os.MkdirAll(filepath.Join(v2ForeignDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2ForeignDir, "city.toml"),
+		[]byte("[workspace]\nname = \"modern\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2ForeignDir, "pack.toml"),
+		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	foreignTarget := filepath.Join(dir, "foreign", "run.sh")
+	if err := os.MkdirAll(filepath.Dir(foreignTarget), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(foreignTarget, []byte("#!/bin/sh\necho foreign\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(foreignTarget, filepath.Join(v2ForeignDir, "scripts", "run.sh")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3003,9 +3111,11 @@ func TestInitFromSkipForSource(t *testing.T) {
 		want    bool
 	}{
 		{name: "legacy keeps top-level scripts", srcDir: v1Dir, relPath: "scripts", isDir: true, want: false},
-		{name: "packv2 skips top-level scripts", srcDir: v2Dir, relPath: "scripts", isDir: true, want: true},
-		{name: "packv2 still skips .gc", srcDir: v2Dir, relPath: ".gc", isDir: true, want: true},
-		{name: "packv2 still skips tests", srcDir: v2Dir, relPath: "helper_test.go", isDir: false, want: true},
+		{name: "packv2 preserves real top-level scripts", srcDir: v2RealDir, relPath: "scripts", isDir: true, want: false},
+		{name: "packv2 skips only legacy shim scripts", srcDir: v2ShimDir, relPath: "scripts", isDir: true, want: true},
+		{name: "packv2 preserves foreign symlink tree", srcDir: v2ForeignDir, relPath: "scripts", isDir: true, want: false},
+		{name: "packv2 still skips .gc", srcDir: v2ShimDir, relPath: ".gc", isDir: true, want: true},
+		{name: "packv2 still skips tests", srcDir: v2ShimDir, relPath: "helper_test.go", isDir: false, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3014,6 +3124,15 @@ func TestInitFromSkipForSource(t *testing.T) {
 				t.Errorf("initFromSkipForSource(%q)(%q, %v) = %v, want %v", tt.srcDir, tt.relPath, tt.isDir, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSourceTemplatePackSchemaFSUsesProvidedFS(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/src/pack.toml"] = []byte("[pack]\nname = \"modern\"\nschema = 2\n")
+
+	if got := sourceTemplatePackSchemaFS(fs, "/src"); got != 2 {
+		t.Fatalf("sourceTemplatePackSchemaFS() = %d, want 2", got)
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3136,6 +3136,26 @@ func TestSourceTemplatePackSchemaFSUsesProvidedFS(t *testing.T) {
 	}
 }
 
+func TestInitFromSkipForSourceFSUsesProvidedLegacyOrigins(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(srcDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shimTarget := filepath.Join(srcDir, "assets", "scripts", "run.sh")
+	if err := os.Symlink(shimTarget, filepath.Join(srcDir, "scripts", "run.sh")); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.NewFake()
+	fs.Files[filepath.Join(srcDir, "pack.toml")] = []byte("[pack]\nname = \"modern\"\nschema = 2\n")
+	fs.Dirs[filepath.Join(srcDir, "assets")] = true
+	fs.Dirs[filepath.Join(srcDir, "assets", "scripts")] = true
+
+	if got := initFromSkipForSourceFS(fs, srcDir)("scripts", true); !got {
+		t.Fatalf("initFromSkipForSourceFS() should skip legacy shim scripts when assets/scripts only exists in provided FS")
+	}
+}
+
 // --- gc stop (doStop with runtime.Fake) ---
 
 func TestDoStopOneAgentRunning(t *testing.T) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2868,7 +2868,7 @@ func TestDoInitFromDirAlreadyInitializedByCityToml(t *testing.T) {
 	}
 }
 
-func TestDoInitFromDirPreservesPermissions(t *testing.T) {
+func TestDoInitFromDirPreservesPermissionsForLegacyTopLevelScripts(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	configureIsolatedRuntimeEnv(t)
@@ -2908,6 +2908,46 @@ func TestDoInitFromDirPreservesPermissions(t *testing.T) {
 	}
 }
 
+func TestDoInitFromDirSkipsTopLevelScriptsForPackV2Template(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"src\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
+		[]byte("[pack]\nname = \"src\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(srcDir, "scripts", "run.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "dst")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDir(srcDir, cityPath, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doInitFromDir = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("top-level scripts/ should be skipped for PackV2 templates, stat err=%v", err)
+	}
+}
+
 func TestInitFromSkip(t *testing.T) {
 	tests := []struct {
 		relPath string
@@ -2930,6 +2970,48 @@ func TestInitFromSkip(t *testing.T) {
 			got := initFromSkip(tt.relPath, tt.isDir)
 			if got != tt.want {
 				t.Errorf("initFromSkip(%q, %v) = %v, want %v", tt.relPath, tt.isDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitFromSkipForSource(t *testing.T) {
+	dir := t.TempDir()
+	v1Dir := filepath.Join(dir, "v1")
+	if err := os.MkdirAll(v1Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v1Dir, "pack.toml"),
+		[]byte("[pack]\nname = \"legacy\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	v2Dir := filepath.Join(dir, "v2")
+	if err := os.MkdirAll(v2Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2Dir, "pack.toml"),
+		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		srcDir  string
+		relPath string
+		isDir   bool
+		want    bool
+	}{
+		{name: "legacy keeps top-level scripts", srcDir: v1Dir, relPath: "scripts", isDir: true, want: false},
+		{name: "packv2 skips top-level scripts", srcDir: v2Dir, relPath: "scripts", isDir: true, want: true},
+		{name: "packv2 still skips .gc", srcDir: v2Dir, relPath: ".gc", isDir: true, want: true},
+		{name: "packv2 still skips tests", srcDir: v2Dir, relPath: "helper_test.go", isDir: false, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := initFromSkipForSource(tt.srcDir)(tt.relPath, tt.isDir)
+			if got != tt.want {
+				t.Errorf("initFromSkipForSource(%q)(%q, %v) = %v, want %v", tt.srcDir, tt.relPath, tt.isDir, got, tt.want)
 			}
 		})
 	}

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -186,11 +186,29 @@ func expandSessionSetup(cmds []string, ctx SessionSetupContext) []string {
 	return result
 }
 
-// resolveSetupScript resolves a session_setup_script path relative to cityPath.
-// Returns the path unchanged if already absolute.
-func resolveSetupScript(script, cityPath string) string {
+// resolveSetupScript resolves a session_setup_script path for runtime use.
+// Absolute paths pass through unchanged. "//" paths resolve against cityPath.
+// Other relative paths resolve against sourceDir when present; otherwise they
+// resolve against cityPath. City-root-relative strings produced by older
+// composition code remain supported during the transition.
+func resolveSetupScript(script, sourceDir, cityPath string) string {
+	if strings.HasPrefix(script, "//") {
+		return filepath.Join(cityPath, strings.TrimPrefix(script, "//"))
+	}
 	if script == "" || filepath.IsAbs(script) {
 		return script
+	}
+	if sourceDir != "" {
+		relSource, err := filepath.Rel(cityPath, sourceDir)
+		if err == nil {
+			relSource = filepath.Clean(relSource)
+			cleanScript := filepath.Clean(script)
+			if relSource != "." && relSource != "" && !strings.HasPrefix(relSource, "..") &&
+				(cleanScript == relSource || strings.HasPrefix(cleanScript, relSource+string(os.PathSeparator))) {
+				return filepath.Join(cityPath, cleanScript)
+			}
+		}
+		return filepath.Join(sourceDir, script)
 	}
 	return filepath.Join(cityPath, script)
 }

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -208,9 +208,22 @@ func resolveSetupScript(script, sourceDir, cityPath string) string {
 				return filepath.Join(cityPath, cleanScript)
 			}
 		}
-		return filepath.Join(sourceDir, script)
+		sourceCandidate := filepath.Join(sourceDir, script)
+		cityCandidate := filepath.Join(cityPath, filepath.Clean(script))
+		if fileExists(cityCandidate) && !fileExists(sourceCandidate) {
+			return cityCandidate
+		}
+		return sourceCandidate
 	}
 	return filepath.Join(cityPath, script)
+}
+
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // deepCopyAgent creates a deep copy of a config.Agent with a new name and dir.

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -531,6 +531,26 @@ func TestResolveSetupScript_LegacyCityRelativeStillWorks(t *testing.T) {
 	}
 }
 
+func TestResolveSetupScript_LegacySharedCityRelativeFallback(t *testing.T) {
+	cityPath := t.TempDir()
+	sourceDir := filepath.Join(cityPath, "packs", "feature")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityScript := filepath.Join(cityPath, "packs", "shared", "scripts", "setup.sh")
+	if err := os.MkdirAll(filepath.Dir(cityScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cityScript, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveSetupScript("packs/shared/scripts/setup.sh", sourceDir, cityPath)
+	if got != cityScript {
+		t.Errorf("got %q, want legacy shared city-root-relative path to remain supported", got)
+	}
+}
+
 func TestResolveSetupScript_Absolute(t *testing.T) {
 	got := resolveSetupScript("/usr/local/bin/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
 	if got != "/usr/local/bin/setup.sh" {

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -511,21 +511,35 @@ func TestExpandSessionSetup_Empty(t *testing.T) {
 }
 
 func TestResolveSetupScript_Relative(t *testing.T) {
-	got := resolveSetupScript("scripts/setup.sh", "/home/user/city")
-	if got != "/home/user/city/scripts/setup.sh" {
+	got := resolveSetupScript("scripts/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	if got != "/home/user/city/packs/gastown/scripts/setup.sh" {
 		t.Errorf("got %q, want absolute path", got)
 	}
 }
 
+func TestResolveSetupScript_DoubleSlashUsesCityRoot(t *testing.T) {
+	got := resolveSetupScript("//scripts/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	if got != "/home/user/city/scripts/setup.sh" {
+		t.Errorf("got %q, want city-root path", got)
+	}
+}
+
+func TestResolveSetupScript_LegacyCityRelativeStillWorks(t *testing.T) {
+	got := resolveSetupScript("packs/gastown/scripts/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	if got != "/home/user/city/packs/gastown/scripts/setup.sh" {
+		t.Errorf("got %q, want legacy city-root-relative path to remain supported", got)
+	}
+}
+
 func TestResolveSetupScript_Absolute(t *testing.T) {
-	got := resolveSetupScript("/usr/local/bin/setup.sh", "/home/user/city")
+	got := resolveSetupScript("/usr/local/bin/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
 	if got != "/usr/local/bin/setup.sh" {
 		t.Errorf("got %q, want unchanged absolute path", got)
 	}
 }
 
 func TestResolveSetupScript_Empty(t *testing.T) {
-	got := resolveSetupScript("", "/home/user/city")
+	got := resolveSetupScript("", "/home/user/city/packs/gastown", "/home/user/city")
 	if got != "" {
 		t.Errorf("got %q, want empty", got)
 	}

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -15,7 +15,8 @@ import (
 // directories left behind by the old ResolveScripts compatibility shim.
 // Real user-authored files are preserved.
 func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr func(scope string, err error)) {
-	if err := pruneLegacyScripts(cityPath); err != nil {
+	cityOrigins := legacyScriptSourceDirs(cfg.PackDirs)
+	if err := pruneLegacyScripts(cityPath, cityOrigins); err != nil {
 		handleErr("city", err)
 	}
 	for _, r := range cfg.Rigs {
@@ -26,20 +27,45 @@ func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr f
 		if !filepath.IsAbs(rigPath) {
 			rigPath = filepath.Join(cityPath, rigPath)
 		}
-		if err := pruneLegacyScripts(rigPath); err != nil {
+		rigOrigins := append([]string{}, cityOrigins...)
+		rigOrigins = append(rigOrigins, legacyScriptSourceDirs(cfg.RigPackDirs[r.Name])...)
+		if err := pruneLegacyScripts(rigPath, rigOrigins); err != nil {
 			handleErr(fmt.Sprintf("rig %q", r.Name), err)
 		}
 	}
 }
 
 // pruneLegacyScripts removes a top-level scripts/ directory only when it
-// contains compatibility-shim symlinks and no real files.
-func pruneLegacyScripts(targetDir string) error {
+// contains compatibility-shim symlinks and no real files. The symlinks must
+// resolve into one of the legacy script source directories derived from the
+// current pack graph; foreign symlink-only trees are preserved as user-owned.
+func pruneLegacyScripts(targetDir string, legacySourceDirs []string) error {
+	symlinks, ok, err := legacyShimLinks(targetDir, legacySourceDirs)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	for _, path := range symlinks {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing legacy script symlink %q: %w", path, err)
+		}
+	}
+	return removeEmptyDirsInclusive(filepath.Join(targetDir, "scripts"))
+}
+
+// legacyShimLinks returns the legacy top-level scripts/ symlinks for targetDir
+// only when the tree is entirely composed of shim symlinks backed by the
+// supplied pack script origins. Any real file or foreign symlink preserves the
+// tree as user-owned.
+func legacyShimLinks(targetDir string, legacySourceDirs []string) ([]string, bool, error) {
 	scriptsDir := filepath.Join(targetDir, "scripts")
 	if _, err := os.Stat(scriptsDir); os.IsNotExist(err) {
-		return nil
+		return nil, false, nil
 	} else if err != nil {
-		return fmt.Errorf("stat %q: %w", scriptsDir, err)
+		return nil, false, fmt.Errorf("stat %q: %w", scriptsDir, err)
 	}
 
 	var symlinks []string
@@ -53,6 +79,10 @@ func pruneLegacyScripts(targetDir string) error {
 			return lErr
 		}
 		if fi.Mode()&os.ModeSymlink != 0 {
+			if !symlinkMatchesLegacySource(path, legacySourceDirs) {
+				sawReal = true
+				return nil
+			}
 			symlinks = append(symlinks, path)
 			return nil
 		}
@@ -60,18 +90,57 @@ func pruneLegacyScripts(targetDir string) error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("walking %q: %w", scriptsDir, err)
+		return nil, false, fmt.Errorf("walking %q: %w", scriptsDir, err)
 	}
 	if sawReal || len(symlinks) == 0 {
+		return nil, false, nil
+	}
+	return symlinks, true, nil
+}
+
+func legacyScriptSourceDirs(packDirs []string) []string {
+	if len(packDirs) == 0 {
 		return nil
 	}
-
-	for _, path := range symlinks {
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing legacy script symlink %q: %w", path, err)
+	seen := make(map[string]struct{}, len(packDirs)*2)
+	var dirs []string
+	for _, packDir := range packDirs {
+		for _, rel := range []string{"scripts", filepath.Join("assets", "scripts")} {
+			dir := filepath.Join(packDir, rel)
+			info, err := os.Stat(dir)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+			dir = filepath.Clean(dir)
+			if _, ok := seen[dir]; ok {
+				continue
+			}
+			seen[dir] = struct{}{}
+			dirs = append(dirs, dir)
 		}
 	}
-	return removeEmptyDirsInclusive(scriptsDir)
+	return dirs
+}
+
+func symlinkMatchesLegacySource(linkPath string, legacySourceDirs []string) bool {
+	if len(legacySourceDirs) == 0 {
+		return false
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		return false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(linkPath), target)
+	}
+	target = filepath.Clean(target)
+	for _, dir := range legacySourceDirs {
+		dir = filepath.Clean(dir)
+		if target == dir || strings.HasPrefix(target, dir+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // removeEmptyDirsInclusive removes empty directories bottom-up, including root.

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -12,6 +12,11 @@ import (
 // ResolveScripts computes per-relative-path winners from layered script
 // directories and creates symlinks in targetDir/scripts/.
 //
+// Compatibility note: PackV2's desired layout does not define a top-level
+// scripts/ surface. The runtime still materializes this directory so legacy
+// city-root script references continue to work until remaining path consumers
+// migrate to pack-local resolution.
+//
 // Layers are ordered lowest→highest priority. For each file found across
 // all layers, the highest-priority layer wins. Winners are symlinked into
 // targetDir/scripts/ preserving subdirectory structure.

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -9,13 +9,14 @@ import (
 	"syscall"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // pruneLegacyConfiguredScripts removes symlink-only top-level scripts/
 // directories left behind by the old ResolveScripts compatibility shim.
 // Real user-authored files are preserved.
 func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr func(scope string, err error)) {
-	cityOrigins := legacyScriptSourceDirs(cfg.PackDirs)
+	cityOrigins := legacyScriptOriginsForScope(cityPath, cfg.PackDirs)
 	if err := pruneLegacyScripts(cityPath, cityOrigins); err != nil {
 		handleErr("city", err)
 	}
@@ -28,7 +29,7 @@ func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr f
 			rigPath = filepath.Join(cityPath, rigPath)
 		}
 		rigOrigins := append([]string{}, cityOrigins...)
-		rigOrigins = append(rigOrigins, legacyScriptSourceDirs(cfg.RigPackDirs[r.Name])...)
+		rigOrigins = append(rigOrigins, legacyScriptOriginsForScope(rigPath, cfg.RigPackDirs[r.Name])...)
 		if err := pruneLegacyScripts(rigPath, rigOrigins); err != nil {
 			handleErr(fmt.Sprintf("rig %q", r.Name), err)
 		}
@@ -99,6 +100,18 @@ func legacyShimLinks(targetDir string, legacySourceDirs []string) ([]string, boo
 }
 
 func legacyScriptSourceDirs(packDirs []string) []string {
+	return legacyScriptSourceDirsFS(fsys.OSFS{}, packDirs)
+}
+
+func legacyScriptOriginsForScope(scopeRoot string, packDirs []string) []string {
+	dirs := legacyScriptSourceDirs(packDirs)
+	if len(dirs) > 0 {
+		return dirs
+	}
+	return legacyScriptSourceDirs([]string{scopeRoot})
+}
+
+func legacyScriptSourceDirsFS(fs fsys.FS, packDirs []string) []string {
 	if len(packDirs) == 0 {
 		return nil
 	}
@@ -107,7 +120,7 @@ func legacyScriptSourceDirs(packDirs []string) []string {
 	for _, packDir := range packDirs {
 		for _, rel := range []string{"scripts", filepath.Join("assets", "scripts")} {
 			dir := filepath.Join(packDir, rel)
-			info, err := os.Stat(dir)
+			info, err := fs.Stat(dir)
 			if err != nil || !info.IsDir() {
 				continue
 			}

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -1,98 +1,21 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
 
-// ResolveScripts computes per-relative-path winners from layered script
-// directories and creates symlinks in targetDir/scripts/.
-//
-// Compatibility note: PackV2's desired layout does not define a top-level
-// scripts/ surface. The runtime still materializes this directory so legacy
-// city-root script references continue to work until remaining path consumers
-// migrate to pack-local resolution.
-//
-// Layers are ordered lowest→highest priority. For each file found across
-// all layers, the highest-priority layer wins. Winners are symlinked into
-// targetDir/scripts/ preserving subdirectory structure.
-//
-// Idempotent: correct symlinks are left alone, stale ones are updated,
-// and symlinks for scripts no longer in any layer are removed. Real files
-// (non-symlinks) in the target directory are never overwritten.
-func ResolveScripts(targetDir string, layers []string) error {
-	// Build winner map: relative path → absolute source path.
-	// Later layers overwrite earlier ones (higher priority).
-	winners := make(map[string]string)
-	for _, layerDir := range layers {
-		err := filepath.WalkDir(layerDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return nil // skip unreadable entries
-			}
-			if d.IsDir() {
-				return nil
-			}
-			rel, err := filepath.Rel(layerDir, path)
-			if err != nil {
-				return nil
-			}
-			abs, err := filepath.Abs(path)
-			if err != nil {
-				return nil
-			}
-			winners[rel] = abs
-			return nil
-		})
-		if err != nil {
-			continue // Layer dir doesn't exist — skip.
-		}
-	}
-
-	symlinkDir := filepath.Join(targetDir, "scripts")
-
-	if len(winners) == 0 {
-		return cleanStaleScriptSymlinks(symlinkDir, winners)
-	}
-
-	// Create/update symlinks for winners.
-	for rel, srcPath := range winners {
-		linkPath := filepath.Join(symlinkDir, rel)
-
-		// Ensure parent directory exists.
-		if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
-			return fmt.Errorf("creating script symlink parent dir: %w", err)
-		}
-
-		// Check if a real file (non-symlink) exists — don't overwrite.
-		fi, err := os.Lstat(linkPath)
-		if err == nil && fi.Mode()&os.ModeSymlink == 0 {
-			continue // Real file — leave it alone.
-		}
-
-		// If symlink exists, check if it's correct.
-		if err == nil && fi.Mode()&os.ModeSymlink != 0 {
-			existing, readErr := os.Readlink(linkPath)
-			if readErr == nil && existing == srcPath {
-				continue // Already correct.
-			}
-			// Stale symlink — remove it.
-			os.Remove(linkPath) //nolint:errcheck // will be recreated
-		}
-
-		if err := os.Symlink(srcPath, linkPath); err != nil {
-			return fmt.Errorf("creating script symlink %q → %q: %w", rel, srcPath, err)
-		}
-	}
-
-	return cleanStaleScriptSymlinks(symlinkDir, winners)
-}
-
-func resolveConfiguredScripts(cityPath string, cfg *config.City, handleErr func(scope string, err error)) {
-	if err := ResolveScripts(cityPath, cfg.ScriptLayers.City); err != nil {
+// pruneLegacyConfiguredScripts removes symlink-only top-level scripts/
+// directories left behind by the old ResolveScripts compatibility shim.
+// Real user-authored files are preserved.
+func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr func(scope string, err error)) {
+	if err := pruneLegacyScripts(cityPath); err != nil {
 		handleErr("city", err)
 	}
 	for _, r := range cfg.Rigs {
@@ -103,73 +26,78 @@ func resolveConfiguredScripts(cityPath string, cfg *config.City, handleErr func(
 		if !filepath.IsAbs(rigPath) {
 			rigPath = filepath.Join(cityPath, rigPath)
 		}
-		if err := ResolveScripts(rigPath, cfg.ScriptLayers.Rigs[r.Name]); err != nil {
+		if err := pruneLegacyScripts(rigPath); err != nil {
 			handleErr(fmt.Sprintf("rig %q", r.Name), err)
 		}
 	}
 }
 
-// cleanStaleScriptSymlinks removes symlinks in symlinkDir that are not in
-// winners. Walks recursively and removes empty subdirectories afterward.
-// Skips non-symlinks. No-op if symlinkDir doesn't exist.
-func cleanStaleScriptSymlinks(symlinkDir string, winners map[string]string) error {
-	if _, err := os.Stat(symlinkDir); os.IsNotExist(err) {
+// pruneLegacyScripts removes a top-level scripts/ directory only when it
+// contains compatibility-shim symlinks and no real files.
+func pruneLegacyScripts(targetDir string) error {
+	scriptsDir := filepath.Join(targetDir, "scripts")
+	if _, err := os.Stat(scriptsDir); os.IsNotExist(err) {
 		return nil
+	} else if err != nil {
+		return fmt.Errorf("stat %q: %w", scriptsDir, err)
 	}
 
-	// Collect stale symlinks.
-	var stale []string
-	err := filepath.WalkDir(symlinkDir, func(path string, d os.DirEntry, err error) error {
+	var symlinks []string
+	var sawReal bool
+	err := filepath.WalkDir(scriptsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
-			return nil
+			return err
 		}
 		fi, lErr := os.Lstat(path)
 		if lErr != nil {
+			return lErr
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			symlinks = append(symlinks, path)
 			return nil
 		}
-		if fi.Mode()&os.ModeSymlink == 0 {
-			return nil // Real file — skip.
-		}
-		rel, rErr := filepath.Rel(symlinkDir, path)
-		if rErr != nil {
-			return nil
-		}
-		if _, isWinner := winners[rel]; !isWinner {
-			stale = append(stale, path)
-		}
+		sawReal = true
 		return nil
 	})
 	if err != nil {
+		return fmt.Errorf("walking %q: %w", scriptsDir, err)
+	}
+	if sawReal || len(symlinks) == 0 {
 		return nil
 	}
 
-	for _, path := range stale {
-		os.Remove(path) //nolint:errcheck // best-effort cleanup
+	for _, path := range symlinks {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing legacy script symlink %q: %w", path, err)
+		}
 	}
-
-	// Remove empty directories (bottom-up).
-	removeEmptyDirs(symlinkDir)
-
-	return nil
+	return removeEmptyDirsInclusive(scriptsDir)
 }
 
-// removeEmptyDirs walks symlinkDir bottom-up and removes empty directories.
-// The root symlinkDir itself is not removed.
-func removeEmptyDirs(root string) {
-	// Collect all directories.
+// removeEmptyDirsInclusive removes empty directories bottom-up, including root.
+func removeEmptyDirsInclusive(root string) error {
 	var dirs []string
-	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error { //nolint:errcheck // best-effort
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			return err
 		}
-		if d.IsDir() && path != root {
+		if d.IsDir() {
 			dirs = append(dirs, path)
 		}
 		return nil
-	})
+	}); err != nil {
+		return fmt.Errorf("walking empty-dir cleanup for %q: %w", root, err)
+	}
 
 	// Process deepest first.
 	for i := len(dirs) - 1; i >= 0; i-- {
-		os.Remove(dirs[i]) //nolint:errcheck // fails silently if non-empty
+		if err := os.Remove(dirs[i]); err != nil && !os.IsNotExist(err) && !isDirectoryNotEmpty(err) {
+			return fmt.Errorf("removing empty dir %q: %w", dirs[i], err)
+		}
 	}
+	return nil
+}
+
+func isDirectoryNotEmpty(err error) bool {
+	return errors.Is(err, syscall.ENOTEMPTY)
 }

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -17,7 +17,7 @@ import (
 // Real user-authored files are preserved.
 func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr func(scope string, err error)) {
 	cityOrigins := legacyScriptOriginsForScope(cityPath, cfg.PackDirs)
-	if err := pruneLegacyScripts(cityPath, cityOrigins); err != nil {
+	if err := pruneLegacyScripts(cityPath, cityOrigins, cityPath); err != nil {
 		handleErr("city", err)
 	}
 	for _, r := range cfg.Rigs {
@@ -30,18 +30,19 @@ func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr f
 		}
 		rigOrigins := append([]string{}, cityOrigins...)
 		rigOrigins = append(rigOrigins, legacyScriptOriginsForScope(rigPath, cfg.RigPackDirs[r.Name])...)
-		if err := pruneLegacyScripts(rigPath, rigOrigins); err != nil {
+		if err := pruneLegacyScripts(rigPath, rigOrigins, rigPath, cityPath); err != nil {
 			handleErr(fmt.Sprintf("rig %q", r.Name), err)
 		}
 	}
 }
 
 // pruneLegacyScripts removes a top-level scripts/ directory only when it
-// contains compatibility-shim symlinks and no real files. The symlinks must
-// resolve into one of the legacy script source directories derived from the
-// current pack graph; foreign symlink-only trees are preserved as user-owned.
-func pruneLegacyScripts(targetDir string, legacySourceDirs []string) error {
-	symlinks, ok, err := legacyShimLinks(targetDir, legacySourceDirs)
+// exactly matches the absolute symlink tree the old ResolveScripts shim would
+// have generated from the legacy origins still represented in the current
+// tree. Real files, foreign symlinks, or user-managed symlink layouts that
+// merely point into pack script directories are preserved as user-owned.
+func pruneLegacyScripts(targetDir string, legacySourceDirs []string, fallbackRoots ...string) error {
+	symlinks, ok, err := legacyShimLinks(targetDir, legacySourceDirs, fallbackRoots...)
 	if err != nil {
 		return err
 	}
@@ -58,20 +59,32 @@ func pruneLegacyScripts(targetDir string, legacySourceDirs []string) error {
 }
 
 // legacyShimLinks returns the legacy top-level scripts/ symlinks for targetDir
-// only when the tree is entirely composed of shim symlinks backed by the
-// supplied pack script origins. Any real file or foreign symlink preserves the
-// tree as user-owned.
-func legacyShimLinks(targetDir string, legacySourceDirs []string) ([]string, bool, error) {
+// only when the tree is entirely composed of the exact absolute winner links
+// that the old ResolveScripts compatibility shim would have emitted for the
+// legacy origins still backing the observed tree. Any real file, relative
+// symlink, foreign symlink, or user-managed relayout preserves the tree as
+// user-owned.
+func legacyShimLinks(targetDir string, legacySourceDirs []string, fallbackRoots ...string) ([]string, bool, error) {
+	return legacyShimLinksFS(targetDir, legacySourceDirs, fsys.OSFS{}, fallbackRoots...)
+}
+
+func legacyShimLinksFS(targetDir string, legacySourceDirs []string, sourceFS fsys.FS, fallbackRoots ...string) ([]string, bool, error) {
 	scriptsDir := filepath.Join(targetDir, "scripts")
 	if _, err := os.Stat(scriptsDir); os.IsNotExist(err) {
 		return nil, false, nil
 	} else if err != nil {
 		return nil, false, fmt.Errorf("stat %q: %w", scriptsDir, err)
 	}
+	winners, err := legacyShimWinnersFS(sourceFS, legacySourceDirs)
+	if err != nil {
+		return nil, false, err
+	}
 
 	var symlinks []string
 	var sawReal bool
-	err := filepath.WalkDir(scriptsDir, func(path string, d os.DirEntry, err error) error {
+	usedOrigins := make(map[string]struct{}, len(legacySourceDirs))
+	fallbackRoots = normalizedFallbackRoots(targetDir, fallbackRoots)
+	err = filepath.WalkDir(scriptsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
 		}
@@ -80,9 +93,24 @@ func legacyShimLinks(targetDir string, legacySourceDirs []string) ([]string, boo
 			return lErr
 		}
 		if fi.Mode()&os.ModeSymlink != 0 {
-			if !symlinkMatchesLegacySource(path, legacySourceDirs) {
+			rel, rErr := filepath.Rel(scriptsDir, path)
+			if rErr != nil {
+				return rErr
+			}
+			target, matchedWinner := legacyWinnerTarget(path, rel, winners)
+			matchesLegacy := matchedWinner ||
+				(len(winners) == 0 && symlinkMatchesLegacyShape(path, scriptsDir, rel, fallbackRoots))
+			if !matchesLegacy {
 				sawReal = true
 				return nil
+			}
+			if matchedWinner {
+				origin := legacySourceDirForTarget(target, legacySourceDirs)
+				if origin == "" {
+					sawReal = true
+					return nil
+				}
+				usedOrigins[origin] = struct{}{}
 			}
 			symlinks = append(symlinks, path)
 			return nil
@@ -96,7 +124,76 @@ func legacyShimLinks(targetDir string, legacySourceDirs []string) ([]string, boo
 	if sawReal || len(symlinks) == 0 {
 		return nil, false, nil
 	}
+	if len(winners) == 0 {
+		return symlinks, true, nil
+	}
+
+	scopedOrigins := filterLegacyOrigins(legacySourceDirs, usedOrigins)
+	scopedWinners, err := legacyShimWinnersFS(sourceFS, scopedOrigins)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(symlinks) != len(scopedWinners) {
+		return nil, false, nil
+	}
 	return symlinks, true, nil
+}
+
+func legacyShimWinnersFS(fs fsys.FS, legacySourceDirs []string) (map[string]string, error) {
+	winners := make(map[string]string)
+	for _, layerDir := range legacySourceDirs {
+		if err := walkFilesFS(fs, layerDir, func(path string) error {
+			rel, err := filepath.Rel(layerDir, path)
+			if err != nil {
+				return nil
+			}
+			winners[rel] = filepath.Clean(path)
+			return nil
+		}); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("walking legacy script origin %q: %w", layerDir, err)
+		}
+	}
+	return winners, nil
+}
+
+func walkFilesFS(fs fsys.FS, dir string, visit func(path string) error) error {
+	entries, err := fs.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		if entry.IsDir() {
+			if err := walkFilesFS(fs, path, visit); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := visit(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizedFallbackRoots(targetDir string, fallbackRoots []string) []string {
+	if len(fallbackRoots) == 0 {
+		return []string{filepath.Clean(targetDir)}
+	}
+	seen := make(map[string]struct{}, len(fallbackRoots))
+	var cleaned []string
+	for _, root := range fallbackRoots {
+		root = filepath.Clean(root)
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		cleaned = append(cleaned, root)
+	}
+	return cleaned
 }
 
 func legacyScriptSourceDirs(packDirs []string) []string {
@@ -108,7 +205,7 @@ func legacyScriptOriginsForScope(scopeRoot string, packDirs []string) []string {
 	if len(dirs) > 0 {
 		return dirs
 	}
-	return legacyScriptSourceDirs([]string{scopeRoot})
+	return legacyLocalScriptOrigins(scopeRoot)
 }
 
 func legacyScriptSourceDirsFS(fs fsys.FS, packDirs []string) []string {
@@ -135,25 +232,94 @@ func legacyScriptSourceDirsFS(fs fsys.FS, packDirs []string) []string {
 	return dirs
 }
 
-func symlinkMatchesLegacySource(linkPath string, legacySourceDirs []string) bool {
-	if len(legacySourceDirs) == 0 {
-		return false
+func legacyLocalScriptOrigins(scopeRoot string) []string {
+	return legacyLocalScriptOriginsFS(fsys.OSFS{}, scopeRoot)
+}
+
+func legacyLocalScriptOriginsFS(fs fsys.FS, scopeRoot string) []string {
+	dir := filepath.Join(scopeRoot, "assets", "scripts")
+	info, err := fs.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	return []string{filepath.Clean(dir)}
+}
+
+func legacyWinnerTarget(linkPath, rel string, winners map[string]string) (string, bool) {
+	if len(winners) == 0 {
+		return "", false
+	}
+	wantTarget, ok := winners[rel]
+	if !ok {
+		return "", false
 	}
 	target, err := os.Readlink(linkPath)
 	if err != nil {
-		return false
+		return "", false
 	}
 	if !filepath.IsAbs(target) {
-		target = filepath.Join(filepath.Dir(linkPath), target)
+		return "", false
 	}
 	target = filepath.Clean(target)
+	return target, target == wantTarget
+}
+
+func legacySourceDirForTarget(target string, legacySourceDirs []string) string {
+	target = filepath.Clean(target)
+	var best string
 	for _, dir := range legacySourceDirs {
 		dir = filepath.Clean(dir)
-		if target == dir || strings.HasPrefix(target, dir+string(os.PathSeparator)) {
-			return true
+		if target != dir && !strings.HasPrefix(target, dir+string(os.PathSeparator)) {
+			continue
+		}
+		if len(dir) > len(best) {
+			best = dir
 		}
 	}
-	return false
+	return best
+}
+
+func filterLegacyOrigins(legacySourceDirs []string, usedOrigins map[string]struct{}) []string {
+	if len(usedOrigins) == 0 {
+		return nil
+	}
+	origins := make([]string, 0, len(usedOrigins))
+	for _, dir := range legacySourceDirs {
+		dir = filepath.Clean(dir)
+		if _, ok := usedOrigins[dir]; ok {
+			origins = append(origins, dir)
+		}
+	}
+	return origins
+}
+
+func symlinkMatchesLegacyShape(linkPath, scriptsDir, rel string, fallbackRoots []string) bool {
+	target, err := os.Readlink(linkPath)
+	if err != nil || !filepath.IsAbs(target) {
+		return false
+	}
+	target = filepath.Clean(target)
+	scriptsDir = filepath.Clean(scriptsDir)
+	rel = filepath.Clean(rel)
+	suffix := string(os.PathSeparator) + rel
+	if !strings.HasSuffix(target, suffix) {
+		return false
+	}
+	origin := filepath.Clean(strings.TrimSuffix(target, suffix))
+	if origin == scriptsDir || strings.HasPrefix(origin, scriptsDir+string(os.PathSeparator)) {
+		return false
+	}
+	var underAllowedRoot bool
+	for _, root := range fallbackRoots {
+		if origin == root || strings.HasPrefix(origin, root+string(os.PathSeparator)) {
+			underAllowedRoot = true
+			break
+		}
+	}
+	if !underAllowedRoot {
+		return false
+	}
+	return filepath.Base(origin) == "scripts"
 }
 
 // removeEmptyDirsInclusive removes empty directories bottom-up, including root.

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -9,7 +9,18 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
-func writeScriptFile(t *testing.T, dir, relPath, content string) {
+func writeLegacyScriptLink(t *testing.T, dir, relPath, target string) {
+	t.Helper()
+	path := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeLegacyScriptFile(t *testing.T, dir, relPath, content string) {
 	t.Helper()
 	path := filepath.Join(dir, relPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -20,397 +31,150 @@ func writeScriptFile(t *testing.T, dir, relPath, content string) {
 	}
 }
 
-func TestResolveScripts_SingleLayer(t *testing.T) {
+func TestPruneLegacyScripts_RemovesSymlinkOnlyTree(t *testing.T) {
 	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "setup.sh", "#!/bin/sh\necho setup")
-	writeScriptFile(t, layer, "teardown.sh", "#!/bin/sh\necho teardown")
-
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("ResolveScripts: %v", err)
+	cityPath := filepath.Join(dir, "city")
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll src: %v", err)
+	}
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile src: %v", err)
 	}
 
-	symlinkDir := filepath.Join(target, "scripts")
-	for _, name := range []string{"setup.sh", "teardown.sh"} {
-		linkPath := filepath.Join(symlinkDir, name)
-		fi, err := os.Lstat(linkPath)
-		if err != nil {
-			t.Errorf("%s: %v", name, err)
-			continue
-		}
-		if fi.Mode()&os.ModeSymlink == 0 {
-			t.Errorf("%s: not a symlink", name)
-		}
-		dest, err := os.Readlink(linkPath)
-		if err != nil {
-			t.Errorf("%s: readlink: %v", name, err)
-			continue
-		}
-		want := filepath.Join(layer, name)
-		if dest != want {
-			t.Errorf("%s: link target = %q, want %q", name, dest, want)
-		}
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", srcFile)
+	writeLegacyScriptLink(t, cityPath, "scripts/checks/review.sh", srcFile)
+
+	if err := pruneLegacyScripts(cityPath); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("scripts/ should be removed after pruning, err=%v", err)
 	}
 }
 
-func TestResolveScripts_Subdirectory(t *testing.T) {
+func TestPruneLegacyScripts_LeavesRealFilesAlone(t *testing.T) {
 	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "checks/review-approved.sh", "#!/bin/sh\nexit 0")
-	writeScriptFile(t, layer, "checks/design-approved.sh", "#!/bin/sh\nexit 0")
-	writeScriptFile(t, layer, "top-level.sh", "#!/bin/sh\necho hi")
+	cityPath := filepath.Join(dir, "city")
+	writeLegacyScriptFile(t, cityPath, "scripts/run.sh", "#!/bin/sh\necho run\n")
 
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("ResolveScripts: %v", err)
+	if err := pruneLegacyScripts(cityPath); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
 	}
 
-	symlinkDir := filepath.Join(target, "scripts")
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts", "run.sh")); err != nil {
+		t.Fatalf("real scripts/run.sh should remain, err=%v", err)
+	}
+}
 
-	// Check nested file.
-	linkPath := filepath.Join(symlinkDir, "checks", "review-approved.sh")
-	fi, err := os.Lstat(linkPath)
+func TestPruneLegacyScripts_LeavesMixedTreeUntouched(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll src: %v", err)
+	}
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile src: %v", err)
+	}
+
+	writeLegacyScriptFile(t, cityPath, "scripts/run.sh", "#!/bin/sh\necho run\n")
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", srcFile)
+
+	if err := pruneLegacyScripts(cityPath); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts", "run.sh")); err != nil {
+		t.Fatalf("real scripts/run.sh should remain, err=%v", err)
+	}
+	fi, err := os.Lstat(filepath.Join(cityPath, "scripts", "helper.sh"))
 	if err != nil {
-		t.Fatalf("checks/review-approved.sh: %v", err)
+		t.Fatalf("symlink helper.sh should remain in mixed tree, err=%v", err)
 	}
 	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Error("checks/review-approved.sh: not a symlink")
-	}
-	dest, err := os.Readlink(linkPath)
-	if err != nil {
-		t.Fatalf("readlink: %v", err)
-	}
-	if dest != filepath.Join(layer, "checks", "review-approved.sh") {
-		t.Errorf("link target = %q, want pack source", dest)
-	}
-
-	// Check top-level file.
-	if _, err := os.Lstat(filepath.Join(symlinkDir, "top-level.sh")); err != nil {
-		t.Errorf("top-level.sh should exist: %v", err)
+		t.Fatalf("helper.sh should remain a symlink in mixed tree, mode=%v", fi.Mode())
 	}
 }
 
-func TestResolveScripts_Shadow(t *testing.T) {
-	dir := t.TempDir()
-	layer1 := filepath.Join(dir, "pack1", "scripts")
-	layer2 := filepath.Join(dir, "pack2", "scripts")
-
-	writeScriptFile(t, layer1, "setup.sh", "layer1 version")
-	writeScriptFile(t, layer1, "only-in-1.sh", "layer1 only")
-	writeScriptFile(t, layer2, "setup.sh", "layer2 version")
-	writeScriptFile(t, layer2, "only-in-2.sh", "layer2 only")
-
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	if err := ResolveScripts(target, []string{layer1, layer2}); err != nil {
-		t.Fatalf("ResolveScripts: %v", err)
-	}
-
-	symlinkDir := filepath.Join(target, "scripts")
-
-	// setup.sh should point to layer2 (higher priority).
-	dest, err := os.Readlink(filepath.Join(symlinkDir, "setup.sh"))
-	if err != nil {
-		t.Fatalf("setup.sh readlink: %v", err)
-	}
-	if dest != filepath.Join(layer2, "setup.sh") {
-		t.Errorf("setup.sh target = %q, want layer2 version", dest)
-	}
-
-	// only-in-1.sh should point to layer1.
-	dest, err = os.Readlink(filepath.Join(symlinkDir, "only-in-1.sh"))
-	if err != nil {
-		t.Fatalf("only-in-1.sh readlink: %v", err)
-	}
-	if dest != filepath.Join(layer1, "only-in-1.sh") {
-		t.Errorf("only-in-1.sh target = %q, want layer1 version", dest)
-	}
-
-	// only-in-2.sh should point to layer2.
-	dest, err = os.Readlink(filepath.Join(symlinkDir, "only-in-2.sh"))
-	if err != nil {
-		t.Fatalf("only-in-2.sh readlink: %v", err)
-	}
-	if dest != filepath.Join(layer2, "only-in-2.sh") {
-		t.Errorf("only-in-2.sh target = %q, want layer2 version", dest)
-	}
-}
-
-func TestResolveScripts_Idempotent(t *testing.T) {
-	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "setup.sh", "#!/bin/sh\necho setup")
-
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("first ResolveScripts: %v", err)
-	}
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("second ResolveScripts: %v", err)
-	}
-
-	dest, err := os.Readlink(filepath.Join(target, "scripts", "setup.sh"))
-	if err != nil {
-		t.Fatalf("readlink: %v", err)
-	}
-	if dest != filepath.Join(layer, "setup.sh") {
-		t.Errorf("symlink target = %q, want %q", dest, filepath.Join(layer, "setup.sh"))
-	}
-}
-
-func TestResolveScripts_StaleCleanup(t *testing.T) {
-	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "setup.sh", "setup")
-	writeScriptFile(t, layer, "old.sh", "old")
-
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	// First pass: both scripts.
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("first ResolveScripts: %v", err)
-	}
-
-	// Remove old.sh from the layer.
-	os.Remove(filepath.Join(layer, "old.sh")) //nolint:errcheck
-
-	// Second pass.
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("second ResolveScripts: %v", err)
-	}
-
-	// setup.sh should still exist.
-	if _, err := os.Lstat(filepath.Join(target, "scripts", "setup.sh")); err != nil {
-		t.Errorf("setup.sh should still exist: %v", err)
-	}
-
-	// old.sh should be removed.
-	if _, err := os.Lstat(filepath.Join(target, "scripts", "old.sh")); !os.IsNotExist(err) {
-		t.Error("old.sh should have been removed (stale symlink)")
-	}
-}
-
-func TestResolveScripts_RealFileNotOverwritten(t *testing.T) {
-	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "setup.sh", "layer version")
-
-	target := filepath.Join(dir, "city")
-	symlinkDir := filepath.Join(target, "scripts")
-	os.MkdirAll(symlinkDir, 0o755) //nolint:errcheck
-
-	// Create a real file in the target.
-	realFile := filepath.Join(symlinkDir, "setup.sh")
-	os.WriteFile(realFile, []byte("real file"), 0o644) //nolint:errcheck
-
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("ResolveScripts: %v", err)
-	}
-
-	fi, err := os.Lstat(realFile)
-	if err != nil {
-		t.Fatalf("Lstat: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("real file should not have been replaced with symlink")
-	}
-	content, err := os.ReadFile(realFile)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if string(content) != "real file" {
-		t.Errorf("real file content = %q, want %q", content, "real file")
-	}
-}
-
-func TestResolveScripts_EmptyLayers(t *testing.T) {
-	target := filepath.Join(t.TempDir(), "city")
-	if err := ResolveScripts(target, nil); err != nil {
-		t.Errorf("nil layers should be no-op: %v", err)
-	}
-	if err := ResolveScripts(target, []string{}); err != nil {
-		t.Errorf("empty layers should be no-op: %v", err)
-	}
-}
-
-func TestResolveScripts_EmptyLayersCleanStaleSymlinks(t *testing.T) {
-	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "setup.sh", "setup")
-
-	target := filepath.Join(dir, "city")
-	if err := os.MkdirAll(target, 0o755); err != nil {
-		t.Fatalf("MkdirAll target: %v", err)
-	}
-
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("first ResolveScripts: %v", err)
-	}
-
-	if err := ResolveScripts(target, nil); err != nil {
-		t.Fatalf("second ResolveScripts: %v", err)
-	}
-
-	if _, err := os.Lstat(filepath.Join(target, "scripts", "setup.sh")); !os.IsNotExist(err) {
-		t.Fatalf("setup.sh should have been removed after empty-layer cleanup, err=%v", err)
-	}
-}
-
-func TestResolveScripts_MissingLayerDir(t *testing.T) {
-	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "setup.sh", "setup")
-
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	// Include a missing dir — should be skipped.
-	if err := ResolveScripts(target, []string{"/nonexistent", layer}); err != nil {
-		t.Fatalf("ResolveScripts: %v", err)
-	}
-
-	if _, err := os.Lstat(filepath.Join(target, "scripts", "setup.sh")); err != nil {
-		t.Errorf("setup.sh should exist: %v", err)
-	}
-}
-
-func TestResolveScripts_EmptySubdirCleanup(t *testing.T) {
-	dir := t.TempDir()
-	layer := filepath.Join(dir, "pack", "scripts")
-	writeScriptFile(t, layer, "checks/review.sh", "review")
-
-	target := filepath.Join(dir, "city")
-	os.MkdirAll(target, 0o755) //nolint:errcheck
-
-	// First pass: creates checks/ subdir.
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("first ResolveScripts: %v", err)
-	}
-
-	// Remove the script from the layer.
-	os.Remove(filepath.Join(layer, "checks", "review.sh")) //nolint:errcheck
-
-	// Second pass: stale symlink and empty dir should be cleaned.
-	if err := ResolveScripts(target, []string{layer}); err != nil {
-		t.Fatalf("second ResolveScripts: %v", err)
-	}
-
-	checksDir := filepath.Join(target, "scripts", "checks")
-	if _, err := os.Stat(checksDir); !os.IsNotExist(err) {
-		t.Errorf("empty checks/ subdir should have been removed, err=%v", err)
-	}
-}
-
-func TestResolveConfiguredScripts_CleansCityAndRigWhenLayersDisappear(t *testing.T) {
+func TestPruneLegacyConfiguredScripts_PrunesCityAndRigOnly(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	cityLayer := filepath.Join(dir, "pack", "scripts")
-	rigLayer := filepath.Join(dir, "rig-pack", "scripts")
-	writeScriptFile(t, cityLayer, "city.sh", "city")
-	writeScriptFile(t, rigLayer, "rig.sh", "rig")
-
 	cityPath := filepath.Join(dir, "city")
 	rigPath := filepath.Join(cityPath, "rig")
-	if err := os.MkdirAll(cityPath, 0o755); err != nil {
-		t.Fatalf("MkdirAll city: %v", err)
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll src: %v", err)
 	}
-	if err := os.MkdirAll(rigPath, 0o755); err != nil {
-		t.Fatalf("MkdirAll rig: %v", err)
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile src: %v", err)
 	}
-	cwdStale := filepath.Join(dir, "scripts", "stale.sh")
-	if err := os.MkdirAll(filepath.Dir(cwdStale), 0o755); err != nil {
-		t.Fatalf("MkdirAll cwd scripts: %v", err)
-	}
-	if err := os.Symlink(filepath.Join(dir, "unbound.sh"), cwdStale); err != nil {
-		t.Fatalf("cwd stale symlink: %v", err)
-	}
+
+	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", srcFile)
+	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", srcFile)
+	writeLegacyScriptLink(t, dir, "scripts/cwd.sh", srcFile)
 
 	cfg := &config.City{
 		Rigs: []config.Rig{
 			{Name: "app", Path: "rig"},
 			{Name: "unbound"},
 		},
-		ScriptLayers: config.ScriptLayers{
-			City: []string{cityLayer},
-			Rigs: map[string][]string{"app": {cityLayer, rigLayer}},
-		},
 	}
+
 	var warnings []string
-	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+	pruneLegacyConfiguredScripts(cityPath, cfg, func(scope string, err error) {
 		warnings = append(warnings, scope+": "+err.Error())
 	})
 	if len(warnings) > 0 {
-		t.Fatalf("resolveConfiguredScripts warnings: %v", warnings)
+		t.Fatalf("pruneLegacyConfiguredScripts warnings: %v", warnings)
 	}
 
-	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
-		t.Fatalf("city script should exist: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("city scripts/ should be pruned, err=%v", err)
 	}
-	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
-		t.Fatalf("rig script should exist: %v", err)
+	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("rig scripts/ should be pruned, err=%v", err)
 	}
-
-	cfg.ScriptLayers = config.ScriptLayers{Rigs: map[string][]string{}}
-	resolveConfiguredScripts(cityPath, cfg, func(scope string, err error) {
-		warnings = append(warnings, scope+": "+err.Error())
-	})
-	if len(warnings) > 0 {
-		t.Fatalf("resolveConfiguredScripts cleanup warnings: %v", warnings)
-	}
-
-	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); !os.IsNotExist(err) {
-		t.Fatalf("city script should be cleaned after layers disappear, err=%v", err)
-	}
-	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); !os.IsNotExist(err) {
-		t.Fatalf("rig script should be cleaned after layers disappear, err=%v", err)
-	}
-	if _, err := os.Lstat(cwdStale); err != nil {
-		t.Fatalf("blank rig path should not clean cwd scripts, err=%v", err)
+	if _, err := os.Lstat(filepath.Join(dir, "scripts", "cwd.sh")); err != nil {
+		t.Fatalf("blank rig path should not prune cwd scripts, err=%v", err)
 	}
 }
 
-func TestPrepareCityForSupervisorCleansScriptsWhenLayersDisappear(t *testing.T) {
+func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
 	rigPath := filepath.Join(dir, "rig")
-	if err := os.MkdirAll(filepath.Join(cityPath, "scripts"), 0o755); err != nil {
-		t.Fatalf("MkdirAll city scripts: %v", err)
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll src: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(rigPath, "scripts"), 0o755); err != nil {
-		t.Fatalf("MkdirAll rig scripts: %v", err)
+	srcFile := filepath.Join(srcDir, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile src: %v", err)
 	}
-	if err := os.Symlink(filepath.Join(dir, "old-city.sh"), filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
-		t.Fatalf("city symlink: %v", err)
-	}
-	if err := os.Symlink(filepath.Join(dir, "old-rig.sh"), filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
-		t.Fatalf("rig symlink: %v", err)
-	}
+
+	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", srcFile)
+	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", srcFile)
 
 	logFile := filepath.Join(t.TempDir(), "beads.log")
 	t.Setenv("GC_BEADS", "exec:"+writeSpyScript(t, logFile))
 
 	cfg := config.DefaultCity("bright-lights")
 	cfg.Rigs = []config.Rig{{Name: "app", Path: rigPath}}
-	cfg.ScriptLayers = config.ScriptLayers{Rigs: map[string][]string{}}
 
 	if err := prepareCityForSupervisor(cityPath, "bright-lights", &cfg, io.Discard, nil); err != nil {
 		t.Fatalf("prepareCityForSupervisor: %v", err)
 	}
 
-	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); !os.IsNotExist(err) {
-		t.Fatalf("city script should be cleaned by supervisor start path, err=%v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("city scripts/ should be pruned by supervisor start path, err=%v", err)
 	}
-	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); !os.IsNotExist(err) {
-		t.Fatalf("rig script should be cleaned by supervisor start path, err=%v", err)
+	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("rig scripts/ should be pruned by supervisor start path, err=%v", err)
 	}
 }

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -42,9 +42,16 @@ func TestPruneLegacyScripts_RemovesSymlinkOnlyTree(t *testing.T) {
 	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile src: %v", err)
 	}
+	reviewSrc := filepath.Join(packScripts, "checks", "review.sh")
+	if err := os.MkdirAll(filepath.Dir(reviewSrc), 0o755); err != nil {
+		t.Fatalf("MkdirAll review src: %v", err)
+	}
+	if err := os.WriteFile(reviewSrc, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile review src: %v", err)
+	}
 
 	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", srcFile)
-	writeLegacyScriptLink(t, cityPath, "scripts/checks/review.sh", srcFile)
+	writeLegacyScriptLink(t, cityPath, "scripts/checks/review.sh", reviewSrc)
 
 	if err := pruneLegacyScripts(cityPath, []string{packScripts}); err != nil {
 		t.Fatalf("pruneLegacyScripts: %v", err)
@@ -121,6 +128,67 @@ func TestPruneLegacyScripts_LeavesForeignSymlinkOnlyTreeUntouched(t *testing.T) 
 
 	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "helper.sh")); err != nil {
 		t.Fatalf("foreign symlink should remain, err=%v", err)
+	}
+}
+
+func TestPruneLegacyScripts_LeavesUserManagedRelayoutUntouched(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	packScripts := filepath.Join(dir, "packs/base/assets/scripts")
+	if err := os.MkdirAll(packScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll pack scripts: %v", err)
+	}
+	srcFile := filepath.Join(packScripts, "helper.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile src: %v", err)
+	}
+
+	writeLegacyScriptLink(t, cityPath, "scripts/custom.sh", srcFile)
+
+	if err := pruneLegacyScripts(cityPath, []string{packScripts}); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "custom.sh")); err != nil {
+		t.Fatalf("user-managed relayout symlink should remain, err=%v", err)
+	}
+}
+
+func TestPruneLegacyScripts_LeavesSubsetOfLegacyOriginUntouched(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	packScripts := filepath.Join(dir, "packs/base/assets/scripts")
+	if err := os.MkdirAll(packScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll pack scripts: %v", err)
+	}
+	helperSrc := filepath.Join(packScripts, "helper.sh")
+	if err := os.WriteFile(helperSrc, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile helper src: %v", err)
+	}
+	extraSrc := filepath.Join(packScripts, "extra.sh")
+	if err := os.WriteFile(extraSrc, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile extra src: %v", err)
+	}
+
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", helperSrc)
+
+	if err := pruneLegacyScripts(cityPath, []string{packScripts}); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "helper.sh")); err != nil {
+		t.Fatalf("subset of legacy origin should remain user-owned, err=%v", err)
+	}
+}
+
+func TestPruneLegacyScripts_RemovesStaleLegacyShapeWhenOriginsMissing(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", filepath.Join(cityPath, "packs", "removed", "assets", "scripts", "helper.sh"))
+
+	if err := pruneLegacyScripts(cityPath, nil); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("stale legacy-shaped scripts/ should be removed, err=%v", err)
 	}
 }
 
@@ -202,6 +270,7 @@ func TestPruneLegacyConfiguredScripts_FallsBackToScopeAssetsWhenPackDirsMissing(
 	}
 
 	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", cityAsset)
+	writeLegacyScriptLink(t, rigPath, "scripts/city.sh", cityAsset)
 	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", rigAsset)
 
 	cfg := &config.City{
@@ -220,6 +289,23 @@ func TestPruneLegacyConfiguredScripts_FallsBackToScopeAssetsWhenPackDirsMissing(
 	}
 	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
 		t.Fatalf("rig scripts/ should be pruned via local assets fallback, err=%v", err)
+	}
+}
+
+func TestPruneLegacyConfiguredScripts_FallbackPreservesTopLevelScriptsTargets(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", filepath.Join(cityPath, "scripts", "generated", "helper.sh"))
+
+	var warnings []string
+	pruneLegacyConfiguredScripts(cityPath, &config.City{}, func(scope string, err error) {
+		warnings = append(warnings, scope+": "+err.Error())
+	})
+	if len(warnings) > 0 {
+		t.Fatalf("pruneLegacyConfiguredScripts warnings: %v", warnings)
+	}
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "helper.sh")); err != nil {
+		t.Fatalf("user-managed top-level scripts symlink should remain, err=%v", err)
 	}
 }
 
@@ -245,6 +331,7 @@ func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
 	}
 
 	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", citySrcFile)
+	writeLegacyScriptLink(t, rigPath, "scripts/city.sh", citySrcFile)
 	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", rigSrcFile)
 
 	logFile := filepath.Join(t.TempDir(), "beads.log")

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -34,11 +34,11 @@ func writeLegacyScriptFile(t *testing.T, dir, relPath, content string) {
 func TestPruneLegacyScripts_RemovesSymlinkOnlyTree(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
-	srcDir := filepath.Join(dir, "src")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll src: %v", err)
+	packScripts := filepath.Join(dir, "packs/base/assets/scripts")
+	if err := os.MkdirAll(packScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll pack scripts: %v", err)
 	}
-	srcFile := filepath.Join(srcDir, "helper.sh")
+	srcFile := filepath.Join(packScripts, "helper.sh")
 	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile src: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestPruneLegacyScripts_RemovesSymlinkOnlyTree(t *testing.T) {
 	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", srcFile)
 	writeLegacyScriptLink(t, cityPath, "scripts/checks/review.sh", srcFile)
 
-	if err := pruneLegacyScripts(cityPath); err != nil {
+	if err := pruneLegacyScripts(cityPath, []string{packScripts}); err != nil {
 		t.Fatalf("pruneLegacyScripts: %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestPruneLegacyScripts_LeavesRealFilesAlone(t *testing.T) {
 	cityPath := filepath.Join(dir, "city")
 	writeLegacyScriptFile(t, cityPath, "scripts/run.sh", "#!/bin/sh\necho run\n")
 
-	if err := pruneLegacyScripts(cityPath); err != nil {
+	if err := pruneLegacyScripts(cityPath, nil); err != nil {
 		t.Fatalf("pruneLegacyScripts: %v", err)
 	}
 
@@ -72,11 +72,11 @@ func TestPruneLegacyScripts_LeavesRealFilesAlone(t *testing.T) {
 func TestPruneLegacyScripts_LeavesMixedTreeUntouched(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
-	srcDir := filepath.Join(dir, "src")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll src: %v", err)
+	packScripts := filepath.Join(dir, "packs/base/assets/scripts")
+	if err := os.MkdirAll(packScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll pack scripts: %v", err)
 	}
-	srcFile := filepath.Join(srcDir, "helper.sh")
+	srcFile := filepath.Join(packScripts, "helper.sh")
 	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile src: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestPruneLegacyScripts_LeavesMixedTreeUntouched(t *testing.T) {
 	writeLegacyScriptFile(t, cityPath, "scripts/run.sh", "#!/bin/sh\necho run\n")
 	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", srcFile)
 
-	if err := pruneLegacyScripts(cityPath); err != nil {
+	if err := pruneLegacyScripts(cityPath, []string{packScripts}); err != nil {
 		t.Fatalf("pruneLegacyScripts: %v", err)
 	}
 
@@ -100,29 +100,65 @@ func TestPruneLegacyScripts_LeavesMixedTreeUntouched(t *testing.T) {
 	}
 }
 
+func TestPruneLegacyScripts_LeavesForeignSymlinkOnlyTreeUntouched(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	foreignDir := filepath.Join(dir, "foreign")
+	if err := os.MkdirAll(foreignDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll foreign: %v", err)
+	}
+	foreignFile := filepath.Join(foreignDir, "helper.sh")
+	if err := os.WriteFile(foreignFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile foreign: %v", err)
+	}
+	legacyOrigin := filepath.Join(dir, "packs/base/assets/scripts")
+
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", foreignFile)
+
+	if err := pruneLegacyScripts(cityPath, []string{legacyOrigin}); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "helper.sh")); err != nil {
+		t.Fatalf("foreign symlink should remain, err=%v", err)
+	}
+}
+
 func TestPruneLegacyConfiguredScripts_PrunesCityAndRigOnly(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
 	cityPath := filepath.Join(dir, "city")
 	rigPath := filepath.Join(cityPath, "rig")
-	srcDir := filepath.Join(dir, "src")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll src: %v", err)
+	cityPackScripts := filepath.Join(dir, "packs/city/assets/scripts")
+	rigPackScripts := filepath.Join(dir, "packs/rig/assets/scripts")
+	if err := os.MkdirAll(cityPackScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll city pack scripts: %v", err)
 	}
-	srcFile := filepath.Join(srcDir, "helper.sh")
-	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile src: %v", err)
+	if err := os.MkdirAll(rigPackScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll rig pack scripts: %v", err)
+	}
+	citySrcFile := filepath.Join(cityPackScripts, "city.sh")
+	if err := os.WriteFile(citySrcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile city src: %v", err)
+	}
+	rigSrcFile := filepath.Join(rigPackScripts, "rig.sh")
+	if err := os.WriteFile(rigSrcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile rig src: %v", err)
 	}
 
-	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", srcFile)
-	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", srcFile)
-	writeLegacyScriptLink(t, dir, "scripts/cwd.sh", srcFile)
+	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", citySrcFile)
+	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", rigSrcFile)
+	writeLegacyScriptLink(t, dir, "scripts/cwd.sh", citySrcFile)
 
 	cfg := &config.City{
+		PackDirs: []string{filepath.Join(dir, "packs/city")},
 		Rigs: []config.Rig{
 			{Name: "app", Path: "rig"},
 			{Name: "unbound"},
+		},
+		RigPackDirs: map[string][]string{
+			"app": {filepath.Join(dir, "packs/rig")},
 		},
 	}
 
@@ -149,23 +185,35 @@ func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
 	rigPath := filepath.Join(dir, "rig")
-	srcDir := filepath.Join(dir, "src")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll src: %v", err)
+	cityPackScripts := filepath.Join(dir, "packs/city/assets/scripts")
+	rigPackScripts := filepath.Join(dir, "packs/rig/assets/scripts")
+	if err := os.MkdirAll(cityPackScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll city pack scripts: %v", err)
 	}
-	srcFile := filepath.Join(srcDir, "helper.sh")
-	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile src: %v", err)
+	if err := os.MkdirAll(rigPackScripts, 0o755); err != nil {
+		t.Fatalf("MkdirAll rig pack scripts: %v", err)
+	}
+	citySrcFile := filepath.Join(cityPackScripts, "city.sh")
+	if err := os.WriteFile(citySrcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile city src: %v", err)
+	}
+	rigSrcFile := filepath.Join(rigPackScripts, "rig.sh")
+	if err := os.WriteFile(rigSrcFile, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile rig src: %v", err)
 	}
 
-	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", srcFile)
-	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", srcFile)
+	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", citySrcFile)
+	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", rigSrcFile)
 
 	logFile := filepath.Join(t.TempDir(), "beads.log")
 	t.Setenv("GC_BEADS", "exec:"+writeSpyScript(t, logFile))
 
 	cfg := config.DefaultCity("bright-lights")
 	cfg.Rigs = []config.Rig{{Name: "app", Path: rigPath}}
+	cfg.PackDirs = []string{filepath.Join(dir, "packs/city")}
+	cfg.RigPackDirs = map[string][]string{
+		"app": {filepath.Join(dir, "packs/rig")},
+	}
 
 	if err := prepareCityForSupervisor(cityPath, "bright-lights", &cfg, io.Discard, nil); err != nil {
 		t.Fatalf("prepareCityForSupervisor: %v", err)

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -181,6 +181,48 @@ func TestPruneLegacyConfiguredScripts_PrunesCityAndRigOnly(t *testing.T) {
 	}
 }
 
+func TestPruneLegacyConfiguredScripts_FallsBackToScopeAssetsWhenPackDirsMissing(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	rigPath := filepath.Join(cityPath, "rig")
+
+	cityAsset := filepath.Join(cityPath, "assets", "scripts", "city.sh")
+	if err := os.MkdirAll(filepath.Dir(cityAsset), 0o755); err != nil {
+		t.Fatalf("MkdirAll city assets: %v", err)
+	}
+	if err := os.WriteFile(cityAsset, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile city asset: %v", err)
+	}
+	rigAsset := filepath.Join(rigPath, "assets", "scripts", "rig.sh")
+	if err := os.MkdirAll(filepath.Dir(rigAsset), 0o755); err != nil {
+		t.Fatalf("MkdirAll rig assets: %v", err)
+	}
+	if err := os.WriteFile(rigAsset, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile rig asset: %v", err)
+	}
+
+	writeLegacyScriptLink(t, cityPath, "scripts/city.sh", cityAsset)
+	writeLegacyScriptLink(t, rigPath, "scripts/rig.sh", rigAsset)
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "app", Path: rigPath}},
+	}
+
+	var warnings []string
+	pruneLegacyConfiguredScripts(cityPath, cfg, func(scope string, err error) {
+		warnings = append(warnings, scope+": "+err.Error())
+	})
+	if len(warnings) > 0 {
+		t.Fatalf("pruneLegacyConfiguredScripts warnings: %v", warnings)
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("city scripts/ should be pruned via local assets fallback, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
+		t.Fatalf("rig scripts/ should be pruned via local assets fallback, err=%v", err)
+	}
+}
+
 func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -356,7 +356,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		command = expanded[0]
 	}
 	expandedSetup := expandSessionSetup(cfgAgent.SessionSetup, setupCtx)
-	resolvedScript := resolveSetupScript(cfgAgent.SessionSetupScript, p.cityPath)
+	resolvedScript := resolveSetupScript(cfgAgent.SessionSetupScript, cfgAgent.SourceDir, p.cityPath)
 	expandedPreStart := expandSessionSetup(cfgAgent.PreStart, setupCtx)
 	expandedLive := expandSessionSetup(cfgAgent.SessionLive, setupCtx)
 

--- a/cmd/gc/testdata/init-from-dir.txtar
+++ b/cmd/gc/testdata/init-from-dir.txtar
@@ -49,6 +49,11 @@ stderr 'no city.toml'
 # gc init --from and --file are mutually exclusive (exits non-zero).
 ! exec gc init --from $WORK/template --file $WORK/template/city.toml $WORK/other-city
 
+# PackV2 templates should not copy the deprecated top-level scripts/ shim.
+exec gc init --from $WORK/v2-template $WORK/v2-city
+! exists $WORK/v2-city/scripts/run.sh
+exists $WORK/v2-city/pack.toml
+
 -- template/city.toml --
 [workspace]
 provider = "claude"
@@ -77,5 +82,18 @@ prompt_template = "prompts/mayor.md"
 
 -- named-template/prompts/mayor.md --
 You are the mayor.
+
+-- v2-template/city.toml --
+[workspace]
+provider = "claude"
+
+-- v2-template/pack.toml --
+[pack]
+name = "v2-template"
+schema = 2
+
+-- v2-template/scripts/run.sh --
+#!/bin/sh
+echo compatibility shim
 
 -- no-city/.keep --

--- a/cmd/gc/testdata/init-from-dir.txtar
+++ b/cmd/gc/testdata/init-from-dir.txtar
@@ -49,10 +49,17 @@ stderr 'no city.toml'
 # gc init --from and --file are mutually exclusive (exits non-zero).
 ! exec gc init --from $WORK/template --file $WORK/template/city.toml $WORK/other-city
 
-# PackV2 templates should not copy the deprecated top-level scripts/ shim.
+# PackV2 templates preserve real top-level scripts.
 exec gc init --from $WORK/v2-template $WORK/v2-city
-! exists $WORK/v2-city/scripts/run.sh
+exists $WORK/v2-city/scripts/run.sh
 exists $WORK/v2-city/pack.toml
+
+# PackV2 templates should not copy the deprecated top-level scripts/ shim.
+exec mkdir -p $WORK/v2-shim-template/scripts
+exec ln -s $WORK/v2-shim-template/assets/scripts/run.sh $WORK/v2-shim-template/scripts/run.sh
+exec gc init --from $WORK/v2-shim-template $WORK/v2-shim-city
+! exists $WORK/v2-shim-city/scripts/run.sh
+exists $WORK/v2-shim-city/pack.toml
 
 -- template/city.toml --
 [workspace]
@@ -93,6 +100,19 @@ name = "v2-template"
 schema = 2
 
 -- v2-template/scripts/run.sh --
+#!/bin/sh
+echo real top-level script
+
+-- v2-shim-template/city.toml --
+[workspace]
+provider = "claude"
+
+-- v2-shim-template/pack.toml --
+[pack]
+name = "v2-shim-template"
+schema = 2
+
+-- v2-shim-template/assets/scripts/run.sh --
 #!/bin/sh
 echo compatibility shim
 

--- a/docs/packv2/doc-loader-v2.md
+++ b/docs/packv2/doc-loader-v2.md
@@ -115,7 +115,6 @@ type City struct {
     NamedSessions      []NamedSession
     Providers          map[string]ProviderSpec
     FormulaLayers      FormulaLayers
-    ScriptLayers       ScriptLayers
     OverlayLayers      OverlayLayers
     Patches            Patches             // applied during compose
 

--- a/docs/packv2/skew-analysis.md
+++ b/docs/packv2/skew-analysis.md
@@ -251,7 +251,7 @@ All Import fields match spec. No changes needed.
 | 🟢 | Import `shadow` field | doc-pack-v2 | Warning/silent logic in pack.go |
 | 🟢 | `orders/` top-level discovery | doc-directory-conventions | `discoverFlatFiles` in orders/discovery.go |
 | 🟢 | `commands/` convention discovery | doc-commands | `DiscoverPackCommands` in command_discovery.go |
-| 🔵 | No top-level `scripts/` surface / no `ScriptLayers` runtime shim | doc-directory-conventions, doc-loader-v2 | Not implemented. Runtime still collects pack `scripts/` and `assets/scripts/` directories into `ScriptLayers` and materializes `<city>/scripts` for compatibility until remaining path consumers migrate to pack-local resolution. |
+| 🟢 | No top-level `scripts/` surface / no `ScriptLayers` runtime shim | doc-directory-conventions, doc-loader-v2 | Implemented. Runtime no longer collects `ScriptLayers` or materializes `<city>/scripts`; startup paths only prune stale symlink-only artifacts left by older versions. |
 | 🔴 | `[defaults.rig.imports]` loader support | doc-pack-v2 | Migrate tool writes it, loader ignores it |
 | 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented. The current rollout stores the chosen registration name in the machine-local supervisor registry without rewriting `city.toml`; no-flag registration uses the effective city identity (site binding / legacy config / basename) and stores the selected name only in the registry. |
 | 🔴 | `patches/` directory convention | doc-agent-v2 | Not implemented |

--- a/docs/packv2/skew-analysis.md
+++ b/docs/packv2/skew-analysis.md
@@ -251,6 +251,7 @@ All Import fields match spec. No changes needed.
 | 🟢 | Import `shadow` field | doc-pack-v2 | Warning/silent logic in pack.go |
 | 🟢 | `orders/` top-level discovery | doc-directory-conventions | `discoverFlatFiles` in orders/discovery.go |
 | 🟢 | `commands/` convention discovery | doc-commands | `DiscoverPackCommands` in command_discovery.go |
+| 🔵 | No top-level `scripts/` surface / no `ScriptLayers` runtime shim | doc-directory-conventions, doc-loader-v2 | Not implemented. Runtime still collects pack `scripts/` and `assets/scripts/` directories into `ScriptLayers` and materializes `<city>/scripts` for compatibility until remaining path consumers migrate to pack-local resolution. |
 | 🔴 | `[defaults.rig.imports]` loader support | doc-pack-v2 | Migrate tool writes it, loader ignores it |
 | 🟢 | `gc register --name` flag | doc-pack-v2 | Implemented. The current rollout stores the chosen registration name in the machine-local supervisor registry without rewriting `city.toml`; no-flag registration uses the effective city identity (site binding / legacy config / basename) and stores the selected name only in the registry. |
 | 🔴 | `patches/` directory convention | doc-agent-v2 | Not implemented |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -97,7 +97,7 @@ Agent defines a configured agent in the city.
 | `mcp` | []string |  |  | MCP is a tombstone field retained for v0.15.1 backwards compatibility. Accepted during parse for migration visibility, but attachment-list fields are accepted but ignored by the active materializer. |
 | `hooks_installed` | boolean |  |  | HooksInstalled overrides automatic hook detection. Set to true when hooks are manually installed (e.g., merged into the project's own hook config) and auto-installation via install_agent_hooks is not desired. When true, the agent is treated as hook-enabled for startup behavior: no prime instruction in beacon and no delayed nudge. Interacts with install_agent_hooks — set this instead when hooks are pre-installed. |
 | `session_setup` | []string |  |  | SessionSetup is a list of shell commands run after session creation. Each command is a template string supporting placeholders: &#123;&#123;.Session&#125;&#125;, &#123;&#123;.Agent&#125;&#125;, &#123;&#123;.AgentBase&#125;&#125;, &#123;&#123;.Rig&#125;&#125;, &#123;&#123;.RigRoot&#125;&#125;, &#123;&#123;.CityRoot&#125;&#125;, &#123;&#123;.CityName&#125;&#125;, &#123;&#123;.WorkDir&#125;&#125;. Commands run in gc's process (not inside the agent session) via sh -c. |
-| `session_setup_script` | string |  |  | SessionSetupScript is the path to a script run after session_setup commands. Relative paths resolve against the city directory. The script receives context via environment variables (GC_SESSION plus existing GC_* vars). |
+| `session_setup_script` | string |  |  | SessionSetupScript is the path to a script run after session_setup commands. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. The script receives context via environment variables (GC_SESSION plus existing GC_* vars). |
 | `session_live` | []string |  |  | SessionLive is a list of shell commands that are safe to re-apply without restarting the agent. Run at startup (after session_setup) and re-applied on config change without triggering a restart. Must be idempotent. Typical use: tmux theming, keybindings, status bars. Same template placeholders as session_setup. |
 | `overlay_dir` | string |  |  | OverlayDir is a directory whose contents are recursively copied (additive) into the agent's working directory at startup. Existing files are not overwritten. Relative paths resolve against the declaring config file's directory (pack-safe). |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula is the formula name automatically applied via --on when beads are slung to this agent, unless --no-formula is set. Example: "mol-polecat-work" |
@@ -152,7 +152,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `hooks_installed` | boolean |  |  | HooksInstalled overrides automatic hook detection. |
 | `inject_assigned_skills` | boolean |  |  | InjectAssignedSkills overrides Agent.InjectAssignedSkills (see that field for semantics). |
 | `session_setup` | []string |  |  | SessionSetup overrides the agent's session_setup commands. |
-| `session_setup_script` | string |  |  | SessionSetupScript overrides the agent's session_setup_script path. Relative paths resolve against the city directory. |
+| `session_setup_script` | string |  |  | SessionSetupScript overrides the agent's session_setup_script path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session_live` | []string |  |  | SessionLive overrides the agent's session_live commands. |
 | `overlay_dir` | string |  |  | OverlayDir overrides the agent's overlay_dir path. Copies contents additively into the agent's working directory at startup. Relative paths resolve against the city directory. |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula overrides the default sling formula. |
@@ -203,7 +203,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `hooks_installed` | boolean |  |  | HooksInstalled overrides automatic hook detection. |
 | `inject_assigned_skills` | boolean |  |  | InjectAssignedSkills overrides per-agent appendix injection (see Agent.InjectAssignedSkills). |
 | `session_setup` | []string |  |  | SessionSetup overrides the agent's session_setup commands. |
-| `session_setup_script` | string |  |  | SessionSetupScript overrides the agent's session_setup_script path. Relative paths resolve against the city directory. |
+| `session_setup_script` | string |  |  | SessionSetupScript overrides the agent's session_setup_script path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session_live` | []string |  |  | SessionLive overrides the agent's session_live commands. |
 | `overlay_dir` | string |  |  | OverlayDir overrides the agent's overlay_dir path. Copies contents additively into the agent's working directory at startup. Relative paths resolve against the city directory. |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula overrides the default sling formula. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -238,7 +238,7 @@
         },
         "session_setup_script": {
           "type": "string",
-          "description": "SessionSetupScript is the path to a script run after session_setup commands.\nRelative paths resolve against the city directory. The script receives\ncontext via environment variables (GC_SESSION plus existing GC_* vars)."
+          "description": "SessionSetupScript is the path to a script run after session_setup commands.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root.\nThe script receives context via environment variables (GC_SESSION plus\nexisting GC_* vars)."
         },
         "session_live": {
           "items": {
@@ -472,7 +472,7 @@
         },
         "session_setup_script": {
           "type": "string",
-          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the city directory."
+          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session_live": {
           "items": {
@@ -722,7 +722,7 @@
         },
         "session_setup_script": {
           "type": "string",
-          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the city directory."
+          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session_live": {
           "items": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -238,7 +238,7 @@
         },
         "session_setup_script": {
           "type": "string",
-          "description": "SessionSetupScript is the path to a script run after session_setup commands.\nRelative paths resolve against the city directory. The script receives\ncontext via environment variables (GC_SESSION plus existing GC_* vars)."
+          "description": "SessionSetupScript is the path to a script run after session_setup commands.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root.\nThe script receives context via environment variables (GC_SESSION plus\nexisting GC_* vars)."
         },
         "session_live": {
           "items": {
@@ -472,7 +472,7 @@
         },
         "session_setup_script": {
           "type": "string",
-          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the city directory."
+          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session_live": {
           "items": {
@@ -722,7 +722,7 @@
         },
         "session_setup_script": {
           "type": "string",
-          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the city directory."
+          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session_live": {
           "items": {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -439,8 +439,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	cityLocalFormulas := citylayout.ResolveFormulasDir(cityRoot, root.FormulasDir())
 	root.FormulaLayers = ComputeFormulaLayers(
 		cityTopoFormulas, cityLocalFormulas, rigFormulaDirs, root.Rigs, cityRoot)
-	root.ScriptLayers = ComputeScriptLayers(
-		root.PackScriptDirs, root.RigScriptDirs, root.Rigs)
 
 	// Inject implicit agents for built-in providers not already defined.
 	// Must happen after all composition (fragments, packs, patches) so

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -288,6 +288,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Adjust fragment agent paths to be city-root-relative.
 		fragDir := filepath.Dir(fragPath)
 		adjustAgentPaths(frag.Agents, fragDir, cityRoot)
+		adjustFragmentPatchPaths(&frag.Patches, fragDir, cityRoot)
 
 		// Merge fragment into root.
 		mergeFragment(root, frag, fragMeta, fragPath, prov)
@@ -521,6 +522,22 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// explicitly-declared agent. Populate the fields here so the
 	// convention works uniformly.
 	return root, prov, nil
+}
+
+// adjustFragmentPatchPaths resolves fragment patch session_setup_script values
+// to absolute paths rooted at the fragment directory. Patches do not retain
+// independent source provenance after merge, so runtime cannot otherwise
+// distinguish whether a relative override came from the target agent's source
+// or from the patch file itself.
+func adjustFragmentPatchPaths(patches *Patches, fragDir, cityRoot string) {
+	for i := range patches.Agents {
+		p := &patches.Agents[i]
+		if p.SessionSetupScript == nil || *p.SessionSetupScript == "" {
+			continue
+		}
+		v := resolveConfigPath(*p.SessionSetupScript, fragDir, cityRoot)
+		p.SessionSetupScript = &v
+	}
 }
 
 // populateAgentLocalAssetDirs fills Agent.SkillsDir and Agent.MCPDir for
@@ -992,20 +1009,18 @@ func resolveConfigPath(p, declDir, cityRoot string) string {
 	return filepath.Join(declDir, p)
 }
 
-// adjustAgentPaths converts relative prompt_template and session_setup_script
-// paths in fragment agents to be city-root-relative, based on the fragment's
-// directory. Also sets SourceDir so session_setup templates can reference
-// scripts relative to their source directory.
+// adjustAgentPaths converts relative prompt_template, overlay_dir, and
+// namepool paths in fragment agents to be city-root-relative, based on the
+// fragment's directory. session_setup_script is left as-authored so runtime
+// resolution can interpret it relative to SourceDir. SourceDir is always set
+// so session_setup templates and runtime path resolution know the declaring
+// config directory.
 func adjustAgentPaths(agents []Agent, fragDir, cityRoot string) {
 	for i := range agents {
 		agents[i].SourceDir = fragDir
 		if agents[i].PromptTemplate != "" {
 			agents[i].PromptTemplate = adjustFragmentPath(
 				agents[i].PromptTemplate, fragDir, cityRoot)
-		}
-		if agents[i].SessionSetupScript != "" {
-			agents[i].SessionSetupScript = adjustFragmentPath(
-				agents[i].SessionSetupScript, fragDir, cityRoot)
 		}
 		if agents[i].OverlayDir != "" {
 			agents[i].OverlayDir = adjustFragmentPath(

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -288,7 +288,8 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Adjust fragment agent paths to be city-root-relative.
 		fragDir := filepath.Dir(fragPath)
 		adjustAgentPaths(frag.Agents, fragDir, cityRoot)
-		adjustFragmentPatchPaths(&frag.Patches, fragDir, cityRoot)
+		adjustPatchPaths(&frag.Patches, fragDir, cityRoot)
+		adjustRigOverridePaths(frag.Rigs, fragDir, cityRoot)
 
 		// Merge fragment into root.
 		mergeFragment(root, frag, fragMeta, fragPath, prov)
@@ -310,6 +311,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		root.Workspace.Includes = append(root.Workspace.Includes, inc)
 	}
+
+	adjustPatchPaths(&root.Patches, cityRoot, cityRoot)
+	adjustRigOverridePaths(root.Rigs, cityRoot, cityRoot)
 
 	// Resolve named pack references to cache paths before any expansion.
 	resolveNamedPacks(root, cityRoot)
@@ -522,19 +526,41 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	return root, prov, nil
 }
 
-// adjustFragmentPatchPaths resolves fragment patch session_setup_script values
-// to absolute paths rooted at the fragment directory. Patches do not retain
+// adjustPatchPaths resolves patch session_setup_script values to absolute
+// paths rooted at the declaring config directory. Patches do not retain
 // independent source provenance after merge, so runtime cannot otherwise
 // distinguish whether a relative override came from the target agent's source
 // or from the patch file itself.
-func adjustFragmentPatchPaths(patches *Patches, fragDir, cityRoot string) {
+func adjustPatchPaths(patches *Patches, declDir, cityRoot string) {
 	for i := range patches.Agents {
 		p := &patches.Agents[i]
 		if p.SessionSetupScript == nil || *p.SessionSetupScript == "" {
 			continue
 		}
-		v := resolveConfigPath(*p.SessionSetupScript, fragDir, cityRoot)
+		v := resolveConfigPath(*p.SessionSetupScript, declDir, cityRoot)
 		p.SessionSetupScript = &v
+	}
+}
+
+// adjustRigOverridePaths resolves rig override session_setup_script values to
+// absolute paths rooted at the declaring config directory. Once overrides are
+// applied to pack-stamped agents, runtime only sees the target agent's
+// SourceDir, so relative override paths must be normalized during composition.
+func adjustRigOverridePaths(rigs []Rig, declDir, cityRoot string) {
+	for i := range rigs {
+		adjustAgentOverridePaths(rigs[i].Overrides, declDir, cityRoot)
+		adjustAgentOverridePaths(rigs[i].RigPatches, declDir, cityRoot)
+	}
+}
+
+func adjustAgentOverridePaths(overrides []AgentOverride, declDir, cityRoot string) {
+	for i := range overrides {
+		ov := &overrides[i]
+		if ov.SessionSetupScript == nil || *ov.SessionSetupScript == "" {
+			continue
+		}
+		v := resolveConfigPath(*ov.SessionSetupScript, declDir, cityRoot)
+		ov.SessionSetupScript = &v
 	}
 }
 

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -1249,7 +1249,7 @@ func TestAdjustAgentPaths_SourceDirSet(t *testing.T) {
 	}
 }
 
-func TestAdjustAgentPaths_SessionSetupScriptAdjusted(t *testing.T) {
+func TestAdjustAgentPaths_SessionSetupScriptPreserved(t *testing.T) {
 	agents := []Agent{
 		{Name: "worker", SessionSetupScript: "scripts/setup.sh"},
 		{Name: "boss", SessionSetupScript: "//scripts/global.sh"},
@@ -1257,17 +1257,65 @@ func TestAdjustAgentPaths_SessionSetupScriptAdjusted(t *testing.T) {
 	}
 	adjustAgentPaths(agents, "/city/fragments", "/city")
 
-	// Relative path: resolved fragment-relative → city-root-relative.
-	if agents[0].SessionSetupScript != "fragments/scripts/setup.sh" {
-		t.Errorf("worker script = %q, want fragments/scripts/setup.sh", agents[0].SessionSetupScript)
+	// Relative path: preserved for runtime SourceDir-based resolution.
+	if agents[0].SessionSetupScript != "scripts/setup.sh" {
+		t.Errorf("worker script = %q, want scripts/setup.sh", agents[0].SessionSetupScript)
 	}
-	// "//" path: resolved to city root.
-	if agents[1].SessionSetupScript != "scripts/global.sh" {
-		t.Errorf("boss script = %q, want scripts/global.sh", agents[1].SessionSetupScript)
+	// "//" path: preserved so runtime can resolve explicitly against city root.
+	if agents[1].SessionSetupScript != "//scripts/global.sh" {
+		t.Errorf("boss script = %q, want //scripts/global.sh", agents[1].SessionSetupScript)
 	}
 	// Empty: unchanged.
 	if agents[2].SessionSetupScript != "" {
 		t.Errorf("plain script = %q, want empty", agents[2].SessionSetupScript)
+	}
+}
+
+func TestLoadWithIncludes_FragmentPatchSessionSetupScriptResolvedFromFragmentDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+include = ["fragments/patch.toml"]
+
+[workspace]
+name = "test"
+includes = ["packs/base"]
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+`)
+	writeFile("fragments/patch.toml", `
+[[patches.agent]]
+name = "worker"
+session_setup_script = "scripts/theme.sh"
+`)
+	writeFile("fragments/scripts/theme.sh", "#!/bin/sh\necho themed\n")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	want := filepath.Join(dir, "fragments/scripts/theme.sh")
+	if cfg.Agents[0].SessionSetupScript != want {
+		t.Fatalf("SessionSetupScript = %q, want %q", cfg.Agents[0].SessionSetupScript, want)
 	}
 }
 

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -1319,6 +1319,152 @@ session_setup_script = "scripts/theme.sh"
 	}
 }
 
+func TestLoadWithIncludes_RootPatchSessionSetupScriptResolvedFromCityDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+[workspace]
+name = "test"
+includes = ["packs/base"]
+
+[[patches.agent]]
+name = "worker"
+session_setup_script = "scripts/local.sh"
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+`)
+	writeFile("scripts/local.sh", "#!/bin/sh\necho local\n")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	want := filepath.Join(dir, "scripts/local.sh")
+	if cfg.Agents[0].SessionSetupScript != want {
+		t.Fatalf("SessionSetupScript = %q, want %q", cfg.Agents[0].SessionSetupScript, want)
+	}
+}
+
+func TestLoadWithIncludes_RootRigOverrideSessionSetupScriptResolvedFromCityDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "hw"
+path = "rig"
+includes = ["packs/base"]
+
+  [[rigs.overrides]]
+  agent = "worker"
+  session_setup_script = "scripts/rig-local.sh"
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "rig"
+`)
+	writeFile("scripts/rig-local.sh", "#!/bin/sh\necho city-override\n")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	want := filepath.Join(dir, "scripts/rig-local.sh")
+	if cfg.Agents[0].SessionSetupScript != want {
+		t.Fatalf("SessionSetupScript = %q, want %q", cfg.Agents[0].SessionSetupScript, want)
+	}
+}
+
+func TestLoadWithIncludes_FragmentRigOverrideSessionSetupScriptResolvedFromFragmentDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+include = ["fragments/rig.toml"]
+
+[workspace]
+name = "test"
+`)
+	writeFile("fragments/rig.toml", `
+[[rigs]]
+name = "hw"
+path = "rig"
+includes = ["packs/base"]
+
+  [[rigs.overrides]]
+  agent = "worker"
+  session_setup_script = "scripts/fragment-local.sh"
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "rig"
+`)
+	writeFile("fragments/scripts/fragment-local.sh", "#!/bin/sh\necho fragment-override\n")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	want := filepath.Join(dir, "fragments/scripts/fragment-local.sh")
+	if cfg.Agents[0].SessionSetupScript != want {
+		t.Fatalf("SessionSetupScript = %q, want %q", cfg.Agents[0].SessionSetupScript, want)
+	}
+}
+
 func TestAdjustAgentPaths_OverlayDirAdjusted(t *testing.T) {
 	agents := []Agent{
 		{Name: "worker", OverlayDir: "overlays/worker"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -519,7 +519,8 @@ type AgentOverride struct {
 	// SessionSetup overrides the agent's session_setup commands.
 	SessionSetup []string `toml:"session_setup,omitempty"`
 	// SessionSetupScript overrides the agent's session_setup_script path.
-	// Relative paths resolve against the city directory.
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
 	SessionSetupScript *string `toml:"session_setup_script,omitempty"`
 	// SessionLive overrides the agent's session_live commands.
 	SessionLive []string `toml:"session_live,omitempty"`
@@ -1637,8 +1638,10 @@ type Agent struct {
 	// Commands run in gc's process (not inside the agent session) via sh -c.
 	SessionSetup []string `toml:"session_setup,omitempty"`
 	// SessionSetupScript is the path to a script run after session_setup commands.
-	// Relative paths resolve against the city directory. The script receives
-	// context via environment variables (GC_SESSION plus existing GC_* vars).
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
+	// The script receives context via environment variables (GC_SESSION plus
+	// existing GC_* vars).
 	SessionSetupScript string `toml:"session_setup_script,omitempty"`
 	// SessionLive is a list of shell commands that are safe to re-apply
 	// without restarting the agent. Run at startup (after session_setup)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,9 +188,6 @@ type City struct {
 	// FormulaLayers holds the resolved formula directories per scope.
 	// Populated during pack expansion in LoadWithIncludes. Not from TOML.
 	FormulaLayers FormulaLayers `toml:"-" json:"-"`
-	// ScriptLayers holds the resolved script directories per scope.
-	// Populated during pack expansion in LoadWithIncludes. Not from TOML.
-	ScriptLayers ScriptLayers `toml:"-" json:"-"`
 	// PackDirs is the ordered, deduplicated list of pack directories
 	// from all loaded city packs (includes resolved). Consumers derive
 	// resource-specific search paths by scanning subdirectories:
@@ -239,12 +236,6 @@ type City struct {
 	// RigPackGlobals maps rig name to resolved [global] sections from
 	// rig-level packs. Rig globals apply only to that rig's agents.
 	RigPackGlobals map[string][]ResolvedPackGlobal `toml:"-" json:"-"`
-	// PackScriptDirs is the ordered list of scripts/ directories from
-	// city packs. Populated during pack expansion. Not from TOML.
-	PackScriptDirs []string `toml:"-" json:"-"`
-	// RigScriptDirs maps rig name to its ordered scripts/ directories
-	// from rig packs. Populated during pack expansion. Not from TOML.
-	RigScriptDirs map[string][]string `toml:"-" json:"-"`
 	// PackCommands holds convention-discovered pack commands composed
 	// during city expansion. Runtime-only.
 	PackCommands []DiscoveredCommand `toml:"-" json:"-"`
@@ -402,16 +393,6 @@ func (fl FormulaLayers) SearchPaths(rigName string) []string {
 		}
 	}
 	return fl.City
-}
-
-// ScriptLayers holds resolved script directories for symlink materialization.
-// Each slice is ordered lowest→highest priority; later entries shadow earlier
-// ones by relative path.
-type ScriptLayers struct {
-	// City holds script dirs for city-scoped materialization.
-	City []string
-	// Rigs maps rig name → script dir layers.
-	Rigs map[string][]string
 }
 
 // Rig defines an external project registered in the city.

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1386,11 +1386,9 @@ func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName s
 			agents[i].PromptTemplate = adjustFragmentPath(
 				agents[i].PromptTemplate, topoDir, cityRoot)
 		}
-		// Resolve session_setup_script paths relative to pack directory.
-		if agents[i].SessionSetupScript != "" {
-			agents[i].SessionSetupScript = adjustFragmentPath(
-				agents[i].SessionSetupScript, topoDir, cityRoot)
-		}
+		// Leave session_setup_script as-authored and resolve it at runtime
+		// against SourceDir so pack-local script paths do not collapse back
+		// into city-root-relative strings.
 		// Resolve overlay_dir paths relative to pack directory.
 		if agents[i].OverlayDir != "" {
 			agents[i].OverlayDir = adjustFragmentPath(
@@ -2150,13 +2148,15 @@ func resolveConfigDirInCommands(cmds []string, configDir string) []string {
 }
 
 // adjustPackPatchPaths resolves file-path fields in patches relative to
-// the pack directory, matching how agent fields are resolved during
-// pack loading.
+// the pack directory. session_setup_script is resolved all the way to an
+// absolute path because patches do not retain independent source provenance
+// after application; prompt_template and overlay_dir keep the existing
+// city-root-relative representation used elsewhere in composition.
 func adjustPackPatchPaths(patches *Patches, topoDir, cityRoot string) {
 	for i := range patches.Agents {
 		p := &patches.Agents[i]
 		if p.SessionSetupScript != nil && *p.SessionSetupScript != "" {
-			v := adjustFragmentPath(*p.SessionSetupScript, topoDir, cityRoot)
+			v := resolveConfigPath(*p.SessionSetupScript, topoDir, cityRoot)
 			p.SessionSetupScript = &v
 		}
 		if p.PromptTemplate != nil && *p.PromptTemplate != "" {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -393,25 +393,6 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 			cfg.RigOverlayDirs[rig.Name] = rigOverlayDirs
 		}
 
-		// Collect scripts dirs from rig pack dirs. V2 packs ship scripts
-		// under assets/scripts/; legacy packs may still use scripts/ at
-		// the pack root.
-		var rigScriptDirs []string
-		for _, dir := range rigTopoDirs {
-			for _, rel := range []string{"scripts", filepath.Join("assets", "scripts")} {
-				sd := filepath.Join(dir, rel)
-				if info, sErr := fs.Stat(sd); sErr == nil && info.IsDir() {
-					rigScriptDirs = appendUnique(rigScriptDirs, sd)
-				}
-			}
-		}
-		if len(rigScriptDirs) > 0 {
-			if cfg.RigScriptDirs == nil {
-				cfg.RigScriptDirs = make(map[string][]string)
-			}
-			cfg.RigScriptDirs[rig.Name] = rigScriptDirs
-		}
-
 		// Resolve fallback agents before collision detection.
 		rigAgents = resolveFallbackAgents(rigAgents)
 
@@ -752,19 +733,6 @@ func expandCityPacks(cfg *City, fs fsys.FS, cityRoot string, opts LoadOptions) (
 		}
 	}
 
-	// Collect scripts dirs from pack dirs. V2 packs ship scripts under
-	// assets/scripts/; legacy packs may still use scripts/ at the pack
-	// root. Scan both so `gc` continues to symlink scripts into
-	// <city>/scripts/ regardless of where the source pack put them.
-	for _, dir := range allPackDirs {
-		for _, rel := range []string{"scripts", filepath.Join("assets", "scripts")} {
-			sd := filepath.Join(dir, rel)
-			if info, err := fs.Stat(sd); err == nil && info.IsDir() {
-				cfg.PackScriptDirs = appendUnique(cfg.PackScriptDirs, sd)
-			}
-		}
-	}
-
 	// Resolve fallback agents before collision detection.
 	allAgents = resolveFallbackAgents(allAgents)
 
@@ -879,29 +847,6 @@ func ComputeFormulaLayers(cityTopoFormulas []string, cityLocalFormulas string, r
 	}
 
 	return fl
-}
-
-// ComputeScriptLayers builds the ScriptLayers from the resolved script
-// directories. Each layer slice is ordered lowest→highest priority.
-// City pack scripts form the base; rig pack scripts layer on top.
-func ComputeScriptLayers(cityPackScripts []string, rigPackScripts map[string][]string, rigs []Rig) ScriptLayers {
-	sl := ScriptLayers{
-		Rigs: make(map[string][]string),
-	}
-	sl.City = append([]string{}, cityPackScripts...)
-
-	for _, r := range rigs {
-		layers := make([]string, len(cityPackScripts))
-		copy(layers, cityPackScripts)
-		if sds, ok := rigPackScripts[r.Name]; ok {
-			layers = append(layers, sds...)
-		}
-		if len(layers) > 0 {
-			sl.Rigs[r.Name] = layers
-		}
-	}
-
-	return sl
 }
 
 // resolveFallbackAgents resolves fallback agent collisions. When agents

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -1558,7 +1558,7 @@ name = "witness"
 	}
 }
 
-func TestExpandPacks_SessionSetupScriptAdjusted(t *testing.T) {
+func TestExpandPacks_SessionSetupScriptPreserved(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gt/pack.toml", `
 [pack]
@@ -1581,8 +1581,8 @@ session_setup_script = "scripts/setup.sh"
 		t.Fatalf("ExpandPacks: %v", err)
 	}
 
-	// session_setup_script should be adjusted relative to pack dir → city root.
-	want := "packs/gt/scripts/setup.sh"
+	// session_setup_script stays pack-local and resolves later via SourceDir.
+	want := "scripts/setup.sh"
 	if cfg.Agents[0].SessionSetupScript != want {
 		t.Errorf("SessionSetupScript = %q, want %q", cfg.Agents[0].SessionSetupScript, want)
 	}
@@ -3131,12 +3131,14 @@ session_setup_script = "scripts/theme.sh"
 	if a.Name != "worker" {
 		t.Errorf("name = %q, want worker", a.Name)
 	}
-	// session_setup_script should be set (resolved path).
+	// session_setup_script should be resolved against the patch pack since
+	// patches do not retain their own SourceDir at runtime.
 	if a.SessionSetupScript == "" {
 		t.Fatal("SessionSetupScript not set by patch")
 	}
-	if !strings.Contains(a.SessionSetupScript, "scripts/theme.sh") {
-		t.Errorf("SessionSetupScript = %q, want to contain scripts/theme.sh", a.SessionSetupScript)
+	wantScript := filepath.Join(dir, "packs/overlay/scripts/theme.sh")
+	if a.SessionSetupScript != wantScript {
+		t.Errorf("SessionSetupScript = %q, want %q", a.SessionSetupScript, wantScript)
 	}
 	// Nudge should be inherited from base (not cleared by patch).
 	if a.Nudge != "do work" {
@@ -3177,7 +3179,7 @@ overlay_dir = "overlays/custom"
 	}
 	a := cfg.Agents[0]
 	// Paths should be resolved relative to the overlay pack dir.
-	wantScript := "packs/overlay/scripts/neon.sh"
+	wantScript := filepath.Join(dir, "packs/overlay/scripts/neon.sh")
 	if a.SessionSetupScript != wantScript {
 		t.Errorf("SessionSetupScript = %q, want %q", a.SessionSetupScript, wantScript)
 	}

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -84,7 +84,8 @@ type AgentPatch struct {
 	// SessionSetup overrides the agent's session_setup commands.
 	SessionSetup []string `toml:"session_setup,omitempty"`
 	// SessionSetupScript overrides the agent's session_setup_script path.
-	// Relative paths resolve against the city directory.
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
 	SessionSetupScript *string `toml:"session_setup_script,omitempty"`
 	// SessionLive overrides the agent's session_live commands.
 	SessionLive []string `toml:"session_live,omitempty"`


### PR DESCRIPTION
## Summary

- Fixes the immediate contradiction in #1018: `gc doctor` no longer treats runtime-generated top-level `scripts/` as a healthy PackV2 state.
- Moves `session_setup_script` onto pack-safe path semantics.
- Stops `gc init --from` from copying the deprecated top-level `scripts/` shim forward for schema-2 / PackV2 templates.
- Removes `ScriptLayers` / `ResolveScripts` entirely, replacing them with startup-time pruning of stale symlink-only leftovers from older versions.

## Why This Supersedes #1019

- `#1019` only addressed the doctor-side symptom.
- This PR keeps that fix, migrates the remaining script-path dependency that mattered (`session_setup_script`), and then deletes the runtime shim instead of preserving it indefinitely.

## Phase 1: Compatibility-Aware Doctor Check

- `v2ScriptsLayoutCheck` was taught to distinguish real files from runtime-created symlinks so #1018 stopped warning on its own compatibility shim.
- `docs/packv2/skew-analysis.md` recorded the remaining `ScriptLayers` / top-level `scripts/` runtime skew.

## Phase 2: Move `session_setup_script` Off City-Root Semantics

- Direct agent `session_setup_script` values now stay as-authored during composition instead of being rewritten into city-root-relative strings.
- Runtime resolution now uses the agent's `SourceDir` when present, so pack-defined and fragment-defined setup scripts resolve relative to the declaring config file.
- Explicit `//...` paths still resolve against the city root.
- Legacy city-root-relative strings remain supported during the transition.
- Patch-provided `session_setup_script` values are resolved to absolute paths during composition because patches do not retain independent source provenance after merge.
- Generated config reference/schema docs now describe the pack-safe `session_setup_script` semantics.

## Phase 3: Stop Propagating the Shim During `gc init --from`

- `gc init --from` now inspects the source template's `pack.toml`.
- When the source is a schema-2 / PackV2 template, init skips the top-level `scripts/` subtree instead of copying the compatibility shim into the new city.
- Legacy templates keep the historical behavior, including preserving top-level script file permissions.

## Phase 4: Remove `ResolveScripts` / `ScriptLayers`

- Pack expansion no longer collects `PackScriptDirs`, `RigScriptDirs`, or `ScriptLayers`.
- Startup/reload paths (`gc init`, `gc start`, supervisor prep, and config reload) no longer materialize `<city>/scripts`.
- Those paths now only prune symlink-only `scripts/` directories left behind by older runtimes, while leaving real user-authored files alone.
- `v2-scripts-layout` now reports symlink-only `scripts/` as stale legacy artifacts rather than a passing compatibility state.
- The PackV2 loader/skew docs were updated to show that the shim is gone.

## Remaining Migration Plan

1. Keep the `session_setup_script` migration and shim removal in place.
2. Migrate any future script-authored surfaces toward explicit pack-local or absolute path semantics instead of reintroducing a city-root `scripts/` bucket.
3. Delete the remaining legacy cleanup path after the compatibility window closes.

## Changes

- `internal/config/{config.go,pack.go,compose.go}`
  - Removed `ScriptLayers`, `PackScriptDirs`, `RigScriptDirs`, and the compose-time script-layer plumbing.
- `cmd/gc/{cmd_init.go,cmd_start.go,cmd_supervisor.go,city_runtime.go}`
  - Removed `ResolveScripts` startup hooks and replaced them with legacy symlink-only cleanup.
- `cmd/gc/script_resolve.go`
  - Replaced the old materialization logic with `pruneLegacyScripts` / `pruneLegacyConfiguredScripts`.
- `cmd/gc/doctor_v2_checks.go`
  - Symlink-only top-level `scripts/` is now treated as stale legacy state rather than a healthy compatibility surface.
- `cmd/gc/{script_resolve_test.go,doctor_v2_checks_test.go,main_test.go}`
  - Added/updated regression coverage for legacy cleanup, PackV2 init behavior, and the doctor semantics.
- `docs/packv2/{doc-loader-v2.md,skew-analysis.md}`
  - Updated the PackV2 docs to reflect that the top-level `scripts/` shim has been removed.

## Test Plan

- [x] `go test ./internal/config`
- [x] `go test ./cmd/gc -run 'TestV2ScriptsLayout|TestV2DeprecationChecksWarnOnLegacyPatterns|TestDoInitFromDir|TestInitNameFlagWithFrom|TestInitFromDefaultsToTargetDirBasename|TestInitFromSkip|TestPruneLegacyScripts|TestPrepareCityForSupervisorPrunesLegacyScripts'`
- [x] `go test ./cmd/gc -run 'TestResolveSetupScript_|TestV2ScriptsLayout|TestPrepareCityForSupervisorPrunesLegacyScripts'`
- [x] `go test ./test/docsync`

Fixes #1018.
Supersedes #1019.
