### PR TITLE
feat(init): add --preserve-existing flag to gc init

### DIFF
--- a/cmd/gc/cityinit_exact_output_test.go
+++ b/cmd/gc/cityinit_exact_output_test.go
@@ -12,7 +12,7 @@ import (
 func TestCityInitExactOutput_DefaultScaffold(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
-	code := doInit(fsys.NewFake(), "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(fsys.NewFake(), "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 
 	if code != 0 {
 		t.Fatalf("doInit code = %d, want 0", code)
@@ -45,7 +45,7 @@ func TestCityInitExactOutput_CommandProviderSkipReadiness(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitWithOptions([]string{filepath.Join(t.TempDir(), "bright-lights")}, "codex", "", "", &stdout, &stderr, true)
+	code := cmdInitWithOptions([]string{filepath.Join(t.TempDir(), "bright-lights")}, "codex", "", "", &stdout, &stderr, true, false)
 
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions code = %d, want 0", code)

--- a/cmd/gc/cityinit_impl.go
+++ b/cmd/gc/cityinit_impl.go
@@ -120,7 +120,7 @@ func cityInitDoInit(_ context.Context, req cityinit.InitRequest) error {
 		startCommand:     req.StartCommand,
 		bootstrapProfile: req.BootstrapProfile,
 	}
-	if code := doInit(fsys.OSFS{}, req.Dir, wiz, req.NameOverride, io.Discard, io.Discard); code != 0 {
+	if code := doInit(fsys.OSFS{}, req.Dir, wiz, req.NameOverride, io.Discard, io.Discard, false); code != 0 {
 		if code == initExitAlreadyInitialized {
 			return cityinit.ErrAlreadyInitialized
 		}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -236,6 +236,7 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var providerFlag string
 	var bootstrapProfileFlag string
 	var skipProviderReadiness bool
+	var preserveExisting bool
 	cmd := &cobra.Command{
 		Use:   "init [path]",
 		Short: "Initialize a new city",
@@ -245,23 +246,28 @@ Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, then
 materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
-non-interactively, or --file to initialize from an existing TOML config file.`,
+non-interactively, or --file to initialize from an existing TOML config file.
+
+Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
+agent prompt files in the target directory (useful when bootstrapping a
+committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 		Example: `  gc init
   gc init ~/my-city
   gc init --provider codex ~/my-city
   gc init --provider codex --bootstrap-profile k8s-cell /city
   gc init --name my-city
   gc init --from ~/elan --name elan /city
-  gc init --file examples/gastown.toml ~/bright-lights`,
+  gc init --file examples/gastown.toml ~/bright-lights
+  gc init --file city.toml --preserve-existing .`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if fromFlag != "" {
 				return exitForCode(cmdInitFromDirWithOptions(fromFlag, args, nameFlag, stdout, stderr, skipProviderReadiness))
 			}
 			if fileFlag != "" {
-				return exitForCode(cmdInitFromFileWithOptions(fileFlag, args, nameFlag, stdout, stderr, skipProviderReadiness))
+				return exitForCode(cmdInitFromFileWithOptions(fileFlag, args, nameFlag, stdout, stderr, skipProviderReadiness, preserveExisting))
 			}
-			return exitForCode(cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, stdout, stderr, skipProviderReadiness))
+			return exitForCode(cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, stdout, stderr, skipProviderReadiness, preserveExisting))
 		},
 	}
 	cmd.Flags().StringVar(&fileFlag, "file", "", "path to a TOML file to use as city.toml")
@@ -270,6 +276,7 @@ non-interactively, or --file to initialize from an existing TOML config file.`,
 	cmd.Flags().StringVar(&providerFlag, "provider", "", "built-in workspace provider to use for the default mayor config")
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
+	cmd.Flags().BoolVar(&preserveExisting, "preserve-existing", false, "keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them")
 	cmd.MarkFlagsMutuallyExclusive("file", "from")
 	cmd.MarkFlagsMutuallyExclusive("provider", "file")
 	cmd.MarkFlagsMutuallyExclusive("provider", "from")
@@ -283,10 +290,10 @@ non-interactively, or --file to initialize from an existing TOML config file.`,
 // Creates the runtime scaffold and city.toml. If the bead provider is "bd", also
 // runs bd init.
 func cmdInit(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer) int {
-	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false)
+	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false, false)
 }
 
-func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -321,7 +328,7 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 	default:
 		wiz = defaultWizardConfig()
 	}
-	if code := doInit(fsys.OSFS{}, cityPath, wiz, nameOverride, stdout, stderr); code != 0 {
+	if code := doInit(fsys.OSFS{}, cityPath, wiz, nameOverride, stdout, stderr, preserveExisting); code != 0 {
 		return code
 	}
 	return finalizeInit(cityPath, stdout, stderr, initFinalizeOptions{
@@ -417,12 +424,30 @@ func ensureInitConventionDirs(fs fsys.FS, cityPath string) error {
 	return nil
 }
 
-func writeInitPackToml(fs fsys.FS, cityPath string, packCfg initPackConfig) error {
+// writeInitFile writes data to path. When preserve is true and path already
+// exists, the existing file is kept untouched and wrote=false is returned.
+// preserve is set by --preserve-existing, which callers (e.g. bootstrap
+// scripts operating on a pre-authored workspace) use to avoid clobbering
+// committed user files like pack.toml, city.toml, and agent prompts.
+func writeInitFile(fs fsys.FS, path string, data []byte, preserve bool) (wrote bool, err error) {
+	if preserve {
+		if _, err := fs.Stat(path); err == nil {
+			return false, nil
+		} else if !os.IsNotExist(err) {
+			return false, err
+		}
+	}
+	return true, fs.WriteFile(path, data, 0o644)
+}
+
+// writeInitPackTomlOpts marshals and writes pack.toml, honoring the
+// preserve-existing option. Returns (wrote, err) mirroring writeInitFile.
+func writeInitPackTomlOpts(fs fsys.FS, cityPath string, packCfg initPackConfig, preserve bool) (bool, error) {
 	content, err := marshalInitPackConfig(packCfg)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return fs.WriteFile(filepath.Join(cityPath, "pack.toml"), content, 0o644)
+	return writeInitFile(fs, filepath.Join(cityPath, "pack.toml"), content, preserve)
 }
 
 func marshalInitPackConfig(cfg initPackConfig) ([]byte, error) {
@@ -631,7 +656,7 @@ func appendUniqueStrings(dst []string, items ...string) []string {
 	return dst
 }
 
-func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -649,16 +674,16 @@ func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride stri
 		}
 	}
 
-	return cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, fileArg, cityPath, nameOverride, stdout, stderr, skipProviderReadiness)
+	return cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, fileArg, cityPath, nameOverride, stdout, stderr, skipProviderReadiness, preserveExisting)
 }
 
 // cmdInitFromTOMLFile initializes a city by copying a user-provided TOML
 // file as city.toml. Creates the runtime scaffold, visible roots, and runs bead init.
 func cmdInitFromTOMLFile(fs fsys.FS, tomlSrc, cityPath string, stdout, stderr io.Writer) int {
-	return cmdInitFromTOMLFileWithOptions(fs, tomlSrc, cityPath, "", stdout, stderr, false)
+	return cmdInitFromTOMLFileWithOptions(fs, tomlSrc, cityPath, "", stdout, stderr, false, false)
 }
 
-func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
+func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	// Validate the source file parses as a valid city config.
 	data, err := os.ReadFile(tomlSrc)
 	if err != nil {
@@ -681,8 +706,15 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	}
 	cfg.Workspace.Name = cityName
 
-	// Create directory structure.
-	if cityAlreadyInitializedFS(fs, cityPath) {
+	// Create directory structure. With --preserve-existing, only refuse when
+	// the runtime scaffold is already in place — a pre-authored city.toml in
+	// the target directory (e.g. a committed workspace being bootstrapped)
+	// is preserved below rather than blocking init.
+	alreadyInitialized := cityAlreadyInitializedFS(fs, cityPath)
+	if preserveExisting {
+		alreadyInitialized = cityHasScaffoldFS(fs, cityPath)
+	}
+	if alreadyInitialized {
 		return initAlreadyInitialized(stderr)
 	}
 	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
@@ -698,8 +730,9 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return code
 	}
 
-	// Write prompt scaffolds only for the explicit agents declared by the template.
-	if code := writeInitAgentPrompts(fs, cityPath, cfg, stderr); code != 0 {
+	// Write prompt scaffolds only for the explicit agents declared by the
+	// template — preserved individually if --preserve-existing is set.
+	if code := writeInitAgentPrompts(fs, cityPath, cfg, stderr, preserveExisting); code != 0 {
 		return code
 	}
 
@@ -709,9 +742,13 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	rewriteInitPromptTemplates(cfg)
 	packCfg, cityCfg := splitInitConfig(cityName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
-	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
+	wrotePack, err := writeInitPackTomlOpts(fs, cityPath, packCfg, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !wrotePack {
+		fmt.Fprintln(stdout, "Preserved existing pack.toml.") //nolint:errcheck // best-effort stdout
 	}
 
 	formulasInitDir := filepath.Join(cityPath, citylayout.FormulasRoot)
@@ -726,10 +763,17 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return 1
 	}
 
-	// Write city.toml.
-	if err := fs.WriteFile(filepath.Join(cityPath, "city.toml"), content, 0o644); err != nil {
+	// Write city.toml — preserved if --preserve-existing is set and a
+	// committed city.toml is already in place. Persist the workspace identity
+	// regardless so .gc/site.toml agrees with the preserved or newly-written
+	// config.
+	wroteCity, err := writeInitFile(fs, filepath.Join(cityPath, "city.toml"), content, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !wroteCity {
+		fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, filepath.Join(cityPath, "city.toml"), &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -761,7 +805,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 // when a provider or start command is supplied; otherwise init writes the
 // default mayor-only city. Errors if the runtime scaffold already exists. Accepts an
 // injected FS for testability.
-func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, stdout, stderr io.Writer) int {
+func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, stdout, stderr io.Writer, preserveExisting bool) int {
 	tomlPath := filepath.Join(cityPath, citylayout.CityConfigFile)
 	if cityHasScaffoldFS(fs, cityPath) {
 		return initAlreadyInitialized(stderr)
@@ -824,7 +868,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 
 	// Write prompt files only for the agents declared by the init template.
 	logInitProgress(stdout, 3, "Writing default prompts")
-	if code := writeInitAgentPrompts(fs, cityPath, &cfg, stderr); code != 0 {
+	if code := writeInitAgentPrompts(fs, cityPath, &cfg, stderr, preserveExisting); code != 0 {
 		return code
 	}
 
@@ -847,14 +891,22 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		return 1
 	}
 	logInitProgress(stdout, 4, "Writing pack.toml")
-	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
+	wrotePack, err := writeInitPackTomlOpts(fs, cityPath, packCfg, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if !wrotePack {
+		fmt.Fprintln(stdout, "Preserved existing pack.toml.") //nolint:errcheck // best-effort stdout
+	}
 	logInitProgress(stdout, 5, "Writing city configuration")
-	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
+	wroteCity, err := writeInitFile(fs, tomlPath, content, preserveExisting)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !wroteCity {
+		fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, tomlPath, &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -932,7 +984,7 @@ func bootstrapScopedFileProviderCityFS(fs fsys.FS, cityPath string) error {
 // default prompt scaffolds referenced by the init template's explicit agents.
 // This keeps a freshly initialized city aligned with the city.toml it writes
 // instead of silently creating additional convention-discoverable agents.
-func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer) int {
+func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer, preserveExisting bool) int {
 	if err := fs.MkdirAll(filepath.Join(cityPath, "agents"), 0o755); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -957,7 +1009,7 @@ func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if err := fs.WriteFile(dst, data, 0o644); err != nil {
+		if _, err := writeInitFile(fs, dst, data, preserveExisting); err != nil {
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/gitignore_test.go
+++ b/cmd/gc/gitignore_test.go
@@ -115,7 +115,7 @@ func TestDoInit_WritesGitignoreEntries(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -137,7 +137,7 @@ func TestDoInit_GitignoreIdempotent(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("first doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/init_identity_failure_test.go
+++ b/cmd/gc/init_identity_failure_test.go
@@ -31,7 +31,7 @@ func TestDoInitRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testing.T) {
 	fs := &failSiteBindingRenameFS{target: filepath.Join(cityPath, ".gc", "site.toml")}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(fs, cityPath, defaultWizardConfig(), "machine-alias", &stdout, &stderr)
+	code := doInit(fs, cityPath, defaultWizardConfig(), "machine-alias", &stdout, &stderr, false)
 	if code == 0 {
 		t.Fatalf("doInit = %d, want failure", code)
 	}
@@ -71,7 +71,7 @@ func TestDoInitFromFileRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testin
 	fs := &failSiteBindingRenameFS{target: filepath.Join(cityPath, ".gc", "site.toml")}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitFromTOMLFileWithOptions(fs, srcToml, cityPath, "machine-alias", &stdout, &stderr, true)
+	code := cmdInitFromTOMLFileWithOptions(fs, srcToml, cityPath, "machine-alias", &stdout, &stderr, true, false)
 	if code == 0 {
 		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want failure", code)
 	}

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -65,7 +65,7 @@ func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *test
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -243,7 +243,7 @@ func TestFinalizeInitDoesNotWriteImplicitImportState(t *testing.T) {
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
-	code := doInit(fsys.OSFS{}, cityPath, defaultWizardConfig(), "", &initStdout, &initStderr)
+	code := doInit(fsys.OSFS{}, cityPath, defaultWizardConfig(), "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -316,7 +316,7 @@ func TestFinalizeInitWithoutProgressSkipsStepCounter(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -376,7 +376,7 @@ func TestCmdInitResumesFinalizeForExistingCity(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "gastown",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -438,7 +438,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -467,7 +467,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true)
+	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions = %d, want 0: %s", code, stderr.String())
 	}
@@ -823,7 +823,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -883,7 +883,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -932,7 +932,7 @@ func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -2237,7 +2238,7 @@ func TestDoInitSuccess(t *testing.T) {
 	// No pre-existing files — doInit creates everything from scratch.
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2328,7 +2329,7 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2366,7 +2367,7 @@ func TestDoInitGastownWritesCanonicalPackV2Shape(t *testing.T) {
 	f := fsys.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wizardConfig{configName: "gastown", provider: "claude"}, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wizardConfig{configName: "gastown", provider: "claude"}, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2404,7 +2405,7 @@ func TestDoInitAlreadyInitialized(t *testing.T) {
 	markFakeCityScaffold(f, "/city")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr, false)
 	if code != initExitAlreadyInitialized {
 		t.Errorf("doInit = %d, want %d", code, initExitAlreadyInitialized)
 	}
@@ -2430,7 +2431,7 @@ func TestDoInitBootstrapsExistingCityToml(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = original
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -2456,7 +2457,7 @@ func TestDoInitBootstrapWithNameOverride(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = []byte("[workspace]\nname = \"old-name\"\n")
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "new-name", &stdout, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "new-name", &stdout, &stderr, false)
 	if code != 0 {
 		t.Errorf("doInit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -2478,7 +2479,7 @@ func TestDoInitMkdirGCFails(t *testing.T) {
 	f.Errors[filepath.Join("/city", ".gc")] = fmt.Errorf("permission denied")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr, false)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -2492,7 +2493,7 @@ func TestDoInitWriteFails(t *testing.T) {
 	f.Errors[filepath.Join("/city", "city.toml")] = fmt.Errorf("read-only fs")
 
 	var stderr bytes.Buffer
-	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr)
+	code := doInit(f, "/city", defaultWizardConfig(), "", &bytes.Buffer{}, &stderr, false)
 	if code != 1 {
 		t.Errorf("doInit = %d, want 1", code)
 	}
@@ -2506,7 +2507,7 @@ func TestDoInitWriteFails(t *testing.T) {
 func TestDoInitCreatesSettings(t *testing.T) {
 	f := fsys.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2526,7 +2527,7 @@ func TestDoInitCreatesSettings(t *testing.T) {
 func TestDoInitSettingsIsValidJSON(t *testing.T) {
 	f := fsys.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", defaultWizardConfig(), "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2868,7 +2869,7 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2922,7 +2923,7 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2958,7 +2959,7 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/bright-lights", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -3006,7 +3007,7 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/my-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/my-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -3043,7 +3044,7 @@ func TestDoInitWithProviderFlagAndBootstrapProfile(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/hosted-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/hosted-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -3087,7 +3088,7 @@ func TestDoInitWithOpenCodeProviderInstallsWorkspaceHooks(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/open-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/open-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -3116,7 +3117,7 @@ func TestDoInitWithClaudeProviderLeavesWorkspaceHooksEmpty(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doInit(f, "/claude-city", wiz, "", &stdout, &stderr)
+	code := doInit(f, "/claude-city", wiz, "", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -3322,6 +3323,139 @@ func TestCmdInitFromTOMLFileAlreadyInitializedByCityToml(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "already initialized") {
 		t.Errorf("stderr = %q, want 'already initialized'", stderr.String())
+	}
+}
+
+func TestCmdInitFromTOMLFilePreservesExistingFiles(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	if err := os.MkdirAll(filepath.Join(cityPath, "agents", "mayor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	preExistingPack := []byte("[pack]\nname = \"user-authored\"\nschema = 2\nversion = \"9.9.9\"\n")
+	preExistingCity := []byte("[workspace]\nname = \"user-authored\"\nprovider = \"claude\"\n")
+	preExistingPrompt := []byte("user-authored mayor prompt\n")
+	for _, f := range []struct {
+		path string
+		data []byte
+	}{
+		{filepath.Join(cityPath, "pack.toml"), preExistingPack},
+		{filepath.Join(cityPath, "city.toml"), preExistingCity},
+		{filepath.Join(cityPath, "agents", "mayor", "prompt.template.md"), preExistingPrompt},
+	} {
+		if err := os.WriteFile(f.path, f.data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	src := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(src,
+		[]byte("[workspace]\nname = \"from-template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, true)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	for _, f := range []struct {
+		path string
+		want []byte
+	}{
+		{filepath.Join(cityPath, "pack.toml"), preExistingPack},
+		{filepath.Join(cityPath, "city.toml"), preExistingCity},
+		{filepath.Join(cityPath, "agents", "mayor", "prompt.template.md"), preExistingPrompt},
+	} {
+		got, err := os.ReadFile(f.path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f.path, err)
+		}
+		if !bytes.Equal(got, f.want) {
+			t.Errorf("%s was rewritten under --preserve-existing\n got: %s\nwant: %s", f.path, got, f.want)
+		}
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"Preserved existing pack.toml.", "Preserved existing city.toml."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestCmdInitFromTOMLFilePreserveExistingBlockedByScaffold(t *testing.T) {
+	f := fsys.NewFake()
+	cityPath := "/city"
+
+	// A fully-initialized runtime scaffold should still cause init to refuse,
+	// even with --preserve-existing. Only committed config files are meant to
+	// be tolerated; an active runtime indicates the city is already live.
+	f.Files[filepath.Join(cityPath, ".gc", "events.jsonl")] = []byte("")
+	for _, sub := range []string{"cache", "runtime", "system"} {
+		f.Dirs[filepath.Join(cityPath, ".gc", sub)] = true
+	}
+	f.Dirs[filepath.Join(cityPath, ".gc")] = true
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(src, []byte("[workspace]\nname = \"x\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(f, src, cityPath, "", &stdout, &stderr, true, true)
+	if code != initExitAlreadyInitialized {
+		t.Errorf("code = %d, want %d", code, initExitAlreadyInitialized)
+	}
+	if !strings.Contains(stderr.String(), "already initialized") {
+		t.Errorf("stderr = %q, want 'already initialized'", stderr.String())
+	}
+}
+
+func TestWriteInitFile_PreserveExistingStatError(t *testing.T) {
+	// When preserve=true, a Stat error that isn't os.IsNotExist must surface
+	// to the caller instead of being silently treated as "does not exist".
+	f := fsys.NewFake()
+	target := "/city/pack.toml"
+	f.Errors[target] = errors.New("permission denied")
+
+	wrote, err := writeInitFile(f, target, []byte("new"), true)
+	if err == nil {
+		t.Fatal("expected error propagation, got nil")
+	}
+	if wrote {
+		t.Errorf("wrote = true on stat error; want false")
+	}
+	// Must not have attempted to write over the file.
+	for _, c := range f.Calls {
+		if c.Method == "WriteFile" && c.Path == target {
+			t.Errorf("WriteFile called despite stat error; calls=%v", f.Calls)
+		}
+	}
+}
+
+func TestWriteInitFile_PreserveFalseOverwrites(t *testing.T) {
+	// When preserve=false, the helper writes unconditionally — even over
+	// an existing file — mirroring the pre-flag default behavior.
+	f := fsys.NewFake()
+	target := "/city/pack.toml"
+	f.Files[target] = []byte("existing")
+
+	wrote, err := writeInitFile(f, target, []byte("replacement"), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrote {
+		t.Errorf("wrote = false; want true when preserve=false")
+	}
+	if got := string(f.Files[target]); got != "replacement" {
+		t.Errorf("file contents = %q, want %q", got, "replacement")
 	}
 }
 
@@ -3551,7 +3685,7 @@ func TestInitNameFlagWithFile(t *testing.T) {
 	cityPath := filepath.Join(dir, "target-dir")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitFromFileWithOptions(tomlFile, []string{cityPath}, "my-file-name", &stdout, &stderr, true)
+	code := cmdInitFromFileWithOptions(tomlFile, []string{cityPath}, "my-file-name", &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("cmdInitFromFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -3579,7 +3713,7 @@ func TestInitNameFlagWithBareInit(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "my-bare-name", &stdout, &stderr)
+	}, "my-bare-name", &stdout, &stderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3459,6 +3459,60 @@ func TestWriteInitFile_PreserveFalseOverwrites(t *testing.T) {
 	}
 }
 
+// TestDoInitPreservesExistingPackToml exercises the wizard-init path
+// (`doInit`, not `cmdInitFromTOMLFileWithOptions`) with `preserveExisting=true`
+// and a pre-seeded pack.toml. Covers the "Preserved existing pack.toml."
+// stdout branch unique to the wizard path.
+func TestDoInitPreservesExistingPackToml(t *testing.T) {
+	f := fsys.NewFake()
+	// Pre-seed pack.toml. No pre-seeded city.toml — that would route
+	// doInit into the separate "bootstrap existing" path above the
+	// preserve branches and never reach the pack.toml write.
+	preExistingPack := []byte("[pack]\nname = \"user-authored\"\nschema = 2\nversion = \"9.9.9\"\n")
+	f.Files["/city/pack.toml"] = preExistingPack
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(f, "/city", defaultWizardConfig(), "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if got := f.Files["/city/pack.toml"]; !bytes.Equal(got, preExistingPack) {
+		t.Errorf("pack.toml was rewritten under preserveExisting=true\n got: %s\nwant: %s", got, preExistingPack)
+	}
+	if !strings.Contains(stdout.String(), "Preserved existing pack.toml.") {
+		t.Errorf("stdout missing preservation log; got:\n%s", stdout.String())
+	}
+}
+
+// TestCmdInitFromFileWithOptionsUsesCWDWhenArgsEmpty covers the wrapper
+// branch that defaults cityPath to the current working directory when no
+// positional arg is supplied. The inner `cmdInitFromTOMLFileWithOptions`
+// call is exercised by the broader preserve-existing test; this case
+// pins the wrapper's default-path behavior itself.
+func TestCmdInitFromFileWithOptionsUsesCWDWhenArgsEmpty(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	src := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(src,
+		[]byte("[workspace]\nname = \"from-template\"\nprovider = \"claude\"\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromFileWithOptions(src, nil, "", &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("cmdInitFromFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	// Init should have written city.toml into the CWD.
+	if _, err := os.Stat(filepath.Join(dir, "city.toml")); err != nil {
+		t.Errorf("city.toml not written to CWD: %v", err)
+	}
+}
+
 func TestRunInitFromFileAlreadyInitializedPropagatesExitCode(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1311,6 +1311,10 @@ the standard top-level directories, and .template.md prompt templates, then
 materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
 non-interactively, or --file to initialize from an existing TOML config file.
 
+Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
+agent prompt files in the target directory (useful when bootstrapping a
+committed workspace — e.g. from a bootstrap.sh shipped in the repo).
+
 ```
 gc init [path] [flags]
 ```
@@ -1325,6 +1329,7 @@ gc init
   gc init --name my-city
   gc init --from ~/elan --name elan /city
   gc init --file examples/gastown.toml ~/bright-lights
+  gc init --file city.toml --preserve-existing .
 ```
 
 | Flag | Type | Default | Description |
@@ -1333,6 +1338,7 @@ gc init
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
 | `--name` | string |  | workspace name (default: target directory basename) |
+| `--preserve-existing` | bool |  | keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
 | `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
 


### PR DESCRIPTION
## Summary

Add `--preserve-existing` to `gc init` so `gc init --file` can bootstrap
into a directory that already has a committed `pack.toml`, `city.toml`,
or hand-authored agent prompts — without clobbering them.

Opt-in only; default behavior is byte-identical to before.

## Why

A common Gas City deployment pattern is to check the workspace config
into a repo. `city.toml`, `pack.toml`, and each
`agents/<name>/prompt.template.md` are hand-authored artifacts that live
alongside the code. When a developer clones the repo on a new machine,
the canonical bootstrap script calls:

```sh
gc init --file ./city.toml .
```

…to materialize the `.gc/` runtime in place. Today that one command is
destructive to the committed workspace:

- **`pack.toml`** is overwritten with the init-template version,
  losing pack metadata (`description`, `includes`, `requires_gc`,
  pack-level formula/agent entries, etc.).
- **`city.toml`** is re-marshalled from the split pack/city config,
  losing any formatting, ordering, or comments the repo ships.
- **Each agent's `prompt.template.md`** is overwritten with the default
  scaffold, losing hand-tuned prompts.

The only workaround today is for bootstrap scripts to stash those files
aside, run `gc init`, then `git checkout --` them back. And for
`pack.toml` there's no good workaround because there's no way to tell
whether the repo's version or the template's version is "right" — it
silently changes on every bootstrap.

Put simply: `gc init` should be able to run against a pre-authored
workspace without rewriting the committed source. This PR adds the
opt-in flag to make that possible, for the cross-device /
clone-and-bootstrap case.

## What changes

With `--preserve-existing`:

- For `pack.toml`, `city.toml`, and each `agents/<name>/prompt.template.md`,
  skip-if-exists: the existing file is kept untouched, and stdout logs
  `Preserved existing <file>.`.
- The "already initialized" guard tightens from
  `cityAlreadyInitializedFS` (which trips on a committed `city.toml`)
  to `cityHasScaffoldFS` (which only trips on a populated `.gc/`
  runtime). A committed workspace without a runtime is no longer
  refused; a live city with a real runtime still is.
- All other init work runs normally (scaffold dirs, convention dirs,
  hook install, gitignore entries, workspace identity persistence,
  formula resolution, bootstrap file-store, finalize).

Default behavior (without the flag) is unchanged — the flag is pure
opt-in.

### Example

After this change, a bootstrap script for a committed workspace becomes
one line:

```sh
gc init --preserve-existing --file ./city.toml .
```

## Tests

- `TestCmdInitFromTOMLFilePreservesExistingFiles` — flag preserves
  pack.toml / city.toml / agent prompt verbatim and logs preservation.
- `TestCmdInitFromTOMLFilePreserveExistingBlockedByScaffold` — a
  populated `.gc/` scaffold still causes init to refuse even with the
  flag (live cities stay protected).
- `TestWriteInitFile_PreserveExistingStatError` — a non-IsNotExist
  stat error propagates instead of silently overwriting.
- `TestWriteInitFile_PreserveFalseOverwrites` — preserve=false writes
  unconditionally, mirroring pre-flag default.

`writeInitFile` is at 100% coverage.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc/... -run 'TestCmdInit|TestInit|TestGitignore|TestRunInit|TestWriteInitFile'`
- [ ] Sanity: `gc init` without the flag continues to rewrite files
  canonically in a fresh workspace.



## Related issue

Closes #1143.
