### PR TITLE
fix: use positional $3 for config path in fake dolt test scripts

### DIFF
--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -2174,7 +2174,7 @@ set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
 case "$*" in
   "sql-server --config "*)
-    config_file=${*#sql-server --config }
+    config_file=$3
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
     data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
     exec python3 - "$port" "$data_dir" <<'INNERPY'
@@ -2603,7 +2603,7 @@ set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
 case "$*" in
   "sql-server --config "*)
-    config_file=${*#sql-server --config }
+    config_file=$3
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
     data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
     exec python3 - "$port" "$data_dir" <<'INNERPY'


### PR DESCRIPTION
## Summary

- Replace unreliable `${*#sql-server --config }` prefix removal with positional `$3` in fake dolt test scripts
- Fixes `TestDoltStateRecoverManagedCmdFailsWhenPostStartHealthFails` which was failing due to incorrect config path extraction

## Test plan

- [x] `TestDoltStateRecoverManagedCmdFailsWhenPostStartHealthFails` passes
- [x] All other dolt state tests unaffected

Fixes: ga-9rq

🤖 Generated with [Claude Code](https://claude.com/claude-code)