### PR TITLE
feat(packs): convert three dog molecules to exec orders

### DIFF
--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -916,6 +917,12 @@ source = "`+doltDir+`"
 		t.Fatalf("scanAllOrders: %v; stderr: %s", err, stderr.String())
 	}
 
+	wantExecDogOrders := map[string]string{
+		"mol-dog-backup":     "mol-dog-backup.sh",
+		"mol-dog-doctor":     "mol-dog-doctor.sh",
+		"mol-dog-phantom-db": "mol-dog-phantom-db.sh",
+	}
+	gotExecDogOrders := map[string]bool{}
 	const wantFormulaDogOrders = 2
 	var gotFormulaDogOrders int
 	for _, a := range aa {
@@ -923,6 +930,27 @@ source = "`+doltDir+`"
 			continue
 		}
 		if a.Exec != "" {
+			scriptName, ok := wantExecDogOrders[a.Name]
+			if !ok {
+				t.Fatalf("unexpected exec dog order %q", a.Name)
+			}
+			if a.Pool != "" {
+				t.Fatalf("%s exec order pool = %q, want empty", a.Name, a.Pool)
+			}
+			wantExec := "$PACK_DIR/assets/scripts/" + scriptName
+			if a.Exec != wantExec {
+				t.Fatalf("%s exec = %q, want %q", a.Name, a.Exec, wantExec)
+			}
+			scriptPath := filepath.Join(doltDir, "assets", "scripts", scriptName)
+			if _, err := os.Stat(scriptPath); err != nil {
+				t.Fatalf("%s exec script missing: %v", a.Name, err)
+			}
+			if _, err := exec.LookPath("bash"); err == nil {
+				if out, err := exec.Command("bash", "-n", scriptPath).CombinedOutput(); err != nil {
+					t.Fatalf("%s bash -n failed: %v\n%s", a.Name, err, out)
+				}
+			}
+			gotExecDogOrders[a.Name] = true
 			continue
 		}
 		gotFormulaDogOrders++
@@ -939,6 +967,9 @@ source = "`+doltDir+`"
 	}
 	if gotFormulaDogOrders != wantFormulaDogOrders {
 		t.Fatalf("Dolt formula-based dog order count = %d, want %d", gotFormulaDogOrders, wantFormulaDogOrders)
+	}
+	if len(gotExecDogOrders) != len(wantExecDogOrders) {
+		t.Fatalf("Dolt exec dog orders = %v, want %v", gotExecDogOrders, wantExecDogOrders)
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -916,13 +916,16 @@ source = "`+doltDir+`"
 		t.Fatalf("scanAllOrders: %v; stderr: %s", err, stderr.String())
 	}
 
-	const wantDogOrders = 5
-	var gotDogOrders int
+	const wantFormulaDogOrders = 2
+	var gotFormulaDogOrders int
 	for _, a := range aa {
 		if !strings.HasPrefix(a.Name, "mol-dog-") {
 			continue
 		}
-		gotDogOrders++
+		if a.Exec != "" {
+			continue
+		}
+		gotFormulaDogOrders++
 		if a.Pool != "dog" {
 			t.Fatalf("%s pool = %q, want portable bare dog", a.Name, a.Pool)
 		}
@@ -934,8 +937,8 @@ source = "`+doltDir+`"
 			t.Fatalf("qualifyOrderPool(%s) = %q, want ops.dog", a.Name, got)
 		}
 	}
-	if gotDogOrders != wantDogOrders {
-		t.Fatalf("Dolt dog order count = %d, want %d", gotDogOrders, wantDogOrders)
+	if gotFormulaDogOrders != wantFormulaDogOrders {
+		t.Fatalf("Dolt formula-based dog order count = %d, want %d", gotFormulaDogOrders, wantFormulaDogOrders)
 	}
 }
 

--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# mol-dog-backup — sync Dolt databases to backup remotes and offsite storage.
+#
+# Replaces mol-dog-backup formula. All operations are deterministic:
+# dolt backup sync per DB, rsync to offsite path. No LLM judgment needed.
+#
+# Runs as an exec order (no LLM, no agent, no wisp).
+set -euo pipefail
+
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+PORT="${GC_DOLT_PORT:-3307}"
+HOST="${GC_DOLT_HOST:-127.0.0.1}"
+USER="${GC_DOLT_USER:-root}"
+OFFSITE_PATH="${GC_BACKUP_OFFSITE_PATH:-}"
+SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$"
+
+dolt_sql() {
+    DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
+        run_bounded 30 \
+        dolt --host "$HOST" --port "$PORT" --user "$USER" --no-tls sql "$@"
+}
+
+# --- Step 1: Sync databases to backup remotes ---
+
+# If GC_BACKUP_DATABASES is set, use it; otherwise auto-discover DBs that
+# have a <db>-backup remote configured.
+if [ -n "${GC_BACKUP_DATABASES:-}" ]; then
+    DATABASES=$(echo "$GC_BACKUP_DATABASES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true)
+else
+    # Auto-discover: find databases that have a backup remote named <db>-backup.
+    ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | \
+        grep -vi "$SYSTEM_DBS" || true)
+    DATABASES=""
+    for db in $ALL_DBS; do
+        db_dir="$DOLT_DATA_DIR/$db"
+        if [ -d "$db_dir/.dolt" ]; then
+            if (cd "$db_dir" && dolt remote 2>/dev/null | grep -q "^${db}-backup$"); then
+                DATABASES="$DATABASES $db"
+            fi
+        fi
+    done
+    DATABASES=$(echo "$DATABASES" | tr ' ' '\n' | grep -v '^$' || true)
+fi
+
+if [ -z "$DATABASES" ]; then
+    echo "backup: no databases with backup remotes found, skipping"
+    exit 0
+fi
+
+TOTAL=$(echo "$DATABASES" | grep -c . || echo "0")
+SYNCED=0
+FAILED_DBS=""
+
+for db in $DATABASES; do
+    db_dir="$DOLT_DATA_DIR/$db"
+    if [ ! -d "$db_dir" ]; then
+        FAILED_DBS="$FAILED_DBS $db(not found)"
+        continue
+    fi
+    if (cd "$db_dir" && run_bounded 120 dolt backup sync "${db}-backup" 2>/dev/null); then
+        SYNCED=$((SYNCED + 1))
+    else
+        FAILED_DBS="$FAILED_DBS $db(sync failed)"
+    fi
+done
+
+FAILED_COUNT=$(echo "$FAILED_DBS" | tr ' ' '\n' | grep -c . 2>/dev/null || echo "0")
+OFFSITE_STATUS="skipped"
+
+# --- Step 2: Rsync to offsite storage ---
+
+if [ -n "$OFFSITE_PATH" ] && [ -d "$DOLT_DATA_DIR" ]; then
+    if run_bounded 300 rsync -a --delete "$DOLT_DATA_DIR/" "$OFFSITE_PATH/" 2>/dev/null; then
+        OFFSITE_STATUS="ok"
+    else
+        OFFSITE_STATUS="failed (non-fatal)"
+    fi
+fi
+
+# --- Step 3: Report ---
+
+if [ "$FAILED_COUNT" -gt 0 ]; then
+    gc mail send mayor/ \
+        -s "Backup dog: $FAILED_COUNT/$TOTAL databases failed to sync [MEDIUM]" \
+        -m "Failed databases:$FAILED_DBS" \
+        2>/dev/null || true
+fi
+
+SUMMARY="backup — synced: $SYNCED/$TOTAL, offsite: $OFFSITE_STATUS"
+gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+echo "backup: $SUMMARY"

--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -2,7 +2,7 @@
 # mol-dog-backup — sync Dolt databases to backup remotes and offsite storage.
 #
 # Replaces mol-dog-backup formula. All operations are deterministic:
-# dolt backup sync per DB, rsync to offsite path. No LLM judgment needed.
+# dolt backup sync per DB, rsync backup artifacts to offsite path. No LLM judgment needed.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
@@ -14,7 +14,9 @@ PORT="${GC_DOLT_PORT:-3307}"
 HOST="${GC_DOLT_HOST:-127.0.0.1}"
 USER="${GC_DOLT_USER:-root}"
 OFFSITE_PATH="${GC_BACKUP_OFFSITE_PATH:-}"
-SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$"
+BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
+SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$\|^performance_schema$\|^sys$"
+MIN_DOLT_BACKUP_VERSION="1.86.2"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
@@ -22,21 +24,81 @@ dolt_sql() {
         dolt --host "$HOST" --port "$PORT" --user "$USER" --no-tls sql "$@"
 }
 
-# --- Step 1: Sync databases to backup remotes ---
+dolt_version_at_least() {
+    current="${1#v}"
+    minimum="$2"
+    current="${current%%+*}"
+    minimum="${minimum%%+*}"
+    case "$current" in
+        *-*) return 1 ;;
+    esac
+    IFS=. read -r cur_major cur_minor cur_patch <<EOF
+$current
+EOF
+    IFS=. read -r min_major min_minor min_patch <<EOF
+$minimum
+EOF
+    for part in "$cur_major" "$cur_minor" "$cur_patch" "$min_major" "$min_minor" "$min_patch"; do
+        case "$part" in
+            ''|*[!0-9]*) return 1 ;;
+        esac
+    done
+    cur_major=$((10#$cur_major))
+    cur_minor=$((10#$cur_minor))
+    cur_patch=$((10#$cur_patch))
+    min_major=$((10#$min_major))
+    min_minor=$((10#$min_minor))
+    min_patch=$((10#$min_patch))
+    if [ "$cur_major" -ne "$min_major" ]; then
+        [ "$cur_major" -gt "$min_major" ]
+        return $?
+    fi
+    if [ "$cur_minor" -ne "$min_minor" ]; then
+        [ "$cur_minor" -gt "$min_minor" ]
+        return $?
+    fi
+    [ "$cur_patch" -ge "$min_patch" ]
+}
+
+append_failed_db() {
+    db_failure="$1"
+    FAILED=$((FAILED + 1))
+    if [ -n "$FAILED_DBS" ]; then
+        FAILED_DBS="$FAILED_DBS, $db_failure"
+    else
+        FAILED_DBS="$db_failure"
+    fi
+}
+
+# --- Step 1: Preflight Dolt version before backup sync ---
+
+DOLT_VERSION="$(dolt version 2>/dev/null | awk 'NR == 1 {print $NF}' || true)"
+if ! dolt_version_at_least "$DOLT_VERSION" "$MIN_DOLT_BACKUP_VERSION"; then
+    gc mail send mayor/ \
+        -s "Backup dog: dolt-too-old for backup sync [HIGH]" \
+        -m "Skipping backup sync: dolt version ${DOLT_VERSION:-unknown} is below required ${MIN_DOLT_BACKUP_VERSION}. Older versions can hang the sql-server during dolt backup sync." \
+        2>/dev/null || true
+    SUMMARY="backup — dolt-too-old: ${DOLT_VERSION:-unknown}, required: $MIN_DOLT_BACKUP_VERSION"
+    gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+    echo "backup: $SUMMARY"
+    exit 1
+fi
+
+# --- Step 2: Sync databases to backup remotes ---
 
 # If GC_BACKUP_DATABASES is set, use it; otherwise auto-discover DBs that
-# have a <db>-backup remote configured.
+# have a named Dolt backup <db>-backup configured.
 if [ -n "${GC_BACKUP_DATABASES:-}" ]; then
     DATABASES=$(echo "$GC_BACKUP_DATABASES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' || true)
 else
-    # Auto-discover: find databases that have a backup remote named <db>-backup.
+    # Auto-discover: find databases that have a named Dolt backup <db>-backup.
     ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | \
         grep -vi "$SYSTEM_DBS" || true)
     DATABASES=""
     for db in $ALL_DBS; do
         db_dir="$DOLT_DATA_DIR/$db"
         if [ -d "$db_dir/.dolt" ]; then
-            if (cd "$db_dir" && dolt remote 2>/dev/null | grep -q "^${db}-backup$"); then
+            if (cd "$db_dir" && dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${db}-backup"); then
                 DATABASES="$DATABASES $db"
             fi
         fi
@@ -49,37 +111,42 @@ if [ -z "$DATABASES" ]; then
     exit 0
 fi
 
-TOTAL=$(echo "$DATABASES" | grep -c . || echo "0")
+TOTAL=$(printf '%s\n' "$DATABASES" | awk 'NF {count++} END {print count + 0}')
 SYNCED=0
+FAILED=0
 FAILED_DBS=""
 
 for db in $DATABASES; do
     db_dir="$DOLT_DATA_DIR/$db"
     if [ ! -d "$db_dir" ]; then
-        FAILED_DBS="$FAILED_DBS $db(not found)"
+        append_failed_db "$db(not found)"
         continue
     fi
     if (cd "$db_dir" && run_bounded 120 dolt backup sync "${db}-backup" 2>/dev/null); then
         SYNCED=$((SYNCED + 1))
     else
-        FAILED_DBS="$FAILED_DBS $db(sync failed)"
+        append_failed_db "$db(sync failed)"
     fi
 done
 
-FAILED_COUNT=$(echo "$FAILED_DBS" | tr ' ' '\n' | grep -c . 2>/dev/null || echo "0")
+FAILED_COUNT=$FAILED
 OFFSITE_STATUS="skipped"
 
-# --- Step 2: Rsync to offsite storage ---
+# --- Step 3: Rsync backup artifacts to offsite storage ---
 
-if [ -n "$OFFSITE_PATH" ] && [ -d "$DOLT_DATA_DIR" ]; then
-    if run_bounded 300 rsync -a --delete "$DOLT_DATA_DIR/" "$OFFSITE_PATH/" 2>/dev/null; then
+if [ -n "$OFFSITE_PATH" ]; then
+    if [ ! -d "$BACKUP_ARTIFACT_DIR" ]; then
+        OFFSITE_STATUS="missing-artifacts"
+    elif same_path "$BACKUP_ARTIFACT_DIR" "$DOLT_DATA_DIR"; then
+        OFFSITE_STATUS="invalid-source"
+    elif run_bounded 300 rsync -a --delete "$BACKUP_ARTIFACT_DIR/" "$OFFSITE_PATH/" 2>/dev/null; then
         OFFSITE_STATUS="ok"
     else
         OFFSITE_STATUS="failed (non-fatal)"
     fi
 fi
 
-# --- Step 3: Report ---
+# --- Step 4: Report ---
 
 if [ "$FAILED_COUNT" -gt 0 ]; then
     gc mail send mayor/ \

--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -89,5 +89,5 @@ if [ "$FAILED_COUNT" -gt 0 ]; then
 fi
 
 SUMMARY="backup — synced: $SYNCED/$TOTAL, offsite: $OFFSITE_STATUS"
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "backup: $SUMMARY"

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -33,7 +33,7 @@ if ! dolt_sql -q "SELECT active_branch()" >/dev/null 2>&1; then
         -s "ESCALATION: Dolt server unreachable on port $PORT [CRITICAL]" \
         -m "Doctor probe failed: server did not respond to active_branch() query." \
         2>/dev/null || true
-    gc nudge deacon/ "DOG_DONE: doctor — server: UNREACHABLE (escalated)" 2>/dev/null || true
+    gc session nudge deacon/ "DOG_DONE: doctor — server: UNREACHABLE (escalated)" 2>/dev/null || true
     echo "doctor: server unreachable on port $PORT (escalated)"
     exit 0
 fi
@@ -98,5 +98,5 @@ Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}" \
 fi
 
 SUMMARY="doctor — server: ok, latency: ${LATENCY_S}s, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}"
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "doctor: $SUMMARY"

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# mol-dog-doctor — probe Dolt server health and report findings.
+#
+# Replaces mol-dog-doctor formula. All checks are read-only: SQL probe,
+# PROCESSLIST count, disk usage, orphan DB detection, backup freshness.
+# No LLM judgment needed — runs inline in the controller.
+#
+# Runs as an exec order (no LLM, no agent, no wisp).
+set -euo pipefail
+
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+PORT="${GC_DOLT_PORT:-3307}"
+HOST="${GC_DOLT_HOST:-127.0.0.1}"
+USER="${GC_DOLT_USER:-root}"
+LATENCY_WARN_S="${GC_DOCTOR_LATENCY_WARN_S:-1}"
+CONN_MAX="${GC_DOCTOR_CONN_MAX:-50}"
+CONN_WARN_PCT="${GC_DOCTOR_CONN_WARN_PCT:-80}"
+BACKUP_STALE_S="${GC_DOCTOR_BACKUP_STALE_S:-43200}"  # 2x 6h backup interval
+
+dolt_sql() {
+    DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
+        run_bounded 10 \
+        dolt --host "$HOST" --port "$PORT" --user "$USER" --no-tls sql "$@"
+}
+
+# --- Step 1: Probe connectivity and measure latency ---
+
+PROBE_START=$(date +%s)
+if ! dolt_sql -q "SELECT active_branch()" >/dev/null 2>&1; then
+    gc mail send mayor/ \
+        -s "ESCALATION: Dolt server unreachable on port $PORT [CRITICAL]" \
+        -m "Doctor probe failed: server did not respond to active_branch() query." \
+        2>/dev/null || true
+    gc nudge deacon/ "DOG_DONE: doctor — server: UNREACHABLE (escalated)" 2>/dev/null || true
+    echo "doctor: server unreachable on port $PORT (escalated)"
+    exit 0
+fi
+PROBE_END=$(date +%s)
+LATENCY_S=$((PROBE_END - PROBE_START))
+LATENCY_WARN=""
+if [ "$LATENCY_S" -ge "$LATENCY_WARN_S" ]; then
+    LATENCY_WARN=" [WARN: latency ${LATENCY_S}s >= threshold ${LATENCY_WARN_S}s]"
+fi
+
+# --- Step 2: Check resource conditions ---
+
+CONN_COUNT=$(dolt_sql -r csv -q "SELECT COUNT(*) FROM information_schema.PROCESSLIST" 2>/dev/null \
+    | tail -1 || echo "0")
+CONN_WARN=""
+CONN_WARN_AT=$(( (CONN_MAX * CONN_WARN_PCT) / 100 ))
+if [ "${CONN_COUNT:-0}" -ge "$CONN_WARN_AT" ]; then
+    CONN_WARN=" [WARN: ${CONN_COUNT} connections >= ${CONN_WARN_PCT}% of max ${CONN_MAX}]"
+fi
+
+# Disk usage of Dolt data directory.
+DISK_USAGE=$(du -sh "$DOLT_DATA_DIR" 2>/dev/null | cut -f1 || echo "unknown")
+
+# Orphan database detection.
+ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 || true)
+ORPHAN_PATTERNS="^testdb_\|^beads_t\|^beads_pt\|^beads_vr\|^doctest_\|^doctortest_"
+SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$"
+ORPHANS=$(echo "$ALL_DBS" | grep -i "$ORPHAN_PATTERNS" | grep -vi "$SYSTEM_DBS" || true)
+ORPHAN_COUNT=$(echo "$ORPHANS" | grep -c . || echo "0")
+ORPHAN_WARN=""
+if [ "${ORPHAN_COUNT:-0}" -gt 0 ]; then
+    ORPHAN_WARN=" [WARN: $ORPHAN_COUNT orphan DBs detected — run gc dolt cleanup]"
+fi
+
+# Backup freshness: check mtime of most-recently-modified backup file.
+BACKUP_STALE=""
+if [ -d "$DOLT_DATA_DIR" ]; then
+    NEWEST_BACKUP=$(find "$DOLT_DATA_DIR" -name "*.bak" -o -name "*.backup" 2>/dev/null \
+        | xargs ls -t 2>/dev/null | head -1 || true)
+    if [ -n "$NEWEST_BACKUP" ]; then
+        BACKUP_MTIME=$(stat -c %Y "$NEWEST_BACKUP" 2>/dev/null \
+            || stat -f %m "$NEWEST_BACKUP" 2>/dev/null || echo "0")
+        NOW_S=$(date +%s)
+        BACKUP_AGE=$((NOW_S - BACKUP_MTIME))
+        if [ "$BACKUP_AGE" -gt "$BACKUP_STALE_S" ]; then
+            BACKUP_STALE=" [WARN: newest backup is $((BACKUP_AGE / 3600))h old]"
+        fi
+    fi
+fi
+
+# --- Step 3: Compose report and escalate if critical ---
+
+WARNINGS="${LATENCY_WARN}${CONN_WARN}${ORPHAN_WARN}${BACKUP_STALE}"
+if [ -n "$WARNINGS" ]; then
+    gc mail send mayor/ \
+        -s "Dolt health advisory [MEDIUM]" \
+        -m "Latency: ${LATENCY_S}s${LATENCY_WARN}
+Connections: ${CONN_COUNT}/${CONN_MAX}${CONN_WARN}
+Disk: ${DISK_USAGE}
+Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}" \
+        2>/dev/null || true
+fi
+
+SUMMARY="doctor — server: ok, latency: ${LATENCY_S}s, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}"
+gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+echo "doctor: $SUMMARY"

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -2,7 +2,7 @@
 # mol-dog-doctor — probe Dolt server health and report findings.
 #
 # Replaces mol-dog-doctor formula. All checks are read-only: SQL probe,
-# PROCESSLIST count, disk usage, orphan DB detection, backup freshness.
+# PROCESSLIST count, disk usage, orphan DB detection, backup artifact freshness.
 # No LLM judgment needed — runs inline in the controller.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
@@ -18,11 +18,57 @@ LATENCY_WARN_S="${GC_DOCTOR_LATENCY_WARN_S:-1}"
 CONN_MAX="${GC_DOCTOR_CONN_MAX:-50}"
 CONN_WARN_PCT="${GC_DOCTOR_CONN_WARN_PCT:-80}"
 BACKUP_STALE_S="${GC_DOCTOR_BACKUP_STALE_S:-43200}"  # 2x 6h backup interval
+BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
         run_bounded 10 \
         dolt --host "$HOST" --port "$PORT" --user "$USER" --no-tls sql "$@"
+}
+
+file_mtime() {
+    file_path="$1"
+    file_mtime_value=$(stat -c %Y "$file_path" 2>/dev/null \
+        || stat -f %m "$file_path" 2>/dev/null || echo "0")
+    case "$file_mtime_value" in
+        ''|*[!0-9]*) file_mtime_value=0 ;;
+    esac
+    printf '%s\n' "$file_mtime_value"
+}
+
+backup_path_matches_db() {
+    db_name="$1"
+    backup_rel_path="$2"
+    case "$backup_rel_path" in
+        "$db_name"|"$db_name"/*|"$db_name".*|"$db_name"-*|*"/$db_name"|*"/$db_name"/*|*"/$db_name".*|*"/$db_name"-*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+newest_backup_mtime_for_db() {
+    db_name="$1"
+    newest_mtime=0
+    while IFS= read -r -d '' backup_path; do
+        backup_rel_path="${backup_path#$BACKUP_ARTIFACT_DIR/}"
+        if backup_path_matches_db "$db_name" "$backup_rel_path"; then
+            backup_mtime=$(file_mtime "$backup_path")
+            if [ "$backup_mtime" -gt "$newest_mtime" ]; then
+                newest_mtime="$backup_mtime"
+            fi
+        fi
+    done < <(find "$BACKUP_ARTIFACT_DIR" -type f -print0 2>/dev/null)
+    printf '%s\n' "$newest_mtime"
+}
+
+append_backup_stale() {
+    backup_stale_item="$1"
+    if [ -n "$BACKUP_STALE_ITEMS" ]; then
+        BACKUP_STALE_ITEMS="$BACKUP_STALE_ITEMS, $backup_stale_item"
+    else
+        BACKUP_STALE_ITEMS="$backup_stale_item"
+    fi
 }
 
 # --- Step 1: Probe connectivity and measure latency ---
@@ -60,26 +106,36 @@ DISK_USAGE=$(du -sh "$DOLT_DATA_DIR" 2>/dev/null | cut -f1 || echo "unknown")
 # Orphan database detection.
 ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 || true)
 ORPHAN_PATTERNS="^testdb_\|^beads_t\|^beads_pt\|^beads_vr\|^doctest_\|^doctortest_"
-SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$"
-ORPHANS=$(echo "$ALL_DBS" | grep -i "$ORPHAN_PATTERNS" | grep -vi "$SYSTEM_DBS" || true)
-ORPHAN_COUNT=$(echo "$ORPHANS" | grep -c . || echo "0")
+SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$\|^performance_schema$\|^sys$"
+USER_DBS=$(printf '%s\n' "$ALL_DBS" | grep -vi "$SYSTEM_DBS" || true)
+ORPHANS=$(printf '%s\n' "$USER_DBS" | grep -i "$ORPHAN_PATTERNS" || true)
+ORPHAN_COUNT=$(printf '%s\n' "$ORPHANS" | awk 'NF {count++} END {print count + 0}')
 ORPHAN_WARN=""
 if [ "${ORPHAN_COUNT:-0}" -gt 0 ]; then
     ORPHAN_WARN=" [WARN: $ORPHAN_COUNT orphan DBs detected — run gc dolt cleanup]"
 fi
 
-# Backup freshness: check mtime of most-recently-modified backup file.
+# Backup freshness: check newest backup artifact per database.
 BACKUP_STALE=""
-if [ -d "$DOLT_DATA_DIR" ]; then
-    NEWEST_BACKUP=$(find "$DOLT_DATA_DIR" -name "*.bak" -o -name "*.backup" 2>/dev/null \
-        | xargs ls -t 2>/dev/null | head -1 || true)
-    if [ -n "$NEWEST_BACKUP" ]; then
-        BACKUP_MTIME=$(stat -c %Y "$NEWEST_BACKUP" 2>/dev/null \
-            || stat -f %m "$NEWEST_BACKUP" 2>/dev/null || echo "0")
+if [ -n "$USER_DBS" ]; then
+    if [ ! -d "$BACKUP_ARTIFACT_DIR" ]; then
+        BACKUP_STALE=" [WARN: backup artifact dir missing]"
+    else
+        BACKUP_STALE_ITEMS=""
         NOW_S=$(date +%s)
-        BACKUP_AGE=$((NOW_S - BACKUP_MTIME))
-        if [ "$BACKUP_AGE" -gt "$BACKUP_STALE_S" ]; then
-            BACKUP_STALE=" [WARN: newest backup is $((BACKUP_AGE / 3600))h old]"
+        for db in $USER_DBS; do
+            NEWEST_BACKUP_MTIME=$(newest_backup_mtime_for_db "$db")
+            if [ "$NEWEST_BACKUP_MTIME" -le 0 ]; then
+                append_backup_stale "$db backup missing"
+                continue
+            fi
+            BACKUP_AGE=$((NOW_S - NEWEST_BACKUP_MTIME))
+            if [ "$BACKUP_AGE" -gt "$BACKUP_STALE_S" ]; then
+                append_backup_stale "$db backup is $((BACKUP_AGE / 3600))h old"
+            fi
+        done
+        if [ -n "$BACKUP_STALE_ITEMS" ]; then
+            BACKUP_STALE=" [WARN: backup freshness: $BACKUP_STALE_ITEMS]"
         fi
     fi
 fi

--- a/examples/dolt/assets/scripts/mol-dog-phantom-db.sh
+++ b/examples/dolt/assets/scripts/mol-dog-phantom-db.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# mol-dog-phantom-db — detect and quarantine phantom Dolt database directories.
+#
+# Replaces mol-dog-phantom-db formula. All operations are deterministic:
+# filesystem scan for .dolt/ dirs without noms/manifest, rm -rf of corrupted
+# dirs, escalation mail if any found. No LLM judgment needed.
+#
+# A phantom database has a .dolt/ subdirectory but no .dolt/noms/manifest.
+# Dolt's auto-discovery crashes INFORMATION_SCHEMA on these at startup.
+#
+# Runs as an exec order (no LLM, no agent, no wisp).
+set -euo pipefail
+
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+DATA_DIR="${GC_PHANTOM_DATA_DIR:-$DOLT_DATA_DIR}"
+
+# --- Step 1: Scan for phantom database directories ---
+
+if [ ! -d "$DATA_DIR" ]; then
+    echo "phantom-db: data dir $DATA_DIR not found, skipping"
+    exit 0
+fi
+
+SCANNED=0
+PHANTOMS=""
+PHANTOM_COUNT=0
+VALID=0
+
+for dir in "$DATA_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    SCANNED=$((SCANNED + 1))
+    db_name=$(basename "$dir")
+    if [ -d "$dir/.dolt" ] && [ ! -f "$dir/.dolt/noms/manifest" ]; then
+        PHANTOMS="$PHANTOMS $db_name"
+        PHANTOM_COUNT=$((PHANTOM_COUNT + 1))
+    else
+        VALID=$((VALID + 1))
+    fi
+done
+
+if [ "$PHANTOM_COUNT" -eq 0 ]; then
+    SUMMARY="phantom-db — scanned: $SCANNED, phantoms: 0, valid: $VALID"
+    gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+    echo "phantom-db: $SUMMARY"
+    exit 0
+fi
+
+# --- Step 2: Quarantine phantom databases ---
+
+QUARANTINED=0
+ERRORS=0
+for db_name in $PHANTOMS; do
+    phantom_path="$DATA_DIR/$db_name"
+    if [ -d "$phantom_path" ]; then
+        if rm -rf "$phantom_path" 2>/dev/null; then
+            QUARANTINED=$((QUARANTINED + 1))
+        else
+            ERRORS=$((ERRORS + 1))
+        fi
+    fi
+done
+
+# Phantom DBs indicate a Dolt bug — always escalate when found.
+gc mail send mayor/ \
+    -s "ESCALATION: Quarantined phantom databases [HIGH]" \
+    -m "Found and quarantined $QUARANTINED phantom database(s) in $DATA_DIR:$PHANTOMS
+$([ "$ERRORS" -gt 0 ] && echo "Removal errors: $ERRORS" || true)" \
+    2>/dev/null || true
+
+# --- Step 3: Report ---
+
+SUMMARY="phantom-db — scanned: $SCANNED, phantoms: $PHANTOM_COUNT, quarantined: $QUARANTINED"
+gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+echo "phantom-db: $SUMMARY"

--- a/examples/dolt/assets/scripts/mol-dog-phantom-db.sh
+++ b/examples/dolt/assets/scripts/mol-dog-phantom-db.sh
@@ -42,7 +42,7 @@ done
 
 if [ "$PHANTOM_COUNT" -eq 0 ]; then
     SUMMARY="phantom-db — scanned: $SCANNED, phantoms: 0, valid: $VALID"
-    gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+    gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
     echo "phantom-db: $SUMMARY"
     exit 0
 fi
@@ -72,5 +72,5 @@ $([ "$ERRORS" -gt 0 ] && echo "Removal errors: $ERRORS" || true)" \
 # --- Step 3: Report ---
 
 SUMMARY="phantom-db — scanned: $SCANNED, phantoms: $PHANTOM_COUNT, quarantined: $QUARANTINED"
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "phantom-db: $SUMMARY"

--- a/examples/dolt/assets/scripts/mol-dog-phantom-db.sh
+++ b/examples/dolt/assets/scripts/mol-dog-phantom-db.sh
@@ -2,11 +2,13 @@
 # mol-dog-phantom-db — detect and quarantine phantom Dolt database directories.
 #
 # Replaces mol-dog-phantom-db formula. All operations are deterministic:
-# filesystem scan for .dolt/ dirs without noms/manifest, rm -rf of corrupted
-# dirs, escalation mail if any found. No LLM judgment needed.
+# filesystem scan for unservable .dolt/ dirs, quarantine by move, escalation
+# mail if any found. No LLM judgment needed.
 #
 # A phantom database has a .dolt/ subdirectory but no .dolt/noms/manifest.
 # Dolt's auto-discovery crashes INFORMATION_SCHEMA on these at startup.
+# A retired replacement database has a .dolt/ subdirectory and a basename
+# matching *.replaced-YYYYMMDDTHHMMSSZ.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
@@ -24,37 +26,59 @@ if [ ! -d "$DATA_DIR" ]; then
 fi
 
 SCANNED=0
-PHANTOMS=""
+UNSERVABLES=""
 PHANTOM_COUNT=0
+RETIRED_COUNT=0
+UNSERVABLE_COUNT=0
 VALID=0
 
 for dir in "$DATA_DIR"/*/; do
     [ -d "$dir" ] || continue
-    SCANNED=$((SCANNED + 1))
     db_name=$(basename "$dir")
-    if [ -d "$dir/.dolt" ] && [ ! -f "$dir/.dolt/noms/manifest" ]; then
-        PHANTOMS="$PHANTOMS $db_name"
-        PHANTOM_COUNT=$((PHANTOM_COUNT + 1))
+    if [ "$db_name" = ".quarantine" ]; then
+        continue
+    fi
+    SCANNED=$((SCANNED + 1))
+    is_unservable=0
+    if [ -d "$dir/.dolt" ]; then
+        if [ ! -f "$dir/.dolt/noms/manifest" ]; then
+            PHANTOM_COUNT=$((PHANTOM_COUNT + 1))
+            is_unservable=1
+        fi
+        case "$db_name" in
+            *.replaced-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]Z)
+                RETIRED_COUNT=$((RETIRED_COUNT + 1))
+                is_unservable=1
+                ;;
+        esac
+    fi
+    if [ "$is_unservable" -eq 1 ]; then
+        UNSERVABLES="$UNSERVABLES $db_name"
+        UNSERVABLE_COUNT=$((UNSERVABLE_COUNT + 1))
     else
         VALID=$((VALID + 1))
     fi
 done
 
-if [ "$PHANTOM_COUNT" -eq 0 ]; then
-    SUMMARY="phantom-db — scanned: $SCANNED, phantoms: 0, valid: $VALID"
+if [ "$UNSERVABLE_COUNT" -eq 0 ]; then
+    SUMMARY="phantom-db — scanned: $SCANNED, phantoms: 0, retired: 0, valid: $VALID"
     gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
     echo "phantom-db: $SUMMARY"
     exit 0
 fi
 
-# --- Step 2: Quarantine phantom databases ---
+# --- Step 2: Quarantine unservable databases ---
 
 QUARANTINED=0
 ERRORS=0
-for db_name in $PHANTOMS; do
-    phantom_path="$DATA_DIR/$db_name"
-    if [ -d "$phantom_path" ]; then
-        if rm -rf "$phantom_path" 2>/dev/null; then
+QUARANTINE_DIR="$DATA_DIR/.quarantine"
+mkdir -p "$QUARANTINE_DIR"
+QUARANTINE_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+for db_name in $UNSERVABLES; do
+    source_path="$DATA_DIR/$db_name"
+    quarantine_path="$QUARANTINE_DIR/${QUARANTINE_STAMP}-$db_name"
+    if [ -d "$source_path" ]; then
+        if mv -f "$source_path" "$quarantine_path" 2>/dev/null; then
             QUARANTINED=$((QUARANTINED + 1))
         else
             ERRORS=$((ERRORS + 1))
@@ -62,15 +86,15 @@ for db_name in $PHANTOMS; do
     fi
 done
 
-# Phantom DBs indicate a Dolt bug — always escalate when found.
+# Unservable DBs indicate a Dolt bug or failed replacement — always escalate when found.
 gc mail send mayor/ \
-    -s "ESCALATION: Quarantined phantom databases [HIGH]" \
-    -m "Found and quarantined $QUARANTINED phantom database(s) in $DATA_DIR:$PHANTOMS
-$([ "$ERRORS" -gt 0 ] && echo "Removal errors: $ERRORS" || true)" \
+    -s "ESCALATION: Quarantined unservable databases [HIGH]" \
+    -m "Found and quarantined $QUARANTINED unservable database(s) in $DATA_DIR:$UNSERVABLES
+$([ "$ERRORS" -gt 0 ] && echo "Quarantine errors: $ERRORS" || true)" \
     2>/dev/null || true
 
 # --- Step 3: Report ---
 
-SUMMARY="phantom-db — scanned: $SCANNED, phantoms: $PHANTOM_COUNT, quarantined: $QUARANTINED"
+SUMMARY="phantom-db — scanned: $SCANNED, phantoms: $PHANTOM_COUNT, retired: $RETIRED_COUNT, quarantined: $QUARANTINED"
 gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "phantom-db: $SUMMARY"

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -1,0 +1,436 @@
+package dolt_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+func runDogScriptCommand(t *testing.T, scriptName, binDir, cityPath, dataDir string, extraEnv ...string) (string, error) {
+	t.Helper()
+	root := repoRoot(t)
+	cmd := exec.Command("bash", filepath.Join(root, "assets", "scripts", scriptName))
+	cmd.Env = append(filteredEnv(
+		"PATH",
+		"GC_CITY_PATH",
+		"GC_PACK_DIR",
+		"GC_DOLT_DATA_DIR",
+		"GC_DOLT_PORT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+		"GC_BACKUP_DATABASES",
+		"GC_BACKUP_OFFSITE_PATH",
+		"GC_BACKUP_ARTIFACT_DIR",
+		"GC_PHANTOM_DATA_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func runDogScript(t *testing.T, scriptName, binDir, cityPath, dataDir string, extraEnv ...string) string {
+	t.Helper()
+	out, err := runDogScriptCommand(t, scriptName, binDir, cityPath, dataDir, extraEnv...)
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", scriptName, err, out)
+	}
+	return out
+}
+
+func writeDogFakeGC(t *testing.T, binDir string) string {
+	t.Helper()
+	logPath := filepath.Join(binDir, "gc.log")
+	writeExecutable(t, filepath.Join(binDir, "gc"), fmt.Sprintf(`#!/bin/sh
+printf 'gc %s\n' "$*" >> %s
+exit 0
+`, "%s", shellQuote(logPath)))
+	return logPath
+}
+
+func TestDogExecScriptsAreBashSyntaxValid(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not found: %v", err)
+	}
+	root := repoRoot(t)
+	for _, scriptName := range []string{
+		"mol-dog-backup.sh",
+		"mol-dog-doctor.sh",
+		"mol-dog-phantom-db.sh",
+	} {
+		t.Run(scriptName, func(t *testing.T) {
+			cmd := exec.Command("bash", "-n", filepath.Join(root, "assets", "scripts", scriptName))
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("bash -n failed: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
+func TestPhantomDBScriptQuarantinesPhantomsAndRetiredReplacements(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	binDir := t.TempDir()
+	_ = writeDogFakeGC(t, binDir)
+
+	for _, path := range []string{
+		filepath.Join(dataDir, "valid", ".dolt", "noms"),
+		filepath.Join(dataDir, "phantom", ".dolt"),
+		filepath.Join(dataDir, "orders.replaced-20260509T010203Z", ".dolt", "noms"),
+	} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	writeTestFile(t, filepath.Join(dataDir, "valid", ".dolt", "noms", "manifest"), "ok")
+	writeTestFile(t, filepath.Join(dataDir, "orders.replaced-20260509T010203Z", ".dolt", "noms", "manifest"), "ok")
+
+	out := runDogScript(t, "mol-dog-phantom-db.sh", binDir, cityPath, dataDir)
+	if !strings.Contains(out, "phantoms: 1") || !strings.Contains(out, "retired: 1") || !strings.Contains(out, "quarantined: 2") {
+		t.Fatalf("unexpected phantom summary:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "phantom")); !os.IsNotExist(err) {
+		t.Fatalf("phantom source should be moved, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "orders.replaced-20260509T010203Z")); !os.IsNotExist(err) {
+		t.Fatalf("retired replacement source should be moved, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "valid", ".dolt", "noms", "manifest")); err != nil {
+		t.Fatalf("valid database should remain: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dataDir, ".quarantine", "*"))
+	if err != nil {
+		t.Fatalf("glob quarantine: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("quarantined entries = %d, want 2: %v", len(matches), matches)
+	}
+}
+
+func writeBackupFakeDolt(t *testing.T, binDir, version string, syncExit int, sqlDatabases ...string) string {
+	t.Helper()
+	logPath := filepath.Join(binDir, "dolt.log")
+	dbCSV := "Database\n" + strings.Join(sqlDatabases, "\n") + "\n"
+	writeExecutable(t, filepath.Join(binDir, "dolt"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf 'dolt %%s\n' "$*" >> %s
+if [ "${1:-}" = "version" ]; then
+  printf 'dolt version %%s\n' %s
+  exit 0
+fi
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf %%s %s
+    exit 0
+    ;;
+esac
+if [ "${1:-}" = "backup" ] && [ "$#" -eq 1 ]; then
+  db="$(basename "$PWD")"
+  printf '%%s-backup file:///backups/%%s\n' "$db" "$db"
+  exit 0
+fi
+if [ "${1:-}" = "remote" ]; then
+  printf 'remote should not be used\n' >&2
+  exit 64
+fi
+if [ "${1:-} ${2:-}" = "backup sync" ]; then
+  exit %d
+fi
+exit 0
+`, shellQuote(logPath), shellQuote(version), shellQuote(dbCSV), syncExit))
+	return logPath
+}
+
+func writeBackupFakeRsync(t *testing.T, binDir string) string {
+	t.Helper()
+	logPath := filepath.Join(binDir, "rsync.log")
+	writeExecutable(t, filepath.Join(binDir, "rsync"), fmt.Sprintf(`#!/bin/sh
+printf 'rsync %s\n' "$*" >> %s
+exit 0
+`, "%s", shellQuote(logPath)))
+	return logPath
+}
+
+func TestBackupScriptSkipsOldDoltBeforeSync(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "prod", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	binDir := t.TempDir()
+	_ = writeDogFakeGC(t, binDir)
+	doltLogPath := writeBackupFakeDolt(t, binDir, "1.86.1", 0)
+
+	out, err := runDogScriptCommand(t, "mol-dog-backup.sh", binDir, cityPath, dataDir, "GC_BACKUP_DATABASES=prod")
+	if err == nil {
+		t.Fatalf("old Dolt preflight succeeded; want failure\n%s", out)
+	}
+	if !strings.Contains(out, "dolt-too-old") {
+		t.Fatalf("output missing dolt-too-old skip:\n%s", out)
+	}
+	doltLog, err := os.ReadFile(doltLogPath)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(doltLog), "backup sync") {
+		t.Fatalf("old dolt must not reach backup sync:\n%s", doltLog)
+	}
+}
+
+func TestBackupOrderTimeoutCoversScriptBudget(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "orders", "mol-dog-backup.toml"))
+	if err != nil {
+		t.Fatalf("read backup order: %v", err)
+	}
+	order, err := orders.Parse(data)
+	if err != nil {
+		t.Fatalf("parse backup order: %v", err)
+	}
+
+	const intendedDBs = 10
+	required := 30*time.Second + intendedDBs*120*time.Second + 300*time.Second
+	if got := order.TimeoutOrDefault(); got < required {
+		t.Fatalf("backup order timeout = %s, want at least %s for SQL probe + %d DB syncs + offsite rsync", got, required, intendedDBs)
+	}
+}
+
+func TestBackupScriptDiscoversNamedBackupsAndSyncsArtifactsOffsite(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	offsiteDir := filepath.Join(cityPath, "offsite")
+	for _, path := range []string{
+		filepath.Join(dataDir, "prod", ".dolt"),
+		artifactDir,
+		offsiteDir,
+	} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	binDir := t.TempDir()
+	_ = writeDogFakeGC(t, binDir)
+	doltLogPath := writeBackupFakeDolt(t, binDir, "1.86.2", 0, "prod")
+	rsyncLogPath := writeBackupFakeRsync(t, binDir)
+
+	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir, "GC_BACKUP_OFFSITE_PATH="+offsiteDir)
+	if !strings.Contains(out, "synced: 1/1") || !strings.Contains(out, "offsite: ok") {
+		t.Fatalf("unexpected backup summary:\n%s", out)
+	}
+	doltLog, err := os.ReadFile(doltLogPath)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	for _, want := range []string{"SHOW DATABASES", "backup", "backup sync prod-backup"} {
+		if !strings.Contains(string(doltLog), want) {
+			t.Fatalf("dolt log missing %q:\n%s", want, doltLog)
+		}
+	}
+	if strings.Contains(string(doltLog), "remote") {
+		t.Fatalf("backup discovery should not use dolt remote:\n%s", doltLog)
+	}
+	rsyncLog, err := os.ReadFile(rsyncLogPath)
+	if err != nil {
+		t.Fatalf("read rsync log: %v", err)
+	}
+	if !strings.Contains(string(rsyncLog), artifactDir+"/") {
+		t.Fatalf("rsync should use backup artifact dir, log:\n%s", rsyncLog)
+	}
+	if strings.Contains(string(rsyncLog), dataDir+"/") {
+		t.Fatalf("rsync must not use live data dir, log:\n%s", rsyncLog)
+	}
+}
+
+func TestBackupScriptCountsFailedDatabasesByDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "prod", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	_ = writeBackupFakeDolt(t, binDir, "1.86.2", 1)
+
+	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir, "GC_BACKUP_DATABASES=prod")
+	if !strings.Contains(out, "synced: 0/1") {
+		t.Fatalf("unexpected backup summary:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "Backup dog: 1/1 databases failed to sync") {
+		t.Fatalf("failure mail should count databases, log:\n%s", gcLog)
+	}
+}
+
+func TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	freshBackup := filepath.Join(artifactDir, "prod.backup")
+	writeTestFile(t, freshBackup, "backup")
+	fresh := time.Now()
+	if err := os.Chtimes(freshBackup, fresh, fresh); err != nil {
+		t.Fatalf("chtimes fresh backup: %v", err)
+	}
+	staleBackup := filepath.Join(artifactDir, "archive.backup")
+	writeTestFile(t, staleBackup, "backup")
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(staleBackup, old, old); err != nil {
+		t.Fatalf("chtimes stale backup: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n1\n'
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\narchive\n'
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, "GC_DOCTOR_BACKUP_STALE_S=1")
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("unexpected doctor output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "archive backup is") {
+		t.Fatalf("doctor did not report stale archive backup artifact, log:\n%s", gcLog)
+	}
+	if strings.Contains(string(gcLog), "prod backup is") {
+		t.Fatalf("fresh prod backup should not be reported stale, log:\n%s", gcLog)
+	}
+}
+
+func TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	freshBackup := filepath.Join(artifactDir, "prod.backup")
+	writeTestFile(t, freshBackup, "backup")
+	fresh := time.Now()
+	if err := os.Chtimes(freshBackup, fresh, fresh); err != nil {
+		t.Fatalf("chtimes fresh backup: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n1\n'
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\nperformance_schema\nsys\n'
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, "GC_DOCTOR_BACKUP_STALE_S=1")
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("unexpected doctor output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	for _, systemDB := range []string{"performance_schema", "sys"} {
+		if strings.Contains(string(gcLog), systemDB) {
+			t.Fatalf("doctor should ignore %s for backup freshness, log:\n%s", systemDB, gcLog)
+		}
+	}
+}
+
+func TestDoctorScriptDoesNotCreditSharedPrefixBackupToDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	freshSiblingBackup := filepath.Join(artifactDir, "prod_dev.backup")
+	writeTestFile(t, freshSiblingBackup, "backup")
+	fresh := time.Now()
+	if err := os.Chtimes(freshSiblingBackup, fresh, fresh); err != nil {
+		t.Fatalf("chtimes fresh sibling backup: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n1\n'
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\nprod_dev\n'
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, "GC_DOCTOR_BACKUP_STALE_S=1")
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("unexpected doctor output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "prod backup missing") {
+		t.Fatalf("doctor should not credit prod_dev backup to prod, log:\n%s", gcLog)
+	}
+	if strings.Contains(string(gcLog), "prod_dev backup") {
+		t.Fatalf("fresh prod_dev backup should not be reported stale, log:\n%s", gcLog)
+	}
+}

--- a/examples/dolt/orders/mol-dog-backup.toml
+++ b/examples/dolt/orders/mol-dog-backup.toml
@@ -1,8 +1,10 @@
 # Converted from formula+pool to exec. All backup operations are
-# deterministic: dolt backup sync per DB, rsync to offsite path.
-# No LLM judgment needed — runs inline in the controller.
+# deterministic: dolt backup sync per DB, rsync backup artifacts to offsite path.
+# No LLM judgment needed — runs inline in the controller. The timeout covers a
+# 30s SQL probe, up to 10 120s database syncs, and one 300s offsite rsync.
 [order]
 description = "Sync Dolt backups to configured remotes"
 exec = "$PACK_DIR/assets/scripts/mol-dog-backup.sh"
 trigger = "cooldown"
 interval = "6h"
+timeout = "1800s"

--- a/examples/dolt/orders/mol-dog-backup.toml
+++ b/examples/dolt/orders/mol-dog-backup.toml
@@ -1,6 +1,8 @@
+# Converted from formula+pool to exec. All backup operations are
+# deterministic: dolt backup sync per DB, rsync to offsite path.
+# No LLM judgment needed — runs inline in the controller.
 [order]
 description = "Sync Dolt backups to configured remotes"
-formula = "mol-dog-backup"
+exec = "$PACK_DIR/assets/scripts/mol-dog-backup.sh"
 trigger = "cooldown"
 interval = "6h"
-pool = "dog"

--- a/examples/dolt/orders/mol-dog-doctor.toml
+++ b/examples/dolt/orders/mol-dog-doctor.toml
@@ -1,6 +1,6 @@
 # Converted from formula+pool to exec. All doctor checks are read-only:
 # SQL probe, PROCESSLIST count, disk usage, orphan DB detection, backup
-# freshness. No LLM judgment needed — runs inline in the controller.
+# artifact freshness. No LLM judgment needed — runs inline in the controller.
 [order]
 description = "Probe Dolt server health and report status"
 exec = "$PACK_DIR/assets/scripts/mol-dog-doctor.sh"

--- a/examples/dolt/orders/mol-dog-doctor.toml
+++ b/examples/dolt/orders/mol-dog-doctor.toml
@@ -1,6 +1,8 @@
+# Converted from formula+pool to exec. All doctor checks are read-only:
+# SQL probe, PROCESSLIST count, disk usage, orphan DB detection, backup
+# freshness. No LLM judgment needed — runs inline in the controller.
 [order]
 description = "Probe Dolt server health and report status"
-formula = "mol-dog-doctor"
+exec = "$PACK_DIR/assets/scripts/mol-dog-doctor.sh"
 trigger = "cooldown"
 interval = "5m"
-pool = "dog"

--- a/examples/dolt/orders/mol-dog-phantom-db.toml
+++ b/examples/dolt/orders/mol-dog-phantom-db.toml
@@ -1,6 +1,8 @@
+# Converted from formula+pool to exec. Phantom-DB detection is a pure
+# filesystem scan: dirs with .dolt/ but no noms/manifest are corrupted
+# and safe to remove. No LLM judgment needed — runs inline in the controller.
 [order]
 description = "Detect phantom database resurrection after cleanup"
-formula = "mol-dog-phantom-db"
+exec = "$PACK_DIR/assets/scripts/mol-dog-phantom-db.sh"
 trigger = "cooldown"
 interval = "1h"
-pool = "dog"

--- a/examples/dolt/orders/mol-dog-phantom-db.toml
+++ b/examples/dolt/orders/mol-dog-phantom-db.toml
@@ -1,6 +1,7 @@
 # Converted from formula+pool to exec. Phantom-DB detection is a pure
-# filesystem scan: dirs with .dolt/ but no noms/manifest are corrupted
-# and safe to remove. No LLM judgment needed — runs inline in the controller.
+# filesystem scan: dirs with .dolt/ but no noms/manifest and retired
+# replacements are unservable and moved to quarantine. No LLM judgment
+# needed — runs inline in the controller.
 [order]
 description = "Detect phantom database resurrection after cleanup"
 exec = "$PACK_DIR/assets/scripts/mol-dog-phantom-db.sh"


### PR DESCRIPTION
## Summary

Convert three dolt-pack dog molecules from formula+pool dispatch to exec
orders. Same rationale as dcb20ad5 ("feat(packs): convert reaper +
jsonl-export dogs to exec orders", 2026-03-05): eliminate unnecessary
LLM invocations for deterministic shell/SQL work.

- `mol-dog-doctor` — 5m cooldown (SQL probe + resource inspection)
- `mol-dog-phantom-db` — 1h cooldown (filesystem phantom scan + rm)
- `mol-dog-backup` — 6h cooldown (dolt backup sync + rsync offsite)

Each dog is now an `exec = "$PACK_DIR/assets/scripts/mol-dog-<name>.sh"`
order.toml + a shell script that does the same work the formula
described. Formula `.toml` files are kept in `formulas/` for historical
reference (same pattern as the dcb20ad5 conversion).

`mol-dog-stale-db` was originally part of this conversion but is kept
as formula+pool upstream after #1548's threshold-gating hardening: the
scan/decide/apply/escalate choice with `max_orphans_for_sql` and
`warn_threshold` needs agent-level decisioning, so exec conversion is
no longer appropriate there.

`mol-dog-compactor` (the fifth dog formula) remains formula-backed and
will be converted separately — its surgical-mode retry logic and a
stale ZFC-exemption docstring need a closer look first.

## Detail

With `dog.max_active_sessions = 0` in production, these formula-backed
orders can't execute — they only accumulate zombie step beads.
Converting to exec makes them functional without re-enabling the dog
pool.

The scripts source `$PACK_DIR/assets/scripts/runtime.sh` for `dolt_sql`
setup and `run_bounded` helpers (same pattern as the dolt commands).
Escalation paths (unreachable server, phantom DBs found, backup
failures) use `gc mail send mayor/` as the formula did.

## Files touched

Conversion (mol-dog-doctor, mol-dog-phantom-db, mol-dog-backup):
- `examples/dolt/orders/mol-dog-<name>.toml` — switched from formula+pool to exec form
- `examples/dolt/assets/scripts/mol-dog-<name>.sh` — new shell scripts

Test:
- `cmd/gc/order_dispatch_test.go` — adapted `TestDoltPackDogOrdersResolveWithNonGastownMaintenanceBinding` (added in #1631) to skip exec orders and assert the 2 remaining formula-based dogs (stale-db, compactor) still qualify with `pool="dog"` → `ops.dog`.

## Note on CI

Rebased onto current main; build is clean. Pre-existing failures in
`TestDoImportAddRemote*`, `TestDoSupervisorStart*`, `TestTutorial01/doctor`,
and `internal/api` were the same on `origin/main` before this rebase. None
of the failing tests exercise `examples/dolt/`.
