### PR TITLE
chore: align release pipeline with gastown (Phase 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -21,11 +26,25 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Reject replace directives in go.mod
+        run: |
+          if grep -qE '^replace\s' go.mod; then
+            echo "ERROR: go.mod contains replace directives — aborting release."
+            echo "Replace directives break 'go install ...@latest' and bottle builds in homebrew-core."
+            grep -n '^replace' go.mod
+            exit 1
+          fi
+
+      - name: Verify release tag is stable
+        run: make check-version-tag
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           version: "~> v2"
-          args: release --clean
+          args: >
+            release --clean
+            ${{ github.repository != 'gastownhall/gascity' && '--skip=publish --skip=announce' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,3 +56,15 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^ci:"
+      - "^chore:"
+      - "Merge pull request"
+      - "Merge branch"
+  groups:
+    - title: "Features"
+      regexp: '^.*feat(\(\w+\))?:.*$'
+      order: 0
+    - title: "Bug Fixes"
+      regexp: '^.*fix(\(\w+\))?:.*$'
+      order: 1
+    - title: "Others"
+      order: 999

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to Gas City will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-04-21
+
+First stable release. Between `v0.15.1` and `v1.0.0` the project received 610
+commits across 1,273 files (+303,902 / −46,437) from the core team and 12
+community contributors. See the GitHub release page for the full narrative.
+
+### Added
+
+- `gc reload [path]` — structured live config reload. Failures keep the previous
+  runtime config active instead of silently degrading.
+- `gc prime --strict` — turns silent prompt/agent fallback paths into explicit
+  CLI failures for debugging.
+- `rig adopt` — adopt existing rigs without a full rebuild.
+- Provider-native MCP projection for Claude, Codex, and Gemini, with multi-layer
+  catalog resolution and projected-only `gc mcp list`.
+- Per-agent `append_fragments` so prompt layering is configurable through the
+  supported config and migration paths.
+- Wave 1 pass over orders and dispatch runtime — store resolution, dispatch
+  surfaces, rig-aware execution, and verifier coverage.
+
+### Changed
+
+- **Session model unified.** Declarative `[[agent]]` policy/config is now
+  cleanly separated from runtime session identity; session beads are the
+  canonical runtime projection.
+- **Pack V2 is the active layout.** Bundled packs use `[imports.<name>]`;
+  builtin formulas, prompts, hooks, and orders come from the builtin `core`
+  pack. V1-era city-local seeding is retired.
+- `gc init` is back on the pack-first scaffold contract. Agent and named
+  sessions belong in `pack.toml`; machine-local identity stays in
+  `.gc/site.toml`; `city.toml` keeps workspace/provider state.
+- `gc import install` is now the explicit bootstrap path for importable packs.
+- `gc session logs --tail N` returns the last `N` entries (matches Unix `tail`
+  convention) instead of the old compaction-oriented behavior.
+- Supervisor API migrated to Huma/OpenAPI; Go client regenerated; dashboard SPA
+  restored.
+- Order "gates" renamed to **triggers**.
+
+### Fixed
+
+- Startup proofs for hook-enabled providers — correct startup prompt delivery,
+  no duplicate `SessionStart` hook context, no replay of startup prompts on
+  resumed sessions.
+- Managed Dolt hardening: recovery, transient failures, health probes,
+  runtime-state validation, and late-cycle macOS portability fixes (start-lock
+  FD inheritance, path canonicalization, `lsof` reachability, PID confirmation,
+  portable `sed` parsing).
+- Pack V2 tmux startup regression where large prompt launches could silently
+  fall back to the known-broken inline path.
+- Custom provider option defaults now fail early instead of silently degrading.
+- Beads storage core quality pass — cache recovery, close-all fallback
+  semantics, watchdog reconciliation cadence, dirty-cache fallback reads.
+- Long tail of session lifecycle, wake-budget, and pool identity fixes.
+
+[Unreleased]: https://github.com/gastownhall/gascity/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/gastownhall/gascity/releases/tag/v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt lint fmt-check fmt vet test test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev
 
 ## build: compile gc binary with version metadata
 build:
@@ -79,6 +79,30 @@ check-docker:
 check-dolt:
 	@command -v dolt >/dev/null 2>&1 || \
 		(echo "Error: dolt not found. See docs/getting-started/installation.md" && exit 1)
+
+## check-version-tag: verify HEAD's release tag (if any) is a clean stable vX.Y.Z
+## No-op on untagged HEADs, so safe to run on every checkout. Used by release.yml
+## to reject pre-release tags (vX.Y.Z-rc1, -beta, etc.) — the release workflow
+## publishes stable releases only.
+check-version-tag:
+	@TAG=$$(git describe --tags --exact-match HEAD 2>/dev/null || true); \
+	if [ -z "$$TAG" ]; then \
+		echo "check-version-tag: HEAD is not a release tag, skipping"; \
+		exit 0; \
+	fi; \
+	if echo "$$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "check-version-tag: OK ($$TAG is a stable release tag)"; \
+		exit 0; \
+	fi; \
+	if echo "$$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-'; then \
+		echo "ERROR: tag '$$TAG' has a pre-release suffix"; \
+		echo "The release workflow publishes stable releases only."; \
+		echo "Pre-release tags should not trigger release.yml."; \
+		exit 1; \
+	fi; \
+	echo "ERROR: tag '$$TAG' is not a vX.Y.Z release tag"; \
+	echo "Release tags must match vMAJOR.MINOR.PATCH exactly."; \
+	exit 1
 
 ## check-all: run all quality gates including integration tests (CI)
 check-all: fmt-check lint vet check-bd check-dolt check-docker test-integration check-docs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,107 @@
+# Releasing Gas City
+
+## Distribution Channels
+
+| Channel | Mechanism | Automatic? |
+|---------|-----------|------------|
+| **GitHub Release** | GoReleaser via `release.yml` on tag push | Yes |
+| **Homebrew tap** (`gastownhall/gascity`) | GoReleaser `brews:` block writes to the tap on tag push | Yes |
+| **Homebrew core** (`Homebrew/homebrew-core`) | BrewTestBot autobump, once listed | Yes (~3h delay) |
+
+The homebrew-core submission is [in progress](https://github.com/Homebrew/homebrew-core). Until it lands and is added to the autobump list, users install via `brew install gastownhall/gascity/gascity`.
+
+## How to Release
+
+### Recommended: bump script
+
+```bash
+./scripts/bump-version.sh X.Y.Z --commit --tag --push
+```
+
+This rewrites the `[Unreleased]` section of `CHANGELOG.md` into `[X.Y.Z] - YYYY-MM-DD`, commits, tags `vX.Y.Z`, and pushes. GitHub Actions takes it from there.
+
+### Manual
+
+If you want to do the steps by hand:
+
+1. Edit `CHANGELOG.md`: move `[Unreleased]` contents under a new `## [X.Y.Z] - YYYY-MM-DD` section.
+2. Commit:
+   ```bash
+   git add CHANGELOG.md
+   git commit -m "chore: release vX.Y.Z"
+   ```
+3. Tag and push:
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin HEAD
+   git push origin vX.Y.Z
+   ```
+
+Version numbers live **only** in the git tag — there is no `Version` constant in Go source to keep in sync. `cmd/gc/cmd_version.go` has `var version = "dev"` that the Makefile and `.goreleaser.yml` inject at build time via `-X main.version=$(VERSION)`.
+
+## What Happens After Tag Push
+
+`.github/workflows/release.yml` fires on any `v*` tag and runs, in order:
+
+1. **Reject `replace` directives in `go.mod`** — they break `go install ...@latest` and bottle builds in homebrew-core.
+2. **`make check-version-tag`** — asserts the tag is a clean `vMAJOR.MINOR.PATCH` with no pre-release suffix. RC/beta tags will fail the release. Pre-release tags should be cut on a dedicated branch or not trigger this workflow.
+3. **GoReleaser** — builds binaries for linux/darwin × amd64/arm64, creates the GitHub Release with grouped changelog (`feat:` → Features, `fix:` → Bug Fixes, others → Others), and writes the Homebrew tap formula via the `brews:` block in `.goreleaser.yml`.
+
+Forks skip publish/announce steps automatically via the `--skip=publish --skip=announce` flag (the workflow checks `github.repository != 'gastownhall/gascity'`).
+
+### Running checks locally before pushing the tag
+
+```bash
+make check-version-tag    # no-op unless HEAD is a release tag
+grep '^replace' go.mod    # should print nothing
+```
+
+## Homebrew tap (`gastownhall/gascity`)
+
+The GoReleaser `brews:` block automatically overwrites `Formula/gascity.rb` in the `gastownhall/homebrew-gascity` repo on every tag push, using `HOMEBREW_TAP_TOKEN`. No manual action required.
+
+**This section will change when homebrew-core lands.** The `brews:` block will be removed, the tap will be deprecated, and releases will flow only through the source-built formula in homebrew-core.
+
+## Homebrew core (planned)
+
+Once the formula is merged to `Homebrew/homebrew-core` and added to the autobump list, the flow becomes:
+
+1. Tag push → GoReleaser creates GitHub Release (as today).
+2. BrewTestBot polls releases every ~3h, opens a PR to homebrew-core bumping the formula's `url` and `sha256`.
+3. Homebrew maintainers merge; bottles are built for macOS (arm64 + x86_64) and Linux.
+4. `brew upgrade gascity` picks up the new version worldwide.
+
+Manual `brew bump-formula-pr` is refused for autobump formulae. If the bot stalls, check `https://github.com/Homebrew/homebrew-core/pulls?q=gascity` for stuck PRs.
+
+## Files Updated During a Release
+
+| File | What changes | Updated by |
+|------|-------------|------------|
+| `CHANGELOG.md` | `[Unreleased]` → `[X.Y.Z] - DATE` | `scripts/bump-version.sh` |
+| Git tag `vX.Y.Z` | Created and pushed | `scripts/bump-version.sh` |
+| GitHub Release page | Created with binaries + grouped changelog | GoReleaser in `release.yml` |
+| `gastownhall/homebrew-gascity/Formula/gascity.rb` | `url` + `sha256` updated | GoReleaser in `release.yml` |
+
+## Troubleshooting
+
+### `make check-version-tag` fails with "pre-release suffix"
+
+The tag has a suffix (`-rc1`, `-beta`, `-alpha.1`). The release workflow only publishes stable releases. Either retag without the suffix, or don't trigger `release.yml` for this tag.
+
+### GoReleaser fails with "replace directives"
+
+`go.mod` contains a `replace` directive. These break `go install ...@latest` and homebrew-core bottle builds. Remove the directive and commit before tagging.
+
+### Release tag pushed but workflow didn't run
+
+Check `.github/workflows/release.yml` still matches `tags: v*`. Verify the tag was pushed to `origin` (`git ls-remote origin refs/tags/vX.Y.Z`).
+
+### Tap formula not updated
+
+Check `HOMEBREW_TAP_TOKEN` in repo secrets. It needs `contents: write` on `gastownhall/homebrew-gascity`. The workflow logs will show the exact error.
+
+### Homebrew shows old version after a release
+
+While on the tap: a tag push updates the tap directly; users pick it up on the next `brew update && brew upgrade gascity`. If the formula wasn't updated, see above.
+
+After homebrew-core lands: the autobump bot runs every ~3h. After ~6h without a PR, check `https://github.com/Homebrew/homebrew-core/pulls?q=gascity`.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Version bump script for Gas City.
+#
+# Gas City does NOT carry a Version constant in Go source — version is injected
+# into main.version at build time via ldflags (see Makefile + .goreleaser.yml).
+# The git tag is the single source of truth.
+#
+# This script exists to move the CHANGELOG [Unreleased] section to a new
+# [X.Y.Z] section, commit, tag, and push. That's it. If future channels (npm,
+# Nix) get added, extend here.
+#
+# QUICK START:
+#   ./scripts/bump-version.sh X.Y.Z --commit --tag --push
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+usage() {
+    cat <<EOF
+Usage: $0 <version> [--commit] [--tag] [--push]
+
+Cut a Gas City release.
+
+Arguments:
+  <version>        Semantic version (e.g., 1.0.0, 1.1.0). No leading 'v', no pre-release suffix.
+  --commit         Automatically create a git commit for the CHANGELOG change.
+  --tag            Create annotated git tag vX.Y.Z (requires --commit).
+  --push           Push commit and tag to origin (requires --tag).
+
+Examples:
+  $0 1.0.0                          # Update CHANGELOG, show diff, stop.
+  $0 1.0.0 --commit                 # Update and commit.
+  $0 1.0.0 --commit --tag           # Update, commit, tag.
+  $0 1.0.0 --commit --tag --push    # Full release.
+
+After --push, GitHub Actions release.yml runs GoReleaser and publishes
+the GitHub release. Once the formula is in homebrew-core on the autobump list,
+BrewTestBot opens the bump PR automatically within a few hours.
+
+See RELEASING.md for the full process.
+EOF
+    exit 1
+}
+
+validate_version() {
+    local version=$1
+    if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        printf '%bError: version must be MAJOR.MINOR.PATCH with no prefix or suffix (got: %s)%b\n' \
+            "$RED" "$version" "$NC" >&2
+        exit 1
+    fi
+}
+
+update_changelog() {
+    local version=$1
+    local date
+    date=$(date +%Y-%m-%d)
+
+    if [ ! -f "CHANGELOG.md" ]; then
+        printf '%bError: CHANGELOG.md not found at repo root%b\n' "$RED" "$NC" >&2
+        exit 1
+    fi
+
+    if ! grep -q "^## \[Unreleased\]" CHANGELOG.md; then
+        printf '%bError: No [Unreleased] section in CHANGELOG.md%b\n' "$RED" "$NC" >&2
+        exit 1
+    fi
+
+    # Insert a new "## [X.Y.Z] - DATE" header directly under "## [Unreleased]".
+    # Portable across GNU and BSD sed via sed_i helper.
+    sed_i "s/^## \[Unreleased\]$/## [Unreleased]\\n\\n## [$version] - $date/" CHANGELOG.md
+}
+
+main() {
+    [ $# -lt 1 ] && usage
+    case "$1" in
+        -h|--help) usage ;;
+    esac
+
+    local NEW_VERSION=$1
+    shift
+    local AUTO_COMMIT=false AUTO_TAG=false AUTO_PUSH=false
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --commit) AUTO_COMMIT=true ;;
+            --tag)    AUTO_TAG=true ;;
+            --push)   AUTO_PUSH=true ;;
+            -h|--help) usage ;;
+            *)
+                printf '%bError: unknown option %q%b\n' "$RED" "$1" "$NC" >&2
+                usage
+                ;;
+        esac
+        shift
+    done
+
+    if [ "$AUTO_TAG" = true ] && [ "$AUTO_COMMIT" = false ]; then
+        printf '%bError: --tag requires --commit%b\n' "$RED" "$NC" >&2
+        exit 1
+    fi
+    if [ "$AUTO_PUSH" = true ] && [ "$AUTO_TAG" = false ]; then
+        printf '%bError: --push requires --tag%b\n' "$RED" "$NC" >&2
+        exit 1
+    fi
+
+    validate_version "$NEW_VERSION"
+
+    if [ ! -f "CHANGELOG.md" ] || [ ! -f "go.mod" ]; then
+        printf '%bError: must run from repository root%b\n' "$RED" "$NC" >&2
+        exit 1
+    fi
+
+    if ! git diff-index --quiet HEAD --; then
+        if [ "$AUTO_COMMIT" = true ]; then
+            printf '%bError: cannot auto-commit with existing uncommitted changes%b\n' \
+                "$RED" "$NC" >&2
+            exit 1
+        fi
+        printf '%bWarning: you have uncommitted changes%b\n' "$YELLOW" "$NC"
+    fi
+
+    local TAG="v$NEW_VERSION"
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        printf '%bError: tag %s already exists%b\n' "$RED" "$TAG" "$NC" >&2
+        exit 1
+    fi
+
+    printf '%bBumping CHANGELOG to %s%b\n\n' "$YELLOW" "$NEW_VERSION" "$NC"
+    update_changelog "$NEW_VERSION"
+
+    printf '%b✓ CHANGELOG.md updated%b\n\n' "$GREEN" "$NC"
+    git diff --stat CHANGELOG.md
+    echo
+
+    if [ "$AUTO_COMMIT" = true ]; then
+        git add CHANGELOG.md
+        git commit -m "chore: release v$NEW_VERSION"
+        printf '%b✓ Commit created%b\n' "$GREEN" "$NC"
+
+        if [ "$AUTO_TAG" = true ]; then
+            git tag -a "$TAG" -m "Release $TAG"
+            printf '%b✓ Tag %s created%b\n' "$GREEN" "$TAG" "$NC"
+        fi
+
+        if [ "$AUTO_PUSH" = true ]; then
+            git push origin HEAD
+            git push origin "$TAG"
+            printf '%b✓ Pushed commit and tag to origin%b\n' "$GREEN" "$NC"
+            printf '\nRelease %s initiated. GitHub Actions will build artifacts in ~5-10 minutes.\n' "$TAG"
+            printf 'Monitor: https://github.com/gastownhall/gascity/actions\n'
+        else
+            printf '\nNext steps:\n'
+            [ "$AUTO_TAG" = false ] && printf '  git tag -a %s -m "Release %s"\n' "$TAG" "$TAG"
+            printf '  git push origin HEAD\n'
+            printf '  git push origin %s\n' "$TAG"
+        fi
+    else
+        printf 'Review the diff above.\n\n'
+        printf 'To complete the release:\n'
+        printf '  %s %s --commit --tag --push\n' "$0" "$NEW_VERSION"
+    fi
+}
+
+main "$@"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared helpers for Gas City release scripts.
+#
+# Source this file in other scripts:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/common.sh"
+
+# shellcheck disable=SC2034  # colors are consumed by sourcing scripts
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+is_darwin_sed() {
+    [[ "$OSTYPE" == "darwin"* && "$(command -v sed)" == "/usr/bin/sed" ]]
+}
+
+# Cross-platform `sed -i` wrapper (BSD sed on macOS needs an explicit empty backup arg).
+sed_i() {
+    if is_darwin_sed; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}


### PR DESCRIPTION
## Summary

Phase 1 of aligning Gas City's release pipeline with upstream gastown, in preparation for a homebrew-core submission. All changes are additive — no behavior change for merged-to-main commits. The next tag push is the first time the new guardrails run.

### What's new
- **`CHANGELOG.md`** — Keep-a-Changelog format, seeded with `[Unreleased]` and `[1.0.0]` sections distilled from the `v1.0.0-rc2` release notes.
- **`scripts/bump-version.sh` + `scripts/lib/common.sh`** — since version is injected via ldflags (no `Version` Go constant to keep in sync), the script only rewrites `CHANGELOG` `[Unreleased]` → `[X.Y.Z]`, commits, tags, and pushes. Simpler than gastown's script because we don't have multiple version files to sync.
- **`RELEASING.md`** — documents the current tap flow and the planned homebrew-core migration path, modeled on gastown's doc.
- **`make check-version-tag`** — rejects pre-release suffixes (`-rc`, `-beta`, etc.) and non-`vX.Y.Z` tag shapes. No-op on untagged HEADs so it's safe to run anywhere (including pre-commit).

### What's hardened
- **`.github/workflows/release.yml`**:
  - `go.mod` `replace` directive guard (breaks `go install ...@latest` and homebrew-core bottle builds).
  - `make check-version-tag` step before GoReleaser runs.
  - Fork-safe `--skip=publish --skip=announce` when the workflow runs outside `gastownhall/gascity`.
  - Concurrency group + `workflow_dispatch` trigger.
- **`.goreleaser.yml`** — changelog groups (`feat:` → Features, `fix:` → Bug Fixes, rest → Others) matching gastown; excludes `chore:` and merge commits from the release body.

### What's NOT in this PR (Phase 2+)
- GoReleaser `brews:` block removal — stays until the homebrew-core formula is live.
- Hand-authored source-built formula in `gastownhall/homebrew-gascity`.
- `cmd/gc/main.go` completion enablement (currently `DisableDefaultCmd = true`).
- homebrew-core submission itself.

## Test plan

- [x] `make check-version-tag` — manually validated four cases: untagged HEAD (skip), stable `v99.99.99` (OK), `v99.99.99-rc1` (rejected with pre-release error), `release-1` (rejected as malformed shape).
- [x] `./scripts/bump-version.sh --help` — works; rejects `1.0.0-rc5` as invalid version; rejects `--tag` without `--commit`.
- [x] `bash -n` clean on both shell scripts; `shellcheck` clean except for SC1091 (standard single-file limitation).
- [x] YAML validated for both modified workflow files.
- [ ] Next stable tag push exercises the new release.yml guardrails end-to-end (will validate on first real use).

## Context

See the planning thread for the full four-phase roadmap:
1. **This PR** — release pipeline parity with gastown.
2. Source-built formula landed in `gastownhall/homebrew-gascity` (dogfood `brew audit --strict --new --online` locally).
3. Homebrew-core PR once `v1.0.0` final is tagged.
4. Autobump request + tap deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)