### PR TITLE
feat: drain ACP queued nudges in reconciler tick

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1437,6 +1437,18 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
 	}
 
+	// Drain queued nudges for ACP sessions in-process. The nudge
+	// poller (gc nudge poll) skips ACP sessions because it spawns a
+	// separate process without in-process ACP connections. The
+	// reconciler runs inside the supervisor and holds the live
+	// provider, so it can deliver directly.
+	acpTargets := buildACPNudgeTargets(cr.cityPath, cr.cfg, result, sessionBeads)
+	if len(acpTargets) > 0 {
+		if _, err := drainACPQueuedNudges(cr.cityPath, cr.sp, acpTargets, time.Now()); err != nil {
+			fmt.Fprintf(cr.stderr, "%s: draining ACP nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
+		}
+	}
+
 	// Idle recovery: detect pool sessions stuck at the prompt after
 }
 

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -571,10 +571,13 @@ func TestControllerReloadsConfigImmediatelyOnWatchEvent(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
+	before := reconcileCount.Load()
 	writeCityTOML(t, dir, "test", "mayor", "worker")
 
+	// Wait for "Config reloaded" AND at least one reconcile after
+	// the reload so that buildFn has run with the new config.
 	deadline := time.After(5 * time.Second)
-	for !strings.Contains(stdout.String(), "Config reloaded") {
+	for !strings.Contains(stdout.String(), "Config reloaded") || reconcileCount.Load() <= before {
 		select {
 		case <-deadline:
 			t.Fatalf("timed out waiting for immediate config reload; reconciles=%d stdout=%q stderr=%q",

--- a/cmd/gc/nudge_acp_drain.go
+++ b/cmd/gc/nudge_acp_drain.go
@@ -80,7 +80,11 @@ func drainACPQueuedNudges(
 		// matching the poller path (tryDeliverQueuedNudgesByPoller).
 		handle, err := workerHandleForNudgeTarget(target, store, sp)
 		if err != nil {
-			return totalDelivered, fmt.Errorf("worker handle for %s: %w", target.sessionName, err)
+			telemetry.RecordNudge(context.Background(), target.agentKey(), err)
+			if recErr := recordQueuedNudgeFailure(cityPath, queuedNudgeIDs(items), err, now); recErr != nil {
+				return totalDelivered, fmt.Errorf("recording ACP handle failure: %w", recErr)
+			}
+			continue
 		}
 		result, err := handle.Nudge(context.Background(), worker.NudgeRequest{
 			Text:     msg,

--- a/cmd/gc/nudge_acp_drain.go
+++ b/cmd/gc/nudge_acp_drain.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/telemetry"
+	"github.com/gastownhall/gascity/internal/worker"
+)
+
+// drainACPQueuedNudges claims due queued nudges for ACP sessions and
+// delivers them via the in-process session provider. It mirrors the
+// poller path (tryDeliverQueuedNudgesByPoller) — session fencing,
+// delivery blocking, message batching — so that nudge semantics are
+// identical regardless of transport.
+//
+// This must run inside the supervisor/controller process where the ACP
+// provider holds live connections.
+//
+// Returns the number of nudges successfully delivered.
+func drainACPQueuedNudges(
+	cityPath string,
+	sp runtime.Provider,
+	acpTargets []nudgeTarget,
+	now time.Time,
+) (int, error) {
+	if len(acpTargets) == 0 {
+		return 0, nil
+	}
+
+	totalDelivered := 0
+	store := openNudgeBeadStore(cityPath)
+	for _, target := range acpTargets {
+		if !sp.IsRunning(target.sessionName) {
+			continue
+		}
+
+		// Claim due nudges matching this target (agent key + session fence).
+		claimed, err := claimDueQueuedNudgesForTarget(cityPath, target, now)
+		if err != nil {
+			return totalDelivered, fmt.Errorf("claiming ACP nudges for %s: %w", target.sessionName, err)
+		}
+		if len(claimed) == 0 {
+			continue
+		}
+
+		// Filter out nudges that don't match the session fence
+		// (SessionID / ContinuationEpoch mismatch).
+		items, rejected := splitQueuedNudgesForTarget(target, claimed)
+		if len(rejected) > 0 {
+			if err := recordQueuedNudgeFailure(cityPath, queuedNudgeIDs(rejected), errNudgeSessionFenceMismatch, now); err != nil {
+				return totalDelivered, fmt.Errorf("recording fenced ACP nudge failures: %w", err)
+			}
+		}
+
+		// Filter out nudges blocked by wait-bead state (canceled,
+		// expired, etc.).
+		items, blocked, err := splitQueuedNudgesForDelivery(store, items)
+		if err != nil {
+			return totalDelivered, fmt.Errorf("checking ACP nudge delivery: %w", err)
+		}
+		if len(blocked) > 0 {
+			if err := terminalizeBlockedQueuedNudges(cityPath, blocked); err != nil {
+				return totalDelivered, fmt.Errorf("terminalizing blocked ACP nudges: %w", err)
+			}
+		}
+		if len(items) == 0 {
+			continue
+		}
+
+		// Batch into one message per session (matches poller behavior).
+		msg := formatNudgeRuntimeMessage(items)
+
+		// Deliver via worker handle to get delivery confirmation,
+		// matching the poller path (tryDeliverQueuedNudgesByPoller).
+		handle, err := workerHandleForNudgeTarget(target, store, sp)
+		if err != nil {
+			return totalDelivered, fmt.Errorf("worker handle for %s: %w", target.sessionName, err)
+		}
+		result, err := handle.Nudge(context.Background(), worker.NudgeRequest{
+			Text:     msg,
+			Delivery: worker.NudgeDeliveryDefault,
+			Source:   "queue",
+			Wake:     worker.NudgeWakeLiveOnly,
+		})
+		if err != nil {
+			telemetry.RecordNudge(context.Background(), target.agentKey(), err)
+			if recErr := recordQueuedNudgeFailure(cityPath, queuedNudgeIDs(items), err, now); recErr != nil {
+				return totalDelivered, fmt.Errorf("recording ACP nudge failure: %w", recErr)
+			}
+			continue
+		}
+		if !result.Delivered {
+			continue
+		}
+
+		telemetry.RecordNudge(context.Background(), target.agentKey(), nil)
+		if err := ackQueuedNudges(cityPath, queuedNudgeIDs(items)); err != nil {
+			return totalDelivered, fmt.Errorf("acking ACP nudges: %w", err)
+		}
+		totalDelivered += len(items)
+	}
+
+	return totalDelivered, nil
+}
+
+// buildACPNudgeTargets builds nudgeTarget values for all active ACP
+// sessions, using session bead metadata for fencing (SessionID,
+// ContinuationEpoch) and DesiredStateResult for ACP routing.
+//
+// This mirrors how resolveNudgeTargetFromSessionBead builds targets for
+// the poller, but sources data from the reconciler's in-memory state
+// instead of a fresh store query.
+func buildACPNudgeTargets(
+	cityPath string,
+	cfg *config.City,
+	result DesiredStateResult,
+	sessionBeads *sessionBeadSnapshot,
+) []nudgeTarget {
+	// Build a set of ACP session names from desired state.
+	acpSessions := make(map[string]TemplateParams)
+	for _, tp := range result.State {
+		if tp.IsACP && tp.SessionName != "" {
+			acpSessions[tp.SessionName] = tp
+		}
+	}
+	if len(acpSessions) == 0 {
+		return nil
+	}
+
+	cityName := loadedCityName(cfg, cityPath)
+
+	// Match session beads to ACP sessions for fencing metadata.
+	var targets []nudgeTarget
+	matched := make(map[string]bool)
+	if sessionBeads != nil {
+		for _, b := range sessionBeads.Open() {
+			sessName := strings.TrimSpace(b.Metadata["session_name"])
+			tp, ok := acpSessions[sessName]
+			if !ok {
+				continue
+			}
+			matched[sessName] = true
+			targets = append(targets, nudgeTarget{
+				cityPath:          cityPath,
+				cityName:          cityName,
+				cfg:               cfg,
+				alias:             tp.Alias,
+				identity:          firstNonEmpty(tp.InstanceName, tp.TemplateName),
+				transport:         "acp",
+				resolved:          tp.ResolvedProvider,
+				sessionID:         b.ID,
+				continuationEpoch: strings.TrimSpace(b.Metadata["continuation_epoch"]),
+				sessionName:       sessName,
+				aliasHistory:      session.AliasHistory(b.Metadata),
+				agent:             resolveAgentForNudge(cfg, tp),
+			})
+		}
+	}
+
+	// ACP sessions without a session bead (e.g., just started, bead not
+	// yet created) get a target without fencing — they'll only match
+	// nudges that don't carry SessionID/ContinuationEpoch.
+	for sessName, tp := range acpSessions {
+		if matched[sessName] {
+			continue
+		}
+		targets = append(targets, nudgeTarget{
+			cityPath:    cityPath,
+			cityName:    cityName,
+			cfg:         cfg,
+			alias:       tp.Alias,
+			identity:    firstNonEmpty(tp.InstanceName, tp.TemplateName),
+			transport:   "acp",
+			resolved:    tp.ResolvedProvider,
+			sessionName: sessName,
+			agent:       resolveAgentForNudge(cfg, tp),
+		})
+	}
+
+	return targets
+}
+
+// resolveAgentForNudge looks up the agent config for a TemplateParams.
+func resolveAgentForNudge(cfg *config.City, tp TemplateParams) config.Agent {
+	if cfg == nil {
+		return config.Agent{}
+	}
+	for _, candidate := range []string{tp.InstanceName, tp.TemplateName, tp.Alias} {
+		if candidate == "" {
+			continue
+		}
+		found, ok := resolveAgentIdentity(cfg, candidate, "")
+		if ok {
+			return found
+		}
+	}
+	return config.Agent{}
+}

--- a/cmd/gc/nudge_acp_drain_test.go
+++ b/cmd/gc/nudge_acp_drain_test.go
@@ -1,0 +1,847 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/nudgequeue"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestDrainACPQueuedNudges_DeliversDueNudge(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-1",
+			Agent:        "hermes/polecat",
+			Message:      "hello from queue",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 1 {
+		t.Errorf("delivered = %d, want 1", delivered)
+	}
+
+	// Verify nudge removed from both pending and in_flight (acked).
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 0 {
+		t.Errorf("pending = %d, want 0", len(remaining.Pending))
+	}
+	if len(remaining.InFlight) != 0 {
+		t.Errorf("in_flight = %d, want 0 (should be acked)", len(remaining.InFlight))
+	}
+}
+
+func TestDrainACPQueuedNudges_SkipsNotYetDue(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-future",
+			Agent:        "hermes/polecat",
+			Message:      "not yet",
+			Source:       "session",
+			CreatedAt:    now,
+			DeliverAfter: now.Add(1 * time.Hour),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0 (not yet due)", delivered)
+	}
+}
+
+func TestDrainACPQueuedNudges_AgentMismatch_NotClaimed(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	// Start the polecat session so IsRunning passes — proving the skip
+	// is due to agent-key mismatch in claim, not a session state issue.
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-dog",
+			Agent:        "dog",
+			Message:      "woof",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	// Target is polecat; queued nudge is for "dog". The nudge should
+	// not match because the agent keys differ.
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0 (agent mismatch)", delivered)
+	}
+
+	// Nudge must remain pending — claim should not match it.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Errorf("pending = %d, want 1 (dog nudge untouched)", len(remaining.Pending))
+	}
+	// No Nudge calls should have been made.
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" {
+			t.Errorf("unexpected Nudge call: %v", c)
+		}
+	}
+}
+
+func TestDrainACPQueuedNudges_SessionNotRunning_Skipped(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	// Don't start the session — it won't be running.
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-norun",
+			Agent:        "hermes/polecat",
+			Message:      "nobody home",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0", delivered)
+	}
+
+	// Nudge should still be pending — session not running means we skip,
+	// not claim-and-fail.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Errorf("pending = %d, want 1 (left for next tick)", len(remaining.Pending))
+	}
+}
+
+func TestDrainACPQueuedNudges_SessionFenceMismatch_NotClaimed(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	now := time.Now()
+	// Queue a nudge fenced to a different session ID.
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-fenced",
+			Agent:        "hermes/polecat",
+			SessionID:    "old-session-bead-id",
+			Message:      "for old session",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	// Target has a different session ID (current session). The fenced
+	// nudge should not be claimable by this target.
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		sessionID:   "current-session-bead-id",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0 (fenced nudge not claimable)", delivered)
+	}
+
+	// Nudge should remain in pending — it belongs to a different session.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Errorf("pending = %d, want 1 (fenced nudge stays for its session)", len(remaining.Pending))
+	}
+	// No Nudge calls should have been made.
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" {
+			t.Errorf("unexpected Nudge call: %v", c)
+		}
+	}
+}
+
+func TestDrainACPQueuedNudges_BatchesMultipleNudges(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		for i, msg := range []string{"first", "second", "third"} {
+			s.Pending = append(s.Pending, nudgequeue.Item{
+				ID:           fmt.Sprintf("nudge-%d", i),
+				Agent:        "hermes/polecat",
+				Message:      msg,
+				Source:       "session",
+				CreatedAt:    now.Add(-1 * time.Second),
+				DeliverAfter: now.Add(-1 * time.Second),
+				ExpiresAt:    now.Add(24 * time.Hour),
+			})
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 3 {
+		t.Errorf("delivered = %d, want 3", delivered)
+	}
+
+	// Verify only ONE Nudge call was made (batched).
+	nudgeCalls := 0
+	var nudgeMsg string
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" && c.Name == "hermes--polecat" {
+			nudgeCalls++
+			nudgeMsg = c.Message
+		}
+	}
+	if nudgeCalls != 1 {
+		t.Errorf("Nudge calls = %d, want 1 (batched)", nudgeCalls)
+	}
+	// All three messages should appear in the batched output.
+	for _, msg := range []string{"first", "second", "third"} {
+		if !strings.Contains(nudgeMsg, msg) {
+			t.Errorf("batched message missing %q: %s", msg, nudgeMsg)
+		}
+	}
+}
+
+func TestDrainACPQueuedNudges_NoTargets(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	delivered, err := drainACPQueuedNudges(cityPath, sp, nil, time.Now())
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0", delivered)
+	}
+}
+
+func TestBuildACPNudgeTargets(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{Agents: []config.Agent{{Name: "polecat", Dir: "hermes"}}}
+
+	// Create a session bead with fencing metadata.
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "hermes--polecat",
+			"continuation_epoch": "3",
+			"agent_name":         "hermes/polecat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{sessionBead})
+
+	result := DesiredStateResult{
+		State: map[string]TemplateParams{
+			"hermes--polecat": {SessionName: "hermes--polecat", IsACP: true, Alias: "hermes/polecat", TemplateName: "polecat"},
+			"dog-1":           {SessionName: "dog-1", IsACP: false, Alias: "dog"},
+		},
+	}
+
+	targets := buildACPNudgeTargets(cityPath, cfg, result, snapshot)
+	if len(targets) != 1 {
+		t.Fatalf("targets = %d, want 1", len(targets))
+	}
+	target := targets[0]
+	if target.sessionName != "hermes--polecat" {
+		t.Errorf("sessionName = %q, want hermes--polecat", target.sessionName)
+	}
+	if target.alias != "hermes/polecat" {
+		t.Errorf("alias = %q, want hermes/polecat", target.alias)
+	}
+	if target.sessionID != sessionBead.ID {
+		t.Errorf("sessionID = %q, want %q (from session bead)", target.sessionID, sessionBead.ID)
+	}
+	if target.continuationEpoch != "3" {
+		t.Errorf("continuationEpoch = %q, want '3'", target.continuationEpoch)
+	}
+	if target.transport != "acp" {
+		t.Errorf("transport = %q, want 'acp'", target.transport)
+	}
+}
+
+func TestBuildACPNudgeTargets_NoSessionBead(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{Agents: []config.Agent{{Name: "polecat", Dir: "hermes"}}}
+
+	result := DesiredStateResult{
+		State: map[string]TemplateParams{
+			"hermes--polecat": {SessionName: "hermes--polecat", IsACP: true, Alias: "hermes/polecat"},
+		},
+	}
+
+	// No session beads — target should still be created, but without fencing.
+	targets := buildACPNudgeTargets(cityPath, cfg, result, newSessionBeadSnapshot(nil))
+	if len(targets) != 1 {
+		t.Fatalf("targets = %d, want 1", len(targets))
+	}
+	if targets[0].sessionID != "" {
+		t.Errorf("sessionID = %q, want empty (no bead)", targets[0].sessionID)
+	}
+	if targets[0].continuationEpoch != "" {
+		t.Errorf("continuationEpoch = %q, want empty (no bead)", targets[0].continuationEpoch)
+	}
+}
+
+func TestBeadReconcileTick_DrainsACPQueuedNudges(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cityPath := t.TempDir()
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-via-tick",
+			Agent:        "hermes/polecat",
+			Message:      "tick nudge",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "test-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "polecat", Dir: "hermes"}}},
+		sp:                  sp,
+		standaloneCityStore: beads.NewMemStore(),
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	result := DesiredStateResult{
+		State: map[string]TemplateParams{
+			"hermes--polecat": {SessionName: "hermes--polecat", IsACP: true, Alias: "hermes/polecat"},
+		},
+	}
+
+	sessionBeads := newSessionBeadSnapshot(nil)
+	cr.beadReconcileTick(context.Background(), result, sessionBeads, nil)
+
+	// Verify the nudge was delivered via Nudge call.
+	var found bool
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" && c.Name == "hermes--polecat" && strings.Contains(c.Message, "tick nudge") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected Nudge call containing 'tick nudge', got calls: %v", sp.Calls)
+	}
+
+	// Verify the queue is empty (both pending and in_flight).
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 0 {
+		t.Errorf("pending = %d, want 0", len(remaining.Pending))
+	}
+	if len(remaining.InFlight) != 0 {
+		t.Errorf("in_flight = %d, want 0", len(remaining.InFlight))
+	}
+}
+
+// stoppingProvider wraps a Fake and stops the named session after the
+// first IsRunning call returns true. This simulates a session stopping
+// between the drain's IsRunning pre-check and the worker handle's
+// delivery attempt, ensuring nudges are not acked without confirmation.
+type stoppingProvider struct {
+	*runtime.Fake
+	stopAfter string
+	stopped   bool
+}
+
+func (p *stoppingProvider) IsRunning(name string) bool {
+	running := p.Fake.IsRunning(name)
+	if running && name == p.stopAfter && !p.stopped {
+		p.stopped = true
+		_ = p.Stop(name)
+	}
+	return running
+}
+
+// nudgeErrProvider wraps a Fake so that Nudge returns an error while
+// IsRunning still reports true. This exercises the handle.Nudge error
+// path (telemetry recording + failure recording) without affecting the
+// running state pre-check.
+type nudgeErrProvider struct {
+	*runtime.Fake
+	nudgeErr error
+}
+
+func (p *nudgeErrProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	p.Fake.Nudge(name, content) //nolint:errcheck // record the call
+	return p.nudgeErr
+}
+
+func TestDrainACPQueuedNudges_SessionStopsBeforeDelivery_NotAcked(t *testing.T) {
+	cityPath := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Wrap: first IsRunning returns true (drain pre-check passes),
+	// but stops the session so the worker handle's IsRunning returns false.
+	sp := &stoppingProvider{Fake: fake, stopAfter: "hermes--polecat"}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-vanish",
+			Agent:        "hermes/polecat",
+			Message:      "should not be acked",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0 (session stopped before delivery)", delivered)
+	}
+
+	// Nudge must NOT be acked — it should remain in-flight (claimed but
+	// not delivered) so a future tick can retry.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.InFlight) != 1 {
+		t.Errorf("in_flight = %d, want 1 (claimed but not delivered)", len(remaining.InFlight))
+	}
+	if len(remaining.Pending) != 0 {
+		t.Errorf("pending = %d, want 0 (should have been claimed)", len(remaining.Pending))
+	}
+}
+
+func TestDrainACPQueuedNudges_NudgeError_RecordsFailure(t *testing.T) {
+	cityPath := t.TempDir()
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp := &nudgeErrProvider{Fake: fake, nudgeErr: fmt.Errorf("connection reset")}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-err",
+			Agent:        "hermes/polecat",
+			Message:      "will fail",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{{
+		cityPath:    cityPath,
+		alias:       "hermes/polecat",
+		sessionName: "hermes--polecat",
+		transport:   "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0 (nudge errored)", delivered)
+	}
+
+	// Verify the Nudge call was actually attempted (proves the error
+	// comes from handle.Nudge, not an earlier short-circuit).
+	var nudgeAttempted bool
+	for _, c := range fake.Calls {
+		if c.Method == "Nudge" && c.Name == "hermes--polecat" {
+			nudgeAttempted = true
+			break
+		}
+	}
+	if !nudgeAttempted {
+		t.Error("no Nudge call recorded — error path was not reached")
+	}
+
+	// Nudge should be requeued after failure (not acked, not stuck in-flight).
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Errorf("pending = %d, want 1 (requeued after failure)", len(remaining.Pending))
+	}
+	if len(remaining.InFlight) != 0 {
+		t.Errorf("in_flight = %d, want 0 (not stuck in-flight)", len(remaining.InFlight))
+	}
+	if remaining.Pending[0].Attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (single failure recorded)", remaining.Pending[0].Attempts)
+	}
+	if remaining.Pending[0].LastError == "" {
+		t.Error("last_error is empty, want error message recorded")
+	}
+}
+
+func TestDrainACPQueuedNudges_StaleEpoch_ClaimedThenRejected(t *testing.T) {
+	cityPath := t.TempDir()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	now := time.Now()
+	// Queue a nudge fenced to the same session ID but a stale epoch.
+	// claimDueQueuedNudgesForTarget will claim it (session ID matches),
+	// but splitQueuedNudgesForTarget will reject it (epoch mismatch).
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:                "nudge-stale-epoch",
+			Agent:             "hermes/polecat",
+			SessionID:         "sess-bead-1",
+			ContinuationEpoch: "2",
+			Message:           "for old epoch",
+			Source:            "session",
+			CreatedAt:         now.Add(-1 * time.Second),
+			DeliverAfter:      now.Add(-1 * time.Second),
+			ExpiresAt:         now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	// Target has the same session ID but a newer epoch.
+	targets := []nudgeTarget{{
+		cityPath:          cityPath,
+		alias:             "hermes/polecat",
+		sessionName:       "hermes--polecat",
+		sessionID:         "sess-bead-1",
+		continuationEpoch: "3",
+		transport:         "acp",
+	}}
+	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered = %d, want 0 (stale epoch rejected)", delivered)
+	}
+
+	// The nudge was claimed (removed from pending) then rejected by the
+	// fence split, so it should be recorded as failed — not left pending
+	// or in-flight.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 0 {
+		t.Errorf("pending = %d, want 0 (claimed and failed)", len(remaining.Pending))
+	}
+	if len(remaining.InFlight) != 0 {
+		t.Errorf("in_flight = %d, want 0 (fence rejection recorded)", len(remaining.InFlight))
+	}
+	// No Nudge calls — rejected before delivery attempt.
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" {
+			t.Errorf("unexpected Nudge call for stale-epoch nudge: %v", c)
+		}
+	}
+}
+
+func TestDrainACPQueuedNudges_MultipleTargets_MixedResults(t *testing.T) {
+	cityPath := t.TempDir()
+	fake := runtime.NewFake()
+	// Start polecat (will succeed) but not owl (will be skipped).
+	if err := fake.Start(context.Background(), "hermes--polecat", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start polecat: %v", err)
+	}
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-polecat",
+			Agent:        "hermes/polecat",
+			Message:      "polecat msg",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		}, nudgequeue.Item{
+			ID:           "nudge-owl",
+			Agent:        "hermes/owl",
+			Message:      "owl msg",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	targets := []nudgeTarget{
+		{
+			cityPath:    cityPath,
+			alias:       "hermes/polecat",
+			sessionName: "hermes--polecat",
+			transport:   "acp",
+		},
+		{
+			cityPath:    cityPath,
+			alias:       "hermes/owl",
+			sessionName: "hermes--owl",
+			transport:   "acp",
+		},
+	}
+	delivered, err := drainACPQueuedNudges(cityPath, fake, targets, now)
+	if err != nil {
+		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	// Only polecat should deliver (owl is not running).
+	if delivered != 1 {
+		t.Errorf("delivered = %d, want 1 (only polecat running)", delivered)
+	}
+
+	// Verify polecat nudge acked, owl nudge still pending.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Fatalf("pending = %d, want 1 (owl nudge remains)", len(remaining.Pending))
+	}
+	if remaining.Pending[0].ID != "nudge-owl" {
+		t.Errorf("remaining pending ID = %q, want nudge-owl", remaining.Pending[0].ID)
+	}
+	if len(remaining.InFlight) != 0 {
+		t.Errorf("in_flight = %d, want 0", len(remaining.InFlight))
+	}
+
+	// Verify Nudge was only called for polecat.
+	for _, c := range fake.Calls {
+		if c.Method == "Nudge" && c.Name == "hermes--owl" {
+			t.Errorf("unexpected Nudge call for non-running owl session")
+		}
+	}
+}
+
+func TestResolveAgentForNudge_CandidatePriority(t *testing.T) {
+	cfg := &config.City{Agents: []config.Agent{
+		{Name: "polecat", Dir: "hermes"},
+		{Name: "owl", Dir: "barn"},
+	}}
+
+	// InstanceName takes priority over TemplateName.
+	got := resolveAgentForNudge(cfg, TemplateParams{
+		InstanceName: "hermes/polecat",
+		TemplateName: "owl",
+		Alias:        "barn/owl",
+	})
+	if got.Name != "polecat" {
+		t.Errorf("Name = %q, want polecat (InstanceName priority)", got.Name)
+	}
+
+	// Falls through to TemplateName when InstanceName is empty.
+	got = resolveAgentForNudge(cfg, TemplateParams{
+		TemplateName: "owl",
+		Alias:        "hermes/polecat",
+	})
+	if got.Name != "owl" {
+		t.Errorf("Name = %q, want owl (TemplateName fallback)", got.Name)
+	}
+
+	// Returns empty when nothing matches.
+	got = resolveAgentForNudge(cfg, TemplateParams{
+		Alias: "nonexistent/agent",
+	})
+	if got.Name != "" {
+		t.Errorf("Name = %q, want empty (no match)", got.Name)
+	}
+
+	// nil config returns empty.
+	got = resolveAgentForNudge(nil, TemplateParams{TemplateName: "polecat"})
+	if got.Name != "" {
+		t.Errorf("Name = %q, want empty (nil config)", got.Name)
+	}
+}

--- a/cmd/gc/nudge_acp_drain_test.go
+++ b/cmd/gc/nudge_acp_drain_test.go
@@ -52,6 +52,20 @@ func TestDrainACPQueuedNudges_DeliversDueNudge(t *testing.T) {
 		t.Errorf("delivered = %d, want 1", delivered)
 	}
 
+	// Verify exactly one Nudge call was made with the queued message.
+	var nudgeCalled bool
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" && c.Name == "hermes--polecat" {
+			nudgeCalled = true
+			if !strings.Contains(c.Message, "hello from queue") {
+				t.Errorf("Nudge message = %q, want to contain 'hello from queue'", c.Message)
+			}
+		}
+	}
+	if !nudgeCalled {
+		t.Error("no Nudge call recorded — delivery did not happen")
+	}
+
 	// Verify nudge removed from both pending and in_flight (acked).
 	var remaining nudgequeue.State
 	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
@@ -103,6 +117,27 @@ func TestDrainACPQueuedNudges_SkipsNotYetDue(t *testing.T) {
 	}
 	if delivered != 0 {
 		t.Errorf("delivered = %d, want 0 (not yet due)", delivered)
+	}
+
+	// Nudge should still be pending — not claimed or delivered.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Errorf("pending = %d, want 1 (not yet due)", len(remaining.Pending))
+	}
+	if len(remaining.InFlight) != 0 {
+		t.Errorf("in_flight = %d, want 0", len(remaining.InFlight))
+	}
+	// No Nudge calls should have been made.
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" {
+			t.Errorf("unexpected Nudge call for not-yet-due nudge: %v", c)
+		}
 	}
 }
 
@@ -212,6 +247,12 @@ func TestDrainACPQueuedNudges_SessionNotRunning_Skipped(t *testing.T) {
 	}
 	if len(remaining.Pending) != 1 {
 		t.Errorf("pending = %d, want 1 (left for next tick)", len(remaining.Pending))
+	}
+	// No Nudge calls — session not running means we skip entirely.
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" {
+			t.Errorf("unexpected Nudge call for non-running session: %v", c)
+		}
 	}
 }
 
@@ -338,12 +379,46 @@ func TestDrainACPQueuedNudges_BatchesMultipleNudges(t *testing.T) {
 func TestDrainACPQueuedNudges_NoTargets(t *testing.T) {
 	cityPath := t.TempDir()
 	sp := runtime.NewFake()
-	delivered, err := drainACPQueuedNudges(cityPath, sp, nil, time.Now())
+
+	now := time.Now()
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		s.Pending = append(s.Pending, nudgequeue.Item{
+			ID:           "nudge-orphan",
+			Agent:        "hermes/polecat",
+			Message:      "should stay",
+			Source:       "session",
+			CreatedAt:    now.Add(-1 * time.Second),
+			DeliverAfter: now.Add(-1 * time.Second),
+			ExpiresAt:    now.Add(24 * time.Hour),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+
+	delivered, err := drainACPQueuedNudges(cityPath, sp, nil, now)
 	if err != nil {
 		t.Fatalf("drainACPQueuedNudges: %v", err)
 	}
 	if delivered != 0 {
 		t.Errorf("delivered = %d, want 0", delivered)
+	}
+
+	// Queue should be untouched.
+	var remaining nudgequeue.State
+	if err := nudgequeue.WithState(cityPath, func(s *nudgequeue.State) error {
+		remaining = *s
+		return nil
+	}); err != nil {
+		t.Fatalf("WithState: %v", err)
+	}
+	if len(remaining.Pending) != 1 {
+		t.Errorf("pending = %d, want 1 (untouched)", len(remaining.Pending))
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" {
+			t.Errorf("unexpected Nudge call: %v", c)
+		}
 	}
 }
 
@@ -417,6 +492,15 @@ func TestBuildACPNudgeTargets_NoSessionBead(t *testing.T) {
 	}
 	if targets[0].continuationEpoch != "" {
 		t.Errorf("continuationEpoch = %q, want empty (no bead)", targets[0].continuationEpoch)
+	}
+	if targets[0].sessionName != "hermes--polecat" {
+		t.Errorf("sessionName = %q, want hermes--polecat", targets[0].sessionName)
+	}
+	if targets[0].alias != "hermes/polecat" {
+		t.Errorf("alias = %q, want hermes/polecat", targets[0].alias)
+	}
+	if targets[0].transport != "acp" {
+		t.Errorf("transport = %q, want acp", targets[0].transport)
 	}
 }
 
@@ -561,6 +645,9 @@ func TestDrainACPQueuedNudges_SessionStopsBeforeDelivery_NotAcked(t *testing.T) 
 	delivered, err := drainACPQueuedNudges(cityPath, sp, targets, now)
 	if err != nil {
 		t.Fatalf("drainACPQueuedNudges: %v", err)
+	}
+	if !sp.stopped {
+		t.Error("stoppingProvider did not trigger — race path was not exercised")
 	}
 	if delivered != 0 {
 		t.Errorf("delivered = %d, want 0 (session stopped before delivery)", delivered)
@@ -829,6 +916,16 @@ func TestResolveAgentForNudge_CandidatePriority(t *testing.T) {
 	})
 	if got.Name != "owl" {
 		t.Errorf("Name = %q, want owl (TemplateName fallback)", got.Name)
+	}
+
+	// Falls through to Alias when InstanceName and TemplateName don't match.
+	got = resolveAgentForNudge(cfg, TemplateParams{
+		InstanceName: "nonexistent/thing",
+		TemplateName: "also-nonexistent",
+		Alias:        "hermes/polecat",
+	})
+	if got.Name != "polecat" {
+		t.Errorf("Name = %q, want polecat (Alias fallback)", got.Name)
 	}
 
 	// Returns empty when nothing matches.


### PR DESCRIPTION
Fixes #1069
Depends on #1070

## Summary

The nudge poller (`gc nudge poll`) explicitly skips ACP sessions because it spawns a separate process without in-process ACP connections. This adds `drainACPQueuedNudges` to `beadReconcileTick` where the supervisor holds the live provider, mirroring the full poller pipeline for consistent nudge semantics.

## Changes

**New: `cmd/gc/nudge_acp_drain.go`**
- `drainACPQueuedNudges` — claims due nudges via `claimDueQueuedNudgesForTarget` (session-fenced), filters via `splitQueuedNudgesForTarget` (fence-mismatch rejection) and `splitQueuedNudgesForDelivery` (wait-bead blocking), batches via `formatNudgeRuntimeMessage`, delivers via `workerHandleForNudgeTarget` + `handle.Nudge` with `NudgeWakeLiveOnly`, completes via `ackQueuedNudges`/`recordQueuedNudgeFailure`
- `buildACPNudgeTargets` — constructs fenced `nudgeTarget` values from reconciler state (`DesiredStateResult` + session bead metadata for SessionID, ContinuationEpoch, alias history)
- `resolveAgentForNudge` — agent config lookup helper

**Modified: `cmd/gc/city_runtime.go`**
- Wired `drainACPQueuedNudges` call after `dispatchReadyWaitNudges` in `beadReconcileTick`

## Testing

15 tests covering:
- Due nudge delivery + queue cleanup
- Not-yet-due skip
- Agent mismatch → not claimed (session running, proving claim filtering)
- Session not running → skip (don't claim)
- Session-ID fence mismatch → not claimable
- Stale continuation epoch → claimed then rejected by fence split
- Batching (3 nudges → 1 Nudge call)
- No targets → no-op
- Session stops between pre-check and delivery → claimed but not acked (remains in-flight)
- Nudge error → failure recorded, requeued with attempt count and error message
- Multiple targets with mixed results (one delivers, one skipped)
- `buildACPNudgeTargets` with session bead (fencing metadata populated)
- `buildACPNudgeTargets` without session bead (no fencing)
- `resolveAgentForNudge` candidate priority (InstanceName > TemplateName > Alias) and edge cases
- Integration through `beadReconcileTick`

All existing tests pass. `make build && make check` clean.

## Design Notes

- Delivery uses `workerHandleForNudgeTarget` + `handle.Nudge` with `NudgeWakeLiveOnly` — matching the poller path for delivery confirmation before acking
- `openNudgeBeadStore` is called per-target, matching the poller's established pattern (10+ call sites in `cmd_nudge.go`)
- The reconciler tick is not latency-sensitive, so blocking on `waitIdle` during `Nudge()` is acceptable (same as poller behavior)