### PR TITLE
fix: exclude formula step beads from Ready (#1039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,9 +348,12 @@ jobs:
           - shard_name: review-formulas-basic
             timeout_minutes: 30
             command: make test-integration-review-formulas-basic
-          - shard_name: review-formulas-retries
-            timeout_minutes: 30
-            command: make test-integration-review-formulas-retries
+          - shard_name: review-formulas-retries-1-of-2
+            timeout_minutes: 20
+            command: ./scripts/test-integration-shard review-formulas-retries-1-of-2
+          - shard_name: review-formulas-retries-2-of-2
+            timeout_minutes: 20
+            command: ./scripts/test-integration-shard review-formulas-retries-2-of-2
           - shard_name: review-formulas-recovery
             timeout_minutes: 25
             command: make test-integration-review-formulas-recovery

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -147,9 +147,16 @@ jobs:
           - label: basic
             command: make test-integration-review-formulas-basic-cover
             coverprofile: coverage.integration-review-formulas-basic.txt
-          - label: retries
-            command: make test-integration-review-formulas-retries-cover
-            coverprofile: coverage.integration-review-formulas-retries.txt
+          - label: retries-1-of-2
+            command: >-
+              GO_TEST_COVERPROFILE=coverage.integration-review-formulas-retries-1-of-2.txt
+              ./scripts/test-integration-shard review-formulas-retries-1-of-2
+            coverprofile: coverage.integration-review-formulas-retries-1-of-2.txt
+          - label: retries-2-of-2
+            command: >-
+              GO_TEST_COVERPROFILE=coverage.integration-review-formulas-retries-2-of-2.txt
+              ./scripts/test-integration-shard review-formulas-retries-2-of-2
+            coverprofile: coverage.integration-review-formulas-retries-2-of-2.txt
           - label: recovery
             command: make test-integration-review-formulas-recovery-cover
             coverprofile: coverage.integration-review-formulas-recovery.txt

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5482,7 +5482,7 @@ esac
 		"SELECT 1 FROM config LIMIT 1",
 		"USE `hq`",
 		"VALUES ('issue_prefix', 'gc') ON DUPLICATE KEY UPDATE",
-		"VALUES ('types.custom', 'molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence') ON DUPLICATE KEY UPDATE",
+		"VALUES ('types.custom', 'molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step') ON DUPLICATE KEY UPDATE",
 	} {
 		if !strings.Contains(sqlText, want) {
 			t.Fatalf("dolt SQL log missing %q:\n%s", want, sqlText)
@@ -5569,7 +5569,7 @@ case "$query" in
     fi
     exit 0
     ;;
-  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
     exit 0
     ;;
   'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''issue_prefix'\'', '\''gc'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
@@ -5675,7 +5675,7 @@ case "$query" in
     fi
     exit 0
     ;;
-  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
     if [ ! -f %q ] || [ "$(cat %q)" -lt 3 ]; then
       echo "table not found: config" >&2
       exit 1
@@ -5797,7 +5797,7 @@ case "$query" in
     fi
     exit 0
     ;;
-  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
     count=0
     if [ -f %q ]; then
       count=$(cat %q)
@@ -5951,7 +5951,7 @@ case "$query" in
     fi
     exit 0
     ;;
-  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
     exit 0
     ;;
   'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''issue_prefix'\'', '\''gc'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')

--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -195,7 +195,7 @@ case "$op" in
         run_bd config set types.custom "$CUSTOM_TYPES" >/dev/null 2>&1 || true
       else
         # Must match the init-branch default below and doctor.RequiredCustomTypes.
-        custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
+        custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step}"
         run_bd config set types.custom "$custom_types" >/dev/null 2>&1 || true
       fi
       exit 0
@@ -285,7 +285,7 @@ case "$op" in
     # and doctor.RequiredCustomTypes). Without this, bd rejects creates for
     # types like "session" that aren't in the default set. "convergence" is
     # required because gc's convergence handler creates beads with that type.
-    custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
+    custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step}"
     GC_STORE_ROOT="$scope_root" run_bd config set types.custom "$custom_types" >/dev/null 2>&1 || true
     ;;
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2130,8 +2130,9 @@ op_init() {
     # Custom bead types for bd (extracted from beads core in v0.46.0).
     # GC_BEADS_CUSTOM_TYPES overrides the default SDK set.
     # "convergence" is required because gc's convergence handler creates
-    # beads with that type — must match doctor.RequiredCustomTypes.
-    local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
+    # beads with that type. "step" is required for non-root formula step
+    # beads (#1039). Must match doctor.RequiredCustomTypes.
+    local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step}"
 
     # If already initialized on disk and the server has a bd schema, ensure the
     # database is also registered with the running server. Local metadata can be

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -90,6 +90,7 @@ var readyExcludeTypes = map[string]bool{
 	"merge-request": true, // processed by automation
 	"gate":          true, // async wait conditions
 	"molecule":      true, // workflow containers
+	"step":          true, // non-root formula steps; parent molecule is the actionable unit (#1039)
 	"message":       true, // mail/communication items
 	"session":       true, // runtime/session continuity beads, never actionable work
 	"agent":         true, // identity/state tracking beads

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -52,6 +52,7 @@ func TestIsReadyExcludedType(t *testing.T) {
 		{"merge-request", true},
 		{"gate", true},
 		{"molecule", true},
+		{"step", true},
 		{"message", true},
 		{"session", true},
 		{"agent", true},

--- a/internal/beads/beadstest/conformance.go
+++ b/internal/beads/beadstest/conformance.go
@@ -575,7 +575,7 @@ func RunStoreTests(t *testing.T, newStore func() beads.Store) {
 			t.Fatal(err)
 		}
 		// Create beads with types that bd ready excludes.
-		for _, typ := range []string{"molecule", "message", "gate", "merge-request", "session", "agent", "role", "rig"} {
+		for _, typ := range []string{"molecule", "step", "message", "gate", "merge-request", "session", "agent", "role", "rig"} {
 			if _, err := s.Create(beads.Bead{Title: typ, Type: typ}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -16,10 +16,16 @@ import (
 // (internal/convergence/create.go) creates beads with type="convergence"
 // as the root of every convergence loop. Without it registered, every
 // `gc converge create` call fails with "invalid issue type: convergence".
+//
+// "step" is included because formula instantiation creates non-root
+// step beads with type="step" (internal/molecule/molecule.go Instantiate)
+// so Ready() and `bd ready` can exclude formula scaffolding from actionable
+// work queues. Without it registered, formula dispatch fails with
+// "invalid issue type: step" (#1039).
 var RequiredCustomTypes = []string{
 	"molecule", "convoy", "message", "event", "gate",
 	"merge-request", "agent", "role", "rig", "session", "spec",
-	"convergence",
+	"convergence", "step",
 }
 
 // CustomTypesCheck verifies that all required Gas City custom bead

--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -190,6 +190,7 @@ func TestCustomTypesCheck_RequiredTypesComplete(t *testing.T) {
 		"event": true, "gate": true, "merge-request": true,
 		"agent": true, "role": true, "rig": true,
 		"session": true, "spec": true, "convergence": true,
+		"step": true,
 	}
 	for _, typ := range RequiredCustomTypes {
 		if !expected[typ] {

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -297,6 +297,10 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 		if err != nil {
 			return nil, err
 		}
+		// Fragment entries stay "task" — unlike formula scaffolding steps,
+		// fanout-expanded fragment nodes are actionable work that pool
+		// workers claim from `bd ready`. Do not apply nonRootStepBeadType
+		// here (#1039).
 		if node.Metadata == nil {
 			node.Metadata = make(map[string]string, 2)
 		}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -150,6 +150,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				node.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
+			node.Type = nonRootStepBeadType(node.Type, step.Type)
 			if node.Metadata == nil {
 				node.Metadata = make(map[string]string, 1)
 			}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -150,7 +150,12 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				node.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
-			node.Type = nonRootStepBeadType(node.Type)
+			// graph.v2 workflows use step beads as independently routable
+			// actionable work, not scaffolding — skip the #1039 coercion
+			// so Ready() still surfaces them for worker claim.
+			if !graphWorkflow {
+				node.Type = nonRootStepBeadType(node.Type)
+			}
 			if node.Metadata == nil {
 				node.Metadata = make(map[string]string, 1)
 			}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -150,7 +150,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				node.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
-			node.Type = nonRootStepBeadType(node.Type, step.Type)
+			node.Type = nonRootStepBeadType(node.Type)
 			if node.Metadata == nil {
 				node.Metadata = make(map[string]string, 1)
 			}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -111,7 +111,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 
 	vars := applyVarDefaults(opts.Vars, recipe.Vars)
 	priorityOverride := clonePriority(opts.PriorityOverride)
-	graphWorkflow := len(recipe.Steps) > 0 && recipe.Steps[0].Metadata["gc.kind"] == "workflow"
+	graphWorkflow := preservesGraphActionTypes(recipe)
 	rootKey := recipe.Steps[0].ID
 	rootIncluded := false
 
@@ -150,9 +150,10 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				node.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
-			// graph.v2 workflows use step beads as independently routable
-			// actionable work, not scaffolding — skip the #1039 coercion
-			// so Ready() still surfaces them for worker claim.
+			// graph.v2 workflows and their retry/Ralph attempt sub-recipes
+			// use step beads as independently routable actionable work, not
+			// scaffolding — skip the #1039 coercion so Ready() still surfaces
+			// them for worker claim.
 			if !graphWorkflow {
 				node.Type = nonRootStepBeadType(node.Type)
 			}

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -434,7 +434,12 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
-			b.Type = nonRootStepBeadType(b.Type)
+			// graph.v2 workflows use step beads as independently routable
+			// actionable work, not scaffolding — skip the #1039 coercion
+			// so Ready() still surfaces them for worker claim.
+			if !graphWorkflow {
+				b.Type = nonRootStepBeadType(b.Type)
+			}
 			// Non-root beads: resolve ParentID from the parent-child deps.
 			for _, dep := range recipe.Deps {
 				if dep.StepID == step.ID && dep.Type == "parent-child" {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -434,7 +434,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
-			b.Type = nonRootStepBeadType(b.Type, step.Type)
+			b.Type = nonRootStepBeadType(b.Type)
 			// Non-root beads: resolve ParentID from the parent-child deps.
 			for _, dep := range recipe.Deps {
 				if dep.StepID == step.ID && dep.Type == "parent-child" {
@@ -612,9 +612,6 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 
 	for _, step := range recipe.Steps {
 		b := stepToBead(step, vars, priorityOverride)
-		// Fragments are rootless by construction, so every step is non-root —
-		// apply the #1039 step-type coercion to each bead.
-		b.Type = nonRootStepBeadType(b.Type, step.Type)
 		hasFutureBlocker := false
 		for _, dep := range recipe.Deps {
 			if dep.StepID != step.ID || dep.Type == "parent-child" {
@@ -794,12 +791,13 @@ func groupExternalDeps(deps []ExternalDep) (map[string][]ExternalDep, error) {
 }
 
 // nonRootStepBeadType returns the type to stamp on a non-root formula step
-// bead. Beads whose type defaulted to "task" (i.e. the TOML declared no
-// explicit type) become "step" so Ready() and `bd ready` skip formula
-// scaffolding (#1039). Explicit TOML types and the "gate" type produced by
-// deferBeadRouting are preserved.
-func nonRootStepBeadType(currentType, tomlType string) string {
-	if currentType == "task" && tomlType == "" {
+// bead. Beads typed "task" (the compiler's default — either from an explicit
+// TOML `type = "task"` or an unset type) become "step" so Ready() and
+// `bd ready` skip formula scaffolding (#1039). Other explicit types
+// ("bug", "epic", ...) and the "gate" type produced by deferBeadRouting
+// are preserved.
+func nonRootStepBeadType(currentType string) string {
+	if currentType == "task" {
 		return "step"
 	}
 	return currentType

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -386,7 +386,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 	var createdIDs []string
 	embeddedDeps := make(map[string]bool)
 	pendingAssignees := make(map[string]string)
-	graphWorkflow := len(recipe.Steps) > 0 && recipe.Steps[0].Metadata["gc.kind"] == "workflow"
+	graphWorkflow := preservesGraphActionTypes(recipe)
 
 	for i, step := range recipe.Steps {
 		// For RootOnly recipes, only create the root bead.
@@ -434,9 +434,10 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
-			// graph.v2 workflows use step beads as independently routable
-			// actionable work, not scaffolding — skip the #1039 coercion
-			// so Ready() still surfaces them for worker claim.
+			// graph.v2 workflows and their retry/Ralph attempt sub-recipes
+			// use step beads as independently routable actionable work, not
+			// scaffolding — skip the #1039 coercion so Ready() still surfaces
+			// them for worker claim.
 			if !graphWorkflow {
 				b.Type = nonRootStepBeadType(b.Type)
 			}
@@ -810,6 +811,17 @@ func nonRootStepBeadType(currentType string) string {
 		return "step"
 	}
 	return currentType
+}
+
+func preservesGraphActionTypes(recipe *formula.Recipe) bool {
+	if recipe == nil || len(recipe.Steps) == 0 {
+		return false
+	}
+	root := recipe.Steps[0]
+	if root.Metadata["gc.kind"] == "workflow" {
+		return true
+	}
+	return root.Metadata["gc.attempt"] != "" && root.Metadata["gc.step_ref"] != ""
 }
 
 // stepToBead converts a RecipeStep to a Bead with variable substitution.

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -612,6 +612,10 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 
 	for _, step := range recipe.Steps {
 		b := stepToBead(step, vars, priorityOverride)
+		// Fragment entries stay "task" — unlike formula scaffolding steps,
+		// fanout-expanded fragment beads are actionable work that pool
+		// workers claim from `bd ready`. Do not apply nonRootStepBeadType
+		// here (#1039).
 		hasFutureBlocker := false
 		for _, dep := range recipe.Deps {
 			if dep.StepID != step.ID || dep.Type == "parent-child" {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -434,6 +434,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {
+			b.Type = nonRootStepBeadType(b.Type, step.Type)
 			// Non-root beads: resolve ParentID from the parent-child deps.
 			for _, dep := range recipe.Deps {
 				if dep.StepID == step.ID && dep.Type == "parent-child" {
@@ -611,6 +612,9 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 
 	for _, step := range recipe.Steps {
 		b := stepToBead(step, vars, priorityOverride)
+		// Fragments are rootless by construction, so every step is non-root —
+		// apply the #1039 step-type coercion to each bead.
+		b.Type = nonRootStepBeadType(b.Type, step.Type)
 		hasFutureBlocker := false
 		for _, dep := range recipe.Deps {
 			if dep.StepID != step.ID || dep.Type == "parent-child" {
@@ -787,6 +791,18 @@ func groupExternalDeps(deps []ExternalDep) (map[string][]ExternalDep, error) {
 		byStep[dep.StepID] = append(byStep[dep.StepID], dep)
 	}
 	return byStep, nil
+}
+
+// nonRootStepBeadType returns the type to stamp on a non-root formula step
+// bead. Beads whose type defaulted to "task" (i.e. the TOML declared no
+// explicit type) become "step" so Ready() and `bd ready` skip formula
+// scaffolding (#1039). Explicit TOML types and the "gate" type produced by
+// deferBeadRouting are preserved.
+func nonRootStepBeadType(currentType, tomlType string) string {
+	if currentType == "task" && tomlType == "" {
+		return "step"
+	}
+	return currentType
 }
 
 // stepToBead converts a RecipeStep to a Bead with variable substitution.

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2392,6 +2392,64 @@ func TestBuildRecipeApplyPlan_NonRootStepsGetStepType(t *testing.T) {
 	}
 }
 
+// TestInstantiate_GraphWorkflowSkipsStepCoercion verifies that non-root
+// steps of a graph.v2 workflow (recipe.Steps[0] marked with
+// gc.kind=workflow) retain their original type rather than being
+// coerced to "step". Graph workflows use step beads as independently
+// claimable actionable work; coercing them would hide real work from
+// `bd ready` and stall the workflow (#1039 regression guard).
+func TestInstantiate_GraphWorkflowSkipsStepCoercion(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{ID: "wf", Title: "Workflow root", Type: "task", IsRoot: true,
+				Metadata: map[string]string{"gc.kind": "workflow"}},
+			{ID: "wf.body", Title: "Body work", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.body", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	body, err := store.Get(result.IDMapping["wf.body"])
+	if err != nil {
+		t.Fatalf("Get(body): %v", err)
+	}
+	if body.Type != "task" {
+		t.Errorf("graph-workflow step.Type = %q, want %q (must stay actionable)", body.Type, "task")
+	}
+}
+
+func TestBuildRecipeApplyPlan_GraphWorkflowSkipsStepCoercion(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{ID: "wf", Title: "Workflow root", Type: "task", IsRoot: true,
+				Metadata: map[string]string{"gc.kind": "workflow"}},
+			{ID: "wf.body", Title: "Body work", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.body", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	for _, n := range plan.Nodes {
+		if n.Key == "wf.body" && n.Type != "task" {
+			t.Errorf("graph-workflow node.Type = %q, want %q (must stay actionable)", n.Type, "task")
+		}
+	}
+}
+
 func TestNonRootStepBeadType(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2262,20 +2262,20 @@ func TestBuildRecipeApplyPlan_PreserveRootTypeKeepsTaskRoot(t *testing.T) {
 }
 
 // TestInstantiate_NonRootStepsGetStepType verifies that non-root step beads
-// created without an explicit type in the recipe default to "step" so Ready()
-// and `bd ready` skip them (#1039). The root keeps its coerced "molecule"
-// type; steps with an explicit type in TOML keep that type.
+// defaulting to "task" (empty or explicit) get coerced to "step" so Ready()
+// and `bd ready` skip them (#1039). Explicit non-"task" types ("bug",
+// "epic", ...) are preserved. The root still becomes "molecule".
 func TestInstantiate_NonRootStepsGetStepType(t *testing.T) {
 	store := beads.NewMemStore()
 	recipe := &formula.Recipe{
 		Name: "mol-demo",
 		Steps: []formula.RecipeStep{
 			{ID: "mol-demo", Title: "Root", IsRoot: true},
-			// step-a: no explicit type -> should become "step"
+			// step-a: no explicit type -> "step"
 			{ID: "mol-demo.step-a", Title: "Step A"},
-			// step-b: explicit type "task" -> should stay "task"
+			// step-b: explicit "task" (mirrors the compiler's default) -> "step"
 			{ID: "mol-demo.step-b", Title: "Step B", Type: "task"},
-			// step-c: explicit type "bug" -> should stay "bug"
+			// step-c: explicit non-"task" type is preserved
 			{ID: "mol-demo.step-c", Title: "Step C", Type: "bug"},
 		},
 		Deps: []formula.RecipeDep{
@@ -2293,7 +2293,7 @@ func TestInstantiate_NonRootStepsGetStepType(t *testing.T) {
 	cases := map[string]string{
 		"mol-demo":        "molecule",
 		"mol-demo.step-a": "step",
-		"mol-demo.step-b": "task",
+		"mol-demo.step-b": "step",
 		"mol-demo.step-c": "bug",
 	}
 	for stepID, wantType := range cases {
@@ -2382,7 +2382,7 @@ func TestBuildRecipeApplyPlan_NonRootStepsGetStepType(t *testing.T) {
 	cases := map[string]string{
 		"mol-demo":        "molecule",
 		"mol-demo.step-a": "step",
-		"mol-demo.step-b": "task",
+		"mol-demo.step-b": "step",
 		"mol-demo.step-c": "bug",
 	}
 	for key, wantType := range cases {
@@ -2392,73 +2392,22 @@ func TestBuildRecipeApplyPlan_NonRootStepsGetStepType(t *testing.T) {
 	}
 }
 
-// TestInstantiateFragment_StepsGetStepType verifies that fragment steps
-// (always non-root by construction) get Type "step" when no explicit TOML
-// type was declared (#1039).
-func TestInstantiateFragment_StepsGetStepType(t *testing.T) {
-	store := beads.NewMemStore()
-	root, err := store.Create(beads.Bead{
-		Title:    "Workflow root",
-		Type:     "task",
-		Metadata: map[string]string{"gc.kind": "workflow"},
-	})
-	if err != nil {
-		t.Fatalf("create root: %v", err)
-	}
-
-	recipe := &formula.FragmentRecipe{
-		Steps: []formula.RecipeStep{
-			// No explicit type -> should become "step"
-			{ID: "frag.a", Title: "Default"},
-			// Explicit "task" -> should stay "task"
-			{ID: "frag.b", Title: "Task", Type: "task"},
-			// Explicit "bug" -> should stay "bug"
-			{ID: "frag.c", Title: "Bug", Type: "bug"},
-		},
-		Deps: []formula.RecipeDep{
-			{StepID: "frag.b", DependsOnID: "frag.a", Type: "blocks"},
-			{StepID: "frag.c", DependsOnID: "frag.a", Type: "blocks"},
-		},
-	}
-
-	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{RootID: root.ID})
-	if err != nil {
-		t.Fatalf("InstantiateFragment: %v", err)
-	}
-
-	cases := map[string]string{
-		"frag.a": "step",
-		"frag.b": "task",
-		"frag.c": "bug",
-	}
-	for stepID, wantType := range cases {
-		b, err := store.Get(result.IDMapping[stepID])
-		if err != nil {
-			t.Fatalf("Get(%s): %v", stepID, err)
-		}
-		if b.Type != wantType {
-			t.Errorf("%s.Type = %q, want %q", stepID, b.Type, wantType)
-		}
-	}
-}
-
 func TestNonRootStepBeadType(t *testing.T) {
 	cases := []struct {
 		name        string
 		currentType string
-		tomlType    string
 		want        string
 	}{
-		{"defaulted task becomes step", "task", "", "step"},
-		{"explicit task stays task", "task", "task", "task"},
-		{"explicit bug stays bug", "bug", "bug", "bug"},
-		{"gate from deferBeadRouting stays gate", "gate", "", "gate"},
-		{"empty stays empty", "", "", ""},
+		{"task becomes step", "task", "step"},
+		{"explicit bug stays bug", "bug", "bug"},
+		{"epic stays epic", "epic", "epic"},
+		{"gate from deferBeadRouting stays gate", "gate", "gate"},
+		{"empty stays empty", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := nonRootStepBeadType(tc.currentType, tc.tomlType); got != tc.want {
-				t.Errorf("nonRootStepBeadType(%q, %q) = %q, want %q", tc.currentType, tc.tomlType, got, tc.want)
+			if got := nonRootStepBeadType(tc.currentType); got != tc.want {
+				t.Errorf("nonRootStepBeadType(%q) = %q, want %q", tc.currentType, got, tc.want)
 			}
 		})
 	}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2475,9 +2475,9 @@ func TestNonRootStepBeadType(t *testing.T) {
 	}
 }
 
-// TestInstantiate_DeferredStepsStayGate verifies that graph-workflow steps
-// converted to "gate" by deferBeadRouting are NOT overridden to "step" by
-// the #1039 non-root type coercion. Gate-ness wins.
+// TestInstantiate_DeferredStepsStayGate verifies that deferBeadRouting's
+// "gate" type is preserved for deferred non-root steps in non-graph
+// workflows and is not coerced to "step" by the #1039 non-root type coercion.
 func TestInstantiate_DeferredStepsStayGate(t *testing.T) {
 	store := beads.NewMemStore()
 	recipe := &formula.Recipe{

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2260,3 +2260,237 @@ func TestBuildRecipeApplyPlan_PreserveRootTypeKeepsTaskRoot(t *testing.T) {
 		t.Fatalf("plan root type = %q, want task", plan.Nodes[0].Type)
 	}
 }
+
+// TestInstantiate_NonRootStepsGetStepType verifies that non-root step beads
+// created without an explicit type in the recipe default to "step" so Ready()
+// and `bd ready` skip them (#1039). The root keeps its coerced "molecule"
+// type; steps with an explicit type in TOML keep that type.
+func TestInstantiate_NonRootStepsGetStepType(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "mol-demo",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-demo", Title: "Root", IsRoot: true},
+			// step-a: no explicit type -> should become "step"
+			{ID: "mol-demo.step-a", Title: "Step A"},
+			// step-b: explicit type "task" -> should stay "task"
+			{ID: "mol-demo.step-b", Title: "Step B", Type: "task"},
+			// step-c: explicit type "bug" -> should stay "bug"
+			{ID: "mol-demo.step-c", Title: "Step C", Type: "bug"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-demo.step-a", DependsOnID: "mol-demo", Type: "parent-child"},
+			{StepID: "mol-demo.step-b", DependsOnID: "mol-demo", Type: "parent-child"},
+			{StepID: "mol-demo.step-c", DependsOnID: "mol-demo", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	cases := map[string]string{
+		"mol-demo":        "molecule",
+		"mol-demo.step-a": "step",
+		"mol-demo.step-b": "task",
+		"mol-demo.step-c": "bug",
+	}
+	for stepID, wantType := range cases {
+		beadID := result.IDMapping[stepID]
+		b, err := store.Get(beadID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", stepID, err)
+		}
+		if b.Type != wantType {
+			t.Errorf("%s.Type = %q, want %q", stepID, b.Type, wantType)
+		}
+	}
+}
+
+// TestInstantiate_StepBeadsExcludedFromReady verifies the end-to-end intent:
+// after instantiating a formula, Ready() skips every step bead whose type
+// defaulted (#1039). The root is already "molecule" and excluded.
+func TestInstantiate_StepBeadsExcludedFromReady(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "mol-demo",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-demo", Title: "Root", IsRoot: true},
+			{ID: "mol-demo.step-a", Title: "Load context"},
+			{ID: "mol-demo.step-b", Title: "Run tests"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-demo.step-a", DependsOnID: "mol-demo", Type: "parent-child"},
+			{StepID: "mol-demo.step-b", DependsOnID: "mol-demo", Type: "parent-child"},
+		},
+	}
+
+	if _, err := Instantiate(context.Background(), store, recipe, Options{}); err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	// Add a real actionable task alongside the formula to confirm Ready() still
+	// returns genuine work.
+	if _, err := store.Create(beads.Bead{Title: "real work", Type: "task"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ready, err := store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(ready) != 1 {
+		titles := make([]string, 0, len(ready))
+		for _, b := range ready {
+			titles = append(titles, b.Title+"/"+b.Type)
+		}
+		t.Fatalf("Ready() returned %d beads, want 1 (only the real task); got %v", len(ready), titles)
+	}
+	if ready[0].Title != "real work" || ready[0].Type != "task" {
+		t.Errorf("Ready()[0] = %q/%q, want %q/%q", ready[0].Title, ready[0].Type, "real work", "task")
+	}
+}
+
+// TestBuildRecipeApplyPlan_NonRootStepsGetStepType mirrors
+// TestInstantiate_NonRootStepsGetStepType for the graph-apply plan path.
+func TestBuildRecipeApplyPlan_NonRootStepsGetStepType(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "mol-demo",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-demo", Title: "Root", IsRoot: true},
+			{ID: "mol-demo.step-a", Title: "Step A"},
+			{ID: "mol-demo.step-b", Title: "Step B", Type: "task"},
+			{ID: "mol-demo.step-c", Title: "Step C", Type: "bug"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-demo.step-a", DependsOnID: "mol-demo", Type: "parent-child"},
+			{StepID: "mol-demo.step-b", DependsOnID: "mol-demo", Type: "parent-child"},
+			{StepID: "mol-demo.step-c", DependsOnID: "mol-demo", Type: "parent-child"},
+		},
+	}
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+
+	typesByKey := make(map[string]string, len(plan.Nodes))
+	for _, n := range plan.Nodes {
+		typesByKey[n.Key] = n.Type
+	}
+	cases := map[string]string{
+		"mol-demo":        "molecule",
+		"mol-demo.step-a": "step",
+		"mol-demo.step-b": "task",
+		"mol-demo.step-c": "bug",
+	}
+	for key, wantType := range cases {
+		if got := typesByKey[key]; got != wantType {
+			t.Errorf("plan node %q Type = %q, want %q", key, got, wantType)
+		}
+	}
+}
+
+// TestInstantiateFragment_StepsGetStepType verifies that fragment steps
+// (always non-root by construction) get Type "step" when no explicit TOML
+// type was declared (#1039).
+func TestInstantiateFragment_StepsGetStepType(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "Workflow root",
+		Type:     "task",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	recipe := &formula.FragmentRecipe{
+		Steps: []formula.RecipeStep{
+			// No explicit type -> should become "step"
+			{ID: "frag.a", Title: "Default"},
+			// Explicit "task" -> should stay "task"
+			{ID: "frag.b", Title: "Task", Type: "task"},
+			// Explicit "bug" -> should stay "bug"
+			{ID: "frag.c", Title: "Bug", Type: "bug"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "frag.b", DependsOnID: "frag.a", Type: "blocks"},
+			{StepID: "frag.c", DependsOnID: "frag.a", Type: "blocks"},
+		},
+	}
+
+	result, err := InstantiateFragment(context.Background(), store, recipe, FragmentOptions{RootID: root.ID})
+	if err != nil {
+		t.Fatalf("InstantiateFragment: %v", err)
+	}
+
+	cases := map[string]string{
+		"frag.a": "step",
+		"frag.b": "task",
+		"frag.c": "bug",
+	}
+	for stepID, wantType := range cases {
+		b, err := store.Get(result.IDMapping[stepID])
+		if err != nil {
+			t.Fatalf("Get(%s): %v", stepID, err)
+		}
+		if b.Type != wantType {
+			t.Errorf("%s.Type = %q, want %q", stepID, b.Type, wantType)
+		}
+	}
+}
+
+func TestNonRootStepBeadType(t *testing.T) {
+	cases := []struct {
+		name        string
+		currentType string
+		tomlType    string
+		want        string
+	}{
+		{"defaulted task becomes step", "task", "", "step"},
+		{"explicit task stays task", "task", "task", "task"},
+		{"explicit bug stays bug", "bug", "bug", "bug"},
+		{"gate from deferBeadRouting stays gate", "gate", "", "gate"},
+		{"empty stays empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nonRootStepBeadType(tc.currentType, tc.tomlType); got != tc.want {
+				t.Errorf("nonRootStepBeadType(%q, %q) = %q, want %q", tc.currentType, tc.tomlType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInstantiate_DeferredStepsStayGate verifies that graph-workflow steps
+// converted to "gate" by deferBeadRouting are NOT overridden to "step" by
+// the #1039 non-root type coercion. Gate-ness wins.
+func TestInstantiate_DeferredStepsStayGate(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "mol-demo",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-demo", Title: "Root", IsRoot: true},
+			{ID: "mol-demo.step", Title: "Step", Assignee: "worker"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-demo.step", DependsOnID: "mol-demo", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{DeferAssignees: true})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	stepID := result.IDMapping["mol-demo.step"]
+	b, err := store.Get(stepID)
+	if err != nil {
+		t.Fatalf("Get(step): %v", err)
+	}
+	if b.Type != "gate" {
+		t.Errorf("deferred step.Type = %q, want %q", b.Type, "gate")
+	}
+}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2454,6 +2454,73 @@ func TestBuildRecipeApplyPlan_GraphWorkflowSkipsStepCoercion(t *testing.T) {
 	}
 }
 
+func TestInstantiate_GraphAttemptRecipeSkipsStepCoercion(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := graphAttemptRecipeForStepTypeTest()
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	body, err := store.Get(result.IDMapping["wf.review.iteration.1.body"])
+	if err != nil {
+		t.Fatalf("Get(body): %v", err)
+	}
+	if body.Type != "task" {
+		t.Errorf("graph-attempt child Type = %q, want %q (must stay actionable)", body.Type, "task")
+	}
+}
+
+func TestBuildRecipeApplyPlan_GraphAttemptRecipeSkipsStepCoercion(t *testing.T) {
+	recipe := graphAttemptRecipeForStepTypeTest()
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	for _, n := range plan.Nodes {
+		if n.Key == "wf.review.iteration.1.body" && n.Type != "task" {
+			t.Errorf("graph-attempt child node Type = %q, want %q (must stay actionable)", n.Type, "task")
+		}
+	}
+}
+
+func graphAttemptRecipeForStepTypeTest() *formula.Recipe {
+	return &formula.Recipe{
+		Name: "wf.review.iteration.1",
+		Steps: []formula.RecipeStep{
+			{
+				ID:     "wf.review.iteration.1",
+				Title:  "Review iteration",
+				Type:   "task",
+				IsRoot: true,
+				Metadata: map[string]string{
+					"gc.kind":     "scope",
+					"gc.attempt":  "1",
+					"gc.step_ref": "wf.review.iteration.1",
+				},
+			},
+			{
+				ID:    "wf.review.iteration.1.body",
+				Title: "Body work",
+				Type:  "task",
+				Metadata: map[string]string{
+					"gc.scope_ref": "wf.review.iteration.1",
+					"gc.step_ref":  "wf.review.iteration.1.body",
+				},
+			},
+		},
+		Deps: []formula.RecipeDep{
+			{
+				StepID:      "wf.review.iteration.1",
+				DependsOnID: "wf.review.iteration.1.body",
+				Type:        "blocks",
+			},
+		},
+	}
+}
+
 func TestNonRootStepBeadType(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2403,8 +2403,10 @@ func TestInstantiate_GraphWorkflowSkipsStepCoercion(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
-			{ID: "wf", Title: "Workflow root", Type: "task", IsRoot: true,
-				Metadata: map[string]string{"gc.kind": "workflow"}},
+			{
+				ID: "wf", Title: "Workflow root", Type: "task", IsRoot: true,
+				Metadata: map[string]string{"gc.kind": "workflow"},
+			},
 			{ID: "wf.body", Title: "Body work", Type: "task"},
 		},
 		Deps: []formula.RecipeDep{
@@ -2430,8 +2432,10 @@ func TestBuildRecipeApplyPlan_GraphWorkflowSkipsStepCoercion(t *testing.T) {
 	recipe := &formula.Recipe{
 		Name: "wf",
 		Steps: []formula.RecipeStep{
-			{ID: "wf", Title: "Workflow root", Type: "task", IsRoot: true,
-				Metadata: map[string]string{"gc.kind": "workflow"}},
+			{
+				ID: "wf", Title: "Workflow root", Type: "task", IsRoot: true,
+				Metadata: map[string]string{"gc.kind": "workflow"},
+			},
 			{ID: "wf.body", Title: "Body work", Type: "task"},
 		},
 		Deps: []formula.RecipeDep{


### PR DESCRIPTION
## Summary

Non-root formula step beads were created with default type `"task"` and appeared in `Ready()` / `bd ready` output alongside real work, causing two visible problems:
- **Queue pollution** — after a few formula dispatches, step names dominated `bd ready` output
- **Worker confusion** — pool workers claimed step beads (`Run tests to verify implementation`, `Load context`) out of context

Coerce non-root step beads with type `"task"` to type `"step"` during instantiation and add `"step"` to `readyExcludeTypes`. Register `"step"` in `doctor.RequiredCustomTypes` and the matching shell init scripts so fresh and upgraded cities accept the new type.

## Scope

The coercion is deliberately narrowed to **legacy sequential formulas** (i.e. `gc.kind != "workflow"` on the root):

| Recipe shape | Non-root step type | Rationale |
|---|---|---|
| Legacy sequential (mol-demo) | `"task"` → `"step"` | scaffolding walked by a single worker |
| graph.v2 workflow | preserved | step beads are independently claimable actionable work |
| Fanout fragment | preserved | fragment entries are actionable work spawned per-item |
| Retry / Ralph | preserved (runs on graph.v2) | same as graph.v2 |
| Deferred (`opts.DeferAssignees`) | preserved as `"gate"` | `deferBeadRouting` runs before the coercion |

This PR addresses **symptom 1** (`bd ready` / `store.Ready()` pollution) and **symptom 2** (worker claim via gascity-side callers). Symptom 2 for direct `bd ready` passthroughs and symptom 3 (molecule root never closes) are out of scope — tracked separately.

## Migration

Matches the PR #421 "convergence" precedent: existing cities need `gc doctor --fix` to add `"step"` to `types.custom`, or formula dispatch will fail with `invalid issue type: step`. Fresh `gc init` wires it automatically via the updated shell init scripts.

## Key design decisions

- **Type-based filtering** matches the existing `readyExcludeTypes` pattern (consistent with how `"molecule"` is used for roots) rather than introducing a new metadata-based filter
- **Unconditional `"task"` → `"step"`** (no `step.Type == ""` discriminator) — needed because `internal/formula/compile.go:310` rewrites empty types to `"task"` before `Instantiate` sees them. An explicit `type = "task"` in TOML (no production formulas use this) is rare enough that the simpler rule wins.
- **graph.v2 bypass via existing `graphWorkflow` flag** — the flag is already computed in both `Instantiate` and `buildRecipeApplyPlan` (molecule.go:383, graph_apply.go:114), and gating on it preserves all graph.v2 semantics

## Test plan

- [x] `TestInstantiate_NonRootStepsGetStepType` — legacy formula steps get type `"step"` (including explicit `Type: "task"`)
- [x] `TestInstantiate_StepBeadsExcludedFromReady` — end-to-end: Ready() skips step beads, surfaces real tasks
- [x] `TestInstantiate_DeferredStepsStayGate` — gate conversion preserved
- [x] `TestInstantiate_GraphWorkflowSkipsStepCoercion` — graph.v2 steps stay `"task"`
- [x] `TestBuildRecipeApplyPlan_NonRootStepsGetStepType` — same assertions on graph-apply path
- [x] `TestBuildRecipeApplyPlan_GraphWorkflowSkipsStepCoercion` — graph.v2 bypass on graph-apply path
- [x] `TestNonRootStepBeadType` — table-driven unit test for the helper
- [x] `TestIsReadyExcludedType` extended with `{"step", true}`
- [x] `TestCustomTypesCheck_RequiredTypesComplete` extended with `"step"`
- [x] Conformance test `ReadyExcludesInfraTypes` extended with `"step"`
- [x] `make build` ✓
- [x] `make check` ✓ (full suite + lint + vet + docsync)
- [x] Regression guard: `TestGraphWorkflowInMemorySuccessPath` / `FailureRunsCleanup` / `CreateExecuteWaitFlow` (pre-existing graph.v2 integration tests all pass)

## Review

Iterated multi-model review (Claude + Codex GPT-5.4 + Copilot GPT-5.3-codex) through 3 rounds to converge on zero blockers/majors. Codex caught two real correctness blockers (compile-time `step.Type` bypass, fragment graph-apply bypass); the gascity-checker agent caught the graph.v2 regression. All resolved before push.