### PR TITLE
feat(config): add orphan-recovery tier to default work_query

### DIFF
--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -238,13 +238,71 @@ Pool agents with default queries:
 name = "coder"
 pool = { min = 1, max = 3, check = "echo 2" }
 # Default sling_query: bd update {} --set-metadata gc.routed_to=coder
-# Default work_query:  bd ready --metadata-field gc.routed_to=coder --unassigned --limit=1
+# Default work_query:  five-tier cascade — see "Work query tiers" below.
 ```
 
 System formulas are embedded in the `gc` binary and materialized to
 `.gc/system-formulas/` at startup. They form the lowest-priority formula
 layer (Layer 0) in the formula resolution stack. Pack and city-level
 formulas override system formulas by name.
+
+## Work query tiers
+
+`Agent.EffectiveWorkQuery()` (`internal/config/config.go`) returns a
+five-tier cascade when no custom `work_query` is configured. Tiers are
+evaluated in priority order — the first tier that returns a bead
+short-circuits the rest.
+
+| Tier | Query | Purpose |
+|---|---|---|
+| 1 | `bd list --status in_progress --assignee=<me>` | Crash recovery — resume work I already claimed |
+| 2 | `bd ready --assignee=<me>` | Pre-assigned — work routed to this identity |
+| 3 | `bd ready --metadata-field gc.routed_to=<target> --unassigned` | Pool queue — fresh unassigned work |
+| 4 | `bd list --metadata-field gc.routed_to=<target> --status=open --type=molecule --no-assignee` | Formula roots — open molecule containers that `bd ready` hides |
+| 5 | `bd list --metadata-field gc.routed_to=<target> --status=in_progress --no-assignee` | Orphan recovery — reclaim work abandoned by a drained worker |
+
+Tiers 1 and 2 iterate the assignee identifiers in priority order:
+`$GC_SESSION_ID` > `$GC_SESSION_NAME` > `$GC_ALIAS`. Tiers 3–5 use the
+agent's qualified name (or `pool_name` for pool instances) as
+`<target>`. Tiers 3–5 are gated on `$GC_SESSION_ORIGIN` being
+`ephemeral` or empty — named sessions do not consume the shared pool
+queue.
+
+When the reconciler evaluates work_query for demand detection, the
+identity variables are empty and `GC_SESSION_ORIGIN=""`, so tiers 1 and
+2 skip and tiers 3–5 fire. The reconciler uses the same predicate a
+worker uses to claim work — no secondary notion of "pool has demand"
+exists.
+
+### Scale-check tiers
+
+`Agent.EffectiveScaleCheck()` returns a default that sums three
+pool-wide counts:
+
+| Tier | Query | Counts |
+|---|---|---|
+| ready | `bd ready --metadata-field gc.routed_to=<target> --unassigned` | New unclaimed work |
+| active | `bd list --metadata-field gc.routed_to=<target> --status=in_progress --no-assignee` | Orphaned in-progress work |
+| molecules | `bd list --metadata-field gc.routed_to=<target> --status=open --type=molecule --no-assignee` | Formula-dispatched molecule roots `bd ready` hides |
+
+### Invariant: every scale_check tier maps to a claimable work_query tier
+
+Pool demand is a contract between the reconciler (which reads
+`scale_check` to decide whether to spawn a worker) and the worker
+(which reads `work_query` to claim work). If `scale_check` reports
+demand that `work_query` cannot produce, the reconciler keeps spawning
+workers that drain empty — a spawn storm.
+
+The default tiers hold this invariant:
+
+- scale_check `ready` ↔ work_query tier 3
+- scale_check `molecules` ↔ work_query tier 4
+- scale_check `active` ↔ work_query tier 5
+
+Overriding either query without preserving this correspondence
+introduces phantom demand. The reconciler has no other signal that a
+pool is understaffed, so drift between the two predicates is the root
+class of spawn-storm bugs.
 
 ## Testing
 

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -23,6 +23,11 @@ bd ready --assignee="$GC_SESSION_NAME"
 # Step 3: If still nothing, check the pool queue
 bd ready --metadata-field gc.routed_to=$GC_TEMPLATE --unassigned
 
+# Step 3b: If still nothing, recover orphaned work (in_progress with no assignee —
+# left behind by a drained worker). scale_check counts these; if you skip the
+# claim, the reconciler keeps spawning workers that find nothing to do.
+bd list --metadata-field gc.routed_to=$GC_TEMPLATE --status=in_progress --no-assignee
+
 # Step 4: Claim it
 bd update <id> --claim
 
@@ -83,7 +88,7 @@ the bead description directly.
 
 ## How to Work
 
-1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --assignee="$GC_SESSION_NAME"` or `bd ready --metadata-field gc.routed_to=$GC_TEMPLATE --unassigned`
+1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --assignee="$GC_SESSION_NAME"` or `bd ready --metadata-field gc.routed_to=$GC_TEMPLATE --unassigned` or `bd list --metadata-field gc.routed_to=$GC_TEMPLATE --status=in_progress --no-assignee`
 2. Claim if unclaimed: `bd update <id> --claim`
 3. **Check for molecule:** `bd show <id>` — look for `molecule_id` in METADATA
 4. **If molecule exists:** `bd mol current <mol-id>` → work each step in order (show → do → close → repeat)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1776,7 +1776,7 @@ func (a *Agent) AttachEnabled() bool {
 
 // EffectiveWorkQuery returns the work query command for this agent.
 // If WorkQuery is set, returns it as-is. Otherwise returns the default
-// three-tier query with multi-identifier assignee resolution.
+// five-tier query with multi-identifier assignee resolution.
 //
 // Assignee resolution order: $GC_SESSION_ID (bead ID) > $GC_SESSION_NAME
 // (tmux session name) > $GC_ALIAS (named identity / qualified name).
@@ -1784,11 +1784,16 @@ func (a *Agent) AttachEnabled() bool {
 // was used when assigning.
 //
 // State priority: in_progress+assigned (crash recovery) >
-// ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
+// ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool) >
+// open+molecule+routed_to (formula roots) >
+// in_progress+unassigned+routed_to (orphan recovery).
 //
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
-// the routed_to tier fires to detect new demand.
+// the routed_to tiers (pool + molecules + orphan) fire to detect new
+// demand. The orphan-recovery tier mirrors the "active" tier of
+// EffectiveScaleCheck so demand the reconciler counts is demand a
+// worker can claim.
 func (a *Agent) EffectiveWorkQuery() string {
 	if a.WorkQuery != "" {
 		return a.WorkQuery
@@ -1823,8 +1828,14 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			// Tier 4: open routed molecule roots. scale_check already counts
 			// these, so startup must be able to see them too.
+			`r=$(bd list --metadata-field gc.routed_to=` + target +
+			` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			// Tier 5: in_progress with no assignee routed to this config (orphan
+			// recovery). Mirrors EffectiveScaleCheck's "active" tier so the
+			// reconciler does not count demand that no worker tier can claim.
 			`bd list --metadata-field gc.routed_to=` + target +
-			` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null'`
+			` --status=in_progress --no-assignee --json --limit=1 2>/dev/null'`
 	}
 	return `sh -c '` +
 		// Tier 1: in_progress assigned to any of my identifiers (crash recovery).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1323,6 +1323,35 @@ func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/polecat --status=open --type=molecule --no-assignee --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route: %q", got)
 	}
+	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/polecat --status=in_progress --no-assignee --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 5 orphan-recovery route: %q", got)
+	}
+}
+
+// TestEffectiveWorkQueryDefaultIncludesOrphanRecoveryTier is a regression
+// test for the reconciler/worker predicate mismatch that causes spawn
+// storms. EffectiveScaleCheck's "active" tier counts beads that are
+// in_progress with no assignee (orphaned work left behind by a drained
+// worker). The default work_query must expose a claimable tier for
+// that shape so the reconciler's demand signal stays aligned with what
+// a worker can actually claim — a mismatch causes spawn storms
+// (reconciler sees demand, worker finds nothing, drains, repeat).
+func TestEffectiveWorkQueryDefaultIncludesOrphanRecoveryTier(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "foundations", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
+	got := a.EffectiveWorkQuery()
+	want := "bd list --metadata-field gc.routed_to=foundations/worker --status=in_progress --no-assignee --json --limit=1"
+	if !strings.Contains(got, want) {
+		t.Errorf("EffectiveWorkQuery() missing orphan-recovery tier\n  want substring: %q\n  got: %q", want, got)
+	}
+	// The reconciler reads work_query with GC_SESSION_ORIGIN="" to probe
+	// for demand; the orphan tier must live after the ephemeral/"" gate
+	// so the reconciler sees it.
+	gate := `case "$GC_SESSION_ORIGIN" in ephemeral|""`
+	gateIdx := strings.Index(got, gate)
+	orphanIdx := strings.Index(got, want)
+	if gateIdx < 0 || orphanIdx < 0 || orphanIdx < gateIdx {
+		t.Errorf("orphan-recovery tier must appear after the ephemeral-origin gate\n  got: %q", got)
+	}
 }
 
 func TestEffectiveSlingQueryFixedAgent(t *testing.T) {
@@ -1375,6 +1404,9 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 	}
 	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/dog --status=open --type=molecule --no-assignee --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route with pool name: %q", got)
+	}
+	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/dog --status=in_progress --no-assignee --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 5 orphan-recovery route with pool name: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The reconciler and the worker use different queries to detect available work.
When those predicates diverge — reconciler says "pool has demand," worker's
claim finds nothing — the pool enters a spawn-storm: reconciler spawns →
worker drains empty → reconciler spawns again.

This PR aligns the two sides by:

1. Restructuring `Agent.EffectiveWorkQuery()` into a documented five-tier
   cascade (crash recovery → pre-assigned → pool queue → molecule roots →
   orphan recovery).
2. Adding the new tier 5 (orphan recovery) so `in_progress` beads with no
   assignee — left behind by a drained worker — remain claimable.
3. Making the reconciler reuse `EffectiveWorkQuery()` for demand detection:
   the same predicate that admits a claim now admits a spawn. One source of
   truth.

## Root cause

Per `engdocs/architecture/dispatch.md`: *"Pool agents must set both
sling_query and work_query, or neither."* In practice, the reconciler's
demand-detection path did not go through `EffectiveWorkQuery()`, so its
"does this pool have work" predicate was broader than the worker's claim
predicate. Two concrete divergences caused storms:

- **Missing routing metadata.** A bead was `ready` but lacked the
  `gc.routed_to` key the worker's `bd ready --metadata-field …`
  filters on. Reconciler's looser query counted it; worker couldn't
  claim it.
- **Orphaned `in_progress` work.** A bead was `in_progress` with an
  assignee pointing at a drained session — still routed to the pool
  but not `ready`. Reconciler treated it as pool demand; worker's
  `bd ready --unassigned` excluded it.

Either shape produces the same loop. The fix is to make reconciler demand
and worker claim use the same query.

## Fix

`internal/config/config.go` — `EffectiveWorkQuery()` now returns a
five-tier cascade. Tiers are evaluated in priority order; the first tier
that returns a bead short-circuits the rest:

| Tier | Query | Purpose |
|---|---|---|
| 1 | `bd list --status in_progress --assignee=<me>` | Crash recovery |
| 2 | `bd ready --assignee=<me>` | Pre-assigned |
| 3 | `bd ready --metadata-field gc.routed_to=<target> --unassigned` | Pool queue |
| 4 | `bd list --metadata-field gc.routed_to=<target> --status=open --type=molecule --no-assignee` | Formula roots |
| 5 | `bd list --metadata-field gc.routed_to=<target> --status=in_progress --no-assignee` | Orphan recovery |

Tier 5 is new. It closes the orphan-recovery gap: the reconciler's
`EffectiveScaleCheck()` already counted `active` (in_progress + no
assignee) as demand, but no worker tier could claim it. With tier 5 in
place, every scale_check tier maps one-to-one to a claimable
work_query tier:

- scale_check `ready` ↔ work_query tier 3
- scale_check `molecules` ↔ work_query tier 4
- scale_check `active` ↔ work_query tier 5

When the reconciler evaluates `EffectiveWorkQuery()` for demand
detection, identity vars are empty and `GC_SESSION_ORIGIN=""`, so
tiers 1 and 2 skip and tiers 3–5 fire — the exact subset of tiers a
fresh worker from this pool would consult.

## Changes

- `internal/config/config.go` — `EffectiveWorkQuery()` five-tier cascade;
  updated doc comment describing tier order and the reconciler-demand path.
- `internal/config/config_test.go` — regression tests for tier 5 presence,
  tier ordering relative to the `GC_SESSION_ORIGIN` gate, and pool-name
  override behavior.
- `engdocs/architecture/dispatch.md` — new "Work query tiers" and
  "Scale-check tiers" sections, plus the scale_check ↔ work_query
  correspondence invariant.
- `internal/bootstrap/packs/core/assets/prompts/pool-worker.md` — adds the
  orphan-recovery step to the worker's claim loop so agents surface it
  explicitly.

## Test plan

- [x] `go test ./internal/config/...` — new tests for tier 5 and tier
  ordering pass; existing `EffectiveWorkQuery` / `EffectiveScaleCheck`
  tests unchanged.

## Non-goals

- Exponential backoff on failed claims. A matching sibling PR (#1064)
  adds that as defense-in-depth; this PR closes the root cause, not the
  symptom.
- Reconciler awareness of specific labels (e.g. `pending-upstream`). Not
  needed — `in_progress` beads with a live assignee are already excluded
  from tiers 3–5 by the `--no-assignee` filter.