### PR TITLE
Add pre_launch startup hooks

### DIFF
--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -518,6 +518,9 @@ func explainAgent(w io.Writer, a *config.Agent, prov *config.Provenance) {
 	if len(a.PreStart) > 0 {
 		explainField(w, "pre_start", fmt.Sprintf("[%d commands]", len(a.PreStart)), source)
 	}
+	if len(a.PreLaunch) > 0 {
+		explainField(w, "pre_launch", fmt.Sprintf("[%d commands]", len(a.PreLaunch)), source)
+	}
 	if a.PromptTemplate != "" {
 		explainField(w, "prompt_template", a.PromptTemplate, source)
 	}

--- a/cmd/gc/cmd_work.go
+++ b/cmd/gc/cmd_work.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	resolveWorkCity = resolveCity
+	openWorkStoreAt = openStoreAtForCity
+	claimNextWorkFn = claimNextWork
+)
+
 func newWorkCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "work",
@@ -38,15 +44,21 @@ func newWorkClaimNextCmd(stdout, stderr io.Writer) *cobra.Command {
 			if strings.TrimSpace(template) == "" || strings.TrimSpace(assignee) == "" {
 				return fmt.Errorf("claim-next requires --template and --assignee (or GC_TEMPLATE/GC_SESSION_ID env)")
 			}
-			cityPath, err := resolveCity()
+			cityPath, err := resolveWorkCity()
 			if err != nil {
 				return err
 			}
-			store, err := openCityStoreAt(cityPath)
+			storeRoot := claimNextStoreRoot(cityPath)
+			store, err := openWorkStoreAt(storeRoot, cityPath)
 			if err != nil {
 				return err
 			}
-			result, err := claimNextWork(cmd.Context(), store, cityPath, template, assignee)
+			result, err := claimNextWorkFn(cmd.Context(), store, storeRoot, template, assignee, claimIdentityCandidates(
+				assignee,
+				os.Getenv("GC_SESSION_ID"),
+				os.Getenv("GC_SESSION_NAME"),
+				os.Getenv("GC_ALIAS"),
+			))
 			if err != nil {
 				return err
 			}
@@ -73,44 +85,149 @@ type claimNextResult struct {
 	Reason string
 }
 
-func claimNextWork(ctx context.Context, store beads.Store, cityPath, template, assignee string) (claimNextResult, error) {
-	existing, err := store.List(beads.ListQuery{Assignee: assignee, Status: "in_progress", Limit: 1})
-	if err != nil {
-		return claimNextResult{}, err
-	}
-	if len(existing) > 0 {
-		return claimNextResult{Bead: existing[0], Reason: "existing_assignment"}, nil
-	}
-	candidates, err := store.List(beads.ListQuery{
-		Metadata: map[string]string{"gc.routed_to": template},
-		Status:   "open",
-		Limit:    10,
-	})
-	if err != nil {
-		return claimNextResult{}, err
-	}
-	for _, candidate := range candidates {
-		if strings.TrimSpace(candidate.Assignee) != "" {
-			continue
-		}
-		if err := claimWork(ctx, cityPath, candidate.ID, assignee); err != nil {
-			if beads.IsClaimConflict(err) {
-				continue
-			}
-			return claimNextResult{}, err
-		}
-		claimed, err := store.Get(candidate.ID)
+func claimNextWork(ctx context.Context, store beads.Store, claimDir, template, assignee string, identities []string) (claimNextResult, error) {
+	identities = claimIdentityCandidates(append([]string{assignee}, identities...)...)
+	for _, identity := range identities {
+		existing, err := store.List(beads.ListQuery{Assignee: identity, Status: "in_progress", Limit: 1})
 		if err != nil {
 			return claimNextResult{}, err
 		}
-		if claimed.Assignee == assignee {
-			return claimNextResult{Bead: claimed, Reason: "claimed"}, nil
+		if len(existing) > 0 {
+			return claimNextResult{Bead: existing[0], Reason: "existing_assignment"}, nil
 		}
 	}
+
+	ready, err := store.Ready()
+	if err != nil {
+		return claimNextResult{}, err
+	}
+	for _, candidate := range ready {
+		if claimNextHasIdentity(candidate.Assignee, identities) {
+			return claimNextResult{Bead: candidate, Reason: "ready_assignment"}, nil
+		}
+	}
+
+	routeTargets := claimRouteTargets(template)
+	for _, candidate := range ready {
+		if strings.TrimSpace(candidate.Assignee) != "" || !claimNextMatchesRoute(candidate, routeTargets) {
+			continue
+		}
+		claimed, ok, err := claimNextCandidate(ctx, store, claimDir, candidate.ID, assignee)
+		if err != nil {
+			return claimNextResult{}, err
+		}
+		if !ok {
+			continue
+		}
+		return claimNextResult{Bead: claimed, Reason: "claimed"}, nil
+	}
+
+	for _, target := range routeTargets {
+		molecules, err := store.List(beads.ListQuery{
+			Metadata: map[string]string{"gc.routed_to": target},
+			Status:   "open",
+			Type:     "molecule",
+			Limit:    10,
+		})
+		if err != nil {
+			return claimNextResult{}, err
+		}
+		for _, candidate := range molecules {
+			if strings.TrimSpace(candidate.Assignee) != "" {
+				continue
+			}
+			claimed, ok, err := claimNextCandidate(ctx, store, claimDir, candidate.ID, assignee)
+			if err != nil {
+				return claimNextResult{}, err
+			}
+			if !ok {
+				continue
+			}
+			return claimNextResult{Bead: claimed, Reason: "claimed_molecule"}, nil
+		}
+	}
+
 	return claimNextResult{Reason: "no_work"}, nil
 }
 
 var claimWork = beads.ClaimWithBD
+
+func claimNextStoreRoot(cityPath string) string {
+	if root := strings.TrimSpace(os.Getenv("GC_STORE_ROOT")); root != "" {
+		return root
+	}
+	return cityPath
+}
+
+func claimIdentityCandidates(values ...string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			return
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	for _, value := range values {
+		add(value)
+		if legacy := claimLegacyWorkflowControlName(value); legacy != "" {
+			add(legacy)
+		}
+	}
+	return out
+}
+
+func claimRouteTargets(template string) []string {
+	return claimIdentityCandidates(template)
+}
+
+func claimLegacyWorkflowControlName(value string) string {
+	value = strings.TrimSpace(value)
+	const suffix = "control-dispatcher"
+	if !strings.HasSuffix(value, suffix) {
+		return ""
+	}
+	return strings.TrimSuffix(value, suffix) + "workflow-control"
+}
+
+func claimNextHasIdentity(assignee string, identities []string) bool {
+	assignee = strings.TrimSpace(assignee)
+	for _, identity := range identities {
+		if assignee == identity {
+			return true
+		}
+	}
+	return false
+}
+
+func claimNextMatchesRoute(candidate beads.Bead, routeTargets []string) bool {
+	routedTo := strings.TrimSpace(candidate.Metadata["gc.routed_to"])
+	for _, target := range routeTargets {
+		if routedTo == target {
+			return true
+		}
+	}
+	return false
+}
+
+func claimNextCandidate(ctx context.Context, store beads.Store, claimDir, beadID, assignee string) (beads.Bead, bool, error) {
+	if err := claimWork(ctx, claimDir, beadID, assignee); err != nil {
+		if beads.IsClaimConflict(err) {
+			return beads.Bead{}, false, nil
+		}
+		return beads.Bead{}, false, err
+	}
+	claimed, err := store.Get(beadID)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	if claimed.Assignee != assignee {
+		return beads.Bead{}, false, nil
+	}
+	return claimed, true, nil
+}
 
 func writePreLaunchClaimResult(w io.Writer, result claimNextResult) error {
 	type response struct {

--- a/cmd/gc/cmd_work.go
+++ b/cmd/gc/cmd_work.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/spf13/cobra"
+)
+
+func newWorkCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "work",
+		Short: "Manage runnable work for agents",
+	}
+	cmd.AddCommand(newWorkClaimNextCmd(stdout, stderr))
+	return cmd
+}
+
+func newWorkClaimNextCmd(stdout, stderr io.Writer) *cobra.Command {
+	var template string
+	var assignee string
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "claim-next",
+		Short: "Atomically claim the next routed work item",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(template) == "" {
+				template = os.Getenv("GC_TEMPLATE")
+			}
+			if strings.TrimSpace(assignee) == "" {
+				assignee = firstNonEmptyWorkEnv(os.Getenv("GC_SESSION_ID"), os.Getenv("GC_SESSION_NAME"), os.Getenv("GC_ALIAS"), os.Getenv("GC_AGENT"))
+			}
+			if strings.TrimSpace(template) == "" || strings.TrimSpace(assignee) == "" {
+				return fmt.Errorf("claim-next requires --template and --assignee (or GC_TEMPLATE/GC_SESSION_ID env)")
+			}
+			cityPath, err := resolveCity()
+			if err != nil {
+				return err
+			}
+			store, err := openCityStoreAt(cityPath)
+			if err != nil {
+				return err
+			}
+			result, err := claimNextWork(cmd.Context(), store, cityPath, template, assignee)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return writePreLaunchClaimResult(stdout, result)
+			}
+			if result.Bead.ID == "" {
+				fmt.Fprintln(stdout, "no work") //nolint:errcheck
+				return nil
+			}
+			fmt.Fprintf(stdout, "%s\n", result.Bead.ID) //nolint:errcheck
+			_ = stderr
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&template, "template", "", "agent template/routing target")
+	cmd.Flags().StringVar(&assignee, "assignee", "", "session identity to claim as")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit pre_launch JSON")
+	return cmd
+}
+
+type claimNextResult struct {
+	Bead   beads.Bead
+	Reason string
+}
+
+func claimNextWork(ctx context.Context, store beads.Store, cityPath, template, assignee string) (claimNextResult, error) {
+	existing, err := store.List(beads.ListQuery{Assignee: assignee, Status: "in_progress", Limit: 1})
+	if err != nil {
+		return claimNextResult{}, err
+	}
+	if len(existing) > 0 {
+		return claimNextResult{Bead: existing[0], Reason: "existing_assignment"}, nil
+	}
+	candidates, err := store.List(beads.ListQuery{
+		Metadata: map[string]string{"gc.routed_to": template},
+		Status:   "open",
+		Limit:    10,
+	})
+	if err != nil {
+		return claimNextResult{}, err
+	}
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate.Assignee) != "" {
+			continue
+		}
+		if err := claimWork(ctx, cityPath, candidate.ID, assignee); err != nil {
+			if beads.IsClaimConflict(err) {
+				continue
+			}
+			return claimNextResult{}, err
+		}
+		claimed, err := store.Get(candidate.ID)
+		if err != nil {
+			return claimNextResult{}, err
+		}
+		if claimed.Assignee == assignee {
+			return claimNextResult{Bead: claimed, Reason: "claimed"}, nil
+		}
+	}
+	return claimNextResult{Reason: "no_work"}, nil
+}
+
+var claimWork = beads.ClaimWithBD
+
+func writePreLaunchClaimResult(w io.Writer, result claimNextResult) error {
+	type response struct {
+		Action      string            `json:"action"`
+		Reason      string            `json:"reason,omitempty"`
+		Env         map[string]string `json:"env,omitempty"`
+		NudgeAppend string            `json:"nudge_append,omitempty"`
+		Metadata    map[string]string `json:"metadata,omitempty"`
+	}
+	if result.Bead.ID == "" {
+		return json.NewEncoder(w).Encode(response{Action: "drain", Reason: result.Reason})
+	}
+	return json.NewEncoder(w).Encode(response{
+		Action:      "continue",
+		Reason:      result.Reason,
+		Env:         map[string]string{"GC_WORK_BEAD": result.Bead.ID},
+		NudgeAppend: "\n\nClaimed work bead: " + result.Bead.ID,
+		Metadata:    map[string]string{"pre_launch.user.claimed_work_bead": result.Bead.ID},
+	})
+}
+
+func firstNonEmptyWorkEnv(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cmd/gc/cmd_work_test.go
+++ b/cmd/gc/cmd_work_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -45,5 +46,335 @@ func TestWritePreLaunchClaimResultContinue(t *testing.T) {
 	}
 	if got.Metadata["pre_launch.user.claimed_work_bead"] != "ga-123" {
 		t.Fatalf("metadata = %#v, want claimed work bead", got.Metadata)
+	}
+}
+
+func TestClaimNextWorkReturnsExistingInProgressAssignment(t *testing.T) {
+	store := beads.NewMemStore()
+	assigned, err := store.Create(beads.Bead{Title: "existing assignment"})
+	if err != nil {
+		t.Fatalf("Create(existing): %v", err)
+	}
+	status := "in_progress"
+	assignee := "sess-1"
+	if err := store.Update(assigned.ID, beads.UpdateOpts{
+		Status:   &status,
+		Assignee: &assignee,
+	}); err != nil {
+		t.Fatalf("Update(existing): %v", err)
+	}
+
+	result, err := claimNextWork(context.Background(), store, t.TempDir(), "mayor", "sess-1", []string{"sess-1"})
+	if err != nil {
+		t.Fatalf("claimNextWork(existing): %v", err)
+	}
+	if result.Bead.ID != assigned.ID {
+		t.Fatalf("claimNextWork(existing) bead = %q, want %q", result.Bead.ID, assigned.ID)
+	}
+	if result.Reason != "existing_assignment" {
+		t.Fatalf("claimNextWork(existing) reason = %q, want existing_assignment", result.Reason)
+	}
+}
+
+func TestClaimNextWorkReturnsAssignedReadyBeforeClaimingNewWork(t *testing.T) {
+	store := beads.NewMemStore()
+	assigned, err := store.Create(beads.Bead{Title: "ready assigned"})
+	if err != nil {
+		t.Fatalf("Create(assigned): %v", err)
+	}
+	readyAssignee := "alias-1"
+	if err := store.Update(assigned.ID, beads.UpdateOpts{Assignee: &readyAssignee}); err != nil {
+		t.Fatalf("Update(assigned): %v", err)
+	}
+	routed, err := store.Create(beads.Bead{
+		Title:    "unassigned routed",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("Create(routed): %v", err)
+	}
+
+	oldClaimWork := claimWork
+	claimWork = func(context.Context, string, string, string) error {
+		t.Fatalf("claimWork called unexpectedly with routed bead %q", routed.ID)
+		return nil
+	}
+	t.Cleanup(func() { claimWork = oldClaimWork })
+
+	result, err := claimNextWork(context.Background(), store, t.TempDir(), "mayor", "sess-1", []string{"sess-1", "alias-1"})
+	if err != nil {
+		t.Fatalf("claimNextWork(assigned ready): %v", err)
+	}
+	if result.Bead.ID != assigned.ID {
+		t.Fatalf("claimNextWork(assigned ready) bead = %q, want %q", result.Bead.ID, assigned.ID)
+	}
+	if result.Reason != "ready_assignment" {
+		t.Fatalf("claimNextWork(assigned ready) reason = %q, want ready_assignment", result.Reason)
+	}
+}
+
+func TestClaimNextWorkReturnsLegacyWorkflowControlAssignment(t *testing.T) {
+	store := beads.NewMemStore()
+	assigned, err := store.Create(beads.Bead{Title: "legacy ready assigned"})
+	if err != nil {
+		t.Fatalf("Create(assigned): %v", err)
+	}
+	readyAssignee := "gascity--workflow-control"
+	if err := store.Update(assigned.ID, beads.UpdateOpts{Assignee: &readyAssignee}); err != nil {
+		t.Fatalf("Update(assigned): %v", err)
+	}
+
+	result, err := claimNextWork(
+		context.Background(),
+		store,
+		t.TempDir(),
+		"gascity/control-dispatcher",
+		"gascity--control-dispatcher",
+		[]string{"gascity--control-dispatcher"},
+	)
+	if err != nil {
+		t.Fatalf("claimNextWork(legacy assigned): %v", err)
+	}
+	if result.Bead.ID != assigned.ID {
+		t.Fatalf("claimNextWork(legacy assigned) bead = %q, want %q", result.Bead.ID, assigned.ID)
+	}
+	if result.Reason != "ready_assignment" {
+		t.Fatalf("claimNextWork(legacy assigned) reason = %q, want ready_assignment", result.Reason)
+	}
+}
+
+func TestClaimNextWorkClaimsReadyUnassignedRoutedWork(t *testing.T) {
+	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	blocked, err := store.Create(beads.Bead{
+		Title:    "blocked routed",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("Create(blocked): %v", err)
+	}
+	if err := store.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(blocked): %v", err)
+	}
+	routed, err := store.Create(beads.Bead{
+		Title:    "ready routed",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("Create(routed): %v", err)
+	}
+
+	oldClaimWork := claimWork
+	claimWork = func(ctx context.Context, dir, beadID, assignee string) error {
+		if beadID != routed.ID {
+			t.Fatalf("claimWork bead = %q, want %q", beadID, routed.ID)
+		}
+		inProgress := "in_progress"
+		return store.Update(beadID, beads.UpdateOpts{
+			Status:   &inProgress,
+			Assignee: &assignee,
+		})
+	}
+	t.Cleanup(func() { claimWork = oldClaimWork })
+
+	result, err := claimNextWork(context.Background(), store, t.TempDir(), "mayor", "sess-1", []string{"sess-1"})
+	if err != nil {
+		t.Fatalf("claimNextWork(routed): %v", err)
+	}
+	if result.Bead.ID != routed.ID {
+		t.Fatalf("claimNextWork(routed) bead = %q, want %q", result.Bead.ID, routed.ID)
+	}
+	if result.Reason != "claimed" {
+		t.Fatalf("claimNextWork(routed) reason = %q, want claimed", result.Reason)
+	}
+	gotBlocked, err := store.Get(blocked.ID)
+	if err != nil {
+		t.Fatalf("Get(blocked): %v", err)
+	}
+	if gotBlocked.Assignee != "" {
+		t.Fatalf("blocked bead assignee = %q, want empty", gotBlocked.Assignee)
+	}
+}
+
+func TestClaimNextWorkClaimsLegacyWorkflowControlRoute(t *testing.T) {
+	store := beads.NewMemStore()
+	routed, err := store.Create(beads.Bead{
+		Title:    "legacy routed",
+		Metadata: map[string]string{"gc.routed_to": "gascity/workflow-control"},
+	})
+	if err != nil {
+		t.Fatalf("Create(routed): %v", err)
+	}
+
+	oldClaimWork := claimWork
+	claimWork = func(ctx context.Context, dir, beadID, assignee string) error {
+		if beadID != routed.ID {
+			t.Fatalf("claimWork bead = %q, want %q", beadID, routed.ID)
+		}
+		inProgress := "in_progress"
+		return store.Update(beadID, beads.UpdateOpts{
+			Status:   &inProgress,
+			Assignee: &assignee,
+		})
+	}
+	t.Cleanup(func() { claimWork = oldClaimWork })
+
+	result, err := claimNextWork(
+		context.Background(),
+		store,
+		t.TempDir(),
+		"gascity/control-dispatcher",
+		"gascity--control-dispatcher",
+		[]string{"gascity--control-dispatcher"},
+	)
+	if err != nil {
+		t.Fatalf("claimNextWork(legacy route): %v", err)
+	}
+	if result.Bead.ID != routed.ID {
+		t.Fatalf("claimNextWork(legacy route) bead = %q, want %q", result.Bead.ID, routed.ID)
+	}
+	if result.Reason != "claimed" {
+		t.Fatalf("claimNextWork(legacy route) reason = %q, want claimed", result.Reason)
+	}
+}
+
+func TestClaimNextWorkRetriesAfterClaimConflict(t *testing.T) {
+	store := beads.NewMemStore()
+	first, err := store.Create(beads.Bead{
+		Title:    "first routed",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("Create(first): %v", err)
+	}
+	second, err := store.Create(beads.Bead{
+		Title:    "second routed",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("Create(second): %v", err)
+	}
+
+	oldClaimWork := claimWork
+	claimAttempts := 0
+	claimWork = func(ctx context.Context, dir, beadID, assignee string) error {
+		claimAttempts++
+		if claimAttempts == 1 {
+			return beads.ErrClaimConflict
+		}
+		inProgress := "in_progress"
+		return store.Update(beadID, beads.UpdateOpts{
+			Status:   &inProgress,
+			Assignee: &assignee,
+		})
+	}
+	t.Cleanup(func() { claimWork = oldClaimWork })
+
+	result, err := claimNextWork(context.Background(), store, t.TempDir(), "mayor", "sess-1", []string{"sess-1"})
+	if err != nil {
+		t.Fatalf("claimNextWork(conflict): %v", err)
+	}
+	if claimAttempts != 2 {
+		t.Fatalf("claimAttempts = %d, want 2", claimAttempts)
+	}
+	if result.Bead.ID != second.ID {
+		t.Fatalf("claimNextWork(conflict) bead = %q, want %q", result.Bead.ID, second.ID)
+	}
+	if result.Bead.ID == first.ID {
+		t.Fatalf("claimNextWork(conflict) returned first conflicted bead %q", first.ID)
+	}
+}
+
+func TestClaimNextWorkFallsBackToOpenRoutedMoleculeRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	molecule, err := store.Create(beads.Bead{
+		Title:    "molecule root",
+		Type:     "molecule",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("Create(molecule): %v", err)
+	}
+
+	oldClaimWork := claimWork
+	claimWork = func(ctx context.Context, dir, beadID, assignee string) error {
+		inProgress := "in_progress"
+		return store.Update(beadID, beads.UpdateOpts{
+			Status:   &inProgress,
+			Assignee: &assignee,
+		})
+	}
+	t.Cleanup(func() { claimWork = oldClaimWork })
+
+	result, err := claimNextWork(context.Background(), store, t.TempDir(), "mayor", "sess-1", []string{"sess-1"})
+	if err != nil {
+		t.Fatalf("claimNextWork(molecule): %v", err)
+	}
+	if result.Bead.ID != molecule.ID {
+		t.Fatalf("claimNextWork(molecule) bead = %q, want %q", result.Bead.ID, molecule.ID)
+	}
+	if result.Reason != "claimed_molecule" {
+		t.Fatalf("claimNextWork(molecule) reason = %q, want claimed_molecule", result.Reason)
+	}
+}
+
+func TestWorkClaimNextCmdUsesStoreScopeRoot(t *testing.T) {
+	oldResolveCity := resolveWorkCity
+	oldOpenStoreAt := openWorkStoreAt
+	oldClaimNextWork := claimNextWorkFn
+	t.Cleanup(func() {
+		resolveWorkCity = oldResolveCity
+		openWorkStoreAt = oldOpenStoreAt
+		claimNextWorkFn = oldClaimNextWork
+	})
+
+	resolveWorkCity = func() (string, error) {
+		return "/tmp/test-city", nil
+	}
+
+	var gotStoreRoot, gotCityPath string
+	openWorkStoreAt = func(storeRoot, cityPath string) (beads.Store, error) {
+		gotStoreRoot = storeRoot
+		gotCityPath = cityPath
+		return beads.NewMemStore(), nil
+	}
+	claimNextWorkFn = func(ctx context.Context, store beads.Store, claimDir, template, assignee string, identities []string) (claimNextResult, error) {
+		if claimDir != "/tmp/test-rig" {
+			t.Fatalf("claimDir = %q, want /tmp/test-rig", claimDir)
+		}
+		if template != "mayor" {
+			t.Fatalf("template = %q, want mayor", template)
+		}
+		if assignee != "sess-1" {
+			t.Fatalf("assignee = %q, want sess-1", assignee)
+		}
+		return claimNextResult{Reason: "no_work"}, nil
+	}
+
+	t.Setenv("GC_STORE_ROOT", "/tmp/test-rig")
+	t.Setenv("GC_TEMPLATE", "mayor")
+	t.Setenv("GC_SESSION_ID", "sess-1")
+
+	var stdout, stderr bytes.Buffer
+	cmd := newWorkClaimNextCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(): %v", err)
+	}
+	if gotStoreRoot != "/tmp/test-rig" {
+		t.Fatalf("openWorkStoreAt storeRoot = %q, want /tmp/test-rig", gotStoreRoot)
+	}
+	if gotCityPath != "/tmp/test-city" {
+		t.Fatalf("openWorkStoreAt cityPath = %q, want /tmp/test-city", gotCityPath)
+	}
+	if got := stdout.String(); got == "" {
+		t.Fatal("stdout empty, want JSON output")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout = %q, want valid JSON: %v", stdout.String(), err)
 	}
 }

--- a/cmd/gc/cmd_work_test.go
+++ b/cmd/gc/cmd_work_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestWritePreLaunchClaimResultDrain(t *testing.T) {
+	var out bytes.Buffer
+	if err := writePreLaunchClaimResult(&out, claimNextResult{Reason: "no_work"}); err != nil {
+		t.Fatalf("writePreLaunchClaimResult: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got["action"] != "drain" || got["reason"] != "no_work" {
+		t.Fatalf("response = %#v, want drain/no_work", got)
+	}
+}
+
+func TestWritePreLaunchClaimResultContinue(t *testing.T) {
+	var out bytes.Buffer
+	if err := writePreLaunchClaimResult(&out, claimNextResult{
+		Reason: "claimed",
+		Bead:   beads.Bead{ID: "ga-123"},
+	}); err != nil {
+		t.Fatalf("writePreLaunchClaimResult: %v", err)
+	}
+	var got struct {
+		Action      string            `json:"action"`
+		Reason      string            `json:"reason"`
+		Env         map[string]string `json:"env"`
+		NudgeAppend string            `json:"nudge_append"`
+		Metadata    map[string]string `json:"metadata"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Action != "continue" || got.Env["GC_WORK_BEAD"] != "ga-123" {
+		t.Fatalf("response = %#v, want continue with GC_WORK_BEAD", got)
+	}
+	if got.Metadata["pre_launch.user.claimed_work_bead"] != "ga-123" {
+		t.Fatalf("metadata = %#v, want claimed work bead", got.Metadata)
+	}
+}

--- a/cmd/gc/config_hash.go
+++ b/cmd/gc/config_hash.go
@@ -77,6 +77,13 @@ func canonicalConfigHash(params TemplateParams, overlay map[string]string) strin
 	}
 	h.Write([]byte{1}) //nolint:errcheck
 
+	// PreLaunch.
+	for _, pl := range params.Hints.PreLaunch {
+		h.Write([]byte(pl)) //nolint:errcheck
+		h.Write([]byte{0})  //nolint:errcheck
+	}
+	h.Write([]byte{1}) //nolint:errcheck
+
 	// SessionSetup.
 	for _, ss := range params.Hints.SessionSetup {
 		h.Write([]byte(ss)) //nolint:errcheck

--- a/cmd/gc/config_hash_test.go
+++ b/cmd/gc/config_hash_test.go
@@ -14,6 +14,7 @@ func TestConfigHash_Canonical(t *testing.T) {
 		Env:     map[string]string{"FOO": "bar", "BAZ": "qux"},
 		Hints: agent.StartupHints{
 			PreStart:     []string{"echo setup"},
+			PreLaunch:    []string{"gc work claim-next --json"},
 			SessionSetup: []string{"echo ready"},
 		},
 		WorkDir:     "/home/user/project",
@@ -63,6 +64,12 @@ func TestConfigHash_Behavioral(t *testing.T) {
 	envChanged.Env = map[string]string{"KEY": "different"}
 	if h := canonicalConfigHash(envChanged, nil); h == baseHash {
 		t.Error("env change should produce different hash")
+	}
+
+	preLaunchChanged := base
+	preLaunchChanged.Hints.PreLaunch = []string{"gc work claim-next --json"}
+	if h := canonicalConfigHash(preLaunchChanged, nil); h == baseHash {
+		t.Error("pre_launch change should produce different hash")
 	}
 }
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -172,6 +172,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newWispCmd(stdout, stderr),
 		newPrimeCmd(stdout, stderr),
 		newHandoffCmd(stdout, stderr),
+		newWorkCmd(stdout, stderr),
 		newBeadsCmd(stdout, stderr),
 		newBuildImageCmd(stdout, stderr),
 		newSkillCmd(stdout, stderr),

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -286,6 +286,10 @@ func deepCopyAgent(src *config.Agent, name, dir string) config.Agent {
 		dst.PreStart = make([]string, len(src.PreStart))
 		copy(dst.PreStart, src.PreStart)
 	}
+	if len(src.PreLaunch) > 0 {
+		dst.PreLaunch = make([]string, len(src.PreLaunch))
+		copy(dst.PreLaunch, src.PreLaunch)
+	}
 	if len(src.SessionSetup) > 0 {
 		dst.SessionSetup = make([]string, len(src.SessionSetup))
 		copy(dst.SessionSetup, src.SessionSetup)

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -632,6 +632,7 @@ func TestDeepCopyAgentCoversAllFields(t *testing.T) {
 		Scope:                        "city",
 		Suspended:                    true,
 		PreStart:                     []string{"pre-cmd"},
+		PreLaunch:                    []string{"pre-launch-cmd"},
 		PromptTemplate:               "prompts/test.md",
 		Nudge:                        "nudge text",
 		Session:                      "acp",
@@ -735,6 +736,7 @@ func TestDeepCopyAgentCoversAllFields(t *testing.T) {
 
 	// Verify deep independence: mutating src slices/maps should not affect dst.
 	src.PreStart[0] = "MUTATED"
+	src.PreLaunch[0] = "MUTATED"
 	src.Env["K"] = "MUTATED"
 	src.SessionSetup[0] = "MUTATED"
 	src.Args[0] = "MUTATED"
@@ -748,6 +750,9 @@ func TestDeepCopyAgentCoversAllFields(t *testing.T) {
 
 	if dst.PreStart[0] == "MUTATED" {
 		t.Error("PreStart is not a deep copy")
+	}
+	if dst.PreLaunch[0] == "MUTATED" {
+		t.Error("PreLaunch is not a deep copy")
 	}
 	if dst.Env["K"] == "MUTATED" {
 		t.Error("Env is not a deep copy")

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -675,6 +675,7 @@ func commitStartResultTraced(
 			reason = strings.TrimSpace(result.preLaunchDecision.Reason)
 		}
 		metadata := sessionpkg.ArchivePatch(clk.Now(), "pre_launch_drained", true)
+		metadata["last_woke_at"] = ""
 		if result.preLaunchDecision != nil {
 			for key, value := range result.preLaunchDecision.Metadata {
 				metadata[key] = value
@@ -718,6 +719,9 @@ func commitStartResultTraced(
 		metadata["gc.pre_launch.failure_stage"] = stage
 		metadata["gc.pre_launch.at"] = clk.Now().UTC().Format(time.RFC3339)
 		metadata["gc.pre_launch.provider_started"] = "false"
+		metadata["state"] = string(sessionpkg.StateAsleep)
+		metadata["state_reason"] = "pre_launch_aborted"
+		metadata["last_woke_at"] = ""
 		metadata["pending_create_claim"] = ""
 		if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
 			fmt.Fprintf(stderr, "session reconciler: recording pre_launch abort for %s: %v\n", name, err) //nolint:errcheck
@@ -729,15 +733,6 @@ func commitStartResultTraced(
 				session.Metadata[key] = value
 			}
 		}
-		if err := store.SetMetadata(session.ID, "last_woke_at", ""); err != nil {
-			fmt.Fprintf(stderr, "session reconciler: clearing last_woke_at for %s: %v\n", name, err) //nolint:errcheck
-		} else {
-			if session.Metadata == nil {
-				session.Metadata = make(map[string]string)
-			}
-			session.Metadata["last_woke_at"] = ""
-		}
-		recordWakeFailure(session, store, clk)
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
 		return false
 	}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -58,12 +58,13 @@ type preparedStart struct {
 }
 
 type startResult struct {
-	prepared        preparedStart
-	err             error
-	outcome         string
-	started         time.Time
-	finished        time.Time
-	rollbackPending bool
+	prepared          preparedStart
+	err               error
+	outcome           string
+	started           time.Time
+	finished          time.Time
+	rollbackPending   bool
+	preLaunchDecision *runtime.PreLaunchDecisionError
 }
 
 type stopTarget struct {
@@ -430,6 +431,27 @@ func buildPreparedStart(
 		agentCfg.Env = mergeEnv(agentCfg.Env, map[string]string{"GC_PROVIDER": gcProvider})
 	}
 	agentCfg = runtime.SyncWorkDirEnv(agentCfg)
+	if store != nil && strings.TrimSpace(session.ID) != "" {
+		sessionID := session.ID
+		agentCfg.PreLaunchMetadataSink = func(action, reason, stage string, userMetadata map[string]string) error {
+			metadata := make(map[string]string, len(userMetadata)+5)
+			for key, value := range userMetadata {
+				metadata[key] = value
+			}
+			metadata["gc.pre_launch.action"] = action
+			if reason != "" {
+				metadata["gc.pre_launch.reason"] = reason
+			}
+			if stage != "" {
+				metadata["gc.pre_launch.failure_stage"] = stage
+			}
+			metadata["gc.pre_launch.at"] = time.Now().UTC().Format(time.RFC3339)
+			if action != "continue" {
+				metadata["gc.pre_launch.provider_started"] = "false"
+			}
+			return store.SetMetadataBatch(sessionID, metadata)
+		}
+	}
 	return &preparedStart{
 		candidate:     candidate,
 		cfg:           agentCfg,
@@ -521,6 +543,7 @@ func executePreparedStartWave(
 				return
 			}
 			var outcome string
+			var preLaunchDecision *runtime.PreLaunchDecisionError
 			switch {
 			case err == nil:
 				outcome = "success"
@@ -531,6 +554,14 @@ func executePreparedStartWave(
 			case errors.Is(err, runtime.ErrSessionInitializing):
 				outcome = "session_initializing"
 				err = nil
+			case errors.Is(err, runtime.ErrPreLaunchDrained):
+				outcome = "pre_launch_drained"
+				_ = errors.As(err, &preLaunchDecision)
+				err = nil
+				rollbackPending = false
+			case errors.Is(err, runtime.ErrPreLaunchAborted):
+				outcome = "pre_launch_aborted"
+				_ = errors.As(err, &preLaunchDecision)
 			case errors.Is(err, runtime.ErrSessionExists):
 				running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
 				switch {
@@ -547,12 +578,13 @@ func executePreparedStartWave(
 				outcome = "provider_error"
 			}
 			results[i] = startResult{
-				prepared:        item,
-				err:             err,
-				outcome:         outcome,
-				started:         started,
-				finished:        finished,
-				rollbackPending: rollbackPending,
+				prepared:          item,
+				err:               err,
+				outcome:           outcome,
+				started:           started,
+				finished:          finished,
+				rollbackPending:   rollbackPending,
+				preLaunchDecision: preLaunchDecision,
 			}
 		}()
 	}
@@ -635,6 +667,78 @@ func commitStartResultTraced(
 	// The reconciler will retry on the next patrol tick.
 	if result.outcome == "session_initializing" {
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
+		return false
+	}
+	if result.outcome == "pre_launch_drained" {
+		reason := "no work"
+		if result.preLaunchDecision != nil && strings.TrimSpace(result.preLaunchDecision.Reason) != "" {
+			reason = strings.TrimSpace(result.preLaunchDecision.Reason)
+		}
+		metadata := sessionpkg.ArchivePatch(clk.Now(), "pre_launch_drained", true)
+		if result.preLaunchDecision != nil {
+			for key, value := range result.preLaunchDecision.Metadata {
+				metadata[key] = value
+			}
+		}
+		metadata["gc.pre_launch.action"] = "drain"
+		metadata["gc.pre_launch.reason"] = reason
+		metadata["gc.pre_launch.at"] = clk.Now().UTC().Format(time.RFC3339)
+		metadata["gc.pre_launch.provider_started"] = "false"
+		if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: archiving pre_launch drain for %s: %v\n", name, err) //nolint:errcheck
+			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "pre_launch_drain_metadata_failed", result.started, result.finished, err)
+			return false
+		}
+		if session.Metadata == nil {
+			session.Metadata = make(map[string]string)
+		}
+		for key, value := range metadata {
+			session.Metadata[key] = value
+		}
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
+		return true
+	}
+	if result.outcome == "pre_launch_aborted" {
+		reason := "abort"
+		stage := "script_exit"
+		metadata := map[string]string{}
+		if result.preLaunchDecision != nil {
+			if strings.TrimSpace(result.preLaunchDecision.Reason) != "" {
+				reason = strings.TrimSpace(result.preLaunchDecision.Reason)
+			}
+			if strings.TrimSpace(result.preLaunchDecision.Stage) != "" {
+				stage = strings.TrimSpace(result.preLaunchDecision.Stage)
+			}
+			for key, value := range result.preLaunchDecision.Metadata {
+				metadata[key] = value
+			}
+		}
+		metadata["gc.pre_launch.action"] = "abort"
+		metadata["gc.pre_launch.reason"] = reason
+		metadata["gc.pre_launch.failure_stage"] = stage
+		metadata["gc.pre_launch.at"] = clk.Now().UTC().Format(time.RFC3339)
+		metadata["gc.pre_launch.provider_started"] = "false"
+		metadata["pending_create_claim"] = ""
+		if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: recording pre_launch abort for %s: %v\n", name, err) //nolint:errcheck
+		} else {
+			if session.Metadata == nil {
+				session.Metadata = make(map[string]string)
+			}
+			for key, value := range metadata {
+				session.Metadata[key] = value
+			}
+		}
+		if err := store.SetMetadata(session.ID, "last_woke_at", ""); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: clearing last_woke_at for %s: %v\n", name, err) //nolint:errcheck
+		} else {
+			if session.Metadata == nil {
+				session.Metadata = make(map[string]string)
+			}
+			session.Metadata["last_woke_at"] = ""
+		}
+		recordWakeFailure(session, store, clk)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
 		return false
 	}
 	if result.err != nil {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -2302,6 +2302,10 @@ func TestPrepareStartCandidate_PreservesRuntimeConfigAndProviderEnv(t *testing.T
 	))
 	expected.Env = mergeEnv(expected.Env, map[string]string{"GC_PROVIDER": "gemini"})
 	expected = runtime.SyncWorkDirEnv(expected)
+	if prepared.cfg.PreLaunchMetadataSink == nil {
+		t.Fatal("prepared cfg PreLaunchMetadataSink is nil")
+	}
+	prepared.cfg.PreLaunchMetadataSink = nil
 
 	if !reflect.DeepEqual(prepared.cfg, expected) {
 		t.Fatalf("prepared cfg mismatch\n got: %#v\nwant: %#v", prepared.cfg, expected)

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1784,6 +1784,156 @@ func TestCommitStartResult_SanitizesMultilineError(t *testing.T) {
 	}
 }
 
+func TestCommitStartResult_PreLaunchAbortedDoesNotRecordWakeFailure(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"session_name":         "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+			"last_woke_at":         "2026-03-18T12:00:00Z",
+			"wake_attempts":        "4",
+			"session_key":          "session-key-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &bead,
+				tp:      TemplateParams{TemplateName: "worker", InstanceName: "worker"},
+			},
+		},
+		err: &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchAborted,
+			Action: "abort",
+			Reason: "script_failed",
+			Stage:  "script_exit",
+			Metadata: map[string]string{
+				"claimed_bead": "ga-123",
+			},
+		},
+		outcome:           "pre_launch_aborted",
+		preLaunchDecision: &runtime.PreLaunchDecisionError{Reason: "script_failed", Stage: "script_exit", Metadata: map[string]string{"claimed_bead": "ga-123"}},
+		started:           time.Unix(1, 0),
+		finished:          time.Unix(2, 0),
+	}
+	var stderr bytes.Buffer
+	ok := commitStartResult(result, store, &clock.Fake{Time: time.Unix(3, 0)}, events.Discard, 0, ioDiscard{}, &stderr)
+	if ok {
+		t.Fatal("commitStartResult returned true for pre_launch abort")
+	}
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["state"] != string(sessionpkg.StateAsleep) {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], sessionpkg.StateAsleep)
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["wake_attempts"] != "4" {
+		t.Fatalf("wake_attempts = %q, want preserved", got.Metadata["wake_attempts"])
+	}
+	if got.Metadata["quarantined_until"] != "" {
+		t.Fatalf("quarantined_until = %q, want empty", got.Metadata["quarantined_until"])
+	}
+	if got.Metadata["gc.pre_launch.action"] != "abort" {
+		t.Fatalf("gc.pre_launch.action = %q, want abort", got.Metadata["gc.pre_launch.action"])
+	}
+	if got.Metadata["gc.pre_launch.reason"] != "script_failed" {
+		t.Fatalf("gc.pre_launch.reason = %q, want script_failed", got.Metadata["gc.pre_launch.reason"])
+	}
+	if got.Metadata["gc.pre_launch.failure_stage"] != "script_exit" {
+		t.Fatalf("gc.pre_launch.failure_stage = %q, want script_exit", got.Metadata["gc.pre_launch.failure_stage"])
+	}
+	if got.Metadata["claimed_bead"] != "ga-123" {
+		t.Fatalf("claimed_bead = %q, want ga-123", got.Metadata["claimed_bead"])
+	}
+	if got.Metadata["session_key"] != "session-key-1" {
+		t.Fatalf("session_key = %q, want preserved", got.Metadata["session_key"])
+	}
+}
+
+func TestCommitStartResult_PreLaunchDrainedClearsWakeMarker(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"session_name":         "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+			"last_woke_at":         "2026-03-18T12:00:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &bead,
+				tp:      TemplateParams{TemplateName: "worker", InstanceName: "worker"},
+			},
+		},
+		outcome: "pre_launch_drained",
+		preLaunchDecision: &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchDrained,
+			Action: "drain",
+			Reason: "no work",
+			Metadata: map[string]string{
+				"claimed_bead": "ga-123",
+			},
+		},
+		started:  time.Unix(1, 0),
+		finished: time.Unix(2, 0),
+	}
+	ok := commitStartResult(result, store, &clock.Fake{Time: time.Unix(3, 0)}, events.Discard, 0, ioDiscard{}, ioDiscard{})
+	if !ok {
+		t.Fatal("commitStartResult returned false for pre_launch drain")
+	}
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["state"] != string(sessionpkg.StateArchived) {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], sessionpkg.StateArchived)
+	}
+	if got.Metadata["state_reason"] != "pre_launch_drained" {
+		t.Fatalf("state_reason = %q, want pre_launch_drained", got.Metadata["state_reason"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["gc.pre_launch.action"] != "drain" {
+		t.Fatalf("gc.pre_launch.action = %q, want drain", got.Metadata["gc.pre_launch.action"])
+	}
+	if got.Metadata["gc.pre_launch.reason"] != "no work" {
+		t.Fatalf("gc.pre_launch.reason = %q, want no work", got.Metadata["gc.pre_launch.reason"])
+	}
+	if got.Metadata["claimed_bead"] != "ga-123" {
+		t.Fatalf("claimed_bead = %q, want ga-123", got.Metadata["claimed_bead"])
+	}
+}
+
 func TestInterruptTargetsBounded_LogsSuccessOutcome(t *testing.T) {
 	sp := runtime.NewFake()
 	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -359,6 +359,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	expandedSetup := expandSessionSetup(cfgAgent.SessionSetup, setupCtx)
 	resolvedScript := resolveSetupScript(cfgAgent.SessionSetupScript, cfgAgent.SourceDir, p.cityPath)
 	expandedPreStart := expandSessionSetup(cfgAgent.PreStart, setupCtx)
+	expandedPreLaunch := expandSessionSetup(cfgAgent.PreLaunch, setupCtx)
 	expandedLive := expandSessionSetup(cfgAgent.SessionLive, setupCtx)
 
 	// Step 11b: Skill materialization integration (per engdocs
@@ -477,6 +478,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		EmitsPermissionWarning: resolved.EmitsPermissionWarning,
 		Nudge:                  cfgAgent.Nudge,
 		PreStart:               expandedPreStart,
+		PreLaunch:              expandedPreLaunch,
 		SessionSetup:           expandedSetup,
 		SessionSetupScript:     resolvedScript,
 		SessionLive:            expandedLive,
@@ -577,6 +579,7 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 		Command:                tp.Command,
 		PromptSuffix:           promptSuffix,
 		PromptFlag:             promptFlag,
+		PromptMode:             resolvedPromptMode(tp.ResolvedProvider),
 		Env:                    env,
 		WorkDir:                tp.WorkDir,
 		ReadyPromptPrefix:      tp.Hints.ReadyPromptPrefix,
@@ -585,6 +588,7 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 		EmitsPermissionWarning: tp.Hints.EmitsPermissionWarning,
 		Nudge:                  nudge,
 		PreStart:               tp.Hints.PreStart,
+		PreLaunch:              tp.Hints.PreLaunch,
 		SessionSetup:           tp.Hints.SessionSetup,
 		SessionSetupScript:     tp.Hints.SessionSetupScript,
 		SessionLive:            tp.Hints.SessionLive,
@@ -595,4 +599,11 @@ func templateParamsToConfig(tp TemplateParams) runtime.Config {
 		CopyFiles:              tp.Hints.CopyFiles,
 		FingerprintExtra:       tp.FPExtra,
 	}
+}
+
+func resolvedPromptMode(rp *config.ResolvedProvider) string {
+	if rp == nil || rp.PromptMode == "" {
+		return "arg"
+	}
+	return rp.PromptMode
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,7 @@ gc [flags]
 | [gc beads](#gc-beads) | Manage the beads provider |
 | [gc build-image](#gc-build-image) | Build a prebaked agent container image |
 | [gc cities](#gc-cities) | List registered cities |
+| [gc completion](#gc-completion) | Generate the autocompletion script for the specified shell |
 | [gc config](#gc-config) | Inspect and validate city configuration |
 | [gc converge](#gc-converge) | Manage convergence loops (bounded iterative refinement) |
 | [gc convoy](#gc-convoy) | Manage convoys — graphs of related work |
@@ -63,6 +64,7 @@ gc [flags]
 | [gc unregister](#gc-unregister) | Remove a city from the machine-wide supervisor |
 | [gc version](#gc-version) | Print gc version |
 | [gc wait](#gc-wait) | Inspect and manage durable session waits |
+| [gc work](#gc-work) | Manage runnable work for agents |
 
 ## gc agent
 
@@ -303,6 +305,127 @@ List registered cities
 ```
 gc cities list
 ```
+
+## gc completion
+
+Generate the autocompletion script for gc for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+```
+gc completion
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc completion bash](#gc-completion-bash) | Generate the autocompletion script for bash |
+| [gc completion fish](#gc-completion-fish) | Generate the autocompletion script for fish |
+| [gc completion powershell](#gc-completion-powershell) | Generate the autocompletion script for powershell |
+| [gc completion zsh](#gc-completion-zsh) | Generate the autocompletion script for zsh |
+
+## gc completion bash
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source &lt;(gc completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	gc completion bash &gt; /etc/bash_completion.d/gc
+
+#### macOS:
+
+	gc completion bash &gt; $(brew --prefix)/etc/bash_completion.d/gc
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion bash
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion fish
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	gc completion fish | source
+
+To load completions for every new session, execute once:
+
+	gc completion fish &gt; ~/.config/fish/completions/gc.fish
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion fish [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion powershell
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	gc completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+```
+gc completion powershell [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion zsh
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" &gt;&gt; ~/.zshrc
+
+To load completions in your current shell session:
+
+	source &lt;(gc completion zsh)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	gc completion zsh &gt; "$&#123;fpath[1]&#125;/_gc"
+
+#### macOS:
+
+	gc completion zsh &gt; $(brew --prefix)/share/zsh/site-functions/_gc
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion zsh [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
 
 ## gc config
 
@@ -2700,3 +2823,29 @@ Manually mark a wait ready
 ```
 gc wait ready <wait-id>
 ```
+
+## gc work
+
+Manage runnable work for agents
+
+```
+gc work
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc work claim-next](#gc-work-claim-next) | Atomically claim the next routed work item |
+
+## gc work claim-next
+
+Atomically claim the next routed work item
+
+```
+gc work claim-next [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--assignee` | string |  | session identity to claim as |
+| `--json` | bool |  | emit pre_launch JSON |
+| `--template` | string |  | agent template/routing target |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -67,6 +67,7 @@ Agent defines a configured agent in the city.
 | `scope` | string |  |  | Scope defines where this agent is instantiated: "city" (one per city) or "rig" (one per rig, the default). Only meaningful for pack-defined agents; inline agents in city.toml use Dir directly. Enum: `city`, `rig` |
 | `suspended` | boolean |  |  | Suspended prevents the reconciler from spawning this agent. Toggle with gc agent suspend/resume. |
 | `pre_start` | []string |  |  | PreStart is a list of shell commands run before session creation. Commands run on the target filesystem: locally for tmux, inside the pod/container for exec providers. Template variables same as session_setup. |
+| `pre_launch` | []string |  |  | PreLaunch is a list of shell commands run after pre_start and session identity preparation, but before the provider process is launched. Commands may emit a bounded JSON response to continue, drain, abort, or patch startup prompt/nudge/env/metadata. |
 | `prompt_template` | string |  |  | PromptTemplate is the path to this agent's prompt template file. Relative paths resolve against the city directory. |
 | `nudge` | string |  |  | Nudge is text typed into the agent's tmux session after startup. Used for CLI agents that don't accept command-line prompts. |
 | `session` | string |  |  | Session overrides the session transport for this agent. "" (default) uses the city-level session provider (typically tmux). "acp" uses the Agent Client Protocol (JSON-RPC over stdio). The agent's resolved provider must have supports_acp = true. Enum: `acp` |
@@ -140,6 +141,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `env` | map[string]string |  |  | Env adds or overrides environment variables. |
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
+| `pre_launch` | []string |  |  | PreLaunch overrides the agent's pre_launch commands. |
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
 | `session` | string |  |  | Session overrides the session transport ("acp"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
@@ -160,6 +162,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `inject_fragments` | []string |  |  | InjectFragments overrides the agent's inject_fragments list. |
 | `append_fragments` | []string |  |  | AppendFragments appends named template fragments to this agent's rendered prompt. It is the V2 spelling for per-agent fragment selection. |
 | `pre_start_append` | []string |  |  | PreStartAppend appends commands to the agent's pre_start list (instead of replacing). Applied after PreStart if both are set. |
+| `pre_launch_append` | []string |  |  | PreLaunchAppend appends commands to the agent's pre_launch list (instead of replacing). Applied after PreLaunch if both are set. |
 | `session_setup_append` | []string |  |  | SessionSetupAppend appends commands to the agent's session_setup list. |
 | `session_live_append` | []string |  |  | SessionLiveAppend appends commands to the agent's session_live list. |
 | `install_agent_hooks_append` | []string |  |  | InstallAgentHooksAppend appends to the agent's install_agent_hooks list. |
@@ -190,6 +193,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `env` | map[string]string |  |  | Env adds or overrides environment variables. |
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove after merging. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
+| `pre_launch` | []string |  |  | PreLaunch overrides the agent's pre_launch commands. |
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
 | `session` | string |  |  | Session overrides the session transport ("acp"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
@@ -216,6 +220,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `resume_command` | string |  |  | ResumeCommand overrides the agent's resume_command template. |
 | `wake_mode` | string |  |  | WakeMode overrides the agent's wake mode ("resume" or "fresh"). Enum: `resume`, `fresh` |
 | `pre_start_append` | []string |  |  | PreStartAppend appends commands to the agent's pre_start list (instead of replacing). Applied after PreStart if both are set. |
+| `pre_launch_append` | []string |  |  | PreLaunchAppend appends commands to the agent's pre_launch list (instead of replacing). Applied after PreLaunch if both are set. |
 | `session_setup_append` | []string |  |  | SessionSetupAppend appends commands to the agent's session_setup list. |
 | `session_live_append` | []string |  |  | SessionLiveAppend appends commands to the agent's session_live list. |
 | `install_agent_hooks_append` | []string |  |  | InstallAgentHooksAppend appends to the agent's install_agent_hooks list. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -81,6 +81,13 @@
           "type": "array",
           "description": "PreStart is a list of shell commands run before session creation.\nCommands run on the target filesystem: locally for tmux, inside the\npod/container for exec providers. Template variables same as session_setup."
         },
+        "pre_launch": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunch is a list of shell commands run after pre_start and session\nidentity preparation, but before the provider process is launched.\nCommands may emit a bounded JSON response to continue, drain, abort,\nor patch startup prompt/nudge/env/metadata."
+        },
         "prompt_template": {
           "type": "string",
           "description": "PromptTemplate is the path to this agent's prompt template file.\nRelative paths resolve against the city directory."
@@ -413,6 +420,13 @@
           "type": "array",
           "description": "PreStart overrides the agent's pre_start commands."
         },
+        "pre_launch": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunch overrides the agent's pre_launch commands."
+        },
         "prompt_template": {
           "type": "string",
           "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
@@ -516,6 +530,13 @@
           },
           "type": "array",
           "description": "PreStartAppend appends commands to the agent's pre_start list\n(instead of replacing). Applied after PreStart if both are set."
+        },
+        "pre_launch_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunchAppend appends commands to the agent's pre_launch list\n(instead of replacing). Applied after PreLaunch if both are set."
         },
         "session_setup_append": {
           "items": {
@@ -655,6 +676,13 @@
           },
           "type": "array",
           "description": "PreStart overrides the agent's pre_start commands."
+        },
+        "pre_launch": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunch overrides the agent's pre_launch commands."
         },
         "prompt_template": {
           "type": "string",
@@ -796,6 +824,13 @@
           },
           "type": "array",
           "description": "PreStartAppend appends commands to the agent's pre_start list\n(instead of replacing). Applied after PreStart if both are set."
+        },
+        "pre_launch_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunchAppend appends commands to the agent's pre_launch list\n(instead of replacing). Applied after PreLaunch if both are set."
         },
         "session_setup_append": {
           "items": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -81,6 +81,13 @@
           "type": "array",
           "description": "PreStart is a list of shell commands run before session creation.\nCommands run on the target filesystem: locally for tmux, inside the\npod/container for exec providers. Template variables same as session_setup."
         },
+        "pre_launch": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunch is a list of shell commands run after pre_start and session\nidentity preparation, but before the provider process is launched.\nCommands may emit a bounded JSON response to continue, drain, abort,\nor patch startup prompt/nudge/env/metadata."
+        },
         "prompt_template": {
           "type": "string",
           "description": "PromptTemplate is the path to this agent's prompt template file.\nRelative paths resolve against the city directory."
@@ -413,6 +420,13 @@
           "type": "array",
           "description": "PreStart overrides the agent's pre_start commands."
         },
+        "pre_launch": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunch overrides the agent's pre_launch commands."
+        },
         "prompt_template": {
           "type": "string",
           "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
@@ -516,6 +530,13 @@
           },
           "type": "array",
           "description": "PreStartAppend appends commands to the agent's pre_start list\n(instead of replacing). Applied after PreStart if both are set."
+        },
+        "pre_launch_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunchAppend appends commands to the agent's pre_launch list\n(instead of replacing). Applied after PreLaunch if both are set."
         },
         "session_setup_append": {
           "items": {
@@ -655,6 +676,13 @@
           },
           "type": "array",
           "description": "PreStart overrides the agent's pre_start commands."
+        },
+        "pre_launch": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunch overrides the agent's pre_launch commands."
         },
         "prompt_template": {
           "type": "string",
@@ -796,6 +824,13 @@
           },
           "type": "array",
           "description": "PreStartAppend appends commands to the agent's pre_start list\n(instead of replacing). Applied after PreStart if both are set."
+        },
+        "pre_launch_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreLaunchAppend appends commands to the agent's pre_launch list\n(instead of replacing). Applied after PreLaunch if both are set."
         },
         "session_setup_append": {
           "items": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -299,6 +299,24 @@
           "Pool": {
             "$ref": "#/components/schemas/PoolOverride"
           },
+          "PreLaunch": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "PreLaunchAppend": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "PreStart": {
             "items": {
               "type": "string"
@@ -454,6 +472,7 @@
           "Env",
           "EnvRemove",
           "PreStart",
+          "PreLaunch",
           "PromptTemplate",
           "Session",
           "Provider",
@@ -480,6 +499,7 @@
           "ResumeCommand",
           "WakeMode",
           "PreStartAppend",
+          "PreLaunchAppend",
           "SessionSetupAppend",
           "SessionLiveAppend",
           "InstallAgentHooksAppend",

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -299,6 +299,24 @@
           "Pool": {
             "$ref": "#/components/schemas/PoolOverride"
           },
+          "PreLaunch": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "PreLaunchAppend": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "PreStart": {
             "items": {
               "type": "string"
@@ -454,6 +472,7 @@
           "Env",
           "EnvRemove",
           "PreStart",
+          "PreLaunch",
           "PromptTemplate",
           "Session",
           "Provider",
@@ -480,6 +499,7 @@
           "ResumeCommand",
           "WakeMode",
           "PreStartAppend",
+          "PreLaunchAppend",
           "SessionSetupAppend",
           "SessionLiveAppend",
           "InstallAgentHooksAppend",

--- a/engdocs/design/index.md
+++ b/engdocs/design/index.md
@@ -27,4 +27,5 @@ lives in the [Architecture](../architecture/index.md) section.
 | `session-lifecycle-domain-cleanup-plan` | Implemented with hardening | Red-green-refactor plan for centralizing session lifecycle projection and transition writes behind typed abstractions |
 | `external-messaging-fabric` | Implemented | Provider-neutral external conversation bindings, delivery context, and group sessions |
 | `external-messaging-shared-threads` | Implemented | Transcript-backed shared-thread model with membership replay and speaker-only group routing |
+| `pre-launch-hooks` | Proposed | General pre-inference startup hook for deterministic prompt/env/metadata injection and claim-or-drain scripts |
 | `worker-conformance` | Proposed | Canonical WorkerCore/WorkerInference contract, transcript-first conformance, and migration toward `internal/worker` |

--- a/engdocs/design/pre-launch-hooks-implementation-plan.md
+++ b/engdocs/design/pre-launch-hooks-implementation-plan.md
@@ -1,0 +1,153 @@
+---
+title: Pre-Launch Hooks Implementation Plan
+status: Proposed
+design: ./pre-launch-hooks.md
+issues:
+  - https://github.com/gastownhall/gascity/issues/845
+  - https://github.com/gastownhall/gascity/issues/1052
+---
+
+# Pre-Launch Hooks Implementation Plan
+
+## Overview
+
+Implement the approved `pre_launch` design in small, testable slices. The
+generic lifecycle hook lands first, with no agents opted in. The deterministic
+claim helper lands after the hook engine is covered by tests. Pack opt-in is
+last and only happens after the #845 drift case and #1052 duplicate-execution
+race have regression coverage.
+
+## Phase 1: Config And Fingerprint Plumbing
+
+### Task 1: Add Config Fields
+
+Add `pre_launch` and `pre_launch_append` to the same config surfaces as
+`pre_start`:
+
+- `config.Agent`
+- `config.AgentPatch`
+- `config.AgentOverride`
+- patch and override application
+- deep-copy helpers
+- template resolution and startup hints
+- runtime config
+
+Acceptance criteria:
+
+- `pre_launch` parses from agent TOML.
+- `pre_launch_append` composes like `pre_start_append`.
+- `pre_launch` is available in resolved template startup hints.
+- Existing agents without `pre_launch` resolve unchanged.
+
+Verification:
+
+- `go test ./internal/config ./cmd/gc -run 'PreLaunch|AgentFieldSync|ExpandPacks|TemplateResolve|Pool'`
+
+### Task 2: Add Fingerprint And Schema Coverage
+
+Include declared `pre_launch` commands in startup fingerprints and generated
+config docs.
+
+Acceptance criteria:
+
+- Changing `pre_launch` changes core fingerprint.
+- Runtime hook result patches do not participate in fingerprints.
+- Fingerprint breakdown and drift logging include `PreLaunch`.
+- Generated schema/docs expose the field.
+
+Verification:
+
+- `go test ./internal/runtime ./cmd/gc -run 'Fingerprint|ConfigHash|Schema|PreLaunch'`
+- `go run ./cmd/genschema`
+
+## Phase 2: Generic Pre-Launch Engine
+
+### Task 3: Define Result Contract And Validation
+
+Add typed result parsing and validation for `pre_launch` command stdout.
+
+Acceptance criteria:
+
+- Empty stdout is `continue`.
+- Unknown actions, malformed JSON, non-zero exit, invalid env, invalid
+  metadata namespace, and oversized output fail closed.
+- Bounds and failure stages match the design.
+- Raw stdout and env values are not logged or persisted.
+
+Verification:
+
+- Unit tests for parser/validator failure stages.
+
+### Task 4: Execute Pre-Launch Before Provider Start
+
+Wire `pre_launch` into runtime startup after `pre_start` and before any provider
+process creation.
+
+Acceptance criteria:
+
+- No-hook startup call order is unchanged.
+- `pre_launch` runs after `pre_start` and before tmux `ensureFreshSession`.
+- Prompt/nudge/env/metadata patches are applied before provider launch.
+- `drain` archives without provider start.
+- `abort` fails startup without provider start and records diagnostics.
+
+Verification:
+
+- `go test ./internal/runtime/tmux ./cmd/gc -run 'PreLaunch'`
+
+## Phase 3: Claim Helper
+
+### Task 5: Implement `gc work claim-next`
+
+Add a deterministic helper that claims work for a concrete session using
+existing bead semantics.
+
+Acceptance criteria:
+
+- Existing self-assigned work is returned before generic demand.
+- Concurrent workers racing one bead produce one claim and one empty/conflict
+  outcome.
+- Claim conflict retries the next candidate.
+- Retained `gc.routed_to` provenance does not reactivate generic demand after
+  concrete assignment.
+
+Verification:
+
+- `go test ./cmd/gc ./internal/beads -run 'ClaimNext|PreLaunch|WorkQuery'`
+
+## Phase 4: Docs, Examples, And Opt-In
+
+### Task 6: Add Docs And Pack Example
+
+Document `pre_launch`, add a safe example script, and avoid broad pack opt-in
+until the generic hook and helper are green.
+
+Acceptance criteria:
+
+- Reference docs describe `pre_launch` and `pre_launch_append`.
+- Example script sends diagnostics to stderr and emits one JSON object on stdout.
+- PR description references #845 and #1052 explicitly.
+
+Verification:
+
+- Docs generated and checked in.
+
+## Review Checkpoints
+
+- Run local tests after each phase.
+- After Phase 2, run `$review-pr --diff` against the staged generic hook change
+  and fix blockers/majors.
+- After Phase 3, run `$review-pr --diff` again, focused on claim helper and
+  race behavior.
+- Before PR creation, run full relevant test suite and `$review-pr` on the
+  branch. Fix until no blockers or majors remain.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Provider startup boundary is misplaced | Env or drain patches silently fail | Tests assert call ordering before provider creation |
+| Claim helper is not truly atomic | #1052 remains possible | CAS/verify/retry tests with concurrent claim attempts |
+| Drain is misclassified as crash | Reconciler resurrects intentionally drained sessions | Archive terminal-success state and metadata/event checks |
+| Script output leaks secrets | Operator logs expose sensitive data | Bound stdout/stderr and persist sanitized metadata only |
+| Feature becomes pool-specific | Poor abstraction and future churn | Keep claim helper separate from generic `pre_launch` |

--- a/engdocs/design/pre-launch-hooks.md
+++ b/engdocs/design/pre-launch-hooks.md
@@ -559,7 +559,7 @@ Failure stages:
 - `metadata_write`
 - `unsupported_prompt_patch`
 - `patch_too_large`
-- `context_cancelled`
+- `context_canceled`
 
 Abort retry uses the existing wake failure machinery, but the failure is tagged
 as pre-launch rather than provider-start. A retry must be idempotent. The

--- a/engdocs/design/pre-launch-hooks.md
+++ b/engdocs/design/pre-launch-hooks.md
@@ -1,0 +1,777 @@
+---
+title: Pre-Launch Hooks
+status: Proposed
+issues:
+  - https://github.com/gastownhall/gascity/issues/845
+  - https://github.com/gastownhall/gascity/issues/1052
+---
+
+# Pre-Launch Hooks
+
+## Summary
+
+Add an agent-level `pre_launch` lifecycle hook that runs after Gas City has
+created or selected a concrete session bead and prepared its runtime
+environment, but before the provider process starts and before any LLM
+inference can occur.
+
+`pre_launch` is a general deterministic startup extension point. It is not a
+pool-worker primitive. A hook may inspect the prepared session context, perform
+mechanical setup, and return a small structured patch that changes the initial
+runtime configuration or stops startup before the model process launches.
+
+The motivating use case is issue #845: pool workers sometimes need a
+deterministic claim-or-drain cascade before inference starts. The same
+mechanism also addresses issue #1052: two concurrently spawned pool sessions can
+observe the same unassigned `gc.routed_to` bead and both execute it if claim
+verification happens only inside prompt-following behavior. With `pre_launch`,
+that behavior becomes a reusable script layered on top of the general hook:
+query, atomically claim, inject the claimed bead into the first prompt, or drain
+without launching the model when no work is available.
+
+## Goals
+
+- Provide a reusable pre-inference lifecycle boundary named `pre_launch`.
+- Let scripts patch the initial prompt, nudge, environment, and session
+  metadata using a typed JSON result contract.
+- Let scripts stop startup with a clear controller-visible action instead of
+  starting an idle or incorrectly scoped model process.
+- Preserve existing behavior by default. Agents without `pre_launch` continue
+  to start exactly as they do today.
+- Keep bead-claiming as a script/helper use case, not a controller-special
+  pool primitive.
+- Make startup failures diagnosable from logs and session bead metadata.
+
+## Non-Goals
+
+- Do not replace `pre_start`. `pre_start` remains target-filesystem setup before
+  provider session creation, such as worktree preparation.
+- Do not add a new bead-store primitive. Claiming continues to use existing
+  `bd update --claim` compare-and-swap behavior.
+- Do not change the ownership meaning of `gc.routed_to`. It remains generic
+  routing/provenance. Concrete ownership remains `assignee`.
+- Do not run arbitrary semantic decision-making in Go. Scripts own their policy;
+  Gas City only executes the declared lifecycle hook and applies the structured
+  result.
+- Do not support arbitrary command mutation in v1. Command rewriting would
+  create a second provider-resolution layer and is deliberately excluded.
+
+## Current Behavior
+
+The current startup path resolves an agent template into a runtime config, then
+starts the configured provider. Existing startup extension points are:
+
+- `pre_start`: shell commands run before session creation on the target
+  filesystem. Failures abort startup.
+- `session_setup`: shell commands run after provider session creation and
+  readiness. Failures are warnings.
+- `session_setup_script`: a script run after `session_setup`.
+- `session_live`: idempotent commands run at startup and re-applied on live-only
+  config drift.
+- Provider hooks such as `gc hook --inject`, which run after the model process
+  exists and depend on the provider's hook mechanism.
+
+For pool work, `EffectiveWorkQuery()` can return unassigned work routed by
+`gc.routed_to=<template>`. `gc hook --inject` currently reminds the model to
+claim that work. The atomic claim happens inside model-followed instructions,
+not before inference starts.
+
+That is acceptable for templates that want prompt-level ownership. It is a poor
+fit for deterministic startup plumbing: a model can drift from the FIRST ACTION
+block, and two sessions can both observe the same unclaimed bead before either
+claim has persisted.
+
+## Proposed Configuration
+
+Add an agent field:
+
+```toml
+[[agent]]
+name = "worker"
+pre_launch = [
+  "{{.ConfigDir}}/scripts/claim-next-work.sh"
+]
+```
+
+`pre_launch` is a list of shell command templates, expanded with the same
+context as `pre_start` and `session_setup`:
+
+- `{{.Session}}`
+- `{{.Agent}}`
+- `{{.AgentBase}}`
+- `{{.Rig}}`
+- `{{.RigRoot}}`
+- `{{.CityRoot}}`
+- `{{.CityName}}`
+- `{{.WorkDir}}`
+- `{{.ConfigDir}}`
+
+The field should also be available in agent patches and rig overrides:
+
+```toml
+[patches.agent.worker]
+pre_launch_append = [
+  "{{.ConfigDir}}/scripts/startup-policy.sh"
+]
+```
+
+`pre_launch_append` has exactly the same replace-then-append semantics as
+`pre_start_append`. Within one patch, `pre_launch = [...]` replaces the current
+list, then `pre_launch_append = [...]` appends to the resulting list. Across
+layered pack overrides and patches, ordering follows the existing patch
+application order used by `pre_start`.
+
+The initial implementation supports `pre_launch` and `pre_launch_append`
+wherever existing `pre_start` and `pre_start_append` are supported:
+
+- `config.Agent`
+- `config.AgentPatch`
+- `config.AgentOverride`
+- pack expansion and patch application
+- deep-copy paths used by pool/template resolution
+- runtime startup hints
+
+Future config nesting such as `[agent.lifecycle]` can be added as syntax sugar
+if the project standardizes a lifecycle block later. The public name remains
+`pre_launch`.
+
+## Execution Point
+
+Run `pre_launch` after all of the following are true:
+
+1. The session bead exists or has been selected for wake.
+2. `preWakeCommit` has written the new generation and instance token for a
+   wake.
+3. The resolved runtime config includes the concrete session environment:
+   `GC_SESSION_ID`, `GC_SESSION_NAME`, `GC_ALIAS`, `GC_TEMPLATE`,
+   `GC_SESSION_ORIGIN`, `GC_INSTANCE_TOKEN`, generation, and continuation
+   epoch.
+4. The final command, prompt, nudge, work directory, overlay paths, and
+   startup hints have been resolved.
+5. The provider process has not started.
+
+This places the hook at a controller-owned deterministic boundary: scripts can
+act with concrete session identity, but no LLM turn has occurred.
+
+### Placement In Runtime Providers
+
+For the tmux provider, `pre_launch` runs inside `doStartSession()` immediately
+after `runPreStart()` returns and before `ensureFreshSession()` is called.
+
+The ordering is:
+
+1. `runPreStart()`
+2. `runPreLaunch()`
+3. `ensureFreshSession()`
+4. `setRemainOnExit()`
+5. readiness waits, dialog handling, `session_setup`, nudge, and
+   `session_live`
+
+This placement is required because `ensureFreshSession()` creates the tmux pane
+and commits the launch command and environment. Any later placement would make
+`env`, prompt, and drain patches partially or fully ineffective.
+
+For exec-style providers, the equivalent anchor is after target preparation
+(`pre_start`) and before finalizing `exec.Cmd.Env`, command arguments, container
+spec, pod spec, or provider-specific start payload. A provider must not create a
+process, pane, pod, container, ACP child, or remote session before `pre_launch`
+has returned `continue`.
+
+The following provider-side actions have not happened when `pre_launch` runs:
+tmux `new-session`, `setRemainOnExit`, `waitForCommand`, startup dialog
+handling, readiness polling, `session_setup`, startup nudge, `session_live`, and
+provider process creation.
+
+`pre_launch` runs even when no other startup hints are present. It must not be
+skipped by the existing no-hints fire-and-forget path.
+
+## Hook Environment
+
+Each `pre_launch` command runs with the runtime config environment plus
+controller context:
+
+- `GC_CITY_PATH`
+- `GC_CITY_NAME`
+- `GC_WORK_DIR`
+- `GC_AGENT`
+- `GC_TEMPLATE`
+- `GC_ALIAS`
+- `GC_SESSION_ID`
+- `GC_SESSION_NAME`
+- `GC_SESSION_ORIGIN`
+- `GC_INSTANCE_TOKEN`
+- `GC_RUNTIME_EPOCH`
+- `GC_CONTINUATION_EPOCH`
+- rig-specific bead-store variables already used by hooks and work-query probes
+  when the agent belongs to a rig
+- `GC_SESSION`, as a compatibility alias for `GC_SESSION_NAME`
+
+Commands run in the resolved work directory when present. If the work directory
+is empty, they run from the city directory.
+
+Command stdin is closed. Scripts must not wait for interactive input. Commands
+execute through the same shell model as `pre_start` and use the same
+per-command setup timeout plus the total timeout described below.
+
+## Result Contract
+
+Each command may write JSON to stdout. Empty stdout means:
+
+```json
+{"action": "continue"}
+```
+
+The JSON object shape is:
+
+```json
+{
+  "action": "continue",
+  "prompt_prepend": "",
+  "prompt_append": "",
+  "nudge_prepend": "",
+  "nudge_append": "",
+  "env": {
+    "KEY": "value"
+  },
+  "metadata": {
+    "key": "value"
+  },
+  "reason": "human-readable context"
+}
+```
+
+Allowed `action` values:
+
+- `continue`: apply the patch and continue to the next `pre_launch` command or
+  provider start.
+- `drain`: apply metadata, do not start the provider process, and transition the
+  session into the normal drain/idle completion path.
+- `abort`: fail startup. The reconciler records a wake failure and retries or
+  rolls back according to existing startup failure rules.
+
+Unknown actions are treated as `abort`. Malformed JSON is treated as `abort`.
+Non-zero exit status always aborts, even when stdout contains valid JSON.
+Scripts that intentionally return `drain` must exit 0. This avoids treating a
+crashed script that happened to print parseable output as a successful drain.
+
+Stdout must contain exactly one JSON object after trimming surrounding
+whitespace. Empty stdout is equivalent to `{"action":"continue"}`. Unknown JSON
+fields are ignored for forward compatibility. `null` values for string fields
+are treated as empty. `env` and `metadata` must be JSON objects with string
+values.
+
+Patch semantics:
+
+- `prompt_prepend` and `prompt_append` modify the resolved prompt for providers
+  whose first turn is delivered as a command argument or prompt flag.
+- `nudge_prepend` and `nudge_append` modify the startup nudge for providers
+  using `PromptMode=none`.
+- `env` overlays the runtime environment for the provider process and subsequent
+  `pre_launch` commands.
+- `metadata` writes user metadata before the provider starts. Empty values clear
+  keys, matching existing metadata batch semantics.
+- `reason` is diagnostic text recorded in logs and, for `drain` or `abort`,
+  session metadata.
+
+The controller applies `prompt_*`, `nudge_*`, `env`, and `metadata` patches
+after each command so later commands can observe environment changes from
+earlier commands. Metadata writes should be batched per command.
+
+### Provider Mode Matrix
+
+`pre_launch` has two delivery families:
+
+- Prompt-capable launch: the provider has a structured first-turn prompt in the
+  resolved runtime configuration.
+- Nudge-only launch: the provider starts first and receives initial text through
+  `Nudge`.
+
+The implementation adds a distinct `runtime.Config.Prompt` field so prompt
+patches are applied before command assembly. Provider command strings are
+composed from `Command` plus `Prompt` after `pre_launch` runs. `pre_launch` does
+not directly rewrite `Command`.
+
+| Provider/start mode | `prompt_*` | `nudge_*` | `env` | `metadata` |
+|---|---|---|---|---|
+| tmux command-arg or prompt-flag launch | applied to `Config.Prompt` before command assembly | applied to startup nudge if present | applied to provider process and later hooks | applied before provider start |
+| tmux nudge-only (`PromptMode=none`) | rejected with `failure_stage=unsupported_prompt_patch` | applied to startup nudge | applied to provider process and later hooks | applied before provider start |
+| exec provider | serialized in start JSON as `prompt` or command-composed prompt, depending on provider capability | serialized as `nudge` | included in start JSON env | applied before provider start |
+| k8s/container provider | applied before pod/container command/env finalization | applied only if provider supports startup nudge | included in pod/container env | applied before provider start |
+| attach=false fresh launch | same as the provider's launch mode | same as the provider's launch mode | applied | applied |
+| resume of an already-running provider process | `pre_launch` does not run | `pre_launch` does not run | not applicable | not applicable |
+
+`pre_launch` is a launch hook, not a turn hook. It runs only when the controller
+is about to start a provider process. It does not run when submitting follow-up
+messages to an already-running session.
+
+Prompt and nudge patches are bounded. Large prompt/nudge content should be
+written to a file and referenced from the prompt, or delivered through the same
+paste-buffer path used by large hook injections. Direct `prompt_*` and
+`nudge_*` patches over the configured byte limit abort with
+`failure_stage=patch_too_large`.
+
+### Environment Overlay Rules
+
+Environment patches apply to a per-start deep copy of `runtime.Config.Env`.
+They never mutate agent config, template params, shared runtime config, or other
+sessions.
+
+Later `pre_launch` commands inherit earlier `env` patches. The provider process,
+`session_setup`, and `session_live` inherit the final environment after all
+successful `pre_launch` commands.
+
+Environment keys must match:
+
+```text
+^[A-Z_][A-Z0-9_]{0,127}$
+```
+
+Keys or values containing NUL or newline are rejected. Values are capped by the
+limits below.
+
+Scripts may not override controller-owned identity variables:
+
+- `GC_SESSION_ID`
+- `GC_SESSION_NAME`
+- `GC_SESSION`
+- `GC_ALIAS`
+- `GC_AGENT`
+- `GC_TEMPLATE`
+- `GC_SESSION_ORIGIN`
+- `GC_INSTANCE_TOKEN`
+- `GC_RUNTIME_EPOCH`
+- `GC_CONTINUATION_EPOCH`
+- `GC_CITY_PATH`
+- `GC_CITY_NAME`
+- `GC_WORK_DIR`
+
+Scripts also may not set security-sensitive process-injection keys or prefixes:
+
+- `PATH`
+- `LD_*`
+- `DYLD_*`
+- `BASH_ENV`
+- `ENV`
+- `PYTHONPATH`
+- `NODE_OPTIONS`
+- `GODEBUG`
+
+Rejected env patches abort before provider launch with
+`failure_stage=env_validation`.
+
+### Metadata Rules
+
+Controller diagnostics use the reserved `gc.pre_launch.*` metadata namespace.
+Scripts may not write that namespace.
+
+Scripts may write user metadata under `pre_launch.user.*`. Other metadata keys
+are rejected in v1 to prevent collisions with controller fields such as
+`state`, `session_name`, `assignee`, `gc.routed_to`, `pending_create_claim`,
+and `started_config_hash`.
+
+The controller records the command index on every drain or abort:
+
+- `gc.pre_launch.action`
+- `gc.pre_launch.reason`
+- `gc.pre_launch.at`
+- `gc.pre_launch.command_index`
+- `gc.pre_launch.failure_stage`
+- `gc.pre_launch.provider_started=false`
+- `gc.pre_launch.stderr_tail`
+
+## Claim-Or-Drain Example
+
+A pool worker that wants deterministic startup ownership can opt into:
+
+```toml
+pre_launch = [
+  "gc work claim-next --template {{.Agent}} --assignee {{.Session}} --json"
+]
+```
+
+`gc work claim-next --json` writes the single `pre_launch` result JSON object to
+stdout. All diagnostics go to stderr.
+
+Bead bodies can contain untrusted or instruction-like text. Scripts that inject
+bead content into prompts should fence it as data and include explicit
+"work only this claimed bead" instructions. Future helpers may provide a
+standard fenced representation.
+
+### `gc work claim-next` Contract
+
+The first Gas City-provided claim-or-drain helper is `gc work claim-next`.
+It is layered on existing work query and bead update semantics but is in the
+same implementation milestone as `pre_launch` because it is the concrete fix
+path for #845 and #1052.
+
+Inputs:
+
+- `--template <qualified-template>` selects the template whose
+  `EffectiveWorkQuery()` should be used.
+- `--assignee <session-id-or-name>` is the concrete owner to claim for.
+- `--json` emits machine-readable output.
+
+Algorithm:
+
+1. Check for an existing in-progress bead already assigned to the requested
+   assignee. If present, return that bead first. This makes retry after crash or
+   abort idempotent.
+2. Run the template's effective work query in session context.
+3. Consider only generic-demand candidates with no assignee.
+4. Attempt an atomic claim using bd compare-and-swap semantics:
+   "set assignee to `<assignee>` and transition to in-progress only if assignee
+   is empty and the bead is still claimable."
+5. Reload the bead and verify `assignee == <assignee>`.
+6. If claim failed because another worker won, retry the next candidate.
+7. Return no claim only after the candidate set is exhausted.
+
+JSON output:
+
+When an existing self-assigned bead is found, or a new bead is claimed:
+
+```json
+{
+  "action": "continue",
+  "env": {
+    "GC_WORK_BEAD": "ga-123"
+  },
+  "nudge_append": "\n\nClaimed work bead: ga-123",
+  "metadata": {
+    "pre_launch.user.claimed_work_bead": "ga-123"
+  }
+}
+```
+
+When no work is available:
+
+```json
+{
+  "action": "drain",
+  "reason": "no_work"
+}
+```
+
+If the helper cannot query, claim, or verify work, it exits non-zero. The
+`pre_launch` runner treats that as an abort with `failure_stage=command_failed`
+or a more specific stage when available.
+
+Exit codes:
+
+- `0`: successful claim or empty queue
+- `1`: invalid arguments or config
+- `2`: bead store unavailable
+- `3`: claim verification failed for reasons other than ordinary contention
+
+The helper must not derive ownership from `gc.routed_to`. `gc.routed_to` may be
+retained as provenance after claim; generic-demand accounting must exclude any
+bead with concrete `assignee` regardless of retained provenance.
+
+## Interaction With Existing Lifecycle
+
+### `pre_start`
+
+`pre_start` still runs where it does today. It prepares filesystems and runtime
+targets. It has no structured output and does not patch prompt or metadata.
+
+### `pre_launch`
+
+`pre_launch` runs after session identity exists and before provider process
+creation. It can patch initial prompt/nudge/env/metadata or choose not to
+launch.
+
+### `session_setup` and `session_live`
+
+These still run only after a provider session exists. If `pre_launch` returns
+`drain` or `abort`, neither runs because no provider process was started.
+
+### Config Fingerprints
+
+The declared `pre_launch` command list is part of the stable startup config and
+must be included in the core session fingerprint. Runtime results from
+`pre_launch` are not part of the fingerprint because they are per-start facts.
+
+If a `pre_launch` command changes, existing sessions follow the same restart
+path as a `pre_start` change.
+
+`ConfigFingerprint` and `CoreFingerprint` are computed from the declared
+resolved `pre_launch` list before any command executes. Runtime patches returned
+by `pre_launch` for env, prompt, nudge, or metadata are process-start facts and
+never re-enter fingerprint computation. This remains true even if a hook returns
+an allowlisted `GC_*` env value such as `GC_WORK_BEAD`.
+
+`PreLaunch` must appear in fingerprint breakdown and drift logging alongside
+`PreStart`.
+
+### Draining
+
+`action=drain` means no provider process was launched. A pre-launch drain is a
+terminal-success launch outcome, not a provider crash and not a retryable wake
+failure.
+
+The controller archives the session bead immediately with:
+
+- `state=archived`
+- `gc.pre_launch.action=drain`
+- `gc.pre_launch.reason=<bounded reason>`
+- `gc.pre_launch.at=<RFC3339 timestamp>`
+- `gc.pre_launch.command_index=<zero-based index>`
+- `gc.pre_launch.provider_started=false`
+
+No provider stop, interrupt, runtime drain acknowledgment, readiness wait,
+dialog handling, `session_setup`, startup nudge, `session_live`, or
+`setRemainOnExit` is attempted. There is no pane or process to preserve, so the
+forensic surface is the bounded metadata and typed events.
+
+Pool and capacity accounting must not count archived pre-launch drains as
+running or in-flight sessions. The reconciler must not resurrect an archived
+pre-launch drain unless a new explicit wake/materialization request is created.
+
+`drain` preserves continuation epoch because no model turn was produced.
+
+If a script claims a bead and then returns `drain`, the script must release or
+requeue its claim before returning. The controller-owned `gc work claim-next`
+path does not return `drain` after a successful claim.
+
+### Abort And Retry
+
+`action=abort`, non-zero exit, timeout, malformed JSON, invalid patch, metadata
+write failure, or oversized output aborts startup before provider launch.
+
+Abort writes:
+
+- `gc.pre_launch.action=abort`
+- `gc.pre_launch.reason=<bounded reason>`
+- `gc.pre_launch.failure_stage=<closed enum>`
+- `gc.pre_launch.at=<RFC3339 timestamp>`
+- `gc.pre_launch.command_index=<zero-based index>`
+- `gc.pre_launch.provider_started=false`
+
+Failure stages:
+
+- `script_exit`
+- `timeout`
+- `stdout_too_large`
+- `stderr_too_large`
+- `json_parse`
+- `unknown_action`
+- `env_validation`
+- `metadata_validation`
+- `metadata_write`
+- `unsupported_prompt_patch`
+- `patch_too_large`
+- `context_cancelled`
+
+Abort retry uses the existing wake failure machinery, but the failure is tagged
+as pre-launch rather than provider-start. A retry must be idempotent. The
+claim-next helper first returns any self-assigned bead for the session before it
+queries generic demand, so a controller crash after claim and before provider
+start relaunches against the already-owned bead instead of claiming a second
+one.
+
+If a later `pre_launch` command fails after an earlier command claimed work via
+`gc work claim-next`, retry idempotence handles the claim. Scripts that perform
+their own external claims must either be idempotent in the same way or release
+their claim before aborting.
+
+## Error Handling
+
+- Command timeout uses the existing session setup timeout.
+- The pre-launch list also has a total timeout budget, defaulting to the larger
+  of the setup timeout and the sum of per-command timeouts capped by daemon
+  startup timeout. Exceeding the total budget aborts with
+  `failure_stage=timeout`.
+- Non-zero command exit status always aborts startup.
+- Malformed JSON aborts startup and records the raw parse error.
+- Metadata write failure aborts startup before provider creation.
+- Environment keys must match the same conservative variable-name rules used by
+  config env overlays. Invalid keys abort startup.
+- Large stdout should be rejected with a bounded size limit before JSON parsing
+  to avoid unbounded memory use.
+
+Concrete limits for v1:
+
+- stdout: 64 KiB, enforced while reading with a limit reader
+- stderr: 16 KiB retained tail, enforced while reading
+- `reason`: 1 KiB after sanitization
+- each metadata key: 128 bytes
+- each metadata value: 4 KiB
+- total script metadata patch: 16 KiB
+- each env value: 8 KiB
+- total env patch: 32 KiB
+- `prompt_prepend` + `prompt_append`: 64 KiB total per command
+- `nudge_prepend` + `nudge_append`: 16 KiB total per command
+
+On stdout or stderr overflow, the controller terminates the command, aborts
+startup, and persists only the byte count, command index, failure stage, and a
+sanitized error. Raw stdout, raw prompt/nudge patch contents, full env, env
+values, and secret-bearing output are never logged or persisted.
+
+## Security
+
+`pre_launch` executes configured shell commands. It has the same trust model as
+`pre_start`, `session_setup`, and pack scripts: city and pack authors are
+trusted code providers.
+
+Additional safeguards:
+
+- The result contract is data, not shell. Prompt/nudge/env/metadata patches are
+  applied structurally by Go code.
+- Command mutation is excluded in v1.
+- `prompt_*` patches mutate a structured prompt field before provider command
+  assembly; they do not perform shell string rewriting.
+- Secret-bearing environment values should not be serialized into logs.
+- Result parse errors should include command index and action context, but not
+  dump full environment.
+
+## Observability
+
+For each command, log:
+
+- session name
+- template name
+- command index
+- action
+- duration
+- reason, when present
+
+For `drain` and `abort`, persist metadata such as:
+
+- `gc.pre_launch.action`
+- `gc.pre_launch.reason`
+- `gc.pre_launch.at`
+
+Scripts can persist additional domain-specific metadata through the structured
+`metadata` patch.
+
+The event bus emits typed events with registered payloads:
+
+- `session.pre_launch_started`
+- `session.pre_launch_command_completed`
+- `session.pre_launch_drained`
+- `session.pre_launch_aborted`
+
+Payloads include session ID, session name, template, command index, action,
+duration, failure stage, and sanitized reason. `gc trace` should surface
+pre-launch as a distinct startup phase.
+
+Because no tmux pane exists on pre-launch drain or abort, `setRemainOnExit`
+cannot provide forensics. The substitute forensic surface is the event stream,
+bounded stderr tail, and `gc.pre_launch.*` metadata.
+
+## Implementation Checklist
+
+- Add `PreLaunch` and `PreLaunchAppend` to `internal/config/config.go` agent,
+  patch, and override structs.
+- Wire patch and override application in `internal/config/patch.go` and pack
+  expansion.
+- Deep-copy fields in pool/template resolution helpers.
+- Add `PreLaunch` to startup hints and `runtime.Config`.
+- Add `Prompt` to `runtime.Config` so prompt patches do not rewrite `Command`.
+- Add `pre_launch` and `prompt` to exec provider JSON only when supported.
+- Add `PreLaunch` to `runtime.CoreFingerprint`,
+  `CoreFingerprintBreakdown`, canonical config hash, and drift logging.
+- Update config schema generation and generated config docs.
+- Update field-sync tests and any patch-only exclusions deliberately.
+- Register typed event payloads for all new pre-launch events.
+- Expose fields in API/OpenAPI/dashboard typed config views if agent config
+  views include lifecycle fields.
+- Implement `gc work claim-next` with the CAS/verify/retry/idempotence contract
+  above.
+- Add docs and a pack-local example script only after the generic lifecycle hook
+  tests pass.
+
+## Rollout
+
+1. Add config fields and docs with no agents opted in.
+2. Implement generic runtime support and hook-level tests for continue, drain,
+   abort, malformed output, timeout, invalid env, metadata failure, no-hook
+   compatibility, prompt/nudge/env/metadata patches, and fingerprint behavior.
+3. Add `gc work claim-next` with tests for claim success, claim conflict retry,
+   existing self-assigned idempotence, empty queue, store outage, and ownership
+   verification failure.
+4. Add an example script in the relevant pack.
+5. Opt in the first pool worker template only after tests cover claim success,
+   claim-lost, empty-drain, malformed hook result paths, the #1052 concurrent
+   two-sessions-one-bead race, and rollback by removing the config field.
+
+Rollback for the first pool-worker opt-in is removing `pre_launch` from the
+template config. Because the feature is additive and declared in config, rollback
+does not require data migration.
+
+## Test Plan
+
+Tests should use fake runtime providers or `fakeStartOps`; no test should
+require real LLM inference.
+
+- `TestPreLaunchNoHookStartsExactlyAsBefore`: no `pre_launch` produces the same
+  start call order and runtime config as current startup.
+- `TestPreLaunchRunsAfterPreStartBeforeEnsureFreshSession`: verifies tmux start
+  operation ordering.
+- `TestPreLaunchPromptPatchAppliesBeforeCommandAssembly`: prompt append affects
+  `Config.Prompt` and provider command composition.
+- `TestPreLaunchRejectsPromptPatchForNudgeOnlyProvider`: unsupported prompt
+  patch aborts with diagnostic metadata.
+- `TestPreLaunchNudgePatchAppliesToPromptModeNone`: nudge append reaches startup
+  nudge.
+- `TestPreLaunchEnvPatchVisibleToLaterCommandAndProvider`: env overlay is
+  per-start and cumulative.
+- `TestPreLaunchRejectsReservedEnvOverride`: reserved `GC_*`, `PATH`, and
+  `LD_*` keys fail closed.
+- `TestPreLaunchMetadataPatchWritesUserNamespaceOnly`: user metadata writes and
+  reserved namespace rejection.
+- `TestPreLaunchDrainArchivesWithoutProviderStart`: drain records metadata and
+  skips provider-side steps.
+- `TestPreLaunchAbortDoesNotStartProvider`: malformed JSON, non-zero exit,
+  timeout, oversized stdout, invalid env, and metadata write failure each abort.
+- `TestPreLaunchAbortRecordsFailureStage`: every failure stage is visible in
+  metadata/events.
+- `TestPreLaunchFingerprintIncludesDeclaredCommands`: command list changes hash.
+- `TestPreLaunchRuntimePatchDoesNotAffectFingerprint`: env/prompt runtime patch
+  does not change core hash.
+- `TestPreLaunchAppendMatchesPreStartAppendSemantics`: patch and override
+  ordering matches existing lifecycle append behavior.
+- `TestWorkClaimNextClaimsOneOfConcurrentWorkers`: two sessions race one bead;
+  only one claims and the other returns empty.
+- `TestWorkClaimNextRetriesOnClaimConflict`: conflict on first candidate tries
+  the next candidate.
+- `TestWorkClaimNextReturnsExistingSelfAssignedFirst`: retry after crash uses
+  existing ownership.
+- `TestWorkClaimNextRetainsRoutedToAsProvenanceWithoutGenericDemand`: assigned
+  work with retained `gc.routed_to` is excluded from generic demand.
+- `TestPreLaunchAbortAfterClaimRecovery`: retry after abort returns the
+  self-assigned bead instead of claiming another.
+- `TestPreLaunchCrashAfterClaimRecovery`: controller restart between claim and
+  provider launch resumes the self-assigned bead.
+
+## Acceptance Criteria
+
+- Agents without `pre_launch` start exactly as before.
+- A `pre_launch` script can append to the initial prompt before provider start.
+- A `pre_launch` script can append to the startup nudge before provider start.
+- A `pre_launch` script can add provider environment variables visible to the
+  launched process.
+- A `pre_launch` script can write session metadata before provider start.
+- `action=drain` prevents provider process launch and leaves a diagnosable
+  session bead state.
+- `action=abort` and malformed output fail startup without launching the
+  provider process.
+- The declared `pre_launch` command list participates in config drift
+  fingerprinting.
+- Claim-or-drain can be implemented with `gc work claim-next` using existing
+  work-query and bead-claim semantics, addressing #845 and #1052 without giving
+  `gc.routed_to` ownership semantics.
+- The first implementation includes the two issue references in PR text and
+  validates both Stephanie's #845 drift case and Riley's #1052 duplicate
+  execution race.
+
+## Open Questions
+
+- Should `pre_launch` be top-level on `[[agent]]` for symmetry with
+  `pre_start`, or should a future `[agent.lifecycle]` block also be introduced
+  for grouping? This design chooses top-level now for the smallest consistent
+  change.
+- Should a future `gc hook emit` helper generate result JSON for pack authors?
+  The v1 example is POSIX-only, but a helper would improve ergonomics.
+- Should `pre_launch` eventually support a structured claim field in its own
+  JSON result so the controller can own rollback of local bead claims? V1 relies
+  on idempotent helpers and explicit script rollback for external systems.

--- a/examples/gastown/packs/maintenance/agents/dog/agent.toml
+++ b/examples/gastown/packs/maintenance/agents/dog/agent.toml
@@ -1,5 +1,6 @@
 scope = "city"
 fallback = true
+pre_launch = ["gc work claim-next --template {{.Agent}} --assignee {{.Session}} --json"]
 nudge = "Check your hook for work assignments."
 idle_timeout = "2h"
 min_active_sessions = 0

--- a/examples/gastown/packs/maintenance/agents/dog/agent.toml
+++ b/examples/gastown/packs/maintenance/agents/dog/agent.toml
@@ -1,6 +1,6 @@
 scope = "city"
 fallback = true
-pre_launch = ["gc work claim-next --template {{.Agent}} --assignee {{.Session}} --json"]
+pre_launch = ["gc work claim-next --json"]
 nudge = "Check your hook for work assignments."
 idle_timeout = "2h"
 min_active_sessions = 0

--- a/internal/agent/hints.go
+++ b/internal/agent/hints.go
@@ -17,6 +17,10 @@ type StartupHints struct {
 	// PreStart is a list of shell commands run before session creation.
 	// Already template-expanded by the caller. Failures abort startup.
 	PreStart []string
+	// PreLaunch is a list of shell commands run after pre_start and session
+	// identity preparation, but before provider process launch.
+	// Already template-expanded by the caller.
+	PreLaunch []string
 	// SessionSetup is a list of shell commands run after session creation.
 	// Already template-expanded by the caller.
 	SessionSetup []string

--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -182,6 +182,9 @@ func DeepCopyAgent(src *config.Agent, name, dir string) config.Agent {
 	if src.PreStart != nil {
 		dst.PreStart = append([]string(nil), src.PreStart...)
 	}
+	if src.PreLaunch != nil {
+		dst.PreLaunch = append([]string(nil), src.PreLaunch...)
+	}
 	if src.Args != nil {
 		dst.Args = append([]string(nil), src.Args...)
 	}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -267,6 +267,8 @@ type AgentPatch struct {
 	OptionDefaults          map[string]string `json:"OptionDefaults"`
 	OverlayDir              *string           `json:"OverlayDir"`
 	Pool                    PoolOverride      `json:"Pool"`
+	PreLaunch               *[]string         `json:"PreLaunch"`
+	PreLaunchAppend         *[]string         `json:"PreLaunchAppend"`
 	PreStart                *[]string         `json:"PreStart"`
 	PreStartAppend          *[]string         `json:"PreStartAppend"`
 	PromptTemplate          *string           `json:"PromptTemplate"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -299,6 +299,24 @@
           "Pool": {
             "$ref": "#/components/schemas/PoolOverride"
           },
+          "PreLaunch": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "PreLaunchAppend": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "PreStart": {
             "items": {
               "type": "string"
@@ -454,6 +472,7 @@
           "Env",
           "EnvRemove",
           "PreStart",
+          "PreLaunch",
           "PromptTemplate",
           "Session",
           "Provider",
@@ -480,6 +499,7 @@
           "ResumeCommand",
           "WakeMode",
           "PreStartAppend",
+          "PreLaunchAppend",
           "SessionSetupAppend",
           "SessionLiveAppend",
           "InstallAgentHooksAppend",

--- a/internal/beads/claim.go
+++ b/internal/beads/claim.go
@@ -1,0 +1,39 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var ErrClaimConflict = errors.New("bead claim conflict")
+
+func ClaimWithBD(ctx context.Context, dir, beadID, assignee string) error {
+	cmd := exec.CommandContext(ctx, "bd", "update", beadID, "--claim", "--json")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "BEADS_ACTOR="+assignee)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if isClaimConflictMessage(msg) {
+		return fmt.Errorf("%w: %s", ErrClaimConflict, msg)
+	}
+	return fmt.Errorf("bd claim %s: %w: %s", beadID, err, msg)
+}
+
+func IsClaimConflict(err error) bool {
+	return errors.Is(err, ErrClaimConflict)
+}
+
+func isClaimConflictMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "already assigned") ||
+		strings.Contains(msg, "already claimed") ||
+		strings.Contains(msg, "claimed by") ||
+		strings.Contains(msg, "claim conflict")
+}

--- a/internal/beads/claim.go
+++ b/internal/beads/claim.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 )
 
+// ErrClaimConflict marks ordinary contention while claiming a bead.
 var ErrClaimConflict = errors.New("bead claim conflict")
 
+// ClaimWithBD atomically claims a bead for assignee using the bd CLI.
 func ClaimWithBD(ctx context.Context, dir, beadID, assignee string) error {
 	cmd := exec.CommandContext(ctx, "bd", "update", beadID, "--claim", "--json")
 	cmd.Dir = dir
@@ -26,6 +28,7 @@ func ClaimWithBD(ctx context.Context, dir, beadID, assignee string) error {
 	return fmt.Errorf("bd claim %s: %w: %s", beadID, err, msg)
 }
 
+// IsClaimConflict reports whether err is ordinary claim contention.
 func IsClaimConflict(err error) bool {
 	return errors.Is(err, ErrClaimConflict)
 }

--- a/internal/beads/claim_test.go
+++ b/internal/beads/claim_test.go
@@ -1,0 +1,30 @@
+package beads
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsClaimConflictMessage(t *testing.T) {
+	for _, msg := range []string{
+		"issue already claimed by alice",
+		"bead already assigned to worker",
+		"claim conflict: stale assignee",
+	} {
+		if !isClaimConflictMessage(msg) {
+			t.Fatalf("isClaimConflictMessage(%q) = false, want true", msg)
+		}
+	}
+	if isClaimConflictMessage("assignee column missing from database") {
+		t.Fatal("generic assignee error should not be classified as conflict")
+	}
+}
+
+func TestIsClaimConflict(t *testing.T) {
+	if !IsClaimConflict(ErrClaimConflict) {
+		t.Fatal("ErrClaimConflict should classify as claim conflict")
+	}
+	if IsClaimConflict(errors.New("bd not found")) {
+		t.Fatal("hard bd error should not classify as claim conflict")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -466,6 +466,8 @@ type AgentOverride struct {
 	EnvRemove []string `toml:"env_remove,omitempty"`
 	// PreStart overrides the agent's pre_start commands.
 	PreStart []string `toml:"pre_start,omitempty"`
+	// PreLaunch overrides the agent's pre_launch commands.
+	PreLaunch []string `toml:"pre_launch,omitempty"`
 	// PromptTemplate overrides the prompt template path.
 	// Relative paths resolve against the city directory.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
@@ -519,6 +521,9 @@ type AgentOverride struct {
 	// PreStartAppend appends commands to the agent's pre_start list
 	// (instead of replacing). Applied after PreStart if both are set.
 	PreStartAppend []string `toml:"pre_start_append,omitempty"`
+	// PreLaunchAppend appends commands to the agent's pre_launch list
+	// (instead of replacing). Applied after PreLaunch if both are set.
+	PreLaunchAppend []string `toml:"pre_launch_append,omitempty"`
 	// SessionSetupAppend appends commands to the agent's session_setup list.
 	SessionSetupAppend []string `toml:"session_setup_append,omitempty"`
 	// SessionLiveAppend appends commands to the agent's session_live list.
@@ -1496,6 +1501,11 @@ type Agent struct {
 	// Commands run on the target filesystem: locally for tmux, inside the
 	// pod/container for exec providers. Template variables same as session_setup.
 	PreStart []string `toml:"pre_start,omitempty"`
+	// PreLaunch is a list of shell commands run after pre_start and session
+	// identity preparation, but before the provider process is launched.
+	// Commands may emit a bounded JSON response to continue, drain, abort,
+	// or patch startup prompt/nudge/env/metadata.
+	PreLaunch []string `toml:"pre_launch,omitempty"`
 	// PromptTemplate is the path to this agent's prompt template file.
 	// Relative paths resolve against the city directory.
 	PromptTemplate string `toml:"prompt_template,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1090,6 +1090,7 @@ name = "test"
 name = "worker"
 dir = "/repo"
 pre_start = ["mkdir -p /tmp/work", "git worktree add /tmp/work"]
+pre_launch = ["gc work claim-next --json"]
 
 [[agent]]
 name = "mayor"
@@ -1104,15 +1105,26 @@ name = "mayor"
 	if len(cfg.Agents[0].PreStart) != 2 {
 		t.Errorf("Agents[0].PreStart len = %d, want 2", len(cfg.Agents[0].PreStart))
 	}
+	if len(cfg.Agents[0].PreLaunch) != 1 {
+		t.Errorf("Agents[0].PreLaunch len = %d, want 1", len(cfg.Agents[0].PreLaunch))
+	}
 	if len(cfg.Agents[1].PreStart) != 0 {
 		t.Errorf("Agents[1].PreStart len = %d, want 0", len(cfg.Agents[1].PreStart))
+	}
+	if len(cfg.Agents[1].PreLaunch) != 0 {
+		t.Errorf("Agents[1].PreLaunch len = %d, want 0", len(cfg.Agents[1].PreLaunch))
 	}
 }
 
 func TestPreStartRoundTrip(t *testing.T) {
 	c := City{
 		Workspace: Workspace{Name: "test"},
-		Agents:    []Agent{{Name: "worker", Dir: "/repo", PreStart: []string{"echo hello"}}},
+		Agents: []Agent{{
+			Name:      "worker",
+			Dir:       "/repo",
+			PreStart:  []string{"echo hello"},
+			PreLaunch: []string{"gc work claim-next --json"},
+		}},
 	}
 	data, err := c.Marshal()
 	if err != nil {
@@ -1124,6 +1136,9 @@ func TestPreStartRoundTrip(t *testing.T) {
 	}
 	if len(got.Agents[0].PreStart) != 1 || got.Agents[0].PreStart[0] != "echo hello" {
 		t.Errorf("PreStart after round-trip = %v, want [echo hello]", got.Agents[0].PreStart)
+	}
+	if len(got.Agents[0].PreLaunch) != 1 || got.Agents[0].PreLaunch[0] != "gc work claim-next --json" {
+		t.Errorf("PreLaunch after round-trip = %v, want [gc work claim-next --json]", got.Agents[0].PreLaunch)
 	}
 }
 
@@ -1138,6 +1153,9 @@ func TestMarshalOmitsEmptyPreStart(t *testing.T) {
 	}
 	if strings.Contains(string(data), "pre_start") {
 		t.Errorf("Marshal output should not contain 'pre_start' when empty:\n%s", data)
+	}
+	if strings.Contains(string(data), "pre_launch") {
+		t.Errorf("Marshal output should not contain 'pre_launch' when empty:\n%s", data)
 	}
 }
 

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -62,6 +62,7 @@ func TestAgentFieldSync(t *testing.T) {
 		"Agent":                   true, // targeting key on AgentOverride
 		"EnvRemove":               true, // remove modifier, no Agent field
 		"PreStartAppend":          true, // append modifier, no Agent field
+		"PreLaunchAppend":         true, // append modifier, no Agent field
 		"SessionSetupAppend":      true, // append modifier, no Agent field
 		"SessionLiveAppend":       true, // append modifier, no Agent field
 		"InstallAgentHooksAppend": true, // append modifier, no Agent field
@@ -173,6 +174,7 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		Pool:                    &PoolOverride{Min: intVal(2), Max: intVal(10), Check: strVal("echo 5"), OnDeath: strVal("echo dead"), OnBoot: strVal("echo boot")},
 		Env:                     map[string]string{"KEY": "val"},
 		PreStart:                []string{"pre-cmd"},
+		PreLaunch:               []string{"pre-launch-cmd"},
 		PromptTemplate:          strVal("prompts/test.md"),
 		Session:                 strVal("acp"),
 		Provider:                strVal("claude"),
@@ -194,6 +196,7 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 		ResumeCommand:           strVal("claude --resume {{.SessionKey}}"),
 		WakeMode:                strVal("fresh"),
 		PreStartAppend:          []string{"pre-append"},
+		PreLaunchAppend:         []string{"pre-launch-append"},
 		SessionSetupAppend:      []string{"setup-append"},
 		SessionLiveAppend:       []string{"live-append"},
 		InstallAgentHooksAppend: []string{"gemini"},
@@ -230,6 +233,7 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 	modifiers := map[string]bool{
 		"EnvRemove":               true,
 		"PreStartAppend":          true,
+		"PreLaunchAppend":         true,
 		"SessionSetupAppend":      true,
 		"SessionLiveAppend":       true,
 		"InstallAgentHooksAppend": true,
@@ -288,6 +292,9 @@ func TestApplyAgentPatchCoversAllFields(t *testing.T) {
 	if len(agent.PreStart) != 2 || agent.PreStart[1] != "pre-append" {
 		t.Errorf("PreStartAppend not applied: %v", agent.PreStart)
 	}
+	if len(agent.PreLaunch) != 2 || agent.PreLaunch[1] != "pre-launch-append" {
+		t.Errorf("PreLaunchAppend not applied: %v", agent.PreLaunch)
+	}
 	if len(agent.SessionSetup) != 2 || agent.SessionSetup[1] != "setup-append" {
 		t.Errorf("SessionSetupAppend not applied: %v", agent.SessionSetup)
 	}
@@ -321,6 +328,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		Env:                     map[string]string{"KEY": "val"},
 		EnvRemove:               []string{"REMOVE_ME"},
 		PreStart:                []string{"pre-cmd"},
+		PreLaunch:               []string{"pre-launch-cmd"},
 		PromptTemplate:          strVal("prompts/test.md"),
 		Session:                 strVal("acp"),
 		Provider:                strVal("claude"),
@@ -342,6 +350,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 		ResumeCommand:           strVal("claude --resume {{.SessionKey}}"),
 		WakeMode:                strVal("fresh"),
 		PreStartAppend:          []string{"pre-append"},
+		PreLaunchAppend:         []string{"pre-launch-append"},
 		SessionSetupAppend:      []string{"setup-append"},
 		SessionLiveAppend:       []string{"live-append"},
 		InstallAgentHooksAppend: []string{"gemini"},
@@ -375,6 +384,7 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 	modifiers := map[string]bool{
 		"EnvRemove":               true,
 		"PreStartAppend":          true,
+		"PreLaunchAppend":         true,
 		"SessionSetupAppend":      true,
 		"SessionLiveAppend":       true,
 		"InstallAgentHooksAppend": true,
@@ -424,6 +434,9 @@ func TestApplyAgentOverrideCoversAllFields(t *testing.T) {
 	}
 	if agent.MinActiveSessions == nil || *agent.MinActiveSessions != 2 || agent.MaxActiveSessions == nil || *agent.MaxActiveSessions != 10 {
 		t.Errorf("Scaling not applied correctly: min=%v max=%v", agent.MinActiveSessions, agent.MaxActiveSessions)
+	}
+	if len(agent.PreLaunch) != 2 || agent.PreLaunch[1] != "pre-launch-append" {
+		t.Errorf("PreLaunchAppend not applied: %v", agent.PreLaunch)
 	}
 }
 

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1499,6 +1499,7 @@ func deepCopyAgents(in []Agent) []Agent {
 		out[i] = in[i]
 		out[i].Args = append([]string(nil), in[i].Args...)
 		out[i].PreStart = append([]string(nil), in[i].PreStart...)
+		out[i].PreLaunch = append([]string(nil), in[i].PreLaunch...)
 		out[i].ProcessNames = append([]string(nil), in[i].ProcessNames...)
 		out[i].Env = deepCopyStringMap(in[i].Env)
 		out[i].OptionDefaults = deepCopyStringMap(in[i].OptionDefaults)
@@ -2331,6 +2332,12 @@ func applyAgentOverride(a *Agent, ov *AgentOverride) {
 	}
 	if len(ov.PreStartAppend) > 0 {
 		a.PreStart = append(a.PreStart, ov.PreStartAppend...)
+	}
+	if len(ov.PreLaunch) > 0 {
+		a.PreLaunch = append([]string(nil), ov.PreLaunch...)
+	}
+	if len(ov.PreLaunchAppend) > 0 {
+		a.PreLaunch = append(a.PreLaunch, ov.PreLaunchAppend...)
 	}
 	if ov.PromptTemplate != nil {
 		a.PromptTemplate = *ov.PromptTemplate

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -2990,6 +2990,7 @@ schema = 1
 [[agent]]
 name = "polecat"
 pre_start = ["base-setup.sh"]
+pre_launch = ["base-claim.sh"]
 session_setup = ["tmux set status"]
 install_agent_hooks = ["claude"]
 inject_fragments = ["tdd"]
@@ -3000,6 +3001,7 @@ inject_fragments = ["tdd"]
 			Overrides: []AgentOverride{{
 				Agent:                   "polecat",
 				PreStartAppend:          []string{"extra-setup.sh"},
+				PreLaunchAppend:         []string{"extra-claim.sh"},
 				SessionSetupAppend:      []string{"tmux set mouse on"},
 				InstallAgentHooksAppend: []string{"gemini"},
 				InjectFragmentsAppend:   []string{"safety"},
@@ -3013,6 +3015,10 @@ inject_fragments = ["tdd"]
 	wantPreStart := []string{"base-setup.sh", "extra-setup.sh"}
 	if !sliceEqual(a.PreStart, wantPreStart) {
 		t.Errorf("PreStart = %v, want %v", a.PreStart, wantPreStart)
+	}
+	wantPreLaunch := []string{"base-claim.sh", "extra-claim.sh"}
+	if !sliceEqual(a.PreLaunch, wantPreLaunch) {
+		t.Errorf("PreLaunch = %v, want %v", a.PreLaunch, wantPreLaunch)
 	}
 	wantSetup := []string{"tmux set status", "tmux set mouse on"}
 	if !sliceEqual(a.SessionSetup, wantSetup) {
@@ -3038,14 +3044,17 @@ schema = 1
 [[agent]]
 name = "polecat"
 pre_start = ["old-a.sh", "old-b.sh"]
+pre_launch = ["old-claim-a.sh", "old-claim-b.sh"]
 `)
 	cfg := &City{
 		Rigs: []Rig{{
 			Name: "hw", Path: "/tmp/hw", Includes: []string{"packs/test"},
 			Overrides: []AgentOverride{{
-				Agent:          "polecat",
-				PreStart:       []string{"new-base.sh"},
-				PreStartAppend: []string{"extra.sh"},
+				Agent:           "polecat",
+				PreStart:        []string{"new-base.sh"},
+				PreStartAppend:  []string{"extra.sh"},
+				PreLaunch:       []string{"new-claim.sh"},
+				PreLaunchAppend: []string{"extra-claim.sh"},
 			}},
 		}},
 	}
@@ -3055,6 +3064,10 @@ pre_start = ["old-a.sh", "old-b.sh"]
 	want := []string{"new-base.sh", "extra.sh"}
 	if !sliceEqual(cfg.Agents[0].PreStart, want) {
 		t.Errorf("PreStart = %v, want %v", cfg.Agents[0].PreStart, want)
+	}
+	wantLaunch := []string{"new-claim.sh", "extra-claim.sh"}
+	if !sliceEqual(cfg.Agents[0].PreLaunch, wantLaunch) {
+		t.Errorf("PreLaunch = %v, want %v", cfg.Agents[0].PreLaunch, wantLaunch)
 	}
 }
 
@@ -3074,6 +3087,7 @@ name = "polecat"
 			Overrides: []AgentOverride{{
 				Agent:              "polecat",
 				PreStartAppend:     []string{"setup.sh"},
+				PreLaunchAppend:    []string{"claim.sh"},
 				SessionSetupAppend: []string{"tmux set mouse on"},
 			}},
 		}},
@@ -3084,6 +3098,9 @@ name = "polecat"
 	a := cfg.Agents[0]
 	if !sliceEqual(a.PreStart, []string{"setup.sh"}) {
 		t.Errorf("PreStart = %v, want [setup.sh]", a.PreStart)
+	}
+	if !sliceEqual(a.PreLaunch, []string{"claim.sh"}) {
+		t.Errorf("PreLaunch = %v, want [claim.sh]", a.PreLaunch)
 	}
 	if !sliceEqual(a.SessionSetup, []string{"tmux set mouse on"}) {
 		t.Errorf("SessionSetup = %v, want [tmux set mouse on]", a.SessionSetup)

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -36,6 +36,8 @@ type AgentPatch struct {
 	EnvRemove []string `toml:"env_remove,omitempty"`
 	// PreStart overrides the agent's pre_start commands.
 	PreStart []string `toml:"pre_start,omitempty"`
+	// PreLaunch overrides the agent's pre_launch commands.
+	PreLaunch []string `toml:"pre_launch,omitempty"`
 	// PromptTemplate overrides the prompt template path.
 	// Relative paths resolve against the city directory.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
@@ -110,6 +112,9 @@ type AgentPatch struct {
 	// PreStartAppend appends commands to the agent's pre_start list
 	// (instead of replacing). Applied after PreStart if both are set.
 	PreStartAppend []string `toml:"pre_start_append,omitempty"`
+	// PreLaunchAppend appends commands to the agent's pre_launch list
+	// (instead of replacing). Applied after PreLaunch if both are set.
+	PreLaunchAppend []string `toml:"pre_launch_append,omitempty"`
 	// SessionSetupAppend appends commands to the agent's session_setup list.
 	SessionSetupAppend []string `toml:"session_setup_append,omitempty"`
 	// SessionLiveAppend appends commands to the agent's session_live list.
@@ -266,6 +271,12 @@ func applyAgentPatchFields(a *Agent, p *AgentPatch) {
 	}
 	if len(p.PreStartAppend) > 0 {
 		a.PreStart = append(a.PreStart, p.PreStartAppend...)
+	}
+	if len(p.PreLaunch) > 0 {
+		a.PreLaunch = append([]string(nil), p.PreLaunch...)
+	}
+	if len(p.PreLaunchAppend) > 0 {
+		a.PreLaunch = append(a.PreLaunch, p.PreLaunchAppend...)
 	}
 	if p.PromptTemplate != nil {
 		a.PromptTemplate = *p.PromptTemplate

--- a/internal/config/patch_test.go
+++ b/internal/config/patch_test.go
@@ -578,6 +578,7 @@ func TestApplyPatches_AppendAlone(t *testing.T) {
 		Agents: []Agent{{
 			Name:              "worker",
 			PreStart:          []string{"base-setup.sh"},
+			PreLaunch:         []string{"base-claim.sh"},
 			SessionSetup:      []string{"tmux set status"},
 			InstallAgentHooks: []string{"claude"},
 			InjectFragments:   []string{"tdd"},
@@ -587,6 +588,7 @@ func TestApplyPatches_AppendAlone(t *testing.T) {
 		Agents: []AgentPatch{{
 			Name:                    "worker",
 			PreStartAppend:          []string{"extra-setup.sh"},
+			PreLaunchAppend:         []string{"extra-claim.sh"},
 			SessionSetupAppend:      []string{"tmux set mouse on"},
 			InstallAgentHooksAppend: []string{"gemini"},
 			InjectFragmentsAppend:   []string{"safety"},
@@ -599,6 +601,10 @@ func TestApplyPatches_AppendAlone(t *testing.T) {
 	wantPreStart := []string{"base-setup.sh", "extra-setup.sh"}
 	if !sliceEqual(a.PreStart, wantPreStart) {
 		t.Errorf("PreStart = %v, want %v", a.PreStart, wantPreStart)
+	}
+	wantPreLaunch := []string{"base-claim.sh", "extra-claim.sh"}
+	if !sliceEqual(a.PreLaunch, wantPreLaunch) {
+		t.Errorf("PreLaunch = %v, want %v", a.PreLaunch, wantPreLaunch)
 	}
 	wantSetup := []string{"tmux set status", "tmux set mouse on"}
 	if !sliceEqual(a.SessionSetup, wantSetup) {
@@ -617,15 +623,18 @@ func TestApplyPatches_AppendAlone(t *testing.T) {
 func TestApplyPatches_ReplacePlusAppend(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{{
-			Name:     "worker",
-			PreStart: []string{"old-a.sh", "old-b.sh"},
+			Name:      "worker",
+			PreStart:  []string{"old-a.sh", "old-b.sh"},
+			PreLaunch: []string{"old-claim-a.sh", "old-claim-b.sh"},
 		}},
 	}
 	err := ApplyPatches(cfg, Patches{
 		Agents: []AgentPatch{{
-			Name:           "worker",
-			PreStart:       []string{"new-base.sh"},
-			PreStartAppend: []string{"extra.sh"},
+			Name:            "worker",
+			PreStart:        []string{"new-base.sh"},
+			PreStartAppend:  []string{"extra.sh"},
+			PreLaunch:       []string{"new-claim.sh"},
+			PreLaunchAppend: []string{"extra-claim.sh"},
 		}},
 	})
 	if err != nil {
@@ -634,6 +643,10 @@ func TestApplyPatches_ReplacePlusAppend(t *testing.T) {
 	want := []string{"new-base.sh", "extra.sh"}
 	if !sliceEqual(cfg.Agents[0].PreStart, want) {
 		t.Errorf("PreStart = %v, want %v", cfg.Agents[0].PreStart, want)
+	}
+	wantLaunch := []string{"new-claim.sh", "extra-claim.sh"}
+	if !sliceEqual(cfg.Agents[0].PreLaunch, wantLaunch) {
+		t.Errorf("PreLaunch = %v, want %v", cfg.Agents[0].PreLaunch, wantLaunch)
 	}
 }
 
@@ -645,6 +658,7 @@ func TestApplyPatches_AppendToEmptyBase(t *testing.T) {
 		Agents: []AgentPatch{{
 			Name:               "worker",
 			PreStartAppend:     []string{"setup.sh"},
+			PreLaunchAppend:    []string{"claim.sh"},
 			SessionSetupAppend: []string{"tmux set mouse on"},
 		}},
 	})
@@ -654,6 +668,9 @@ func TestApplyPatches_AppendToEmptyBase(t *testing.T) {
 	a := cfg.Agents[0]
 	if !sliceEqual(a.PreStart, []string{"setup.sh"}) {
 		t.Errorf("PreStart = %v, want [setup.sh]", a.PreStart)
+	}
+	if !sliceEqual(a.PreLaunch, []string{"claim.sh"}) {
+		t.Errorf("PreLaunch = %v, want [claim.sh]", a.PreLaunch)
 	}
 	if !sliceEqual(a.SessionSetup, []string{"tmux set mouse on"}) {
 		t.Errorf("SessionSetup = %v, want [tmux set mouse on]", a.SessionSetup)

--- a/internal/docgen/markdown_test.go
+++ b/internal/docgen/markdown_test.go
@@ -103,4 +103,7 @@ func TestRenderMarkdownEnumValues(t *testing.T) {
 	if !strings.Contains(md, "pre_start") {
 		t.Error("pre_start not shown in markdown")
 	}
+	if !strings.Contains(md, "pre_launch") {
+		t.Error("pre_launch not shown in markdown")
+	}
 }

--- a/internal/docgen/schema_test.go
+++ b/internal/docgen/schema_test.go
@@ -206,7 +206,7 @@ func TestCitySchemaAgentDefinition(t *testing.T) {
 	agentProps := defProperties(t, raw, "Agent")
 
 	// Check expected fields exist.
-	for _, field := range []string{"name", "dir", "prompt_template", "provider", "pre_start"} {
+	for _, field := range []string{"name", "dir", "prompt_template", "provider", "pre_start", "pre_launch"} {
 		if _, ok := agentProps[field]; !ok {
 			t.Errorf("Agent missing field %q", field)
 		}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -61,6 +61,7 @@ type agentFile struct {
 	Scope                  string            `toml:"scope,omitempty"`
 	Suspended              bool              `toml:"suspended,omitempty"`
 	PreStart               []string          `toml:"pre_start,omitempty"`
+	PreLaunch              []string          `toml:"pre_launch,omitempty"`
 	Nudge                  string            `toml:"nudge,omitempty"`
 	Session                string            `toml:"session,omitempty"`
 	Provider               string            `toml:"provider,omitempty"`
@@ -805,6 +806,7 @@ func agentConfigFromAgent(agent config.Agent) agentFile {
 		Scope:                  agent.Scope,
 		Suspended:              agent.Suspended,
 		PreStart:               agent.PreStart,
+		PreLaunch:              agent.PreLaunch,
 		Nudge:                  agent.Nudge,
 		Session:                agent.Session,
 		Provider:               agent.Provider,

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -591,6 +591,7 @@ func TestAgentConfigFromAgentCoversPersistedFields(t *testing.T) {
 		Scope:                  "city",
 		Suspended:              true,
 		PreStart:               []string{"pre-cmd"},
+		PreLaunch:              []string{"pre-launch-cmd"},
 		PromptTemplate:         "prompts/worker.md",
 		Nudge:                  "nudge text",
 		Session:                "acp",

--- a/internal/runtime/acp/acp.go
+++ b/internal/runtime/acp/acp.go
@@ -100,6 +100,14 @@ func NewProviderWithDir(dir string, cfg Config) *Provider {
 // optionally sends the initial nudge. Returns an error if a session with
 // that name already exists or the handshake fails.
 func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	if len(cfg.PreLaunch) > 0 {
+		return &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchAborted,
+			Action: "abort",
+			Reason: "pre_launch is only supported by the tmux provider",
+			Stage:  "unsupported_provider",
+		}
+	}
 	p.mu.Lock()
 
 	// Check in-memory tracking first.

--- a/internal/runtime/exec/exec.go
+++ b/internal/runtime/exec/exec.go
@@ -121,6 +121,14 @@ func (p *Provider) runWithTTY(args ...string) error {
 // trust, bypass permissions) in Go using Peek + SendKeys, sharing the
 // same logic as the tmux provider via [runtime.AcceptStartupDialogs].
 func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	if len(cfg.PreLaunch) > 0 {
+		return &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchAborted,
+			Action: "abort",
+			Reason: "pre_launch is only supported by the tmux provider",
+			Stage:  "unsupported_provider",
+		}
+	}
 	data, err := marshalStartConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("exec provider: marshaling start config: %w", err)

--- a/internal/runtime/exec/json.go
+++ b/internal/runtime/exec/json.go
@@ -28,9 +28,11 @@ type startConfig struct {
 	Env                map[string]string `json:"env,omitempty"`
 	ProcessNames       []string          `json:"process_names,omitempty"`
 	Nudge              string            `json:"nudge,omitempty"`
+	PromptMode         string            `json:"prompt_mode,omitempty"`
 	ReadyPromptPrefix  string            `json:"ready_prompt_prefix,omitempty"`
 	ReadyDelayMs       int               `json:"ready_delay_ms,omitempty"`
 	PreStart           []string          `json:"pre_start,omitempty"`
+	PreLaunch          []string          `json:"pre_launch,omitempty"`
 	SessionSetup       []string          `json:"session_setup,omitempty"`
 	SessionSetupScript string            `json:"session_setup_script,omitempty"`
 	SessionLive        []string          `json:"session_live,omitempty"`
@@ -51,9 +53,11 @@ func marshalStartConfig(cfg runtime.Config) ([]byte, error) {
 		Env:                cfg.Env,
 		ProcessNames:       cfg.ProcessNames,
 		Nudge:              cfg.Nudge,
+		PromptMode:         cfg.PromptMode,
 		ReadyPromptPrefix:  cfg.ReadyPromptPrefix,
 		ReadyDelayMs:       cfg.ReadyDelayMs,
 		PreStart:           cfg.PreStart,
+		PreLaunch:          cfg.PreLaunch,
 		SessionSetup:       cfg.SessionSetup,
 		SessionSetupScript: cfg.SessionSetupScript,
 		SessionLive:        cfg.SessionLive,

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -14,7 +14,7 @@ import (
 // the agent should be restarted (via drain when drain ops are available).
 //
 // Included: Command, Env, FingerprintExtra (pool config, etc.),
-// PreStart, SessionSetup, SessionSetupScript, OverlayDir, CopyFiles,
+// PreStart, PreLaunch, SessionSetup, SessionSetupScript, OverlayDir, CopyFiles,
 // SessionLive.
 //
 // Excluded (observation-only hints): WorkDir, ReadyPromptPrefix,
@@ -141,6 +141,13 @@ func hashCoreFields(h hash.Hash, cfg Config) {
 	}
 	h.Write([]byte{1}) //nolint:errcheck // sentinel between slices
 
+	// PreLaunch
+	for _, pl := range cfg.PreLaunch {
+		h.Write([]byte(pl)) //nolint:errcheck // hash.Write never errors
+		h.Write([]byte{0})  //nolint:errcheck // hash.Write never errors
+	}
+	h.Write([]byte{1}) //nolint:errcheck // sentinel between slices
+
 	// SessionSetup
 	for _, ss := range cfg.SessionSetup {
 		h.Write([]byte(ss)) //nolint:errcheck // hash.Write never errors
@@ -249,6 +256,12 @@ func CoreFingerprintBreakdown(cfg Config) map[string]string {
 				h.Write([]byte{0})
 			}
 		}),
+		"PreLaunch": fieldHash(func(h hash.Hash) {
+			for _, pl := range cfg.PreLaunch {
+				h.Write([]byte(pl))
+				h.Write([]byte{0})
+			}
+		}),
 		"SessionSetup": fieldHash(func(h hash.Hash) {
 			for _, ss := range cfg.SessionSetup {
 				h.Write([]byte(ss))
@@ -318,6 +331,8 @@ func LogCoreFingerprintDrift(w io.Writer, name string, storedBreakdown map[strin
 			fmt.Fprintf(w, "    FPExtra: %v (len=%d)\n", current.FingerprintExtra, len(current.FingerprintExtra)) //nolint:errcheck // best-effort diag
 		case "PreStart":
 			fmt.Fprintf(w, "    PreStart: %v\n", current.PreStart) //nolint:errcheck // best-effort diag
+		case "PreLaunch":
+			fmt.Fprintf(w, "    PreLaunch: %v\n", current.PreLaunch) //nolint:errcheck // best-effort diag
 		case "OverlayDir":
 			fmt.Fprintf(w, "    OverlayDir: %q\n", current.OverlayDir) //nolint:errcheck // best-effort diag
 		case "SessionSetup":

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -225,6 +225,14 @@ func TestConfigFingerprintIncludesPreStart(t *testing.T) {
 	}
 }
 
+func TestConfigFingerprintIncludesPreLaunch(t *testing.T) {
+	a := Config{Command: "claude"}
+	b := Config{Command: "claude", PreLaunch: []string{"gc work claim-next --json"}}
+	if ConfigFingerprint(a) == ConfigFingerprint(b) {
+		t.Error("different PreLaunch should produce different hashes")
+	}
+}
+
 func TestConfigFingerprintIncludesSessionSetup(t *testing.T) {
 	a := Config{Command: "claude"}
 	b := Config{Command: "claude", SessionSetup: []string{"tmux set-option -t {{.Session}} remain-on-exit on"}}
@@ -262,6 +270,14 @@ func TestConfigFingerprintPreStartOrderMatters(t *testing.T) {
 	b := Config{Command: "claude", PreStart: []string{"b", "a"}}
 	if ConfigFingerprint(a) == ConfigFingerprint(b) {
 		t.Error("different PreStart order should produce different hashes")
+	}
+}
+
+func TestConfigFingerprintPreLaunchOrderMatters(t *testing.T) {
+	a := Config{Command: "claude", PreLaunch: []string{"a", "b"}}
+	b := Config{Command: "claude", PreLaunch: []string{"b", "a"}}
+	if ConfigFingerprint(a) == ConfigFingerprint(b) {
+		t.Error("different PreLaunch order should produce different hashes")
 	}
 }
 

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -119,6 +119,14 @@ func newProviderWithOps(ops k8sOps) *Provider {
 
 // Start creates a new K8s pod running a tmux session with the agent command.
 func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	if len(cfg.PreLaunch) > 0 {
+		return &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchAborted,
+			Action: "abort",
+			Reason: "pre_launch is only supported by the tmux provider",
+			Stage:  "unsupported_provider",
+		}
+	}
 	if p.image == "" {
 		return fmt.Errorf("starting session %q: GC_K8S_IMAGE is required", name)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -35,6 +35,42 @@ var ErrInteractionUnsupported = errors.New("session interaction is unsupported")
 // process, but it exited before startup completed successfully.
 var ErrSessionDiedDuringStartup = errors.New("session died during startup")
 
+// ErrPreLaunchDrained reports that a pre_launch hook intentionally skipped
+// provider launch because there was no useful work for this session.
+var ErrPreLaunchDrained = errors.New("pre_launch drained")
+
+// ErrPreLaunchAborted reports that a pre_launch hook intentionally failed
+// startup before provider launch.
+var ErrPreLaunchAborted = errors.New("pre_launch aborted")
+
+// PreLaunchDecisionError carries the structured decision from a pre_launch
+// hook when it prevents provider launch.
+type PreLaunchDecisionError struct {
+	Err      error
+	Action   string
+	Reason   string
+	Stage    string
+	Metadata map[string]string
+}
+
+func (e *PreLaunchDecisionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	reason := strings.TrimSpace(e.Reason)
+	if reason == "" {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("%s: %s", e.Err, reason)
+}
+
+func (e *PreLaunchDecisionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // ErrSessionNotFound reports that an operation targeted a session the
 // runtime does not know about. Benign for Stop() — the session was
 // already gone — but fatal for Attach/Send. Providers wrap their own
@@ -374,6 +410,19 @@ type Config struct {
 	// on the target filesystem. Used for directory/worktree preparation.
 	// Failures abort startup so agents never launch into an unprepared workDir.
 	PreStart []string
+
+	// PreLaunch is a list of shell commands run after PreStart and session
+	// identity preparation, but before provider process launch.
+	PreLaunch []string
+
+	// PromptMode records how the startup prompt is delivered ("arg", "flag",
+	// or "none"). pre_launch prompt patches need this to mutate the same
+	// delivery path that template resolution selected.
+	PromptMode string
+
+	// PreLaunchMetadataSink persists validated pre_launch metadata before the
+	// provider process is launched. Providers call it only after validation.
+	PreLaunchMetadataSink func(action, reason, stage string, metadata map[string]string) error
 
 	// SessionSetup is a list of shell commands run after session creation,
 	// between verify-alive and nudge. Commands run in gc's process via sh -c.

--- a/internal/runtime/subprocess/subprocess.go
+++ b/internal/runtime/subprocess/subprocess.go
@@ -76,6 +76,14 @@ func NewProviderWithDir(dir string) *Provider {
 // Startup hints (ReadyPromptPrefix, ProcessNames, etc.) are ignored —
 // all sessions are fire-and-forget.
 func (p *Provider) Start(_ context.Context, name string, cfg runtime.Config) error {
+	if len(cfg.PreLaunch) > 0 {
+		return &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchAborted,
+			Action: "abort",
+			Reason: "pre_launch is only supported by the tmux provider",
+			Stage:  "unsupported_provider",
+		}
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -1,9 +1,11 @@
 package tmux
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -570,6 +572,7 @@ type startOps interface {
 	sendKeys(name, text string) error
 	setRemainOnExit(name string) error
 	runSetupCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) error
+	runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, error)
 }
 
 // tmuxStartOps adapts [*Tmux] to the [startOps] interface.
@@ -637,6 +640,28 @@ func (o *tmuxStartOps) runSetupCommand(ctx context.Context, cmd string, env map[
 	return c.Run()
 }
 
+func (o *tmuxStartOps) runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, "sh", "-c", cmd)
+	if workDir := strings.TrimSpace(env["GC_DIR"]); workDir != "" {
+		c.Dir = workDir
+	}
+	c.Env = os.Environ()
+	for k, v := range env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+	if o.tm.cfg.SocketName != "" {
+		c.Env = append(c.Env, "GC_TMUX_SOCKET="+o.tm.cfg.SocketName)
+	}
+	stdout := &limitedBuffer{max: maxPreLaunchStdout}
+	stderr := &limitedBuffer{max: maxPreLaunchStderr}
+	c.Stdout = stdout
+	c.Stderr = stderr
+	err := c.Run()
+	return stdout.String(), stderr.String(), err
+}
+
 // doStartSession is the pure startup orchestration logic.
 // Testable via fakeStartOps without a real tmux server.
 // The setupTimeout parameter controls the per-command timeout for
@@ -645,10 +670,27 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if len(cfg.PreLaunch) > 0 && cfg.PreLaunchMetadataSink == nil {
+		return &runtime.PreLaunchDecisionError{
+			Err:    runtime.ErrPreLaunchAborted,
+			Action: "abort",
+			Reason: "pre_launch is only supported for reconciler-managed starts",
+			Stage:  "unsupported_start_path",
+		}
+	}
 
 	// Step 0: Run pre-start commands (directory/worktree preparation).
 	if err := runPreStart(ctx, ops, name, cfg, setupTimeout); err != nil {
 		return fmt.Errorf("running pre_start: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	var err error
+	cfg, err = runPreLaunch(ctx, ops, name, cfg, setupTimeout)
+	if err != nil {
+		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
@@ -667,7 +709,7 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 
 	hasHints := cfg.ReadyPromptPrefix != "" || cfg.ReadyDelayMs > 0 ||
 		len(cfg.ProcessNames) > 0 || cfg.EmitsPermissionWarning ||
-		cfg.Nudge != "" || len(cfg.PreStart) > 0 || len(cfg.SessionSetup) > 0 || cfg.SessionSetupScript != "" ||
+		cfg.Nudge != "" || len(cfg.PreStart) > 0 || len(cfg.PreLaunch) > 0 || len(cfg.SessionSetup) > 0 || cfg.SessionSetupScript != "" ||
 		len(cfg.SessionLive) > 0
 
 	if !hasHints {
@@ -821,6 +863,315 @@ func runPreStart(ctx context.Context, ops startOps, _ string, cfg runtime.Config
 		}
 	}
 	return nil
+}
+
+type preLaunchCommandResult struct {
+	Action        string            `json:"action,omitempty"`
+	Reason        string            `json:"reason,omitempty"`
+	PromptPrepend string            `json:"prompt_prepend,omitempty"`
+	PromptAppend  string            `json:"prompt_append,omitempty"`
+	NudgePrepend  string            `json:"nudge_prepend,omitempty"`
+	NudgeAppend   string            `json:"nudge_append,omitempty"`
+	Env           map[string]string `json:"env,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+const maxPreLaunchStdout = 64 * 1024
+const maxPreLaunchStderr = 16 * 1024
+const maxPreLaunchReason = 1024
+const maxPreLaunchEnvValue = 8 * 1024
+const maxPreLaunchPromptPatch = 64 * 1024
+const maxPreLaunchNudgePatch = 16 * 1024
+
+type limitedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := b.max + 1 - b.buf.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = b.buf.Write(p[:remaining])
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string { return b.buf.String() }
+func (b *limitedBuffer) Len() int       { return b.buf.Len() }
+
+func runPreLaunch(ctx context.Context, ops startOps, name string, cfg runtime.Config, setupTimeout time.Duration) (runtime.Config, error) {
+	if len(cfg.PreLaunch) == 0 {
+		return cfg, nil
+	}
+	if cfg.Env != nil {
+		copied := make(map[string]string, len(cfg.Env))
+		for k, v := range cfg.Env {
+			copied[k] = v
+		}
+		cfg.Env = copied
+	}
+	ctx, cancel := context.WithTimeout(ctx, setupTimeout)
+	defer cancel()
+	env := make(map[string]string, len(cfg.Env)+1)
+	for k, v := range cfg.Env {
+		env[k] = v
+	}
+	env["GC_SESSION"] = name
+	for i, cmd := range cfg.PreLaunch {
+		stdout, stderr, err := ops.runPreLaunchCommand(ctx, cmd, env, setupTimeout)
+		if err != nil {
+			stage := "script_exit"
+			if errors.Is(err, context.DeadlineExceeded) {
+				stage = "timeout"
+			} else if errors.Is(err, context.Canceled) {
+				stage = "context_cancelled"
+			}
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: strings.TrimSpace(err.Error()),
+				Stage:  stage,
+			})
+		}
+		if len(stdout) > maxPreLaunchStdout {
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: "stdout_too_large",
+				Stage:  "stdout_too_large",
+			})
+		}
+		if len(stderr) > maxPreLaunchStderr {
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: "stderr_too_large",
+				Stage:  "stderr_too_large",
+			})
+		}
+		result, err := parsePreLaunchResult(stdout)
+		if err != nil {
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: err.Error(),
+				Stage:  "json_parse",
+			})
+		}
+		if len(result.Reason) > maxPreLaunchReason {
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: "reason_too_large",
+				Stage:  "metadata_validation",
+			})
+		}
+		next, err := applyPreLaunchResult(cfg, result)
+		if err != nil {
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: err.Error(),
+				Stage:  preLaunchFailureStage(err),
+			})
+		}
+		cfg = next
+		for k, v := range cfg.Env {
+			env[k] = v
+		}
+		switch result.Action {
+		case "", "continue":
+			if err := emitPreLaunchMetadata(cfg, "continue", result.Reason, "", result.Metadata); err != nil {
+				return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+					Err:    runtime.ErrPreLaunchAborted,
+					Action: "abort",
+					Reason: err.Error(),
+					Stage:  "metadata_write",
+				})
+			}
+			continue
+		case "drain":
+			return cfg, &runtime.PreLaunchDecisionError{
+				Err:      runtime.ErrPreLaunchDrained,
+				Action:   "drain",
+				Reason:   result.Reason,
+				Metadata: result.Metadata,
+			}
+		case "abort":
+			return cfg, &runtime.PreLaunchDecisionError{
+				Err:      runtime.ErrPreLaunchAborted,
+				Action:   "abort",
+				Reason:   result.Reason,
+				Stage:    "script_exit",
+				Metadata: result.Metadata,
+			}
+		default:
+			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
+				Err:    runtime.ErrPreLaunchAborted,
+				Action: "abort",
+				Reason: "unknown action " + result.Action,
+				Stage:  "unknown_action",
+			})
+		}
+	}
+	return cfg, nil
+}
+
+func parsePreLaunchResult(stdout string) (preLaunchCommandResult, error) {
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return preLaunchCommandResult{Action: "continue"}, nil
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return preLaunchCommandResult{}, fmt.Errorf("json_parse: expected object")
+	}
+	var result preLaunchCommandResult
+	if err := json.Unmarshal([]byte(trimmed), &result); err != nil {
+		return preLaunchCommandResult{}, fmt.Errorf("json_parse: %w", err)
+	}
+	if result.Action == "" {
+		result.Action = "continue"
+	}
+	return result, nil
+}
+
+func applyPreLaunchResult(cfg runtime.Config, result preLaunchCommandResult) (runtime.Config, error) {
+	if len(result.Env) > 0 {
+		if cfg.Env == nil {
+			cfg.Env = map[string]string{}
+		}
+		for k, v := range result.Env {
+			if err := validatePreLaunchEnv(k, v); err != nil {
+				return cfg, err
+			}
+			cfg.Env[k] = v
+		}
+	}
+	if err := validatePreLaunchMetadata(result.Metadata); err != nil {
+		return cfg, err
+	}
+	if result.PromptPrepend != "" || result.PromptAppend != "" {
+		if len(result.PromptPrepend)+len(result.PromptAppend) > maxPreLaunchPromptPatch {
+			return cfg, fmt.Errorf("patch_too_large: prompt patch")
+		}
+		if cfg.PromptMode == "none" {
+			return cfg, fmt.Errorf("unsupported_prompt_patch: prompt patches are not supported for prompt_mode=none")
+		} else {
+			prompt, err := promptSuffixPayload(cfg.PromptSuffix)
+			if err != nil {
+				return cfg, fmt.Errorf("unsupported_prompt_patch: %w", err)
+			}
+			cfg.PromptSuffix = shellquote.Quote(result.PromptPrepend + prompt + result.PromptAppend)
+		}
+	}
+	if result.NudgePrepend != "" || result.NudgeAppend != "" {
+		if len(result.NudgePrepend)+len(result.NudgeAppend) > maxPreLaunchNudgePatch {
+			return cfg, fmt.Errorf("patch_too_large: nudge patch")
+		}
+		cfg.Nudge = result.NudgePrepend + cfg.Nudge + result.NudgeAppend
+	}
+	return cfg, nil
+}
+
+func emitPreLaunchMetadata(cfg runtime.Config, action, reason, stage string, metadata map[string]string) error {
+	if len(metadata) == 0 && reason == "" && stage == "" {
+		return nil
+	}
+	if cfg.PreLaunchMetadataSink == nil {
+		return nil
+	}
+	return cfg.PreLaunchMetadataSink(action, reason, stage, metadata)
+}
+
+func promptSuffixPayload(promptSuffix string) (string, error) {
+	if promptSuffix == "" {
+		return "", nil
+	}
+	parts := shellquote.Split(promptSuffix)
+	if len(parts) != 1 {
+		return "", fmt.Errorf("prompt suffix parsed as %d arguments", len(parts))
+	}
+	return parts[0], nil
+}
+
+func validatePreLaunchEnv(key, value string) error {
+	if key == "" || len(key) > 128 {
+		return fmt.Errorf("env_validation: invalid key %q", key)
+	}
+	for i, r := range key {
+		valid := r == '_' || ('A' <= r && r <= 'Z') || (i > 0 && '0' <= r && r <= '9')
+		if !valid {
+			return fmt.Errorf("env_validation: invalid key %q", key)
+		}
+	}
+	if strings.ContainsAny(value, "\x00\n") {
+		return fmt.Errorf("env_validation: invalid value for %q", key)
+	}
+	if len(value) > maxPreLaunchEnvValue {
+		return fmt.Errorf("env_validation: value too large for %q", key)
+	}
+	switch {
+	case reservedPreLaunchEnvKey(key):
+		return fmt.Errorf("env_validation: reserved key %q", key)
+	case key == "PATH", key == "BASH_ENV", key == "ENV", key == "PYTHONPATH", key == "NODE_OPTIONS", key == "GODEBUG":
+		return fmt.Errorf("env_validation: reserved key %q", key)
+	case strings.HasPrefix(key, "LD_"), strings.HasPrefix(key, "DYLD_"):
+		return fmt.Errorf("env_validation: reserved key %q", key)
+	}
+	return nil
+}
+
+func reservedPreLaunchEnvKey(key string) bool {
+	switch key {
+	case "GC_SESSION_ID", "GC_SESSION_NAME", "GC_SESSION", "GC_ALIAS", "GC_AGENT",
+		"GC_TEMPLATE", "GC_SESSION_ORIGIN", "GC_INSTANCE_TOKEN", "GC_RUNTIME_EPOCH",
+		"GC_CONTINUATION_EPOCH", "GC_CITY_PATH", "GC_CITY_NAME", "GC_WORK_DIR",
+		"GC_DIR", "GC_CITY", "GC_HOME", "GT_ROOT":
+		return true
+	}
+	return false
+}
+
+func validatePreLaunchMetadata(metadata map[string]string) error {
+	total := 0
+	for key, value := range metadata {
+		if !strings.HasPrefix(key, "pre_launch.user.") {
+			return fmt.Errorf("metadata_validation: reserved key %q", key)
+		}
+		if len(key) > 128 {
+			return fmt.Errorf("metadata_validation: key too long %q", key)
+		}
+		if len(value) > 4*1024 {
+			return fmt.Errorf("metadata_validation: value too large for %q", key)
+		}
+		total += len(key) + len(value)
+		if total > 16*1024 {
+			return fmt.Errorf("metadata_validation: metadata too large")
+		}
+	}
+	return nil
+}
+
+func preLaunchFailureStage(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.HasPrefix(msg, "env_validation:"):
+		return "env_validation"
+	case strings.HasPrefix(msg, "metadata_validation:"):
+		return "metadata_validation"
+	case strings.HasPrefix(msg, "unsupported_prompt_patch:"):
+		return "unsupported_prompt_patch"
+	case strings.HasPrefix(msg, "patch_too_large:"):
+		return "patch_too_large"
+	default:
+		return "script_exit"
+	}
 }
 
 // ensureFreshSession creates a session, handling stale tmux state.

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -876,12 +876,14 @@ type preLaunchCommandResult struct {
 	Metadata      map[string]string `json:"metadata,omitempty"`
 }
 
-const maxPreLaunchStdout = 64 * 1024
-const maxPreLaunchStderr = 16 * 1024
-const maxPreLaunchReason = 1024
-const maxPreLaunchEnvValue = 8 * 1024
-const maxPreLaunchPromptPatch = 64 * 1024
-const maxPreLaunchNudgePatch = 16 * 1024
+const (
+	maxPreLaunchStdout      = 64 * 1024
+	maxPreLaunchStderr      = 16 * 1024
+	maxPreLaunchReason      = 1024
+	maxPreLaunchEnvValue    = 8 * 1024
+	maxPreLaunchPromptPatch = 64 * 1024
+	maxPreLaunchNudgePatch  = 16 * 1024
+)
 
 type limitedBuffer struct {
 	buf bytes.Buffer
@@ -927,7 +929,7 @@ func runPreLaunch(ctx context.Context, ops startOps, name string, cfg runtime.Co
 			if errors.Is(err, context.DeadlineExceeded) {
 				stage = "timeout"
 			} else if errors.Is(err, context.Canceled) {
-				stage = "context_cancelled"
+				stage = "context_canceled"
 			}
 			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
 				Err:    runtime.ErrPreLaunchAborted,
@@ -1059,13 +1061,12 @@ func applyPreLaunchResult(cfg runtime.Config, result preLaunchCommandResult) (ru
 		}
 		if cfg.PromptMode == "none" {
 			return cfg, fmt.Errorf("unsupported_prompt_patch: prompt patches are not supported for prompt_mode=none")
-		} else {
-			prompt, err := promptSuffixPayload(cfg.PromptSuffix)
-			if err != nil {
-				return cfg, fmt.Errorf("unsupported_prompt_patch: %w", err)
-			}
-			cfg.PromptSuffix = shellquote.Quote(result.PromptPrepend + prompt + result.PromptAppend)
 		}
+		prompt, err := promptSuffixPayload(cfg.PromptSuffix)
+		if err != nil {
+			return cfg, fmt.Errorf("unsupported_prompt_patch: %w", err)
+		}
+		cfg.PromptSuffix = shellquote.Quote(result.PromptPrepend + prompt + result.PromptAppend)
 	}
 	if result.NudgePrepend != "" || result.NudgeAppend != "" {
 		if len(result.NudgePrepend)+len(result.NudgeAppend) > maxPreLaunchNudgePatch {

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/overlay"
@@ -572,7 +573,7 @@ type startOps interface {
 	sendKeys(name, text string) error
 	setRemainOnExit(name string) error
 	runSetupCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) error
-	runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, error)
+	runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, bool, bool, error)
 }
 
 // tmuxStartOps adapts [*Tmux] to the [startOps] interface.
@@ -640,10 +641,12 @@ func (o *tmuxStartOps) runSetupCommand(ctx context.Context, cmd string, env map[
 	return c.Run()
 }
 
-func (o *tmuxStartOps) runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, error) {
+func (o *tmuxStartOps) runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, bool, bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	c := exec.CommandContext(ctx, "sh", "-c", cmd)
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	c.WaitDelay = 2 * time.Second
 	if workDir := strings.TrimSpace(env["GC_DIR"]); workDir != "" {
 		c.Dir = workDir
 	}
@@ -658,8 +661,17 @@ func (o *tmuxStartOps) runPreLaunchCommand(ctx context.Context, cmd string, env 
 	stderr := &limitedBuffer{max: maxPreLaunchStderr}
 	c.Stdout = stdout
 	c.Stderr = stderr
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = runtime.SignalProcessGroup(c, syscall.SIGKILL)
+		case <-done:
+		}
+	}()
 	err := c.Run()
-	return stdout.String(), stderr.String(), err
+	return stdout.String(), stderr.String(), stdout.Overflowed(), stderr.Overflowed(), err
 }
 
 // doStartSession is the pure startup orchestration logic.
@@ -886,23 +898,34 @@ const (
 )
 
 type limitedBuffer struct {
-	buf bytes.Buffer
-	max int
+	buf        bytes.Buffer
+	max        int
+	overflowed bool
 }
 
 func (b *limitedBuffer) Write(p []byte) (int, error) {
-	remaining := b.max + 1 - b.buf.Len()
-	if remaining > 0 {
-		if remaining > len(p) {
-			remaining = len(p)
+	remaining := b.max - b.buf.Len()
+	if remaining <= 0 {
+		if len(p) > 0 {
+			b.overflowed = true
 		}
-		_, _ = b.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	if remaining > len(p) {
+		remaining = len(p)
+	}
+	_, _ = b.buf.Write(p[:remaining])
+	if len(p) > remaining {
+		b.overflowed = true
 	}
 	return len(p), nil
 }
 
 func (b *limitedBuffer) String() string { return b.buf.String() }
 func (b *limitedBuffer) Len() int       { return b.buf.Len() }
+func (b *limitedBuffer) Overflowed() bool {
+	return b.overflowed
+}
 
 func runPreLaunch(ctx context.Context, ops startOps, name string, cfg runtime.Config, setupTimeout time.Duration) (runtime.Config, error) {
 	if len(cfg.PreLaunch) == 0 {
@@ -915,30 +938,23 @@ func runPreLaunch(ctx context.Context, ops startOps, name string, cfg runtime.Co
 		}
 		cfg.Env = copied
 	}
-	ctx, cancel := context.WithTimeout(ctx, setupTimeout)
-	defer cancel()
 	env := make(map[string]string, len(cfg.Env)+1)
 	for k, v := range cfg.Env {
 		env[k] = v
 	}
 	env["GC_SESSION"] = name
 	for i, cmd := range cfg.PreLaunch {
-		stdout, stderr, err := ops.runPreLaunchCommand(ctx, cmd, env, setupTimeout)
+		stdout, _, stdoutTooBig, stderrTooBig, err := ops.runPreLaunchCommand(ctx, cmd, env, setupTimeout)
 		if err != nil {
-			stage := "script_exit"
-			if errors.Is(err, context.DeadlineExceeded) {
-				stage = "timeout"
-			} else if errors.Is(err, context.Canceled) {
-				stage = "context_canceled"
-			}
+			reason, stage := preLaunchCommandFailure(err)
 			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
 				Err:    runtime.ErrPreLaunchAborted,
 				Action: "abort",
-				Reason: strings.TrimSpace(err.Error()),
+				Reason: reason,
 				Stage:  stage,
 			})
 		}
-		if len(stdout) > maxPreLaunchStdout {
+		if stdoutTooBig {
 			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
 				Err:    runtime.ErrPreLaunchAborted,
 				Action: "abort",
@@ -946,7 +962,7 @@ func runPreLaunch(ctx context.Context, ops startOps, name string, cfg runtime.Co
 				Stage:  "stdout_too_large",
 			})
 		}
-		if len(stderr) > maxPreLaunchStderr {
+		if stderrTooBig {
 			return cfg, fmt.Errorf("pre_launch[%d]: %w", i, &runtime.PreLaunchDecisionError{
 				Err:    runtime.ErrPreLaunchAborted,
 				Action: "abort",
@@ -1020,6 +1036,17 @@ func runPreLaunch(ctx context.Context, ops startOps, name string, cfg runtime.Co
 		}
 	}
 	return cfg, nil
+}
+
+func preLaunchCommandFailure(err error) (reason, stage string) {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout", "timeout"
+	case errors.Is(err, context.Canceled):
+		return "context_canceled", "context_canceled"
+	default:
+		return "script_failed", "script_exit"
+	}
 }
 
 func parsePreLaunchResult(stdout string) (preLaunchCommandResult, error) {

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -59,6 +59,9 @@ type fakeStartOps struct {
 	hasSessionErr            error
 	setRemainOnExitErr       error
 	runSetupCommandErr       error
+	runPreLaunchStdout       string
+	runPreLaunchStderr       string
+	runPreLaunchErr          error
 }
 
 type errReader struct{}
@@ -176,6 +179,16 @@ func (f *fakeStartOps) runSetupCommand(_ context.Context, cmd string, env map[st
 		return f.runSetupCommandErr
 	}
 	return nil
+}
+
+func (f *fakeStartOps) runPreLaunchCommand(_ context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, error) {
+	f.calls = append(f.calls, startCall{
+		method:  "runPreLaunchCommand",
+		command: cmd,
+		env:     env,
+		timeout: timeout,
+	})
+	return f.runPreLaunchStdout, f.runPreLaunchStderr, f.runPreLaunchErr
 }
 
 // callMethods returns just the method names for sequence assertions.
@@ -984,6 +997,168 @@ func TestDoStartSession_PreStartFailureIsFatal(t *testing.T) {
 	}
 
 	assertCallSequence(t, ops, []string{"runSetupCommand"})
+}
+
+func TestDoStartSession_PreLaunchRunsBeforeCreate(t *testing.T) {
+	ops := &fakeStartOps{
+		hasSessionResult:   true,
+		runPreLaunchStdout: `{"action":"continue","env":{"GC_WORK_BEAD":"ga-1"},"prompt_append":"\nClaimed ga-1","nudge_prepend":"claimed\n"}`,
+	}
+
+	cfg := runtime.Config{
+		Command:      "claude",
+		WorkDir:      "/proj",
+		PromptSuffix: "'base prompt'",
+		Nudge:        "start",
+		Env:          map[string]string{"GC_AGENT": "worker"},
+		PreLaunch:    []string{"claim-work"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runPreLaunchCommand", "createSession", "setRemainOnExit", "hasSession", "sendKeys"})
+
+	if got := ops.calls[0].env["GC_SESSION"]; got != "test" {
+		t.Errorf("pre_launch GC_SESSION = %q, want test", got)
+	}
+	create := ops.calls[1]
+	if create.env["GC_WORK_BEAD"] != "ga-1" {
+		t.Errorf("create env GC_WORK_BEAD = %q, want ga-1", create.env["GC_WORK_BEAD"])
+	}
+	if !strings.Contains(create.command, "Claimed ga-1") {
+		t.Errorf("create command = %q, want patched prompt", create.command)
+	}
+	if got := ops.calls[4].command; got != "claimed\nstart" {
+		t.Errorf("nudge = %q, want patched nudge", got)
+	}
+}
+
+func TestDoStartSession_PreLaunchDrainSkipsCreate(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchStdout: `{"action":"drain","reason":"no work"}`,
+	}
+
+	cfg := runtime.Config{
+		Command:   "claude",
+		PreLaunch: []string{"claim-work"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch drain")
+	}
+	if !errors.Is(err, runtime.ErrPreLaunchDrained) {
+		t.Fatalf("error = %v, want ErrPreLaunchDrained", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runPreLaunchCommand"})
+}
+
+func TestDoStartSession_PreLaunchInvalidEnvAborts(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchStdout: `{"action":"continue","env":{"GC_SESSION_ID":"wrong"}}`,
+	}
+
+	cfg := runtime.Config{
+		Command:   "claude",
+		PreLaunch: []string{"bad-env"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch abort")
+	}
+	if !errors.Is(err, runtime.ErrPreLaunchAborted) {
+		t.Fatalf("error = %v, want ErrPreLaunchAborted", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runPreLaunchCommand"})
+}
+
+func TestDoStartSession_PreLaunchPromptPatchRejectsPromptModeNone(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchStdout: `{"action":"continue","prompt_append":"\nClaimed ga-1"}`,
+	}
+
+	cfg := runtime.Config{
+		Command:    "opencode",
+		PromptMode: "none",
+		Nudge:      "base prompt",
+		PreLaunch:  []string{"claim-work"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch abort")
+	}
+	if !errors.Is(err, runtime.ErrPreLaunchAborted) {
+		t.Fatalf("error = %v, want ErrPreLaunchAborted", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runPreLaunchCommand"})
+}
+
+func TestDoStartSession_PreLaunchReservedMetadataAborts(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchStdout: `{"action":"drain","metadata":{"state":"active"}}`,
+	}
+
+	cfg := runtime.Config{
+		Command:   "claude",
+		PreLaunch: []string{"claim-work"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch abort")
+	}
+	if !errors.Is(err, runtime.ErrPreLaunchAborted) {
+		t.Fatalf("error = %v, want ErrPreLaunchAborted", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runPreLaunchCommand"})
+}
+
+func TestDoStartSession_PreLaunchNullJSONAborts(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchStdout: `null`,
+	}
+
+	cfg := runtime.Config{
+		Command:   "claude",
+		PreLaunch: []string{"broken-hook"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch abort")
+	}
+	if !errors.Is(err, runtime.ErrPreLaunchAborted) {
+		t.Fatalf("error = %v, want ErrPreLaunchAborted", err)
+	}
+
+	assertCallSequence(t, ops, []string{"runPreLaunchCommand"})
 }
 
 func TestDoStartSession_SetupEnvPassthrough(t *testing.T) {

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -61,6 +63,8 @@ type fakeStartOps struct {
 	runSetupCommandErr       error
 	runPreLaunchStdout       string
 	runPreLaunchStderr       string
+	runPreLaunchStdoutTooBig bool
+	runPreLaunchStderrTooBig bool
 	runPreLaunchErr          error
 }
 
@@ -181,14 +185,35 @@ func (f *fakeStartOps) runSetupCommand(_ context.Context, cmd string, env map[st
 	return nil
 }
 
-func (f *fakeStartOps) runPreLaunchCommand(_ context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, error) {
+func (f *fakeStartOps) runPreLaunchCommand(_ context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, bool, bool, error) {
 	f.calls = append(f.calls, startCall{
 		method:  "runPreLaunchCommand",
 		command: cmd,
 		env:     env,
 		timeout: timeout,
 	})
-	return f.runPreLaunchStdout, f.runPreLaunchStderr, f.runPreLaunchErr
+	return f.runPreLaunchStdout, f.runPreLaunchStderr, f.runPreLaunchStdoutTooBig, f.runPreLaunchStderrTooBig, f.runPreLaunchErr
+}
+
+type timingPreLaunchOps struct {
+	fakeStartOps
+	sleeps []time.Duration
+}
+
+func (o *timingPreLaunchOps) runPreLaunchCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) (string, string, bool, bool, error) {
+	o.calls = append(o.calls, startCall{
+		method:  "runPreLaunchCommand",
+		command: cmd,
+		env:     env,
+		timeout: timeout,
+	})
+	sleep := o.sleeps[len(o.calls)-1]
+	select {
+	case <-time.After(sleep):
+		return `{"action":"continue"}`, "", false, false, nil
+	case <-ctx.Done():
+		return "", "", false, false, ctx.Err()
+	}
 }
 
 // callMethods returns just the method names for sequence assertions.
@@ -1159,6 +1184,106 @@ func TestDoStartSession_PreLaunchNullJSONAborts(t *testing.T) {
 	}
 
 	assertCallSequence(t, ops, []string{"runPreLaunchCommand"})
+}
+
+func TestDoStartSession_PreLaunchScriptFailureSanitizesReason(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchErr: errors.New(`sh: export SECRET_TOKEN=topsecret: command not found`),
+	}
+
+	cfg := runtime.Config{
+		Command:   "claude",
+		PreLaunch: []string{"broken-hook"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch abort")
+	}
+	var decision *runtime.PreLaunchDecisionError
+	if !errors.As(err, &decision) {
+		t.Fatalf("error = %v, want PreLaunchDecisionError", err)
+	}
+	if decision.Reason != "script_failed" {
+		t.Fatalf("decision.Reason = %q, want script_failed", decision.Reason)
+	}
+	if strings.Contains(decision.Reason, "SECRET_TOKEN") {
+		t.Fatalf("decision.Reason leaked secret: %q", decision.Reason)
+	}
+}
+
+func TestDoStartSession_PreLaunchStdoutOverflowAborts(t *testing.T) {
+	ops := &fakeStartOps{
+		runPreLaunchStdout:       `{"action":"continue"}`,
+		runPreLaunchStdoutTooBig: true,
+	}
+
+	cfg := runtime.Config{
+		Command:   "claude",
+		PreLaunch: []string{"overflow-hook"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected pre_launch abort")
+	}
+	var decision *runtime.PreLaunchDecisionError
+	if !errors.As(err, &decision) {
+		t.Fatalf("error = %v, want PreLaunchDecisionError", err)
+	}
+	if decision.Stage != "stdout_too_large" {
+		t.Fatalf("decision.Stage = %q, want stdout_too_large", decision.Stage)
+	}
+}
+
+func TestRunPreLaunchUsesPerCommandTimeoutWithoutSharedOuterBudget(t *testing.T) {
+	ops := &timingPreLaunchOps{
+		sleeps: []time.Duration{25 * time.Millisecond, 25 * time.Millisecond},
+	}
+	cfg := runtime.Config{
+		PreLaunch: []string{"first", "second"},
+		PreLaunchMetadataSink: func(_, _, _ string, _ map[string]string) error {
+			return nil
+		},
+	}
+
+	_, err := runPreLaunch(context.Background(), ops, "test", cfg, 30*time.Millisecond)
+	if err != nil {
+		t.Fatalf("runPreLaunch returned error with per-command budgeting: %v", err)
+	}
+	assertCallSequence(t, &ops.fakeStartOps, []string{"runPreLaunchCommand", "runPreLaunchCommand"})
+}
+
+func TestTmuxStartOpsRunPreLaunchCommandKillsProcessGroupOnTimeout(t *testing.T) {
+	ops := &tmuxStartOps{tm: &Tmux{}}
+	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+	defer cancel()
+
+	stdout, _, stdoutTooBig, stderrTooBig, err := ops.runPreLaunchCommand(ctx, "sleep 30 & child=$!; echo $child; wait $child", map[string]string{}, time.Second)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if stdoutTooBig || stderrTooBig {
+		t.Fatalf("unexpected overflow flags stdout=%v stderr=%v", stdoutTooBig, stderrTooBig)
+	}
+	childPID, convErr := strconv.Atoi(strings.TrimSpace(stdout))
+	if convErr != nil {
+		t.Fatalf("stdout = %q, want child pid: %v", stdout, convErr)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if killErr := syscall.Kill(childPID, 0); killErr == syscall.ESRCH {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("child process %d still alive after timeout kill", childPID)
 }
 
 func TestDoStartSession_SetupEnvPassthrough(t *testing.T) {

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -194,6 +194,9 @@ func (m *Manager) sessionBead(id string) (beads.Bead, string, error) {
 }
 
 func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, sessName, resumeCommand string, hints runtime.Config) error {
+	if err := rejectDirectPreLaunch(hints); err != nil {
+		return err
+	}
 	transport, transportVerified := m.transportForBead(b, sessName)
 	unroute := m.routeACPIfNeeded(b.Metadata["provider"], transport, sessName)
 	if State(b.Metadata["state"]) != StateSuspended && m.sp.IsRunning(sessName) {
@@ -305,6 +308,9 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 }
 
 func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b beads.Bead, sessName, resumeCommand string, hints runtime.Config) error {
+	if err := rejectDirectPreLaunch(hints); err != nil {
+		return err
+	}
 	transport, _ := m.transportForBead(b, sessName)
 	unroute := m.routeACPIfNeeded(b.Metadata["provider"], transport, sessName)
 	if m.sp.IsRunning(sessName) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -50,6 +50,21 @@ const (
 	StateQuarantined State = "quarantined"
 )
 
+func rejectDirectPreLaunch(hints runtime.Config) error {
+	if len(hints.PreLaunch) == 0 {
+		return nil
+	}
+	if hints.PreLaunchMetadataSink != nil {
+		return nil
+	}
+	return &runtime.PreLaunchDecisionError{
+		Err:    runtime.ErrPreLaunchAborted,
+		Action: "abort",
+		Reason: "pre_launch is only supported for reconciler-managed starts",
+		Stage:  "unsupported_start_path",
+	}
+}
+
 // BeadType is the bead type for chat sessions.
 const BeadType = "session"
 
@@ -246,6 +261,9 @@ func (m *Manager) CreateAliasedNamedWithTransportAndMetadata(ctx context.Context
 }
 
 func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, explicitName, template, title, command, workDir, provider, transport string, env map[string]string, resume ProviderResume, hints runtime.Config, extraMeta map[string]string) (Info, error) {
+	if err := rejectDirectPreLaunch(hints); err != nil {
+		return Info{}, err
+	}
 	alias, err := ValidateAlias(alias)
 	if err != nil {
 		return Info{}, err

--- a/internal/worker/handle_clone.go
+++ b/internal/worker/handle_clone.go
@@ -46,6 +46,7 @@ func cloneRuntimeConfig(cfg runtime.Config) runtime.Config {
 	cfg.Env = cloneStringMap(cfg.Env)
 	cfg.ProcessNames = append([]string(nil), cfg.ProcessNames...)
 	cfg.PreStart = append([]string(nil), cfg.PreStart...)
+	cfg.PreLaunch = append([]string(nil), cfg.PreLaunch...)
 	cfg.SessionSetup = append([]string(nil), cfg.SessionSetup...)
 	cfg.SessionLive = append([]string(nil), cfg.SessionLive...)
 	cfg.PackOverlayDirs = append([]string(nil), cfg.PackOverlayDirs...)


### PR DESCRIPTION
## Summary

Adds a reusable `pre_launch` lifecycle hook that runs after a concrete session identity is prepared and before any provider process or inference starts. The hook can return structured JSON to continue, drain, or abort startup while patching prompt/nudge/env/session metadata in a bounded and validated way.

This also adds `gc work claim-next --json` as the first deterministic claim-or-drain helper and opts the maintenance `dog` worker into it, so routed pool work is claimed before inference starts instead of relying on prompt-following behavior.

Fixes #845.
Fixes #1052.

## Design and Review

- Added design doc: `engdocs/design/pre-launch-hooks.md`
- Added implementation plan: `engdocs/design/pre-launch-hooks-implementation-plan.md`
- Ran `$design-review` until no blockers or majors remained; final design review approved the direction.
- Ran `$review-pr --skip-gemini` at natural implementation boundaries and fixed returned blockers/majors. Final focused review after the last code blocker/major fix returned no blockers or majors.

## Implementation Notes

- `pre_launch` and `pre_launch_append` are available on agent config, patches, overrides, config hashing/fingerprints, startup hints, template resolution, migration, docs/schema coverage, and runtime config.
- Tmux-backed reconciler starts run `pre_launch` after `pre_start` and before provider launch. Other provider/direct paths reject configured `pre_launch` in v1 unless the reconciler metadata sink is available.
- `continue`, `drain`, and `abort` outcomes persist bounded `gc.pre_launch.*` diagnostics and validated `pre_launch.user.*` metadata.
- The helper command emits `pre_launch` JSON directly:
  - claimed work: `continue` with `GC_WORK_BEAD`, nudge append, and `pre_launch.user.claimed_work_bead`
  - no work: `drain` with `reason=no_work`

## Tests

Passed after rebasing onto current `origin/main`:

```bash
go test ./cmd/gc ./internal/beads -run 'TestNoBdExecOutsideBeads|TestWritePreLaunchClaimResult|TestIsClaimConflict|TestConfigHash|TestWork' -count=1 -timeout 120s
go test ./internal/config ./internal/runtime ./internal/runtime/tmux ./internal/runtime/exec ./internal/agentutil ./internal/worker ./internal/migrate ./internal/docgen ./internal/session ./internal/beads -count=1 -timeout 180s
```

Caveat: an earlier broader `go test ./cmd/gc ... -timeout 180s` run timed out in an unrelated bd provider lifecycle test (`TestGcBeadsBdInitNormalizesScopeAndRemovesLocalServerArtifacts`). The touched `cmd/gc` focused tests above passed.
