### PR TITLE
fix: add verified-sling.sh guard + verified dispatch pattern

### DIFF
--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -144,6 +144,28 @@ Wrong. The issue is about beads code, so it goes in the beads rig.
 **NOT your job**: Per-worker cleanup, session killing, routine nudging (Witness handles that)
 **Exception**: If refinery/witness is stuck, use `{{ cmd }} nudge refinery "Process MQ"`
 
+## Bead Creation — NEVER Fabricate IDs
+
+When creating assignment beads for review legs, you MUST capture the bead ID
+from command output. NEVER invent, guess, or reuse a bead ID.
+
+**Correct pattern:**
+```bash
+LEG_BEAD=$(gc bd create --title "..." --description "..." \
+  --type task --priority 2 --json | jq -r .id)
+echo "Created: $LEG_BEAD"    # verify it printed a real ID
+bd show "$LEG_BEAD"           # verify it exists before slinging
+```
+
+**Wrong pattern (causes stranded workers):**
+```bash
+LEG_BEAD="sc-qq3a0"           # ← fabricated ID, will break everything
+gc sling ... "$LEG_BEAD" ...  # ← slings a dead reference
+```
+
+Always use `assets/scripts/verified-sling.sh` instead of raw `gc sling`
+when dispatching review legs. It validates the bead exists before slinging.
+
 ## Rig Wake/Sleep Protocol
 
 Rigs start **dormant by default** (`--start-suspended`). The Mayor activates

--- a/examples/gastown/packs/gastown/assets/scripts/verified-sling.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/verified-sling.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# verified-sling.sh — wrap `gc sling` with pre-flight bead existence checks.
+#
+# Usage: verified-sling.sh [gc-sling-args...]
+#
+# Scans positional args for anything that looks like a bead ID
+# (e.g. sc-xxxxx, hq-xxxx, sc-xxxxx.12) and runs `bd show` on each before
+# invoking `gc sling`. Exits non-zero with a clear error if any bead is
+# missing, preventing molecules from being poured against fabricated IDs.
+#
+# This is the defensive companion to the quartermaster prompt's "NEVER
+# fabricate IDs" rule — catches hallucinated IDs before they strand workers.
+# See hq-7zv for the 2026-04-21 incident that motivated this guard.
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "verified-sling.sh: usage: verified-sling.sh [gc-sling-args...]" >&2
+    exit 2
+fi
+
+looks_like_bead_id() {
+    # Matches: sc-abc12, hq-x3y7, sc-abcde.12
+    # Two or more lowercase letters, a dash, then alphanumerics,
+    # optionally a .number step suffix. Flags are excluded.
+    case "$1" in
+        -*) return 1 ;;
+        *.*.*) return 1 ;;
+    esac
+    printf '%s\n' "$1" | grep -Eq '^[a-z]{2,}-[a-z0-9]{3,}(\.[0-9]+)?$'
+}
+
+missing=""
+for arg in "$@"; do
+    if looks_like_bead_id "$arg"; then
+        if ! bd show "$arg" >/dev/null 2>&1; then
+            missing="$missing $arg"
+        fi
+    fi
+done
+
+if [ -n "$missing" ]; then
+    echo "verified-sling.sh: refusing to sling — bead(s) not found:$missing" >&2
+    echo "verified-sling.sh: create the bead with \`gc bd create ... --json | jq -r .id\` and capture its real ID before slinging." >&2
+    exit 3
+fi
+
+exec gc sling "$@"

--- a/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
@@ -141,19 +141,35 @@ description = """
 Fan out parallel PRD review using review task beads plus `mol-review-leg`.
 
 **Dispatch pattern for EVERY review leg in this workflow:**
-1. `gc bd create` a task bead with a detailed description
-2. set metadata:
-   - `coordinator=$COORDINATOR`
-   - `review_id=$REVIEW_ID`
-   - `review_phase=<phase>`
-   - `review_leg=<leg>`
-3. sling it to `$REVIEW_TARGET` with:
+1. Create the assignment bead and CAPTURE its ID from command output:
 ```bash
-gc sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
+LEG_BEAD=$(gc bd create --title "<leg title>" --description "<prompt>" \
+  --type task --priority 2 --json | jq -r .id)
+echo "Created bead: $LEG_BEAD"    # MUST print a real ID like sc-xxxxx
 ```
-4. record the bead ID in the round log
-5. wait for completion mail or poll the bead until it closes
-6. read the full report from the bead notes with `gc bd show <id>`
+2. VERIFY the bead exists (guards against fabricated IDs):
+```bash
+bd show "$LEG_BEAD"               # MUST succeed — stop if it fails
+```
+3. Set metadata on the verified bead:
+```bash
+bd update "$LEG_BEAD" \
+  --set-metadata coordinator="$COORDINATOR" \
+  --set-metadata review_id="$REVIEW_ID" \
+  --set-metadata review_phase=<phase> \
+  --set-metadata review_leg=<leg>
+```
+4. Sling using the validated wrapper:
+```bash
+"$GC_CITY_DIR/assets/scripts/verified-sling.sh" "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
+```
+5. Record the bead ID in the round log
+6. Wait for completion mail or poll the bead until it closes
+7. Read the full report from the bead notes with `gc bd show "$LEG_BEAD"`
+
+⚠️ **NEVER fabricate bead IDs.** The ID MUST come from `gc bd create --json`
+output. If the create command fails or returns empty, STOP and escalate.
+Do NOT invent an ID like `sc-xxxxx` and proceed — this strands workers.
 
 **Standard instructions each review bead must include:**
 - read `.prd-reviews/$REVIEW_ID/prd-draft.md`


### PR DESCRIPTION
## Summary

- Add `verified-sling.sh` to gastown pack scripts (`assets/scripts/verified-sling.sh`). Wraps `gc sling` with pre-flight `bd show` checks on every bead-like argument, refusing to sling if any bead is missing.
- Update `mol-idea-to-plan.toml` dispatch pattern to capture bead IDs from `gc bd create --json`, verify existence with `bd show`, and sling via `verified-sling.sh` instead of raw `gc sling`.
- Add "NEVER Fabricate IDs" section to mayor prompt template (the upstream agent that runs `mol-idea-to-plan`).

## Context

Incident hq-7zv (2026-04-21): a quartermaster session used placeholder bead IDs from an unsubstituted template when dispatching `mol-review-leg` molecules, stranding 7+ polecat workers on non-existent assignments.

The quartermaster agent is deployment-specific (not in the upstream pack), so the prompt guard is added to the mayor — the pack's coordinator that runs `mol-idea-to-plan`.

## Test plan

- [ ] `shellcheck examples/gastown/packs/gastown/assets/scripts/verified-sling.sh` passes
- [ ] Formula TOML parses correctly (`taplo check` or `toml-lint`)
- [ ] Mayor prompt template renders without errors in a test deployment