### PR TITLE
fix: harden managed dolt reachability checks

### DIFF
--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -48,6 +48,28 @@ read_runtime_state_string() (
   sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
 )
 
+managed_runtime_tcp_reachable() (
+  port="$1"
+
+  case "$port" in
+    ''|*[!0-9]*)
+      return 1
+      ;;
+  esac
+
+  if command -v nc >/dev/null 2>&1; then
+    nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+    return $?
+  fi
+
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+
+  return 1
+)
+
 managed_runtime_port() (
   state_file="$1"
   expected_data_dir="$2"
@@ -67,9 +89,10 @@ managed_runtime_port() (
 
   if command -v lsof >/dev/null 2>&1; then
     holder_pid=$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-    [ -n "$holder_pid" ] || return 0
-    [ "$holder_pid" = "$pid" ] || return 0
-  else
+    [ -n "$holder_pid" ] && [ "$holder_pid" != "$pid" ] && return 0
+  fi
+
+  if ! managed_runtime_tcp_reachable "$port"; then
     return 0
   fi
 

--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -48,6 +48,33 @@ read_runtime_state_string() (
   sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
 )
 
+managed_runtime_listener_pid() (
+  port="$1"
+
+  case "$port" in
+    ''|*[!0-9]*)
+      return 0
+      ;;
+  esac
+
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+
+  lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null \
+    | while IFS= read -r holder_pid; do
+        case "$holder_pid" in
+          ''|*[!0-9]*)
+            continue
+            ;;
+        esac
+        if kill -0 "$holder_pid" 2>/dev/null; then
+          printf '%s\n' "$holder_pid"
+          break
+        fi
+      done
+)
+
 managed_runtime_tcp_reachable() (
   port="$1"
 
@@ -62,8 +89,20 @@ managed_runtime_tcp_reachable() (
     return $?
   fi
 
-  if command -v lsof >/dev/null 2>&1; then
-    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$port" <<'PY' >/dev/null 2>&1
+import socket
+import sys
+
+sock = socket.socket()
+sock.settimeout(0.25)
+try:
+    sock.connect(("127.0.0.1", int(sys.argv[1])))
+except OSError:
+    raise SystemExit(1)
+finally:
+    sock.close()
+PY
     return $?
   fi
 
@@ -87,9 +126,11 @@ managed_runtime_port() (
   [ "$data_dir" = "$expected_data_dir" ] || return 0
   kill -0 "$pid" 2>/dev/null || return 0
 
-  if command -v lsof >/dev/null 2>&1; then
-    holder_pid=$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-    [ -n "$holder_pid" ] && [ "$holder_pid" != "$pid" ] && return 0
+  holder_pid=$(managed_runtime_listener_pid "$port" || true)
+  if [ -n "$holder_pid" ]; then
+    [ "$holder_pid" = "$pid" ] || return 0
+    printf '%s\n' "$port"
+    return 0
   fi
 
   if ! managed_runtime_tcp_reachable "$port"; then

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -78,10 +78,10 @@ server_latency=0
 server_reachable=false
 
 # Find dolt PID by port.
-pid=$(lsof -nP -t -iTCP:"$GC_DOLT_PORT" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-if [ -n "$pid" ]; then
+pid=$(managed_runtime_listener_pid "$GC_DOLT_PORT" || true)
+if [ -n "$pid" ] || managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
   server_running=true
-  server_pid="$pid"
+  [ -n "$pid" ] && server_pid="$pid"
   # Measure query latency.
   start_ms=$(date +%s%N 2>/dev/null | cut -c1-13 || date +%s)
   conn_args="--host $host --port $GC_DOLT_PORT --user $GC_DOLT_USER --no-tls"

--- a/examples/dolt/commands/sql/run.sh
+++ b/examples/dolt/commands/sql/run.sh
@@ -22,8 +22,7 @@ is_running() {
     command -v nc >/dev/null 2>&1 && nc -z "$GC_DOLT_HOST" "$GC_DOLT_PORT" 2>/dev/null && return 0
     return 1
   fi
-  # Local server — check if anything listens on the port.
-  lsof -nP -iTCP:"$GC_DOLT_PORT" -sTCP:LISTEN >/dev/null 2>&1
+  managed_runtime_tcp_reachable "$GC_DOLT_PORT"
 }
 
 if is_running; then

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -48,7 +48,7 @@ fi
 
 # Check if server is running.
 is_running() {
-  lsof -nP -iTCP:"$GC_DOLT_PORT" -sTCP:LISTEN >/dev/null 2>&1
+  managed_runtime_tcp_reachable "$GC_DOLT_PORT"
 }
 
 # routes_files — emit one routes.jsonl path per line.

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -283,6 +283,90 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 }
 
 func TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof(t *testing.T) {
+	tests := []struct {
+		name        string
+		lsofBody    string
+		ncBody      func(port string) string
+		wantManaged bool
+	}{
+		{
+			name:     "inconclusive lsof accepts reachable port",
+			lsofBody: "#!/bin/sh\nexit 0\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+host="$2"
+probe_port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$probe_port" = "` + port + `" ]; then
+  exit 0
+fi
+exit 1
+`
+			},
+			wantManaged: true,
+		},
+		{
+			name:     "mismatched lsof pid still rejects port",
+			lsofBody: "#!/bin/sh\necho $$\nsleep 5\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+exit 0
+`
+			},
+			wantManaged: false,
+		},
+		{
+			name:     "inconclusive lsof with unreachable port still rejects port",
+			lsofBody: "#!/bin/sh\nexit 0\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+exit 1
+`
+			},
+			wantManaged: false,
+		},
+	}
+
+	root := repoRoot(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			fakeBin := t.TempDir()
+
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("Listen: %v", err)
+			}
+			t.Cleanup(func() { _ = listener.Close() })
+			port := listener.Addr().(*net.TCPAddr).Port
+			managedPort := strconv.Itoa(port)
+			want := "3307"
+			if tt.wantManaged {
+				want = managedPort
+			}
+
+			writeManagedRuntimeStateForScript(t, cityPath, port)
+			writeExecutable(t, filepath.Join(fakeBin, "lsof"), tt.lsofBody)
+			writeExecutable(t, filepath.Join(fakeBin, "nc"), tt.ncBody(managedPort))
+
+			cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; printf '%s\n' "$GC_DOLT_PORT"`)
+			cmd.Env = filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_PORT", "GC_DOLT_HOST", "PATH")
+			cmd.Env = append(cmd.Env,
+				"GC_CITY_PATH="+cityPath,
+				"GC_PACK_DIR="+root,
+				"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("runtime.sh failed: %v\n%s", err, out)
+			}
+			if got := strings.TrimSpace(string(out)); got != want {
+				t.Fatalf("GC_DOLT_PORT = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestHealthScriptReportsRunningWhenLsofIsInconclusive(t *testing.T) {
 	cityPath := t.TempDir()
 	fakeBin := t.TempDir()
 
@@ -291,36 +375,41 @@ func TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof(t *testing.T) {
 		t.Fatalf("Listen: %v", err)
 	}
 	t.Cleanup(func() { _ = listener.Close() })
-	port := listener.Addr().(*net.TCPAddr).Port
-	want := strconv.Itoa(port)
+	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
 
-	writeManagedRuntimeStateForScript(t, cityPath, port)
 	writeExecutable(t, filepath.Join(fakeBin, "lsof"), `#!/bin/sh
 exit 0
 `)
 	writeExecutable(t, filepath.Join(fakeBin, "nc"), `#!/bin/sh
 host="$2"
-port="$3"
-if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$port" = "`+want+`" ]; then
+probe_port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$probe_port" = "`+port+`" ]; then
   exit 0
 fi
 exit 1
 `)
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), `#!/bin/sh
+exit 0
+`)
 
 	root := repoRoot(t)
-	cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; printf '%s\n' "$GC_DOLT_PORT"`)
-	cmd.Env = filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_PORT", "GC_DOLT_HOST", "PATH")
-	cmd.Env = append(cmd.Env,
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=",
+		"GC_DOLT_PORT="+port,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_HEALTH_SKIP_ZOMBIE_SCAN=1",
 		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("runtime.sh failed: %v\n%s", err, out)
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
 	}
-	if got := strings.TrimSpace(string(out)); got != want {
-		t.Fatalf("GC_DOLT_PORT = %q, want %q", got, want)
+	if !strings.Contains(string(out), `"running": true`) {
+		t.Fatalf("health output missing running=true:\n%s", out)
 	}
 }
 

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -282,6 +282,48 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 	}
 }
 
+func TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof(t *testing.T) {
+	cityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+	want := strconv.Itoa(port)
+
+	writeManagedRuntimeStateForScript(t, cityPath, port)
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"), `#!/bin/sh
+exit 0
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), `#!/bin/sh
+host="$2"
+port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$port" = "`+want+`" ]; then
+  exit 0
+fi
+exit 1
+`)
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; printf '%s\n' "$GC_DOLT_PORT"`)
+	cmd.Env = filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_PORT", "GC_DOLT_HOST", "PATH")
+	cmd.Env = append(cmd.Env,
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("runtime.sh failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Fatalf("GC_DOLT_PORT = %q, want %q", got, want)
+	}
+}
+
 func writeManagedRuntimeStateForScript(t *testing.T, cityPath string, port int) {
 	t.Helper()
 	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
@@ -296,6 +338,13 @@ func writeManagedRuntimeStateForScript(t *testing.T, cityPath string, port int) 
 	))
 	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), payload, 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
 }
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -239,6 +239,94 @@ exit 0
 	}
 }
 
+func TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof(t *testing.T) {
+	scripts := []struct {
+		name   string
+		script string
+		env    map[string]string
+	}{
+		{
+			name:   "reaper",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "reaper.sh"),
+			env: map[string]string{
+				"GC_REAPER_DRY_RUN": "1",
+			},
+		},
+		{
+			name:   "jsonl export",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "jsonl-export.sh"),
+			env: map[string]string{
+				"GC_JSONL_ARCHIVE_REPO":      "archive",
+				"GC_JSONL_MAX_PUSH_FAILURES": "99",
+			},
+		},
+	}
+
+	for _, tt := range scripts {
+		t.Run(tt.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			binDir := t.TempDir()
+			doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+			listener := listenManagedDoltPort(t)
+			wantPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+			writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
+
+			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+exit 0
+`)
+			writeExecutable(t, filepath.Join(binDir, "lsof"), `#!/bin/sh
+exit 0
+`)
+			writeExecutable(t, filepath.Join(binDir, "nc"), `#!/bin/sh
+host="$2"
+port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$port" = "`+wantPort+`" ]; then
+  exit 0
+fi
+exit 1
+`)
+
+			env := map[string]string{
+				"DOLT_ARGS_LOG":       doltLog,
+				"GC_CITY":             cityDir,
+				"GC_CITY_PATH":        cityDir,
+				"GC_DOLT_HOST":        "",
+				"GC_DOLT_PORT":        "",
+				"GC_DOLT_USER":        "",
+				"GC_DOLT_PASSWORD":    "",
+				"GIT_CONFIG_GLOBAL":   filepath.Join(t.TempDir(), "gitconfig"),
+				"GIT_CONFIG_NOSYSTEM": "1",
+				"PATH":                binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			}
+			for key, value := range tt.env {
+				if key == "GC_JSONL_ARCHIVE_REPO" {
+					value = filepath.Join(cityDir, value)
+				}
+				env[key] = value
+			}
+
+			runScript(t, filepath.Join(exampleDir(), tt.script), env)
+
+			logData, err := os.ReadFile(doltLog)
+			if err != nil {
+				t.Fatalf("ReadFile(dolt log): %v", err)
+			}
+			log := string(logData)
+			for _, want := range []string{
+				"--host 127.0.0.1",
+				"--port " + wantPort,
+				"--user root",
+			} {
+				if !strings.Contains(log, want) {
+					t.Fatalf("dolt calls missing %q:\n%s", want, log)
+				}
+			}
+		})
+	}
+}
+
 func TestMaintenanceDoltScriptsRejectInvalidManagedPort(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -262,68 +262,108 @@ func TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof
 		},
 	}
 
-	for _, tt := range scripts {
-		t.Run(tt.name, func(t *testing.T) {
-			cityDir := t.TempDir()
-			binDir := t.TempDir()
-			doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
-
-			listener := listenManagedDoltPort(t)
-			wantPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-			writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
-
-			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
-exit 0
-`)
-			writeExecutable(t, filepath.Join(binDir, "lsof"), `#!/bin/sh
-exit 0
-`)
-			writeExecutable(t, filepath.Join(binDir, "nc"), `#!/bin/sh
+	cases := []struct {
+		name        string
+		lsofBody    string
+		ncBody      func(port string) string
+		wantManaged bool
+	}{
+		{
+			name:     "inconclusive lsof accepts reachable port",
+			lsofBody: "#!/bin/sh\nexit 0\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
 host="$2"
-port="$3"
-if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$port" = "`+wantPort+`" ]; then
+probe_port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$probe_port" = "` + port + `" ]; then
   exit 0
 fi
 exit 1
+`
+			},
+			wantManaged: true,
+		},
+		{
+			name:     "mismatched lsof pid still rejects port",
+			lsofBody: "#!/bin/sh\necho $$\nsleep 5\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+exit 0
+`
+			},
+			wantManaged: false,
+		},
+		{
+			name:     "inconclusive lsof with unreachable port still rejects port",
+			lsofBody: "#!/bin/sh\nexit 0\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+exit 1
+`
+			},
+			wantManaged: false,
+		},
+	}
+
+	for _, tt := range scripts {
+		for _, tc := range cases {
+			t.Run(tt.name+"/"+tc.name, func(t *testing.T) {
+				cityDir := t.TempDir()
+				binDir := t.TempDir()
+				doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+				listener := listenManagedDoltPort(t)
+				managedPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+				wantPort := "3307"
+				if tc.wantManaged {
+					wantPort = managedPort
+				}
+				writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
+
+				writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+				writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+exit 0
 `)
+				writeExecutable(t, filepath.Join(binDir, "lsof"), tc.lsofBody)
+				writeExecutable(t, filepath.Join(binDir, "nc"), tc.ncBody(managedPort))
 
-			env := map[string]string{
-				"DOLT_ARGS_LOG":       doltLog,
-				"GC_CITY":             cityDir,
-				"GC_CITY_PATH":        cityDir,
-				"GC_DOLT_HOST":        "",
-				"GC_DOLT_PORT":        "",
-				"GC_DOLT_USER":        "",
-				"GC_DOLT_PASSWORD":    "",
-				"GIT_CONFIG_GLOBAL":   filepath.Join(t.TempDir(), "gitconfig"),
-				"GIT_CONFIG_NOSYSTEM": "1",
-				"PATH":                binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
-			}
-			for key, value := range tt.env {
-				if key == "GC_JSONL_ARCHIVE_REPO" {
-					value = filepath.Join(cityDir, value)
+				env := map[string]string{
+					"DOLT_ARGS_LOG":       doltLog,
+					"GC_CITY":             cityDir,
+					"GC_CITY_PATH":        cityDir,
+					"GC_DOLT_HOST":        "",
+					"GC_DOLT_PORT":        "",
+					"GC_DOLT_USER":        "",
+					"GC_DOLT_PASSWORD":    "",
+					"GIT_CONFIG_GLOBAL":   filepath.Join(t.TempDir(), "gitconfig"),
+					"GIT_CONFIG_NOSYSTEM": "1",
+					"PATH":                binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 				}
-				env[key] = value
-			}
-
-			runScript(t, filepath.Join(exampleDir(), tt.script), env)
-
-			logData, err := os.ReadFile(doltLog)
-			if err != nil {
-				t.Fatalf("ReadFile(dolt log): %v", err)
-			}
-			log := string(logData)
-			for _, want := range []string{
-				"--host 127.0.0.1",
-				"--port " + wantPort,
-				"--user root",
-			} {
-				if !strings.Contains(log, want) {
-					t.Fatalf("dolt calls missing %q:\n%s", want, log)
+				for key, value := range tt.env {
+					if key == "GC_JSONL_ARCHIVE_REPO" {
+						value = filepath.Join(cityDir, value)
+					}
+					env[key] = value
 				}
-			}
-		})
+
+				runScript(t, filepath.Join(exampleDir(), tt.script), env)
+
+				logData, err := os.ReadFile(doltLog)
+				if err != nil {
+					t.Fatalf("ReadFile(dolt log): %v", err)
+				}
+				log := string(logData)
+				for _, want := range []string{
+					"--host 127.0.0.1",
+					"--port " + wantPort,
+					"--user root",
+				} {
+					if !strings.Contains(log, want) {
+						t.Fatalf("dolt calls missing %q:\n%s", want, log)
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -24,6 +24,33 @@ read_runtime_state_string() (
     sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
 )
 
+managed_runtime_listener_pid() (
+    port="$1"
+
+    case "$port" in
+        ''|*[!0-9]*)
+            return 0
+            ;;
+    esac
+
+    if ! command -v lsof >/dev/null 2>&1; then
+        return 0
+    fi
+
+    lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null \
+        | while IFS= read -r holder_pid; do
+            case "$holder_pid" in
+                ''|*[!0-9]*)
+                    continue
+                    ;;
+            esac
+            if kill -0 "$holder_pid" 2>/dev/null; then
+                printf '%s\n' "$holder_pid"
+                break
+            fi
+        done
+)
+
 managed_runtime_tcp_reachable() (
     port="$1"
 
@@ -38,8 +65,20 @@ managed_runtime_tcp_reachable() (
         return $?
     fi
 
-    if command -v lsof >/dev/null 2>&1; then
-        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$port" <<'PY' >/dev/null 2>&1
+import socket
+import sys
+
+sock = socket.socket()
+sock.settimeout(0.25)
+try:
+    sock.connect(("127.0.0.1", int(sys.argv[1])))
+except OSError:
+    raise SystemExit(1)
+finally:
+    sock.close()
+PY
         return $?
     fi
 
@@ -63,9 +102,11 @@ managed_runtime_port() (
     [ "$data_dir" = "$expected_data_dir" ] || return 0
     kill -0 "$pid" 2>/dev/null || return 0
 
-    if command -v lsof >/dev/null 2>&1; then
-        holder_pid=$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-        [ -n "$holder_pid" ] && [ "$holder_pid" != "$pid" ] && return 0
+    holder_pid=$(managed_runtime_listener_pid "$port" || true)
+    if [ -n "$holder_pid" ]; then
+        [ "$holder_pid" = "$pid" ] || return 0
+        printf '%s\n' "$port"
+        return 0
     fi
 
     if ! managed_runtime_tcp_reachable "$port"; then

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -24,6 +24,28 @@ read_runtime_state_string() (
     sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
 )
 
+managed_runtime_tcp_reachable() (
+    port="$1"
+
+    case "$port" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
+
+    if command -v nc >/dev/null 2>&1; then
+        nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+        return $?
+    fi
+
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+        return $?
+    fi
+
+    return 1
+)
+
 managed_runtime_port() (
     state_file="$1"
     expected_data_dir="$2"
@@ -43,9 +65,10 @@ managed_runtime_port() (
 
     if command -v lsof >/dev/null 2>&1; then
         holder_pid=$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1 || true)
-        [ -n "$holder_pid" ] || return 0
-        [ "$holder_pid" = "$pid" ] || return 0
-    else
+        [ -n "$holder_pid" ] && [ "$holder_pid" != "$pid" ] && return 0
+    fi
+
+    if ! managed_runtime_tcp_reachable "$port"; then
         return 0
     fi
 


### PR DESCRIPTION
## Summary
- stop treating inconclusive `lsof` output as proof that managed Dolt is down
- accept the managed port when the listener is reachable, but still reject conclusive PID mismatches
- apply the same tolerant reachability logic to `gc dolt health`, `gc dolt sql`, and `gc dolt sync`
- add regression coverage for inconclusive `lsof`, mismatched PID, and unreachable-port cases

## Validation
- `GC_FAST_UNIT=1 go test ./...`
- `go vet ./...`
- dual-model review first pass completed; follow-up commit addressed the returned blocker/major findings