### PR TITLE
fix(beads): tolerate numeric metadata in bd.updated event payloads

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -3,6 +3,8 @@
 package beads
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"time"
 )
@@ -28,6 +30,45 @@ type Bead struct {
 	Labels       []string          `json:"labels,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 	Dependencies []Dep             `json:"dependencies,omitempty"`
+}
+
+// UnmarshalJSON tolerates legacy bd-hook event payloads that serialize
+// numeric / boolean metadata values as raw JSON scalars rather than strings.
+// Such payloads used to fail the entire bead decode, causing per-event
+// log spam in the caching store. Values that are already JSON strings are
+// decoded normally; numbers and booleans are stringified; null becomes "";
+// objects and arrays preserve their raw JSON text as a fallback so data is
+// not silently lost.
+func (b *Bead) UnmarshalJSON(data []byte) error {
+	type alias Bead
+	aux := struct {
+		Metadata map[string]json.RawMessage `json:"metadata,omitempty"`
+		*alias
+	}{alias: (*alias)(b)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(aux.Metadata) > 0 {
+		b.Metadata = make(map[string]string, len(aux.Metadata))
+		for k, raw := range aux.Metadata {
+			b.Metadata[k] = coerceMetadataValue(raw)
+		}
+	}
+	return nil
+}
+
+func coerceMetadataValue(raw json.RawMessage) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return ""
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err == nil {
+			return s
+		}
+	}
+	return string(trimmed)
 }
 
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1,9 +1,54 @@
 package beads
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
+
+// TestBeadUnmarshalJSON_TolerateNumericMetadata reproduces the bd-hook event
+// shape seen in ~/.gc/supervisor.log that was spamming parse failures at
+// ~100/s: a bead.updated payload whose metadata carries JSON numbers (and
+// occasionally booleans/nulls) rather than strings. The custom UnmarshalJSON
+// must coerce these to strings so the caching store can apply the event.
+func TestBeadUnmarshalJSON_TolerateNumericMetadata(t *testing.T) {
+	payload := []byte(`{
+	    "id": "at-tmgg5",
+	    "title": "gastown.mayor",
+	    "status": "open",
+	    "issue_type": "session",
+	    "created_at": "2026-04-17T06:29:26Z",
+	    "metadata": {
+	        "agent_name": "gastown.mayor",
+	        "continuation_epoch": 10,
+	        "generation": 11,
+	        "pool_managed": true,
+	        "closed_at": null
+	    }
+	}`)
+	var b Bead
+	if err := json.Unmarshal(payload, &b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		"agent_name":         "gastown.mayor",
+		"continuation_epoch": "10",
+		"generation":         "11",
+		"pool_managed":       "true",
+		"closed_at":          "",
+	}
+	for k, v := range want {
+		if got := b.Metadata[k]; got != v {
+			t.Errorf("Metadata[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if b.ID != "at-tmgg5" {
+		t.Errorf("ID = %q, want %q", b.ID, "at-tmgg5")
+	}
+	if b.Type != "session" {
+		t.Errorf("Type = %q, want %q", b.Type, "session")
+	}
+}
 
 func TestIsContainerType(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Stops a ~100/s log-spam regression introduced by #994: after every `bd.updated` event, `CachingStore.ApplyEvent` logs

```
beads cache: apply bead.updated event: json: cannot unmarshal number into Go struct field Bead.metadata of type string
```

…and silently drops the event. Observed rate on a busy atlas supervisor: **8,500+ occurrences in ~90 minutes**.

## Root cause

The on_update hook `gc` installs at `.beads/hooks/on_update` (see `cmd/gc/hooks.go`) forwards the bd issue JSON verbatim via `gc event emit --payload "$DATA"`. Bd serializes metadata values as their native JSON types — e.g.

```json
"metadata": { "continuation_epoch": 10, "generation": 11, "pool_managed": true, "closed_at": null }
```

Before #994 this was effectively ignored by the cache. Since #994 `caching_store_events.go:ApplyEvent` calls `json.Unmarshal(payload, &Bead{})` directly, and `Bead.Metadata` is typed `map[string]string`, so the decode fails on every numeric/boolean/null value — every `bead.updated` event, on every city.

## Fix

Custom `UnmarshalJSON` on `Bead` that:

- decodes metadata values as `json.RawMessage` first,
- leaves JSON strings alone,
- stringifies numbers / booleans via their raw text (`10` → `"10"`, `true` → `"true"`),
- maps `null` to `""`,
- falls back to the raw JSON text for objects/arrays so data isn't silently dropped.

Scope is deliberately narrow: nothing in `Bead`'s struct tags changes, nor does the canonical wire format `gc` itself writes. Only the inbound decode contract relaxes to match what bd actually emits.

## Test plan

- [x] `TestBeadUnmarshalJSON_TolerateNumericMetadata` — drives the exact supervisor-log payload shape (numeric, boolean, and null metadata values) and asserts each coerces to the expected string.
- [x] `go test ./internal/beads/ -count=1` — full package passes.
- [x] `go test ./cmd/gc/ -run TestSyncSessionBeads_RefreshesStoredCommandOnConfigChange -count=1` — PR 1044's test still passes (no interaction with the caching decode).
- [x] `go build ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)