### PR TITLE
fix(sling): refuse dispatch against bead IDs not in the store

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -103,7 +103,7 @@ Examples:
 	}
 	cmd.Flags().BoolVarP(&formula, "formula", "f", false, "treat argument as formula name")
 	cmd.Flags().BoolVar(&nudge, "nudge", false, "nudge target after routing")
-	cmd.Flags().BoolVar(&force, "force", false, "suppress warnings, allow cross-rig routing, and dispatch even if the bead does not resolve in the local store")
+	cmd.Flags().BoolVar(&force, "force", false, "suppress warnings, allow cross-rig routing, allow graph workflow replacement, and for direct bead routes dispatch even if the bead does not resolve in the local store")
 	cmd.Flags().StringVarP(&title, "title", "t", "", "wisp root bead title (with --formula or --on)")
 	cmd.Flags().StringArrayVar(&vars, "var", nil, "variable substitution for formula (key=value, repeatable)")
 	cmd.Flags().StringVar(&merge, "merge", "", "merge strategy: direct, mr, or local")
@@ -195,6 +195,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	}
 	emitLoadCityConfigWarnings(stderr, prov)
 	applyFeatureFlags(cfg)
+	cityName := loadedCityName(cfg, cityPath)
 
 	var target, beadOrFormula string
 	switch {
@@ -211,7 +212,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 			fmt.Fprintf(stderr, "gc sling: --formula requires explicit target\n") //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if !looksLikeBeadID(beadOrFormula) {
+		if !canInferSlingDefaultTargetFromBead(cfg, beadOrFormula) {
 			fmt.Fprintf(stderr, "gc sling: inline text requires explicit target\n  usage: gc sling <target> %q\n", beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
 		}
@@ -245,12 +246,10 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	}
 
 	sp := newSessionProvider()
-	cityName := loadedCityName(cfg, cityPath)
 
-	storeDir := resolveSlingStoreRoot(cfg, cityPath, beadOrFormula, a)
-	store, err := openStoreAtForCity(storeDir, cityPath)
+	storeDir, store, err := openSlingStoreForSource(cfg, cityPath, beadOrFormula, a)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: opening store %s: %v\n", storeDir, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	storeRef := workflowStoreRefForDir(storeDir, cityPath, cityName, cfg)
@@ -258,33 +257,20 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	// Inline text mode: if the argument doesn't look like a bead ID
 	// (and we're not in formula mode), create a task bead from the text.
-	// Skip during dry-run to avoid side effects.
-	// Also check if the bead exists in the store — hierarchical IDs like
-	// "Prefix-abc.1" have dots that looksLikeBeadID doesn't recognize.
-	if !isFormula && !dryRun && !looksLikeBeadID(beadOrFormula) && !beadExistsInStore(store, beadOrFormula) {
-		created, err := store.Create(beads.Bead{Title: beadOrFormula, Description: stdinDescription, Type: "task"})
-		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: creating bead: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+	// During dry-run, mark the text as preview-only instead of creating it.
+	inlineText := false
+	if !isFormula {
+		createInlineBead, previewInlineText := resolveInlineBeadAction(cfg, beadOrFormula, dryRun)
+		inlineText = previewInlineText
+		if createInlineBead {
+			created, err := store.Create(beads.Bead{Title: beadOrFormula, Description: stdinDescription, Type: "task"})
+			if err != nil {
+				fmt.Fprintf(stderr, "gc sling: creating bead: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			fmt.Fprintf(stdout, "Created %s — %q\n", created.ID, beadOrFormula) //nolint:errcheck // best-effort stdout
+			beadOrFormula = created.ID
 		}
-		fmt.Fprintf(stdout, "Created %s — %q\n", created.ID, beadOrFormula) //nolint:errcheck // best-effort stdout
-		beadOrFormula = created.ID
-	}
-
-	// Refuse to dispatch against a bead-shaped argument that doesn't
-	// resolve in the store. `looksLikeBeadID` was originally a routing
-	// heuristic (bead ID vs. session-template name) introduced for
-	// name-based session addressing, and the inline-text block above
-	// reused it for text-vs-ID disambiguation — neither ever validated
-	// existence. Without a check here a typo'd or fabricated bead ID
-	// silently flows through and strands workers on a dead reference.
-	// `resolveSessionID` already errors when its template-shaped
-	// argument doesn't resolve; this brings sling to parity.
-	// --force bypasses for timing-race cases where the bead exists in a
-	// remote store view not yet synced locally.
-	if !isFormula && looksLikeBeadID(beadOrFormula) && !beadExistsInStore(store, beadOrFormula) && !force {
-		fmt.Fprintf(stderr, "gc sling: bead %q not found in store %s\n  use --force to dispatch anyway (e.g. bead exists in a remote view not yet synced locally)\n", beadOrFormula, storeRef) //nolint:errcheck // best-effort stderr
-		return 1
 	}
 
 	opts := slingOpts{
@@ -301,6 +287,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		Nudge:         doNudge,
 		Force:         force,
 		DryRun:        dryRun,
+		InlineText:    inlineText,
 		ScopeKind:     scopeKind,
 		ScopeRef:      scopeRef,
 	}
@@ -405,7 +392,10 @@ func resolveSlingStoreRoot(cfg *config.City, cityPath, beadOrFormula string, a c
 	// resolveStoreScopeRoot would silently alias them to the city
 	// scope. Skip them so sling falls back to the agent's rig_dir or
 	// the city store instead of operating on the wrong store.
-	if bp := beadPrefix(beadOrFormula); bp != "" {
+	if bp := beadPrefix(beadOrFormula); bp != "" && !looksLikeInlineText(cfg, beadOrFormula) {
+		if sling.IsHQPrefix(cfg, bp) {
+			return storeDir
+		}
 		if rig, found := findRigByPrefix(cfg, bp); found && strings.TrimSpace(rig.Path) != "" {
 			return resolveStoreScopeRoot(cityPath, rig.Path)
 		}
@@ -414,6 +404,19 @@ func resolveSlingStoreRoot(cfg *config.City, cityPath, beadOrFormula string, a c
 		return resolveStoreScopeRoot(cityPath, rd)
 	}
 	return storeDir
+}
+
+func openSlingStoreForSource(cfg *config.City, cityPath, beadOrFormula string, a config.Agent) (string, beads.Store, error) {
+	storeDir := resolveSlingStoreRoot(cfg, cityPath, beadOrFormula, a)
+	store, err := openStoreAtForCity(storeDir, cityPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("opening store %s: %w", storeDir, err)
+	}
+	return storeDir, store, nil
+}
+
+func canInferSlingDefaultTargetFromBead(cfg *config.City, beadOrFormula string) bool {
+	return looksLikeBeadID(beadOrFormula) || looksLikeConfiguredBeadID(cfg, beadOrFormula)
 }
 
 // populateSlingDepsCallbacks fills in the interface fields on SlingDeps.
@@ -656,6 +659,11 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, stderr
 			printSourceWorkflowConflict(stderr, conflictErr, deps.StoreRef)
 			return 3
 		}
+		var missingBeadErr *sling.MissingBeadError
+		if errors.As(err, &missingBeadErr) {
+			printMissingBeadError(stderr, missingBeadErr, missingBeadForceApplies(opts))
+			return 1
+		}
 		fmt.Fprintln(stderr, err) //nolint:errcheck
 		return 1
 	}
@@ -690,8 +698,14 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		result, err = sling.DoSlingBatch(opts, deps, querier)
 	} else {
 		result, err = sl.ExpandConvoy(context.Background(), opts.BeadOrFormula, opts.Target, sling.RouteOpts{
-			Merge: opts.Merge, NoConvoy: opts.NoConvoy, Owned: opts.Owned,
-			Nudge: opts.Nudge, Force: opts.Force, SkipPoke: opts.SkipPoke, DryRun: opts.DryRun,
+			Merge:      opts.Merge,
+			NoConvoy:   opts.NoConvoy,
+			Owned:      opts.Owned,
+			Nudge:      opts.Nudge,
+			Force:      opts.Force,
+			SkipPoke:   opts.SkipPoke,
+			DryRun:     opts.DryRun,
+			InlineText: opts.InlineText,
 		}, querier)
 	}
 	// Print warnings before error check so they're visible on failure.
@@ -711,6 +725,11 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		// misattributed to the first child.
 		if printed := printSourceWorkflowConflicts(stderr, err, deps.StoreRef); printed > 0 {
 			return 3
+		}
+		var missingBeadErr *sling.MissingBeadError
+		if errors.As(err, &missingBeadErr) {
+			printMissingBeadError(stderr, missingBeadErr, missingBeadForceApplies(opts))
+			return 1
 		}
 		// In batch mode, per-child FailReasons have already been rendered
 		// by printBatchSlingResult above. The error returned from
@@ -747,6 +766,19 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
 	}
 	return 0
+}
+
+func printMissingBeadError(stderr io.Writer, err *sling.MissingBeadError, allowForce bool) {
+	fmt.Fprintln(stderr, err) //nolint:errcheck
+	if allowForce {
+		fmt.Fprintln(stderr, "  verify the bead ID, or use --force if it exists in a remote view not yet synced locally") //nolint:errcheck
+		return
+	}
+	fmt.Fprintln(stderr, "  verify the bead ID; --force does not bypass missing source validation for formula-backed routes") //nolint:errcheck
+}
+
+func missingBeadForceApplies(opts sling.SlingOpts) bool {
+	return !opts.IsFormula && opts.OnFormula == "" && (opts.NoFormula || opts.Target.EffectiveDefaultSlingFormula() == "")
 }
 
 func sourceWorkflowCleanupCommand(sourceBeadID, storeRef string) string {
@@ -1689,63 +1721,54 @@ func isCustomSlingQuery(a config.Agent) bool {
 // one digit to distinguish base36 hashes from English words like
 // "hello-world". Strings with spaces or multiple dashes (like
 // "code-review") are treated as inline text for ad-hoc bead creation.
-// beadExistsInStore returns true if the given ID resolves to a bead in the store.
-// Used as a fallback when looksLikeBeadID returns false for valid hierarchical
-// IDs (e.g., "ProjectWrenUnity-0fze.1").
-func beadExistsInStore(store beads.Store, id string) bool {
-	_, err := store.Get(id)
-	return err == nil
+func looksLikeBeadID(s string) bool {
+	_, baseSuffix, ok := sling.BeadIDParts(s)
+	if !ok || len(baseSuffix) > 8 {
+		return false
+	}
+	return looksLikeBeadIDSuffix(baseSuffix)
 }
 
-func looksLikeBeadID(s string) bool {
-	if strings.ContainsAny(s, " \t\n") {
-		return false
-	}
-	i := strings.Index(s, "-")
-	if i <= 0 || i == len(s)-1 {
-		return false
-	}
-	// Must have exactly one dash.
-	if strings.Count(s, "-") != 1 {
-		return false
-	}
-	prefix := s[:i]
-	for idx, c := range prefix {
-		if idx == 0 {
-			if ('A' > c || c > 'Z') && ('a' > c || c > 'z') {
-				return false
-			}
-			continue
-		}
-		if ('0' > c || c > '9') && ('a' > c || c > 'z') && ('A' > c || c > 'Z') {
-			return false
-		}
-	}
-	suffix := s[i+1:]
-	// Strip hierarchical child suffix (e.g., ".1" from "0fze.1") for validation.
-	// Dots delimit parent-child hierarchy in bead IDs.
-	baseSuffix := suffix
-	if dot := strings.IndexByte(suffix, '.'); dot > 0 {
-		baseSuffix = suffix[:dot]
-	}
-	for _, c := range baseSuffix {
-		if ('0' > c || c > '9') && ('a' > c || c > 'z') && ('A' > c || c > 'Z') {
-			return false
-		}
-	}
-	// Bead ID suffixes from bd are base36 hashes (3-8 chars) or
-	// sequential integers. Short suffixes (1-4 chars) are accepted
-	// unconditionally — no English words are that short after a dash.
-	// Longer suffixes (5-8 chars) must contain at least one digit to
-	// distinguish base36 hashes from English words like "world".
-	if len(baseSuffix) > 8 {
-		return false
-	}
+func looksLikeBeadIDSuffix(baseSuffix string) bool {
 	if len(baseSuffix) <= 4 {
 		return true
 	}
 	for _, c := range baseSuffix {
 		if '0' <= c && c <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldCreateInlineBead(cfg *config.City, beadOrFormula string) bool {
+	return looksLikeInlineText(cfg, beadOrFormula)
+}
+
+func resolveInlineBeadAction(cfg *config.City, beadOrFormula string, dryRun bool) (createInlineBead, previewInlineText bool) {
+	if dryRun && looksLikeInlineText(cfg, beadOrFormula) {
+		return false, true
+	}
+	return shouldCreateInlineBead(cfg, beadOrFormula), false
+}
+
+func looksLikeInlineText(cfg *config.City, beadOrFormula string) bool {
+	return !looksLikeBeadID(beadOrFormula) && !looksLikeConfiguredBeadID(cfg, beadOrFormula)
+}
+
+func looksLikeConfiguredBeadID(cfg *config.City, s string) bool {
+	prefix, baseSuffix, ok := sling.BeadIDParts(s)
+	if !ok || len(baseSuffix) > 8 {
+		return false
+	}
+	if cfg == nil {
+		return false
+	}
+	if strings.EqualFold(prefix, config.EffectiveHQPrefix(cfg)) {
+		return true
+	}
+	for i := range cfg.Rigs {
+		if strings.EqualFold(prefix, cfg.Rigs[i].EffectivePrefix()) {
 			return true
 		}
 	}

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -103,7 +103,7 @@ Examples:
 	}
 	cmd.Flags().BoolVarP(&formula, "formula", "f", false, "treat argument as formula name")
 	cmd.Flags().BoolVar(&nudge, "nudge", false, "nudge target after routing")
-	cmd.Flags().BoolVar(&force, "force", false, "suppress warnings and allow cross-rig routing")
+	cmd.Flags().BoolVar(&force, "force", false, "suppress warnings, allow cross-rig routing, and dispatch even if the bead does not resolve in the local store")
 	cmd.Flags().StringVarP(&title, "title", "t", "", "wisp root bead title (with --formula or --on)")
 	cmd.Flags().StringArrayVar(&vars, "var", nil, "variable substitution for formula (key=value, repeatable)")
 	cmd.Flags().StringVar(&merge, "merge", "", "merge strategy: direct, mr, or local")
@@ -269,6 +269,22 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		}
 		fmt.Fprintf(stdout, "Created %s — %q\n", created.ID, beadOrFormula) //nolint:errcheck // best-effort stdout
 		beadOrFormula = created.ID
+	}
+
+	// Refuse to dispatch against a bead-shaped argument that doesn't
+	// resolve in the store. `looksLikeBeadID` was originally a routing
+	// heuristic (bead ID vs. session-template name) introduced for
+	// name-based session addressing, and the inline-text block above
+	// reused it for text-vs-ID disambiguation — neither ever validated
+	// existence. Without a check here a typo'd or fabricated bead ID
+	// silently flows through and strands workers on a dead reference.
+	// `resolveSessionID` already errors when its template-shaped
+	// argument doesn't resolve; this brings sling to parity.
+	// --force bypasses for timing-race cases where the bead exists in a
+	// remote store view not yet synced locally.
+	if !isFormula && looksLikeBeadID(beadOrFormula) && !beadExistsInStore(store, beadOrFormula) && !force {
+		fmt.Fprintf(stderr, "gc sling: bead %q not found in store %s\n  use --force to dispatch anyway (e.g. bead exists in a remote view not yet synced locally)\n", beadOrFormula, storeRef) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 
 	opts := slingOpts{

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -41,6 +42,29 @@ func (s *selectiveErrStore) Create(b beads.Bead) (beads.Bead, error) {
 		return beads.Bead{}, err
 	}
 	return s.Store.Create(b)
+}
+
+type getErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s *getErrStore) Get(_ string) (beads.Bead, error) {
+	return beads.Bead{}, s.err
+}
+
+func seededStore(ids ...string) beads.Store {
+	seed := make([]beads.Bead, 0, len(ids))
+	for _, id := range ids {
+		seed = append(seed, beads.Bead{
+			ID:       id,
+			Title:    id,
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{},
+		})
+	}
+	return beads.NewMemStoreFrom(0, seed, nil)
 }
 
 // recordingStore wraps a store and overrides Get for bead injection.
@@ -90,7 +114,10 @@ func (s *slingTestStore) Get(id string) (beads.Bead, error) {
 	}
 	b, ok := s.synthetic[id]
 	if !ok {
-		return beads.Bead{}, err
+		if _, _, looksLikeBead := sling.BeadIDParts(id); !looksLikeBead {
+			return beads.Bead{}, err
+		}
+		return s.ensureSynthetic(id), nil
 	}
 	return b, nil
 }
@@ -1025,6 +1052,379 @@ func TestCmdSlingRefusesMissingBead(t *testing.T) {
 	}
 }
 
+func TestPrintMissingBeadErrorFormulaBackedDoesNotSuggestForce(t *testing.T) {
+	var stderr bytes.Buffer
+	printMissingBeadError(&stderr, &sling.MissingBeadError{BeadID: "FE-ghost1", StoreRef: "rig:frontend"}, false)
+
+	got := stderr.String()
+	if strings.Contains(got, "use --force") {
+		t.Fatalf("stderr = %q, should not suggest force for formula-backed missing source", got)
+	}
+	if !strings.Contains(got, "does not bypass missing source validation") {
+		t.Fatalf("stderr = %q, want formula-backed force diagnostic", got)
+	}
+}
+
+func TestCmdSlingDryRunRefusesMissingBead(t *testing.T) {
+	setupCmdSlingBeadExistsFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "FE-ghost1"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, true,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code == 0 {
+		t.Fatalf("cmdSling dry-run returned 0, want non-zero; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "FE-ghost1") {
+		t.Errorf("stderr missing bead ID; got: %s", got)
+	}
+	if !strings.Contains(got, "not found") {
+		t.Errorf("stderr missing missing-bead phrasing; got: %s", got)
+	}
+}
+
+func TestCmdSlingDryRunPreviewsInlineText(t *testing.T) {
+	cityDir := setupCmdSlingBeadExistsFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "write docs"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, true,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling dry-run returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("stderr = %s, want no missing-bead diagnostic", stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "write docs") {
+		t.Fatalf("stdout = %s, want inline text in dry-run preview", out)
+	}
+	if strings.Contains(out, "Created ") {
+		t.Fatalf("stdout = %s, want no bead creation during dry-run", out)
+	}
+	if !strings.Contains(out, "No side effects executed (--dry-run).") {
+		t.Fatalf("stdout = %s, want dry-run footer", out)
+	}
+
+	rigStore, err := openStoreAtForCity(filepath.Join(cityDir, "frontend"), cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	beadList, err := rigStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("rigStore.List: %v", err)
+	}
+	if len(beadList) != 0 {
+		t.Fatalf("rig store bead count = %d, want 0: %#v", len(beadList), beadList)
+	}
+}
+
+func TestResolveInlineBeadActionDryRunInlineTextDoesNotProbeStore(t *testing.T) {
+	create, inlineText := resolveInlineBeadAction(&config.City{}, "write docs", true)
+	if create {
+		t.Fatal("create = true, want false during dry-run")
+	}
+	if !inlineText {
+		t.Fatal("inlineText = false, want true")
+	}
+}
+
+func TestResolveInlineBeadActionWhitespaceInlineTextDoesNotProbeStore(t *testing.T) {
+	create, inlineText := resolveInlineBeadAction(&config.City{}, "write docs", false)
+	if !create {
+		t.Fatal("create = false, want true for whitespace inline text")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false outside dry-run")
+	}
+}
+
+func TestResolveInlineBeadActionSingleTokenInlineTextDoesNotProbeStore(t *testing.T) {
+	create, inlineText := resolveInlineBeadAction(&config.City{}, "docs", false)
+	if !create {
+		t.Fatal("create = false, want true for single-token inline text")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false outside dry-run")
+	}
+}
+
+func TestResolveInlineBeadActionBeadIDDoesNotProbeStore(t *testing.T) {
+	create, inlineText := resolveInlineBeadAction(&config.City{}, "FE-123", false)
+	if create {
+		t.Fatal("create = true, want false for bead ID")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false")
+	}
+}
+
+func TestResolveInlineBeadActionConfiguredAlphaSuffixIsBeadID(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test", Prefix: "HQ"},
+		Rigs:      []config.Rig{{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"}},
+	}
+
+	create, inlineText := resolveInlineBeadAction(cfg, "FE-hello", false)
+	if create {
+		t.Fatal("create = true, want false for configured bead ID with all-alpha suffix")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false outside dry-run")
+	}
+
+	create, inlineText = resolveInlineBeadAction(cfg, "FE-a1pha", false)
+	if create {
+		t.Fatal("create = true, want false for configured bead ID with digit")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false for configured bead ID")
+	}
+}
+
+func TestCmdSlingConfiguredPrefixAllAlphaExistingBeadUsesPrefixStore(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	frontendDir := filepath.Join(cityDir, "frontend")
+	ordersDir := filepath.Join(cityDir, "orders")
+	for _, dir := range []string{frontendDir, ordersDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, frontendDir, ordersDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	writeTestFileStoreBeads(t, frontendDir, []beads.Bead{{
+		ID:       "FE-abcde",
+		Title:    "existing frontend work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{},
+	}})
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "FE"
+
+[[rigs]]
+name = "orders"
+path = "orders"
+prefix = "OD"
+
+[[agent]]
+name = "worker"
+dir = "orders"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"orders/worker", "FE-abcde"},
+		false, false, true,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+
+	frontendStore, err := openStoreAtForCity(frontendDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(frontend): %v", err)
+	}
+	routed, err := frontendStore.Get("FE-abcde")
+	if err != nil {
+		t.Fatalf("frontendStore.Get(FE-abcde): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "orders/worker" {
+		t.Fatalf("frontend bead gc.routed_to = %q, want orders/worker", routed.Metadata["gc.routed_to"])
+	}
+
+	ordersStore, err := openStoreAtForCity(ordersDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(orders): %v", err)
+	}
+	ordersBeads, err := ordersStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("ordersStore.List: %v", err)
+	}
+	if len(ordersBeads) != 0 {
+		t.Fatalf("orders store bead count = %d, want 0: %#v", len(ordersBeads), ordersBeads)
+	}
+}
+
+func TestCmdSlingConfiguredPrefixAllAlphaExistingBeadUsesSelectedPrefixStore(t *testing.T) {
+	cityDir, frontendDir := setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t, false, true)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "FE-abcde"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+
+	frontendStore, err := openStoreAtForCity(frontendDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(frontend): %v", err)
+	}
+	routed, err := frontendStore.Get("FE-abcde")
+	if err != nil {
+		t.Fatalf("frontendStore.Get(FE-abcde): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "frontend/worker" {
+		t.Fatalf("frontend bead gc.routed_to = %q, want frontend/worker", routed.Metadata["gc.routed_to"])
+	}
+	all, err := frontendStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("frontendStore.List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("frontend store bead count = %d, want 1: %#v", len(all), all)
+	}
+}
+
+func TestCmdSlingOneArgConfiguredPrefixAllAlphaExistingBeadUsesDefaultTarget(t *testing.T) {
+	cityDir, frontendDir := setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t, true, true)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"FE-abcde"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+
+	frontendStore, err := openStoreAtForCity(frontendDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(frontend): %v", err)
+	}
+	routed, err := frontendStore.Get("FE-abcde")
+	if err != nil {
+		t.Fatalf("frontendStore.Get(FE-abcde): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "frontend/worker" {
+		t.Fatalf("frontend bead gc.routed_to = %q, want frontend/worker", routed.Metadata["gc.routed_to"])
+	}
+}
+
+func setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t *testing.T, defaultTarget, seedExisting bool) (cityDir, frontendDir string) {
+	t.Helper()
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir = t.TempDir()
+	frontendDir = filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(frontendDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(frontend): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, frontendDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	if seedExisting {
+		writeTestFileStoreBeads(t, frontendDir, []beads.Bead{{
+			ID:       "FE-abcde",
+			Title:    "existing frontend work",
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{},
+		}})
+	}
+	defaultTargetLine := ""
+	if defaultTarget {
+		defaultTargetLine = "default_sling_target = \"frontend/worker\"\n"
+	}
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "FE"
+` + defaultTargetLine + `
+[[agent]]
+name = "worker"
+dir = "frontend"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+	return cityDir, frontendDir
+}
+
+func writeTestFileStoreBeads(t *testing.T, scopeRoot string, stored []beads.Bead) {
+	t.Helper()
+	data := struct {
+		Seq   int          `json:"seq"`
+		Beads []beads.Bead `json:"beads"`
+	}{Seq: len(stored), Beads: stored}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("Marshal file store beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scopeRoot, ".gc", "beads.json"), append(raw, '\n'), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", filepath.Join(scopeRoot, ".gc", "beads.json"), err)
+	}
+}
+
 func TestCmdSlingForceBypassesMissingBeadCheck(t *testing.T) {
 	// --force must bypass the bead-existence check. The call may still
 	// fail further downstream (we don't assert a success exit here), but
@@ -1044,6 +1444,59 @@ func TestCmdSlingForceBypassesMissingBeadCheck(t *testing.T) {
 	got := stderr.String()
 	if strings.Contains(got, "not found in store") {
 		t.Errorf("--force did not bypass bead-existence check; stderr: %s", got)
+	}
+}
+
+func TestCmdSlingForceMissingBeadPrintsAutoConvoyWarning(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "FE"
+
+[[agent]]
+name = "worker"
+dir = "frontend"
+sling_query = "true"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "FE-ghost1"},
+		false, false, true,
+		"", nil, "",
+		false, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "forced dispatch skipped missing-bead validation") {
+		t.Fatalf("stderr = %q, want forced missing-bead auto-convoy warning", stderr.String())
 	}
 }
 
@@ -1077,6 +1530,98 @@ func TestCmdSlingAcceptsExistingBead(t *testing.T) {
 	)
 	if strings.Contains(stderr.String(), "not found in store") {
 		t.Errorf("existence check incorrectly tripped on a real bead; stderr: %s", stderr.String())
+	}
+}
+
+func TestCmdSlingRefusesMissingConfiguredFallbackBeadID(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "orders")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "orders"
+path = "orders"
+prefix = "od"
+
+[[agent]]
+name = "worker"
+dir = "orders"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"orders/worker", "od-zzzz1"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code == 0 {
+		t.Fatalf("cmdSling returned 0, want non-zero; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want missing bead error instead of inline creation", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("stderr = %q, want missing bead diagnostic", stderr.String())
+	}
+}
+
+func TestCmdSlingRefusesMissingConfiguredPrefixAllAlphaBeadID(t *testing.T) {
+	cityDir, _ := setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t, false, false)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "FE-abcde"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code == 0 {
+		t.Fatalf("cmdSling returned 0, want non-zero; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want missing bead error instead of inline creation", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("stderr = %q, want missing bead diagnostic", stderr.String())
+	}
+
+	frontendStore, err := openStoreAtForCity(filepath.Join(cityDir, "frontend"), cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(frontend): %v", err)
+	}
+	all, err := frontendStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("frontendStore.List: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("frontend store bead count = %d, want 0: %#v", len(all), all)
 	}
 }
 
@@ -1600,11 +2145,14 @@ func TestDoSlingBatchGetFails(t *testing.T) {
 	opts := testOpts(a, "BL-42")
 	code := doSlingBatch(opts, deps, q, stdout, stderr)
 
-	if code != 0 {
-		t.Fatalf("doSlingBatch returned %d, want 0 (falls through to doSling); stderr: %s", code, stderr.String())
+	if code == 0 {
+		t.Fatalf("doSlingBatch returned 0, want lookup failure; stdout: %s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "Slung BL-42") {
-		t.Errorf("stdout = %q, want direct sling output", stdout.String())
+	if !strings.Contains(stderr.String(), "bd not available") {
+		t.Errorf("stderr = %q, want lookup failure", stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
 	}
 }
 
@@ -2304,6 +2852,37 @@ func TestResolveSlingStoreRootPrefersBeadPrefixRig(t *testing.T) {
 	want := filepath.Join(cityPath, "rigs", "beta")
 	if got != want {
 		t.Fatalf("resolveSlingStoreRoot() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSlingStoreRootUsesPrefixRigForConfiguredAllAlphaBeadID(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "city")
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "frontend", Path: filepath.Join("rigs", "frontend"), Prefix: "FE"},
+			{Name: "orders", Path: filepath.Join("rigs", "orders"), Prefix: "od"},
+		},
+	}
+
+	got := resolveSlingStoreRoot(cfg, cityPath, "FE-hello", config.Agent{Dir: "orders"})
+	want := filepath.Join(cityPath, "rigs", "frontend")
+	if got != want {
+		t.Fatalf("resolveSlingStoreRoot() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSlingStoreRootUsesCityRootForHQPrefix(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "city")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "bright-lights", Prefix: "hq"},
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: filepath.Join("rigs", "alpha"), Prefix: "al"},
+		},
+	}
+
+	got := resolveSlingStoreRoot(cfg, cityPath, "hq-123", config.Agent{Dir: "alpha"})
+	if got != cityPath {
+		t.Fatalf("resolveSlingStoreRoot() = %q, want city root %q", got, cityPath)
 	}
 }
 
@@ -3207,6 +3786,7 @@ func TestDryRunSingleBead(t *testing.T) {
 	q := &fakeQuerier{bead: beads.Bead{ID: "BL-42", Title: "Implement login page", Type: "task", Status: "open"}}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, q, stdout, stderr)
@@ -3258,6 +3838,7 @@ func TestDryRunSingleBeadExpandsSlingQuerySummary(t *testing.T) {
 	q := &fakeQuerier{bead: beads.Bead{ID: "FR-42", Title: "Implement login page", Type: "task", Status: "open"}}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("FR-42")
 	opts := testOpts(a, "FR-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, q, stdout, stderr)
@@ -3314,6 +3895,7 @@ func TestDryRunOnFormula(t *testing.T) {
 	q.childrenOf["BL-42"] = []beads.Bead{} // no molecule children
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.OnFormula = "code-review"
 	opts.DryRun = true
@@ -3351,6 +3933,7 @@ func TestDryRunMultiSessionConfig(t *testing.T) {
 	}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, nil, stdout, stderr)
@@ -3487,6 +4070,7 @@ func TestDryRunNudgeRunning(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-1")
 	opts := testOpts(a, "BL-1")
 	opts.Nudge = true
 	opts.DryRun = true
@@ -3520,6 +4104,7 @@ func TestDryRunNudgeNotRunning(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-1")
 	opts := testOpts(a, "BL-1")
 	opts.Nudge = true
 	opts.DryRun = true
@@ -3541,6 +4126,7 @@ func TestDryRunNoMutations(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, nil, stdout, stderr)
@@ -3560,6 +4146,7 @@ func TestDryRunSuspendedWarning(t *testing.T) {
 	a := config.Agent{Name: "mayor", Suspended: true, MaxActiveSessions: intPtr(1)}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-1")
 	opts := testOpts(a, "BL-1")
 	opts.DryRun = true
 	code := doSling(opts, deps, nil, stdout, stderr)
@@ -3590,6 +4177,7 @@ func TestDryRunOnExistingMolecule(t *testing.T) {
 	}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.OnFormula = "code-review"
 	opts.DryRun = true
@@ -3613,6 +4201,7 @@ func TestDryRunNilQuerier(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, nil, stdout, stderr)
@@ -3888,6 +4477,7 @@ func TestDryRunIdempotentBead(t *testing.T) {
 	q := &fakeQuerier{bead: beads.Bead{ID: "BL-42", Title: "Login page", Assignee: "mayor", Status: "open"}}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	opts := testOpts(a, "BL-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, q, stdout, stderr)
@@ -4125,6 +4715,7 @@ func TestDryRunCrossRigSection(t *testing.T) {
 	q := &fakeQuerier{bead: beads.Bead{ID: "FE-123", Type: "task", Status: "open"}}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("FE-123")
 	opts := testOpts(a, "FE-123")
 	opts.DryRun = true
 	code := doSling(opts, deps, q, stdout, stderr)
@@ -4526,6 +5117,7 @@ func TestDefaultFormulaDryRun(t *testing.T) {
 	a := config.Agent{Name: "polecat", Dir: "hw", DefaultSlingFormula: strPtr("mol-polecat-work")}
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("HW-42")
 	opts := testOpts(a, "HW-42")
 	opts.DryRun = true
 	code := doSling(opts, deps, nil, stdout, stderr)
@@ -4938,7 +5530,7 @@ func TestLooksLikeBeadID(t *testing.T) {
 	}
 }
 
-func TestBeadExistsInStoreFallback(t *testing.T) {
+func TestProbeBeadInStoreFallback(t *testing.T) {
 	base := beads.NewMemStore()
 	store := &recordingStore{
 		Store:     base,
@@ -4946,13 +5538,33 @@ func TestBeadExistsInStoreFallback(t *testing.T) {
 	}
 
 	// beadExistsInStore should find it.
-	if !beadExistsInStore(store, "ProjectWrenUnity-0fze.1") {
+	exists, err := sling.ProbeBeadInStore(store, "ProjectWrenUnity-0fze.1")
+	if err != nil {
+		t.Fatalf("beadExistsInStore(existing): %v", err)
+	}
+	if !exists {
 		t.Error("beadExistsInStore should find existing bead")
 	}
 
 	// Non-existent bead should return false.
-	if beadExistsInStore(store, "nonexistent-xyz") {
+	exists, err = sling.ProbeBeadInStore(store, "nonexistent-xyz")
+	if err != nil {
+		t.Fatalf("beadExistsInStore(missing): %v", err)
+	}
+	if exists {
 		t.Error("beadExistsInStore should return false for missing bead")
+	}
+}
+
+func TestProbeBeadInStoreSurfacesLookupError(t *testing.T) {
+	store := &recordingStore{Store: &getErrStore{Store: beads.NewMemStore(), err: fmt.Errorf("lookup failed")}}
+
+	_, err := sling.ProbeBeadInStore(store, "gc-1")
+	if err == nil {
+		t.Fatal("ProbeBeadInStore error = nil, want lookup failure")
+	}
+	if !strings.Contains(err.Error(), "lookup failed") {
+		t.Fatalf("ProbeBeadInStore error = %q, want lookup failure", err)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -953,6 +953,133 @@ dir = "frontend"
 	}
 }
 
+// setupCmdSlingBeadExistsFixture writes a minimal city.toml with a single
+// rig + worker agent and positions the test CWD inside the city. Used by
+// the bead-existence tests below. Returns the city directory.
+func setupCmdSlingBeadExistsFixture(t *testing.T) string {
+	t.Helper()
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "FE"
+
+[[agent]]
+name = "worker"
+dir = "frontend"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+	return cityDir
+}
+
+func TestCmdSlingRefusesMissingBead(t *testing.T) {
+	// A bead-ID-shaped argument that doesn't resolve in the store must
+	// cause sling to error out — otherwise a fabricated / typo'd ID
+	// would flow through and strand workers on a dead reference.
+	setupCmdSlingBeadExistsFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "FE-ghost1"},
+		false, false, false, // isFormula, doNudge, force=false
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code == 0 {
+		t.Fatalf("cmdSling returned 0, want non-zero; stderr: %s", stderr.String())
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "FE-ghost1") {
+		t.Errorf("stderr missing bead ID; got: %s", got)
+	}
+	if !strings.Contains(got, "not found") {
+		t.Errorf("stderr missing 'not found' phrasing; got: %s", got)
+	}
+	if !strings.Contains(got, "--force") {
+		t.Errorf("stderr should mention --force as the escape hatch; got: %s", got)
+	}
+}
+
+func TestCmdSlingForceBypassesMissingBeadCheck(t *testing.T) {
+	// --force must bypass the bead-existence check. The call may still
+	// fail further downstream (we don't assert a success exit here), but
+	// stderr must not contain the "not found" guard message.
+	setupCmdSlingBeadExistsFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	_ = cmdSling(
+		[]string{"frontend/worker", "FE-ghost1"},
+		false, false, true, // force=true
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	got := stderr.String()
+	if strings.Contains(got, "not found in store") {
+		t.Errorf("--force did not bypass bead-existence check; stderr: %s", got)
+	}
+}
+
+func TestCmdSlingAcceptsExistingBead(t *testing.T) {
+	// When a bead-ID-shaped argument IS present in the store, the new
+	// existence check must not fire. This test only asserts the check
+	// does not trip — it doesn't assert sling completes successfully,
+	// since downstream routing has its own gates (cross-rig, etc.)
+	// that are out of scope for this change.
+	cityDir := setupCmdSlingBeadExistsFixture(t)
+	rigDir := filepath.Join(cityDir, "frontend")
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	seeded, err := rigStore.Create(beads.Bead{Title: "real work", Type: "task"})
+	if err != nil {
+		t.Fatalf("seeding bead: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_ = cmdSling(
+		[]string{"frontend/worker", seeded.ID},
+		false, false, false, // force=false; existence check should pass naturally
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if strings.Contains(stderr.String(), "not found in store") {
+		t.Errorf("existence check incorrectly tripped on a real bead; stderr: %s", stderr.String())
+	}
+}
+
 func TestSlingStoreEnvUsesRigBdRuntimeForMixedProviderRig(t *testing.T) {
 	cityDir := t.TempDir()
 	wantPort := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2315,7 +2315,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-n`, `--dry-run` | bool |  | show what would be done without executing |
-| `--force` | bool |  | suppress warnings and allow cross-rig routing |
+| `--force` | bool |  | suppress warnings, allow cross-rig routing, allow graph workflow replacement, and for direct bead routes dispatch even if the bead does not resolve in the local store |
 | `-f`, `--formula` | bool |  | treat argument as formula name |
 | `--merge` | string |  | merge strategy: direct, mr, or local |
 | `--no-convoy` | bool |  | skip auto-convoy creation |

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1796,10 +1796,16 @@
             "default": "about:blank",
             "description": "A URI reference to human-readable documentation for the error.",
             "examples": [
-              "https://example.com/errors/example"
+              "https://example.com/errors/example",
+              "urn:gascity:error:sling-missing-bead",
+              "urn:gascity:error:sling-cross-rig"
             ],
             "format": "uri",
-            "type": "string"
+            "type": "string",
+            "x-gascity-problem-types": [
+              "urn:gascity:error:sling-missing-bead",
+              "urn:gascity:error:sling-cross-rig"
+            ]
           }
         },
         "type": "object"
@@ -5824,6 +5830,10 @@
           "bead": {
             "description": "Bead ID to sling.",
             "type": "string"
+          },
+          "force": {
+            "description": "Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.",
+            "type": "boolean"
           },
           "formula": {
             "description": "Formula name for workflow launch.",

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -1796,10 +1796,16 @@
             "default": "about:blank",
             "description": "A URI reference to human-readable documentation for the error.",
             "examples": [
-              "https://example.com/errors/example"
+              "https://example.com/errors/example",
+              "urn:gascity:error:sling-missing-bead",
+              "urn:gascity:error:sling-cross-rig"
             ],
             "format": "uri",
-            "type": "string"
+            "type": "string",
+            "x-gascity-problem-types": [
+              "urn:gascity:error:sling-missing-bead",
+              "urn:gascity:error:sling-cross-rig"
+            ]
           }
         },
         "type": "object"
@@ -5824,6 +5830,10 @@
           "bead": {
             "description": "Bead ID to sling.",
             "type": "string"
+          },
+          "force": {
+            "description": "Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.",
+            "type": "boolean"
           },
           "formula": {
             "description": "Formula name for workflow launch.",

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2273,6 +2273,9 @@ type SlingInputBody struct {
 	// Bead Bead ID to sling.
 	Bead *string `json:"bead,omitempty"`
 
+	// Force Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.
+	Force *bool `json:"force,omitempty"`
+
 	// Formula Formula name for workflow launch.
 	Formula *string `json:"formula,omitempty"`
 

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -65,16 +65,26 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 
 	formulaName := strings.TrimSpace(body.Formula)
 	attachedBeadID := strings.TrimSpace(body.AttachedBeadID)
+	storeBeadID := slingStoreBeadID(body)
 
 	// Build deps and construct Sling instance.
-	store := s.findSlingStore(body.Rig, agentCfg)
+	store := s.findSlingStore(body.Rig, agentCfg, storeBeadID)
+	storeRef := s.slingStoreRef(body.Rig, agentCfg, storeBeadID)
+	if store == nil && allowsForceStoreFallback(body, agentCfg) {
+		store = s.findSlingStore(body.Rig, agentCfg, "")
+		storeRef = s.slingStoreRef(body.Rig, agentCfg, "")
+	}
+	if store == nil {
+		message := fmt.Sprintf("bead prefix store %s is not registered; cannot verify bead %q", storeRef, storeBeadID)
+		return nil, http.StatusBadRequest, "missing_bead", message, nil
+	}
 	deps := sling.SlingDeps{
 		CityName: s.state.CityName(),
 		CityPath: s.state.CityPath(),
 		Cfg:      s.state.Config(),
 		SP:       s.state.SessionProvider(),
 		Store:    store,
-		StoreRef: s.slingStoreRef(body.Rig, agentCfg),
+		StoreRef: storeRef,
 		SourceWorkflowStores: func() ([]sling.SourceWorkflowStore, error) {
 			return s.sourceWorkflowStores(), nil
 		},
@@ -145,6 +155,19 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		if errors.As(err, &conflictErr) {
 			return nil, http.StatusConflict, "conflict", err.Error(), conflictErr
 		}
+		var lookupErr *sling.BeadLookupError
+		if errors.As(err, &lookupErr) {
+			fmt.Fprintf(apiSlingStderr(), "gc api sling: %v\n", lookupErr) //nolint:errcheck
+			return nil, http.StatusInternalServerError, "internal", "sling bead lookup failed", nil
+		}
+		var missingBeadErr *sling.MissingBeadError
+		if errors.As(err, &missingBeadErr) {
+			return nil, http.StatusBadRequest, "missing_bead", err.Error(), nil
+		}
+		var crossRigErr *sling.CrossRigError
+		if errors.As(err, &crossRigErr) {
+			return nil, http.StatusBadRequest, "cross_rig", err.Error(), nil
+		}
 		return nil, http.StatusBadRequest, "invalid", err.Error(), nil
 	}
 
@@ -170,6 +193,24 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 	return resp, http.StatusCreated, "", "", nil
 }
 
+func allowsForceStoreFallback(body slingBody, agentCfg config.Agent) bool {
+	if !body.Force || strings.TrimSpace(body.Bead) == "" {
+		return false
+	}
+	if strings.TrimSpace(body.Formula) != "" || strings.TrimSpace(body.AttachedBeadID) != "" {
+		return false
+	}
+	return agentCfg.EffectiveDefaultSlingFormula() == ""
+}
+
+func slingStoreBeadID(body slingBody) string {
+	// Formula attachment validates the attached bead, not the formula name.
+	if attachedBeadID := strings.TrimSpace(body.AttachedBeadID); attachedBeadID != "" {
+		return attachedBeadID
+	}
+	return strings.TrimSpace(body.Bead)
+}
+
 // sourceWorkflowCleanupHint renders the CLI command that clears the blocking
 // source workflow. Surfaced in the conflict response body so users can fix
 // the state without grepping docs.
@@ -183,7 +224,14 @@ func sourceWorkflowCleanupHint(sourceBeadID, storeRef string) string {
 }
 
 // findSlingStore returns the bead store for sling operations.
-func (s *Server) findSlingStore(rig string, agentCfg config.Agent) beads.Store {
+func (s *Server) findSlingStore(rig string, agentCfg config.Agent, beadID string) beads.Store {
+	// Match the CLI's bead-prefix-first resolution so existence checks consult
+	// the bead's home store before any cross-rig guard runs.
+	if resolvedRig, cityScope := s.slingStoreScopeForBead(beadID); cityScope {
+		return s.state.CityBeadStore()
+	} else if resolvedRig != "" {
+		return s.state.BeadStore(resolvedRig)
+	}
 	if rig != "" {
 		if store := s.state.BeadStore(rig); store != nil {
 			return store
@@ -198,7 +246,12 @@ func (s *Server) findSlingStore(rig string, agentCfg config.Agent) beads.Store {
 }
 
 // slingStoreRef returns a store ref string for the sling context.
-func (s *Server) slingStoreRef(rig string, agentCfg config.Agent) string {
+func (s *Server) slingStoreRef(rig string, agentCfg config.Agent, beadID string) string {
+	if resolvedRig, cityScope := s.slingStoreScopeForBead(beadID); cityScope {
+		return "city:" + s.state.CityName()
+	} else if resolvedRig != "" {
+		return "rig:" + resolvedRig
+	}
 	if rig != "" {
 		return "rig:" + rig
 	}
@@ -206,6 +259,25 @@ func (s *Server) slingStoreRef(rig string, agentCfg config.Agent) string {
 		return "rig:" + agentCfg.Dir
 	}
 	return "city:" + s.state.CityName()
+}
+
+func (s *Server) slingStoreScopeForBead(beadID string) (rigName string, cityScope bool) {
+	beadID = strings.TrimSpace(beadID)
+	if beadID == "" {
+		return "", false
+	}
+	prefix := sling.BeadPrefix(beadID)
+	if prefix == "" {
+		return "", false
+	}
+	if sling.IsHQPrefix(s.state.Config(), prefix) {
+		return "", true
+	}
+	rig, ok := sling.FindRigByPrefix(s.state.Config(), prefix)
+	if !ok {
+		return "", false
+	}
+	return rig.Name, false
 }
 
 func (s *Server) sourceWorkflowStores() []sling.SourceWorkflowStore {

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -17,6 +19,15 @@ import (
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
+
+type getErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s *getErrStore) Get(_ string) (beads.Bead, error) {
+	return beads.Bead{}, s.err
+}
 
 // newSlingTestServer creates a test handler wrapping a Server that has a
 // fake runner injected (captures commands without executing real shell
@@ -80,6 +91,317 @@ func TestSlingWithBead(t *testing.T) {
 	}
 	if resp["mode"] != "direct" {
 		t.Fatalf("mode = %q, want %q", resp["mode"], "direct")
+	}
+}
+
+func TestSlingWithMissingBeadReturnsBadRequest(t *testing.T) {
+	h, state := newSlingTestServer(t)
+
+	body := `{"target":"myrig/worker","bead":"gc-zzzzz"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-missing-bead" {
+		t.Fatalf("type = %q, want missing-bead discriminator", problem.Type)
+	}
+	if !strings.Contains(problem.Detail, "not found") {
+		t.Fatalf("detail = %s, want missing bead diagnostic", problem.Detail)
+	}
+	if strings.Contains(problem.Detail, "--force") {
+		t.Fatalf("detail = %s, want transport-neutral missing bead error", problem.Detail)
+	}
+}
+
+func TestSlingAttachFormulaMissingBeadReturnsBadRequest(t *testing.T) {
+	h, state := newSlingTestServer(t)
+
+	body := `{"target":"myrig/worker","formula":"code-review","attached_bead_id":"gc-zzzzz"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-missing-bead" {
+		t.Fatalf("type = %q, want missing-bead discriminator", problem.Type)
+	}
+	if !strings.Contains(problem.Detail, "gc-zzzzz") || !strings.Contains(problem.Detail, "not found") {
+		t.Fatalf("detail = %s, want attached missing bead diagnostic", problem.Detail)
+	}
+}
+
+func TestSlingWithLookupFailureReturnsInternalServerError(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.stores["myrig"] = &getErrStore{
+		Store: state.stores["myrig"],
+		err:   errors.New("backend unavailable"),
+	}
+	var stderr bytes.Buffer
+	oldStderr := apiSlingStderr
+	apiSlingStderr = func() io.Writer { return &stderr }
+	t.Cleanup(func() { apiSlingStderr = oldStderr })
+
+	body := `{"target":"myrig/worker","bead":"gc-zzzzz"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "sling bead lookup failed") {
+		t.Fatalf("body = %s, want sanitized lookup failure", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "backend unavailable") {
+		t.Fatalf("body = %s, should not expose backend failure detail", rec.Body.String())
+	}
+	if !strings.Contains(stderr.String(), "backend unavailable") {
+		t.Fatalf("stderr = %s, want backend failure detail logged", stderr.String())
+	}
+}
+
+func TestSlingWithForceBypassesMissingBeadGuard(t *testing.T) {
+	h, state := newSlingTestServer(t)
+
+	body := `{"target":"myrig/worker","bead":"gc-zzzzz","force":true}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSlingCrossRigExistingBeadReturnsCrossRigError(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.stores["frontend"] = beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "FE-123", Title: "frontend task", Type: "task", Status: "open"},
+	}, nil)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"})
+
+	body := `{"rig":"myrig","target":"myrig/worker","bead":"FE-123"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-cross-rig" {
+		t.Fatalf("type = %q, want cross-rig discriminator", problem.Type)
+	}
+	if !strings.Contains(problem.Detail, "cross-rig") {
+		t.Fatalf("detail = %s, want cross-rig diagnostic", problem.Detail)
+	}
+	if strings.Contains(problem.Detail, "not found") {
+		t.Fatalf("detail = %s, want cross-rig error instead of missing bead", problem.Detail)
+	}
+}
+
+func TestSlingCrossRigExistingCityBeadReturnsCrossRigError(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.cfg.Workspace.Prefix = "HQ"
+	state.cityBeadStore = beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "HQ-123", Title: "city task", Type: "task", Status: "open"},
+	}, nil)
+
+	body := `{"rig":"myrig","target":"myrig/worker","bead":"HQ-123"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-cross-rig" {
+		t.Fatalf("type = %q, want cross-rig discriminator", problem.Type)
+	}
+	if strings.Contains(problem.Detail, "not found") {
+		t.Fatalf("detail = %s, want city bead to be found before cross-rig guard", problem.Detail)
+	}
+}
+
+func TestSlingStoreRefReportsPrefixStoreWhenPrefixStoreMissing(t *testing.T) {
+	state := newFakeMutatorState(t)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"})
+	srv := New(state)
+	agentCfg := config.Agent{Name: "worker", Dir: "myrig"}
+
+	store := srv.findSlingStore("myrig", agentCfg, "FE-123")
+	if store != nil {
+		t.Fatalf("findSlingStore returned %T, want nil missing prefix store", store)
+	}
+	if got := srv.slingStoreRef("myrig", agentCfg, "FE-123"); got != "rig:frontend" {
+		t.Fatalf("slingStoreRef = %q, want rig:frontend", got)
+	}
+}
+
+func TestSlingPrefixStoreMissingReturnsMissingBead(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"})
+
+	body := `{"target":"myrig/worker","bead":"FE-123"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-missing-bead" {
+		t.Fatalf("type = %q, want missing-bead discriminator", problem.Type)
+	}
+	if !strings.Contains(problem.Detail, "rig:frontend") {
+		t.Fatalf("detail = %s, want prefix store ref", problem.Detail)
+	}
+}
+
+func TestSlingForcePrefixStoreMissingFallsBackToTargetStore(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"})
+
+	body := `{"target":"myrig/worker","bead":"FE-123","force":true}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSlingAttachFormulaForcePrefixStoreMissingDoesNotFallbackToTargetStore(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"})
+	state.stores["myrig"] = beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "FE-123", Title: "wrong-store task", Type: "task", Status: "open"},
+	}, nil)
+
+	body := `{"target":"myrig/worker","formula":"code-review","attached_bead_id":"FE-123","force":true}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-missing-bead" {
+		t.Fatalf("type = %q, want missing-bead discriminator; body = %s", problem.Type, rec.Body.String())
+	}
+	if !strings.Contains(problem.Detail, "rig:frontend") {
+		t.Fatalf("detail = %s, want prefix store ref", problem.Detail)
+	}
+}
+
+func TestSlingDefaultFormulaForcePrefixStoreMissingDoesNotFallbackToTargetStore(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "FE"})
+	defaultFormula := "code-review"
+	state.cfg.Agents[0].DefaultSlingFormula = &defaultFormula
+	state.stores["myrig"] = beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "FE-123", Title: "wrong-store task", Type: "task", Status: "open"},
+	}, nil)
+
+	body := `{"target":"myrig/worker","bead":"FE-123","title":"Review this","force":true}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Type   string `json:"type"`
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if problem.Type != "urn:gascity:error:sling-missing-bead" {
+		t.Fatalf("type = %q, want missing-bead discriminator; body = %s", problem.Type, rec.Body.String())
+	}
+	if !strings.Contains(problem.Detail, "rig:frontend") {
+		t.Fatalf("detail = %s, want prefix store ref", problem.Detail)
+	}
+}
+
+func TestSlingProblemTypesDocumentedInOpenAPI(t *testing.T) {
+	spec := readCommittedOpenAPISpec(t)
+	components, err := json.Marshal(spec["components"])
+	if err != nil {
+		t.Fatalf("marshal components: %v", err)
+	}
+	for _, want := range []string{slingMissingBeadProblemType, slingCrossRigProblemType} {
+		if !bytes.Contains(components, []byte(want)) {
+			t.Fatalf("OpenAPI components missing problem type %q", want)
+		}
+	}
+}
+
+func TestDocumentProblemTypesIsIdempotent(t *testing.T) {
+	state := newFakeMutatorState(t)
+	sm := NewSupervisorMux(&stateCityResolver{state: state}, false, "test", time.Now())
+	oapi := sm.humaAPI.OpenAPI()
+
+	documentProblemTypes(oapi)
+	documentProblemTypes(oapi)
+
+	errorModel := oapi.Components.Schemas.Map()["ErrorModel"]
+	if errorModel == nil || errorModel.Properties == nil {
+		t.Fatal("ErrorModel schema missing")
+	}
+	typeSchema := errorModel.Properties["type"]
+	if typeSchema == nil {
+		t.Fatal("ErrorModel.type schema missing")
+	}
+	counts := map[string]int{}
+	for _, example := range typeSchema.Examples {
+		if s, ok := example.(string); ok {
+			counts[s]++
+		}
+	}
+	for _, problemType := range documentedProblemTypes {
+		if counts[problemType] != 1 {
+			t.Fatalf("example count for %q = %d, want 1", problemType, counts[problemType])
+		}
 	}
 }
 

--- a/internal/api/huma_handlers_sling.go
+++ b/internal/api/huma_handlers_sling.go
@@ -28,6 +28,7 @@ func (s *Server) humaHandleSling(ctx context.Context, input *SlingInput) (*Sling
 		Vars:           input.Body.Vars,
 		ScopeKind:      input.Body.ScopeKind,
 		ScopeRef:       input.Body.ScopeRef,
+		Force:          input.Body.Force,
 	}
 
 	if body.Target == "" {
@@ -100,7 +101,7 @@ func (s *Server) humaHandleSling(ctx context.Context, input *SlingInput) (*Sling
 		// only a string detail, so we build the Problem Details error
 		// manually with structured extensions.
 		if conflict != nil && status == http.StatusConflict {
-			storeRef := s.slingStoreRef(body.Rig, agentCfg)
+			storeRef := s.slingStoreRef(body.Rig, agentCfg, slingStoreBeadID(body))
 			hint := sourceWorkflowCleanupHint(conflict.SourceBeadID, storeRef)
 			return nil, &huma.ErrorModel{
 				Status: http.StatusConflict,
@@ -111,6 +112,25 @@ func (s *Server) humaHandleSling(ctx context.Context, input *SlingInput) (*Sling
 					{Location: "body.blocking_workflow_ids", Value: conflict.WorkflowIDs},
 					{Location: "body.hint", Value: hint},
 				},
+			}
+		}
+		if status >= http.StatusInternalServerError {
+			return nil, huma.Error500InternalServerError(message)
+		}
+		if code == "missing_bead" {
+			return nil, &huma.ErrorModel{
+				Type:   slingMissingBeadProblemType,
+				Status: http.StatusBadRequest,
+				Title:  http.StatusText(http.StatusBadRequest),
+				Detail: message,
+			}
+		}
+		if code == "cross_rig" {
+			return nil, &huma.ErrorModel{
+				Type:   slingCrossRigProblemType,
+				Status: http.StatusBadRequest,
+				Title:  http.StatusText(http.StatusBadRequest),
+				Detail: message,
 			}
 		}
 		return nil, huma.Error400BadRequest(message)

--- a/internal/api/huma_types_sling.go
+++ b/internal/api/huma_types_sling.go
@@ -23,5 +23,6 @@ type SlingInput struct {
 		Vars           map[string]string `json:"vars,omitempty" doc:"Formula variables."`
 		ScopeKind      string            `json:"scope_kind,omitempty" doc:"Scope kind (city or rig)."`
 		ScopeRef       string            `json:"scope_ref,omitempty" doc:"Scope reference."`
+		Force          bool              `json:"force,omitempty" doc:"Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist."`
 	}
 }

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -1796,10 +1796,16 @@
             "default": "about:blank",
             "description": "A URI reference to human-readable documentation for the error.",
             "examples": [
-              "https://example.com/errors/example"
+              "https://example.com/errors/example",
+              "urn:gascity:error:sling-missing-bead",
+              "urn:gascity:error:sling-cross-rig"
             ],
             "format": "uri",
-            "type": "string"
+            "type": "string",
+            "x-gascity-problem-types": [
+              "urn:gascity:error:sling-missing-bead",
+              "urn:gascity:error:sling-cross-rig"
+            ]
           }
         },
         "type": "object"
@@ -5824,6 +5830,10 @@
           "bead": {
             "description": "Bead ID to sling.",
             "type": "string"
+          },
+          "force": {
+            "description": "Bypass cross-rig guards; for direct bead routes, also bypass missing-bead validation. Formula-backed graph routes may replace existing live workflow roots but still require the source bead to exist.",
+            "type": "boolean"
           },
           "formula": {
             "description": "Formula name for workflow launch.",

--- a/internal/api/openapi_problem_types.go
+++ b/internal/api/openapi_problem_types.go
@@ -1,0 +1,45 @@
+package api
+
+import "github.com/danielgtaylor/huma/v2"
+
+const (
+	slingMissingBeadProblemType = "urn:gascity:error:sling-missing-bead"
+	slingCrossRigProblemType    = "urn:gascity:error:sling-cross-rig"
+)
+
+var documentedProblemTypes = []string{
+	slingMissingBeadProblemType,
+	slingCrossRigProblemType,
+}
+
+func documentProblemTypes(oapi *huma.OpenAPI) {
+	if oapi == nil || oapi.Components == nil || oapi.Components.Schemas == nil {
+		return
+	}
+	errorModel := oapi.Components.Schemas.Map()["ErrorModel"]
+	if errorModel == nil || errorModel.Properties == nil {
+		return
+	}
+	typeSchema := errorModel.Properties["type"]
+	if typeSchema == nil {
+		return
+	}
+	for _, problemType := range documentedProblemTypes {
+		if !hasProblemTypeExample(typeSchema.Examples, problemType) {
+			typeSchema.Examples = append(typeSchema.Examples, problemType)
+		}
+	}
+	if typeSchema.Extensions == nil {
+		typeSchema.Extensions = map[string]any{}
+	}
+	typeSchema.Extensions["x-gascity-problem-types"] = append([]string(nil), documentedProblemTypes...)
+}
+
+func hasProblemTypeExample(examples []any, problemType string) bool {
+	for _, example := range examples {
+		if s, ok := example.(string); ok && s == problemType {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -90,6 +90,7 @@ func NewSupervisorMux(resolver CityResolver, readOnly bool, version string, star
 	}
 	sm.registerSupervisorRoutes()
 	sm.registerCityRoutes()
+	documentProblemTypes(sm.humaAPI.OpenAPI())
 	// /svc/* workspace-service pass-through. This is the single remaining
 	// non-Huma registration on the supervisor — untyped by design (the
 	// proxy passes bodies through to external service processes, which

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -6,6 +6,7 @@ package sling
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -50,8 +51,11 @@ type SlingOpts struct {
 	Nudge         bool
 	Force         bool
 	DryRun        bool
-	ScopeKind     string
-	ScopeRef      string
+	// InlineText is set only by the CLI path for ad-hoc task text. API
+	// callers always provide explicit bead or formula references.
+	InlineText bool
+	ScopeKind  string
+	ScopeRef   string
 }
 
 // AgentResolver resolves an agent name to a config.Agent.
@@ -103,6 +107,9 @@ type SlingDeps struct {
 	Runner   SlingRunner
 	Store    beads.Store
 	StoreRef string
+	// ValidationQuerier overrides Store for existence checks when a caller has
+	// already resolved the bead through a narrower view.
+	ValidationQuerier BeadQuerier
 	// SourceWorkflowStores lists every bead store that may contain workflow
 	// roots for source-workflow singleton checks and recovery.
 	SourceWorkflowStores func() ([]SourceWorkflowStore, error)
@@ -185,7 +192,10 @@ type RouteOpts struct {
 	Nudge    bool
 	Force    bool
 	DryRun   bool
-	SkipPoke bool
+	// InlineText is set only by the CLI path for ad-hoc task text. API
+	// callers always provide explicit bead or formula references.
+	InlineText bool
+	SkipPoke   bool
 }
 
 // FormulaOpts holds options for formula-based operations.
@@ -213,6 +223,7 @@ func (s *Sling) RouteBead(_ context.Context, beadID string, target config.Agent,
 		Force:         opts.Force,
 		SkipPoke:      opts.SkipPoke,
 		DryRun:        opts.DryRun,
+		InlineText:    opts.InlineText,
 	}, s.deps, s.deps.Store)
 }
 
@@ -264,6 +275,7 @@ func (s *Sling) ExpandConvoy(_ context.Context, convoyID string, target config.A
 		Force:         opts.Force,
 		SkipPoke:      opts.SkipPoke,
 		DryRun:        opts.DryRun,
+		InlineText:    opts.InlineText,
 	}, s.deps, querier)
 }
 
@@ -293,6 +305,9 @@ func SlingTracef(format string, args ...any) {
 
 // FindRigByPrefix finds a rig whose effective prefix matches (case-insensitive).
 func FindRigByPrefix(cfg *config.City, prefix string) (config.Rig, bool) {
+	if cfg == nil {
+		return config.Rig{}, false
+	}
 	lp := strings.ToLower(prefix)
 	for _, r := range cfg.Rigs {
 		if strings.ToLower(r.EffectivePrefix()) == lp {
@@ -300,6 +315,12 @@ func FindRigByPrefix(cfg *config.City, prefix string) (config.Rig, bool) {
 		}
 	}
 	return config.Rig{}, false
+}
+
+// IsHQPrefix reports whether prefix matches the city's HQ bead prefix.
+func IsHQPrefix(cfg *config.City, prefix string) bool {
+	prefix = strings.TrimSpace(prefix)
+	return cfg != nil && prefix != "" && strings.EqualFold(prefix, config.EffectiveHQPrefix(cfg))
 }
 
 // RigDirForBead resolves the rig directory for a bead ID by extracting
@@ -398,50 +419,159 @@ func RigPrefixForAgent(a config.Agent, cfg *config.City) string {
 // CheckCrossRig returns a warning message if a rig-scoped agent receives
 // a bead from a different rig. Returns "" if routing is safe.
 func CheckCrossRig(beadID string, a config.Agent, cfg *config.City) string {
-	if cfg == nil || a.Dir == "" {
+	err := CrossRigRouteError(beadID, a, cfg)
+	if err == nil {
 		return ""
+	}
+	return err.Error()
+}
+
+// CrossRigError reports that a rig-scoped agent was asked to route a bead from
+// a different rig.
+type CrossRigError struct {
+	BeadID     string
+	BeadPrefix string
+	Target     string
+	RigPrefix  string
+}
+
+// Error returns the cross-rig routing diagnostic.
+func (e *CrossRigError) Error() string {
+	return fmt.Sprintf("cross-rig routing — bead %s (prefix %q) → agent %s (rig prefix %q)", e.BeadID, e.BeadPrefix, e.Target, e.RigPrefix)
+}
+
+// CrossRigRouteError returns a typed cross-rig error when routing is unsafe.
+func CrossRigRouteError(beadID string, a config.Agent, cfg *config.City) *CrossRigError {
+	if cfg == nil || a.Dir == "" {
+		return nil
 	}
 	bp := BeadPrefix(beadID)
 	if bp == "" {
-		return ""
+		return nil
 	}
 	rp := RigPrefixForAgent(a, cfg)
 	if rp == "" {
-		return ""
+		return nil
 	}
 	if strings.EqualFold(bp, rp) {
-		return ""
+		return nil
 	}
-	return fmt.Sprintf("cross-rig routing — bead %s (prefix %q) → agent %s (rig prefix %q)", beadID, bp, a.QualifiedName(), rp)
+	return &CrossRigError{
+		BeadID:     beadID,
+		BeadPrefix: bp,
+		Target:     a.QualifiedName(),
+		RigPrefix:  rp,
+	}
 }
 
-// BeadExistsInStore checks if a bead exists in the given store.
-func BeadExistsInStore(store beads.Store, id string) bool {
-	if store == nil {
-		return false
-	}
-	_, err := store.Get(id)
-	return err == nil
+// ProbeBeadInStore checks if a bead exists in the given store and surfaces
+// non-not-found lookup errors.
+func ProbeBeadInStore(store beads.Store, id string) (bool, error) {
+	return probeBeadInQuerier(store, id)
 }
 
-// LooksLikeBeadID reports whether a string looks like a bead ID.
+func probeBeadInQuerier(querier BeadQuerier, id string) (bool, error) {
+	if querier == nil {
+		return false, fmt.Errorf("store unavailable")
+	}
+	_, err := querier.Get(id)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, beads.ErrNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+// LooksLikeBeadID reports whether a string loosely resembles a bead ID.
+//
+// Deprecated: use BeadIDParts for the stricter routing heuristic.
 func LooksLikeBeadID(s string) bool {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return false
 	}
-	// Bead IDs are typically prefix-NNN or just NNN.
-	// They don't contain spaces, slashes, or common text punctuation.
 	if strings.ContainsAny(s, " \t\n/\\") {
 		return false
 	}
-	// If it contains a digit, it's likely a bead ID.
 	for _, c := range s {
 		if c >= '0' && c <= '9' {
 			return true
 		}
 	}
 	return false
+}
+
+// BeadIDParts trims surrounding whitespace and parses a bead-like string into
+// prefix and base suffix, ignoring any hierarchical ".child" suffix. It
+// validates the structured bead-ID shape used by the CLI's stricter routing
+// heuristic.
+func BeadIDParts(s string) (prefix, baseSuffix string, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.ContainsAny(s, " \t\n") {
+		return "", "", false
+	}
+	i := strings.Index(s, "-")
+	if i <= 0 || i == len(s)-1 || strings.Count(s, "-") != 1 {
+		return "", "", false
+	}
+	prefix = s[:i]
+	for idx, c := range prefix {
+		if idx == 0 {
+			if ('A' > c || c > 'Z') && ('a' > c || c > 'z') {
+				return "", "", false
+			}
+			continue
+		}
+		if ('0' > c || c > '9') && ('a' > c || c > 'z') && ('A' > c || c > 'Z') {
+			return "", "", false
+		}
+	}
+	suffix := s[i+1:]
+	baseSuffix = suffix
+	if dot := strings.IndexByte(suffix, '.'); dot > 0 {
+		baseSuffix = suffix[:dot]
+	}
+	if baseSuffix == "" {
+		return "", "", false
+	}
+	for _, c := range baseSuffix {
+		if ('0' > c || c > '9') && ('a' > c || c > 'z') && ('A' > c || c > 'Z') {
+			return "", "", false
+		}
+	}
+	return prefix, baseSuffix, true
+}
+
+// MissingBeadError reports that a requested bead reference did not resolve in
+// the target store.
+type MissingBeadError struct {
+	BeadID   string
+	StoreRef string
+}
+
+// Error returns the missing-bead diagnostic.
+func (e *MissingBeadError) Error() string {
+	return fmt.Sprintf("bead %q not found in store %s", e.BeadID, e.StoreRef)
+}
+
+// BeadLookupError reports an operational failure while checking whether a bead
+// exists in the target store.
+type BeadLookupError struct {
+	BeadID   string
+	StoreRef string
+	Err      error
+}
+
+// Error returns the lookup-failure diagnostic.
+func (e *BeadLookupError) Error() string {
+	return fmt.Sprintf("getting bead %q from store %s: %v", e.BeadID, e.StoreRef, e.Err)
+}
+
+// Unwrap returns the underlying lookup failure.
+func (e *BeadLookupError) Unwrap() error {
+	return e.Err
 }
 
 func normalizeSlingQuery(query string) string {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -75,15 +75,19 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 		result.PoolEmpty = true
 	}
 
-	// Cross-rig guard.
-	if !opts.IsFormula && !opts.Force && !opts.DryRun {
-		if msg := CheckCrossRig(opts.BeadOrFormula, a, deps.Cfg); msg != "" {
-			return result, fmt.Errorf("%s", msg)
+	if shouldValidateExistingBead(opts) {
+		if err := validateExistingBead(opts.BeadOrFormula, deps); err != nil {
+			return result, err
+		}
+	}
+	if shouldGuardCrossRig(opts) {
+		if err := CrossRigRouteError(opts.BeadOrFormula, a, deps.Cfg); err != nil {
+			return result, err
 		}
 	}
 
 	// Pre-flight idempotency check.
-	if !opts.IsFormula && !opts.Force {
+	if shouldCheckBeadState(opts) {
 		check := CheckBeadState(querier, opts.BeadOrFormula, a, deps)
 		if check.Idempotent {
 			result.Idempotent = true
@@ -113,6 +117,51 @@ func preflight(opts SlingOpts, deps SlingDeps, querier BeadQuerier) (SlingResult
 	}
 
 	return result, nil
+}
+
+func shouldValidateExistingBead(opts SlingOpts) bool {
+	if opts.IsFormula || (opts.DryRun && opts.InlineText) {
+		return false
+	}
+	return !opts.Force || usesFormulaBackedRoute(opts)
+}
+
+func usesFormulaBackedRoute(opts SlingOpts) bool {
+	return opts.OnFormula != "" || (!opts.NoFormula && opts.Target.EffectiveDefaultSlingFormula() != "")
+}
+
+func shouldGuardCrossRig(opts SlingOpts) bool {
+	return !opts.IsFormula && !opts.Force && !opts.DryRun
+}
+
+func shouldCheckBeadState(opts SlingOpts) bool {
+	return !opts.IsFormula && !opts.Force && (!opts.DryRun || !opts.InlineText)
+}
+
+func validateExistingBead(beadID string, deps SlingDeps) error {
+	querier := deps.ValidationQuerier
+	if querier == nil {
+		querier = deps.Store
+	}
+	return validateExistingBeadInQuerier(beadID, deps.StoreRef, querier)
+}
+
+func validateExistingBeadInQuerier(beadID, storeRef string, querier BeadQuerier) error {
+	storeRef = strings.TrimSpace(storeRef)
+	if storeRef == "" {
+		storeRef = "local"
+	}
+	if querier == nil {
+		return &BeadLookupError{BeadID: beadID, StoreRef: storeRef, Err: errors.New("store not configured")}
+	}
+	exists, err := probeBeadInQuerier(querier, beadID)
+	if err != nil {
+		return &BeadLookupError{BeadID: beadID, StoreRef: storeRef, Err: err}
+	}
+	if exists {
+		return nil
+	}
+	return &MissingBeadError{BeadID: beadID, StoreRef: storeRef}
 }
 
 // slingFormula handles the --formula dispatch path.
@@ -294,25 +343,43 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 
 	// Auto-convoy.
 	if !opts.NoConvoy && !opts.IsFormula && deps.Store != nil {
-		var convoyLabels []string
-		if opts.Owned {
-			convoyLabels = []string{"owned"}
-		}
-		convoy, err := deps.Store.Create(beads.Bead{
-			Title:  fmt.Sprintf("sling-%s", beadID),
-			Type:   "convoy",
-			Labels: convoyLabels,
-		})
+		createAutoConvoy := true
+		exists, err := ProbeBeadInStore(deps.Store, beadID)
 		if err != nil {
 			result.MetadataErrors = append(result.MetadataErrors,
-				fmt.Sprintf("creating auto-convoy: %v", err))
-		} else {
-			parentID := convoy.ID
-			if err := deps.Store.Update(beadID, beads.UpdateOpts{ParentID: &parentID}); err != nil {
+				fmt.Sprintf("checking bead before auto-convoy: %v", err))
+			createAutoConvoy = false
+		} else if !exists {
+			if opts.Force {
 				result.MetadataErrors = append(result.MetadataErrors,
-					fmt.Sprintf("linking bead to convoy: %v", err))
+					fmt.Sprintf("forced dispatch skipped missing-bead validation for %s; no local auto-convoy created", beadID))
 			} else {
-				result.ConvoyID = convoy.ID
+				result.MetadataErrors = append(result.MetadataErrors,
+					fmt.Sprintf("skipping auto-convoy: bead %s is not present in the local store", beadID))
+			}
+			createAutoConvoy = false
+		}
+		if createAutoConvoy {
+			var convoyLabels []string
+			if opts.Owned {
+				convoyLabels = []string{"owned"}
+			}
+			convoy, err := deps.Store.Create(beads.Bead{
+				Title:  fmt.Sprintf("sling-%s", beadID),
+				Type:   "convoy",
+				Labels: convoyLabels,
+			})
+			if err != nil {
+				result.MetadataErrors = append(result.MetadataErrors,
+					fmt.Sprintf("creating auto-convoy: %v", err))
+			} else {
+				parentID := convoy.ID
+				if err := deps.Store.Update(beadID, beads.UpdateOpts{ParentID: &parentID}); err != nil {
+					result.MetadataErrors = append(result.MetadataErrors,
+						fmt.Sprintf("linking bead to convoy: %v", err))
+				} else {
+					result.ConvoyID = convoy.ID
+				}
 			}
 		}
 	}
@@ -725,11 +792,34 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 		return DoSling(opts, deps, querier)
 	}
 
+	containerQuerier := BeadQuerier(querier)
 	b, err := querier.Get(opts.BeadOrFormula)
 	if err != nil {
-		singleOpts := opts
-		singleOpts.IsFormula = false
-		return DoSling(singleOpts, deps, querier)
+		if !errors.Is(err, beads.ErrNotFound) {
+			return SlingResult{Target: a.QualifiedName()}, &BeadLookupError{
+				BeadID:   opts.BeadOrFormula,
+				StoreRef: deps.StoreRef,
+				Err:      err,
+			}
+		}
+		if selected, ok := selectedStoreContainer(opts, deps); ok {
+			b = selected
+			// The caller's querier could not see the container, so deps.Store
+			// becomes authoritative for both validation and child expansion.
+			querier = deps.Store
+			containerQuerier = deps.Store
+		} else {
+			singleOpts := opts
+			singleOpts.IsFormula = false
+			return DoSling(singleOpts, deps, querier)
+		}
+	}
+	if b.Type == "epic" || beads.IsContainerType(b.Type) {
+		if shouldValidateExistingBead(opts) {
+			if err := validateExistingBeadInQuerier(opts.BeadOrFormula, deps.StoreRef, containerQuerier); err != nil {
+				return SlingResult{Target: a.QualifiedName()}, err
+			}
+		}
 	}
 	if b.Type == "epic" {
 		return SlingResult{}, fmt.Errorf("bead %s is an epic; first-class support is for convoys only", b.ID)
@@ -738,7 +828,9 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 	if !beads.IsContainerType(b.Type) {
 		singleOpts := opts
 		singleOpts.IsFormula = false
-		return DoSling(singleOpts, deps, querier)
+		singleDeps := deps
+		singleDeps.ValidationQuerier = containerQuerier
+		return DoSling(singleOpts, singleDeps, querier)
 	}
 
 	children, err := querier.List(beads.ListQuery{
@@ -765,8 +857,8 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 
 	// Cross-rig guard on container.
 	if !opts.Force && !opts.DryRun {
-		if msg := CheckCrossRig(b.ID, a, deps.Cfg); msg != "" {
-			return SlingResult{}, fmt.Errorf("%s", msg)
+		if err := CrossRigRouteError(b.ID, a, deps.Cfg); err != nil {
+			return SlingResult{}, err
 		}
 	}
 
@@ -938,4 +1030,15 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 		return batchResult, errors.Join(joined...)
 	}
 	return batchResult, nil
+}
+
+func selectedStoreContainer(opts SlingOpts, deps SlingDeps) (beads.Bead, bool) {
+	if deps.Store == nil {
+		return beads.Bead{}, false
+	}
+	b, err := deps.Store.Get(opts.BeadOrFormula)
+	if err != nil {
+		return beads.Bead{}, false
+	}
+	return b, b.Type == "epic" || beads.IsContainerType(b.Type)
 }

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	beadsexec "github.com/gastownhall/gascity/internal/beads/exec"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
@@ -30,6 +32,15 @@ type fakeRunner struct {
 	dirs  []string
 	envs  []map[string]string
 	rules []fakeRunnerRule
+}
+
+type getErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s *getErrStore) Get(_ string) (beads.Bead, error) {
+	return beads.Bead{}, s.err
 }
 
 type closeAllFailMemStore struct {
@@ -77,7 +88,22 @@ func (r *fakeRunner) run(dir, command string, env map[string]string) (string, er
 	return "", nil
 }
 
-func intPtr(v int) *int { return &v }
+func intPtr(v int) *int          { return &v }
+func stringPtr(v string) *string { return &v }
+
+func seededStore(ids ...string) *beads.MemStore {
+	seed := make([]beads.Bead, 0, len(ids))
+	for _, id := range ids {
+		seed = append(seed, beads.Bead{
+			ID:       id,
+			Title:    id,
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{},
+		})
+	}
+	return beads.NewMemStoreFrom(0, seed, nil)
+}
 
 // testResolver implements AgentResolver for tests using exact match.
 type testResolver struct{}
@@ -324,6 +350,7 @@ func TestDoSlingBeadToFixedAgent(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
 	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	result, err := DoSling(testOpts(a, "BL-42"), deps, nil)
 	if err != nil {
 		t.Fatalf("DoSling error: %v", err)
@@ -346,6 +373,7 @@ func TestDoSlingSuspendedAgentWarns(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1), Suspended: true}
 
 	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	result, err := DoSling(testOpts(a, "BL-42"), deps, nil)
 	if err != nil {
 		t.Fatalf("DoSling error: %v", err)
@@ -363,6 +391,7 @@ func TestDoSlingRunnerError(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 
 	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	_, err := DoSling(testOpts(a, "BL-42"), deps, nil)
 
 	if err == nil {
@@ -406,6 +435,7 @@ func TestDoSlingCrossRigBlocks(t *testing.T) {
 	a := config.Agent{Name: "worker", Dir: "other", MaxActiveSessions: intPtr(1)}
 
 	deps := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
 	_, err := DoSling(testOpts(a, "BL-42"), deps, nil)
 
 	if err == nil {
@@ -579,6 +609,7 @@ func TestDoSlingCustomSlingQueryExpandsTemplateContext(t *testing.T) {
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
 	deps.CityPath = cityPath
 	deps.CityName = ""
+	deps.Store = seededStore("FR-99")
 	opts := testOpts(a, "FR-99")
 	result, err := DoSling(opts, deps, nil)
 	if err != nil {
@@ -616,6 +647,7 @@ func TestNewSlingValid(t *testing.T) {
 func TestSlingRouteBead(t *testing.T) {
 	runner := newFakeRunner()
 	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-42")
 	s, err := New(deps)
 	if err != nil {
 		t.Fatal(err)
@@ -637,6 +669,337 @@ func TestSlingRouteBead(t *testing.T) {
 	}
 	if len(runner.calls) != 1 {
 		t.Fatalf("got %d runner calls, want 1", len(runner.calls))
+	}
+}
+
+func TestSlingRouteBeadRejectsMissingBead(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	_, err = s.RouteBead(context.Background(), "BL-404", a, RouteOpts{})
+	if err == nil {
+		t.Fatal("RouteBead error = nil, want missing bead error")
+	}
+	if !strings.Contains(err.Error(), "BL-404") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("RouteBead error = %q, want missing bead diagnostic", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
+	}
+}
+
+func TestProbeBeadInStoreTreatsBackendNotFoundAsMissing(t *testing.T) {
+	fileStore, err := beads.OpenFileStore(fsys.OSFS{}, filepath.Join(t.TempDir(), "beads.json"))
+	if err != nil {
+		t.Fatalf("OpenFileStore: %v", err)
+	}
+	bdStore := beads.NewBdStore(t.TempDir(), func(_, _ string, _ ...string) ([]byte, error) {
+		return []byte(`[]`), nil
+	})
+	execScript := filepath.Join(t.TempDir(), "beads-provider")
+	if err := os.WriteFile(execScript, []byte("#!/bin/sh\ncase \"$1\" in\n  get) echo 'not found' >&2; exit 1 ;;\n  *) exit 2 ;;\nesac\n"), 0o755); err != nil {
+		t.Fatalf("write exec provider: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		store beads.Store
+	}{
+		{name: "mem", store: beads.NewMemStore()},
+		{name: "file", store: fileStore},
+		{name: "caching", store: beads.NewCachingStoreForTest(beads.NewMemStore(), nil)},
+		{name: "bd", store: bdStore},
+		{name: "exec", store: beadsexec.NewStore(execScript)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exists, err := ProbeBeadInStore(tt.store, "NOPE-1")
+			if err != nil {
+				t.Fatalf("ProbeBeadInStore error = %v, want nil", err)
+			}
+			if exists {
+				t.Fatal("ProbeBeadInStore exists = true, want false")
+			}
+		})
+	}
+}
+
+func TestSlingRouteBeadDryRunRejectsMissingBead(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	_, err = s.RouteBead(context.Background(), "BL-404", a, RouteOpts{DryRun: true})
+	if err == nil {
+		t.Fatal("RouteBead dry-run error = nil, want missing bead error")
+	}
+	if !strings.Contains(err.Error(), "BL-404") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("RouteBead dry-run error = %q, want missing bead diagnostic", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
+	}
+}
+
+func TestDoSlingDryRunInlineTextSkipsMissingBeadValidation(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	result, err := DoSling(SlingOpts{
+		Target:        a,
+		BeadOrFormula: "write docs",
+		DryRun:        true,
+		InlineText:    true,
+	}, deps, nil)
+	if err != nil {
+		t.Fatalf("DoSling dry-run inline text: %v", err)
+	}
+	if !result.DryRun {
+		t.Fatalf("DryRun = false, want true")
+	}
+	if result.BeadID != "write docs" {
+		t.Fatalf("BeadID = %q, want inline text", result.BeadID)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
+	}
+}
+
+func TestDoSlingBatchValidatesContainerInQuerierStore(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	querier := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Title: "convoy", Type: "convoy", Status: "open", Metadata: map[string]string{}},
+		{ID: "BL-2", Title: "child", Type: "task", Status: "open", ParentID: "BL-1", Metadata: map[string]string{}},
+	}, nil)
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := DoSlingBatch(SlingOpts{Target: a, BeadOrFormula: "BL-1"}, deps, querier)
+	if err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+	if result.Method != "batch" {
+		t.Fatalf("Method = %q, want batch", result.Method)
+	}
+	if result.Routed != 1 {
+		t.Fatalf("Routed = %d, want 1", result.Routed)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %#v, want one", runner.calls)
+	}
+}
+
+func TestDoSlingBatchFallsBackToSelectedStoreForContainerExpansion(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	convoy, err := deps.Store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	if _, err := deps.Store.Create(beads.Bead{Title: "child", Type: "task", Status: "open", ParentID: convoy.ID}); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	wrongQuerier := beads.NewMemStore()
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := DoSlingBatch(SlingOpts{Target: a, BeadOrFormula: convoy.ID}, deps, wrongQuerier)
+	if err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+	if result.Method != "batch" {
+		t.Fatalf("Method = %q, want batch", result.Method)
+	}
+	if result.Routed != 1 {
+		t.Fatalf("Routed = %d, want 1", result.Routed)
+	}
+}
+
+func TestDoSlingBatchUsesCallerQuerierChildrenWhenContainerExistsThere(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Title: "convoy", Type: "convoy", Status: "open", Metadata: map[string]string{}},
+		{ID: "BL-store-only", Title: "store child", Type: "task", Status: "open", ParentID: "BL-1", Metadata: map[string]string{}},
+	}, nil)
+	querier := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Title: "convoy", Type: "convoy", Status: "open", Metadata: map[string]string{}},
+		{ID: "BL-query-only", Title: "query child", Type: "task", Status: "open", ParentID: "BL-1", Metadata: map[string]string{}},
+	}, nil)
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := DoSlingBatch(SlingOpts{Target: a, BeadOrFormula: "BL-1"}, deps, querier)
+	if err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+	if result.Routed != 1 {
+		t.Fatalf("Routed = %d, want 1", result.Routed)
+	}
+	if len(result.Children) != 1 || result.Children[0].BeadID != "BL-query-only" {
+		t.Fatalf("children = %#v, want caller querier child", result.Children)
+	}
+}
+
+func TestDoSlingBatchRoutesNonContainerFoundInQuerierStore(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	querier := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "BL-1", Title: "task", Type: "task", Status: "open", Metadata: map[string]string{}},
+	}, nil)
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := DoSlingBatch(SlingOpts{Target: a, BeadOrFormula: "BL-1"}, deps, querier)
+	if err != nil {
+		t.Fatalf("DoSlingBatch: %v", err)
+	}
+	if result.Method != "bead" {
+		t.Fatalf("Method = %q, want bead", result.Method)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %#v, want one", runner.calls)
+	}
+	if result.ConvoyID != "" {
+		t.Fatalf("ConvoyID = %q, want no local auto-convoy", result.ConvoyID)
+	}
+	if len(result.MetadataErrors) != 1 || !strings.Contains(result.MetadataErrors[0], "skipping auto-convoy") {
+		t.Fatalf("MetadataErrors = %#v, want auto-convoy skip warning", result.MetadataErrors)
+	}
+}
+
+func TestDoSlingBatchDoesNotFallbackOnQuerierLookupError(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.StoreRef = "rig:selected"
+	convoy, err := deps.Store.Create(beads.Bead{Title: "convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	if _, err := deps.Store.Create(beads.Bead{Title: "child", Type: "task", Status: "open", ParentID: convoy.ID}); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	querier := &getErrStore{Store: beads.NewMemStore(), err: fmt.Errorf("backend unavailable")}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	_, err = DoSlingBatch(SlingOpts{Target: a, BeadOrFormula: convoy.ID}, deps, querier)
+	if err == nil {
+		t.Fatal("DoSlingBatch error = nil, want lookup error")
+	}
+	var lookup *BeadLookupError
+	if !errors.As(err, &lookup) {
+		t.Fatalf("DoSlingBatch error = %T %[1]v, want BeadLookupError", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
+	}
+}
+
+func TestSlingRouteBeadForceAllowsMissingBead(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.RouteBead(context.Background(), "BL-404", a, RouteOpts{Force: true})
+	if err != nil {
+		t.Fatalf("RouteBead force: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %#v, want one call", runner.calls)
+	}
+	if len(result.MetadataErrors) != 1 || !strings.Contains(result.MetadataErrors[0], "forced dispatch skipped missing-bead validation") {
+		t.Fatalf("MetadataErrors = %#v, want forced missing-bead warning", result.MetadataErrors)
+	}
+	all, err := deps.Store.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("list beads: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("stored beads = %#v, want no orphan auto-convoy", all)
+	}
+}
+
+func TestSlingRouteDefaultFormulaForceStillRejectsMissingBead(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", DefaultSlingFormula: stringPtr("code-review"), MaxActiveSessions: intPtr(1)}
+	_, err = s.RouteBead(context.Background(), "BL-404", a, RouteOpts{Force: true})
+	if err == nil {
+		t.Fatal("RouteBead force with default formula error = nil, want missing bead error")
+	}
+	var missing *MissingBeadError
+	if !errors.As(err, &missing) {
+		t.Fatalf("RouteBead force with default formula error = %T %[1]v, want MissingBeadError", err)
+	}
+	all, listErr := deps.Store.List(beads.ListQuery{AllowScan: true})
+	if listErr != nil {
+		t.Fatalf("list beads: %v", listErr)
+	}
+	if len(all) != 0 {
+		t.Fatalf("stored beads = %#v, want no orphan formula state", all)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
+	}
+}
+
+func TestValidateExistingBeadInQuerierNilIsLookupError(t *testing.T) {
+	err := validateExistingBeadInQuerier("BL-42", "rig:missing", nil)
+	var lookup *BeadLookupError
+	if !errors.As(err, &lookup) {
+		t.Fatalf("error = %T %[1]v, want BeadLookupError", err)
+	}
+	var missing *MissingBeadError
+	if errors.As(err, &missing) {
+		t.Fatalf("error = %T %[1]v, should not report missing bead for nil store", err)
+	}
+}
+
+func TestSlingRouteBeadSurfacesStoreLookupError(t *testing.T) {
+	runner := newFakeRunner()
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), runner.run)
+	deps.Store = &getErrStore{Store: beads.NewMemStore(), err: fmt.Errorf("backend unavailable")}
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	_, err = s.RouteBead(context.Background(), "BL-42", a, RouteOpts{})
+	if err == nil {
+		t.Fatal("RouteBead error = nil, want store lookup failure")
+	}
+	if !strings.Contains(err.Error(), "backend unavailable") {
+		t.Fatalf("RouteBead error = %q, want backend failure", err)
+	}
+	if strings.Contains(err.Error(), "not found") {
+		t.Fatalf("RouteBead error = %q, want store failure, not not-found", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
 	}
 }
 
@@ -681,6 +1044,7 @@ func TestSlingRouteBeadWithTypedRouter(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
 	deps.Router = router
+	deps.Store = seededStore("BL-42")
 
 	s, err := New(deps)
 	if err != nil {
@@ -730,6 +1094,61 @@ func TestSlingAttachFormula(t *testing.T) {
 	}
 	if result.FormulaName != "code-review" {
 		t.Errorf("FormulaName = %q, want code-review", result.FormulaName)
+	}
+}
+
+func TestSlingAttachFormulaRejectsMissingBead(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	_, err = s.AttachFormula(context.Background(), "code-review", "BL-404", a, FormulaOpts{})
+	if err == nil {
+		t.Fatal("AttachFormula error = nil, want missing bead error")
+	}
+	var missing *MissingBeadError
+	if !errors.As(err, &missing) {
+		t.Fatalf("AttachFormula error = %T %[1]v, want MissingBeadError", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
+	}
+}
+
+func TestSlingAttachFormulaForceStillRejectsMissingBead(t *testing.T) {
+	runner := newFakeRunner()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = beads.NewMemStore()
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	_, err = s.AttachFormula(context.Background(), "code-review", "BL-404", a, FormulaOpts{Force: true})
+	if err == nil {
+		t.Fatal("AttachFormula force error = nil, want missing bead error")
+	}
+	var missing *MissingBeadError
+	if !errors.As(err, &missing) {
+		t.Fatalf("AttachFormula force error = %T %[1]v, want MissingBeadError", err)
+	}
+	all, listErr := deps.Store.List(beads.ListQuery{AllowScan: true})
+	if listErr != nil {
+		t.Fatalf("list beads: %v", listErr)
+	}
+	if len(all) != 0 {
+		t.Fatalf("stored beads = %#v, want no orphan formula state", all)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", runner.calls)
 	}
 }
 
@@ -1901,6 +2320,7 @@ func TestDoSlingPoolEmptyWarns(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	a := config.Agent{Name: "pool", MaxActiveSessions: intPtr(0)}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 	result, err := DoSling(testOpts(a, "BL-1"), deps, nil)
 	if err != nil {
 		t.Fatalf("DoSling: %v", err)
@@ -1937,6 +2357,7 @@ func TestFinalizeNoConvoyWhenSuppressed(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 
 	result, err := DoSling(SlingOpts{
 		Target: a, BeadOrFormula: "BL-1", NoConvoy: true,
@@ -2026,6 +2447,7 @@ func TestDoSlingDryRun(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 
 	result, err := DoSling(SlingOpts{
 		Target: a, BeadOrFormula: "BL-1", DryRun: true,
@@ -2046,6 +2468,7 @@ func TestDoSlingNudgeSignal(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 
 	result, err := DoSling(SlingOpts{
 		Target: a, BeadOrFormula: "BL-1", Nudge: true,
@@ -2067,6 +2490,7 @@ func TestDoSlingSuspendedAgentWarnsEvenOnFailure(t *testing.T) {
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1), Suspended: true}
 
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 	result, err := DoSling(testOpts(a, "BL-1"), deps, nil)
 
 	if err == nil {
@@ -2089,6 +2513,7 @@ func TestDoSlingNonexistentTargetFails(_ *testing.T) {
 	}
 	nonexistent := config.Agent{Name: "nonexistent", MaxActiveSessions: intPtr(1)}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 	// Cross-rig and routing should still work even if agent doesn't exist in config.
 	// The runner will fail, but the domain doesn't validate agent existence.
 	result, err := DoSling(testOpts(nonexistent, "BL-1"), deps, nil)
@@ -2107,6 +2532,7 @@ func TestDoSlingPoolEmptyWarnsOnFailure(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	a := config.Agent{Name: "empty-pool", MaxActiveSessions: intPtr(0)}
 	deps := testDeps(cfg, runtime.NewFake(), runner.run)
+	deps.Store = seededStore("BL-1")
 
 	result, err := DoSling(testOpts(a, "BL-1"), deps, nil)
 	if err == nil {


### PR DESCRIPTION
## Summary

Refuse `gc sling <target> <BEAD-ID>` when `<BEAD-ID>` doesn't resolve in
the local store. `--force` bypasses.

## Why

A bead-ID-shaped argument that doesn't resolve in the store currently
flows through sling unchecked. The existing `beadExistsInStore` lookup
at `cmd_sling.go:264` only fires when the argument *doesn't* look like
a bead ID — that check exists for the inline-text auto-create path.
When the argument DOES look like a bead ID, sling assumes it's a
reference and dispatches without validating.

That assumption is fine for humans who copy-paste real IDs, but breaks
down in two cases:

1. **LLM-driven dispatch** that emits well-formed-looking bead IDs it
   invented (hallucinated IDs, unsubstituted template placeholders).
   Workers receive assignments to beads that never existed.
2. **Plain typos**. `sc-qq3q0` for `sc-qq3a0` gets the same silent
   success — dispatch proceeds to a dead reference and workers stall.

The downstream failure mode (workers routed to a bead that can't be
found) is quiet: no loud error at dispatch time, the worker just can't
make progress. This is already a latent bug, observable any time a
user typos a bead ID; LLM dispatch just makes it routine.

## Historical context

`looksLikeBeadID` was added in 777c9edf (Phase 3a: name-based session
addressing) as a routing heuristic — does this string look like a bead
ID or a session-template name? It was never validation.
`resolveSessionID`, the original caller, already errors out when the
downstream lookup fails.

efa9f337 (inline sling) reused `looksLikeBeadID` to distinguish inline
text from bead IDs. The resulting condition
`!looksLikeBeadID && !beadExistsInStore` only fires the store lookup
for text-shaped args; bead-shaped args went unchecked. This PR brings
`gc sling` to parity with `resolveSessionID`.

## What changes

Add an explicit guard after the inline-create block:

```go
if !isFormula && looksLikeBeadID(beadOrFormula) &&
   !beadExistsInStore(store, beadOrFormula) && !force {
    // error with a clear message pointing at --force
}
```

- Formula mode (`--formula` / `-f`) is exempt — the argument is a
  formula name, not a bead ID.
- `--force` bypasses, consistent with the flag's existing role as the
  escape hatch for cross-rig routing and suspended-agent sling.
  Semantically: "the bead exists in a view the local store hasn't
  synced yet — dispatch anyway."
- The error message names the store root so operators can tell *which*
  store view disagrees with the caller.
- `--force` flag help text updated to reflect the new behavior.

## Tests

- `TestCmdSlingRefusesMissingBead` — bead-shaped arg with no matching
  bead → exit non-zero; stderr names the bead, says "not found",
  mentions `--force`.
- `TestCmdSlingForceBypassesMissingBeadCheck` — same setup + `--force`
  → guard message absent from stderr.
- `TestCmdSlingAcceptsExistingBead` — seeded real bead + matching
  prefix → guard does not fire.

## Backwards compatibility

Any existing caller that intentionally slings a bead that isn't yet
visible in the local store (e.g. races with a remote Dolt push) gets a
new error. `--force` is the documented escape hatch. No existing test
changed behavior under this PR; no existing workflow relies on silent
dispatch of a nonexistent bead.

## Related

Supersedes the sidecar `verified-sling.sh` + mol-idea-to-plan /
mayor-prompt surgery that was bundled in #1126 (closed). Keeping the
fix in Go at the sling entry point means callers get the protection
without opting into a wrapper script.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/gc/... -run 'TestCmdSling' -count=1`
- [x] Full cmd/gc test suite passed



## Related issue

Closes #1144.
