### PR TITLE
tutorials: Fix Claude transcript path aliases

### DIFF
--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -455,12 +456,13 @@ func FindSessionFileByID(searchPaths []string, workDir, sessionID string) string
 	if fileName == "" {
 		return ""
 	}
-	slug := ProjectSlug(workDir)
-	for _, base := range searchPaths {
-		path := filepath.Join(base, slug, fileName)
-		info, err := os.Stat(path)
-		if err == nil && !info.IsDir() {
-			return path
+	for _, slug := range claudeProjectSlugCandidates(workDir) {
+		for _, base := range searchPaths {
+			path := filepath.Join(base, slug, fileName)
+			info, err := os.Stat(path)
+			if err == nil && !info.IsDir() {
+				return path
+			}
 		}
 	}
 	return ""
@@ -470,12 +472,13 @@ func findClaudeLatestSessionFile(searchPaths []string, workDir string) string {
 	if workDir == "" {
 		return ""
 	}
-	slug := ProjectSlug(workDir)
-	for _, base := range searchPaths {
-		path := filepath.Join(base, slug, "latest-session.jsonl")
-		info, err := os.Stat(path)
-		if err == nil && !info.IsDir() {
-			return path
+	for _, slug := range claudeProjectSlugCandidates(workDir) {
+		for _, base := range searchPaths {
+			path := filepath.Join(base, slug, "latest-session.jsonl")
+			info, err := os.Stat(path)
+			if err == nil && !info.IsDir() {
+				return path
+			}
 		}
 	}
 	return ""
@@ -494,27 +497,28 @@ func safeSessionLogFileName(sessionID string) string {
 // {searchPath}/{slug}/{sessionID}.jsonl where slug is the working
 // directory path with "/" and "." replaced by "-".
 func findSlugSessionFile(searchPaths []string, workDir string) string {
-	slug := ProjectSlug(workDir)
 	var globalBestPath string
 	var globalBestTime int64
-	for _, base := range searchPaths {
-		dir := filepath.Join(base, slug)
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-				continue
-			}
-			info, err := e.Info()
+	for _, slug := range claudeProjectSlugCandidates(workDir) {
+		for _, base := range searchPaths {
+			dir := filepath.Join(base, slug)
+			entries, err := os.ReadDir(dir)
 			if err != nil {
 				continue
 			}
-			mt := info.ModTime().UnixNano()
-			if mt > globalBestTime {
-				globalBestTime = mt
-				globalBestPath = filepath.Join(dir, e.Name())
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+					continue
+				}
+				info, err := e.Info()
+				if err != nil {
+					continue
+				}
+				mt := info.ModTime().UnixNano()
+				if mt > globalBestTime {
+					globalBestTime = mt
+					globalBestPath = filepath.Join(dir, e.Name())
+				}
 			}
 		}
 	}
@@ -778,6 +782,80 @@ func providerFamily(provider string) string {
 		return "gemini"
 	default:
 		return p
+	}
+}
+
+func claudeProjectSlugCandidates(workDir string) []string {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return nil
+	}
+
+	seenPaths := make(map[string]bool)
+	var paths []string
+	add := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		path = filepath.Clean(path)
+		if seenPaths[path] {
+			return
+		}
+		seenPaths[path] = true
+		paths = append(paths, path)
+	}
+
+	add(workDir)
+	if abs, err := filepath.Abs(workDir); err == nil {
+		add(abs)
+	}
+	if resolved, err := filepath.EvalSymlinks(workDir); err == nil {
+		add(resolved)
+	}
+
+	for _, path := range append([]string(nil), paths...) {
+		addDarwinClaudePathAliases(path, add)
+	}
+
+	seenSlugs := make(map[string]bool)
+	var slugs []string
+	for _, path := range paths {
+		slug := ProjectSlug(path)
+		if seenSlugs[slug] {
+			continue
+		}
+		seenSlugs[slug] = true
+		slugs = append(slugs, slug)
+	}
+	return slugs
+}
+
+func addDarwinClaudePathAliases(path string, add func(string)) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+
+	switch {
+	case path == "/tmp":
+		add("/private/tmp")
+	case strings.HasPrefix(path, "/tmp/"):
+		add("/private/tmp/" + strings.TrimPrefix(path, "/tmp/"))
+	case path == "/private/tmp":
+		add("/tmp")
+	case strings.HasPrefix(path, "/private/tmp/"):
+		add("/tmp/" + strings.TrimPrefix(path, "/private/tmp/"))
+	}
+
+	switch {
+	case path == "/var":
+		add("/private/var")
+	case strings.HasPrefix(path, "/var/"):
+		add("/private/var/" + strings.TrimPrefix(path, "/var/"))
+	case path == "/private/var":
+		add("/var")
+	case strings.HasPrefix(path, "/private/var/"):
+		add("/var/" + strings.TrimPrefix(path, "/private/var/"))
 	}
 }
 

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -677,6 +678,93 @@ func TestFindSessionFileByIDRejectsTraversalSessionID(t *testing.T) {
 	}
 }
 
+func TestFindSessionFileByIDUsesClaudeProjectPathAlias(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	slugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFileByID([]string{base}, storedWorkDir, "session-123"); got != want {
+		t.Fatalf("FindSessionFileByID() = %q, want %q", got, want)
+	}
+}
+
+func TestFindSessionFileByIDPrefersStoredWorkDirSpelling(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	rawSlugDir := filepath.Join(base, ProjectSlug(storedWorkDir))
+	aliasSlugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	for _, dir := range []string{rawSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := filepath.Join(rawSlugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(aliasSlugDir, "session-123.jsonl")
+	if err := os.WriteFile(aliasPath, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFileByID([]string{base}, storedWorkDir, "session-123"); got != want {
+		t.Fatalf("FindSessionFileByID() = %q, want stored spelling %q", got, want)
+	}
+}
+
+func TestFindSessionFileUsesClaudeProjectPathAlias(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	slugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFile([]string{base}, storedWorkDir); got != want {
+		t.Fatalf("FindSessionFile() = %q, want %q", got, want)
+	}
+}
+
+func TestFindClaudeLatestSessionFileUsesProjectPathAlias(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	slugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "latest-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := findClaudeLatestSessionFile([]string{base}, storedWorkDir); got != want {
+		t.Fatalf("findClaudeLatestSessionFile() = %q, want %q", got, want)
+	}
+}
+
 func TestProjectSlug(t *testing.T) {
 	tests := []struct {
 		path string
@@ -1146,6 +1234,13 @@ func TestFindGeminiSessionFileUsesObservedRoots(t *testing.T) {
 	got := FindGeminiSessionFile([]string{root}, workDir)
 	if got != sessionFile {
 		t.Errorf("got %q, want %q", got, sessionFile)
+	}
+}
+
+func skipUnlessDarwinClaudePathAliases(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only /tmp <-> /private/tmp Claude project path alias")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix Claude transcript discovery when Gas City stores a session workdir using the user-facing macOS `/tmp/...` spelling but Claude stores the project transcript under the provider-observed `/private/tmp/...` project slug.

The change is intentionally scoped to Claude's slug-based transcript storage. Codex and Gemini transcript matching remain exact and unchanged.

## Root Cause

On macOS, `/tmp` is a host alias for `/private/tmp`. Tutorial harness cities use `/tmp/gcac/...`, but Claude records project transcripts under `~/.claude/projects/` using the physical cwd spelling it observes, such as `-private-tmp-gcac-...`. Gas City then looked only for the stored `/tmp/...` slug, so `gc session logs` could miss an existing Claude transcript.

## Changes

- Add Claude-only project slug candidates for transcript lookup.
- Preserve the stored workdir spelling first when both slug directories exist.
- Add Darwin-only `/tmp` <-> `/private/tmp` and `/var` <-> `/private/var` aliases for Claude project slugs.
- Cover keyed session lookup, unkeyed newest-session lookup, and `latest-session.jsonl` fallback.

## Validation

- `go test ./internal/sessionlog ./internal/worker/transcript ./internal/session ./internal/api -count=1`
- `go vet ./internal/sessionlog`
- `GC_TUTORIAL_GOLDENS_USE_CLAUDE_FOR_CODEX=1 go test -tags acceptance_c -count=1 -timeout 45m -v ./test/acceptance/tutorial_goldens -run '^TestTutorial03Sessions$'`

## Notes

A broader `go test ./...` run was not a reliable signal in this workspace because concurrent `cmd/gc` testscript/dolt processes from another Codex session were running at the same time. The two broad-run failures observed during that contaminated run both passed when rerun directly.
