### PR TITLE
fix: coerce cache event metadata

### DIFF
--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -67,22 +67,24 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 }
 
 func decodeCacheEvent(payload json.RawMessage) (Bead, error) {
-	var b Bead
-	if err := json.Unmarshal(payload, &b); err != nil {
+	var wire struct {
+		Bead
+		Metadata   StringMap `json:"metadata,omitempty"`
+		TypeCompat string    `json:"type,omitempty"`
+	}
+	if err := json.Unmarshal(payload, &wire); err != nil {
 		return Bead{}, err
+	}
+	b := wire.Bead
+	if wire.Metadata != nil {
+		b.Metadata = map[string]string(wire.Metadata)
 	}
 	if b.ID == "" {
 		return Bead{}, fmt.Errorf("missing bead id")
 	}
-	// bd hook payloads use "issue_type" while Bead uses "type". If Type
-	// wasn't populated from "type", check for the bd field name.
-	if b.Type == "" {
-		var bdCompat struct {
-			IssueType string `json:"issue_type"`
-		}
-		if err := json.Unmarshal(payload, &bdCompat); err == nil && bdCompat.IssueType != "" {
-			b.Type = bdCompat.IssueType
-		}
+	// bd hook payloads use "issue_type" while exec-style payloads may use "type".
+	if b.Type == "" && wire.TypeCompat != "" {
+		b.Type = wire.TypeCompat
 	}
 	return b, nil
 }

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -320,6 +320,60 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 }
 
+func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	b1, err := mem.Create(beads.Bead{Title: "Existing"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cs := beads.NewCachingStoreForTest(mem, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"id":         b1.ID,
+		"title":      "mayor",
+		"status":     "open",
+		"issue_type": "session",
+		"metadata": map[string]any{
+			"generation":           3,
+			"pending_create_claim": true,
+			"state":                "creating",
+			"wake_attempts":        0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	cs.ApplyEvent("bead.updated", payload)
+
+	stats := cs.Stats()
+	if stats.ProblemCount != 0 {
+		t.Fatalf("ProblemCount = %d, want 0 (last problem: %s)", stats.ProblemCount, stats.LastProblem)
+	}
+
+	got, err := cs.Get(b1.ID)
+	if err != nil {
+		t.Fatalf("Get after ApplyEvent update: %v", err)
+	}
+	if got.Type != "session" {
+		t.Fatalf("Type = %q, want session", got.Type)
+	}
+	if got.Metadata["generation"] != "3" {
+		t.Fatalf("generation = %q, want 3; metadata=%v", got.Metadata["generation"], got.Metadata)
+	}
+	if got.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want true; metadata=%v", got.Metadata["pending_create_claim"], got.Metadata)
+	}
+	if got.Metadata["wake_attempts"] != "0" {
+		t.Fatalf("wake_attempts = %q, want 0; metadata=%v", got.Metadata["wake_attempts"], got.Metadata)
+	}
+}
+
 func TestCachingStoreApplyEventIgnoredWhenDegraded(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()


### PR DESCRIPTION
## Summary

Fixes #1049.

The bd hook event path can receive raw bead JSON where bd has type-inferred metadata values into JSON numbers or booleans. `CachingStore.ApplyEvent` previously decoded those payloads directly into `beads.Bead`, whose metadata is `map[string]string`, causing the supervisor log error:

```text
json: cannot unmarshal number into Go struct field Bead.metadata of type string
```

This keeps the change minimal by decoding cache-event metadata through the existing tolerant `StringMap` while leaving the rest of the `Bead` decode path intact.

## TDD

- Added `TestCachingStoreApplyEventCoercesNonStringMetadata` with a bd-hook-shaped `bead.updated` payload containing numeric and boolean metadata.
- Verified the test failed first with the same unmarshal error seen in the supervisor log.
- Made the smallest decoder change needed to pass.

## Verification

- `go test ./internal/beads -run TestCachingStoreApplyEventCoercesNonStringMetadata -count=1`
- `go test ./internal/beads -count=1`
- `go vet ./...`

I also ran `go test ./...`. The touched package passed, but the repo-wide run failed in unrelated existing areas: `cmd/gc`, path canonicalization tests, supervisor path tests, worker/workspacesvc tests. None referenced the cache event decoder or the new regression test.
