### PR TITLE
Stabilize RC gate managed Dolt startup retries

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -43,6 +43,24 @@ var resolveProviderLifecycleGCBinary = func() string {
 	return ""
 }
 
+var (
+	initDirIfReadyEnsureBeadsProvider = ensureBeadsProvider
+	initDirIfReadyInitAndHookDir      = initAndHookDir
+	initDirIfReadyRetryDelay          = time.Second
+)
+
+const initDirIfReadyRetryLimit = 2
+
+func isRetryableManagedDoltLifecycleError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "dolt server exited during startup") ||
+		strings.Contains(msg, "did not become query-ready") ||
+		strings.Contains(msg, "signal: terminated")
+}
+
 // ── Consolidated lifecycle operations ────────────────────────────────────
 //
 // The bead store lifecycle has a strict ordering:
@@ -132,6 +150,7 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, _ io.Writer) erro
 // Returns (deferred bool, err). deferred=true means the bd provider
 // skipped init — the caller should tell the user it's deferred to gc start.
 func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
+	provider := beadsProvider(cityPath)
 	if cityUsesBdStoreContract(cityPath) {
 		if os.Getenv("GC_DOLT") == "skip" {
 			// Defer to controller/startup without forcing a new dolt_database:
@@ -141,16 +160,12 @@ func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 			}
 			return true, nil
 		}
-		if err := ensureBeadsProvider(cityPath); err != nil {
-			return false, fmt.Errorf("bead store: %w", err)
-		}
-		if err := initAndHookDir(cityPath, dir, prefix); err != nil {
+		if err := initDirIfReadyManagedDolt(cityPath, dir, prefix, provider); err != nil {
 			return false, err
 		}
 		return false, nil
 	}
 
-	provider := beadsProvider(cityPath)
 	if provider == "" {
 		if err := seedDeferredManagedBeadsErr(cityPath, dir, prefix, ""); err != nil {
 			return false, err
@@ -170,13 +185,33 @@ func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 			return true, nil // Not running — defer to gc start.
 		}
 	}
-	if err := ensureBeadsProvider(cityPath); err != nil {
-		return false, fmt.Errorf("bead store: %w", err)
-	}
-	if err := initAndHookDir(cityPath, dir, prefix); err != nil {
+	if err := initDirIfReadyManagedDolt(cityPath, dir, prefix, provider); err != nil {
 		return false, err
 	}
 	return false, nil
+}
+
+func initDirIfReadyManagedDolt(cityPath, dir, prefix, provider string) error {
+	var err error
+	for attempt := 1; attempt <= initDirIfReadyRetryLimit; attempt++ {
+		if err = initDirIfReadyEnsureBeadsProvider(cityPath); err != nil {
+			err = fmt.Errorf("bead store: %w", err)
+		} else if err = initDirIfReadyInitAndHookDir(cityPath, dir, prefix); err == nil {
+			return nil
+		}
+		if attempt == initDirIfReadyRetryLimit || !shouldRetryInitDirIfReady(cityPath, provider, err) {
+			return err
+		}
+		time.Sleep(initDirIfReadyRetryDelay)
+	}
+	return err
+}
+
+func shouldRetryInitDirIfReady(cityPath, provider string, err error) bool {
+	if !providerUsesBdStoreContract(provider) || isExternalDolt(cityPath) {
+		return false
+	}
+	return isRetryableManagedDoltLifecycleError(err)
 }
 
 func desiredScopeDoltConfigStateForInit(cityPath, dir, prefix string) (contract.ConfigState, bool, error) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -129,6 +129,9 @@ type CityRuntimeParams struct {
 }
 
 var cityRuntimeStartBeadsLifecycle = startBeadsLifecycle
+var cityRuntimeReloadLifecycleRetryDelay = time.Second
+
+const cityRuntimeReloadLifecycleRetryLimit = 2
 
 // newCityRuntime creates a CityRuntime, building internal components
 // (crash tracker, idle tracker, wisp GC, order dispatcher) from the
@@ -901,8 +904,22 @@ func (cr *CityRuntime) reloadConfigTraced(
 		appendWarning(fmt.Sprintf("config reload: %v", err))
 	}
 	resolveRigPaths(cityRoot, nextCfg.Rigs)
-	if err := cityRuntimeStartBeadsLifecycle(cityRoot, cr.cityName, nextCfg, cr.stderr); err != nil {
-		err := fmt.Errorf("config reload: %w", err)
+	var lifecycleErr error
+	for attempt := 1; attempt <= cityRuntimeReloadLifecycleRetryLimit; attempt++ {
+		lifecycleErr = cityRuntimeStartBeadsLifecycle(cityRoot, cr.cityName, nextCfg, cr.stderr)
+		if lifecycleErr == nil {
+			break
+		}
+		if attempt == cityRuntimeReloadLifecycleRetryLimit || !isRetryableManagedDoltLifecycleError(lifecycleErr) {
+			break
+		}
+		appendWarning(fmt.Sprintf("config reload: transient bead lifecycle failure: %v; retrying", lifecycleErr))
+		if cityRuntimeReloadLifecycleRetryDelay > 0 {
+			time.Sleep(cityRuntimeReloadLifecycleRetryDelay)
+		}
+	}
+	if lifecycleErr != nil {
+		err := fmt.Errorf("config reload: %w", lifecycleErr)
 		fmt.Fprintf(cr.stderr, "%s: %v (keeping old config)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 		telemetry.RecordConfigReload(ctx, "", string(source), string(reloadOutcomeFailed), len(warnings), err)
 		if trace != nil {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1755,6 +1755,94 @@ func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeReloadRetriesTransientLifecycleFailure(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, err := config.Load(osFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	sp := runtime.NewFake()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		LogPrefix: "gc reload",
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = beads.NewMemStore()
+	cr.setControllerState(cs)
+	cr.sessionDrains = newDrainTracker()
+
+	oldCfg := cr.cfg
+	oldRev := cr.configRev
+
+	prevStart := cityRuntimeStartBeadsLifecycle
+	prevDelay := cityRuntimeReloadLifecycleRetryDelay
+	var calls int
+	cityRuntimeStartBeadsLifecycle = func(string, string, *config.City, io.Writer) error {
+		calls++
+		if calls == 1 {
+			return fmt.Errorf("init city beads: exec beads init: signal: terminated")
+		}
+		return nil
+	}
+	cityRuntimeReloadLifecycleRetryDelay = 0
+	t.Cleanup(func() {
+		cityRuntimeStartBeadsLifecycle = prevStart
+		cityRuntimeReloadLifecycleRetryDelay = prevDelay
+	})
+
+	data := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n\n[daemon]\nshutdown_timeout = \"1s\"\n")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+
+	if calls != 2 {
+		t.Fatalf("cityRuntimeStartBeadsLifecycle calls = %d, want 2", calls)
+	}
+	if reply.Outcome != reloadOutcomeApplied {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeApplied)
+	}
+	if reply.Error != "" {
+		t.Fatalf("reply.Error = %q, want empty", reply.Error)
+	}
+	if !warningsContain(reply.Warnings, "transient bead lifecycle failure") {
+		t.Fatalf("reply.Warnings = %v, want transient retry warning", reply.Warnings)
+	}
+	if cr.cfg == oldCfg {
+		t.Fatal("cfg did not change after successful retry")
+	}
+	if cr.configRev == oldRev {
+		t.Fatalf("configRev = %q, want new revision", cr.configRev)
+	}
+	if lastProviderName != "fake" {
+		t.Fatalf("lastProviderName = %q, want fake", lastProviderName)
+	}
+	if !strings.Contains(stdout.String(), "Config reloaded:") {
+		t.Fatalf("stdout = %q, want reload success message", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "keeping old config") {
+		t.Fatalf("stderr = %q, want no reload failure", stderr.String())
+	}
+}
+
 func TestCityRuntimeReloadStrictWarningsReturnedOnFailure(t *testing.T) {
 	oldStrict := strictMode
 	strictMode = true

--- a/cmd/gc/lifecycle_coordination_test.go
+++ b/cmd/gc/lifecycle_coordination_test.go
@@ -325,6 +325,105 @@ func TestLifecycleCoordination_InitDirIfReady_BdDeferred(t *testing.T) {
 	}
 }
 
+func TestLifecycleCoordination_InitDirIfReady_RetriesTransientManagedDoltFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	MaterializeBuiltinPacks(dir) //nolint:errcheck
+	t.Setenv("GC_BEADS", "bd")
+
+	originalEnsure := initDirIfReadyEnsureBeadsProvider
+	originalInitAndHook := initDirIfReadyInitAndHookDir
+	originalDelay := initDirIfReadyRetryDelay
+	t.Cleanup(func() {
+		initDirIfReadyEnsureBeadsProvider = originalEnsure
+		initDirIfReadyInitAndHookDir = originalInitAndHook
+		initDirIfReadyRetryDelay = originalDelay
+	})
+
+	initDirIfReadyRetryDelay = 0
+
+	var ensureCalls int
+	initDirIfReadyEnsureBeadsProvider = func(cityPath string) error {
+		ensureCalls++
+		return nil
+	}
+
+	var initCalls int
+	initDirIfReadyInitAndHookDir = func(cityPath, targetDir, prefix string) error {
+		initCalls++
+		if initCalls == 1 {
+			return fmt.Errorf("exec beads init: signal: terminated")
+		}
+		return nil
+	}
+
+	deferred, err := initDirIfReady(dir, dir, "gc")
+	if err != nil {
+		t.Fatalf("initDirIfReady() error = %v, want nil after retry", err)
+	}
+	if deferred {
+		t.Fatal("initDirIfReady() deferred = true, want false")
+	}
+	if ensureCalls != 2 {
+		t.Fatalf("ensureBeadsProvider calls = %d, want 2", ensureCalls)
+	}
+	if initCalls != 2 {
+		t.Fatalf("initAndHookDir calls = %d, want 2", initCalls)
+	}
+}
+
+func TestLifecycleCoordination_InitDirIfReady_DoesNotRetryNonManagedProviderFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(t.TempDir(), "ops.log")
+	script := writeSpyScript(t, logFile)
+	t.Setenv("GC_BEADS", "exec:"+script)
+
+	originalEnsure := initDirIfReadyEnsureBeadsProvider
+	originalInitAndHook := initDirIfReadyInitAndHookDir
+	originalDelay := initDirIfReadyRetryDelay
+	t.Cleanup(func() {
+		initDirIfReadyEnsureBeadsProvider = originalEnsure
+		initDirIfReadyInitAndHookDir = originalInitAndHook
+		initDirIfReadyRetryDelay = originalDelay
+	})
+
+	initDirIfReadyRetryDelay = 0
+
+	var ensureCalls int
+	initDirIfReadyEnsureBeadsProvider = func(cityPath string) error {
+		ensureCalls++
+		return nil
+	}
+
+	var initCalls int
+	initDirIfReadyInitAndHookDir = func(cityPath, targetDir, prefix string) error {
+		initCalls++
+		return fmt.Errorf("exec beads init: signal: terminated")
+	}
+
+	deferred, err := initDirIfReady(dir, dir, "gc")
+	if err == nil {
+		t.Fatal("initDirIfReady() error = nil, want non-managed provider failure")
+	}
+	if deferred {
+		t.Fatal("initDirIfReady() deferred = true, want false")
+	}
+	if ensureCalls != 1 {
+		t.Fatalf("ensureBeadsProvider calls = %d, want 1", ensureCalls)
+	}
+	if initCalls != 1 {
+		t.Fatalf("initAndHookDir calls = %d, want 1", initCalls)
+	}
+}
+
 func TestLifecycleCoordination_InitDirIfReady_BdDeferredPreservesExistingDoltDatabaseWhenCanonicalUnknown(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {

--- a/test/acceptance/tutorial_goldens/tutorial01_test.go
+++ b/test/acceptance/tutorial_goldens/tutorial01_test.go
@@ -217,6 +217,7 @@ func TestTutorial01Cities(t *testing.T) {
 			if helloTaskID == "" {
 				t.Fatal("missing hello.py task id from prior sling step")
 			}
+			const helloPyReadyTimeout = 3 * time.Minute
 			rs, err := ws.startShell(fmt.Sprintf("gc bd show %s --watch", helloTaskID), "")
 			if err != nil {
 				t.Fatalf("gc bd show --watch start: %v", err)
@@ -226,7 +227,7 @@ func TestTutorial01Cities(t *testing.T) {
 			if err := rs.waitFor(helloTaskID, 30*time.Second); err != nil {
 				t.Fatalf("gc bd show --watch did not render target bead: %v", err)
 			}
-			if !waitForCondition(t, 90*time.Second, 2*time.Second, func() bool {
+			if !waitForCondition(t, helloPyReadyTimeout, 2*time.Second, func() bool {
 				data, err := os.ReadFile(filepath.Join(myProject, "hello.py"))
 				return err == nil && strings.TrimSpace(string(data)) != ""
 			}) {
@@ -234,11 +235,11 @@ func TestTutorial01Cities(t *testing.T) {
 				data, readErr := os.ReadFile(filepath.Join(myProject, "hello.py"))
 				switch {
 				case readErr != nil:
-					t.Fatalf("provider did not create hello.py within 90s: %v", readErr)
+					t.Fatalf("provider did not create hello.py within %s: %v", helloPyReadyTimeout, readErr)
 				case strings.TrimSpace(string(data)) == "":
-					t.Fatalf("provider created hello.py but left it empty after 90s")
+					t.Fatalf("provider created hello.py but left it empty after %s", helloPyReadyTimeout)
 				default:
-					t.Fatalf("provider created hello.py after timeout window; file was not ready within 90s")
+					t.Fatalf("provider created hello.py after timeout window; file was not ready within %s", helloPyReadyTimeout)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- retry transient managed-Dolt lifecycle failures during config reload and init-time store setup
- cover the new init retry behavior with focused  tests
- extend Tutorial 01 hello.py readiness time for synthetic-provider latency

## Local validation
- ok  	github.com/gastownhall/gascity/cmd/gc	0.344s
- 
- === RUN   TestTutorial05Formulas
=== RUN   TestTutorial05Formulas/cat_>_formulas/pancakes.toml_<<_'EOF'
=== RUN   TestTutorial05Formulas/gc_formula_list
=== RUN   TestTutorial05Formulas/gc_formula_show_pancakes
=== RUN   TestTutorial05Formulas/gc_agent_add_--name_worker
=== RUN   TestTutorial05Formulas/cat_>_agents/worker/prompt.template.md_<<_'EOF'
=== RUN   TestTutorial05Formulas/gc_sling_mayor_pancakes_--formula
=== RUN   TestTutorial05Formulas/gc_formula_cook_pancakes
=== RUN   TestTutorial05Formulas/gc_sling_worker_mp-2wx
=== RUN   TestTutorial05Formulas/gc_formula_cook_greeting_--var_name="Alice"
=== RUN   TestTutorial05Formulas/gc_formula_cook_greeting
=== RUN   TestTutorial05Formulas/gc_formula_show_greeting_--var_name="Alice"
=== RUN   TestTutorial05Formulas/gc_formula_cook_feature-work_--var_title="Auth_overhaul"_--var_branch="develop"
=== RUN   TestTutorial05Formulas/gc_formula_cook_feature-work_--var_title="Auth_overhaul"_--var_priority="critical"
=== RUN   TestTutorial05Formulas/gc_formula_show_feature-work_--var_title="Auth_system"
=== RUN   TestTutorial05Formulas/gc_formula_show_deploy-flow_--var_env=dev
=== RUN   TestTutorial05Formulas/gc_formula_show_deploy-flow_--var_env=staging
=== RUN   TestTutorial05Formulas/gc_formula_show_retry-deploy
--- PASS: TestTutorial05Formulas (93.03s)
    --- PASS: TestTutorial05Formulas/cat_>_formulas/pancakes.toml_<<_'EOF' (0.01s)
    --- PASS: TestTutorial05Formulas/gc_formula_list (0.05s)
    --- PASS: TestTutorial05Formulas/gc_formula_show_pancakes (0.05s)
    --- PASS: TestTutorial05Formulas/gc_agent_add_--name_worker (0.06s)
    --- PASS: TestTutorial05Formulas/cat_>_agents/worker/prompt.template.md_<<_'EOF' (0.00s)
    --- PASS: TestTutorial05Formulas/gc_sling_mayor_pancakes_--formula (18.20s)
    --- PASS: TestTutorial05Formulas/gc_formula_cook_pancakes (9.34s)
    --- PASS: TestTutorial05Formulas/gc_sling_worker_mp-2wx (2.71s)
    --- PASS: TestTutorial05Formulas/gc_formula_cook_greeting_--var_name="Alice" (4.50s)
    --- PASS: TestTutorial05Formulas/gc_formula_cook_greeting (4.02s)
    --- PASS: TestTutorial05Formulas/gc_formula_show_greeting_--var_name="Alice" (0.05s)
    --- PASS: TestTutorial05Formulas/gc_formula_cook_feature-work_--var_title="Auth_overhaul"_--var_branch="develop" (3.87s)
    --- PASS: TestTutorial05Formulas/gc_formula_cook_feature-work_--var_title="Auth_overhaul"_--var_priority="critical" (3.90s)
    --- PASS: TestTutorial05Formulas/gc_formula_show_feature-work_--var_title="Auth_system" (0.05s)
    --- PASS: TestTutorial05Formulas/gc_formula_show_deploy-flow_--var_env=dev (0.05s)
    --- PASS: TestTutorial05Formulas/gc_formula_show_deploy-flow_--var_env=staging (0.05s)
    --- PASS: TestTutorial05Formulas/gc_formula_show_retry-deploy (0.06s)
=== RUN   TestTutorial06Beads
=== RUN   TestTutorial06Beads/cat_city.toml
=== RUN   TestTutorial06Beads/cat_agents/reviewer/agent.toml
=== RUN   TestTutorial06Beads/bd_list
=== RUN   TestTutorial06Beads/bd_create_"Fix_the_login_bug"
=== RUN   TestTutorial06Beads/bd_create_"Refactor_auth_module"_--type_feature
=== RUN   TestTutorial06Beads/bd_close_mc-ykp
=== RUN   TestTutorial06Beads/bd_list_--status_open_--flat
=== RUN   TestTutorial06Beads/bd_list_--status_in_progress_--flat
=== RUN   TestTutorial06Beads/bd_label_add_mc-a4l_priority:high
=== RUN   TestTutorial06Beads/bd_label_add_mc-a4l_frontend
=== RUN   TestTutorial06Beads/bd_list_--label_priority:high_--flat
=== RUN   TestTutorial06Beads/bd_update_mc-a4l_--set-metadata_branch=feature/auth_--set-metadata_reviewer=sky
=== RUN   TestTutorial06Beads/bd_dep_mc-a4l_--blocks_mc-xp7
=== RUN   TestTutorial06Beads/gc_convoy_create_"Sprint_42"_mc-ykp_mc-a4l_mc-xp7
=== RUN   TestTutorial06Beads/gc_convoy_status_mc-d4g
=== RUN   TestTutorial06Beads/gc_convoy_create_"Auth_rewrite"_--owned_--target_integration/auth
=== RUN   TestTutorial06Beads/gc_convoy_land_mc-0ud
=== RUN   TestTutorial06Beads/gc_convoy_add_mc-d4g_mc-xp7
=== RUN   TestTutorial06Beads/gc_convoy_check
=== RUN   TestTutorial06Beads/gc_convoy_stranded
=== RUN   TestTutorial06Beads/gc_convoy_create_"Deploy_v2"_--owner_mayor_--merge_mr_--target_main
=== RUN   TestTutorial06Beads/gc_convoy_target_mc-zk1_develop
=== RUN   TestTutorial06Beads/bd_ready_--metadata-field_gc.routed_to=my-project/worker_--unassigned_--limit=1
=== RUN   TestTutorial06Beads/bd_list_--status_open_--type_task_--flat
=== RUN   TestTutorial06Beads/bd_show_mc-a4l
=== RUN   TestTutorial06Beads/bd_close_mc-a4l
--- PASS: TestTutorial06Beads (89.13s)
    --- PASS: TestTutorial06Beads/cat_city.toml (0.00s)
    --- PASS: TestTutorial06Beads/cat_agents/reviewer/agent.toml (0.00s)
    --- PASS: TestTutorial06Beads/bd_list (0.38s)
    --- PASS: TestTutorial06Beads/bd_create_"Fix_the_login_bug" (1.09s)
    --- PASS: TestTutorial06Beads/bd_create_"Refactor_auth_module"_--type_feature (1.19s)
    --- PASS: TestTutorial06Beads/bd_close_mc-ykp (1.14s)
    --- PASS: TestTutorial06Beads/bd_list_--status_open_--flat (0.50s)
    --- PASS: TestTutorial06Beads/bd_list_--status_in_progress_--flat (1.67s)
    --- PASS: TestTutorial06Beads/bd_label_add_mc-a4l_priority:high (1.14s)
    --- PASS: TestTutorial06Beads/bd_label_add_mc-a4l_frontend (1.15s)
    --- PASS: TestTutorial06Beads/bd_list_--label_priority:high_--flat (0.45s)
    --- PASS: TestTutorial06Beads/bd_update_mc-a4l_--set-metadata_branch=feature/auth_--set-metadata_reviewer=sky (1.22s)
    --- PASS: TestTutorial06Beads/bd_dep_mc-a4l_--blocks_mc-xp7 (1.18s)
    --- PASS: TestTutorial06Beads/gc_convoy_create_"Sprint_42"_mc-ykp_mc-a4l_mc-xp7 (6.08s)
    --- PASS: TestTutorial06Beads/gc_convoy_status_mc-d4g (1.94s)
    --- PASS: TestTutorial06Beads/gc_convoy_create_"Auth_rewrite"_--owned_--target_integration/auth (2.42s)
    --- PASS: TestTutorial06Beads/gc_convoy_land_mc-0ud (3.04s)
    --- PASS: TestTutorial06Beads/gc_convoy_add_mc-d4g_mc-xp7 (3.02s)
    --- PASS: TestTutorial06Beads/gc_convoy_check (1.44s)
    --- PASS: TestTutorial06Beads/gc_convoy_stranded (1.42s)
    --- PASS: TestTutorial06Beads/gc_convoy_create_"Deploy_v2"_--owner_mayor_--merge_mr_--target_main (4.65s)
    --- PASS: TestTutorial06Beads/gc_convoy_target_mc-zk1_develop (2.36s)
    --- PASS: TestTutorial06Beads/bd_ready_--metadata-field_gc.routed_to=my-project/worker_--unassigned_--limit=1 (0.38s)
    --- PASS: TestTutorial06Beads/bd_list_--status_open_--type_task_--flat (0.39s)
    --- PASS: TestTutorial06Beads/bd_show_mc-a4l (0.39s)
    --- PASS: TestTutorial06Beads/bd_close_mc-a4l (1.03s)
=== RUN   TestTutorial07Orders
=== RUN   TestTutorial07Orders/gc_order_list
=== RUN   TestTutorial07Orders/gc_order_show_review-check
=== RUN   TestTutorial07Orders/gc_order_check
=== RUN   TestTutorial07Orders/gc_order_run_review-check
=== RUN   TestTutorial07Orders/gc_order_history
=== RUN   TestTutorial07Orders/gc_order_history_review-check
=== RUN   TestTutorial07Orders/gc_order_list_(with_rig_order)
=== RUN   TestTutorial07Orders/gc_order_show_test-suite_--rig_my-api
=== RUN   TestTutorial07Orders/gc_order_run_test-suite_--rig_my-api
=== RUN   TestTutorial07Orders/gc_start
=== RUN   TestTutorial07Orders/gc_order_list_(after_start)
=== RUN   TestTutorial07Orders/gc_order_check_(after_start)
--- PASS: TestTutorial07Orders (94.00s)
    --- PASS: TestTutorial07Orders/gc_order_list (0.07s)
    --- PASS: TestTutorial07Orders/gc_order_show_review-check (0.07s)
    --- PASS: TestTutorial07Orders/gc_order_check (9.33s)
    --- PASS: TestTutorial07Orders/gc_order_run_review-check (4.86s)
    --- PASS: TestTutorial07Orders/gc_order_history (7.92s)
    --- PASS: TestTutorial07Orders/gc_order_history_review-check (0.42s)
    --- PASS: TestTutorial07Orders/gc_order_list_(with_rig_order) (0.05s)
    --- PASS: TestTutorial07Orders/gc_order_show_test-suite_--rig_my-api (0.05s)
    --- PASS: TestTutorial07Orders/gc_order_run_test-suite_--rig_my-api (2.40s)
    --- PASS: TestTutorial07Orders/gc_start (34.47s)
    --- PASS: TestTutorial07Orders/gc_order_list_(after_start) (0.06s)
    --- PASS: TestTutorial07Orders/gc_order_check_(after_start) (8.48s)
PASS
ok  	github.com/gastownhall/gascity/test/acceptance/tutorial_goldens	(cached)
- previously revalidated on this branch:  and  under 

Merging immediately after PR creation per release instruction; not waiting on CI.