### PR TITLE
Fix Tutorial 01 managed Dolt path canonicalization

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -426,6 +426,7 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 }
 
 func cityRuntimeProcessEnv(cityPath string) []string {
+	cityPath = normalizePathForCompare(cityPath)
 	overrides := citylayout.CityRuntimeEnvMap(cityPath)
 	if cityUsesBdStoreContract(cityPath) {
 		source := map[string]string{"BEADS_DOLT_AUTO_START": "0"}

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -754,7 +754,7 @@ func validDoltRuntimeState(state doltRuntimeState, cityPath string) bool {
 		return false
 	}
 	expectedDataDir := filepath.Join(cityPath, ".beads", "dolt")
-	if filepath.Clean(strings.TrimSpace(state.DataDir)) != filepath.Clean(expectedDataDir) {
+	if !samePath(strings.TrimSpace(state.DataDir), expectedDataDir) {
 		return false
 	}
 	if !pidAlive(state.PID) {
@@ -1231,6 +1231,7 @@ func runProviderProbe(script, cityPath, provider string) bool {
 }
 
 func providerLifecycleDoltPathEnv(cityPath string) []string {
+	cityPath = normalizePathForCompare(cityPath)
 	packStateDir := citylayout.PackStateDir(cityPath, "dolt")
 	dataDir := filepath.Join(cityPath, ".beads", "dolt")
 	return []string{
@@ -1248,6 +1249,7 @@ func providerLifecycleProcessEnv(cityPath, provider string) []string {
 	if strings.TrimSpace(cityPath) == "" {
 		return nil
 	}
+	cityPath = normalizePathForCompare(cityPath)
 	env := cityRuntimeProcessEnv(cityPath)
 	if !providerUsesBdStoreContract(provider) {
 		return env

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -61,6 +61,7 @@ func TestEnsureBeadsProvider_exec(t *testing.T) {
 
 func TestProviderLifecycleProcessEnvProjectsCanonicalDoltPaths(t *testing.T) {
 	cityPath := t.TempDir()
+	wantCityPath := normalizePathForCompare(cityPath)
 	t.Setenv("GC_PACK_STATE_DIR", "/tmp/wrong-pack")
 	t.Setenv("GC_DOLT_DATA_DIR", "/tmp/wrong-data")
 	t.Setenv("GC_DOLT_LOG_FILE", "/tmp/wrong-log")
@@ -78,14 +79,57 @@ func TestProviderLifecycleProcessEnvProjectsCanonicalDoltPaths(t *testing.T) {
 		}
 	}
 
-	packStateDir := citylayout.PackStateDir(cityPath, "dolt")
+	packStateDir := citylayout.PackStateDir(wantCityPath, "dolt")
 	want := map[string]string{
 		"GC_PACK_STATE_DIR":   packStateDir,
-		"GC_DOLT_DATA_DIR":    filepath.Join(cityPath, ".beads", "dolt"),
+		"GC_DOLT_DATA_DIR":    filepath.Join(wantCityPath, ".beads", "dolt"),
 		"GC_DOLT_LOG_FILE":    filepath.Join(packStateDir, "dolt.log"),
 		"GC_DOLT_STATE_FILE":  filepath.Join(packStateDir, "dolt-provider-state.json"),
 		"GC_DOLT_PID_FILE":    filepath.Join(packStateDir, "dolt.pid"),
 		"GC_DOLT_LOCK_FILE":   filepath.Join(packStateDir, "dolt.lock"),
+		"GC_DOLT_CONFIG_FILE": filepath.Join(packStateDir, "dolt-config.yaml"),
+	}
+	for key, expected := range want {
+		if got := env[key]; got != expected {
+			t.Fatalf("providerLifecycleProcessEnv()[%s] = %q, want %q", key, got, expected)
+		}
+	}
+}
+
+func TestProviderLifecycleProcessEnvCanonicalizesSymlinkedCityPath(t *testing.T) {
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	if err := os.MkdirAll(realParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasParent := filepath.Join(root, "alias")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skip("symlinks not supported")
+	}
+	aliasCity := filepath.Join(aliasParent, "bright-lights")
+	realCity := filepath.Join(realParent, "bright-lights")
+	if err := os.MkdirAll(realCity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantCityPath := normalizePathForCompare(realCity)
+
+	envEntries := providerLifecycleProcessEnv(aliasCity, "exec:"+gcBeadsBdScriptPath(aliasCity))
+	env := map[string]string{}
+	for _, entry := range envEntries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+
+	packStateDir := citylayout.PackStateDir(wantCityPath, "dolt")
+	want := map[string]string{
+		"GC_CITY":             wantCityPath,
+		"GC_CITY_PATH":        wantCityPath,
+		"GC_CITY_RUNTIME_DIR": filepath.Join(wantCityPath, ".gc", "runtime"),
+		"GC_PACK_STATE_DIR":   packStateDir,
+		"GC_DOLT_DATA_DIR":    filepath.Join(wantCityPath, ".beads", "dolt"),
+		"GC_DOLT_STATE_FILE":  filepath.Join(packStateDir, "dolt-provider-state.json"),
 		"GC_DOLT_CONFIG_FILE": filepath.Join(packStateDir, "dolt-config.yaml"),
 	}
 	for key, expected := range want {

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -62,16 +62,17 @@ func requireDeletedPathHeld(t *testing.T, pid int, targetPath string) {
 
 func TestDoltStateRuntimeLayoutCmdUsesCanonicalPaths(t *testing.T) {
 	cityPath := t.TempDir()
+	wantCityPath := normalizePathForCompare(cityPath)
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"dolt-state", "runtime-layout", "--city", cityPath}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
 	}
 	got := parseDoltRuntimeLayoutOutput(t, stdout.String())
-	wantPack := citylayout.PackStateDir(cityPath, "dolt")
+	wantPack := citylayout.PackStateDir(wantCityPath, "dolt")
 	want := map[string]string{
 		"GC_PACK_STATE_DIR":   wantPack,
-		"GC_DOLT_DATA_DIR":    filepath.Join(cityPath, ".beads", "dolt"),
+		"GC_DOLT_DATA_DIR":    filepath.Join(wantCityPath, ".beads", "dolt"),
 		"GC_DOLT_LOG_FILE":    filepath.Join(wantPack, "dolt.log"),
 		"GC_DOLT_STATE_FILE":  filepath.Join(wantPack, "dolt-provider-state.json"),
 		"GC_DOLT_PID_FILE":    filepath.Join(wantPack, "dolt.pid"),
@@ -82,6 +83,43 @@ func TestDoltStateRuntimeLayoutCmdUsesCanonicalPaths(t *testing.T) {
 		if got[key] != wantValue {
 			t.Fatalf("%s = %q, want %q; output=%q", key, got[key], wantValue, stdout.String())
 		}
+	}
+}
+
+func TestResolveManagedDoltRuntimeLayoutCanonicalizesSymlinkedCityPath(t *testing.T) {
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	if err := os.MkdirAll(realParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasParent := filepath.Join(root, "alias")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skip("symlinks not supported")
+	}
+	aliasCity := filepath.Join(aliasParent, "bright-lights")
+	realCity := filepath.Join(realParent, "bright-lights")
+	if err := os.MkdirAll(realCity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantCityPath := normalizePathForCompare(realCity)
+
+	layout, err := resolveManagedDoltRuntimeLayout(aliasCity)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	packStateDir := citylayout.PackStateDir(wantCityPath, "dolt")
+	want := managedDoltRuntimeLayout{
+		PackStateDir: packStateDir,
+		DataDir:      filepath.Join(wantCityPath, ".beads", "dolt"),
+		LogFile:      filepath.Join(packStateDir, "dolt.log"),
+		StateFile:    filepath.Join(packStateDir, "dolt-provider-state.json"),
+		PIDFile:      filepath.Join(packStateDir, "dolt.pid"),
+		LockFile:     filepath.Join(packStateDir, "dolt.lock"),
+		ConfigFile:   filepath.Join(packStateDir, "dolt-config.yaml"),
+	}
+	if layout != want {
+		t.Fatalf("resolveManagedDoltRuntimeLayout() = %+v, want %+v", layout, want)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -60,6 +60,25 @@ func requireDeletedPathHeld(t *testing.T, pid int, targetPath string) {
 	}
 }
 
+func symlinkedCityPaths(t *testing.T) (aliasCity, realCity string) {
+	t.Helper()
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	if err := os.MkdirAll(realParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasParent := filepath.Join(root, "alias")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skip("symlinks not supported")
+	}
+	aliasCity = filepath.Join(aliasParent, "bright-lights")
+	realCity = filepath.Join(realParent, "bright-lights")
+	if err := os.MkdirAll(realCity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return aliasCity, realCity
+}
+
 func TestDoltStateRuntimeLayoutCmdUsesCanonicalPaths(t *testing.T) {
 	cityPath := t.TempDir()
 	wantCityPath := normalizePathForCompare(cityPath)
@@ -87,20 +106,7 @@ func TestDoltStateRuntimeLayoutCmdUsesCanonicalPaths(t *testing.T) {
 }
 
 func TestResolveManagedDoltRuntimeLayoutCanonicalizesSymlinkedCityPath(t *testing.T) {
-	root := t.TempDir()
-	realParent := filepath.Join(root, "real")
-	if err := os.MkdirAll(realParent, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	aliasParent := filepath.Join(root, "alias")
-	if err := os.Symlink(realParent, aliasParent); err != nil {
-		t.Skip("symlinks not supported")
-	}
-	aliasCity := filepath.Join(aliasParent, "bright-lights")
-	realCity := filepath.Join(realParent, "bright-lights")
-	if err := os.MkdirAll(realCity, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	aliasCity, realCity := symlinkedCityPaths(t)
 	wantCityPath := normalizePathForCompare(realCity)
 
 	layout, err := resolveManagedDoltRuntimeLayout(aliasCity)
@@ -120,6 +126,109 @@ func TestResolveManagedDoltRuntimeLayoutCanonicalizesSymlinkedCityPath(t *testin
 	}
 	if layout != want {
 		t.Fatalf("resolveManagedDoltRuntimeLayout() = %+v, want %+v", layout, want)
+	}
+}
+
+func TestValidDoltRuntimeStateAcceptsSymlinkEquivalentDataDir(t *testing.T) {
+	aliasCity, realCity := symlinkedCityPaths(t)
+	layout, err := resolveManagedDoltRuntimeLayout(realCity)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	cases := []struct {
+		name     string
+		cityPath string
+		dataDir  string
+	}{
+		{
+			name:     "real state data dir against aliased city path",
+			cityPath: aliasCity,
+			dataDir:  layout.DataDir,
+		},
+		{
+			name:     "aliased state data dir against real city path",
+			cityPath: realCity,
+			dataDir:  filepath.Join(aliasCity, ".beads", "dolt"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := doltRuntimeState{
+				Running:   true,
+				PID:       listener.Process.Pid,
+				Port:      port,
+				DataDir:   tc.dataDir,
+				StartedAt: time.Now().UTC().Format(time.RFC3339),
+			}
+			if !validDoltRuntimeState(state, tc.cityPath) {
+				t.Fatalf("validDoltRuntimeState(%q, %q) = false, want true", tc.dataDir, tc.cityPath)
+			}
+		})
+	}
+}
+
+func TestRepairedManagedDoltRuntimeStateAcceptsSymlinkEquivalentDataDir(t *testing.T) {
+	aliasCity, realCity := symlinkedCityPaths(t)
+	layout, err := resolveManagedDoltRuntimeLayout(realCity)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	cases := []struct {
+		name    string
+		dataDir string
+	}{
+		{
+			name:    "real data dir",
+			dataDir: layout.DataDir,
+		},
+		{
+			name:    "aliased data dir",
+			dataDir: filepath.Join(aliasCity, ".beads", "dolt"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repaired, ok := repairedManagedDoltRuntimeState(aliasCity, layout, doltRuntimeState{
+				Port:    port,
+				DataDir: tc.dataDir,
+			})
+			if !ok {
+				t.Fatalf("repairedManagedDoltRuntimeState(%q) = not ok, want ok", tc.dataDir)
+			}
+			if !repaired.Running {
+				t.Fatal("repaired state Running = false, want true")
+			}
+			if repaired.PID != listener.Process.Pid {
+				t.Fatalf("repaired state PID = %d, want %d", repaired.PID, listener.Process.Pid)
+			}
+			if repaired.Port != port {
+				t.Fatalf("repaired state Port = %d, want %d", repaired.Port, port)
+			}
+			if repaired.DataDir != layout.DataDir {
+				t.Fatalf("repaired state DataDir = %q, want %q", repaired.DataDir, layout.DataDir)
+			}
+			if strings.TrimSpace(repaired.StartedAt) == "" {
+				t.Fatal("repaired state StartedAt is empty")
+			}
+		})
 	}
 }
 
@@ -166,6 +275,26 @@ func TestDoltStateAllocatePortCmdHonorsEnvOverride(t *testing.T) {
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "4406" {
 		t.Fatalf("allocate-port = %q, want 4406", got)
+	}
+}
+
+func TestChooseManagedDoltPortUsesCanonicalSeedForSymlinkedCityPath(t *testing.T) {
+	aliasCity, realCity := symlinkedCityPaths(t)
+
+	if got, want := deterministicManagedDoltPortSeed(aliasCity), deterministicManagedDoltPortSeed(realCity); got != want {
+		t.Fatalf("deterministicManagedDoltPortSeed(alias) = %d, want %d", got, want)
+	}
+
+	aliasPort, err := chooseManagedDoltPort(aliasCity, "")
+	if err != nil {
+		t.Fatalf("chooseManagedDoltPort(alias): %v", err)
+	}
+	realPort, err := chooseManagedDoltPort(realCity, "")
+	if err != nil {
+		t.Fatalf("chooseManagedDoltPort(real): %v", err)
+	}
+	if aliasPort != realPort {
+		t.Fatalf("chooseManagedDoltPort(alias) = %q, want %q", aliasPort, realPort)
 	}
 }
 

--- a/cmd/gc/dolt_port_selection.go
+++ b/cmd/gc/dolt_port_selection.go
@@ -12,6 +12,7 @@ import (
 )
 
 func chooseManagedDoltPort(cityPath, stateFile string) (string, error) {
+	cityPath = normalizePathForCompare(cityPath)
 	if port := strings.TrimSpace(os.Getenv("GC_DOLT_PORT")); port != "" {
 		return port, nil
 	}
@@ -91,6 +92,7 @@ func repairedManagedDoltRuntimeState(_ string, layout managedDoltRuntimeLayout, 
 }
 
 func deterministicManagedDoltPortSeed(cityPath string) int {
+	cityPath = normalizePathForCompare(cityPath)
 	if seed, err := cksumManagedDoltPortSeed(cityPath); err == nil {
 		return seed
 	}

--- a/cmd/gc/dolt_runtime_layout.go
+++ b/cmd/gc/dolt_runtime_layout.go
@@ -24,6 +24,7 @@ func resolveManagedDoltRuntimeLayout(cityPath string) (managedDoltRuntimeLayout,
 	if cityPath == "" || cityPath == "." {
 		return managedDoltRuntimeLayout{}, fmt.Errorf("missing --city")
 	}
+	cityPath = normalizePathForCompare(cityPath)
 
 	packStateDir := strings.TrimSpace(os.Getenv("GC_PACK_STATE_DIR"))
 	if packStateDir == "" {
@@ -53,9 +54,9 @@ func resolveManagedDoltRuntimeLayout(cityPath string) (managedDoltRuntimeLayout,
 
 func defaultEnvPath(key, fallback string) string {
 	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-		return value
+		return normalizePathForCompare(value)
 	}
-	return fallback
+	return normalizePathForCompare(fallback)
 }
 
 func doltRuntimeLayoutFields(layout managedDoltRuntimeLayout) []string {


### PR DESCRIPTION
## Summary
- canonicalize city paths before projecting managed Dolt lifecycle env
- canonicalize managed Dolt runtime layout paths and port seeds
- accept equivalent symlinked data_dir paths when validating/repairing runtime state
- add direct alias-vs-canonical tests for runtime-state validation/repair and deterministic port selection

## Validation
- go test ./cmd/gc -run '^(TestProviderLifecycleProcessEnvCanonicalizesSymlinkedCityPath|TestResolveManagedDoltRuntimeLayoutCanonicalizesSymlinkedCityPath|TestProviderLifecycleProcessEnvProjectsCanonicalDoltPaths|TestDoltStateRuntimeLayoutCmdUsesCanonicalPaths|TestDoltStateRuntimeLayoutCmdHonorsProjectedOverrides|TestGcBeadsBdStartManagedHelperDoesNotInheritStartLockFD)$' -count=1
- go test ./cmd/gc -run '^(TestValidDoltRuntimeStateAcceptsSymlinkEquivalentDataDir|TestRepairedManagedDoltRuntimeStateAcceptsSymlinkEquivalentDataDir|TestChooseManagedDoltPortUsesCanonicalSeedForSymlinkedCityPath)$' -count=1
- go vet ./cmd/gc

## Notes
- Supersedes #1065
- Credit: original fix by @csells
- Maintainer follow-up: add the missing direct coverage for the load-bearing symlink-equivalence paths called out in adoption review
- Related to #1013
