### PR TITLE
fix: eliminate redundant bd/tmux calls per session in gc session list

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -575,13 +575,14 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 
 	// Build attachment cache. Active sessions already have Info.Attached
 	// populated by ListFullFromBeads; for inactive sessions, query the
-	// provider directly. Going through workerSessionTargetAttachedWithConfig
-	// here triggered 2-3 extra bd show subprocess lookups per session.
+	// provider directly while preserving the old "running and attached"
+	// semantics. Going through workerSessionTargetAttachedWithConfig here
+	// triggered 2-3 extra bd show subprocess lookups per session.
 	attachedSet := buildAttachmentCache(sessions, func(info session.Info) (bool, error) {
 		if info.State == session.StateActive || sp == nil {
 			return info.Attached, nil
 		}
-		return sp.IsAttached(info.SessionName), nil
+		return sessionAttachedForWakeReason(sp, info.SessionName), nil
 	})
 
 	if len(sessions) == 0 {
@@ -679,6 +680,22 @@ func (p *attachmentCachingProvider) Respond(name string, response runtime.Intera
 		return ip.Respond(name, response)
 	}
 	return runtime.ErrInteractionUnsupported
+}
+
+func sessionAttachedForWakeReason(sp runtime.Provider, name string) bool {
+	if sp == nil || strings.TrimSpace(name) == "" {
+		return false
+	}
+	if !sp.IsAttached(name) {
+		return false
+	}
+	// attachmentCachingProvider caches the already-vetted attachment state for
+	// the list path, so re-checking IsRunning here would just add the extra
+	// tmux probe this shortcut was introduced to avoid.
+	if _, ok := sp.(*attachmentCachingProvider); ok {
+		return true
+	}
+	return sp.IsRunning(name)
 }
 
 func buildAttachmentCache(sessions []session.Info, observe ...func(session.Info) (bool, error)) map[string]bool {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -573,10 +573,15 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 	cfg := providerCtx.cfg
 	poolDesired := cliPoolDesired(cfg)
 
-	// Build attachment cache from worker observations so reason evaluation
-	// does not bypass the worker boundary for attachment checks.
+	// Build attachment cache. Active sessions already have Info.Attached
+	// populated by ListFullFromBeads; for inactive sessions, query the
+	// provider directly. Going through workerSessionTargetAttachedWithConfig
+	// here triggered 2-3 extra bd show subprocess lookups per session.
 	attachedSet := buildAttachmentCache(sessions, func(info session.Info) (bool, error) {
-		return workerSessionTargetAttachedWithConfig("", store, sp, cfg, info.ID)
+		if info.State == session.StateActive || sp == nil {
+			return info.Attached, nil
+		}
+		return sp.IsAttached(info.SessionName), nil
 	})
 
 	if len(sessions) == 0 {

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -465,6 +465,67 @@ func TestBuildAttachmentCache_CachesWorkerObservedAttachmentState(t *testing.T) 
 	}
 }
 
+func TestBuildAttachmentCache_UsesSessionInfoForActiveSessions(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "sleeping", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp.SetAttached("active", false)
+	sp.SetAttached("sleeping", true)
+
+	cache := buildAttachmentCache([]session.Info{
+		{SessionName: "active", State: session.StateActive, Attached: true},
+		{SessionName: "sleeping", State: session.StateAsleep, Attached: false},
+	}, func(info session.Info) (bool, error) {
+		if info.State == session.StateActive || sp == nil {
+			return info.Attached, nil
+		}
+		return sessionAttachedForWakeReason(sp, info.SessionName), nil
+	})
+
+	if got, ok := cache["active"]; !ok || !got {
+		t.Fatalf("cache[active] = (%v, %v), want (true, true)", got, ok)
+	}
+	if got, ok := cache["sleeping"]; !ok || !got {
+		t.Fatalf("cache[sleeping] = (%v, %v), want (true, true)", got, ok)
+	}
+
+	activeCalls := 0
+	activeRunningCalls := 0
+	sleepingCalls := 0
+	sleepingRunningCalls := 0
+	for _, call := range sp.Calls {
+		switch call.Method {
+		case "IsAttached":
+			switch call.Name {
+			case "active":
+				activeCalls++
+			case "sleeping":
+				sleepingCalls++
+			}
+		case "IsRunning":
+			switch call.Name {
+			case "active":
+				activeRunningCalls++
+			case "sleeping":
+				sleepingRunningCalls++
+			}
+		}
+	}
+	if activeCalls != 0 {
+		t.Fatalf("IsAttached(active) calls = %d, want 0", activeCalls)
+	}
+	if activeRunningCalls != 0 {
+		t.Fatalf("IsRunning(active) calls = %d, want 0", activeRunningCalls)
+	}
+	if sleepingCalls != 1 {
+		t.Fatalf("IsAttached(sleeping) calls = %d, want 1", sleepingCalls)
+	}
+	if sleepingRunningCalls != 1 {
+		t.Fatalf("IsRunning(sleeping) calls = %d, want 1", sleepingRunningCalls)
+	}
+}
+
 func TestSessionListTargetPrefersAlias(t *testing.T) {
 	info := session.Info{
 		Alias:       "hal",

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -119,7 +119,7 @@ func evaluateWakeReasons(
 		reasons = append(reasons, WakeKeepWarm)
 	}
 
-	if !waitHold && sp != nil && sp.IsAttached(name) {
+	if !waitHold && sessionAttachedForWakeReason(sp, name) {
 		reasons = append(reasons, WakeAttached)
 	}
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -119,10 +119,8 @@ func evaluateWakeReasons(
 		reasons = append(reasons, WakeKeepWarm)
 	}
 
-	if !waitHold && sp != nil {
-		if attached, err := workerSessionTargetAttachedWithConfig("", nil, sp, nil, name); err == nil && attached {
-			reasons = append(reasons, WakeAttached)
-		}
+	if !waitHold && sp != nil && sp.IsAttached(name) {
+		reasons = append(reasons, WakeAttached)
 	}
 
 	if pendingInteractionReady(sp, name) {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -327,6 +327,26 @@ func TestWakeReasons_Attached(t *testing.T) {
 	}
 }
 
+func TestWakeReasons_IgnoresAttachedNonRunningSession(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := &config.City{}
+
+	sp := runtime.NewFake()
+	sp.SetAttached("test-worker", true)
+
+	session := makeBead("b1", map[string]string{
+		"template":     "worker",
+		"session_name": "test-worker",
+	})
+
+	reasons := wakeReasons(session, cfg, sp, nil, nil, nil, clk)
+	if containsWakeReason(reasons, WakeAttached) {
+		t.Fatalf("non-running attached session should not get WakeAttached, got %v", reasons)
+	}
+}
+
 func TestWakeReasons_DemandWakesSession(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}


### PR DESCRIPTION
## Summary

`gc session list` (non-JSON) was observed taking ~3 minutes on an 8-session city while `--json` took ~5s on the same city. Investigation traced the non-JSON blowup to 42 bd subprocess calls (2 `list` + 40 `show`, 5 per session) and 318 tmux subprocess calls, where 2 bd calls and ~30 tmux calls would suffice. Each bd query costs ~5s against the local dolt store, so the per-session redundancy multiplies directly into wall-clock latency.

Two call sites were re-observing state the CLI already had in hand:

1. **`cmdSessionList` → `buildAttachmentCache` observer.** The observer shelled `workerSessionTargetAttachedWithConfig` for every session, which rebuilds a `worker.Handle` and calls `manager.Get` (a `bd show`) twice plus re-runs tmux `IsAttached` + `GetLastActivity` subprocesses. `ListFullFromBeads` already populated `session.Info.Attached` from the same provider a moment earlier. Replace the observer body with a direct `Info.Attached` read for active sessions, falling back to direct provider attachment checks for inactive sessions while still requiring the session to be running so asleep-but-attached sessions still surface the `attached` wake reason without reviving dead tmux corpses.

2. **`evaluateWakeReasons` → attachment check.** The legacy `wakeReasons` path synthesised a `RuntimeHandle` via `workerSessionTargetAttachedWithConfig("", nil, sp, nil, name)` just to read one field; `LiveObservation` then ran `IsRunning`, two `GetMeta`, `ProcessAlive`, `IsAttached`, and `GetLastActivity` tmux subprocess calls per session. Call `sp.IsAttached(name)` directly. The CLI already wraps `sp` in `attachmentCachingProvider`, so this reduces to an in-process map lookup for sessions in the cache.

Measured with an 8-session city on an 11GB `.beads/dolt` store:

| Path       | Before | After | bd calls | tmux calls |
| ---------- | -----: | ----: | -------: | ---------: |
| `list`     |  ~192s | ~5.2s |  42 → 2  | 318 → 33   |
| `--json`   |  ~5.3s | ~5.1s |   1 → 1  |  17 → 17   |

37x speedup on the non-JSON path. The remaining ~5s floor on both paths is the single `bd list --label=gc:session` call itself; reaching the issue's `<500ms` JSON target requires addressing bd/dolt query latency separately (supervisor-side status cache, or dolt GC of the store — not within scope here).

## Testing

- [x] `go build ./...`
- [x] `go test -run 'TestSessionReason|TestBuildAttachmentCache|TestEvaluateWakeReasons|TestWakeReasons|TestSessionList' ./cmd/gc/`
- [x] Wall-clock verification on real store: `time gc session list` dropped from ~192s to ~5.2s
- [x] `GC_BD_TRACE` subprocess count: 42 → 2 bd calls
- [ ] `make check`
- [ ] `make test-integration`

## Checklist

- [x] Attachment-state semantics called out — `TestSessionReason_FallsThroughToProviderForSleepingAttachment` still passes for running asleep sessions, while dead remain-on-exit tmux corpses stay suppressed and active sessions reuse the already-observed attachment state.
- [x] No API changes.
- [ ] Follow-up: achieving the `<500ms` JSON target requires new infrastructure (caching layer or dolt store maintenance); tracked separately.

