### PR TITLE
feat: grace period for manual sessions before idle-sleep

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -37,6 +37,7 @@ func buildAwakeInputFromReconciler(
 		AttachedSessions:   make(map[string]bool),
 		PendingSessions:    make(map[string]bool),
 		ChatIdleTimeout:    cfg.ChatSessions.IdleTimeoutDuration(),
+		ManualGracePeriod:  cfg.ChatSessions.GracePeriodDuration(),
 		Now:                clk,
 	}
 
@@ -120,6 +121,7 @@ func buildAwakeInputFromReconciler(
 		}
 		bead.HeldUntil = lifecycle.HeldUntil
 		bead.QuarantinedUntil = lifecycle.QuarantinedUntil
+		bead.CreatedAt = b.CreatedAt
 		if t, err := time.Parse(time.RFC3339, b.Metadata["detached_at"]); err == nil && !t.IsZero() {
 			bead.IdleSince = t
 		}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -32,6 +32,7 @@ type AwakeInput struct {
 	PendingSessions    map[string]bool // session name → pending interaction
 	ReadyWaitSet       map[string]bool // session bead ID → durable wait is ready
 	ChatIdleTimeout    time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	ManualGracePeriod  time.Duration   // grace period before manual sessions can be idle-slept (0 = disabled)
 	Now                time.Time
 }
 
@@ -71,6 +72,7 @@ type AwakeSessionBead struct {
 	HeldUntil                time.Time // zero = not held
 	QuarantinedUntil         time.Time // zero = not quarantined
 	IdleSince                time.Time // zero = unknown/not idle
+	CreatedAt                time.Time // bead creation time (for grace period checks)
 	RestartRequested         bool      // restart_requested metadata is still active
 	ContinuationResetPending bool      // continuation_reset_pending metadata is set
 }
@@ -400,11 +402,13 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// Attached, pending, pinned, mode=always named, and sessions with
 		// assigned demand work are exempt. Assigned demand work means either
 		// in_progress ownership or open work with Ready=true; blocked open
-		// assignments do not prevent idle sleep.
+		// assignments do not prevent idle sleep. Manual sessions within their
+		// grace period are also exempt.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
 			desired[name] != "assigned-work" && desired[name] != "min-active" &&
-			desired[name] != "reset-pending" {
+			desired[name] != "reset-pending" &&
+			!inManualGracePeriod(bead, input.ManualGracePeriod, input.Now) {
 			agent, hasAgent := lookupAgent(bead.Template)
 			var idleTimeout time.Duration
 			switch {
@@ -721,4 +725,11 @@ func isCreatingCandidateState(state string) bool {
 	default:
 		return false
 	}
+}
+
+// inManualGracePeriod returns true if the session is a manual session
+// created recently enough to be protected from idle sleep.
+func inManualGracePeriod(bead AwakeSessionBead, gracePeriod time.Duration, now time.Time) bool {
+	return bead.ManualSession && gracePeriod > 0 && !bead.CreatedAt.IsZero() &&
+		now.Sub(bead.CreatedAt) < gracePeriod
 }

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -2058,10 +2058,10 @@ func TestGracePeriod_ProtectsManualFromIdleSleep(t *testing.T) {
 			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
 			CreatedAt: now.Add(-3 * time.Minute),
 		}},
-		RunningSessions:    map[string]bool{"s-mc-1": true},
-		ChatIdleTimeout:    2 * time.Minute,
-		ManualGracePeriod:  10 * time.Minute,
-		Now:                now,
+		RunningSessions:   map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:   2 * time.Minute,
+		ManualGracePeriod: 10 * time.Minute,
+		Now:               now,
 	})
 	assertAwake(t, result, "s-mc-1")
 }
@@ -2076,10 +2076,10 @@ func TestGracePeriod_Expired_IdleSleepApplies(t *testing.T) {
 			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
 			CreatedAt: now.Add(-15 * time.Minute),
 		}},
-		RunningSessions:    map[string]bool{"s-mc-1": true},
-		ChatIdleTimeout:    2 * time.Minute,
-		ManualGracePeriod:  10 * time.Minute,
-		Now:                now,
+		RunningSessions:   map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:   2 * time.Minute,
+		ManualGracePeriod: 10 * time.Minute,
+		Now:               now,
 	})
 	assertAsleep(t, result, "s-mc-1")
 }
@@ -2128,10 +2128,10 @@ func TestGracePeriod_ReasonIsGracePeriod(t *testing.T) {
 			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
 			CreatedAt: now.Add(-3 * time.Minute),
 		}},
-		RunningSessions:    map[string]bool{"s-mc-1": true},
-		ChatIdleTimeout:    2 * time.Minute,
-		ManualGracePeriod:  10 * time.Minute,
-		Now:                now,
+		RunningSessions:   map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:   2 * time.Minute,
+		ManualGracePeriod: 10 * time.Minute,
+		Now:               now,
 	})
 	assertReason(t, result, "s-mc-1", "manual")
 }

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -2044,6 +2044,98 @@ func TestNamedAlways_SuspensionPropagation(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Ad-hoc session grace period (ga-dr4)
+// ---------------------------------------------------------------------------
+
+func TestGracePeriod_ProtectsManualFromIdleSleep(t *testing.T) {
+	// A manual session created 3 min ago with ChatIdleTimeout=2min should
+	// normally be idle-slept. But the 10-min grace period protects it.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/claude"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "s-mc-1", Template: "gascity/claude", State: "active",
+			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
+			CreatedAt: now.Add(-3 * time.Minute),
+		}},
+		RunningSessions:    map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:    2 * time.Minute,
+		ManualGracePeriod:  10 * time.Minute,
+		Now:                now,
+	})
+	assertAwake(t, result, "s-mc-1")
+}
+
+func TestGracePeriod_Expired_IdleSleepApplies(t *testing.T) {
+	// A manual session created 15 min ago, idle for 3 min, with
+	// ChatIdleTimeout=2min. Grace period (10m) has expired → idle sleep.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/claude"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "s-mc-1", Template: "gascity/claude", State: "active",
+			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
+			CreatedAt: now.Add(-15 * time.Minute),
+		}},
+		RunningSessions:    map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:    2 * time.Minute,
+		ManualGracePeriod:  10 * time.Minute,
+		Now:                now,
+	})
+	assertAsleep(t, result, "s-mc-1")
+}
+
+func TestGracePeriod_ZeroDisabled_IdleSleepApplies(t *testing.T) {
+	// ManualGracePeriod=0 disables the grace period. Normal idle sleep applies.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/claude"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "s-mc-1", Template: "gascity/claude", State: "active",
+			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
+			CreatedAt: now.Add(-3 * time.Minute),
+		}},
+		RunningSessions:   map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:   2 * time.Minute,
+		ManualGracePeriod: 0,
+		Now:               now,
+	})
+	assertAsleep(t, result, "s-mc-1")
+}
+
+func TestGracePeriod_NonManualSession_NoEffect(t *testing.T) {
+	// Grace period should NOT protect non-manual (ephemeral) sessions.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", SleepAfterIdle: 2 * time.Minute}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active",
+			IdleSince: now.Add(-3 * time.Minute),
+			CreatedAt: now.Add(-3 * time.Minute),
+		}},
+		ScaleCheckCounts:  map[string]int{"hello-world/polecat": 1},
+		RunningSessions:   map[string]bool{"polecat-mc-1": true},
+		ManualGracePeriod: 10 * time.Minute,
+		Now:               now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestGracePeriod_ReasonIsGracePeriod(t *testing.T) {
+	// When grace period protects a session from idle sleep, the reason
+	// should remain "manual" (the desired-set reason), not change.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/claude"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "mc-1", SessionName: "s-mc-1", Template: "gascity/claude", State: "active",
+			ManualSession: true, IdleSince: now.Add(-3 * time.Minute),
+			CreatedAt: now.Add(-3 * time.Minute),
+		}},
+		RunningSessions:    map[string]bool{"s-mc-1": true},
+		ChatIdleTimeout:    2 * time.Minute,
+		ManualGracePeriod:  10 * time.Minute,
+		Now:                now,
+	})
+	assertReason(t, result, "s-mc-1", "manual")
+}
+
 func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	// Pool with scale=0 and running session. Override must NOT
 	// keep pool sessions alive — scale-down must work.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -278,6 +278,7 @@ ChatSessionsConfig configures chat session behavior.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `idle_timeout` | string |  |  | IdleTimeout is the duration after which a detached chat session is auto-suspended. Duration string (e.g., "30m", "1h"). 0 = disabled. |
+| `grace_period` | string |  |  | GracePeriod is the duration after creation during which a manual session is protected from idle-sleep scale-to-zero. Duration string (e.g., "10m"). Empty = use default (10m). "0" = disabled. |
 
 ## ConvergenceConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1014,6 +1014,10 @@
         "idle_timeout": {
           "type": "string",
           "description": "IdleTimeout is the duration after which a detached chat session\nis auto-suspended. Duration string (e.g., \"30m\", \"1h\"). 0 = disabled."
+        },
+        "grace_period": {
+          "type": "string",
+          "description": "GracePeriod is the duration after creation during which a manual\nsession is protected from idle-sleep scale-to-zero. Duration string\n(e.g., \"10m\"). Empty = use default (10m). \"0\" = disabled."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1014,6 +1014,10 @@
         "idle_timeout": {
           "type": "string",
           "description": "IdleTimeout is the duration after which a detached chat session\nis auto-suspended. Duration string (e.g., \"30m\", \"1h\"). 0 = disabled."
+        },
+        "grace_period": {
+          "type": "string",
+          "description": "GracePeriod is the duration after creation during which a manual\nsession is protected from idle-sleep scale-to-zero. Duration string\n(e.g., \"10m\"). Empty = use default (10m). \"0\" = disabled."
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1930,6 +1930,10 @@ type ChatSessionsConfig struct {
 	// IdleTimeout is the duration after which a detached chat session
 	// is auto-suspended. Duration string (e.g., "30m", "1h"). 0 = disabled.
 	IdleTimeout string `toml:"idle_timeout,omitempty"`
+	// GracePeriod is the duration after creation during which a manual
+	// session is protected from idle-sleep scale-to-zero. Duration string
+	// (e.g., "10m"). Empty = use default (10m). "0" = disabled.
+	GracePeriod string `toml:"grace_period,omitempty"`
 }
 
 // SessionSleepConfig configures default idle sleep policies by session class.
@@ -1953,6 +1957,27 @@ func (c ChatSessionsConfig) IdleTimeoutDuration() time.Duration {
 	d, err := time.ParseDuration(c.IdleTimeout)
 	if err != nil {
 		return 0
+	}
+	return d
+}
+
+// DefaultManualGracePeriod is the grace period for manual sessions when
+// no explicit grace_period is configured. Protects ad-hoc sessions from
+// idle-sleep scale-to-zero during their initial startup window.
+const DefaultManualGracePeriod = 10 * time.Minute
+
+// GracePeriodDuration parses GracePeriod, returning DefaultManualGracePeriod
+// if unset, 0 if explicitly set to "0", or the parsed duration.
+func (c ChatSessionsConfig) GracePeriodDuration() time.Duration {
+	switch c.GracePeriod {
+	case "":
+		return DefaultManualGracePeriod
+	case "0", "0s":
+		return 0
+	}
+	d, err := time.ParseDuration(c.GracePeriod)
+	if err != nil {
+		return DefaultManualGracePeriod
 	}
 	return d
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5043,6 +5043,92 @@ func TestMaxSessionAgeOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+// --- ChatSessionsConfig tests ---
+
+func TestChatSessionsIdleTimeoutDurationEmpty(t *testing.T) {
+	c := ChatSessionsConfig{}
+	if got := c.IdleTimeoutDuration(); got != 0 {
+		t.Errorf("IdleTimeoutDuration() = %v, want 0", got)
+	}
+}
+
+func TestChatSessionsIdleTimeoutDurationValid(t *testing.T) {
+	c := ChatSessionsConfig{IdleTimeout: "30m"}
+	if got := c.IdleTimeoutDuration(); got != 30*time.Minute {
+		t.Errorf("IdleTimeoutDuration() = %v, want 30m", got)
+	}
+}
+
+func TestChatSessionsIdleTimeoutDurationInvalid(t *testing.T) {
+	c := ChatSessionsConfig{IdleTimeout: "not-a-duration"}
+	if got := c.IdleTimeoutDuration(); got != 0 {
+		t.Errorf("IdleTimeoutDuration() = %v, want 0 for invalid", got)
+	}
+}
+
+func TestGracePeriodDurationDefault(t *testing.T) {
+	c := ChatSessionsConfig{}
+	if got := c.GracePeriodDuration(); got != DefaultManualGracePeriod {
+		t.Errorf("GracePeriodDuration() = %v, want %v", got, DefaultManualGracePeriod)
+	}
+}
+
+func TestGracePeriodDurationExplicitZero(t *testing.T) {
+	for _, val := range []string{"0", "0s"} {
+		c := ChatSessionsConfig{GracePeriod: val}
+		if got := c.GracePeriodDuration(); got != 0 {
+			t.Errorf("GracePeriodDuration(%q) = %v, want 0", val, got)
+		}
+	}
+}
+
+func TestGracePeriodDurationValid(t *testing.T) {
+	c := ChatSessionsConfig{GracePeriod: "5m"}
+	if got := c.GracePeriodDuration(); got != 5*time.Minute {
+		t.Errorf("GracePeriodDuration() = %v, want 5m", got)
+	}
+}
+
+func TestGracePeriodDurationInvalid(t *testing.T) {
+	c := ChatSessionsConfig{GracePeriod: "bogus"}
+	if got := c.GracePeriodDuration(); got != DefaultManualGracePeriod {
+		t.Errorf("GracePeriodDuration() = %v, want %v for invalid", got, DefaultManualGracePeriod)
+	}
+}
+
+func TestGracePeriodRoundTrip(t *testing.T) {
+	c := City{
+		Workspace:    Workspace{Name: "test"},
+		Agents:       []Agent{{Name: "mayor"}},
+		ChatSessions: ChatSessionsConfig{GracePeriod: "15m"},
+	}
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.ChatSessions.GracePeriod != "15m" {
+		t.Errorf("GracePeriod after round-trip = %q, want %q", got.ChatSessions.GracePeriod, "15m")
+	}
+}
+
+func TestGracePeriodOmittedWhenEmpty(t *testing.T) {
+	c := City{
+		Workspace: Workspace{Name: "test"},
+		Agents:    []Agent{{Name: "mayor"}},
+	}
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "grace_period") {
+		t.Errorf("TOML output should omit grace_period when empty, got:\n%s", data)
+	}
+}
+
 // --- install_agent_hooks ---
 
 func TestParseInstallAgentHooksWorkspace(t *testing.T) {

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -90,6 +90,7 @@ func ValidateDurations(cfg *City, source string) []string {
 
 	// Chat sessions config durations.
 	check("[chat_sessions]", "idle_timeout", cfg.ChatSessions.IdleTimeout)
+	check("[chat_sessions]", "grace_period", cfg.ChatSessions.GracePeriod)
 
 	// Maintenance (dolt) config durations.
 	check("[maintenance.dolt]", "interval", cfg.Maintenance.Dolt.Interval)

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -373,3 +373,19 @@ func TestValidateDurationsIncludesSource(t *testing.T) {
 		t.Errorf("warning should include source path: %s", warnings[0])
 	}
 }
+
+func TestValidateDurationsBadChatSessionsGracePeriod(t *testing.T) {
+	cfg := &City{
+		ChatSessions: ChatSessionsConfig{GracePeriod: "bogus"},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "grace_period") {
+		t.Errorf("warning should mention field name: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "bogus") {
+		t.Errorf("warning should mention bad value: %s", warnings[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Manual sessions created via `gc session new` now have a configurable grace period (default 10m) before the reconciler can idle-sleep them
- Prevents ad-hoc sessions from being killed mid-task when they briefly appear idle during startup
- New config: `[chat_sessions] grace_period = "10m"` (empty = 10m default, `"0"` = disabled)
- Grace period only protects manual sessions — ephemeral polecat sessions are unaffected

## Test plan

- [x] `TestGracePeriod_ProtectsManualFromIdleSleep` — within grace period, stays awake
- [x] `TestGracePeriod_Expired_IdleSleepApplies` — past grace period, normal idle sleep
- [x] `TestGracePeriod_ZeroDisabled_IdleSleepApplies` — disabled when set to 0
- [x] `TestGracePeriod_NonManualSession_NoEffect` — ephemeral sessions unaffected
- [x] `TestGracePeriod_ReasonIsGracePeriod` — reason stays "manual"

Closes: ga-dr4

🤖 Generated with [Claude Code](https://claude.com/claude-code)