### PR TITLE
ci: add Homebrew tap smoke regression coverage

### DIFF
--- a/.github/workflows/homebrew-tap-smoke.yml
+++ b/.github/workflows/homebrew-tap-smoke.yml
@@ -1,0 +1,43 @@
+name: Homebrew Tap Smoke
+
+on:
+  schedule:
+    - cron: "25 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: homebrew-tap-smoke-${{ github.ref || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  tap-smoke:
+    name: Tap install smoke
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+    steps:
+      - name: Update Homebrew metadata
+        run: brew update
+
+      - name: Tap gastownhall/gascity
+        run: brew tap gastownhall/gascity
+
+      - name: Show current tap formula
+        run: brew cat gastownhall/gascity/gascity | sed -n '1,120p'
+
+      - name: Remove any existing gascity install
+        run: brew uninstall --force gascity || true
+
+      - name: Install gascity from the live tap
+        run: brew install --build-from-source gastownhall/gascity/gascity
+
+      - name: Run formula test block
+        run: brew test gastownhall/gascity/gascity
+
+      - name: Verify installed gc version
+        run: gc version

--- a/cmd/gc/completion_command_test.go
+++ b/cmd/gc/completion_command_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompletionCommandBash(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if code := run([]string{"completion", "bash"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("run([completion bash]) = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	script := stdout.String()
+	if !strings.Contains(script, "# bash completion V2 for gc") {
+		t.Fatalf("completion output missing bash header:\n%s", script)
+	}
+	if !strings.Contains(script, "__start_gc()") {
+		t.Fatalf("completion output missing gc completion entrypoint:\n%s", script)
+	}
+}


### PR DESCRIPTION
## Summary
- add a `cmd/gc` regression test that fails if `gc completion bash` stops working again
- add a dedicated scheduled macOS workflow that installs `gastownhall/gascity/gascity` from the live Homebrew tap and runs the formula smoke path
- keep the Homebrew check separate from the larger nightly suites so packaging regressions are obvious in Actions

## Why
Issue #1084 slipped through because we had no automated check for the real Homebrew install path, and our existing tests did not exercise the Cobra `completion` subcommand directly.

This adds both layers:
- PR-time source regression coverage in Go tests
- scheduled/manual tap smoke coverage on a clean macOS runner

Refs #1084
Refs #1088