### PR TITLE
test: codify per-bead SetMetadataBatch isolation on transient EOF (#663)

### DIFF
--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -2131,6 +2132,126 @@ func TestSyncSessionBeads_BatchesExistingMetadataBackfill(t *testing.T) {
 	}
 	if got := b.Metadata["synced_at"]; got == "" {
 		t.Fatal("synced_at not set")
+	}
+}
+
+// eofOnBeadStore wraps a MemStore and returns an unexpected-EOF error from
+// SetMetadataBatch for one specific bead ID, simulating a transient Dolt
+// packet failure on a single write. All other writes pass through to the
+// underlying MemStore.
+type eofOnBeadStore struct {
+	*beads.MemStore
+	failID    string
+	failCalls int
+}
+
+func (s *eofOnBeadStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.failID {
+		s.failCalls++
+		return fmt.Errorf(
+			"setting metadata on %q: exit status 1: [mysql] 2026/04/12 22:39:29 packets.go:58 unexpected EOF",
+			id,
+		)
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+// TestSyncSessionBeads_IsolatesSetMetadataBatchEOFToSingleBead is a
+// regression test for issue #663: a transient unexpected-EOF on a single
+// session bead's SetMetadataBatch write must not prevent other session
+// beads in the same reconciliation tick from being updated. Per-bead
+// isolation keeps the reconciler resilient to transient Dolt packet
+// failures without cascading into a full-city interrupt wave.
+//
+// Before this contract was enforced, a single EOF from the Dolt MySQL
+// driver during the supervisor's reconciliation loop could propagate
+// through syncSessionBeads and trigger downstream failure handling that
+// stopped every managed session. The reconciler MUST iterate through the
+// remaining beads after one fails, logging the error but continuing.
+func TestSyncSessionBeads_IsolatesSetMetadataBatchEOFToSingleBead(t *testing.T) {
+	inner := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+
+	// Seed three session beads, each missing the template field so
+	// syncSessionBeads will queue a backfill batch write for every bead.
+	seed := func(name string) beads.Bead {
+		b, err := inner.Create(beads.Bead{
+			Title:  name,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel, "agent:" + name},
+			Metadata: map[string]string{
+				"session_name": name,
+				"state":        "active",
+			},
+		})
+		if err != nil {
+			t.Fatalf("creating bead %s: %v", name, err)
+		}
+		return b
+	}
+	beadA := seed("mayor")
+	beadB := seed("witness")
+	beadC := seed("dog")
+
+	// Wrap the store so bead B's SetMetadataBatch returns an EOF-shaped
+	// error every time. The underlying MemStore never sees writes for B.
+	store := &eofOnBeadStore{MemStore: inner, failID: beadB.ID}
+
+	ds := map[string]TemplateParams{
+		"mayor":   {TemplateName: "mayor", Command: "true"},
+		"witness": {TemplateName: "witness", Command: "true"},
+		"dog":     {TemplateName: "dog", Command: "true"},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	// The EOF must have been observed at least once on bead B.
+	if store.failCalls == 0 {
+		t.Fatalf("SetMetadataBatch(%s) was never called; test did not exercise failure path", beadB.ID)
+	}
+
+	// stderr must identify the failed bead and the transient EOF marker
+	// so operators can correlate the log with the underlying transport
+	// failure.
+	msg := stderr.String()
+	if !strings.Contains(msg, beadB.ID) {
+		t.Errorf("stderr missing failed bead ID %q:\n%s", beadB.ID, msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "unexpected eof") {
+		t.Errorf("stderr missing 'unexpected EOF' marker:\n%s", msg)
+	}
+
+	// The unrelated beads MUST have their template backfilled. A broken
+	// isolation contract would skip the whole loop or propagate the EOF
+	// and leave A and C unwritten.
+	gotA, err := inner.Get(beadA.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", beadA.ID, err)
+	}
+	if gotA.Metadata["template"] != "mayor" {
+		t.Errorf("bead A template = %q, want %q (isolation broken)",
+			gotA.Metadata["template"], "mayor")
+	}
+	gotC, err := inner.Get(beadC.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", beadC.ID, err)
+	}
+	if gotC.Metadata["template"] != "dog" {
+		t.Errorf("bead C template = %q, want %q (isolation broken)",
+			gotC.Metadata["template"], "dog")
+	}
+
+	// The failed bead's metadata MUST remain unwritten so the next tick
+	// retries the full backfill from a clean state (idempotence).
+	gotB, err := inner.Get(beadB.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", beadB.ID, err)
+	}
+	if gotB.Metadata["template"] != "" {
+		t.Errorf("bead B template = %q, want empty (EOF should block write)",
+			gotB.Metadata["template"])
 	}
 }
 

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2135,18 +2135,20 @@ func TestSyncSessionBeads_BatchesExistingMetadataBackfill(t *testing.T) {
 	}
 }
 
-// eofOnBeadStore wraps a MemStore and returns an unexpected-EOF error from
-// SetMetadataBatch for one specific bead ID, simulating a transient Dolt
-// packet failure on a single write. All other writes pass through to the
-// underlying MemStore.
+// eofOnBeadStore wraps a MemStore and returns one unexpected-EOF error from
+// SetMetadataBatch, simulating a transient Dolt packet failure on a single
+// write. All other writes pass through to the underlying MemStore.
 type eofOnBeadStore struct {
 	*beads.MemStore
-	failID    string
+	failNext  bool
+	failedID  string
 	failCalls int
 }
 
 func (s *eofOnBeadStore) SetMetadataBatch(id string, kvs map[string]string) error {
-	if id == s.failID {
+	if s.failNext {
+		s.failNext = false
+		s.failedID = id
 		s.failCalls++
 		return fmt.Errorf(
 			"setting metadata on %q: exit status 1: [mysql] 2026/04/12 22:39:29 packets.go:58 unexpected EOF",
@@ -2190,68 +2192,80 @@ func TestSyncSessionBeads_IsolatesSetMetadataBatchEOFToSingleBead(t *testing.T) 
 		}
 		return b
 	}
-	beadA := seed("mayor")
-	beadB := seed("witness")
-	beadC := seed("dog")
-
-	// Wrap the store so bead B's SetMetadataBatch returns an EOF-shaped
-	// error every time. The underlying MemStore never sees writes for B.
-	store := &eofOnBeadStore{MemStore: inner, failID: beadB.ID}
+	beadA := seed("configured-alpha")
+	beadB := seed("configured-beta")
+	beadC := seed("configured-gamma")
 
 	ds := map[string]TemplateParams{
-		"mayor":   {TemplateName: "mayor", Command: "true"},
-		"witness": {TemplateName: "witness", Command: "true"},
-		"dog":     {TemplateName: "dog", Command: "true"},
+		"configured-alpha": {TemplateName: "configured-alpha", Command: "true"},
+		"configured-beta":  {TemplateName: "configured-beta", Command: "true"},
+		"configured-gamma": {TemplateName: "configured-gamma", Command: "true"},
 	}
+	expectedTemplates := map[string]string{
+		beadA.ID: "configured-alpha",
+		beadB.ID: "configured-beta",
+		beadC.ID: "configured-gamma",
+	}
+
+	// Wrap the store so the first SetMetadataBatch returns an EOF-shaped
+	// error. Because syncSessionBeads ranges over a map, failing the first
+	// metadata write makes the continuation assertion order-independent.
+	store := &eofOnBeadStore{MemStore: inner, failNext: true}
 
 	var stderr bytes.Buffer
 	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
 
-	// The EOF must have been observed at least once on bead B.
-	if store.failCalls == 0 {
-		t.Fatalf("SetMetadataBatch(%s) was never called; test did not exercise failure path", beadB.ID)
+	// The EOF must have been observed on exactly one seeded bead.
+	if store.failCalls != 1 {
+		t.Fatalf("SetMetadataBatch failure calls = %d, want 1", store.failCalls)
+	}
+	failedID := store.failedID
+	failedTemplate, ok := expectedTemplates[failedID]
+	if failedID == "" || !ok {
+		t.Fatalf("failed metadata write ID = %q, want one of %v", failedID, expectedTemplates)
 	}
 
 	// stderr must identify the failed bead and the transient EOF marker
 	// so operators can correlate the log with the underlying transport
 	// failure.
 	msg := stderr.String()
-	if !strings.Contains(msg, beadB.ID) {
-		t.Errorf("stderr missing failed bead ID %q:\n%s", beadB.ID, msg)
+	if !strings.Contains(msg, failedID) {
+		t.Errorf("stderr missing failed bead ID %q:\n%s", failedID, msg)
 	}
 	if !strings.Contains(strings.ToLower(msg), "unexpected eof") {
 		t.Errorf("stderr missing 'unexpected EOF' marker:\n%s", msg)
 	}
 
-	// The unrelated beads MUST have their template backfilled. A broken
-	// isolation contract would skip the whole loop or propagate the EOF
-	// and leave A and C unwritten.
-	gotA, err := inner.Get(beadA.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", beadA.ID, err)
-	}
-	if gotA.Metadata["template"] != "mayor" {
-		t.Errorf("bead A template = %q, want %q (isolation broken)",
-			gotA.Metadata["template"], "mayor")
-	}
-	gotC, err := inner.Get(beadC.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", beadC.ID, err)
-	}
-	if gotC.Metadata["template"] != "dog" {
-		t.Errorf("bead C template = %q, want %q (isolation broken)",
-			gotC.Metadata["template"], "dog")
+	// Every non-failed bead MUST have its template backfilled in the same
+	// tick. The failed bead MUST remain unwritten so the next tick retries
+	// the full backfill from a clean state.
+	for id, want := range expectedTemplates {
+		got, err := inner.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if id == failedID {
+			if got.Metadata["template"] != "" {
+				t.Errorf("failed bead template = %q, want empty (EOF should block write)",
+					got.Metadata["template"])
+			}
+			continue
+		}
+		if got.Metadata["template"] != want {
+			t.Errorf("non-failed bead %s template = %q, want %q (isolation broken)",
+				id, got.Metadata["template"], want)
+		}
 	}
 
-	// The failed bead's metadata MUST remain unwritten so the next tick
-	// retries the full backfill from a clean state (idempotence).
-	gotB, err := inner.Get(beadB.ID)
+	var retryStderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &retryStderr, false)
+
+	retried, err := inner.Get(failedID)
 	if err != nil {
-		t.Fatalf("Get(%s): %v", beadB.ID, err)
+		t.Fatalf("Get(%s) after retry: %v", failedID, err)
 	}
-	if gotB.Metadata["template"] != "" {
-		t.Errorf("bead B template = %q, want empty (EOF should block write)",
-			gotB.Metadata["template"])
+	if retried.Metadata["template"] != failedTemplate {
+		t.Errorf("retried bead template = %q, want %q", retried.Metadata["template"], failedTemplate)
 	}
 }
 


### PR DESCRIPTION
Partially addresses #663. Pairs with the already-merged #937 panic-recovery wrapper.

## Summary
Adds a regression test that locks in per-bead isolation inside `syncSessionBeads` when a single bead's `SetMetadataBatch` call returns a transient Dolt-shaped error (`unexpected EOF`).

## Context
Issue #663 observed 73 full-city restart cascades in 37 hours driven by `packets.go:58 unexpected EOF` during session-bead metadata writes. PR #937 landed `cr.safeTick(...)` to recover reconciler-tick panics, closing the cascade path that flowed through `cmd_supervisor.go:1418-1427` into `gracefulStopAll` with `op=interrupt wave=0` for every managed session.

`syncSessionBeads` already handles per-bead `setMetaBatch` failures with a `continue` so unrelated beads keep reconciling in the same tick — but that contract had no test. A future refactor could collapse the loop or bubble the error up and silently break the isolation that #937 relies on.

This change adds `eofOnBeadStore`, a test-only wrapper that injects an EOF-shaped error on one specific bead's `SetMetadataBatch`, and asserts:

- stderr identifies the failed bead ID and contains the `unexpected EOF` marker so operators can correlate with the transport failure;
- the two unrelated beads still have their `template` backfilled — isolation held;
- the failed bead stays unwritten, so the next tick retries the full backfill from a clean state (idempotence).

## What's not in this PR
- No production code change. The existing skip-via-continue behavior is already correct — the test simply codifies the contract.
- Does not touch the EOF root cause (tracked in #525 / #560 per the #663 issue text).
- No new retry layer. Transport-level retry already runs in `bdCommandRunnerWithManagedRetry` (`cmd/gc/bd_env.go:271`) for the realistic `BdStore` path; injecting another retry at `setMetaBatch` would be redundant and add latency to the already-retrying path.

## Test plan
- [x] `go test ./cmd/gc/ -run TestSyncSessionBeads_IsolatesSetMetadataBatchEOFToSingleBead -count=1` — PASS on this branch.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test ./cmd/gc/ -run "TestSyncSessionBeads|TestSetMeta" -count=1` — PASS (all existing session-bead tests still pass alongside the new one).
- [x] `go test ./cmd/gc/ -run "TestSafeTick|TestCityRuntimeSafeTick|TestCityRuntimeRun_Panic" -count=1` — PASS (existing #663 tests from PR #937 still green).

Pre-existing `TestCityRuntimeReload*` failures reproduce on clean `origin/main` without this change and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)