### PR TITLE
feat(api): read-path routing enabler (ga-71l)

### DIFF
--- a/cmd/gc/route_log.go
+++ b/cmd/gc/route_log.go
@@ -40,16 +40,16 @@ func routeLogEnabled() bool {
 // logRoute emits a single route audit line to the given writer when GC_DEBUG
 // is truthy. Each line carries cmd=<cmd> route=<route> reason=<reason>. A
 // route=api line typically omits reason; a route=fallback line always includes
-// it.
+// it, followed by any extras as key=value pairs.
 //
 // Callers pass their command-scoped stderr so CLI test harnesses observe
 // the audit trail through the buffer they already assert on, instead of
 // racing against the process-wide os.Stderr.
-func logRoute(w io.Writer, cmd, route, reason string) {
+func logRoute(w io.Writer, cmd, route, reason string, extra ...string) {
 	if !routeLogEnabled() {
 		return
 	}
-	logRouteTo(w, cmd, route, reason)
+	logRouteTo(w, cmd, route, reason, extra...)
 }
 
 // logRouteTo writes the route audit line to the given writer unconditionally.

--- a/cmd/gc/route_log.go
+++ b/cmd/gc/route_log.go
@@ -45,7 +45,7 @@ func routeLogEnabled() bool {
 // Callers pass their command-scoped stderr so CLI test harnesses observe
 // the audit trail through the buffer they already assert on, instead of
 // racing against the process-wide os.Stderr.
-func logRoute(w io.Writer, cmd, route, reason string, extra ...string) {
+func logRoute(w io.Writer, cmd, route, reason string, extra ...string) { //nolint:unparam // enabler: callers in follow-up read-path routing PR will supply extra key=value pairs
 	if !routeLogEnabled() {
 		return
 	}


### PR DESCRIPTION
## What this changes

Foundational scaffolding only. Introduces the pattern that lets
read-path CLI commands route through the supervisor's live HTTP API
(cached by the supervisor, same endpoints the dashboard uses) with a
clean fallback to the existing `bd` path when the supervisor is
unreachable.

No CLI command is routed yet — that's the follow-up PR. This PR is
infrastructure, nothing changes for users.

**What it adds:**

- `internal/api/types_read.go` — the `CachedRead[T]` envelope +
  `X-GC-Cache-Age-S` wire contract.
- `internal/api/cache_liveness.go` — `cacheLiveOr503` handler gate
  and `cacheAgeSeconds` helper; handlers that refuse to serve stale
  cache classify the refusal as fallbackable (CLI transparently falls
  back to `bd`).
- `cmd/gc/route_log.go` — `logRoute()` for `route=api|fallback
  reason=...` audit lines, gated on `GC_DEBUG`.
- `GC_NO_API` escape hatch — operators can force fallback without
  touching code.
- `scripts/check-routed-test-rows.sh` — lint that enforces the
  six-row test matrix (alive / down / non-fallbackable-error across
  JSON and text outputs) on every routed command added later.

**Why ship alone:**

This is the contract layer. Reviewing it separately lets us confirm
the pattern is right before it's multiplied across nine commands and
a maintenance API surface in the follow-up PR (stacked on this one).

## Review notes

- No user-visible behavior change.
- No change to any existing command's execution.
- `internal/api/types_read.go` is additive; it introduces one generic
  envelope type that downstream code will populate.
- The `cacheLiveOr503` gate returns 503 only when the supervisor's
  `CachingStore` has not yet reached live state (cold start); under
  normal operation it's a no-op.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/api/...` clean
- [x] `scripts/check-routed-test-rows.sh` — runs cleanly (no consumers
  yet so the matrix check is a no-op in this PR)

## Follow-up

PR follow-up will stack on this branch (`feat/split-ga-71l-enabler`)
and add:
- Nine read-path command routings (ADR 0001)
- Scheduled Dolt store maintenance (ADR 0002)
- `StoreHealth` block on `gc status`
- `gc maintenance` CLI + handlers
