### PR TITLE
docs: close agent-local append_fragments gap (#671)

### DIFF
--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -155,11 +155,16 @@ append_fragments = ["footer"]
 		t.Fatalf("config.Parse: %v", err)
 	}
 	var mayor config.Agent
+	found := false
 	for _, a := range cfg.Agents {
 		if a.Name == "mayor" {
 			mayor = a
+			found = true
 			break
 		}
+	}
+	if !found {
+		t.Fatalf(`expected [[agent]] with name "mayor" in parsed config`)
 	}
 	if got := mayor.AppendFragments; len(got) != 1 || got[0] != "footer" {
 		t.Fatalf("[[agent]] AppendFragments = %v, want [footer]", got)

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -140,6 +140,46 @@ prompt_template = "agents/mayor/prompt.template.md"
 	}
 }
 
+func TestRenderPromptAgentBlockAppendFragmentsAffectRenderedPrompt(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "agents/mayor/prompt.template.md"
+append_fragments = ["footer"]
+`)
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatalf("config.Parse: %v", err)
+	}
+	var mayor config.Agent
+	for _, a := range cfg.Agents {
+		if a.Name == "mayor" {
+			mayor = a
+			break
+		}
+	}
+	if got := mayor.AppendFragments; len(got) != 1 || got[0] != "footer" {
+		t.Fatalf("[[agent]] AppendFragments = %v, want [footer]", got)
+	}
+	f := fsys.NewFake()
+	f.Files["/city/agents/mayor/prompt.template.md"] = []byte("Hello")
+	f.Files["/city/agents/mayor/template-fragments/footer.template.md"] = []byte(`{{ define "footer" }}Goodbye{{ end }}`)
+	fragments := effectivePromptFragments(
+		cfg.Workspace.GlobalFragments,
+		mayor.InjectFragments,
+		mayor.AppendFragments,
+		mayor.InheritedAppendFragments,
+		cfg.AgentDefaults.AppendFragments,
+	)
+	got := renderPrompt(f, "/city", "", "agents/mayor/prompt.template.md", PromptContext{}, "", io.Discard, nil, fragments, nil)
+	if got != "Hello\n\nGoodbye" {
+		t.Errorf("renderPrompt([[agent]] append_fragments) = %q, want %q", got, "Hello\n\nGoodbye")
+	}
+}
+
 func TestRenderPromptPatchedTemplateSuffixRenders(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files["/city/patches/gastown-mayor-prompt.template.md"] = []byte("Hello {{ .AgentName }}")

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -481,13 +481,19 @@ each prompt file:
 append_fragments = ["operational-awareness", "command-glossary"]
 ```
 
+Per-agent `append_fragments` is also supported, declared on an
+`[[agent]]` block or in `agents/<name>/agent.toml`, and layers in front
+of the `[agent_defaults]` list:
+
+```toml
+[[agent]]
+name = "mayor"
+prompt_template = "agents/mayor/prompt.template.md"
+append_fragments = ["mayor-footer"]
+```
+
 Plain `.md` prompts are inert — no fragments attach, no template engine
 runs.
-
-> **As of release v0.15.0:** `[agent_defaults].append_fragments` is the
-> proven migration bridge in the current release. Agent-local
-> `append_fragments` is still tracked as a spec/runtime parity gap in
-> [#671](https://github.com/gastownhall/gascity/issues/671).
 
 ## Assets and paths
 

--- a/docs/packv2/doc-agent-v2.md
+++ b/docs/packv2/doc-agent-v2.md
@@ -408,9 +408,23 @@ auto-append fragments via `[agent_defaults].append_fragments`:
 append_fragments = ["operational-awareness", "command-glossary"]
 ```
 
-Agent-local `append_fragments` remains a follow-up tracked in
-[#671](https://github.com/gastownhall/gascity/issues/671); it is not part
-of the supported migration contract as of release v0.15.0.
+Agent-local `append_fragments` is also supported on a per-agent basis,
+declared directly on an `[[agent]]` block or in an
+`agents/<name>/agent.toml`:
+
+```toml
+[[agent]]
+name = "mayor"
+prompt_template = "agents/mayor/prompt.template.md"
+append_fragments = ["mayor-footer"]
+```
+
+Among the `append_fragments` sources, the layering order is per-agent
+first, then imported-pack `[agent_defaults].append_fragments`, then
+city-level `[agent_defaults].append_fragments`. Duplicates across
+layers are de-duplicated. Legacy `global_fragments` (workspace) and
+`inject_fragments` (per-agent) still prepend to this list during
+migration.
 
 `append_fragments` only works on `.template.md` prompts. Plain `.md` prompts are inert — nothing is injected, no template engine runs.
 

--- a/engdocs/architecture/prompt-templates.md
+++ b/engdocs/architecture/prompt-templates.md
@@ -34,9 +34,13 @@ prompt dynamically customized to its deployment context.
   conventions like command glossaries and architecture context.
 
 - **Appended Fragments**: Named template fragments that are rendered and
-  appended after the main prompt body. These are configured through
-  `append_fragments` in `[agent_defaults]`. Per-agent appended fragments
-  still come from `inject_fragments` on the agent. Explicit
+  appended after the main prompt body. Configured through
+  `append_fragments` on either `[agent_defaults]` (city- and pack-wide)
+  or per-agent on an `[[agent]]` block / `agents/<name>/agent.toml`.
+  Per-agent `append_fragments` layers in front of imported-pack and
+  city-level `[agent_defaults].append_fragments`. `inject_fragments` on
+  an agent is the legacy per-agent spelling; it still appends, but new
+  configs should prefer `append_fragments`. Explicit
   `{{template "name" .}}` calls still control in-body placement;
   appended fragment settings do not.
 
@@ -188,7 +192,8 @@ prompt:
 |---|---|---|
 | `{{ template "name" . }}` | inside `prompt.template.md` | Places fragment content exactly where referenced |
 | `append_fragments = ["name"]` | `[agent_defaults]` | Appends fragment content after the rendered prompt body |
-| `inject_fragments = ["name"]` | per-agent settings | Appends fragment content after the rendered prompt body |
+| `append_fragments = ["name"]` | per-agent (`[[agent]]` or `agents/<name>/agent.toml`) | Appends fragment content after the rendered prompt body; layers in front of `[agent_defaults]` |
+| `inject_fragments = ["name"]` | per-agent settings (legacy) | Appends fragment content after the rendered prompt body; retained for migration, new configs should use `append_fragments` |
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Closes #671.

Runtime support for per-agent `append_fragments` (both `[[agent]]` and `agents/<name>/agent.toml` forms) already landed in PR #1047. This PR closes out the remaining surface:

- **Docs**: removes stale "remains a follow-up tracked in #671" / "spec/runtime parity gap" language from three locations (one user guide, one pack-v2 reference doc, one engdoc).
- **Docs — layering order**: per julianknutsen's direction in the issue, documents that per-agent `append_fragments` layers additively in front of imported-pack `[agent_defaults].append_fragments`, then city-level `[agent_defaults].append_fragments`. Scoped the "first, then..." wording to the `append_fragments` sources so it does not implicitly contradict the `global_fragments` / `inject_fragments` prepends that still fire during migration.
- **Regression test**: adds `TestRenderPromptAgentBlockAppendFragmentsAffectRenderedPrompt` in `cmd/gc/prompt_test.go` covering the `[[agent]] append_fragments = [...]` TOML form alongside the existing `[agents]` alias and `[agent_defaults]` coverage. The test asserts both the parse path (`mayor.AppendFragments == ["footer"]`) and the render path (fragment content reaches the rendered prompt), mirroring the runtime call at `cmd/gc/template_resolve.go:260-266`.

The convention form (`agents/<name>/agent.toml`) was already covered by `TestResolveTemplateConventionAgentAppendFragments`; this PR adds the missing form.

## Files changed

- `cmd/gc/prompt_test.go` — new test (+44 / -0)
- `docs/packv2/doc-agent-v2.md` — removed #671 follow-up note; added per-agent example + layering-order paragraph
- `docs/guides/migrating-to-pack-vnext.md` — removed "spec/runtime parity gap" callout; added per-agent example
- `engdocs/architecture/prompt-templates.md` — corrected "per-agent appended fragments still come from `inject_fragments`" text; added per-agent row to fragment composition table; annotated `inject_fragments` as legacy

No production code changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/gc/...`
- [x] `go test ./cmd/gc/ -run 'AppendFragments'` — 6/6 pass (3 pre-existing + 1 new + 2 resolveTemplate-path siblings)
- [x] `make check-docs` — `test/docsync` passes
- [x] `make check` — clean