### PR TITLE
fix: harden managed Dolt PID probes on macOS

### DIFF
--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -48,6 +48,27 @@ read_runtime_state_string() (
   sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
 )
 
+pid_is_running() (
+  pid="$1"
+
+  case "$pid" in
+    ''|*[!0-9]*)
+      return 1
+      ;;
+  esac
+
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  if command -v ps >/dev/null 2>&1; then
+    ps_pid=$(ps -p "$pid" -o pid= 2>/dev/null | tr -d '[:space:]')
+    [ "$ps_pid" = "$pid" ] && return 0
+  fi
+
+  return 1
+)
+
 managed_runtime_listener_pid() (
   port="$1"
 
@@ -68,7 +89,7 @@ managed_runtime_listener_pid() (
             continue
             ;;
         esac
-        if kill -0 "$holder_pid" 2>/dev/null; then
+        if pid_is_running "$holder_pid"; then
           printf '%s\n' "$holder_pid"
           break
         fi
@@ -124,7 +145,7 @@ managed_runtime_port() (
   [ -n "$pid" ] || return 0
   [ -n "$port" ] || return 0
   [ "$data_dir" = "$expected_data_dir" ] || return 0
-  kill -0 "$pid" 2>/dev/null || return 0
+  pid_is_running "$pid" || return 0
 
   holder_pid=$(managed_runtime_listener_pid "$port" || true)
   if [ -n "$holder_pid" ]; then

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -366,6 +366,80 @@ exit 1
 	}
 }
 
+func TestRuntimeScriptPortPrecedenceAcceptsPsConfirmedPid(t *testing.T) {
+	tests := []struct {
+		name     string
+		lsofBody string
+		ncBody   func(port string) string
+	}{
+		{
+			name:     "listener pid match via ps fallback",
+			lsofBody: "#!/bin/sh\necho 424242\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+exit 1
+`
+			},
+		},
+		{
+			name:     "reachable port via ps fallback when lsof is inconclusive",
+			lsofBody: "#!/bin/sh\nexit 0\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+host="$2"
+probe_port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$probe_port" = "` + port + `" ]; then
+  exit 0
+fi
+exit 1
+`
+			},
+		},
+	}
+
+	root := repoRoot(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			fakeBin := t.TempDir()
+
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("Listen: %v", err)
+			}
+			t.Cleanup(func() { _ = listener.Close() })
+			port := listener.Addr().(*net.TCPAddr).Port
+			managedPort := strconv.Itoa(port)
+
+			writeManagedRuntimeStateForScriptWithPID(t, cityPath, port, 424242)
+			writeExecutable(t, filepath.Join(fakeBin, "lsof"), tt.lsofBody)
+			writeExecutable(t, filepath.Join(fakeBin, "nc"), tt.ncBody(managedPort))
+			writeExecutable(t, filepath.Join(fakeBin, "ps"), `#!/bin/sh
+if [ "$1" = "-p" ] && [ "$2" = "424242" ]; then
+  echo " 424242"
+  exit 0
+fi
+exit 1
+`)
+
+			cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; printf '%s\n' "$GC_DOLT_PORT"`)
+			cmd.Env = filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_PORT", "GC_DOLT_HOST", "PATH")
+			cmd.Env = append(cmd.Env,
+				"GC_CITY_PATH="+cityPath,
+				"GC_PACK_DIR="+root,
+				"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("runtime.sh failed: %v\n%s", err, out)
+			}
+			if got := strings.TrimSpace(string(out)); got != managedPort {
+				t.Fatalf("GC_DOLT_PORT = %q, want %q", got, managedPort)
+			}
+		})
+	}
+}
+
 func TestHealthScriptReportsRunningWhenLsofIsInconclusive(t *testing.T) {
 	cityPath := t.TempDir()
 	fakeBin := t.TempDir()
@@ -415,13 +489,18 @@ exit 0
 
 func writeManagedRuntimeStateForScript(t *testing.T, cityPath string, port int) {
 	t.Helper()
+	writeManagedRuntimeStateForScriptWithPID(t, cityPath, port, os.Getpid())
+}
+
+func writeManagedRuntimeStateForScriptWithPID(t *testing.T, cityPath string, port int, pid int) {
+	t.Helper()
 	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	payload := []byte(fmt.Sprintf(
 		`{"running":true,"pid":%d,"port":%d,"data_dir":%q,"started_at":"2026-04-20T00:00:00Z"}`,
-		os.Getpid(),
+		pid,
 		port,
 		filepath.Join(cityPath, ".beads", "dolt"),
 	))

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -367,6 +367,124 @@ exit 0
 	}
 }
 
+func TestMaintenanceDoltScriptsUsePsConfirmedManagedRuntimePorts(t *testing.T) {
+	scripts := []struct {
+		name   string
+		script string
+		env    map[string]string
+	}{
+		{
+			name:   "reaper",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "reaper.sh"),
+			env: map[string]string{
+				"GC_REAPER_DRY_RUN": "1",
+			},
+		},
+		{
+			name:   "jsonl export",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "jsonl-export.sh"),
+			env: map[string]string{
+				"GC_JSONL_ARCHIVE_REPO":      "archive",
+				"GC_JSONL_MAX_PUSH_FAILURES": "99",
+			},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		lsofBody string
+		ncBody   func(port string) string
+	}{
+		{
+			name:     "listener pid match via ps fallback",
+			lsofBody: "#!/bin/sh\necho 424242\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+exit 1
+`
+			},
+		},
+		{
+			name:     "reachable port via ps fallback when lsof is inconclusive",
+			lsofBody: "#!/bin/sh\nexit 0\n",
+			ncBody: func(port string) string {
+				return `#!/bin/sh
+host="$2"
+probe_port="$3"
+if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$probe_port" = "` + port + `" ]; then
+  exit 0
+fi
+exit 1
+`
+			},
+		},
+	}
+
+	for _, tt := range scripts {
+		for _, tc := range cases {
+			t.Run(tt.name+"/"+tc.name, func(t *testing.T) {
+				cityDir := t.TempDir()
+				binDir := t.TempDir()
+				doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+				listener := listenManagedDoltPort(t)
+				managedPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+				writeManagedRuntimeStateWithPID(t, cityDir, listener.Addr().(*net.TCPAddr).Port, 424242)
+
+				writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+				writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+exit 0
+`)
+				writeExecutable(t, filepath.Join(binDir, "lsof"), tc.lsofBody)
+				writeExecutable(t, filepath.Join(binDir, "nc"), tc.ncBody(managedPort))
+				writeExecutable(t, filepath.Join(binDir, "ps"), `#!/bin/sh
+if [ "$1" = "-p" ] && [ "$2" = "424242" ]; then
+  echo " 424242"
+  exit 0
+fi
+exit 1
+`)
+
+				env := map[string]string{
+					"DOLT_ARGS_LOG":       doltLog,
+					"GC_CITY":             cityDir,
+					"GC_CITY_PATH":        cityDir,
+					"GC_DOLT_HOST":        "",
+					"GC_DOLT_PORT":        "",
+					"GC_DOLT_USER":        "",
+					"GC_DOLT_PASSWORD":    "",
+					"GIT_CONFIG_GLOBAL":   filepath.Join(t.TempDir(), "gitconfig"),
+					"GIT_CONFIG_NOSYSTEM": "1",
+					"PATH":                binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+				}
+				for key, value := range tt.env {
+					if key == "GC_JSONL_ARCHIVE_REPO" {
+						value = filepath.Join(cityDir, value)
+					}
+					env[key] = value
+				}
+
+				runScript(t, filepath.Join(exampleDir(), tt.script), env)
+
+				logData, err := os.ReadFile(doltLog)
+				if err != nil {
+					t.Fatalf("ReadFile(dolt log): %v", err)
+				}
+				log := string(logData)
+				for _, want := range []string{
+					"--host 127.0.0.1",
+					"--port " + managedPort,
+					"--user root",
+				} {
+					if !strings.Contains(log, want) {
+						t.Fatalf("dolt calls missing %q:\n%s", want, log)
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestMaintenanceDoltScriptsRejectInvalidManagedPort(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
@@ -407,13 +525,18 @@ func listenManagedDoltPort(t *testing.T) net.Listener {
 
 func writeManagedRuntimeState(t *testing.T, cityDir string, port int) {
 	t.Helper()
+	writeManagedRuntimeStateWithPID(t, cityDir, port, os.Getpid())
+}
+
+func writeManagedRuntimeStateWithPID(t *testing.T, cityDir string, port int, pid int) {
+	t.Helper()
 	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	payload, err := json.Marshal(map[string]any{
 		"running":    true,
-		"pid":        os.Getpid(),
+		"pid":        pid,
 		"port":       port,
 		"data_dir":   filepath.Join(cityDir, ".beads", "dolt"),
 		"started_at": "2026-04-20T00:00:00Z",

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -24,6 +24,27 @@ read_runtime_state_string() (
     sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
 )
 
+pid_is_running() (
+    pid="$1"
+
+    case "$pid" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
+
+    if kill -0 "$pid" 2>/dev/null; then
+        return 0
+    fi
+
+    if command -v ps >/dev/null 2>&1; then
+        ps_pid=$(ps -p "$pid" -o pid= 2>/dev/null | tr -d '[:space:]')
+        [ "$ps_pid" = "$pid" ] && return 0
+    fi
+
+    return 1
+)
+
 managed_runtime_listener_pid() (
     port="$1"
 
@@ -44,7 +65,7 @@ managed_runtime_listener_pid() (
                     continue
                     ;;
             esac
-            if kill -0 "$holder_pid" 2>/dev/null; then
+            if pid_is_running "$holder_pid"; then
                 printf '%s\n' "$holder_pid"
                 break
             fi
@@ -100,7 +121,7 @@ managed_runtime_port() (
     [ -n "$pid" ] || return 0
     [ -n "$port" ] || return 0
     [ "$data_dir" = "$expected_data_dir" ] || return 0
-    kill -0 "$pid" 2>/dev/null || return 0
+    pid_is_running "$pid" || return 0
 
     holder_pid=$(managed_runtime_listener_pid "$port" || true)
     if [ -n "$holder_pid" ]; then


### PR DESCRIPTION
## Summary
- replace raw managed-Dolt pid probes with a cross-platform `kill -0 || ps -p` liveness check
- use that helper in both shared shell resolvers so macOS can accept live managed runtime ports
- add regression coverage for direct pid-match and reachable-port fallback when only `ps` can confirm the recorded pid

## Validation
- go test ./examples/dolt -run 'TestRuntimeScriptPortPrecedence|TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof|TestRuntimeScriptPortPrecedenceAcceptsPsConfirmedPid|TestHealthScriptReportsRunningWhenLsofIsInconclusive' -count=1
- go test ./examples/gastown -run 'TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts|TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof|TestMaintenanceDoltScriptsUsePsConfirmedManagedRuntimePorts' -count=1
- go vet ./...