### PR TITLE
fix(sling): auto-wake warm-idle workers on default sling (#1129)

### DIFF
--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/worker"
 )
 
 type noActivityCapabilityProvider struct {
@@ -1179,7 +1180,7 @@ func TestDeliverSlingNudgeWaitIdleWrapsInSystemReminder(t *testing.T) {
 
 	store := openNudgeBeadStore(dir)
 	var stdout, stderr bytes.Buffer
-	deliverSlingNudge(target, fake, store, dir, &stdout, &stderr)
+	deliverSlingNudge(target, fake, store, dir, worker.NudgeDeliveryWaitIdle, &stdout, &stderr)
 
 	var nudgeNowCalls int
 	var delivered string

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -673,7 +673,7 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, stderr
 	}
 	if result.NudgeAgent != nil {
 		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
-	} else if opts.Target.Name != "" {
+	} else if opts.Target.Name != "" && !result.Idempotent {
 		doSlingAutoNudge(&opts.Target, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
 	}
 	return 0
@@ -765,7 +765,7 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 	}
 	if result.NudgeAgent != nil {
 		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
-	} else if opts.Target.Name != "" {
+	} else if opts.Target.Name != "" && result.Routed > 0 {
 		doSlingAutoNudge(&opts.Target, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
 	}
 	return 0

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -103,7 +103,7 @@ Examples:
 		},
 	}
 	cmd.Flags().BoolVarP(&formula, "formula", "f", false, "treat argument as formula name")
-	cmd.Flags().BoolVar(&nudge, "nudge", false, "nudge target after routing")
+	cmd.Flags().BoolVar(&nudge, "nudge", false, "force nudge even for cold targets (running sessions auto-nudge)")
 	cmd.Flags().BoolVar(&force, "force", false, "suppress warnings, allow cross-rig routing, allow graph workflow replacement, and for direct bead routes dispatch even if the bead does not resolve in the local store")
 	cmd.Flags().StringVarP(&title, "title", "t", "", "wisp root bead title (with --formula or --on)")
 	cmd.Flags().StringArrayVar(&vars, "var", nil, "variable substitution for formula (key=value, repeatable)")
@@ -673,6 +673,8 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, stderr
 	}
 	if result.NudgeAgent != nil {
 		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
+	} else if opts.Target.Name != "" {
+		doSlingAutoNudge(&opts.Target, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
 	}
 	return 0
 }
@@ -763,6 +765,8 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 	}
 	if result.NudgeAgent != nil {
 		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
+	} else if opts.Target.Name != "" {
+		doSlingAutoNudge(&opts.Target, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
 	}
 	return 0
 }
@@ -1290,6 +1294,25 @@ func checkBeadState(q BeadQuerier, beadID string, a config.Agent) beadCheckResul
 	return sling.CheckBeadState(q, beadID, a, deps)
 }
 
+// firstRunningPoolMember scans a multi-session agent's pool instances and
+// returns the qualified name + session name of the first running member.
+// ok=false if no instance is running. Callers handle identity-resolution and
+// cold-target policy themselves — this helper only answers "is anyone home?".
+func firstRunningPoolMember(
+	a *config.Agent, cityName, cityPath string, cfg *config.City,
+	sp runtime.Provider, store beads.Store, st string,
+) (qn, sessionName string, ok bool) {
+	sp0 := scaleParamsFor(a)
+	for _, instanceQN := range discoverPoolInstances(a.Name, a.Dir, sp0, a, cityName, st, sp) {
+		sn := lookupSessionNameOrLegacy(store, cityName, instanceQN, st)
+		running, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, sn)
+		if err == nil && running {
+			return instanceQN, sn, true
+		}
+	}
+	return "", "", false
+}
+
 // doSlingNudge sends a nudge to the target agent after routing.
 // For multi-session configs, nudges the first running instance. If the target is not
 // running, pokes the controller to trigger an immediate reconciler tick
@@ -1305,23 +1328,16 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 	}
 
 	if a.SupportsInstanceExpansion() {
-		// Find a running multi-session instance to nudge.
-		sp0 := scaleParamsFor(a)
-		for _, qn := range discoverPoolInstances(a.Name, a.Dir, sp0, a, cityName, st, sp) {
-			sn := lookupSessionNameOrLegacy(store, cityName, qn, st)
-			running, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, sn)
-			if err == nil && running {
-				member, ok := resolveAgentIdentity(cfg, qn, currentRigContext(cfg))
-				if !ok {
-					fmt.Fprintf(stderr, "gc sling: agent %q not found in config\n", qn) //nolint:errcheck // best-effort
-					return
-				}
-				target := buildSlingNudgeTarget(member, cityName, cityPath, cfg, store, sn)
-				deliverSlingNudge(target, sp, store, cityPath, stdout, stderr)
+		if qn, sn, ok := firstRunningPoolMember(a, cityName, cityPath, cfg, sp, store, st); ok {
+			member, resolved := resolveAgentIdentity(cfg, qn, currentRigContext(cfg))
+			if !resolved {
+				fmt.Fprintf(stderr, "gc sling: agent %q not found in config\n", qn) //nolint:errcheck // best-effort
 				return
 			}
+			target := buildSlingNudgeTarget(member, cityName, cityPath, cfg, store, sn)
+			deliverSlingNudge(target, sp, store, cityPath, worker.NudgeDeliveryWaitIdle, stdout, stderr)
+			return
 		}
-		// No running config session — poke controller for immediate wake.
 		if err := pokeController(cityPath); err != nil {
 			fmt.Fprintf(stderr, "No running sessions for %q; poke failed: %v\n", a.QualifiedName(), err) //nolint:errcheck // best-effort
 		} else {
@@ -1333,7 +1349,46 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 	// Fixed agent: nudge directly.
 	sn := lookupSessionNameOrLegacy(store, cityName, a.QualifiedName(), st)
 	target := buildSlingNudgeTarget(*a, cityName, cityPath, cfg, store, sn)
-	deliverSlingNudge(target, sp, store, cityPath, stdout, stderr)
+	deliverSlingNudge(target, sp, store, cityPath, worker.NudgeDeliveryWaitIdle, stdout, stderr)
+}
+
+// doSlingAutoNudge wakes a warm-idle target session after a default `gc sling`
+// (no --nudge flag). It is a no-op when no running session exists — cold-target
+// wake-up remains an explicit opt-in via --nudge. Uses Immediate delivery to
+// avoid the 30s WaitIdle block on mid-turn sessions: busy workers will surface
+// the routed work via their existing Stop-hook path when the turn ends.
+//
+// Closes issue #1129: routed beads otherwise stall indefinitely on workers
+// that ran `gc prime` but have no active turn to trigger the Stop hook.
+func doSlingAutoNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
+	sp runtime.Provider, store beads.Store, stdout, stderr io.Writer,
+) {
+	if a.Suspended {
+		return
+	}
+	st := cfg.Workspace.SessionTemplate
+
+	if a.SupportsInstanceExpansion() {
+		qn, sn, ok := firstRunningPoolMember(a, cityName, cityPath, cfg, sp, store, st)
+		if !ok {
+			return
+		}
+		member, resolved := resolveAgentIdentity(cfg, qn, currentRigContext(cfg))
+		if !resolved {
+			return
+		}
+		target := buildSlingNudgeTarget(member, cityName, cityPath, cfg, store, sn)
+		deliverSlingNudge(target, sp, store, cityPath, worker.NudgeDeliveryImmediate, stdout, stderr)
+		return
+	}
+
+	sn := lookupSessionNameOrLegacy(store, cityName, a.QualifiedName(), st)
+	target := buildSlingNudgeTarget(*a, cityName, cityPath, cfg, store, sn)
+	obs, err := workerObserveNudgeTarget(target, store, sp)
+	if err != nil || !obs.Running {
+		return
+	}
+	deliverSlingNudge(target, sp, store, cityPath, worker.NudgeDeliveryImmediate, stdout, stderr)
 }
 
 // pokeController sends a "poke" command to the controller socket to
@@ -1393,7 +1448,7 @@ func buildSlingNudgeTarget(agent config.Agent, cityName, cityPath string, cfg *c
 	})
 }
 
-func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Store, cityPath string, stdout, stderr io.Writer) {
+func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Store, cityPath string, delivery worker.NudgeDelivery, stdout, stderr io.Writer) {
 	const msg = "Work slung. Check your hook."
 	obs, err := workerObserveNudgeTarget(target, store, sp)
 	running := err == nil && obs.Running
@@ -1403,7 +1458,7 @@ func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Stor
 		if err == nil {
 			result, nudgeErr := handle.Nudge(context.Background(), worker.NudgeRequest{
 				Text:     msg,
-				Delivery: worker.NudgeDeliveryWaitIdle,
+				Delivery: delivery,
 				Source:   "sling",
 				Wake:     worker.NudgeWakeLiveOnly,
 			})

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1038,6 +1038,77 @@ func TestDoSlingNoAutoNudgeForSuspendedAgent(t *testing.T) {
 	}
 }
 
+// TestDoSlingNoAutoNudgeOnIdempotentSling verifies that an idempotent sling
+// (bead already routed to this target, printed "already routed … skipping")
+// does not auto-nudge. Nudging after a no-op would wake the worker for no
+// new work — misleading and wastes a turn. The explicit --nudge path also
+// skips via the existing routed>0 guard at sling_core.go; auto-nudge should
+// match. Regression guard for PR #1130 review feedback.
+func TestDoSlingNoAutoNudgeOnIdempotentSling(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "mayor", runtime.Config{})
+	sp.Calls = nil
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	// fakeQuerier bead is already routed to "mayor" — sling detects idempotency.
+	q := &fakeQuerier{bead: beads.Bead{ID: "BL-42", Metadata: map[string]string{"gc.routed_to": "mayor"}}}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	opts := testOpts(a, "BL-42")
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "already routed") {
+		t.Fatalf("stdout = %q, want idempotent skip message (test precondition)", stdout.String())
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" || c.Method == "NudgeNow" {
+			t.Errorf("unexpected %s call on idempotent sling (no new work routed): %+v", c.Method, c)
+		}
+	}
+}
+
+// TestDoSlingBatchNoAutoNudgeWhenAllIdempotent verifies that a batch sling
+// (convoy expansion) where all children are already routed does not
+// auto-nudge. Mirrors the existing routed>0 gate from sling_core.go:927 into
+// the auto-nudge code path. Regression guard for PR #1130 review feedback.
+func TestDoSlingBatchNoAutoNudgeWhenAllIdempotent(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "mayor", runtime.Config{})
+	sp.Calls = nil
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["CVY-1"] = beads.Bead{ID: "CVY-1", Type: "convoy", Status: "open"}
+	q.beadsByID["BL-1"] = beads.Bead{ID: "BL-1", Status: "open", Assignee: "mayor"}
+	q.beadsByID["BL-2"] = beads.Bead{ID: "BL-2", Status: "open", Assignee: "mayor"}
+	q.childrenOf["CVY-1"] = []beads.Bead{
+		{ID: "BL-1", Status: "open", Assignee: "mayor"},
+		{ID: "BL-2", Status: "open", Assignee: "mayor"},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "CVY-1")
+	// opts.Nudge = false (default) — exercises the auto-nudge path.
+	code := doSlingBatch(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSlingBatch returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" || c.Method == "NudgeNow" {
+			t.Errorf("all-idempotent batch must not auto-nudge (routed=0): %+v", c)
+		}
+	}
+}
+
 func TestDoSlingCustomSlingQuery(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1006,6 +1006,49 @@ func TestDoSlingAutoNudgesRunningPoolMember(t *testing.T) {
 	}
 }
 
+// TestDoSlingNoAutoNudgeForPoolWithoutRunningMembers verifies that a
+// default sling to a pool agent with NO running instances is a silent
+// no-op — auto-nudge waking cold pools would contradict the fixed-cold
+// case which also no-ops, so --nudge stays the explicit opt-in for
+// cold wake-up. Covers the firstRunningPoolMember=false branch of
+// doSlingAutoNudge that the running-pool test does not reach.
+func TestDoSlingNoAutoNudgeForPoolWithoutRunningMembers(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	// No sp.Start — the pool has no running instances.
+	a := config.Agent{
+		Name:              "polecat",
+		Dir:               "hw",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3),
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	opts := testOpts(a, "BL-1")
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" || c.Method == "NudgeNow" {
+			t.Errorf("unexpected %s call on pool with no running members: %+v", c.Method, c)
+		}
+	}
+	pending, _, dead, err := listQueuedNudges(deps.CityPath, "polecat", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(dead) != 0 {
+		t.Fatalf("pending=%d dead=%d, want 0/0 (no auto-nudge for cold pool)", len(pending), len(dead))
+	}
+}
+
 // TestDoSlingNoAutoNudgeForSuspendedAgent verifies that a default sling to a
 // suspended agent is silent — no "cannot nudge" warning and no delivery
 // attempt. The warning remains a property of the explicit --nudge path,

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -883,6 +883,161 @@ func TestDoSlingNudgePoolNoMembers(t *testing.T) {
 	}
 }
 
+// TestDoSlingAutoNudgesRunningFixedAgent verifies that a default sling (no
+// --nudge flag) to a running fixed-agent session directly delivers a
+// sling-source nudge via the runtime's immediate-nudge path. Without this
+// behavior, routed beads stall on warm-idle workers until a manual
+// `gc session nudge` runs (see issue #1129). Immediate (rather than WaitIdle)
+// delivery is intentional: mid-turn workers surface routed work via their
+// existing Stop-hook path; auto-nudge must not block `gc sling` for 30s.
+func TestDoSlingAutoNudgesRunningFixedAgent(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "mayor", runtime.Config{})
+	sp.Calls = nil
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	opts := testOpts(a, "BL-1")
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	nudgeNowCalls := 0
+	for _, c := range sp.Calls {
+		if c.Method == "NudgeNow" && c.Name == "mayor" {
+			nudgeNowCalls++
+		}
+		if c.Method == "WaitForIdle" {
+			t.Errorf("unexpected WaitForIdle call — auto-nudge must use Immediate delivery to avoid blocking sling: %+v", c)
+		}
+	}
+	if nudgeNowCalls != 1 {
+		t.Fatalf("NudgeNow calls on mayor = %d, want 1 (auto-nudge should deliver immediately to running session)", nudgeNowCalls)
+	}
+	if !strings.Contains(stdout.String(), "Nudged mayor") {
+		t.Errorf("stdout = %q, want 'Nudged mayor'", stdout.String())
+	}
+}
+
+// TestDoSlingNoAutoNudgeWhenTargetNotRunning verifies that a default sling
+// (no --nudge) to an agent with no running session is a pure routing operation
+// — no queued nudge, no poke, no NudgeNow call. Callers who want to wake a
+// cold target must opt in explicitly with --nudge (preserving the existing
+// explicit-opt-in path).
+func TestDoSlingNoAutoNudgeWhenTargetNotRunning(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	opts := testOpts(a, "BL-1")
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" || c.Method == "NudgeNow" {
+			t.Errorf("unexpected %s call on cold target: %+v", c.Method, c)
+		}
+	}
+	pending, _, dead, err := listQueuedNudges(deps.CityPath, "mayor", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 || len(dead) != 0 {
+		t.Fatalf("pending=%d dead=%d, want 0/0 (no auto-nudge for cold target)", len(pending), len(dead))
+	}
+}
+
+// TestDoSlingAutoNudgesRunningPoolMember verifies that a default sling to a
+// pool agent with at least one running instance auto-nudges that specific
+// instance (not instance 1 or any other slot). Pools without running members
+// get no auto-nudge (consistent with the fixed cold-target case — --nudge
+// remains the explicit opt-in).
+func TestDoSlingAutoNudgesRunningPoolMember(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "hw--polecat-2", runtime.Config{})
+	sp.Calls = nil
+	a := config.Agent{
+		Name:              "polecat",
+		Dir:               "hw",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3),
+	}
+	// Agent must be in cfg.Agents so resolveAgentIdentity can map the pool
+	// instance qualified name back to a config.Agent for nudge targeting.
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents:    []config.Agent{a},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	opts := testOpts(a, "BL-1")
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	nudgedSessions := make(map[string]int)
+	for _, c := range sp.Calls {
+		if c.Method == "NudgeNow" {
+			nudgedSessions[c.Name]++
+		}
+		if c.Method == "WaitForIdle" {
+			t.Errorf("unexpected WaitForIdle call — auto-nudge must use Immediate delivery: %+v", c)
+		}
+	}
+	if nudgedSessions["hw--polecat-2"] != 1 {
+		t.Fatalf("NudgeNow calls on running instance hw--polecat-2 = %d, want 1 (all nudges: %v)", nudgedSessions["hw--polecat-2"], nudgedSessions)
+	}
+	if nudgedSessions["hw--polecat-1"] != 0 || nudgedSessions["hw--polecat-3"] != 0 {
+		t.Errorf("auto-nudge targeted non-running instances (bad pool-scan): %v", nudgedSessions)
+	}
+}
+
+// TestDoSlingNoAutoNudgeForSuspendedAgent verifies that a default sling to a
+// suspended agent is silent — no "cannot nudge" warning and no delivery
+// attempt. The warning remains a property of the explicit --nudge path,
+// which is a user signal of intent.
+func TestDoSlingNoAutoNudgeForSuspendedAgent(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	_ = sp.Start(context.Background(), "mayor", runtime.Config{})
+	sp.Calls = nil
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", Suspended: true, MaxActiveSessions: intPtr(1)}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+
+	opts := testOpts(a, "BL-1")
+	opts.Force = true // allow sling-to-suspended
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "cannot nudge") {
+		t.Errorf("stderr = %q, want no 'cannot nudge' warning on auto-nudge path", stderr.String())
+	}
+	for _, c := range sp.Calls {
+		if c.Method == "Nudge" || c.Method == "NudgeNow" {
+			t.Errorf("unexpected %s call on suspended agent: %+v", c.Method, c)
+		}
+	}
+}
+
 func TestDoSlingCustomSlingQuery(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2489,7 +2489,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `--merge` | string |  | merge strategy: direct, mr, or local |
 | `--no-convoy` | bool |  | skip auto-convoy creation |
 | `--no-formula` | bool |  | suppress default formula (route raw bead) |
-| `--nudge` | bool |  | nudge target after routing |
+| `--nudge` | bool |  | force nudge even for cold targets (running sessions auto-nudge) |
 | `--on` | string |  | attach wisp from formula to bead before routing |
 | `--owned` | bool |  | mark auto-convoy as owned (skip auto-close) |
 | `--scope-kind` | string |  | logical workflow scope kind for graph.v2 launches |

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -75,7 +75,8 @@ CLI layer (cmd/gc/cmd_sling.go)
               +-- telemetry.RecordSling()
               +-- store.SetMetadata()   [if --merge] merge strategy
               +-- store.Create(convoy)  [if auto-convoy] tracking wrapper
-              +-- doSlingNudge()        [if --nudge] wake the agent
+              +-- doSlingNudge()        [if --nudge] wake target (queues for cold targets)
+              +-- doSlingAutoNudge()    [default] wake target only if session running
 ```
 
 ### Data Flow
@@ -100,7 +101,10 @@ CLI layer (cmd/gc/cmd_sling.go)
 10. If auto-convoy is enabled (not `--no-convoy`, not `--formula`),
     creates a convoy bead and sets the routed bead's ParentID to the
     convoy.
-11. If `--nudge`, sends a nudge to the target agent.
+11. Nudges the target. Default: auto-nudge only if the target has a
+    running session (wakes warm-idle workers so routed beads do not stall).
+    `--nudge` forces a nudge even for cold targets (queues a reminder and
+    pokes the controller).
 
 **Container expansion** (`gc sling <agent> <convoy-id>`):
 
@@ -110,8 +114,9 @@ CLI layer (cmd/gc/cmd_sling.go)
 4. Routes each open child individually through `buildSlingCommand` +
    `runner`. No auto-convoy is created -- the container IS the convoy.
 5. Reports per-child success/failure and a summary line.
-6. Nudges once after all children are routed (if `--nudge` and at
-   least one succeeded).
+6. Nudges once after all children are routed. Auto-nudge fires when the
+   target session is running; `--nudge` additionally forces a queued
+   reminder for cold targets.
 
 ### Key Types
 
@@ -164,7 +169,9 @@ CLI layer (cmd/gc/cmd_sling.go)
 
 8. **Pool nudge targets the first running instance.** When nudging a
    pool, dispatch iterates pool instances in order and nudges the first
-   one with a running session. If none are running, a warning is emitted.
+   one with a running session. If none are running under the default
+   (auto-nudge) path, sling is silent; under explicit `--nudge`, a warning
+   is emitted and the controller is poked to schedule a wake.
 
 9. **System formulas are idempotent.** `MaterializeSystemFormulas`
    always overwrites files to match the binary version and removes stale
@@ -298,8 +305,8 @@ both `sling_query` and `work_query` together or neither.
   first-served.
 
 - **Nudge targets only one pool instance.** After slinging to a pool,
-  `--nudge` wakes the first running instance found. Other instances
-  discover work on their next poll cycle.
+  the nudge (auto or `--nudge`) wakes the first running instance found.
+  Other instances discover work on their next poll cycle.
 
 - **No dry-run mode.** There is no way to preview what a sling command
   would do without actually executing it. The pre-flight `checkBeadState`


### PR DESCRIPTION
Closes #1129.

## Summary

`gc sling <worker> <bead>` sets `gc.routed_to` metadata and wraps the bead in a convoy/wisp, but does NOT wake the target worker unless `--nudge` is explicitly passed (which defaulted to `false`). A warm-idle worker session (one that ran `gc prime` and has no active turn) never fires its `Stop` hook, so `gc hook --inject` never runs there and routed work stalls indefinitely.

This PR makes default `gc sling` auto-wake a target with a running session, and repurposes `--nudge` to mean "force nudge even for cold targets."

## What changes

| Invocation | Before | After |
|---|---|---|
| `gc sling <target> <bead>` (running target) | no wake — stalled | auto-nudge via `NudgeDeliveryImmediate` |
| `gc sling <target> <bead>` (cold target) | silent routing only | silent routing only (unchanged) |
| `gc sling --nudge <target> <bead>` (running target) | nudge via `WaitIdle` | nudge via `WaitIdle` (unchanged) |
| `gc sling --nudge <target> <bead>` (cold target) | queue reminder + poke controller | queue reminder + poke controller (unchanged) |

Auto-nudge uses `NudgeDeliveryImmediate` — not `WaitIdle` — so mid-turn workers do not block `gc sling` for the 30s idle-wait window. Busy workers will still surface the routed work via their existing `Stop`-hook path when the current turn ends.

## Why this design

- **Fix lives in the CLI layer (`cmd/gc/cmd_sling.go`), not `sling.finalize`.** This preserves the Layer 2 → Layer 0 layering boundary — `sling.SlingDeps` does not get a `runtime.Provider` threaded through it.
- **API `internal/api/handler_sling.go` path is unchanged** — still nudge-free. Programmatic HTTP callers do not pay any new latency.
- **Namespace invariants preserved.** `buildSlingNudgeTarget` + `resolveAgentIdentity` yield instance-scoped qualified names before any queue enqueue, so no factory-token nudge ever lands on a session-family surface (see `session-model-unification.md`).

## Related

- #1027 addressed the **cold-spawn pool** case (first-turn from command-line prompt). @julianknutsen's closing comment explicitly flagged this warm-idle case as separate follow-up work:
  > if we later want `gc sling --nudge` itself to enqueue a post-start reminder for cold pool targets, that remains separate follow-up work
- Relationship to #1110 (`gc.routed_to` short-form normalization): orthogonal — that fixes matching in a different code path.

## Test plan

- [x] Unit (`cmd/gc/cmd_sling_test.go`): 4 new tests
  - `TestDoSlingAutoNudgesRunningFixedAgent` — asserts `NudgeNow` called on running fixed-agent session, `WaitForIdle` NOT called (Immediate semantics), stdout `Nudged mayor`
  - `TestDoSlingNoAutoNudgeWhenTargetNotRunning` — asserts no `Nudge*` call and empty queue on cold target
  - `TestDoSlingAutoNudgesRunningPoolMember` — starts pool instance 2 (slots 1 + 3 not running), asserts `NudgeNow` called on `hw--polecat-2` specifically (not slots 1 or 3)
  - `TestDoSlingNoAutoNudgeForSuspendedAgent` — asserts silent no-op on suspended agent (no `cannot nudge` warning on the auto-nudge path)
- [x] Existing tests cover explicit `--nudge` semantics unchanged (`TestDoSlingNudgeFixedAgent`, `TestDoSlingNudgeNoSession`, `TestDoSlingNudgePoolMember`, `TestDoSlingNudgePoolNoMembers`, `TestDoSlingNudgeSuspended`, `TestDeliverSlingNudgeWaitIdleWrapsInSystemReminder`)
- [x] `make build`, `make check`, `make check-docs` — all pass
- [x] Multi-model review (Claude ×3 + Codex gpt-5.4 + Copilot gpt-5.3-codex): 0 blockers, 0 majors, 1 minor fixed inline

## Refactors included

- Extracted `firstRunningPoolMember` helper (replaces inlined pool-scan loop in `doSlingNudge`; reused by new `doSlingAutoNudge`).
- Parameterized `deliverSlingNudge` with `worker.NudgeDelivery` so both call sites pick their delivery semantics explicitly.

## Docs

- `docs/reference/cli.md` — `--nudge` flag description updated
- `engdocs/architecture/dispatch.md` — wake-path diagram, data flow step 11, batch nudge step 6, invariant 8, and limitation note all updated in lockstep