### PR TITLE
fix: make managed runtime flag parsing portable

### DIFF
--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -31,7 +31,12 @@ read_runtime_state_flag() (
   state_file="$1"
   key="$2"
   [ -f "$state_file" ] || return 0
-  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\\(true\\|false\\).*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
+  value=$(sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\\([^,}[:space:]]*\\).*/\\1/p" "$state_file" 2>/dev/null | head -1 || true)
+  case "$value" in
+    true|false)
+      printf '%s\n' "$value"
+      ;;
+  esac
 )
 
 read_runtime_state_number() (

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -440,6 +440,50 @@ exit 1
 	}
 }
 
+func TestRuntimeScriptPortPrecedenceParsesManagedRuntimeStateWithPortableSed(t *testing.T) {
+	cityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+	managedPort := strconv.Itoa(port)
+
+	realSed, err := exec.LookPath("sed")
+	if err != nil {
+		t.Fatalf("LookPath(sed): %v", err)
+	}
+
+	writeManagedRuntimeStateForScript(t, cityPath, port)
+	writeExecutable(t, filepath.Join(fakeBin, "sed"), fmt.Sprintf(`#!/bin/sh
+case "$2" in
+  *'\\(true\\|false\\)'*)
+    exit 0
+    ;;
+esac
+exec %q "$@"
+`, realSed))
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; printf '%s\n' "$GC_DOLT_PORT"`)
+	cmd.Env = filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_PORT", "GC_DOLT_HOST", "PATH")
+	cmd.Env = append(cmd.Env,
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("runtime.sh failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != managedPort {
+		t.Fatalf("GC_DOLT_PORT = %q, want %q", got, managedPort)
+	}
+}
+
 func TestHealthScriptReportsRunningWhenLsofIsInconclusive(t *testing.T) {
 	cityPath := t.TempDir()
 	fakeBin := t.TempDir()

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2,6 +2,7 @@ package gastown_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -482,6 +483,96 @@ exit 1
 				}
 			})
 		}
+	}
+}
+
+func TestMaintenanceDoltScriptsParseManagedRuntimeStateWithPortableSed(t *testing.T) {
+	realSed, err := exec.LookPath("sed")
+	if err != nil {
+		t.Fatalf("LookPath(sed): %v", err)
+	}
+
+	scripts := []struct {
+		name   string
+		script string
+		env    map[string]string
+	}{
+		{
+			name:   "reaper",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "reaper.sh"),
+			env: map[string]string{
+				"GC_REAPER_DRY_RUN": "1",
+			},
+		},
+		{
+			name:   "jsonl export",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "jsonl-export.sh"),
+			env: map[string]string{
+				"GC_JSONL_ARCHIVE_REPO":      "archive",
+				"GC_JSONL_MAX_PUSH_FAILURES": "99",
+			},
+		},
+	}
+
+	for _, tt := range scripts {
+		t.Run(tt.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			binDir := t.TempDir()
+			doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+			listener := listenManagedDoltPort(t)
+			managedPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+			writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
+
+			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+exit 0
+`)
+			writeExecutable(t, filepath.Join(binDir, "sed"), fmt.Sprintf(`#!/bin/sh
+case "$2" in
+  *'\\(true\\|false\\)'*)
+    exit 0
+    ;;
+esac
+exec %q "$@"
+`, realSed))
+
+			env := map[string]string{
+				"DOLT_ARGS_LOG":       doltLog,
+				"GC_CITY":             cityDir,
+				"GC_CITY_PATH":        cityDir,
+				"GC_DOLT_HOST":        "",
+				"GC_DOLT_PORT":        "",
+				"GC_DOLT_USER":        "",
+				"GC_DOLT_PASSWORD":    "",
+				"GIT_CONFIG_GLOBAL":   filepath.Join(t.TempDir(), "gitconfig"),
+				"GIT_CONFIG_NOSYSTEM": "1",
+				"PATH":                binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			}
+			for key, value := range tt.env {
+				if key == "GC_JSONL_ARCHIVE_REPO" {
+					value = filepath.Join(cityDir, value)
+				}
+				env[key] = value
+			}
+
+			runScript(t, filepath.Join(exampleDir(), tt.script), env)
+
+			logData, err := os.ReadFile(doltLog)
+			if err != nil {
+				t.Fatalf("ReadFile(dolt log): %v", err)
+			}
+			log := string(logData)
+			for _, want := range []string{
+				"--host 127.0.0.1",
+				"--port " + managedPort,
+				"--user root",
+			} {
+				if !strings.Contains(log, want) {
+					t.Fatalf("dolt calls missing %q:\n%s", want, log)
+				}
+			}
+		})
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -7,7 +7,12 @@ read_runtime_state_flag() (
     state_file="$1"
     key="$2"
     [ -f "$state_file" ] || return 0
-    sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\\(true\\|false\\).*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
+    value=$(sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\\([^,}[:space:]]*\\).*/\\1/p" "$state_file" 2>/dev/null | head -1 || true)
+    case "$value" in
+        true|false)
+            printf '%s\n' "$value"
+            ;;
+    esac
 )
 
 read_runtime_state_number() (


### PR DESCRIPTION
## Summary
- replace GNU-specific boolean `sed` alternation in managed runtime-state parsing with a portable token extraction
- keep the earlier cross-platform PID liveness helper in place for macOS runner behavior
- add regressions that simulate a `sed` implementation which drops the old `true|false` pattern, covering both Dolt and gastown maintenance scripts

## Validation
- go test ./examples/dolt -run 'TestRuntimeScriptPortPrecedence|TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof|TestRuntimeScriptPortPrecedenceAcceptsPsConfirmedPid|TestRuntimeScriptPortPrecedenceParsesManagedRuntimeStateWithPortableSed|TestHealthScriptReportsRunningWhenLsofIsInconclusive' -count=1
- go test ./examples/gastown -run 'TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts|TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof|TestMaintenanceDoltScriptsUsePsConfirmedManagedRuntimePorts|TestMaintenanceDoltScriptsParseManagedRuntimeStateWithPortableSed' -count=1
- go vet ./...