### PR TITLE
Gastown pack: add missing core import so cities get base formulas

### DIFF
--- a/examples/gastown/packs/gastown/pack.toml
+++ b/examples/gastown/packs/gastown/pack.toml
@@ -15,6 +15,9 @@
 name = "gastown"
 schema = 2
 
+[imports.core]
+source = "../core"
+
 [imports.maintenance]
 source = "../maintenance"
 


### PR DESCRIPTION
## Summary

- The gastown pack imports `maintenance` but not `core`, so the four core formulas (`mol-do-work`, `mol-polecat-base`, `mol-polecat-commit`, `mol-scoped-work`) aren't available unless the city operator manually copies them into `formulas/`
- Without these, polecats lose access to their base work lifecycle formulas — `gc bd formula list` shows 11 formulas instead of 15
- Adds `[imports.core]` to gastown's `pack.toml`, matching the existing `[imports.maintenance]` pattern
- Symlinks core into the gastown example directory for development parity

## How we found this

In an atlas city, removing the manually-copied core formulas from `formulas/` caused `gc bd formula list` to drop from 15 to 11 — the core formulas weren't being picked up from `.gc/system/packs/core/` because no pack imports core. The gastown formulas worked fine (transitively imported via gastown pack), but core was unreachable.

## Test plan

- [x] `go test ./internal/config/ -run "Pack|Formula"` passes
- [ ] Verify `gc bd formula list` in a fresh city shows all core formulas without manual copies in `formulas/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)