### PR TITLE
fix: limit live in-progress bead queries

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -523,7 +523,7 @@ func collectAssignedWorkBeadsWithStores(
 	for _, s := range stores {
 		seen := make(map[string]struct{})
 		// In-progress beads with an assignee (active work).
-		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress"}); err == nil {
+		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
 			appendAssignedUnique(&result, &resultStores, inProgress, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -530,8 +530,9 @@ func collectAssignedWorkBeadsWithStores(
 			partial = true
 		}
 		// Ready beads with an assignee (queued direct handoff work that is
-		// actually runnable, not merely open).
-		if ready, err := s.Ready(); err == nil {
+		// actually runnable, not merely open). This is a lifecycle gate, so
+		// bypass the cache when a CachingStore wrapper is present.
+		if ready, err := beads.ReadyLive(s); err == nil {
 			appendAssignedUnique(&result, &resultStores, ready, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)

--- a/cmd/gc/cmd_bd_store_bridge.go
+++ b/cmd/gc/cmd_bd_store_bridge.go
@@ -220,7 +220,7 @@ func runBdStoreBridge(op string, args []string, dir, host, port, user string, st
 		}
 		return writeJSON(stdout, bridgeBeads(items))
 	case "ready":
-		items, err := store.Ready()
+		items, err := beads.ReadyLive(store)
 		if err != nil {
 			return err
 		}

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestCollectAssignedWorkBeads_UsesLiveReadyForAssignedOpenHandoff(t *testing.T) {
+	t.Parallel()
+
+	backing := beads.NewMemStore()
+	blocker, err := backing.Create(beads.Bead{
+		Title:  "blocker",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	handoff, err := backing.Create(beads.Bead{
+		Title:    "handoff",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create(handoff): %v", err)
+	}
+	if err := backing.DepAdd(handoff.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(%s <- %s): %v", handoff.ID, blocker.ID, err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if _, err := cache.DepList(handoff.ID, "down"); err != nil {
+		t.Fatalf("DepList prime(%s): %v", handoff.ID, err)
+	}
+
+	closed := "closed"
+	if err := backing.Update(blocker.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("Update(%s, closed): %v", blocker.ID, err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+	if len(got) != 1 || got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] from live ready state", got, handoff.ID)
+	}
+}
+
+func TestSessionHasOpenAssignedWorkInStore_UsesLiveOpenOwnership(t *testing.T) {
+	t.Parallel()
+
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{
+		Title:    "open work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "sess-1",
+	})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	empty := ""
+	if err := backing.Update(work.ID, beads.UpdateOpts{Assignee: &empty}); err != nil {
+		t.Fatalf("Update(%s, unassign): %v", work.ID, err)
+	}
+
+	session := beads.Bead{ID: "sess-1"}
+	hasAssignedWork, err := sessionHasOpenAssignedWorkInStore(cache, session)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkInStore: %v", err)
+	}
+	if hasAssignedWork {
+		t.Fatal("sessionHasOpenAssignedWorkInStore() = true, want false after external open-work reassignment")
+	}
+}
+
+func TestUnclaimWorkAssignedToRetiredSessionBead_UsesLiveOpenOwnership(t *testing.T) {
+	t.Parallel()
+
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{
+		Title:    "open work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "retired-session",
+	})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	reassigned := "replacement-session"
+	if err := backing.Update(work.ID, beads.UpdateOpts{Assignee: &reassigned}); err != nil {
+		t.Fatalf("Update(%s, reassigned): %v", work.ID, err)
+	}
+
+	unclaimWorkAssignedToRetiredSessionBead(cache, "retired-session", "worker", io.Discard)
+
+	got, err := backing.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", work.ID, err)
+	}
+	if got.Assignee != reassigned {
+		t.Fatalf("Assignee = %q, want %q; stale open ownership should not be cleared", got.Assignee, reassigned)
+	}
+}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -375,7 +375,7 @@ func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallb
 	}
 	empty := ""
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status})
+		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: status == "in_progress"})
 		if err != nil {
 			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", sessionID, err) //nolint:errcheck
 			continue
@@ -403,7 +403,7 @@ func reassignWorkAssignedToRetiredSessionBead(store beads.Store, oldSessionID, n
 		stderr = io.Discard
 	}
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status})
+		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status, Live: status == "in_progress"})
 		if err != nil {
 			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", oldSessionID, err) //nolint:errcheck
 			continue

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -375,7 +375,7 @@ func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallb
 	}
 	empty := ""
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: status == "in_progress"})
+		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: true})
 		if err != nil {
 			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", sessionID, err) //nolint:errcheck
 			continue
@@ -403,7 +403,7 @@ func reassignWorkAssignedToRetiredSessionBead(store beads.Store, oldSessionID, n
 		stderr = io.Discard
 	}
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status, Live: status == "in_progress"})
+		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status, Live: true})
 		if err != nil {
 			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", oldSessionID, err) //nolint:errcheck
 			continue

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1143,7 +1143,7 @@ func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (b
 				continue
 			}
 			seen[key] = struct{}{}
-			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status})
+			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: status == "in_progress"})
 			if err != nil {
 				return false, err
 			}
@@ -1498,6 +1498,7 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		assigned, err := store.List(beads.ListQuery{
 			Assignee: assignee,
 			Status:   "in_progress",
+			Live:     true,
 			Sort:     beads.SortCreatedDesc,
 		})
 		if err != nil {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1143,7 +1143,7 @@ func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (b
 				continue
 			}
 			seen[key] = struct{}{}
-			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: status == "in_progress"})
+			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
 			if err != nil {
 				return false, err
 			}

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -202,14 +202,25 @@ func findAgent(cfg *config.City, name string) (config.Agent, bool) {
 	return config.Agent{}, false
 }
 
-// findActiveBead returns the ID of the first in_progress bead assigned to the
-// given agent. If rig is non-empty, only that rig's store is searched;
-// otherwise all stores are searched. Returns "" if no match.
-//
-// Uses ListByAssignee with limit=1 instead of List() to avoid fetching all
-// beads from every store — a critical performance fix when bead counts are
-// large (e.g., 2200+ beads × 102 agents = ~186 full-list subprocess spawns).
+// findActiveBeadForAssignees returns the ID of the first in_progress bead
+// assigned to the given identities using the cached active snapshot. If rig is
+// non-empty, only that rig's store is searched; otherwise all stores are
+// searched. Returns "" if no match.
 func (s *Server) findActiveBeadForAssignees(rig string, assignees ...string) string {
+	return s.findActiveBeadForAssigneesWithFreshness(rig, false, assignees...)
+}
+
+// findLiveActiveBeadForAssignees returns the ID of the first in_progress bead
+// assigned to the given identities, bypassing the cache. Use this on
+// lower-frequency detail views where external reassignment freshness matters.
+func (s *Server) findLiveActiveBeadForAssignees(rig string, assignees ...string) string {
+	return s.findActiveBeadForAssigneesWithFreshness(rig, true, assignees...)
+}
+
+// findActiveBeadForAssigneesWithFreshness uses a targeted ListQuery with
+// Limit=1 instead of broad scans so active-bead lookup stays cheap even when
+// bead counts are large.
+func (s *Server) findActiveBeadForAssigneesWithFreshness(rig string, live bool, assignees ...string) string {
 	stores := s.state.BeadStores()
 	var rigNames []string
 	if rig != "" {
@@ -235,7 +246,7 @@ func (s *Server) findActiveBeadForAssignees(rig string, assignees ...string) str
 			matches, err := stores[rn].List(beads.ListQuery{
 				Assignee: assignee,
 				Status:   "in_progress",
-				Live:     true,
+				Live:     live,
 				Limit:    1,
 				Sort:     beads.SortCreatedDesc,
 			})

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -235,6 +235,7 @@ func (s *Server) findActiveBeadForAssignees(rig string, assignees ...string) str
 			matches, err := stores[rn].List(beads.ListQuery{
 				Assignee: assignee,
 				Status:   "in_progress",
+				Live:     true,
 				Limit:    1,
 				Sort:     beads.SortCreatedDesc,
 			})

--- a/internal/api/handler_agents_test.go
+++ b/internal/api/handler_agents_test.go
@@ -33,6 +33,18 @@ func (p partialAgentSessionLister) ListRunning(prefix string) ([]string, error) 
 	return filtered, p.err
 }
 
+type activeBeadQueryStore struct {
+	beads.Store
+	queries []beads.ListQuery
+}
+
+func (s *activeBeadQueryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Assignee != "" && query.Status == "in_progress" {
+		s.queries = append(s.queries, query)
+	}
+	return s.Store.List(query)
+}
+
 func TestAgentList(t *testing.T) {
 	state := newFakeState(t)
 	state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}) //nolint:errcheck
@@ -47,7 +59,10 @@ func TestAgentList(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 
-	var resp listResponse
+	var resp struct {
+		Items []agentResponse `json:"items"`
+		Total int             `json:"total"`
+	}
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -352,6 +367,109 @@ func TestAgentGetActiveBeadUsesSessionIDOwnership(t *testing.T) {
 	}
 	if got := resp.ActiveBead; got != work.ID {
 		t.Fatalf("active_bead = %q, want %q", got, work.ID)
+	}
+}
+
+func TestAgentListActiveBeadUsesCachedLookup(t *testing.T) {
+	state := newFakeState(t)
+	sessionName := "myrig--worker"
+	sessionID := "mc-session"
+	if err := state.sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("Start(%s): %v", sessionName, err)
+	}
+	if err := state.sp.SetMeta(sessionName, "GC_SESSION_ID", sessionID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	store := &activeBeadQueryStore{Store: beads.NewMemStore()}
+	state.stores["myrig"] = store
+	work, err := store.Create(beads.Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	status := "in_progress"
+	assignee := sessionID
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(work): %v", err)
+	}
+
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+	req := httptest.NewRequest("GET", cityURL(state, "/agents"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []agentResponse `json:"items"`
+		Total int             `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(resp.Items))
+	}
+	if got := resp.Items[0].ActiveBead; got != work.ID {
+		t.Fatalf("active_bead = %q, want %q", got, work.ID)
+	}
+	if len(store.queries) != 1 {
+		t.Fatalf("active-bead queries = %d, want 1", len(store.queries))
+	}
+	if store.queries[0].Live {
+		t.Fatal("agent list active-bead lookup should stay cached")
+	}
+}
+
+func TestAgentGetActiveBeadUsesLiveLookup(t *testing.T) {
+	state := newFakeState(t)
+	sessionName := "myrig--worker"
+	sessionID := "mc-session"
+	if err := state.sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("Start(%s): %v", sessionName, err)
+	}
+	if err := state.sp.SetMeta(sessionName, "GC_SESSION_ID", sessionID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	status := "in_progress"
+	assignee := sessionID
+	if err := backing.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(work): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	state.stores["myrig"] = cache
+
+	reassigned := "other-session"
+	if err := backing.Update(work.ID, beads.UpdateOpts{Assignee: &reassigned}); err != nil {
+		t.Fatalf("reassign backing work: %v", err)
+	}
+
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+	req := httptest.NewRequest("GET", cityURL(state, "/agent/myrig/worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp agentResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := resp.ActiveBead; got != "" {
+		t.Fatalf("active_bead = %q, want empty after external reassignment", got)
 	}
 }
 

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -472,6 +473,86 @@ func TestBeadReady(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
 	if resp.Total != 1 {
 		t.Errorf("ready: Total = %d, want 1", resp.Total)
+	}
+}
+
+func TestBeadListInProgressUsesLiveLookup(t *testing.T) {
+	state := newFakeState(t)
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	state.stores["myrig"] = cache
+	status := "in_progress"
+	if err := backing.Update(work.ID, beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update(work): %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest("GET", cityURL(state, "/beads?status=in_progress"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []beads.Bead `json:"items"`
+		Total int          `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Items) != 1 || resp.Items[0].ID != work.ID {
+		t.Fatalf("in_progress beads = %+v, want only %s", resp.Items, work.ID)
+	}
+}
+
+func TestBeadReadyUsesLiveLookup(t *testing.T) {
+	state := newFakeState(t)
+	backing := beads.NewMemStore()
+	blocker, err := backing.Create(beads.Bead{Title: "blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	ready, err := backing.Create(beads.Bead{Title: "ready"})
+	if err != nil {
+		t.Fatalf("Create(ready): %v", err)
+	}
+	if err := backing.DepAdd(ready.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	state.stores["myrig"] = cache
+	if err := backing.Close(blocker.ID); err != nil {
+		t.Fatalf("Close(blocker): %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest("GET", cityURL(state, "/beads/ready"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []beads.Bead `json:"items"`
+		Total int          `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Items) != 1 || resp.Items[0].ID != ready.ID {
+		t.Fatalf("ready beads = %+v, want only %s", resp.Items, ready.ID)
 	}
 }
 

--- a/internal/api/handler_session_create.go
+++ b/internal/api/handler_session_create.go
@@ -192,7 +192,7 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if handle, handleErr := s.workerHandleForSession(store, info.ID); handleErr == nil {
-		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false)
+		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false, true)
 	}
 	statusCode := http.StatusAccepted // always async for agent sessions
 	s.idem.storeResponse(idemKey, bodyHash, statusCode, resp)
@@ -352,7 +352,7 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 		}
 	}
 	if handle, handleErr := s.workerHandleForSession(store, info.ID); handleErr == nil {
-		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false)
+		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false, true)
 	}
 	statusCode := http.StatusCreated
 	s.idem.storeResponse(idemKey, bodyHash, statusCode, resp)

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -221,7 +221,7 @@ func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
 		items[i] = sessionResponseWithReason(sess, beadIndex[sess.ID], cfg, hasDeferredQueue)
 		handle, err := s.workerHandleForSession(store, sess.ID)
 		if err == nil {
-			s.enrichSessionResponse(&items[i], sess, cfg, handle, wantPeek)
+			s.enrichSessionResponse(&items[i], sess, cfg, handle, wantPeek, false)
 		}
 	}
 
@@ -268,7 +268,7 @@ func (s *Server) handleSessionGet(w http.ResponseWriter, r *http.Request) {
 	resp := sessionResponseWithReason(info, &b, cfg, strings.TrimSpace(s.state.CityPath()) != "")
 	handle, err := s.workerHandleForSession(store, id)
 	if err == nil {
-		s.enrichSessionResponse(&resp, info, cfg, handle, wantPeek)
+		s.enrichSessionResponse(&resp, info, cfg, handle, wantPeek, true)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -449,7 +449,7 @@ func (s *Server) handleSessionRename(w http.ResponseWriter, r *http.Request) {
 
 // enrichSessionResponse populates runtime fields on a session response:
 // running state, active bead, peek output, and model/context metadata.
-func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info, _ *config.City, runtimeHandle any, wantPeek bool) {
+func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info, _ *config.City, runtimeHandle any, wantPeek, liveActiveBead bool) {
 	if info.State != session.StateActive {
 		return
 	}
@@ -493,12 +493,16 @@ func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info,
 	// by alias (e.g., mayor, sky, wolf) until all assigners migrate to the
 	// concrete session ID.
 	//
-	// Signature is findActiveBeadForAssignees(rig string, assignees ...string);
-	// pass "" for rig (search all rigs) and put info.Alias in the variadic.
+	// Search all rig stores for concrete session ownership first, then fall
+	// back to alias/runtime/session names for older assigners.
 	// A previous fix accidentally passed info.Alias as the first positional
 	// (rig) argument, which silently narrowed the search to a rig named after
 	// the alias — so alias-assigned work still disappeared from ActiveBead.
-	resp.ActiveBead = s.findActiveBeadForAssignees("", info.ID, info.SessionName, info.Alias, info.Template)
+	if liveActiveBead {
+		resp.ActiveBead = s.findLiveActiveBeadForAssignees("", info.ID, info.SessionName, info.Alias, info.Template)
+	} else {
+		resp.ActiveBead = s.findActiveBeadForAssignees("", info.ID, info.SessionName, info.Alias, info.Template)
+	}
 
 	// Peek preview (opt-in, only when running).
 	if wantPeek && resp.Running && peekHandle != nil {

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -367,6 +367,82 @@ func TestHandleSessionGet(t *testing.T) {
 	}
 }
 
+func TestHandleSessionListActiveBeadUsesCachedLookup(t *testing.T) {
+	fs := newSessionFakeState(t)
+	backing := beads.NewMemStore()
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	fs.stores["myrig"] = cache
+	srv := New(fs)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "My Session")
+	work, err := backing.Create(beads.Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	status := "in_progress"
+	assignee := info.ID
+	if err := backing.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(work): %v", err)
+	}
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	reassigned := "other-session"
+	if err := backing.Update(work.ID, beads.UpdateOpts{Assignee: &reassigned}); err != nil {
+		t.Fatalf("reassign backing work: %v", err)
+	}
+
+	resp := sessionResponse{}
+	srv.enrichSessionResponse(&resp, info, fs.Config(), sessionResponseCapabilityHandle{
+		state: worker.State{Phase: worker.PhaseReady},
+	}, false, false)
+
+	if !resp.Running {
+		t.Fatal("Running = false, want true")
+	}
+	if got := resp.ActiveBead; got != work.ID {
+		t.Fatalf("active_bead = %q, want cached %q", got, work.ID)
+	}
+}
+
+func TestHandleSessionGetActiveBeadUsesLiveLookup(t *testing.T) {
+	fs := newSessionFakeState(t)
+	backing := beads.NewMemStore()
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	fs.stores["myrig"] = cache
+	srv := New(fs)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "My Session")
+	work, err := backing.Create(beads.Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	status := "in_progress"
+	assignee := info.ID
+	if err := backing.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(work): %v", err)
+	}
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	reassigned := "other-session"
+	if err := backing.Update(work.ID, beads.UpdateOpts{Assignee: &reassigned}); err != nil {
+		t.Fatalf("reassign backing work: %v", err)
+	}
+
+	resp := sessionResponse{}
+	srv.enrichSessionResponse(&resp, info, fs.Config(), sessionResponseCapabilityHandle{
+		state: worker.State{Phase: worker.PhaseReady},
+	}, false, true)
+
+	if !resp.Running {
+		t.Fatal("Running = false, want true")
+	}
+	if got := resp.ActiveBead; got != "" {
+		t.Fatalf("active_bead = %q, want empty after external reassignment", got)
+	}
+}
+
 func TestHandleSessionGetNotFound(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -219,7 +219,7 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 		}
 	}
 
-	resp.ActiveBead = s.findActiveBeadForAssignees(agentCfg.Dir, sessionID, sessionName, name)
+	resp.ActiveBead = s.findLiveActiveBeadForAssignees(agentCfg.Dir, sessionID, sessionName, name)
 	quarantined := s.state.IsQuarantined(sessionName)
 	resp.State = computeAgentState(suspended, quarantined, running, resp.ActiveBead, lastActivity)
 

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -50,6 +50,7 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 				Type:     input.Type,
 				Label:    input.Label,
 				Assignee: assignee,
+				Live:     input.Status == "in_progress",
 			}
 			if !query.HasFilter() {
 				query.AllowScan = true
@@ -127,7 +128,7 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 	var pa partialAggregator
 	for _, rigName := range rigNames {
 		pa.attempt()
-		ready, err := stores[rigName].Ready()
+		ready, err := beads.ReadyLive(stores[rigName])
 		if err != nil {
 			pa.record("rig "+rigName, err)
 			continue

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -164,7 +164,7 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 	if caps, capErr := s.sessionManager(store).SubmissionCapabilities(info.ID); capErr == nil {
 		resp.SubmissionCapabilities = caps
 	}
-	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false)
+	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false, true)
 
 	out := &SessionCreateOutput{Status: http.StatusAccepted}
 	out.Body = resp
@@ -292,7 +292,7 @@ func (s *Server) humaCreateProviderSession(ctx context.Context, store beads.Stor
 	if caps, capErr := s.sessionManager(store).SubmissionCapabilities(info.ID); capErr == nil {
 		resp.SubmissionCapabilities = caps
 	}
-	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false)
+	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false, true)
 
 	out := &SessionCreateOutput{Status: http.StatusCreated}
 	out.Body = resp

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -44,7 +44,7 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	items := make([]sessionResponse, len(sessions))
 	for i, sess := range sessions {
 		items[i] = sessionResponseWithReason(sess, beadIndex[sess.ID], cfg, hasDeferredQueue)
-		s.enrichSessionResponse(&items[i], sess, cfg, sp, wantPeek)
+		s.enrichSessionResponse(&items[i], sess, cfg, sp, wantPeek, false)
 	}
 
 	// Pagination support.
@@ -109,7 +109,7 @@ func (s *Server) humaHandleSessionGet(_ context.Context, input *SessionGetInput)
 	b, _ := store.Get(id)
 	wantPeek := input.Peek
 	resp := sessionResponseWithReason(info, &b, cfg, strings.TrimSpace(s.state.CityPath()) != "")
-	s.enrichSessionResponse(&resp, info, cfg, sp, wantPeek)
+	s.enrichSessionResponse(&resp, info, cfg, sp, wantPeek, true)
 	return &IndexOutput[sessionResponse]{
 		Index: s.latestIndex(),
 		Body:  resp,

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -203,7 +203,7 @@ func reassignOpenWorkAssignedToSession(store beads.Store, oldID, newID string) e
 		return nil
 	}
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldID, Status: status, Live: status == "in_progress"})
+		work, err := store.List(beads.ListQuery{Assignee: oldID, Status: status, Live: true})
 		if err != nil {
 			return fmt.Errorf("listing work assigned to retired session %s: %w", oldID, err)
 		}

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -203,7 +203,7 @@ func reassignOpenWorkAssignedToSession(store beads.Store, oldID, newID string) e
 		return nil
 	}
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldID, Status: status})
+		work, err := store.List(beads.ListQuery{Assignee: oldID, Status: status, Live: status == "in_progress"})
 		if err != nil {
 			return fmt.Errorf("listing work assigned to retired session %s: %w", oldID, err)
 		}

--- a/internal/api/session_resolution_live_query_test.go
+++ b/internal/api/session_resolution_live_query_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestReassignOpenWorkAssignedToSession_UsesLiveOpenOwnership(t *testing.T) {
+	t.Parallel()
+
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{
+		Title:    "open work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "retired-session",
+	})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	reassigned := "replacement-picked-elsewhere"
+	if err := backing.Update(work.ID, beads.UpdateOpts{Assignee: &reassigned}); err != nil {
+		t.Fatalf("Update(%s, reassigned): %v", work.ID, err)
+	}
+
+	if err := reassignOpenWorkAssignedToSession(cache, "retired-session", "new-canonical"); err != nil {
+		t.Fatalf("reassignOpenWorkAssignedToSession: %v", err)
+	}
+
+	got, err := backing.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", work.ID, err)
+	}
+	if got.Assignee != reassigned {
+		t.Fatalf("Assignee = %q, want %q; stale open ownership should not be overwritten", got.Assignee, reassigned)
+	}
+}

--- a/internal/api/worker_capability_guardrail_test.go
+++ b/internal/api/worker_capability_guardrail_test.go
@@ -53,7 +53,7 @@ func TestEnrichSessionResponseAcceptsStateAndPeekCapability(t *testing.T) {
 	}, nil, sessionResponseCapabilityHandle{
 		state:  worker.State{Phase: worker.PhaseReady},
 		output: "peek output",
-	}, true)
+	}, true, false)
 
 	if !resp.Running {
 		t.Fatal("Running = false, want true")

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -41,7 +41,7 @@ func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
 	}
 }
 
-func TestCachingStoreListInProgressUsesBackingStore(t *testing.T) {
+func TestCachingStoreListInProgressUsesCacheByDefault(t *testing.T) {
 	t.Parallel()
 
 	backing := NewMemStore()
@@ -67,8 +67,39 @@ func TestCachingStoreListInProgressUsesBackingStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
+	if len(got) != 0 {
+		t.Fatalf("List(in_progress) = %+v, want cached result before reconcile", got)
+	}
+}
+
+func TestCachingStoreListLiveBypassesCache(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{
+		Title:    "claimed work",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "in_progress"
+	if err := backing.Update(bead.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	got, err := cache.List(ListQuery{Status: "in_progress", Live: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
 	if len(got) != 1 || got[0].ID != bead.ID {
-		t.Fatalf("List(in_progress) = %+v, want %s from backing store", got, bead.ID)
+		t.Fatalf("List(in_progress, Live) = %+v, want %s from backing store", got, bead.ID)
 	}
 }
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -14,7 +14,7 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
 	}
-	if query.Status == "in_progress" {
+	if query.Live {
 		return c.backing.List(query)
 	}
 

--- a/internal/beads/live_ready.go
+++ b/internal/beads/live_ready.go
@@ -1,0 +1,14 @@
+package beads
+
+// ReadyLive returns ready beads using the backing store when a caching layer is
+// present. Other Store implementations ignore the live-read intent and fall
+// back to their normal Ready behavior.
+func ReadyLive(store Store) ([]Bead, error) {
+	type backingStore interface {
+		Backing() Store
+	}
+	if cached, ok := store.(backingStore); ok && cached.Backing() != nil {
+		return cached.Backing().Ready()
+	}
+	return store.Ready()
+}

--- a/internal/beads/live_ready_test.go
+++ b/internal/beads/live_ready_test.go
@@ -1,0 +1,89 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type flakyReadyStore struct {
+	*MemStore
+	failReady error
+}
+
+func (s *flakyReadyStore) Ready() ([]Bead, error) {
+	if s.failReady != nil {
+		return nil, s.failReady
+	}
+	return s.MemStore.Ready()
+}
+
+func TestReadyLiveBypassesCachingStore(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	blocker, err := backing.Create(Bead{Title: "blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	ready, err := backing.Create(Bead{Title: "ready"})
+	if err != nil {
+		t.Fatalf("Create(ready): %v", err)
+	}
+	if err := backing.DepAdd(ready.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := backing.Close(blocker.ID); err != nil {
+		t.Fatalf("Close(blocker): %v", err)
+	}
+
+	stale, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("cache.Ready(): %v", err)
+	}
+	for _, bead := range stale {
+		if bead.ID == ready.ID {
+			t.Fatalf("cache.Ready() = %v, want stale result without %s before reconcile", stale, ready.ID)
+		}
+	}
+
+	live, err := ReadyLive(cache)
+	if err != nil {
+		t.Fatalf("ReadyLive(): %v", err)
+	}
+	if len(live) != 1 || live[0].ID != ready.ID {
+		t.Fatalf("ReadyLive() = %v, want only %s", live, ready.ID)
+	}
+}
+
+func TestReadyLiveReturnsBackingErrors(t *testing.T) {
+	t.Parallel()
+
+	backing := &flakyReadyStore{MemStore: NewMemStore()}
+	if _, err := backing.Create(Bead{Title: "ready"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.failReady = errors.New("backing ready failed")
+
+	if cached, err := cache.Ready(); err != nil {
+		t.Fatalf("cache.Ready(): %v", err)
+	} else if len(cached) != 1 {
+		t.Fatalf("cache.Ready() len = %d, want 1 cached bead", len(cached))
+	}
+
+	if _, err := ReadyLive(cache); err == nil || err.Error() != "backing ready failed" {
+		t.Fatalf("ReadyLive() err = %v, want backing error", err)
+	}
+}

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -36,7 +36,10 @@ type ListQuery struct {
 	Limit         int
 	IncludeClosed bool
 	AllowScan     bool
-	Sort          SortOrder
+	// Live bypasses CachingStore and reads from the backing store. Use it only
+	// for lifecycle gates that must observe external mutations immediately.
+	Live bool
+	Sort SortOrder
 }
 
 // HasFilter reports whether the query includes at least one indexed selector.

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -36,8 +36,9 @@ type ListQuery struct {
 	Limit         int
 	IncludeClosed bool
 	AllowScan     bool
-	// Live bypasses CachingStore and reads from the backing store. Use it only
-	// for lifecycle gates that must observe external mutations immediately.
+	// Live bypasses CachingStore and reads from the backing store. Other Store
+	// implementations ignore it. Use it only for lifecycle gates that must
+	// observe external mutations immediately.
 	Live bool
 	Sort SortOrder
 }


### PR DESCRIPTION
## Summary

- Supersedes #1035.
- Credit: Original fix by @julianknutsen.
- Keep lifecycle-sensitive ownership and ready reads explicitly live where stale cache can misroute work or hide newly-ready handoff beads.
- Preserve cached behavior on hot list endpoints while keeping live reads on lower-frequency detail and reassignment paths.
- Align controller, API, and CLI ready projections through `beads.ReadyLive`; follow-up API hardening is tracked in #1041.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test ./internal/beads ./internal/api`
- [x] `go test ./cmd/gc -run 'Test(CollectAssignedWorkBeads_UsesLiveReadyForAssignedOpenHandoff|BdStoreBridge.*)$'`

## Checklist

- [x] Linked an issue, or explained why one is not needed
  - Supersedes #1035; follow-up hardening is tracked in #1041.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
  - Cached list endpoints can briefly lag live detail endpoints after external reassignment; the hardening follow-up is tracked in #1041.
