### PR TITLE
feat(reconciler): auto-nudge live sessions when gc.routed_to work arrives

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -27,15 +27,16 @@ func buildAwakeInputFromReconciler(
 	clk time.Time,
 ) AwakeInput {
 	input := AwakeInput{
-		ScaleCheckCounts:   poolDesired,
-		NamedSessionDemand: cloneBoolMap(namedSessionDemand),
-		WorkSet:            workSet,
-		ReadyWaitSet:       readyWaitSet,
-		RunningSessions:    make(map[string]bool),
-		AttachedSessions:   make(map[string]bool),
-		PendingSessions:    make(map[string]bool),
-		ChatIdleTimeout:    cfg.ChatSessions.IdleTimeoutDuration(),
-		Now:                clk,
+		ScaleCheckCounts:    poolDesired,
+		NamedSessionDemand:  cloneBoolMap(namedSessionDemand),
+		WorkSet:             workSet,
+		ReadyWaitSet:        readyWaitSet,
+		RoutedWorkTemplates: workSet,
+		RunningSessions:     make(map[string]bool),
+		AttachedSessions:    make(map[string]bool),
+		PendingSessions:     make(map[string]bool),
+		ChatIdleTimeout:     cfg.ChatSessions.IdleTimeoutDuration(),
+		Now:                 clk,
 	}
 
 	// Agents
@@ -153,6 +154,8 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 				reasons = []WakeReason{WakeWait}
 			case "assigned-work", "named-demand", "work-query":
 				reasons = []WakeReason{WakeWork}
+			case "routed":
+				reasons = []WakeReason{WakeRouted}
 			default:
 				reasons = []WakeReason{WakeConfig}
 			}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -16,19 +16,20 @@ const defaultOnDemandIdleTimeout = 5 * time.Minute
 // should be awake. All external I/O (shell commands, tmux checks, store
 // queries) happens before this function is called.
 type AwakeInput struct {
-	Agents             []AwakeAgent
-	NamedSessions      []AwakeNamedSession
-	SessionBeads       []AwakeSessionBead
-	WorkBeads          []AwakeWorkBead
-	ScaleCheckCounts   map[string]int  // agent template → scale_check count
-	NamedSessionDemand map[string]bool // named-session identity → routed/assigned work demand
-	WorkSet            map[string]bool // agent template → work_query found pending work
-	RunningSessions    map[string]bool // session name → tmux exists
-	AttachedSessions   map[string]bool // session name → user attached
-	PendingSessions    map[string]bool // session name → pending interaction
-	ReadyWaitSet       map[string]bool // session bead ID → durable wait is ready
-	ChatIdleTimeout    time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
-	Now                time.Time
+	Agents              []AwakeAgent
+	NamedSessions       []AwakeNamedSession
+	SessionBeads        []AwakeSessionBead
+	WorkBeads           []AwakeWorkBead
+	ScaleCheckCounts    map[string]int  // agent template → scale_check count
+	NamedSessionDemand  map[string]bool // named-session identity → routed/assigned work demand
+	WorkSet             map[string]bool // agent template → work_query found pending work
+	RunningSessions     map[string]bool // session name → tmux exists
+	AttachedSessions    map[string]bool // session name → user attached
+	PendingSessions     map[string]bool // session name → pending interaction
+	ReadyWaitSet        map[string]bool // session bead ID → durable wait is ready
+	ChatIdleTimeout     time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	RoutedWorkTemplates map[string]bool // agent template → has unprocessed gc.routed_to work
+	Now                 time.Time
 }
 
 // AwakeAgent represents an [[agent]] config entry.
@@ -199,6 +200,34 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		if creating := collectCreatingBeads(input.SessionBeads, template); len(creating) > 0 {
 			desired[creating[0].SessionName] = "work-query"
+		}
+	}
+
+	// RoutedWorkTemplates: when beads carry gc.routed_to for a template,
+	// ensure at least one session is desired with reason "routed". Fires
+	// only when ScaleCheckCounts hasn't caught up (same gate as WorkSet).
+	// The "routed" reason upgrades "work-query" from WorkSet so the
+	// bridge emits WakeRouted for tracing and nudge dispatch.
+	for template, hasWork := range input.RoutedWorkTemplates {
+		if !hasWork {
+			continue
+		}
+		if input.ScaleCheckCounts[template] > 0 {
+			continue
+		}
+		agent, ok := agentsByName[template]
+		if !ok || agent.Suspended {
+			continue
+		}
+		if isNamedSessionTemplate(input.NamedSessions, template) {
+			continue
+		}
+		if active := collectActiveBeads(input.SessionBeads, template); len(active) > 0 {
+			desired[active[0].SessionName] = "routed"
+			continue
+		}
+		if creating := collectCreatingBeads(input.SessionBeads, template); len(creating) > 0 {
+			desired[creating[0].SessionName] = "routed"
 		}
 	}
 

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1546,3 +1546,190 @@ func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	})
 	assertAsleep(t, result, "polecat-mc-1")
 }
+
+// ---------------------------------------------------------------------------
+// RoutedWorkTemplates — gc.routed_to wake signal + nudge enabler
+// ---------------------------------------------------------------------------
+
+func TestRoutedWork_WakesActiveSession(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "routed")
+}
+
+func TestRoutedWork_NoOpWhenScaleCheckCovers(t *testing.T) {
+	// When ScaleCheckCounts already covers the template, RoutedWork defers
+	// to ScaleCheck (same gate as WorkSet). Nudge dispatch in the
+	// reconciler handles alive sessions independently.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-2", SessionName: "polecat-mc-2", Template: "hello-world/polecat", State: "active"},
+		},
+		ScaleCheckCounts:    map[string]int{"hello-world/polecat": 1},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true, "polecat-mc-2": true},
+		Now:                 now,
+	})
+	awake := 0
+	for _, d := range result {
+		if d.ShouldWake {
+			awake++
+		}
+	}
+	if awake != 1 {
+		t.Errorf("ScaleCheck=1 should cap to 1, RoutedWork should not add more, got %d awake", awake)
+	}
+	assertReason(t, result, "polecat-mc-1", "scaled:demand")
+}
+
+func TestRoutedWork_DoesNotOverrideExistingReason(t *testing.T) {
+	// When a session is already desired (e.g. via ScaleCheck), RoutedWork
+	// should not overwrite the existing reason.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		ScaleCheckCounts:    map[string]int{"hello-world/polecat": 1},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "scaled:demand")
+}
+
+func TestRoutedWork_SkipsSuspendedAgent(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", Suspended: true}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsDrained(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active", Drained: true},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsDependencyOnly(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active", DependencyOnly: true},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsNamedSession(t *testing.T) {
+	// RoutedWorkTemplates skips named-session templates. The named-session
+	// pass handles those independently.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/worker"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/worker", Template: "hello-world/worker", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "worker", Template: "hello-world/worker", State: "asleep", NamedIdentity: "hello-world/worker"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/worker": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "worker")
+}
+
+func TestRoutedWork_FallsBackToCreating(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "creating"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "routed")
+}
+
+func TestRoutedWork_SuppressedByHeldUntil(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active",
+				HeldUntil: now.Add(5 * time.Minute),
+			},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_FalseValue_NoEffect(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": false},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_NilMap_NoEffect(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: nil,
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_BridgeMapsToWakeRouted(t *testing.T) {
+	decisions := map[string]AwakeDecision{
+		"polecat-mc-1": {ShouldWake: true, Reason: "routed"},
+	}
+	beads := []AwakeSessionBead{
+		{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat"},
+	}
+	evals := awakeSetToWakeEvals(decisions, beads)
+	eval, ok := evals["mc-1"]
+	if !ok {
+		t.Fatal("expected eval for mc-1")
+	}
+	if len(eval.Reasons) != 1 || eval.Reasons[0] != WakeRouted {
+		t.Errorf("reasons = %v, want [%s]", eval.Reasons, WakeRouted)
+	}
+}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -449,6 +449,57 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	return work
 }
 
+// nudgeRoutedWorkSessions queues nudges for alive sessions whose templates
+// have pending routed work. This bridges the gap where scale_check/pool
+// desired correctly wake or keep sessions alive, but the session itself
+// hasn't polled its hook for newly arrived gc.routed_to work.
+func nudgeRoutedWorkSessions(
+	cityPath string,
+	cfg *config.City,
+	_ runtime.Provider,
+	store beads.Store,
+	targets []wakeTarget,
+	awakeDecisions map[string]AwakeDecision,
+	workSet map[string]bool,
+	stdout, stderr io.Writer,
+) {
+	if len(workSet) == 0 || len(targets) == 0 {
+		return
+	}
+	nudged := make(map[string]bool)
+	for _, target := range targets {
+		if !target.alive {
+			continue
+		}
+		template := normalizedSessionTemplate(*target.session, cfg)
+		if !workSet[template] {
+			continue
+		}
+		if nudged[template] {
+			continue
+		}
+		name := strings.TrimSpace(target.session.Metadata["session_name"])
+		if name == "" {
+			continue
+		}
+		decision, ok := awakeDecisions[name]
+		if !ok || !decision.ShouldWake {
+			continue
+		}
+		ref := &nudgeReference{Kind: "routed-work", ID: template}
+		item := newQueuedNudgeWithOptions(name, "routed work available", "reconciler", time.Now(), queuedNudgeOptions{
+			SessionID: target.session.ID,
+			Reference: ref,
+		})
+		if err := enqueueQueuedNudgeWithStore(cityPath, store, item); err != nil {
+			fmt.Fprintf(stderr, "nudgeRoutedWork: %s: %v\n", name, err) //nolint:errcheck
+			continue
+		}
+		fmt.Fprintf(stdout, "Queued routed-work nudge for %s (%s)\n", name, template) //nolint:errcheck
+		nudged[template] = true
+	}
+}
+
 // findAgentByTemplate looks up a config agent by template name.
 // Returns nil if not found.
 func findAgentByTemplate(cfg *config.City, template string) *config.Agent {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2383,3 +2383,270 @@ func TestComputeWorkSet_RigScopedWorkQueryExpandsRigTemplate(t *testing.T) {
 		t.Errorf("beta probe command = %q, want expanded gc.routed_to=beta/worker", got)
 	}
 }
+
+func TestNudgeRoutedWorkSessions_NudgesAliveSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID:     "ses-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{
+		{session: session, alive: true},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if !strings.Contains(stdout.String(), "Queued routed-work nudge") {
+		t.Errorf("expected nudge queued output, got: %q", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsDeadSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID:     "ses-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{
+		{session: session, alive: false},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "routed"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge dead session, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_NudgesOncePerTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	targets := []wakeTarget{
+		{
+			session: &beads.Bead{
+				ID: "ses-1", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-1",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+		{
+			session: &beads.Bead{
+				ID: "ses-2", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-2",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+		"polecat-2": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	nudgeCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "Queued routed-work nudge") {
+			nudgeCount++
+		}
+	}
+	if nudgeCount != 1 {
+		t.Errorf("expected exactly 1 nudge per template, got %d", nudgeCount)
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsNoWorkTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "config"},
+	}
+	workSet := map[string]bool{} // no routed work
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when no routed work, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsTemplateNotInWorkSet(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+			{Name: "refinery", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	// workSet has routed work, but for a different template than the target.
+	workSet := map[string]bool{"gascity/refinery": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when target template has no routed work, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsEmptySessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "", // missing session_name -> cannot queue a nudge
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge session with empty session_name, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsShouldNotWakeDecision(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	// Session IS alive and matches routed work, but the awake decision says
+	// it should not wake (e.g., held under churn/quarantine rules). Don't nudge.
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: false, Reason: "quarantined"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when decision.ShouldWake=false, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsMissingDecision(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	// No entry for "polecat-1" in the decisions map — treat as "no desire to wake".
+	decisions := map[string]AwakeDecision{}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when session is missing from decisions map, got: %q", stdout.String())
+	}
+}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2650,3 +2650,55 @@ func TestNudgeRoutedWorkSessions_SkipsMissingDecision(t *testing.T) {
 		t.Errorf("should not nudge when session is missing from decisions map, got: %q", stdout.String())
 	}
 }
+
+// createErrStore wraps a beads.Store and forces Create to fail. Used to
+// exercise the error branch inside nudgeRoutedWorkSessions where the
+// underlying nudge enqueue fails to persist its bead.
+type createErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s *createErrStore) Create(_ beads.Bead) (beads.Bead, error) {
+	return beads.Bead{}, s.err
+}
+
+func TestNudgeRoutedWorkSessions_LogsEnqueueFailure(t *testing.T) {
+	// When the nudge enqueue fails (e.g., underlying bead Create errors
+	// from a broken store view), the loop must log to stderr and move on
+	// rather than panic or mark the template as nudged.
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	store := &createErrStore{Store: beads.NewMemStore(), err: fmt.Errorf("simulated store failure")}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, store, targets, decisions, workSet, &stdout, &stderr)
+
+	if !strings.Contains(stderr.String(), "nudgeRoutedWork") {
+		t.Errorf("expected stderr to log enqueue failure under nudgeRoutedWork prefix; got: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "simulated store failure") {
+		t.Errorf("expected stderr to include underlying error text; got: %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Queued routed-work nudge") {
+		t.Errorf("stdout should not log a successful nudge when enqueue fails; got: %q", stdout.String())
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1504,6 +1504,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	if ctx != nil && ctx.Err() != nil {
 		return plannedWakes
 	}
+	nudgeRoutedWorkSessions(cityPath, cfg, sp, store, wakeTargets, awakeDecisions, workSet, stdout, stderr)
 
 	// Phase 2: Advance all in-flight drains.
 	sessionLookup := func(id string) *beads.Bead {

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -35,6 +35,9 @@ const (
 	WakePin WakeReason = "pin"
 	// WakeDependency means another awake session depends on this template.
 	WakeDependency WakeReason = "dependency"
+	// WakeRouted means unprocessed routed work (gc.routed_to) targets this
+	// template. Triggers nudge dispatch for alive sessions.
+	WakeRouted WakeReason = "routed"
 )
 
 // ExecSpec defines a validated command for process creation.


### PR DESCRIPTION
## Summary

Close the gap where a bead routed to a session template via
`gc.routed_to=<template>` can sit unworkable indefinitely if a live
session of that template already exists but is idle at its hook.

## Why

Work arrives at sessions through three triggers today:

1. `scale_check` / pool `desired` spawns a new session (which polls on
   startup).
2. A `Stop` / `PreToolUse` hook fires during unrelated activity.
3. A human or another agent invokes `gc session nudge`.

None of those fire when:

- scaling bounds are already satisfied (no new session needed), and
- the existing session of that template just finished its prior task
  and is sitting idle at its prompt waiting for its hook to poll.

In that state, newly-arrived `gc.routed_to` beads for that template stay
in `open` forever — there is no trigger telling the idle session to
poll. Observed behavior: a session finishes work, closes its last bead,
goes idle. Minutes later, orchestrator code creates new beads routed to
that template. The idle session never notices; the beads stall.

## What changes

The reconciler already computes a work-set of templates with pending
routed work (via the scale-probe pipeline). This PR threads that work
set through to the tick handler, and for each **alive** session whose
template has pending routed work, enqueues a single `routed-work` nudge
per tick.

- `session_types.go`: add `WakeRouted` wake-reason constant
- `compute_awake_set.go`: accept `RoutedWorkTemplates`; mark sessions
  of those templates desired-awake with reason `routed`
- `compute_awake_bridge.go`: map `"routed"` → `WakeRouted`; pass the
  work set through as `RoutedWorkTemplates`
- `session_reconcile.go`: add `nudgeRoutedWorkSessions()` (skip dead
  sessions, mismatched templates, empty `session_name`, missing /
  `ShouldWake=false` decisions; at most one nudge per template per tick)
- `session_reconciler.go`: call it in the tick handler after awake-set
  evaluation

Existing paths (scale-spawn, hooks, manual nudges) are unchanged — this
just adds a reconciler-side fallback for the one gap above.

## Tests

- `compute_awake_set_test.go` — covers `RoutedWorkTemplates` plumbing
  and the `routed` wake-reason propagation
- `session_reconcile_test.go` — happy path + skip branches (dead
  session, single-nudge-per-template, empty work set, template-not-in-
  work-set, empty `session_name`, missing decision, `ShouldWake=false`)

`nudgeRoutedWorkSessions` is ~92% covered; the only remaining gap is
the `enqueueQueuedNudgeWithStore` error branch, which requires a mock
store.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc/... -run 'TestNudge|TestCompute|TestSession|TestWake'`



## Related issue

Closes #1129.

**Mechanism note for reviewers.** #1129's proposed fix is a sling-time
auto-nudge in `cmd/gc/cmd_sling.go` post-`DoSling` — nudge the target
immediately when sling dispatches and there's a running session.

This PR takes a reconciler-side approach instead: the reconciler already
computes a work-set of templates with pending routed work, so for each
**alive** session whose template has pending routed work, enqueue a
nudge at tick time.

Tradeoffs:

- **Sling-time (#1129's proposal)**: zero reconciler-tick latency —
  the nudge fires in the same CLI invocation as the sling. But only
  catches work that arrived *via* `gc sling`; direct `bd create
  --set-metadata gc.routed_to=...` or pack-level routing bypass it.
- **Reconciler-time (this PR)**: ~reconciler-tick latency (seconds),
  but catches *any* routed work regardless of arrival channel, and the
  logic lives next to the existing awake-set computation that already
  knows which templates need attention.

The two approaches are compatible and could coexist; if the
maintainers prefer the sling-time approach, I'm happy to rework this PR
along those lines or keep this reconciler-side path as a belt-and-
suspenders complement. Flagging so the right mechanism gets picked
before review churn.
