### PR TITLE
fix: mayor session crashing during pre-compact step

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -14,6 +15,13 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/spf13/cobra"
 )
+
+// handoffRestartWait bounds how long the handoff process blocks after
+// requesting a controller restart. The controller normally tears the
+// process tree down well within this window; if it doesn't (broken
+// reconciler, missed flag, hook fired outside a managed session), we
+// exit cleanly so callers like PreCompact don't hang Claude indefinitely.
+const handoffRestartWait = 30 * time.Second
 
 func newHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
 	var target string
@@ -88,8 +96,14 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	// Block forever. The controller will kill the entire process tree.
-	select {}
+	// Block until the controller tears the process tree down, with a bounded
+	// timeout so a stuck or unreachable controller can't hang the caller
+	// (e.g. PreCompact) forever. A timeout means the controller didn't act on
+	// the persisted restart_requested flag in time; the flag stays set so the
+	// next reconcile cycle can still pick it up.
+	<-time.After(handoffRestartWait)
+	fmt.Fprintf(stderr, "gc handoff: controller did not stop session within %s; exiting hook (restart flag remains set)\n", handoffRestartWait) //nolint:errcheck // best-effort stderr
+	return 1
 }
 
 // cmdHandoffRemote sends handoff mail to a remote session and stops the target
@@ -231,10 +245,21 @@ func sessionRestartableByController(store beads.Store, sessionName string) (bool
 	if err != nil {
 		return false, fmt.Errorf("loading session %q: %w", id, err)
 	}
-	if !isNamedSessionBead(b) {
-		return true, nil
+	if isNamedSessionBead(b) {
+		return namedSessionMode(b) == "always", nil
 	}
-	return namedSessionMode(b) == "always", nil
+	// Pool-managed (and otherwise ephemeral) session beads are commonly
+	// attached to a human tmux/iTerm window via `gc session attach`. Killing
+	// them mid-PreCompact discards in-flight context (the compaction summary
+	// is never written) and crashes the visible terminal even though the
+	// controller will eventually spin up a fresh pool slot. Treat them like
+	// on-demand named sessions for handoff purposes: keep the handoff mail,
+	// skip the restart kill. Regression: pool-managed mayor crashed on every
+	// PreCompact because the #744 fix only protected configured_named beads.
+	if isPoolManagedSessionBead(b) {
+		return false, nil
+	}
+	return true, nil
 }
 
 func clearRestartRequest(store beads.Store, dops drainOps, sessionName string) error {

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -22,6 +24,45 @@ import (
 // reconciler, missed flag, hook fired outside a managed session), we
 // exit cleanly so callers like PreCompact don't hang Claude indefinitely.
 const handoffRestartWait = 30 * time.Second
+
+// readClaudeHookEventName best-effort reads the Claude Code hook payload
+// from stdin and returns the hook_event_name field. Returns "" if stdin
+// is a TTY, empty, or not a valid hook payload — i.e. when gc handoff is
+// invoked manually rather than from a hook.
+//
+// Claude Code passes a JSON object to every hook on stdin; the field
+// hook_event_name distinguishes PreCompact from SessionStart, Stop,
+// PostToolUse, etc. We use this to detect when handoff is being called
+// from PreCompact, where killing the session mid-compaction discards
+// in-flight context (the compaction summary the user wants to keep).
+func readClaudeHookEventName(r io.Reader) string {
+	if r == nil {
+		return ""
+	}
+	if f, ok := r.(*os.File); ok {
+		info, err := f.Stat()
+		if err != nil {
+			return ""
+		}
+		// TTY → no hook payload to read; don't block on user input.
+		if info.Mode()&os.ModeCharDevice != 0 {
+			return ""
+		}
+	}
+	// Hook payloads are tiny (low-KB). Cap the read so a misconfigured
+	// pipe can't make us swallow megabytes.
+	data, err := io.ReadAll(io.LimitReader(r, 64*1024))
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	var payload struct {
+		HookEventName string `json:"hook_event_name"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return ""
+	}
+	return payload.HookEventName
+}
 
 func newHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
 	var target string
@@ -70,6 +111,11 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 		return cmdHandoffRemote(args, target, stdout, stderr)
 	}
 
+	// Detect Claude Code hook context BEFORE doing anything else — stdin is
+	// consumed by the read and we want this to drive whether we even
+	// consider requesting a restart.
+	hookEvent := readClaudeHookEventName(os.Stdin)
+
 	current, err := currentSessionRuntimeTarget()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -88,7 +134,15 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 	cfg, _ := loadCityConfig(current.cityPath, stderr)
 	persistRestart := sessionRestartPersister(current.cityPath, store, sp, cfg, current.sessionName)
 
-	outcome := doHandoffWithOutcome(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr)
+	// PreCompact hooks must finish without killing the session: Claude is
+	// in the middle of producing the compaction summary, and tearing the
+	// process tree down here discards everything in flight (the user's
+	// "the mayor crashed and lost context" symptom). Send the handoff
+	// mail so the post-compact session sees it, then return so compaction
+	// proceeds normally.
+	opts := handoffOptions{forceSkipRestart: hookEvent == "PreCompact"}
+
+	outcome := doHandoffWithOptions(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr, opts)
 	if outcome.code != 0 {
 		return outcome.code
 	}
@@ -153,6 +207,16 @@ type handoffOutcome struct {
 	restartRequested bool
 }
 
+// handoffOptions holds optional parameters for doHandoffWithOptions. Zero
+// value preserves the historical doHandoffWithOutcome behavior.
+type handoffOptions struct {
+	// forceSkipRestart, when true, prevents the restart-requested flag from
+	// being set regardless of session classification. Use for callers that
+	// know killing the session here would lose data — e.g. PreCompact, where
+	// Claude is mid-compaction and the kill discards the in-flight summary.
+	forceSkipRestart bool
+}
+
 // doHandoff sends a handoff mail to self and requests restart when the
 // controller can restart the current session. Testable: does not block.
 func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
@@ -163,6 +227,12 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 
 func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
 	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer,
+) handoffOutcome {
+	return doHandoffWithOptions(store, rec, dops, persistRestart, sessionAddress, sessionName, args, stdout, stderr, handoffOptions{})
+}
+
+func doHandoffWithOptions(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
+	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer, opts handoffOptions,
 ) handoffOutcome {
 	subject := args[0]
 	var message string
@@ -195,16 +265,27 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
 		return handoffOutcome{code: 1}
 	}
-	// On-demand named sessions are human-attended and the controller cannot
-	// respawn their process after a restart request. Preserve the handoff
-	// mail so context survives, but skip both restart flags. Regression
-	// guard: gastownhall/gascity#744.
+	// PreCompact (and other callers that explicitly forbid the restart kill)
+	// override the bead-derived classification — even an always-mode session
+	// must not be torn down here, because Claude's compaction is in flight
+	// and the kill discards the in-flight summary.
+	if opts.forceSkipRestart {
+		restartable = false
+	}
+	// Non-restartable sessions: on-demand configured-named beads, pool-managed
+	// ephemeral beads (which are user-attended through tmux), and any caller
+	// with forceSkipRestart set. Preserve the handoff mail; skip both restart
+	// flags. Regression guard: gastownhall/gascity#744.
 	if !restartable {
 		if err := clearRestartRequest(store, dops, sessionName); err != nil {
 			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
 			return handoffOutcome{code: 1, restartRequested: false}
 		}
-		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session; restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
+		msg := "named session; restart skipped"
+		if opts.forceSkipRestart {
+			msg = "PreCompact context; restart skipped to preserve in-flight context"
+		}
+		fmt.Fprintf(stdout, "Handoff: sent mail %s (%s).\n", b.ID, msg) //nolint:errcheck // best-effort stdout
 		return handoffOutcome{code: 0, restartRequested: false}
 	}
 

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -175,6 +175,90 @@ func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
 	}
 }
 
+// Regression for the pool-managed extension of #744:
+// gc handoff on a pool-managed session bead (mayor in atlas after the
+// pool migration) used to call setRestartRequested because the bead
+// lacked configured_named_session metadata — even though the session
+// is attached to a human tmux/iTerm window. Killing it mid-PreCompact
+// crashed the visible terminal and discarded the in-flight compaction
+// summary. doHandoff must treat pool-managed beads the same way it
+// treats on-demand named sessions: keep the mail, skip the restart.
+func TestDoHandoff_PoolManagedSessionSkipsRestart(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session", "agent:gastown.mayor"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	for k, v := range map[string]string{
+		"session_name":               "gastown__mayor-at-yxbh",
+		"pool_managed":               "true",
+		"pool_slot":                  "1",
+		"session_origin":             "ephemeral",
+		"template":                   "gastown.mayor",
+		"agent_name":                 "gastown.mayor-1",
+		"restart_requested":          "true",
+		"continuation_reset_pending": "true",
+	} {
+		if err := store.SetMetadata(b.ID, k, v); err != nil {
+			t.Fatalf("set %s: %v", k, err)
+		}
+	}
+	dops.restartRequested["gastown__mayor-at-yxbh"] = true
+
+	persistCalled := false
+	outcome := doHandoffWithOutcome(store, rec, dops, func() error {
+		persistCalled = true
+		return nil
+	}, "gastown.mayor-1", "gastown__mayor-at-yxbh",
+		[]string{"context cycle"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	if outcome.restartRequested {
+		t.Fatal("restartRequested = true, want false for pool-managed session")
+	}
+	if dops.restartRequested["gastown__mayor-at-yxbh"] {
+		t.Error("restart-requested flag is still set — pool-managed sessions must skip restart")
+	}
+	if persistCalled {
+		t.Error("persistRestart was called — pool-managed sessions must skip persisted restart requests")
+	}
+
+	refreshed, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("fetching seeded bead: %v", err)
+	}
+	if refreshed.Metadata["restart_requested"] != "" {
+		t.Errorf("bead restart_requested = %q, want cleared", refreshed.Metadata["restart_requested"])
+	}
+	if refreshed.Metadata["continuation_reset_pending"] != "" {
+		t.Errorf("continuation_reset_pending = %q, want cleared", refreshed.Metadata["continuation_reset_pending"])
+	}
+
+	mailFound := false
+	all, _ := store.ListOpen()
+	for _, got := range all {
+		if got.Title == "context cycle" && got.Type == "message" {
+			mailFound = true
+			break
+		}
+	}
+	if !mailFound {
+		t.Fatalf("handoff mail not created; beads=%v", all)
+	}
+
+	if strings.Contains(stdout.String(), "requesting restart") {
+		t.Errorf("stdout = %q, must not promise a restart for pool-managed sessions", stdout.String())
+	}
+}
+
 func TestDoHandoff_NamedSessionClearRestartFailureReturnsError(t *testing.T) {
 	store := beads.NewMemStore()
 	rec := events.NewFake()

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -299,6 +299,97 @@ func TestDoHandoff_NamedSessionClearRestartFailureReturnsError(t *testing.T) {
 	}
 }
 
+// PreCompact context: even an always-mode named session (e.g. the
+// gastown.mayor in atlas) must NOT be torn down via gc handoff. The
+// restart kill happens mid-compaction and discards the in-flight
+// summary the user is trying to keep. forceSkipRestart=true models the
+// path cmdHandoff takes when readClaudeHookEventName returns "PreCompact".
+func TestDoHandoffWithOptions_PreCompactSkipsRestartEvenForAlwaysMode(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{"gc:session"},
+	})
+	if err != nil {
+		t.Fatalf("seeding session bead: %v", err)
+	}
+	for k, v := range map[string]string{
+		"session_name":             "gastown__mayor",
+		"configured_named_session": "true",
+		"configured_named_mode":    "always",
+		"configured_named_identity": "gastown.mayor",
+	} {
+		if err := store.SetMetadata(b.ID, k, v); err != nil {
+			t.Fatalf("set %s: %v", k, err)
+		}
+	}
+
+	persistCalled := false
+	outcome := doHandoffWithOptions(store, rec, dops, func() error {
+		persistCalled = true
+		return nil
+	}, "gastown.mayor", "gastown__mayor",
+		[]string{"context cycle"}, &stdout, &stderr,
+		handoffOptions{forceSkipRestart: true},
+	)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	if outcome.restartRequested {
+		t.Fatal("restartRequested = true, want false in PreCompact context (always mode must still skip the kill)")
+	}
+	if dops.restartRequested["gastown__mayor"] {
+		t.Error("restart-requested flag set — PreCompact context must skip the kill")
+	}
+	if persistCalled {
+		t.Error("persistRestart called — PreCompact context must skip persisted restart")
+	}
+
+	mailFound := false
+	all, _ := store.ListOpen()
+	for _, got := range all {
+		if got.Title == "context cycle" && got.Type == "message" {
+			mailFound = true
+			break
+		}
+	}
+	if !mailFound {
+		t.Fatalf("handoff mail not created; beads=%v", all)
+	}
+	if !strings.Contains(stdout.String(), "PreCompact context") {
+		t.Errorf("stdout = %q, want PreCompact-context note", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "requesting restart") {
+		t.Errorf("stdout = %q, must not promise a restart in PreCompact context", stdout.String())
+	}
+}
+
+func TestReadClaudeHookEventName_ParsesPreCompact(t *testing.T) {
+	r := strings.NewReader(`{"hook_event_name":"PreCompact","session_id":"x","trigger":"auto"}`)
+	if got := readClaudeHookEventName(r); got != "PreCompact" {
+		t.Errorf("got %q, want %q", got, "PreCompact")
+	}
+}
+
+func TestReadClaudeHookEventName_HandlesEmptyAndGarbage(t *testing.T) {
+	if got := readClaudeHookEventName(strings.NewReader("")); got != "" {
+		t.Errorf("empty: got %q, want empty", got)
+	}
+	if got := readClaudeHookEventName(strings.NewReader("not-json")); got != "" {
+		t.Errorf("garbage: got %q, want empty", got)
+	}
+	if got := readClaudeHookEventName(nil); got != "" {
+		t.Errorf("nil: got %q, want empty", got)
+	}
+	if got := readClaudeHookEventName(strings.NewReader(`{"unrelated":"field"}`)); got != "" {
+		t.Errorf("no hook_event_name: got %q, want empty", got)
+	}
+}
+
 func TestDoHandoff_NamedAlwaysSessionRequestsRestart(t *testing.T) {
 	store := beads.NewMemStore()
 	rec := events.NewFake()


### PR DESCRIPTION
## Summary

`gc handoff` runs as the default `PreCompact` Claude Code hook (shipped in `internal/hooks/config/claude.json`). For an `always`-mode named session — which is exactly what the gastown pack creates for the mayor — the handoff sets `restart_requested=true`, the reconciler kills the tmux pane, and the kill races Claude's in-flight compaction. The user sees the mayor "crash" at ~80% context, losing both the partial conversation AND the would-be compaction summary.

This PR extends the [#744](https://github.com/gastownhall/gascity/issues/744) fix so the same protection applies to (1) pool-managed ephemeral session beads and (2) any handoff invoked from `PreCompact` regardless of mode.

## The bug, observed

Reproduces every time on a default atlas/gastown setup:

1. Open the mayor pane (always-mode named session, `configured_named_mode = "always"` per `examples/gastown/packs/gastown/pack.toml`).
2. Have a normal conversation until Claude Code approaches the autocompact threshold (~80%).
3. PreCompact fires `gc handoff "context cycle"`.
4. Mayor's tmux pane goes blank — Claude exits mid-summary. The respawned session boots with only the one-line `"context cycle"` mail (no body) — every bit of in-flight context is gone.

## Root cause

`PreCompact` fires *while Claude is producing the compaction summary*. `gc handoff` then:

1. Calls `sessionRestartableByController` → returns `true` for `always`-mode (per `TestDoHandoff_NamedAlwaysSessionRequestsRestart`).
2. Calls `setRestartRequested` + `persistRestart` so the bead has the kill flag.
3. Blocks on `select {}`, waiting for the controller.
4. Reconciler tears the process tree down → Claude is killed mid-compaction → the partial summary is discarded → the new session boots with no context bridge other than the empty `"context cycle"` subject.

The #744 regression test even names this exact scenario:
> *"the PreCompact hook crashed the mayor to the user's shell on every context compaction"*

…but the fix was scoped to `on_demand` named sessions only. The same race breaks `always`-mode mayors and pool-managed ephemeral mayors for the same root cause: `gc handoff` requests a kill in the one context where the kill destroys data.

## What didn't work (first attempt)

I started by extending `sessionRestartableByController` to also return `false` for `isPoolManagedSessionBead(b)`. This protects the ephemeral pool-slot mayor (`pool_managed=true`, `session_origin=ephemeral`) — useful, but in atlas the user's tmux is attached to the *named* always-mode mayor, not the pool slot. So the fix didn't reach the actual crash. Test still mattered (covers the pool-managed path), so I kept it as commit 1.

## What worked (the fix)

The right discriminator isn't the bead — it's the call site. `PreCompact` is the one place where killing the session is unconditionally destructive; any other invocation of `gc handoff` against an always-mode session should still recycle as designed.

Claude Code passes a JSON payload to every hook on stdin including `hook_event_name`. `cmdHandoff` now best-effort reads that payload at the top of execution; if `hook_event_name == \"PreCompact\"`, it propagates `forceSkipRestart=true` through a new `handoffOptions` parameter to `doHandoffWithOptions`, which then takes the existing skip-restart path regardless of the bead's classification. Mail still gets sent — context preservation is still the whole point.

Stdin reading is gated on `os.File.Stat()` so a TTY (manual `gc handoff` from a shell) doesn't block waiting for user input. The read is capped at 64 KB to bound a misconfigured pipe.

Also bounded the prior unconditional `select {}` to a 30 s timer so a stuck/unreachable controller can't hang a hook indefinitely. The persisted `restart_requested` flag stays set so the next reconcile cycle still picks it up.

## Rationale (why this design vs. alternatives)

- **Why not always skip restart for `always`-mode?** Other call sites (manual `gc handoff` from a shell, scripts, formulas) legitimately want the recycle. Changing the bead-derived classification would break the existing `TestDoHandoff_NamedAlwaysSessionRequestsRestart` and the design intent it encodes.
- **Why not require an explicit CLI flag like `--from-hook`?** Would need a coordinated atlas-side change to every PreCompact hook line. The stdin payload is universal — works for any user with the default PreCompact wiring, no atlas/pack updates needed.
- **Why not just remove `gc handoff` from `PreCompact` in the embedded default?** Removes the recycle pattern even when handoff content is rich. The narrower fix preserves the design intent for callers who write meaningful handoff content while protecting users from the race when content is thin (which is the shipped default — `gc handoff "context cycle"` has no body).
- **Why the bounded `select`?** Defense in depth — even with the PreCompact bypass, callers in genuinely stuck-controller scenarios shouldn't hang forever.

## Tests

All new and existing handoff tests pass:

```
=== RUN   TestHandoffSuccess                                                  PASS
=== RUN   TestDoHandoff_Regression744_NamedSessionSkipsRestart                PASS
=== RUN   TestDoHandoff_PoolManagedSessionSkipsRestart                        PASS  (new)
=== RUN   TestDoHandoff_NamedSessionClearRestartFailureReturnsError           PASS
=== RUN   TestDoHandoffWithOptions_PreCompactSkipsRestartEvenForAlwaysMode    PASS  (new)
=== RUN   TestReadClaudeHookEventName_ParsesPreCompact                        PASS  (new)
=== RUN   TestReadClaudeHookEventName_HandlesEmptyAndGarbage                  PASS  (new)
=== RUN   TestDoHandoff_NamedAlwaysSessionRequestsRestart                     PASS  (unchanged — non-PreCompact always-mode still recycles)
=== RUN   TestCmdHandoff_Regression744_NamedSessionReturnsWithoutBlocking     PASS
=== RUN   TestHandoffWithMessage / TestHandoffMissingSubject / ...            PASS
ok  	github.com/gastownhall/gascity/cmd/gc	0.802s
```

The unchanged `TestDoHandoff_NamedAlwaysSessionRequestsRestart` is the load-bearing one for design-alignment: an `always`-mode handoff invoked outside a hook context still requests restart exactly as before.

## Test plan

- [x] Run targeted handoff suite (`go test ./cmd/gc/ -run 'TestHandoff|TestDoHandoff|TestCmdHandoff|TestReadClaudeHookEventName'`)
- [x] Build succeeds (`go build ./...`)
- [x] Manually verified: drove an always-mode mayor session past 80% context with the new binary; PreCompact ran, mayor stayed alive, compaction completed, conversation continued. Before the fix this was a reproducible crash on every approach to autocompact.
- [ ] CI to confirm the broader suite

## Commits

1. `0b8c3191` — fix: skip controller restart for pool-managed sessions on gc handoff
2. `7d12cd25` — fix: detect Claude PreCompact hook context and skip restart kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)