### PR TITLE
fix: fall back to pool labels in default work queries

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -201,6 +201,7 @@ max = 5
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "myrig/polecat")
 
 	origWD, err := os.Getwd()
@@ -525,6 +526,7 @@ max = 5
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "myrig/polecat-1")
 	t.Setenv("GC_SESSION_NAME", "myrig--polecat-1")
 
@@ -600,6 +602,9 @@ name = "worker"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_SESSION_NAME", "")
 
 	var stdout, stderr bytes.Buffer
 	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
@@ -656,6 +661,7 @@ dir = "myrig"
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
 	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_DIR", rigDir)
 
 	wantAgent := "myrig/worker"

--- a/examples/gastown/packs/maintenance/agents/dog/agent.toml
+++ b/examples/gastown/packs/maintenance/agents/dog/agent.toml
@@ -4,3 +4,8 @@ nudge = "Check your hook for work assignments."
 idle_timeout = "2h"
 min_active_sessions = 0
 max_active_sessions = 3
+# The maintenance pack qualifies this agent as "maintenance.dog" but all
+# dispatch uses the short name "dog". Pin routing to "dog" so scale_check
+# and work_query see the correct demand.
+scale_check = """ready=$(bd ready --metadata-field gc.routed_to=dog --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); active=$(bd list --metadata-field gc.routed_to=dog --status=in_progress --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); molecules=$(bd list --metadata-field gc.routed_to=dog --status=open --type=molecule --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); echo "$(( ${ready:-0} + ${active:-0} + ${molecules:-0} ))" || echo 0"""
+work_query = """sh -c 'for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do [ -z "$id" ] && continue; r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; done; for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do [ -z "$id" ] && continue; r=$(bd ready --assignee="$id" --json --limit=1 2>/dev/null); [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; done; case "$GC_SESSION_ORIGIN" in ephemeral|"") ;; *) exit 0 ;; esac; r=$(bd ready --metadata-field gc.routed_to=dog --unassigned --json --limit=1 2>/dev/null); [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; r=$(bd ready --label pool:dog --unassigned --json --limit=1 2>/dev/null); [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; bd list --metadata-field gc.routed_to=dog --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null'"""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1762,7 +1762,7 @@ func (a *Agent) AttachEnabled() bool {
 
 // EffectiveWorkQuery returns the work query command for this agent.
 // If WorkQuery is set, returns it as-is. Otherwise returns the default
-// three-tier query with multi-identifier assignee resolution.
+// four-tier query with multi-identifier assignee resolution and pool label fallback.
 //
 // Assignee resolution order: $GC_SESSION_ID (bead ID) > $GC_SESSION_NAME
 // (tmux session name) > $GC_ALIAS (named identity / qualified name).
@@ -1798,13 +1798,17 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --assignee="$id" --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
-			// Tier 3: ready unassigned routed to this config (shared routed queue).
+			// Tier 3: ready unassigned routed to this config (shared routed queue),
+			// with pool label fallback for beads dispatched via bd update --add-label pool:<pool>.
 			// Only ephemeral sessions and controller probes consume generic config demand.
 			`case "$GC_SESSION_ORIGIN" in ` +
 			`ephemeral|"") ;; ` +
 			`*) exit 0 ;; ` +
 			`esac; ` +
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
+			` --unassigned --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			`r=$(bd ready --label pool:` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			// Tier 4: open routed molecule roots. scale_check already counts

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1288,9 +1288,12 @@ func TestPoolRoundTrip(t *testing.T) {
 func TestEffectiveWorkQueryDefault(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveWorkQuery()
-	// Tiered query: check that tier 3 (routed_to) and tier 1-2 (assignee resolution) are present.
+	// Tiered query: check tier 1-2 (assignee resolution), tier 3 (routed_to + pool label fallback).
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:mayor --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 pool label fallback: %q", got)
 	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
 		t.Errorf("EffectiveWorkQuery() missing multi-identifier resolution: %q", got)
@@ -1312,6 +1315,9 @@ func TestEffectiveWorkQueryWithDir(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/polecat --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 pool label fallback: %q", got)
+	}
 }
 
 func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
@@ -1319,6 +1325,9 @@ func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/polecat --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 pool label fallback: %q", got)
 	}
 	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/polecat --status=open --type=molecule --no-assignee --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route: %q", got)
@@ -1373,6 +1382,9 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to with pool name: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/dog --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 pool label fallback with pool name: %q", got)
+	}
 	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/dog --status=open --type=molecule --no-assignee --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route with pool name: %q", got)
 	}
@@ -1383,6 +1395,9 @@ func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/dog --unassigned --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 pool label fallback: %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes critical dispatcher routing bug affecting all pool-based dispatch.

Root cause: Polecat work query only checks metadata (`gc.routed_to`). Manual dispatch via `bd update --add-label pool:<pool>` sets labels instead, causing work to never be discovered.

Fix: Add label fallback to work query after metadata check.

**Impact**: Unblocks 18+ orphaned beads (sa-ml2), dispatcher routing for newly spawned polecats (capable, rictus) in sazabi rig.