### PR TITLE
perf(dispatch): exponential backoff on idle in control --follow loop

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1313,6 +1313,93 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 	}
 }
 
+func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testing.T) {
+	eventsDir := t.TempDir()
+	ep := newTestProvider(t, eventsDir)
+
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevProvider := workflowServeOpenEventsProvider
+	prevWait := workflowServeWaitForWake
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	t.Cleanup(func() {
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeOpenEventsProvider = prevProvider
+		workflowServeWaitForWake = prevWait
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	workflowServeOpenEventsProvider = func(io.Writer) (events.Provider, error) {
+		return ep, nil
+	}
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+
+	type waitCall struct {
+		idleSweeps int
+		sleepDur   time.Duration
+	}
+	var waitCalls []waitCall
+	stopErr := fmt.Errorf("stop after sequence")
+	workflowServeWaitForWake = func(_ <-chan workflowWatchResult, sleepDur time.Duration, idleSweeps int) (bool, error) {
+		waitCalls = append(waitCalls, waitCall{idleSweeps: idleSweeps, sleepDur: sleepDur})
+		switch len(waitCalls) {
+		case 1, 2, 3, 5:
+			return false, nil
+		case 4:
+			return true, nil
+		case 6:
+			return false, stopErr
+		default:
+			t.Fatalf("unexpected wait call %d", len(waitCalls))
+			return false, stopErr
+		}
+	}
+
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		switch calls {
+		case 1, 2, 4, 5, 7:
+			return nil, nil
+		case 3:
+			return []hookBead{{ID: "gc-ready", Metadata: map[string]string{"gc.kind": "scope-check"}}}, nil
+		case 6:
+			return []hookBead{{ID: "gc-pending", Metadata: map[string]string{"gc.kind": "retry-eval"}}}, nil
+		default:
+			t.Fatalf("unexpected drain cycle %d", calls)
+			return nil, nil
+		}
+	}
+	controlDispatcherServe = func(beadID string, _ io.Writer, _ io.Writer) error {
+		if beadID == "gc-pending" {
+			return dispatch.ErrControlPending
+		}
+		return nil
+	}
+
+	agent := config.Agent{Name: "control-dispatcher"}
+	err := runWorkflowServeFollow(agent, agent.EffectiveWorkQuery(), t.TempDir(), nil, io.Discard)
+	if err != stopErr {
+		t.Fatalf("runWorkflowServeFollow error = %v, want %v", err, stopErr)
+	}
+
+	want := []waitCall{
+		{idleSweeps: 0, sleepDur: 1 * time.Second},
+		{idleSweeps: 1, sleepDur: 2 * time.Second},
+		{idleSweeps: 0, sleepDur: 1 * time.Second},
+		{idleSweeps: 0, sleepDur: 1 * time.Second},
+		{idleSweeps: 0, sleepDur: 1 * time.Second},
+		{idleSweeps: 0, sleepDur: 1 * time.Second},
+	}
+	if !slices.Equal(waitCalls, want) {
+		t.Fatalf("wait calls = %#v, want %#v", waitCalls, want)
+	}
+}
+
 func TestWorkflowEventRelevantAcceptsBeadLifecycleEvents(t *testing.T) {
 	for _, evt := range []events.Event{
 		{Type: events.BeadCreated},
@@ -2308,6 +2395,30 @@ func TestWaitForRelevantWorkflowWakeReturnsWatcherErr(t *testing.T) {
 	}
 	if eventWake {
 		t.Fatal("eventWake = true on error path, want false")
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeTraceIncludesBackoffState(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "workflow-trace.log")
+	t.Setenv("GC_WORKFLOW_TRACE", tracePath)
+
+	eventCh := make(chan workflowWatchResult) // never receives
+
+	eventWake, err := waitForRelevantWorkflowWakeWithTrace(eventCh, 5*time.Millisecond, 3)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if eventWake {
+		t.Fatal("eventWake = true, want false when timer expires")
+	}
+
+	traceBytes, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	trace := string(traceBytes)
+	if !strings.Contains(trace, "serve wake-sweep idle_sweeps=3 sleep=5ms") {
+		t.Fatalf("trace = %q, want wake-sweep line with idle_sweeps and sleep", trace)
 	}
 }
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2223,3 +2223,111 @@ func TestDeleteWorkflowBeadsReportsRollbackFailure(t *testing.T) {
 		t.Fatalf("child down deps = %#v, want none after failed rollback", down)
 	}
 }
+
+func TestFollowSleepDurationBacksOffThenCaps(t *testing.T) {
+	prevSweep := workflowServeWakeSweepInterval
+	prevMax := workflowServeMaxIdleSleep
+	workflowServeWakeSweepInterval = 1 * time.Second
+	workflowServeMaxIdleSleep = 30 * time.Second
+	t.Cleanup(func() {
+		workflowServeWakeSweepInterval = prevSweep
+		workflowServeMaxIdleSleep = prevMax
+	})
+
+	cases := []struct {
+		idleSweeps int
+		want       time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 8 * time.Second},
+		{4, 16 * time.Second},
+		{5, 30 * time.Second},
+		{6, 30 * time.Second},
+		{20, 30 * time.Second},
+	}
+	for _, tc := range cases {
+		if got := followSleepDuration(tc.idleSweeps); got != tc.want {
+			t.Errorf("followSleepDuration(%d) = %v, want %v", tc.idleSweeps, got, tc.want)
+		}
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeReturnsTrueOnRelevantEvent(t *testing.T) {
+	eventCh := make(chan workflowWatchResult, 1)
+	eventCh <- workflowWatchResult{evt: events.Event{Type: events.BeadCreated, Subject: "gc-1"}}
+
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !eventWake {
+		t.Fatal("eventWake = false, want true when relevant event arrives before timeout")
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeReturnsFalseOnTimer(t *testing.T) {
+	eventCh := make(chan workflowWatchResult) // never receives
+
+	start := time.Now()
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, 5*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if eventWake {
+		t.Fatal("eventWake = true, want false when no event arrives and timer expires")
+	}
+	if elapsed < 5*time.Millisecond {
+		t.Fatalf("returned after %v, want >= 5ms (timer must actually fire)", elapsed)
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeFallsThroughIrrelevantEventsToTimer(t *testing.T) {
+	eventCh := make(chan workflowWatchResult, 1)
+	eventCh <- workflowWatchResult{evt: events.Event{Type: events.SessionUpdated}}
+
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if eventWake {
+		t.Fatal("eventWake = true, want false (irrelevant event must not wake the loop)")
+	}
+}
+
+func TestWaitForRelevantWorkflowWakeReturnsWatcherErr(t *testing.T) {
+	eventCh := make(chan workflowWatchResult, 1)
+	eventCh <- workflowWatchResult{err: os.ErrDeadlineExceeded}
+
+	eventWake, err := waitForRelevantWorkflowWake(eventCh, time.Second)
+	if err == nil {
+		t.Fatal("wait returned nil err, want watcher err surfaced")
+	}
+	if eventWake {
+		t.Fatal("eventWake = true on error path, want false")
+	}
+}
+
+func TestFollowSleepDurationHandlesPathologicalInputs(t *testing.T) {
+	prevSweep := workflowServeWakeSweepInterval
+	prevMax := workflowServeMaxIdleSleep
+	workflowServeWakeSweepInterval = 1 * time.Second
+	workflowServeMaxIdleSleep = 30 * time.Second
+	t.Cleanup(func() {
+		workflowServeWakeSweepInterval = prevSweep
+		workflowServeMaxIdleSleep = prevMax
+	})
+
+	if got := followSleepDuration(1000); got != 30*time.Second {
+		t.Errorf("followSleepDuration(1000) = %v, want 30s (cap)", got)
+	}
+	if got := followSleepDuration(63); got != 30*time.Second {
+		t.Errorf("followSleepDuration(63) = %v, want 30s (overflow-safe cap)", got)
+	}
+	if got := followSleepDuration(-1); got != 1*time.Second {
+		t.Errorf("followSleepDuration(-1) = %v, want base 1s", got)
+	}
+}

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -76,7 +76,28 @@ var (
 	workflowServeIdlePollInterval  = 100 * time.Millisecond
 	workflowServeIdlePollAttempts  = 3
 	workflowServeWakeSweepInterval = 1 * time.Second
+	workflowServeMaxIdleSleep      = 30 * time.Second
 )
+
+// followSleepDuration returns the sleep interval the --follow loop should use
+// before its next drain, given how many consecutive idle sweeps have passed.
+// The idle sweep count doubles the base interval on each step, capped at
+// workflowServeMaxIdleSleep. Fixes gastownhall/gascity#1028.
+func followSleepDuration(idleSweeps int) time.Duration {
+	if idleSweeps <= 0 {
+		return workflowServeWakeSweepInterval
+	}
+	const maxShift = 30
+	shift := idleSweeps
+	if shift > maxShift {
+		shift = maxShift
+	}
+	d := workflowServeWakeSweepInterval << uint(shift)
+	if d <= 0 || d > workflowServeMaxIdleSleep {
+		return workflowServeMaxIdleSleep
+	}
+	return d
+}
 
 const workflowServeScanLimit = 20
 
@@ -172,19 +193,23 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	workQuery := expandAgentCommandTemplate(cityPath, loadedCityName(cfg, cityPath), &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
-		return drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
+		_, err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
+		return err
 	}
 	return runWorkflowServeFollow(agentCfg, workQuery, workDir, workEnv, stderr)
 }
 
-func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir string, workEnv map[string]string, stderr io.Writer) error {
+// drainWorkflowServeWork runs the control-dispatcher drain loop to completion
+// for a single invocation. Returns processedAny=true when it advanced at least
+// one control bead, so the --follow caller can reset its idle backoff.
+func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir string, workEnv map[string]string, stderr io.Writer) (bool, error) {
 	processedAny := false
 	idlePolls := 0
 	for {
 		queue, err := workflowServeList(workflowServeQuery(workQuery), workDir, workEnv)
 		if err != nil {
 			workflowTracef("serve query-error agent=%s err=%v", agentCfg.QualifiedName(), err)
-			return fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
+			return processedAny, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
 		}
 		if len(queue) == 0 {
 			if processedAny && idlePolls < workflowServeIdlePollAttempts {
@@ -194,7 +219,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 				continue
 			}
 			workflowTracef("serve idle-exit agent=%s", agentCfg.QualifiedName())
-			return nil
+			return processedAny, nil
 		}
 		idlePolls = 0
 		processedThisCycle := false
@@ -204,7 +229,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 			kind := strings.TrimSpace(candidate.Metadata["gc.kind"])
 			if !isControlDispatcherKind(kind) {
 				workflowTracef("serve unexpected-kind bead=%s kind=%s", beadID, kind)
-				return fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
+				return processedAny, fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
 			}
 			workflowTracef("serve process bead=%s kind=%s", beadID, kind)
 			// controlDispatcherServe currently returns nil both when it
@@ -223,7 +248,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 					continue
 				}
 				workflowTracef("serve process-error bead=%s kind=%s err=%v", beadID, kind, err)
-				return fmt.Errorf("processing control bead %s: %w", beadID, err)
+				return processedAny, fmt.Errorf("processing control bead %s: %w", beadID, err)
 			}
 			workflowTracef("serve processed bead=%s kind=%s", beadID, kind)
 			processedAny = true
@@ -235,7 +260,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 		}
 		if pendingCount > 0 {
 			workflowTracef("serve pending-queue agent=%s count=%d", agentCfg.QualifiedName(), pendingCount)
-			return nil
+			return processedAny, nil
 		}
 	}
 }
@@ -262,12 +287,23 @@ func runWorkflowServeFollow(agentCfg config.Agent, workQuery string, workDir str
 	eventCh := make(chan workflowWatchResult, 1)
 	go pumpWorkflowEvents(done, watcher, eventCh)
 
+	idleSweeps := 0
 	for {
-		if err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr); err != nil {
+		processed, err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
+		if err != nil {
 			return err
 		}
-		if err := waitForRelevantWorkflowWake(eventCh); err != nil {
+		if processed {
+			idleSweeps = 0
+		}
+		eventWake, err := waitForRelevantWorkflowWake(eventCh, followSleepDuration(idleSweeps))
+		if err != nil {
 			return err
+		}
+		if eventWake {
+			idleSweeps = 0
+		} else if !processed {
+			idleSweeps++
 		}
 	}
 }
@@ -291,24 +327,28 @@ func pumpWorkflowEvents(done <-chan struct{}, watcher events.Watcher, eventCh ch
 	}
 }
 
-func waitForRelevantWorkflowWake(eventCh <-chan workflowWatchResult) error {
-	timer := time.NewTimer(workflowServeWakeSweepInterval)
+// waitForRelevantWorkflowWake blocks until either a relevant city event wakes
+// the --follow loop or sleepDur elapses. Returns eventWake=true on the event
+// path (so the caller can reset any idle-backoff counter), false when the
+// timer fires.
+func waitForRelevantWorkflowWake(eventCh <-chan workflowWatchResult, sleepDur time.Duration) (bool, error) {
+	timer := time.NewTimer(sleepDur)
 	defer timer.Stop()
 
 	for {
 		select {
 		case res := <-eventCh:
 			if res.err != nil {
-				return res.err
+				return false, res.err
 			}
 			if workflowEventRelevant(res.evt) {
 				workflowTracef("serve wake-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
-				return nil
+				return true, nil
 			}
 			workflowTracef("serve ignore-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
 		case <-timer.C:
 			workflowTracef("serve wake-sweep")
-			return nil
+			return false, nil
 		}
 	}
 }

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -77,6 +77,7 @@ var (
 	workflowServeIdlePollAttempts  = 3
 	workflowServeWakeSweepInterval = 1 * time.Second
 	workflowServeMaxIdleSleep      = 30 * time.Second
+	workflowServeWaitForWake       = waitForRelevantWorkflowWakeWithTrace
 )
 
 // followSleepDuration returns the sleep interval the --follow loop should use
@@ -199,27 +200,33 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	return runWorkflowServeFollow(agentCfg, workQuery, workDir, workEnv, stderr)
 }
 
+type workflowServeDrainResult struct {
+	processedAny bool
+	pendingAny   bool
+}
+
 // drainWorkflowServeWork runs the control-dispatcher drain loop to completion
-// for a single invocation. Returns processedAny=true when it advanced at least
-// one control bead, so the --follow caller can reset its idle backoff.
-func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir string, workEnv map[string]string, stderr io.Writer) (bool, error) {
-	processedAny := false
+// for a single invocation. Returns whether it advanced a control bead and
+// whether the queue still contains only pending work so the --follow caller
+// can distinguish blocked work from genuine idle.
+func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir string, workEnv map[string]string, stderr io.Writer) (workflowServeDrainResult, error) {
+	result := workflowServeDrainResult{}
 	idlePolls := 0
 	for {
 		queue, err := workflowServeList(workflowServeQuery(workQuery), workDir, workEnv)
 		if err != nil {
 			workflowTracef("serve query-error agent=%s err=%v", agentCfg.QualifiedName(), err)
-			return processedAny, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
+			return result, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
 		}
 		if len(queue) == 0 {
-			if processedAny && idlePolls < workflowServeIdlePollAttempts {
+			if result.processedAny && idlePolls < workflowServeIdlePollAttempts {
 				idlePolls++
 				workflowTracef("serve idle-retry agent=%s attempt=%d", agentCfg.QualifiedName(), idlePolls)
 				time.Sleep(workflowServeIdlePollInterval)
 				continue
 			}
 			workflowTracef("serve idle-exit agent=%s", agentCfg.QualifiedName())
-			return processedAny, nil
+			return result, nil
 		}
 		idlePolls = 0
 		processedThisCycle := false
@@ -229,7 +236,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 			kind := strings.TrimSpace(candidate.Metadata["gc.kind"])
 			if !isControlDispatcherKind(kind) {
 				workflowTracef("serve unexpected-kind bead=%s kind=%s", beadID, kind)
-				return processedAny, fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
+				return result, fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
 			}
 			workflowTracef("serve process bead=%s kind=%s", beadID, kind)
 			// controlDispatcherServe currently returns nil both when it
@@ -244,14 +251,15 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 			if err := controlDispatcherServe(beadID, io.Discard, stderr); err != nil {
 				if errors.Is(err, dispatch.ErrControlPending) {
 					pendingCount++
+					result.pendingAny = true
 					workflowTracef("serve pending bead=%s kind=%s", beadID, kind)
 					continue
 				}
 				workflowTracef("serve process-error bead=%s kind=%s err=%v", beadID, kind, err)
-				return processedAny, fmt.Errorf("processing control bead %s: %w", beadID, err)
+				return result, fmt.Errorf("processing control bead %s: %w", beadID, err)
 			}
 			workflowTracef("serve processed bead=%s kind=%s", beadID, kind)
-			processedAny = true
+			result.processedAny = true
 			processedThisCycle = true
 			break
 		}
@@ -260,7 +268,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 		}
 		if pendingCount > 0 {
 			workflowTracef("serve pending-queue agent=%s count=%d", agentCfg.QualifiedName(), pendingCount)
-			return processedAny, nil
+			return result, nil
 		}
 	}
 }
@@ -289,20 +297,31 @@ func runWorkflowServeFollow(agentCfg config.Agent, workQuery string, workDir str
 
 	idleSweeps := 0
 	for {
-		processed, err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
+		drainResult, err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
 		if err != nil {
 			return err
 		}
-		if processed {
+		if drainResult.processedAny || drainResult.pendingAny {
 			idleSweeps = 0
 		}
-		eventWake, err := waitForRelevantWorkflowWake(eventCh, followSleepDuration(idleSweeps))
+		sleepDur := followSleepDuration(idleSweeps)
+		workflowTracef(
+			"serve wait agent=%s idle_sweeps=%d sleep=%s processed=%t pending=%t",
+			agentCfg.QualifiedName(),
+			idleSweeps,
+			sleepDur,
+			drainResult.processedAny,
+			drainResult.pendingAny,
+		)
+		eventWake, err := workflowServeWaitForWake(eventCh, sleepDur, idleSweeps)
 		if err != nil {
 			return err
 		}
 		if eventWake {
 			idleSweeps = 0
-		} else if !processed {
+		} else if drainResult.pendingAny {
+			idleSweeps = 0
+		} else if !drainResult.processedAny {
 			idleSweeps++
 		}
 	}
@@ -332,6 +351,10 @@ func pumpWorkflowEvents(done <-chan struct{}, watcher events.Watcher, eventCh ch
 // path (so the caller can reset any idle-backoff counter), false when the
 // timer fires.
 func waitForRelevantWorkflowWake(eventCh <-chan workflowWatchResult, sleepDur time.Duration) (bool, error) {
+	return waitForRelevantWorkflowWakeWithTrace(eventCh, sleepDur, -1)
+}
+
+func waitForRelevantWorkflowWakeWithTrace(eventCh <-chan workflowWatchResult, sleepDur time.Duration, idleSweeps int) (bool, error) {
 	timer := time.NewTimer(sleepDur)
 	defer timer.Stop()
 
@@ -342,12 +365,20 @@ func waitForRelevantWorkflowWake(eventCh <-chan workflowWatchResult, sleepDur ti
 				return false, res.err
 			}
 			if workflowEventRelevant(res.evt) {
-				workflowTracef("serve wake-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
+				if idleSweeps >= 0 {
+					workflowTracef("serve wake-event type=%s subject=%s idle_sweeps=%d sleep=%s", res.evt.Type, res.evt.Subject, idleSweeps, sleepDur)
+				} else {
+					workflowTracef("serve wake-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
+				}
 				return true, nil
 			}
 			workflowTracef("serve ignore-event type=%s subject=%s", res.evt.Type, res.evt.Subject)
 		case <-timer.C:
-			workflowTracef("serve wake-sweep")
+			if idleSweeps >= 0 {
+				workflowTracef("serve wake-sweep idle_sweeps=%d sleep=%s", idleSweeps, sleepDur)
+			} else {
+				workflowTracef("serve wake-sweep")
+			}
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Fixes #1028

## Summary

The `gc convoy control --serve --follow` loop currently runs a 1-second sweep even at idle. Each sweep invokes the default control-dispatcher `work_query`, which expands to up to 8 `bd` subprocesses — each a fresh Go process + TCP/MySQL handshake to dolt. Across multiple rigs this accounts for a meaningful fraction of dolt-server CPU on an otherwise quiet city.

This change adds exponential backoff on consecutive idle sweeps:

- Base: `workflowServeWakeSweepInterval` (1s, unchanged)
- Growth: 1s → 2s → 4s → 8s → 16s → 30s-cap
- Cap: `workflowServeMaxIdleSleep` (30s, matching the default `patrol_interval`)

`idleSweeps` resets whenever a drain actually processes work, or whenever a relevant bead event arrives during the wait. Only genuine idle sweeps (no work, no event, timer-driven wake) increment the counter.

## Changes

- `drainWorkflowServeWork` now returns `(processedAny bool, err error)` so the `--follow` caller can reset the idle counter when work was advanced
- `waitForRelevantWorkflowWake` now takes `sleepDur time.Duration` and returns `(eventWake bool, err error)` so the same caller can distinguish event-driven wakes from timer-driven ones
- New `followSleepDuration(idleSweeps int) time.Duration` helper with an overflow guard (shift clamped to 30, cap re-checked before return)
- New `workflowServeMaxIdleSleep = 30 * time.Second` package-level var (overridable in tests, matching the existing `workflowServeWakeSweepInterval` pattern)

No publisher changes, no `bd` changes, no dolt or schema changes. All work is contained in `cmd/gc/dispatch_runtime.go` and `cmd/gc/cmd_convoy_dispatch_test.go`.

## Test plan

- [x] `followSleepDuration` unit tests cover: base (`idleSweeps=0`), doubling (1-4), cap-reached (5-20), overflow-safe high values (63, 1000), negative input
- [x] `waitForRelevantWorkflowWake` unit tests cover: relevant event wake, timer-only wake, irrelevant-event fallthrough, watcher-error surface
- [x] Existing `TestRunWorkflowServeFollowUsesSweepFallback` passes unchanged (its sweep-interval override keeps the test fast against the new signature)
- [x] `go test ./cmd/gc/ -run "Workflow|Convoy|Dispatch|FollowSleepDuration|WaitForRelevantWorkflowWake"` clean in ~3.3s
- [x] `go vet ./cmd/gc/` clean
- [x] `go build ./cmd/gc` clean
- [x] Rebuilt binary and exercised live on a multi-rig city: `--follow` children drop to 0% CPU at idle and wake promptly on real bead events

## Follow-up (not in this PR)

This PR addresses the fan-out observed in the idle path. In cities with frequent scheduled-order activity (maintenance patrols, etc.), the `--follow` loop can still be woken on every bead event, which prevents backoff from engaging. A separate fix — narrowing `workflowEventRelevant` to skip session-bead and order-triggered events, and adding trailing-edge debouncing of event wakes — addresses that amplification path. It's kept as its own change so reviewers can adopt each independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)