### PR TITLE
fix(gc): replace dolt-health probe with @@global.read_only sysvar read

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -166,7 +166,7 @@ func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	}
 }
 
-func TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase(t *testing.T) {
+func TestGcBeadsBdReadOnlyFallbackUsesGlobalSysvar(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
 		t.Fatalf("MaterializeBuiltinPacks: %v", err)
@@ -177,10 +177,15 @@ func TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase(t *testing.T) {
 	}
 	script := string(scriptData)
 	assertNoManagedDoltProbeDrop(t, "gc-beads-bd read-only fallback", script)
-	if !strings.Contains(script, "CREATE TABLE IF NOT EXISTS __gc_probe.__probe") {
-		t.Fatalf("gc-beads-bd read-only fallback missing qualified persistent probe table")
+	if strings.Contains(script, "CREATE TABLE IF NOT EXISTS __gc_probe") {
+		t.Fatalf("gc-beads-bd read-only fallback must not write to probe database")
 	}
-	assertManagedDoltProbeWrites(t, "gc-beads-bd read-only fallback", script)
+	if strings.Contains(script, "REPLACE INTO __gc_probe") {
+		t.Fatalf("gc-beads-bd read-only fallback must not write to probe database")
+	}
+	if !strings.Contains(script, "@@global.read_only") {
+		t.Fatalf("gc-beads-bd read-only fallback must use @@global.read_only sysvar")
+	}
 }
 
 func TestGcBeadsBdInitRejectsManagedProbeDatabaseName(t *testing.T) {

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1778,8 +1778,8 @@ func TestDoltStateReadOnlyCheckCmdDetectsReadOnly(t *testing.T) {
 	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
-echo 'database is read only' >&2
-exit 1
+printf '@@global.read_only\n1\n'
+exit 0
 `)
 	t.Setenv("INVOCATION_FILE", invocationFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -1794,7 +1794,9 @@ exit 1
 		t.Fatalf("ReadFile(invocation): %v", err)
 	}
 	assertNoManagedDoltProbeDrop(t, "read-only-check invocation", string(invocation))
-	assertManagedDoltProbeWrites(t, "read-only-check invocation", string(invocation))
+	if !strings.Contains(string(invocation), "@@global.read_only") {
+		t.Fatalf("read-only-check must use @@global.read_only sysvar: %s", string(invocation))
+	}
 }
 
 func TestDoltStateReadOnlyCheckCmdReturnsErrExitWhenWritable(t *testing.T) {
@@ -1803,6 +1805,7 @@ func TestDoltStateReadOnlyCheckCmdReturnsErrExitWhenWritable(t *testing.T) {
 	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
+printf '@@global.read_only\n0\n'
 exit 0
 `)
 	t.Setenv("INVOCATION_FILE", invocationFile)
@@ -1901,9 +1904,9 @@ case "$*" in
   *"sql -q SELECT active_branch()"*)
     exit 0
     ;;
-  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);"*)
-    echo 'database is read only' >&2
-    exit 1
+  *"sql -r csv -q SELECT @@global.read_only"*)
+    printf '@@global.read_only\n1\n'
+    exit 0
     ;;
   *"sql -r csv -q SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST"*)
     printf 'cnt\n812\n'
@@ -1939,7 +1942,9 @@ esac
 	}
 	text := string(invocation)
 	assertNoManagedDoltProbeDrop(t, "health-check read-only probe", text)
-	assertManagedDoltProbeWrites(t, "health-check read-only probe", text)
+	if !strings.Contains(text, "@@global.read_only") {
+		t.Fatalf("health-check read-only probe must use @@global.read_only sysvar: %s", text)
+	}
 	for _, want := range []string{"--host 127.0.0.1", "--port 3311", "--user root", "SELECT active_branch()", "information_schema.PROCESSLIST"} {
 		if strings.Contains(text, want) == false {
 			t.Fatalf("dolt invocation missing %q: %s", want, text)
@@ -1986,7 +1991,7 @@ esac
 		t.Fatalf("ReadFile(invocation): %v", err)
 	}
 	text := string(invocation)
-	if strings.Contains(text, "CREATE DATABASE IF NOT EXISTS __gc_probe") {
+	if strings.Contains(text, "@@global.read_only") {
 		t.Fatalf("health-check unexpectedly ran read-only probe: %s", text)
 	}
 	for _, want := range []string{"SELECT active_branch()", "information_schema.PROCESSLIST"} {
@@ -2025,7 +2030,7 @@ case "$*" in
   *"sql -q SELECT active_branch()"*)
     exit 0
     ;;
-  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);"*)
+  *"sql -r csv -q SELECT @@global.read_only"*)
     echo 'probe exploded' >&2
     exit 1
     ;;
@@ -2418,11 +2423,12 @@ INNERPY
   *"SELECT active_branch()"*)
     exit 0
     ;;
-  *"CREATE DATABASE IF NOT EXISTS __gc_probe;"*)
+  *"SELECT @@global.read_only"*)
     if [ -f "$READ_ONLY_ONCE" ]; then
       rm -f "$READ_ONLY_ONCE"
-      echo "read only" >&2
-      exit 1
+      printf '@@global.read_only\n1\n'
+    else
+      printf '@@global.read_only\n0\n'
     fi
     exit 0
     ;;
@@ -2857,7 +2863,8 @@ INNERPY
     echo "final health probe failed" >&2
     exit 1
     ;;
-  *"CREATE DATABASE IF NOT EXISTS __gc_probe;"*)
+  *"sql -r csv -q SELECT @@global.read_only"*)
+    printf '@@global.read_only\n0\n'
     exit 0
     ;;
   *)

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -29,17 +29,6 @@ var (
 	managedDoltSQLCommandTimeout       = 5 * time.Second
 )
 
-// The probe database is intentionally persistent. Dropping Dolt databases leaves
-// .dolt_dropped_databases backups, so the health check keeps a stable table and
-// rewrites a single row to test writability.
-var managedDoltReadOnlyProbeStatements = [...]string{
-	"CREATE DATABASE IF NOT EXISTS " + managedDoltProbeDatabase,
-	"CREATE TABLE IF NOT EXISTS " + managedDoltProbeDatabase + ".__probe (k INT PRIMARY KEY)",
-	"REPLACE INTO " + managedDoltProbeDatabase + ".__probe VALUES (1)",
-}
-
-var managedDoltReadOnlyProbeSQL = strings.Join(managedDoltReadOnlyProbeStatements[:], "; ") + ";"
-
 func managedDoltQueryProbe(host, port, user string) error {
 	if managedDoltPassword() != "" {
 		return managedDoltQueryProbeDirectFn(host, port, user)
@@ -58,15 +47,19 @@ func managedDoltReadOnlyState(host, port, user string) (string, error) {
 	if managedDoltPassword() != "" {
 		return managedDoltReadOnlyStateDirectFn(host, port, user)
 	}
-	_, err := runManagedDoltSQL(host, port, user, "-q", managedDoltReadOnlyProbeSQL)
-	if err == nil {
-		return "false", nil
+	out, err := runManagedDoltSQL(host, port, user, "-r", "csv", "-q", "SELECT @@global.read_only")
+	if err != nil {
+		return "unknown", err
 	}
-	msg := strings.ToLower(err.Error())
-	if strings.Contains(msg, "read only") || strings.Contains(msg, "read-only") {
-		return "true", nil
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		switch strings.TrimSpace(line) {
+		case "1":
+			return "true", nil
+		case "0":
+			return "false", nil
+		}
 	}
-	return "unknown", err
+	return "unknown", fmt.Errorf("parse read_only from %q", strings.TrimSpace(out))
 }
 
 func managedDoltConnectionCount(host, port, user string) (string, error) {
@@ -187,14 +180,12 @@ func managedDoltReadOnlyStateDirect(host, port, user string) (string, error) {
 	}
 	defer conn.Close() //nolint:errcheck
 
-	for _, query := range managedDoltReadOnlyProbeStatements {
-		if _, err := conn.ExecContext(ctx, query); err != nil {
-			msg := strings.ToLower(err.Error())
-			if strings.Contains(msg, "read only") || strings.Contains(msg, "read-only") {
-				return "true", nil
-			}
-			return "unknown", err
-		}
+	var readOnly int
+	if err := conn.QueryRowContext(ctx, "SELECT @@global.read_only").Scan(&readOnly); err != nil {
+		return "unknown", err
+	}
+	if readOnly == 1 {
+		return "true", nil
 	}
 	return "false", nil
 }

--- a/cmd/gc/dolt_sql_health_test.go
+++ b/cmd/gc/dolt_sql_health_test.go
@@ -10,19 +10,34 @@ import (
 	"time"
 )
 
-func TestManagedDoltReadOnlyProbeDoesNotDropProbeDatabase(t *testing.T) {
-	for _, query := range append(append([]string{}, managedDoltReadOnlyProbeStatements[:]...), managedDoltReadOnlyProbeSQL) {
-		assertNoManagedDoltProbeDrop(t, "read-only probe", query)
+func TestManagedDoltReadOnlyStateUsesGlobalSysvar(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$INVOCATION_FILE\"\nprintf '@@global.read_only\\n0\\n'\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	assertManagedDoltProbeWrites(t, "joined read-only probe", managedDoltReadOnlyProbeSQL)
-	foundWriteStatement := false
-	for _, query := range managedDoltReadOnlyProbeStatements {
-		if strings.Contains(query, "REPLACE INTO __gc_probe.__probe VALUES (1)") {
-			foundWriteStatement = true
-		}
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	state, err := managedDoltReadOnlyState("127.0.0.1", "3311", "root")
+	if err != nil {
+		t.Fatalf("managedDoltReadOnlyState() error = %v", err)
 	}
-	if !foundWriteStatement {
-		t.Fatal("read-only probe statements must include a write to __gc_probe.__probe")
+	if state != "false" {
+		t.Fatalf("managedDoltReadOnlyState() = %q, want false", state)
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	text := string(invocation)
+	if !strings.Contains(text, "@@global.read_only") {
+		t.Fatalf("managedDoltReadOnlyState did not use @@global.read_only sysvar: %s", text)
+	}
+	assertNoManagedDoltProbeDrop(t, "read-only state", text)
+	if strings.Contains(text, "__gc_probe") {
+		t.Fatalf("managedDoltReadOnlyState must not reference probe database: %s", text)
 	}
 }
 
@@ -35,13 +50,6 @@ func assertNoManagedDoltProbeDrop(t *testing.T, label, text string) {
 	}
 	if dropProbeTable.MatchString(text) {
 		t.Fatalf("%s must keep __gc_probe.__probe stable: %s", label, text)
-	}
-}
-
-func assertManagedDoltProbeWrites(t *testing.T, label, text string) {
-	t.Helper()
-	if !strings.Contains(text, "REPLACE INTO __gc_probe.__probe VALUES (1)") {
-		t.Fatalf("%s must write to __gc_probe.__probe: %s", label, text)
 	}
 }
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1003,15 +1003,17 @@ check_read_only() {
         esac
     fi
     local output
-    # Keep __gc_probe stable. Dropping Dolt databases leaves
-    # .dolt_dropped_databases backups behind.
-    output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls         sql -q "CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);" 2>&1) || true
-    case "$output" in
-        *"read only"*|*"READ ONLY"*|*"Read-only"*)
-            return 0  # Is read-only.
-            ;;
-    esac
-    return 1  # Writable.
+    output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls \
+        sql -r csv -q "SELECT @@global.read_only" 2>&1) || return 1
+    while IFS= read -r line; do
+        case "$line" in
+            1) return 0 ;;
+            0) return 1 ;;
+        esac
+    done <<EOF
+$output
+EOF
+    return 1
 }
 
 load_health_check_from_gc() {


### PR DESCRIPTION
## Summary

This PR proposes a different approach to the dolt-health liveness probe
than the one taken in eddf7b72 ("fix: stop dropping Dolt health probe
database", merged 2026-04-20).

**eddf7b72 approach**: stabilize the probe database lifecycle — keep
`__gc_probe` persistent, use CREATE IF NOT EXISTS + REPLACE INTO rather
than DROP/CREATE each tick, and provide a `dolt-state reset-probe`
command to clean up the DB when needed.

**This PR's approach**: eliminate the probe database entirely. Instead
of writing to a test database to check writability, read
`@@global.read_only` — a single round-trip with no side effects.

Benefits of the sysvar approach:

- Zero on-disk state: no `__gc_probe` database exists at all, so no
  `.dolt_dropped_databases/` accumulation is possible by construction
  (not just stabilized)
- Single round-trip read vs. multiple CREATE/REPLACE writes
- Matches the recommendation in the mol-dog-doctor probe code comments
  (Dolt CEO's earlier guidance)
- The `dolt-state reset-probe` command is retained for migration cleanup
  of any pre-existing `__gc_probe` from older installs

This supersedes eddf7b72's approach by removing the probe DB entirely
rather than stabilizing its lifecycle. Happy to defer to maintainer
preference if the stabilization path is preferred.

The key invariant (`@@global.read_only` is `0` when Dolt is accepting
writes) has been verified in a live production deployment on 2026-04-18:
`.dolt_dropped_databases/` drained from 3810 entries / 164 MB to 0
entries / 228 KB after this fix was deployed.

## Changes

- `cmd/gc/dolt_sql_health.go`: `managedDoltReadOnlyState` and
  `managedDoltReadOnlyStateDirect` now query
  `SELECT @@global.read_only` instead of CREATE/REPLACE probing.
- `examples/bd/assets/scripts/gc-beads-bd.sh`: shell fallback path uses
  the same sysvar query.
- Tests updated to match the new probe-free approach.

## References

Prior art: eddf7b72 (same area, different approach — referenced as
context for reviewers).