### PR TITLE
fix(sling): use tracks dep for auto-convoy, stop evicting prior parent

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/spf13/cobra"
@@ -47,7 +48,7 @@ func newConvoyCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Manage convoys — graphs of related work beads.
 
 A convoy is a named graph of beads with dependencies. Convoys
-group related issues via parent-child relationships.
+group related issues via tracks dependencies.
 
 Convoys are distinct from workflows (graph.v2 formula-compiled
 DAGs managed by the dispatch subsystem) — gc convoy commands do
@@ -91,8 +92,8 @@ func newConvoyCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Create a convoy and optionally track issues",
 		Long: `Create a convoy and optionally link existing issues to it.
 
-Creates a convoy bead and sets the parent of any provided issue IDs to
-the new convoy. Issues can also be added later with "gc convoy add".`,
+Creates a convoy bead and tracks any provided issue IDs. Issues can
+also be added later with "gc convoy add".`,
 		Example: `  gc convoy create sprint-42
   gc convoy create sprint-42 issue-1 issue-2 issue-3
   gc convoy create deploy --owner mayor --notify mayor --merge mr
@@ -253,9 +254,8 @@ func doConvoyCreateWithOptionsJSON(store beads.Store, cfg *config.City, cityPath
 			fmt.Fprintf(stderr, "gc convoy create: issue %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		parentID := convoy.ID
-		if err := childStore.Update(id, beads.UpdateOpts{ParentID: &parentID}); err != nil {
-			fmt.Fprintf(stderr, "gc convoy create: setting parent on %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
+		if err := convoycore.TrackItem(childStore, convoy.ID, id); err != nil {
+			fmt.Fprintf(stderr, "gc convoy create: tracking %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -548,12 +548,8 @@ func doConvoyList(store beads.Store, stdout, stderr io.Writer) int {
 	return doConvoyListAcrossStores([]convoyStoreView{{store: store}}, false, stdout, stderr)
 }
 
-func listConvoyChildren(store beads.Store, parentID string, includeClosed bool) ([]beads.Bead, error) {
-	return store.List(beads.ListQuery{
-		ParentID:      parentID,
-		IncludeClosed: includeClosed,
-		Sort:          beads.SortCreatedAsc,
-	})
+func listConvoyChildren(store beads.Store, convoyID string, includeClosed bool) ([]beads.Bead, error) {
+	return convoycore.Members(store, convoyID, includeClosed)
 }
 
 func doConvoyListAcrossStores(stores []convoyStoreView, jsonOut bool, stdout, stderr io.Writer) int {
@@ -878,8 +874,8 @@ func newConvoyAddCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Add an issue to a convoy",
 		Long: `Link an existing issue bead to a convoy.
 
-Sets the issue's parent to the convoy ID, making it appear in the
-convoy's progress tracking.`,
+Adds a tracks dependency from the convoy to the issue, making it appear
+in the convoy's progress tracking without changing the issue parent.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			code := 0
@@ -918,7 +914,7 @@ func cmdConvoyAddJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 	return doConvoyAddJSON(store, args, jsonOut, stdout, stderr)
 }
 
-// doConvoyAdd adds an issue to a convoy by setting the issue's ParentID.
+// doConvoyAdd adds an issue to a convoy by recording a tracks dependency.
 func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int {
 	return doConvoyAddJSON(store, args, false, stdout, stderr)
 }
@@ -946,7 +942,7 @@ func doConvoyAddJSON(store beads.Store, args []string, jsonOut bool, stdout, std
 		return 1
 	}
 
-	if err := store.Update(issueID, beads.UpdateOpts{ParentID: &convoyID}); err != nil {
+	if err := convoycore.TrackItem(store, convoyID, issueID); err != nil {
 		fmt.Fprintf(stderr, "gc convoy add: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -1459,7 +1455,7 @@ func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opt
 func newConvoyAutocloseCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:    "autoclose <bead-id>",
-		Short:  "Auto-close parent convoy if all siblings are closed",
+		Short:  "Auto-close completed convoys for a closed bead",
 		Hidden: true,
 		Args:   cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -1514,25 +1510,44 @@ func autocloseCityPathForStoreRoot(storeRoot string) string {
 	return cityForStoreDir(storeRoot)
 }
 
-// doConvoyAutocloseWith checks whether the closed bead's parent is a
-// convoy with all children closed, and if so closes it. All errors are
-// silently swallowed — this is best-effort infrastructure called from
-// a bd hook script.
+// doConvoyAutocloseWith checks whether the closed bead's legacy parent or
+// tracks dependents are convoys with all children closed, and if so closes
+// them. All errors are silently swallowed — this is best-effort
+// infrastructure called from a bd hook script.
 func doConvoyAutocloseWith(store beads.Store, rec events.Recorder, beadID string, stdout, _ io.Writer) {
 	bead, err := store.Get(beadID)
-	if err != nil || bead.ParentID == "" {
+	if err != nil {
 		return
 	}
 
-	parent, err := store.Get(bead.ParentID)
-	if err != nil || parent.Type != "convoy" || parent.Status == "closed" {
+	seen := make(map[string]bool)
+	if bead.ParentID != "" {
+		parent, err := store.Get(bead.ParentID)
+		if err == nil {
+			seen[parent.ID] = true
+			autocloseConvoyIfComplete(store, rec, parent, stdout)
+		}
+	}
+
+	trackingConvoys, err := convoycore.TrackingConvoysForItem(store, beadID)
+	if err != nil {
 		return
 	}
-	if hasLabel(parent.Labels, "owned") {
+	for _, convoy := range trackingConvoys {
+		if seen[convoy.ID] {
+			continue
+		}
+		seen[convoy.ID] = true
+		autocloseConvoyIfComplete(store, rec, convoy, stdout)
+	}
+}
+
+func autocloseConvoyIfComplete(store beads.Store, rec events.Recorder, convoy beads.Bead, stdout io.Writer) {
+	if convoy.Type != "convoy" || convoy.Status == "closed" || hasLabel(convoy.Labels, "owned") {
 		return
 	}
 
-	children, err := listConvoyChildren(store, parent.ID, true)
+	children, err := listConvoyChildren(store, convoy.ID, true)
 	if err != nil || len(children) == 0 {
 		return
 	}
@@ -1542,15 +1557,15 @@ func doConvoyAutocloseWith(store beads.Store, rec events.Recorder, beadID string
 		}
 	}
 
-	if err := closeConvoyWithReason(store, parent.ID, convoyAutocloseReason); err != nil {
+	if err := closeConvoyWithReason(store, convoy.ID, convoyAutocloseReason); err != nil {
 		return
 	}
 
 	rec.Record(events.Event{
 		Type:    events.ConvoyClosed,
 		Actor:   eventActor(),
-		Subject: parent.ID,
+		Subject: convoy.ID,
 	})
 
-	fmt.Fprintf(stdout, "Auto-closed convoy %s %q\n", parent.ID, parent.Title) //nolint:errcheck // best-effort stdout
+	fmt.Fprintf(stdout, "Auto-closed convoy %s %q\n", convoy.ID, convoy.Title) //nolint:errcheck // best-effort stdout
 }

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -578,7 +578,7 @@ func doConvoyListAcrossStores(stores []convoyStoreView, jsonOut bool, stdout, st
 		}
 		closed := 0
 		for _, ch := range children {
-			if ch.Status == "closed" {
+			if convoycore.IsTerminalStatus(ch.Status) {
 				closed++
 			}
 		}
@@ -615,7 +615,7 @@ func convoySummaryFromBead(convoy beads.Bead, children []beads.Bead) convoySumma
 	closed := 0
 	for _, ch := range children {
 		childIDs = append(childIDs, ch.ID)
-		if ch.Status == "closed" {
+		if convoycore.IsTerminalStatus(ch.Status) {
 			closed++
 		}
 	}
@@ -707,7 +707,7 @@ func doConvoyStatusWithJSON(store beads.Store, args []string, jsonOut bool, stdo
 
 	closed := 0
 	for _, ch := range children {
-		if ch.Status == "closed" {
+		if convoycore.IsTerminalStatus(ch.Status) {
 			closed++
 		}
 	}
@@ -1162,7 +1162,7 @@ func doConvoyCheckAcrossStoresJSON(stores []convoyStoreView, rec events.Recorder
 		}
 		allClosed := true
 		for _, ch := range children {
-			if ch.Status != "closed" {
+			if !convoycore.IsTerminalStatus(ch.Status) {
 				allClosed = false
 				break
 			}
@@ -1264,7 +1264,7 @@ func doConvoyStrandedAcrossStoresJSON(stores []convoyStoreView, jsonOut bool, st
 			return 1
 		}
 		for _, ch := range children {
-			if ch.Status != "closed" && ch.Assignee == "" {
+			if !convoycore.IsTerminalStatus(ch.Status) && ch.Assignee == "" {
 				items = append(items, strandedItem{convoyID: item.bead.ID, issue: ch})
 			}
 		}
@@ -1384,7 +1384,7 @@ func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opt
 	}
 
 	// Already closed → idempotent success.
-	if convoy.Status == "closed" {
+	if convoycore.IsTerminalStatus(convoy.Status) {
 		if jsonOut {
 			return writeCLIJSONLineOrExit(stdout, stderr, "gc convoy land", convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.land", Action: "land", ConvoyID: convoyID, Title: convoy.Title, AlreadyClosed: true, DryRun: opts.DryRun, Forced: opts.Force})
 		}
@@ -1401,7 +1401,7 @@ func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opt
 
 	var openChildren []beads.Bead
 	for _, ch := range children {
-		if ch.Status != "closed" {
+		if !convoycore.IsTerminalStatus(ch.Status) {
 			openChildren = append(openChildren, ch)
 		}
 	}
@@ -1543,7 +1543,7 @@ func doConvoyAutocloseWith(store beads.Store, rec events.Recorder, beadID string
 }
 
 func autocloseConvoyIfComplete(store beads.Store, rec events.Recorder, convoy beads.Bead, stdout io.Writer) {
-	if convoy.Type != "convoy" || convoy.Status == "closed" || hasLabel(convoy.Labels, "owned") {
+	if convoy.Type != "convoy" || convoycore.IsTerminalStatus(convoy.Status) || hasLabel(convoy.Labels, "owned") {
 		return
 	}
 
@@ -1552,7 +1552,7 @@ func autocloseConvoyIfComplete(store beads.Store, rec events.Recorder, convoy be
 		return
 	}
 	for _, ch := range children {
-		if ch.Status != "closed" {
+		if !convoycore.IsTerminalStatus(ch.Status) {
 			return
 		}
 	}

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -929,6 +929,58 @@ func TestConvoyCheckTracksDeps(t *testing.T) {
 	}
 }
 
+func TestConvoyCheckTreatsTombstoneTrackAsComplete(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                // gc-2
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	tombstone := "tombstone"
+	requireNoError(t, store.Update("gc-2", beads.UpdateOpts{Status: &tombstone}))
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCheck(store, events.Discard, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyCheck = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `Auto-closed convoy gc-1 "batch"`) {
+		t.Errorf("stdout missing auto-close message:\n%s", stdout.String())
+	}
+
+	b, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead Status = %q, want closed", b.Status)
+	}
+}
+
+func TestConvoyCheckDanglingTrackDoesNotAutoClose(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                // gc-2
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	requireNoError(t, store.DepAdd("gc-1", "gc-missing", "tracks"))
+	_ = store.Close("gc-2")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCheck(store, events.Discard, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyCheck = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Auto-closed") {
+		t.Errorf("stdout should not contain Auto-closed for unresolved tracked item:\n%s", stdout.String())
+	}
+
+	b, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Status != "open" {
+		t.Errorf("bead Status = %q, want open", b.Status)
+	}
+}
+
 func TestConvoyCheckJSONAutoCloseEmitsSingleResult(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"})    // gc-1

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -47,11 +47,12 @@ func TestConvoyCreate(t *testing.T) {
 func TestConvoyCreateWithIssues(t *testing.T) {
 	store := beads.NewMemStore()
 	// Pre-create issues.
-	_, _ = store.Create(beads.Bead{Title: "fix auth"})    // gc-1
-	_, _ = store.Create(beads.Bead{Title: "fix logging"}) // gc-2
+	_, _ = store.Create(beads.Bead{Title: "epic", Type: "epic"})         // gc-1
+	_, _ = store.Create(beads.Bead{Title: "fix auth", ParentID: "gc-1"}) // gc-2
+	_, _ = store.Create(beads.Bead{Title: "fix logging"})                // gc-3
 
 	var stdout, stderr bytes.Buffer
-	code := doConvoyCreate(store, events.Discard, []string{"security fixes", "gc-1", "gc-2"}, &stdout, &stderr)
+	code := doConvoyCreate(store, events.Discard, []string{"security fixes", "gc-2", "gc-3"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doConvoyCreate = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -59,16 +60,15 @@ func TestConvoyCreateWithIssues(t *testing.T) {
 		t.Errorf("stdout = %q, want tracking count", stdout.String())
 	}
 
-	// Verify issues have convoy as parent.
-	for _, id := range []string{"gc-1", "gc-2"} {
-		b, err := store.Get(id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if b.ParentID != "gc-3" {
-			t.Errorf("bead %s ParentID = %q, want %q", id, b.ParentID, "gc-3")
-		}
+	got, err := store.Get("gc-2")
+	if err != nil {
+		t.Fatal(err)
 	}
+	if got.ParentID != "gc-1" {
+		t.Errorf("bead gc-2 ParentID = %q, want preserved epic parent gc-1", got.ParentID)
+	}
+	requireConvoyTrack(t, store, "gc-4", "gc-2")
+	requireConvoyTrack(t, store, "gc-4", "gc-3")
 }
 
 func TestConvoyCreateJSON(t *testing.T) {
@@ -154,16 +154,28 @@ func TestConvoyCreateMultiRig(t *testing.T) {
 		t.Errorf("stdout = %q, want tracking 2 issues", stdout.String())
 	}
 
-	// Verify children have parent set.
+	// Verify children are tracked without requiring parent changes.
 	got3, _ := cityStore.Get(child3.ID)
 	got4, _ := cityStore.Get(child4.ID)
-	convoyID := got3.ParentID
+	if got3.ParentID != "" || got4.ParentID != "" {
+		t.Fatalf("children were reparented: %q, %q", got3.ParentID, got4.ParentID)
+	}
+	convoys, err := cityStore.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("list convoys: %v", err)
+	}
+	convoyID := ""
+	for _, convoy := range convoys {
+		if convoy.Title == "same-store batch" {
+			convoyID = convoy.ID
+			break
+		}
+	}
 	if convoyID == "" {
-		t.Fatal("child3 has no parent")
+		t.Fatalf("same-store convoy not found: %+v", convoys)
 	}
-	if got4.ParentID != convoyID {
-		t.Errorf("child4 parent = %q, want %q", got4.ParentID, convoyID)
-	}
+	requireConvoyTrack(t, cityStore, convoyID, child3.ID)
+	requireConvoyTrack(t, cityStore, convoyID, child4.ID)
 	convoy, _ := cityStore.Get(convoyID)
 	if convoy.Type != "convoy" {
 		t.Errorf("convoy type = %q, want convoy", convoy.Type)
@@ -172,8 +184,8 @@ func TestConvoyCreateMultiRig(t *testing.T) {
 
 // TestConvoyCreateRigChildrenShareStore is a regression test: when children
 // have a rig prefix, the convoy must be created in the same store as the
-// children (not the city root store). Otherwise bd update --parent fails
-// because the parent bead doesn't exist in the child's database.
+// children (not the city root store). Otherwise the membership relationship
+// points at beads in a different database.
 func TestValidateConvoyCreateStoreScopeRejectsMixedStores(t *testing.T) {
 	cfg := &config.City{
 		Rigs: []config.Rig{{Name: "frontend", Prefix: "fe", Path: "frontend"}},
@@ -209,17 +221,24 @@ func TestConvoyCreateRigChildrenShareStore(t *testing.T) {
 		t.Fatalf("convoy create failed: %s", stderr.String())
 	}
 
-	// All children must have parent set to the convoy.
+	// All children must be tracked by the convoy without being reparented.
 	got1, _ := store.Get(c1.ID)
 	got2, _ := store.Get(c2.ID)
 	got3, _ := store.Get(c3.ID)
-	convoyID := got1.ParentID
-	if convoyID == "" {
-		t.Fatal("child1 has no parent — convoy not linked")
+	if got1.ParentID != "" || got2.ParentID != "" || got3.ParentID != "" {
+		t.Fatalf("children were reparented: %q, %q, %q", got1.ParentID, got2.ParentID, got3.ParentID)
 	}
-	if got2.ParentID != convoyID || got3.ParentID != convoyID {
-		t.Errorf("children have different parents: %q, %q, %q", got1.ParentID, got2.ParentID, got3.ParentID)
+	convoys, err := store.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("list convoys: %v", err)
 	}
+	if len(convoys) != 1 {
+		t.Fatalf("convoys = %d, want 1", len(convoys))
+	}
+	convoyID := convoys[0].ID
+	requireConvoyTrack(t, store, convoyID, c1.ID)
+	requireConvoyTrack(t, store, convoyID, c2.ID)
+	requireConvoyTrack(t, store, convoyID, c3.ID)
 
 	// Convoy must exist in the SAME store as children.
 	convoy, err := store.Get(convoyID)
@@ -233,10 +252,10 @@ func TestConvoyCreateRigChildrenShareStore(t *testing.T) {
 		t.Errorf("convoy title = %q, want Hello World Variants", convoy.Title)
 	}
 
-	// Verify the convoy is expandable (Children returns all 3).
-	children, err := store.Children(convoyID)
+	// Verify the convoy is expandable through the compatibility helper.
+	children, err := listConvoyChildren(store, convoyID, false)
 	if err != nil {
-		t.Fatalf("listing children: %v", err)
+		t.Fatalf("listing convoy children: %v", err)
 	}
 	if len(children) != 3 {
 		t.Errorf("got %d children, want 3", len(children))
@@ -417,6 +436,29 @@ func TestConvoyStatus(t *testing.T) {
 		"task A", "closed",
 		"task B", "worker",
 	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestConvoyStatusTracksDeps(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "deploy", Type: "convoy"})     // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                     // gc-2
+	_, _ = store.Create(beads.Bead{Title: "task B", Assignee: "worker"}) // gc-3
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	requireNoError(t, store.DepAdd("gc-1", "gc-3", "tracks"))
+	_ = store.Close("gc-2")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyStatus(store, []string{"gc-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyStatus = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"1/2 closed", "task A", "closed", "task B", "worker"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout missing %q:\n%s", want, out)
 		}
@@ -721,25 +763,27 @@ func TestConvoyStatusMissingID(t *testing.T) {
 
 func TestConvoyAdd(t *testing.T) {
 	store := beads.NewMemStore()
-	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"}) // gc-1
-	_, _ = store.Create(beads.Bead{Title: "task A"})                // gc-2
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"})    // gc-1
+	_, _ = store.Create(beads.Bead{Title: "epic", Type: "epic"})       // gc-2
+	_, _ = store.Create(beads.Bead{Title: "task A", ParentID: "gc-2"}) // gc-3
 
 	var stdout, stderr bytes.Buffer
-	code := doConvoyAdd(store, []string{"gc-1", "gc-2"}, &stdout, &stderr)
+	code := doConvoyAdd(store, []string{"gc-1", "gc-3"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doConvoyAdd = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Added gc-2 to convoy gc-1") {
+	if !strings.Contains(stdout.String(), "Added gc-3 to convoy gc-1") {
 		t.Errorf("stdout = %q, want add confirmation", stdout.String())
 	}
 
-	b, err := store.Get("gc-2")
+	b, err := store.Get("gc-3")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if b.ParentID != "gc-1" {
-		t.Errorf("bead ParentID = %q, want %q", b.ParentID, "gc-1")
+	if b.ParentID != "gc-2" {
+		t.Errorf("bead ParentID = %q, want preserved epic parent gc-2", b.ParentID)
 	}
+	requireConvoyTrack(t, store, "gc-1", "gc-3")
 }
 
 func TestConvoyAddNotConvoy(t *testing.T) {
@@ -854,6 +898,34 @@ func TestConvoyCheck(t *testing.T) {
 	}
 	if b.Status != "closed" {
 		t.Errorf("bead Status = %q, want %q", b.Status, "closed")
+	}
+}
+
+func TestConvoyCheckTracksDeps(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                // gc-2
+	_, _ = store.Create(beads.Bead{Title: "task B"})                // gc-3
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	requireNoError(t, store.DepAdd("gc-1", "gc-3", "tracks"))
+	_ = store.Close("gc-2")
+	_ = store.Close("gc-3")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCheck(store, events.Discard, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyCheck = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `Auto-closed convoy gc-1 "batch"`) {
+		t.Errorf("stdout missing auto-close message:\n%s", stdout.String())
+	}
+
+	b, err := store.Get("gc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead Status = %q, want closed", b.Status)
 	}
 }
 
@@ -1164,6 +1236,34 @@ func TestConvoyAutocloseHappyPath(t *testing.T) {
 	}
 	if b.Status != "closed" {
 		t.Errorf("convoy Status = %q, want %q", b.Status, "closed")
+	}
+}
+
+func TestConvoyAutocloseTracksDeps(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "epic", Type: "epic"})       // gc-1
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"})    // gc-2
+	_, _ = store.Create(beads.Bead{Title: "task A", ParentID: "gc-1"}) // gc-3
+	_, _ = store.Create(beads.Bead{Title: "task B"})                   // gc-4
+	requireNoError(t, store.DepAdd("gc-2", "gc-3", "tracks"))
+	requireNoError(t, store.DepAdd("gc-2", "gc-4", "tracks"))
+	_ = store.Close("gc-3")
+	_ = store.Close("gc-4")
+
+	var stdout bytes.Buffer
+	doConvoyAutocloseWith(store, events.Discard, "gc-3", &stdout, &bytes.Buffer{})
+
+	out := stdout.String()
+	if !strings.Contains(out, `Auto-closed convoy gc-2 "batch"`) {
+		t.Errorf("stdout = %q, want tracks convoy auto-close message", out)
+	}
+
+	b, err := store.Get("gc-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("convoy Status = %q, want closed", b.Status)
 	}
 }
 
@@ -1636,5 +1736,26 @@ func TestConvoyLandWithNotify(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "notify: mayor") {
 		t.Errorf("stdout = %q, want notify message", stdout.String())
+	}
+}
+
+func requireConvoyTrack(t *testing.T, store beads.Store, convoyID, itemID string) {
+	t.Helper()
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", convoyID, err)
+	}
+	for _, dep := range deps {
+		if dep.IssueID == convoyID && dep.DependsOnID == itemID && dep.Type == "tracks" {
+			return
+		}
+	}
+	t.Fatalf("missing tracks dep %s -> %s; deps=%v", convoyID, itemID, deps)
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
@@ -883,9 +884,7 @@ func doSlingBatchWithJSON(opts slingOpts, deps slingDeps, querier BeadChildQueri
 		// For batch dry-run, look up the container bead for display.
 		if querier != nil {
 			if b, getErr := querier.Get(opts.BeadOrFormula); getErr == nil {
-				children, _ := querier.List(beads.ListQuery{
-					ParentID: b.ID, IncludeClosed: true, Sort: beads.SortCreatedAsc,
-				})
+				children, _ := dryRunBatchChildren(querier, b.ID)
 				var open []beads.Bead
 				for _, c := range children {
 					if c.Status == "open" {
@@ -904,6 +903,15 @@ func doSlingBatchWithJSON(opts slingOpts, deps slingDeps, querier BeadChildQueri
 		return writeSlingJSONResult(result, jsonStdout, stderr)
 	}
 	return 0
+}
+
+func dryRunBatchChildren(querier BeadChildQuerier, containerID string) ([]beads.Bead, error) {
+	if store, ok := querier.(beads.Store); ok {
+		return convoycore.Members(store, containerID, true)
+	}
+	return querier.List(beads.ListQuery{
+		ParentID: containerID, IncludeClosed: true, Sort: beads.SortCreatedAsc,
+	})
 }
 
 type slingJSONResult struct {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -5930,10 +5930,10 @@ func TestDoSlingIdempotentSkipsRouting(t *testing.T) {
 
 // TestDoSlingRecoversMissingConvoyOnPreRoutedBead covers the case where a
 // bead has gc.routed_to set (e.g., declared via bd create --metadata) but
-// no convoy parent — a prior sling never finished, or the route came from
-// outside gc sling. A subsequent sling must re-run finalize() to create
-// the auto-convoy and poke the controller, instead of skipping as
-// idempotent and leaving the work orphaned.
+// no auto-convoy membership — a prior sling never finished, or the route came
+// from outside gc sling. A subsequent sling must re-run finalize() to create
+// the auto-convoy tracking dependency and poke the controller, instead of
+// skipping as idempotent and leaving the work orphaned.
 func TestDoSlingRecoversMissingConvoyOnPreRoutedBead(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
@@ -5975,15 +5975,28 @@ func TestDoSlingRecoversMissingConvoyOnPreRoutedBead(t *testing.T) {
 	if got := bead.Metadata["gc.routed_to"]; got != "mayor" {
 		t.Errorf("gc.routed_to = %q, want %q (should be unchanged)", got, "mayor")
 	}
-	if bead.ParentID == "" {
-		t.Fatalf("expected recovered bead to have a convoy parent, got empty ParentID")
+	if bead.ParentID != "" {
+		t.Fatalf("ParentID = %q, want empty because auto-convoy membership uses tracks deps", bead.ParentID)
 	}
-	if bead.ParentID == existingConvoy.ID {
-		t.Fatalf("recovered bead parent = pre-existing convoy %s, want a fresh convoy", existingConvoy.ID)
-	}
-	parent, err := deps.Store.Get(bead.ParentID)
+	trackDeps, err := deps.Store.DepList(bead.ID, "up")
 	if err != nil {
-		t.Fatalf("store.Get(%s): %v", bead.ParentID, err)
+		t.Fatalf("DepList(%s, up): %v", bead.ID, err)
+	}
+	var recoveredConvoyID string
+	for _, dep := range trackDeps {
+		if dep.Type == "tracks" && dep.DependsOnID == bead.ID {
+			recoveredConvoyID = dep.IssueID
+		}
+	}
+	if recoveredConvoyID == "" {
+		t.Fatalf("expected recovered bead to have a tracks dependency, got deps=%v", trackDeps)
+	}
+	if recoveredConvoyID == existingConvoy.ID {
+		t.Fatalf("recovered convoy = pre-existing convoy %s, want a fresh convoy", existingConvoy.ID)
+	}
+	parent, err := deps.Store.Get(recoveredConvoyID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", recoveredConvoyID, err)
 	}
 	if parent.Type != "convoy" {
 		t.Errorf("parent.Type = %q, want %q", parent.Type, "convoy")

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -5547,6 +5547,52 @@ func TestDryRunConvoy(t *testing.T) {
 	}
 }
 
+func TestDryRunConvoyUsesTracksMembers(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CVY-1", Type: "convoy", Status: "open", Title: "Sprint 12 tasks"},
+		{ID: "EPIC-1", Type: "epic", Status: "open", Title: "Product work"},
+		{ID: "BL-1", Type: "task", Status: "open", Title: "Login page", ParentID: "EPIC-1"},
+		{ID: "BL-2", Type: "task", Status: "closed", Title: "Auth backend", ParentID: "EPIC-1"},
+	}, []beads.Dep{
+		{IssueID: "CVY-1", DependsOnID: "BL-1", Type: "tracks"},
+		{IssueID: "CVY-1", DependsOnID: "BL-2", Type: "tracks"},
+	})
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = store
+	opts := testOpts(a, "CVY-1")
+	opts.DryRun = true
+	code := doSlingBatch(opts, deps, store, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dry-run returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Children (2 total, 1 open)") {
+		t.Fatalf("stdout missing tracks children summary: %s", out)
+	}
+	if !strings.Contains(out, "BL-1") || !strings.Contains(out, "would route") {
+		t.Errorf("stdout missing tracked open child route preview: %s", out)
+	}
+	if !strings.Contains(out, "BL-2") || !strings.Contains(out, "skip") {
+		t.Errorf("stdout missing tracked closed child skip preview: %s", out)
+	}
+	if !strings.Contains(out, "bd update 'BL-1' --set-metadata gc.routed_to=mayor") {
+		t.Errorf("stdout missing tracked BL-1 route command: %s", out)
+	}
+	if strings.Contains(out, "bd update 'BL-2' --set-metadata gc.routed_to=mayor") {
+		t.Errorf("stdout should not route closed tracked BL-2: %s", out)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("got %d runner calls, want 0: %v", len(runner.calls), runner.calls)
+	}
+}
+
 func TestDryRunBatchOnFormula(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -768,7 +768,7 @@ gc converge test-gate <bead-id> [flags]
 Manage convoys — graphs of related work beads.
 
 A convoy is a named graph of beads with dependencies. Convoys
-group related issues via parent-child relationships.
+group related issues via tracks dependencies.
 
 Convoys are distinct from workflows (graph.v2 formula-compiled
 DAGs managed by the dispatch subsystem) — gc convoy commands do
@@ -798,8 +798,8 @@ gc convoy
 
 Link an existing issue bead to a convoy.
 
-Sets the issue's parent to the convoy ID, making it appear in the
-convoy's progress tracking.
+Adds a tracks dependency from the convoy to the issue, making it appear
+in the convoy's progress tracking without changing the issue parent.
 
 ```
 gc convoy add <convoy-id> <issue-id> [flags]
@@ -858,8 +858,8 @@ gc convoy control [bead-id] [flags]
 
 Create a convoy and optionally link existing issues to it.
 
-Creates a convoy bead and sets the parent of any provided issue IDs to
-the new convoy. Issues can also be added later with "gc convoy add".
+Creates a convoy bead and tracks any provided issue IDs. Issues can
+also be added later with "gc convoy add".
 
 ```
 gc convoy create <name> [issue-ids...] [flags]

--- a/internal/api/handler_beads_partial_test.go
+++ b/internal/api/handler_beads_partial_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 // failingBeadStore wraps an in-memory bead store and injects failures
-// into List, Ready, or Update. Used to verify list handlers surface
+// into List, Ready, Update, or DepAdd. Used to verify list handlers surface
 // store errors as Partial/PartialErrors instead of silently dropping
-// a rig, and to drive the convoy rollback tests which need Update to
-// fail on a specific item ID.
+// a rig, and to drive the convoy rollback tests which need selected
+// mutations to fail on a specific item ID.
 type failingBeadStore struct {
 	beads.Store
 	listErr        error
@@ -23,6 +23,7 @@ type failingBeadStore struct {
 	readyResult    []beads.Bead
 	updateFailAt   map[string]error // item ID → error (fails Update for that ID)
 	updateCallback func(id string)  // optional: called on every Update before injecting failure
+	depAddFailAt   map[string]error // dependsOnID → error (fails DepAdd for that tracked item)
 }
 
 func (f *failingBeadStore) List(q beads.ListQuery) ([]beads.Bead, error) {
@@ -53,6 +54,13 @@ func (f *failingBeadStore) Update(id string, opts beads.UpdateOpts) error {
 		return err
 	}
 	return f.Store.Update(id, opts)
+}
+
+func (f *failingBeadStore) DepAdd(issueID, dependsOnID, depType string) error {
+	if err, ok := f.depAddFailAt[dependsOnID]; ok {
+		return err
+	}
+	return f.Store.DepAdd(issueID, dependsOnID, depType)
 }
 
 func newPartialListState(t *testing.T, listErr, readyErr error) *fakeState {

--- a/internal/api/handler_convoys_rollback_test.go
+++ b/internal/api/handler_convoys_rollback_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// humaHandleConvoyCreate applies per-item Update calls after creating
-// the convoy bead. If the nth Update fails, earlier successful updates
-// must be rolled back so items don't end up pointing at the deleted
-// convoy ID. Round 2 (R2-9) extended the Add/Remove rollback to Create.
+// humaHandleConvoyCreate links items to the new convoy after creating the
+// convoy bead. If the nth link fails, earlier successful links must be
+// rolled back so items don't end up tracked by a deleted convoy ID.
 func TestConvoyCreateRollsBackOnLinkFailure(t *testing.T) {
 	fs := newMutatorState(t)
 	store := fs.stores["myrig"]
@@ -31,11 +30,11 @@ func TestConvoyCreateRollsBackOnLinkFailure(t *testing.T) {
 		t.Fatalf("seed b: %v", err)
 	}
 
-	boom := errors.New("simulated update failure")
-	// Wrap the store so Update fails specifically on itemB.
+	boom := errors.New("simulated dep add failure")
+	// Wrap the store so DepAdd fails specifically on itemB.
 	fs.stores["myrig"] = &failingBeadStore{
 		Store:        store,
-		updateFailAt: map[string]error{itemB.ID: boom},
+		depAddFailAt: map[string]error{itemB.ID: boom},
 	}
 
 	h := newTestCityHandler(t, fs.fakeState)
@@ -52,14 +51,23 @@ func TestConvoyCreateRollsBackOnLinkFailure(t *testing.T) {
 		t.Errorf("body = %q, want 'failed to link' mention", rec.Body.String())
 	}
 
-	// itemA was re-parented before the failure; rollback must restore
-	// its original parent, NOT leave it pointing at the deleted convoy.
+	// itemA's parent should never be changed, and rollback must remove the
+	// tracks dependency added before itemB failed.
 	restored, err := store.Get(itemA.ID)
 	if err != nil {
 		t.Fatalf("get itemA: %v", err)
 	}
 	if restored.ParentID != oldParent {
-		t.Errorf("itemA.ParentID = %q, want %q (rollback should restore original parent)", restored.ParentID, oldParent)
+		t.Errorf("itemA.ParentID = %q, want %q", restored.ParentID, oldParent)
+	}
+	deps, err := store.DepList(itemA.ID, "up")
+	if err != nil {
+		t.Fatalf("DepList(itemA): %v", err)
+	}
+	for _, dep := range deps {
+		if dep.Type == "tracks" {
+			t.Fatalf("itemA still has tracks dep after rollback: %v", deps)
+		}
 	}
 
 	// The convoy bead itself must not survive as an orphan.

--- a/internal/api/handler_convoys_test.go
+++ b/internal/api/handler_convoys_test.go
@@ -14,9 +14,13 @@ func TestConvoyCreateAndGet(t *testing.T) {
 	state := newFakeMutatorState(t)
 	h := newTestCityHandler(t, state)
 
-	// Create a bead to link as convoy item.
+	// Create a bead to link as convoy item while preserving its parent.
 	store := state.stores["myrig"]
-	item, err := store.Create(beads.Bead{Title: "task-1"})
+	epic, err := store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	if err != nil {
+		t.Fatalf("create epic: %v", err)
+	}
+	item, err := store.Create(beads.Bead{Title: "task-1", ParentID: epic.ID})
 	if err != nil {
 		t.Fatalf("create item: %v", err)
 	}
@@ -37,12 +41,27 @@ func TestConvoyCreateAndGet(t *testing.T) {
 	if convoy.Type != "convoy" {
 		t.Fatalf("type = %q, want %q", convoy.Type, "convoy")
 	}
+	gotItem, err := store.Get(item.ID)
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if gotItem.ParentID != epic.ID {
+		t.Fatalf("item parent = %q, want preserved parent %q", gotItem.ParentID, epic.ID)
+	}
+	requireAPITracksDep(t, store, convoy.ID, item.ID)
 
 	// Get convoy.
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/convoy/")+convoy.ID, nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("get: status = %d, want 200", rec.Code)
+	}
+	var getResp convoyGetResponse
+	if err := json.NewDecoder(rec.Body).Decode(&getResp); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if len(getResp.Children) != 1 || getResp.Children[0].ID != item.ID {
+		t.Fatalf("children = %+v, want tracked item %s", getResp.Children, item.ID)
 	}
 }
 
@@ -65,7 +84,8 @@ func TestConvoyAddItems(t *testing.T) {
 
 	store := state.stores["myrig"]
 	convoy, _ := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
-	item, _ := store.Create(beads.Bead{Title: "task"})
+	epic, _ := store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	item, _ := store.Create(beads.Bead{Title: "task", ParentID: epic.ID})
 
 	body := `{"items":["` + item.ID + `"]}`
 	rec := httptest.NewRecorder()
@@ -74,6 +94,11 @@ func TestConvoyAddItems(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("add: status = %d, want 200; body = %s", rec.Code, rec.Body.String())
 	}
+	got, _ := store.Get(item.ID)
+	if got.ParentID != epic.ID {
+		t.Fatalf("item parent = %q, want preserved parent %q", got.ParentID, epic.ID)
+	}
+	requireAPITracksDep(t, store, convoy.ID, item.ID)
 }
 
 func TestConvoyClose(t *testing.T) {
@@ -131,6 +156,33 @@ func TestConvoyRemoveItems(t *testing.T) {
 	}
 }
 
+func TestConvoyRemoveTracksItems(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	convoy, _ := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	epic, _ := store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	item, _ := store.Create(beads.Bead{Title: "task", ParentID: epic.ID})
+	if err := store.DepAdd(convoy.ID, item.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"items":["` + item.ID + `"]}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/convoy/")+convoy.ID+"/remove", strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove: status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+
+	got, _ := store.Get(item.ID)
+	if got.ParentID != epic.ID {
+		t.Errorf("ParentID = %q, want preserved parent %q", got.ParentID, epic.ID)
+	}
+	requireAPINoTracksDep(t, store, convoy.ID, item.ID)
+}
+
 func TestConvoyRemoveNonMember(t *testing.T) {
 	state := newFakeMutatorState(t)
 	h := newTestCityHandler(t, state)
@@ -180,6 +232,45 @@ func TestConvoyCheck(t *testing.T) {
 	}
 	if resp["complete"] != false {
 		t.Errorf("complete = %v, want false", resp["complete"])
+	}
+}
+
+func TestConvoyCheckTracksItems(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	convoy, _ := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	item1, _ := store.Create(beads.Bead{Title: "task1"})
+	item2, _ := store.Create(beads.Bead{Title: "task2"})
+
+	if err := store.DepAdd(convoy.ID, item1.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DepAdd(convoy.ID, item2.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	store.Close(item1.ID) //nolint:errcheck
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/convoy/")+convoy.ID+"/check", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("check: status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp convoyCheckResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode check: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Errorf("total = %d, want 2", resp.Total)
+	}
+	if resp.Closed != 1 {
+		t.Errorf("closed = %d, want 1", resp.Closed)
+	}
+	if resp.Complete {
+		t.Error("complete = true, want false")
 	}
 }
 
@@ -270,5 +361,32 @@ func TestConvoyList(t *testing.T) {
 	}
 	if resp.Total != 1 {
 		t.Fatalf("total = %d, want 1 (only convoys)", resp.Total)
+	}
+}
+
+func requireAPITracksDep(t *testing.T, store beads.Store, convoyID, itemID string) {
+	t.Helper()
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", convoyID, err)
+	}
+	for _, dep := range deps {
+		if dep.IssueID == convoyID && dep.DependsOnID == itemID && dep.Type == "tracks" {
+			return
+		}
+	}
+	t.Fatalf("missing tracks dep %s -> %s; deps=%v", convoyID, itemID, deps)
+}
+
+func requireAPINoTracksDep(t *testing.T, store beads.Store, convoyID, itemID string) {
+	t.Helper()
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", convoyID, err)
+	}
+	for _, dep := range deps {
+		if dep.IssueID == convoyID && dep.DependsOnID == itemID && dep.Type == "tracks" {
+			t.Fatalf("unexpected tracks dep %s -> %s; deps=%v", convoyID, itemID, deps)
+		}
 	}
 }

--- a/internal/api/handler_convoys_test.go
+++ b/internal/api/handler_convoys_test.go
@@ -274,6 +274,66 @@ func TestConvoyCheckTracksItems(t *testing.T) {
 	}
 }
 
+func TestConvoyCheckTracksTombstoneItemsAsComplete(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	convoy, _ := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	item, _ := store.Create(beads.Bead{Title: "task"})
+	if err := store.DepAdd(convoy.ID, item.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	tombstone := "tombstone"
+	if err := store.Update(item.ID, beads.UpdateOpts{Status: &tombstone}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/convoy/")+convoy.ID+"/check", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("check: status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp convoyCheckResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode check: %v", err)
+	}
+	if resp.Total != 1 || resp.Closed != 1 || !resp.Complete {
+		t.Fatalf("resp = %+v, want total=1 closed=1 complete=true", resp)
+	}
+}
+
+func TestConvoyCheckDanglingTracksAreIncomplete(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	convoy, _ := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	item, _ := store.Create(beads.Bead{Title: "task"})
+	if err := store.DepAdd(convoy.ID, item.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DepAdd(convoy.ID, "gc-missing", "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	store.Close(item.ID) //nolint:errcheck
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/convoy/")+convoy.ID+"/check", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("check: status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp convoyCheckResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode check: %v", err)
+	}
+	if resp.Total != 2 || resp.Closed != 1 || resp.Complete {
+		t.Fatalf("resp = %+v, want total=2 closed=1 complete=false", resp)
+	}
+}
+
 func TestConvoyCheckComplete(t *testing.T) {
 	state := newFakeMutatorState(t)
 	h := newTestCityHandler(t, state)

--- a/internal/api/handler_store_selection_test.go
+++ b/internal/api/handler_store_selection_test.go
@@ -78,7 +78,8 @@ func TestConvoyCreateUsesCityStoreWhenAvailableWithoutRig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload city item: %v", err)
 	}
-	if updatedItem.ParentID != convoy.ID {
-		t.Fatalf("city item parent = %q, want %q", updatedItem.ParentID, convoy.ID)
+	if updatedItem.ParentID != "" {
+		t.Fatalf("city item parent = %q, want unchanged empty parent", updatedItem.ParentID)
 	}
+	requireAPITracksDep(t, state.cityBeadStore, convoy.ID, item.ID)
 }

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -175,7 +175,7 @@ func (s *Server) humaHandleConvoyGet(_ context.Context, input *ConvoyGetInput) (
 		total := len(children)
 		closed := 0
 		for _, c := range children {
-			if c.Status == "closed" {
+			if convoycore.IsTerminalStatus(c.Status) {
 				closed++
 			}
 		}
@@ -402,7 +402,7 @@ func (s *Server) humaHandleConvoyCheck(_ context.Context, input *ConvoyCheckInpu
 		total := len(children)
 		closed := 0
 		for _, c := range children {
-			if c.Status == "closed" {
+			if convoycore.IsTerminalStatus(c.Status) {
 				closed++
 			}
 		}

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
@@ -163,11 +164,7 @@ func (s *Server) humaHandleConvoyGet(_ context.Context, input *ConvoyGetInput) (
 			return nil, huma.Error404NotFound("bead " + id + " is not a convoy")
 		}
 
-		children, err := store.List(beads.ListQuery{
-			ParentID:      id,
-			IncludeClosed: true,
-			Sort:          beads.SortCreatedAsc,
-		})
+		children, err := convoycore.Members(store, id, true)
 		if err != nil {
 			return nil, huma.Error500InternalServerError(err.Error())
 		}
@@ -203,16 +200,11 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 		return nil, huma.Error400BadRequest("rig is required when multiple rigs are configured")
 	}
 
-	// Pre-validate all items exist AND capture their current parent so
-	// a mid-link failure can roll each one back, not just delete the
-	// new convoy and leave items pointing at a deleted ID.
-	prevParent := make(map[string]string, len(input.Body.Items))
+	// Pre-validate all items exist before creating the convoy.
 	for _, itemID := range input.Body.Items {
-		item, err := store.Get(itemID)
-		if err != nil {
+		if _, err := store.Get(itemID); err != nil {
 			return nil, storeError(err)
 		}
-		prevParent[itemID] = item.ParentID
 	}
 
 	convoy, err := store.Create(beads.Bead{
@@ -223,17 +215,12 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
-	// Link child items to convoy one at a time. On first failure,
-	// roll back previously-reparented items to their original
-	// parents (via rollbackConvoyMembership) and THEN delete the
-	// new convoy bead. Earlier code deleted the convoy without
-	// restoring item parents, leaving items pointing at a deleted
-	// convoy ID — a worse state than half-populated.
+	// Link child items to convoy one at a time. On first failure, roll
+	// back previously-created tracks deps and THEN delete the new convoy.
 	applied := make([]string, 0, len(input.Body.Items))
 	for _, itemID := range input.Body.Items {
-		pid := convoy.ID
-		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &pid}); err != nil {
-			rollbackConvoyMembership(store, applied, prevParent, "convoy.create")
+		if err := convoycore.TrackItem(store, convoy.ID, itemID); err != nil {
+			rollbackConvoyTracks(store, convoy.ID, applied, "convoy.create")
 			if delErr := store.Delete(convoy.ID); delErr != nil {
 				log.Printf("gc api: convoy create rollback: delete %s after link failure: %v", convoy.ID, delErr)
 			}
@@ -249,8 +236,8 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 }
 
 // humaHandleConvoyAdd is the Huma-typed handler for POST /v0/convoy/{id}/add.
-// Applies each parent-link update one at a time; on first failure, rolls
-// back previously-applied updates so the convoy never ends up half-added.
+// Applies each tracks link one at a time; on first failure, rolls back
+// previously-applied links so the convoy never ends up half-added.
 func (s *Server) humaHandleConvoyAdd(_ context.Context, input *ConvoyAddInput) (*OKResponse, error) {
 	id := input.ID
 	stores := s.state.BeadStores()
@@ -266,21 +253,16 @@ func (s *Server) humaHandleConvoyAdd(_ context.Context, input *ConvoyAddInput) (
 		if b.Type != "convoy" {
 			return nil, huma.Error400BadRequest("bead " + id + " is not a convoy")
 		}
-		// Pre-validate all items exist and capture their previous parent
-		// so rollback can restore it if one of the Updates later fails.
-		prevParent := make(map[string]string, len(input.Body.Items))
+		// Pre-validate all items exist before linking.
 		for _, itemID := range input.Body.Items {
-			item, err := store.Get(itemID)
-			if err != nil {
+			if _, err := store.Get(itemID); err != nil {
 				return nil, storeError(err)
 			}
-			prevParent[itemID] = item.ParentID
 		}
 		applied := make([]string, 0, len(input.Body.Items))
 		for _, itemID := range input.Body.Items {
-			pid := id
-			if err := store.Update(itemID, beads.UpdateOpts{ParentID: &pid}); err != nil {
-				rollbackConvoyMembership(store, applied, prevParent, "convoy.add")
+			if err := convoycore.TrackItem(store, id, itemID); err != nil {
+				rollbackConvoyTracks(store, id, applied, "convoy.add")
 				return nil, huma.Error500InternalServerError("failed to link item " + itemID + ": " + err.Error())
 			}
 			applied = append(applied, itemID)
@@ -308,7 +290,9 @@ func (s *Server) humaHandleConvoyRemove(_ context.Context, input *ConvoyRemoveIn
 		if b.Type != "convoy" {
 			return nil, huma.Error400BadRequest("bead " + id + " is not a convoy")
 		}
-		// Pre-validate all items exist and belong to this convoy.
+		// Pre-validate all items exist and belong to this convoy via either
+		// legacy parent-child membership or the current tracks dependency.
+		snapshots := make(map[string]convoyMembershipSnapshot, len(input.Body.Items))
 		for _, itemID := range input.Body.Items {
 			item, gerr := store.Get(itemID)
 			if gerr != nil {
@@ -317,23 +301,39 @@ func (s *Server) humaHandleConvoyRemove(_ context.Context, input *ConvoyRemoveIn
 				}
 				return nil, huma.Error500InternalServerError(gerr.Error())
 			}
-			if item.ParentID != id {
+			hadTrack, terr := convoycore.HasTrack(store, id, itemID)
+			if terr != nil {
+				return nil, huma.Error500InternalServerError(terr.Error())
+			}
+			if item.ParentID != id && !hadTrack {
 				return nil, huma.Error400BadRequest("item " + itemID + " does not belong to convoy " + id)
 			}
+			snapshots[itemID] = convoyMembershipSnapshot{
+				ParentID: item.ParentID,
+				HadTrack: hadTrack,
+			}
 		}
-		// Unlink items by clearing their ParentID. Same rollback shape
-		// as ConvoyAdd: record the old parent per item so a mid-loop
-		// failure can restore the convoy to its pre-call state.
-		prevParent := make(map[string]string, len(input.Body.Items))
-		for _, itemID := range input.Body.Items {
-			prevParent[itemID] = id
-		}
+
 		applied := make([]string, 0, len(input.Body.Items))
 		empty := ""
 		for _, itemID := range input.Body.Items {
-			if err := store.Update(itemID, beads.UpdateOpts{ParentID: &empty}); err != nil {
-				rollbackConvoyMembership(store, applied, prevParent, "convoy.remove")
-				return nil, huma.Error500InternalServerError("failed to unlink item " + itemID + ": " + err.Error())
+			snapshot := snapshots[itemID]
+			if snapshot.HadTrack {
+				if err := convoycore.UntrackItem(store, id, itemID); err != nil {
+					rollbackConvoyMembershipRemoval(store, id, applied, snapshots, "convoy.remove")
+					return nil, huma.Error500InternalServerError("failed to unlink item " + itemID + ": " + err.Error())
+				}
+			}
+			if snapshot.ParentID == id {
+				if err := store.Update(itemID, beads.UpdateOpts{ParentID: &empty}); err != nil {
+					if snapshot.HadTrack {
+						if trackErr := convoycore.TrackItem(store, id, itemID); trackErr != nil {
+							log.Printf("gc api: convoy.remove rollback failed for current item %s tracks dep: %v", itemID, trackErr)
+						}
+					}
+					rollbackConvoyMembershipRemoval(store, id, applied, snapshots, "convoy.remove")
+					return nil, huma.Error500InternalServerError("failed to unlink item " + itemID + ": " + err.Error())
+				}
 			}
 			applied = append(applied, itemID)
 		}
@@ -344,17 +344,34 @@ func (s *Server) humaHandleConvoyRemove(_ context.Context, input *ConvoyRemoveIn
 	return nil, huma.Error404NotFound("convoy " + id + " not found")
 }
 
-// rollbackConvoyMembership reverses a series of ParentID updates. If a
-// rollback Update itself fails, the inconsistent state is logged — an
-// operator-visible signal that a reconciler or follow-up delete is
-// needed. Best-effort: walks applied in reverse so later-applied items
-// are restored first.
-func rollbackConvoyMembership(store beads.Store, applied []string, prevParent map[string]string, op string) {
+func rollbackConvoyTracks(store beads.Store, convoyID string, applied []string, op string) {
 	for i := len(applied) - 1; i >= 0; i-- {
 		itemID := applied[i]
-		prev := prevParent[itemID]
-		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &prev}); err != nil {
-			log.Printf("gc api: %s rollback failed for item %s (→ %q): %v", op, itemID, prev, err)
+		if err := convoycore.UntrackItem(store, convoyID, itemID); err != nil {
+			log.Printf("gc api: %s rollback failed for item %s tracks dep: %v", op, itemID, err)
+		}
+	}
+}
+
+type convoyMembershipSnapshot struct {
+	ParentID string
+	HadTrack bool
+}
+
+func rollbackConvoyMembershipRemoval(store beads.Store, convoyID string, applied []string, snapshots map[string]convoyMembershipSnapshot, op string) {
+	for i := len(applied) - 1; i >= 0; i-- {
+		itemID := applied[i]
+		snapshot := snapshots[itemID]
+		if snapshot.ParentID == convoyID {
+			prev := snapshot.ParentID
+			if err := store.Update(itemID, beads.UpdateOpts{ParentID: &prev}); err != nil {
+				log.Printf("gc api: %s rollback failed for item %s parent (→ %q): %v", op, itemID, prev, err)
+			}
+		}
+		if snapshot.HadTrack {
+			if err := convoycore.TrackItem(store, convoyID, itemID); err != nil {
+				log.Printf("gc api: %s rollback failed for item %s tracks dep: %v", op, itemID, err)
+			}
 		}
 	}
 }
@@ -377,11 +394,7 @@ func (s *Server) humaHandleConvoyCheck(_ context.Context, input *ConvoyCheckInpu
 			return nil, huma.Error400BadRequest("bead " + id + " is not a convoy")
 		}
 
-		children, err := store.List(beads.ListQuery{
-			ParentID:      id,
-			IncludeClosed: true,
-			Sort:          beads.SortCreatedAsc,
-		})
+		children, err := convoycore.Members(store, id, true)
 		if err != nil {
 			return nil, huma.Error500InternalServerError(err.Error())
 		}

--- a/internal/convoy/convoy.go
+++ b/internal/convoy/convoy.go
@@ -90,7 +90,7 @@ func ConvoyProgress(_ ConvoyDeps, store beads.Store, id string) (ConvoyProgressR
 	total := len(children)
 	closed := 0
 	for _, c := range children {
-		if c.Status == "closed" {
+		if IsTerminalStatus(c.Status) {
 			closed++
 		}
 	}

--- a/internal/convoy/convoy.go
+++ b/internal/convoy/convoy.go
@@ -55,8 +55,7 @@ func ConvoyCreate(deps ConvoyDeps, store beads.Store, input ConvoyCreateInput) (
 
 	linked := 0
 	for _, itemID := range input.Items {
-		pid := convoy.ID
-		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &pid}); err != nil {
+		if err := TrackItem(store, convoy.ID, itemID); err != nil {
 			return ConvoyCreateResult{Convoy: convoy, LinkedCount: linked},
 				fmt.Errorf("linking item %s: %w", itemID, err)
 		}
@@ -83,13 +82,9 @@ func ConvoyProgress(_ ConvoyDeps, store beads.Store, id string) (ConvoyProgressR
 		return ConvoyProgressResult{}, fmt.Errorf("bead %s is not a convoy (type: %s)", id, b.Type)
 	}
 
-	children, err := store.List(beads.ListQuery{
-		ParentID:      id,
-		IncludeClosed: true,
-		Sort:          beads.SortCreatedAsc,
-	})
+	children, err := Members(store, id, true)
 	if err != nil {
-		return ConvoyProgressResult{}, fmt.Errorf("listing children of %s: %w", id, err)
+		return ConvoyProgressResult{}, fmt.Errorf("listing tracked items of %s: %w", id, err)
 	}
 
 	total := len(children)
@@ -119,8 +114,7 @@ func ConvoyAddItems(_ ConvoyDeps, store beads.Store, convoyID string, items []st
 	}
 
 	for _, itemID := range items {
-		pid := convoyID
-		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &pid}); err != nil {
+		if err := TrackItem(store, convoyID, itemID); err != nil {
 			return fmt.Errorf("linking item %s to convoy %s: %w", itemID, convoyID, err)
 		}
 	}

--- a/internal/convoy/convoy_test.go
+++ b/internal/convoy/convoy_test.go
@@ -62,7 +62,8 @@ func TestConvoyCreateWithItemsOps(t *testing.T) {
 	deps := testConvoyDeps(store)
 
 	// Create child beads first.
-	b1, _ := store.Create(beads.Bead{Title: "task 1"})
+	epic, _ := store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	b1, _ := store.Create(beads.Bead{Title: "task 1", ParentID: epic.ID})
 	b2, _ := store.Create(beads.Bead{Title: "task 2"})
 
 	result, err := ConvoyCreate(deps, store, ConvoyCreateInput{
@@ -76,11 +77,13 @@ func TestConvoyCreateWithItemsOps(t *testing.T) {
 		t.Errorf("linked = %d, want 2", result.LinkedCount)
 	}
 
-	// Verify children are linked.
+	// Verify children are tracked without evicting their existing parent.
 	child1, _ := store.Get(b1.ID)
-	if child1.ParentID != result.Convoy.ID {
-		t.Errorf("child1 parent = %q, want %q", child1.ParentID, result.Convoy.ID)
+	if child1.ParentID != epic.ID {
+		t.Errorf("child1 parent = %q, want preserved epic parent %q", child1.ParentID, epic.ID)
 	}
+	requireTracksDep(t, store, result.Convoy.ID, b1.ID)
+	requireTracksDep(t, store, result.Convoy.ID, b2.ID)
 }
 
 func TestConvoyProgressOps(t *testing.T) {
@@ -130,12 +133,45 @@ func TestConvoyProgressCompleteOps(t *testing.T) {
 	}
 }
 
-func TestConvoyAddItemsOps(t *testing.T) {
+func TestConvoyProgressTracksDepsOps(t *testing.T) {
 	store := beads.NewMemStore()
 	deps := testConvoyDeps(store)
 
 	convoy, _ := store.Create(beads.Bead{Title: "test", Type: "convoy"})
 	b1, _ := store.Create(beads.Bead{Title: "task 1"})
+	b2, _ := store.Create(beads.Bead{Title: "task 2"})
+	if err := store.DepAdd(convoy.ID, b1.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DepAdd(convoy.ID, b2.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(b1.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	progress, err := ConvoyProgress(deps, store, convoy.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if progress.Total != 2 {
+		t.Errorf("total = %d, want 2", progress.Total)
+	}
+	if progress.Closed != 1 {
+		t.Errorf("closed = %d, want 1", progress.Closed)
+	}
+	if progress.Complete {
+		t.Error("expected not complete")
+	}
+}
+
+func TestConvoyAddItemsOps(t *testing.T) {
+	store := beads.NewMemStore()
+	deps := testConvoyDeps(store)
+
+	convoy, _ := store.Create(beads.Bead{Title: "test", Type: "convoy"})
+	epic, _ := store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	b1, _ := store.Create(beads.Bead{Title: "task 1", ParentID: epic.ID})
 
 	err := ConvoyAddItems(deps, store, convoy.ID, []string{b1.ID})
 	if err != nil {
@@ -143,9 +179,10 @@ func TestConvoyAddItemsOps(t *testing.T) {
 	}
 
 	child, _ := store.Get(b1.ID)
-	if child.ParentID != convoy.ID {
-		t.Errorf("parent = %q, want %q", child.ParentID, convoy.ID)
+	if child.ParentID != epic.ID {
+		t.Errorf("parent = %q, want preserved epic parent %q", child.ParentID, epic.ID)
 	}
+	requireTracksDep(t, store, convoy.ID, b1.ID)
 }
 
 func TestConvoyCloseOps(t *testing.T) {
@@ -185,4 +222,18 @@ func TestConvoyCloseNotFoundOps(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nonexistent convoy")
 	}
+}
+
+func requireTracksDep(t *testing.T, store beads.Store, convoyID, itemID string) {
+	t.Helper()
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		t.Fatalf("DepList(%s): %v", convoyID, err)
+	}
+	for _, dep := range deps {
+		if dep.IssueID == convoyID && dep.DependsOnID == itemID && dep.Type == "tracks" {
+			return
+		}
+	}
+	t.Fatalf("missing tracks dep %s -> %s; deps=%v", convoyID, itemID, deps)
 }

--- a/internal/convoy/convoy_test.go
+++ b/internal/convoy/convoy_test.go
@@ -165,6 +165,58 @@ func TestConvoyProgressTracksDepsOps(t *testing.T) {
 	}
 }
 
+func TestConvoyProgressTreatsTombstoneAsCompleteOps(t *testing.T) {
+	store := beads.NewMemStore()
+	deps := testConvoyDeps(store)
+
+	convoy, _ := store.Create(beads.Bead{Title: "test", Type: "convoy"})
+	b1, _ := store.Create(beads.Bead{Title: "task 1"})
+	if err := store.DepAdd(convoy.ID, b1.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+	tombstone := "tombstone"
+	if err := store.Update(b1.ID, beads.UpdateOpts{Status: &tombstone}); err != nil {
+		t.Fatal(err)
+	}
+
+	progress, err := ConvoyProgress(deps, store, convoy.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if progress.Total != 1 {
+		t.Errorf("total = %d, want 1", progress.Total)
+	}
+	if progress.Closed != 1 {
+		t.Errorf("closed = %d, want 1", progress.Closed)
+	}
+	if !progress.Complete {
+		t.Error("expected tombstone tracked item to complete convoy")
+	}
+}
+
+func TestConvoyMembersKeepsDanglingTracksUnknownOps(t *testing.T) {
+	store := beads.NewMemStore()
+
+	convoy, _ := store.Create(beads.Bead{Title: "test", Type: "convoy"})
+	if err := store.DepAdd(convoy.ID, "gc-missing", "tracks"); err != nil {
+		t.Fatal(err)
+	}
+
+	members, err := Members(store, convoy.ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("members = %d, want 1", len(members))
+	}
+	if members[0].ID != "gc-missing" {
+		t.Errorf("member ID = %q, want gc-missing", members[0].ID)
+	}
+	if members[0].Status != "unknown" {
+		t.Errorf("member status = %q, want unknown", members[0].Status)
+	}
+}
+
 func TestConvoyAddItemsOps(t *testing.T) {
 	store := beads.NewMemStore()
 	deps := testConvoyDeps(store)

--- a/internal/convoy/membership.go
+++ b/internal/convoy/membership.go
@@ -1,0 +1,138 @@
+package convoy
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// TrackingDepType is the dependency type used for convoy membership edges.
+const TrackingDepType = "tracks"
+
+// TrackItem records that convoyID tracks itemID without changing itemID's
+// parent-child relationship.
+func TrackItem(store beads.Store, convoyID, itemID string) error {
+	if _, err := store.Get(itemID); err != nil {
+		return fmt.Errorf("getting tracked item %s: %w", itemID, err)
+	}
+	if err := store.DepAdd(convoyID, itemID, TrackingDepType); err != nil {
+		return fmt.Errorf("adding %s dependency %s -> %s: %w", TrackingDepType, convoyID, itemID, err)
+	}
+	return nil
+}
+
+// UntrackItem removes a convoy membership edge from convoyID to itemID.
+func UntrackItem(store beads.Store, convoyID, itemID string) error {
+	if err := store.DepRemove(convoyID, itemID); err != nil {
+		return fmt.Errorf("removing %s dependency %s -> %s: %w", TrackingDepType, convoyID, itemID, err)
+	}
+	return nil
+}
+
+// Members returns beads tracked by a convoy. It supports both the current
+// tracks dependency relation and legacy parent-child convoy membership.
+func Members(store beads.Store, convoyID string, includeClosed bool) ([]beads.Bead, error) {
+	legacyChildren, err := store.List(beads.ListQuery{
+		ParentID:      convoyID,
+		IncludeClosed: includeClosed,
+		Sort:          beads.SortCreatedAsc,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing legacy convoy children of %s: %w", convoyID, err)
+	}
+
+	seen := make(map[string]bool, len(legacyChildren))
+	members := make([]beads.Bead, 0, len(legacyChildren))
+	add := func(b beads.Bead) {
+		if seen[b.ID] {
+			return
+		}
+		if !includeClosed && b.Status == "closed" {
+			return
+		}
+		seen[b.ID] = true
+		members = append(members, b)
+	}
+	for _, child := range legacyChildren {
+		add(child)
+	}
+
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		return nil, fmt.Errorf("listing convoy %s dependencies: %w", convoyID, err)
+	}
+	for _, dep := range deps {
+		if dep.Type != TrackingDepType {
+			continue
+		}
+		item, err := store.Get(dep.DependsOnID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("getting tracked item %s: %w", dep.DependsOnID, err)
+		}
+		add(item)
+	}
+
+	sortMembers(members)
+	return members, nil
+}
+
+// HasTrack reports whether convoyID has a tracks dependency to itemID.
+func HasTrack(store beads.Store, convoyID, itemID string) (bool, error) {
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		return false, fmt.Errorf("listing convoy %s dependencies: %w", convoyID, err)
+	}
+	for _, dep := range deps {
+		if dep.Type == TrackingDepType && dep.IssueID == convoyID && dep.DependsOnID == itemID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// TrackingConvoysForItem returns convoy beads that track itemID via a tracks
+// dependency. Dangling dependency sources are ignored.
+func TrackingConvoysForItem(store beads.Store, itemID string) ([]beads.Bead, error) {
+	deps, err := store.DepList(itemID, "up")
+	if err != nil {
+		return nil, fmt.Errorf("listing dependents of item %s: %w", itemID, err)
+	}
+
+	seen := make(map[string]bool, len(deps))
+	convoys := make([]beads.Bead, 0, len(deps))
+	for _, dep := range deps {
+		if dep.Type != TrackingDepType || seen[dep.IssueID] {
+			continue
+		}
+		b, err := store.Get(dep.IssueID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("getting tracking convoy %s: %w", dep.IssueID, err)
+		}
+		if b.Type != "convoy" {
+			continue
+		}
+		seen[b.ID] = true
+		convoys = append(convoys, b)
+	}
+	sortMembers(convoys)
+	return convoys, nil
+}
+
+func sortMembers(items []beads.Bead) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		if left.CreatedAt.Equal(right.CreatedAt) {
+			return left.ID < right.ID
+		}
+		return left.CreatedAt.Before(right.CreatedAt)
+	})
+}

--- a/internal/convoy/membership.go
+++ b/internal/convoy/membership.go
@@ -11,6 +11,14 @@ import (
 // TrackingDepType is the dependency type used for convoy membership edges.
 const TrackingDepType = "tracks"
 
+const trackedStatusUnknown = "unknown"
+
+// IsTerminalStatus reports whether a tracked item should count as complete for
+// convoy progress and auto-close decisions.
+func IsTerminalStatus(status string) bool {
+	return status == "closed" || status == "tombstone"
+}
+
 // TrackItem records that convoyID tracks itemID without changing itemID's
 // parent-child relationship.
 func TrackItem(store beads.Store, convoyID, itemID string) error {
@@ -33,6 +41,8 @@ func UntrackItem(store beads.Store, convoyID, itemID string) error {
 
 // Members returns beads tracked by a convoy. It supports both the current
 // tracks dependency relation and legacy parent-child convoy membership.
+// Unresolved tracks dependencies are returned with unknown status so completion
+// paths never mistake missing dependency details for completed work.
 func Members(store beads.Store, convoyID string, includeClosed bool) ([]beads.Bead, error) {
 	legacyChildren, err := store.List(beads.ListQuery{
 		ParentID:      convoyID,
@@ -49,7 +59,7 @@ func Members(store beads.Store, convoyID string, includeClosed bool) ([]beads.Be
 		if seen[b.ID] {
 			return
 		}
-		if !includeClosed && b.Status == "closed" {
+		if !includeClosed && IsTerminalStatus(b.Status) {
 			return
 		}
 		seen[b.ID] = true
@@ -70,6 +80,7 @@ func Members(store beads.Store, convoyID string, includeClosed bool) ([]beads.Be
 		item, err := store.Get(dep.DependsOnID)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
+				add(unresolvedTrackedItem(dep.DependsOnID))
 				continue
 			}
 			return nil, fmt.Errorf("getting tracked item %s: %w", dep.DependsOnID, err)
@@ -79,6 +90,15 @@ func Members(store beads.Store, convoyID string, includeClosed bool) ([]beads.Be
 
 	sortMembers(members)
 	return members, nil
+}
+
+func unresolvedTrackedItem(id string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Title:  id,
+		Type:   "task",
+		Status: trackedStatusUnknown,
+	}
 }
 
 // HasTrack reports whether convoyID has a tracks dependency to itemID.

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
@@ -320,9 +321,12 @@ func checkBatchNoMoleculeChildren(q BeadChildQuerier, open []beads.Bead, store b
 }
 
 // needsConvoyRecovery reports whether an already-routed bead should re-enter
-// finalize to repair a missing or closed convoy parent.
-func needsConvoyRecovery(q BeadQuerier, b beads.Bead, opts BeadCheckOptions) bool {
+// finalize to repair missing or closed auto-convoy membership.
+func needsConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadCheckOptions) bool {
 	if opts.NoConvoy {
+		return false
+	}
+	if hasLiveTrackingConvoy(deps.Store, b.ID) {
 		return false
 	}
 	parentID := strings.TrimSpace(b.ParentID)
@@ -339,6 +343,22 @@ func needsConvoyRecovery(q BeadQuerier, b beads.Bead, opts BeadCheckOptions) boo
 	return parent.Type == "convoy" && parent.Status == "closed"
 }
 
+func hasLiveTrackingConvoy(store beads.Store, itemID string) bool {
+	if store == nil {
+		return false
+	}
+	convoys, err := convoycore.TrackingConvoysForItem(store, itemID)
+	if err != nil {
+		return false
+	}
+	for _, convoy := range convoys {
+		if !convoycore.IsTerminalStatus(convoy.Status) {
+			return true
+		}
+	}
+	return false
+}
+
 // CheckBeadState checks whether a bead is already routed and returns a
 // structured result. Best-effort: nil querier or query failure → empty result.
 func CheckBeadState(q BeadQuerier, beadID string, a config.Agent, deps SlingDeps) BeadCheckResult {
@@ -347,7 +367,7 @@ func CheckBeadState(q BeadQuerier, beadID string, a config.Agent, deps SlingDeps
 
 // CheckBeadStateWithOptions checks whether a bead is already routed for the
 // requested route options and returns a structured result.
-func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, _ SlingDeps, opts BeadCheckOptions) BeadCheckResult {
+func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, deps SlingDeps, opts BeadCheckOptions) BeadCheckResult {
 	if q == nil {
 		return BeadCheckResult{}
 	}
@@ -375,7 +395,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, _ S
 	target := a.QualifiedName()
 	if strings.TrimSpace(b.Metadata["gc.routed_to"]) == target {
 		if b.Assignee == "" || b.Assignee == target {
-			if needsConvoyRecovery(q, b, opts) {
+			if needsConvoyRecovery(q, b, deps, opts) {
 				// Prior sling set gc.routed_to but left no convoy — let
 				// finalize re-run to create it and poke the controller.
 				return BeadCheckResult{}
@@ -390,7 +410,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, _ S
 	isMulti := agentutil.IsMultiSessionAgent(&a)
 	if !isMulti {
 		if b.Assignee == target {
-			if needsConvoyRecovery(q, b, opts) {
+			if needsConvoyRecovery(q, b, deps, opts) {
 				return BeadCheckResult{}
 			}
 			return BeadCheckResult{Idempotent: true}
@@ -414,7 +434,7 @@ func CheckBeadStateWithOptions(q BeadQuerier, beadID string, a config.Agent, _ S
 		poolLabel := "pool:" + target
 		for _, l := range b.Labels {
 			if l == poolLabel {
-				if needsConvoyRecovery(q, b, opts) {
+				if needsConvoyRecovery(q, b, deps, opts) {
 					return BeadCheckResult{}
 				}
 				return BeadCheckResult{Idempotent: true}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
@@ -422,7 +423,7 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 				// bd update --parent evicts any prior parent-child edge; the
 				// tracks dep is additive and does not disturb the epic
 				// rollup.
-				if err := deps.Store.DepAdd(convoy.ID, beadID, "tracks"); err != nil {
+				if err := convoycore.TrackItem(deps.Store, convoy.ID, beadID); err != nil {
 					result.MetadataErrors = append(result.MetadataErrors,
 						fmt.Sprintf("linking bead to convoy: %v", err))
 				} else {
@@ -956,6 +957,17 @@ func sourceWorkflowLockScope(deps SlingDeps) string {
 	})
 }
 
+func listContainerChildren(querier BeadChildQuerier, containerID string, includeClosed bool) ([]beads.Bead, error) {
+	if store, ok := querier.(beads.Store); ok {
+		return convoycore.Members(store, containerID, includeClosed)
+	}
+	return querier.List(beads.ListQuery{
+		ParentID:      containerID,
+		IncludeClosed: includeClosed,
+		Sort:          beads.SortCreatedAsc,
+	})
+}
+
 // DoSlingBatch handles convoy expansion before delegating to DoSling.
 func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (SlingResult, error) {
 	a := opts.Target
@@ -1006,11 +1018,7 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 		return DoSling(singleOpts, singleDeps, querier)
 	}
 
-	children, err := querier.List(beads.ListQuery{
-		ParentID:      b.ID,
-		IncludeClosed: true,
-		Sort:          beads.SortCreatedAsc,
-	})
+	children, err := listContainerChildren(querier, b.ID, true)
 	if err != nil {
 		return SlingResult{}, fmt.Errorf("listing children of %s: %w", b.ID, err)
 	}

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -417,8 +417,12 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 				result.MetadataErrors = append(result.MetadataErrors,
 					fmt.Sprintf("creating auto-convoy: %v", err))
 			} else {
-				parentID := convoy.ID
-				if err := deps.Store.Update(beadID, beads.UpdateOpts{ParentID: &parentID}); err != nil {
+				// Use a "tracks" dep (convoy → bead) instead of parent-child
+				// so the bead's existing parent (e.g. its epic) is preserved.
+				// bd update --parent evicts any prior parent-child edge; the
+				// tracks dep is additive and does not disturb the epic
+				// rollup.
+				if err := deps.Store.DepAdd(convoy.ID, beadID, "tracks"); err != nil {
 					result.MetadataErrors = append(result.MetadataErrors,
 						fmt.Sprintf("linking bead to convoy: %v", err))
 				} else {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -449,6 +449,61 @@ func TestCheckBeadStateRoutedWithoutConvoyIsNotIdempotent(t *testing.T) {
 	}
 }
 
+func TestCheckBeadStateRoutedWithLiveTrackingConvoyIsIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "auto convoy", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(convoy): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "route me",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, bead.ID, "tracks"); err != nil {
+		t.Fatalf("store.DepAdd(tracks): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+	if !result.Idempotent {
+		t.Fatalf("expected Idempotent=true when routed bead has live tracking convoy, got %+v", result)
+	}
+}
+
+func TestCheckBeadStateRoutedWithClosedTrackingConvoyIsNotIdempotent(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, err := store.Create(beads.Bead{Title: "old convoy", Type: "convoy", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(convoy): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "route me",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, bead.ID, "tracks"); err != nil {
+		t.Fatalf("store.DepAdd(tracks): %v", err)
+	}
+	if err := store.Close(convoy.ID); err != nil {
+		t.Fatalf("store.Close(convoy): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+	if result.Idempotent {
+		t.Fatalf("expected Idempotent=false when routed bead has only closed tracking convoy, got %+v", result)
+	}
+}
+
 // TestCheckBeadStateRoutedWithClosedConvoyIsNotIdempotent ensures a prior
 // convoy whose run has finished does not count as a live attachment — the
 // next sling should still create a fresh convoy and poke the controller.

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -3565,6 +3565,132 @@ func TestFinalizeAutoConvoy(t *testing.T) {
 	}
 }
 
+// TestFinalizeAutoConvoyPreservesEpicParent is a regression test for the
+// bug where `gc sling` re-parented a bead to its auto-convoy via
+// `bd update --parent`, silently evicting the bead's existing
+// parent-child edge to its epic. After this fix, the auto-convoy links
+// to the bead via a "tracks" dep instead, leaving the epic parent
+// intact.
+func TestFinalizeAutoConvoyPreservesEpicParent(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+
+	epic, err := deps.Store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	if err != nil {
+		t.Fatalf("create epic: %v", err)
+	}
+	child, err := deps.Store.Create(beads.Bead{Title: "work", Type: "task", ParentID: epic.ID})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	result, err := DoSling(SlingOpts{Target: a, BeadOrFormula: child.ID}, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("DoSling: %v", err)
+	}
+	if result.ConvoyID == "" {
+		t.Fatal("expected auto-convoy creation")
+	}
+
+	got, err := deps.Store.Get(child.ID)
+	if err != nil {
+		t.Fatalf("get child: %v", err)
+	}
+	if got.ParentID != epic.ID {
+		t.Errorf("child parent = %q, want %q (epic parent evicted by sling)", got.ParentID, epic.ID)
+	}
+
+	epicChildren, err := deps.Store.Children(epic.ID)
+	if err != nil {
+		t.Fatalf("epic children: %v", err)
+	}
+	var found bool
+	for _, c := range epicChildren {
+		if c.ID == child.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("epic %s children missing %s; got %d children", epic.ID, child.ID, len(epicChildren))
+	}
+
+	convoyOut, err := deps.Store.DepList(result.ConvoyID, "down")
+	if err != nil {
+		t.Fatalf("DepList convoy: %v", err)
+	}
+	var tracks bool
+	for _, d := range convoyOut {
+		if d.DependsOnID == child.ID && d.Type == "tracks" {
+			tracks = true
+			break
+		}
+	}
+	if !tracks {
+		t.Errorf("convoy %s has no tracks dep to %s; got deps=%v", result.ConvoyID, child.ID, convoyOut)
+	}
+}
+
+// failingDepAddStore wraps a beads.Store and returns an error when
+// DepAdd is called with a specific dep type. Used to exercise error
+// branches in code that links beads via DepAdd.
+type failingDepAddStore struct {
+	beads.Store
+	failType string
+	err      error
+}
+
+func (f *failingDepAddStore) DepAdd(issueID, dependsOnID, depType string) error {
+	if depType == f.failType {
+		return f.err
+	}
+	return f.Store.DepAdd(issueID, dependsOnID, depType)
+}
+
+// TestFinalizeAutoConvoyTracksDepAddError covers the error branch of
+// the auto-convoy linking step: if DepAdd("tracks") fails, the failure
+// is recorded in result.MetadataErrors rather than bubbled up.
+func TestFinalizeAutoConvoyTracksDepAddError(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = &failingDepAddStore{
+		Store:    deps.Store,
+		failType: "tracks",
+		err:      errors.New("injected DepAdd failure"),
+	}
+
+	b, err := deps.Store.Create(beads.Bead{Title: "work", Type: "task"})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+
+	result, err := DoSling(SlingOpts{Target: a, BeadOrFormula: b.ID}, deps, deps.Store)
+	if err != nil {
+		t.Fatalf("DoSling: %v", err)
+	}
+	// When DepAdd fails, result.ConvoyID is intentionally left unset and
+	// the error is appended to MetadataErrors (soft failure — sling
+	// itself still succeeds).
+	if result.ConvoyID != "" {
+		t.Errorf("result.ConvoyID = %q, want empty (DepAdd failed)", result.ConvoyID)
+	}
+
+	var found bool
+	for _, e := range result.MetadataErrors {
+		if strings.Contains(e, "linking bead to convoy") && strings.Contains(e, "injected DepAdd failure") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected MetadataErrors to include tracks DepAdd failure; got %v", result.MetadataErrors)
+	}
+}
+
 func TestFinalizeNoConvoyWhenSuppressed(t *testing.T) {
 	runner := newFakeRunner()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1434,6 +1434,39 @@ func TestDoSlingBatchUsesCallerQuerierChildrenWhenContainerExistsThere(t *testin
 	}
 }
 
+func TestDoSlingBatchExpandsTracksConvoy(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	store := deps.Store
+	convoy, err := store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	epic, err := store.Create(beads.Bead{Title: "epic", Type: "epic"})
+	if err != nil {
+		t.Fatalf("create epic: %v", err)
+	}
+	child, err := store.Create(beads.Bead{Title: "child", Type: "task", Status: "open", ParentID: epic.ID})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, child.ID, "tracks"); err != nil {
+		t.Fatalf("track child: %v", err)
+	}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := DoSlingBatch(SlingOpts{Target: a, BeadOrFormula: convoy.ID}, deps, store)
+	if err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+	if result.Routed != 1 {
+		t.Fatalf("Routed = %d, want 1", result.Routed)
+	}
+	if len(result.Children) != 1 || result.Children[0].BeadID != child.ID {
+		t.Fatalf("children = %#v, want tracked child %s", result.Children, child.ID)
+	}
+}
+
 func TestDoSlingBatchRoutesNonContainerFoundInQuerierStore(t *testing.T) {
 	runner := newFakeRunner()
 	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)


### PR DESCRIPTION
## Summary

`gc sling` creates an auto-convoy and re-parents the slung bead to it via `bd update --parent`, silently evicting any prior parent-child edge (e.g. the bead's epic parent). Evicted beads disappear from the epic's children list; completion percentages read artificially high.

## Root cause

The eviction is a CLI-layer rule in `bd update --parent` (`beads` repo, `cmd/bd/update.go:425-467`): it explicitly removes any existing parent-child dep before adding the new one. The schema itself permits multi-parent — `internal/storage/schema/migrations/0002_create_dependencies.up.sql` keys on `(issue_id, depends_on_id)` with no UNIQUE on `(issue_id, type)`.

Gascity's sling opts into that eviction — `internal/sling/sling_core.go:finalize()` calls `deps.Store.Update(beadID, beads.UpdateOpts{ParentID: &parentID})`, which routes through `bd update --parent`.

Gastown takes a different approach: `gastown/internal/cmd/sling_convoy.go:createAutoConvoy()` adds a `"tracks"` dep (convoy → bead) instead of reparenting. The prior parent survives.

## Fix

Replace the `Store.Update(..., ParentID: ...)` call in `internal/sling/sling_core.go:finalize()` with `Store.DepAdd(convoy.ID, beadID, "tracks")`, matching the gastown pattern. The prior parent-child edge is preserved; the convoy gets its own `tracks` edge to the bead.

## Testing

New regression test `TestFinalizeAutoConvoyPreservesEpicParent` in `internal/sling/sling_test.go`:
- Creates an epic + child bead (child parent-child → epic)
- Runs sling's `finalize()` via the full auto-convoy path
- Asserts: child's parent-child dep to epic survives; convoy gets a `tracks` dep to the bead; epic's children list still contains the bead

All existing `internal/sling` tests pass.