### PR TITLE
feat: complete session/rig/order args dynamically

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -84,8 +84,10 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to disambiguate same-name orders")
+	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigNames)
 	return cmd
 }
 
@@ -107,8 +109,10 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to disambiguate same-name orders")
+	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigNames)
 	return cmd
 }
 
@@ -150,8 +154,10 @@ name. Use --rig to filter by rig.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to filter order history")
+	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigNames)
 	return cmd
 }
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -87,7 +87,7 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to disambiguate same-name orders")
-	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigNames)
+	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	return cmd
 }
 
@@ -112,7 +112,7 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to disambiguate same-name orders")
-	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigNames)
+	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	return cmd
 }
 
@@ -157,7 +157,7 @@ name. Use --rig to filter by rig.`,
 		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to filter order history")
-	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigNames)
+	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	return cmd
 }
 

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -76,6 +76,7 @@ quick way to force-refresh all agents working on a particular project.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeRigNames,
 	}
 }
 

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -763,6 +763,7 @@ database remains accessible. Use "gc rig resume" to restore.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeRigNames,
 	}
 }
 
@@ -843,6 +844,7 @@ The reconciler will start the rig's agents on its next tick.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeRigNames,
 	}
 }
 
@@ -925,6 +927,7 @@ binding from .gc/site.toml.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeRigNames,
 	}
 }
 

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -57,6 +57,7 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeRigNames,
 	}
 	cmd.Flags().BoolVar(&opts.Inherit, "inherit", false, "inherit the city endpoint")
 	cmd.Flags().BoolVar(&opts.External, "external", false, "set an explicit external endpoint for the rig")

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -96,6 +96,7 @@ according to the selected semantic intent.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().StringVar(&intent, "intent", string(session.SubmitIntentDefault), "submit intent: default, follow_up, or interrupt_now")
 	return cmd
@@ -955,6 +956,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 
@@ -1115,6 +1117,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 
@@ -1195,6 +1198,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 
@@ -1253,6 +1257,7 @@ func newSessionRenameCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 
@@ -1394,6 +1399,7 @@ func newSessionPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().IntVar(&lines, "lines", 50, "number of lines to capture")
 	return cmd
@@ -1456,6 +1462,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 
@@ -1529,6 +1536,7 @@ joined automatically.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().StringVar(&delivery, "delivery", string(nudgeDeliveryWaitIdle), "delivery mode: immediate, wait-idle, or queue")
 	return cmd

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -53,6 +53,7 @@ Use -f to follow new messages as they arrive.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow new messages as they arrive")
 	cmd.Flags().IntVar(&tail, "tail", 10, "Number of most recent transcript entries to show (0 = all; compact dividers count as entries)")

--- a/cmd/gc/cmd_session_pin.go
+++ b/cmd/gc/cmd_session_pin.go
@@ -25,6 +25,7 @@ canonical bead so the reconciler can start it when unblocked.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 
@@ -43,6 +44,7 @@ normal wake/sleep rules on its next pass.`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -27,6 +27,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -33,6 +33,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 }
 

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -26,6 +26,7 @@ func newRigStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: completeRigNames,
 	}
 }
 

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -62,6 +62,7 @@ func newSessionWaitCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().StringSliceVar(&depIDs, "on-beads", nil, "bead IDs to watch")
 	cmd.Flags().BoolVar(&matchAny, "any", false, "wake when any watched bead closes (default: all)")

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -49,16 +50,20 @@ func completeRigNames(_ *cobra.Command, args []string, toComplete string) ([]str
 	return rigNameCandidates(toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
+// completeRigFlagNames completes rig names for --rig flags. Flag completion
+// must ignore existing positional args; a user often completes --rig after
+// typing the command's required positional.
+func completeRigFlagNames(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return rigNameCandidates(toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
 // completeOrderNames completes order names for commands whose first
 // positional is an order name.
 func completeOrderNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	var aa []orders.Order
-	quietDefaultLogger(func() {
-		aa, _ = loadOrders(io.Discard, "gc completion")
-	})
+	aa := loadOrdersForCompletion()
 	candidates := make([]string, 0, len(aa))
 	for _, o := range aa {
 		if !strings.HasPrefix(o.Name, toComplete) {
@@ -72,7 +77,9 @@ func completeOrderNames(_ *cobra.Command, args []string, toComplete string) ([]s
 // quietDefaultLogger runs fn with the default log.Logger's output redirected
 // to io.Discard, then restores it. Needed because some internal paths (e.g.,
 // orders discovery) write migration warnings via log.Printf, which would
-// corrupt the terminal during tab completion.
+// corrupt the terminal during tab completion. This helper is intended only for
+// one-shot completion paths; it is not safe against concurrent log writer
+// mutation.
 func quietDefaultLogger(fn func()) {
 	orig := log.Default().Writer()
 	log.SetOutput(io.Discard)
@@ -80,66 +87,150 @@ func quietDefaultLogger(fn func()) {
 	fn()
 }
 
-// rigNameCandidates returns rig names (with path descriptions) as cobra
-// completion entries. Extracted so that both the positional-arg completer
-// and the --rig flag completer can share it.
+// rigNameCandidates returns rig names with path descriptions as cobra
+// completion entries.
 func rigNameCandidates(toComplete string) []string {
-	cityPath, err := resolveCity()
-	if err != nil {
-		return nil
-	}
-	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), io.Discard)
-	if err != nil {
-		return nil
-	}
-	resolveRigPaths(cityPath, cfg.Rigs)
-	candidates := make([]string, 0, len(cfg.Rigs)+1)
-	// HQ rig first.
-	cityName := cfg.EffectiveCityName()
-	if strings.HasPrefix(cityName, toComplete) {
-		candidates = append(candidates, cityName+"\tHQ — "+cityPath)
-	}
-	for i := range cfg.Rigs {
-		name := cfg.Rigs[i].Name
-		if !strings.HasPrefix(name, toComplete) {
-			continue
+	var candidates []string
+	quietDefaultLogger(func() {
+		cityPath, err := resolveCityForCompletionContext(false)
+		if err != nil {
+			return
 		}
-		desc := cfg.Rigs[i].Path
-		if cfg.Rigs[i].Suspended {
-			desc += " (suspended)"
+		cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), io.Discard)
+		if err != nil {
+			return
 		}
-		candidates = append(candidates, name+"\t"+desc)
-	}
+		resolveRigPaths(cityPath, cfg.Rigs)
+		candidates = make([]string, 0, len(cfg.Rigs))
+		for i := range cfg.Rigs {
+			name := cfg.Rigs[i].Name
+			if !strings.HasPrefix(name, toComplete) {
+				continue
+			}
+			desc := cfg.Rigs[i].Path
+			if cfg.Rigs[i].Suspended {
+				desc += " (suspended)"
+			}
+			candidates = append(candidates, name+"\t"+desc)
+		}
+	})
 	return candidates
+}
+
+func resolveCityForCompletion() (string, error) {
+	return resolveCityForCompletionContext(true)
+}
+
+func resolveCityForCompletionContext(honorRigFlag bool) (string, error) {
+	if city := strings.TrimSpace(cityFlag); city != "" {
+		return validateCityPath(city)
+	}
+	if honorRigFlag {
+		if rig := strings.TrimSpace(rigFlag); rig != "" {
+			ctx, err := resolveRigForCompletion(rig)
+			if err != nil {
+				return "", err
+			}
+			return ctx.CityPath, nil
+		}
+	}
+	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
+		return cityPath, nil
+	}
+	if cityPath, ok := resolveCityPathFromGCDir(); ok {
+		return cityPath, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	if ctx, ok := lookupRigFromCwd(cwd); ok {
+		return ctx.CityPath, nil
+	}
+	return findCity(cwd)
+}
+
+func resolveRigForCompletion(nameOrPath string) (resolvedContext, error) {
+	matches, _, err := registeredRigBindingsByName(nameOrPath, false)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	if len(matches) > 0 {
+		return resolveRigBindingMatches(nameOrPath, matches)
+	}
+
+	abs, err := filepath.Abs(nameOrPath)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	matches, _, err = registeredRigBindingsByPath(abs, false)
+	if err != nil {
+		return resolvedContext{}, err
+	}
+	if len(matches) > 0 {
+		return resolveRigBindingMatches(abs, matches)
+	}
+	return resolvedContext{}, os.ErrNotExist
+}
+
+func loadOrdersForCompletion() []orders.Order {
+	var aa []orders.Order
+	quietDefaultLogger(func() {
+		cityPath, err := resolveCityForCompletion()
+		if err != nil {
+			return
+		}
+		cfg, err := loadCityConfig(cityPath, io.Discard)
+		if err != nil {
+			return
+		}
+		var code int
+		aa, code = loadAllOrders(cityPath, cfg, io.Discard, "gc completion")
+		if code != 0 {
+			aa = nil
+		}
+	})
+	return aa
 }
 
 // loadSessionsForCompletion returns session info without triggering the
 // slow live-state and attachment checks performed by the non-JSON path of
 // `gc session list`. This mirrors the JSON-path of cmdSessionList.
 func loadSessionsForCompletion() []session.Info {
-	cityPath, err := resolveCity()
-	if err != nil {
-		return nil
-	}
-	store, err := openCityStoreAt(cityPath)
-	if err != nil {
-		return nil
-	}
-	providerCtx := loadSessionProviderContext()
-	allSessionBeads, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-		Sort:  beads.SortCreatedDesc,
+	var sessions []session.Info
+	quietDefaultLogger(func() {
+		cityPath, err := resolveCityForCompletion()
+		if err != nil {
+			return
+		}
+		store, err := openCityStoreAt(cityPath)
+		if err != nil {
+			return
+		}
+		cfg, err := loadCityConfig(cityPath, io.Discard)
+		if err != nil {
+			return
+		}
+		providerCtx := sessionProviderContextForCity(cfg, cityPath, os.Getenv("GC_SESSION"))
+		allSessionBeads, err := store.List(beads.ListQuery{
+			Label: session.LabelSession,
+			Sort:  beads.SortCreatedDesc,
+		})
+		if err != nil {
+			return
+		}
+		sessionBeads := newSessionBeadSnapshot(allSessionBeads)
+		sp, err := newSessionProviderFromContextWithError(providerCtx, sessionBeads)
+		if err != nil {
+			return
+		}
+		catalog, err := workerSessionCatalogWithConfig("", store, sp, providerCtx.cfg)
+		if err != nil {
+			return
+		}
+		sessions = catalog.ListFullFromBeads(allSessionBeads, "", "").Sessions
 	})
-	if err != nil {
-		return nil
-	}
-	sessionBeads := newSessionBeadSnapshot(allSessionBeads)
-	sp := newSessionProviderFromContext(providerCtx, sessionBeads)
-	catalog, err := workerSessionCatalogWithConfig("", store, sp, providerCtx.cfg)
-	if err != nil {
-		return nil
-	}
-	return catalog.ListFullFromBeads(allSessionBeads, "", "").Sessions
+	return sessions
 }
 
 // sessionCompletionDescription formats a session as "alias (state)" or
@@ -176,6 +267,9 @@ func orderCompletionDescription(o orders.Order) string {
 	}
 	if timing == "" {
 		timing = "-"
+	}
+	if o.Rig != "" {
+		return typ + ", " + timing + " (rig: " + o.Rig + ")"
 	}
 	return typ + ", " + timing
 }

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"io"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/spf13/cobra"
+)
+
+// Tab completion is load-bearing: these functions are called on every
+// keystroke after <TAB>. They must be fast and never write to the terminal,
+// since any stderr output would appear as garbage under the user's prompt.
+// All errors are swallowed; a failed completion returns an empty candidate
+// list with ShellCompDirectiveNoFileComp so the shell doesn't fall back to
+// filename completion.
+
+// completeSessionIDs completes session IDs and aliases for commands whose
+// first positional argument is a session ID-or-alias.
+func completeSessionIDs(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	sessions := loadSessionsForCompletion()
+	candidates := make([]string, 0, len(sessions)*2)
+	for _, s := range sessions {
+		desc := sessionCompletionDescription(s)
+		if strings.HasPrefix(s.ID, toComplete) {
+			candidates = append(candidates, s.ID+"\t"+desc)
+		}
+		if s.Alias != "" && s.Alias != s.ID && strings.HasPrefix(s.Alias, toComplete) {
+			candidates = append(candidates, s.Alias+"\t"+desc)
+		}
+	}
+	return candidates, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeRigNames completes rig names for commands whose first positional
+// is a rig name.
+func completeRigNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return rigNameCandidates(toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeOrderNames completes order names for commands whose first
+// positional is an order name.
+func completeOrderNames(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var aa []orders.Order
+	quietDefaultLogger(func() {
+		aa, _ = loadOrders(io.Discard, "gc completion")
+	})
+	candidates := make([]string, 0, len(aa))
+	for _, o := range aa {
+		if !strings.HasPrefix(o.Name, toComplete) {
+			continue
+		}
+		candidates = append(candidates, o.Name+"\t"+orderCompletionDescription(o))
+	}
+	return candidates, cobra.ShellCompDirectiveNoFileComp
+}
+
+// quietDefaultLogger runs fn with the default log.Logger's output redirected
+// to io.Discard, then restores it. Needed because some internal paths (e.g.,
+// orders discovery) write migration warnings via log.Printf, which would
+// corrupt the terminal during tab completion.
+func quietDefaultLogger(fn func()) {
+	orig := log.Default().Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(orig)
+	fn()
+}
+
+// rigNameCandidates returns rig names (with path descriptions) as cobra
+// completion entries. Extracted so that both the positional-arg completer
+// and the --rig flag completer can share it.
+func rigNameCandidates(toComplete string) []string {
+	cityPath, err := resolveCity()
+	if err != nil {
+		return nil
+	}
+	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), io.Discard)
+	if err != nil {
+		return nil
+	}
+	resolveRigPaths(cityPath, cfg.Rigs)
+	candidates := make([]string, 0, len(cfg.Rigs)+1)
+	// HQ rig first.
+	cityName := cfg.EffectiveCityName()
+	if strings.HasPrefix(cityName, toComplete) {
+		candidates = append(candidates, cityName+"\tHQ — "+cityPath)
+	}
+	for i := range cfg.Rigs {
+		name := cfg.Rigs[i].Name
+		if !strings.HasPrefix(name, toComplete) {
+			continue
+		}
+		desc := cfg.Rigs[i].Path
+		if cfg.Rigs[i].Suspended {
+			desc += " (suspended)"
+		}
+		candidates = append(candidates, name+"\t"+desc)
+	}
+	return candidates
+}
+
+// loadSessionsForCompletion returns session info without triggering the
+// slow live-state and attachment checks performed by the non-JSON path of
+// `gc session list`. This mirrors the JSON-path of cmdSessionList.
+func loadSessionsForCompletion() []session.Info {
+	cityPath, err := resolveCity()
+	if err != nil {
+		return nil
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		return nil
+	}
+	providerCtx := loadSessionProviderContext()
+	allSessionBeads, err := store.List(beads.ListQuery{
+		Label: session.LabelSession,
+		Sort:  beads.SortCreatedDesc,
+	})
+	if err != nil {
+		return nil
+	}
+	sessionBeads := newSessionBeadSnapshot(allSessionBeads)
+	sp := newSessionProviderFromContext(providerCtx, sessionBeads)
+	catalog, err := workerSessionCatalogWithConfig("", store, sp, providerCtx.cfg)
+	if err != nil {
+		return nil
+	}
+	return catalog.ListFullFromBeads(allSessionBeads, "", "").Sessions
+}
+
+// sessionCompletionDescription formats a session as "alias (state)" or
+// "template (state)" when no alias is set. Title is omitted to keep the
+// zsh completion menu scannable.
+func sessionCompletionDescription(s session.Info) string {
+	target := s.Alias
+	if target == "" {
+		target = s.Template
+	}
+	if target == "" {
+		target = "-"
+	}
+	state := string(s.State)
+	if state == "" {
+		state = "closed"
+	}
+	return target + " (" + state + ")"
+}
+
+// orderCompletionDescription formats an order as "<type>, <timing>" where
+// type is "formula" or "exec" and timing is interval/schedule/event.
+func orderCompletionDescription(o orders.Order) string {
+	typ := "formula"
+	if o.IsExec() {
+		typ = "exec"
+	}
+	timing := o.Interval
+	if timing == "" {
+		timing = o.Schedule
+	}
+	if timing == "" {
+		timing = o.On
+	}
+	if timing == "" {
+		timing = "-"
+	}
+	return typ + ", " + timing
+}

--- a/cmd/gc/completion_test.go
+++ b/cmd/gc/completion_test.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -76,6 +80,7 @@ func TestOrderCompletionDescription(t *testing.T) {
 		{"formula + interval", orders.Order{Formula: "f", Interval: "5m"}, "formula, 5m"},
 		{"exec + schedule", orders.Order{Exec: "s", Schedule: "0 0 * * *"}, "exec, 0 0 * * *"},
 		{"formula + event", orders.Order{Formula: "f", On: "bead.closed"}, "formula, bead.closed"},
+		{"rig scoped", orders.Order{Formula: "f", Interval: "5m", Rig: "frontend"}, "formula, 5m (rig: frontend)"},
 		{"no timing", orders.Order{Formula: "f"}, "formula, -"},
 	}
 	for _, tc := range cases {
@@ -92,9 +97,11 @@ func TestQuietDefaultLogger_RestoresOutput(t *testing.T) {
 	// The default logger's writer must be restored after fn returns, even if
 	// fn panics or writes to it — otherwise a single noisy completion call
 	// would leave the logger silenced for the rest of the process.
+	origWriter := log.Default().Writer()
+	t.Cleanup(func() { log.SetOutput(origWriter) })
+
 	var before bytes.Buffer
 	log.SetOutput(&before)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
 
 	quietDefaultLogger(func() {
 		log.Print("silenced")
@@ -109,32 +116,58 @@ func TestQuietDefaultLogger_RestoresOutput(t *testing.T) {
 	}
 }
 
+func TestResolveCityForCompletion_UsesExplicitRigBindingOutsideCity(t *testing.T) {
+	gcHome := t.TempDir()
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(cityPath, "rigs", "frontend")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", gcHome)
+	registerRigBindingForResolution(t, gcHome, cityPath, "completion-city", "frontend", rigDir)
+
+	isolateCompletionContext(t, "")
+	rigFlag = "frontend"
+	t.Chdir(t.TempDir())
+
+	got, err := resolveCityForCompletion()
+	if err != nil {
+		t.Fatalf("resolveCityForCompletion: %v", err)
+	}
+	if !samePath(got, cityPath) {
+		t.Fatalf("city path = %q, want %q", got, cityPath)
+	}
+}
+
 func TestRigNameCandidates_LoadsAndFilters(t *testing.T) {
 	// Integration check for the rig source-of-truth — exercises resolveCity
 	// (via t.Chdir into a temp city), loadCityConfigFS, and the prefix filter.
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	cityToml := "[workspace]\nname = \"my-city\"\n\n[[rigs]]\nname = \"alpha\"\npath = \"/tmp/alpha\"\n\n[[rigs]]\nname = \"beta\"\npath = \"/tmp/beta\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeCompletionCity(t, cityPath, cityToml)
+	isolateCompletionContext(t, "")
 	t.Chdir(cityPath)
+	t.Setenv("GC_RIG", "ambient-rig-from-agent-session")
+	t.Setenv("GC_RIG_ROOT", "/does/not/matter")
 
 	got := rigNameCandidates("")
-	// HQ + 2 rigs = 3 candidates.
-	if len(got) != 3 {
-		t.Fatalf("expected 3 candidates (HQ + 2 rigs), got %d: %v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rig candidates, got %d: %v", len(got), got)
 	}
 	names := make([]string, len(got))
 	for i, c := range got {
 		names[i] = strings.SplitN(c, "\t", 2)[0]
 	}
-	for _, want := range []string{"my-city", "alpha", "beta"} {
+	for _, want := range []string{"alpha", "beta"} {
 		if !slicesContains(names, want) {
 			t.Errorf("missing candidate %q in %v", want, names)
 		}
+	}
+	if slicesContains(names, "my-city") {
+		t.Errorf("synthetic HQ candidate should not be offered for rig arguments: %v", names)
 	}
 
 	// Prefix filter.
@@ -142,6 +175,280 @@ func TestRigNameCandidates_LoadsAndFilters(t *testing.T) {
 	if len(got) != 1 || !strings.HasPrefix(got[0], "alpha\t") {
 		t.Errorf("expected only alpha candidate for prefix 'al', got %v", got)
 	}
+}
+
+func TestCompleteRigFlagNames_IgnoresPositionalArgs(t *testing.T) {
+	cityPath := t.TempDir()
+	writeCompletionCity(t, cityPath, "[workspace]\nname = \"my-city\"\n\n[[rigs]]\nname = \"alpha\"\npath = \"/tmp/alpha\"\n\n[[rigs]]\nname = \"beta\"\npath = \"/tmp/beta\"\n")
+	isolateCompletionContext(t, cityPath)
+
+	for _, cmd := range []*cobra.Command{
+		newOrderShowCmd(os.Stdout, os.Stderr),
+		newOrderRunCmd(os.Stdout, os.Stderr),
+	} {
+		complete, ok := cmd.GetFlagCompletionFunc("rig")
+		if !ok {
+			t.Fatalf("%s missing --rig completion function", cmd.Name())
+		}
+		got, dir := complete(cmd, []string{"existing-order"}, "a")
+		if dir != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("%s --rig directive = %v, want NoFileComp", cmd.Name(), dir)
+		}
+		if len(got) != 1 || !strings.HasPrefix(got[0], "alpha\t") {
+			t.Errorf("%s --rig completion with positional args = %v, want alpha", cmd.Name(), got)
+		}
+	}
+}
+
+func TestCompleteOrderNames_LoadsOrders(t *testing.T) {
+	cityPath := t.TempDir()
+	writeCompletionCity(t, cityPath, "[workspace]\nname = \"orders-city\"\n")
+	isolateCompletionContext(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, "orders"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "orders", "digest.toml"), []byte(`
+[order]
+formula = "mol-digest"
+trigger = "cron"
+schedule = "*/5 * * * *"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, dir := completeOrderNames(nil, nil, "di")
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", dir)
+	}
+	if len(got) != 1 || got[0] != "digest\tformula, */5 * * * *" {
+		t.Fatalf("order candidates = %v, want digest with cron description", got)
+	}
+}
+
+func TestCompleteOrderNames_SuppressesConfigPackWarnings(t *testing.T) {
+	cityPath := t.TempDir()
+	writeCompletionCity(t, cityPath, `[workspace]
+name = "orders-city"
+includes = ["packs/missing"]
+`)
+	isolateCompletionContext(t, cityPath)
+
+	origWriter := log.Default().Writer()
+	t.Cleanup(func() { log.SetOutput(origWriter) })
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+
+	_, dir := completeOrderNames(nil, nil, "")
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", dir)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("completion wrote default logger output: %q", logs.String())
+	}
+}
+
+func TestCompleteSessionIDs_LoadsBeadBackedSessions(t *testing.T) {
+	cityPath := t.TempDir()
+	writeCompletionCity(t, cityPath, `[workspace]
+name = "sessions-city"
+
+[session]
+provider = "fake"
+
+[beads]
+provider = "file"
+`)
+	isolateCompletionContext(t, cityPath)
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityPath, err)
+	}
+	created, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "sessions-city--worker",
+			"state":        "asleep",
+			"template":     "codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session): %v", err)
+	}
+
+	got, dir := completeSessionIDs(nil, nil, "")
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", dir)
+	}
+	names := completionCandidateNames(got)
+	if !slicesContains(names, created.ID) {
+		t.Errorf("session ID candidate %q missing from %v", created.ID, got)
+	}
+	if !slicesContains(names, "worker") {
+		t.Errorf("session alias candidate missing from %v", got)
+	}
+	if !slicesContains(got, "worker\tworker (asleep)") {
+		t.Errorf("session alias description missing from %v", got)
+	}
+}
+
+func TestLoadSessionsForCompletion_SwallowsProviderConstructionError(t *testing.T) {
+	cityPath := t.TempDir()
+	writeCompletionCity(t, cityPath, `[workspace]
+name = "sessions-city"
+
+[session]
+provider = "fake"
+
+[beads]
+provider = "file"
+
+[providers.opencode]
+command = "/bin/echo"
+path_check = "true"
+supports_acp = true
+acp_command = "/bin/echo"
+
+[[agent]]
+name = "worker"
+provider = "opencode"
+session = "acp"
+`)
+	isolateCompletionContext(t, cityPath)
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityPath, err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	}); err != nil {
+		t.Fatalf("store.Create(session): %v", err)
+	}
+	oldBuild := buildSessionProviderByName
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+		if name == "acp" {
+			return nil, errors.New("provider unavailable")
+		}
+		return oldBuild(name, sc, cityName, cityPath)
+	}
+
+	got := loadSessionsForCompletion()
+	if len(got) != 0 {
+		t.Fatalf("sessions = %v, want none after provider construction failure", got)
+	}
+}
+
+func TestCompleteOrderNames_DistinguishesSameNameRigOrders(t *testing.T) {
+	cityPath := t.TempDir()
+	sidecarPackDir := filepath.Join(cityPath, "packs", "sidecar")
+	for _, dir := range []string{
+		filepath.Join(cityPath, ".gc"),
+		filepath.Join(cityPath, "rigs", "frontend"),
+		filepath.Join(cityPath, "rigs", "backend"),
+		filepath.Join(sidecarPackDir, "formulas"),
+		filepath.Join(sidecarPackDir, "orders"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(cityPath, "pack.toml"), `
+[pack]
+name = "orders-city"
+schema = 2
+`)
+	writeFile(t, filepath.Join(cityPath, "city.toml"), `
+[workspace]
+name = "orders-city"
+
+[[rigs]]
+name = "frontend"
+path = "rigs/frontend"
+
+[rigs.imports.sidecar]
+source = "./packs/sidecar"
+
+[[rigs]]
+name = "backend"
+path = "rigs/backend"
+
+[rigs.imports.sidecar]
+source = "./packs/sidecar"
+`)
+	writeFile(t, filepath.Join(sidecarPackDir, "pack.toml"), `
+[pack]
+name = "sidecar"
+schema = 2
+`)
+	writeFile(t, filepath.Join(sidecarPackDir, "orders", "digest.toml"), `
+[order]
+formula = "mol-digest"
+trigger = "cooldown"
+interval = "5m"
+`)
+	isolateCompletionContext(t, cityPath)
+
+	got, dir := completeOrderNames(nil, nil, "dig")
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", dir)
+	}
+	for _, want := range []string{
+		"digest\tformula, 5m (rig: backend)",
+		"digest\tformula, 5m (rig: frontend)",
+	} {
+		if !slicesContains(got, want) {
+			t.Errorf("missing candidate %q in %v", want, got)
+		}
+	}
+}
+
+func isolateCompletionContext(t *testing.T, cityPath string) {
+	t.Helper()
+	origCity, origRig := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag, rigFlag = origCity, origRig
+	})
+	for _, key := range []string{
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_CITY_ROOT",
+		"GC_DIR",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+		"GC_SESSION",
+	} {
+		t.Setenv(key, "")
+	}
+	if cityPath != "" {
+		t.Setenv("GC_CITY", cityPath)
+		t.Setenv("GC_CITY_PATH", cityPath)
+	}
+}
+
+func writeCompletionCity(t *testing.T, cityPath, cityToml string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func completionCandidateNames(candidates []string) []string {
+	names := make([]string, len(candidates))
+	for i, c := range candidates {
+		names[i] = strings.SplitN(c, "\t", 2)[0]
+	}
+	return names
 }
 
 func slicesContains(xs []string, want string) bool {

--- a/cmd/gc/completion_test.go
+++ b/cmd/gc/completion_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/spf13/cobra"
+)
+
+func TestCompleteSessionIDs_EarlyExitOnExtraArgs(t *testing.T) {
+	// When the positional is already satisfied, the completer must return no
+	// candidates and must not attempt to open the city store — otherwise it
+	// would error out or emit noise for every keystroke after the ID is typed.
+	got, dir := completeSessionIDs(nil, []string{"gc-42"}, "anything")
+	if len(got) != 0 {
+		t.Errorf("expected no candidates with args set, got %v", got)
+	}
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected NoFileComp directive, got %v", dir)
+	}
+}
+
+func TestCompleteRigNames_EarlyExitOnExtraArgs(t *testing.T) {
+	got, dir := completeRigNames(nil, []string{"myrig"}, "x")
+	if len(got) != 0 {
+		t.Errorf("expected no candidates, got %v", got)
+	}
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected NoFileComp directive, got %v", dir)
+	}
+}
+
+func TestCompleteOrderNames_EarlyExitOnExtraArgs(t *testing.T) {
+	got, dir := completeOrderNames(nil, []string{"some-order"}, "x")
+	if len(got) != 0 {
+		t.Errorf("expected no candidates, got %v", got)
+	}
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected NoFileComp directive, got %v", dir)
+	}
+}
+
+func TestSessionCompletionDescription(t *testing.T) {
+	cases := []struct {
+		name string
+		in   session.Info
+		want string
+	}{
+		{"alias + state", session.Info{Alias: "mayor", State: session.State("asleep")}, "mayor (asleep)"},
+		{"template fallback", session.Info{Template: "gascity/claude", State: session.State("active")}, "gascity/claude (active)"},
+		{"empty state renders as closed", session.Info{Alias: "a"}, "a (closed)"},
+		{"no alias and no template", session.Info{State: session.State("suspended")}, "- (suspended)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sessionCompletionDescription(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOrderCompletionDescription(t *testing.T) {
+	cases := []struct {
+		name string
+		in   orders.Order
+		want string
+	}{
+		{"formula + interval", orders.Order{Formula: "f", Interval: "5m"}, "formula, 5m"},
+		{"exec + schedule", orders.Order{Exec: "s", Schedule: "0 0 * * *"}, "exec, 0 0 * * *"},
+		{"formula + event", orders.Order{Formula: "f", On: "bead.closed"}, "formula, bead.closed"},
+		{"no timing", orders.Order{Formula: "f"}, "formula, -"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orderCompletionDescription(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQuietDefaultLogger_RestoresOutput(t *testing.T) {
+	// The default logger's writer must be restored after fn returns, even if
+	// fn panics or writes to it — otherwise a single noisy completion call
+	// would leave the logger silenced for the rest of the process.
+	var before bytes.Buffer
+	log.SetOutput(&before)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	quietDefaultLogger(func() {
+		log.Print("silenced")
+	})
+	if strings.Contains(before.String(), "silenced") {
+		t.Errorf("expected log output to be suppressed inside quietDefaultLogger, got %q", before.String())
+	}
+
+	log.Print("audible")
+	if !strings.Contains(before.String(), "audible") {
+		t.Errorf("expected log output restored after quietDefaultLogger, got %q", before.String())
+	}
+}
+
+func TestRigNameCandidates_LoadsAndFilters(t *testing.T) {
+	// Integration check for the rig source-of-truth — exercises resolveCity
+	// (via t.Chdir into a temp city), loadCityConfigFS, and the prefix filter.
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[rigs]]\nname = \"alpha\"\npath = \"/tmp/alpha\"\n\n[[rigs]]\nname = \"beta\"\npath = \"/tmp/beta\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cityPath)
+
+	got := rigNameCandidates("")
+	// HQ + 2 rigs = 3 candidates.
+	if len(got) != 3 {
+		t.Fatalf("expected 3 candidates (HQ + 2 rigs), got %d: %v", len(got), got)
+	}
+	names := make([]string, len(got))
+	for i, c := range got {
+		names[i] = strings.SplitN(c, "\t", 2)[0]
+	}
+	for _, want := range []string{"my-city", "alpha", "beta"} {
+		if !slicesContains(names, want) {
+			t.Errorf("missing candidate %q in %v", want, names)
+		}
+	}
+
+	// Prefix filter.
+	got = rigNameCandidates("al")
+	if len(got) != 1 || !strings.HasPrefix(got[0], "alpha\t") {
+		t.Errorf("expected only alpha candidate for prefix 'al', got %v", got)
+	}
+}
+
+func slicesContains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -150,7 +150,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		"path to the city directory (default: walk up from cwd)")
 	root.PersistentFlags().StringVar(&rigFlag, "rig", "",
 		"rig name or path (default: discover from cwd)")
-	_ = root.RegisterFlagCompletionFunc("rig", completeRigNames)
+	_ = root.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	root.AddCommand(
 		newStartCmd(stdout, stderr),
 		newInitCmd(stdout, stderr),

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -150,6 +150,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		"path to the city directory (default: walk up from cwd)")
 	root.PersistentFlags().StringVar(&rigFlag, "rig", "",
 		"rig name or path (default: discover from cwd)")
+	_ = root.RegisterFlagCompletionFunc("rig", completeRigNames)
 	root.AddCommand(
 		newStartCmd(stdout, stderr),
 		newInitCmd(stdout, stderr),

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -189,7 +189,7 @@ func newSessionProviderFromContext(ctx sessionProviderContext, sessionBeads *ses
 }
 
 func newSessionProviderFromContextWithError(ctx sessionProviderContext, sessionBeads *sessionBeadSnapshot) (runtime.Provider, error) {
-	sp, err := newSessionProviderByName(ctx.providerName, ctx.sc, ctx.cityName, ctx.cityPath)
+	sp, err := buildSessionProviderByName(ctx.providerName, ctx.sc, ctx.cityName, ctx.cityPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Builds on #692 (`gc shell install`): wires cobra `ValidArgsFunction` and `RegisterFlagCompletionFunc` so tab completion covers dynamic args, not just subcommands and flag names.

- Session ID / alias completion for `attach`, `peek`, `close`, `kill`, `logs`, `nudge`, `pin`, `unpin`, `rename`, `reset`, `submit`, `suspend`, `wake`, `wait`
- Rig name completion for `rig status|restart|suspend|resume|remove|set-endpoint` and the persistent `--rig` flag
- Order name completion for `order show|run|history` and those commands' `--rig` flags
- Each candidate ships with a description (alias + state for sessions, path for rigs, type + interval for orders) that zsh renders as a second column. Bash ignores the `\t description` and just uses the names.

## Implementation notes

- Sessions reuse the JSON-path of `cmdSessionList` — no live state probes, no attachment cache, no wait-set computation. ~130ms locally.
- Rigs and orders hit the config files directly via existing helpers (`loadCityConfigFS`, `loadOrders`). ~10ms each.
- `quietDefaultLogger` wrapper suppresses `log.Printf` deprecation warnings emitted by orders discovery — those would otherwise corrupt the terminal at tab time.
- All candidate helpers short-circuit when the positional arg is already satisfied, so no store opens happen on subsequent keystrokes.

## Test plan

- [x] Unit tests: early-exit on extra args, description formatting matrix, logger-restore invariant, `rigNameCandidates` integration via `t.Chdir`
- [x] `go vet` clean
- [x] Manual `gc __complete` smoke across sessions / rigs / orders / `--rig` flag
- [ ] Reviewer: try `gc shell install zsh` then tab through a real city

🤖 Generated with [Claude Code](https://claude.com/claude-code)