### PR TITLE
fix: rebuild bare resume command to include schema defaults (#799)

### DIFF
--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -366,7 +366,16 @@ func shouldPreserveStoredRuntimeCommand(storedCommand, resolvedCommand string) b
 	if resolvedCommand == "" {
 		return true
 	}
-	return storedCommand == resolvedCommand || strings.HasPrefix(storedCommand, resolvedCommand+" ")
+	// A bare stored command (just the provider binary) lacks schema
+	// defaults like --dangerously-skip-permissions and the --settings
+	// path. Rebuild from the current config instead of preserving it.
+	// See #799: pool-agent sessions resumed through the control-
+	// dispatcher path wedged on interactive permission prompts because
+	// the bare stored command was preserved without re-injecting flags.
+	if storedCommand == resolvedCommand {
+		return false
+	}
+	return strings.HasPrefix(storedCommand, resolvedCommand+" ")
 }
 
 func resolveWorkerRuntimeWithConfig(cfg *config.City, info session.Info, sessionKind string) *config.ResolvedProvider {

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -142,6 +142,62 @@ func TestResolvedWorkerRuntimeWithConfigUsesProviderLaunchCommand(t *testing.T) 
 	}
 }
 
+// TestResolvedWorkerRuntimeResumesPoolSessionPreservesLaunchFlags is a
+// regression test for gastownhall/gascity#799: a pool-agent session
+// resumed through the control-dispatcher path must reconstruct the full
+// launch command (--dangerously-skip-permissions, --settings, schema
+// defaults) even when the persisted session command is the bare
+// provider name. The pre-fix path dropped those flags and caused pool
+// workers resumed via `claude --resume <uuid>` to wedge on interactive
+// permission prompts.
+func TestResolvedWorkerRuntimeResumesPoolSessionPreservesLaunchFlags(t *testing.T) {
+	cityDir := t.TempDir()
+	gcDir := filepath.Join(cityDir, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gcDir, "settings.json"), []byte(`{"hooks":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	claude := config.BuiltinProviders()["claude"]
+	maxActive := 3
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "perspective_planner",
+			Provider:          "claude",
+			MaxActiveSessions: &maxActive,
+		}},
+		Providers: map[string]config.ProviderSpec{
+			"claude": claude,
+		},
+	}
+
+	// Simulate a pool-instance session bead whose persisted command is
+	// the bare provider name — the shape produced before the April 2026
+	// worker-boundary refactor when the API created the bead with
+	// sessionCreateAgentCommand(resolved) before the reconciler synced
+	// the full tp.Command.
+	runtimeCfg := resolvedWorkerRuntimeWithConfig(cityDir, cfg, session.Info{
+		Template: "perspective_planner",
+		Command:  "claude",
+		WorkDir:  cityDir,
+	}, "")
+	if runtimeCfg == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
+	}
+	if !strings.Contains(runtimeCfg.Command, "--dangerously-skip-permissions") {
+		t.Fatalf("resumed pool Command = %q, want --dangerously-skip-permissions", runtimeCfg.Command)
+	}
+	if !strings.Contains(runtimeCfg.Command, "--effort max") {
+		t.Fatalf("resumed pool Command = %q, want --effort max default", runtimeCfg.Command)
+	}
+	if !strings.Contains(runtimeCfg.Command, "--settings") {
+		t.Fatalf("resumed pool Command = %q, want --settings arg", runtimeCfg.Command)
+	}
+}
+
 func TestWorkerHandleForSessionWithConfigUsesResolvedProviderOnResume(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,7 @@ gc [flags]
 | [gc beads](#gc-beads) | Manage the beads provider |
 | [gc build-image](#gc-build-image) | Build a prebaked agent container image |
 | [gc cities](#gc-cities) | List registered cities |
+| [gc completion](#gc-completion) | Generate the autocompletion script for the specified shell |
 | [gc config](#gc-config) | Inspect and validate city configuration |
 | [gc converge](#gc-converge) | Manage convergence loops (bounded iterative refinement) |
 | [gc convoy](#gc-convoy) | Manage convoys — graphs of related work |
@@ -52,6 +53,7 @@ gc [flags]
 | [gc runtime](#gc-runtime) | Process-intrinsic runtime operations |
 | [gc service](#gc-service) | Inspect workspace services |
 | [gc session](#gc-session) | Manage interactive chat sessions |
+| [gc shell](#gc-shell) | Manage the Gas City shell integration hook |
 | [gc skill](#gc-skill) | List visible skills |
 | [gc sling](#gc-sling) | Route work to a session config or agent |
 | [gc start](#gc-start) | Start the city under the machine-wide supervisor |
@@ -303,6 +305,127 @@ List registered cities
 ```
 gc cities list
 ```
+
+## gc completion
+
+Generate the autocompletion script for gc for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+```
+gc completion
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc completion bash](#gc-completion-bash) | Generate the autocompletion script for bash |
+| [gc completion fish](#gc-completion-fish) | Generate the autocompletion script for fish |
+| [gc completion powershell](#gc-completion-powershell) | Generate the autocompletion script for powershell |
+| [gc completion zsh](#gc-completion-zsh) | Generate the autocompletion script for zsh |
+
+## gc completion bash
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source &lt;(gc completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	gc completion bash &gt; /etc/bash_completion.d/gc
+
+#### macOS:
+
+	gc completion bash &gt; $(brew --prefix)/etc/bash_completion.d/gc
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion bash
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion fish
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	gc completion fish | source
+
+To load completions for every new session, execute once:
+
+	gc completion fish &gt; ~/.config/fish/completions/gc.fish
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion fish [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion powershell
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	gc completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+```
+gc completion powershell [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion zsh
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" &gt;&gt; ~/.zshrc
+
+To load completions in your current shell session:
+
+	source &lt;(gc completion zsh)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	gc completion zsh &gt; "$&#123;fpath[1]&#125;/_gc"
+
+#### macOS:
+
+	gc completion zsh &gt; $(brew --prefix)/share/zsh/site-functions/_gc
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion zsh [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
 
 ## gc config
 
@@ -2247,6 +2370,51 @@ gc session wake <session-id-or-alias>
 ```
 gc session wake gc-42
   gc session wake mayor
+```
+
+## gc shell
+
+The shell integration adds a completion hook to your shell RC file that
+provides tab-completion for gc commands and flags.
+
+Subcommands: install, remove, status.
+
+```
+gc shell
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc shell install](#gc-shell-install) | Install or update shell integration |
+| [gc shell remove](#gc-shell-remove) | Remove shell integration |
+| [gc shell status](#gc-shell-status) | Show shell integration status |
+
+## gc shell install
+
+Install or update the gc shell completion hook.
+
+If no shell is specified, the shell is detected from $SHELL.
+The completion script is written to ~/.gc/completions/ and a source line
+is added to your shell RC file.
+
+```
+gc shell install [bash|zsh|fish]
+```
+
+## gc shell remove
+
+Remove the gc shell completion hook from your shell RC file and delete the completion script.
+
+```
+gc shell remove
+```
+
+## gc shell status
+
+Show shell integration status
+
+```
+gc shell status
 ```
 
 ## gc skill

--- a/internal/api/handler_session_chat_test.go
+++ b/internal/api/handler_session_chat_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -109,5 +110,51 @@ func TestBuildSessionResumePreservesStoredResolvedCommand(t *testing.T) {
 	cmd, _ := srv.buildSessionResume(info)
 	if got, want := cmd, "claude --dangerously-skip-permissions --settings /tmp/settings.json"; got != want {
 		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent is a
+// regression test for gastownhall/gascity#799: when a pool-agent session
+// resumed through the control-dispatcher path has only the bare
+// provider binary ("claude") as its stored command, the API must
+// re-inject schema defaults (--dangerously-skip-permissions) and the
+// provider-owned --settings path from the current resolved config.
+// Before the fix, the bare stored command was preserved as-is and pool
+// workers wedged on interactive permission prompts on resume.
+func TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent(t *testing.T) {
+	fs := newSessionFakeState(t)
+	claude := config.BuiltinProviders()["claude"]
+	maxActive := 3
+	fs.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "perspective_planner",
+				Provider:          "claude",
+				MaxActiveSessions: &maxActive,
+			},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"claude": claude,
+		},
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:         "gc-1",
+		Template:   "perspective_planner",
+		Command:    "claude",
+		Provider:   "claude",
+		WorkDir:    fs.cityPath,
+		SessionKey: "abc-123",
+		ResumeFlag: "--resume",
+	}
+
+	cmd, _ := srv.buildSessionResume(info)
+	if !strings.Contains(cmd, "--dangerously-skip-permissions") {
+		t.Fatalf("resume command missing default args:\n  got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--resume abc-123") {
+		t.Fatalf("resume command missing resume flag:\n  got: %s", cmd)
 	}
 }

--- a/internal/api/handler_session_chat_test.go
+++ b/internal/api/handler_session_chat_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -125,6 +127,13 @@ func TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent(t *testin
 	fs := newSessionFakeState(t)
 	claude := config.BuiltinProviders()["claude"]
 	maxActive := 3
+	gcDir := filepath.Join(fs.cityPath, ".gc")
+	if err := os.MkdirAll(gcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gcDir, "settings.json"), []byte(`{"hooks":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	fs.cfg = &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{
@@ -156,5 +165,8 @@ func TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent(t *testin
 	}
 	if !strings.Contains(cmd, "--resume abc-123") {
 		t.Fatalf("resume command missing resume flag:\n  got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--settings") {
+		t.Fatalf("resume command missing settings arg:\n  got: %s", cmd)
 	}
 }

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -150,7 +150,16 @@ func shouldPreserveStoredRuntimeCommand(storedCommand, resolvedCommand string) b
 	if resolvedCommand == "" {
 		return true
 	}
-	return storedCommand == resolvedCommand || strings.HasPrefix(storedCommand, resolvedCommand+" ")
+	// A bare stored command (just the provider binary) lacks schema
+	// defaults like --dangerously-skip-permissions and the --settings
+	// path. Rebuild from the current config instead of preserving it.
+	// See #799: pool-agent sessions resumed through the control-
+	// dispatcher path wedged on interactive permission prompts because
+	// the bare stored command was preserved without re-injecting flags.
+	if storedCommand == resolvedCommand {
+		return false
+	}
+	return strings.HasPrefix(storedCommand, resolvedCommand+" ")
 }
 
 func (s *Server) resolveWorkerSessionRuntime(info session.Info, _ string) (*worker.ResolvedRuntime, error) {


### PR DESCRIPTION
## Summary

Regression test + fix for #799. Pool-agent sessions resumed through the control-dispatcher path launched `claude --resume <uuid>` without `--dangerously-skip-permissions` or `--settings`, wedging on interactive permission prompts.

- `shouldPreserveStoredRuntimeCommand` preserved the stored command when it exactly equalled the bare provider binary, skipping `BuildProviderLaunchCommand` and losing schema-default flags.
- Rebuild when the stored command is only the bare binary; keep preserving longer stored commands that already carry flags (so paths persisting fully-resolved commands still win).
- Parallel fix in the API path (`internal/api/session_runtime.go`) and the CLI worker-boundary path (`cmd/gc/worker_handle.go`). Both carry their own copy of the helper.

## Test plan

- [x] New regression test `TestResolvedWorkerRuntimeResumesPoolSessionPreservesLaunchFlags` in `cmd/gc/worker_handle_test.go` covers the worker-boundary resume.
- [x] New regression test `TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent` in `internal/api/handler_session_chat_test.go` covers the API resume.
- [x] Both tests verified to fail on pre-fix code and pass after the fix.
- [x] Existing tests still pass: `TestBuildSessionResumePreservesStoredResolvedCommand` (longer stored command is preserved), `TestResolvedWorkerRuntimeWithConfigUsesProviderLaunchCommand` (empty stored command triggers rebuild).
- [x] `go test ./internal/api ./internal/worker ./internal/config ./internal/session` all pass.
- [x] `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)