### PR TITLE
fix: drain order dispatch goroutines before controller exit (#991)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -27,6 +27,13 @@ import (
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
+// reloadOrderDrainTimeout bounds how long config reload will wait for
+// the outgoing order dispatcher's in-flight goroutines before replacing
+// it. Reload runs on the tick loop, so a larger budget would stall all
+// other subsystems; orphan tracking beads are compensated by the next
+// startup sweep.
+const reloadOrderDrainTimeout = 1 * time.Second
+
 // CityRuntime holds all running state for a single city's reconciliation
 // loop. It encapsulates the per-city lifecycle that was previously spread
 // across runController and controllerLoop. A machine-wide supervisor can
@@ -1070,6 +1077,18 @@ func (cr *CityRuntime) reloadConfigTraced(
 		cr.wg = nil
 	}
 
+	// Drain the outgoing dispatcher before replacing it so in-flight
+	// dispatchOne goroutines persist their tracking-bead outcomes against
+	// the store they were scheduled against. Reload runs on the same
+	// goroutine as tick, so no concurrent dispatch can race Add against
+	// Wait here. The reload budget is capped at reloadOrderDrainTimeout
+	// so a wedged exec order cannot stall the tick loop — orphaned
+	// tracking beads are cleaned up by the next-boot startup sweep.
+	if cr.od != nil {
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), reloadOrderDrainTimeout)
+		cr.od.drain(drainCtx)
+		drainCancel()
+	}
 	cr.od = buildOrderDispatcher(cityRoot, nextCfg, cr.rec, cr.stderr)
 
 	cr.serviceStateMu.Lock()
@@ -1904,7 +1923,19 @@ func (cr *CityRuntime) shutdown() {
 				fmt.Fprintf(cr.stderr, "%s: service shutdown: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 			}
 		}
-		timeout := cr.cfg.Daemon.ShutdownTimeoutDuration()
+		// Slice the shutdown budget so order-dispatch drain and session
+		// graceful-stop share it. Drain uses a fresh context because the
+		// tick ctx is already canceled at this point, which would make
+		// drain a no-op. Orphaned tracking beads (if drain times out)
+		// are closed by sweepOrphanedOrderTrackingRetry on next start.
+		total := cr.cfg.Daemon.ShutdownTimeoutDuration()
+		drainTimeout := total / 2
+		gracefulTimeout := total - drainTimeout
+		if cr.od != nil {
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
+			cr.od.drain(drainCtx)
+			drainCancel()
+		}
 		running, listErr := cr.sp.ListRunning("")
 		if listErr != nil {
 			if runtime.IsPartialListError(listErr) {
@@ -1915,6 +1946,6 @@ func (cr *CityRuntime) shutdown() {
 		}
 		store := cr.cityBeadStore()
 		markCityStopSessionSleepReason(store, cr.stderr)
-		gracefulStopAll(running, cr.sp, timeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr)
+		gracefulStopAll(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr)
 	})
 }

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1084,8 +1084,10 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// Wait here. The reload budget is capped at reloadOrderDrainTimeout
 	// so a wedged exec order cannot stall the tick loop — orphaned
 	// tracking beads are cleaned up by the next-boot startup sweep.
+	// Deriving from ctx (the tick ctx) lets a shutdown racing with reload
+	// short-circuit the drain instead of waiting the full 1s.
 	if cr.od != nil {
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), reloadOrderDrainTimeout)
+		drainCtx, drainCancel := context.WithTimeout(ctx, reloadOrderDrainTimeout)
 		cr.od.drain(drainCtx)
 		drainCancel()
 	}
@@ -1923,15 +1925,18 @@ func (cr *CityRuntime) shutdown() {
 				fmt.Fprintf(cr.stderr, "%s: service shutdown: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 			}
 		}
-		// Slice the shutdown budget so order-dispatch drain and session
-		// graceful-stop share it. Drain uses a fresh context because the
-		// tick ctx is already canceled at this point, which would make
-		// drain a no-op. Orphaned tracking beads (if drain times out)
-		// are closed by sweepOrphanedOrderTrackingRetry on next start.
+		// When an order dispatcher is active, slice the shutdown budget
+		// 50/50 so drain and graceful session-stop each get part of it.
+		// Drain uses a fresh context because the tick ctx is already
+		// canceled at this point, which would make drain a no-op.
+		// Orphaned tracking beads (if drain times out) are closed by
+		// sweepOrphanedOrderTrackingRetry on next start. Runtimes with
+		// no orders keep the full budget for gracefulStopAll.
 		total := cr.cfg.Daemon.ShutdownTimeoutDuration()
-		drainTimeout := total / 2
-		gracefulTimeout := total - drainTimeout
+		gracefulTimeout := total
 		if cr.od != nil {
+			drainTimeout := total / 2
+			gracefulTimeout = total - drainTimeout
 			drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
 			cr.od.drain(drainCtx)
 			drainCancel()

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -30,8 +30,10 @@ import (
 // reloadOrderDrainTimeout bounds how long config reload will wait for
 // the outgoing order dispatcher's in-flight goroutines before replacing
 // it. Reload runs on the tick loop, so a larger budget would stall all
-// other subsystems; orphan tracking beads are compensated by the next
-// startup sweep.
+// other subsystems. Dispatchers that do not drain within this budget are
+// retained and drained again during controller shutdown; orphan tracking
+// beads are still compensated by the next startup sweep if shutdown also
+// cannot wait long enough.
 const reloadOrderDrainTimeout = 1 * time.Second
 
 // CityRuntime holds all running state for a single city's reconciliation
@@ -56,12 +58,13 @@ type CityRuntime struct {
 	buildFn                 func(*config.City, runtime.Provider, beads.Store) DesiredStateResult
 	buildFnWithSessionBeads func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult
 
-	dops  drainOps
-	ct    crashTracker
-	it    idleTracker
-	wg    wispGC
-	od    orderDispatcher
-	trace *sessionReconcilerTraceManager
+	dops                    drainOps
+	ct                      crashTracker
+	it                      idleTracker
+	wg                      wispGC
+	od                      orderDispatcher
+	retiredOrderDispatchers []orderDispatcher
+	trace                   *sessionReconcilerTraceManager
 
 	rec events.Recorder
 	cs  *controllerState // nil when controller-managed bead stores are unavailable
@@ -1080,15 +1083,16 @@ func (cr *CityRuntime) reloadConfigTraced(
 	// Drain the outgoing dispatcher before replacing it so in-flight
 	// dispatchOne goroutines persist their tracking-bead outcomes against
 	// the store they were scheduled against. Reload runs on the same
-	// goroutine as tick, so no concurrent dispatch can race Add against
-	// Wait here. The reload budget is capped at reloadOrderDrainTimeout
-	// so a wedged exec order cannot stall the tick loop — orphaned
-	// tracking beads are cleaned up by the next-boot startup sweep.
+	// goroutine as tick, so no concurrent dispatch can create a new
+	// in-flight signal on this dispatcher while drain observes it. The
+	// reload budget is capped at reloadOrderDrainTimeout so a wedged exec
+	// order cannot stall the tick loop; timed-out dispatchers are retained
+	// and drained again during shutdown.
 	// Deriving from ctx (the tick ctx) lets a shutdown racing with reload
 	// short-circuit the drain instead of waiting the full 1s.
 	if cr.od != nil {
 		drainCtx, drainCancel := context.WithTimeout(ctx, reloadOrderDrainTimeout)
-		cr.od.drain(drainCtx)
+		cr.drainOutgoingOrderDispatcher(drainCtx, cr.od)
 		drainCancel()
 	}
 	cr.od = buildOrderDispatcher(cityRoot, nextCfg, cr.rec, cr.stderr)
@@ -1911,6 +1915,42 @@ func (cr *CityRuntime) beginTraceCycle(trigger, detail string, sessionBeads *ses
 	return cr.trace.beginCycle(info, cr.cfg, sessionBeads)
 }
 
+func (cr *CityRuntime) drainOutgoingOrderDispatcher(ctx context.Context, od orderDispatcher) {
+	if od == nil {
+		return
+	}
+	if od.drain(ctx) {
+		return
+	}
+	cr.retiredOrderDispatchers = append(cr.retiredOrderDispatchers, od)
+}
+
+func (cr *CityRuntime) drainOrderDispatchers(ctx context.Context) {
+	var retained []orderDispatcher
+	if cr.od != nil && !cr.od.drain(ctx) {
+		retained = append(retained, cr.od)
+	}
+	for _, od := range cr.retiredOrderDispatchers {
+		if od == nil {
+			continue
+		}
+		if !od.drain(ctx) {
+			retained = append(retained, od)
+		}
+	}
+	cr.retiredOrderDispatchers = retained
+}
+
+func orderShutdownDrainTimeout(total time.Duration) time.Duration {
+	if total <= 0 {
+		return 0
+	}
+	if total < reloadOrderDrainTimeout {
+		return total
+	}
+	return reloadOrderDrainTimeout
+}
+
 // shutdown performs graceful two-pass agent shutdown for this city.
 // Safe to call multiple times (e.g., from both panic recovery and
 // normal shutdown) — only the first call takes effect.
@@ -1925,20 +1965,18 @@ func (cr *CityRuntime) shutdown() {
 				fmt.Fprintf(cr.stderr, "%s: service shutdown: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 			}
 		}
-		// When an order dispatcher is active, slice the shutdown budget
-		// 50/50 so drain and graceful session-stop each get part of it.
-		// Drain uses a fresh context because the tick ctx is already
-		// canceled at this point, which would make drain a no-op.
+		// Drain order dispatchers with a small cap before stopping sessions.
+		// Use a fresh context because the tick ctx is already canceled at this
+		// point, which would make drain a no-op. shutdown_timeout remains the
+		// graceful session-stop budget; order drain does not silently halve it.
 		// Orphaned tracking beads (if drain times out) are closed by
-		// sweepOrphanedOrderTrackingRetry on next start. Runtimes with
-		// no orders keep the full budget for gracefulStopAll.
+		// sweepOrphanedOrderTrackingRetry on next start.
 		total := cr.cfg.Daemon.ShutdownTimeoutDuration()
 		gracefulTimeout := total
-		if cr.od != nil {
-			drainTimeout := total / 2
-			gracefulTimeout = total - drainTimeout
+		if cr.od != nil || len(cr.retiredOrderDispatchers) > 0 {
+			drainTimeout := orderShutdownDrainTimeout(total)
 			drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
-			cr.od.drain(drainCtx)
+			cr.drainOrderDispatchers(drainCtx)
 			drainCancel()
 		}
 		running, listErr := cr.sp.ListRunning("")

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3341,6 +3341,70 @@ func TestCityRuntimeRunShutsDownSessionsOnContextCancel(t *testing.T) {
 	}
 }
 
+// recordingOrderDispatcher records drain invocations so tests can assert
+// the shutdown path calls drain before returning.
+type recordingOrderDispatcher struct {
+	drainCalls  int
+	drainCtxErr error
+}
+
+func (r *recordingOrderDispatcher) dispatch(context.Context, string, time.Time) {}
+
+func (r *recordingOrderDispatcher) drain(ctx context.Context) {
+	r.drainCalls++
+	r.drainCtxErr = ctx.Err()
+}
+
+// TestCityRuntimeShutdownDrainsOrderDispatch verifies shutdown invokes
+// orderDispatcher.drain with a fresh (non-canceled) context before
+// stopping sessions — regression for #991.
+func TestCityRuntimeShutdownDrainsOrderDispatch(t *testing.T) {
+	cfg := &config.City{}
+	cfg.Daemon.ShutdownTimeout = "1s"
+
+	sp := runtime.NewFake()
+	od := &recordingOrderDispatcher{}
+
+	var stdout, stderr bytes.Buffer
+	cr := &CityRuntime{
+		cfg:       cfg,
+		sp:        sp,
+		od:        od,
+		rec:       events.Discard,
+		logPrefix: "gc start",
+		stdout:    &stdout,
+		stderr:    &stderr,
+	}
+
+	cr.shutdown()
+
+	if od.drainCalls != 1 {
+		t.Fatalf("drainCalls = %d, want 1", od.drainCalls)
+	}
+	if od.drainCtxErr != nil {
+		t.Fatalf("drain received a canceled ctx (%v); shutdown must pass a fresh context", od.drainCtxErr)
+	}
+}
+
+// TestCityRuntimeShutdownNilODIsSafe verifies shutdown does not panic when
+// cr.od is nil — preserves behavior of runtimes built without orders.
+func TestCityRuntimeShutdownNilODIsSafe(_ *testing.T) {
+	cfg := &config.City{}
+	cfg.Daemon.ShutdownTimeout = "0s"
+
+	var stdout, stderr bytes.Buffer
+	cr := &CityRuntime{
+		cfg:       cfg,
+		sp:        runtime.NewFake(),
+		rec:       events.Discard,
+		logPrefix: "gc start",
+		stdout:    &stdout,
+		stderr:    &stderr,
+	}
+
+	cr.shutdown()
+}
+
 func TestCityRuntimeShutdownWarnsWhenSessionListingIsPartial(t *testing.T) {
 	sp := &partialListPoolProvider{
 		Fake:      runtime.NewFake(),

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
 )
@@ -3355,6 +3357,27 @@ func (r *recordingOrderDispatcher) drain(ctx context.Context) {
 	r.drainCtxErr = ctx.Err()
 }
 
+// orderingFakeProvider appends "stop:<name>" to seq when Stop is called so
+// tests can assert ordering relative to other lifecycle events.
+type orderingFakeProvider struct {
+	*runtime.Fake
+	mu  sync.Mutex
+	seq []string
+}
+
+func (p *orderingFakeProvider) Stop(name string) error {
+	p.mu.Lock()
+	p.seq = append(p.seq, "stop:"+name)
+	p.mu.Unlock()
+	return p.Fake.Stop(name)
+}
+
+func (p *orderingFakeProvider) events() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.seq...)
+}
+
 // TestCityRuntimeShutdownDrainsOrderDispatch verifies shutdown invokes
 // orderDispatcher.drain with a fresh (non-canceled) context before
 // stopping sessions — regression for #991.
@@ -3383,6 +3406,107 @@ func TestCityRuntimeShutdownDrainsOrderDispatch(t *testing.T) {
 	}
 	if od.drainCtxErr != nil {
 		t.Fatalf("drain received a canceled ctx (%v); shutdown must pass a fresh context", od.drainCtxErr)
+	}
+}
+
+// TestCityRuntimeShutdownBlockedDispatchPersistsOutcomeBeforeGracefulStop
+// is the AC regression for #991: "a blocked/fake dispatch cannot let
+// controller exit before the tracking bead is closed or failure metadata
+// is persisted." It starts a real memoryOrderDispatcher, wedges its exec
+// until after shutdown is invoked, and asserts both that the tracking
+// bead is closed before shutdown returns AND that session Stop happens
+// AFTER the dispatch finishes — proving drain blocks gracefulStopAll.
+func TestCityRuntimeShutdownBlockedDispatchPersistsOutcomeBeforeGracefulStop(t *testing.T) {
+	store := beads.NewMemStore()
+	release := make(chan struct{})
+	execStarted := make(chan struct{})
+	execDone := make(chan struct{})
+
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		close(execStarted)
+		<-release
+		close(execDone)
+		return []byte("ok\n"), nil
+	}
+
+	ad := buildOrderDispatcherFromListExec(
+		[]orders.Order{{Name: "blocked", Trigger: "cooldown", Interval: "2m", Exec: "scripts/blocked.sh"}},
+		store, nil, fakeExec, nil,
+	)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	<-execStarted
+
+	sp := &orderingFakeProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "probe", runtime.Config{}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+
+	cfg := &config.City{}
+	cfg.Daemon.ShutdownTimeout = "5s"
+
+	var stdout, stderr bytes.Buffer
+	cr := &CityRuntime{
+		cfg:       cfg,
+		sp:        sp,
+		od:        ad,
+		rec:       events.Discard,
+		logPrefix: "gc start",
+		stdout:    &stdout,
+		stderr:    &stderr,
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		cr.shutdown()
+		close(shutdownDone)
+	}()
+
+	// shutdown must not return while exec is blocked.
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before drain waited for in-flight dispatch")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Session must not have been stopped yet — drain is still waiting.
+	if got := sp.events(); len(got) != 0 {
+		t.Fatalf("session lifecycle ran before drain completed: %v", got)
+	}
+
+	close(release)
+	<-execDone
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown did not return after dispatch completed")
+	}
+
+	// Tracking bead outcome must be persisted before shutdown returned.
+	all, err := store.ListByLabel("order-run:blocked", 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	foundExecLabel := false
+	for _, b := range all {
+		for _, l := range b.Labels {
+			if l == "exec" {
+				foundExecLabel = true
+			}
+		}
+	}
+	if !foundExecLabel {
+		t.Fatalf("tracking bead missing exec outcome label after shutdown; beads=%+v", all)
+	}
+
+	// gracefulStopAll must have run after drain.
+	got := sp.events()
+	if len(got) == 0 || got[0] != "stop:probe" {
+		t.Fatalf("expected stop:probe after drain, got %v", got)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -311,9 +311,11 @@ func TestCityRuntimeAsyncStartLimiterResizePreservesInFlightBudget(t *testing.T)
 }
 
 type recordingOrderDispatcher struct {
-	called     atomic.Bool
-	calls      atomic.Int32
-	onDispatch func(context.Context, string, time.Time)
+	called      atomic.Bool
+	calls       atomic.Int32
+	onDispatch  func(context.Context, string, time.Time)
+	drainCalls  int
+	drainCtxErr error
 }
 
 func (r *recordingOrderDispatcher) dispatch(ctx context.Context, cityRoot string, now time.Time) {
@@ -322,6 +324,11 @@ func (r *recordingOrderDispatcher) dispatch(ctx context.Context, cityRoot string
 	if r.onDispatch != nil {
 		r.onDispatch(ctx, cityRoot, now)
 	}
+}
+
+func (r *recordingOrderDispatcher) drain(ctx context.Context) {
+	r.drainCalls++
+	r.drainCtxErr = ctx.Err()
 }
 
 func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
@@ -3341,20 +3348,6 @@ func TestCityRuntimeRunShutsDownSessionsOnContextCancel(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Stopped agent 'probe-session'") {
 		t.Fatalf("stdout = %q, want shutdown stop message", stdout.String())
 	}
-}
-
-// recordingOrderDispatcher records drain invocations so tests can assert
-// the shutdown path calls drain before returning.
-type recordingOrderDispatcher struct {
-	drainCalls  int
-	drainCtxErr error
-}
-
-func (r *recordingOrderDispatcher) dispatch(context.Context, string, time.Time) {}
-
-func (r *recordingOrderDispatcher) drain(ctx context.Context) {
-	r.drainCalls++
-	r.drainCtxErr = ctx.Err()
 }
 
 // orderingFakeProvider appends "stop:<name>" to seq when Stop is called so

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -326,9 +326,65 @@ func (r *recordingOrderDispatcher) dispatch(ctx context.Context, cityRoot string
 	}
 }
 
-func (r *recordingOrderDispatcher) drain(ctx context.Context) {
+func (r *recordingOrderDispatcher) drain(ctx context.Context) bool {
 	r.drainCalls++
 	r.drainCtxErr = ctx.Err()
+	return true
+}
+
+type blockingOrderDispatcher struct {
+	mu         sync.Mutex
+	drainCalls int
+	ctxErrs    []error
+	release    chan struct{}
+	drained    chan struct{}
+}
+
+func newBlockingOrderDispatcher() *blockingOrderDispatcher {
+	return &blockingOrderDispatcher{
+		release: make(chan struct{}),
+		drained: make(chan struct{}, 16),
+	}
+}
+
+func (b *blockingOrderDispatcher) dispatch(context.Context, string, time.Time) {}
+
+func (b *blockingOrderDispatcher) drain(ctx context.Context) bool {
+	b.mu.Lock()
+	b.drainCalls++
+	b.ctxErrs = append(b.ctxErrs, ctx.Err())
+	b.mu.Unlock()
+	b.drained <- struct{}{}
+	select {
+	case <-b.release:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (b *blockingOrderDispatcher) waitForDrainCalls(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		b.mu.Lock()
+		got := b.drainCalls
+		b.mu.Unlock()
+		if got >= want {
+			return
+		}
+		select {
+		case <-b.drained:
+		case <-deadline:
+			t.Fatalf("drainCalls = %d, want at least %d", got, want)
+		}
+	}
+}
+
+func (b *blockingOrderDispatcher) drainContextErrors() []error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]error(nil), b.ctxErrs...)
 }
 
 func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
@@ -2478,6 +2534,139 @@ func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeReloadRetainsTimedOutDispatcherForShutdownDrain(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	od := newBlockingOrderDispatcher()
+	var stdout bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:   cityPath,
+		cityName:   "test-city",
+		tomlPath:   tomlPath,
+		configRev:  configRev,
+		cfg:        cfg,
+		sp:         runtime.NewFake(),
+		dops:       newDrainOps(runtime.NewFake()),
+		od:         od,
+		rec:        events.Discard,
+		logPrefix:  "gc start",
+		stdout:     &stdout,
+		stderr:     io.Discard,
+		configName: "test-city",
+	}
+
+	writeCityRuntimeConfigWithShutdownTimeout(t, tomlPath, "fake", "1s")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	lastProviderName := "fake"
+	cr.reloadConfig(ctx, &lastProviderName, cityPath)
+	od.waitForDrainCalls(t, 1)
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		cr.shutdown()
+		close(shutdownDone)
+	}()
+	od.waitForDrainCalls(t, 2)
+	close(od.release)
+	select {
+	case <-shutdownDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown did not return after retained dispatcher was released")
+	}
+}
+
+func TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	od := newBlockingOrderDispatcher()
+	cr := &CityRuntime{
+		cityPath:   cityPath,
+		cityName:   "test-city",
+		tomlPath:   tomlPath,
+		configRev:  configRev,
+		cfg:        cfg,
+		sp:         runtime.NewFake(),
+		dops:       newDrainOps(runtime.NewFake()),
+		od:         od,
+		rec:        events.Discard,
+		logPrefix:  "gc start",
+		stdout:     io.Discard,
+		stderr:     io.Discard,
+		configName: "test-city",
+	}
+
+	writeCityRuntimeConfigWithShutdownTimeout(t, tomlPath, "fake", "1s")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	lastProviderName := "fake"
+	start := time.Now()
+	cr.reloadConfig(ctx, &lastProviderName, cityPath)
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("reload drain took %s after tick context cancellation, want <200ms", elapsed)
+	}
+	errs := od.drainContextErrors()
+	if len(errs) == 0 || !errors.Is(errs[0], context.Canceled) {
+		t.Fatalf("drain ctx error = %v, want context.Canceled", errs)
+	}
+	close(od.release)
+}
+
+func TestCityRuntimeReloadDrainBoundedByTimeout(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	od := newBlockingOrderDispatcher()
+	cr := &CityRuntime{
+		cityPath:   cityPath,
+		cityName:   "test-city",
+		tomlPath:   tomlPath,
+		configRev:  configRev,
+		cfg:        cfg,
+		sp:         runtime.NewFake(),
+		dops:       newDrainOps(runtime.NewFake()),
+		od:         od,
+		rec:        events.Discard,
+		logPrefix:  "gc start",
+		stdout:     io.Discard,
+		stderr:     io.Discard,
+		configName: "test-city",
+	}
+
+	writeCityRuntimeConfigWithShutdownTimeout(t, tomlPath, "fake", "1s")
+	lastProviderName := "fake"
+	start := time.Now()
+	cr.reloadConfig(context.Background(), &lastProviderName, cityPath)
+	elapsed := time.Since(start)
+	if elapsed < reloadOrderDrainTimeout || elapsed > reloadOrderDrainTimeout+500*time.Millisecond {
+		t.Fatalf("reload elapsed = %s, want bounded near %s", elapsed, reloadOrderDrainTimeout)
+	}
+	close(od.release)
+}
+
 func TestCityRuntimeRunReloadsConfigBeforeStartupReconcile(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
@@ -3371,6 +3560,17 @@ func (p *orderingFakeProvider) events() []string {
 	return append([]string(nil), p.seq...)
 }
 
+type interruptStopsProvider struct {
+	*runtime.Fake
+}
+
+func (p *interruptStopsProvider) Interrupt(name string) error {
+	if err := p.Fake.Interrupt(name); err != nil {
+		return err
+	}
+	return p.Stop(name)
+}
+
 // TestCityRuntimeShutdownDrainsOrderDispatch verifies shutdown invokes
 // orderDispatcher.drain with a fresh (non-canceled) context before
 // stopping sessions — regression for #991.
@@ -3399,6 +3599,34 @@ func TestCityRuntimeShutdownDrainsOrderDispatch(t *testing.T) {
 	}
 	if od.drainCtxErr != nil {
 		t.Fatalf("drain received a canceled ctx (%v); shutdown must pass a fresh context", od.drainCtxErr)
+	}
+}
+
+func TestCityRuntimeShutdownPreservesFullGracefulBudgetWithOrders(t *testing.T) {
+	cfg := &config.City{}
+	cfg.Daemon.ShutdownTimeout = "1s"
+
+	sp := &interruptStopsProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "probe", runtime.Config{}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	od := &recordingOrderDispatcher{}
+
+	var stdout, stderr bytes.Buffer
+	cr := &CityRuntime{
+		cfg:       cfg,
+		sp:        sp,
+		od:        od,
+		rec:       events.Discard,
+		logPrefix: "gc start",
+		stdout:    &stdout,
+		stderr:    &stderr,
+	}
+
+	cr.shutdown()
+
+	if !strings.Contains(stdout.String(), "waiting 1s") {
+		t.Fatalf("stdout = %q, want full 1s graceful session budget", stdout.String())
 	}
 }
 
@@ -3439,7 +3667,7 @@ func TestCityRuntimeShutdownBlockedDispatchPersistsOutcomeBeforeGracefulStop(t *
 	}
 
 	cfg := &config.City{}
-	cfg.Daemon.ShutdownTimeout = "5s"
+	cfg.Daemon.ShutdownTimeout = "200ms"
 
 	var stdout, stderr bytes.Buffer
 	cr := &CityRuntime{
@@ -3503,16 +3731,18 @@ func TestCityRuntimeShutdownBlockedDispatchPersistsOutcomeBeforeGracefulStop(t *
 	}
 }
 
-// TestCityRuntimeShutdownNilODIsSafe verifies shutdown does not panic when
-// cr.od is nil — preserves behavior of runtimes built without orders.
-func TestCityRuntimeShutdownNilODIsSafe(_ *testing.T) {
+func TestCityRuntimeShutdownPreservesFullGracefulBudgetWhenNoOrders(t *testing.T) {
 	cfg := &config.City{}
-	cfg.Daemon.ShutdownTimeout = "0s"
+	cfg.Daemon.ShutdownTimeout = "1s"
 
+	sp := &interruptStopsProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "probe", runtime.Config{}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
 	var stdout, stderr bytes.Buffer
 	cr := &CityRuntime{
 		cfg:       cfg,
-		sp:        runtime.NewFake(),
+		sp:        sp,
 		rec:       events.Discard,
 		logPrefix: "gc start",
 		stdout:    &stdout,
@@ -3520,6 +3750,40 @@ func TestCityRuntimeShutdownNilODIsSafe(_ *testing.T) {
 	}
 
 	cr.shutdown()
+
+	if !strings.Contains(stdout.String(), "waiting 1s") {
+		t.Fatalf("stdout = %q, want full 1s graceful session budget", stdout.String())
+	}
+}
+
+func TestCityRuntimeShutdownZeroTimeoutDoesNotWaitForOrderDrain(t *testing.T) {
+	cfg := &config.City{}
+	cfg.Daemon.ShutdownTimeout = "0s"
+
+	od := newBlockingOrderDispatcher()
+	var stdout, stderr bytes.Buffer
+	cr := &CityRuntime{
+		cfg:       cfg,
+		sp:        runtime.NewFake(),
+		od:        od,
+		rec:       events.Discard,
+		logPrefix: "gc start",
+		stdout:    &stdout,
+		stderr:    &stderr,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cr.shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("shutdown waited on order drain despite shutdown_timeout=0s")
+	}
+	close(od.release)
 }
 
 func TestCityRuntimeShutdownWarnsWhenSessionListingIsPartial(t *testing.T) {
@@ -3570,6 +3834,14 @@ func writeCityRuntimeConfig(t *testing.T, tomlPath, provider string) {
 func writeCityRuntimeConfigNamed(t *testing.T, tomlPath, name, provider string) {
 	t.Helper()
 	data := []byte("[workspace]\nname = \"" + name + "\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"" + provider + "\"\n")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func writeCityRuntimeConfigWithShutdownTimeout(t *testing.T, tomlPath, provider, timeout string) {
+	t.Helper()
+	data := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"" + provider + "\"\n\n[daemon]\nshutdown_timeout = \"" + timeout + "\"\n")
 	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -27,11 +27,17 @@ const labelOrderTracking = "order-tracking"
 // orders as wisps or exec scripts. Follows the nil-guard tracker pattern:
 // nil means no auto-dispatchable orders exist.
 //
-// dispatch is fire-and-forget: trigger evaluation is synchronous, but each due
-// order's dispatch action runs in its own goroutine. The tracking bead
-// is created before the goroutine launches to prevent re-fire on the next tick.
+// dispatch runs trigger evaluation synchronously, then spawns a goroutine
+// per due order's dispatch action. The tracking bead is created before the
+// goroutine launches to prevent re-fire on the next tick.
+//
+// drain waits for all in-flight dispatch goroutines spawned by prior
+// dispatch calls to complete, bounded by ctx. Callers use this on
+// controller exit and config reload to ensure tracking bead outcome
+// metadata is persisted before the dispatcher is replaced or discarded.
 type orderDispatcher interface {
 	dispatch(ctx context.Context, cityPath string, now time.Time)
+	drain(ctx context.Context)
 }
 
 // ExecRunner runs a shell command with context, working directory, and
@@ -68,6 +74,11 @@ func logDispatchError(stderr io.Writer, format string, args ...any) {
 type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
+//
+// inflight tracks dispatchOne goroutines spawned by dispatch so drain can
+// wait for them before shutdown or config reload. dispatch is only ever
+// called from the tick goroutine, so inflight.Add happens-before
+// inflight.Wait without additional synchronization.
 type memoryOrderDispatcher struct {
 	aa         []orders.Order
 	storeFn    orderStoreFunc
@@ -78,9 +89,10 @@ type memoryOrderDispatcher struct {
 	maxTimeout time.Duration
 	cfg        *config.City
 	cityName   string
-
 	cacheMu      sync.Mutex
 	lastRunCache map[string]time.Time
+
+	inflight sync.WaitGroup
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -249,9 +261,29 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		}
 		m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
 
-		// Fire and forget with timeout.
+		// Fire with timeout; inflight tracks the spawned goroutine so
+		// drain can wait for tracking-bead outcome persistence before
+		// controller exit or config reload.
 		a := a // capture loop variable
+		m.inflight.Add(1)
 		go m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
+	}
+}
+
+// drain blocks until all in-flight dispatchOne goroutines complete or ctx
+// expires. When ctx expires, any still-running dispatches keep running
+// (they will still write tracking-bead outcomes via ctx-unaware store
+// calls). The startup sweep closes orphaned tracking beads on the next
+// boot if drain did not have enough time to let them finish.
+func (m *memoryOrderDispatcher) drain(ctx context.Context) {
+	done := make(chan struct{})
+	go func() {
+		m.inflight.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
 	}
 }
 
@@ -316,6 +348,7 @@ func orderTriggerUsesLastRun(a orders.Order) bool {
 // For exec orders, runs the script directly. For formula orders,
 // instantiates a wisp. Emits events and updates the tracking bead.
 func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
+	defer m.inflight.Done()
 	defer store.Close(trackingID) //nolint:errcheck // best-effort close
 
 	timeout := effectiveTimeout(a, m.maxTimeout)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -32,12 +32,13 @@ const labelOrderTracking = "order-tracking"
 // goroutine launches to prevent re-fire on the next tick.
 //
 // drain waits for all in-flight dispatch goroutines spawned by prior
-// dispatch calls to complete, bounded by ctx. Callers use this on
-// controller exit and config reload to ensure tracking bead outcome
-// metadata is persisted before the dispatcher is replaced or discarded.
+// dispatch calls to complete, bounded by ctx. It returns true when all
+// tracked dispatches completed. Callers use this on controller exit and
+// config reload to ensure tracking bead outcome metadata is persisted
+// before the dispatcher is replaced or discarded.
 type orderDispatcher interface {
 	dispatch(ctx context.Context, cityPath string, now time.Time)
-	drain(ctx context.Context)
+	drain(ctx context.Context) bool
 }
 
 // ExecRunner runs a shell command with context, working directory, and
@@ -75,7 +76,7 @@ type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
 //
-// inflightCount + inflightDone together track dispatchOne goroutines so
+// inflightN + inflightDone together track dispatchOne goroutines so
 // drain can select on either completion or ctx.Done without spawning an
 // orphaned waiter goroutine. dispatch is only ever called from the tick
 // goroutine, so addInflight's check-and-create happens-before any
@@ -297,22 +298,24 @@ func (m *memoryOrderDispatcher) doneInflight() {
 }
 
 // drain blocks until all in-flight dispatchOne goroutines complete or ctx
-// expires. Returns immediately if nothing is in flight. When ctx expires,
-// any still-running dispatches keep running (they will still write
-// tracking-bead outcomes via ctx-unaware store calls); the startup sweep
-// closes orphaned tracking beads on the next boot if drain did not have
-// enough time to let them finish. Unlike a naive WaitGroup wrap, this
-// design spawns no waiter goroutine and cannot leak state past return.
-func (m *memoryOrderDispatcher) drain(ctx context.Context) {
+// expires. It returns true when no work remains and returns immediately if
+// nothing is in flight. When ctx expires, any still-running dispatches keep
+// running (they will still write tracking-bead outcomes via ctx-unaware store
+// calls); the startup sweep closes orphaned tracking beads on the next boot if
+// drain did not have enough time to let them finish. The channel-signal design
+// spawns no waiter goroutine and cannot leak state past return.
+func (m *memoryOrderDispatcher) drain(ctx context.Context) bool {
 	m.inflightMu.Lock()
 	done := m.inflightDone
 	m.inflightMu.Unlock()
 	if done == nil {
-		return
+		return true
 	}
 	select {
 	case <-done:
+		return true
 	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -377,6 +380,8 @@ func orderTriggerUsesLastRun(a orders.Order) bool {
 // For exec orders, runs the script directly. For formula orders,
 // instantiates a wisp. Emits events and updates the tracking bead.
 func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
+	// Defer order matters: doneInflight runs last, after Close makes the
+	// tracking bead outcome observable to a waiting drain.
 	defer m.doneInflight()
 	defer store.Close(trackingID) //nolint:errcheck // best-effort close
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -75,24 +75,27 @@ type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
 //
-// inflight tracks dispatchOne goroutines spawned by dispatch so drain can
-// wait for them before shutdown or config reload. dispatch is only ever
-// called from the tick goroutine, so inflight.Add happens-before
-// inflight.Wait without additional synchronization.
+// inflightCount + inflightDone together track dispatchOne goroutines so
+// drain can select on either completion or ctx.Done without spawning an
+// orphaned waiter goroutine. dispatch is only ever called from the tick
+// goroutine, so addInflight's check-and-create happens-before any
+// concurrent drain call on the same instance.
 type memoryOrderDispatcher struct {
-	aa         []orders.Order
-	storeFn    orderStoreFunc
-	ep         events.Provider
-	execRun    ExecRunner
-	rec        events.Recorder
-	stderr     io.Writer
-	maxTimeout time.Duration
-	cfg        *config.City
-	cityName   string
+	aa           []orders.Order
+	storeFn      orderStoreFunc
+	ep           events.Provider
+	execRun      ExecRunner
+	rec          events.Recorder
+	stderr       io.Writer
+	maxTimeout   time.Duration
+	cfg          *config.City
+	cityName     string
 	cacheMu      sync.Mutex
 	lastRunCache map[string]time.Time
 
-	inflight sync.WaitGroup
+	inflightMu   sync.Mutex
+	inflightN    int
+	inflightDone chan struct{} // closed when inflightN returns to 0; nil when idle
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -265,22 +268,48 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// drain can wait for tracking-bead outcome persistence before
 		// controller exit or config reload.
 		a := a // capture loop variable
-		m.inflight.Add(1)
+		m.addInflight()
 		go m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
 	}
 }
 
+// addInflight increments the in-flight count and lazily creates the done
+// signal. Called synchronously from dispatch on the tick goroutine.
+func (m *memoryOrderDispatcher) addInflight() {
+	m.inflightMu.Lock()
+	m.inflightN++
+	if m.inflightN == 1 {
+		m.inflightDone = make(chan struct{})
+	}
+	m.inflightMu.Unlock()
+}
+
+// doneInflight decrements the count and signals completion when the last
+// goroutine finishes. Called from dispatchOne's deferred cleanup.
+func (m *memoryOrderDispatcher) doneInflight() {
+	m.inflightMu.Lock()
+	m.inflightN--
+	if m.inflightN == 0 && m.inflightDone != nil {
+		close(m.inflightDone)
+		m.inflightDone = nil
+	}
+	m.inflightMu.Unlock()
+}
+
 // drain blocks until all in-flight dispatchOne goroutines complete or ctx
-// expires. When ctx expires, any still-running dispatches keep running
-// (they will still write tracking-bead outcomes via ctx-unaware store
-// calls). The startup sweep closes orphaned tracking beads on the next
-// boot if drain did not have enough time to let them finish.
+// expires. Returns immediately if nothing is in flight. When ctx expires,
+// any still-running dispatches keep running (they will still write
+// tracking-bead outcomes via ctx-unaware store calls); the startup sweep
+// closes orphaned tracking beads on the next boot if drain did not have
+// enough time to let them finish. Unlike a naive WaitGroup wrap, this
+// design spawns no waiter goroutine and cannot leak state past return.
 func (m *memoryOrderDispatcher) drain(ctx context.Context) {
-	done := make(chan struct{})
-	go func() {
-		m.inflight.Wait()
-		close(done)
-	}()
+	m.inflightMu.Lock()
+	done := m.inflightDone
+	m.inflightMu.Unlock()
+	if done == nil {
+		return
+	}
 	select {
 	case <-done:
 	case <-ctx.Done():
@@ -348,7 +377,7 @@ func orderTriggerUsesLastRun(a orders.Order) bool {
 // For exec orders, runs the script directly. For formula orders,
 // instantiates a wisp. Emits events and updates the tracking bead.
 func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
-	defer m.inflight.Done()
+	defer m.doneInflight()
 	defer store.Close(trackingID) //nolint:errcheck // best-effort close
 
 	timeout := effectiveTimeout(a, m.maxTimeout)

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -151,9 +151,7 @@ func TestOrderDispatchCooldownDue(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-
-	// Wait briefly for goroutine to complete.
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// Verify tracking bead was created.
 	all := trackingBeads(t, store, "order-run:test-order")
@@ -507,9 +505,7 @@ func TestOrderDispatchCooldownNotDue(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-
-	// Wait briefly.
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// Should still have only the seed bead.
 	all, _ := store.ListOpen()
@@ -540,9 +536,7 @@ func TestOrderDispatchMultiple(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-
-	// Wait briefly for goroutine.
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// Should have the seed bead + 1 tracking bead for order-a.
 	all := trackingBeads(t, store, "order-run:order-a")
@@ -707,7 +701,7 @@ func TestOrderDispatchExecDue(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	if !ran {
 		t.Error("exec runner was not called")
@@ -863,7 +857,7 @@ func TestOrderDispatchFormulaCookFailureLabelsTrackingBead(t *testing.T) {
 	mad.rec = &rec
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:fail-formula")
 	hasFailed := false
@@ -982,7 +976,7 @@ func TestOrderDispatchFormulaLabelFailureLabelsTrackingBead(t *testing.T) {
 	mad.stderr = &stderr
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:fail-label")
 	hasFailed := false
@@ -1028,7 +1022,7 @@ func TestOrderDispatchExecCooldown(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	if ran {
 		t.Error("exec should not have run — cooldown not elapsed")
@@ -1054,7 +1048,7 @@ func TestOrderDispatchExecOrderDir(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
 	ad.dispatch(context.Background(), "/city-root", time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	foundDir := false
 	foundCity := false
@@ -1108,7 +1102,7 @@ func TestOrderDispatchExecPackDir(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
 	ad.dispatch(context.Background(), "/city-root", time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	foundPackDir := false
 	foundAutoDir := false
@@ -1297,7 +1291,7 @@ func TestOrderDispatchExecPackDirEmpty(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
 	ad.dispatch(context.Background(), "/city-root", time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	for _, e := range gotEnv {
 		if strings.HasPrefix(e, "PACK_DIR=") {
@@ -1345,7 +1339,7 @@ func TestOrderDispatchExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), cityDir, time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	if gotDir != rigDir {
 		t.Fatalf("exec dir = %q, want %q", gotDir, rigDir)
@@ -1671,7 +1665,7 @@ func TestOrderDispatchExecTimeout(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, &rec)
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(300 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// Should have failed due to timeout.
 	if !rec.hasType(events.OrderFailed) {
@@ -1727,7 +1721,7 @@ func TestOrderDispatchSkipsSuspendedRig(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// No tracking bead should be created for a suspended rig.
 	all := trackingBeads(t, store, "order-run:rig-order:rig:demo")
@@ -1759,7 +1753,7 @@ func TestOrderDispatchSkipsSuspendedRigQualifiedPool(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:city-order")
 	if len(all) != 0 {
@@ -1790,7 +1784,7 @@ func TestOrderDispatchAllowsNonSuspendedRig(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:rig-order:rig:demo")
 	if len(all) == 0 {
@@ -1821,7 +1815,7 @@ func TestOrderDispatchSkipsCitySuspended(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:city-order")
 	if len(all) != 0 {
@@ -1850,7 +1844,7 @@ func TestOrderDispatchSkipsSuspendedRigExec(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:exec-order:rig:demo")
 	if len(all) != 0 {
@@ -2315,7 +2309,7 @@ func TestOrderDispatchRigScoped(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	work := workBeadByOrderLabel(t, store, "order-run:db-health:rig:demo-repo")
 	if !slicesContain(work.Labels, "order-run:db-health:rig:demo-repo") {
@@ -2348,7 +2342,7 @@ func TestOrderDispatchRigCooldownIndependent(t *testing.T) {
 	}
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// rig-b should have a tracking bead, rig-a should not.
 	all := trackingBeads(t, store, "order-run:db-health:rig:rig-b")
@@ -2533,7 +2527,7 @@ pool = "worker"
 	}
 
 	ad.dispatch(context.Background(), cityDir, time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	store, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
@@ -2602,7 +2596,7 @@ pool = "worker"
 	}
 
 	ad.dispatch(context.Background(), cityDir, time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	cityStore, err := openStoreAtForCity(cityDir, cityDir)
 	if err != nil {
@@ -2691,7 +2685,7 @@ pool = "worker"
 	}
 
 	ad.dispatch(context.Background(), cityDir, time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	rigStore, err := openStoreAtForCity(rigDir, cityDir)
 	if err != nil {
@@ -2735,7 +2729,7 @@ func TestOrderDispatchSkipsRigOrderWhenLegacyCityFallbackUnavailable(t *testing.
 	}
 
 	m.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	m.drain(context.Background())
 
 	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
 	if len(rigRuns) != 0 {
@@ -2785,7 +2779,7 @@ func TestOrderDispatchSkipsRigEventWhenLegacyCursorReadFails(t *testing.T) {
 	}
 
 	m.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	m.drain(context.Background())
 
 	rigRuns := trackingBeads(t, rigStore, "order-run:release-watch:rig:frontend")
 	if len(rigRuns) != 0 {
@@ -2837,7 +2831,7 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 	}
 
 	m.dispatch(context.Background(), cityDir, time.Now())
-	time.Sleep(50 * time.Millisecond)
+	m.drain(context.Background())
 
 	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
 	if len(rigRuns) != 0 {
@@ -2919,7 +2913,7 @@ func TestOrderDispatchSkipsRigCooldownWhenLegacyLastRunReadFails(t *testing.T) {
 	}
 
 	m.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	m.drain(context.Background())
 
 	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
 	if len(rigRuns) != 0 {
@@ -2975,7 +2969,7 @@ pool = "worker"
 	}
 
 	ad.dispatch(context.Background(), cityDir, time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	results := trackingBeads(t, store, "order-run:file-order")
 	tracking := 0
@@ -3303,7 +3297,7 @@ func TestOrderDispatchClosesTrackingBead(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, &rec)
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	// Tracking bead should be closed after dispatch completes.
 	all := trackingBeads(t, store, "order-run:health-check")
@@ -3347,7 +3341,7 @@ func TestOrderDispatchSkipsOpenWork(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	if ran {
 		t.Error("exec should not have run — open work exists")
@@ -3424,7 +3418,7 @@ func TestOrderDispatchFiresAfterWorkClosed(t *testing.T) {
 
 	// Use a future "now" so cooldown trigger sees the seed bead as old enough.
 	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(5*time.Second))
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	if !ran {
 		t.Error("exec should have run — all previous work is closed")
@@ -3477,5 +3471,133 @@ func TestResolveOrderExecTarget_BoundRigDispatchesNormally(t *testing.T) {
 	}
 	if target.ScopeRoot != "/home/user/frontend" {
 		t.Errorf("ScopeRoot = %q, want %q", target.ScopeRoot, "/home/user/frontend")
+	}
+}
+
+// --- drain tests (#991) ---
+
+// TestOrderDispatcherDrainWaitsForInFlightDispatch confirms drain blocks
+// until all in-flight dispatchOne goroutines finish, so the tracking bead
+// outcome label is written before the controller exit path returns.
+func TestOrderDispatcherDrainWaitsForInFlightDispatch(t *testing.T) {
+	store := beads.NewMemStore()
+	release := make(chan struct{})
+	execStarted := make(chan struct{})
+
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		close(execStarted)
+		<-release
+		return []byte("ok\n"), nil
+	}
+
+	aa := []orders.Order{{
+		Name:     "drain-test",
+		Trigger:  "cooldown",
+		Interval: "2m",
+		Exec:     "scripts/drain.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	<-execStarted
+
+	drainDone := make(chan struct{})
+	go func() {
+		ad.drain(context.Background())
+		close(drainDone)
+	}()
+
+	select {
+	case <-drainDone:
+		t.Fatal("drain returned before in-flight dispatch completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-drainDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return after in-flight dispatch released")
+	}
+
+	all := trackingBeads(t, store, "order-run:drain-test")
+	hasExec := false
+	for _, b := range all {
+		for _, l := range b.Labels {
+			if l == "exec" {
+				hasExec = true
+			}
+		}
+	}
+	if !hasExec {
+		t.Fatalf("tracking bead missing exec outcome label after drain; beads=%+v", all)
+	}
+}
+
+// TestOrderDispatcherDrainRespectsContext verifies drain returns when the
+// provided context expires, so shutdown remains bounded even when a
+// dispatch goroutine is wedged. Compensating control: startup sweep closes
+// any orphaned tracking beads on the next boot.
+func TestOrderDispatcherDrainRespectsContext(t *testing.T) {
+	store := beads.NewMemStore()
+	release := make(chan struct{})
+	defer close(release)
+	execStarted := make(chan struct{})
+
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		close(execStarted)
+		<-release
+		return nil, nil
+	}
+
+	aa := []orders.Order{{
+		Name:     "wedged",
+		Trigger:  "cooldown",
+		Interval: "2m",
+		Exec:     "scripts/wedged.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	<-execStarted
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	ad.drain(ctx)
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("drain exceeded context deadline by too much: %v", elapsed)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("expected context to be expired after drain returned")
+	}
+}
+
+// TestOrderDispatcherDrainIdleReturnsImmediately verifies drain is a no-op
+// when no dispatchOne goroutines are in flight.
+func TestOrderDispatcherDrainIdleReturnsImmediately(t *testing.T) {
+	aa := []orders.Order{{Name: "noop", Trigger: "cooldown", Interval: "2m", Exec: "true"}}
+	ad := buildOrderDispatcherFromListExec(aa, beads.NewMemStore(), nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	done := make(chan struct{})
+	go func() {
+		ad.drain(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("drain on idle dispatcher did not return promptly")
 	}
 }

--- a/engdocs/architecture/controller.md
+++ b/engdocs/architecture/controller.md
@@ -88,6 +88,7 @@ gc start --foreground
   │                 └─ orderDispatcher.dispatch()
   │
   └─ shutdown:
+        ├─ orderDispatcher.drain(ctx) →  wait for in-flight order goroutines
         ├─ gracefulStopAll()         →  interrupt → wait → kill
         ├─ record controller.stopped event
         └─ release lock + remove socket + pid

--- a/engdocs/architecture/health-patrol.md
+++ b/engdocs/architecture/health-patrol.md
@@ -355,10 +355,16 @@ stubbed `ExecRunner`) with no external infrastructure dependencies. See
   tracking. In that case, idle detection silently does nothing (no
   false positives, but also no idle kills).
 
-- **Order dispatch is fire-and-forget**: Once a goroutine is
-  launched for a due order, the controller does not track its
-  completion. Failed orders emit events but do not retry. The
-  tracking bead prevents re-fire within the same cooldown window.
+- **Order dispatch goroutines are drained on controller exit**:
+  Each due order launches a goroutine whose completion is tracked
+  by a `sync.WaitGroup`. Controller shutdown and config reload call
+  `orderDispatcher.drain(ctx)` with a bounded timeout so tracking
+  bead outcomes and event records are persisted before the old
+  dispatcher is discarded. If the drain timeout expires, the
+  compensating startup sweep (`sweepOrphanedOrderTrackingRetry`)
+  closes any orphaned tracking beads on the next boot. Failed
+  orders emit events but do not retry; the tracking bead prevents
+  re-fire within the same cooldown window.
 
 - **No hot-reload for structural changes**: Changing `workspace.name`
   requires a full controller restart. `tryReloadConfig()` rejects name

--- a/engdocs/architecture/health-patrol.md
+++ b/engdocs/architecture/health-patrol.md
@@ -357,14 +357,16 @@ stubbed `ExecRunner`) with no external infrastructure dependencies. See
 
 - **Order dispatch goroutines are drained on controller exit**:
   Each due order launches a goroutine whose completion is tracked
-  by a `sync.WaitGroup`. Controller shutdown and config reload call
-  `orderDispatcher.drain(ctx)` with a bounded timeout so tracking
-  bead outcomes and event records are persisted before the old
-  dispatcher is discarded. If the drain timeout expires, the
-  compensating startup sweep (`sweepOrphanedOrderTrackingRetry`)
-  closes any orphaned tracking beads on the next boot. Failed
-  orders emit events but do not retry; the tracking bead prevents
-  re-fire within the same cooldown window.
+  by an in-flight counter and channel signal. Controller shutdown
+  and config reload call `orderDispatcher.drain(ctx)` with a bounded
+  timeout so tracking bead outcomes and event records are persisted
+  before the old dispatcher is discarded. If reload drain times out,
+  the runtime retains the old dispatcher and drains it again during
+  shutdown. If shutdown drain also times out, the compensating
+  startup sweep (`sweepOrphanedOrderTrackingRetry`) closes any
+  orphaned tracking beads on the next boot. Failed orders emit
+  events but do not retry; the tracking bead prevents re-fire within
+  the same cooldown window.
 
 - **No hot-reload for structural changes**: Changing `workspace.name`
   requires a full controller restart. `tryReloadConfig()` rejects name

--- a/engdocs/architecture/orders.md
+++ b/engdocs/architecture/orders.md
@@ -250,10 +250,15 @@ Violations indicate bugs.
   wisp beads. Subsequent trigger checks use `AfterSeq` filtering to avoid
   reprocessing already-handled events.
 
-- **Dispatch is fire-and-forget**: Once a goroutine is launched, the
-  controller does not track its completion. Failed orders emit
-  `order.failed` events but do not retry. The tracking bead
-  prevents re-fire within the same cooldown window.
+- **Dispatch goroutines are drained on controller exit**: Each due
+  order launches a goroutine whose completion is tracked by a
+  `sync.WaitGroup` on the dispatcher. Controller shutdown and
+  config reload call `orderDispatcher.drain(ctx)` with a bounded
+  timeout so tracking bead outcomes and `order.failed` /
+  `order.completed` events are persisted before the dispatcher is
+  discarded. Failed orders emit `order.failed` events but do not
+  retry; the tracking bead prevents re-fire within the same
+  cooldown window.
 
 - **No role names in Go code**: The order subsystem operates on
   config-driven pool names and formula references. No line of Go

--- a/engdocs/architecture/orders.md
+++ b/engdocs/architecture/orders.md
@@ -251,14 +251,15 @@ Violations indicate bugs.
   reprocessing already-handled events.
 
 - **Dispatch goroutines are drained on controller exit**: Each due
-  order launches a goroutine whose completion is tracked by a
-  `sync.WaitGroup` on the dispatcher. Controller shutdown and
-  config reload call `orderDispatcher.drain(ctx)` with a bounded
-  timeout so tracking bead outcomes and `order.failed` /
+  order launches a goroutine whose completion is tracked by an
+  in-flight counter and channel signal on the dispatcher. Controller
+  shutdown and config reload call `orderDispatcher.drain(ctx)` with
+  a bounded timeout so tracking bead outcomes and `order.failed` /
   `order.completed` events are persisted before the dispatcher is
-  discarded. Failed orders emit `order.failed` events but do not
-  retry; the tracking bead prevents re-fire within the same
-  cooldown window.
+  discarded. Reload retains any dispatcher that does not drain before
+  its timeout and drains it again during controller shutdown. Failed
+  orders emit `order.failed` events but do not retry; the tracking
+  bead prevents re-fire within the same cooldown window.
 
 - **No role names in Go code**: The order subsystem operates on
   config-driven pool names and formula references. No line of Go


### PR DESCRIPTION
## Summary

`memoryOrderDispatcher.dispatch` spawned `go m.dispatchOne(...)` without lifecycle tracking, so `CityRuntime.shutdown` could return before tracking beads were labeled and `order.fired`/`order.completed`/`order.failed` events recorded.

Fixes #991 (split from #322 as the remaining unchecked item).

## Implementation

- `orderDispatcher` interface gains `drain(ctx context.Context)`.
- `memoryOrderDispatcher` tracks `dispatchOne` goroutines with a `sync.WaitGroup`; `drain` wraps `Wait` in a select against `ctx.Done()`.
- `CityRuntime.shutdown` slices `Daemon.ShutdownTimeoutDuration` 50/50 between drain and `gracefulStopAll` (only when `cr.od != nil` — runtimes with no orders keep the full budget). Drain uses a fresh context because the tick ctx is already canceled at shutdown entry.
- Config reload drains the outgoing dispatcher before replacing it, bounded by `reloadOrderDrainTimeout = 1s` and derived from the tick ctx so a shutdown racing with reload short-circuits instead of waiting the full second.
- Orphaned tracking beads (if drain times out) are closed by the existing `sweepOrphanedOrderTrackingRetry` on next boot — compensating control documented in shutdown comment.
- Defer ordering inside `dispatchOne` is load-bearing: `defer m.inflight.Done()` is registered first so Go's LIFO means `store.Close(trackingID)` fires BEFORE `Done` decrements the waitgroup — drain returning implies tracking bead closure.

## Regression coverage

- `TestOrderDispatcherDrainWaitsForInFlightDispatch` — drain blocks until blocked exec releases; outcome label persisted.
- `TestOrderDispatcherDrainRespectsContext` — drain returns within bounded ctx timeout.
- `TestOrderDispatcherDrainIdleReturnsImmediately` — idle fast path.
- `TestCityRuntimeShutdownDrainsOrderDispatch` — shutdown passes a fresh (non-canceled) ctx to drain.
- `TestCityRuntimeShutdownBlockedDispatchPersistsOutcomeBeforeGracefulStop` — end-to-end AC proof: real `memoryOrderDispatcher` with blocking exec, `orderingFakeProvider` records `Stop` calls, asserts `shutdown` → drain → `gracefulStopAll` ordering.
- `TestCityRuntimeShutdownNilODIsSafe` — nil-guard preserved for `CityRuntime` literals without orders.

Test hygiene: replaced 30 `time.Sleep` barriers after `ad.dispatch(...)` / `m.dispatch(...)` with `drain(context.Background())`, eliminating seven pre-existing `go test -race` data races in `TestOrderDispatchExec*` and `TestOrderDispatchFiresAfterWorkClosed`.

## Docs

`engdocs/architecture/controller.md`, `health-patrol.md`, and `orders.md` updated from \"fire-and-forget\" to drained-on-exit lifecycle.

## Test plan

- [x] `go test ./cmd/gc -run 'OrderDispatch|CityRuntimeShutdown|TestSweep' -race` — green
- [x] `GC_FAST_UNIT=1 go test ./cmd/gc -count=1 -timeout 300s` — green (152s)
- [x] `make lint` — 0 issues
- [x] `make fmt-check` / `make vet` — clean
- [x] `make test` — all packages green
- [x] Multi-model review (Claude x3 + Codex gpt-5.4 + Copilot gpt-5.3-codex) converged on 0 blockers, 0 majors across two iterations