### PR TITLE
fix: inherit Phase and Pour across formula 'extends' merge (#1040)

### DIFF
--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -363,6 +363,29 @@ extends = ["base"]
 			// RootOnly is gated on !Pour && Phase=="vapor"; Pour=true overrides.
 			wantRootOnly: false,
 		},
+		{
+			// Guards against a future refactor that stops seeding merged
+			// from the child: without seeding, a child-only Pour=true would
+			// be dropped because the parent loop only propagates true values.
+			name: "child_sets_pour_parent_unset",
+			parent: `
+formula = "base"
+version = 1
+
+[[steps]]
+id = "scan"
+title = "Scan"
+`,
+			child: `
+formula = "derived"
+version = 1
+extends = ["base"]
+pour = true
+`,
+			wantPhase:    "",
+			wantPour:     true,
+			wantRootOnly: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -436,6 +459,63 @@ extends = ["parentA", "parentB"]
 
 	if recipe.Phase != "vapor" {
 		t.Errorf("Phase = %q, want %q (first non-empty parent wins)", recipe.Phase, "vapor")
+	}
+}
+
+// TestCompileExtendsMultiParentPourAnyParentWins verifies OR semantics for
+// Pour across multiple parents — unlike Phase (first-non-empty-wins), any
+// parent declaring pour=true promotes the merged formula regardless of
+// parent order. Pins the Phase-vs-Pour semantic asymmetry so future
+// refactors don't silently align them.
+func TestCompileExtendsMultiParentPourAnyParentWins(t *testing.T) {
+	cases := []struct {
+		name    string
+		extends string
+	}{
+		{name: "pour_first", extends: `["pourParent", "plainParent"]`},
+		{name: "pour_second", extends: `["plainParent", "pourParent"]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			files := map[string]string{
+				"pourParent.toml": `
+formula = "pourParent"
+version = 1
+pour = true
+
+[[steps]]
+id = "a"
+title = "A"
+`,
+				"plainParent.toml": `
+formula = "plainParent"
+version = 1
+
+[[steps]]
+id = "b"
+title = "B"
+`,
+				"child.toml": `
+formula = "child"
+version = 1
+extends = ` + tc.extends + `
+`,
+			}
+			for name, content := range files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			recipe, err := Compile(context.Background(), "child", []string{dir}, nil)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			if !recipe.Pour {
+				t.Errorf("Pour = false, want true (any parent with pour=true promotes)")
+			}
+		})
 	}
 }
 

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -268,6 +268,177 @@ title = "Scan"
 	}
 }
 
+// TestCompileExtendsPhasePour regresses the merge bug where the 'extends'
+// resolver dropped Phase and Pour from the merged formula, silently coercing
+// vapor formulas to persistent and pour formulas back to root-only.
+func TestCompileExtendsPhasePour(t *testing.T) {
+	cases := []struct {
+		name         string
+		parent       string
+		child        string
+		wantPhase    string
+		wantPour     bool
+		wantRootOnly bool
+	}{
+		{
+			name: "parent_sets_phase_child_inherits",
+			parent: `
+formula = "base"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "scan"
+title = "Scan"
+`,
+			child: `
+formula = "derived"
+version = 1
+extends = ["base"]
+`,
+			wantPhase:    "vapor",
+			wantPour:     false,
+			wantRootOnly: true,
+		},
+		{
+			name: "child_sets_phase_overrides_parent",
+			parent: `
+formula = "base"
+version = 1
+phase = "liquid"
+
+[[steps]]
+id = "scan"
+title = "Scan"
+`,
+			child: `
+formula = "derived"
+version = 1
+extends = ["base"]
+phase = "vapor"
+`,
+			wantPhase:    "vapor",
+			wantPour:     false,
+			wantRootOnly: true,
+		},
+		{
+			name: "parent_sets_pour_child_inherits",
+			parent: `
+formula = "base"
+version = 1
+pour = true
+
+[[steps]]
+id = "scan"
+title = "Scan"
+`,
+			child: `
+formula = "derived"
+version = 1
+extends = ["base"]
+`,
+			wantPhase:    "",
+			wantPour:     true,
+			wantRootOnly: false,
+		},
+		{
+			name: "parent_sets_both_child_inherits",
+			parent: `
+formula = "base"
+version = 1
+phase = "vapor"
+pour = true
+
+[[steps]]
+id = "scan"
+title = "Scan"
+`,
+			child: `
+formula = "derived"
+version = 1
+extends = ["base"]
+`,
+			wantPhase: "vapor",
+			wantPour:  true,
+			// RootOnly is gated on !Pour && Phase=="vapor"; Pour=true overrides.
+			wantRootOnly: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "base.toml"), []byte(tc.parent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "derived.toml"), []byte(tc.child), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			recipe, err := Compile(context.Background(), "derived", []string{dir}, nil)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+
+			if recipe.Phase != tc.wantPhase {
+				t.Errorf("Phase = %q, want %q", recipe.Phase, tc.wantPhase)
+			}
+			if recipe.Pour != tc.wantPour {
+				t.Errorf("Pour = %v, want %v", recipe.Pour, tc.wantPour)
+			}
+			if recipe.RootOnly != tc.wantRootOnly {
+				t.Errorf("RootOnly = %v, want %v", recipe.RootOnly, tc.wantRootOnly)
+			}
+		})
+	}
+}
+
+// TestCompileExtendsMultiParentPhaseFirstWins verifies that when multiple
+// parents declare Phase, the first non-empty parent wins — matching the
+// inheritance semantics already used for Vars and Contract.
+func TestCompileExtendsMultiParentPhaseFirstWins(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"parentA.toml": `
+formula = "parentA"
+version = 1
+phase = "vapor"
+
+[[steps]]
+id = "a"
+title = "A"
+`,
+		"parentB.toml": `
+formula = "parentB"
+version = 1
+phase = "liquid"
+
+[[steps]]
+id = "b"
+title = "B"
+`,
+		"child.toml": `
+formula = "child"
+version = 1
+extends = ["parentA", "parentB"]
+`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	recipe, err := Compile(context.Background(), "child", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	if recipe.Phase != "vapor" {
+		t.Errorf("Phase = %q, want %q (first non-empty parent wins)", recipe.Phase, "vapor")
+	}
+}
+
 func TestCompileCheckSyntaxWithoutGraphContractKeepsMoleculeRoot(t *testing.T) {
 	enableV2ForTest(t)
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -195,6 +195,8 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 		Contract:    formula.Contract,
 		Type:        formula.Type,
 		Source:      formula.Source,
+		Phase:       formula.Phase,
+		Pour:        formula.Pour,
 		Vars:        make(map[string]*VarDef),
 		Steps:       nil,
 		Template:    nil,
@@ -216,6 +218,21 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 
 		if merged.Contract == "" {
 			merged.Contract = parent.Contract
+		}
+
+		// Phase cascades from the first parent that declares one; child
+		// declaration wins because merged was seeded from the child.
+		if merged.Phase == "" {
+			merged.Phase = parent.Phase
+		}
+
+		// Pour is an opt-in escalation: any parent or the child requesting
+		// pour promotes the merged formula. With a plain bool the zero value
+		// is indistinguishable from "unset", so OR is the only coherent rule
+		// here; a *bool field would allow explicit child override but isn't
+		// worth the complexity for this flag.
+		if !merged.Pour {
+			merged.Pour = parent.Pour
 		}
 
 		// Merge parent vars (parent vars are inherited, child overrides)

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -228,9 +228,9 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 
 		// Pour is an opt-in escalation: any parent or the child requesting
 		// pour promotes the merged formula. With a plain bool the zero value
-		// is indistinguishable from "unset", so OR is the only coherent rule
-		// here; a *bool field would allow explicit child override but isn't
-		// worth the complexity for this flag.
+		// is indistinguishable from "unset", so OR is the simplest coherent
+		// rule that preserves monotonic opt-in; a *bool field would allow
+		// explicit child opt-out but isn't worth the complexity for this flag.
 		if !merged.Pour {
 			merged.Pour = parent.Pour
 		}


### PR DESCRIPTION
## Summary

Fixes #1040. The `Resolve()` merge in `internal/formula/parser.go` enumerates which scalar fields survive an `extends` resolution. `Phase` and `Pour` were omitted, so any formula with a non-empty `extends` silently coerced `Phase` to `""` and `Pour` to `false` — regardless of what parents or the child declared.

Downstream, `compile.go:205` gates `Recipe.RootOnly` on `!f.Pour && f.Phase == "vapor"`, so vapor formulas were materialized as persistent (extra bead rows, duplicate tracking) and pour-promoted formulas were forced back to root-only.

The fix mirrors the existing `Contract` inheritance pattern already in main:

- Seed both fields from the child in the merged constructor.
- In the parent loop, fall back to the first parent that declares `Phase` (first-non-empty-wins, matching `Contract`/`Vars`).
- OR any parent's `Pour` onto the merged value (plain `bool` zero value is indistinguishable from "unset", so OR is the simplest monotonic-opt-in rule; the comment at `parser.go:229-234` calls out `*bool` as the explicit-override alternative).

## Scope note

`Advice` and `Pointcuts` are also absent from the same merge — latent sibling bugs that predate this PR. Left out of scope; happy to send a follow-up if maintainers want them addressed together.

## Test plan

- [x] `TestCompileExtendsPhasePour` — 5 subcases covering parent-sets-Phase / child-overrides / parent-sets-Pour / both-set (with RootOnly interaction) / child-only-Pour (guards future seed-from-child regression).
- [x] `TestCompileExtendsMultiParentPhaseFirstWins` — pins first-non-empty-parent-wins for Phase.
- [x] `TestCompileExtendsMultiParentPourAnyParentWins` — pins OR semantics for Pour across parent orderings, making the intentional Phase-vs-Pour semantic asymmetry explicit.
- [x] `go test ./... -race` clean (71 packages, 0 failures).
- [x] `go vet`, `gofmt`, `staticcheck` clean.

## Example impact

`mol-polecat-commit` extends `mol-polecat-base` in the bootstrap pack. Neither declares `phase`/`pour` today, so this is a latent correctness fix — the minute either file declares `phase = "vapor"`, the child inherits correctly. Without the fix, the child always materialized as persistent.