### PR TITLE
test(sling): guard rig-scoped inline bead creation for bd provider (#200)

### DIFF
--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"os"
 	"os/exec"
@@ -1049,6 +1050,183 @@ dir = "frontend"
 	}
 	t.Chdir(cityDir)
 	return cityDir
+}
+
+// setupRigScopedBdCity writes a city.toml with one rig ("frontend",
+// prefix "FE") and a rig-scoped .beads/config.yaml compatible with the
+// bd provider contract. Returns the city and rig paths. Used by the
+// #200 regression guards for the bd provider.
+func setupRigScopedBdCity(t *testing.T) (cityDir, rigDir string) {
+	t.Helper()
+	cityDir = t.TempDir()
+	rigDir = filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte(`issue_prefix: FE
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "FE"
+
+[[agent]]
+name = "worker"
+dir = "frontend"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	return cityDir, rigDir
+}
+
+// bdInvocation records a single bd subprocess call — env snapshot,
+// dir, and argv — so tests can assert on the scope the command ran in.
+type bdInvocation struct {
+	Env  map[string]string
+	Dir  string
+	Args []string
+}
+
+// installCaptureBdRunner swaps beadsExecCommandRunnerWithEnv with a
+// fake that records every bd invocation and returns plausible
+// responses for the subcommands cmdSling's inline-text path actually
+// runs (show, create, update). Unexpected subcommands fail the test
+// loudly so drift in sling's bd usage surfaces instead of silently
+// passing. Returns a pointer to the capture slice; auto-restores via
+// t.Cleanup.
+func installCaptureBdRunner(t *testing.T) *[]bdInvocation {
+	t.Helper()
+	orig := beadsExecCommandRunnerWithEnv
+	t.Cleanup(func() { beadsExecCommandRunnerWithEnv = orig })
+
+	calls := &[]bdInvocation{}
+	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+		snap := maps.Clone(env)
+		return func(dir, name string, args ...string) ([]byte, error) {
+			*calls = append(*calls, bdInvocation{Env: snap, Dir: dir, Args: append([]string(nil), args...)})
+			if name != "bd" {
+				t.Errorf("unexpected command %q args=%v", name, args)
+				return nil, fmt.Errorf("unexpected command %q", name)
+			}
+			switch {
+			case len(args) >= 2 && args[0] == "create" && args[1] == "--json":
+				title := ""
+				if len(args) > 2 {
+					title = args[2]
+				}
+				return []byte(fmt.Sprintf(`{"id":"FE-abc","title":%q,"status":"open","issue_type":"task","created_at":"2026-04-22T00:00:00Z","assignee":"","from":"","parent":"","ref":"","needs":null,"description":"","labels":null}`, title)), nil
+			case len(args) >= 2 && args[0] == "update" && args[1] == "--json":
+				return []byte(`{}`), nil
+			case len(args) >= 2 && args[0] == "show" && args[1] == "--json":
+				return nil, fmt.Errorf("issue not found")
+			case len(args) >= 2 && args[0] == "list" && args[1] == "--json":
+				return []byte(`[]`), nil
+			default:
+				t.Errorf("unexpected bd subcommand args=%v — fake must be extended if sling now invokes this", args)
+				return nil, fmt.Errorf("unexpected bd subcommand args=%v", args)
+			}
+		}
+	}
+	return calls
+}
+
+// firstBdCreate returns the first `bd create --json` invocation
+// captured by installCaptureBdRunner, or fails the test if none was
+// observed.
+func firstBdCreate(t *testing.T, calls []bdInvocation) bdInvocation {
+	t.Helper()
+	for _, c := range calls {
+		if len(c.Args) >= 2 && c.Args[0] == "create" && c.Args[1] == "--json" {
+			return c
+		}
+	}
+	t.Fatalf("no bd create invocation observed. Captured %d calls: %v", len(calls), calls)
+	return bdInvocation{}
+}
+
+// Regression guard for #200: on 0.13.5 the pre-bdStoreForRig code path
+// hardcoded BEADS_DIR to <cityPath>/.beads for every bd subprocess, so
+// bd create landed the inline bead in the city store and the cross-rig
+// guard blocked routing. Commit 92c6c0d7 introduced bdStoreForRig +
+// bdRuntimeEnvForRig which silently fixed it; this test locks the
+// invariant for the default bd provider so the scoping cannot regress.
+func TestCmdSlingInlineBeadRigScopedBdProvider(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	cityDir, rigDir := setupRigScopedBdCity(t)
+	calls := installCaptureBdRunner(t)
+
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling([]string{"frontend/worker", "ship feature"}, false, false, true, "", nil, "", true, false, "", false, false, false, "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	create := firstBdCreate(t, *calls)
+	wantBeadsDir := filepath.Join(rigDir, ".beads")
+	if got := create.Env["BEADS_DIR"]; got != wantBeadsDir {
+		t.Fatalf("bd create BEADS_DIR = %q, want %q (rig-scoped); all calls: %v", got, wantBeadsDir, *calls)
+	}
+	if got := create.Env["GC_RIG_ROOT"]; got != rigDir {
+		t.Fatalf("bd create GC_RIG_ROOT = %q, want %q", got, rigDir)
+	}
+	if got := create.Env["GC_RIG"]; got != "frontend" {
+		t.Fatalf("bd create GC_RIG = %q, want %q", got, "frontend")
+	}
+	if got := create.Dir; got != rigDir {
+		t.Fatalf("bd create dir = %q, want %q", got, rigDir)
+	}
+}
+
+// Reporter's exact #200 repro: CWD=rig, bare target resolves to
+// rig-scoped agent via currentRigContext, and the inline bead must
+// still land in the rig store.
+func TestCmdSlingInlineBeadBareTargetFromRigCwdBdProvider(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	_, rigDir := setupRigScopedBdCity(t)
+	calls := installCaptureBdRunner(t)
+
+	t.Chdir(rigDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling([]string{"worker", "ship feature"}, false, false, true, "", nil, "", true, false, "", false, false, false, "", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	create := firstBdCreate(t, *calls)
+	wantBeadsDir := filepath.Join(rigDir, ".beads")
+	if got := create.Env["BEADS_DIR"]; got != wantBeadsDir {
+		t.Fatalf("bd create BEADS_DIR = %q, want %q (rig-scoped). Bare target %q from rig cwd must land in the rig store; all calls: %v",
+			got, wantBeadsDir, "worker", *calls)
+	}
+	// Mirror the env-surface assertions from the qualified-target
+	// variant so a regression that sets BEADS_DIR correctly but drops
+	// GC_RIG/GC_RIG_ROOT via the currentRigContext path still fails
+	// loudly.
+	if got := create.Env["GC_RIG_ROOT"]; got != rigDir {
+		t.Fatalf("bd create GC_RIG_ROOT = %q, want %q", got, rigDir)
+	}
+	if got := create.Env["GC_RIG"]; got != "frontend" {
+		t.Fatalf("bd create GC_RIG = %q, want %q", got, "frontend")
+	}
+	if got := create.Dir; got != rigDir {
+		t.Fatalf("bd create dir = %q, want %q", got, rigDir)
+	}
 }
 
 func TestCmdSlingRefusesMissingBead(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #200.

Issue #200 reported that `gc sling <agent> \"inline text\"` from a rig directory created the task bead in the **city** store (wrong prefix), then the cross-rig guard blocked routing. The 0.13.5 root cause — `bdCommandRunnerForCity` hardcoding `BEADS_DIR=<cityPath>/.beads` for every bd subprocess — was silently fixed by commit 92c6c0d7 (\"feat: rig-level Dolt config for cross-server bead routing\"), which introduced `bdStoreForRig` / `bdRuntimeEnvForRig` with per-scope BEADS_DIR.

No regression test was added for the bd provider; only the file provider had coverage (`TestCmdSlingUsesRigScopedFileStoreForBuiltInRouting`). This PR closes that gap with two focused tests that will fail loudly if the BEADS_DIR rig-scoping regresses for the default bd provider.

## Changes

Test-only: `cmd/gc/cmd_sling_test.go`, +190 LOC.

- **`TestCmdSlingInlineBeadRigScopedBdProvider`** — qualified target `frontend/worker`, inline text from city cwd. Asserts `bd create` env has `BEADS_DIR=<rig>/.beads`, `GC_RIG=frontend`, `GC_RIG_ROOT=<rig>`, and the command runs in the rig dir.
- **`TestCmdSlingInlineBeadBareTargetFromRigCwdBdProvider`** — reporter's exact repro: `cd <rig> && gc sling worker \"ship feature\"`. Same env-surface assertions so a regression that sets `BEADS_DIR` correctly but drops `GC_RIG`/`GC_RIG_ROOT` via the `currentRigContext` path still fails.

Three helpers in the same file: `setupRigScopedBdCity` (city.toml + rig `.beads` layout), `installCaptureBdRunner` (swaps `beadsExecCommandRunnerWithEnv` with a fake that records every bd invocation and fails loudly on unknown subcommands), and `firstBdCreate` (extracts the first `bd create` call for assertions).

## Regression-verified

Temporarily reverting `cmd/gc/bd_env.go`'s rig BEADS_DIR scoping to `filepath.Join(cityPath, \".beads\")` causes both tests to fail with the expected diagnostic (captured bd call list dumped on failure for CI triage).

## Test plan

- [x] `go test -run 'TestCmdSlingInlineBead' ./cmd/gc/ -count=1` passes
- [x] `go test -run 'TestCmdSling|TestResolveSling|TestSlingStore|TestBdRuntimeEnv|TestBdCommandEnv|TestSlingFormula' ./cmd/gc/ -count=1` all green
- [x] `go test -race -run 'TestCmdSlingInlineBead' ./cmd/gc/ -count=1` clean
- [x] `go vet ./cmd/gc/` clean
- [x] Regression-verified: temporarily reintroducing the 0.13.5 bug causes both tests to fail

## Review

Multi-model review converged in 2 iterations:
- Anthropic agents caught silent `default`-arm swallow + thin failure messages (majors) and `maps.Clone` / unused `cityDir/.beads` / asymmetric assertions (minors).
- Codex (gpt-5.4) grounded review caught incorrect PR attribution in the original docstring — corrected to credit the actual fix commit `92c6c0d7` instead of unrelated PR numbers.
- Copilot (gpt-5.3-codex) confirmed the exact bd subcommand sequence (`show → create → show → update`) and corroborated the default-arm and failure-message findings.
- Contributor check (29-rule audit) passed all applicable rules.