### PR TITLE
fix/beads filestore freshness

### DIFF
--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -22,10 +23,31 @@ type fileData struct {
 // write. Fine for Tutorial 01 volumes.
 type FileStore struct {
 	*MemStore
-	fmu    sync.Mutex // guards mutate-then-save atomicity
-	fs     fsys.FS
-	path   string
-	locker Locker // cross-process file lock; nopLocker when unset
+	fmu       sync.Mutex // guards mutate-then-save atomicity
+	fs        fsys.FS
+	path      string
+	locker    Locker // cross-process file lock; nopLocker when unset
+	freshness fileFreshness
+}
+
+type fileFreshness struct {
+	known   bool
+	exists  bool
+	size    int64
+	modTime time.Time
+}
+
+func (f fileFreshness) same(other fileFreshness) bool {
+	if !f.known || !other.known {
+		return false
+	}
+	if f.exists != other.exists {
+		return false
+	}
+	if !f.exists {
+		return true
+	}
+	return f.size == other.size && f.modTime.Equal(other.modTime)
 }
 
 // OpenFileStore opens or creates a file-backed bead store at path. All file
@@ -45,7 +67,13 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &FileStore{MemStore: NewMemStore(), fs: fs, path: path, locker: locker}, nil
+			return &FileStore{
+				MemStore:  NewMemStore(),
+				fs:        fs,
+				path:      path,
+				locker:    locker,
+				freshness: fileFreshness{known: true},
+			}, nil
 		}
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
@@ -54,7 +82,17 @@ func OpenFileStore(fs fsys.FS, path string) (*FileStore, error) {
 	if err := json.Unmarshal(data, &fd); err != nil {
 		return nil, fmt.Errorf("opening file store: %w", err)
 	}
-	return &FileStore{MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps), fs: fs, path: path, locker: locker}, nil
+	store := &FileStore{
+		MemStore: NewMemStoreFrom(fd.Seq, fd.Beads, fd.Deps),
+		fs:       fs,
+		path:     path,
+		locker:   locker,
+	}
+	// The JSON we just loaded and the file's current freshness can diverge if
+	// another handle rewrites the store between ReadFile and a follow-up Stat.
+	// Leave the cache unknown so the first read revalidates against disk.
+	store.freshness = fileFreshness{}
+	return store, nil
 }
 
 // SetLocker sets a cross-process Locker (typically a FileFlock). When set,
@@ -84,6 +122,59 @@ func (fs *FileStore) reloadFromDisk() error {
 	return nil
 }
 
+func (fs *FileStore) currentFreshness() (fileFreshness, error) {
+	fi, err := fs.fs.Stat(fs.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fileFreshness{known: true}, nil
+		}
+		return fileFreshness{}, fmt.Errorf("stating file store: %w", err)
+	}
+	return fileFreshness{
+		known:   true,
+		exists:  true,
+		size:    fi.Size(),
+		modTime: fi.ModTime(),
+	}, nil
+}
+
+func (fs *FileStore) refreshFreshnessCache() {
+	current, err := fs.currentFreshness()
+	if err != nil {
+		fs.freshness = fileFreshness{}
+		return
+	}
+	fs.freshness = current
+}
+
+// refreshReadStateLocked favors cross-process correctness for long-lived
+// readers, but uses an mtime+size fast path to avoid full JSON reloads on
+// every read. The remaining per-read Stat cost is acceptable for now; if
+// polling latency becomes measurable, we can replace it with a lighter seq hint.
+func (fs *FileStore) refreshReadStateLocked() error {
+	current, err := fs.currentFreshness()
+	if err != nil {
+		if err := fs.reloadFromDisk(); err != nil {
+			return err
+		}
+		fs.freshness = fileFreshness{}
+		return nil
+	}
+	if fs.freshness.same(current) {
+		return nil
+	}
+	if !current.exists {
+		fs.restoreFrom(0, nil, nil)
+		fs.freshness = current
+		return nil
+	}
+	if err := fs.reloadFromDisk(); err != nil {
+		return err
+	}
+	fs.freshness = current
+	return nil
+}
+
 // Create delegates to MemStore.Create and flushes to disk.
 // If the disk flush fails, the in-memory mutation is rolled back to keep
 // the MemStore and file in sync.
@@ -94,7 +185,7 @@ func (fs *FileStore) Create(b Bead) (Bead, error) {
 		return Bead{}, err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return Bead{}, err
 	}
 	snap := fs.snapshotLocked()
@@ -118,7 +209,7 @@ func (fs *FileStore) Update(id string, opts UpdateOpts) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -141,7 +232,7 @@ func (fs *FileStore) Close(id string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -164,11 +255,34 @@ func (fs *FileStore) Reopen(id string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
 	if err := fs.MemStore.Reopen(id); err != nil {
+		return err
+	}
+	if err := fs.save(); err != nil {
+		fs.restoreFrom(snap.seq, snap.beads, snap.deps)
+		return err
+	}
+	return nil
+}
+
+// Delete delegates to MemStore.Delete and flushes to disk.
+// If the disk flush fails, the in-memory mutation is rolled back.
+func (fs *FileStore) Delete(id string) error {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.locker.Lock(); err != nil {
+		return err
+	}
+	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return err
+	}
+	snap := fs.snapshotLocked()
+	if err := fs.MemStore.Delete(id); err != nil {
 		return err
 	}
 	if err := fs.save(); err != nil {
@@ -186,7 +300,7 @@ func (fs *FileStore) CloseAll(ids []string, metadata map[string]string) (int, er
 		return 0, err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return 0, err
 	}
 	snap := fs.snapshotLocked()
@@ -212,7 +326,7 @@ func (fs *FileStore) SetMetadata(id, key, value string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -235,7 +349,7 @@ func (fs *FileStore) SetMetadataBatch(id string, kvs map[string]string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -249,27 +363,84 @@ func (fs *FileStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	return nil
 }
 
-// Delete delegates to MemStore.Delete and flushes to disk.
-// If the disk flush fails, the in-memory mutation is rolled back.
-func (fs *FileStore) Delete(id string) error {
+// Get reloads the on-disk store before reading a bead by ID.
+func (fs *FileStore) Get(id string) (Bead, error) {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
-	if err := fs.locker.Lock(); err != nil {
-		return err
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return Bead{}, err
 	}
-	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
-		return err
+	return fs.MemStore.Get(id)
+}
+
+// List reloads the on-disk store before listing beads that match the query.
+func (fs *FileStore) List(query ListQuery) ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
 	}
-	snap := fs.snapshotLocked()
-	if err := fs.MemStore.Delete(id); err != nil {
-		return err
+	return fs.MemStore.List(query)
+}
+
+// ListOpen reloads the on-disk store before listing open beads.
+func (fs *FileStore) ListOpen(status ...string) ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
 	}
-	if err := fs.save(); err != nil {
-		fs.restoreFrom(snap.seq, snap.beads, snap.deps)
-		return err
+	return fs.MemStore.ListOpen(status...)
+}
+
+// Ready reloads the on-disk store before listing ready beads.
+func (fs *FileStore) Ready() ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
 	}
-	return nil
+	return fs.MemStore.Ready()
+}
+
+// Children reloads the on-disk store before listing child beads.
+func (fs *FileStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
+	}
+	return fs.MemStore.Children(parentID, opts...)
+}
+
+// ListByLabel reloads the on-disk store before listing beads for a label.
+func (fs *FileStore) ListByLabel(label string, limit int, opts ...QueryOpt) ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
+	}
+	return fs.MemStore.ListByLabel(label, limit, opts...)
+}
+
+// ListByAssignee reloads the on-disk store before listing beads for an assignee.
+func (fs *FileStore) ListByAssignee(assignee, status string, limit int) ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
+	}
+	return fs.MemStore.ListByAssignee(assignee, status, limit)
+}
+
+// ListByMetadata reloads the on-disk store before listing beads by metadata.
+func (fs *FileStore) ListByMetadata(filters map[string]string, limit int, opts ...QueryOpt) ([]Bead, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
+	}
+	return fs.MemStore.ListByMetadata(filters, limit, opts...)
 }
 
 // Ping checks that the store file is accessible.
@@ -292,7 +463,7 @@ func (fs *FileStore) DepAdd(issueID, dependsOnID, depType string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -315,7 +486,7 @@ func (fs *FileStore) DepRemove(issueID, dependsOnID string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.reloadFromDisk(); err != nil {
+	if err := fs.refreshReadStateLocked(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -327,6 +498,16 @@ func (fs *FileStore) DepRemove(issueID, dependsOnID string) error {
 		return err
 	}
 	return nil
+}
+
+// DepList reloads the on-disk store before listing dependencies.
+func (fs *FileStore) DepList(id, direction string) ([]Dep, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
+	}
+	return fs.MemStore.DepList(id, direction)
 }
 
 // memSnapshot holds a snapshot of MemStore state for rollback.
@@ -365,5 +546,6 @@ func (fs *FileStore) save() error {
 	if err := fs.fs.Rename(tmp, fs.path); err != nil {
 		return fmt.Errorf("saving file store: %w", err)
 	}
+	fs.refreshFreshnessCache()
 	return nil
 }

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -151,6 +151,8 @@ func (fs *FileStore) refreshFreshnessCache() {
 // readers, but uses an mtime+size fast path to avoid full JSON reloads on
 // every read. The remaining per-read Stat cost is acceptable for now; if
 // polling latency becomes measurable, we can replace it with a lighter seq hint.
+// Read wrappers intentionally skip the cross-process locker because writers
+// publish complete JSON files with temp-file-plus-rename atomic replacement.
 func (fs *FileStore) refreshReadStateLocked() error {
 	current, err := fs.currentFreshness()
 	if err != nil {
@@ -185,7 +187,7 @@ func (fs *FileStore) Create(b Bead) (Bead, error) {
 		return Bead{}, err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return Bead{}, err
 	}
 	snap := fs.snapshotLocked()
@@ -209,7 +211,7 @@ func (fs *FileStore) Update(id string, opts UpdateOpts) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -232,7 +234,7 @@ func (fs *FileStore) Close(id string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -255,7 +257,7 @@ func (fs *FileStore) Reopen(id string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -278,7 +280,7 @@ func (fs *FileStore) Delete(id string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -300,7 +302,7 @@ func (fs *FileStore) CloseAll(ids []string, metadata map[string]string) (int, er
 		return 0, err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return 0, err
 	}
 	snap := fs.snapshotLocked()
@@ -326,7 +328,7 @@ func (fs *FileStore) SetMetadata(id, key, value string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -349,7 +351,7 @@ func (fs *FileStore) SetMetadataBatch(id string, kvs map[string]string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -463,7 +465,7 @@ func (fs *FileStore) DepAdd(issueID, dependsOnID, depType string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()
@@ -486,7 +488,7 @@ func (fs *FileStore) DepRemove(issueID, dependsOnID string) error {
 		return err
 	}
 	defer fs.locker.Unlock() //nolint:errcheck // best-effort unlock
-	if err := fs.refreshReadStateLocked(); err != nil {
+	if err := fs.reloadFromDisk(); err != nil {
 		return err
 	}
 	snap := fs.snapshotLocked()

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -198,6 +198,164 @@ func TestFileStoreRefreshesReadsAcrossOpenInstances(t *testing.T) {
 	}
 }
 
+func TestFileStoreReadyRefreshesAcrossOpenInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocker, err := s1.Create(beads.Bead{Title: "blocker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := s1.Create(beads.Bead{Title: "target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ready, err := s2.Ready()
+	if err != nil {
+		t.Fatalf("Ready() before dep add: %v", err)
+	}
+	if !hasBeadID(ready, blocker.ID) || !hasBeadID(ready, target.ID) {
+		t.Fatalf("Ready() before dep add = %+v, want %s and %s", ready, blocker.ID, target.ID)
+	}
+
+	if err := s1.DepAdd(target.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(%s, %s): %v", target.ID, blocker.ID, err)
+	}
+
+	ready, err = s2.Ready()
+	if err != nil {
+		t.Fatalf("Ready() after dep add: %v", err)
+	}
+	if !hasBeadID(ready, blocker.ID) {
+		t.Fatalf("Ready() after dep add = %+v, want blocker %s", ready, blocker.ID)
+	}
+	if hasBeadID(ready, target.ID) {
+		t.Fatalf("Ready() after dep add still contains blocked bead %s: %+v", target.ID, ready)
+	}
+}
+
+func TestFileStoreChildrenRefreshesAcrossOpenInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent, err := s1.Create(beads.Bead{Title: "parent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	children, err := s2.Children(parent.ID)
+	if err != nil {
+		t.Fatalf("Children(%q) before child create: %v", parent.ID, err)
+	}
+	if len(children) != 0 {
+		t.Fatalf("Children(%q) before child create = %+v, want empty", parent.ID, children)
+	}
+
+	child, err := s1.Create(beads.Bead{Title: "child", ParentID: parent.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	children, err = s2.Children(parent.ID)
+	if err != nil {
+		t.Fatalf("Children(%q) after child create: %v", parent.ID, err)
+	}
+	if len(children) != 1 || children[0].ID != child.ID {
+		t.Fatalf("Children(%q) after child create = %+v, want only %s", parent.ID, children, child.ID)
+	}
+}
+
+func TestFileStoreDepListRefreshesAcrossOpenInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := s1.Create(beads.Bead{Title: "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s1.Create(beads.Bead{Title: "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := s2.DepList(a.ID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%q, down) before dep add: %v", a.ID, err)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("DepList(%q, down) before dep add = %+v, want empty", a.ID, deps)
+	}
+
+	if err := s1.DepAdd(a.ID, b.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(%s, %s): %v", a.ID, b.ID, err)
+	}
+
+	deps, err = s2.DepList(a.ID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%q, down) after dep add: %v", a.ID, err)
+	}
+	if len(deps) != 1 || deps[0].DependsOnID != b.ID {
+		t.Fatalf("DepList(%q, down) after dep add = %+v, want one dep on %s", a.ID, deps, b.ID)
+	}
+}
+
+func TestFileStoreListByAssigneeRefreshesAcrossOpenInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assigned, err := s2.ListByAssignee("mayor", "open", 0)
+	if err != nil {
+		t.Fatalf("ListByAssignee before create: %v", err)
+	}
+	if len(assigned) != 0 {
+		t.Fatalf("ListByAssignee before create = %+v, want empty", assigned)
+	}
+
+	created, err := s1.Create(beads.Bead{Title: "owned", Assignee: "mayor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assigned, err = s2.ListByAssignee("mayor", "open", 0)
+	if err != nil {
+		t.Fatalf("ListByAssignee after create: %v", err)
+	}
+	if len(assigned) != 1 || assigned[0].ID != created.ID {
+		t.Fatalf("ListByAssignee after create = %+v, want only %s", assigned, created.ID)
+	}
+}
+
 func TestFileStoreRefreshesAfterOpenRace(t *testing.T) {
 	path := "/city/.gc/beads.json"
 	base := fsys.NewFake()
@@ -434,6 +592,15 @@ func TestFileStoreDeletePersistence(t *testing.T) {
 
 func ptr[T any](v T) *T {
 	return &v
+}
+
+func hasBeadID(beadsList []beads.Bead, id string) bool {
+	for _, b := range beadsList {
+		if b.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func TestFileStoreChildrenExcludeClosedByDefault(t *testing.T) {

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -32,6 +32,42 @@ func (f *statRaceFS) Stat(name string) (os.FileInfo, error) {
 	return f.FS.Stat(name)
 }
 
+type toggledErrorFS struct {
+	fsys.FS
+	path    string
+	statErr error
+	readErr error
+}
+
+func (f *toggledErrorFS) Stat(name string) (os.FileInfo, error) {
+	if name == f.path && f.statErr != nil {
+		return nil, f.statErr
+	}
+	return f.FS.Stat(name)
+}
+
+func (f *toggledErrorFS) ReadFile(name string) ([]byte, error) {
+	if name == f.path && f.readErr != nil {
+		return nil, f.readErr
+	}
+	return f.FS.ReadFile(name)
+}
+
+type oneShotStatErrorFS struct {
+	fsys.FS
+	path  string
+	err   error
+	fired bool
+}
+
+func (f *oneShotStatErrorFS) Stat(name string) (os.FileInfo, error) {
+	if name == f.path && !f.fired {
+		f.fired = true
+		return nil, f.err
+	}
+	return f.FS.Stat(name)
+}
+
 func TestFileStore(t *testing.T) {
 	factory := func() beads.Store {
 		path := filepath.Join(t.TempDir(), "beads.json")
@@ -485,6 +521,305 @@ func TestFileStoreRefreshesSameSizeExternalRewrite(t *testing.T) {
 	}
 	if readCalls != 1 {
 		t.Fatalf("ReadFile(%s) calls = %d, want 1 after same-size rewrite", path, readCalls)
+	}
+}
+
+func TestFileStoreRefreshFallbackReloadsWhenStatFails(t *testing.T) {
+	base := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	writer, err := beads.OpenFileStore(base, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := writer.Create(beads.Bead{Title: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readerFS := &oneShotStatErrorFS{
+		FS:   base,
+		path: path,
+		err:  fmt.Errorf("stat unavailable"),
+	}
+	reader, err := beads.OpenFileStore(readerFS, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := reader.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%q) after Stat failure fallback: %v", created.ID, err)
+	}
+	if got.Title != "alpha" {
+		t.Fatalf("Get(%q) title = %q, want alpha", created.ID, got.Title)
+	}
+}
+
+func TestFileStoreCreateRewarmsAfterFreshnessStatFailure(t *testing.T) {
+	base := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+	fs := &toggledErrorFS{
+		FS:      base,
+		path:    path,
+		statErr: fmt.Errorf("stat unavailable"),
+	}
+
+	s, err := beads.OpenFileStore(fs, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := s.Create(beads.Bead{Title: "alpha"})
+	if err != nil {
+		t.Fatalf("Create() with post-save Stat failure: %v", err)
+	}
+
+	fs.statErr = nil
+	base.Calls = nil
+
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%q) after clearing Stat failure: %v", created.ID, err)
+	}
+	if got.Title != "alpha" {
+		t.Fatalf("Get(%q) title = %q, want alpha", created.ID, got.Title)
+	}
+
+	var readCalls int
+	for _, call := range base.Calls {
+		if call.Method == "ReadFile" && call.Path == path {
+			readCalls++
+		}
+	}
+	if readCalls == 0 {
+		t.Fatalf("expected Get(%q) to re-read %s after freshness cache was cleared", created.ID, path)
+	}
+}
+
+func TestFileStoreReadWrappersPropagateRefreshErrors(t *testing.T) {
+	base := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+	fs := &toggledErrorFS{FS: base, path: path}
+
+	s, err := beads.OpenFileStore(fs, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.statErr = fmt.Errorf("stat boom")
+	fs.readErr = fmt.Errorf("read boom")
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "Get",
+			call: func() error {
+				_, err := s.Get("gc-1")
+				return err
+			},
+		},
+		{
+			name: "List",
+			call: func() error {
+				_, err := s.List(beads.ListQuery{})
+				return err
+			},
+		},
+		{
+			name: "ListOpen",
+			call: func() error {
+				_, err := s.ListOpen()
+				return err
+			},
+		},
+		{
+			name: "Ready",
+			call: func() error {
+				_, err := s.Ready()
+				return err
+			},
+		},
+		{
+			name: "Children",
+			call: func() error {
+				_, err := s.Children("gc-1")
+				return err
+			},
+		},
+		{
+			name: "ListByLabel",
+			call: func() error {
+				_, err := s.ListByLabel("x", 0)
+				return err
+			},
+		},
+		{
+			name: "ListByAssignee",
+			call: func() error {
+				_, err := s.ListByAssignee("mayor", "open", 0)
+				return err
+			},
+		},
+		{
+			name: "ListByMetadata",
+			call: func() error {
+				_, err := s.ListByMetadata(map[string]string{"k": "v"}, 0)
+				return err
+			},
+		},
+		{
+			name: "DepList",
+			call: func() error {
+				_, err := s.DepList("gc-1", "down")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil {
+				t.Fatalf("%s() err = nil, want refresh error", tc.name)
+			}
+			if !strings.Contains(err.Error(), "read boom") {
+				t.Fatalf("%s() err = %v, want read boom", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestFileStoreMutatorsPropagateRefreshErrors(t *testing.T) {
+	base := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+	fs := &toggledErrorFS{FS: base, path: path}
+
+	s, err := beads.OpenFileStore(fs, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.statErr = fmt.Errorf("stat boom")
+	fs.readErr = fmt.Errorf("read boom")
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "Create",
+			call: func() error {
+				_, err := s.Create(beads.Bead{Title: "x"})
+				return err
+			},
+		},
+		{
+			name: "Update",
+			call: func() error {
+				return s.Update("gc-1", beads.UpdateOpts{Title: ptr("updated")})
+			},
+		},
+		{
+			name: "Close",
+			call: func() error {
+				return s.Close("gc-1")
+			},
+		},
+		{
+			name: "Delete",
+			call: func() error {
+				return s.Delete("gc-1")
+			},
+		},
+		{
+			name: "CloseAll",
+			call: func() error {
+				_, err := s.CloseAll([]string{"gc-1"}, map[string]string{"phase": "done"})
+				return err
+			},
+		},
+		{
+			name: "SetMetadata",
+			call: func() error {
+				return s.SetMetadata("gc-1", "k", "v")
+			},
+		},
+		{
+			name: "SetMetadataBatch",
+			call: func() error {
+				return s.SetMetadataBatch("gc-1", map[string]string{"k": "v"})
+			},
+		},
+		{
+			name: "DepAdd",
+			call: func() error {
+				return s.DepAdd("gc-1", "gc-2", "blocks")
+			},
+		},
+		{
+			name: "DepRemove",
+			call: func() error {
+				return s.DepRemove("gc-1", "gc-2")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil {
+				t.Fatalf("%s() err = nil, want refresh error", tc.name)
+			}
+			if !strings.Contains(err.Error(), "read boom") {
+				t.Fatalf("%s() err = %v, want read boom", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestFileStoreCloseAllRefreshesAcrossOpenInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := s1.Create(beads.Bead{Title: "first", Labels: []string{"x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := s1.Create(beads.Bead{Title: "second", Labels: []string{"x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	closed, err := s1.CloseAll([]string{first.ID, second.ID}, map[string]string{"gc.batch": "done"})
+	if err != nil {
+		t.Fatalf("CloseAll(): %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("CloseAll() closed = %d, want 2", closed)
+	}
+
+	open, err := s2.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen() after CloseAll: %v", err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("ListOpen() after CloseAll = %+v, want empty", open)
+	}
+
+	got, err := s2.ListByMetadata(map[string]string{"gc.batch": "done"}, 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("ListByMetadata() after CloseAll: %v", err)
+	}
+	if len(got) != 2 || !hasBeadID(got, first.ID) || !hasBeadID(got, second.ID) {
+		t.Fatalf("ListByMetadata() after CloseAll = %+v, want %s and %s", got, first.ID, second.ID)
 	}
 }
 

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
+type statRaceFS struct {
+	fsys.FS
+	path            string
+	beforeFirstStat func()
+	fired           bool
+}
+
+func (f *statRaceFS) Stat(name string) (os.FileInfo, error) {
+	if name == f.path && !f.fired {
+		f.fired = true
+		if f.beforeFirstStat != nil {
+			f.beforeFirstStat()
+		}
+	}
+	return f.FS.Stat(name)
+}
+
 func TestFileStore(t *testing.T) {
 	factory := func() beads.Store {
 		path := filepath.Join(t.TempDir(), "beads.json")
@@ -140,6 +157,255 @@ func TestFileStoreMetadataPersistence(t *testing.T) {
 	}
 }
 
+func TestFileStoreRefreshesReadsAcrossOpenInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+
+	s1, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := s1.Create(beads.Bead{
+		Title:  "manual session",
+		Type:   "session",
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s1.SetMetadata(created.ID, "state", "creating"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s2.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%q) from second handle: %v", created.ID, err)
+	}
+	if got.Metadata["state"] != "creating" {
+		t.Fatalf("Get(%q) metadata[state] = %q, want %q", created.ID, got.Metadata["state"], "creating")
+	}
+
+	sessions, err := s2.List(beads.ListQuery{Label: "gc:session"})
+	if err != nil {
+		t.Fatalf("List(session label) from second handle: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != created.ID {
+		t.Fatalf("List(session label) = %+v, want only %s", sessions, created.ID)
+	}
+}
+
+func TestFileStoreRefreshesAfterOpenRace(t *testing.T) {
+	path := "/city/.gc/beads.json"
+	base := fsys.NewFake()
+
+	s1, err := beads.OpenFileStore(base, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := s1.Create(beads.Bead{Title: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	racyFS := &statRaceFS{
+		FS:   base,
+		path: path,
+		beforeFirstStat: func() {
+			if err := s1.Update(created.ID, beads.UpdateOpts{Title: ptr("bravo")}); err != nil {
+				t.Fatalf("Update(%q) during open race: %v", created.ID, err)
+			}
+		},
+	}
+
+	s2, err := beads.OpenFileStore(racyFS, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s2.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%q) after open race: %v", created.ID, err)
+	}
+	if got.Title != "bravo" {
+		t.Fatalf("Title after open race = %q, want bravo", got.Title)
+	}
+}
+
+func TestFileStoreSkipsReadReloadWhenFileIsUnchanged(t *testing.T) {
+	f := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	s1, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := s1.Create(beads.Bead{Title: "cached bead"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Calls = nil
+	for i := 0; i < 2; i++ {
+		if _, err := s2.Get(created.ID); err != nil {
+			t.Fatalf("Get(%q) #%d: %v", created.ID, i+1, err)
+		}
+	}
+
+	var statCalls, readCalls int
+	for _, call := range f.Calls {
+		if call.Path != path {
+			continue
+		}
+		switch call.Method {
+		case "Stat":
+			statCalls++
+		case "ReadFile":
+			readCalls++
+		}
+	}
+	if statCalls != 2 {
+		t.Fatalf("Stat(%s) calls = %d, want 2", path, statCalls)
+	}
+	if readCalls != 1 {
+		t.Fatalf("ReadFile(%s) calls = %d, want 1 after cache warmup", path, readCalls)
+	}
+}
+
+func TestFileStoreRefreshesSameSizeExternalRewrite(t *testing.T) {
+	f := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	s1, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := s1.Create(beads.Bead{Title: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Get(created.ID); err != nil {
+		t.Fatalf("initial Get(%q): %v", created.ID, err)
+	}
+
+	beforeLen := len(f.Files[path])
+	if err := s1.Update(created.ID, beads.UpdateOpts{Title: ptr("bravo")}); err != nil {
+		t.Fatal(err)
+	}
+	afterLen := len(f.Files[path])
+	if beforeLen != afterLen {
+		t.Fatalf("expected same-size rewrite, got %d -> %d bytes", beforeLen, afterLen)
+	}
+
+	f.Calls = nil
+	got, err := s2.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%q) after same-size update: %v", created.ID, err)
+	}
+	if got.Title != "bravo" {
+		t.Fatalf("Title after same-size update = %q, want bravo", got.Title)
+	}
+
+	var readCalls int
+	for _, call := range f.Calls {
+		if call.Method == "ReadFile" && call.Path == path {
+			readCalls++
+		}
+	}
+	if readCalls != 1 {
+		t.Fatalf("ReadFile(%s) calls = %d, want 1 after same-size rewrite", path, readCalls)
+	}
+}
+
+func TestFileStoreClearsCacheWhenBackingFileDisappears(t *testing.T) {
+	f := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	s1, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := s1.Create(beads.Bead{Title: "ephemeral"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Get(created.ID); err != nil {
+		t.Fatalf("initial Get(%q): %v", created.ID, err)
+	}
+
+	if err := f.Remove(path); err != nil {
+		t.Fatalf("Remove(%s): %v", path, err)
+	}
+
+	if _, err := s2.Get(created.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get(%q) after external delete err = %v, want ErrNotFound", created.ID, err)
+	}
+
+	got, err := s2.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen() after external delete: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ListOpen() after external delete = %+v, want empty", got)
+	}
+}
+
+func TestFileStoreDeletePersistsAcrossOpenInstances(t *testing.T) {
+	f := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	s1, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := s1.Create(beads.Bead{Title: "ephemeral"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Get(created.ID); err != nil {
+		t.Fatalf("initial Get(%q): %v", created.ID, err)
+	}
+
+	if err := s1.Delete(created.ID); err != nil {
+		t.Fatalf("Delete(%q): %v", created.ID, err)
+	}
+
+	if _, err := s2.Get(created.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get(%q) after persisted delete err = %v, want ErrNotFound", created.ID, err)
+	}
+
+	got, err := s2.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen() after persisted delete: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ListOpen() after persisted delete = %+v, want empty", got)
+	}
+}
+
 func TestFileStoreDeletePersistence(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "beads.json")
 
@@ -164,6 +430,10 @@ func TestFileStoreDeletePersistence(t *testing.T) {
 	} else if !errors.Is(err, beads.ErrNotFound) {
 		t.Fatalf("Get(%q) after reopen = %v, want ErrNotFound", b.ID, err)
 	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }
 
 func TestFileStoreChildrenExcludeClosedByDefault(t *testing.T) {

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -68,6 +68,14 @@ func (f *oneShotStatErrorFS) Stat(name string) (os.FileInfo, error) {
 	return f.FS.Stat(name)
 }
 
+type errLocker struct {
+	lockErr   error
+	unlockErr error
+}
+
+func (l errLocker) Lock() error   { return l.lockErr }
+func (l errLocker) Unlock() error { return l.unlockErr }
+
 func TestFileStore(t *testing.T) {
 	factory := func() beads.Store {
 		path := filepath.Join(t.TempDir(), "beads.json")
@@ -556,6 +564,40 @@ func TestFileStoreRefreshFallbackReloadsWhenStatFails(t *testing.T) {
 	}
 }
 
+func TestFileStoreRefreshPropagatesReloadErrorAfterExternalRewrite(t *testing.T) {
+	base := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	writer, err := beads.OpenFileStore(base, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := writer.Create(beads.Bead{Title: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readerFS := &toggledErrorFS{FS: base, path: path}
+	reader, err := beads.OpenFileStore(readerFS, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.Get(created.ID); err != nil {
+		t.Fatalf("initial Get(%q): %v", created.ID, err)
+	}
+
+	if err := writer.Update(created.ID, beads.UpdateOpts{Title: ptr("bravo")}); err != nil {
+		t.Fatalf("Update(%q): %v", created.ID, err)
+	}
+	readerFS.readErr = fmt.Errorf("read boom")
+
+	if _, err := reader.Get(created.ID); err == nil {
+		t.Fatalf("Get(%q) after external rewrite err = nil, want read boom", created.ID)
+	} else if !strings.Contains(err.Error(), "read boom") {
+		t.Fatalf("Get(%q) after external rewrite err = %v, want read boom", created.ID, err)
+	}
+}
+
 func TestFileStoreCreateRewarmsAfterFreshnessStatFailure(t *testing.T) {
 	base := fsys.NewFake()
 	path := "/city/.gc/beads.json"
@@ -896,6 +938,71 @@ func TestFileStoreDeletePersistsAcrossOpenInstances(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("ListOpen() after persisted delete = %+v, want empty", got)
+	}
+}
+
+func TestFileStoreDeletePropagatesLockError(t *testing.T) {
+	f := fsys.NewFake()
+	s, err := beads.OpenFileStore(f, "/city/.gc/beads.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetLocker(errLocker{lockErr: fmt.Errorf("lock boom")})
+
+	if err := s.Delete("gc-1"); err == nil {
+		t.Fatal("Delete(gc-1) err = nil, want lock boom")
+	} else if !strings.Contains(err.Error(), "lock boom") {
+		t.Fatalf("Delete(gc-1) err = %v, want lock boom", err)
+	}
+}
+
+func TestFileStoreDeletePropagatesMemStoreError(t *testing.T) {
+	f := fsys.NewFake()
+	s, err := beads.OpenFileStore(f, "/city/.gc/beads.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Delete("gc-404"); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Delete(gc-404) err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFileStoreDeleteRollsBackWhenSaveFails(t *testing.T) {
+	f := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	s1, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := s1.Create(beads.Bead{Title: "keep me"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Errors[path+".tmp"] = fmt.Errorf("disk full")
+
+	err = s1.Delete(created.ID)
+	if err == nil {
+		t.Fatalf("Delete(%q) err = nil, want disk full", created.ID)
+	}
+	if !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("Delete(%q) err = %v, want disk full", created.ID, err)
+	}
+
+	delete(f.Errors, path+".tmp")
+
+	if _, err := s1.Get(created.ID); err != nil {
+		t.Fatalf("Get(%q) after rollback: %v", created.ID, err)
+	}
+
+	s2, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s2.Get(created.ID); err != nil {
+		t.Fatalf("Get(%q) after reopen: %v", created.ID, err)
 	}
 }
 

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -532,6 +532,54 @@ func TestFileStoreRefreshesSameSizeExternalRewrite(t *testing.T) {
 	}
 }
 
+func TestFileStoreMutatorReloadsSameSizeExternalRewriteWithUnchangedFreshness(t *testing.T) {
+	f := fsys.NewFake()
+	path := "/city/.gc/beads.json"
+
+	stale, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := stale.Create(beads.Bead{Title: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalModTime := f.ModTimes[path]
+	originalLen := len(f.Files[path])
+
+	if err := writer.Update(created.ID, beads.UpdateOpts{Title: ptr("bravo")}); err != nil {
+		t.Fatalf("Update(%q) from second handle: %v", created.ID, err)
+	}
+	if gotLen := len(f.Files[path]); gotLen != originalLen {
+		t.Fatalf("expected same-size external rewrite, got %d -> %d bytes", originalLen, gotLen)
+	}
+	f.ModTimes[path] = originalModTime
+
+	if err := stale.SetMetadata(created.ID, "owner", "controller"); err != nil {
+		t.Fatalf("SetMetadata(%q) from stale handle: %v", created.ID, err)
+	}
+
+	fresh, err := beads.OpenFileStore(f, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := fresh.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(%q) after stale-handle mutator: %v", created.ID, err)
+	}
+	if got.Title != "bravo" {
+		t.Fatalf("Title after stale-handle mutator = %q, want bravo", got.Title)
+	}
+	if got.Metadata["owner"] != "controller" {
+		t.Fatalf("metadata[owner] after stale-handle mutator = %q, want controller", got.Metadata["owner"])
+	}
+}
+
 func TestFileStoreRefreshFallbackReloadsWhenStatFails(t *testing.T) {
 	base := fsys.NewFake()
 	path := "/city/.gc/beads.json"

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -83,9 +83,6 @@ func (f *Fake) WriteFile(name string, data []byte, perm os.FileMode) error {
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
-	if f.Files == nil {
-		f.Files = make(map[string][]byte)
-	}
 	modTime := f.nextModTime()
 	cp := make([]byte, len(data))
 	copy(cp, data)

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -11,14 +11,18 @@ import (
 
 // Fake is an in-memory [FS] for testing. It records all calls (spy) and
 // simulates filesystem state (fake). Pre-populate Dirs, Files, Symlinks,
-// and Errors before calling methods.
+// and Errors before calling methods. ModTimes is optional unless a test needs
+// exact timestamp control; Stat synthesizes and stores a mod time on demand.
 type Fake struct {
 	Dirs     map[string]bool   // pre-populated directories
 	Files    map[string][]byte // pre-populated files
 	Modes    map[string]os.FileMode
-	Symlinks map[string]string // pre-populated symlinks (path -> target)
-	Errors   map[string]error  // path → injected error (checked first)
-	Calls    []Call            // spy log
+	Symlinks map[string]string    // pre-populated symlinks (path -> target)
+	Errors   map[string]error     // path → injected error (checked first)
+	ModTimes map[string]time.Time // file path → synthetic mod time
+	Calls    []Call               // spy log
+
+	clock time.Time
 }
 
 // Call records a single method invocation on [Fake].
@@ -35,7 +39,20 @@ func NewFake() *Fake {
 		Modes:    make(map[string]os.FileMode),
 		Symlinks: make(map[string]string),
 		Errors:   make(map[string]error),
+		ModTimes: make(map[string]time.Time),
+		clock:    time.Unix(0, 0).UTC(),
 	}
+}
+
+func (f *Fake) nextModTime() time.Time {
+	if f.ModTimes == nil {
+		f.ModTimes = make(map[string]time.Time)
+	}
+	if f.clock.IsZero() {
+		f.clock = time.Unix(0, 0).UTC()
+	}
+	f.clock = f.clock.Add(time.Second)
+	return f.clock
 }
 
 // MkdirAll records the call and adds the directory (and parents) to Dirs.
@@ -66,6 +83,10 @@ func (f *Fake) WriteFile(name string, data []byte, perm os.FileMode) error {
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
+	if f.Files == nil {
+		f.Files = make(map[string][]byte)
+	}
+	modTime := f.nextModTime()
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	if f.Files == nil {
@@ -76,6 +97,7 @@ func (f *Fake) WriteFile(name string, data []byte, perm os.FileMode) error {
 	}
 	f.Files[name] = cp
 	f.Modes[name] = perm.Perm()
+	f.ModTimes[name] = modTime
 	return nil
 }
 
@@ -136,7 +158,12 @@ func (f *Fake) Stat(name string) (os.FileInfo, error) {
 			return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(target), id: fakeIdentity(target), hasID: true}, nil
 		}
 		if data, ok := f.Files[target]; ok {
-			return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(target), id: fakeIdentity(target), hasID: true}, nil
+			modTime := f.ModTimes[target]
+			if modTime.IsZero() {
+				modTime = f.nextModTime()
+				f.ModTimes[target] = modTime
+			}
+			return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(target), id: fakeIdentity(target), hasID: true, modTime: modTime}, nil
 		}
 		return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
 	}
@@ -144,7 +171,12 @@ func (f *Fake) Stat(name string) (os.FileInfo, error) {
 		return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
 	}
 	if data, ok := f.Files[name]; ok {
-		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
+		modTime := f.ModTimes[name]
+		if modTime.IsZero() {
+			modTime = f.nextModTime()
+			f.ModTimes[name] = modTime
+		}
+		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(name), id: fakeIdentity(name), hasID: true, modTime: modTime}, nil
 	}
 	return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
 }
@@ -212,6 +244,14 @@ func (f *Fake) Rename(oldpath, newpath string) error {
 	if err, ok := f.Errors[oldpath]; ok {
 		return err
 	}
+	if target, ok := f.Symlinks[oldpath]; ok {
+		if f.Symlinks == nil {
+			f.Symlinks = make(map[string]string)
+		}
+		f.Symlinks[newpath] = target
+		delete(f.Symlinks, oldpath)
+		return nil
+	}
 	if data, ok := f.Files[oldpath]; ok {
 		f.Files[newpath] = data
 		delete(f.Files, oldpath)
@@ -222,6 +262,12 @@ func (f *Fake) Rename(oldpath, newpath string) error {
 		}
 		delete(f.Modes, oldpath)
 		delete(f.Symlinks, newpath)
+		if modTime, ok := f.ModTimes[oldpath]; ok {
+			f.ModTimes[newpath] = modTime
+			delete(f.ModTimes, oldpath)
+		} else {
+			f.ModTimes[newpath] = f.nextModTime()
+		}
 		return nil
 	}
 	return &os.PathError{Op: "rename", Path: oldpath, Err: os.ErrNotExist}
@@ -233,13 +279,14 @@ func (f *Fake) Remove(name string) error {
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
+	if _, ok := f.Symlinks[name]; ok {
+		delete(f.Symlinks, name)
+		return nil
+	}
 	if _, ok := f.Files[name]; ok {
 		delete(f.Files, name)
 		delete(f.Modes, name)
-		return nil
-	}
-	if _, ok := f.Symlinks[name]; ok {
-		delete(f.Symlinks, name)
+		delete(f.ModTimes, name)
 		return nil
 	}
 	if f.Dirs[name] {
@@ -255,6 +302,9 @@ func (f *Fake) Chmod(name string, mode os.FileMode) error {
 	f.Calls = append(f.Calls, Call{Method: "Chmod", Path: name})
 	if err, ok := f.Errors[name]; ok {
 		return err
+	}
+	if _, ok := f.Symlinks[name]; ok {
+		return nil
 	}
 	if f.Modes == nil {
 		f.Modes = make(map[string]os.FileMode)
@@ -286,6 +336,7 @@ type fakeFileInfo struct {
 	id      fileIdentity
 	hasID   bool
 	dir     bool
+	modTime time.Time
 	symlink bool
 }
 
@@ -300,7 +351,7 @@ func (fi fakeFileInfo) Mode() os.FileMode {
 	}
 	return fi.mode
 }
-func (fi fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fi fakeFileInfo) ModTime() time.Time { return fi.modTime }
 func (fi fakeFileInfo) IsDir() bool        { return fi.dir }
 func (fi fakeFileInfo) Sys() any {
 	if !fi.hasID {

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -245,9 +245,6 @@ func (f *Fake) Rename(oldpath, newpath string) error {
 		return err
 	}
 	if target, ok := f.Symlinks[oldpath]; ok {
-		if f.Symlinks == nil {
-			f.Symlinks = make(map[string]string)
-		}
 		f.Symlinks[newpath] = target
 		delete(f.Symlinks, oldpath)
 		return nil

--- a/internal/fsys/fake_test.go
+++ b/internal/fsys/fake_test.go
@@ -87,6 +87,59 @@ func TestFakeStatSynthesizesModTimeForPrepopulatedFile(t *testing.T) {
 	}
 }
 
+func TestFakeStatFollowsSymlinkTargets(t *testing.T) {
+	t.Run("file", func(t *testing.T) {
+		f := NewFake()
+		f.Files["/city/target.toml"] = []byte("hello")
+		f.Symlinks["/city/link.toml"] = "/city/target.toml"
+
+		fi, err := f.Stat("/city/link.toml")
+		if err != nil {
+			t.Fatalf("Stat symlink to file: %v", err)
+		}
+		if fi.Name() != "link.toml" {
+			t.Fatalf("Name() = %q, want link.toml", fi.Name())
+		}
+		if fi.Size() != 5 {
+			t.Fatalf("Size() = %d, want 5", fi.Size())
+		}
+		wantModTime := f.ModTimes["/city/target.toml"]
+		if wantModTime.IsZero() {
+			t.Fatal("expected Stat to synthesize and store target mod time")
+		}
+		if !fi.ModTime().Equal(wantModTime) {
+			t.Fatalf("ModTime() = %v, want %v", fi.ModTime(), wantModTime)
+		}
+	})
+
+	t.Run("dir", func(t *testing.T) {
+		f := NewFake()
+		f.Dirs["/city/rigs"] = true
+		f.Symlinks["/city/rig-link"] = "/city/rigs"
+
+		fi, err := f.Stat("/city/rig-link")
+		if err != nil {
+			t.Fatalf("Stat symlink to dir: %v", err)
+		}
+		if !fi.IsDir() {
+			t.Fatal("expected symlink to dir to report directory")
+		}
+	})
+
+	t.Run("missing target", func(t *testing.T) {
+		f := NewFake()
+		f.Symlinks["/city/missing-link"] = "/city/missing"
+
+		_, err := f.Stat("/city/missing-link")
+		if err == nil {
+			t.Fatal("expected error for missing symlink target")
+		}
+		if !os.IsNotExist(err) {
+			t.Fatalf("expected os.IsNotExist, got %v", err)
+		}
+	})
+}
+
 func TestFakeStatMissing(t *testing.T) {
 	f := NewFake()
 
@@ -338,6 +391,33 @@ func TestFakeChmodInitializesModes(t *testing.T) {
 	}
 }
 
+func TestFakeRenameSymlink(t *testing.T) {
+	f := NewFake()
+	f.Symlinks["/city/beads-link"] = "/city/beads.json"
+
+	if err := f.Rename("/city/beads-link", "/city/beads-renamed"); err != nil {
+		t.Fatalf("Rename symlink: %v", err)
+	}
+	if _, ok := f.Symlinks["/city/beads-link"]; ok {
+		t.Fatal("old symlink path still exists after Rename")
+	}
+	if got := f.Symlinks["/city/beads-renamed"]; got != "/city/beads.json" {
+		t.Fatalf("renamed symlink target = %q, want /city/beads.json", got)
+	}
+}
+
+func TestFakeRenameSynthesizesModTimeWhenMissing(t *testing.T) {
+	f := NewFake()
+	f.Files["/city/beads.json.tmp"] = []byte(`{"seq":1}`)
+
+	if err := f.Rename("/city/beads.json.tmp", "/city/beads.json"); err != nil {
+		t.Fatalf("Rename without source modtime: %v", err)
+	}
+	if f.ModTimes["/city/beads.json"].IsZero() {
+		t.Fatal("expected Rename to synthesize a mod time when source mod time is missing")
+	}
+}
+
 func TestFakeRenameError(t *testing.T) {
 	f := NewFake()
 	injected := fmt.Errorf("cross-device link")
@@ -358,5 +438,69 @@ func TestFakeRenameMissing(t *testing.T) {
 	}
 	if !os.IsNotExist(err) {
 		t.Errorf("expected os.IsNotExist, got: %v", err)
+	}
+}
+
+func TestFakeRemoveVariants(t *testing.T) {
+	t.Run("file removes modtime", func(t *testing.T) {
+		f := NewFake()
+		if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		if err := f.Remove("/city/city.toml"); err != nil {
+			t.Fatalf("Remove file: %v", err)
+		}
+		if _, ok := f.Files["/city/city.toml"]; ok {
+			t.Fatal("file still exists after Remove")
+		}
+		if _, ok := f.ModTimes["/city/city.toml"]; ok {
+			t.Fatal("mod time still exists after Remove")
+		}
+	})
+
+	t.Run("dir", func(t *testing.T) {
+		f := NewFake()
+		f.Dirs["/city/.gc"] = true
+
+		if err := f.Remove("/city/.gc"); err != nil {
+			t.Fatalf("Remove dir: %v", err)
+		}
+		if f.Dirs["/city/.gc"] {
+			t.Fatal("dir still exists after Remove")
+		}
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		f := NewFake()
+		f.Symlinks["/city/link"] = "/city/target"
+
+		if err := f.Remove("/city/link"); err != nil {
+			t.Fatalf("Remove symlink: %v", err)
+		}
+		if _, ok := f.Symlinks["/city/link"]; ok {
+			t.Fatal("symlink still exists after Remove")
+		}
+	})
+}
+
+func TestFakeChmodVariants(t *testing.T) {
+	f := NewFake()
+	if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	f.Dirs["/city/.gc"] = true
+	f.Symlinks["/city/link"] = "/city/city.toml"
+
+	for _, path := range []string{"/city/city.toml", "/city/.gc", "/city/link"} {
+		if err := f.Chmod(path, 0o600); err != nil {
+			t.Fatalf("Chmod(%s): %v", path, err)
+		}
+	}
+
+	if err := f.Chmod("/city/missing", 0o600); err == nil {
+		t.Fatal("expected error for missing path")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("expected os.IsNotExist, got %v", err)
 	}
 }

--- a/internal/fsys/fake_test.go
+++ b/internal/fsys/fake_test.go
@@ -41,7 +41,9 @@ func TestFakeStatDirModeIncludesDirBit(t *testing.T) {
 
 func TestFakeStatFile(t *testing.T) {
 	f := NewFake()
-	f.Files["/city/city.toml"] = []byte("hello")
+	if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	fi, err := f.Stat("/city/city.toml")
 	if err != nil {
@@ -52,6 +54,36 @@ func TestFakeStatFile(t *testing.T) {
 	}
 	if fi.Size() != 5 {
 		t.Errorf("Size() = %d, want 5", fi.Size())
+	}
+	if fi.ModTime().IsZero() {
+		t.Error("expected synthetic mod time for written file")
+	}
+}
+
+func TestFakeStatSynthesizesModTimeForPrepopulatedFile(t *testing.T) {
+	f := &Fake{
+		Files: map[string][]byte{
+			"/city/city.toml": []byte("hello"),
+		},
+	}
+
+	fi, err := f.Stat("/city/city.toml")
+	if err != nil {
+		t.Fatalf("Stat existing file: %v", err)
+	}
+	if fi.ModTime().IsZero() {
+		t.Fatal("expected synthetic mod time for prepopulated file")
+	}
+	if got := f.ModTimes["/city/city.toml"]; !got.Equal(fi.ModTime()) {
+		t.Fatalf("stored mod time = %v, want %v", got, fi.ModTime())
+	}
+
+	fi2, err := f.Stat("/city/city.toml")
+	if err != nil {
+		t.Fatalf("second Stat existing file: %v", err)
+	}
+	if !fi2.ModTime().Equal(fi.ModTime()) {
+		t.Fatalf("second Stat mod time = %v, want %v", fi2.ModTime(), fi.ModTime())
 	}
 }
 
@@ -127,6 +159,24 @@ func TestFakeWriteFile(t *testing.T) {
 
 	if len(f.Calls) != 1 || f.Calls[0].Method != "WriteFile" {
 		t.Errorf("Calls = %+v, want single WriteFile", f.Calls)
+	}
+	if f.ModTimes["/city/city.toml"].IsZero() {
+		t.Error("expected WriteFile to set a synthetic mod time")
+	}
+}
+
+func TestFakeWriteFileInitializesNilMaps(t *testing.T) {
+	f := &Fake{}
+
+	if err := f.WriteFile("/city/city.toml", []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := string(f.Files["/city/city.toml"]); got != "hello" {
+		t.Fatalf("Files content = %q, want %q", got, "hello")
+	}
+	if f.ModTimes["/city/city.toml"].IsZero() {
+		t.Fatal("expected WriteFile to initialize synthetic mod time")
 	}
 }
 
@@ -233,7 +283,10 @@ func TestFakeReadDirEmpty(t *testing.T) {
 
 func TestFakeRename(t *testing.T) {
 	f := NewFake()
-	f.Files["/city/beads.json.tmp"] = []byte(`{"seq":1}`)
+	if err := f.WriteFile("/city/beads.json.tmp", []byte(`{"seq":1}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	oldModTime := f.ModTimes["/city/beads.json.tmp"]
 
 	if err := f.Rename("/city/beads.json.tmp", "/city/beads.json"); err != nil {
 		t.Fatalf("Rename: %v", err)
@@ -246,9 +299,12 @@ func TestFakeRename(t *testing.T) {
 	if string(f.Files["/city/beads.json"]) != `{"seq":1}` {
 		t.Errorf("new path content = %q, want %q", f.Files["/city/beads.json"], `{"seq":1}`)
 	}
+	if got := f.ModTimes["/city/beads.json"]; !got.Equal(oldModTime) {
+		t.Errorf("renamed file mod time = %v, want %v", got, oldModTime)
+	}
 
-	if len(f.Calls) != 1 || f.Calls[0].Method != "Rename" {
-		t.Errorf("Calls = %+v, want single Rename", f.Calls)
+	if len(f.Calls) != 2 || f.Calls[1].Method != "Rename" {
+		t.Errorf("Calls = %+v, want WriteFile then Rename", f.Calls)
 	}
 }
 


### PR DESCRIPTION
## Compared with main
- add freshness tracking to `internal/beads.FileStore` using file size and mod time so long-lived handles notice when another handle rewrites or deletes the backing store
- refresh read APIs and mutators against disk before serving cached state, while still avoiding a full JSON reload when the file metadata is unchanged
- extend `internal/fsys.Fake` so freshness tests can model synthetic mod times, symlink-aware rename/remove/chmod behavior, and cross-instance rewrites accurately

## Codecov follow-up
- add targeted regression coverage for refresh fallback when `Stat` fails, read-wrapper error propagation, mutator error propagation, and `CloseAll` across multiple open file stores
- add fake-fs regression coverage for symlink stat/rename behavior and synthesized mod times used by the freshness path
- drop one unreachable symlink-rename setup branch in `internal/fsys/fake.go`; the follow-up commit is otherwise test-focused and keeps runtime behavior unchanged

## Validation
- `go test ./internal/beads`
- `go test ./internal/fsys`
- `go vet ./...`