### PR TITLE
feat: routed-work auto-nudge, gc init --preserve-existing, and assorted fixes

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -441,20 +441,12 @@ func ensureInitConventionDirs(fs fsys.FS, cityPath string) error {
 	return nil
 }
 
-func writeInitPackToml(fs fsys.FS, cityPath string, packCfg initPackConfig) error {
-	content, err := marshalInitPackConfig(packCfg)
-	if err != nil {
-		return err
-	}
-	return fs.WriteFile(filepath.Join(cityPath, "pack.toml"), content, 0o644)
-}
-
 // writeInitFile writes data to path. When preserve is true and path already
 // exists, the existing file is kept untouched and wrote=false is returned.
 // preserve is set by --preserve-existing, which callers (e.g. bootstrap
 // scripts operating on a pre-authored workspace) use to avoid clobbering
 // committed user files like pack.toml, city.toml, and agent prompts.
-func writeInitFile(fs fsys.FS, path string, data []byte, perm os.FileMode, preserve bool) (wrote bool, err error) {
+func writeInitFile(fs fsys.FS, path string, data []byte, preserve bool) (wrote bool, err error) {
 	if preserve {
 		if _, err := fs.Stat(path); err == nil {
 			return false, nil
@@ -462,7 +454,7 @@ func writeInitFile(fs fsys.FS, path string, data []byte, perm os.FileMode, prese
 			return false, err
 		}
 	}
-	return true, fs.WriteFile(path, data, perm)
+	return true, fs.WriteFile(path, data, 0o644)
 }
 
 // writeInitPackTomlOpts marshals and writes pack.toml, honoring the
@@ -472,7 +464,7 @@ func writeInitPackTomlOpts(fs fsys.FS, cityPath string, packCfg initPackConfig, 
 	if err != nil {
 		return false, err
 	}
-	return writeInitFile(fs, filepath.Join(cityPath, "pack.toml"), content, 0o644, preserve)
+	return writeInitFile(fs, filepath.Join(cityPath, "pack.toml"), content, preserve)
 }
 
 func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
@@ -792,7 +784,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	// committed city.toml is already in place. Persist the workspace identity
 	// regardless so .gc/site.toml agrees with the preserved or newly-written
 	// config.
-	wroteCity, err := writeInitFile(fs, filepath.Join(cityPath, "city.toml"), content, 0o644, preserveExisting)
+	wroteCity, err := writeInitFile(fs, filepath.Join(cityPath, "city.toml"), content, preserveExisting)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -925,7 +917,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		fmt.Fprintln(stdout, "Preserved existing pack.toml.") //nolint:errcheck // best-effort stdout
 	}
 	logInitProgress(stdout, 5, "Writing city configuration")
-	wroteCity, err := writeInitFile(fs, tomlPath, content, 0o644, preserveExisting)
+	wroteCity, err := writeInitFile(fs, tomlPath, content, preserveExisting)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1034,7 +1026,7 @@ func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if _, err := writeInitFile(fs, dst, data, 0o644, preserveExisting); err != nil {
+		if _, err := writeInitFile(fs, dst, data, preserveExisting); err != nil {
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -244,6 +244,7 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var providerFlag string
 	var bootstrapProfileFlag string
 	var skipProviderReadiness bool
+	var preserveExisting bool
 	cmd := &cobra.Command{
 		Use:   "init [path]",
 		Short: "Initialize a new city",
@@ -253,23 +254,28 @@ Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, then
 materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
-non-interactively, or --file to initialize from an existing TOML config file.`,
+non-interactively, or --file to initialize from an existing TOML config file.
+
+Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
+agent prompt files in the target directory (useful when bootstrapping a
+committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 		Example: `  gc init
   gc init ~/my-city
   gc init --provider codex ~/my-city
   gc init --provider codex --bootstrap-profile k8s-cell /city
   gc init --name my-city
   gc init --from ~/elan --name elan /city
-  gc init --file examples/gastown.toml ~/bright-lights`,
+  gc init --file examples/gastown.toml ~/bright-lights
+  gc init --file city.toml --preserve-existing .`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if fromFlag != "" {
 				return exitForCode(cmdInitFromDirWithOptions(fromFlag, args, nameFlag, stdout, stderr, skipProviderReadiness))
 			}
 			if fileFlag != "" {
-				return exitForCode(cmdInitFromFileWithOptions(fileFlag, args, nameFlag, stdout, stderr, skipProviderReadiness))
+				return exitForCode(cmdInitFromFileWithOptions(fileFlag, args, nameFlag, stdout, stderr, skipProviderReadiness, preserveExisting))
 			}
-			return exitForCode(cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, stdout, stderr, skipProviderReadiness))
+			return exitForCode(cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, stdout, stderr, skipProviderReadiness, preserveExisting))
 		},
 	}
 	cmd.Flags().StringVar(&fileFlag, "file", "", "path to a TOML file to use as city.toml")
@@ -278,6 +284,7 @@ non-interactively, or --file to initialize from an existing TOML config file.`,
 	cmd.Flags().StringVar(&providerFlag, "provider", "", "built-in workspace provider to use for the default mayor config")
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
+	cmd.Flags().BoolVar(&preserveExisting, "preserve-existing", false, "keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them")
 	cmd.MarkFlagsMutuallyExclusive("file", "from")
 	cmd.MarkFlagsMutuallyExclusive("provider", "file")
 	cmd.MarkFlagsMutuallyExclusive("provider", "from")
@@ -291,10 +298,10 @@ non-interactively, or --file to initialize from an existing TOML config file.`,
 // Creates the runtime scaffold and city.toml. If the bead provider is "bd", also
 // runs bd init.
 func cmdInit(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer) int {
-	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false)
+	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false, false)
 }
 
-func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -329,7 +336,7 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 	default:
 		wiz = defaultWizardConfig()
 	}
-	if code := doInit(fsys.OSFS{}, cityPath, wiz, nameOverride, stdout, stderr); code != 0 {
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, nameOverride, stdout, stderr, preserveExisting); code != 0 {
 		return code
 	}
 	return finalizeInit(cityPath, stdout, stderr, initFinalizeOptions{
@@ -440,6 +447,32 @@ func writeInitPackToml(fs fsys.FS, cityPath string, packCfg initPackConfig) erro
 		return err
 	}
 	return fs.WriteFile(filepath.Join(cityPath, "pack.toml"), content, 0o644)
+}
+
+// writeInitFile writes data to path. When preserve is true and path already
+// exists, the existing file is kept untouched and wrote=false is returned.
+// preserve is set by --preserve-existing, which callers (e.g. bootstrap
+// scripts operating on a pre-authored workspace) use to avoid clobbering
+// committed user files like pack.toml, city.toml, and agent prompts.
+func writeInitFile(fs fsys.FS, path string, data []byte, perm os.FileMode, preserve bool) (wrote bool, err error) {
+	if preserve {
+		if _, err := fs.Stat(path); err == nil {
+			return false, nil
+		} else if !os.IsNotExist(err) {
+			return false, err
+		}
+	}
+	return true, fs.WriteFile(path, data, perm)
+}
+
+// writeInitPackTomlOpts marshals and writes pack.toml, honoring the
+// preserve-existing option. Returns (wrote, err) mirroring writeInitFile.
+func writeInitPackTomlOpts(fs fsys.FS, cityPath string, packCfg initPackConfig, preserve bool) (bool, error) {
+	content, err := marshalInitPackConfig(packCfg)
+	if err != nil {
+		return false, err
+	}
+	return writeInitFile(fs, filepath.Join(cityPath, "pack.toml"), content, 0o644, preserve)
 }
 
 func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
@@ -648,7 +681,7 @@ func appendUniqueStrings(dst []string, items ...string) []string {
 	return dst
 }
 
-func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -666,16 +699,16 @@ func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride stri
 		}
 	}
 
-	return cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, fileArg, cityPath, nameOverride, stdout, stderr, skipProviderReadiness)
+	return cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, fileArg, cityPath, nameOverride, stdout, stderr, skipProviderReadiness, preserveExisting)
 }
 
 // cmdInitFromTOMLFile initializes a city by copying a user-provided TOML
 // file as city.toml. Creates the runtime scaffold, visible roots, and runs bead init.
 func cmdInitFromTOMLFile(fs fsys.FS, tomlSrc, cityPath string, stdout, stderr io.Writer) int {
-	return cmdInitFromTOMLFileWithOptions(fs, tomlSrc, cityPath, "", stdout, stderr, false)
+	return cmdInitFromTOMLFileWithOptions(fs, tomlSrc, cityPath, "", stdout, stderr, false, false)
 }
 
-func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	// Validate the source file parses as a valid city config.
 	data, err := os.ReadFile(tomlSrc)
 	if err != nil {
@@ -698,8 +731,15 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	}
 	cfg.Workspace.Name = cityName
 
-	// Create directory structure.
-	if cityAlreadyInitializedFS(fs, cityPath) {
+	// Create directory structure. With --preserve-existing, only refuse when
+	// the runtime scaffold is already in place — a pre-authored city.toml in
+	// the target directory (e.g. a committed workspace being bootstrapped)
+	// is preserved below rather than blocking init.
+	alreadyInitialized := cityAlreadyInitializedFS(fs, cityPath)
+	if preserveExisting {
+		alreadyInitialized = cityHasScaffoldFS(fs, cityPath)
+	}
+	if alreadyInitialized {
 		return initAlreadyInitialized(stderr)
 	}
 	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
@@ -715,8 +755,9 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return code
 	}
 
-	// Write prompt scaffolds only for the explicit agents declared by the template.
-	if code := writeInitAgentPrompts(fs, cityPath, cfg, stderr); code != 0 {
+	// Write prompt scaffolds only for the explicit agents declared by the
+	// template — preserved individually if --preserve-existing is set.
+	if code := writeInitAgentPrompts(fs, cityPath, cfg, stderr, preserveExisting); code != 0 {
 		return code
 	}
 
@@ -726,9 +767,13 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	rewriteInitPromptTemplates(cfg)
 	packCfg, cityCfg := splitInitConfig(cityName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
-	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
+	wrotePack, err := writeInitPackTomlOpts(fs, cityPath, packCfg, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !wrotePack {
+		fmt.Fprintln(stdout, "Preserved existing pack.toml.") //nolint:errcheck // best-effort stdout
 	}
 
 	formulasInitDir := filepath.Join(cityPath, citylayout.FormulasRoot)
@@ -743,10 +788,17 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return 1
 	}
 
-	// Write city.toml.
-	if err := fs.WriteFile(filepath.Join(cityPath, "city.toml"), content, 0o644); err != nil {
+	// Write city.toml — preserved if --preserve-existing is set and a
+	// committed city.toml is already in place. Persist the workspace identity
+	// regardless so .gc/site.toml agrees with the preserved or newly-written
+	// config.
+	wroteCity, err := writeInitFile(fs, filepath.Join(cityPath, "city.toml"), content, 0o644, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !wroteCity {
+		fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, filepath.Join(cityPath, "city.toml"), &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -778,7 +830,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 // when a provider or start command is supplied; otherwise init writes the
 // default mayor-only city. Errors if the runtime scaffold already exists. Accepts an
 // injected FS for testability.
-func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, stdout, stderr io.Writer) int {
+func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, stdout, stderr io.Writer, preserveExisting bool) int {
 	tomlPath := filepath.Join(cityPath, citylayout.CityConfigFile)
 	if cityHasScaffoldFS(fs, cityPath) {
 		return initAlreadyInitialized(stderr)
@@ -841,7 +893,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 
 	// Write prompt files only for the agents declared by the init template.
 	logInitProgress(stdout, 3, "Writing default prompts")
-	if code := writeInitAgentPrompts(fs, cityPath, &cfg, stderr); code != 0 {
+	if code := writeInitAgentPrompts(fs, cityPath, &cfg, stderr, preserveExisting); code != 0 {
 		return code
 	}
 
@@ -864,14 +916,22 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		return 1
 	}
 	logInitProgress(stdout, 4, "Writing pack.toml")
-	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
+	wrotePack, err := writeInitPackTomlOpts(fs, cityPath, packCfg, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if !wrotePack {
+		fmt.Fprintln(stdout, "Preserved existing pack.toml.") //nolint:errcheck // best-effort stdout
+	}
 	logInitProgress(stdout, 5, "Writing city configuration")
-	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
+	wroteCity, err := writeInitFile(fs, tomlPath, content, 0o644, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !wroteCity {
+		fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, tomlPath, &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -949,7 +1009,7 @@ func bootstrapScopedFileProviderCityFS(fs fsys.FS, cityPath string) error {
 // default prompt scaffolds referenced by the init template's explicit agents.
 // This keeps a freshly initialized city aligned with the city.toml it writes
 // instead of silently creating additional convention-discoverable agents.
-func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer) int {
+func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer, preserveExisting bool) int {
 	if err := fs.MkdirAll(filepath.Join(cityPath, "agents"), 0o755); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -974,7 +1034,7 @@ func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if err := fs.WriteFile(dst, data, 0o644); err != nil {
+		if _, err := writeInitFile(fs, dst, data, 0o644, preserveExisting); err != nil {
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -26,14 +26,15 @@ func buildAwakeInputFromReconciler(
 	clk time.Time,
 ) AwakeInput {
 	input := AwakeInput{
-		ScaleCheckCounts: poolDesired,
-		WorkSet:          workSet,
-		ReadyWaitSet:     readyWaitSet,
-		RunningSessions:  make(map[string]bool),
-		AttachedSessions: make(map[string]bool),
-		PendingSessions:  make(map[string]bool),
-		ChatIdleTimeout:  cfg.ChatSessions.IdleTimeoutDuration(),
-		Now:              clk,
+		ScaleCheckCounts:    poolDesired,
+		WorkSet:             workSet,
+		ReadyWaitSet:        readyWaitSet,
+		RoutedWorkTemplates: workSet,
+		RunningSessions:     make(map[string]bool),
+		AttachedSessions:    make(map[string]bool),
+		PendingSessions:     make(map[string]bool),
+		ChatIdleTimeout:     cfg.ChatSessions.IdleTimeoutDuration(),
+		Now:                 clk,
 	}
 
 	// Agents
@@ -151,6 +152,8 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 				reasons = []WakeReason{WakeWait}
 			case "assigned-work", "work-query":
 				reasons = []WakeReason{WakeWork}
+			case "routed":
+				reasons = []WakeReason{WakeRouted}
 			default:
 				reasons = []WakeReason{WakeConfig}
 			}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -16,18 +16,19 @@ const defaultOnDemandIdleTimeout = 5 * time.Minute
 // should be awake. All external I/O (shell commands, tmux checks, store
 // queries) happens before this function is called.
 type AwakeInput struct {
-	Agents           []AwakeAgent
-	NamedSessions    []AwakeNamedSession
-	SessionBeads     []AwakeSessionBead
-	WorkBeads        []AwakeWorkBead
-	ScaleCheckCounts map[string]int  // agent template → desired count
-	WorkSet          map[string]bool // agent template → work_query found pending work
-	RunningSessions  map[string]bool // session name → tmux exists
-	AttachedSessions map[string]bool // session name → user attached
-	PendingSessions  map[string]bool // session name → pending interaction
-	ReadyWaitSet     map[string]bool // session bead ID → durable wait is ready
-	ChatIdleTimeout  time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
-	Now              time.Time
+	Agents              []AwakeAgent
+	NamedSessions       []AwakeNamedSession
+	SessionBeads        []AwakeSessionBead
+	WorkBeads           []AwakeWorkBead
+	ScaleCheckCounts    map[string]int  // agent template → desired count
+	WorkSet             map[string]bool // agent template → work_query found pending work
+	RunningSessions     map[string]bool // session name → tmux exists
+	AttachedSessions    map[string]bool // session name → user attached
+	PendingSessions     map[string]bool // session name → pending interaction
+	ReadyWaitSet        map[string]bool // session bead ID → durable wait is ready
+	ChatIdleTimeout     time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	RoutedWorkTemplates map[string]bool // agent template → has unprocessed gc.routed_to work
+	Now                 time.Time
 }
 
 // AwakeAgent represents an [[agent]] config entry.
@@ -185,6 +186,34 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		if creating := collectCreatingBeads(input.SessionBeads, template); len(creating) > 0 {
 			desired[creating[0].SessionName] = "work-query"
+		}
+	}
+
+	// RoutedWorkTemplates: when beads carry gc.routed_to for a template,
+	// ensure at least one session is desired with reason "routed". Fires
+	// only when ScaleCheckCounts hasn't caught up (same gate as WorkSet).
+	// The "routed" reason upgrades "work-query" from WorkSet so the
+	// bridge emits WakeRouted for tracing and nudge dispatch.
+	for template, hasWork := range input.RoutedWorkTemplates {
+		if !hasWork {
+			continue
+		}
+		if input.ScaleCheckCounts[template] > 0 {
+			continue
+		}
+		agent, ok := agentsByName[template]
+		if !ok || agent.Suspended {
+			continue
+		}
+		if isNamedSessionTemplate(input.NamedSessions, template) {
+			continue
+		}
+		if active := collectActiveBeads(input.SessionBeads, template); len(active) > 0 {
+			desired[active[0].SessionName] = "routed"
+			continue
+		}
+		if creating := collectCreatingBeads(input.SessionBeads, template); len(creating) > 0 {
+			desired[creating[0].SessionName] = "routed"
 		}
 	}
 

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1504,3 +1504,190 @@ func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	})
 	assertAsleep(t, result, "polecat-mc-1")
 }
+
+// ---------------------------------------------------------------------------
+// RoutedWorkTemplates — gc.routed_to wake signal + nudge enabler
+// ---------------------------------------------------------------------------
+
+func TestRoutedWork_WakesActiveSession(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "routed")
+}
+
+func TestRoutedWork_NoOpWhenScaleCheckCovers(t *testing.T) {
+	// When ScaleCheckCounts already covers the template, RoutedWork defers
+	// to ScaleCheck (same gate as WorkSet). Nudge dispatch in the
+	// reconciler handles alive sessions independently.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-2", SessionName: "polecat-mc-2", Template: "hello-world/polecat", State: "active"},
+		},
+		ScaleCheckCounts:    map[string]int{"hello-world/polecat": 1},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true, "polecat-mc-2": true},
+		Now:                 now,
+	})
+	awake := 0
+	for _, d := range result {
+		if d.ShouldWake {
+			awake++
+		}
+	}
+	if awake != 1 {
+		t.Errorf("ScaleCheck=1 should cap to 1, RoutedWork should not add more, got %d awake", awake)
+	}
+	assertReason(t, result, "polecat-mc-1", "scaled:demand")
+}
+
+func TestRoutedWork_DoesNotOverrideExistingReason(t *testing.T) {
+	// When a session is already desired (e.g. via ScaleCheck), RoutedWork
+	// should not overwrite the existing reason.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		ScaleCheckCounts:    map[string]int{"hello-world/polecat": 1},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "scaled:demand")
+}
+
+func TestRoutedWork_SkipsSuspendedAgent(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", Suspended: true}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsDrained(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active", Drained: true},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsDependencyOnly(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active", DependencyOnly: true},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsNamedSession(t *testing.T) {
+	// RoutedWorkTemplates skips named-session templates. The named-session
+	// pass handles those independently.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/worker"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/worker", Template: "hello-world/worker", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "worker", Template: "hello-world/worker", State: "asleep", NamedIdentity: "hello-world/worker"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/worker": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "worker")
+}
+
+func TestRoutedWork_FallsBackToCreating(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "creating"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "routed")
+}
+
+func TestRoutedWork_SuppressedByHeldUntil(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active",
+				HeldUntil: now.Add(5 * time.Minute),
+			},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_FalseValue_NoEffect(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": false},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_NilMap_NoEffect(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: nil,
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_BridgeMapsToWakeRouted(t *testing.T) {
+	decisions := map[string]AwakeDecision{
+		"polecat-mc-1": {ShouldWake: true, Reason: "routed"},
+	}
+	beads := []AwakeSessionBead{
+		{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat"},
+	}
+	evals := awakeSetToWakeEvals(decisions, beads)
+	eval, ok := evals["mc-1"]
+	if !ok {
+		t.Fatal("expected eval for mc-1")
+	}
+	if len(eval.Reasons) != 1 || eval.Reasons[0] != WakeRouted {
+		t.Errorf("reasons = %v, want [%s]", eval.Reasons, WakeRouted)
+	}
+}

--- a/cmd/gc/gitignore_test.go
+++ b/cmd/gc/gitignore_test.go
@@ -115,7 +115,7 @@ func TestDoInit_WritesGitignoreEntries(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -137,7 +137,7 @@ func TestDoInit_GitignoreIdempotent(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("first doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/init_identity_failure_test.go
+++ b/cmd/gc/init_identity_failure_test.go
@@ -31,7 +31,7 @@ func TestDoInitRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testing.T) {
 	fs := &failSiteBindingRenameFS{target: filepath.Join(cityPath, ".gc", "site.toml")}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(fs, cityPath, defaultWizardConfig(), "machine-alias", &stdout, &stderr)
+	code := doInit(fs, cityPath, defaultWizardConfig(), "machine-alias", &stdout, &stderr, false)
 	if code == 0 {
 		t.Fatalf("doInit = %d, want failure", code)
 	}
@@ -71,7 +71,7 @@ func TestDoInitFromFileRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testin
 	fs := &failSiteBindingRenameFS{target: filepath.Join(cityPath, ".gc", "site.toml")}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitFromTOMLFileWithOptions(fs, srcToml, cityPath, "machine-alias", &stdout, &stderr, true)
+	code := cmdInitFromTOMLFileWithOptions(fs, srcToml, cityPath, "machine-alias", &stdout, &stderr, true, false)
 	if code == 0 {
 		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want failure", code)
 	}

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -65,7 +65,7 @@ func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *test
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -243,7 +243,7 @@ func TestFinalizeInitDoesNotWriteImplicitImportState(t *testing.T) {
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
-	code := doInit(fsys.OSFS{}, cityPath, defaultWizardConfig(), "", &initStdout, &initStderr)
+	code := doInit(fsys.OSFS{}, cityPath, defaultWizardConfig(), "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -316,7 +316,7 @@ func TestFinalizeInitWithoutProgressSkipsStepCounter(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -376,7 +376,7 @@ func TestCmdInitResumesFinalizeForExistingCity(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "gastown",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -438,7 +438,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -467,7 +467,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true)
+	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions = %d, want 0: %s", code, stderr.String())
 	}
@@ -722,7 +722,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -782,7 +782,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -831,7 +831,7 @@ func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1395,7 +1395,7 @@ func TestDoInitSuccess(t *testing.T) {
 	// No pre-existing files — doInit creates everything from scratch.
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1486,7 +1486,7 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1524,7 +1524,7 @@ func TestDoInitGastownWritesCanonicalPackV2Shape(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wizardConfig{configName: "gastown", provider: "claude"}, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wizardConfig{configName: "gastown", provider: "claude"}, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1562,7 +1562,7 @@ func TestDoInitAlreadyInitialized(t *testing.T) {
 	markFakeCityScaffold(f, "/city")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr, false)
 	if code != initExitAlreadyInitialized {
 		t.Errorf("doInit = %d, want %d", code, initExitAlreadyInitialized)
 	}
@@ -1588,7 +1588,7 @@ func TestDoInitBootstrapsExistingCityToml(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = original
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -1614,7 +1614,7 @@ func TestDoInitBootstrapWithNameOverride(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = []byte("[workspace]\nname = \"old-name\"\n")
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "new-name", &stdout, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "new-name", &stdout, &stderr, false)
 	if code != 0 {
 		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -1636,7 +1636,7 @@ func TestDoInitMkdirGCFails(t *testing.T) {
 	f.Errors[filepath.Join("/city", ".gc")] = fmt.Errorf("permission denied")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr, false)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -1650,7 +1650,7 @@ func TestDoInitWriteFails(t *testing.T) {
 	f.Errors[filepath.Join("/city", "city.toml")] = fmt.Errorf("read-only fs")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr, false)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -1664,7 +1664,7 @@ func TestDoInitWriteFails(t *testing.T) {
 func TestDoInitCreatesSettings(t *testing.T) {
 	f := fsys.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1684,7 +1684,7 @@ func TestDoInitCreatesSettings(t *testing.T) {
 func TestDoInitSettingsIsValidJSON(t *testing.T) {
 	f := fsys.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2026,7 +2026,7 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2080,7 +2080,7 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2116,7 +2116,7 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2164,7 +2164,7 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/my-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/my-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2201,7 +2201,7 @@ func TestDoInitWithProviderFlagAndBootstrapProfile(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/hosted-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/hosted-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2245,7 +2245,7 @@ func TestDoInitWithOpenCodeProviderInstallsWorkspaceHooks(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/open-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/open-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2274,7 +2274,7 @@ func TestDoInitWithClaudeProviderLeavesWorkspaceHooksEmpty(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/claude-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/claude-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2475,6 +2475,98 @@ func TestCmdInitFromTOMLFileAlreadyInitializedByCityToml(t *testing.T) {
 
 	var stderr bytes.Buffer
 	code := cmdInitFromTOMLFile(f, src, "/city", &bytes.Buffer{}, &stderr)
+	if code != initExitAlreadyInitialized {
+		t.Errorf("code = %d, want %d", code, initExitAlreadyInitialized)
+	}
+	if !strings.Contains(stderr.String(), "already initialized") {
+		t.Errorf("stderr = %q, want 'already initialized'", stderr.String())
+	}
+}
+
+func TestCmdInitFromTOMLFilePreservesExistingFiles(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	if err := os.MkdirAll(filepath.Join(cityPath, "agents", "mayor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	preExistingPack := []byte("[pack]\nname = \"user-authored\"\nschema = 2\nversion = \"9.9.9\"\n")
+	preExistingCity := []byte("[workspace]\nname = \"user-authored\"\nprovider = \"claude\"\n")
+	preExistingPrompt := []byte("user-authored mayor prompt\n")
+	for _, f := range []struct {
+		path string
+		data []byte
+	}{
+		{filepath.Join(cityPath, "pack.toml"), preExistingPack},
+		{filepath.Join(cityPath, "city.toml"), preExistingCity},
+		{filepath.Join(cityPath, "agents", "mayor", "prompt.template.md"), preExistingPrompt},
+	} {
+		if err := os.WriteFile(f.path, f.data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	src := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(src,
+		[]byte("[workspace]\nname = \"from-template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, true)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	for _, f := range []struct {
+		path string
+		want []byte
+	}{
+		{filepath.Join(cityPath, "pack.toml"), preExistingPack},
+		{filepath.Join(cityPath, "city.toml"), preExistingCity},
+		{filepath.Join(cityPath, "agents", "mayor", "prompt.template.md"), preExistingPrompt},
+	} {
+		got, err := os.ReadFile(f.path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f.path, err)
+		}
+		if !bytes.Equal(got, f.want) {
+			t.Errorf("%s was rewritten under --preserve-existing\n got: %s\nwant: %s", f.path, got, f.want)
+		}
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"Preserved existing pack.toml.", "Preserved existing city.toml."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestCmdInitFromTOMLFilePreserveExistingBlockedByScaffold(t *testing.T) {
+	f := fsys.NewFake()
+	cityPath := "/city"
+
+	// A fully-initialized runtime scaffold should still cause init to refuse,
+	// even with --preserve-existing. Only committed config files are meant to
+	// be tolerated; an active runtime indicates the city is already live.
+	f.Files[filepath.Join(cityPath, ".gc", "events.jsonl")] = []byte("")
+	for _, sub := range []string{"cache", "runtime", "system"} {
+		f.Dirs[filepath.Join(cityPath, ".gc", sub)] = true
+	}
+	f.Dirs[filepath.Join(cityPath, ".gc")] = true
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(src, []byte("[workspace]\nname = \"x\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(f, src, cityPath, "", &stdout, &stderr, true, true)
 	if code != initExitAlreadyInitialized {
 		t.Errorf("code = %d, want %d", code, initExitAlreadyInitialized)
 	}
@@ -2709,7 +2801,7 @@ func TestInitNameFlagWithFile(t *testing.T) {
 	cityPath := filepath.Join(dir, "target-dir")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitFromFileWithOptions(tomlFile, []string{cityPath}, "my-file-name", &stdout, &stderr, true)
+	code := cmdInitFromFileWithOptions(tomlFile, []string{cityPath}, "my-file-name", &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("cmdInitFromFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2737,7 +2829,7 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "my-bare-name", &stdout, &stderr)
+	}, "my-bare-name", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -2572,6 +2573,47 @@ func TestCmdInitFromTOMLFilePreserveExistingBlockedByScaffold(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "already initialized") {
 		t.Errorf("stderr = %q, want 'already initialized'", stderr.String())
+	}
+}
+
+func TestWriteInitFile_PreserveExistingStatError(t *testing.T) {
+	// When preserve=true, a Stat error that isn't os.IsNotExist must surface
+	// to the caller instead of being silently treated as "does not exist".
+	f := fsys.NewFake()
+	target := "/city/pack.toml"
+	f.Errors[target] = errors.New("permission denied")
+
+	wrote, err := writeInitFile(f, target, []byte("new"), true)
+	if err == nil {
+		t.Fatal("expected error propagation, got nil")
+	}
+	if wrote {
+		t.Errorf("wrote = true on stat error; want false")
+	}
+	// Must not have attempted to write over the file.
+	for _, c := range f.Calls {
+		if c.Method == "WriteFile" && c.Path == target {
+			t.Errorf("WriteFile called despite stat error; calls=%v", f.Calls)
+		}
+	}
+}
+
+func TestWriteInitFile_PreserveFalseOverwrites(t *testing.T) {
+	// When preserve=false, the helper writes unconditionally — even over
+	// an existing file — mirroring the pre-flag default behavior.
+	f := fsys.NewFake()
+	target := "/city/pack.toml"
+	f.Files[target] = []byte("existing")
+
+	wrote, err := writeInitFile(f, target, []byte("replacement"), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrote {
+		t.Errorf("wrote = false; want true when preserve=false")
+	}
+	if got := string(f.Files[target]); got != "replacement" {
+		t.Errorf("file contents = %q, want %q", got, "replacement")
 	}
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -452,7 +452,7 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 func nudgeRoutedWorkSessions(
 	cityPath string,
 	cfg *config.City,
-	sp runtime.Provider,
+	_ runtime.Provider,
 	store beads.Store,
 	targets []wakeTarget,
 	awakeDecisions map[string]AwakeDecision,

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -445,6 +445,57 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	return work
 }
 
+// nudgeRoutedWorkSessions queues nudges for alive sessions whose templates
+// have pending routed work. This bridges the gap where scale_check/pool
+// desired correctly wake or keep sessions alive, but the session itself
+// hasn't polled its hook for newly arrived gc.routed_to work.
+func nudgeRoutedWorkSessions(
+	cityPath string,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	targets []wakeTarget,
+	awakeDecisions map[string]AwakeDecision,
+	workSet map[string]bool,
+	stdout, stderr io.Writer,
+) {
+	if len(workSet) == 0 || len(targets) == 0 {
+		return
+	}
+	nudged := make(map[string]bool)
+	for _, target := range targets {
+		if !target.alive {
+			continue
+		}
+		template := normalizedSessionTemplate(*target.session, cfg)
+		if !workSet[template] {
+			continue
+		}
+		if nudged[template] {
+			continue
+		}
+		name := strings.TrimSpace(target.session.Metadata["session_name"])
+		if name == "" {
+			continue
+		}
+		decision, ok := awakeDecisions[name]
+		if !ok || !decision.ShouldWake {
+			continue
+		}
+		ref := &nudgeReference{Kind: "routed-work", ID: template}
+		item := newQueuedNudgeWithOptions(name, "routed work available", "reconciler", time.Now(), queuedNudgeOptions{
+			SessionID: target.session.ID,
+			Reference: ref,
+		})
+		if err := enqueueQueuedNudgeWithStore(cityPath, store, item); err != nil {
+			fmt.Fprintf(stderr, "nudgeRoutedWork: %s: %v\n", name, err) //nolint:errcheck
+			continue
+		}
+		fmt.Fprintf(stdout, "Queued routed-work nudge for %s (%s)\n", name, template) //nolint:errcheck
+		nudged[template] = true
+	}
+}
+
 // findAgentByTemplate looks up a config agent by template name.
 // Returns nil if not found.
 func findAgentByTemplate(cfg *config.City, template string) *config.Agent {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2321,3 +2321,122 @@ func TestNudgeRoutedWorkSessions_SkipsNoWorkTemplate(t *testing.T) {
 		t.Errorf("should not nudge when no routed work, got: %q", stdout.String())
 	}
 }
+
+func TestNudgeRoutedWorkSessions_SkipsTemplateNotInWorkSet(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+			{Name: "refinery", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	// workSet has routed work, but for a different template than the target.
+	workSet := map[string]bool{"gascity/refinery": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when target template has no routed work, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsEmptySessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "", // missing session_name -> cannot queue a nudge
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge session with empty session_name, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsShouldNotWakeDecision(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	// Session IS alive and matches routed work, but the awake decision says
+	// it should not wake (e.g., held under churn/quarantine rules). Don't nudge.
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: false, Reason: "quarantined"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when decision.ShouldWake=false, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsMissingDecision(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	// No entry for "polecat-1" in the decisions map — treat as "no desire to wake".
+	decisions := map[string]AwakeDecision{}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when session is missing from decisions map, got: %q", stdout.String())
+	}
+}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2173,3 +2173,151 @@ func TestComputeWorkSet_RigScopedWorkQueryExpandsRigTemplate(t *testing.T) {
 		t.Errorf("beta probe command = %q, want expanded gc.routed_to=beta/worker", got)
 	}
 }
+
+func TestNudgeRoutedWorkSessions_NudgesAliveSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID:     "ses-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{
+		{session: session, alive: true},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if !strings.Contains(stdout.String(), "Queued routed-work nudge") {
+		t.Errorf("expected nudge queued output, got: %q", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsDeadSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID:     "ses-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{
+		{session: session, alive: false},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "routed"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge dead session, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_NudgesOncePerTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	targets := []wakeTarget{
+		{
+			session: &beads.Bead{
+				ID: "ses-1", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-1",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+		{
+			session: &beads.Bead{
+				ID: "ses-2", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-2",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+		"polecat-2": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	nudgeCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "Queued routed-work nudge") {
+			nudgeCount++
+		}
+	}
+	if nudgeCount != 1 {
+		t.Errorf("expected exactly 1 nudge per template, got %d", nudgeCount)
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsNoWorkTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "config"},
+	}
+	workSet := map[string]bool{} // no routed work
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when no routed work, got: %q", stdout.String())
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1046,6 +1046,8 @@ func reconcileSessionBeadsTraced(
 		clk, rec, startupTimeout, stdout, stderr, trace,
 	)
 
+	nudgeRoutedWorkSessions(cityPath, cfg, sp, store, wakeTargets, awakeDecisions, workSet, stdout, stderr)
+
 	// Phase 2: Advance all in-flight drains.
 	sessionLookup := func(id string) *beads.Bead {
 		return beadByID[id]

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -35,6 +35,9 @@ const (
 	WakePin WakeReason = "pin"
 	// WakeDependency means another awake session depends on this template.
 	WakeDependency WakeReason = "dependency"
+	// WakeRouted means unprocessed routed work (gc.routed_to) targets this
+	// template. Triggers nudge dispatch for alive sessions.
+	WakeRouted WakeReason = "routed"
 )
 
 // ExecSpec defines a validated command for process creation.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1127,6 +1127,10 @@ the standard top-level directories, and .template.md prompt templates, then
 materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
 non-interactively, or --file to initialize from an existing TOML config file.
 
+Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
+agent prompt files in the target directory (useful when bootstrapping a
+committed workspace — e.g. from a bootstrap.sh shipped in the repo).
+
 ```
 gc init [path] [flags]
 ```
@@ -1141,6 +1145,7 @@ gc init
   gc init --name my-city
   gc init --from ~/elan --name elan /city
   gc init --file examples/gastown.toml ~/bright-lights
+  gc init --file city.toml --preserve-existing .
 ```
 
 | Flag | Type | Default | Description |
@@ -1149,6 +1154,7 @@ gc init
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
 | `--name` | string |  | workspace name (default: target directory basename) |
+| `--preserve-existing` | bool |  | keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
 | `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
 

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -77,13 +77,24 @@ server_pid=0
 server_latency=0
 server_reachable=false
 
+# Portable millisecond timestamp. BSD date(1) on macOS treats %N as a
+# literal 'N' (exits 0, output like "1776740122N"), so the GNU-only
+# || fallback never triggers. Feature-test the output instead.
+now_ms() {
+  _raw=$(date +%s%N 2>/dev/null)
+  case "$_raw" in
+    *[!0-9]*) printf '%s000' "$(date +%s)" ;;
+    *)        printf '%s' "$_raw" | cut -c1-13 ;;
+  esac
+}
+
 # Find dolt PID by port.
 pid=$(managed_runtime_listener_pid "$GC_DOLT_PORT" || true)
 if [ -n "$pid" ] || managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
   server_running=true
   [ -n "$pid" ] && server_pid="$pid"
   # Measure query latency.
-  start_ms=$(date +%s%N 2>/dev/null | cut -c1-13 || date +%s)
+  start_ms=$(now_ms)
   conn_args="--host $host --port $GC_DOLT_PORT --user $GC_DOLT_USER --no-tls"
   # Always export DOLT_CLI_PASSWORD (even empty) so the client does not
   # prompt for a password on stdin. Without this, the SELECT 1 probe
@@ -96,7 +107,7 @@ if [ -n "$pid" ] || managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
   # goroutine, saturated pool, migration lock) would otherwise hang.
   if run_bounded 5 dolt $conn_args sql -q "SELECT 1" >/dev/null 2>&1; then
     server_reachable=true
-    end_ms=$(date +%s%N 2>/dev/null | cut -c1-13 || date +%s)
+    end_ms=$(now_ms)
     server_latency=$((end_ms - start_ms))
     [ "$server_latency" -lt 0 ] && server_latency=0
   fi

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -636,7 +636,7 @@ func TestIdeaToPlanFormulaUsesSupportedPrimitives(t *testing.T) {
 	body := string(data)
 	for _, want := range []string{
 		`formula = "mol-idea-to-plan"`,
-		`gc sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}`,
+		`"$GC_CITY_DIR/assets/scripts/verified-sling.sh" "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}`,
 		`gc bd create`,
 		`gc mail send`,
 		`gc bd dep add`,

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -144,6 +144,28 @@ Wrong. The issue is about beads code, so it goes in the beads rig.
 **NOT your job**: Per-worker cleanup, session killing, routine nudging (Witness handles that)
 **Exception**: If refinery/witness is stuck, use `{{ cmd }} nudge refinery "Process MQ"`
 
+## Bead Creation — NEVER Fabricate IDs
+
+When creating assignment beads for review legs, you MUST capture the bead ID
+from command output. NEVER invent, guess, or reuse a bead ID.
+
+**Correct pattern:**
+```bash
+LEG_BEAD=$(gc bd create --title "..." --description "..." \
+  --type task --priority 2 --json | jq -r .id)
+echo "Created: $LEG_BEAD"    # verify it printed a real ID
+bd show "$LEG_BEAD"           # verify it exists before slinging
+```
+
+**Wrong pattern (causes stranded workers):**
+```bash
+LEG_BEAD="sc-qq3a0"           # ← fabricated ID, will break everything
+gc sling ... "$LEG_BEAD" ...  # ← slings a dead reference
+```
+
+Always use `assets/scripts/verified-sling.sh` instead of raw `gc sling`
+when dispatching review legs. It validates the bead exists before slinging.
+
 ## Rig Wake/Sleep Protocol
 
 Rigs start **dormant by default** (`--start-suspended`). The Mayor activates

--- a/examples/gastown/packs/gastown/assets/scripts/verified-sling.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/verified-sling.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# verified-sling.sh — wrap `gc sling` with pre-flight bead existence checks.
+#
+# Usage: verified-sling.sh [gc-sling-args...]
+#
+# Scans positional args for anything that looks like a bead ID
+# (e.g. sc-xxxxx, hq-xxxx, sc-xxxxx.12) and runs `bd show` on each before
+# invoking `gc sling`. Exits non-zero with a clear error if any bead is
+# missing, preventing molecules from being poured against fabricated IDs.
+#
+# This is the defensive companion to the quartermaster prompt's "NEVER
+# fabricate IDs" rule — catches hallucinated IDs before they strand workers.
+# See hq-7zv for the 2026-04-21 incident that motivated this guard.
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "verified-sling.sh: usage: verified-sling.sh [gc-sling-args...]" >&2
+    exit 2
+fi
+
+looks_like_bead_id() {
+    # Matches: sc-abc12, hq-x3y7, sc-abcde.12
+    # Two or more lowercase letters, a dash, then alphanumerics,
+    # optionally a .number step suffix. Flags are excluded.
+    case "$1" in
+        -*) return 1 ;;
+        *.*.*) return 1 ;;
+    esac
+    printf '%s\n' "$1" | grep -Eq '^[a-z]{2,}-[a-z0-9]{3,}(\.[0-9]+)?$'
+}
+
+missing=""
+for arg in "$@"; do
+    if looks_like_bead_id "$arg"; then
+        if ! bd show "$arg" >/dev/null 2>&1; then
+            missing="$missing $arg"
+        fi
+    fi
+done
+
+if [ -n "$missing" ]; then
+    echo "verified-sling.sh: refusing to sling — bead(s) not found:$missing" >&2
+    echo "verified-sling.sh: create the bead with \`gc bd create ... --json | jq -r .id\` and capture its real ID before slinging." >&2
+    exit 3
+fi
+
+exec gc sling "$@"

--- a/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
@@ -142,19 +142,35 @@ description = """
 Fan out parallel PRD review using review task beads plus `mol-review-leg`.
 
 **Dispatch pattern for EVERY review leg in this workflow:**
-1. `gc bd create` a task bead with a detailed description
-2. set metadata:
-   - `coordinator=$COORDINATOR`
-   - `review_id=$REVIEW_ID`
-   - `review_phase=<phase>`
-   - `review_leg=<leg>`
-3. sling it to `$REVIEW_TARGET` with:
+1. Create the assignment bead and CAPTURE its ID from command output:
 ```bash
-gc sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
+LEG_BEAD=$(gc bd create --title "<leg title>" --description "<prompt>" \
+  --type task --priority 2 --json | jq -r .id)
+echo "Created bead: $LEG_BEAD"    # MUST print a real ID like sc-xxxxx
 ```
-4. record the bead ID in the round log
-5. wait for completion mail or poll the bead until it closes
-6. read the full report from the bead notes with `gc bd show <id>`
+2. VERIFY the bead exists (guards against fabricated IDs):
+```bash
+bd show "$LEG_BEAD"               # MUST succeed — stop if it fails
+```
+3. Set metadata on the verified bead:
+```bash
+bd update "$LEG_BEAD" \
+  --set-metadata coordinator="$COORDINATOR" \
+  --set-metadata review_id="$REVIEW_ID" \
+  --set-metadata review_phase=<phase> \
+  --set-metadata review_leg=<leg>
+```
+4. Sling using the validated wrapper:
+```bash
+"$GC_CITY_DIR/assets/scripts/verified-sling.sh" "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
+```
+5. Record the bead ID in the round log
+6. Wait for completion mail or poll the bead until it closes
+7. Read the full report from the bead notes with `gc bd show "$LEG_BEAD"`
+
+⚠️ **NEVER fabricate bead IDs.** The ID MUST come from `gc bd create --json`
+output. If the create command fails or returns empty, STOP and escalate.
+Do NOT invent an ID like `sc-xxxxx` and proceed — this strands workers.
 
 **Standard instructions each review bead must include:**
 - read `.prd-reviews/$REVIEW_ID/prd-draft.md`


### PR DESCRIPTION
## Summary

Bundled set of session-reconciler and init-scaffolding improvements, plus a
couple of user-facing fixes for `gc dolt health` portability and molecule
dispatch safety.

### 1. Auto-nudge sessions on routed-work arrival

Add `WakeRouted` reason and `RoutedWorkTemplates` to the awake-set computation
so the reconciler detects unprocessed `gc.routed_to` beads and queues nudges
for alive sessions of the target template. This closes the gap where routed
beads sat idle because no external trigger prompted existing sessions to
poll their hooks.

- `session_types.go`: add `WakeRouted` constant
- `compute_awake_set.go`: add `RoutedWorkTemplates`; mark sessions desired
  with reason `routed` when pending routed work exists
- `compute_awake_bridge.go`: map `"routed"` → `WakeRouted`, pass workSet as
  `RoutedWorkTemplates`
- `session_reconcile.go`: add `nudgeRoutedWorkSessions()` to queue nudges
  for alive sessions with matching routed work
- `session_reconciler.go`: call `nudgeRoutedWorkSessions` in tick handler

### 2. `gc init --preserve-existing`

When bootstrap scripts run `gc init --file` against a directory that already
has committed `pack.toml`, `city.toml`, or agent prompt files, the canonical
rewrite silently clobbered user configuration. Callers had to move files
aside and restore from git to work around it.

`--preserve-existing` opts into skip-if-exists behavior for all three file
types and relaxes the already-initialized guard to fire only on scaffold
presence, so a committed workspace can be bootstrapped in place. Default
behavior (overwrite) is unchanged.

### 3. Portable millisecond timestamps for `gc dolt health`

BSD `date(1)` on macOS treats `%N` as a literal `N`, exiting 0 with output
like `1776740122N`. The previous `|| date +%s` fallback never fired because
the exit code was 0. A feature-test on the output (`case *[!0-9]*`) handles
both platforms without a `uname` check.

### 4. `verified-sling.sh` guard + verified dispatch pattern

Adds `verified-sling.sh` to the gastown pack scripts bundle — a wrapper
around `gc sling` that performs pre-flight bead existence checks, preventing
molecules from being poured against fabricated bead IDs. Updates
`mol-idea-to-plan.toml` to capture bead IDs from `gc bd create --json`
output, verify with `bd show` before slinging, and use the wrapper. Adds
a "NEVER Fabricate IDs" section to the mayor prompt template for the
gastown pack.

## Test plan

- [x] New unit tests in `compute_awake_set_test.go` and
  `session_reconcile_test.go` cover the routed-work nudge logic, including
  skip paths (dead session, no routed work, template mismatch, empty
  session_name, missing / should-not-wake decisions).
- [x] New unit tests in `main_test.go` cover `--preserve-existing` (file
  preservation, scaffold guard, `writeInitFile` stat-error propagation).
- [x] `go test ./...`
- [x] `go vet ./...`
