### PR TITLE
Fix: backup dog discovers remotes instead of assuming naming convention

### DIFF
--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -1,16 +1,18 @@
 description = """
 Sync Dolt database backups to local and offsite storage.
 
-The Backup Dog runs `dolt backup sync` for each production database, then
-rsyncs the local backup directory to offsite storage for replication.
+The Backup Dog discovers configured backup remotes for each production
+database, syncs them, then rsyncs the local backup directory to offsite
+storage for replication.
 
 ## Dog Contract
 
 This is infrastructure work. You:
-1. Sync each production database to its backup remote
-2. Rsync local backups to offsite storage
-3. Report results and exit
-4. Return to kennel
+1. Discover backup remotes configured by gc init
+2. Sync each production database to its backup remote
+3. Rsync local backups to offsite storage
+4. Report results and exit
+5. Return to kennel
 
 ## Variables
 
@@ -25,7 +27,7 @@ overwrites the backup destination, but that is the intended behavior.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-backup"
-version = 1
+version = 2
 
 [vars]
 [vars.databases]
@@ -64,7 +66,7 @@ id = "sync"
 title = "Sync databases to backup remotes"
 needs = ["preflight"]
 description = """
-Run dolt backup sync for each production database.
+Discover and sync backup remotes for each production database.
 
 **1. Verify preflight passed:**
 Before running any `dolt backup sync`, read the `preflight` bead in this
@@ -75,17 +77,30 @@ sync. This formula does not wire scoped-abort metadata; this check is the
 enforcement point.
 
 **2. Determine databases:**
-Use configured databases list, or auto-discover databases with
-`<name>-backup` remotes configured.
+Use configured databases list, or auto-discover all databases in the
+data directory (skip __gc_probe and other internal databases).
 
-**3. For each database:**
+**3. For each database, discover its backup remote:**
 ```bash
 cd <data_dir>/<db>
-dolt backup sync <db>-backup
+dolt backup
+```
+This lists configured backup names. Use whatever name `dolt backup`
+returns — do NOT assume a naming convention. The remote name was set
+by `gc init` and may be `backup_export`, `<db>-backup`, or any other
+valid name.
+
+If `dolt backup` returns no configured backups, skip the database and
+record it as "no backup configured".
+
+**4. Sync each discovered backup:**
+```bash
+dolt backup sync <backup_name>
 ```
 
-**4. Record results:**
-- Databases synced successfully
+**5. Record results:**
+- Databases synced successfully (with backup remote name used)
+- Databases skipped (no backup configured)
 - Databases that failed (with error)
 - Duration per database
 
@@ -98,16 +113,22 @@ needs = ["sync"]
 description = """
 Rsync local backups to offsite storage for replication.
 
-**1. Check prerequisites:**
-- .dolt-backup/ directory exists
+**1. Locate backup directory:**
+Check the backup remote URL from the sync step to find the local
+backup path. The path is encoded in the dolt backup URL
+(e.g., `file:///path/to/.beads/backup`). Use `dolt backup -v` in
+any synced database to discover it if needed.
+
+**2. Check prerequisites:**
+- Backup directory exists and has content
 - Offsite path is accessible
 
-**2. Run offsite sync:**
+**3. Run offsite sync:**
 ```bash
-rsync -a --delete .dolt-backup/ <offsite_path>/
+rsync -a --delete <backup_dir>/ <offsite_path>/
 ```
 
-**3. Record results:**
+**4. Record results:**
 - Success/failure
 - Duration
 
@@ -124,8 +145,9 @@ Generate summary and signal completion.
 
 **1. Generate report summary:**
 - Databases synced: count/total
+- Databases skipped (no backup configured): count
 - Offsite sync status
-- Per-database breakdown: status, duration
+- Per-database breakdown: backup remote name, status, duration
 - Any failures
 
 **2. Signal completion:**

--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -8,8 +8,8 @@ storage for replication.
 ## Dog Contract
 
 This is infrastructure work. You:
-1. Discover backup remotes configured by gc init
-2. Sync each production database to its backup remote
+1. Discover backup remotes configured by operator/bootstrap setup
+2. Sync each production database to its backup remotes
 3. Rsync local backups to offsite storage
 4. Report results and exit
 5. Return to kennel
@@ -77,18 +77,23 @@ sync. This formula does not wire scoped-abort metadata; this check is the
 enforcement point.
 
 **2. Determine databases:**
-Use configured databases list, or auto-discover all databases in the
-data directory (skip __gc_probe and other internal databases).
+Use the configured databases list when it is non-empty. Otherwise,
+auto-discover databases by scanning `<data_dir>/*/` and including only
+directories that contain `.dolt/`. Skip the system/internal database names
+`information_schema`, `mysql`, `dolt_cluster`, `performance_schema`, `sys`,
+and `__gc_probe` case-insensitively. Also skip database directories marked by
+configured non-sync markers such as `.no-sync`. Do not treat backup/export
+directories without `.dolt/` as databases.
 
-**3. For each database, discover its backup remote:**
+**3. For each database, discover its backup remotes:**
 ```bash
 cd <data_dir>/<db>
 dolt backup
 ```
-This lists configured backup names. Use whatever name `dolt backup`
-returns — do NOT assume a naming convention. The remote name was set
-by `gc init` and may be `backup_export`, `<db>-backup`, or any other
-valid name.
+This lists configured backup names, one per line. Sync every name returned by
+`dolt backup`; do NOT assume a naming convention and do NOT choose an arbitrary
+single remote when multiple backups are configured. Backup names are configured
+by operator/bootstrap setup and may vary by deployment.
 
 If `dolt backup` returns no configured backups, skip the database and
 record it as "no backup configured".
@@ -97,12 +102,16 @@ record it as "no backup configured".
 ```bash
 dolt backup sync <backup_name>
 ```
+For each attempted backup, record one result row keyed by
+`(database, backup_name)`. After syncing, read `dolt backup -v` in that
+database and capture the matching `backup_url` for the row, so offsite sync can
+operate on the exact `(database, backup_name, backup_url)` tuple.
 
 **5. Record results:**
-- Databases synced successfully (with backup remote name used)
+- Databases and backup remotes synced successfully
 - Databases skipped (no backup configured)
-- Databases that failed (with error)
-- Duration per database
+- Backup remotes that failed (with database, backup name, and error)
+- Duration per `(database, backup_name)`
 
 **Exit criteria:** All databases attempted, results recorded."""
 
@@ -113,28 +122,36 @@ needs = ["sync"]
 description = """
 Rsync local backups to offsite storage for replication.
 
-**1. Locate backup directory:**
-Check the backup remote URL from the sync step to find the local
-backup path. The path is encoded in the dolt backup URL
-(e.g., `file:///path/to/.beads/backup`). Use `dolt backup -v` in
-any synced database to discover it if needed.
+**1. Locate backup directories:**
+Use the successful `(database, backup_name, backup_url)` rows recorded by the
+sync step. Handle each row independently. If a `backup_url` is missing, run
+`dolt backup -v` in that row's database and match the exact backup name.
+
+Only `file://` backup URLs have a local directory that can be copied with
+`rsync`. For non-`file://` URLs, skip offsite for that row and record
+`offsite_skip=remote_scheme` with the URL scheme.
 
 **2. Check prerequisites:**
-- Backup directory exists and has content
+- For each file-backed row, the decoded backup directory exists and has content
 - Offsite path is accessible
 
-**3. Run offsite sync:**
+**3. Run offsite sync per database and backup:**
 ```bash
-rsync -a --delete <backup_dir>/ <offsite_path>/
+mkdir -p <offsite_path>/<db>/<backup_name>/
+rsync -a --delete <backup_dir>/ <offsite_path>/<db>/<backup_name>/
 ```
+Keep the destination scoped to `<db>/<backup_name>/` so `--delete` can only
+remove files for the specific backup row being copied.
 
 **4. Record results:**
-- Success/failure
-- Duration
+- Success/failure per `(database, backup_name)`
+- Skipped non-file backup URLs with `offsite_skip=remote_scheme`
+- Duration per offsite copy
 
 **Note:** If offsite is unavailable, log and continue — not a fatal error.
 
-**Exit criteria:** Offsite sync attempted."""
+**Exit criteria:** Offsite sync attempted for every successful file-backed
+backup row, and non-file rows skipped observably."""
 
 [[steps]]
 id = "report"
@@ -144,10 +161,11 @@ description = """
 Generate summary and signal completion.
 
 **1. Generate report summary:**
-- Databases synced: count/total
+- Backup remotes synced: count/total
 - Databases skipped (no backup configured): count
 - Offsite sync status
-- Per-database breakdown: backup remote name, status, duration
+- Per-backup breakdown: database, backup remote name, sync status, offsite
+  status, duration
 - Any failures
 
 **2. Signal completion:**


### PR DESCRIPTION
## Summary

- The `mol-dog-backup` formula hardcoded `<db>-backup` as the expected backup remote name, but `gc init` creates remotes named `backup_export`. This caused the dog to report **0/N databases synced** even though backups were running correctly — a false alarm that triggered unnecessary escalations.
- Formula now runs `dolt backup` to discover whatever remote name is actually configured, and `dolt backup -v` to locate the backup directory path. No naming convention assumed.
- Databases with no configured backup are skipped and reported, not treated as sync failures.
- Version bumped to v2.

## Context

All 9 production databases in atlas have `backup_export` remotes pointing at `file:///.beads/backup`. The backup infrastructure (190 .darc archives, 8.4GB) is healthy and current. The dog was reporting failure purely because of the name mismatch.

## Test plan

- [ ] Deploy updated formula to atlas
- [ ] Run backup dog manually (`gc sling dog mol-dog-backup --formula`)
- [ ] Verify dog discovers `backup_export` remotes and syncs all databases
- [ ] Verify report shows correct count (9/9 or actual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)