### PR TITLE
fix(reconciler): rebase session config hashes on gc reload

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -707,6 +707,15 @@ func (cr *CityRuntime) tick(
 		cr.stderr,
 	)
 
+	// Rebase session config hashes after successful manual reload to
+	// prevent the reconciler from treating the new config as drift.
+	// This implements "gc reload = accept new baseline" semantics.
+	if manualReload != nil && manualReply.Outcome == reloadOutcomeApplied {
+		if n := rebaseSessionConfigHashes(cr.cityBeadStore(), cr.cfg, result.State, sessionBeads, cr.stdout, cr.stderr); n > 0 {
+			sessionBeads = cr.loadSessionBeadSnapshot()
+		}
+	}
+
 	// Bead-driven reconciliation (requires bead store / drain tracker).
 	if cr.sessionDrains != nil {
 		cr.beadReconcileTick(ctx, result, sessionBeads, trace)

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2244,6 +2244,129 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeTick_RebasesConfigHashesAfterManualReload(t *testing.T) {
+	// Isolate from ambient GC_BEADS so the config's [beads] provider wins.
+	t.Setenv("GC_BEADS", "file")
+
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+
+	// Initial config with agent "worker".
+	initial := "[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n\n[[agent]]\nname = \"worker\"\ncommand = \"echo hello\"\n"
+	if err := os.WriteFile(tomlPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	sp := runtime.NewFake()
+
+	// Register session in fake provider so reapStaleSessionBeads doesn't close it.
+	sessionName := "worker"
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("start fake session: %v", err)
+	}
+
+	doneCh := make(chan reloadControlReply, 1)
+	dirty := &atomic.Bool{}
+	dirty.Store(true)
+
+	var stdout bytes.Buffer
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:    cityPath,
+		CityName:    "test-city",
+		TomlPath:    tomlPath,
+		ConfigRev:   configRev,
+		ConfigDirty: dirty,
+		Cfg:         cfg,
+		SP:          sp,
+		BuildFn: func(_ *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+			return DesiredStateResult{
+				State: map[string]TemplateParams{
+					sessionName: {
+						Command:      "echo world",
+						SessionName:  sessionName,
+						TemplateName: "worker",
+					},
+				},
+			}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: io.Discard,
+	})
+
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cr.setControllerState(cs)
+	cr.sessionDrains = newDrainTracker()
+	cr.activeReload = &reloadRequest{doneCh: doneCh}
+
+	// Create session bead with a stale config hash in the controller's
+	// file store so it survives the store re-open during reload.
+	store := cs.CityBeadStore()
+	created, err := store.Create(beads.Bead{
+		Title:  sessionName,
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":        sessionName,
+			"template":            "worker",
+			"started_config_hash": "stale-hash-value",
+			"state":               "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// Hook lifecycle to no-op (avoids real bead lifecycle init).
+	prevStart := cityRuntimeStartBeadsLifecycle
+	cityRuntimeStartBeadsLifecycle = func(string, string, *config.City, io.Writer) error { return nil }
+	t.Cleanup(func() { cityRuntimeStartBeadsLifecycle = prevStart })
+
+	// Write modified config so revision changes → reloadOutcomeApplied.
+	modified := "[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"fake\"\n\n[daemon]\nshutdown_timeout = \"1s\"\n\n[[agent]]\nname = \"worker\"\ncommand = \"echo world\"\n"
+	if err := os.WriteFile(tomlPath, []byte(modified), 0o644); err != nil {
+		t.Fatalf("write modified config: %v", err)
+	}
+
+	lastProviderName := "fake"
+	var prevPoolRunning map[string]bool
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "poke")
+
+	// Verify reload was applied.
+	select {
+	case reply := <-doneCh:
+		if reply.Outcome != reloadOutcomeApplied {
+			t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeApplied)
+		}
+	default:
+		t.Fatal("manual reload did not reply after tick")
+	}
+
+	// Re-read from the controller's store (may have been re-opened during reload).
+	postStore := cr.cityBeadStore()
+	got, err := postStore.Get(created.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got.Metadata["started_config_hash"] == "stale-hash-value" {
+		t.Fatalf("started_config_hash was not rebased after manual reload (metadata=%v)", got.Metadata)
+	}
+	if got.Metadata["started_config_hash"] == "" {
+		t.Fatal("started_config_hash is empty after rebase")
+	}
+	if !strings.Contains(stdout.String(), "Rebased config hash") {
+		t.Fatalf("stdout = %q, want rebase message", stdout.String())
+	}
+}
+
 func TestCityRuntimeReloadRestartsConfigWatcherWithNewPackTargets(t *testing.T) {
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1265,7 +1265,7 @@ func reconcileCities(
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, path)
 		pokeCh := make(chan struct{}, 1)
 		configDirty := &atomic.Bool{}
-		reloadReqCh := make(chan reloadRequest)
+		reloadReqCh := make(chan reloadRequest, 1) // buffered so gc reload can enqueue during mid-tick reconciliation
 		cityCtx, cityCancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
 		mc := &managedCity{name: cityName, cancel: cityCancel, done: done, closer: fr}

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1068,7 +1068,7 @@ func runController(
 	}()
 
 	convergenceReqCh := make(chan convergenceRequest, 16)
-	reloadReqCh := make(chan reloadRequest)
+	reloadReqCh := make(chan reloadRequest, 1) // buffered so gc reload can enqueue during mid-tick reconciliation
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}

--- a/cmd/gc/session_hash_rebase.go
+++ b/cmd/gc/session_hash_rebase.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// rebaseSessionConfigHashes updates the stored config hash baseline for
+// all active sessions to match the current resolved config. Called after
+// a manual gc reload so that the reconciler does not treat the freshly
+// resolved config as drift requiring session restarts.
+//
+// This implements the "gc reload = accept new baseline" semantics: the
+// user is telling the system "this is the new normal — stop trying to
+// converge on the old config."
+//
+// Returns the number of sessions whose hashes were updated.
+func rebaseSessionConfigHashes(
+	store beads.Store,
+	cfg *config.City,
+	desiredState map[string]TemplateParams,
+	sessionBeads *sessionBeadSnapshot,
+	stdout, stderr io.Writer,
+) int {
+	if store == nil || sessionBeads == nil {
+		return 0
+	}
+
+	updated := 0
+	for _, session := range sessionBeads.Open() {
+		name := strings.TrimSpace(session.Metadata["session_name"])
+		storedHash := session.Metadata["started_config_hash"]
+		if name == "" || storedHash == "" {
+			continue // startup window (no hash yet) or unnamed
+		}
+
+		tp, ok := desiredState[name]
+		if !ok {
+			continue // not in desired state (orphaned/suspended)
+		}
+
+		template := tp.TemplateName
+		if template == "" {
+			template = normalizedSessionTemplate(session, cfg)
+		}
+		if template == "" {
+			continue
+		}
+
+		if findAgentByTemplate(cfg, template) == nil {
+			continue
+		}
+
+		// Compute the effective config the same way the reconciler does
+		// in session_reconciler.go (config-drift section), including
+		// template_overrides application.
+		agentCfg := templateParamsToConfig(tp)
+		if rawOvr := session.Metadata["template_overrides"]; rawOvr != "" {
+			if tp.ResolvedProvider != nil && len(tp.ResolvedProvider.OptionsSchema) > 0 {
+				var ovr map[string]string
+				if err := json.Unmarshal([]byte(rawOvr), &ovr); err == nil && len(ovr) > 0 {
+					fullOptions := make(map[string]string)
+					for k, v := range tp.ResolvedProvider.EffectiveDefaults {
+						fullOptions[k] = v
+					}
+					for k, v := range ovr {
+						if k == "initial_message" {
+							continue
+						}
+						fullOptions[k] = v
+					}
+					if extra, rErr := config.ResolveExplicitOptions(tp.ResolvedProvider.OptionsSchema, fullOptions); rErr == nil && len(extra) > 0 {
+						agentCfg.Command = replaceSchemaFlags(agentCfg.Command, tp.ResolvedProvider.OptionsSchema, extra)
+					}
+				}
+			}
+		}
+
+		newCoreHash := runtime.CoreFingerprint(agentCfg)
+		newLiveHash := runtime.LiveFingerprint(agentCfg)
+
+		updates := make(map[string]string)
+		if storedHash != newCoreHash {
+			updates["started_config_hash"] = newCoreHash
+			breakdown := runtime.CoreFingerprintBreakdown(agentCfg)
+			breakdownJSON, _ := json.Marshal(breakdown)
+			updates["core_hash_breakdown"] = string(breakdownJSON)
+		}
+
+		storedLive := session.Metadata["started_live_hash"]
+		if storedLive != "" && storedLive != newLiveHash {
+			updates["started_live_hash"] = newLiveHash
+		}
+
+		if len(updates) == 0 {
+			continue
+		}
+
+		if err := store.SetMetadataBatch(session.ID, updates); err != nil {
+			fmt.Fprintf(stderr, "rebase config hash %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		fmt.Fprintf(stdout, "Rebased config hash for '%s'\n", name) //nolint:errcheck // best-effort stdout
+		updated++
+	}
+
+	return updated
+}

--- a/cmd/gc/session_hash_rebase_test.go
+++ b/cmd/gc/session_hash_rebase_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestRebaseSessionConfigHashes_UpdatesDriftedHash(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	// Desired state with a NEW command (simulates config change after reload).
+	desiredState := map[string]TemplateParams{
+		"worker": {
+			Command:      "new-cmd",
+			SessionName:  "worker",
+			TemplateName: "worker",
+		},
+	}
+
+	// Session bead has the OLD config hash.
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	oldLive := runtime.LiveFingerprint(runtime.Config{Command: "old-cmd"})
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldHash,
+			"started_live_hash":   oldLive,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", n, stderr.String())
+	}
+
+	// Verify the stored hash now matches the new config.
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantHash := runtime.CoreFingerprint(runtime.Config{Command: "new-cmd"})
+	if got.Metadata["started_config_hash"] != wantHash {
+		t.Errorf("started_config_hash = %q, want %q", got.Metadata["started_config_hash"], wantHash)
+	}
+	if got.Metadata["core_hash_breakdown"] == "" {
+		t.Error("core_hash_breakdown should be set after rebase")
+	}
+}
+
+func TestRebaseSessionConfigHashes_SkipsSessionWithoutHash(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	// Session in startup window — no started_config_hash yet.
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"template":     "worker",
+			"state":        "creating",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 for sessions without stored hash", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_SkipsOrphanedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	// Empty desired state — session is orphaned.
+	desiredState := map[string]TemplateParams{}
+
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": "old-hash",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 for orphaned sessions", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_NoUpdateWhenHashMatches(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "test-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	// Session hash already matches the desired config.
+	currentHash := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	currentLive := runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"})
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": currentHash,
+			"started_live_hash":   currentLive,
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 when hashes already match", n)
+	}
+	if stdout.Len() > 0 {
+		t.Errorf("expected no stdout output, got %q", stdout.String())
+	}
+}
+
+func TestRebaseSessionConfigHashes_NilStoreReturnsZero(t *testing.T) {
+	n := rebaseSessionConfigHashes(nil, nil, nil, nil, nil, nil)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 for nil store", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_MultipleSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{
+		{Name: "worker"},
+		{Name: "mayor"},
+	}}
+
+	oldWorkerHash := runtime.CoreFingerprint(runtime.Config{Command: "old-worker-cmd"})
+	oldMayorHash := runtime.CoreFingerprint(runtime.Config{Command: "old-mayor-cmd"})
+
+	desiredState := map[string]TemplateParams{
+		"worker-1": {Command: "new-worker-cmd", SessionName: "worker-1", TemplateName: "worker"},
+		"mayor-1":  {Command: "new-mayor-cmd", SessionName: "mayor-1", TemplateName: "mayor"},
+	}
+
+	w, _ := store.Create(beads.Bead{
+		Title:  "worker-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker-1",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldWorkerHash,
+		},
+	})
+	m, _ := store.Create(beads.Bead{
+		Title:  "mayor-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "mayor-1",
+			"template":            "mayor",
+			"state":               "active",
+			"started_config_hash": oldMayorHash,
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{w, m})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 2 {
+		t.Fatalf("updated = %d, want 2 (stderr=%s)", n, stderr.String())
+	}
+
+	gotW, _ := store.Get(w.ID)
+	wantWorkerHash := runtime.CoreFingerprint(runtime.Config{Command: "new-worker-cmd"})
+	if gotW.Metadata["started_config_hash"] != wantWorkerHash {
+		t.Errorf("worker hash = %q, want %q", gotW.Metadata["started_config_hash"], wantWorkerHash)
+	}
+
+	gotM, _ := store.Get(m.ID)
+	wantMayorHash := runtime.CoreFingerprint(runtime.Config{Command: "new-mayor-cmd"})
+	if gotM.Metadata["started_config_hash"] != wantMayorHash {
+		t.Errorf("mayor hash = %q, want %q", gotM.Metadata["started_config_hash"], wantMayorHash)
+	}
+}
+
+// TestRebaseSessionConfigHashes_ReconciledAfterRebaseShowsNoDrift verifies
+// the end-to-end scenario: after rebase, the reconciler sees no config drift.
+func TestRebaseSessionConfigHashes_ReconciledAfterRebaseShowsNoDrift(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	// Set up desired state with NEW config (simulating post-reload state).
+	env.addRunningWorkerDesiredWithNewConfig()
+	session := env.createSessionBead("worker", "worker")
+
+	// Session started with OLD config hash.
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": oldHash,
+	})
+
+	// Without rebase, reconciler would detect drift.
+	// Rebase first.
+	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
+	var stdout, stderr bytes.Buffer
+	n := rebaseSessionConfigHashes(env.store, env.cfg, env.desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("rebase updated = %d, want 1 (stderr=%s)", n, stderr.String())
+	}
+
+	// Reload the session from store (rebase updated metadata).
+	updated, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reconcile — should NOT initiate a drain.
+	env.reconcile([]beads.Bead{updated})
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Errorf("expected no drain after rebase, got reason=%q", ds.reason)
+	}
+}

--- a/cmd/gc/session_hash_rebase_test.go
+++ b/cmd/gc/session_hash_rebase_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -250,5 +253,461 @@ func TestRebaseSessionConfigHashes_ReconciledAfterRebaseShowsNoDrift(t *testing.
 	env.reconcile([]beads.Bead{updated})
 	if ds := env.dt.get(session.ID); ds != nil {
 		t.Errorf("expected no drain after rebase, got reason=%q", ds.reason)
+	}
+}
+
+func TestRebaseSessionConfigHashes_SkipsEmptySessionName(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	// Session with blank session_name but non-empty hash — should be skipped.
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": "some-hash",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 for empty session_name", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_TemplateFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	// TemplateName is empty in desired state — function falls back to
+	// normalizedSessionTemplate which reads the bead's "template" metadata.
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: ""},
+	}
+
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldHash,
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", n, stderr.String())
+	}
+}
+
+func TestRebaseSessionConfigHashes_SkipsWhenBothTemplatesEmpty(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	// TemplateName is empty AND bead has no "template" metadata —
+	// normalizedSessionTemplate returns "" so the session is skipped.
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: ""},
+	}
+
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"state":               "active",
+			"started_config_hash": "old-hash",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 when both template paths are empty", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_SkipsUnknownTemplate(t *testing.T) {
+	store := beads.NewMemStore()
+	// Config has "worker" but bead's template is "unknown" — findAgentByTemplate returns nil.
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	desiredState := map[string]TemplateParams{
+		"rogue": {Command: "new-cmd", SessionName: "rogue", TemplateName: "unknown"},
+	}
+
+	b, _ := store.Create(beads.Bead{
+		Title:  "rogue",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "rogue",
+			"template":            "unknown",
+			"state":               "active",
+			"started_config_hash": "old-hash",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 for template not in agent config", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_TemplateOverridesModifyHash(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	schema := []config.ProviderOption{{
+		Key:   "model",
+		Label: "Model",
+		Type:  "select",
+		Choices: []config.OptionChoice{
+			{Value: "fast", Label: "Fast", FlagArgs: []string{"--model", "fast"}},
+			{Value: "smart", Label: "Smart", FlagArgs: []string{"--model", "smart"}},
+		},
+	}}
+
+	desiredState := map[string]TemplateParams{
+		"worker": {
+			Command:      "claude --model fast",
+			SessionName:  "worker",
+			TemplateName: "worker",
+			ResolvedProvider: &config.ResolvedProvider{
+				OptionsSchema:     schema,
+				EffectiveDefaults: map[string]string{"model": "fast"},
+			},
+		},
+	}
+
+	// Session was started with "fast" model. template_overrides selects "smart".
+	// The rebase must apply the override to compute the correct hash.
+	overrides := map[string]string{"model": "smart"}
+	overridesJSON, _ := json.Marshal(overrides)
+
+	baseCfg := templateParamsToConfig(desiredState["worker"])
+	oldHash := runtime.CoreFingerprint(baseCfg)
+
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldHash,
+			"template_overrides":  string(overridesJSON),
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", n, stderr.String())
+	}
+
+	got, _ := store.Get(b.ID)
+	// The hash should differ from the base (non-overridden) hash because the
+	// override changed the command via replaceSchemaFlags.
+	if got.Metadata["started_config_hash"] == oldHash {
+		t.Error("hash should change when template_overrides modify the command")
+	}
+}
+
+func TestRebaseSessionConfigHashes_TemplateOverridesSkipsInitialMessage(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	schema := []config.ProviderOption{{
+		Key:   "model",
+		Label: "Model",
+		Type:  "select",
+		Choices: []config.OptionChoice{
+			{Value: "fast", Label: "Fast", FlagArgs: []string{"--model", "fast"}},
+		},
+	}}
+
+	desiredState := map[string]TemplateParams{
+		"worker": {
+			Command:      "claude --model fast",
+			SessionName:  "worker",
+			TemplateName: "worker",
+			ResolvedProvider: &config.ResolvedProvider{
+				OptionsSchema:     schema,
+				EffectiveDefaults: map[string]string{"model": "fast"},
+			},
+		},
+	}
+
+	// Override contains only initial_message which is filtered out.
+	// No effective schema change → hash should match the base config.
+	overrides := map[string]string{"initial_message": "hello", "model": "fast"}
+	overridesJSON, _ := json.Marshal(overrides)
+
+	baseCfg := templateParamsToConfig(desiredState["worker"])
+	// Compute the hash the rebase function would produce (with overrides applied
+	// but initial_message filtered): effective options are model=fast (same as default).
+	extra, _ := config.ResolveExplicitOptions(schema, map[string]string{"model": "fast"})
+	expectedCfg := baseCfg
+	if len(extra) > 0 {
+		expectedCfg.Command = config.ReplaceSchemaFlags(baseCfg.Command, schema, extra)
+	}
+	expectedHash := runtime.CoreFingerprint(expectedCfg)
+
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": "different-old-hash",
+			"template_overrides":  string(overridesJSON),
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", n, stderr.String())
+	}
+
+	got, _ := store.Get(b.ID)
+	if got.Metadata["started_config_hash"] != expectedHash {
+		t.Errorf("hash = %q, want %q", got.Metadata["started_config_hash"], expectedHash)
+	}
+}
+
+func TestRebaseSessionConfigHashes_TemplateOverridesIgnoredWithoutProvider(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	// No ResolvedProvider — template_overrides should be ignored entirely.
+	desiredState := map[string]TemplateParams{
+		"worker": {
+			Command:      "new-cmd",
+			SessionName:  "worker",
+			TemplateName: "worker",
+		},
+	}
+
+	overrides := map[string]string{"model": "smart"}
+	overridesJSON, _ := json.Marshal(overrides)
+
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldHash,
+			"template_overrides":  string(overridesJSON),
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", n, stderr.String())
+	}
+
+	// Hash should match the base config (no override processing).
+	got, _ := store.Get(b.ID)
+	wantHash := runtime.CoreFingerprint(runtime.Config{Command: "new-cmd"})
+	if got.Metadata["started_config_hash"] != wantHash {
+		t.Errorf("hash = %q, want %q (base config, no overrides)", got.Metadata["started_config_hash"], wantHash)
+	}
+}
+
+func TestRebaseSessionConfigHashes_TemplateOverridesInvalidJSON(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	desiredState := map[string]TemplateParams{
+		"worker": {
+			Command:      "new-cmd",
+			SessionName:  "worker",
+			TemplateName: "worker",
+			ResolvedProvider: &config.ResolvedProvider{
+				OptionsSchema: []config.ProviderOption{{Key: "model"}},
+			},
+		},
+	}
+
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldHash,
+			"template_overrides":  "{invalid json",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 (invalid JSON ignored, base hash used)", n)
+	}
+
+	// Hash should match the base config since invalid JSON is silently ignored.
+	got, _ := store.Get(b.ID)
+	wantHash := runtime.CoreFingerprint(runtime.Config{Command: "new-cmd"})
+	if got.Metadata["started_config_hash"] != wantHash {
+		t.Errorf("hash = %q, want %q", got.Metadata["started_config_hash"], wantHash)
+	}
+}
+
+func TestRebaseSessionConfigHashes_LiveHashOnlyDiffers(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "test-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	// Core hash already matches, but live hash differs.
+	currentCoreHash := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	currentLiveHash := runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"})
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": currentCoreHash,
+			"started_live_hash":   "stale-live-hash",
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 1 {
+		t.Fatalf("updated = %d, want 1 for live-only hash drift (stderr=%s)", n, stderr.String())
+	}
+
+	got, _ := store.Get(b.ID)
+	if got.Metadata["started_live_hash"] != currentLiveHash {
+		t.Errorf("started_live_hash = %q, want %q", got.Metadata["started_live_hash"], currentLiveHash)
+	}
+	// Core hash should NOT have been updated (it already matched).
+	if got.Metadata["started_config_hash"] != currentCoreHash {
+		t.Errorf("started_config_hash changed unexpectedly: %q → %q", currentCoreHash, got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["core_hash_breakdown"] != "" {
+		t.Error("core_hash_breakdown should not be set when core hash matches")
+	}
+}
+
+func TestRebaseSessionConfigHashes_LiveHashEmptySkipped(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "test-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	// Core hash matches and live hash is empty — no update needed.
+	currentCoreHash := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	b, _ := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": currentCoreHash,
+		},
+	})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(store, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 when core matches and live hash is empty", n)
+	}
+}
+
+func TestRebaseSessionConfigHashes_SetMetadataBatchError(t *testing.T) {
+	// Use unavailableStore to simulate a store write failure.
+	// We need a store that can hold data but fails on SetMetadataBatch.
+	// Build a real store for setup, then wrap with a failing store.
+	realStore := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+
+	desiredState := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	b, _ := realStore.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": oldHash,
+		},
+	})
+	// Use the snapshot from the real store but pass the failing store for writes.
+	snapshot := newSessionBeadSnapshot([]beads.Bead{b})
+	failStore := unavailableStore{err: errors.New("disk full")}
+	var stdout, stderr bytes.Buffer
+
+	n := rebaseSessionConfigHashes(failStore, cfg, desiredState, snapshot, &stdout, &stderr)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 when store write fails", n)
+	}
+	if !strings.Contains(stderr.String(), "disk full") {
+		t.Errorf("stderr = %q, want error message mentioning 'disk full'", stderr.String())
+	}
+	if stdout.Len() > 0 {
+		t.Errorf("stdout should be empty on failure, got %q", stdout.String())
+	}
+}
+
+func TestRebaseSessionConfigHashes_NilSessionBeadsReturnsZero(t *testing.T) {
+	store := beads.NewMemStore()
+	n := rebaseSessionConfigHashes(store, nil, nil, nil, nil, nil)
+	if n != 0 {
+		t.Errorf("updated = %d, want 0 for nil sessionBeads", n)
 	}
 }


### PR DESCRIPTION
## Summary

- `gc reload` now rebases session config hashes to match the new resolved config, preventing the reconciler from treating post-reload config as drift
- Buffers the reload request channel to fix the "controller is busy" deadlock during active reconciliation cycles
- Attached and detached sessions both get their stored hashes updated after reload

## Context

Fixes ga-v9m: when `gc reload` re-resolves city config, stored session hashes become stale vs the new resolved hash, causing `restart_in_place` decisions. This made `gc reload` a restart trigger instead of a stabilization tool. Additionally, during heavy config churn the "controller is busy" catch-22 prevented reloading at all.

## Test plan

- [x] `TestRebaseSessionConfigHashes_UpdatesDriftedHash` — verifies drifted hashes are updated
- [x] `TestRebaseSessionConfigHashes_SkipsSessionWithoutHash` — sessions without stored hashes are skipped
- [x] `TestRebaseSessionConfigHashes_SkipsOrphanedSession` — orphaned sessions not rebased
- [x] `TestRebaseSessionConfigHashes_NoUpdateWhenHashMatches` — matching hashes left untouched
- [x] `TestRebaseSessionConfigHashes_NilStoreReturnsZero` — nil store handled gracefully
- [x] `TestRebaseSessionConfigHashes_MultipleSessions` — batch update across multiple sessions
- [x] `TestRebaseSessionConfigHashes_ReconciledAfterRebaseShowsNoDrift` — reconciler sees no drift after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)