### PR TITLE
tutorials: Fix Claude transcript path aliases

### DIFF
--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -455,12 +456,13 @@ func FindSessionFileByID(searchPaths []string, workDir, sessionID string) string
 	if fileName == "" {
 		return ""
 	}
-	slug := ProjectSlug(workDir)
-	for _, base := range searchPaths {
-		path := filepath.Join(base, slug, fileName)
-		info, err := os.Stat(path)
-		if err == nil && !info.IsDir() {
-			return path
+	for _, slug := range claudeProjectSlugCandidates(workDir) {
+		for _, base := range searchPaths {
+			path := filepath.Join(base, slug, fileName)
+			info, err := os.Stat(path)
+			if err == nil && !info.IsDir() {
+				return path
+			}
 		}
 	}
 	return ""
@@ -470,12 +472,13 @@ func findClaudeLatestSessionFile(searchPaths []string, workDir string) string {
 	if workDir == "" {
 		return ""
 	}
-	slug := ProjectSlug(workDir)
-	for _, base := range searchPaths {
-		path := filepath.Join(base, slug, "latest-session.jsonl")
-		info, err := os.Stat(path)
-		if err == nil && !info.IsDir() {
-			return path
+	for _, slug := range claudeProjectSlugCandidates(workDir) {
+		for _, base := range searchPaths {
+			path := filepath.Join(base, slug, "latest-session.jsonl")
+			info, err := os.Stat(path)
+			if err == nil && !info.IsDir() {
+				return path
+			}
 		}
 	}
 	return ""
@@ -494,27 +497,28 @@ func safeSessionLogFileName(sessionID string) string {
 // {searchPath}/{slug}/{sessionID}.jsonl where slug is the working
 // directory path with "/" and "." replaced by "-".
 func findSlugSessionFile(searchPaths []string, workDir string) string {
-	slug := ProjectSlug(workDir)
 	var globalBestPath string
 	var globalBestTime int64
-	for _, base := range searchPaths {
-		dir := filepath.Join(base, slug)
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-				continue
-			}
-			info, err := e.Info()
+	for _, slug := range claudeProjectSlugCandidates(workDir) {
+		for _, base := range searchPaths {
+			dir := filepath.Join(base, slug)
+			entries, err := os.ReadDir(dir)
 			if err != nil {
 				continue
 			}
-			mt := info.ModTime().UnixNano()
-			if mt > globalBestTime {
-				globalBestTime = mt
-				globalBestPath = filepath.Join(dir, e.Name())
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+					continue
+				}
+				info, err := e.Info()
+				if err != nil {
+					continue
+				}
+				mt := info.ModTime().UnixNano()
+				if mt > globalBestTime {
+					globalBestTime = mt
+					globalBestPath = filepath.Join(dir, e.Name())
+				}
 			}
 		}
 	}
@@ -778,6 +782,80 @@ func providerFamily(provider string) string {
 		return "gemini"
 	default:
 		return p
+	}
+}
+
+func claudeProjectSlugCandidates(workDir string) []string {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return nil
+	}
+
+	seenPaths := make(map[string]bool)
+	var paths []string
+	add := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		path = filepath.Clean(path)
+		if seenPaths[path] {
+			return
+		}
+		seenPaths[path] = true
+		paths = append(paths, path)
+	}
+
+	add(workDir)
+	if abs, err := filepath.Abs(workDir); err == nil {
+		add(abs)
+	}
+	if resolved, err := filepath.EvalSymlinks(workDir); err == nil {
+		add(resolved)
+	}
+
+	for _, path := range append([]string(nil), paths...) {
+		addDarwinClaudePathAliases(path, add)
+	}
+
+	seenSlugs := make(map[string]bool)
+	var slugs []string
+	for _, path := range paths {
+		slug := ProjectSlug(path)
+		if seenSlugs[slug] {
+			continue
+		}
+		seenSlugs[slug] = true
+		slugs = append(slugs, slug)
+	}
+	return slugs
+}
+
+func addDarwinClaudePathAliases(path string, add func(string)) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+
+	switch {
+	case path == "/tmp":
+		add("/private/tmp")
+	case strings.HasPrefix(path, "/tmp/"):
+		add("/private/tmp/" + strings.TrimPrefix(path, "/tmp/"))
+	case path == "/private/tmp":
+		add("/tmp")
+	case strings.HasPrefix(path, "/private/tmp/"):
+		add("/tmp/" + strings.TrimPrefix(path, "/private/tmp/"))
+	}
+
+	switch {
+	case path == "/var":
+		add("/private/var")
+	case strings.HasPrefix(path, "/var/"):
+		add("/private/var/" + strings.TrimPrefix(path, "/var/"))
+	case path == "/private/var":
+		add("/var")
+	case strings.HasPrefix(path, "/private/var/"):
+		add("/var/" + strings.TrimPrefix(path, "/private/var/"))
 	}
 }
 

--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // Session is the resolved view of a Claude JSONL session file.
@@ -456,13 +458,27 @@ func FindSessionFileByID(searchPaths []string, workDir, sessionID string) string
 	if fileName == "" {
 		return ""
 	}
-	for _, slug := range claudeProjectSlugCandidates(workDir) {
-		for _, base := range searchPaths {
+	return findSessionFileByIDForCandidates(searchPaths, claudeProjectSlugCandidates(workDir), fileName)
+}
+
+func findSessionFileByIDForCandidates(searchPaths, slugs []string, fileName string) string {
+	for _, base := range searchPaths {
+		var bestPath string
+		var bestTime int64
+		for _, slug := range slugs {
 			path := filepath.Join(base, slug, fileName)
 			info, err := os.Stat(path)
-			if err == nil && !info.IsDir() {
-				return path
+			if err != nil || info.IsDir() {
+				continue
 			}
+			mt := info.ModTime().UnixNano()
+			if mt > bestTime {
+				bestTime = mt
+				bestPath = path
+			}
+		}
+		if bestPath != "" {
+			return bestPath
 		}
 	}
 	return ""
@@ -472,13 +488,27 @@ func findClaudeLatestSessionFile(searchPaths []string, workDir string) string {
 	if workDir == "" {
 		return ""
 	}
-	for _, slug := range claudeProjectSlugCandidates(workDir) {
-		for _, base := range searchPaths {
+	return findClaudeLatestSessionFileForCandidates(searchPaths, claudeProjectSlugCandidates(workDir))
+}
+
+func findClaudeLatestSessionFileForCandidates(searchPaths, slugs []string) string {
+	for _, base := range searchPaths {
+		var bestPath string
+		var bestTime int64
+		for _, slug := range slugs {
 			path := filepath.Join(base, slug, "latest-session.jsonl")
 			info, err := os.Stat(path)
-			if err == nil && !info.IsDir() {
-				return path
+			if err != nil || info.IsDir() {
+				continue
 			}
+			mt := info.ModTime().UnixNano()
+			if mt > bestTime {
+				bestTime = mt
+				bestPath = path
+			}
+		}
+		if bestPath != "" {
+			return bestPath
 		}
 	}
 	return ""
@@ -493,13 +523,18 @@ func safeSessionLogFileName(sessionID string) string {
 }
 
 // findSlugSessionFile searches slug-organized search paths for the most
-// recently modified JSONL session file. Files are stored at
+// recently modified JSONL session file across all matching Claude
+// project slug candidates. Files are stored at
 // {searchPath}/{slug}/{sessionID}.jsonl where slug is the working
 // directory path with "/" and "." replaced by "-".
 func findSlugSessionFile(searchPaths []string, workDir string) string {
+	return findSlugSessionFileForCandidates(searchPaths, claudeProjectSlugCandidates(workDir))
+}
+
+func findSlugSessionFileForCandidates(searchPaths, slugs []string) string {
 	var globalBestPath string
 	var globalBestTime int64
-	for _, slug := range claudeProjectSlugCandidates(workDir) {
+	for _, slug := range slugs {
 		for _, base := range searchPaths {
 			dir := filepath.Join(base, slug)
 			entries, err := os.ReadDir(dir)
@@ -810,9 +845,7 @@ func claudeProjectSlugCandidates(workDir string) []string {
 	if abs, err := filepath.Abs(workDir); err == nil {
 		add(abs)
 	}
-	if resolved, err := filepath.EvalSymlinks(workDir); err == nil {
-		add(resolved)
-	}
+	add(pathutil.NormalizePathForCompare(workDir))
 
 	for _, path := range append([]string(nil), paths...) {
 		addDarwinClaudePathAliases(path, add)

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -677,6 +678,93 @@ func TestFindSessionFileByIDRejectsTraversalSessionID(t *testing.T) {
 	}
 }
 
+func TestFindSessionFileByIDUsesClaudeProjectPathAlias(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	slugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFileByID([]string{base}, storedWorkDir, "session-123"); got != want {
+		t.Fatalf("FindSessionFileByID() = %q, want %q", got, want)
+	}
+}
+
+func TestFindSessionFileByIDPrefersStoredWorkDirSpelling(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	rawSlugDir := filepath.Join(base, ProjectSlug(storedWorkDir))
+	aliasSlugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	for _, dir := range []string{rawSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := filepath.Join(rawSlugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(aliasSlugDir, "session-123.jsonl")
+	if err := os.WriteFile(aliasPath, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFileByID([]string{base}, storedWorkDir, "session-123"); got != want {
+		t.Fatalf("FindSessionFileByID() = %q, want stored spelling %q", got, want)
+	}
+}
+
+func TestFindSessionFileUsesClaudeProjectPathAlias(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	slugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFile([]string{base}, storedWorkDir); got != want {
+		t.Fatalf("FindSessionFile() = %q, want %q", got, want)
+	}
+}
+
+func TestFindClaudeLatestSessionFileUsesProjectPathAlias(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	slugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "latest-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := findClaudeLatestSessionFile([]string{base}, storedWorkDir); got != want {
+		t.Fatalf("findClaudeLatestSessionFile() = %q, want %q", got, want)
+	}
+}
+
 func TestProjectSlug(t *testing.T) {
 	tests := []struct {
 		path string
@@ -1146,6 +1234,13 @@ func TestFindGeminiSessionFileUsesObservedRoots(t *testing.T) {
 	got := FindGeminiSessionFile([]string{root}, workDir)
 	if got != sessionFile {
 		t.Errorf("got %q, want %q", got, sessionFile)
+	}
+}
+
+func skipUnlessDarwinClaudePathAliases(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only /tmp <-> /private/tmp Claude project path alias")
 	}
 }
 

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -719,9 +719,73 @@ func TestFindSessionFileByIDPrefersStoredWorkDirSpelling(t *testing.T) {
 	if err := os.WriteFile(aliasPath, []byte(`{}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	stamp := time.Unix(1_700_000_000, 0)
+	for _, path := range []string{want, aliasPath} {
+		if err := os.Chtimes(path, stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	if got := FindSessionFileByID([]string{base}, storedWorkDir, "session-123"); got != want {
 		t.Fatalf("FindSessionFileByID() = %q, want stored spelling %q", got, want)
+	}
+}
+
+func TestFindSessionFileByIDForCandidatesUsesNewestMatch(t *testing.T) {
+	base := t.TempDir()
+	storedSlugDir := filepath.Join(base, "stored-slug")
+	aliasSlugDir := filepath.Join(base, "alias-slug")
+	for _, dir := range []string{storedSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	storedPath := filepath.Join(storedSlugDir, "session-123.jsonl")
+	if err := os.WriteFile(storedPath, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(storedPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(aliasSlugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findSessionFileByIDForCandidates([]string{base}, []string{"stored-slug", "alias-slug"}, "session-123.jsonl")
+	if got != want {
+		t.Fatalf("findSessionFileByIDForCandidates() = %q, want newest match %q", got, want)
+	}
+}
+
+func TestFindSessionFileByIDForCandidatesPrefersEarlierSearchPath(t *testing.T) {
+	firstBase := t.TempDir()
+	secondBase := t.TempDir()
+	for _, base := range []string{firstBase, secondBase} {
+		if err := os.MkdirAll(filepath.Join(base, "alias-slug"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	want := filepath.Join(firstBase, "alias-slug", "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newerInLaterBase := filepath.Join(secondBase, "alias-slug", "session-123.jsonl")
+	if err := os.WriteFile(newerInLaterBase, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(want, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findSessionFileByIDForCandidates([]string{firstBase, secondBase}, []string{"alias-slug"}, "session-123.jsonl")
+	if got != want {
+		t.Fatalf("findSessionFileByIDForCandidates() = %q, want earlier search path %q", got, want)
 	}
 }
 
@@ -742,6 +806,188 @@ func TestFindSessionFileUsesClaudeProjectPathAlias(t *testing.T) {
 
 	if got := FindSessionFile([]string{base}, storedWorkDir); got != want {
 		t.Fatalf("FindSessionFile() = %q, want %q", got, want)
+	}
+}
+
+func TestFindSessionFileUsesNewestClaudeProjectPathAliasMatch(t *testing.T) {
+	skipUnlessDarwinClaudePathAliases(t)
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	rawSlugDir := filepath.Join(base, ProjectSlug(storedWorkDir))
+	aliasSlugDir := filepath.Join(base, ProjectSlug(providerWorkDir))
+	for _, dir := range []string{rawSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	storedPath := filepath.Join(rawSlugDir, "stored-session.jsonl")
+	if err := os.WriteFile(storedPath, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(storedPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(aliasSlugDir, "alias-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFile([]string{base}, storedWorkDir); got != want {
+		t.Fatalf("FindSessionFile() = %q, want newest alias match %q", got, want)
+	}
+}
+
+func TestFindSlugSessionFileForCandidatesUsesNewestMatch(t *testing.T) {
+	base := t.TempDir()
+	storedSlugDir := filepath.Join(base, "stored-slug")
+	aliasSlugDir := filepath.Join(base, "alias-slug")
+	for _, dir := range []string{storedSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	storedPath := filepath.Join(storedSlugDir, "stored-session.jsonl")
+	if err := os.WriteFile(storedPath, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(storedPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(aliasSlugDir, "alias-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findSlugSessionFileForCandidates([]string{base}, []string{"stored-slug", "alias-slug"})
+	if got != want {
+		t.Fatalf("findSlugSessionFileForCandidates() = %q, want newest match %q", got, want)
+	}
+}
+
+func TestFindClaudeLatestSessionFileForCandidatesUsesNewestMatch(t *testing.T) {
+	base := t.TempDir()
+	storedSlugDir := filepath.Join(base, "stored-slug")
+	aliasSlugDir := filepath.Join(base, "alias-slug")
+	for _, dir := range []string{storedSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	storedPath := filepath.Join(storedSlugDir, "latest-session.jsonl")
+	if err := os.WriteFile(storedPath, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(storedPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(aliasSlugDir, "latest-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findClaudeLatestSessionFileForCandidates([]string{base}, []string{"stored-slug", "alias-slug"})
+	if got != want {
+		t.Fatalf("findClaudeLatestSessionFileForCandidates() = %q, want newest match %q", got, want)
+	}
+}
+
+func TestFindClaudeLatestSessionFileForCandidatesPrefersEarlierSearchPath(t *testing.T) {
+	firstBase := t.TempDir()
+	secondBase := t.TempDir()
+	for _, base := range []string{firstBase, secondBase} {
+		if err := os.MkdirAll(filepath.Join(base, "alias-slug"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	want := filepath.Join(firstBase, "alias-slug", "latest-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newerInLaterBase := filepath.Join(secondBase, "alias-slug", "latest-session.jsonl")
+	if err := os.WriteFile(newerInLaterBase, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(want, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findClaudeLatestSessionFileForCandidates([]string{firstBase, secondBase}, []string{"alias-slug"})
+	if got != want {
+		t.Fatalf("findClaudeLatestSessionFileForCandidates() = %q, want earlier search path %q", got, want)
+	}
+}
+
+func TestFindSessionFileUsesResolvedSymlinkProjectSlug(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	base := t.TempDir()
+	workRoot := t.TempDir()
+	realWorkDir := filepath.Join(workRoot, "real-city")
+	linkWorkDir := filepath.Join(workRoot, "link-city")
+	if err := os.MkdirAll(realWorkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realWorkDir, linkWorkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	slugDir := filepath.Join(base, ProjectSlug(realWorkDir))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFile([]string{base}, linkWorkDir); got != want {
+		t.Fatalf("FindSessionFile() = %q, want resolved symlink slug %q", got, want)
+	}
+}
+
+func TestFindSessionFileUsesResolvedMissingSymlinkPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	base := t.TempDir()
+	workRoot := t.TempDir()
+	realRoot := filepath.Join(workRoot, "real-root")
+	linkRoot := filepath.Join(workRoot, "link-root")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	missingWorkDir := filepath.Join(linkRoot, "missing-city")
+	slugDir := filepath.Join(base, ProjectSlug(filepath.Join(realRoot, "missing-city")))
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(slugDir, "session-123.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := FindSessionFile([]string{base}, missingWorkDir); got != want {
+		t.Fatalf("FindSessionFile() = %q, want resolved missing-path slug %q", got, want)
 	}
 }
 

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/sessionlog"
 )
@@ -52,6 +54,42 @@ func TestDiscoverFallbackPathUsesClaudeLatestSession(t *testing.T) {
 	got := DiscoverFallbackPath([]string{base}, "claude/tmux-cli", workDir, "gc-123")
 	if got != fallback {
 		t.Fatalf("DiscoverFallbackPath() = %q, want %q", got, fallback)
+	}
+}
+
+func TestDiscoverFallbackPathUsesNewestClaudeLatestSessionAcrossAliases(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only /tmp <-> /private/tmp Claude project path alias")
+	}
+
+	base := t.TempDir()
+	storedWorkDir := "/tmp/gcac/gctutenv-123/home/my-city"
+	providerWorkDir := "/private/tmp/gcac/gctutenv-123/home/my-city"
+	rawSlugDir := filepath.Join(base, sessionlog.ProjectSlug(storedWorkDir))
+	aliasSlugDir := filepath.Join(base, sessionlog.ProjectSlug(providerWorkDir))
+	for _, dir := range []string{rawSlugDir, aliasSlugDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	storedFallback := filepath.Join(rawSlugDir, "latest-session.jsonl")
+	if err := os.WriteFile(storedFallback, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(storedFallback, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(aliasSlugDir, "latest-session.jsonl")
+	if err := os.WriteFile(want, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := DiscoverFallbackPath([]string{base}, "claude/tmux-cli", storedWorkDir, "gc-123")
+	if got != want {
+		t.Fatalf("DiscoverFallbackPath() = %q, want newest fallback %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #1098.
- Preserve the original Claude transcript lookup fix for macOS path aliases where Gas City stores `/tmp/...` but Claude writes project transcripts under the provider-observed `/private/tmp/...` slug.
- Add maintainer follow-ups so keyed lookup, unkeyed slug scans, and `latest-session.jsonl` fallback all search alias slug candidates consistently while preserving search-root precedence.

Credit: Original fix by @csells (commit preserved with original authorship).

## Testing

- [x] `go vet ./...`
- [x] `go test ./internal/sessionlog ./internal/worker/transcript ./internal/session ./internal/api -count=1`
- [x] `go test ./cmd/gc -run '^TestRegisterCityWithSupervisorKeepsRegistrationWhenReloadFails$' -count=1`
- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No separate issue is needed; this supersedes #1098.
No breaking changes or migration notes.

## Notes

- `go test ./...` timed out in `cmd/gc` after 10 minutes under ambient workspace bd/Dolt load. The touched packages passed, and the specifically timed-out `cmd/gc` test passed in isolation.
