### PR TITLE
feat(dolt): scheduled GC nudge, doctor checks, recovery runbook, tightened server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Managed Dolt config now emits listener backlog and connection-timeout keys.
+  Existing managed cities may see a `dolt-config` doctor warning until
+  `gc dolt restart` or the next managed server start regenerates
+  `dolt-config.yaml`.
+
 ## [1.0.0] - 2026-04-21
 
 First stable release. Between `v0.15.1` and `v1.0.0` the project received 610

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -406,7 +406,7 @@ func bdRuntimeEnvForRig(cityPath string, cfg *config.City, rigPath string) map[s
 }
 
 func bdRuntimeEnv(cityPath string) map[string]string {
-	env := citylayout.CityRuntimeEnvMap(cityPath)
+	env := cityRuntimeEnvMapForCity(cityPath)
 	env["BEADS_DIR"] = filepath.Join(cityPath, ".beads")
 	env["GC_RIG"] = ""
 	env["GC_RIG_ROOT"] = ""
@@ -423,6 +423,27 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 		mirrorBeadsDoltEnv(env)
 	}
 	return env
+}
+
+func cityRuntimeEnvMapForCity(cityPath string) map[string]string {
+	env := citylayout.CityRuntimeEnvMap(cityPath)
+	if runtimeDir := trustedAmbientCityRuntimeDir(cityPath); runtimeDir != "" {
+		env["GC_CITY_RUNTIME_DIR"] = runtimeDir
+	}
+	return env
+}
+
+func trustedAmbientCityRuntimeDir(cityPath string) string {
+	runtimeDir := strings.TrimSpace(os.Getenv("GC_CITY_RUNTIME_DIR"))
+	if runtimeDir == "" {
+		return ""
+	}
+	for _, key := range []string{"GC_CITY_PATH", "GC_CITY"} {
+		if samePath(strings.TrimSpace(os.Getenv(key)), cityPath) {
+			return normalizePathForCompare(runtimeDir)
+		}
+	}
+	return ""
 }
 
 func cityRuntimeProcessEnv(cityPath string) []string {
@@ -525,9 +546,16 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 		"GC_CITY_PATH",
 		"GC_CITY_RUNTIME_DIR",
 		"GC_DOLT",
+		"GC_DOLT_CONFIG_FILE",
+		"GC_DOLT_DATA_DIR",
 		"GC_DOLT_HOST",
+		"GC_DOLT_LOCK_FILE",
+		"GC_DOLT_LOG_FILE",
+		"GC_DOLT_MANAGED_LOCAL",
 		"GC_DOLT_PASSWORD",
+		"GC_DOLT_PID_FILE",
 		"GC_DOLT_PORT",
+		"GC_DOLT_STATE_FILE",
 		"GC_DOLT_USER",
 		"GC_PACK_STATE_DIR",
 		"GC_RIG",

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -6456,6 +6456,8 @@ type managedDoltConfigForTest struct {
 		Port               int    `yaml:"port"`
 		Host               string `yaml:"host"`
 		MaxConnections     int    `yaml:"max_connections"`
+		BackLog            int    `yaml:"back_log"`
+		MaxConnTimeoutMS   int    `yaml:"max_connections_timeout_millis"`
 		ReadTimeoutMillis  int    `yaml:"read_timeout_millis"`
 		WriteTimeoutMillis int    `yaml:"write_timeout_millis"`
 	} `yaml:"listener"`

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -190,6 +190,14 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	}
 	skipCityDoltCheck := os.Getenv("GC_DOLT") == "skip" || (!scopeUsesManagedBdStoreContract(cityPath, cityPath) && !workspaceNeedsCityDoltCheck(cityPath, cfg))
 	d.Register(newDoctorDoltServerCheck(cityPath, skipCityDoltCheck))
+	// Managed Dolt ops checks (PR 3). Size + config drift are only
+	// meaningful when the city uses the managed bd/Dolt backend; the
+	// version check always runs so operators see drift even on external
+	// or file-backed setups.
+	skipManagedDoltCheck := os.Getenv("GC_DOLT") == "skip" || !scopeUsesManagedBdStoreContract(cityPath, cityPath)
+	d.Register(doctor.NewDoltNomsSizeCheck(cityPath, skipManagedDoltCheck))
+	d.Register(doctor.NewDoltConfigCheck(cityPath, skipManagedDoltCheck))
+	d.Register(doctor.NewDoltVersionCheck())
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
 

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -77,6 +77,13 @@ func workspaceNeedsCityDoltCheck(cityPath string, cfg *config.City) bool {
 	return false
 }
 
+func managedDoltOpsCheckSkip(cityPath string, cfg *config.City, cfgErr error) bool {
+	if os.Getenv("GC_DOLT") == "skip" {
+		return true
+	}
+	return !doctor.ManagedLocalDoltChecksApplicableForConfig(cityPath, cfg, cfgErr)
+}
+
 type doltTopologyCheck struct {
 	cityPath string
 	cfg      *config.City
@@ -191,13 +198,14 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	skipCityDoltCheck := os.Getenv("GC_DOLT") == "skip" || (!scopeUsesManagedBdStoreContract(cityPath, cityPath) && !workspaceNeedsCityDoltCheck(cityPath, cfg))
 	d.Register(newDoctorDoltServerCheck(cityPath, skipCityDoltCheck))
 	// Managed Dolt ops checks (PR 3). Size + config drift are only
-	// meaningful when the city uses the managed bd/Dolt backend; the
-	// version check always runs so operators see drift even on external
-	// or file-backed setups.
-	skipManagedDoltCheck := os.Getenv("GC_DOLT") == "skip" || !scopeUsesManagedBdStoreContract(cityPath, cityPath)
-	d.Register(doctor.NewDoltNomsSizeCheck(cityPath, skipManagedDoltCheck))
-	d.Register(doctor.NewDoltConfigCheck(cityPath, skipManagedDoltCheck))
-	d.Register(doctor.NewDoltVersionCheck())
+	// meaningful when the workspace uses the managed bd/Dolt backend; rigs
+	// can inherit the city-managed server even when the city itself is not a
+	// managed bd scope. The version check follows the same gate so file-backed
+	// and external Dolt workspaces do not get irrelevant local-binary warnings.
+	skipManagedDoltCheck := managedDoltOpsCheckSkip(cityPath, cfg, cfgErr)
+	d.Register(doctor.NewDoltNomsSizeCheckForConfig(cityPath, skipManagedDoltCheck, cfg, cfgErr))
+	d.Register(doctor.NewDoltConfigCheckForConfig(cityPath, skipManagedDoltCheck, cfg, cfgErr))
+	d.Register(doctor.NewScopedDoltVersionCheckForConfig(cityPath, skipManagedDoltCheck, cfg, cfgErr))
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
 

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -50,6 +50,72 @@ prefix = "fe"
 	}
 }
 
+func TestManagedDoltOpsCheckSkipKeepsCityManagedWorkspaceEnabled(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Rigs: nil}
+	if managedDoltOpsCheckSkip(cityDir, cfg, nil) {
+		t.Fatal("managedDoltOpsCheckSkip() = true, want false for city-managed workspace without rigs")
+	}
+}
+
+func TestManagedDoltOpsCheckSkipOnConfigError(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !managedDoltOpsCheckSkip(cityDir, nil, os.ErrInvalid) {
+		t.Fatal("managedDoltOpsCheckSkip() = false, want true when city config failed to load")
+	}
+}
+
+func TestManagedDoltOpsCheckUsesDoctorApplicabilityOnConfigError(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if managedDoltOpsCheckSkip(cityDir, nil, os.ErrInvalid) {
+		t.Fatal("managedDoltOpsCheckSkip() = true, want false when broken city still has managed bd metadata")
+	}
+	if !doctor.ManagedLocalDoltChecksApplicableForConfig(cityDir, nil, os.ErrInvalid) {
+		t.Fatal("doctor applicability = false, want true for same broken managed city")
+	}
+}
+
+func TestManagedDoltOpsCheckDiscoversRigMetadataOnConfigError(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if managedDoltOpsCheckSkip(cityDir, nil, os.ErrInvalid) {
+		t.Fatal("managedDoltOpsCheckSkip() = true, want false when broken city still has managed rig metadata")
+	}
+}
+
 func TestDoDoctorRunsCityDoltCheckForInheritedBdRigUnderFileBackedCity(t *testing.T) {
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "frontend")

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -127,6 +127,8 @@ listener:
   port: %s
   host: %s
   max_connections: 1000
+  back_log: 50
+  max_connections_timeout_millis: 5000
   read_timeout_millis: 300000
   write_timeout_millis: 300000
 

--- a/cmd/gc/cmd_dolt_config_test.go
+++ b/cmd/gc/cmd_dolt_config_test.go
@@ -34,6 +34,8 @@ func TestDoltConfigWriteManagedCmd(t *testing.T) {
 		"host: 127.0.0.1",
 		`data_dir: "/tmp/city/.beads/dolt"`,
 		"archive_level: 1",
+		"back_log: 50",
+		"max_connections_timeout_millis: 5000",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("config missing %q:\n%s", want, text)

--- a/cmd/gc/cmd_dolt_config_test.go
+++ b/cmd/gc/cmd_dolt_config_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDoltConfigWriteManagedCmd(t *testing.T) {
@@ -41,6 +44,70 @@ func TestDoltConfigWriteManagedCmd(t *testing.T) {
 			t.Fatalf("config missing %q:\n%s", want, text)
 		}
 	}
+}
+
+func TestDoltConfigWriterIncludesDoctorExpectedCoreValues(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "packs", "dolt", "dolt-config.yaml")
+	if err := writeManagedDoltConfigFile(configPath, "127.0.0.1", "3311", "/tmp/city/.beads/dolt", "warning"); err != nil {
+		t.Fatalf("writeManagedDoltConfigFile: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", configPath, err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Unmarshal config: %v", err)
+	}
+
+	for _, exp := range doctor.DoltConfigExpectedValues() {
+		got, ok := lookupTestYAMLPath(doc, exp.Path)
+		if !ok {
+			t.Fatalf("managed config missing doctor-expected core path %q:\n%s", exp.Path, data)
+		}
+		if !testYAMLValueEqual(got, exp.Value) {
+			t.Fatalf("managed config %s = %v (%T), want %v (%T)", exp.Path, got, got, exp.Value, exp.Value)
+		}
+	}
+}
+
+func lookupTestYAMLPath(doc map[string]any, dotted string) (any, bool) {
+	parts := strings.Split(dotted, ".")
+	var cur any = doc
+	for _, part := range parts {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+func testYAMLValueEqual(got, want any) bool {
+	switch want := want.(type) {
+	case int:
+		switch got := got.(type) {
+		case int:
+			return got == want
+		case int64:
+			return got == int64(want)
+		case uint64:
+			return got == uint64(want)
+		case float64:
+			return got == float64(want)
+		}
+	case bool:
+		gotBool, ok := got.(bool)
+		return ok && gotBool == want
+	default:
+		return got == want
+	}
+	return false
 }
 
 func TestDoltConfigNormalizeScopeCmd(t *testing.T) {

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -527,7 +527,11 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 
 // doOrderRunExec runs an exec order directly via shell.
 func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, stderr io.Writer) int {
-	timeout := a.TimeoutOrDefault()
+	var maxTimeout time.Duration
+	if cfg != nil {
+		maxTimeout = cfg.Orders.MaxTimeoutDuration()
+	}
+	timeout := effectiveTimeout(a, maxTimeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -883,6 +883,9 @@ func TestOrderRunExecProjectsExternalDoltTarget(t *testing.T) {
 name = "test-city"
 prefix = "ct"
 `)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
 		"issue_prefix: ct",
 		"gc.endpoint_origin: city_canonical",
@@ -941,6 +944,9 @@ func TestOrderRunExecPreservesAuthOnlyOverridesForManagedLocal(t *testing.T) {
 name = "test-city"
 prefix = "ct"
 `)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
 		"issue_prefix: ct",
 		"gc.endpoint_origin: managed_city",
@@ -1014,6 +1020,164 @@ prefix = "ct"
 	}
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("exec dolt env:\ngot:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestOrderRunExecMarksExternalDoltTargetForManagedLocalOnlyOrders(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_PACK_STATE_DIR", filepath.Join(t.TempDir(), "poison-pack-state"))
+	t.Setenv("GC_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "poison-dolt-data"))
+	t.Setenv("GC_DOLT_CONFIG_FILE", filepath.Join(t.TempDir(), "poison-dolt-config.yaml"))
+	t.Setenv("GC_DOLT_STATE_FILE", filepath.Join(t.TempDir(), "poison-state.json"))
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+`)
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: city_canonical",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"dolt.host: external.example.internal",
+		"dolt.port: 4406",
+		"",
+	}, "\n"))
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	outPath := filepath.Join(cityDir, "exec-managed-marker.txt")
+	a := orders.Order{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     fmt.Sprintf(`printf 'managed=<%%s>\nhost=<%%s>\nport=<%%s>\npack_state=<%%s>\ndata=<%%s>\nconfig=<%%s>\nstate=<%%s>\n' "$GC_DOLT_MANAGED_LOCAL" "$GC_DOLT_HOST" "$GC_DOLT_PORT" "$GC_PACK_STATE_DIR" "$GC_DOLT_DATA_DIR" "$GC_DOLT_CONFIG_FILE" "$GC_DOLT_STATE_FILE" > %q`, outPath),
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunExec(a, cityDir, cfg, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunExec = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	got := strings.TrimSpace(readFileString(t, outPath))
+	externalRoot := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt", "external-target")
+	want := strings.Join([]string{
+		"managed=<0>",
+		"host=<external.example.internal>",
+		"port=<4406>",
+		"pack_state=<>",
+		"data=<" + externalRoot + ">",
+		"config=<" + filepath.Join(externalRoot, "dolt-config.yaml") + ">",
+		"state=<" + filepath.Join(externalRoot, "dolt-state.json") + ">",
+	}, "\n")
+	if got != want {
+		t.Fatalf("order exec env:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestOrderRunExecPropagatesManagedDoltLayout(t *testing.T) {
+	cityDir := t.TempDir()
+	dataDir := filepath.Join(t.TempDir(), "managed-dolt")
+	configFile := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+`)
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"",
+	}, "\n"))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("Close listener: %v", err)
+		}
+	}()
+	port := fmt.Sprint(listener.Addr().(*net.TCPAddr).Port)
+	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(stateDir, "dolt-state.json"), fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":%s,"data_dir":%q}`,
+		os.Getpid(),
+		port,
+		dataDir,
+	))
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	t.Setenv("GC_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "poison-dolt-data"))
+	t.Setenv("GC_DOLT_CONFIG_FILE", filepath.Join(t.TempDir(), "poison-dolt-config.yaml"))
+	t.Setenv("GC_PACK_STATE_DIR", filepath.Join(t.TempDir(), "poison-pack-state"))
+	t.Setenv("GC_DOLT_STATE_FILE", filepath.Join(t.TempDir(), "poison-state.json"))
+	outPath := filepath.Join(cityDir, "exec-managed-layout.txt")
+	a := orders.Order{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     fmt.Sprintf(`printf 'managed=<%%s>\nport=<%%s>\ndata=<%%s>\nconfig=<%%s>\n' "$GC_DOLT_MANAGED_LOCAL" "$GC_DOLT_PORT" "$GC_DOLT_DATA_DIR" "$GC_DOLT_CONFIG_FILE" > %q`, outPath),
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunExec(a, cityDir, cfg, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunExec = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	got := strings.TrimSpace(readFileString(t, outPath))
+	want := strings.Join([]string{
+		"managed=<1>",
+		"port=<" + port + ">",
+		"data=<" + dataDir + ">",
+		"config=<" + configFile + ">",
+	}, "\n")
+	if got != want {
+		t.Fatalf("order exec env:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestOrderRunExecHonorsOrdersMaxTimeout(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Orders: config.OrdersConfig{MaxTimeout: "50ms"},
+	}
+	a := orders.Order{
+		Name:    "slow-exec",
+		Trigger: "manual",
+		Exec:    "while :; do :; done",
+		Timeout: "5s",
+	}
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := doOrderRunExec(a, cityDir, cfg, &stdout, &stderr)
+	elapsed := time.Since(start)
+	if code == 0 {
+		t.Fatalf("doOrderRunExec = 0, want timeout failure; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if elapsed > time.Second {
+		t.Fatalf("doOrderRunExec elapsed = %s, want capped below 1s", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "exec failed") {
+		t.Fatalf("stderr = %q, want exec failure", stderr.String())
 	}
 }
 

--- a/cmd/gc/dolt_gc_nudge_script_test.go
+++ b/cmd/gc/dolt_gc_nudge_script_test.go
@@ -1,0 +1,1090 @@
+package main
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDoltGCNudgeSourcesRuntimeBeforePortValidation(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	writeDoltGCNudgeRuntimeState(t, cityPath)
+	binDir := doltGCNudgeToolPath(t, false, nil)
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_GC_DRY_RUN=1",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge without GC_DOLT_PORT failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "dry-run") {
+		t.Fatalf("gc-nudge output = %q, want dry-run; runtime should default GC_DOLT_PORT", out)
+	}
+}
+
+func TestDoltGCNudgeAcceptsSymlinkEquivalentRuntimeDataDir(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	writeDoltGCNudgeRuntimeState(t, cityPath)
+	linkPath := filepath.Join(t.TempDir(), "dolt-link")
+	if err := os.Symlink(filepath.Join(cityPath, ".beads", "dolt"), linkPath); err != nil {
+		t.Fatal(err)
+	}
+	binDir := doltGCNudgeToolPath(t, false, nil)
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_DATA_DIR="+linkPath,
+		"GC_DOLT_GC_DRY_RUN=1",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with symlink data dir failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "dry-run") {
+		t.Fatalf("gc-nudge output = %q, want dry-run; symlink data_dir should match runtime state", out)
+	}
+}
+
+func TestDoltGCNudgeSkipsWhenManagedRuntimeInactiveWithoutExplicitPort(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	shouldNotRun := filepath.Join(t.TempDir(), "dolt-ran")
+	binDir := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge without managed runtime failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "managed local Dolt runtime is not active") {
+		t.Fatalf("gc-nudge output = %q, want managed-runtime skip", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("dolt ran despite inactive managed runtime")
+	}
+}
+
+func TestDoltGCNudgeSkipsWhenOrderEnvMarksExternalTarget(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	shouldNotRun := filepath.Join(t.TempDir(), "dolt-ran")
+	binDir := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_MANAGED_LOCAL=0",
+		"GC_DOLT_HOST=external.example.internal",
+		"GC_DOLT_PORT=4406",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with external order marker failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "not applicable") {
+		t.Fatalf("gc-nudge output = %q, want not-applicable skip", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("dolt ran despite external-order marker")
+	}
+}
+
+func TestDoltGCNudgeSkipsUnmarkedExternalPort(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	shouldNotRun := filepath.Join(t.TempDir(), "dolt-ran")
+	binDir := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_MANAGED_LOCAL=",
+		"GC_DOLT_HOST=external.example.internal",
+		"GC_DOLT_PORT=4406",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with unmarked external port failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "not a local managed Dolt host") {
+		t.Fatalf("gc-nudge output = %q, want external-host skip", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("dolt ran despite unconfirmed external port")
+	}
+}
+
+func TestDoltGCNudgeSkipsUnmarkedExternalHostEvenWhenPortMatchesManagedRuntime(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	port := writeDoltGCNudgeRuntimeState(t, cityPath)
+	shouldNotRun := filepath.Join(t.TempDir(), "dolt-ran")
+	binDir := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_MANAGED_LOCAL=",
+		"GC_DOLT_HOST=external.example.internal",
+		"GC_DOLT_PORT="+port,
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with matching external port failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "not a local managed Dolt host") {
+		t.Fatalf("gc-nudge output = %q, want external-host skip", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("dolt ran despite unconfirmed external port")
+	}
+}
+
+func TestDoltGCNudgeSkipsUnmarkedLocalhostPortWithoutManagedRuntime(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	shouldNotRun := filepath.Join(t.TempDir(), "dolt-ran")
+	binDir := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_MANAGED_LOCAL=",
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with unmarked local port failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "does not match managed runtime") {
+		t.Fatalf("gc-nudge output = %q, want managed-runtime mismatch skip", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("dolt ran despite unmarked local port without managed runtime")
+	}
+}
+
+func TestDoltGCNudgeRejectsInvalidThreshold(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	binDir := doltGCNudgeToolPath(t, true, nil)
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_DRY_RUN=1",
+		"GC_DOLT_GC_THRESHOLD_BYTES=2GB",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc-nudge with invalid threshold succeeded; output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "invalid GC_DOLT_GC_THRESHOLD_BYTES") {
+		t.Fatalf("gc-nudge output = %q, want invalid-threshold message", out)
+	}
+}
+
+func TestDoltGCNudgePassesPasswordThroughEnvironment(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	captureDir := t.TempDir()
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$DOLT_ARGV_CAPTURE\"\nprintf '%s\\n' \"${DOLT_CLI_PASSWORD:-}\" > \"$DOLT_PASSWORD_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_PASSWORD=supersecret",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+filepath.Join(captureDir, "argv"),
+		"DOLT_PASSWORD_CAPTURE="+filepath.Join(captureDir, "password"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with fake dolt failed: %v\n%s", err, out)
+	}
+
+	argv := readFileString(t, filepath.Join(captureDir, "argv"))
+	if strings.Contains(argv, "supersecret") || strings.Contains(argv, "--password") {
+		t.Fatalf("dolt argv leaked password or --password flag: %q", argv)
+	}
+	password := strings.TrimSpace(readFileString(t, filepath.Join(captureDir, "password")))
+	if password != "supersecret" {
+		t.Fatalf("DOLT_CLI_PASSWORD = %q, want supersecret", password)
+	}
+}
+
+func TestDoltGCNudgeFailsIfAnyDatabaseGCFails(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	rigMeta := filepath.Join(cityPath, "rigs", "demo", ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(rigMeta), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rigMeta, []byte(`{"dolt_database":"rigdb"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "rigdb", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "rigdb", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\ncount_file=${DOLT_CALL_COUNT_FILE:?}\ncount=0\nif [ -f \"$count_file\" ]; then\n  count=$(sed -n '1p' \"$count_file\")\nfi\ncount=$((count + 1))\nprintf '%s\\n' \"$count\" > \"$count_file\"\nif [ \"$count\" -eq 1 ]; then\n  exit 7\nfi\nexit 0\n",
+		"gc":   "#!/bin/sh\nprintf '{\"rigs\":[{\"path\":\"%s/rigs/demo\"}]}\n' \"$GC_CITY_PATH\"\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_CALL_COUNT_FILE="+filepath.Join(captureDir, "count"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc-nudge succeeded after one database GC failed:\n%s", out)
+	}
+
+	count := strings.TrimSpace(readFileString(t, filepath.Join(captureDir, "count")))
+	if count != "2" {
+		t.Fatalf("dolt call count = %q, want 2", count)
+	}
+}
+
+func TestDoltGCNudgeDefaultCallTimeoutMatchesOrderBudget(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nexit 124\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc-nudge succeeded despite timed-out fake dolt:\n%s", out)
+	}
+	if !strings.Contains(string(out), "timed out after=1800s") {
+		t.Fatalf("gc-nudge output = %q, want default timeout marker", out)
+	}
+}
+
+func TestDoltGCNudgeBoundsGCCall(t *testing.T) {
+	if _, err := exec.LookPath("timeout"); err != nil {
+		if _, gtimeoutErr := exec.LookPath("gtimeout"); gtimeoutErr != nil {
+			t.Skip("timeout/gtimeout not available")
+		}
+	}
+
+	cityPath := writeDoltGCNudgeCity(t)
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("LookPath(sleep): %v", err)
+	}
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\n" + sleepPath + " 5\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"GC_DOLT_GC_CALL_TIMEOUT_SECS=1",
+	)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc-nudge succeeded despite hung dolt GC call:\n%s", out)
+	}
+	if elapsed := time.Since(start); elapsed > 4*time.Second {
+		t.Fatalf("gc-nudge elapsed = %s, want bounded timeout; output:\n%s", elapsed, out)
+	}
+	if !strings.Contains(string(out), "timed out after=1s") {
+		t.Fatalf("gc-nudge output = %q, want timeout marker", out)
+	}
+}
+
+func TestDoltGCNudgeFailsClosedWithoutBoundedRunner(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	binDir := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\nexit 0\n",
+	})
+	for _, name := range []string{"gtimeout", "timeout", "python3"} {
+		if err := os.Remove(filepath.Join(binDir, name)); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove %s: %v", name, err)
+		}
+	}
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc-nudge succeeded without bounded runner:\n%s", out)
+	}
+	if !strings.Contains(string(out), "cannot run bounded command") {
+		t.Fatalf("gc-nudge output = %q, want bounded-runner failure", out)
+	}
+}
+
+func TestDoltGCNudgeFallbackLockHonorsFlockHolder(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("LookPath(sleep): %v", err)
+	}
+
+	captureDir := t.TempDir()
+	startedFile := filepath.Join(captureDir, "started")
+	withFlock := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_STARTED_FILE\"\n" + sleepPath + " 2\nexit 0\n",
+	})
+
+	cmd1 := doltGCNudgeCommand(t, cityPath, withFlock,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_STARTED_FILE="+startedFile,
+	)
+	var firstStdout, firstStderr bytes.Buffer
+	cmd1.Stdout = &firstStdout
+	cmd1.Stderr = &firstStderr
+	if err := cmd1.Start(); err != nil {
+		t.Fatalf("start first gc-nudge: %v", err)
+	}
+	waitForFile(t, startedFile)
+	defer func() {
+		if err := cmd1.Wait(); err != nil {
+			t.Fatalf("wait first gc-nudge: %v\nstdout=%s\nstderr=%s", err, firstStdout.String(), firstStderr.String())
+		}
+	}()
+
+	shouldNotRun := filepath.Join(captureDir, "second-dolt")
+	withoutFlock := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+	cmd2 := doltGCNudgeCommand(t, cityPath, withoutFlock,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+	)
+	out, err := cmd2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("second gc-nudge failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "another nudge already running") {
+		t.Fatalf("second gc-nudge output = %q, want lock-held message", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("second dolt invocation ran despite active flock lock")
+	}
+}
+
+func TestDoltGCNudgeLockNormalizesLocalHostAliases(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("LookPath(sleep): %v", err)
+	}
+
+	captureDir := t.TempDir()
+	tmpDir := t.TempDir()
+	startedFile := filepath.Join(captureDir, "started")
+	withHostAlias := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_STARTED_FILE\"\n" + sleepPath + " 2\nexit 0\n",
+	})
+
+	cmd1 := doltGCNudgeCommand(t, cityPath, withHostAlias,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_STARTED_FILE="+startedFile,
+		"TMPDIR="+tmpDir,
+	)
+	var firstStdout, firstStderr bytes.Buffer
+	cmd1.Stdout = &firstStdout
+	cmd1.Stderr = &firstStderr
+	if err := cmd1.Start(); err != nil {
+		t.Fatalf("start first gc-nudge: %v", err)
+	}
+	waitForFile(t, startedFile)
+	defer func() {
+		if err := cmd1.Wait(); err != nil {
+			t.Fatalf("wait first gc-nudge: %v\nstdout=%s\nstderr=%s", err, firstStdout.String(), firstStderr.String())
+		}
+	}()
+
+	shouldNotRun := filepath.Join(captureDir, "second-dolt")
+	withoutFlock := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+	cmd2 := doltGCNudgeCommand(t, cityPath, withoutFlock,
+		"GC_DOLT_HOST=localhost",
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+		"TMPDIR="+tmpDir,
+	)
+	out, err := cmd2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("second gc-nudge failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "another nudge already running") {
+		t.Fatalf("second gc-nudge output = %q, want lock-held message", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("second dolt invocation ran despite alias-normalized lock")
+	}
+}
+
+func TestDoltGCNudgeLockIgnoresDifferentTmpDirs(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("LookPath(sleep): %v", err)
+	}
+	lockDir := filepath.Join("/tmp", "gc-dolt-gc", "127.0.0.1-3307.lock.d")
+	_ = os.RemoveAll(lockDir)
+	t.Cleanup(func() { _ = os.RemoveAll(lockDir) })
+
+	captureDir := t.TempDir()
+	startedFile := filepath.Join(captureDir, "started")
+	withTmpOne := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_STARTED_FILE\"\n" + sleepPath + " 2\nexit 0\n",
+	})
+
+	cmd1 := doltGCNudgeCommand(t, cityPath, withTmpOne,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_STARTED_FILE="+startedFile,
+		"TMPDIR="+t.TempDir(),
+	)
+	var firstStdout, firstStderr bytes.Buffer
+	cmd1.Stdout = &firstStdout
+	cmd1.Stderr = &firstStderr
+	if err := cmd1.Start(); err != nil {
+		t.Fatalf("start first gc-nudge: %v", err)
+	}
+	waitForFile(t, startedFile)
+	defer func() {
+		if err := cmd1.Wait(); err != nil {
+			t.Fatalf("wait first gc-nudge: %v\nstdout=%s\nstderr=%s", err, firstStdout.String(), firstStderr.String())
+		}
+	}()
+
+	shouldNotRun := filepath.Join(captureDir, "second-dolt")
+	withTmpTwo := doltGCNudgeToolPath(t, false, map[string]string{
+		"dolt": "#!/bin/sh\n: > \"$DOLT_SHOULD_NOT_RUN\"\nexit 0\n",
+	})
+	cmd2 := doltGCNudgeCommand(t, cityPath, withTmpTwo,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_SHOULD_NOT_RUN="+shouldNotRun,
+		"TMPDIR="+t.TempDir(),
+	)
+	out, err := cmd2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("second gc-nudge failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "another nudge already running") {
+		t.Fatalf("second gc-nudge output = %q, want lock-held message", out)
+	}
+	if _, err := os.Stat(shouldNotRun); !os.IsNotExist(err) {
+		t.Fatalf("second dolt invocation ran despite different TMPDIR")
+	}
+}
+
+func TestDoltGCNudgeRecoversStaleLockMarker(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		includeFlock bool
+	}{
+		{name: "with flock", includeFlock: true},
+		{name: "without flock", includeFlock: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := writeDoltGCNudgeCity(t)
+			captureDir := t.TempDir()
+			lockDir := filepath.Join("/tmp", "gc-dolt-gc", "127.0.0.1-3307.lock.d")
+			_ = os.RemoveAll(lockDir)
+			t.Cleanup(func() { _ = os.RemoveAll(lockDir) })
+			if err := os.MkdirAll(lockDir, 0o700); err != nil {
+				t.Fatalf("MkdirAll(lockDir): %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(lockDir, "pid"), []byte("999999\n"), 0o600); err != nil {
+				t.Fatalf("WriteFile(lock pid): %v", err)
+			}
+
+			ranFile := filepath.Join(captureDir, "dolt-ran")
+			binDir := doltGCNudgeToolPath(t, tc.includeFlock, map[string]string{
+				"dolt": "#!/bin/sh\n: > \"$DOLT_RAN_FILE\"\nexit 0\n",
+			})
+
+			cmd := doltGCNudgeCommand(t, cityPath, binDir,
+				"GC_DOLT_PORT=3307",
+				"GC_DOLT_GC_THRESHOLD_BYTES=0",
+				"DOLT_RAN_FILE="+ranFile,
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("gc-nudge with stale lock marker failed: %v\n%s", err, out)
+			}
+			if strings.Contains(string(out), "another nudge already running") {
+				t.Fatalf("gc-nudge treated stale lock as active:\n%s", out)
+			}
+			if _, err := os.Stat(ranFile); err != nil {
+				t.Fatalf("dolt did not run after stale lock recovery: %v\n%s", err, out)
+			}
+			if _, err := os.Stat(lockDir); !os.IsNotExist(err) {
+				t.Fatalf("stale lock dir still exists after run, err=%v", err)
+			}
+		})
+	}
+}
+
+func TestDoltGCNudgeSkipsExternalRigDatabaseWithoutLocalData(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	externalRigDir := t.TempDir()
+	externalMeta := filepath.Join(externalRigDir, ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(externalMeta), 0o755); err != nil {
+		t.Fatalf("MkdirAll(externalMeta): %v", err)
+	}
+	if err := os.WriteFile(externalMeta, []byte(`{"dolt_database":"extdb"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(externalMeta): %v", err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+		"gc":   "#!/bin/sh\nprintf '{\"rigs\":[{\"path\":\"%s\"}]}\n' \"$EXTERNAL_RIG_PATH\"\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+		"EXTERNAL_RIG_PATH="+externalRigDir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with external rig metadata failed: %v\n%s", err, out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	lines := strings.Split(argv, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("dolt argv lines = %d, want 1 for local managed db only:\n%s", len(lines), argv)
+	}
+	if !strings.Contains(lines[0], "--database testdb") {
+		t.Fatalf("dolt argv = %q, want local managed testdb", lines[0])
+	}
+	if strings.Contains(argv, "--database extdb") {
+		t.Fatalf("dolt argv should not target external rig db:\n%s", argv)
+	}
+}
+
+func TestDoltGCNudgeDefaultsMissingDatabaseMetadataToBeads(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "beads", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "beads", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with missing dolt_database failed: %v\n%s", err, out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	if !strings.Contains(argv, "--database beads") {
+		t.Fatalf("dolt argv = %q, want default beads database", argv)
+	}
+}
+
+func TestDoltGCNudgeSkipsInvalidDatabaseMetadata(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	rigMeta := filepath.Join(cityPath, "rigs", "bad", ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(rigMeta), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rigMeta, []byte(`{"dolt_database":"--help"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with invalid database metadata failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "invalid database name") {
+		t.Fatalf("gc-nudge output = %q, want invalid database message", out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	lines := strings.Split(argv, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("dolt argv lines = %d, want 1 valid database:\n%s", len(lines), argv)
+	}
+	if !strings.Contains(lines[0], "--database testdb") {
+		t.Fatalf("dolt argv = %q, want local managed testdb", lines[0])
+	}
+	if strings.Contains(argv, "--database --help") {
+		t.Fatalf("dolt argv should not target invalid database:\n%s", argv)
+	}
+}
+
+func TestDoltGCNudgeSkipsSystemDatabaseMetadata(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	rigMeta := filepath.Join(cityPath, "rigs", "bad", ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(rigMeta), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rigMeta, []byte(`{"dolt_database":"mysql"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "mysql", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with system database metadata failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "system database") {
+		t.Fatalf("gc-nudge output = %q, want system database message", out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	if strings.Contains(argv, "--database mysql") {
+		t.Fatalf("dolt argv should not target system database:\n%s", argv)
+	}
+	if !strings.Contains(argv, "--database testdb") {
+		t.Fatalf("dolt argv = %q, want valid testdb", argv)
+	}
+}
+
+func TestDoltGCNudgeAllowsHyphenatedDatabaseMetadata(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "frontend-db", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"dolt_database":"frontend-db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "frontend-db", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with hyphenated database metadata failed: %v\n%s", err, out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	if !strings.Contains(argv, "--database frontend-db") {
+		t.Fatalf("dolt argv = %q, want hyphenated database", argv)
+	}
+}
+
+func TestDoltGCNudgeHonorsDataDirOverride(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(t.TempDir(), "managed-dolt")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"dolt_database":"testdb"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dataDir, "testdb", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "testdb", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with GC_DOLT_DATA_DIR failed: %v\n%s", err, out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	if !strings.Contains(argv, "--database testdb") {
+		t.Fatalf("dolt argv = %q, want override-backed testdb", argv)
+	}
+}
+
+func TestDoltGCNudgeDiscoversOrphanDatabaseDirs(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "orphan-db", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "orphan-db", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge with orphan database dir failed: %v\n%s", err, out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	if !strings.Contains(argv, "--database orphan-db") {
+		t.Fatalf("dolt argv = %q, want orphan database", argv)
+	}
+}
+
+func TestDoltGCNudgeAggregateThresholdTriggersSubthresholdDatabases(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	rigMeta := filepath.Join(cityPath, "rigs", "demo", ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(rigMeta), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rigMeta, []byte(`{"dolt_database":"rigdb"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "rigdb", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "rigdb", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	testDBSize := doltGCNudgeDirBytes(t, filepath.Join(cityPath, ".beads", "dolt", "testdb", ".dolt"))
+	rigDBSize := doltGCNudgeDirBytes(t, filepath.Join(cityPath, ".beads", "dolt", "rigdb", ".dolt"))
+	threshold := testDBSize
+	if rigDBSize > threshold {
+		threshold = rigDBSize
+	}
+	threshold++
+	if testDBSize+rigDBSize < threshold {
+		t.Fatalf("test setup cannot create aggregate threshold: testdb=%d rigdb=%d threshold=%d", testDBSize, rigDBSize, threshold)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES="+strconv.FormatInt(threshold, 10),
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge aggregate threshold failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "aggregate_bytes=") {
+		t.Fatalf("gc-nudge output = %q, want aggregate trigger marker", out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	if !strings.Contains(argv, "--database testdb") || !strings.Contains(argv, "--database rigdb") {
+		t.Fatalf("dolt argv = %q, want both subthreshold databases under aggregate trigger", argv)
+	}
+}
+
+func TestDoltGCNudgeFallbackFindsLocalRigOutsideRigsDir(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	rigMeta := filepath.Join(cityPath, "frontend", ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(rigMeta), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rigMeta, []byte(`{"dolt_database":"frontenddb"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "frontenddb", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "frontenddb", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge fallback scan failed: %v\n%s", err, out)
+	}
+
+	argv := strings.TrimSpace(readFileString(t, argvCapture))
+	lines := strings.Split(argv, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("dolt argv lines = %d, want 2 databases from fallback scan:\n%s", len(lines), argv)
+	}
+	if !strings.Contains(argv, "--database testdb") {
+		t.Fatalf("dolt argv = %q, want city database", argv)
+	}
+	if !strings.Contains(argv, "--database frontenddb") {
+		t.Fatalf("dolt argv = %q, want rig database outside rigs/ dir", argv)
+	}
+}
+
+func TestDoltGCNudgeWarnsWhenRigListFailsBeforeFallback(t *testing.T) {
+	cityPath := writeDoltGCNudgeCity(t)
+	captureDir := t.TempDir()
+	argvCapture := filepath.Join(captureDir, "argv")
+	binDir := doltGCNudgeToolPath(t, true, map[string]string{
+		"dolt": "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOLT_ARGV_CAPTURE\"\nexit 0\n",
+		"gc":   "#!/bin/sh\nexit 7\n",
+	})
+
+	cmd := doltGCNudgeCommand(t, cityPath, binDir,
+		"GC_DOLT_PORT=3307",
+		"GC_DOLT_GC_THRESHOLD_BYTES=0",
+		"DOLT_ARGV_CAPTURE="+argvCapture,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-nudge fallback after rig list failure failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "gc rig list failed rc=7") {
+		t.Fatalf("gc-nudge output = %q, want rig-list failure warning", out)
+	}
+	if !strings.Contains(readFileString(t, argvCapture), "--database testdb") {
+		t.Fatalf("gc-nudge did not fall back to local metadata scan; output:\n%s", out)
+	}
+}
+
+func writeDoltGCNudgeCity(t *testing.T) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt", "testdb", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"dolt_database":"testdb"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt", "testdb", ".dolt", "chunk"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cityPath
+}
+
+func writeDoltGCNudgeRuntimeState(t *testing.T, cityPath string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"running":true,"pid":` + strconv.Itoa(os.Getpid()) + `,"port":` + port + `,"data_dir":"` + filepath.Join(cityPath, ".beads", "dolt") + `"}`
+	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func doltGCNudgeCommand(t *testing.T, cityPath, binDir string, extraEnv ...string) *exec.Cmd {
+	t.Helper()
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "examples", "dolt", "commands", "gc-nudge", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	packDir, err := filepath.Abs(filepath.Join("..", "..", "examples", "dolt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(scriptPath)
+	baseEnv := []string{
+		"PATH=" + binDir,
+		"GC_CITY_PATH=" + cityPath,
+		"GC_PACK_DIR=" + packDir,
+	}
+	if !doltGCNudgeEnvHasKey(extraEnv, "GC_DOLT_MANAGED_LOCAL") {
+		baseEnv = append(baseEnv, "GC_DOLT_MANAGED_LOCAL=1")
+	}
+	cmd.Env = append([]string{}, baseEnv...)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	return cmd
+}
+
+func doltGCNudgeEnvHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func doltGCNudgeToolPath(t *testing.T, includeFlock bool, custom map[string]string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range []string{"awk", "chmod", "date", "dirname", "du", "find", "grep", "head", "mkdir", "mktemp", "python3", "rm", "rmdir", "sed", "sleep", "tr"} {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			t.Fatalf("LookPath(%s): %v", name, err)
+		}
+		if err := os.Symlink(path, filepath.Join(binDir, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	for _, name := range []string{"gtimeout", "timeout"} {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		if err := os.Symlink(path, filepath.Join(binDir, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	if includeFlock {
+		path, err := exec.LookPath("flock")
+		if err != nil {
+			t.Fatalf("LookPath(flock): %v", err)
+		}
+		if err := os.Symlink(path, filepath.Join(binDir, "flock")); err != nil {
+			t.Fatalf("symlink flock: %v", err)
+		}
+	}
+	for name, body := range custom {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(body), 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	return binDir
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func doltGCNudgeDirBytes(t *testing.T, path string) int64 {
+	t.Helper()
+	out, err := exec.Command("du", "-sk", path).Output()
+	if err != nil {
+		t.Fatalf("du -sk %s: %v", path, err)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		t.Fatalf("du -sk %s produced empty output", path)
+	}
+	kb, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		t.Fatalf("parse du output %q: %v", fields[0], err)
+	}
+	return kb * 1024
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -158,6 +158,156 @@ func TestDoltSyncRejectsManagedProbeDatabaseFilter(t *testing.T) {
 	}
 }
 
+func TestBuiltinDoltDoctorAllowsOlderVersionWhenProbeSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	binDir := t.TempDir()
+	for _, tool := range []struct {
+		name string
+		body string
+	}{
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.75.2\\n'\n"},
+		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
+		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
+	} {
+		if err := os.WriteFile(filepath.Join(binDir, tool.name), []byte(tool.body), 0o755); err != nil {
+			t.Fatalf("WriteFile(%s): %v", tool.name, err)
+		}
+	}
+
+	script := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "doctor", "check-dolt", "run.sh")
+	cmd := exec.Command(script)
+	cmd.Env = append(sanitizedBaseEnv(), "PATH="+binDir+":"+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-dolt unexpectedly rejected old Dolt probe: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "dolt available (dolt version 1.75.2)") {
+		t.Fatalf("check-dolt output = %s, want successful version probe", out)
+	}
+}
+
+func TestBuiltinDoltDoctorBoundsVersionProbe(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	binDir := t.TempDir()
+	capturePath := filepath.Join(t.TempDir(), "timeout-argv")
+	for _, tool := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "timeout",
+			body: "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$TIMEOUT_CAPTURE\"\nif [ \"$1\" = \"--kill-after=2\" ]; then\n  shift\nfi\nshift\nexec \"$@\"\n",
+		},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.1\\n'\n"},
+		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
+		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
+	} {
+		if err := os.WriteFile(filepath.Join(binDir, tool.name), []byte(tool.body), 0o755); err != nil {
+			t.Fatalf("WriteFile(%s): %v", tool.name, err)
+		}
+	}
+
+	script := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "doctor", "check-dolt", "run.sh")
+	cmd := exec.Command(script)
+	cmd.Env = append(
+		sanitizedBaseEnv(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"TIMEOUT_CAPTURE="+capturePath,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-dolt with fake timeout failed: %v\n%s", err, out)
+	}
+
+	capture, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("ReadFile(timeout capture): %v", err)
+	}
+	if !strings.Contains(string(capture), "--kill-after=2 10 dolt version") {
+		t.Fatalf("timeout argv = %q, want bounded dolt version probe", capture)
+	}
+}
+
+func TestBuiltinDoltDoctorReportsTimedOutVersionProbe(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	binDir := t.TempDir()
+	for _, tool := range []struct {
+		name string
+		body string
+	}{
+		{name: "timeout", body: "#!/bin/sh\nexit 124\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.1\\n'\n"},
+		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
+		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
+	} {
+		if err := os.WriteFile(filepath.Join(binDir, tool.name), []byte(tool.body), 0o755); err != nil {
+			t.Fatalf("WriteFile(%s): %v", tool.name, err)
+		}
+	}
+
+	script := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "doctor", "check-dolt", "run.sh")
+	cmd := exec.Command(script)
+	cmd.Env = append(sanitizedBaseEnv(), "PATH="+binDir+":"+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("check-dolt unexpectedly accepted timed out version probe:\n%s", out)
+	}
+	if !strings.Contains(string(out), "dolt version timed out after 10s") {
+		t.Fatalf("check-dolt output = %s, want timeout warning", out)
+	}
+}
+
+func TestBuiltinDoltDoctorFailsClosedWithoutBoundedRunner(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	binDir := t.TempDir()
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatalf("LookPath(bash): %v", err)
+	}
+	if err := os.Symlink(bashPath, filepath.Join(binDir, "bash")); err != nil {
+		t.Fatalf("symlink bash: %v", err)
+	}
+	for _, tool := range []struct {
+		name string
+		body string
+	}{
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.1\\n'\n"},
+		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
+		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
+	} {
+		if err := os.WriteFile(filepath.Join(binDir, tool.name), []byte(tool.body), 0o755); err != nil {
+			t.Fatalf("WriteFile(%s): %v", tool.name, err)
+		}
+	}
+
+	script := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "doctor", "check-dolt", "run.sh")
+	cmd := exec.Command(script)
+	cmd.Env = append(sanitizedBaseEnv(), "PATH="+binDir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("check-dolt unexpectedly succeeded without bounded runner:\n%s", out)
+	}
+	if !strings.Contains(string(out), "dolt version timed out after 10s") {
+		t.Fatalf("check-dolt output = %s, want timeout warning", out)
+	}
+}
+
 func TestMaterializeBuiltinPacks_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doltversion"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
@@ -467,8 +468,8 @@ var initRunVersion = func(binary string) (string, error) {
 
 // Minimum versions for beads-provider binaries.
 const (
-	doltMinVersion = "1.86.1" // sql-server features used by gc-beads-bd
-	bdMinVersion   = "1.0.0"  // BdStore shell-out interface
+	doltMinVersion = doltversion.ManagedMin // sql-server features used by gc-beads-bd
+	bdMinVersion   = "1.0.0"                // BdStore shell-out interface
 )
 
 // checkHardDependencies verifies that all required binaries are available
@@ -482,6 +483,7 @@ func checkHardDependencies(cityPath string) []missingDep {
 		installHint string
 		minVersion  string      // empty = no version check
 		condition   func() bool // if non-nil, only checked when true
+		available   func() bool // if non-nil, custom availability probe
 	}
 
 	needsBd := initNeedsBdTooling(cityPath)
@@ -517,6 +519,14 @@ func checkHardDependencies(cityPath string) []missingDep {
 			condition:   func() bool { return needsBd },
 		},
 		{
+			name:        "timeout/gtimeout/python3",
+			installHint: "install GNU coreutils timeout/gtimeout or python3",
+			condition:   func() bool { return needsBd },
+			available: func() bool {
+				return initAnyToolAvailable("timeout", "gtimeout", "python3")
+			},
+		},
+		{
 			name:        "pgrep",
 			installHint: "brew install proctools (macOS) or apt install procps (Linux)",
 		},
@@ -529,6 +539,15 @@ func checkHardDependencies(cityPath string) []missingDep {
 	var missing []missingDep
 	for _, d := range deps {
 		if d.condition != nil && !d.condition() {
+			continue
+		}
+		if d.available != nil {
+			if !d.available() {
+				missing = append(missing, missingDep{
+					name:        d.name,
+					installHint: d.installHint,
+				})
+			}
 			continue
 		}
 		if _, err := initLookPath(d.name); err != nil {
@@ -550,6 +569,15 @@ func checkHardDependencies(cityPath string) []missingDep {
 		}
 	}
 	return missing
+}
+
+func initAnyToolAvailable(names ...string) bool {
+	for _, name := range names {
+		if _, err := initLookPath(name); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func initNeedsBdTooling(cityPath string) bool {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -602,6 +602,74 @@ func TestCheckHardDependenciesTreatsExecGcBeadsBdAsBdContract(t *testing.T) {
 	}
 }
 
+func TestCheckHardDependenciesRequiresBoundedRunnerForBdContract(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		switch name {
+		case "timeout", "gtimeout", "python3":
+			return "", os.ErrNotExist
+		default:
+			return "/usr/bin/" + name, nil
+		}
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version " + bdMinVersion, nil
+		case "flock", "tmux", "jq", "git", "pgrep", "lsof":
+			return binary + " version", nil
+		default:
+			return binary + " version " + doltMinVersion, nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+
+	missing := checkHardDependencies(t.TempDir())
+	if len(missing) != 1 {
+		t.Fatalf("missing deps = %#v, want only bounded runner", missing)
+	}
+	if missing[0].name != "timeout/gtimeout/python3" {
+		t.Fatalf("missing dep = %#v, want timeout/gtimeout/python3", missing[0])
+	}
+}
+
+func TestCheckHardDependenciesAcceptsPythonFallbackForBdContract(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		switch name {
+		case "timeout", "gtimeout":
+			return "", os.ErrNotExist
+		default:
+			return "/usr/bin/" + name, nil
+		}
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version " + bdMinVersion, nil
+		case "flock", "tmux", "jq", "git", "pgrep", "lsof":
+			return binary + " version", nil
+		default:
+			return binary + " version " + doltMinVersion, nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+
+	if missing := checkHardDependencies(t.TempDir()); len(missing) != 0 {
+		t.Fatalf("missing deps = %#v, want python3 fallback to satisfy bounded runner", missing)
+	}
+}
+
 func TestCheckHardDependenciesRequiresBdToolsForBdRigUnderFileCity(t *testing.T) {
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "frontend")

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -38,8 +38,19 @@ type ExecRunner func(ctx context.Context, command, dir string, env []string) ([]
 func shellExecRunner(ctx context.Context, command, dir string, env []string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = dir
-	cmd.Env = append(cmd.Environ(), env...)
+	cmd.Env = mergeOrderExecEnv(cmd.Environ(), env)
 	return cmd.CombinedOutput()
+}
+
+func mergeOrderExecEnv(environ, env []string) []string {
+	out := mergeRuntimeEnv(environ, nil)
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			out = removeEnvKey(out, key)
+		}
+	}
+	return append(out, env...)
 }
 
 func logDispatchError(stderr io.Writer, format string, args ...any) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -535,6 +536,140 @@ func TestOrderDispatchExecPackDir(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchExecManagedDoltPreservesOrderPackStateDir(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	dataDir := filepath.Join(cityDir, ".beads", "dolt")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+`)
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"",
+	}, "\n"))
+	writeFile(t, filepath.Join(cityDir, ".beads", "metadata.json"), `{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"ct"}`)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("Close listener: %v", err)
+		}
+	}()
+	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(stateDir, "dolt-state.json"), fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":%d,"data_dir":%q}`,
+		os.Getpid(),
+		listener.Addr().(*net.TCPAddr).Port,
+		dataDir,
+	))
+
+	envCh := make(chan []string, 1)
+	fakeExec := func(_ context.Context, _, _ string, env []string) ([]byte, error) {
+		envCh <- env
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:         "gate-sweep",
+		Trigger:      "cooldown",
+		Interval:     "1m",
+		Exec:         "$PACK_DIR/scripts/gate-sweep.sh",
+		Source:       filepath.Join(cityDir, "packs", "maintenance", "formulas", "orders", "gate-sweep", "order.toml"),
+		FormulaLayer: filepath.Join(cityDir, "packs", "maintenance", "formulas"),
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	got := orderDispatchTestEnv(t, envCh)
+	wantPackState := filepath.Join(cityDir, ".gc", "runtime", "packs", "maintenance")
+	if got["GC_PACK_STATE_DIR"] != wantPackState {
+		t.Fatalf("GC_PACK_STATE_DIR = %q, want order pack state %q; env=%v", got["GC_PACK_STATE_DIR"], wantPackState, got)
+	}
+	wantDoltState := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	if got["GC_DOLT_STATE_FILE"] != wantDoltState {
+		t.Fatalf("GC_DOLT_STATE_FILE = %q, want %q; env=%v", got["GC_DOLT_STATE_FILE"], wantDoltState, got)
+	}
+}
+
+func TestOrderDispatchExecManagedDoltUsesTrustedCityRuntimeDir(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	dataDir := filepath.Join(cityDir, ".beads", "dolt")
+	customRuntimeDir := filepath.Join(t.TempDir(), "runtime-root")
+	packStateDir := filepath.Join(customRuntimeDir, "packs", "dolt")
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_RUNTIME_DIR", customRuntimeDir)
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(packStateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+
+[beads]
+provider = "bd"
+`)
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"",
+	}, "\n"))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("Close listener: %v", err)
+		}
+	}()
+	writeFile(t, filepath.Join(packStateDir, "dolt-state.json"), fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":%d,"data_dir":%q}`,
+		os.Getpid(),
+		listener.Addr().(*net.TCPAddr).Port,
+		dataDir,
+	))
+
+	envCh := make(chan []string, 1)
+	fakeExec := func(_ context.Context, _, _ string, env []string) ([]byte, error) {
+		envCh <- env
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "gc dolt gc-nudge",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	got := orderDispatchTestEnv(t, envCh)
+	if got["GC_CITY_RUNTIME_DIR"] != customRuntimeDir {
+		t.Fatalf("GC_CITY_RUNTIME_DIR = %q, want %q; env=%v", got["GC_CITY_RUNTIME_DIR"], customRuntimeDir, got)
+	}
+	wantStateFile := filepath.Join(packStateDir, "dolt-state.json")
+	if got["GC_DOLT_STATE_FILE"] != wantStateFile {
+		t.Fatalf("GC_DOLT_STATE_FILE = %q, want %q; env=%v", got["GC_DOLT_STATE_FILE"], wantStateFile, got)
+	}
+}
+
 func TestOrderDispatchExecPackDirEmpty(t *testing.T) {
 	// When FormulaLayer is empty, PACK_DIR should not be in env.
 	store := beads.NewMemStore()
@@ -625,6 +760,288 @@ func TestOrderDispatchExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
 		if !slicesContain(gotEnv, entry) {
 			t.Fatalf("missing %s in env: %v", entry, gotEnv)
 		}
+	}
+}
+
+func TestOrderDispatchExecMarksExternalDoltTargetForManagedLocalOnlyOrders(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	t.Setenv("GC_PACK_STATE_DIR", filepath.Join(t.TempDir(), "poison-pack-state"))
+	t.Setenv("GC_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "poison-dolt-data"))
+	t.Setenv("GC_DOLT_CONFIG_FILE", filepath.Join(t.TempDir(), "poison-dolt-config.yaml"))
+	t.Setenv("GC_DOLT_STATE_FILE", filepath.Join(t.TempDir(), "poison-state.json"))
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: city_canonical",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"dolt.host: external.example.internal",
+		"dolt.port: 4406",
+		"",
+	}, "\n"))
+
+	envCh := make(chan []string, 1)
+	fakeExec := func(_ context.Context, _, _ string, env []string) ([]byte, error) {
+		envCh <- env
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "gc dolt gc-nudge",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	got := orderDispatchTestEnv(t, envCh)
+	externalRoot := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt", "external-target")
+	checks := map[string]string{
+		"GC_DOLT_MANAGED_LOCAL": "0",
+		"GC_DOLT_HOST":          "external.example.internal",
+		"GC_DOLT_PORT":          "4406",
+		"GC_DOLT_DATA_DIR":      externalRoot,
+		"GC_DOLT_CONFIG_FILE":   filepath.Join(externalRoot, "dolt-config.yaml"),
+		"GC_DOLT_STATE_FILE":    filepath.Join(externalRoot, "dolt-state.json"),
+	}
+	for key, want := range checks {
+		if got[key] != want {
+			t.Fatalf("%s = %q, want %q; env=%v", key, got[key], want, got)
+		}
+	}
+}
+
+func TestOrderDispatchExecPropagatesManagedDoltLayout(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	dataDir := filepath.Join(t.TempDir(), "managed-dolt")
+	configFile := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"",
+	}, "\n"))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("Close listener: %v", err)
+		}
+	}()
+	port := fmt.Sprint(listener.Addr().(*net.TCPAddr).Port)
+	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(stateDir, "dolt-state.json"), fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":%s,"data_dir":%q}`,
+		os.Getpid(),
+		port,
+		dataDir,
+	))
+	t.Setenv("GC_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "poison-dolt-data"))
+	t.Setenv("GC_DOLT_CONFIG_FILE", filepath.Join(t.TempDir(), "poison-dolt-config.yaml"))
+	t.Setenv("GC_PACK_STATE_DIR", filepath.Join(t.TempDir(), "poison-pack-state"))
+	t.Setenv("GC_DOLT_STATE_FILE", filepath.Join(t.TempDir(), "poison-state.json"))
+
+	envCh := make(chan []string, 1)
+	fakeExec := func(_ context.Context, _, _ string, env []string) ([]byte, error) {
+		envCh <- env
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "gc dolt gc-nudge",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	got := orderDispatchTestEnv(t, envCh)
+	checks := map[string]string{
+		"GC_DOLT_MANAGED_LOCAL": "1",
+		"GC_DOLT_PORT":          port,
+		"GC_DOLT_DATA_DIR":      dataDir,
+		"GC_DOLT_CONFIG_FILE":   configFile,
+	}
+	for key, want := range checks {
+		if got[key] != want {
+			t.Fatalf("%s = %q, want %q; env=%v", key, got[key], want, got)
+		}
+	}
+}
+
+func TestOrderDispatchExecPropagatesLegacyManagedDoltDataDir(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	dataDir := filepath.Join(cityDir, ".gc", "dolt-data")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"",
+	}, "\n"))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("Close listener: %v", err)
+		}
+	}()
+	port := fmt.Sprint(listener.Addr().(*net.TCPAddr).Port)
+	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(stateDir, "dolt-state.json"), fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":%s,"data_dir":%q}`,
+		os.Getpid(),
+		port,
+		dataDir,
+	))
+
+	envCh := make(chan []string, 1)
+	fakeExec := func(_ context.Context, _, _ string, env []string) ([]byte, error) {
+		envCh <- env
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "gc dolt gc-nudge",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	got := orderDispatchTestEnv(t, envCh)
+	checks := map[string]string{
+		"GC_DOLT_MANAGED_LOCAL": "1",
+		"GC_DOLT_PORT":          port,
+		"GC_DOLT_DATA_DIR":      dataDir,
+	}
+	for key, want := range checks {
+		if got[key] != want {
+			t.Fatalf("%s = %q, want %q; env=%v", key, got[key], want, got)
+		}
+	}
+}
+
+func TestOrderDispatchExecIgnoresPublishedRunningDataDirWithUnreachablePort(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	staleDataDir := filepath.Join(t.TempDir(), "stale-published-dolt")
+	defaultDataDir := filepath.Join(cityDir, ".beads", "dolt")
+	if err := os.MkdirAll(defaultDataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(staleDataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+		"dolt.auto-start: false",
+		"",
+	}, "\n"))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := fmt.Sprint(listener.Addr().(*net.TCPAddr).Port)
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Close listener: %v", err)
+	}
+	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(stateDir, "dolt-state.json"), fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":%s,"data_dir":%q}`,
+		os.Getpid(),
+		port,
+		staleDataDir,
+	))
+
+	envCh := make(chan []string, 1)
+	fakeExec := func(_ context.Context, _, _ string, env []string) ([]byte, error) {
+		envCh <- env
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:     "dolt-gc-nudge",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "gc dolt gc-nudge",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	got := orderDispatchTestEnv(t, envCh)
+	if got["GC_DOLT_DATA_DIR"] != defaultDataDir {
+		t.Fatalf("GC_DOLT_DATA_DIR = %q, want default %q; env=%v", got["GC_DOLT_DATA_DIR"], defaultDataDir, got)
+	}
+}
+
+func TestOrderExecManagedDoltFallbackSkipsInheritedExternalCity(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: city_canonical",
+		"gc.endpoint_status: verified",
+		"dolt.host: external.example.internal",
+		"dolt.port: 4406",
+		"",
+	}, "\n"))
+	writeFile(t, filepath.Join(rigDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: fe",
+		"gc.endpoint_origin: inherited_city",
+		"gc.endpoint_status: verified",
+		"dolt.host: external.example.internal",
+		"dolt.port: 4406",
+		"",
+	}, "\n"))
+
+	env := map[string]string{
+		"GC_DOLT_HOST": "external.example.internal",
+		"GC_DOLT_PORT": "4406",
+	}
+	if applyOrderExecManagedDoltFallback(cityDir, rigDir, env, fmt.Errorf("simulated target error")) {
+		t.Fatal("managed fallback applied to inherited external city endpoint")
+	}
+	if env["GC_DOLT_MANAGED_LOCAL"] == "1" {
+		t.Fatalf("GC_DOLT_MANAGED_LOCAL = %q, want not managed-local; env=%v", env["GC_DOLT_MANAGED_LOCAL"], env)
 	}
 }
 
@@ -1193,6 +1610,24 @@ func slicesContain(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func orderDispatchTestEnv(t *testing.T, envCh <-chan []string) map[string]string {
+	t.Helper()
+	select {
+	case entries := <-envCh:
+		env := map[string]string{}
+		for _, entry := range entries {
+			key, value, ok := strings.Cut(entry, "=")
+			if ok {
+				env[key] = value
+			}
+		}
+		return env
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for order exec env")
+	}
+	return nil
 }
 
 // --- rig-scoped dispatch tests ---

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doltauth"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -131,12 +136,249 @@ func applyOrderExecCanonicalDoltEnv(cityPath, scopeRoot string, env map[string]s
 		scopeRoot = cityPath
 	}
 	target, ok, err := canonicalScopeDoltTarget(cityPath, scopeRoot)
-	if err != nil || !ok {
+	if err != nil {
+		if applyOrderExecManagedDoltFallback(cityPath, scopeRoot, env, err) {
+			return
+		}
+		return
+	}
+	if !ok {
 		return
 	}
 	applyCanonicalDoltTargetEnv(env, target)
 	applyResolvedDoltAuthEnv(env, doltauth.AuthScopeRoot(cityPath, scopeRoot, target), strings.TrimSpace(target.User))
+	if target.External {
+		env["GC_DOLT_MANAGED_LOCAL"] = "0"
+		clearManagedDoltRuntimeLayoutEnv(env, cityPath)
+	} else {
+		env["GC_DOLT_MANAGED_LOCAL"] = "1"
+		applyManagedDoltRuntimeLayoutEnv(env, cityPath)
+	}
 	mirrorBeadsDoltEnv(env)
+}
+
+func applyOrderExecManagedDoltFallback(cityPath, scopeRoot string, env map[string]string, _ error) bool {
+	resolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, scopeRoot, "")
+	if err != nil || resolved.Kind != contract.ScopeConfigAuthoritative {
+		return false
+	}
+	switch resolved.State.EndpointOrigin {
+	case contract.EndpointOriginManagedCity:
+	case contract.EndpointOriginInheritedCity:
+		cityResolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, cityPath, "")
+		if err != nil || cityResolved.Kind != contract.ScopeConfigAuthoritative || cityResolved.State.EndpointOrigin != contract.EndpointOriginManagedCity {
+			return false
+		}
+	default:
+		return false
+	}
+
+	layout, err := resolveManagedDoltOrderRuntimeLayout(cityPath, env)
+	if err != nil {
+		return false
+	}
+	delete(env, "GC_DOLT_HOST")
+	if port := managedDoltPortForLayout(layout); port != "" {
+		env["GC_DOLT_PORT"] = port
+	} else {
+		delete(env, "GC_DOLT_PORT")
+	}
+	env["GC_DOLT_MANAGED_LOCAL"] = "1"
+	applyManagedDoltRuntimeLayoutEnv(env, cityPath)
+	target := contract.DoltConnectionTarget{EndpointOrigin: resolved.State.EndpointOrigin}
+	applyResolvedDoltAuthEnv(env, doltauth.AuthScopeRoot(cityPath, scopeRoot, target), strings.TrimSpace(resolved.State.DoltUser))
+	mirrorBeadsDoltEnv(env)
+	return true
+}
+
+func applyManagedDoltRuntimeLayoutEnv(env map[string]string, cityPath string) {
+	layout, err := resolveManagedDoltOrderRuntimeLayout(cityPath, env)
+	if err != nil {
+		return
+	}
+	env["GC_DOLT_DATA_DIR"] = layout.DataDir
+	env["GC_DOLT_LOG_FILE"] = layout.LogFile
+	env["GC_DOLT_STATE_FILE"] = managedDoltOrderStateFile(layout)
+	env["GC_DOLT_PID_FILE"] = layout.PIDFile
+	env["GC_DOLT_LOCK_FILE"] = layout.LockFile
+	env["GC_DOLT_CONFIG_FILE"] = layout.ConfigFile
+}
+
+func clearManagedDoltRuntimeLayoutEnv(env map[string]string, cityPath string) {
+	root := normalizePathForCompare(filepath.Join(managedDoltOrderPackStateDir(cityPath, env), "external-target"))
+	env["GC_DOLT_DATA_DIR"] = root
+	env["GC_DOLT_LOG_FILE"] = filepath.Join(root, "dolt.log")
+	env["GC_DOLT_STATE_FILE"] = filepath.Join(root, "dolt-state.json")
+	env["GC_DOLT_PID_FILE"] = filepath.Join(root, "dolt.pid")
+	env["GC_DOLT_LOCK_FILE"] = filepath.Join(root, "dolt.lock")
+	env["GC_DOLT_CONFIG_FILE"] = filepath.Join(root, "dolt-config.yaml")
+}
+
+func resolveManagedDoltOrderRuntimeLayout(cityPath string, env map[string]string) (managedDoltRuntimeLayout, error) {
+	cityPath = filepath.Clean(strings.TrimSpace(cityPath))
+	if cityPath == "" || cityPath == "." {
+		return managedDoltRuntimeLayout{}, fmt.Errorf("missing --city")
+	}
+	cityPath = normalizePathForCompare(cityPath)
+	packStateDir := managedDoltOrderPackStateDir(cityPath, env)
+	layout := managedDoltRuntimeLayout{
+		PackStateDir: packStateDir,
+		DataDir:      normalizePathForCompare(filepath.Join(cityPath, ".beads", "dolt")),
+		LogFile:      normalizePathForCompare(filepath.Join(packStateDir, "dolt.log")),
+		StateFile:    normalizePathForCompare(filepath.Join(packStateDir, "dolt-state.json")),
+		PIDFile:      normalizePathForCompare(filepath.Join(packStateDir, "dolt.pid")),
+		LockFile:     normalizePathForCompare(filepath.Join(packStateDir, "dolt.lock")),
+		ConfigFile:   normalizePathForCompare(filepath.Join(packStateDir, "dolt-config.yaml")),
+	}
+	layout.DataDir = managedDoltOrderDataDir(cityPath, layout.DataDir)
+	return layout, nil
+}
+
+func managedDoltOrderPackStateDir(cityPath string, env map[string]string) string {
+	if runtimeDir := trustedAmbientCityRuntimeDir(cityPath); runtimeDir != "" {
+		return normalizePathForCompare(filepath.Join(runtimeDir, "packs", "dolt"))
+	}
+	if env != nil {
+		if runtimeDir := strings.TrimSpace(env["GC_CITY_RUNTIME_DIR"]); runtimeDir != "" {
+			return normalizePathForCompare(filepath.Join(runtimeDir, "packs", "dolt"))
+		}
+	}
+	return normalizePathForCompare(citylayout.PackStateDir(cityPath, "dolt"))
+}
+
+func managedDoltOrderDataDir(cityPath, fallback string) string {
+	if dataDir := publishedManagedDoltDataDir(cityPath); dataDir != "" {
+		return dataDir
+	}
+	if info, err := os.Stat(fallback); err == nil && info.IsDir() {
+		return fallback
+	}
+	legacy := normalizePathForCompare(filepath.Join(cityPath, ".gc", "dolt-data"))
+	if info, err := os.Stat(legacy); err == nil && info.IsDir() {
+		return legacy
+	}
+	return fallback
+}
+
+func publishedManagedDoltDataDir(cityPath string) string {
+	packStateDir := managedDoltOrderPackStateDir(cityPath, nil)
+	data, err := os.ReadFile(managedDoltOrderStateFile(managedDoltRuntimeLayout{
+		PackStateDir: packStateDir,
+	})) //nolint:gosec // path is derived from managed city layout
+	if err != nil {
+		return ""
+	}
+	var state doltRuntimeState
+	if json.Unmarshal(data, &state) != nil {
+		return ""
+	}
+	dataDir := strings.TrimSpace(state.DataDir)
+	if dataDir == "" {
+		return ""
+	}
+	if info, err := os.Stat(dataDir); err != nil || !info.IsDir() {
+		return ""
+	}
+	if state.Running {
+		if !validPublishedManagedDoltDataDirState(cityPath, state, dataDir) {
+			return ""
+		}
+		return normalizePathForCompare(dataDir)
+	}
+	if !state.Running && managedDoltDefaultDataDirExists(cityPath, dataDir) {
+		return ""
+	}
+	return normalizePathForCompare(dataDir)
+}
+
+func validPublishedManagedDoltDataDirState(cityPath string, state doltRuntimeState, dataDir string) bool {
+	if !state.Running || state.Port <= 0 || state.PID <= 0 {
+		return false
+	}
+	if !samePath(strings.TrimSpace(state.DataDir), dataDir) {
+		return false
+	}
+	if !pidAlive(state.PID) || !doltPortReachable(strconv.Itoa(state.Port)) {
+		return false
+	}
+	holderPID := findPortHolderPID(strconv.Itoa(state.Port))
+	if holderPID > 0 {
+		return holderPID == state.PID
+	}
+	layout := managedDoltOrderRuntimeLayoutForDataDir(cityPath, dataDir)
+	owned, deleted := inspectManagedDoltOwnership(state.PID, layout)
+	return owned && !deleted
+}
+
+func managedDoltOrderRuntimeLayoutForDataDir(cityPath, dataDir string) managedDoltRuntimeLayout {
+	packStateDir := managedDoltOrderPackStateDir(cityPath, nil)
+	return managedDoltRuntimeLayout{
+		PackStateDir: packStateDir,
+		DataDir:      normalizePathForCompare(dataDir),
+		LogFile:      normalizePathForCompare(filepath.Join(packStateDir, "dolt.log")),
+		StateFile:    normalizePathForCompare(filepath.Join(packStateDir, "dolt-state.json")),
+		PIDFile:      normalizePathForCompare(filepath.Join(packStateDir, "dolt.pid")),
+		LockFile:     normalizePathForCompare(filepath.Join(packStateDir, "dolt.lock")),
+		ConfigFile:   normalizePathForCompare(filepath.Join(packStateDir, "dolt-config.yaml")),
+	}
+}
+
+func managedDoltDefaultDataDirExists(cityPath, dataDir string) bool {
+	for _, candidate := range []string{
+		filepath.Join(cityPath, ".beads", "dolt"),
+		filepath.Join(cityPath, ".gc", "dolt-data"),
+	} {
+		if samePath(candidate, dataDir) {
+			continue
+		}
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+func managedDoltOrderStateFile(layout managedDoltRuntimeLayout) string {
+	return filepath.Join(layout.PackStateDir, "dolt-state.json")
+}
+
+func managedDoltPortForLayout(layout managedDoltRuntimeLayout) string {
+	data, err := os.ReadFile(managedDoltOrderStateFile(layout)) //nolint:gosec // path is derived from managed city layout
+	if err != nil {
+		return ""
+	}
+	var state doltRuntimeState
+	if json.Unmarshal(data, &state) != nil {
+		return ""
+	}
+	if !validDoltRuntimeStateForLayout(state, layout) {
+		return ""
+	}
+	return strconv.Itoa(state.Port)
+}
+
+func validDoltRuntimeStateForLayout(state doltRuntimeState, layout managedDoltRuntimeLayout) bool {
+	if !state.Running || state.Port <= 0 || state.PID <= 0 {
+		return false
+	}
+	if !samePath(strings.TrimSpace(state.DataDir), layout.DataDir) {
+		return false
+	}
+	if !pidAlive(state.PID) || !doltPortReachable(strconv.Itoa(state.Port)) {
+		return false
+	}
+	holderPID := findPortHolderPID(strconv.Itoa(state.Port))
+	if holderPID > 0 && holderPID != state.PID {
+		return false
+	}
+	owned, deleted := inspectManagedDoltOwnership(state.PID, layout)
+	if deleted {
+		return false
+	}
+	if holderPID == state.PID {
+		return true
+	}
+	return owned
 }
 
 func cachedOrderStoresResolver(cityPath string, cfg *config.City) orderStoresResolver {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,6 +99,12 @@
         ]
       },
       {
+        "group": "Troubleshooting",
+        "pages": [
+          "troubleshooting/dolt-bloat-recovery"
+        ]
+      },
+      {
         "group": "Reference",
         "pages": [
           "reference/index",

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,9 @@ These guides are task-oriented and current.
 - [Shareable Packs](/guides/shareable-packs)
 - [Using Gas City as a Multi-Agent Engineering Environment](/guides/multi-agent-engineering-environment)
 
+See also the [Troubleshooting runbooks](/troubleshooting/dolt-bloat-recovery)
+for operational recovery procedures.
+
 Use the [Reference](/reference/index) section for exact command and
 config details. Older roadmaps and notes live in `engdocs/archive/`
 and should not be treated as the current workflow.

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -34,10 +34,11 @@ and verifying the result.
 - **Free disk space.** Dolt GC rewrites chunks into a new store before
   swapping; budget at least **2× the current `.dolt/` size** in free space
   on the same filesystem.
-- **Dolt 1.75.0 or newer.** This matches the floor the `dolt-version`
-  doctor check warns below and ensures default-on auto-GC + archive
-  storage. Check with `dolt version`. If your binary rejects
-  `--archive-level=1` (rare on 1.75+), drop the flag and run plain
+- **Dolt 1.86.1 or newer.** This matches the floor enforced by Gas City's
+  managed Dolt tooling and ensures the listener/config knobs used by the
+  pack plus modern auto-GC behavior are available. Check with
+  `dolt version`. If your binary rejects `--archive-level=1` (rare on
+  modern releases), drop the flag and run plain
   `dolt gc` — archive compression is default-on in 1.75+ so the flag is
   an optimization, not a requirement.
 
@@ -80,7 +81,8 @@ If GC finishes but the size barely moves, the chunks are nearly all live
 
 ## Prevention
 
-- **Keep Dolt at 1.75.0 or newer.** This is what the `dolt-version` doctor check warns below; newer releases ship improved auto-GC
+- **Keep Dolt at 1.86.1 or newer.** This matches Gas City's managed-Dolt
+  floor; newer releases ship improved auto-GC
   heuristics and default archive compression.
 - **Let the dolt pack's `dolt-gc-nudge` order run continuously.** It
   ships embedded in the dolt pack and fires every 6h by default. The
@@ -91,9 +93,9 @@ If GC finishes but the size barely moves, the chunks are nearly all live
   via the `GC_DOLT_GC_THRESHOLD_BYTES` environment variable
   (default: 2 GiB) in the city's environment.
 - **Mind `orders.max_timeout` if you set one.** The nudge order asks
-  for a 35-minute timeout to accommodate `CALL DOLT_GC()` on large
-  stores. A city-level `orders.max_timeout` below 35m will cap the
-  nudge and may kill an in-progress GC — raise the cap or leave it
+  for a 24-hour timeout to accommodate serialized `CALL DOLT_GC()` runs
+  on large stores. A city-level `orders.max_timeout` below 24h will cap the
+  nudge and may kill an in-progress GC; raise the cap or leave it
   unset if you want unattended recovery on big databases.
 - **Run `gc doctor` regularly.** A daily cron or CI job is enough. The
   `dolt-noms-size` check gives early warning well before users notice.

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -1,0 +1,118 @@
+---
+title: Dolt Bloat Recovery
+description: Recover a Gas City beads store whose Dolt noms directory has grown out of proportion.
+---
+
+## Overview
+
+Gas City stores beads in a managed Dolt server. Dolt records every write as
+immutable chunks under `.beads/dolt/<database>/.dolt/noms/`. Chunks are
+only reclaimed by garbage collection. Dolt's auto-GC fires when ~125 MB of
+new chunks have accumulated since the last GC, which means a database that
+bloated once during an agent storm and then went quiet will not auto-GC on
+its own — it sits at its peak size indefinitely.
+
+This runbook walks an operator through recovering such a database: stopping
+writers, taking a safety backup, running a full GC with archive compression,
+and verifying the result.
+
+## Symptoms
+
+1. `gc doctor` reports `dolt-noms-size` as **Warning** or **Error**.
+2. `du -sh <cityPath>/.beads/dolt/<database>/.dolt/` returns more than
+   20 GB.
+3. `bd` writes feel slower than usual, or `bd ready` takes noticeable time.
+4. Agents fail with Dolt connection or timeout errors, especially shortly
+   after start.
+
+## Preconditions
+
+- **Stop all agents.** Run `gc stop` in the affected city so no session is
+  writing to Dolt.
+- **Ensure no external writers are connected.** If you have opened a
+  `dolt sql` shell against the managed port, quit it.
+- **Free disk space.** Dolt GC rewrites chunks into a new store before
+  swapping; budget at least **2× the current `.dolt/` size** in free space
+  on the same filesystem.
+- **Dolt 1.75.0 or newer.** This matches the floor the `dolt-version`
+  doctor check warns below and ensures default-on auto-GC + archive
+  storage. Check with `dolt version`. If your binary rejects
+  `--archive-level=1` (rare on 1.75+), drop the flag and run plain
+  `dolt gc` — archive compression is default-on in 1.75+ so the flag is
+  an optimization, not a requirement.
+
+## Recovery Procedure
+
+```bash
+# 1. Stop the supervisor (and with it, all agents and the managed Dolt server).
+gc stop <cityPath>
+
+# 2. Capture a safety backup before touching the store.
+cd <cityPath>/.beads/dolt/<database>
+cp -a .dolt .dolt.bak-$(date +%Y%m%d-%H%M%S)
+
+# 3. Run a full GC with archive compression. This is the step that actually
+#    reclaims space. On a 120 GB store expect this to take tens of minutes.
+dolt gc --archive-level=1
+
+# 4. Restart the city and verify.
+cd <cityPath>
+gc start
+gc doctor          # dolt-noms-size should now be OK
+du -sh .beads/dolt/<database>/.dolt
+```
+
+If `gc doctor` reports a clean `dolt-noms-size` and agents come back up
+cleanly, the recovery is complete. You may delete the `.dolt.bak-*`
+directory at your leisure once you are confident in the new store.
+
+## Expected Outcome
+
+DoltHub's archive format typically delivers ~30% compression on top of
+normal GC ([DoltHub blog, archive storage](https://www.dolthub.com/blog/)).
+Combined with reclamation of orphan chunks from agent churn, a 120 GB
+pre-GC store typically drops to somewhere between **5 GB and 20 GB** —
+depending on how much of the pre-GC size was live data versus orphan
+chunks.
+
+If GC finishes but the size barely moves, the chunks are nearly all live
+(no garbage to collect). See **When to Escalate** below.
+
+## Prevention
+
+- **Keep Dolt at 1.75.0 or newer.** This is what the `dolt-version` doctor check warns below; newer releases ship improved auto-GC
+  heuristics and default archive compression.
+- **Let the dolt pack's `dolt-gc-nudge` order run continuously.** It
+  ships embedded in the dolt pack and fires every 6h by default. The
+  nudge catches the "bloated-but-stable" corner case where no single
+  write burst crosses Dolt's 125 MB auto-GC threshold. To opt out on a
+  given city, add `dolt-gc-nudge` to the city's `[orders] skip = [...]`
+  list (or to a rig-level `[[order.override]]`). Tune the trigger size
+  via the `GC_DOLT_GC_THRESHOLD_BYTES` environment variable
+  (default: 2 GiB) in the city's environment.
+- **Mind `orders.max_timeout` if you set one.** The nudge order asks
+  for a 35-minute timeout to accommodate `CALL DOLT_GC()` on large
+  stores. A city-level `orders.max_timeout` below 35m will cap the
+  nudge and may kill an in-progress GC — raise the cap or leave it
+  unset if you want unattended recovery on big databases.
+- **Run `gc doctor` regularly.** A daily cron or CI job is enough. The
+  `dolt-noms-size` check gives early warning well before users notice.
+- **Avoid long-lived `dolt sql` sessions from outside Gas City.** External
+  clients hold open transactions that can block GC.
+
+## When to Escalate
+
+If a recovery GC reduces the store by less than ~10% and `gc doctor` still
+flags `dolt-noms-size`:
+
+1. All remaining chunks are probably live — the database legitimately
+   contains this much history. Squashing Dolt history is not a supported
+   self-service operation today; escalate instead.
+2. File a `bd` issue with:
+   - `dolt version` output
+   - `du -sh` of the `.dolt/` directory
+   - `dolt log --oneline | wc -l`
+   - a sample of `dolt log --stat` from the busiest day
+
+Attach the `gc doctor --verbose` output as well. Do not delete the
+`.dolt.bak-*` directory while the issue is open.

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -760,6 +760,8 @@ listener:
   port: $DOLT_PORT
   host: $DOLT_HOST
   max_connections: 1000
+  back_log: 50
+  max_connections_timeout_millis: 5000
   read_timeout_millis: 300000
   write_timeout_millis: 300000
 

--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -12,18 +12,21 @@ else
   DOLT_STATE_DIR="$LEGACY_GC_DIR"
 fi
 
-# Data lives under .beads/dolt (gc-beads-bd canonical path).
-# Fall back to $DOLT_STATE_DIR/dolt-data for legacy cities that haven't migrated.
-DOLT_BEADS_DATA_DIR="$GC_CITY_PATH/.beads/dolt"
-if [ -d "$DOLT_BEADS_DATA_DIR" ]; then
+# Data lives under .beads/dolt (gc-beads-bd canonical path). Honor
+# GC_DOLT_DATA_DIR first so shell pack commands target the same managed data
+# directory as the Go lifecycle and doctor code.
+DOLT_BEADS_DATA_DIR="${GC_DOLT_DATA_DIR:-$GC_CITY_PATH/.beads/dolt}"
+if [ -n "${GC_DOLT_DATA_DIR:-}" ]; then
+  DOLT_DATA_DIR="$GC_DOLT_DATA_DIR"
+elif [ -d "$DOLT_BEADS_DATA_DIR" ]; then
   DOLT_DATA_DIR="$DOLT_BEADS_DATA_DIR"
 else
   DOLT_DATA_DIR="$DOLT_STATE_DIR/dolt-data"
 fi
 
-DOLT_LOG_FILE="$DOLT_STATE_DIR/dolt.log"
-DOLT_PID_FILE="$DOLT_STATE_DIR/dolt.pid"
-DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-state.json"
+DOLT_LOG_FILE="${GC_DOLT_LOG_FILE:-$DOLT_STATE_DIR/dolt.log}"
+DOLT_PID_FILE="${GC_DOLT_PID_FILE:-$DOLT_STATE_DIR/dolt.pid}"
+DOLT_STATE_FILE="${GC_DOLT_STATE_FILE:-$DOLT_STATE_DIR/dolt-state.json}"
 
 GC_BEADS_BD_SCRIPT="$GC_CITY_PATH/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh"
 
@@ -51,6 +54,30 @@ read_runtime_state_string() (
   key="$2"
   [ -f "$state_file" ] || return 0
   sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$state_file" 2>/dev/null | head -1 || true
+)
+
+canonical_path() (
+  path="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$path" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+    return $?
+  fi
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f "$path" 2>/dev/null && return 0
+  fi
+  printf '%s\n' "$path"
+)
+
+same_path() (
+  left="$1"
+  right="$2"
+  [ "$left" = "$right" ] && return 0
+  [ "$(canonical_path "$left")" = "$(canonical_path "$right")" ]
 )
 
 pid_is_running() (
@@ -149,7 +176,11 @@ managed_runtime_port() (
   [ "$running" = "true" ] || return 0
   [ -n "$pid" ] || return 0
   [ -n "$port" ] || return 0
-  [ "$data_dir" = "$expected_data_dir" ] || return 0
+  if ! same_path "$data_dir" "$expected_data_dir"; then
+    printf 'dolt runtime: managed state data_dir=%s does not match expected data_dir=%s\n' \
+      "$data_dir" "$expected_data_dir" >&2
+    return 0
+  fi
   pid_is_running "$pid" || return 0
 
   holder_pid=$(managed_runtime_listener_pid "$port" || true)
@@ -169,7 +200,7 @@ managed_runtime_port() (
 # Resolve GC_DOLT_PORT if not already set by the caller.
 # Priority: env override > validated managed runtime state > default 3307.
 if [ -z "$GC_DOLT_PORT" ]; then
-  GC_DOLT_PORT=$(managed_runtime_port "$DOLT_STATE_FILE" "$GC_CITY_PATH/.beads/dolt")
+  GC_DOLT_PORT=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR")
   : "${GC_DOLT_PORT:=3307}"
 fi
 
@@ -186,18 +217,38 @@ else
   TIMEOUT_BIN=""
 fi
 
+_run_bounded_warned_no_timeout=""
+
 # run_bounded SECS CMD...  — Run CMD with a wall-clock timeout. Exits
 # 124 on timeout (coreutils convention). Uses --kill-after=2 so an
 # uncooperative child that ignores SIGTERM (e.g. a dolt client stuck
 # in kernel socket wait) is escalated to SIGKILL rather than leaking
 # zombies — which is the failure mode the bounded helper exists to
-# prevent. When no timeout binary is available the command runs
-# unbounded; callers must still tolerate a non-zero status.
+# prevent. If no bounded execution mechanism is available, fail closed rather
+# than running a potentially wedged Dolt client unbounded.
 run_bounded() {
   _t="$1"; shift
   if [ -n "$TIMEOUT_BIN" ]; then
     "$TIMEOUT_BIN" --kill-after=2 "$_t" "$@"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 - "$_t" "$@" <<'PY'
+import subprocess
+import sys
+
+limit = float(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=limit)
+except subprocess.TimeoutExpired as exc:
+    sys.stdout.write(exc.stdout or "")
+    sys.stderr.write(exc.stderr or "")
+    sys.exit(124)
+sys.stdout.write(proc.stdout)
+sys.stderr.write(proc.stderr)
+sys.exit(proc.returncode)
+PY
   else
-    "$@"
+    printf 'dolt runtime: timeout/gtimeout/python3 not found; cannot run bounded command\n' >&2
+    return 124
   fi
 }

--- a/examples/dolt/commands/gc-nudge/command.toml
+++ b/examples/dolt/commands/gc-nudge/command.toml
@@ -1,0 +1,1 @@
+description = "Size-triggered CALL DOLT_GC() to compact a bloated Dolt database"

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -21,26 +21,113 @@
 #   GC_DOLT_GC_THRESHOLD_BYTES
 #     (default: 2147483648 = 2 GiB) — minimum .dolt/ size that triggers GC.
 #     Set to 0 to force GC on every tick (useful for tests).
+#   GC_DOLT_GC_CALL_TIMEOUT_SECS
+#     (default: 1800) — wall-clock bound for one `CALL DOLT_GC()` invocation.
 #   GC_DOLT_GC_DRY_RUN   (optional) — when set, prints what would happen
 #                        but does not execute CALL DOLT_GC().
 set -eu
 
 : "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
+: "${GC_DOLT_PORT:=}"
+gc_dolt_port_input="$GC_DOLT_PORT"
+gc_dolt_host_input="${GC_DOLT_HOST:-}"
+
+PACK_DIR="${GC_PACK_DIR:-$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)}"
+# shellcheck disable=SC1091
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+case "${GC_DOLT_MANAGED_LOCAL:-}" in
+  0|false|FALSE|no|NO)
+    printf 'gc-nudge: managed local Dolt runtime is not applicable for this order — skip\n'
+    exit 0
+    ;;
+esac
+
+if [ "${GC_DOLT_MANAGED_LOCAL:-}" = "1" ]; then
+  managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
+  if [ -n "$managed_port" ]; then
+    if [ -n "$gc_dolt_port_input" ] && [ "$gc_dolt_port_input" != "$managed_port" ]; then
+      printf 'gc-nudge: GC_DOLT_PORT=%s does not match managed runtime port=%s for data_dir=%s — skip\n' \
+        "$gc_dolt_port_input" "$managed_port" "$DOLT_DATA_DIR"
+      exit 0
+    fi
+    GC_DOLT_PORT="$managed_port"
+  elif [ -z "$gc_dolt_port_input" ]; then
+    printf 'gc-nudge: managed local Dolt runtime is not active for data_dir=%s — skip\n' \
+      "$DOLT_DATA_DIR"
+    exit 0
+  else
+    GC_DOLT_PORT="$gc_dolt_port_input"
+  fi
+elif [ -n "$gc_dolt_port_input" ]; then
+  case "$gc_dolt_host_input" in
+    ''|127.0.0.1|localhost|0.0.0.0|::1|::|'[::1]'|'[::]')
+      ;;
+    *)
+      printf 'gc-nudge: GC_DOLT_HOST=%s is not a local managed Dolt host — skip\n' \
+        "$gc_dolt_host_input"
+      exit 0
+      ;;
+  esac
+  managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
+  if [ -z "$managed_port" ] || [ "$gc_dolt_port_input" != "$managed_port" ]; then
+    printf 'gc-nudge: GC_DOLT_PORT=%s does not match managed runtime port=%s for data_dir=%s — skip\n' \
+      "$gc_dolt_port_input" "${managed_port:-<inactive>}" "$DOLT_DATA_DIR"
+    exit 0
+  fi
+  GC_DOLT_PORT="$managed_port"
+elif [ -z "$gc_dolt_port_input" ]; then
+  managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
+  if [ -z "$managed_port" ]; then
+    printf 'gc-nudge: managed local Dolt runtime is not active for data_dir=%s — skip\n' \
+      "$DOLT_DATA_DIR"
+    exit 0
+  fi
+  GC_DOLT_PORT="$managed_port"
+fi
+
 : "${GC_DOLT_PORT:?GC_DOLT_PORT must be set}"
 : "${GC_DOLT_USER:=root}"
 
-PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
-. "$PACK_DIR/assets/scripts/runtime.sh"
-
 host="${GC_DOLT_HOST:-127.0.0.1}"
 threshold="${GC_DOLT_GC_THRESHOLD_BYTES:-2147483648}"
+gc_call_timeout="${GC_DOLT_GC_CALL_TIMEOUT_SECS:-1800}"
 dry_run="${GC_DOLT_GC_DRY_RUN:-}"
+
+case "$threshold" in
+  ''|*[!0-9]*)
+    printf 'gc-nudge: invalid GC_DOLT_GC_THRESHOLD_BYTES=%s (must be a non-negative integer)\n' \
+      "$threshold" >&2
+    exit 2
+    ;;
+esac
+
+case "$gc_call_timeout" in
+  ''|*[!0-9]*|0)
+    printf 'gc-nudge: invalid GC_DOLT_GC_CALL_TIMEOUT_SECS=%s (must be a positive integer)\n' \
+      "$gc_call_timeout" >&2
+    exit 2
+    ;;
+esac
 
 # Cross-city flock to serialize CALL DOLT_GC() across multiple cities
 # sharing the same Dolt sql-server. Keyed on host:port so per-city locks
 # don't let concurrent GCs hit the same server.
-lock_key=$(printf '%s-%s' "$host" "$GC_DOLT_PORT" | tr ':/ ' '---')
-lock_file="${TMPDIR:-/tmp}/gc-dolt-gc-${lock_key}.lock"
+lock_host=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]' | sed 's/^\[\(.*\)\]$/\1/')
+case "$lock_host" in
+  ''|127.0.0.1|localhost|0.0.0.0|::1|::)
+    lock_host="127.0.0.1"
+    ;;
+esac
+lock_key=$(printf '%s-%s' "$lock_host" "$GC_DOLT_PORT" | tr -c 'A-Za-z0-9_.-' '-')
+lock_root="/tmp/gc-dolt-gc"
+mkdir -p "$lock_root"
+chmod 700 "$lock_root" 2>/dev/null || true
+lock_path="$lock_root/${lock_key}.lock"
+lock_dir="${lock_path}.d"
+lock_pid_path="${lock_dir}/pid"
+lock_cmd_path="${lock_dir}/cmd"
+lock_cleanup=""
 
 # metadata_files — enumerate managed rig metadata.json files, same as
 # commands/health/run.sh. Authoritative source is `gc rig list --json`;
@@ -52,31 +139,105 @@ metadata_files() {
     # during reconciler incidents) we must not block the nudge for the
     # full 35m order timeout. Degrade to the filesystem fallback below.
     # Matches the pattern in examples/dolt/commands/health/run.sh:22.
-    rig_paths=$(run_bounded 5 gc rig list --json 2>/dev/null \
-      | if command -v jq >/dev/null 2>&1; then
-          jq -r '.rigs[].path' 2>/dev/null
-        else
-          grep '"path"' | sed 's/.*"path": *"//;s/".*//'
-        fi) || true
-    if [ -n "$rig_paths" ]; then
-      printf '%s\n' "$rig_paths" | while IFS= read -r p; do
-        [ -n "$p" ] && printf '%s\n' "$p/.beads/metadata.json"
-      done
-      return
+    if rig_json=$(run_bounded 5 gc rig list --json 2>/dev/null); then
+      rig_paths=$(printf '%s\n' "$rig_json" \
+        | if command -v jq >/dev/null 2>&1; then
+            jq -r '.rigs[].path' 2>/dev/null
+          else
+            grep '"path"' | sed 's/.*"path": *"//;s/".*//'
+          fi) || true
+      if [ -n "$rig_paths" ]; then
+        printf '%s\n' "$rig_paths" | while IFS= read -r p; do
+          [ -n "$p" ] && printf '%s\n' "$p/.beads/metadata.json"
+        done
+        return
+      fi
+    else
+      rig_status=$?
+      if [ "$rig_status" -eq 124 ]; then
+        printf 'gc-nudge: gc rig list timed out after 5s; falling back to local filesystem metadata scan\n' >&2
+      else
+        printf 'gc-nudge: gc rig list failed rc=%s; falling back to local filesystem metadata scan\n' "$rig_status" >&2
+      fi
     fi
   fi
-  find "$GC_CITY_PATH/rigs" -path '*/.beads/metadata.json' 2>/dev/null || true
+  # Fallback: scan the local city tree (excluding runtime/admin roots) so
+  # rigs outside <city>/rigs are still discovered when gc is unavailable.
+  # External rigs remain undiscoverable in this degraded path.
+  find "$GC_CITY_PATH" \
+    \( -path "$GC_CITY_PATH/.gc" -o -path "$GC_CITY_PATH/.git" \) -prune -o \
+    -path '*/.beads/metadata.json' -print 2>/dev/null || true
 }
 
 metadata_db() {
   meta="$1"
-  [ -f "$meta" ] || return 0
-  if command -v jq >/dev/null 2>&1; then
-    jq -r '.dolt_database // empty' "$meta" 2>/dev/null || true
-    return
+  db=""
+  if [ ! -f "$meta" ]; then
+    printf '%s\n' "beads"
+    return 0
   fi
-  grep -o '"dolt_database"[[:space:]]*:[[:space:]]*"[^"]*"' "$meta" 2>/dev/null \
-    | sed 's/.*: *"//;s/"$//' || true
+  if command -v jq >/dev/null 2>&1; then
+    db=$(jq -r '.dolt_database // empty' "$meta" 2>/dev/null || true)
+  else
+    db=$(grep -o '"dolt_database"[[:space:]]*:[[:space:]]*"[^"]*"' "$meta" 2>/dev/null \
+      | sed 's/.*: *"//;s/"$//' || true)
+  fi
+  if [ -z "$db" ]; then
+    db="beads"
+  fi
+  printf '%s\n' "$db"
+}
+
+valid_database_name() {
+  db="$1"
+  case "$db" in
+    [A-Za-z0-9_]*)
+      case "$db" in
+        *[!A-Za-z0-9_-]*) return 1 ;;
+        *) return 0 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+is_system_database() {
+  name=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$name" in
+    information_schema|mysql|dolt_cluster|__gc_probe) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+emit_database_name() {
+  db="$1"
+  if ! valid_database_name "$db"; then
+    printf 'gc-nudge: db=%s invalid database name — skip\n' "$db" >&2
+    return 0
+  fi
+  if is_system_database "$db"; then
+    printf 'gc-nudge: db=%s system database — skip\n' "$db" >&2
+    return 0
+  fi
+  printf '%s\n' "$db"
+}
+
+discover_database_names() {
+  while IFS= read -r meta; do
+    [ -n "$meta" ] || continue
+    db=$(metadata_db "$meta")
+    emit_database_name "$db"
+  done < "$_meta_tmp"
+
+  if [ -d "$DOLT_DATA_DIR" ]; then
+    for d in "$DOLT_DATA_DIR"/*/; do
+      [ -d "$d/.dolt" ] || continue
+      db=${d%/}
+      db=${db##*/}
+      is_system_database "$db" && continue
+      emit_database_name "$db"
+    done
+  fi
 }
 
 # dir_bytes — POSIX byte sum of a directory tree. Uses `du -sk` for
@@ -98,16 +259,17 @@ run_dolt_gc_for_db() {
   db="$1"
   [ -n "$db" ] || return 0
 
-  # Reset rc at function entry. Variables in POSIX sh are global: without
-  # this reset, a previous call's non-zero rc would leak into subsequent
-  # calls whose dolt command succeeds (the `|| rc=$?` branch never fires)
-  # and we'd mis-report success as failure.
-  rc=0
+  cmd_rc=0
 
   db_dir="$DOLT_DATA_DIR/$db/.dolt"
+  if [ ! -d "$db_dir" ]; then
+    printf 'gc-nudge: db=%s local_data_dir=%s missing — skip\n' \
+      "$db" "$db_dir"
+    return 0
+  fi
   size=$(dir_bytes "$db_dir")
 
-  if [ "$threshold" -gt 0 ] && [ "$size" -lt "$threshold" ]; then
+  if [ "$threshold" -gt 0 ] && [ "${aggregate_gc:-0}" != "1" ] && [ "$size" -lt "$threshold" ]; then
     printf 'gc-nudge: db=%s bytes=%s below_threshold=%s — skip\n' \
       "$db" "$size" "$threshold"
     return 0
@@ -125,35 +287,172 @@ run_dolt_gc_for_db() {
   # CALL DOLT_GC() is disruptive on pre-1.75 Dolt; the dolt CLI shells
   # out to a fresh connection per invocation, so connection churn is
   # bounded to this one call. Server-side auto-GC is unaffected.
-  if [ -n "${GC_DOLT_PASSWORD:-}" ]; then
+  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
+  run_bounded "$gc_call_timeout" \
     dolt --host "$host" --port "$GC_DOLT_PORT" \
-      --user "$GC_DOLT_USER" --password "$GC_DOLT_PASSWORD" \
-      --no-tls \
-      sql --database "$db" -q "CALL DOLT_GC()" || rc=$?
-  else
-    dolt --host "$host" --port "$GC_DOLT_PORT" \
-      --user "$GC_DOLT_USER" --no-tls \
-      sql --database "$db" -q "CALL DOLT_GC()" || rc=$?
-  fi
+    --user "$GC_DOLT_USER" --no-tls \
+    sql --database "$db" -q "CALL DOLT_GC()" || cmd_rc=$?
   elapsed=$(( $(date +%s) - start ))
 
   after=$(dir_bytes "$db_dir")
-  if [ "$rc" -eq 0 ]; then
+  if [ "$cmd_rc" -eq 0 ]; then
     printf 'gc-nudge: db=%s before=%s after=%s reclaimed=%s duration=%ss — ok\n' \
       "$db" "$size" "$after" "$((size - after))" "$elapsed"
+  elif [ "$cmd_rc" -eq 124 ]; then
+    printf 'gc-nudge: db=%s bytes=%s duration=%ss timed out after=%ss rc=%s — error\n' \
+      "$db" "$size" "$elapsed" "$gc_call_timeout" "$cmd_rc" >&2
   else
     printf 'gc-nudge: db=%s bytes=%s duration=%ss rc=%s — error\n' \
-      "$db" "$size" "$elapsed" "$rc" >&2
+      "$db" "$size" "$elapsed" "$cmd_rc" >&2
   fi
-  return "$rc"
+  return "$cmd_rc"
+}
+
+# shellcheck disable=SC2317
+cleanup() {
+  if [ -n "${_meta_tmp:-}" ]; then
+    rm -f "$_meta_tmp"
+  fi
+  if [ -n "${_db_tmp:-}" ]; then
+    rm -f "$_db_tmp"
+  fi
+  if [ -n "${_unique_db_tmp:-}" ]; then
+    rm -f "$_unique_db_tmp"
+  fi
+  if [ -n "$lock_cleanup" ]; then
+    rm -f "$lock_pid_path" 2>/dev/null || true
+    rm -f "$lock_cmd_path" 2>/dev/null || true
+    rmdir "$lock_cleanup" 2>/dev/null || true
+  fi
+}
+
+lock_process_command() {
+  pid="$1"
+  command -v ps >/dev/null 2>&1 || return 1
+  ps -p "$pid" -o command= 2>/dev/null | sed -n '1p'
+}
+
+lock_holder_alive() {
+  [ -f "$lock_pid_path" ] || return 1
+  pid=$(sed -n '1p' "$lock_pid_path" 2>/dev/null || true)
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  current_cmd=$(lock_process_command "$pid" || true)
+  if [ -f "$lock_cmd_path" ]; then
+    expected_cmd=$(sed -n '1p' "$lock_cmd_path" 2>/dev/null || true)
+    if [ -n "$current_cmd" ] && [ "$current_cmd" = "$expected_cmd" ]; then
+      return 0
+    fi
+    if [ -n "$current_cmd" ]; then
+      return 1
+    fi
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  [ -n "$current_cmd" ]
+}
+
+claim_lock_dir() {
+  old_umask=$(umask)
+  umask 077
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    umask "$old_umask"
+    return 1
+  fi
+  if ! printf '%s\n' "$$" > "$lock_pid_path"; then
+    umask "$old_umask"
+    rmdir "$lock_dir" 2>/dev/null || true
+    printf 'gc-nudge: unable to write lock metadata %s\n' "$lock_pid_path" >&2
+    exit 1
+  fi
+  lock_cmd=$(lock_process_command "$$" || true)
+  if [ -n "$lock_cmd" ]; then
+    printf '%s\n' "$lock_cmd" > "$lock_cmd_path" 2>/dev/null || true
+  fi
+  umask "$old_umask"
+  lock_cleanup="$lock_dir"
+  return 0
+}
+
+# Stale lock markers can survive SIGKILL / timeout paths. The pid file lets a
+# later run distinguish a live holder from abandoned state before skipping.
+clear_stale_lock_dir() {
+  [ -d "$lock_dir" ] || return 0
+  if [ ! -f "$lock_pid_path" ]; then
+    # Another process may have just created the lock dir and not yet written
+    # pid metadata. Give it a short chance to finish before reclaiming.
+    sleep 1
+  fi
+  if lock_holder_alive; then
+    return 1
+  fi
+  rm -f "$lock_pid_path" "$lock_cmd_path" 2>/dev/null || true
+  rmdir "$lock_dir" 2>/dev/null
+}
+
+acquire_lock() {
+  if command -v flock >/dev/null 2>&1; then
+    old_umask=$(umask)
+    umask 077
+    if ! : >> "$lock_path" 2>/dev/null; then
+      umask "$old_umask"
+      if [ -d "$lock_path" ]; then
+        return 1
+      fi
+      printf 'gc-nudge: unable to create lock file %s\n' "$lock_path" >&2
+      exit 1
+    fi
+    if ! exec 9<>"$lock_path"; then
+      umask "$old_umask"
+      if [ -d "$lock_path" ]; then
+        return 1
+      fi
+      printf 'gc-nudge: unable to open lock file %s\n' "$lock_path" >&2
+      exit 1
+    fi
+    umask "$old_umask"
+    chmod 600 "$lock_path" 2>/dev/null || true
+    if ! flock -n 9; then
+      return $?
+    fi
+    if claim_lock_dir; then
+      return 0
+    fi
+    if [ -d "$lock_dir" ] && clear_stale_lock_dir && claim_lock_dir; then
+      return 0
+    fi
+    if [ -d "$lock_dir" ]; then
+      return 1
+    fi
+    printf 'gc-nudge: unable to create lock directory %s\n' "$lock_dir" >&2
+    exit 1
+  fi
+
+  if claim_lock_dir; then
+    return 0
+  fi
+  if [ -d "$lock_dir" ] && clear_stale_lock_dir && claim_lock_dir; then
+    return 0
+  fi
+  if [ -d "$lock_dir" ]; then
+    return 1
+  fi
+
+  printf 'gc-nudge: unable to create lock directory %s\n' "$lock_dir" >&2
+  exit 1
 }
 
 main() {
+  trap cleanup EXIT
+
   # Non-blocking flock so two concurrent nudges (same host:port) don't
   # double-call GC. Skip silently when held — the other nudge is handling
   # it.
-  exec 9>"$lock_file"
-  if ! flock -n 9; then
+  if ! acquire_lock; then
     printf 'gc-nudge: another nudge already running for %s:%s — skipping\n' \
       "$host" "$GC_DOLT_PORT"
     exit 0
@@ -162,25 +461,52 @@ main() {
   # Snapshot rig list once. `metadata_files` can hit the gc binary which
   # may be slow — we only want to pay that once per run.
   _meta_tmp=$(mktemp)
-  trap 'rm -f "$_meta_tmp"' EXIT
   metadata_files > "$_meta_tmp"
 
+  _db_tmp=$(mktemp)
+  _unique_db_tmp=$(mktemp)
+  discover_database_names > "$_db_tmp"
+
   seen_dbs=""
-  rc=0
-  while IFS= read -r meta; do
-    [ -n "$meta" ] || continue
-    db=$(metadata_db "$meta")
+  while IFS= read -r db; do
     [ -n "$db" ] || continue
     # Dedup: multiple rigs may share a database.
     case " $seen_dbs " in
       *" $db "*) continue ;;
     esac
     seen_dbs="$seen_dbs $db"
+    printf '%s\n' "$db" >> "$_unique_db_tmp"
+  done < "$_db_tmp"
 
-    run_dolt_gc_for_db "$db" || rc=$?
-  done < "$_meta_tmp"
+  aggregate_size=0
+  while IFS= read -r db; do
+    [ -n "$db" ] || continue
+    db_dir="$DOLT_DATA_DIR/$db/.dolt"
+    [ -d "$db_dir" ] || continue
+    size=$(dir_bytes "$db_dir")
+    aggregate_size=$((aggregate_size + size))
+  done < "$_unique_db_tmp"
 
-  exit "$rc"
+  aggregate_gc=0
+  if [ "$threshold" -gt 0 ] && [ "$aggregate_size" -ge "$threshold" ]; then
+    aggregate_gc=1
+    printf 'gc-nudge: aggregate_bytes=%s threshold=%s — enabling GC for discovered databases\n' \
+      "$aggregate_size" "$threshold"
+  fi
+
+  failed_count=0
+  while IFS= read -r db; do
+    [ -n "$db" ] || continue
+    if ! run_dolt_gc_for_db "$db"; then
+      failed_count=$((failed_count + 1))
+    fi
+  done < "$_unique_db_tmp"
+
+  if [ "$failed_count" -gt 0 ]; then
+    printf 'gc-nudge: %s database(s) failed GC\n' "$failed_count" >&2
+    exit 1
+  fi
+  exit 0
 }
 
 main "$@"

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# gc dolt gc-nudge — Size-triggered CALL DOLT_GC() to compact a bloated
+# Dolt database.
+#
+# Why this exists: Dolt's auto-GC (default-on in 1.75+) fires on *growth*
+# — 125 MB delta since last GC. A database that bloated once and then
+# stabilized never auto-GCs on its own. This command closes that corner:
+# it checks disk size on each registered rig's Dolt database, and if any
+# are above the configured threshold, issues CALL DOLT_GC() against the
+# managed sql-server.
+#
+# Runs from the dolt pack's dolt-gc-nudge order on a slow cooldown (6h by
+# default). Intended to be idempotent and cheap when nothing needs GC.
+#
+# Environment:
+#   GC_CITY_PATH         (required) — city root
+#   GC_DOLT_PORT         (required) — managed dolt port
+#   GC_DOLT_HOST         (default: 127.0.0.1)
+#   GC_DOLT_USER         (default: root)
+#   GC_DOLT_PASSWORD     (optional)
+#   GC_DOLT_GC_THRESHOLD_BYTES
+#     (default: 2147483648 = 2 GiB) — minimum .dolt/ size that triggers GC.
+#     Set to 0 to force GC on every tick (useful for tests).
+#   GC_DOLT_GC_DRY_RUN   (optional) — when set, prints what would happen
+#                        but does not execute CALL DOLT_GC().
+set -eu
+
+: "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
+: "${GC_DOLT_PORT:?GC_DOLT_PORT must be set}"
+: "${GC_DOLT_USER:=root}"
+
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+host="${GC_DOLT_HOST:-127.0.0.1}"
+threshold="${GC_DOLT_GC_THRESHOLD_BYTES:-2147483648}"
+dry_run="${GC_DOLT_GC_DRY_RUN:-}"
+
+# Cross-city flock to serialize CALL DOLT_GC() across multiple cities
+# sharing the same Dolt sql-server. Keyed on host:port so per-city locks
+# don't let concurrent GCs hit the same server.
+lock_key=$(printf '%s-%s' "$host" "$GC_DOLT_PORT" | tr ':/ ' '---')
+lock_file="${TMPDIR:-/tmp}/gc-dolt-gc-${lock_key}.lock"
+
+# metadata_files — enumerate managed rig metadata.json files, same as
+# commands/health/run.sh. Authoritative source is `gc rig list --json`;
+# fall back to filesystem scan when gc is unavailable.
+metadata_files() {
+  printf '%s\n' "$GC_CITY_PATH/.beads/metadata.json"
+  if command -v gc >/dev/null 2>&1; then
+    # Bound the gc rig list call: if gc itself is wedged (we've seen this
+    # during reconciler incidents) we must not block the nudge for the
+    # full 35m order timeout. Degrade to the filesystem fallback below.
+    # Matches the pattern in examples/dolt/commands/health/run.sh:22.
+    rig_paths=$(run_bounded 5 gc rig list --json 2>/dev/null \
+      | if command -v jq >/dev/null 2>&1; then
+          jq -r '.rigs[].path' 2>/dev/null
+        else
+          grep '"path"' | sed 's/.*"path": *"//;s/".*//'
+        fi) || true
+    if [ -n "$rig_paths" ]; then
+      printf '%s\n' "$rig_paths" | while IFS= read -r p; do
+        [ -n "$p" ] && printf '%s\n' "$p/.beads/metadata.json"
+      done
+      return
+    fi
+  fi
+  find "$GC_CITY_PATH/rigs" -path '*/.beads/metadata.json' 2>/dev/null || true
+}
+
+metadata_db() {
+  meta="$1"
+  [ -f "$meta" ] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.dolt_database // empty' "$meta" 2>/dev/null || true
+    return
+  fi
+  grep -o '"dolt_database"[[:space:]]*:[[:space:]]*"[^"]*"' "$meta" 2>/dev/null \
+    | sed 's/.*: *"//;s/"$//' || true
+}
+
+# dir_bytes — POSIX byte sum of a directory tree. Uses `du -sk` for
+# portability across Linux/macOS; returns 0 if the path is missing.
+dir_bytes() {
+  dir="$1"
+  if [ ! -d "$dir" ]; then
+    printf '0'
+    return 0
+  fi
+  kb=$(du -sk "$dir" 2>/dev/null | awk '{print $1}')
+  case "$kb" in
+    ''|*[!0-9]*) printf '0' ;;
+    *) printf '%s' $((kb * 1024)) ;;
+  esac
+}
+
+run_dolt_gc_for_db() {
+  db="$1"
+  [ -n "$db" ] || return 0
+
+  # Reset rc at function entry. Variables in POSIX sh are global: without
+  # this reset, a previous call's non-zero rc would leak into subsequent
+  # calls whose dolt command succeeds (the `|| rc=$?` branch never fires)
+  # and we'd mis-report success as failure.
+  rc=0
+
+  db_dir="$DOLT_DATA_DIR/$db/.dolt"
+  size=$(dir_bytes "$db_dir")
+
+  if [ "$threshold" -gt 0 ] && [ "$size" -lt "$threshold" ]; then
+    printf 'gc-nudge: db=%s bytes=%s below_threshold=%s — skip\n' \
+      "$db" "$size" "$threshold"
+    return 0
+  fi
+
+  if [ -n "$dry_run" ]; then
+    printf 'gc-nudge: db=%s bytes=%s — dry-run (would CALL DOLT_GC)\n' \
+      "$db" "$size"
+    return 0
+  fi
+
+  printf 'gc-nudge: db=%s bytes=%s — calling DOLT_GC()...\n' "$db" "$size"
+  start=$(date +%s)
+
+  # CALL DOLT_GC() is disruptive on pre-1.75 Dolt; the dolt CLI shells
+  # out to a fresh connection per invocation, so connection churn is
+  # bounded to this one call. Server-side auto-GC is unaffected.
+  if [ -n "${GC_DOLT_PASSWORD:-}" ]; then
+    dolt --host "$host" --port "$GC_DOLT_PORT" \
+      --user "$GC_DOLT_USER" --password "$GC_DOLT_PASSWORD" \
+      --no-tls \
+      sql --database "$db" -q "CALL DOLT_GC()" || rc=$?
+  else
+    dolt --host "$host" --port "$GC_DOLT_PORT" \
+      --user "$GC_DOLT_USER" --no-tls \
+      sql --database "$db" -q "CALL DOLT_GC()" || rc=$?
+  fi
+  elapsed=$(( $(date +%s) - start ))
+
+  after=$(dir_bytes "$db_dir")
+  if [ "$rc" -eq 0 ]; then
+    printf 'gc-nudge: db=%s before=%s after=%s reclaimed=%s duration=%ss — ok\n' \
+      "$db" "$size" "$after" "$((size - after))" "$elapsed"
+  else
+    printf 'gc-nudge: db=%s bytes=%s duration=%ss rc=%s — error\n' \
+      "$db" "$size" "$elapsed" "$rc" >&2
+  fi
+  return "$rc"
+}
+
+main() {
+  # Non-blocking flock so two concurrent nudges (same host:port) don't
+  # double-call GC. Skip silently when held — the other nudge is handling
+  # it.
+  exec 9>"$lock_file"
+  if ! flock -n 9; then
+    printf 'gc-nudge: another nudge already running for %s:%s — skipping\n' \
+      "$host" "$GC_DOLT_PORT"
+    exit 0
+  fi
+
+  # Snapshot rig list once. `metadata_files` can hit the gc binary which
+  # may be slow — we only want to pay that once per run.
+  _meta_tmp=$(mktemp)
+  trap 'rm -f "$_meta_tmp"' EXIT
+  metadata_files > "$_meta_tmp"
+
+  seen_dbs=""
+  rc=0
+  while IFS= read -r meta; do
+    [ -n "$meta" ] || continue
+    db=$(metadata_db "$meta")
+    [ -n "$db" ] || continue
+    # Dedup: multiple rigs may share a database.
+    case " $seen_dbs " in
+      *" $db "*) continue ;;
+    esac
+    seen_dbs="$seen_dbs $db"
+
+    run_dolt_gc_for_db "$db" || rc=$?
+  done < "$_meta_tmp"
+
+  exit "$rc"
+}
+
+main "$@"

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -123,15 +123,20 @@ if [ -d "$data_dir" ] && [ "$server_reachable" = true ]; then
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
     case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
-    # Reject names with anything outside [A-Za-z0-9_] before interpolating
-    # into the SQL identifier. Dolt permits directory names that shell
+    # Reject names with anything outside [A-Za-z0-9_-] before interpolating
+    # into the SQL identifier. The first byte must still be alnum/underscore
+    # so the command-side contract matches gc-nudge and avoids option-shaped
+    # names. Dolt permits directory names that shell
     # basename happily returns (e.g. backticks, semicolons) but which
     # would break out of the identifier and execute attacker-chosen SQL
     # as the patrol user. Not an external-attack surface today — data
     # directories are server-controlled — but fragile enough under
     # config drift that it's worth skipping rather than probing.
     case "$name" in
-      *[!A-Za-z0-9_]*|'') continue ;;
+      [A-Za-z0-9_]*)
+        case "$name" in *[!A-Za-z0-9_-]*) continue ;; esac
+        ;;
+      *) continue ;;
     esac
     # Count commits via SQL (bounded). 0 on timeout or error — keep
     # going rather than hang the whole report. Extract the first

--- a/examples/dolt/doctor/check-dolt/run.sh
+++ b/examples/dolt/doctor/check-dolt/run.sh
@@ -24,6 +24,61 @@ if ! command -v lsof >/dev/null 2>&1; then
     exit 2
 fi
 
-version=$(dolt version 2>/dev/null | head -1)
+timeout_bin=""
+if command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+    timeout_bin="timeout"
+fi
+
+run_bounded() {
+    limit="$1"
+    shift
+    if [ -n "$timeout_bin" ]; then
+        "$timeout_bin" --kill-after=2 "$limit" "$@"
+        return $?
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$limit" "$@" <<'PY'
+import subprocess
+import sys
+
+limit = float(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=limit)
+except subprocess.TimeoutExpired as exc:
+    sys.stdout.write(exc.stdout or "")
+    sys.stderr.write(exc.stderr or "")
+    sys.exit(124)
+sys.stdout.write(proc.stdout)
+sys.stderr.write(proc.stderr)
+sys.exit(proc.returncode)
+PY
+        return $?
+    fi
+    echo "timeout/gtimeout/python3 not found; cannot run bounded command" >&2
+    return 124
+}
+
+version_output=$(run_bounded 10 dolt version 2>/dev/null)
+version_status=$?
+if [ "$version_status" -ne 0 ]; then
+    if [ "$version_status" -eq 124 ]; then
+        echo "dolt version timed out after 10s"
+        echo "retry after fixing local Dolt startup or PATH"
+        exit 1
+    fi
+    echo "unable to run dolt version"
+    echo "install dolt: https://docs.dolthub.com/introduction/installation"
+    exit 1
+fi
+version=$(printf '%s\n' "$version_output" | head -1)
+if [ -z "$version" ]; then
+    echo "unrecognized dolt version output: $version"
+    echo "install dolt: https://docs.dolthub.com/introduction/installation"
+    exit 1
+fi
+
 echo "dolt available ($version), flock ok, lsof ok"
 exit 0

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -542,11 +542,15 @@ func writeManagedRuntimeStateForScriptWithPID(t *testing.T, cityPath string, por
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	dataDir := filepath.Join(cityPath, ".beads", "dolt")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	payload := []byte(fmt.Sprintf(
 		`{"running":true,"pid":%d,"port":%d,"data_dir":%q,"started_at":"2026-04-20T00:00:00Z"}`,
 		pid,
 		port,
-		filepath.Join(cityPath, ".beads", "dolt"),
+		dataDir,
 	))
 	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), payload, 0o644); err != nil {
 		t.Fatal(err)

--- a/examples/dolt/orders/dolt-gc-nudge.toml
+++ b/examples/dolt/orders/dolt-gc-nudge.toml
@@ -1,0 +1,6 @@
+[order]
+description = "Size-triggered CALL DOLT_GC() when a Dolt database grows past threshold"
+trigger = "cooldown"
+interval = "6h"
+exec = "gc dolt gc-nudge"
+timeout = "35m"

--- a/examples/dolt/orders/dolt-gc-nudge.toml
+++ b/examples/dolt/orders/dolt-gc-nudge.toml
@@ -3,4 +3,4 @@ description = "Size-triggered CALL DOLT_GC() when a Dolt database grows past thr
 trigger = "cooldown"
 interval = "6h"
 exec = "gc dolt gc-nudge"
-timeout = "35m"
+timeout = "24h"

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2,18 +2,22 @@ package doctor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/deps"
+	"gopkg.in/yaml.v3"
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -1553,6 +1557,483 @@ func isWorktreeValid(wtPath string) bool {
 	_, err = os.Stat(target)
 	return err == nil
 }
+
+// --- Managed Dolt ops checks (PR 3) ---
+
+// Thresholds for the managed Dolt data directory footprint (bytes).
+const (
+	doltNomsWarnBytes  = int64(2) * 1024 * 1024 * 1024  // 2 GB
+	doltNomsErrorBytes = int64(20) * 1024 * 1024 * 1024 // 20 GB
+)
+
+// Minimum and recommended Dolt versions for managed operation.
+const (
+	doltMinVersion         = "1.50.0"
+	doltRecommendedVersion = "1.75.0"
+)
+
+// resolveManagedDoltDataDir returns the effective Dolt data directory for the
+// managed provider, honoring the GC_DOLT_DATA_DIR override used by
+// cmd/gc/dolt_runtime_layout.go.
+func resolveManagedDoltDataDir(cityPath string) string {
+	if v := strings.TrimSpace(os.Getenv("GC_DOLT_DATA_DIR")); v != "" {
+		return v
+	}
+	return filepath.Join(cityPath, ".beads", "dolt")
+}
+
+// resolveManagedDoltConfigPath returns the effective path to the managed
+// dolt-config.yaml, honoring the GC_DOLT_CONFIG_FILE override used by
+// cmd/gc/dolt_runtime_layout.go.
+func resolveManagedDoltConfigPath(cityPath string) string {
+	if v := strings.TrimSpace(os.Getenv("GC_DOLT_CONFIG_FILE")); v != "" {
+		return v
+	}
+	return filepath.Join(citylayout.PackStateDir(cityPath, "dolt"), "dolt-config.yaml")
+}
+
+// sumDirBytes walks root recursively and returns the total size of regular
+// files found. Missing roots return (0, false, nil); any other walk error is
+// returned.
+func sumDirBytes(root string) (int64, bool, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if !info.IsDir() {
+		return 0, false, fmt.Errorf("%s is not a directory", root)
+	}
+	var total int64
+	err = filepath.WalkDir(root, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, statErr := d.Info()
+		if statErr != nil {
+			return statErr
+		}
+		if fi.Mode().IsRegular() {
+			total += fi.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, true, err
+	}
+	return total, true, nil
+}
+
+func formatGB(bytes int64) string {
+	gb := float64(bytes) / (1024.0 * 1024.0 * 1024.0)
+	return fmt.Sprintf("%.2f GB", gb)
+}
+
+// DoltNomsSizeCheck warns when the managed Dolt database's on-disk footprint
+// is approaching or exceeds operator-set thresholds.
+type DoltNomsSizeCheck struct {
+	cityPath string
+	skip     bool
+}
+
+// NewDoltNomsSizeCheck creates a Dolt noms/on-disk size check.
+func NewDoltNomsSizeCheck(cityPath string, skip bool) *DoltNomsSizeCheck {
+	return &DoltNomsSizeCheck{cityPath: cityPath, skip: skip}
+}
+
+// Name returns the check identifier.
+func (c *DoltNomsSizeCheck) Name() string { return "dolt-noms-size" }
+
+// Run sums bytes under <dataDir>/<database>/.dolt/ and compares to thresholds.
+func (c *DoltNomsSizeCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.skip {
+		r.Status = StatusOK
+		r.Message = "skipped (file backend or GC_DOLT=skip)"
+		return r
+	}
+
+	target, _, active, err := validateBDStoreTarget(c.cityPath, c.cityPath)
+	if err != nil {
+		// Let the beads-store / dolt-server checks report resolution errors.
+		r.Status = StatusOK
+		r.Message = "skipped (dolt target unresolved)"
+		return r
+	}
+	if !active {
+		r.Status = StatusOK
+		r.Message = "skipped (not a managed dolt backend)"
+		return r
+	}
+	if target.External {
+		// External endpoints (DoltHub, remote DB) aren't our disk to measure;
+		// any local `.dolt/` tree would be stale from a prior managed config.
+		r.Status = StatusOK
+		r.Message = "skipped (external dolt endpoint)"
+		return r
+	}
+
+	dataDir := resolveManagedDoltDataDir(c.cityPath)
+	db := strings.TrimSpace(target.Database)
+	var scanRoot string
+	switch {
+	case db != "":
+		scanRoot = filepath.Join(dataDir, db, ".dolt")
+	default:
+		// No database pinned — sum the entire data dir (still meaningful).
+		scanRoot = dataDir
+	}
+
+	total, exists, err := sumDirBytes(scanRoot)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("scan dolt data dir: %v", err)
+		return r
+	}
+	if !exists {
+		r.Status = StatusOK
+		r.Message = "no dolt data yet"
+		return r
+	}
+
+	size := formatGB(total)
+	switch {
+	case total >= doltNomsErrorBytes:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("dolt noms directory is %s — excessive; recovery recommended", size)
+		r.FixHint = "see docs/troubleshooting/dolt-bloat-recovery.md"
+	case total >= doltNomsWarnBytes:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("dolt noms directory is %s — approaching threshold", size)
+		r.FixHint = "see docs/troubleshooting/dolt-bloat-recovery.md"
+	default:
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("dolt data footprint %s", size)
+	}
+	return r
+}
+
+// CanFix returns false — see PR 4 for bloat recovery runbook.
+func (c *DoltNomsSizeCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *DoltNomsSizeCheck) Fix(_ *CheckContext) error { return nil }
+
+// doltConfigExpectedValues captures the keys and expected values asserted by
+// DoltConfigCheck against the managed dolt-config.yaml. Keys are
+// dotted paths into the YAML document.
+//
+// Any key added here must match the value emitted by
+// writeManagedDoltConfigFile in cmd/gc/cmd_dolt_config.go.
+func doltConfigExpectedValues() []struct {
+	Path  string
+	Value any
+} {
+	return []struct {
+		Path  string
+		Value any
+	}{
+		{"behavior.auto_gc_behavior.enable", true},
+		{"behavior.auto_gc_behavior.archive_level", 1},
+		{"listener.read_timeout_millis", 300000},
+		{"listener.write_timeout_millis", 300000},
+		{"listener.max_connections", 1000},
+		{"listener.back_log", 50},
+		{"listener.max_connections_timeout_millis", 5000},
+	}
+}
+
+// lookupYAMLPath walks a dotted key path through a decoded YAML map and
+// returns the leaf value, whether it was present, and whether the traversal
+// hit a non-map node before reaching the leaf.
+func lookupYAMLPath(doc map[string]any, dotted string) (any, bool) {
+	parts := strings.Split(dotted, ".")
+	var cur any = doc
+	for _, p := range parts {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		v, present := m[p]
+		if !present {
+			return nil, false
+		}
+		cur = v
+	}
+	return cur, true
+}
+
+// yamlIntEqual compares a decoded YAML scalar to an expected int value,
+// accepting int, int64, uint64, and float64 decodings (gopkg.in/yaml.v3
+// normally produces int, but be defensive).
+func yamlIntEqual(got any, want int) bool {
+	switch v := got.(type) {
+	case int:
+		return v == want
+	case int64:
+		return int64(want) == v
+	case uint64:
+		return uint64(want) == v //nolint:gosec // want is a fixed positive constant
+	case float64:
+		return v == float64(want)
+	}
+	return false
+}
+
+// DoltConfigCheck verifies the managed dolt-config.yaml exists and contains
+// the expected keys/values written by writeManagedDoltConfigFile.
+type DoltConfigCheck struct {
+	cityPath string
+	skip     bool
+}
+
+// NewDoltConfigCheck creates a managed Dolt config drift check.
+func NewDoltConfigCheck(cityPath string, skip bool) *DoltConfigCheck {
+	return &DoltConfigCheck{cityPath: cityPath, skip: skip}
+}
+
+// Name returns the check identifier.
+func (c *DoltConfigCheck) Name() string { return "dolt-config" }
+
+// Run parses the managed dolt-config.yaml and verifies required keys/values.
+func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.skip {
+		r.Status = StatusOK
+		r.Message = "skipped (file backend or GC_DOLT=skip)"
+		return r
+	}
+
+	path := resolveManagedDoltConfigPath(c.cityPath)
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from city layout
+	if err != nil {
+		if os.IsNotExist(err) {
+			r.Status = StatusWarning
+			r.Message = "managed dolt-config.yaml not found"
+			r.FixHint = "run gc start (or gc dolt restart) to regenerate"
+			return r
+		}
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("read dolt-config.yaml: %v", err)
+		r.FixHint = "run gc start (or gc dolt restart) to regenerate"
+		return r
+	}
+
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("parse dolt-config.yaml: %v", err)
+		r.FixHint = "stop dolt (gc dolt stop) and restart to regenerate managed config"
+		return r
+	}
+
+	var drifted []string
+	for _, exp := range doltConfigExpectedValues() {
+		got, present := lookupYAMLPath(doc, exp.Path)
+		if !present {
+			drifted = append(drifted, exp.Path+" (missing)")
+			continue
+		}
+		switch want := exp.Value.(type) {
+		case bool:
+			if gotBool, ok := got.(bool); !ok || gotBool != want {
+				drifted = append(drifted, fmt.Sprintf("%s (got %v, want %v)", exp.Path, got, want))
+			}
+		case int:
+			if !yamlIntEqual(got, want) {
+				drifted = append(drifted, fmt.Sprintf("%s (got %v, want %d)", exp.Path, got, want))
+			}
+		default:
+			// Strings / other scalars — stringify for compare.
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+				drifted = append(drifted, fmt.Sprintf("%s (got %v, want %v)", exp.Path, got, want))
+			}
+		}
+	}
+
+	if len(drifted) > 0 {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("managed dolt-config.yaml drift: %s", strings.Join(drifted, ", "))
+		r.FixHint = "stop dolt (gc dolt stop) and restart to regenerate managed config"
+		return r
+	}
+
+	r.Status = StatusOK
+	r.Message = "dolt config OK"
+	return r
+}
+
+// CanFix returns false. TODO: wire Fix() into the same code path as
+// `gc start` uses to rewrite the managed config once that helper is exposed
+// from the doctor package.
+func (c *DoltConfigCheck) CanFix() bool { return false }
+
+// Fix is a no-op. See TODO on CanFix.
+func (c *DoltConfigCheck) Fix(_ *CheckContext) error { return nil }
+
+// doltVersionInfo is the parsed semantic version of the installed `dolt`.
+type doltVersionInfo struct {
+	Major, Minor, Patch int
+	Raw                 string
+}
+
+// parseDoltVersion parses the first version-like token from `dolt version`
+// output. Accepted formats:
+//
+//	"dolt version 1.75.2\nWarning: ..."
+//	"dolt version 1.75.2"
+//	"1.75.2"
+//
+// Any suffix after patch (e.g. "-rc1") is ignored.
+func parseDoltVersion(out string) (doltVersionInfo, error) {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return doltVersionInfo{}, fmt.Errorf("empty version output")
+	}
+	// Only look at the first line — dolt sometimes emits a "Warning: ..."
+	// second line for deprecated flags.
+	if i := strings.IndexByte(out, '\n'); i >= 0 {
+		out = out[:i]
+	}
+	out = strings.TrimSpace(out)
+	// Strip the "dolt version " prefix if present.
+	const prefix = "dolt version "
+	if strings.HasPrefix(strings.ToLower(out), prefix) {
+		out = out[len(prefix):]
+	}
+	// Take the first whitespace-delimited token.
+	if i := strings.IndexAny(out, " \t"); i >= 0 {
+		out = out[:i]
+	}
+	out = strings.TrimPrefix(out, "v")
+	// Strip any pre-release / build suffix after MAJOR.MINOR.PATCH.
+	core := out
+	for _, sep := range []string{"-", "+"} {
+		if i := strings.Index(core, sep); i >= 0 {
+			core = core[:i]
+		}
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) < 3 {
+		return doltVersionInfo{}, fmt.Errorf("unrecognized version %q", out)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return doltVersionInfo{}, fmt.Errorf("unrecognized major in %q: %w", out, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return doltVersionInfo{}, fmt.Errorf("unrecognized minor in %q: %w", out, err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return doltVersionInfo{}, fmt.Errorf("unrecognized patch in %q: %w", out, err)
+	}
+	return doltVersionInfo{Major: major, Minor: minor, Patch: patch, Raw: fmt.Sprintf("%d.%d.%d", major, minor, patch)}, nil
+}
+
+// compareDoltVersion returns -1 if a<b, 0 if a==b, 1 if a>b.
+func compareDoltVersion(a, b doltVersionInfo) int {
+	switch {
+	case a.Major != b.Major:
+		if a.Major < b.Major {
+			return -1
+		}
+		return 1
+	case a.Minor != b.Minor:
+		if a.Minor < b.Minor {
+			return -1
+		}
+		return 1
+	case a.Patch != b.Patch:
+		if a.Patch < b.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// DoltVersionCheck shells out to `dolt version` and reports drift from the
+// minimum and recommended versions for managed operation.
+type DoltVersionCheck struct {
+	// versionOutput is injectable for tests. Nil means exec `dolt version`.
+	versionOutput func() (string, error)
+}
+
+// NewDoltVersionCheck creates a dolt binary version check.
+func NewDoltVersionCheck() *DoltVersionCheck {
+	return &DoltVersionCheck{}
+}
+
+// Name returns the check identifier.
+func (c *DoltVersionCheck) Name() string { return "dolt-version" }
+
+// Run invokes `dolt version` and compares against {min, recommended}.
+func (c *DoltVersionCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+
+	getOutput := c.versionOutput
+	if getOutput == nil {
+		getOutput = func() (string, error) {
+			path, lookErr := exec.LookPath("dolt")
+			if lookErr != nil {
+				return "", lookErr
+			}
+			cmd := exec.Command(path, "version")
+			out, err := cmd.CombinedOutput()
+			return string(out), err
+		}
+	}
+
+	out, err := getOutput()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) || strings.Contains(err.Error(), "executable file not found") {
+			r.Status = StatusWarning
+			r.Message = "dolt binary not in PATH"
+			return r
+		}
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("invoke dolt version: %v", err)
+		return r
+	}
+
+	info, err := parseDoltVersion(out)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("parse dolt version: %v", err)
+		return r
+	}
+
+	minVer, _ := parseDoltVersion(doltMinVersion)
+	recVer, _ := parseDoltVersion(doltRecommendedVersion)
+
+	switch {
+	case compareDoltVersion(info, minVer) < 0:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("dolt version %s is below minimum %s required for managed config", info.Raw, doltMinVersion)
+		r.FixHint = "upgrade dolt: https://docs.dolthub.com/introduction/installation"
+	case compareDoltVersion(info, recVer) < 0:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("dolt version %s is below recommended %s; upgrade for default-on auto-GC + archive storage", info.Raw, doltRecommendedVersion)
+		r.FixHint = "upgrade dolt: https://docs.dolthub.com/introduction/installation"
+	default:
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("dolt %s", info.Raw)
+	}
+	return r
+}
+
+// CanFix returns false — upgrade instructions live in the FixHint.
+func (c *DoltVersionCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *DoltVersionCheck) Fix(_ *CheckContext) error { return nil }
 
 // IsControllerRunning probes the controller lock file to determine if a
 // controller is currently running. It tries to acquire the flock — if it

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,7 +25,9 @@ import (
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doltversion"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
@@ -871,7 +874,12 @@ func activeBDStoreFromMetadata(path string) (string, string) {
 }
 
 func sameDoctorScope(a, b string) bool {
-	return filepath.Clean(a) == filepath.Clean(b)
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	resolvedA, errA := filepath.EvalSymlinks(a)
+	resolvedB, errB := filepath.EvalSymlinks(b)
+	return errA == nil && errB == nil && filepath.Clean(resolvedA) == filepath.Clean(resolvedB)
 }
 
 func splitStoreDetails(activeStore, activeSource string, serverRepos, embeddedRepos []string) []string {
@@ -1566,36 +1574,573 @@ const (
 	doltNomsErrorBytes = int64(20) * 1024 * 1024 * 1024 // 20 GB
 )
 
-// Minimum and recommended Dolt versions for managed operation.
-const (
-	doltMinVersion         = "1.50.0"
-	doltRecommendedVersion = "1.75.0"
-)
+var doltVersionCommandTimeout = 10 * time.Second
+
+const doltDirMeasureTimeout = 60 * time.Second
 
 // resolveManagedDoltDataDir returns the effective Dolt data directory for the
-// managed provider, honoring the GC_DOLT_DATA_DIR override used by
-// cmd/gc/dolt_runtime_layout.go.
+// managed provider. Doctor resolves the inspected city from disk, not ambient
+// GC_DOLT_* shell overrides that may point at a different city.
 func resolveManagedDoltDataDir(cityPath string) string {
-	if v := strings.TrimSpace(os.Getenv("GC_DOLT_DATA_DIR")); v != "" {
-		return v
+	if dataDir := publishedManagedDoltDataDir(cityPath); dataDir != "" {
+		return dataDir
 	}
-	return filepath.Join(cityPath, ".beads", "dolt")
+	beadsDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	if info, err := os.Stat(beadsDataDir); err == nil && info.IsDir() {
+		return beadsDataDir
+	}
+
+	packDataDir := filepath.Join(doctorDoltPackStateDir(cityPath), "dolt-data")
+	legacyDataDir := filepath.Join(cityPath, ".gc", "dolt-data")
+	if info, err := os.Stat(legacyDataDir); err == nil && info.IsDir() {
+		return legacyDataDir
+	}
+	if info, err := os.Stat(doctorDoltPackStateDir(cityPath)); err == nil && info.IsDir() {
+		return packDataDir
+	}
+	return packDataDir
 }
 
 // resolveManagedDoltConfigPath returns the effective path to the managed
-// dolt-config.yaml, honoring the GC_DOLT_CONFIG_FILE override used by
-// cmd/gc/dolt_runtime_layout.go.
+// dolt-config.yaml for the inspected city, ignoring ambient GC_DOLT_* shell
+// overrides that may point at a different city.
 func resolveManagedDoltConfigPath(cityPath string) string {
-	if v := strings.TrimSpace(os.Getenv("GC_DOLT_CONFIG_FILE")); v != "" {
-		return v
+	return filepath.Join(doctorDoltPackStateDir(cityPath), "dolt-config.yaml")
+}
+
+type managedDoltDoctorRuntimeState struct {
+	Running bool   `json:"running"`
+	PID     int    `json:"pid"`
+	Port    int    `json:"port"`
+	DataDir string `json:"data_dir"`
+}
+
+func publishedManagedDoltDataDir(cityPath string) string {
+	stateFile := filepath.Join(doctorDoltPackStateDir(cityPath), "dolt-state.json")
+	data, err := os.ReadFile(stateFile) //nolint:gosec // path is derived from managed city layout
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(citylayout.PackStateDir(cityPath, "dolt"), "dolt-config.yaml")
+	var state managedDoltDoctorRuntimeState
+	if json.Unmarshal(data, &state) != nil {
+		return ""
+	}
+	dataDir := strings.TrimSpace(state.DataDir)
+	if dataDir == "" {
+		return ""
+	}
+	if info, err := os.Stat(dataDir); err != nil || !info.IsDir() {
+		return ""
+	}
+	if state.Running && !validPublishedManagedDoltDoctorState(cityPath, state, dataDir) {
+		return ""
+	}
+	if !state.Running && managedDoltDoctorDefaultDataDirExists(cityPath, dataDir) {
+		return ""
+	}
+	return dataDir
+}
+
+func doctorDoltPackStateDir(cityPath string) string {
+	return filepath.Join(doctorCityRuntimeDir(cityPath), "packs", "dolt")
+}
+
+func doctorCityRuntimeDir(cityPath string) string {
+	runtimeDir := strings.TrimSpace(os.Getenv("GC_CITY_RUNTIME_DIR"))
+	if runtimeDir != "" {
+		for _, key := range []string{"GC_CITY_PATH", "GC_CITY"} {
+			if sameDoctorScope(strings.TrimSpace(os.Getenv(key)), cityPath) {
+				return filepath.Clean(runtimeDir)
+			}
+		}
+	}
+	return citylayout.RuntimeDataDir(cityPath)
+}
+
+func validPublishedManagedDoltDoctorState(cityPath string, state managedDoltDoctorRuntimeState, dataDir string) bool {
+	if state.PID <= 0 || state.Port <= 0 {
+		return false
+	}
+	if !pidutil.Alive(state.PID) {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(state.Port)), 250*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	holderPID := managedDoltDoctorPortHolderPID(state.Port)
+	if holderPID > 0 {
+		return holderPID == state.PID
+	}
+	return managedDoltDoctorProcessOwnsRuntime(state.PID, dataDir, resolveManagedDoltConfigPath(cityPath))
+}
+
+func managedDoltDoctorProcessOwnsRuntime(pid int, dataDir, configPath string) bool {
+	cmdline := managedDoltDoctorProcCmdline(pid)
+	if cmdline != "" {
+		if strings.Contains(cmdline, dataDir) || strings.Contains(cmdline, configPath) {
+			return true
+		}
+	}
+	cwd, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "cwd"))
+	if err == nil && sameDoctorScope(cwd, dataDir) {
+		return true
+	}
+	return false
+}
+
+func managedDoltDoctorProcCmdline(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err == nil {
+		return strings.ReplaceAll(string(data), "\x00", " ")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func managedDoltDoctorPortHolderPID(port int) int {
+	if port <= 0 {
+		return 0
+	}
+	if pid, checked := managedDoltDoctorPortHolderFromProc(uint16(port)); checked {
+		return pid
+	}
+	return managedDoltDoctorPortHolderFromLsof(port)
+}
+
+func managedDoltDoctorPortHolderFromProc(port uint16) (int, bool) {
+	inodes := map[string]struct{}{}
+	checked := false
+	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		checked = true
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 10 || fields[3] != "0A" {
+				continue
+			}
+			_, portHex, ok := strings.Cut(fields[1], ":")
+			if !ok {
+				continue
+			}
+			gotPort, err := strconv.ParseUint(portHex, 16, 16)
+			if err != nil || uint16(gotPort) != port {
+				continue
+			}
+			inodes[fields[9]] = struct{}{}
+		}
+	}
+	if !checked {
+		return 0, false
+	}
+	if len(inodes) == 0 {
+		return 0, true
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, true
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || !pidutil.Alive(pid) {
+			continue
+		}
+		fdDir := filepath.Join("/proc", entry.Name(), "fd")
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			target, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+			if err != nil || !strings.HasPrefix(target, "socket:[") || !strings.HasSuffix(target, "]") {
+				continue
+			}
+			inode := strings.TrimSuffix(strings.TrimPrefix(target, "socket:["), "]")
+			if _, ok := inodes[inode]; ok {
+				return pid, true
+			}
+		}
+	}
+	return 0, true
+}
+
+func managedDoltDoctorPortHolderFromLsof(port int) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "lsof", "-nP", "-iTCP:"+strconv.Itoa(port), "-sTCP:LISTEN", "-t").Output()
+	if err != nil {
+		return 0
+	}
+	for _, field := range strings.Fields(string(out)) {
+		pid, err := strconv.Atoi(field)
+		if err == nil && pidutil.Alive(pid) {
+			return pid
+		}
+	}
+	return 0
+}
+
+func managedDoltDoctorDefaultDataDirExists(cityPath, dataDir string) bool {
+	for _, candidate := range []string{
+		filepath.Join(cityPath, ".beads", "dolt"),
+		filepath.Join(cityPath, ".gc", "dolt-data"),
+	} {
+		if sameDoctorScope(candidate, dataDir) {
+			continue
+		}
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+type doltDataScanTarget struct {
+	Database string
+	ScanRoot string
+	Orphan   bool
+}
+
+func isManagedDoltSystemDatabase(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "information_schema", "mysql", "dolt_cluster", "__gc_probe":
+		return true
+	default:
+		return false
+	}
+}
+
+func isManagedDoltUserDatabase(name string) bool {
+	name = strings.TrimSpace(name)
+	if isManagedDoltSystemDatabase(name) {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		valid := c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '_'
+		if i > 0 {
+			valid = valid || c == '-'
+		}
+		if !valid {
+			return false
+		}
+	}
+	return true
+}
+
+func appendDoltDataScanTarget(targets *[]doltDataScanTarget, seenRoots map[string]struct{}, db, scanRoot string, orphan bool) {
+	if _, seen := seenRoots[scanRoot]; seen {
+		return
+	}
+	seenRoots[scanRoot] = struct{}{}
+	*targets = append(*targets, doltDataScanTarget{
+		Database: db,
+		ScanRoot: scanRoot,
+		Orphan:   orphan,
+	})
+}
+
+func managedDoltScopeRootsFromConfig(cityPath string, cfg *config.City) []string {
+	scopeRoots := []string{cityPath}
+	if cfg == nil {
+		return scopeRoots
+	}
+	for _, rig := range cfg.Rigs {
+		rigPath := strings.TrimSpace(rig.Path)
+		if rigPath == "" {
+			continue
+		}
+		if !filepath.IsAbs(rigPath) {
+			rigPath = filepath.Join(cityPath, rigPath)
+		}
+		scopeRoots = append(scopeRoots, rigPath)
+	}
+	return scopeRoots
+}
+
+func managedDoltScopeRootsForConfig(cityPath string, cfg *config.City, cfgErr error) []string {
+	if cfgErr != nil {
+		return managedDoltScopeRootsFromFilesystem(cityPath)
+	}
+	return managedDoltScopeRootsFromConfig(cityPath, cfg)
+}
+
+func managedDoltScopeRootsFromFilesystem(cityPath string) []string {
+	scopeRoots := []string{cityPath}
+	seen := map[string]struct{}{filepath.Clean(cityPath): {}}
+	err := filepath.WalkDir(cityPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		name := d.Name()
+		if d.IsDir() {
+			switch name {
+			case ".git", ".gc":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if name != "metadata.json" || filepath.Base(filepath.Dir(path)) != ".beads" {
+			return nil
+		}
+		scopeRoot := filepath.Clean(filepath.Dir(filepath.Dir(path)))
+		if _, ok := seen[scopeRoot]; ok {
+			return nil
+		}
+		seen[scopeRoot] = struct{}{}
+		scopeRoots = append(scopeRoots, scopeRoot)
+		return nil
+	})
+	if err != nil {
+		return []string{cityPath}
+	}
+	return scopeRoots
+}
+
+func managedDoltScopeRoots(cityPath string) []string {
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		return managedDoltScopeRootsFromFilesystem(cityPath)
+	}
+	return managedDoltScopeRootsFromConfig(cityPath, cfg)
+}
+
+// managedLocalDoltScanTargets returns distinct local Dolt databases referenced
+// by the workspace plus orphaned on-disk databases under the managed data dir.
+// External targets are skipped because their disk footprint is not local state.
+func managedLocalDoltScanTargets(cityPath string) ([]doltDataScanTarget, bool) {
+	return managedLocalDoltScanTargetsForScopeRoots(cityPath, managedDoltScopeRoots(cityPath))
+}
+
+func managedLocalDoltScanTargetsForScopeRoots(cityPath string, scopeRoots []string) ([]doltDataScanTarget, bool) {
+	dataDir := resolveManagedDoltDataDir(cityPath)
+	seenRoots := map[string]struct{}{}
+	targets := make([]doltDataScanTarget, 0, len(scopeRoots))
+	unresolved := false
+	for _, scopeRoot := range scopeRoots {
+		target, _, active, err := validateBDStoreTarget(cityPath, scopeRoot)
+		if err == nil {
+			if !active || target.External {
+				continue
+			}
+			db := strings.TrimSpace(target.Database)
+			if !isManagedDoltUserDatabase(db) {
+				continue
+			}
+			scanRoot := dataDir
+			if db != "" {
+				scanRoot = filepath.Join(dataDir, db, ".dolt")
+			}
+			appendDoltDataScanTarget(&targets, seenRoots, db, scanRoot, false)
+			continue
+		}
+		if !active {
+			continue
+		}
+
+		resolved, resolveErr := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, scopeRoot, "")
+		if resolveErr != nil || resolved.Kind != contract.ScopeConfigAuthoritative {
+			unresolved = true
+			continue
+		}
+		switch resolved.State.EndpointOrigin {
+		case contract.EndpointOriginManagedCity, contract.EndpointOriginInheritedCity:
+		default:
+			continue
+		}
+		db, ok, dbErr := contract.ReadDoltDatabase(fsys.OSFS{}, filepath.Join(scopeRoot, ".beads", "metadata.json"))
+		if dbErr != nil {
+			unresolved = true
+			continue
+		}
+		if !ok {
+			db = "beads"
+		}
+		db = strings.TrimSpace(db)
+		if !isManagedDoltUserDatabase(db) {
+			continue
+		}
+		scanRoot := dataDir
+		if db != "" {
+			scanRoot = filepath.Join(dataDir, db, ".dolt")
+		}
+		appendDoltDataScanTarget(&targets, seenRoots, db, scanRoot, false)
+	}
+
+	if entries, err := os.ReadDir(dataDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			db := entry.Name()
+			if isManagedDoltSystemDatabase(db) {
+				continue
+			}
+			scanRoot := filepath.Join(dataDir, db, ".dolt")
+			if info, statErr := os.Stat(scanRoot); statErr != nil || !info.IsDir() {
+				continue
+			}
+			appendDoltDataScanTarget(&targets, seenRoots, db, scanRoot, true)
+		}
+	} else if !os.IsNotExist(err) {
+		unresolved = true
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].Database == targets[j].Database {
+			return targets[i].ScanRoot < targets[j].ScanRoot
+		}
+		return targets[i].Database < targets[j].Database
+	})
+	return targets, unresolved
+}
+
+func workspaceHasLocalManagedDoltTarget(cityPath string) bool {
+	targets, _ := managedLocalDoltScanTargets(cityPath)
+	return len(targets) > 0
+}
+
+// ManagedLocalDoltChecksApplicableForConfig reports whether managed-local Dolt
+// doctor checks apply, using an already-loaded city config when available.
+func ManagedLocalDoltChecksApplicableForConfig(cityPath string, cfg *config.City, cfgErr error) bool {
+	return managedLocalDoltChecksApplicableForScopeRoots(cityPath, managedDoltScopeRootsForConfig(cityPath, cfg, cfgErr), cfgErr != nil)
+}
+
+// ManagedLocalDoltChecksApplicable reports whether managed-local Dolt doctor
+// checks apply for a city path.
+func ManagedLocalDoltChecksApplicable(cityPath string) bool {
+	return managedLocalDoltChecksApplicable(cityPath)
+}
+
+func managedLocalDoltChecksApplicable(cityPath string) bool {
+	if strings.TrimSpace(cityPath) == "" {
+		return true
+	}
+
+	cityConfigPath := filepath.Join(cityPath, "city.toml")
+	cityHasConfig := false
+	if info, err := os.Stat(cityConfigPath); err == nil && !info.IsDir() {
+		cityHasConfig = true
+	}
+	if cityHasConfig {
+		cfg, err := config.Load(fsys.OSFS{}, cityConfigPath)
+		if err != nil {
+			return managedLocalDoltChecksApplicableForScopeRoots(cityPath, managedDoltScopeRootsFromFilesystem(cityPath), true)
+		}
+		return managedLocalDoltChecksApplicableForScopeRoots(cityPath, managedDoltScopeRootsFromConfig(cityPath, cfg), false)
+	}
+
+	return managedLocalDoltChecksApplicableForScopeRoots(cityPath, managedDoltScopeRootsFromConfig(cityPath, nil), false)
+}
+
+func managedLocalDoltChecksApplicableForScopeRoots(cityPath string, scopeRoots []string, configLoadErr bool) bool {
+	if strings.TrimSpace(cityPath) == "" {
+		return true
+	}
+	cityHasConfig := false
+	if info, err := os.Stat(filepath.Join(cityPath, "city.toml")); err == nil && !info.IsDir() {
+		cityHasConfig = true
+	}
+
+	seenScopes := map[string]struct{}{}
+	for _, scopeRoot := range scopeRoots {
+		scopeRoot = resolveDoctorScopePath(cityPath, scopeRoot)
+		if _, seen := seenScopes[scopeRoot]; seen {
+			continue
+		}
+		seenScopes[scopeRoot] = struct{}{}
+
+		if sameDoctorScope(scopeRoot, cityPath) && !cityHasConfig && !doctorScopeHasBDMetadata(scopeRoot) {
+			continue
+		}
+		if configLoadErr && sameDoctorScope(scopeRoot, cityPath) && !doctorScopeHasBDMetadata(scopeRoot) {
+			continue
+		}
+		if !scopeUsesBDDoltStore(cityPath, scopeRoot) {
+			continue
+		}
+
+		resolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, scopeRoot, "")
+		if err != nil {
+			if doctorRawScopeUsesManagedCity(cityPath, scopeRoot) {
+				return true
+			}
+			continue
+		}
+		switch resolved.Kind {
+		case contract.ScopeConfigMissing:
+			return true
+		case contract.ScopeConfigAuthoritative:
+			switch resolved.State.EndpointOrigin {
+			case contract.EndpointOriginManagedCity:
+				return true
+			case contract.EndpointOriginInheritedCity:
+				if inheritedDoctorScopeUsesManagedCity(cityPath) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func inheritedDoctorScopeUsesManagedCity(cityPath string) bool {
+	cityResolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, cityPath, "")
+	if err != nil || cityResolved.Kind != contract.ScopeConfigAuthoritative {
+		return false
+	}
+	return cityResolved.State.EndpointOrigin == contract.EndpointOriginManagedCity
+}
+
+func doctorRawScopeUsesManagedCity(cityPath, scopeRoot string) bool {
+	state, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(scopeRoot, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		return false
+	}
+	switch state.EndpointOrigin {
+	case contract.EndpointOriginManagedCity:
+		return true
+	case contract.EndpointOriginInheritedCity:
+		return inheritedDoctorScopeUsesManagedCity(cityPath)
+	default:
+		return false
+	}
+}
+
+func managedDoltRuntimeMaterialized(cityPath string) bool {
+	for _, path := range []string{
+		resolveManagedDoltDataDir(cityPath),
+		filepath.Join(cityPath, ".beads", "dolt"),
+		filepath.Join(cityPath, ".gc", "dolt-data"),
+		doctorDoltPackStateDir(cityPath),
+	} {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 // sumDirBytes walks root recursively and returns the total size of regular
 // files found. Missing roots return (0, false, nil); any other walk error is
 // returned.
 func sumDirBytes(root string) (int64, bool, error) {
+	return sumDirBytesWithContext(context.Background(), root)
+}
+
+func sumDirBytesWithContext(ctx context.Context, root string) (int64, bool, error) {
 	info, err := os.Stat(root)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1608,6 +2153,9 @@ func sumDirBytes(root string) (int64, bool, error) {
 	}
 	var total int64
 	err = filepath.WalkDir(root, func(_ string, d fs.DirEntry, walkErr error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -1629,6 +2177,54 @@ func sumDirBytes(root string) (int64, bool, error) {
 	return total, true, nil
 }
 
+func boundedSumDirBytes(root string) (int64, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), doltDirMeasureTimeout)
+	defer cancel()
+	return sumDirBytesWithContext(ctx, root)
+}
+
+func duDirBytes(root string) (int64, bool, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if !info.IsDir() {
+		return 0, false, fmt.Errorf("%s is not a directory", root)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), doltDirMeasureTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "du", "-sk", root)
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		total, exists, fallbackErr := boundedSumDirBytes(root)
+		if fallbackErr != nil {
+			return 0, true, fmt.Errorf("measure dolt data dir: du -sk timed out after %s; fallback walk: %w", doltDirMeasureTimeout, fallbackErr)
+		}
+		return total, exists, nil
+	}
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return boundedSumDirBytes(root)
+		}
+		return 0, true, fmt.Errorf("measure dolt data dir with du -sk: %w", err)
+	}
+
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0, true, fmt.Errorf("measure dolt data dir with du -sk: empty output")
+	}
+	kb, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0, true, fmt.Errorf("measure dolt data dir with du -sk: parse %q: %w", fields[0], err)
+	}
+	return kb * 1024, true, nil
+}
+
 func formatGB(bytes int64) string {
 	gb := float64(bytes) / (1024.0 * 1024.0 * 1024.0)
 	return fmt.Sprintf("%.2f GB", gb)
@@ -1637,83 +2233,135 @@ func formatGB(bytes int64) string {
 // DoltNomsSizeCheck warns when the managed Dolt database's on-disk footprint
 // is approaching or exceeds operator-set thresholds.
 type DoltNomsSizeCheck struct {
-	cityPath string
-	skip     bool
+	cityPath        string
+	skip            bool
+	measureDir      func(string) (int64, bool, error)
+	applicableKnown bool
+	applicable      bool
+	scopeRoots      []string
 }
 
 // NewDoltNomsSizeCheck creates a Dolt noms/on-disk size check.
 func NewDoltNomsSizeCheck(cityPath string, skip bool) *DoltNomsSizeCheck {
-	return &DoltNomsSizeCheck{cityPath: cityPath, skip: skip}
+	return &DoltNomsSizeCheck{cityPath: cityPath, skip: skip, measureDir: duDirBytes}
+}
+
+// NewDoltNomsSizeCheckForConfig creates a Dolt size check using preloaded city config.
+func NewDoltNomsSizeCheckForConfig(cityPath string, skip bool, cfg *config.City, cfgErr error) *DoltNomsSizeCheck {
+	return &DoltNomsSizeCheck{
+		cityPath:        cityPath,
+		skip:            skip,
+		measureDir:      duDirBytes,
+		applicableKnown: true,
+		applicable:      ManagedLocalDoltChecksApplicableForConfig(cityPath, cfg, cfgErr),
+		scopeRoots:      managedDoltScopeRootsForConfig(cityPath, cfg, cfgErr),
+	}
+}
+
+func (c *DoltNomsSizeCheck) managedApplicable() bool {
+	if c.applicableKnown {
+		return c.applicable
+	}
+	return managedLocalDoltChecksApplicable(c.cityPath)
 }
 
 // Name returns the check identifier.
 func (c *DoltNomsSizeCheck) Name() string { return "dolt-noms-size" }
 
-// Run sums bytes under <dataDir>/<database>/.dolt/ and compares to thresholds.
+// Run inspects the workspace's managed local Dolt databases and compares the
+// largest footprint to warning/error thresholds.
 func (c *DoltNomsSizeCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
-	if c.skip {
+	if c.skip || !c.managedApplicable() {
 		r.Status = StatusOK
-		r.Message = "skipped (file backend or GC_DOLT=skip)"
+		r.Message = "skipped (file backend, external dolt endpoint, or GC_DOLT=skip)"
 		return r
 	}
 
-	target, _, active, err := validateBDStoreTarget(c.cityPath, c.cityPath)
-	if err != nil {
-		// Let the beads-store / dolt-server checks report resolution errors.
-		r.Status = StatusOK
-		r.Message = "skipped (dolt target unresolved)"
-		return r
+	targets, unresolved := managedLocalDoltScanTargets(c.cityPath)
+	if c.applicableKnown {
+		targets, unresolved = managedLocalDoltScanTargetsForScopeRoots(c.cityPath, c.scopeRoots)
 	}
-	if !active {
+	if len(targets) == 0 {
+		if unresolved {
+			// Let the beads-store / dolt-server checks report resolution errors.
+			r.Status = StatusOK
+			r.Message = "skipped (dolt target unresolved)"
+			return r
+		}
 		r.Status = StatusOK
-		r.Message = "skipped (not a managed dolt backend)"
-		return r
-	}
-	if target.External {
-		// External endpoints (DoltHub, remote DB) aren't our disk to measure;
-		// any local `.dolt/` tree would be stale from a prior managed config.
-		r.Status = StatusOK
-		r.Message = "skipped (external dolt endpoint)"
+		r.Message = "skipped (file backend, external dolt endpoint, or GC_DOLT=skip)"
 		return r
 	}
 
-	dataDir := resolveManagedDoltDataDir(c.cityPath)
-	db := strings.TrimSpace(target.Database)
-	var scanRoot string
-	switch {
-	case db != "":
-		scanRoot = filepath.Join(dataDir, db, ".dolt")
-	default:
-		// No database pinned — sum the entire data dir (still meaningful).
-		scanRoot = dataDir
+	var (
+		worstTarget doltDataScanTarget
+		worstBytes  int64
+		totalBytes  int64
+		existsCount int
+	)
+	measureDir := c.measureDir
+	if measureDir == nil {
+		measureDir = duDirBytes
 	}
-
-	total, exists, err := sumDirBytes(scanRoot)
-	if err != nil {
-		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("scan dolt data dir: %v", err)
-		return r
+	for _, target := range targets {
+		total, exists, err := measureDir(target.ScanRoot)
+		if err != nil {
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("scan dolt data dir: %v", err)
+			return r
+		}
+		if !exists {
+			continue
+		}
+		existsCount++
+		totalBytes += total
+		if total > worstBytes {
+			worstBytes = total
+			worstTarget = target
+		}
 	}
-	if !exists {
+	if existsCount == 0 {
 		r.Status = StatusOK
 		r.Message = "no dolt data yet"
 		return r
 	}
 
-	size := formatGB(total)
+	targetLabel := strings.TrimSpace(worstTarget.Database)
+	if targetLabel == "" {
+		targetLabel = "managed dolt data"
+	} else if worstTarget.Orphan {
+		targetLabel = "orphan database " + targetLabel
+	}
+	size := formatGB(worstBytes)
+	scopeNote := ""
+	if existsCount > 1 {
+		scopeNote = fmt.Sprintf(" (largest of %d databases)", existsCount)
+	}
 	switch {
-	case total >= doltNomsErrorBytes:
+	case worstBytes >= doltNomsErrorBytes:
 		r.Status = StatusError
-		r.Message = fmt.Sprintf("dolt noms directory is %s — excessive; recovery recommended", size)
+		r.Message = fmt.Sprintf("dolt noms directory for %s is %s%s — excessive; recovery recommended", targetLabel, size, scopeNote)
 		r.FixHint = "see docs/troubleshooting/dolt-bloat-recovery.md"
-	case total >= doltNomsWarnBytes:
+	case totalBytes >= doltNomsErrorBytes:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("aggregate dolt data footprint is %s across %d databases — excessive; recovery recommended", formatGB(totalBytes), existsCount)
+		r.FixHint = "see docs/troubleshooting/dolt-bloat-recovery.md"
+	case worstBytes >= doltNomsWarnBytes:
 		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("dolt noms directory is %s — approaching threshold", size)
+		r.Message = fmt.Sprintf("dolt noms directory for %s is %s%s — approaching threshold", targetLabel, size, scopeNote)
+		r.FixHint = "see docs/troubleshooting/dolt-bloat-recovery.md"
+	case totalBytes >= doltNomsWarnBytes:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("aggregate dolt data footprint is %s across %d databases — approaching threshold", formatGB(totalBytes), existsCount)
 		r.FixHint = "see docs/troubleshooting/dolt-bloat-recovery.md"
 	default:
 		r.Status = StatusOK
-		r.Message = fmt.Sprintf("dolt data footprint %s", size)
+		if existsCount > 1 {
+			r.Message = fmt.Sprintf("aggregate dolt data footprint is %s across %d databases (largest %s: %s)", formatGB(totalBytes), existsCount, targetLabel, size)
+		} else {
+			r.Message = fmt.Sprintf("dolt data footprint for %s %s%s", targetLabel, size, scopeNote)
+		}
 	}
 	return r
 }
@@ -1724,20 +2372,23 @@ func (c *DoltNomsSizeCheck) CanFix() bool { return false }
 // Fix is a no-op.
 func (c *DoltNomsSizeCheck) Fix(_ *CheckContext) error { return nil }
 
-// doltConfigExpectedValues captures the keys and expected values asserted by
-// DoltConfigCheck against the managed dolt-config.yaml. Keys are
-// dotted paths into the YAML document.
-//
-// Any key added here must match the value emitted by
-// writeManagedDoltConfigFile in cmd/gc/cmd_dolt_config.go.
-func doltConfigExpectedValues() []struct {
+// DoltConfigExpectedValue is a dotted YAML path and value expected in the
+// managed dolt-config.yaml.
+type DoltConfigExpectedValue struct {
 	Path  string
 	Value any
-} {
-	return []struct {
-		Path  string
-		Value any
-	}{
+}
+
+// DoltConfigExpectedValues returns the load-bearing managed Dolt config keys
+// asserted by DoltConfigCheck.
+//
+// This is intentionally a contract subset, not a byte-for-byte mirror of
+// writeManagedDoltConfigFile in cmd/gc/cmd_dolt_config.go. It covers the keys
+// whose drift would change managed runtime behavior materially. Dynamic values
+// such as data_dir are checked by DoltConfigCheck because they depend on the
+// inspected city path.
+func DoltConfigExpectedValues() []DoltConfigExpectedValue {
+	return []DoltConfigExpectedValue{
 		{"behavior.auto_gc_behavior.enable", true},
 		{"behavior.auto_gc_behavior.archive_level", 1},
 		{"listener.read_timeout_millis", 300000},
@@ -1786,15 +2437,34 @@ func yamlIntEqual(got any, want int) bool {
 }
 
 // DoltConfigCheck verifies the managed dolt-config.yaml exists and contains
-// the expected keys/values written by writeManagedDoltConfigFile.
+// the load-bearing keys/values required by Gas City's managed Dolt contract.
 type DoltConfigCheck struct {
-	cityPath string
-	skip     bool
+	cityPath        string
+	skip            bool
+	applicableKnown bool
+	applicable      bool
 }
 
 // NewDoltConfigCheck creates a managed Dolt config drift check.
 func NewDoltConfigCheck(cityPath string, skip bool) *DoltConfigCheck {
 	return &DoltConfigCheck{cityPath: cityPath, skip: skip}
+}
+
+// NewDoltConfigCheckForConfig creates a managed Dolt config drift check using preloaded city config.
+func NewDoltConfigCheckForConfig(cityPath string, skip bool, cfg *config.City, cfgErr error) *DoltConfigCheck {
+	return &DoltConfigCheck{
+		cityPath:        cityPath,
+		skip:            skip,
+		applicableKnown: true,
+		applicable:      ManagedLocalDoltChecksApplicableForConfig(cityPath, cfg, cfgErr),
+	}
+}
+
+func (c *DoltConfigCheck) managedApplicable() bool {
+	if c.applicableKnown {
+		return c.applicable
+	}
+	return managedLocalDoltChecksApplicable(c.cityPath)
 }
 
 // Name returns the check identifier.
@@ -1803,9 +2473,9 @@ func (c *DoltConfigCheck) Name() string { return "dolt-config" }
 // Run parses the managed dolt-config.yaml and verifies required keys/values.
 func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
-	if c.skip {
+	if c.skip || !c.managedApplicable() {
 		r.Status = StatusOK
-		r.Message = "skipped (file backend or GC_DOLT=skip)"
+		r.Message = "skipped (file backend, external dolt endpoint, or GC_DOLT=skip)"
 		return r
 	}
 
@@ -1813,6 +2483,11 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 	data, err := os.ReadFile(path) //nolint:gosec // path is derived from city layout
 	if err != nil {
 		if os.IsNotExist(err) {
+			if !managedDoltRuntimeMaterialized(c.cityPath) {
+				r.Status = StatusOK
+				r.Message = "managed dolt-config.yaml not yet generated (run gc start to materialize)"
+				return r
+			}
 			r.Status = StatusWarning
 			r.Message = "managed dolt-config.yaml not found"
 			r.FixHint = "run gc start (or gc dolt restart) to regenerate"
@@ -1833,7 +2508,7 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 	}
 
 	var drifted []string
-	for _, exp := range doltConfigExpectedValues() {
+	for _, exp := range DoltConfigExpectedValues() {
 		got, present := lookupYAMLPath(doc, exp.Path)
 		if !present {
 			drifted = append(drifted, exp.Path+" (missing)")
@@ -1853,6 +2528,14 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
 				drifted = append(drifted, fmt.Sprintf("%s (got %v, want %v)", exp.Path, got, want))
 			}
+		}
+	}
+	if got, present := lookupYAMLPath(doc, "data_dir"); !present {
+		drifted = append(drifted, "data_dir (missing)")
+	} else {
+		want := resolveManagedDoltDataDir(c.cityPath)
+		if !sameDoctorScope(fmt.Sprintf("%v", got), want) {
+			drifted = append(drifted, fmt.Sprintf("data_dir (got %v, want %s)", got, want))
 		}
 	}
 
@@ -1959,24 +2642,60 @@ func compareDoltVersion(a, b doltVersionInfo) int {
 	return 0
 }
 
-// DoltVersionCheck shells out to `dolt version` and reports drift from the
-// minimum and recommended versions for managed operation.
+// DoltVersionCheck shells out to `dolt version` and verifies the managed-Dolt
+// minimum version requirement.
 type DoltVersionCheck struct {
+	cityPath string
 	// versionOutput is injectable for tests. Nil means exec `dolt version`.
-	versionOutput func() (string, error)
+	versionOutput   func() (string, error)
+	skip            bool
+	applicableKnown bool
+	applicable      bool
 }
 
 // NewDoltVersionCheck creates a dolt binary version check.
-func NewDoltVersionCheck() *DoltVersionCheck {
-	return &DoltVersionCheck{}
+func NewDoltVersionCheck(skip ...bool) *DoltVersionCheck {
+	return NewScopedDoltVersionCheck("", skip...)
+}
+
+// NewScopedDoltVersionCheck creates a dolt binary version check for a
+// specific workspace scope so external-only targets can be skipped cleanly.
+func NewScopedDoltVersionCheck(cityPath string, skip ...bool) *DoltVersionCheck {
+	c := &DoltVersionCheck{cityPath: cityPath}
+	if len(skip) > 0 {
+		c.skip = skip[0]
+	}
+	return c
+}
+
+// NewScopedDoltVersionCheckForConfig creates a scoped Dolt version check using preloaded city config.
+func NewScopedDoltVersionCheckForConfig(cityPath string, skip bool, cfg *config.City, cfgErr error) *DoltVersionCheck {
+	return &DoltVersionCheck{
+		cityPath:        cityPath,
+		skip:            skip,
+		applicableKnown: true,
+		applicable:      ManagedLocalDoltChecksApplicableForConfig(cityPath, cfg, cfgErr),
+	}
+}
+
+func (c *DoltVersionCheck) managedApplicable() bool {
+	if c.applicableKnown {
+		return c.applicable
+	}
+	return managedLocalDoltChecksApplicable(c.cityPath)
 }
 
 // Name returns the check identifier.
 func (c *DoltVersionCheck) Name() string { return "dolt-version" }
 
-// Run invokes `dolt version` and compares against {min, recommended}.
+// Run invokes `dolt version` and compares against the managed-Dolt minimum.
 func (c *DoltVersionCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
+	if c.skip || (c.cityPath != "" && !c.managedApplicable()) {
+		r.Status = StatusOK
+		r.Message = "skipped (file backend, external dolt endpoint, or GC_DOLT=skip)"
+		return r
+	}
 
 	getOutput := c.versionOutput
 	if getOutput == nil {
@@ -1985,8 +2704,13 @@ func (c *DoltVersionCheck) Run(_ *CheckContext) *CheckResult {
 			if lookErr != nil {
 				return "", lookErr
 			}
-			cmd := exec.Command(path, "version")
+			ctx, cancel := context.WithTimeout(context.Background(), doltVersionCommandTimeout)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, path, "version")
 			out, err := cmd.CombinedOutput()
+			if ctx.Err() == context.DeadlineExceeded {
+				return string(out), fmt.Errorf("dolt version timed out after %s", doltVersionCommandTimeout)
+			}
 			return string(out), err
 		}
 	}
@@ -2010,22 +2734,16 @@ func (c *DoltVersionCheck) Run(_ *CheckContext) *CheckResult {
 		return r
 	}
 
-	minVer, _ := parseDoltVersion(doltMinVersion)
-	recVer, _ := parseDoltVersion(doltRecommendedVersion)
+	minVer, _ := parseDoltVersion(doltversion.ManagedMin)
 
-	switch {
-	case compareDoltVersion(info, minVer) < 0:
+	if compareDoltVersion(info, minVer) < 0 {
 		r.Status = StatusError
-		r.Message = fmt.Sprintf("dolt version %s is below minimum %s required for managed config", info.Raw, doltMinVersion)
+		r.Message = fmt.Sprintf("dolt version %s is below minimum %s required for managed config", info.Raw, doltversion.ManagedMin)
 		r.FixHint = "upgrade dolt: https://docs.dolthub.com/introduction/installation"
-	case compareDoltVersion(info, recVer) < 0:
-		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("dolt version %s is below recommended %s; upgrade for default-on auto-GC + archive storage", info.Raw, doltRecommendedVersion)
-		r.FixHint = "upgrade dolt: https://docs.dolthub.com/introduction/installation"
-	default:
-		r.Status = StatusOK
-		r.Message = fmt.Sprintf("dolt %s", info.Raw)
+		return r
 	}
+	r.Status = StatusOK
+	r.Message = fmt.Sprintf("dolt %s", info.Raw)
 	return r
 }
 

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -2209,5 +2211,440 @@ func TestWorktreeCheckFix(t *testing.T) {
 	r = c.Run(ctx)
 	if r.Status != StatusOK {
 		t.Errorf("status = %d, want OK after fix; msg = %s", r.Status, r.Message)
+	}
+}
+
+// --- DoltNomsSizeCheck ---
+
+// setupManagedDoltCity creates a minimal managed-bd/Dolt city in a temp dir
+// and returns its path. Runtime state is written for the pinned database.
+func setupManagedDoltCity(t *testing.T) string {
+	t.Helper()
+	const db = "hq"
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginManagedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, dir, db)
+
+	// Provide a reachable runtime state so ResolveDoltConnectionTarget
+	// returns a valid target.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	writeDoctorRuntimeState(t, fs, dir, port)
+	return dir
+}
+
+// writeFakeFile creates a file at path of exactly size bytes (zero-filled).
+func writeFakeFile(t *testing.T, path string, size int64) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path) //nolint:gosec // test helper
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck // test helper
+	if size > 0 {
+		if err := f.Truncate(size); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestDoltNomsSizeCheck_Skipped(t *testing.T) {
+	c := NewDoltNomsSizeCheck(t.TempDir(), true)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK (skipped); msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "skipped") {
+		t.Errorf("message = %q, want skipped", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_NoDataYet(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// No .beads/dolt/hq/.dolt on disk.
+	c := NewDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no dolt data yet") {
+		t.Errorf("message = %q, want no-data message", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_OKUnderThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// 1 MB of data — well under 2 GB warn.
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "file1"), 1024*1024)
+	c := NewDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "footprint") {
+		t.Errorf("message = %q, want footprint description", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_WarnAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// 3 GB — above warn (2 GB), below error (20 GB). Sparse file (Truncate)
+	// does not actually allocate disk, but reported size is 3 GB which
+	// is what our sum uses.
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "big"), 3*1024*1024*1024)
+	c := NewDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "approaching threshold") {
+		t.Errorf("message = %q, want approaching-threshold text", r.Message)
+	}
+	if !strings.Contains(r.FixHint, "dolt-bloat-recovery") {
+		t.Errorf("fix hint = %q, want bloat-recovery doc reference", r.FixHint)
+	}
+}
+
+func TestDoltNomsSizeCheck_ErrorAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	// 21 GB — above error (20 GB).
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "huge"), 21*1024*1024*1024)
+	c := NewDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "excessive") {
+		t.Errorf("message = %q, want excessive text", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_CanFixFalse(t *testing.T) {
+	c := NewDoltNomsSizeCheck(t.TempDir(), false)
+	if c.CanFix() {
+		t.Error("CanFix() = true, want false")
+	}
+}
+
+// --- DoltConfigCheck ---
+
+// writeDoctorManagedDoltConfig writes a config.yaml at the canonical managed
+// path under city. values overrides individual key defaults; any value set to
+// the sentinel string "__missing__" is omitted entirely.
+func writeDoctorManagedDoltConfig(t *testing.T, cityPath string, overrides map[string]any) {
+	t.Helper()
+	defaults := map[string]any{
+		"log_level": "warning",
+		"listener": map[string]any{
+			"port":                           "3307",
+			"host":                           "127.0.0.1",
+			"max_connections":                1000,
+			"back_log":                       50,
+			"max_connections_timeout_millis": 5000,
+			"read_timeout_millis":            300000,
+			"write_timeout_millis":           300000,
+		},
+		"data_dir": filepath.Join(cityPath, ".beads", "dolt"),
+		"behavior": map[string]any{
+			"auto_gc_behavior": map[string]any{
+				"enable":        true,
+				"archive_level": 1,
+			},
+		},
+	}
+	for k, v := range overrides {
+		// Dotted override paths write into the nested map.
+		parts := strings.Split(k, ".")
+		cur := defaults
+		for i, p := range parts {
+			if i == len(parts)-1 {
+				if v == "__missing__" {
+					delete(cur, p)
+				} else {
+					cur[p] = v
+				}
+				break
+			}
+			next, ok := cur[p].(map[string]any)
+			if !ok {
+				next = map[string]any{}
+				cur[p] = next
+			}
+			cur = next
+		}
+	}
+
+	packStateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(packStateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Using yaml.v3 via the doctor package's import is not re-exported;
+	// hand-render instead.
+	var b strings.Builder
+	renderDoctorTestYAML(&b, defaults, 0)
+	if err := os.WriteFile(filepath.Join(packStateDir, "dolt-config.yaml"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// renderDoctorTestYAML hand-renders a nested map[string]any as YAML. Kept
+// minimal; sufficient for dolt-config.yaml test fixtures.
+func renderDoctorTestYAML(b *strings.Builder, m map[string]any, indent int) {
+	// Sort keys for determinism.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pad := strings.Repeat(" ", indent)
+	for _, k := range keys {
+		v := m[k]
+		switch vv := v.(type) {
+		case map[string]any:
+			fmt.Fprintf(b, "%s%s:\n", pad, k)
+			renderDoctorTestYAML(b, vv, indent+2)
+		case string:
+			fmt.Fprintf(b, "%s%s: %q\n", pad, k, vv)
+		case bool:
+			fmt.Fprintf(b, "%s%s: %t\n", pad, k, vv)
+		case int:
+			fmt.Fprintf(b, "%s%s: %d\n", pad, k, vv)
+		default:
+			fmt.Fprintf(b, "%s%s: %v\n", pad, k, vv)
+		}
+	}
+}
+
+func TestDoltConfigCheck_Skipped(t *testing.T) {
+	c := NewDoltConfigCheck(t.TempDir(), true)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "skipped") {
+		t.Errorf("message = %q, want skipped", r.Message)
+	}
+}
+
+func TestDoltConfigCheck_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "not found") {
+		t.Errorf("message = %q, want not-found", r.Message)
+	}
+	if !strings.Contains(r.FixHint, "gc start") {
+		t.Errorf("fix hint = %q, want gc start reference", r.FixHint)
+	}
+}
+
+func TestDoltConfigCheck_OK(t *testing.T) {
+	dir := t.TempDir()
+	writeDoctorManagedDoltConfig(t, dir, nil)
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "OK") {
+		t.Errorf("message = %q, want OK text", r.Message)
+	}
+}
+
+func TestDoltConfigCheck_MissingKey(t *testing.T) {
+	dir := t.TempDir()
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"listener.back_log": "__missing__",
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "listener.back_log") {
+		t.Errorf("message = %q, want listener.back_log mention", r.Message)
+	}
+	if !strings.Contains(r.FixHint, "gc dolt stop") {
+		t.Errorf("fix hint = %q, want stop/restart hint", r.FixHint)
+	}
+}
+
+func TestDoltConfigCheck_WrongValue(t *testing.T) {
+	dir := t.TempDir()
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"listener.max_connections": 500,
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "max_connections") {
+		t.Errorf("message = %q, want max_connections mention", r.Message)
+	}
+}
+
+func TestDoltConfigCheck_AutoGCDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"behavior.auto_gc_behavior.enable": false,
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "auto_gc_behavior.enable") {
+		t.Errorf("message = %q, want auto_gc_behavior.enable mention", r.Message)
+	}
+}
+
+func TestDoltConfigCheck_CanFixFalse(t *testing.T) {
+	c := NewDoltConfigCheck(t.TempDir(), false)
+	if c.CanFix() {
+		t.Error("CanFix() = true, want false")
+	}
+}
+
+// --- DoltVersionCheck ---
+
+func TestParseDoltVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantMaj int
+		wantMin int
+		wantPat int
+		wantErr bool
+	}{
+		{"plain", "dolt version 1.75.2", 1, 75, 2, false},
+		{"with_warning", "dolt version 1.75.2\nWarning: some deprecation", 1, 75, 2, false},
+		{"no_prefix", "1.50.0", 1, 50, 0, false},
+		{"with_v_prefix", "v1.50.0", 1, 50, 0, false},
+		{"prerelease", "dolt version 1.76.0-rc1", 1, 76, 0, false},
+		{"build_suffix", "dolt version 1.76.0+build.5", 1, 76, 0, false},
+		{"empty", "", 0, 0, 0, true},
+		{"garbage", "hello world", 0, 0, 0, true},
+		{"too_few_parts", "dolt version 1.50", 0, 0, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDoltVersion(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseDoltVersion(%q) = %+v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDoltVersion(%q) error: %v", tc.in, err)
+			}
+			if got.Major != tc.wantMaj || got.Minor != tc.wantMin || got.Patch != tc.wantPat {
+				t.Errorf("parseDoltVersion(%q) = %d.%d.%d, want %d.%d.%d",
+					tc.in, got.Major, got.Minor, got.Patch, tc.wantMaj, tc.wantMin, tc.wantPat)
+			}
+		})
+	}
+}
+
+func TestCompareDoltVersion(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.50.0", "1.50.0", 0},
+		{"1.50.0", "1.75.0", -1},
+		{"1.75.0", "1.50.0", 1},
+		{"2.0.0", "1.99.99", 1},
+		{"1.75.1", "1.75.0", 1},
+	}
+	for _, tc := range cases {
+		av, _ := parseDoltVersion(tc.a)
+		bv, _ := parseDoltVersion(tc.b)
+		if got := compareDoltVersion(av, bv); got != tc.want {
+			t.Errorf("compareDoltVersion(%s, %s) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestDoltVersionCheck_OK(t *testing.T) {
+	c := NewDoltVersionCheck()
+	c.versionOutput = func() (string, error) { return "dolt version 1.75.2\n", nil }
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "1.75.2") {
+		t.Errorf("message = %q, want version in message", r.Message)
+	}
+}
+
+func TestDoltVersionCheck_Warn_BelowRecommended(t *testing.T) {
+	c := NewDoltVersionCheck()
+	c.versionOutput = func() (string, error) { return "dolt version 1.60.0\n", nil }
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "below recommended") {
+		t.Errorf("message = %q, want below-recommended text", r.Message)
+	}
+	if !strings.Contains(r.FixHint, "dolthub.com") {
+		t.Errorf("fix hint = %q, want upgrade URL", r.FixHint)
+	}
+}
+
+func TestDoltVersionCheck_Error_BelowMinimum(t *testing.T) {
+	c := NewDoltVersionCheck()
+	c.versionOutput = func() (string, error) { return "dolt version 1.40.0\n", nil }
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "below minimum") {
+		t.Errorf("message = %q, want below-minimum text", r.Message)
+	}
+}
+
+func TestDoltVersionCheck_NotInstalled(t *testing.T) {
+	c := NewDoltVersionCheck()
+	c.versionOutput = func() (string, error) { return "", exec.ErrNotFound }
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "not in PATH") {
+		t.Errorf("message = %q, want not-in-PATH text", r.Message)
+	}
+}
+
+func TestDoltVersionCheck_ParseError(t *testing.T) {
+	c := NewDoltVersionCheck()
+	c.versionOutput = func() (string, error) { return "not-a-version\n", nil }
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning on parse error; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltVersionCheck_CanFixFalse(t *testing.T) {
+	c := NewDoltVersionCheck()
+	if c.CanFix() {
+		t.Error("CanFix() = true, want false")
 	}
 }

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
@@ -2220,6 +2221,8 @@ func TestWorktreeCheckFix(t *testing.T) {
 // and returns its path. Runtime state is written for the pinned database.
 func setupManagedDoltCity(t *testing.T) string {
 	t.Helper()
+	t.Setenv("GC_DOLT_DATA_DIR", "")
+	t.Setenv("GC_DOLT_CONFIG_FILE", "")
 	const db = "hq"
 	dir := t.TempDir()
 	fs := fsys.OSFS{}
@@ -2228,6 +2231,9 @@ func setupManagedDoltCity(t *testing.T) string {
 		EndpointOrigin: contract.EndpointOriginManagedCity,
 		EndpointStatus: contract.EndpointStatusVerified,
 	})
+	if err := os.MkdirAll(filepath.Join(dir, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeDoctorCanonicalMetadata(t, fs, dir, db)
 
 	// Provide a reachable runtime state so ResolveDoltConnectionTarget
@@ -2239,6 +2245,22 @@ func setupManagedDoltCity(t *testing.T) string {
 	t.Cleanup(func() { _ = ln.Close() })
 	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
 	writeDoctorRuntimeState(t, fs, dir, port)
+	return dir
+}
+
+func setupFreshManagedDoltCity(t *testing.T) string {
+	t.Helper()
+	t.Setenv("GC_DOLT_DATA_DIR", "")
+	t.Setenv("GC_DOLT_CONFIG_FILE", "")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	return dir
 }
 
@@ -2260,8 +2282,14 @@ func writeFakeFile(t *testing.T, path string, size int64) {
 	}
 }
 
+func newTestDoltNomsSizeCheck(cityPath string, skip bool) *DoltNomsSizeCheck {
+	c := NewDoltNomsSizeCheck(cityPath, skip)
+	c.measureDir = sumDirBytes
+	return c
+}
+
 func TestDoltNomsSizeCheck_Skipped(t *testing.T) {
-	c := NewDoltNomsSizeCheck(t.TempDir(), true)
+	c := newTestDoltNomsSizeCheck(t.TempDir(), true)
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK (skipped); msg = %s", r.Status, r.Message)
@@ -2274,7 +2302,7 @@ func TestDoltNomsSizeCheck_Skipped(t *testing.T) {
 func TestDoltNomsSizeCheck_NoDataYet(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	// No .beads/dolt/hq/.dolt on disk.
-	c := NewDoltNomsSizeCheck(dir, false)
+	c := newTestDoltNomsSizeCheck(dir, false)
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
@@ -2284,11 +2312,105 @@ func TestDoltNomsSizeCheck_NoDataYet(t *testing.T) {
 	}
 }
 
+func TestDoltNomsSizeCheck_SkipsExternalTargets(t *testing.T) {
+	t.Run("external city", func(t *testing.T) {
+		dir := setupCity(t, "[workspace]\nname = \"test\"\n")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: contract.EndpointOriginCityCanonical,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "db.example.com",
+			DoltPort:       "4411",
+		})
+		writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+
+		c := newTestDoltNomsSizeCheck(dir, false)
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+
+	t.Run("external rig", func(t *testing.T) {
+		dir := setupCity(t, `[workspace]
+name = "test"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "demo"
+path = "demo"
+`)
+		rigDir := filepath.Join(dir, "demo")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+			IssuePrefix:    "de",
+			EndpointOrigin: contract.EndpointOriginExplicit,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "rig-db.example.com",
+			DoltPort:       "4406",
+		})
+		writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+
+		c := newTestDoltNomsSizeCheck(dir, false)
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+
+	t.Run("inherited external city", func(t *testing.T) {
+		dir := setupCity(t, `[workspace]
+name = "test"
+
+[[rigs]]
+name = "demo"
+path = "demo"
+`)
+		rigDir := filepath.Join(dir, "demo")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: contract.EndpointOriginCityCanonical,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "db.example.com",
+			DoltPort:       "4411",
+		})
+		writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+		writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+			IssuePrefix:    "de",
+			EndpointOrigin: contract.EndpointOriginInheritedCity,
+			EndpointStatus: contract.EndpointStatusVerified,
+		})
+		writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+
+		if ManagedLocalDoltChecksApplicable(dir) {
+			t.Fatal("ManagedLocalDoltChecksApplicable() = true, want false for inherited external city endpoint")
+		}
+		c := newTestDoltNomsSizeCheck(dir, false)
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+}
+
 func TestDoltNomsSizeCheck_OKUnderThreshold(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	// 1 MB of data — well under 2 GB warn.
 	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "file1"), 1024*1024)
-	c := NewDoltNomsSizeCheck(dir, false)
+	c := newTestDoltNomsSizeCheck(dir, false)
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
@@ -2298,13 +2420,35 @@ func TestDoltNomsSizeCheck_OKUnderThreshold(t *testing.T) {
 	}
 }
 
+func TestDuDirBytes_NonSparseFile(t *testing.T) {
+	dir := t.TempDir()
+	data := make([]byte, 64*1024)
+	for i := range data {
+		data[i] = 'x'
+	}
+	if err := os.WriteFile(filepath.Join(dir, "chunk"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	total, exists, err := duDirBytes(dir)
+	if err != nil {
+		t.Fatalf("duDirBytes: %v", err)
+	}
+	if !exists {
+		t.Fatal("duDirBytes exists = false, want true")
+	}
+	if total < int64(len(data)) {
+		t.Fatalf("duDirBytes total = %d, want at least %d", total, len(data))
+	}
+}
+
 func TestDoltNomsSizeCheck_WarnAtThreshold(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	// 3 GB — above warn (2 GB), below error (20 GB). Sparse file (Truncate)
 	// does not actually allocate disk, but reported size is 3 GB which
 	// is what our sum uses.
 	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "big"), 3*1024*1024*1024)
-	c := NewDoltNomsSizeCheck(dir, false)
+	c := newTestDoltNomsSizeCheck(dir, false)
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusWarning {
 		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
@@ -2321,7 +2465,7 @@ func TestDoltNomsSizeCheck_ErrorAtThreshold(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	// 21 GB — above error (20 GB).
 	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "huge"), 21*1024*1024*1024)
-	c := NewDoltNomsSizeCheck(dir, false)
+	c := newTestDoltNomsSizeCheck(dir, false)
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusError {
 		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
@@ -2331,8 +2475,390 @@ func TestDoltNomsSizeCheck_ErrorAtThreshold(t *testing.T) {
 	}
 }
 
+func TestDoltNomsSizeCheck_RigDatabaseWarnAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	rigDir := filepath.Join(dir, "demo")
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+
+[[rigs]]
+name = "demo"
+path = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+		IssuePrefix:    "de",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "de", ".dolt", "noms", "big"), 3*1024*1024*1024)
+
+	c := newTestDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "de") {
+		t.Fatalf("message = %q, want rig database name", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_ConfigErrorScansManagedRigMetadata(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	rigDir := filepath.Join(dir, "demo")
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+		IssuePrefix:    "de",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+
+	c := NewDoltNomsSizeCheckForConfig(dir, false, nil, os.ErrInvalid)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, string(filepath.Separator)+"de"+string(filepath.Separator)+".dolt") {
+			return 3 * 1024 * 1024 * 1024, true, nil
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "de") {
+		t.Fatalf("message = %q, want filesystem-discovered rig database name", r.Message)
+	}
+}
+
+func TestManagedLocalDoltChecksApplicable_ConfigErrorScansManagedRigMetadata(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	rigDir := filepath.Join(dir, "demo")
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+		IssuePrefix:    "de",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+
+	if !ManagedLocalDoltChecksApplicable(dir) {
+		t.Fatal("ManagedLocalDoltChecksApplicable() = false, want true for filesystem-discovered managed rig metadata")
+	}
+}
+
+func TestDoltNomsSizeCheck_AggregateWarnAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	rigDir := filepath.Join(dir, "demo")
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+
+[[rigs]]
+name = "demo"
+path = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+		IssuePrefix:    "de",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "hq", ".dolt", "noms", "one"), 1536*1024*1024)
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "de", ".dolt", "noms", "two"), 1536*1024*1024)
+
+	c := newTestDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "aggregate") {
+		t.Fatalf("message = %q, want aggregate threshold warning", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_OrphanDatabaseWarnAtThreshold(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	writeFakeFile(t, filepath.Join(dir, ".beads", "dolt", "orphan-db", ".dolt", "noms", "big"), 3*1024*1024*1024)
+
+	c := newTestDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "orphan database orphan-db") {
+		t.Fatalf("message = %q, want orphan database name", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_SkipsSystemDatabaseMetadata(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"dolt_database":"mysql"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".beads", "dolt", "mysql", ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, string(filepath.Separator)+"mysql"+string(filepath.Separator)) {
+			t.Fatalf("measureDir called for system database path %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_SkipsInvalidDatabaseMetadata(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "metadata.json"), []byte(`{"dolt_database":"../../outside"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "outside") {
+			t.Fatalf("measureDir called for invalid database path %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_LegacyManagedDataDirWarnAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	fs := fsys.OSFS{}
+	writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginManagedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeFile(t, filepath.Join(dir, ".gc", "dolt-data", "hq", ".dolt", "noms", "big"), 3*1024*1024*1024)
+
+	c := newTestDoltNomsSizeCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "hq") {
+		t.Fatalf("message = %q, want legacy managed database name", r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_IgnoresAmbientDataDirOverride(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	t.Setenv("GC_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "wrong-dolt-data"))
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "wrong-dolt-data") {
+			t.Fatalf("measureDir used ambient data override path %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK ignoring ambient data override; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_UsesPublishedRuntimeDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	dataDir := filepath.Join(t.TempDir(), "relocated-dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+	statePath := filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	state := fmt.Sprintf(`{"running":true,"pid":%d,"port":%d,"data_dir":%q}`, os.Getpid(), port, dataDir)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "relocated-dolt-data") {
+			return 3 * 1024 * 1024 * 1024, true, nil
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning for published relocated data dir; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_IgnoresPublishedRuntimeDataDirWithUnreachablePort(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	dataDir := filepath.Join(t.TempDir(), "unreachable-port-dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Close listener: %v", err)
+	}
+	statePath := filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	state := fmt.Sprintf(`{"running":true,"pid":%d,"port":%d,"data_dir":%q}`, os.Getpid(), port, dataDir)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "unreachable-port-dolt-data") {
+			t.Fatalf("measureDir used stale running data dir %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK after ignoring unreachable published state; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_UsesStoppedPublishedRuntimeDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	if err := os.Remove(filepath.Join(dir, ".beads", "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	dataDir := filepath.Join(t.TempDir(), "relocated-stopped-dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	state := fmt.Sprintf(`{"running":false,"pid":0,"port":0,"data_dir":%q}`, dataDir)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "relocated-stopped-dolt-data") {
+			return 3 * 1024 * 1024 * 1024, true, nil
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning for stopped published data dir; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_IgnoresStaleStoppedPublishedRuntimeDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	dataDir := filepath.Join(t.TempDir(), "stale-stopped-dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	state := fmt.Sprintf(`{"running":false,"pid":0,"port":0,"data_dir":%q}`, dataDir)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "stale-stopped-dolt-data") {
+			t.Fatalf("measureDir used stale stopped data dir %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK after ignoring stale stopped state; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_IgnoresMissingPublishedRuntimeDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	dataDir := filepath.Join(t.TempDir(), "missing-relocated-dolt-data")
+	statePath := filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	state := fmt.Sprintf(`{"running":false,"pid":0,"port":0,"data_dir":%q}`, dataDir)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "missing-relocated-dolt-data") {
+			t.Fatalf("measureDir used missing published data dir %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK after falling back from missing data dir; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltNomsSizeCheck_IgnoresStaleRunningPublishedRuntimeDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	dataDir := filepath.Join(t.TempDir(), "stale-running-dolt-data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(dir, ".gc", "runtime", "packs", "dolt", "dolt-state.json")
+	state := fmt.Sprintf(`{"running":true,"pid":99999999,"port":3307,"data_dir":%q}`, dataDir)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewDoltNomsSizeCheck(dir, false)
+	c.measureDir = func(path string) (int64, bool, error) {
+		if strings.Contains(path, "stale-running-dolt-data") {
+			t.Fatalf("measureDir used stale running data dir %s", path)
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK after ignoring stale running state; msg = %s", r.Status, r.Message)
+	}
+}
+
 func TestDoltNomsSizeCheck_CanFixFalse(t *testing.T) {
-	c := NewDoltNomsSizeCheck(t.TempDir(), false)
+	c := newTestDoltNomsSizeCheck(t.TempDir(), false)
 	if c.CanFix() {
 		t.Error("CanFix() = true, want false")
 	}
@@ -2386,7 +2912,7 @@ func writeDoctorManagedDoltConfig(t *testing.T, cityPath string, overrides map[s
 		}
 	}
 
-	packStateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	packStateDir := filepath.Dir(resolveManagedDoltConfigPath(cityPath))
 	if err := os.MkdirAll(packStateDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -2394,7 +2920,7 @@ func writeDoctorManagedDoltConfig(t *testing.T, cityPath string, overrides map[s
 	// hand-render instead.
 	var b strings.Builder
 	renderDoctorTestYAML(&b, defaults, 0)
-	if err := os.WriteFile(filepath.Join(packStateDir, "dolt-config.yaml"), []byte(b.String()), 0o644); err != nil {
+	if err := os.WriteFile(resolveManagedDoltConfigPath(cityPath), []byte(b.String()), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2439,7 +2965,7 @@ func TestDoltConfigCheck_Skipped(t *testing.T) {
 }
 
 func TestDoltConfigCheck_MissingFile(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupManagedDoltCity(t)
 	c := NewDoltConfigCheck(dir, false)
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusWarning {
@@ -2453,8 +2979,27 @@ func TestDoltConfigCheck_MissingFile(t *testing.T) {
 	}
 }
 
+func TestDoltConfigCheck_FreshManagedCityNotYetGenerated(t *testing.T) {
+	dir := setupFreshManagedDoltCity(t)
+	if workspaceHasLocalManagedDoltTarget(dir) {
+		t.Fatal("workspaceHasLocalManagedDoltTarget() = true, want false for fresh managed city")
+	}
+
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "not yet generated") {
+		t.Fatalf("message = %q, want not-yet-generated text", r.Message)
+	}
+	if strings.Contains(r.Message, "skipped") {
+		t.Fatalf("message = %q, want explicit fresh-managed-city status", r.Message)
+	}
+}
+
 func TestDoltConfigCheck_OK(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, nil)
 	c := NewDoltConfigCheck(dir, false)
 	r := c.Run(&CheckContext{})
@@ -2466,8 +3011,67 @@ func TestDoltConfigCheck_OK(t *testing.T) {
 	}
 }
 
+func TestDoltConfigCheck_UsesTrustedCityRuntimeDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	customRuntimeDir := filepath.Join(t.TempDir(), "runtime-root")
+	t.Setenv("GC_CITY_PATH", dir)
+	t.Setenv("GC_CITY_RUNTIME_DIR", customRuntimeDir)
+	packStateDir := doctorDoltPackStateDir(dir)
+	if err := os.MkdirAll(packStateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	state := fmt.Sprintf(`{"running":true,"pid":%d,"port":%d,"data_dir":%q}`,
+		os.Getpid(),
+		ln.Addr().(*net.TCPAddr).Port,
+		filepath.Join(dir, ".beads", "dolt"),
+	)
+	if err := os.WriteFile(filepath.Join(packStateDir, "dolt-state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorManagedDoltConfig(t, dir, nil)
+
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK with trusted city runtime dir; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltConfigCheck_AcceptsSymlinkEquivalentDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	linkPath := filepath.Join(dir, "dolt-data-link")
+	if err := os.Symlink(filepath.Join(dir, ".beads", "dolt"), linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"data_dir": linkPath,
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK for symlink-equivalent data_dir; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltConfigCheck_IgnoresAmbientConfigOverride(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	writeDoctorManagedDoltConfig(t, dir, nil)
+	t.Setenv("GC_DOLT_CONFIG_FILE", filepath.Join(t.TempDir(), "missing-dolt-config.yaml"))
+
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK ignoring ambient config override; msg = %s", r.Status, r.Message)
+	}
+}
+
 func TestDoltConfigCheck_MissingKey(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, map[string]any{
 		"listener.back_log": "__missing__",
 	})
@@ -2485,7 +3089,7 @@ func TestDoltConfigCheck_MissingKey(t *testing.T) {
 }
 
 func TestDoltConfigCheck_WrongValue(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, map[string]any{
 		"listener.max_connections": 500,
 	})
@@ -2499,8 +3103,23 @@ func TestDoltConfigCheck_WrongValue(t *testing.T) {
 	}
 }
 
+func TestDoltConfigCheck_WrongDataDir(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"data_dir": filepath.Join(t.TempDir(), "wrong-dolt-data"),
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "data_dir") {
+		t.Errorf("message = %q, want data_dir mention", r.Message)
+	}
+}
+
 func TestDoltConfigCheck_AutoGCDisabled(t *testing.T) {
-	dir := t.TempDir()
+	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, map[string]any{
 		"behavior.auto_gc_behavior.enable": false,
 	})
@@ -2518,6 +3137,91 @@ func TestDoltConfigCheck_CanFixFalse(t *testing.T) {
 	c := NewDoltConfigCheck(t.TempDir(), false)
 	if c.CanFix() {
 		t.Error("CanFix() = true, want false")
+	}
+}
+
+func TestDoltConfigCheck_SkipsExternalTargets(t *testing.T) {
+	t.Run("external city", func(t *testing.T) {
+		dir := setupCity(t, "[workspace]\nname = \"test\"\n")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: contract.EndpointOriginCityCanonical,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "db.example.com",
+			DoltPort:       "4411",
+		})
+		writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+
+		c := NewDoltConfigCheck(dir, false)
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+
+	t.Run("external rig", func(t *testing.T) {
+		dir := setupCity(t, `[workspace]
+name = "test"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "demo"
+path = "demo"
+`)
+		rigDir := filepath.Join(dir, "demo")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+			IssuePrefix:    "de",
+			EndpointOrigin: contract.EndpointOriginExplicit,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "rig-db.example.com",
+			DoltPort:       "4406",
+		})
+		writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+
+		c := NewDoltConfigCheck(dir, false)
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+}
+
+func TestManagedDoltChecksSkipInvalidCityConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sizeCheck := NewDoltNomsSizeCheck(dir, false)
+	sizeResult := sizeCheck.Run(&CheckContext{})
+	if sizeResult.Status != StatusOK || !strings.Contains(sizeResult.Message, "skipped") {
+		t.Fatalf("dolt-noms-size status=%d message=%q, want skipped OK", sizeResult.Status, sizeResult.Message)
+	}
+
+	configCheck := NewDoltConfigCheck(dir, false)
+	configResult := configCheck.Run(&CheckContext{})
+	if configResult.Status != StatusOK || !strings.Contains(configResult.Message, "skipped") {
+		t.Fatalf("dolt-config status=%d message=%q, want skipped OK", configResult.Status, configResult.Message)
+	}
+
+	versionCheck := NewScopedDoltVersionCheck(dir)
+	versionCheck.versionOutput = func() (string, error) {
+		t.Fatal("versionOutput should not run when city.toml is invalid")
+		return "", nil
+	}
+	versionResult := versionCheck.Run(&CheckContext{})
+	if versionResult.Status != StatusOK || !strings.Contains(versionResult.Message, "skipped") {
+		t.Fatalf("dolt-version status=%d message=%q, want skipped OK", versionResult.Status, versionResult.Message)
 	}
 }
 
@@ -2584,34 +3288,43 @@ func TestCompareDoltVersion(t *testing.T) {
 
 func TestDoltVersionCheck_OK(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.75.2\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 1.86.2\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if !strings.Contains(r.Message, "1.75.2") {
+	if !strings.Contains(r.Message, "1.86.2") {
 		t.Errorf("message = %q, want version in message", r.Message)
 	}
 }
 
-func TestDoltVersionCheck_Warn_BelowRecommended(t *testing.T) {
+func TestDoltVersionCheck_OK_AtMinimum(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.60.0\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 1.86.1\n", nil }
 	r := c.Run(&CheckContext{})
-	if r.Status != StatusWarning {
-		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if !strings.Contains(r.Message, "below recommended") {
-		t.Errorf("message = %q, want below-recommended text", r.Message)
+	if !strings.Contains(r.Message, "1.86.1") {
+		t.Errorf("message = %q, want version in message", r.Message)
 	}
-	if !strings.Contains(r.FixHint, "dolthub.com") {
-		t.Errorf("fix hint = %q, want upgrade URL", r.FixHint)
+}
+
+func TestDoltVersionCheck_Error_BelowManagedConfigFloor(t *testing.T) {
+	c := NewDoltVersionCheck()
+	c.versionOutput = func() (string, error) { return "dolt version 1.75.2\n", nil }
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "below minimum") {
+		t.Errorf("message = %q, want below-minimum text", r.Message)
 	}
 }
 
 func TestDoltVersionCheck_Error_BelowMinimum(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.40.0\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 1.86.0\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusError {
 		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
@@ -2630,6 +3343,131 @@ func TestDoltVersionCheck_NotInstalled(t *testing.T) {
 	}
 	if !strings.Contains(r.Message, "not in PATH") {
 		t.Errorf("message = %q, want not-in-PATH text", r.Message)
+	}
+}
+
+func TestDoltVersionCheck_Skipped(t *testing.T) {
+	c := NewDoltVersionCheck(true)
+	c.versionOutput = func() (string, error) {
+		t.Fatal("versionOutput should not run when skipped")
+		return "", nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK", r.Status)
+	}
+	if !strings.Contains(r.Message, "skipped") {
+		t.Fatalf("message = %q, want skipped", r.Message)
+	}
+}
+
+func TestDoltVersionCheck_SkipsExternalTargets(t *testing.T) {
+	t.Run("external city", func(t *testing.T) {
+		dir := setupCity(t, "[workspace]\nname = \"test\"\n")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, dir, contract.ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: contract.EndpointOriginCityCanonical,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "db.example.com",
+			DoltPort:       "4411",
+		})
+		writeDoctorCanonicalMetadata(t, fs, dir, "hq")
+
+		c := NewScopedDoltVersionCheck(dir)
+		c.versionOutput = func() (string, error) {
+			t.Fatal("versionOutput should not run for external target")
+			return "", nil
+		}
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+
+	t.Run("external rig", func(t *testing.T) {
+		dir := setupCity(t, `[workspace]
+name = "test"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "demo"
+path = "demo"
+`)
+		rigDir := filepath.Join(dir, "demo")
+		fs := fsys.OSFS{}
+		writeDoctorCanonicalConfig(t, fs, rigDir, contract.ConfigState{
+			IssuePrefix:    "de",
+			EndpointOrigin: contract.EndpointOriginExplicit,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "rig-db.example.com",
+			DoltPort:       "4406",
+		})
+		writeDoctorCanonicalMetadata(t, fs, rigDir, "de")
+
+		c := NewScopedDoltVersionCheck(dir)
+		c.versionOutput = func() (string, error) {
+			t.Fatal("versionOutput should not run for external target")
+			return "", nil
+		}
+		r := c.Run(&CheckContext{})
+		if r.Status != StatusOK {
+			t.Fatalf("status = %d, want OK skip; msg = %s", r.Status, r.Message)
+		}
+		if !strings.Contains(r.Message, "skipped") {
+			t.Fatalf("message = %q, want skipped", r.Message)
+		}
+	})
+}
+
+func TestDoltVersionCheck_FreshManagedCityStillChecksLocalBinary(t *testing.T) {
+	dir := setupFreshManagedDoltCity(t)
+	c := NewScopedDoltVersionCheck(dir)
+	called := false
+	c.versionOutput = func() (string, error) {
+		called = true
+		return "", exec.ErrNotFound
+	}
+	r := c.Run(&CheckContext{})
+	if !called {
+		t.Fatal("versionOutput was not invoked for fresh managed city")
+	}
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "not in PATH") {
+		t.Fatalf("message = %q, want not-in-PATH text", r.Message)
+	}
+}
+
+func TestDoltVersionCheck_Timeout(t *testing.T) {
+	oldTimeout := doltVersionCommandTimeout
+	doltVersionCommandTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { doltVersionCommandTimeout = oldTimeout })
+
+	binDir := t.TempDir()
+	doltPath := filepath.Join(binDir, "dolt")
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("LookPath(sleep): %v", err)
+	}
+	if err := os.WriteFile(doltPath, []byte("#!/bin/sh\n"+sleepPath+" 5\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	c := NewDoltVersionCheck()
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "timed out") {
+		t.Fatalf("message = %q, want timeout warning", r.Message)
 	}
 }
 

--- a/internal/doltversion/doltversion.go
+++ b/internal/doltversion/doltversion.go
@@ -1,0 +1,5 @@
+// Package doltversion centralizes Dolt version requirements.
+package doltversion
+
+// ManagedMin is the minimum Dolt version required for managed bd/Dolt operation.
+const ManagedMin = "1.86.1"

--- a/test/acceptance/worker_inference/worker_inference_test.go
+++ b/test/acceptance/worker_inference/worker_inference_test.go
@@ -59,6 +59,7 @@ const (
 var inferenceDisabledOrders = []string{
 	"beads-health",
 	"cross-rig-deps",
+	"dolt-gc-nudge",
 	"dolt-health",
 	"dolt-remotes-patrol",
 	"gate-sweep",


### PR DESCRIPTION
## Summary

Addresses the observed symptom of managed local Dolt stores growing very large after days of agent-driven work, and tightens Gas City's managed Dolt operational checks.

Operational premise: Dolt auto-GC is growth-triggered rather than size-triggered, so a store that has already grown large may stay large without another trigger event. This PR does not claim a newly isolated upstream bug beyond that observed large-store symptom; it adds a scheduled GC nudge, doctor checks, and a recovery runbook for managed local Dolt workspaces.

## What this does

### Managed `config.yaml` tightening

`cmd/gc/cmd_dolt_config.go` now emits:

- `listener.back_log: 50`
- `listener.max_connections_timeout_millis: 5000`

This makes accept-queue pressure fail fast instead of hanging clients.

Upgrade note: existing managed cities may report a `dolt-config` doctor warning until `gc dolt restart` (or the next managed server start) regenerates `dolt-config.yaml` with these listener keys.

### Scheduled `DOLT_GC` nudge via the Dolt pack

Adds a Dolt pack order and command:

- `examples/dolt/orders/dolt-gc-nudge.toml` schedules the nudge on a 6h cooldown.
- `examples/dolt/commands/gc-nudge/run.sh` scans managed rig metadata plus on-disk database directories, measures database and aggregate `.dolt/` footprint, and calls `CALL DOLT_GC()` when per-database or aggregate size is above `GC_DOLT_GC_THRESHOLD_BYTES`.
- The default threshold is 2 GiB; `GC_DOLT_GC_THRESHOLD_BYTES=0` forces a nudge for smoke testing.
- The command serializes GC per host/port, validates threshold input, sources runtime defaults before requiring `GC_DOLT_PORT`, bounds the GC CLI call, and passes passwords through `DOLT_CLI_PASSWORD` instead of argv.

### Doctor checks

Adds managed Dolt doctor checks in `internal/doctor/checks.go` and registers them in `cmd/gc/cmd_doctor.go`:

- `dolt-noms-size`: warns at 2 GiB and errors at 20 GiB for managed local Dolt data, and skips external-only targets.
- `dolt-config`: verifies the load-bearing managed YAML keys required by the managed Dolt contract.
- `dolt-version`: enforces the managed local Dolt minimum (`1.86.1`) only when managed Dolt is relevant, with a bounded `dolt version` invocation.

### Recovery runbook

Adds `docs/troubleshooting/dolt-bloat-recovery.md` and links it from docs navigation and the guides index. The runbook uses real Dolt commands only: `dolt gc --archive-level=1`, then plain `dolt gc` as fallback.

## What's not in this PR

- No Go supervisor ticker or `supervisor.dolt_gc_nudge_*` config keys. Scheduling is handled by the Dolt pack order.
- No VictoriaMetrics telemetry gauge for `gc.dolt.noms_size_bytes`.
- PR 5 parallelism caps/retry audit remains deferred.
- The deeper slow concurrent write issue is in `bd`'s per-operation commit cadence, not this Gas City PR.

## Impact

| Symptom | Addressed by | Expected relief |
|--|--|--|
| `.beads/dolt/` grows very large | Pack GC nudge + recovery runbook | Recover existing stores manually; reduce recurrence via scheduled nudge |
| Slow concurrent writes | Listener fail-fast tuning | Marginal; deeper fix belongs in `bd` |

## Test plan

- [ ] `go test ./cmd/gc -run 'TestManagedDoltOpsCheckSkipKeepsCityManagedWorkspaceEnabled|TestDoltGCNudge|TestDoltConfig|TestBuiltinDoltDoctor'`
- [ ] `go test ./internal/doctor -run 'TestDoltNomsSize|TestDoltConfig|TestDoltVersion|TestParseDoltVersion|TestCompareDoltVersion'`
- [ ] `go test ./cmd/gc ./internal/doctor`
- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] Smoke-test the nudge against a real city by setting `GC_DOLT_GC_THRESHOLD_BYTES=0` or a low threshold and verifying the `gc-nudge` log line.
- [ ] Smoke-test `gc doctor` on a fresh managed-Dolt city, a bloated workspace, and a file/external-Dolt city.


