### PR TITLE
fix: harden concurrent dolt startup wait

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5361,6 +5361,7 @@ while [ ! -f "$release_file" ]; do
 	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
 		"GC_DOLT_PORT=3311",
+		"GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS=1000",
 		"GC_FAKE_DOLT_INVOCATION_FILE="+invocationFile,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -5620,6 +5621,242 @@ sleep 1
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd start failed while concurrent starter was making progress: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(mustReadFile(t, layout.PIDFile))); got != "4242" {
+		t.Fatalf("pid file = %q, want 4242", got)
+	}
+	if _, err := os.Stat(startedFile); err != nil {
+		t.Fatalf("concurrent starter success marker missing after start returned: %v", err)
+	}
+	if invocation, err := os.ReadFile(invokedDolt); err == nil && strings.TrimSpace(string(invocation)) != "" {
+		t.Fatalf("dolt should not have been invoked while concurrent starter won:\n%s", string(invocation))
+	}
+}
+
+func TestGcBeadsBdStartWaitsForSlowConcurrentStarterSuccess(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(layout.LockFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
+	startedFile := filepath.Join(t.TempDir(), "starter-ready")
+	fakeGC := filepath.Join(binDir, "gc")
+	fakeGCScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+invocation_file=%q
+started_file=%q
+subcmd="$1 $2"
+shift 2
+case "$subcmd" in
+  "dolt-state runtime-layout")
+    city=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city)
+          city="$2"
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state runtime-layout\n' >> "$invocation_file"
+    printf 'GC_PACK_STATE_DIR\t%%s\n' %q
+    printf 'GC_DOLT_DATA_DIR\t%%s\n' %q
+    printf 'GC_DOLT_LOG_FILE\t%%s\n' %q
+    printf 'GC_DOLT_STATE_FILE\t%%s\n' %q
+    printf 'GC_DOLT_PID_FILE\t%%s\n' %q
+    printf 'GC_DOLT_LOCK_FILE\t%%s\n' %q
+    printf 'GC_DOLT_CONFIG_FILE\t%%s\n' %q
+    ;;
+  "dolt-state existing-managed")
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city|--host|--port|--user|--timeout-ms)
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state existing-managed\n' >> "$invocation_file"
+    if [ -f "$started_file" ]; then
+      printf 'managed_pid\t4242\n'
+      printf 'managed_owned\ttrue\n'
+      printf 'deleted_inodes\tfalse\n'
+      printf 'state_port\t3311\n'
+      printf 'ready\ttrue\n'
+      printf 'reusable\ttrue\n'
+    else
+      printf 'managed_pid\t0\n'
+      printf 'managed_owned\tfalse\n'
+      printf 'deleted_inodes\tfalse\n'
+      printf 'state_port\t0\n'
+      printf 'ready\tfalse\n'
+      printf 'reusable\tfalse\n'
+    fi
+    ;;
+  "dolt-state probe-managed")
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city|--host|--port)
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state probe-managed
+' >> "$invocation_file"
+    printf 'running	true
+'
+    printf 'port_holder_pid	4242
+'
+    printf 'port_holder_owned	true
+'
+    printf 'port_holder_deleted_inodes	false
+'
+    printf 'tcp_reachable	true
+'
+    ;;
+  "dolt-state query-probe")
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --host|--port|--user)
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state query-probe
+' >> "$invocation_file"
+    if [ -f "$started_file" ]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  "dolt-state write-provider")
+    state_file=""
+    pid=""
+    running=""
+    port=""
+    data_dir=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --file)
+          state_file="$2"
+          shift 2
+          ;;
+        --pid)
+          pid="$2"
+          shift 2
+          ;;
+        --running)
+          running="$2"
+          shift 2
+          ;;
+        --port)
+          port="$2"
+          shift 2
+          ;;
+        --data-dir)
+          data_dir="$2"
+          shift 2
+          ;;
+        --started-at)
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state write-provider
+' >> "$invocation_file"
+    mkdir -p "$(dirname "$state_file")"
+    printf '{"running":%%s,"pid":%%s,"port":%%s,"data_dir":"%%s","started_at":"2026-04-14T00:00:00Z"}
+' "$running" "$pid" "$port" "$data_dir" > "$state_file"
+    ;;
+  *)
+    echo "unexpected gc args: $subcmd $*" >&2
+    exit 64
+    ;;
+esac
+`, invocationFile, startedFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
+	if err := os.WriteFile(fakeGC, []byte(fakeGCScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nset -eu\ncase \"${1:-}\" in\n  config)\n    exit 0\n    ;;\n  *)\n    printf 'dolt %s\\n' \"$*\" >> \"$GC_FAKE_DOLT_INVOCATION_FILE\"\n    exit 1\n    ;;\nesac\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	invokedDolt := filepath.Join(t.TempDir(), "dolt-invocation")
+
+	readyFile := filepath.Join(t.TempDir(), "holder-ready")
+	holder := exec.Command("sh", "-c", `
+set -eu
+lock_file="$1"
+ready_file="$2"
+started_file="$3"
+: > "$lock_file"
+exec 9>"$lock_file"
+flock 9
+printf 'ready\n' > "$ready_file"
+sleep 11
+printf 'ready\n' > "$started_file"
+sleep 1
+`, "sh", layout.LockFile, readyFile, startedFile)
+	holder.Env = sanitizedBaseEnv("PATH=" + os.Getenv("PATH"))
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start lock holder: %v", err)
+	}
+	defer func() {
+		_ = holder.Process.Kill()
+		_ = holder.Wait()
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for lock holder to acquire flock")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	env := sanitizedBaseEnv(
+		"GC_CITY_PATH="+cityPath,
+		"GC_DOLT_PORT=3311",
+		"GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS=12000",
+		"GC_BIN="+fakeGC,
+		"GC_FAKE_DOLT_INVOCATION_FILE="+invokedDolt,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	cmd := exec.Command(script, "start")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd start failed while slow concurrent starter was making progress: %v\n%s", err, out)
 	}
 	if got := strings.TrimSpace(string(mustReadFile(t, layout.PIDFile))); got != "4242" {
 		t.Fatalf("pid file = %q, want 4242", got)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -6031,8 +6031,8 @@ sleep 5
 		t.Fatalf("gc-beads-bd start output = %q, want lock acquisition failure", out)
 	}
 	invocation := string(mustReadFile(t, invocationFile))
-	if strings.Contains(invocation, "timeout=45000") {
-		t.Fatalf("existing-managed should not receive the default 45s timeout inside concurrent wait:\n%s", invocation)
+	if strings.Contains(invocation, "timeout=30000") {
+		t.Fatalf("existing-managed should not receive the default 30s timeout inside concurrent wait:\n%s", invocation)
 	}
 	if !strings.Contains(invocation, "timeout=1000") {
 		t.Fatalf("existing-managed should receive the remaining wait budget on the first attempt:\n%s", invocation)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5869,6 +5869,176 @@ sleep 1
 	}
 }
 
+func TestGcBeadsBdStartConcurrentWaitPassesRemainingExistingManagedBudget(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the real gc-beads-bd lifecycle script; run make test-cmd-gc-process for full coverage")
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(layout.LockFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
+	fakeGC := filepath.Join(binDir, "gc")
+	fakeGCScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+invocation_file=%q
+subcmd="$1 $2"
+shift 2
+case "$subcmd" in
+  "dolt-state runtime-layout")
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city)
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state runtime-layout\n' >> "$invocation_file"
+    printf 'GC_PACK_STATE_DIR\t%%s\n' %q
+    printf 'GC_DOLT_DATA_DIR\t%%s\n' %q
+    printf 'GC_DOLT_LOG_FILE\t%%s\n' %q
+    printf 'GC_DOLT_STATE_FILE\t%%s\n' %q
+    printf 'GC_DOLT_PID_FILE\t%%s\n' %q
+    printf 'GC_DOLT_LOCK_FILE\t%%s\n' %q
+    printf 'GC_DOLT_CONFIG_FILE\t%%s\n' %q
+    ;;
+  "dolt-state existing-managed")
+    timeout_ms=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city|--host|--port|--user)
+          shift 2
+          ;;
+        --timeout-ms)
+          timeout_ms="$2"
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state existing-managed timeout=%%s\n' "$timeout_ms" >> "$invocation_file"
+    if [ "${timeout_ms:-0}" -gt 1500 ]; then
+      sleep 2
+    fi
+    printf 'managed_pid\t4242\n'
+    printf 'managed_owned\ttrue\n'
+    printf 'deleted_inodes\tfalse\n'
+    printf 'state_port\t3311\n'
+    printf 'ready\tfalse\n'
+    printf 'reusable\tfalse\n'
+    ;;
+  "dolt-state probe-managed")
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --city|--host|--port)
+          shift 2
+          ;;
+        *)
+          exit 66
+          ;;
+      esac
+    done
+    printf 'gc dolt-state probe-managed\n' >> "$invocation_file"
+    printf 'running\tfalse\n'
+    printf 'port_holder_pid\t0\n'
+    printf 'port_holder_owned\tfalse\n'
+    printf 'port_holder_deleted_inodes\tfalse\n'
+    printf 'tcp_reachable\tfalse\n'
+    ;;
+  *)
+    echo "unexpected gc args: $subcmd $*" >&2
+    exit 64
+    ;;
+esac
+`, invocationFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
+	if err := os.WriteFile(fakeGC, []byte(fakeGCScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nset -eu\ncase \"${1:-}\" in\n  config)\n    exit 0\n    ;;\n  *)\n    exit 1\n    ;;\nesac\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	readyFile := filepath.Join(t.TempDir(), "holder-ready")
+	holder := exec.Command("sh", "-c", `
+set -eu
+lock_file="$1"
+ready_file="$2"
+: > "$lock_file"
+exec 9>"$lock_file"
+flock 9
+printf 'ready\n' > "$ready_file"
+sleep 5
+`, "sh", layout.LockFile, readyFile)
+	holder.Env = sanitizedBaseEnv("PATH=" + os.Getenv("PATH"))
+	if err := holder.Start(); err != nil {
+		t.Fatalf("start lock holder: %v", err)
+	}
+	defer func() {
+		_ = holder.Process.Kill()
+		_ = holder.Wait()
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for lock holder to acquire flock")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	env := sanitizedBaseEnv(
+		"GC_CITY_PATH="+cityPath,
+		"GC_DOLT_PORT=3311",
+		"GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS=1000",
+		"GC_BIN="+fakeGC,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	cmd := exec.Command(script, "start")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("gc-beads-bd start unexpected error: %v", err)
+		}
+	}
+	if exitCode != 1 {
+		t.Fatalf("gc-beads-bd start exit %d, want 1\n%s", exitCode, out)
+	}
+	if !strings.Contains(string(out), "could not acquire dolt start lock") {
+		t.Fatalf("gc-beads-bd start output = %q, want lock acquisition failure", out)
+	}
+	invocation := string(mustReadFile(t, invocationFile))
+	if strings.Contains(invocation, "timeout=45000") {
+		t.Fatalf("existing-managed should not receive the default 45s timeout inside concurrent wait:\n%s", invocation)
+	}
+	if !strings.Contains(invocation, "timeout=1000") {
+		t.Fatalf("existing-managed should receive the remaining wait budget on the first attempt:\n%s", invocation)
+	}
+}
+
 func TestGcBeadsBdStartUsesGCBinManagedConfigWriter(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5419,14 +5419,25 @@ func TestGcBeadsBdStartWaitsForConcurrentStarterSuccess(t *testing.T) {
 	}
 	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
 	startedFile := filepath.Join(t.TempDir(), "starter-ready")
+	nowFile := filepath.Join(t.TempDir(), "gc-now-ms")
 	fakeGC := filepath.Join(binDir, "gc")
 	fakeGCScript := fmt.Sprintf(`#!/bin/sh
 set -eu
 invocation_file=%q
 started_file=%q
+now_file=%q
 subcmd="$1 $2"
 shift 2
 case "$subcmd" in
+  "dolt-state now-ms")
+    if [ -f "$now_file" ]; then
+      now=$(cat "$now_file")
+    else
+      now=1000000
+    fi
+    printf '%%s\n' "$now"
+    printf '%%s\n' $((now + 250)) > "$now_file"
+    ;;
   "dolt-state runtime-layout")
     city=""
     while [ "$#" -gt 0 ]; do
@@ -5566,7 +5577,7 @@ case "$subcmd" in
     exit 64
     ;;
 esac
-`, invocationFile, startedFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
+`, invocationFile, startedFile, nowFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
 	if err := os.WriteFile(fakeGC, []byte(fakeGCScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -5654,14 +5665,25 @@ func TestGcBeadsBdStartWaitsForSlowConcurrentStarterSuccess(t *testing.T) {
 	}
 	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
 	startedFile := filepath.Join(t.TempDir(), "starter-ready")
+	nowFile := filepath.Join(t.TempDir(), "gc-now-ms")
 	fakeGC := filepath.Join(binDir, "gc")
 	fakeGCScript := fmt.Sprintf(`#!/bin/sh
 set -eu
 invocation_file=%q
 started_file=%q
+now_file=%q
 subcmd="$1 $2"
 shift 2
 case "$subcmd" in
+  "dolt-state now-ms")
+    if [ -f "$now_file" ]; then
+      now=$(cat "$now_file")
+    else
+      now=1000000
+    fi
+    printf '%%s\n' "$now"
+    printf '%%s\n' $((now + 250)) > "$now_file"
+    ;;
   "dolt-state runtime-layout")
     city=""
     while [ "$#" -gt 0 ]; do
@@ -5801,7 +5823,7 @@ case "$subcmd" in
     exit 64
     ;;
 esac
-`, invocationFile, startedFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
+`, invocationFile, startedFile, nowFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
 	if err := os.WriteFile(fakeGC, []byte(fakeGCScript), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/cmd_dolt_state.go
+++ b/cmd/gc/cmd_dolt_state.go
@@ -230,6 +230,21 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 	_ = existingManaged.MarkFlagRequired("port")
 	cmd.AddCommand(existingManaged)
 
+	nowMS := &cobra.Command{
+		Use:    "now-ms",
+		Short:  "Print the current Unix time in milliseconds",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if _, err := fmt.Fprintln(stdout, time.Now().UnixMilli()); err != nil {
+				fmt.Fprintf(stderr, "gc dolt-state now-ms: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(nowMS)
+
 	queryProbe := &cobra.Command{
 		Use:    "query-probe",
 		Short:  "Probe managed Dolt SQL readiness",

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -27,6 +27,7 @@ DOLT_USER="${GC_DOLT_USER:-root}"
 DOLT_PASSWORD="${GC_DOLT_PASSWORD:-}"
 DOLT_LOGLEVEL="${GC_DOLT_LOGLEVEL:-warning}"
 LSOF_TIMEOUT_SECONDS="${GC_LSOF_TIMEOUT_SECONDS:-2}"
+CONCURRENT_START_READY_TIMEOUT_MS="${GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS:-30000}"
 
 # Derived paths (set after GC_CITY_PATH validation).
 GC_DIR=""
@@ -935,8 +936,18 @@ EOF
 }
 
 wait_for_concurrent_start_ready() {
-    local existing_pid="" existing_port="" holder="" waited=0
-    while [ "$waited" -lt 20 ]; do
+    local existing_pid="" existing_port="" holder="" waited=0 timeout_ms max_attempts
+    timeout_ms="$CONCURRENT_START_READY_TIMEOUT_MS"
+    case "$timeout_ms" in
+        ''|*[!0-9]*)
+            timeout_ms=30000
+            ;;
+    esac
+    if [ "$timeout_ms" -lt 500 ]; then
+        timeout_ms=500
+    fi
+    max_attempts=$(( (timeout_ms + 499) / 500 ))
+    while [ "$waited" -lt "$max_attempts" ]; do
         if load_existing_managed_from_gc; then
             existing_pid="$GC_EXISTING_MANAGED_PID"
             if [ "$GC_EXISTING_REUSABLE" = "true" ] && [ -n "$GC_EXISTING_STATE_PORT" ] && [ -n "$existing_pid" ]; then

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -500,6 +500,30 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+current_time_ms() {
+    local gc_bin now
+    gc_bin=$(resolve_gc_helper_bin)
+    if [ -n "$gc_bin" ]; then
+        now=$("$gc_bin" dolt-state now-ms </dev/null 2>/dev/null) || now=""
+        case "$now" in
+            ''|*[!0-9]*)
+                now=""
+                ;;
+        esac
+        if [ -n "$now" ]; then
+            printf '%s\n' "$now"
+            return 0
+        fi
+    fi
+    now=$(date +%s 2>/dev/null) || return 1
+    case "$now" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
+    printf '%s000\n' "$now"
+}
+
 run_preflight_cleanup() {
     local gc_bin
     gc_bin=$(resolve_gc_helper_bin)
@@ -945,7 +969,7 @@ EOF
 }
 
 wait_for_concurrent_start_ready() {
-    local existing_pid="" existing_port="" holder="" timeout_ms deadline_sec now_sec remaining_sec remaining_ms
+    local existing_pid="" existing_port="" holder="" timeout_ms deadline_ms now_ms remaining_ms sleep_ms
     timeout_ms="$CONCURRENT_START_READY_TIMEOUT_MS"
     case "$timeout_ms" in
         ''|*[!0-9]*)
@@ -955,14 +979,14 @@ wait_for_concurrent_start_ready() {
     if [ "$timeout_ms" -lt 500 ]; then
         timeout_ms=500
     fi
-    deadline_sec=$(( $(date +%s) + ((timeout_ms + 999) / 1000) ))
+    now_ms=$(current_time_ms) || return 1
+    deadline_ms=$((now_ms + timeout_ms))
     while :; do
-        now_sec=$(date +%s)
-        remaining_sec=$((deadline_sec - now_sec))
-        if [ "$remaining_sec" -le 0 ]; then
+        now_ms=$(current_time_ms) || return 1
+        remaining_ms=$((deadline_ms - now_ms))
+        if [ "$remaining_ms" -le 0 ]; then
             return 1
         fi
-        remaining_ms=$((remaining_sec * 1000))
         if load_existing_managed_from_gc "$remaining_ms"; then
             existing_pid="$GC_EXISTING_MANAGED_PID"
             if [ "$GC_EXISTING_REUSABLE" = "true" ] && [ -n "$GC_EXISTING_STATE_PORT" ] && [ -n "$existing_pid" ]; then
@@ -996,12 +1020,23 @@ wait_for_concurrent_start_ready() {
                 fi
             fi
         fi
-        now_sec=$(date +%s)
-        remaining_sec=$((deadline_sec - now_sec))
-        if [ "$remaining_sec" -le 0 ]; then
+        now_ms=$(current_time_ms) || return 1
+        remaining_ms=$((deadline_ms - now_ms))
+        if [ "$remaining_ms" -le 0 ]; then
             return 1
         fi
-        sleep 0.5 2>/dev/null || sleep 1
+        sleep_ms=500
+        if [ "$remaining_ms" -lt "$sleep_ms" ]; then
+            sleep_ms="$remaining_ms"
+        fi
+        if [ "$sleep_ms" -le 0 ]; then
+            return 1
+        fi
+        if [ "$sleep_ms" -lt 500 ]; then
+            sleep "0.$(printf '%03d' "$sleep_ms")" 2>/dev/null || sleep 1
+        else
+            sleep 0.5 2>/dev/null || sleep 1
+        fi
     done
 }
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -441,10 +441,10 @@ EOF
 }
 
 load_existing_managed_from_gc() {
-    local gc_bin host output key value status parsed=false timeout_ms="${1:-45000}"
+    local gc_bin host output key value status parsed=false timeout_ms="${1:-30000}"
     case "$timeout_ms" in
         ''|*[!0-9]*)
-            timeout_ms=45000
+            timeout_ms=30000
             ;;
     esac
     if [ "$timeout_ms" -lt 1 ]; then
@@ -945,7 +945,7 @@ EOF
 }
 
 wait_for_concurrent_start_ready() {
-    local existing_pid="" existing_port="" holder="" waited=0 timeout_ms max_attempts attempt_timeout_ms
+    local existing_pid="" existing_port="" holder="" timeout_ms deadline_sec now_sec remaining_sec remaining_ms
     timeout_ms="$CONCURRENT_START_READY_TIMEOUT_MS"
     case "$timeout_ms" in
         ''|*[!0-9]*)
@@ -955,13 +955,15 @@ wait_for_concurrent_start_ready() {
     if [ "$timeout_ms" -lt 500 ]; then
         timeout_ms=500
     fi
-    max_attempts=$(( (timeout_ms + 499) / 500 ))
-    while [ "$waited" -lt "$max_attempts" ]; do
-        attempt_timeout_ms=$((timeout_ms - (waited * 500)))
-        if [ "$attempt_timeout_ms" -lt 1 ]; then
-            attempt_timeout_ms=1
+    deadline_sec=$(( $(date +%s) + ((timeout_ms + 999) / 1000) ))
+    while :; do
+        now_sec=$(date +%s)
+        remaining_sec=$((deadline_sec - now_sec))
+        if [ "$remaining_sec" -le 0 ]; then
+            return 1
         fi
-        if load_existing_managed_from_gc "$attempt_timeout_ms"; then
+        remaining_ms=$((remaining_sec * 1000))
+        if load_existing_managed_from_gc "$remaining_ms"; then
             existing_pid="$GC_EXISTING_MANAGED_PID"
             if [ "$GC_EXISTING_REUSABLE" = "true" ] && [ -n "$GC_EXISTING_STATE_PORT" ] && [ -n "$existing_pid" ]; then
                 DOLT_PORT="$GC_EXISTING_STATE_PORT"
@@ -994,10 +996,13 @@ wait_for_concurrent_start_ready() {
                 fi
             fi
         fi
+        now_sec=$(date +%s)
+        remaining_sec=$((deadline_sec - now_sec))
+        if [ "$remaining_sec" -le 0 ]; then
+            return 1
+        fi
         sleep 0.5 2>/dev/null || sleep 1
-        waited=$((waited + 1))
     done
-    return 1
 }
 
 load_stop_managed_from_gc() {

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -16,6 +16,7 @@
 #   GC_DOLT_PORT  — dolt server port (default: ephemeral, hashed from city path)
 #   GC_DOLT_USER  — dolt user (default: root)
 #   GC_DOLT_PASSWORD — dolt password (default: empty)
+#   GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS — concurrent-start wait budget in milliseconds (default: 45000)
 
 set -e
 
@@ -27,7 +28,7 @@ DOLT_USER="${GC_DOLT_USER:-root}"
 DOLT_PASSWORD="${GC_DOLT_PASSWORD:-}"
 DOLT_LOGLEVEL="${GC_DOLT_LOGLEVEL:-warning}"
 LSOF_TIMEOUT_SECONDS="${GC_LSOF_TIMEOUT_SECONDS:-2}"
-CONCURRENT_START_READY_TIMEOUT_MS="${GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS:-30000}"
+CONCURRENT_START_READY_TIMEOUT_MS="${GC_DOLT_CONCURRENT_START_READY_TIMEOUT_MS:-45000}"
 
 # Derived paths (set after GC_CITY_PATH validation).
 GC_DIR=""
@@ -440,7 +441,15 @@ EOF
 }
 
 load_existing_managed_from_gc() {
-    local gc_bin host output key value status parsed=false
+    local gc_bin host output key value status parsed=false timeout_ms="${1:-45000}"
+    case "$timeout_ms" in
+        ''|*[!0-9]*)
+            timeout_ms=45000
+            ;;
+    esac
+    if [ "$timeout_ms" -lt 1 ]; then
+        timeout_ms=1
+    fi
     host=$(connect_host)
     gc_bin=$(resolve_gc_helper_bin)
     GC_EXISTING_USED="false"
@@ -452,7 +461,7 @@ load_existing_managed_from_gc() {
     GC_EXISTING_REUSABLE="false"
     [ -n "$gc_bin" ] || return 1
     GC_EXISTING_USED="true"
-    output=$("$gc_bin" dolt-state existing-managed --city "$GC_CITY_PATH" --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --timeout-ms 30000 </dev/null 2>/dev/null)
+    output=$("$gc_bin" dolt-state existing-managed --city "$GC_CITY_PATH" --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --timeout-ms "$timeout_ms" </dev/null 2>/dev/null)
     status=$?
     while IFS="$(printf '	')" read -r key value; do
         case "$key" in
@@ -936,11 +945,11 @@ EOF
 }
 
 wait_for_concurrent_start_ready() {
-    local existing_pid="" existing_port="" holder="" waited=0 timeout_ms max_attempts
+    local existing_pid="" existing_port="" holder="" waited=0 timeout_ms max_attempts attempt_timeout_ms
     timeout_ms="$CONCURRENT_START_READY_TIMEOUT_MS"
     case "$timeout_ms" in
         ''|*[!0-9]*)
-            timeout_ms=30000
+            timeout_ms=45000
             ;;
     esac
     if [ "$timeout_ms" -lt 500 ]; then
@@ -948,7 +957,11 @@ wait_for_concurrent_start_ready() {
     fi
     max_attempts=$(( (timeout_ms + 499) / 500 ))
     while [ "$waited" -lt "$max_attempts" ]; do
-        if load_existing_managed_from_gc; then
+        attempt_timeout_ms=$((timeout_ms - (waited * 500)))
+        if [ "$attempt_timeout_ms" -lt 1 ]; then
+            attempt_timeout_ms=1
+        fi
+        if load_existing_managed_from_gc "$attempt_timeout_ms"; then
             existing_pid="$GC_EXISTING_MANAGED_PID"
             if [ "$GC_EXISTING_REUSABLE" = "true" ] && [ -n "$GC_EXISTING_STATE_PORT" ] && [ -n "$existing_pid" ]; then
                 DOLT_PORT="$GC_EXISTING_STATE_PORT"


### PR DESCRIPTION
## Summary
- address the managed-Dolt startup race from #1030 without touching the pack-first scaffold work already covered by #1022
- make the concurrent-start wait budget configurable and enforce it with a millisecond-accurate deadline via `gc dolt-state now-ms`
- add lifecycle regressions for a slow winning starter and for passing the remaining wait budget into `existing-managed`

## Testing
- `go test ./cmd/gc -run 'TestGcBeadsBdStart(DoesNotReplaceLiveLockFileInode|WaitsForConcurrentStarterSuccess|WaitsForSlowConcurrentStarterSuccess|ConcurrentWaitPassesRemainingExistingManagedBudget)$' -count=1`
- `go build ./cmd/gc`

## Scope
This PR addresses only the startup-path half of #1030. The `gc init` city/pack scaffold split is handled separately by #1022.
