### PR TITLE
fix: stop staging materialized Claude skills

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -812,14 +812,11 @@ func stageHookFiles(copyFiles []runtime.CopyEntry, cityPath, workDir string) []r
 		}
 	}
 
-	// Stage Claude skills directory (if materialized).
-	skillsDir := filepath.Join(workDir, ".claude", "skills")
-	if info, err := os.Stat(skillsDir); err == nil && info.IsDir() {
-		copyFiles = append(copyFiles, runtime.CopyEntry{
-			Src: skillsDir, RelDst: path.Join(relWorkDir, ".claude", "skills"),
-			Probed: true, ContentHash: runtime.HashPathContent(skillsDir),
-		})
-	}
+	// Intentionally do not stage workDir/.claude/skills here. Stage-2 session
+	// startup may materialize skills into that path after template resolve,
+	// which would invalidate the pre-start CopyFiles hash and force a
+	// config-drift drain loop. Skill changes are tracked via
+	// FingerprintExtra["skills:*"] entries during template resolution.
 	// cityDir-based hooks: claude (.gc/settings.json).
 	// Skip if settingsArgs already added it.
 	// These are city-root relative, so no relWorkDir prefix needed.

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -407,6 +407,27 @@ func TestStageHookFilesFallsBackToLegacyClaudeHook(t *testing.T) {
 	t.Fatal("stageHookFiles() did not stage hooks/claude.json")
 }
 
+func TestStageHookFilesDoesNotStageClaudeSkillsDir(t *testing.T) {
+	cityDir := filepath.Join(t.TempDir(), "city")
+	workDir := filepath.Join(cityDir, "worker")
+	skillsDir := filepath.Join(workDir, ".claude", "skills", "plan")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", skillsDir, err)
+	}
+	skillPath := filepath.Join(skillsDir, "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("---\nname: plan\n---\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", skillPath, err)
+	}
+
+	got := stageHookFiles(nil, cityDir, workDir)
+	wantRelDst := path.Join("worker", ".claude", "skills")
+	for _, entry := range got {
+		if entry.RelDst == wantRelDst {
+			t.Fatalf("stageHookFiles() staged %q at %q; want skills drift tracked via FingerprintExtra only", entry.Src, entry.RelDst)
+		}
+	}
+}
+
 func TestConfiguredRigNameMatchesRigByPathWithoutCreatingDirs(t *testing.T) {
 	cityPath := t.TempDir()
 	rigRoot := filepath.Join(cityPath, "repos", "demo")


### PR DESCRIPTION
Fixes #1097.

## Summary
- add a regression test proving `stageHookFiles` must not emit a `CopyFiles` entry for `workDir/.claude/skills`
- stop staging `workDir/.claude/skills` from `stageHookFiles`
- leave skill drift tracking to `FingerprintExtra["skills:*"]`, which avoids the PreStart materialization race

## Testing
- `go test ./cmd/gc -run TestStageHookFilesDoesNotStageClaudeSkillsDir -count=1`
- `go test ./cmd/gc -run 'Test(StageHookFiles.*|MergeSkillFingerprintEntries.*|AppendMaterializeSkillsPreStart|ResolveTemplate.*Skill.*)' -count=1`\n- `go test ./cmd/gc -count=1` *(times out in unrelated existing `bd`/controller tests in this environment; no failures observed in the touched area before timeout)*