### PR TITLE
fix: rename gc init tutorial template to minimal

### DIFF
--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestInitTutorialProviderWritesWorkspaceProvider(t *testing.T) {
+func TestInitMinimalProviderWritesWorkspaceProvider(t *testing.T) {
 	configureSupervisorHooksForTests()
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("PATH", os.Getenv("PATH"))
@@ -24,7 +24,7 @@ func TestInitTutorialProviderWritesWorkspaceProvider(t *testing.T) {
 		t.Fatalf("read city.toml: %v", err)
 	}
 	if !strings.Contains(string(data), `provider = "claude"`) {
-		t.Fatalf("tutorial init contract: city.toml should record workspace provider claude, got:\n%s", string(data))
+		t.Fatalf("minimal init contract: city.toml should record workspace provider claude, got:\n%s", string(data))
 	}
 }
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -73,7 +73,7 @@ var initConventionDirs = []string{
 // for non-interactive paths). doInit uses it to decide which config to write.
 type wizardConfig struct {
 	interactive      bool   // true if the wizard ran with user interaction
-	configName       string // "minimal", "gastown", or "custom"
+	configName       string // canonical values: "minimal", "gastown", or "custom"
 	provider         string // built-in provider key, or "" if startCommand set
 	startCommand     string // custom start command (workspace-level)
 	bootstrapProfile string // hosted bootstrap profile, or "" for local defaults
@@ -252,7 +252,7 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, then
-materializes builtin packs under .gc/system/packs. Use --provider to create the default mayor city
+materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
 non-interactively, or --file to initialize from an existing TOML config file.`,
 		Example: `  gc init
   gc init ~/my-city

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -73,7 +73,7 @@ var initConventionDirs = []string{
 // for non-interactive paths). doInit uses it to decide which config to write.
 type wizardConfig struct {
 	interactive      bool   // true if the wizard ran with user interaction
-	configName       string // "tutorial", "gastown", or "custom"
+	configName       string // "minimal", "gastown", or "custom"
 	provider         string // built-in provider key, or "" if startCommand set
 	startCommand     string // custom start command (workspace-level)
 	bootstrapProfile string // hosted bootstrap profile, or "" for local defaults
@@ -82,7 +82,7 @@ type wizardConfig struct {
 // defaultWizardConfig returns a non-interactive wizardConfig that produces
 // a single mayor agent with no provider.
 func defaultWizardConfig() wizardConfig {
-	return wizardConfig{configName: "tutorial"}
+	return wizardConfig{configName: "minimal"}
 }
 
 func canBootstrapExistingCity(wiz wizardConfig) bool {
@@ -126,23 +126,23 @@ func runWizard(stdin io.Reader, stdout io.Writer) wizardConfig {
 	fmt.Fprintln(stdout, "Welcome to Gas City SDK!")                                //nolint:errcheck // best-effort stdout
 	fmt.Fprintln(stdout, "")                                                        //nolint:errcheck // best-effort stdout
 	fmt.Fprintln(stdout, "Choose a config template:")                               //nolint:errcheck // best-effort stdout
-	fmt.Fprintln(stdout, "  1. tutorial  — default coding agent (default)")         //nolint:errcheck // best-effort stdout
+	fmt.Fprintln(stdout, "  1. minimal   — default coding agent (default)")         //nolint:errcheck // best-effort stdout
 	fmt.Fprintln(stdout, "  2. gastown   — multi-agent orchestration pack")         //nolint:errcheck // best-effort stdout
 	fmt.Fprintln(stdout, "  3. custom    — empty workspace, configure it yourself") //nolint:errcheck // best-effort stdout
 	fmt.Fprintf(stdout, "Template [1]: ")                                           //nolint:errcheck // best-effort stdout
 
 	configChoice := readLine(br)
-	configName := "tutorial"
+	configName := "minimal"
 
 	switch configChoice {
-	case "", "1", "tutorial":
-		configName = "tutorial"
+	case "", "1", "minimal", "tutorial":
+		configName = "minimal"
 	case "2", "gastown":
 		configName = "gastown"
 	case "3", "custom":
 		configName = "custom"
 	default:
-		fmt.Fprintf(stdout, "Unknown template %q, using tutorial.\n", configChoice) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stdout, "Unknown template %q, using minimal.\n", configChoice) //nolint:errcheck // best-effort stdout
 	}
 
 	// Custom config → skip agent question, return minimal config.
@@ -363,7 +363,7 @@ func initWizardConfig(providerFlag, bootstrapProfileFlag string) (wizardConfig, 
 		return wizardConfig{}, err
 	}
 	return wizardConfig{
-		configName:       "tutorial",
+		configName:       "minimal",
 		provider:         provider,
 		bootstrapProfile: bootstrapProfile,
 	}, nil
@@ -774,7 +774,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 }
 
 // doInit is the pure logic for "gc init". It creates the city directory
-// structure and writes city.toml. Tutorial configs use WizardCity
+// structure and writes city.toml. Minimal configs use WizardCity
 // when a provider or start command is supplied; otherwise init writes the
 // default mayor-only city. Errors if the runtime scaffold already exists. Accepts an
 // injected FS for testability.

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -63,7 +63,7 @@ func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *test
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "", &initStdout, &initStderr)
 	if code != 0 {
@@ -314,7 +314,7 @@ func TestFinalizeInitWithoutProgressSkipsStepCounter(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "", &initStdout, &initStderr)
 	if code != 0 {
@@ -436,7 +436,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "", &initStdout, &initStderr)
 	if code != 0 {
@@ -720,7 +720,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "", &initStdout, &initStderr)
 	if code != 0 {
@@ -780,7 +780,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "", &initStdout, &initStderr)
 	if code != 0 {
@@ -829,7 +829,7 @@ func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "", &initStdout, &initStderr)
 	if code != 0 {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1830,7 +1830,7 @@ func TestSettingsArgsMissingFile(t *testing.T) {
 // --- runWizard ---
 
 func TestRunWizardDefaults(t *testing.T) {
-	// Two enters → default template (tutorial) + default agent (claude).
+	// Two enters → default template (minimal) + default agent (claude).
 	stdin := strings.NewReader("\n\n")
 	var stdout bytes.Buffer
 	wiz := runWizard(stdin, &stdout)
@@ -1838,8 +1838,8 @@ func TestRunWizardDefaults(t *testing.T) {
 	if !wiz.interactive {
 		t.Error("expected interactive = true")
 	}
-	if wiz.configName != "tutorial" {
-		t.Errorf("configName = %q, want %q", wiz.configName, "tutorial")
+	if wiz.configName != "minimal" {
+		t.Errorf("configName = %q, want %q", wiz.configName, "minimal")
 	}
 	if wiz.provider != "claude" {
 		t.Errorf("provider = %q, want %q", wiz.provider, "claude")
@@ -1864,8 +1864,8 @@ func TestRunWizardNilStdin(t *testing.T) {
 	if wiz.interactive {
 		t.Error("expected interactive = false for nil stdin")
 	}
-	if wiz.configName != "tutorial" {
-		t.Errorf("configName = %q, want %q", wiz.configName, "tutorial")
+	if wiz.configName != "minimal" {
+		t.Errorf("configName = %q, want %q", wiz.configName, "minimal")
 	}
 	if wiz.provider != "" {
 		t.Errorf("provider = %q, want empty", wiz.provider)
@@ -1944,6 +1944,19 @@ func TestRunWizardGastownByName(t *testing.T) {
 	}
 }
 
+func TestRunWizardTutorialAliasMapsToMinimal(t *testing.T) {
+	stdin := strings.NewReader("tutorial\n\n")
+	var stdout bytes.Buffer
+	wiz := runWizard(stdin, &stdout)
+
+	if wiz.configName != "minimal" {
+		t.Errorf("configName = %q, want %q", wiz.configName, "minimal")
+	}
+	if wiz.provider != "claude" {
+		t.Errorf("provider = %q, want %q", wiz.provider, "claude")
+	}
+}
+
 func TestRunWizardSelectCursorByNumber(t *testing.T) {
 	// Cursor is #4 in the order.
 	stdin := strings.NewReader("\n4\n")
@@ -1996,8 +2009,8 @@ func TestRunWizardEOFStdin(t *testing.T) {
 	wiz := runWizard(stdin, &stdout)
 
 	// EOF means default for both questions.
-	if wiz.configName != "tutorial" {
-		t.Errorf("configName = %q, want %q", wiz.configName, "tutorial")
+	if wiz.configName != "minimal" {
+		t.Errorf("configName = %q, want %q", wiz.configName, "minimal")
 	}
 	if wiz.provider != "claude" {
 		t.Errorf("provider = %q, want %q", wiz.provider, "claude")
@@ -2008,7 +2021,7 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	f := fsys.NewFake()
 	wiz := wizardConfig{
 		interactive: true,
-		configName:  "tutorial",
+		configName:  "minimal",
 		provider:    "claude",
 	}
 
@@ -2023,7 +2036,7 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 
 	// Verify output message.
 	out := stdout.String()
-	if !strings.Contains(out, "Created tutorial config") {
+	if !strings.Contains(out, "Created minimal config") {
 		t.Errorf("stdout missing wizard message: %q", out)
 	}
 
@@ -2062,7 +2075,7 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 	f := fsys.NewFake()
 	wiz := wizardConfig{
 		interactive:  true,
-		configName:   "tutorial",
+		configName:   "minimal",
 		startCommand: "my-agent --auto",
 	}
 
@@ -2182,7 +2195,7 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 func TestDoInitWithProviderFlagAndBootstrapProfile(t *testing.T) {
 	f := fsys.NewFake()
 	wiz := wizardConfig{
-		configName:       "tutorial",
+		configName:       "minimal",
 		provider:         "codex",
 		bootstrapProfile: bootstrapProfileK8sCell,
 	}
@@ -2227,7 +2240,7 @@ func TestDoInitWithProviderFlagAndBootstrapProfile(t *testing.T) {
 func TestDoInitWithOpenCodeProviderInstallsWorkspaceHooks(t *testing.T) {
 	f := fsys.NewFake()
 	wiz := wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "opencode",
 	}
 
@@ -2256,7 +2269,7 @@ func TestDoInitWithOpenCodeProviderInstallsWorkspaceHooks(t *testing.T) {
 func TestDoInitWithClaudeProviderLeavesWorkspaceHooksEmpty(t *testing.T) {
 	f := fsys.NewFake()
 	wiz := wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}
 
@@ -2722,7 +2735,7 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
-		configName: "tutorial",
+		configName: "minimal",
 		provider:   "claude",
 	}, "my-bare-name", &stdout, &stderr)
 	if code != 0 {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1124,7 +1124,7 @@ Create a new Gas City workspace in the given directory (or cwd).
 Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, then
-materializes builtin packs under .gc/system/packs. Use --provider to create the default mayor city
+materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
 non-interactively, or --file to initialize from an existing TOML config file.
 
 ```

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -57,7 +57,7 @@ $ gc init ~/my-city
 Welcome to Gas City SDK!
 
 Choose a config template:
-  1. tutorial  — default coding agent (default)
+  1. minimal   — default coding agent (default)
   2. gastown   — multi-agent orchestration pack
   3. custom    — empty workspace, configure it yourself
 Template [1]:
@@ -80,7 +80,7 @@ Agent [1]:
 [3/8] Scaffolding agent prompts
 [4/8] Writing pack.toml
 [5/8] Writing city configuration
-Created tutorial config (Level 1) in "my-city".
+Created minimal config (Level 1) in "my-city".
 [6/8] Checking provider readiness
 [7/8] Registering city with supervisor
 Registered city 'my-city' (/Users/csells/my-city)
@@ -123,7 +123,7 @@ At the top level of the city directory:
 
 This city comes with a built-in `mayor` agent. The mayor's prompt lives at
 `agents/mayor/prompt.template.md`, and `pack.toml` defines the always-on mayor
-session that uses it. Assuming you chose the default `tutorial` config
+session that uses it. Assuming you chose the default `minimal` config
 template and default provider, `city.toml` keeps the shared runtime settings:
 
 ```shell

--- a/docs/tutorials/04-communication.md
+++ b/docs/tutorials/04-communication.md
@@ -133,7 +133,7 @@ awareness of Gas City. Hooks wire the provider's event system into Gas City so
 agents can receive mail, pick up slung work, and drain queued nudges
 automatically.
 
-The tutorial template sets hooks at the workspace level, so all your agents
+The minimal template sets hooks at the workspace level, so all your agents
 already have them:
 
 ```toml

--- a/engdocs/design/named-configured-sessions.md
+++ b/engdocs/design/named-configured-sessions.md
@@ -771,7 +771,7 @@ Rationale:
 - `witness`: proactive patrol loop per rig
 - `refinery`: canonical merge queue endpoint, wake on work
 
-For the lifecycle/tutorial packs, `refinery` should also be expressed as
+For the lifecycle and minimal packs, `refinery` should also be expressed as
 an `on_demand` named session instead of an implicit singleton.
 
 ### Refinery does not need a new "check" feature
@@ -913,7 +913,7 @@ identity.
    helpers in desired-state and wake evaluation.
 3. Centralize configured-session materialization through one aliased
    helper and switch mail/nudge/sling/workflow to use it.
-4. Update Gastown and tutorial/lifecycle packs to declare explicit named
+4. Update Gastown and the minimal/lifecycle packs to declare explicit named
    sessions.
 5. Update status output and tests so canonical named sessions, not plain
    templates, define singleton runtime presence.
@@ -945,5 +945,5 @@ identity.
 - `gc session new <template>` continues to create fresh ordinary
   sessions even when a configured named session reserves the same
   qualified identity.
-- Gastown and lifecycle/tutorial configs work through explicit named
+- Gastown and lifecycle/minimal configs work through explicit named
   sessions instead of implicit singleton templates.

--- a/test/acceptance/agent_env_test.go
+++ b/test/acceptance/agent_env_test.go
@@ -43,9 +43,9 @@ func TestConfigLoad_GastownCityAgents(t *testing.T) {
 	}
 }
 
-// TestConfigLoad_TutorialAgent verifies the tutorial config produces
+// TestConfigLoad_MinimalAgent verifies the minimal config produces
 // at least one agent.
-func TestConfigLoad_TutorialAgent(t *testing.T) {
+func TestConfigLoad_MinimalAgent(t *testing.T) {
 	c := helpers.NewCity(t, testEnv)
 	c.Init("claude")
 
@@ -55,7 +55,7 @@ func TestConfigLoad_TutorialAgent(t *testing.T) {
 	}
 
 	if !strings.Contains(out, "Agent:") {
-		t.Fatal("config explain shows no agents for tutorial config")
+		t.Fatal("config explain shows no agents for minimal config")
 	}
 }
 

--- a/test/acceptance/init_lifecycle_test.go
+++ b/test/acceptance/init_lifecycle_test.go
@@ -49,9 +49,9 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// TestInitTutorial verifies that gc init with the default tutorial
+// TestInitMinimal verifies that gc init with the default minimal
 // template creates a working city with city.toml, prompts, and formulas.
-func TestInitTutorial(t *testing.T) {
+func TestInitMinimal(t *testing.T) {
 	c := helpers.NewCity(t, testEnv)
 	c.Init("claude")
 

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/01-cities-and-rigs.md
@@ -46,7 +46,7 @@ $ gc init ~/my-city
 Welcome to Gas City SDK!
 
 Choose a config template:
-  1. tutorial  — default coding agent (default)
+  1. minimal   — default coding agent (default)
   2. gastown   — multi-agent orchestration pack
   3. custom    — empty workspace, configure it yourself
 Template [1]:
@@ -69,7 +69,7 @@ Agent [1]:
 [3/8] Scaffolding agent prompts
 [4/8] Writing pack.toml
 [5/8] Writing city configuration
-Created tutorial config (Level 1) in "my-city".
+Created minimal config (Level 1) in "my-city".
 [6/8] Checking provider readiness
 [7/8] Registering city with supervisor
 Registered city 'my-city' (/Users/csells/my-city)
@@ -112,7 +112,7 @@ At the top level of the city directory:
 
 This city comes with a built-in `mayor` agent. The mayor's prompt lives at
 `agents/mayor/prompt.template.md`, and `pack.toml` defines the always-on mayor
-session that uses it. Assuming you chose the default `tutorial` config
+session that uses it. Assuming you chose the default `minimal` config
 template and default provider, `city.toml` keeps the city-local runtime
 settings:
 

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/02-agents.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/02-agents.md
@@ -15,7 +15,7 @@ We'll pick up where Tutorial 01 left off. You should have `my-city` running with
 
 ## Defining an agent
 
-Open `city.toml`. You already have a `mayor` agent from the tutorial template.
+Open `city.toml`. You already have a `mayor` agent from the minimal template.
 Let's add a second agent that uses `codex` instead of `claude`:
 
 ```toml

--- a/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/04-communication.md
+++ b/test/acceptance/tutorial_goldens/testdata/140d5ac39/docs/tutorials/04-communication.md
@@ -122,7 +122,7 @@ awareness of Gas City. Hooks wire the provider's event system into Gas City so
 agents can receive mail, pick up slung work, and drain queued nudges
 automatically.
 
-The tutorial template sets hooks at the workspace level, so all your agents
+The minimal template sets hooks at the workspace level, so all your agents
 already have them:
 
 ```toml

--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -391,7 +391,7 @@ func setupE2ECity(t *testing.T, guard *tmuxtest.Guard, city e2eCity) string {
 	copyE2EScripts(t, cityDir)
 
 	// gc init — seed the city directly from the intended E2E config rather than
-	// the default tutorial scaffold, which brings along unrelated hooks/packs.
+	// the default minimal scaffold, which brings along unrelated hooks/packs.
 	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", "--file", configPath, cityDir)
 	if err != nil {
 		t.Fatalf("gc init failed: %v\noutput: %s", err, out)

--- a/test/integration/gastown_multirig_test.go
+++ b/test/integration/gastown_multirig_test.go
@@ -68,7 +68,7 @@ func waitForActiveSessionTargets(t *testing.T, cityDir string, targets []string,
 // directories under an isolated integration GC_HOME. Returns the city
 // directory and a slice of rig directory paths.
 //
-// The city starts with the default tutorial scaffold. Callers overwrite
+// The city starts with the default minimal scaffold. Callers overwrite
 // city.toml afterward and use gc restart/start against the isolated
 // supervisor-managed city registered for this path.
 func setupMultiRigCity(t *testing.T, rigCount int) (cityDir string, rigDirs []string) {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -69,7 +69,7 @@ func setupCity(t *testing.T, guard *tmuxtest.Guard, agents []agentConfig) string
 	}
 
 	// gc init --file seeds the city directly from the intended config instead
-	// of creating the tutorial scaffold and mutating it afterward.
+	// of creating the minimal scaffold and mutating it afterward.
 	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", "--file", configPath, cityDir)
 	if err != nil {
 		t.Fatalf("gc init --file failed: %v\noutput: %s", err, out)


### PR DESCRIPTION
## Summary
- rename the default `gc init` template label and success output from `tutorial` to `minimal`
- keep `tutorial` accepted as a compatibility alias in the interactive wizard
- update init-path tests and tutorial docs/golden snapshots to match the new name

## Testing
- `go test ./cmd/gc -run 'TestRunWizard|TestDoInitWithWizardConfig|TestDoInitWithCustomCommand|TestDoInitWithProviderFlagAndBootstrapProfile|TestDoInitWithOpenCodeProviderInstallsWorkspaceHooks|TestDoInitWithClaudeProviderLeavesWorkspaceHooksEmpty|TestInitNameFlagWithBareInit|TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration'`
- `go test ./test/docsync`
- `go test -tags acceptance_a ./test/acceptance -run 'TestInitTutorial|TestConfigLoad_TutorialAgent'`

Fixes #1012.