### PR TITLE
fix: improve formula runtime var validation UX

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -141,20 +141,48 @@ Examples:
 				_, _ = fmt.Fprintln(stdout, "Root only: true")
 			}
 			if len(recipe.Vars) > 0 {
-				_, _ = fmt.Fprintln(stdout, "\nVariables:")
-				for vname, def := range recipe.Vars {
-					var attrs []string
-					if def.Required {
-						attrs = append(attrs, "required")
+				names := make([]string, 0, len(recipe.Vars))
+				for name := range recipe.Vars {
+					names = append(names, name)
+				}
+				slices.Sort(names)
+
+				requiredNames := make([]string, 0, len(names))
+				optionalNames := make([]string, 0, len(names))
+				for _, name := range names {
+					def := recipe.Vars[name]
+					if def != nil && def.Required {
+						requiredNames = append(requiredNames, name)
+						continue
 					}
-					if def.Default != nil {
-						attrs = append(attrs, "default="+*def.Default)
+					optionalNames = append(optionalNames, name)
+				}
+
+				if len(requiredNames) > 0 {
+					_, _ = fmt.Fprintln(stdout, "\nRequired vars:")
+					for _, name := range requiredNames {
+						def := recipe.Vars[name]
+						_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s\n", name, def.Description)
 					}
-					attrStr := ""
-					if len(attrs) > 0 {
-						attrStr = " (" + strings.Join(attrs, ", ") + ")"
+				}
+				if len(optionalNames) > 0 {
+					header := "\nVariables:"
+					if len(requiredNames) > 0 {
+						header = "\nOptional vars:"
 					}
-					_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s%s\n", vname, def.Description, attrStr)
+					_, _ = fmt.Fprintln(stdout, header)
+					for _, name := range optionalNames {
+						def := recipe.Vars[name]
+						var attrs []string
+						if def != nil && def.Default != nil {
+							attrs = append(attrs, "default="+*def.Default)
+						}
+						attrStr := ""
+						if len(attrs) > 0 {
+							attrStr = " (" + strings.Join(attrs, ", ") + ")"
+						}
+						_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s%s\n", name, def.Description, attrStr)
+					}
 				}
 			}
 

--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -137,6 +137,52 @@ title = "[{{epic}}] Implement: {{feature}}"
 	}
 }
 
+func TestFormulaShowHighlightsRequiredVars(t *testing.T) {
+	cityDir := writeTutorialFormulaCity(t, "required-vars", `
+formula = "required-vars"
+description = "Formula with required vars"
+
+[vars.epic]
+description = "Epic ticket ID"
+required = true
+
+[vars.feature]
+description = "Feature slug"
+required = true
+
+[vars.branch]
+description = "Target branch"
+default = "main"
+
+[[steps]]
+id = "implement"
+title = "[{{epic}}] Implement: {{feature}}"
+`)
+
+	t.Chdir(cityDir)
+
+	var stdout bytes.Buffer
+	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
+	cmd.SetArgs([]string{"required-vars"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula show should succeed without --var flags on required-var formulas: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Required vars:") {
+		t.Fatalf("formula show should surface a Required vars section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "{{epic}}: Epic ticket ID") || !strings.Contains(out, "{{feature}}: Feature slug") {
+		t.Fatalf("formula show should list each required var in the dedicated section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Optional vars:") {
+		t.Fatalf("formula show should keep optional vars distinct from required vars, got:\n%s", out)
+	}
+	if !strings.Contains(out, "{{branch}}: Target branch (default=main)") {
+		t.Fatalf("formula show should preserve optional var details, got:\n%s", out)
+	}
+}
+
 func writeTutorialFormulaCity(t *testing.T, formulaName, formulaBody string) string {
 	t.Helper()
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -481,6 +481,10 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{}); err != nil {
+		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	if a.Pool != "" && cfg != nil {
 		pool := qualifyPool(a.Pool, a.Rig)

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -719,6 +719,56 @@ func TestOrderRunNoPool(t *testing.T) {
 	}
 }
 
+func TestOrderRunReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	dir := t.TempDir()
+	formulaBody := `
+formula = "order-required-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{target_id}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "order-required-vars.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:         "digest",
+		Formula:      "order-required-vars",
+		Trigger:      "cooldown",
+		Interval:     "24h",
+		FormulaLayer: dir,
+	}}
+
+	store := beads.NewMemStore()
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", "/city", store, nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderRun = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "target_id" is required`) {
+		t.Fatalf("stderr = %q, want missing target_id reported", errText)
+	}
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "bead title contains unresolved variable(s)") {
+		t.Fatalf("stderr = %q, want consolidated required-var validation instead of title-only failure", errText)
+	}
+}
+
 func TestOrderRunGraphWorkflowDecoratesStepRouting(t *testing.T) {
 	cityDir := t.TempDir()
 	formulaDir := t.TempDir()

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2494,6 +2494,53 @@ description = "Target: {{target_id}}, workspace: {{workspace}}"
 	}
 }
 
+func TestFormulaSlingReportsRequiredAndResidualTitleVarsWhenSomeVarsProvided(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "repro-mixed-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{title}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "repro-mixed-vars.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "repro-mixed-vars")
+	opts.IsFormula = true
+	opts.Vars = []string{"target_id=BL-42"}
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSling returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if !strings.Contains(errText, `step "repro-mixed-vars.do-work": bead title contains unresolved variable(s) title`) {
+		t.Fatalf("stderr = %q, want unresolved title variable reported", errText)
+	}
+}
+
 func TestOnFormulaExistingMoleculeErrors(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2445,6 +2445,55 @@ func TestOnFormulaCookMissingFormula(t *testing.T) {
 	}
 }
 
+func TestFormulaSlingReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "repro-required-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{target_id}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "repro.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "repro")
+	opts.IsFormula = true
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSling returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "target_id" is required`) {
+		t.Fatalf("stderr = %q, want missing target_id reported", errText)
+	}
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "bead title contains unresolved variable(s)") {
+		t.Fatalf("stderr = %q, want consolidated required-var validation instead of title-only failure", errText)
+	}
+}
+
 func TestOnFormulaExistingMoleculeErrors(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -319,6 +319,16 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
 		return
 	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{}); err != nil {
+		m.rec.Record(events.Event{
+			Type:    events.OrderFailed,
+			Actor:   "controller",
+			Subject: scoped,
+			Message: err.Error(),
+		})
+		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
+		return
+	}
 
 	// Decorate graph workflow recipes with routing metadata so child step
 	// beads get gc.routed_to set before instantiation.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -353,6 +353,84 @@ func TestOrderDispatchFormulaCookFailureLabelsTrackingBead(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	store := beads.NewMemStore()
+	var rec memRecorder
+
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "order-required-vars.formula.toml"), `
+formula = "order-required-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{target_id}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`)
+
+	aa := []orders.Order{{
+		Name:         "fail-formula-vars",
+		Trigger:      "cooldown",
+		Interval:     "2m",
+		Formula:      "order-required-vars",
+		FormulaLayer: formulaDir,
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	mad := ad.(*memoryOrderDispatcher)
+	mad.rec = &rec
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(100 * time.Millisecond)
+
+	all := trackingBeads(t, store, "order-run:fail-formula-vars")
+	hasFailed := false
+	for _, b := range all {
+		for _, l := range b.Labels {
+			if l == "wisp-failed" {
+				hasFailed = true
+			}
+		}
+	}
+	if !hasFailed {
+		t.Error("tracking bead missing wisp-failed label after validation failure")
+	}
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event")
+	}
+
+	var failedMessage string
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed && event.Subject == "fail-formula-vars" {
+			failedMessage = event.Message
+			break
+		}
+	}
+	if failedMessage == "" {
+		t.Fatal("missing order.failed message for formula validation failure")
+	}
+	if !strings.Contains(failedMessage, `variable "target_id" is required`) {
+		t.Fatalf("order.failed message = %q, want missing target_id reported", failedMessage)
+	}
+	if !strings.Contains(failedMessage, `variable "workspace" is required`) {
+		t.Fatalf("order.failed message = %q, want missing workspace reported", failedMessage)
+	}
+	if strings.Contains(failedMessage, "bead title contains unresolved variable(s)") {
+		t.Fatalf("order.failed message = %q, want consolidated required-var validation instead of title-only failure", failedMessage)
+	}
+}
+
 func TestOrderDispatchFormulaLabelFailureLabelsTrackingBead(t *testing.T) {
 	store := beads.NewMemStore()
 	var rec memRecorder

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
 )
 
 var (
@@ -182,6 +183,11 @@ func buildFormulaDetail(ctx context.Context, name string, paths []string, _ stri
 	recipe, err := formula.Compile(ctx, name, paths, vars)
 	if err != nil {
 		return nil, err
+	}
+	if len(vars) > 0 {
+		if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: vars}); err != nil {
+			return nil, fmt.Errorf("formula %q: %w", name, err)
+		}
 	}
 	displayVars := formula.ApplyDefaults(resolved, vars)
 

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -171,7 +171,7 @@ func buildFormulaRuns(state State, formulaName, requestedScopeKind, requestedSco
 	}, nil
 }
 
-func buildFormulaDetail(ctx context.Context, name string, paths []string, _ string, vars map[string]string) (*formulaDetailResponse, error) {
+func buildFormulaDetail(ctx context.Context, name string, paths []string, _ string, vars map[string]string, validateRuntimeVars bool) (*formulaDetailResponse, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("%w: %q not in search paths", errFormulaNotFound, name)
 	}
@@ -184,7 +184,7 @@ func buildFormulaDetail(ctx context.Context, name string, paths []string, _ stri
 	if err != nil {
 		return nil, err
 	}
-	if len(vars) > 0 {
+	if validateRuntimeVars {
 		if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: vars}); err != nil {
 			return nil, fmt.Errorf("formula %q: %w", name, err)
 		}

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -624,6 +624,51 @@ metadata = { "gc.kind" = "run", "gc.scope_ref" = "body" }
 	}
 }
 
+func TestFormulaPreviewRejectsMissingRequiredVars(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-preview", `
+description = "Preview {{issue}}"
+formula = "mol-preview"
+version = 2
+
+[vars]
+[vars.issue]
+description = "Issue bead ID"
+required = true
+
+[[steps]]
+id = "prep"
+title = "Prep {{issue}}"
+`)
+
+	body := bytes.NewBufferString(`{"scope_kind":"city","scope_ref":"test-city","target":"worker","vars":{"other":"BD-123"}}`)
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodPost, cityURL(state, "/formulas/mol-preview/preview"), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem): %v", err)
+	}
+	if !strings.Contains(problem.Detail, `variable "issue" is required`) {
+		t.Fatalf("detail = %q, want missing issue validation error", problem.Detail)
+	}
+}
+
 // TestFormulaDetailRejectsLegacyVarQueryParams pins the §3.5.1 migration
 // behavior: undeclared var.* query parameters on the GET detail endpoint
 // are now rejected with a 4xx + migration hint pointing at POST /preview.

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -669,6 +669,51 @@ title = "Prep {{issue}}"
 	}
 }
 
+func TestFormulaPreviewRejectsMissingRequiredVarsWithoutVarsBody(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-preview", `
+description = "Preview {{issue}}"
+formula = "mol-preview"
+version = 2
+
+[vars]
+[vars.issue]
+description = "Issue bead ID"
+required = true
+
+[[steps]]
+id = "prep"
+title = "Prep {{issue}}"
+`)
+
+	body := bytes.NewBufferString(`{"scope_kind":"city","scope_ref":"test-city","target":"worker"}`)
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodPost, cityURL(state, "/formulas/mol-preview/preview"), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem): %v", err)
+	}
+	if !strings.Contains(problem.Detail, `variable "issue" is required`) {
+		t.Fatalf("detail = %q, want missing issue validation error", problem.Detail)
+	}
+}
+
 // TestFormulaDetailRejectsLegacyVarQueryParams pins the §3.5.1 migration
 // behavior: undeclared var.* query parameters on the GET detail endpoint
 // are now rejected with a 4xx + migration hint pointing at POST /preview.

--- a/internal/api/huma_handlers_formulas.go
+++ b/internal/api/huma_handlers_formulas.go
@@ -102,7 +102,7 @@ func (s *Server) humaHandleFormulaDetail(ctx context.Context, input *FormulaDeta
 	Body formulaDetailResponse
 }, error,
 ) {
-	return s.formulaDetail(ctx, input.Name, input.ScopeKind, input.ScopeRef, input.Target, nil)
+	return s.formulaDetail(ctx, input.Name, input.ScopeKind, input.ScopeRef, input.Target, nil, false)
 }
 
 // humaHandleFormulaPreview is the Huma-typed handler for
@@ -113,14 +113,14 @@ func (s *Server) humaHandleFormulaPreview(ctx context.Context, input *FormulaPre
 	Body formulaDetailResponse
 }, error,
 ) {
-	return s.formulaDetail(ctx, input.Name, input.Body.ScopeKind, input.Body.ScopeRef, input.Body.Target, input.Body.Vars)
+	return s.formulaDetail(ctx, input.Name, input.Body.ScopeKind, input.Body.ScopeRef, input.Body.Target, input.Body.Vars, true)
 }
 
 // formulaDetail is the shared backing implementation for the GET detail
 // and POST preview endpoints. The two endpoints differ only in how they
 // receive the variable dictionary: GET compiles with defaults, POST
 // accepts a caller-supplied map.
-func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawScopeRef, rawTarget string, vars map[string]string) (*struct {
+func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawScopeRef, rawTarget string, vars map[string]string, validateRuntimeVars bool) (*struct {
 	Body formulaDetailResponse
 }, error,
 ) {
@@ -149,7 +149,7 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 		return nil, huma.Error400BadRequest(msg)
 	}
 
-	detail, err := buildFormulaDetail(ctx, name, paths, target, vars)
+	detail, err := buildFormulaDetail(ctx, name, paths, target, vars, validateRuntimeVars)
 	if err != nil {
 		if errors.Is(err, errFormulaNotWorkflow) || errors.Is(err, errFormulaNotFound) {
 			return nil, huma.Error404NotFound(err.Error())

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -43,16 +43,6 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 		return nil, fmt.Errorf("resolving formula %q: %w", name, err)
 	}
 
-	// Validate required vars only when the caller explicitly provided them.
-	// nil = include-all-steps mode (order dispatch); empty = read-only display
-	// (formula show). Both skip validation. Non-empty = user-supplied vars from
-	// sling, cook, or API — validate.
-	if len(vars) > 0 {
-		if err := ValidateVars(resolved, vars); err != nil {
-			return nil, fmt.Errorf("formula %q: %w", name, err)
-		}
-	}
-
 	compileVars := make(map[string]string)
 	for vname, def := range resolved.Vars {
 		if def != nil && def.Default != nil {

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -482,25 +482,39 @@ func CheckResidualTimeoutVars(s string) []string {
 // ValidateVars checks that all required variables are provided
 // and all values pass their constraints.
 func ValidateVars(formula *Formula, values map[string]string) error {
-	return validateVarDefs(formula.Vars, values)
+	errs, _ := CollectVarValidationErrors(formula.Vars, values)
+	return formatVarValidationErrors(errs)
 }
 
 // ValidateVarDefs validates explicit var definitions against provided values.
 // This is the recipe-level equivalent of ValidateVars, used after formula
 // compilation when only the remaining VarDef map is available.
 func ValidateVarDefs(defs map[string]*VarDef, values map[string]string) error {
-	return validateVarDefs(defs, values)
+	errs, _ := CollectVarValidationErrors(defs, values)
+	return formatVarValidationErrors(errs)
 }
 
-func validateVarDefs(defs map[string]*VarDef, values map[string]string) error {
+// CollectVarValidationErrors validates explicit var definitions against the
+// provided values and returns raw error strings plus the set of missing
+// required vars. Callers that need the historical wrapped error can pass the
+// returned error strings through formatVarValidationErrors.
+func CollectVarValidationErrors(defs map[string]*VarDef, values map[string]string) ([]string, map[string]bool) {
 	var errs []string
+	missingRequired := make(map[string]bool)
+	names := make([]string, 0, len(defs))
+	for name := range defs {
+		names = append(names, name)
+	}
+	slices.Sort(names)
 
-	for name, def := range defs {
+	for _, name := range names {
+		def := defs[name]
 		val, provided := values[name]
 
 		// Check required
 		if def.Required && !provided {
 			errs = append(errs, fmt.Sprintf("variable %q is required", name))
+			missingRequired[name] = true
 			continue
 		}
 
@@ -539,11 +553,17 @@ func validateVarDefs(defs map[string]*VarDef, values map[string]string) error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	if len(missingRequired) == 0 {
+		missingRequired = nil
 	}
+	return errs, missingRequired
+}
 
-	return nil
+func formatVarValidationErrors(errs []string) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 }
 
 // ApplyDefaults returns a new map with default values filled in.

--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -619,3 +619,64 @@ func TestAttachEpochWithIdempotency(t *testing.T) {
 		t.Fatal("second should be duplicate")
 	}
 }
+
+func TestAttachIdempotentDuplicateSkipsRuntimeVarValidation(t *testing.T) {
+	store := beads.NewMemStore()
+	root := setupWorkflow(t, store)
+	control := setupWorkflowChild(t, store, root.ID, "Control")
+
+	recipe := &formula.Recipe{
+		Name: "attempt-required-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "attempt-required-vars", Title: "Attempt {{target_id}}", Type: "task", IsRoot: true},
+			{ID: "attempt-required-vars.run", Title: "Run in {{workspace}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "attempt-required-vars.run", DependsOnID: "attempt-required-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"target_id": {Description: "Bead being worked on", Required: true},
+			"workspace": {Description: "Workspace path", Required: true},
+		},
+	}
+
+	result1, err := Attach(context.Background(), store, recipe, control.ID, AttachOptions{
+		IdempotencyKey: "retry:control:attempt-required-vars:1",
+		Vars: map[string]string{
+			"target_id": control.ID,
+			"workspace": "/tmp/repro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Attach 1: %v", err)
+	}
+	if result1.Duplicate {
+		t.Fatal("first attach should not be duplicate")
+	}
+
+	result2, err := Attach(context.Background(), store, &formula.Recipe{
+		Name: "attempt-required-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "attempt-required-vars", Title: "Attempt {{target_id}}", Type: "task", IsRoot: true},
+			{ID: "attempt-required-vars.run", Title: "Run in {{workspace}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "attempt-required-vars.run", DependsOnID: "attempt-required-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"target_id": {Description: "Bead being worked on", Required: true},
+			"workspace": {Description: "Workspace path", Required: true},
+		},
+	}, control.ID, AttachOptions{
+		IdempotencyKey: "retry:control:attempt-required-vars:1",
+	})
+	if err != nil {
+		t.Fatalf("Duplicate attach should return existing sub-DAG before re-validating vars: %v", err)
+	}
+	if !result2.Duplicate {
+		t.Fatal("second attach should be duplicate")
+	}
+	if result2.RootID != result1.RootID {
+		t.Fatalf("duplicate attach root = %q, want %q", result2.RootID, result1.RootID)
+	}
+}

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -131,6 +131,9 @@ func Cook(ctx context.Context, store beads.Store, formulaName string, searchPath
 	if err != nil {
 		return nil, fmt.Errorf("compiling formula %q: %w", formulaName, err)
 	}
+	if err := ValidateRecipeRuntimeVars(recipe, opts); err != nil {
+		return nil, err
+	}
 	return Instantiate(ctx, store, recipe, opts)
 }
 
@@ -250,6 +253,9 @@ func Attach(ctx context.Context, store beads.Store, recipe *formula.Recipe, atta
 		if currentEpoch != opts.ExpectedEpoch {
 			return nil, ErrEpochConflict
 		}
+	}
+	if err := ValidateRecipeRuntimeVars(recipe, Options{Title: opts.Title, Vars: opts.Vars}); err != nil {
+		return nil, fmt.Errorf("validate runtime vars: %w", err)
 	}
 
 	// Stamp every step with the parent workflow's graph metadata.
@@ -908,6 +914,59 @@ func applyVarDefaults(vars map[string]string, defs map[string]*formula.VarDef) m
 		result[k] = v
 	}
 	return result
+}
+
+func ValidateRecipeRuntimeVars(recipe *formula.Recipe, opts Options) error {
+	validationErrs, missingRequired := formula.CollectVarValidationErrors(recipe.Vars, opts.Vars)
+	titleErrs := unresolvedTitleValidationErrors(recipe, opts, missingRequired)
+	switch {
+	case len(validationErrs) == 0 && len(titleErrs) == 0:
+		return nil
+	case len(validationErrs) == 0 && len(titleErrs) == 1:
+		return fmt.Errorf("%s", titleErrs[0])
+	case len(validationErrs) == 0:
+		return fmt.Errorf("title variable validation failed:\n  - %s", strings.Join(titleErrs, "\n  - "))
+	default:
+		errs := make([]string, 0, len(validationErrs)+len(titleErrs))
+		errs = append(errs, validationErrs...)
+		errs = append(errs, titleErrs...)
+		return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+}
+
+func unresolvedTitleValidationErrors(recipe *formula.Recipe, opts Options, missingRequired map[string]bool) []string {
+	if recipe == nil || len(recipe.Steps) == 0 {
+		return nil
+	}
+	vars := applyVarDefaults(opts.Vars, recipe.Vars)
+	errs := make([]string, 0)
+	for i, step := range recipe.Steps {
+		if recipe.RootOnly && i > 0 {
+			break
+		}
+		title := formula.Substitute(step.Title, vars)
+		if step.IsRoot && opts.Title != "" {
+			title = opts.Title
+		}
+		if !strings.Contains(title, "{{") {
+			continue
+		}
+		residual := formula.CheckResidualVars(title)
+		unexplained := make([]string, 0, len(residual))
+		for _, name := range residual {
+			if missingRequired[name] {
+				continue
+			}
+			unexplained = append(unexplained, name)
+		}
+		if len(unexplained) == 0 {
+			continue
+		}
+		errs = append(errs,
+			fmt.Sprintf(`step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?`,
+				step.ID, strings.Join(unexplained, ", ")))
+	}
+	return errs
 }
 
 // markFailed sets "molecule_failed" metadata on all created beads.

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -944,10 +944,11 @@ func unresolvedTitleValidationErrors(recipe *formula.Recipe, opts Options, missi
 		if recipe.RootOnly && i > 0 {
 			break
 		}
-		title := formula.Substitute(step.Title, vars)
+		rawTitle := step.Title
 		if step.IsRoot && opts.Title != "" {
-			title = opts.Title
+			rawTitle = opts.Title
 		}
+		title := formula.Substitute(rawTitle, vars)
 		if !strings.Contains(title, "{{") {
 			continue
 		}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1843,6 +1843,44 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 	})
 }
 
+func TestAttachReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "Parent", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(parent): %v", err)
+	}
+
+	recipe := &formula.Recipe{
+		Name: "attach-required-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "attach-required-vars", Title: "Attach required vars", Type: "task", IsRoot: true},
+			{ID: "attach-required-vars.step", Title: "Do work for {{target_id}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "attach-required-vars.step", DependsOnID: "attach-required-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"target_id": {Description: "Bead being worked on", Required: true},
+			"workspace": {Description: "Workspace path", Required: true},
+		},
+	}
+
+	_, err = Attach(context.Background(), store, recipe, parent.ID, AttachOptions{})
+	if err == nil {
+		t.Fatal("Attach should reject missing required vars")
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, `variable "target_id" is required`) {
+		t.Fatalf("Attach error = %q, want missing target_id reported", errText)
+	}
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("Attach error = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "bead title contains unresolved variable(s)") {
+		t.Fatalf("Attach error = %q, want consolidated required-var validation instead of title-only failure", errText)
+	}
+}
+
 func TestInstantiateRejectsResidualTimeoutVars(t *testing.T) {
 	makeRecipe := func(stepTimeout string) *formula.Recipe {
 		return &formula.Recipe{

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1821,6 +1821,27 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 		}
 	})
 
+	t.Run("root title override substitutes provided vars", func(t *testing.T) {
+		result, err := Instantiate(context.Background(), store, &formula.Recipe{
+			Name: "root-override-vars",
+			Steps: []formula.RecipeStep{
+				{ID: "root-override-vars", Title: "fallback", Type: "molecule", IsRoot: true},
+			},
+			Vars: map[string]*formula.VarDef{
+				"env": {Description: "Deployment environment", Required: true},
+			},
+		}, Options{
+			Title: "Deploy {{env}}",
+			Vars:  map[string]string{"env": "prod"},
+		})
+		if err != nil {
+			t.Fatalf("should succeed with substituted title override: %v", err)
+		}
+		if result.Created != 1 {
+			t.Errorf("Created = %d, want 1", result.Created)
+		}
+	})
+
 	t.Run("graph-apply path rejects unresolved vars", func(t *testing.T) {
 		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
 		prev := IsGraphApplyEnabled()

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -666,6 +666,10 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 		SlingTracef("instantiate compile-error formula=%s dur=%s err=%v", formulaName, time.Since(compileStart), err)
 		return nil, err
 	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, opts); err != nil {
+		SlingTracef("instantiate validate-error formula=%s err=%v", formulaName, err)
+		return nil, err
+	}
 	SlingTracef("instantiate compiled formula=%s dur=%s steps=%d", formulaName, time.Since(compileStart), len(recipe.Steps))
 	if err := ApplyGraphRouting(recipe, &a, a.QualifiedName(), opts.Vars, sourceBeadID, scopeKind, scopeRef, deps.StoreRef, deps.Store, deps.CityName, deps.Cfg, deps); err != nil {
 		SlingTracef("instantiate decorate-error formula=%s err=%v", formulaName, err)


### PR DESCRIPTION
## Summary
- surface required vars separately in `gc formula show`
- validate runtime vars at sling, order, attach, and preview boundaries so missing required vars are reported together instead of being masked by title placeholders
- preserve title override substitution, duplicate-attach idempotency, and preview validation when `vars` is omitted

## Testing
- go test ./cmd/gc -run 'Test(OrderRun|OrderDispatch.*Formula|OnFormula|FormulaShow|FormulaSlingReports)' -count=1
- go test ./internal/molecule -run 'Test(Attach|InstantiateRejectsResidualVars|InstantiateRejectsResidualTimeoutVars|WithParentID|PreserveRootTypeKeepsTaskRoot)' -count=1
- go test ./internal/api -run 'TestFormula(Preview|Detail)' -count=1
- go test -tags=integration ./test/integration -run 'TestGastown_FormulaShow' -count=1

Fixes #1100
