### PR TITLE
fix: re-route orphaned work beads on drain completion

### DIFF
--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -542,7 +542,11 @@ func advanceSessionDrainsWithSessionsTraced(
 	}
 }
 
-// completeDrain writes drain-complete metadata to the bead.
+// completeDrain writes drain-complete metadata to the bead and re-routes
+// any work beads that were assigned to the now-retired session back to the
+// pool (via gc.routed_to fallback). Without this, drained pool sessions
+// leave orphaned work beads with no assignee and no route — the pool
+// reconciler never sees work to scale for, creating a permanent deadlock.
 func completeDrain(session *beads.Bead, store beads.Store, ds *drainState, clk clock.Clock) {
 	batch := sessions.CompleteDrainPatch(clk.Now(), ds.reason, session.Metadata["wake_mode"] == "fresh")
 	if store != nil {
@@ -556,6 +560,12 @@ func completeDrain(session *beads.Bead, store beads.Store, ds *drainState, clk c
 	for k, v := range batch {
 		session.Metadata[k] = v
 	}
+
+	// Re-route orphaned work beads back to the pool template so the
+	// reconciler can scale a replacement. Uses the same fallback logic
+	// as named-session retirement: template > agent_name.
+	fallback := retiredSessionFallbackRoute(*session)
+	unclaimWorkAssignedToRetiredSessionBead(store, session.ID, fallback, os.Stderr)
 }
 
 // verifiedStop stops a session after verifying the instance_token matches.

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -1286,6 +1286,106 @@ func TestCompleteDrain_ClearsPendingCreateClaim(t *testing.T) {
 	}
 }
 
+func TestCompleteDrain_UnclaimsAssignedWork(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := beads.NewMemStore()
+
+	sessionBead, _ := store.Create(beads.Bead{
+		Title: "polecat session",
+		Metadata: map[string]string{
+			"session_name": "polecat-test",
+			"template":     "android/atlas.polecat",
+		},
+	})
+
+	workBead, _ := store.Create(beads.Bead{
+		Title:    "open work assigned to polecat",
+		Type:     "task",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+	})
+
+	ds := &drainState{reason: "config-drift"}
+	completeDrain(&sessionBead, store, ds, clk)
+
+	got, _ := store.Get(workBead.ID)
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty after drain", got.Assignee)
+	}
+	if got.Metadata["gc.routed_to"] != "android/atlas.polecat" {
+		t.Errorf("gc.routed_to = %q, want %q", got.Metadata["gc.routed_to"], "android/atlas.polecat")
+	}
+}
+
+func TestCompleteDrain_UnclaimsInProgressWork(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := beads.NewMemStore()
+
+	sessionBead, _ := store.Create(beads.Bead{
+		Title: "polecat session",
+		Metadata: map[string]string{
+			"session_name": "polecat-test",
+			"template":     "backend/atlas.polecat",
+			"agent_name":   "backend/furiosa",
+		},
+	})
+
+	workBead, _ := store.Create(beads.Bead{
+		Title:    "in-progress work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+	})
+
+	ds := &drainState{reason: "pool-excess"}
+	completeDrain(&sessionBead, store, ds, clk)
+
+	got, _ := store.Get(workBead.ID)
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty after drain", got.Assignee)
+	}
+	if got.Metadata["gc.routed_to"] != "backend/atlas.polecat" {
+		t.Errorf("gc.routed_to = %q, want %q (fallback from template)", got.Metadata["gc.routed_to"], "backend/atlas.polecat")
+	}
+}
+
+func TestCompleteDrain_PreservesExistingRoute(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := beads.NewMemStore()
+
+	sessionBead, _ := store.Create(beads.Bead{
+		Title: "polecat session",
+		Metadata: map[string]string{
+			"session_name": "polecat-test",
+			"template":     "android/atlas.polecat",
+		},
+	})
+
+	workBead, _ := store.Create(beads.Bead{
+		Title:    "routed work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{
+			"gc.routed_to": "android/atlas.refinery",
+		},
+	})
+
+	ds := &drainState{reason: "config-drift"}
+	completeDrain(&sessionBead, store, ds, clk)
+
+	got, _ := store.Get(workBead.ID)
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty after drain", got.Assignee)
+	}
+	if got.Metadata["gc.routed_to"] != "android/atlas.refinery" {
+		t.Errorf("gc.routed_to = %q, want %q (should preserve existing route)", got.Metadata["gc.routed_to"], "android/atlas.refinery")
+	}
+}
+
 func TestAdvanceSessionDrains_CancelsForReadyWait(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}


### PR DESCRIPTION
## Summary

- **Bug fix for config-drift drain management**: when the reconciler drains a pool session (most commonly triggered by config drift after a `gc` binary rebuild), `completeDrain()` wrote session metadata but never released the work beads assigned to that session
- Work beads were left with an assignee pointing at a dead session and no `gc.routed_to` fallback, making them invisible to the pool scaling logic
- This created a permanent deadlock: drained sessions orphan their work → pool sees zero routed work → no replacement scales → work sits idle forever

## Root cause

`completeDrain()` in `session_wake.go` handled session metadata (state=asleep, sleep_reason, etc.) but did not call `unclaimWorkAssignedToRetiredSessionBead()`. That function already existed and was used for named-session retirement — it clears the assignee and sets `gc.routed_to` to the pool template as a fallback. It was simply never wired into the drain-completion path.

## Fix

Add `unclaimWorkAssignedToRetiredSessionBead()` call at the end of `completeDrain()`, using the existing `retiredSessionFallbackRoute()` (template > agent_name) to derive the fallback route. No new functions or types — just connecting existing plumbing.

The unclaim function:
1. Finds all open/in_progress work beads assigned to the retired session
2. Clears their assignee
3. Sets `gc.routed_to` to the pool template (only if no existing route)

This lets the reconciler's next cycle see the routed work and scale a replacement.

## Test plan

- [x] `TestCompleteDrain_UnclaimsAssignedWork` — open work bead gets assignee cleared + `gc.routed_to` set to pool template
- [x] `TestCompleteDrain_UnclaimsInProgressWork` — same for in_progress beads, verifies template fallback
- [x] `TestCompleteDrain_PreservesExistingRoute` — if work already has `gc.routed_to` (e.g. routed to refinery), the existing route is preserved
- [x] All 4 existing `TestCompleteDrain_*` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)