### PR TITLE
gc doctor: detect + warn on bd-vs-gc Dolt port drift in managed-city mode

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -82,7 +82,7 @@ func isRetryableManagedDoltLifecycleError(err error) bool {
 // start → init+hooks(city) → init+hooks(each rig) → regenerate routes.
 // Called by gc start and controller config reload. Rigs must have absolute
 // paths before calling (resolve relative paths first).
-func startBeadsLifecycle(cityPath, _ string, cfg *config.City, _ io.Writer) error {
+func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer) error {
 	if err := validateCanonicalCompatDoltDrift(cityPath, cfg); err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, _ io.Writer) erro
 			return fmt.Errorf("init rig %q beads: %w", cfg.Rigs[i].Name, err)
 		}
 	}
-	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg); err != nil {
+	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg, stderr); err != nil {
 		return err
 	}
 	// Regenerate routes for cross-rig routing.
@@ -758,7 +758,7 @@ type doltRuntimeState struct {
 // control-plane input.
 func currentDoltPort(cityPath string) string {
 	if port := currentManagedDoltPort(cityPath); port != "" {
-		writeDoltPortFile(cityPath, port)
+		writeDoltPortFile(cityPath, port, "", io.Discard)
 		return port
 	}
 	removeDoltPortFile(cityPath)
@@ -832,7 +832,13 @@ func doltPortReachable(port string) bool {
 	return true
 }
 
-func writeDoltPortFile(dir, port string) {
+// writeDoltPortFile writes the managed Dolt port into dir/.beads/dolt-server.port.
+// When the existing file contains a non-empty port different from the one being
+// written, a WARN line naming scopeLabel and both ports is emitted on warn so
+// operators can see that their on-disk port file is being reconciled to the
+// canonical managed port. scopeLabel may be empty for silent callers; warn may
+// be nil or io.Discard to suppress warnings entirely.
+func writeDoltPortFile(dir, port, scopeLabel string, warn io.Writer) {
 	if dir == "" || port == "" {
 		return
 	}
@@ -841,8 +847,19 @@ func writeDoltPortFile(dir, port string) {
 		return
 	}
 	portFile := filepath.Join(dir, ".beads", "dolt-server.port")
-	if data, err := os.ReadFile(portFile); err == nil && strings.TrimSpace(string(data)) == trimmedPort {
-		return
+	existing := ""
+	if data, err := os.ReadFile(portFile); err == nil {
+		existing = strings.TrimSpace(string(data))
+		if existing == trimmedPort {
+			return
+		}
+	}
+	if warn != nil && existing != "" && existing != trimmedPort {
+		label := strings.TrimSpace(scopeLabel)
+		if label == "" {
+			label = dir
+		}
+		fmt.Fprintf(warn, "WARN: %s .beads/dolt-server.port rewrite %s → %s (managed city port)\n", label, existing, trimmedPort) //nolint:errcheck // best-effort stderr
 	}
 	if err := ensureBeadsDir(fsys.OSFS{}, filepath.Dir(portFile)); err != nil {
 		return
@@ -929,9 +946,16 @@ func enforceCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase st
 	return ensureCanonicalScopeMetadata(fs, scopeRoot, doltDatabase, false)
 }
 
-func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City) error {
+// normalizeCanonicalBdScopeFiles reconciles canonical bd metadata/config/port
+// mirrors under the city and each rig. warn receives operator-visible WARN
+// lines when port-file rewrites change on-disk contents (pass io.Discard to
+// suppress, or a stderr writer from the caller to show them).
+func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City, warn io.Writer) error {
 	if cfg == nil {
 		return nil
+	}
+	if warn == nil {
+		warn = io.Discard
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
 	if scopeUsesManagedBdStoreContract(cityPath, cityPath) {
@@ -947,13 +971,21 @@ func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City) error {
 			return fmt.Errorf("canonicalizing rig %q metadata: %w", cfg.Rigs[i].Name, err)
 		}
 	}
-	if err := syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs); err != nil {
+	if err := syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs, warn); err != nil {
 		return fmt.Errorf("syncing canonical dolt config: %w", err)
 	}
 	return nil
 }
 
-func syncConfiguredDoltPortFiles(cityPath string, cityDolt config.DoltConfig, cityPrefix string, rigs []config.Rig) error {
+// syncConfiguredDoltPortFiles reconciles each scope's .beads/dolt-server.port
+// compatibility mirror with the canonical managed-city Dolt port. When warn is
+// non-nil, a WARN line is emitted for every port file whose prior non-empty
+// contents disagreed with the canonical port (operator-visible signal that gc
+// is overriding a rig-local or stale port). Pass io.Discard to suppress.
+func syncConfiguredDoltPortFiles(cityPath string, cityDolt config.DoltConfig, cityPrefix string, rigs []config.Rig, warn io.Writer) error {
+	if warn == nil {
+		warn = io.Discard
+	}
 	resolveRigPaths(cityPath, rigs)
 	cityUsesBd := scopeUsesManagedBdStoreContract(cityPath, cityPath)
 	anyRigUsesBd := false
@@ -985,7 +1017,7 @@ func syncConfiguredDoltPortFiles(cityPath string, cityDolt config.DoltConfig, ci
 			return err
 		}
 		if managedPort != "" {
-			writeDoltPortFile(cityPath, managedPort)
+			writeDoltPortFile(cityPath, managedPort, "city", warn)
 		} else {
 			removeDoltPortFile(cityPath)
 		}
@@ -1014,7 +1046,7 @@ func syncConfiguredDoltPortFiles(cityPath string, cityDolt config.DoltConfig, ci
 			return err
 		}
 		if rigManagedPort != "" {
-			writeDoltPortFile(rig.Path, rigManagedPort)
+			writeDoltPortFile(rig.Path, rigManagedPort, "rig "+rig.Name, warn)
 		} else {
 			removeDoltPortFile(rig.Path)
 		}

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -949,10 +949,15 @@ func enforceCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase st
 // normalizeCanonicalBdScopeFiles reconciles canonical bd metadata/config/port
 // mirrors under the city and each rig. warn receives operator-visible WARN
 // lines when port-file rewrites change on-disk contents (pass io.Discard to
-// suppress, or a stderr writer from the caller to show them).
-func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City, warn io.Writer) error {
+// suppress, or a stderr writer from the caller to show them). When omitted,
+// warning output is suppressed.
+func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City, warns ...io.Writer) error {
 	if cfg == nil {
 		return nil
+	}
+	var warn io.Writer
+	if len(warns) > 0 {
+		warn = warns[0]
 	}
 	if warn == nil {
 		warn = io.Discard

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -233,7 +233,7 @@ func TestNormalizeCanonicalBdScopeFilesPreservesExistingManagedProbeDatabase(t *
 	}
 
 	cfg := &config.City{Workspace: config.Workspace{Name: "dogfood-city"}}
-	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg); err != nil {
+	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg, io.Discard); err != nil {
 		t.Fatalf("normalizeCanonicalBdScopeFiles: %v", err)
 	}
 	got, ok, err := contract.ReadDoltDatabase(fsys.OSFS{}, metadataPath)
@@ -872,7 +872,7 @@ func TestCurrentManagedDoltPortUsesCanonicalPackStateOnly(t *testing.T) {
 func requireSyncConfiguredDoltPortFiles(t *testing.T, cityPath, provider string, cityDolt config.DoltConfig, cityPrefix string, rigs []config.Rig) {
 	t.Helper()
 	_ = provider
-	if err := syncConfiguredDoltPortFiles(cityPath, cityDolt, cityPrefix, rigs); err != nil {
+	if err := syncConfiguredDoltPortFiles(cityPath, cityDolt, cityPrefix, rigs, io.Discard); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -938,6 +938,107 @@ func TestSyncConfiguredDoltPortFilesWritesArbitraryRigPaths(t *testing.T) {
 		if !strings.Contains(cfg, "gc.endpoint_status: verified") {
 			t.Fatalf("%s config missing gc.endpoint_status:\n%s", tc.dir, cfg)
 		}
+	}
+}
+
+func TestSyncConfiguredDoltPortFilesWarnsOnRigPortFileRewrite(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "drifty")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ln := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = ln.Close() })
+	managedPort := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".beads", "config.yaml"), []byte("dolt.auto-start: true\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Seed the rig with a stale port file pointing at a different port.
+	const stalePort = "29999"
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte(stalePort+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeDoltState(cityDir, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      ln.Addr().(*net.TCPAddr).Port,
+		DataDir:   filepath.Join(cityDir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	if err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "drifty", Path: rigDir}}, &warn); err != nil {
+		t.Fatalf("syncConfiguredDoltPortFiles error = %v", err)
+	}
+
+	out := warn.String()
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("want WARN prefix in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "drifty") {
+		t.Errorf("want rig name in warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, stalePort) || !strings.Contains(out, managedPort) {
+		t.Errorf("want both old port %s and new port %s in warning, got:\n%s", stalePort, managedPort, out)
+	}
+	// Confirm the rewrite happened.
+	data, err := os.ReadFile(filepath.Join(rigDir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("read rig port file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != managedPort {
+		t.Errorf("rig port file = %q, want %q", got, managedPort)
+	}
+}
+
+func TestSyncConfiguredDoltPortFilesSilentOnNoChange(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "quiet")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ln := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = ln.Close() })
+	managedPort := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".beads", "config.yaml"), []byte("dolt.auto-start: true\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Rig port already matches the managed port — no rewrite, no warning.
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte(managedPort+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeDoltState(cityDir, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      ln.Addr().(*net.TCPAddr).Port,
+		DataDir:   filepath.Join(cityDir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	if err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "quiet", Path: rigDir}}, &warn); err != nil {
+		t.Fatalf("syncConfiguredDoltPortFiles error = %v", err)
+	}
+	if strings.Contains(warn.String(), "WARN") {
+		t.Errorf("want no WARN when port files already match, got:\n%s", warn.String())
 	}
 }
 
@@ -1536,7 +1637,7 @@ dolt.port: 3307
 		t.Fatal(err)
 	}
 	before := mustReadFile(t, filepath.Join(cityDir, ".beads", "config.yaml"))
-	err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
+	err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "invalid canonical city endpoint state") {
 		t.Fatalf("syncConfiguredDoltPortFiles() error = %v, want invalid canonical city endpoint state", err)
 	}
@@ -1581,7 +1682,7 @@ dolt.auto-start: false
 		t.Fatal(err)
 	}
 	before := mustReadFile(t, filepath.Join(rigDir, ".beads", "config.yaml"))
-	err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}})
+	err := syncConfiguredDoltPortFiles(cityDir, config.DoltConfig{}, "gc", []config.Rig{{Name: "frontend", Path: rigDir, Prefix: "fe"}}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "invalid canonical rig endpoint state") {
 		t.Fatalf("syncConfiguredDoltPortFiles() error = %v, want invalid canonical rig endpoint state", err)
 	}
@@ -7515,7 +7616,7 @@ func TestNormalizeCanonicalBdScopeFilesRepairsCityAndRigScopeFiles(t *testing.T)
 		Workspace: config.Workspace{Name: "dogfood-city"},
 		Rigs:      []config.Rig{{Name: "frontend", Path: rigPath, Prefix: "fr"}},
 	}
-	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg); err != nil {
+	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg, io.Discard); err != nil {
 		t.Fatalf("normalizeCanonicalBdScopeFiles: %v", err)
 	}
 
@@ -7739,7 +7840,7 @@ func TestNormalizeCanonicalBdScopeFilesMaterializesMissingMetadata(t *testing.T)
 		Workspace: config.Workspace{Name: "dogfood-city"},
 		Rigs:      []config.Rig{{Name: "frontend", Path: rigPath, Prefix: "fr"}},
 	}
-	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg); err != nil {
+	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg, io.Discard); err != nil {
 		t.Fatalf("normalizeCanonicalBdScopeFiles: %v", err)
 	}
 

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -134,6 +134,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		resolveRigPaths(cityPath, cfg.Rigs)
 		if workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs) {
 			d.Register(newDoltTopologyCheck(cityPath, cfg))
+			d.Register(newDoltDriftCheck(cityPath, cfg))
 		}
 		d.Register(doctor.NewConfigValidCheck(cfg))
 		d.Register(doctor.NewConfigRefsCheck(cfg, cityPath))

--- a/cmd/gc/cmd_doctor_drift.go
+++ b/cmd/gc/cmd_doctor_drift.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// doltDriftCheck detects bd-vs-gc Dolt drift in managed-city topology: rigs
+// configured inherited_city but running their own Dolt, port-file mismatches
+// between rig mirrors and the canonical managed city port, and stale
+// .dolt/sql-server.info files left over from abandoned rig-local servers.
+type doltDriftCheck struct {
+	cityPath string
+	cfg      *config.City
+}
+
+func newDoltDriftCheck(cityPath string, cfg *config.City) *doltDriftCheck {
+	return &doltDriftCheck{cityPath: cityPath, cfg: cfg}
+}
+
+func (c *doltDriftCheck) Name() string { return "dolt-drift" }
+
+func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	r := &doctor.CheckResult{Name: c.Name()}
+	if c.cfg == nil || !workspaceUsesManagedBdStoreContract(c.cityPath, c.cfg.Rigs) {
+		r.Status = doctor.StatusOK
+		r.Message = "not using bd-backed Dolt topology"
+		return r
+	}
+
+	cityState, _, err := resolveDesiredCityEndpointState(c.cityPath, c.cfg.Dolt, config.EffectiveHQPrefix(c.cfg))
+	if err != nil {
+		r.Status = doctor.StatusError
+		r.Message = fmt.Sprintf("resolve city endpoint state: %v", err)
+		return r
+	}
+	if cityState.EndpointOrigin != contract.EndpointOriginManagedCity {
+		r.Status = doctor.StatusOK
+		r.Message = "city not in managed_city mode; drift check not applicable"
+		return r
+	}
+
+	managedPort := currentManagedDoltPort(c.cityPath)
+
+	var errors []string
+	var warnings []string
+
+	for i := range c.cfg.Rigs {
+		rig := c.cfg.Rigs[i]
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		if !rigUsesManagedBdStoreContract(c.cityPath, rig) {
+			continue
+		}
+		rigState, err := resolveDesiredRigEndpointState(c.cityPath, rig, cityState)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("rig %q resolve endpoint state: %v", rig.Name, err))
+			continue
+		}
+		if rigState.EndpointOrigin != contract.EndpointOriginInheritedCity {
+			// Rig is explicit (or not inherited). No drift analysis applies —
+			// its Dolt is its own responsibility.
+			continue
+		}
+
+		livePID, infoExists, pidOK := rigLocalDoltPIDFromSQLServerInfo(rig.Path)
+
+		// Case A: rig is inherited_city but has a live rig-local Dolt.
+		if pidOK {
+			errors = append(errors, fmt.Sprintf(
+				"rig %q endpoint_origin=inherited_city but rig-local Dolt pid %d is live (.dolt/sql-server.info); run `gc rig set-endpoint %s --inherit` to rejoin the city or stop the rig-local server",
+				rig.Name, livePID, rig.Name,
+			))
+		} else if infoExists {
+			// Case C: stale rig-local sql-server.info (file present, PID not alive).
+			warnings = append(warnings, fmt.Sprintf(
+				"rig %q has stale .dolt/sql-server.info (pid %d not alive); safe to delete",
+				rig.Name, livePID,
+			))
+		}
+
+		// Case B: rig port file disagrees with managed city port.
+		if managedPort != "" {
+			rigPortFile := filepath.Join(rig.Path, ".beads", "dolt-server.port")
+			if data, err := os.ReadFile(rigPortFile); err == nil {
+				got := strings.TrimSpace(string(data))
+				if got != "" && got != managedPort {
+					errors = append(errors, fmt.Sprintf(
+						"rig %q .beads/dolt-server.port=%s disagrees with managed city port %s; next `gc start` will overwrite the rig port file",
+						rig.Name, got, managedPort,
+					))
+				}
+			}
+		}
+	}
+
+	if len(errors) == 0 && len(warnings) == 0 {
+		r.Status = doctor.StatusOK
+		r.Message = "no bd-vs-gc Dolt drift detected"
+		return r
+	}
+	if len(errors) > 0 {
+		r.Status = doctor.StatusError
+		plural := ""
+		if len(errors) != 1 {
+			plural = "s"
+		}
+		r.Message = fmt.Sprintf("%d drift issue%s between rig-local Dolt state and managed city topology", len(errors), plural)
+		r.Details = append(append([]string{}, errors...), warnings...)
+		r.FixHint = "use `gc rig set-endpoint <rig> --inherit` (rejoin city) or --external (pin explicit endpoint); remove stale .dolt/sql-server.info files"
+		return r
+	}
+	plural := ""
+	if len(warnings) != 1 {
+		plural = "s"
+	}
+	r.Status = doctor.StatusWarning
+	r.Message = fmt.Sprintf("%d stale rig-local Dolt state file%s", len(warnings), plural)
+	r.Details = warnings
+	r.FixHint = "remove stale .dolt/sql-server.info files whose PID is not alive"
+	return r
+}
+
+func (c *doltDriftCheck) CanFix() bool { return false }
+
+func (c *doltDriftCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+// rigLocalDoltPIDFromSQLServerInfo reads the colon-separated PID:PORT:UUID
+// content of rigPath/.dolt/sql-server.info (written by dolt sql-server). It
+// returns the PID parsed from the file, whether the file exists at all, and
+// whether that PID is currently alive. When the file is missing the PID is
+// zero and both bools are false.
+func rigLocalDoltPIDFromSQLServerInfo(rigPath string) (pid int, infoExists bool, pidAliveNow bool) {
+	path := filepath.Join(rigPath, ".dolt", "sql-server.info")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false, false
+	}
+	infoExists = true
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
+	if len(parts) < 1 || strings.TrimSpace(parts[0]) == "" {
+		return 0, true, false
+	}
+	parsed, convErr := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if convErr != nil || parsed <= 0 {
+		return 0, true, false
+	}
+	return parsed, true, pidAlive(parsed)
+}
+

--- a/cmd/gc/cmd_doctor_drift.go
+++ b/cmd/gc/cmd_doctor_drift.go
@@ -144,7 +144,6 @@ func rigLocalDoltPIDFromSQLServerInfo(rigPath string) (pid int, infoExists bool,
 	if err != nil {
 		return 0, false, false
 	}
-	infoExists = true
 	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
 	if len(parts) < 1 || strings.TrimSpace(parts[0]) == "" {
 		return 0, true, false
@@ -155,4 +154,3 @@ func rigLocalDoltPIDFromSQLServerInfo(rigPath string) (pid int, infoExists bool,
 	}
 	return parsed, true, pidAlive(parsed)
 }
-

--- a/cmd/gc/cmd_doctor_drift_test.go
+++ b/cmd/gc/cmd_doctor_drift_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func managedCityDriftFixture(t *testing.T, rigName string) (cityDir, rigDir, managedPort string, cfg *config.City) {
+	t.Helper()
+	cityDir = t.TempDir()
+	rigDir = filepath.Join(t.TempDir(), rigName)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ln := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+	managedPort = strconv.Itoa(port)
+
+	if err := writeDoltState(cityDir, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   filepath.Join(cityDir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeCanonicalScopeConfig(t, cityDir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginManagedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(cityDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "gc",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeCanonicalScopeConfig(t, rigDir, contract.ConfigState{
+		IssuePrefix:    "r",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "r",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg = &config.City{
+		Workspace: config.Workspace{Name: "drift-test"},
+		Rigs:      []config.Rig{{Name: rigName, Path: rigDir, Prefix: "r"}},
+	}
+	return cityDir, rigDir, managedPort, cfg
+}
+
+func writeSQLServerInfo(t *testing.T, rigDir string, pid, port int) {
+	t.Helper()
+	dir := filepath.Join(rigDir, ".dolt")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("%d:%d:dead-beef-cafe-feed\n", pid, port)
+	if err := os.WriteFile(filepath.Join(dir, "sql-server.info"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoltDriftCheckCleanManagedCityIsOK(t *testing.T) {
+	cityDir, rigDir, managedPort, cfg := managedCityDriftFixture(t, "clean")
+	// Port file matches canonical managed port — no drift.
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte(managedPort+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("Run() status = %v, want StatusOK; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+}
+
+func TestDoltDriftCheckDetectsLiveRigLocalDolt(t *testing.T) {
+	cityDir, rigDir, _, cfg := managedCityDriftFixture(t, "runner")
+	// Write sql-server.info with our own PID (definitely alive).
+	writeSQLServerInfo(t, rigDir, os.Getpid(), 28232)
+
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Run() status = %v, want StatusError; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+	joined := r.Message + " " + strings.Join(r.Details, " ")
+	if !strings.Contains(joined, "runner") {
+		t.Errorf("want rig name in message/details, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "rig-local Dolt") && !strings.Contains(joined, "sql-server.info") {
+		t.Errorf("want rig-local Dolt mention in details, got:\n%s", joined)
+	}
+}
+
+func TestDoltDriftCheckDetectsStaleRigLocalInfo(t *testing.T) {
+	cityDir, rigDir, _, cfg := managedCityDriftFixture(t, "stale")
+	// Use a PID that is extremely unlikely to be alive.
+	writeSQLServerInfo(t, rigDir, 2147483640, 28233)
+
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusWarning {
+		t.Fatalf("Run() status = %v, want StatusWarning; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+	joined := r.Message + " " + strings.Join(r.Details, " ")
+	if !strings.Contains(joined, "stale") {
+		t.Errorf("want 'stale' in result, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "stale") {
+		t.Errorf("want stale file mention, got:\n%s", joined)
+	}
+}
+
+func TestDoltDriftCheckDetectsPortFileDrift(t *testing.T) {
+	cityDir, rigDir, managedPort, cfg := managedCityDriftFixture(t, "drifted")
+	const stalePort = "29999"
+	if stalePort == managedPort {
+		t.Fatalf("test fixture picked the stale port %s", managedPort)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte(stalePort+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Run() status = %v, want StatusError; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+	joined := r.Message + " " + strings.Join(r.Details, " ")
+	if !strings.Contains(joined, "drifted") {
+		t.Errorf("want rig name in result, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, stalePort) || !strings.Contains(joined, managedPort) {
+		t.Errorf("want both stale %s and managed %s ports in result, got:\n%s", stalePort, managedPort, joined)
+	}
+}
+
+func TestDoltDriftCheckNoRigsIsOK(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{Workspace: config.Workspace{Name: "empty"}}
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusOK {
+		t.Fatalf("Run() status = %v, want StatusOK", r.Status)
+	}
+}
+
+func TestRigLocalDoltPIDFromSQLServerInfoParsesColonFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeSQLServerInfo(t, dir, 12345, 28232)
+	pid, exists, alive := rigLocalDoltPIDFromSQLServerInfo(dir)
+	if !exists {
+		t.Fatalf("infoExists = false, want true")
+	}
+	if pid != 12345 {
+		t.Errorf("pid = %d, want 12345", pid)
+	}
+	// alive depends on whether pid 12345 happens to be live; don't assert.
+	_ = alive
+}
+
+func TestRigLocalDoltPIDFromSQLServerInfoMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	pid, exists, alive := rigLocalDoltPIDFromSQLServerInfo(dir)
+	if exists {
+		t.Errorf("infoExists = true, want false when file is absent")
+	}
+	if pid != 0 {
+		t.Errorf("pid = %d, want 0", pid)
+	}
+	if alive {
+		t.Errorf("pidAliveNow = true, want false when file absent")
+	}
+}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -433,7 +433,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		return 1
 	}
 	if !reAdd || reAddNeedsConfigWrite {
-		if err := normalizeCanonicalBdScopeFiles(cityPath, nextCfg); err != nil {
+		if err := normalizeCanonicalBdScopeFiles(cityPath, nextCfg, io.Discard); err != nil {
 			writeRigAddRollbackError(fs, stderr, snapshots, "canonicalizing rig topology", err)
 			return 1
 		}

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -26,6 +26,8 @@ import (
 type rigEndpointOptions struct {
 	Inherit         bool
 	External        bool
+	Self            bool
+	Force           bool
 	Host            string
 	Port            string
 	User            string
@@ -44,11 +46,16 @@ func newRigSetEndpointCmd(stdout, stderr io.Writer) *cobra.Command {
 
 Use --inherit to make a rig derive its endpoint from the current city
 topology. Use --external to pin the rig to its own external Dolt endpoint.
+Use --self to mark the rig as running its own local Dolt server on
+127.0.0.1 at the given --port; while the city is in managed_city mode the
+command requires --force because the rig's .beads/dolt-server.port mirror
+will no longer track the managed city Dolt.
 
 This command owns the rig's canonical .beads/config.yaml topology state.`,
 		Example: `  gc rig set-endpoint frontend --inherit
   gc rig set-endpoint frontend --external --host db.example.com --port 3307
   gc rig set-endpoint frontend --external --host db.example.com --port 3307 --user agent --adopt-unverified
+  gc rig set-endpoint frontend --self --port 28232 --force
   gc rig set-endpoint frontend --inherit --dry-run`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -60,8 +67,10 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 	}
 	cmd.Flags().BoolVar(&opts.Inherit, "inherit", false, "inherit the city endpoint")
 	cmd.Flags().BoolVar(&opts.External, "external", false, "set an explicit external endpoint for the rig")
+	cmd.Flags().BoolVar(&opts.Self, "self", false, "mark the rig as running its own local Dolt on 127.0.0.1")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "acknowledge conflicting managed-city state when using --self")
 	cmd.Flags().StringVar(&opts.Host, "host", "", "external Dolt host")
-	cmd.Flags().StringVar(&opts.Port, "port", "", "external Dolt port")
+	cmd.Flags().StringVar(&opts.Port, "port", "", "external Dolt port (required with --external or --self)")
 	cmd.Flags().StringVar(&opts.User, "user", "", "external Dolt user")
 	cmd.Flags().BoolVar(&opts.AdoptUnverified, "adopt-unverified", false, "record the endpoint without live validation")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "show the canonical changes without writing files")
@@ -126,6 +135,11 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 
 	targetState := requestedRigEndpointState(rig, currentState, cityState, opts)
 
+	if opts.Self && cityState.EndpointOrigin == contract.EndpointOriginManagedCity && !opts.Force {
+		fmt.Fprintf(stderr, "gc rig set-endpoint: --self conflicts with managed_city: the rig's .beads/dolt-server.port mirror will stop tracking the managed city Dolt and any rig-local Dolt must be started and managed independently of `gc start`. Re-run with --force to acknowledge.\n") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
 	if opts.DryRun {
 		printRigEndpointDryRun(stdout, rig, currentState, targetState)
 		return 0
@@ -138,13 +152,17 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		}
 	}
 
-	if opts.External && !opts.AdoptUnverified {
+	if (opts.External || opts.Self) && !opts.AdoptUnverified {
 		if err := verifyRigExternalEndpoint(targetState, rig.Path, rig.Path); err != nil {
-			fmt.Fprintf(stderr, "gc rig set-endpoint: validate external endpoint: %v\n", err)                                      //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc rig set-endpoint: validate endpoint: %v\n", err)                                                  //nolint:errcheck // best-effort stderr
 			fmt.Fprintf(stderr, "gc rig set-endpoint: rerun with --adopt-unverified to record this endpoint without validation\n") //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		targetState.EndpointStatus = contract.EndpointStatusVerified
+	}
+
+	if opts.Self && cityState.EndpointOrigin == contract.EndpointOriginManagedCity {
+		fmt.Fprintf(stderr, "gc rig set-endpoint: WARN: rig %q now runs its own Dolt on 127.0.0.1:%s, independent of the city's managed Dolt; `gc start` will not supervise it.\n", rig.Name, targetState.DoltPort) //nolint:errcheck // best-effort stderr
 	}
 
 	snapshots, err := snapshotRigEndpointFiles(fs, cityPath, rig.Path)
@@ -174,8 +192,21 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 }
 
 func validateRigEndpointOptions(opts rigEndpointOptions) error {
-	if opts.Inherit == opts.External {
-		return fmt.Errorf("choose exactly one of --inherit or --external")
+	modes := 0
+	if opts.Inherit {
+		modes++
+	}
+	if opts.External {
+		modes++
+	}
+	if opts.Self {
+		modes++
+	}
+	if modes != 1 {
+		return fmt.Errorf("choose exactly one of --inherit, --external, or --self")
+	}
+	if opts.Force && !opts.Self {
+		return fmt.Errorf("--force is only valid with --self")
 	}
 	if opts.Inherit {
 		if strings.TrimSpace(opts.Host) != "" || strings.TrimSpace(opts.Port) != "" || strings.TrimSpace(opts.User) != "" {
@@ -183,6 +214,24 @@ func validateRigEndpointOptions(opts rigEndpointOptions) error {
 		}
 		if opts.AdoptUnverified {
 			return fmt.Errorf("--adopt-unverified is only valid with --external")
+		}
+		return nil
+	}
+
+	if opts.Self {
+		if strings.TrimSpace(opts.Host) != "" {
+			return fmt.Errorf("--self always uses 127.0.0.1; do not pass --host")
+		}
+		if strings.TrimSpace(opts.User) != "" {
+			return fmt.Errorf("--self does not accept --user")
+		}
+		port := strings.TrimSpace(opts.Port)
+		if port == "" {
+			return fmt.Errorf("--self requires --port")
+		}
+		value, err := strconv.Atoi(port)
+		if err != nil || value <= 0 {
+			return fmt.Errorf("invalid --port %q", port)
 		}
 		return nil
 	}
@@ -233,6 +282,20 @@ func resolveOwnerRigConfigState(cityPath string, rig config.Rig, cityState contr
 func requestedRigEndpointState(rig config.Rig, currentState, cityState contract.ConfigState, opts rigEndpointOptions) contract.ConfigState {
 	if opts.Inherit {
 		return inheritedRigDoltConfigState(rig.Path, rig.EffectivePrefix(), cityState)
+	}
+
+	if opts.Self {
+		state := contract.ConfigState{
+			IssuePrefix:    rig.EffectivePrefix(),
+			EndpointOrigin: contract.EndpointOriginExplicit,
+			EndpointStatus: contract.EndpointStatusVerified,
+			DoltHost:       "127.0.0.1",
+			DoltPort:       strings.TrimSpace(opts.Port),
+		}
+		if opts.AdoptUnverified {
+			state.EndpointStatus = contract.EndpointStatusUnverified
+		}
+		return state
 	}
 
 	user := strings.TrimSpace(opts.User)

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -154,7 +154,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 
 	if (opts.External || opts.Self) && !opts.AdoptUnverified {
 		if err := verifyRigExternalEndpoint(targetState, rig.Path, rig.Path); err != nil {
-			fmt.Fprintf(stderr, "gc rig set-endpoint: validate endpoint: %v\n", err)                                                  //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc rig set-endpoint: validate endpoint: %v\n", err)                                               //nolint:errcheck // best-effort stderr
 			fmt.Fprintf(stderr, "gc rig set-endpoint: rerun with --adopt-unverified to record this endpoint without validation\n") //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -32,6 +32,124 @@ func TestValidateRigEndpointOptionsRejectsWildcardExternalHost(t *testing.T) {
 	}
 }
 
+func TestValidateRigEndpointOptionsSelfRequiresPort(t *testing.T) {
+	err := validateRigEndpointOptions(rigEndpointOptions{Self: true})
+	if err == nil || !strings.Contains(err.Error(), "--self requires --port") {
+		t.Fatalf("validateRigEndpointOptions(Self without port) error = %v", err)
+	}
+}
+
+func TestValidateRigEndpointOptionsSelfRejectsHost(t *testing.T) {
+	err := validateRigEndpointOptions(rigEndpointOptions{Self: true, Port: "28232", Host: "db.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "--self") || !strings.Contains(err.Error(), "--host") {
+		t.Fatalf("validateRigEndpointOptions(Self+Host) error = %v", err)
+	}
+}
+
+func TestValidateRigEndpointOptionsSelfRejectsUser(t *testing.T) {
+	err := validateRigEndpointOptions(rigEndpointOptions{Self: true, Port: "28232", User: "someone"})
+	if err == nil || !strings.Contains(err.Error(), "--self") || !strings.Contains(err.Error(), "--user") {
+		t.Fatalf("validateRigEndpointOptions(Self+User) error = %v", err)
+	}
+}
+
+func TestValidateRigEndpointOptionsForceRequiresSelf(t *testing.T) {
+	err := validateRigEndpointOptions(rigEndpointOptions{External: true, Host: "db.example.com", Port: "3307", Force: true})
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("validateRigEndpointOptions(External+Force) error = %v", err)
+	}
+}
+
+func TestValidateRigEndpointOptionsRejectsMultipleModes(t *testing.T) {
+	err := validateRigEndpointOptions(rigEndpointOptions{Inherit: true, Self: true, Port: "28232"})
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("validateRigEndpointOptions(Inherit+Self) error = %v", err)
+	}
+}
+
+func TestDoRigSetEndpointSelfManagedCityRequiresForce(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRigEndpointCityConfig(t, cityDir, rigDir)
+	writeRigEndpointMetadata(t, cityDir, "hq")
+	writeRigEndpointMetadata(t, rigDir, "fe")
+	writeRigEndpointRuntimeState(t, cityDir, 3311)
+	writeRigEndpointCanonicalConfig(t, rigDir, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doRigSetEndpoint(fsys.OSFS{}, cityDir, "frontend", rigEndpointOptions{
+		Self: true,
+		Port: "28232",
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("doRigSetEndpoint(Self, managed_city, no --force) exit = 0, want non-zero")
+	}
+	if !strings.Contains(stderr.String(), "--force") {
+		t.Errorf("want stderr to mention --force, got:\n%s", stderr.String())
+	}
+	// Canonical config must not have been mutated.
+	state := readRigEndpointConfigState(t, rigDir)
+	if state.EndpointOrigin != contract.EndpointOriginInheritedCity {
+		t.Fatalf("EndpointOrigin = %q, want unchanged %q", state.EndpointOrigin, contract.EndpointOriginInheritedCity)
+	}
+}
+
+func TestDoRigSetEndpointSelfWithForceSucceeds(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRigEndpointCityConfig(t, cityDir, rigDir)
+	writeRigEndpointMetadata(t, cityDir, "hq")
+	writeRigEndpointMetadata(t, rigDir, "fe")
+	writeRigEndpointRuntimeState(t, cityDir, 3311)
+	writeRigEndpointCanonicalConfig(t, rigDir, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+
+	origVerify := verifyRigExternalEndpoint
+	defer func() { verifyRigExternalEndpoint = origVerify }()
+	verifyRigExternalEndpoint = func(contract.ConfigState, string, string) error { return nil }
+
+	var stdout, stderr bytes.Buffer
+	code := doRigSetEndpoint(fsys.OSFS{}, cityDir, "frontend", rigEndpointOptions{
+		Self:  true,
+		Port:  "28232",
+		Force: true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigSetEndpoint(Self+Force, managed_city) = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "WARN") {
+		t.Errorf("want WARN in stderr, got:\n%s", stderr.String())
+	}
+
+	state := readRigEndpointConfigState(t, rigDir)
+	if state.EndpointOrigin != contract.EndpointOriginExplicit {
+		t.Fatalf("EndpointOrigin = %q, want %q", state.EndpointOrigin, contract.EndpointOriginExplicit)
+	}
+	if state.DoltHost != "127.0.0.1" {
+		t.Fatalf("DoltHost = %q, want 127.0.0.1", state.DoltHost)
+	}
+	if state.DoltPort != "28232" {
+		t.Fatalf("DoltPort = %q, want 28232", state.DoltPort)
+	}
+}
+
 func TestDoRigSetEndpointInheritWritesManagedInheritedRigConfig(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 

--- a/cmd/gc/dolt_runtime_publication.go
+++ b/cmd/gc/dolt_runtime_publication.go
@@ -97,7 +97,7 @@ func syncManagedDoltPortMirrors(cityPath string) error {
 		return nil
 	}
 	emitLoadCityConfigWarnings(io.Discard, prov)
-	return syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs)
+	return syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs, io.Discard)
 }
 
 func publishManagedDoltRuntimeState(cityPath string) error {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,7 @@ gc [flags]
 | [gc beads](#gc-beads) | Manage the beads provider |
 | [gc build-image](#gc-build-image) | Build a prebaked agent container image |
 | [gc cities](#gc-cities) | List registered cities |
+| [gc completion](#gc-completion) | Generate the autocompletion script for the specified shell |
 | [gc config](#gc-config) | Inspect and validate city configuration |
 | [gc converge](#gc-converge) | Manage convergence loops (bounded iterative refinement) |
 | [gc convoy](#gc-convoy) | Manage convoys — graphs of related work |
@@ -52,6 +53,7 @@ gc [flags]
 | [gc runtime](#gc-runtime) | Process-intrinsic runtime operations |
 | [gc service](#gc-service) | Inspect workspace services |
 | [gc session](#gc-session) | Manage interactive chat sessions |
+| [gc shell](#gc-shell) | Manage the Gas City shell integration hook |
 | [gc skill](#gc-skill) | List visible skills |
 | [gc sling](#gc-sling) | Route work to a session config or agent |
 | [gc start](#gc-start) | Start the city under the machine-wide supervisor |
@@ -303,6 +305,127 @@ List registered cities
 ```
 gc cities list
 ```
+
+## gc completion
+
+Generate the autocompletion script for gc for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+```
+gc completion
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc completion bash](#gc-completion-bash) | Generate the autocompletion script for bash |
+| [gc completion fish](#gc-completion-fish) | Generate the autocompletion script for fish |
+| [gc completion powershell](#gc-completion-powershell) | Generate the autocompletion script for powershell |
+| [gc completion zsh](#gc-completion-zsh) | Generate the autocompletion script for zsh |
+
+## gc completion bash
+
+Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+	source &lt;(gc completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	gc completion bash &gt; /etc/bash_completion.d/gc
+
+#### macOS:
+
+	gc completion bash &gt; $(brew --prefix)/etc/bash_completion.d/gc
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion bash
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion fish
+
+Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+	gc completion fish | source
+
+To load completions for every new session, execute once:
+
+	gc completion fish &gt; ~/.config/fish/completions/gc.fish
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion fish [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion powershell
+
+Generate the autocompletion script for powershell.
+
+To load completions in your current shell session:
+
+	gc completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+```
+gc completion powershell [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
+
+## gc completion zsh
+
+Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+	echo "autoload -U compinit; compinit" &gt;&gt; ~/.zshrc
+
+To load completions in your current shell session:
+
+	source &lt;(gc completion zsh)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+	gc completion zsh &gt; "$&#123;fpath[1]&#125;/_gc"
+
+#### macOS:
+
+	gc completion zsh &gt; $(brew --prefix)/share/zsh/site-functions/_gc
+
+You will need to start a new shell for this setup to take effect.
+
+```
+gc completion zsh [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--no-descriptions` | bool |  | disable completion descriptions |
 
 ## gc config
 
@@ -1754,6 +1877,10 @@ Set the canonical endpoint ownership for a rig.
 
 Use --inherit to make a rig derive its endpoint from the current city
 topology. Use --external to pin the rig to its own external Dolt endpoint.
+Use --self to mark the rig as running its own local Dolt server on
+127.0.0.1 at the given --port; while the city is in managed_city mode the
+command requires --force because the rig's .beads/dolt-server.port mirror
+will no longer track the managed city Dolt.
 
 This command owns the rig's canonical .beads/config.yaml topology state.
 
@@ -1767,6 +1894,7 @@ gc rig set-endpoint <rig> [flags]
 gc rig set-endpoint frontend --inherit
   gc rig set-endpoint frontend --external --host db.example.com --port 3307
   gc rig set-endpoint frontend --external --host db.example.com --port 3307 --user agent --adopt-unverified
+  gc rig set-endpoint frontend --self --port 28232 --force
   gc rig set-endpoint frontend --inherit --dry-run
 ```
 
@@ -1775,9 +1903,11 @@ gc rig set-endpoint frontend --inherit
 | `--adopt-unverified` | bool |  | record the endpoint without live validation |
 | `--dry-run` | bool |  | show the canonical changes without writing files |
 | `--external` | bool |  | set an explicit external endpoint for the rig |
+| `--force` | bool |  | acknowledge conflicting managed-city state when using --self |
 | `--host` | string |  | external Dolt host |
 | `--inherit` | bool |  | inherit the city endpoint |
-| `--port` | string |  | external Dolt port |
+| `--port` | string |  | external Dolt port (required with --external or --self) |
+| `--self` | bool |  | mark the rig as running its own local Dolt on 127.0.0.1 |
 | `--user` | string |  | external Dolt user |
 
 ## gc rig status
@@ -2247,6 +2377,51 @@ gc session wake <session-id-or-alias>
 ```
 gc session wake gc-42
   gc session wake mayor
+```
+
+## gc shell
+
+The shell integration adds a completion hook to your shell RC file that
+provides tab-completion for gc commands and flags.
+
+Subcommands: install, remove, status.
+
+```
+gc shell
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc shell install](#gc-shell-install) | Install or update shell integration |
+| [gc shell remove](#gc-shell-remove) | Remove shell integration |
+| [gc shell status](#gc-shell-status) | Show shell integration status |
+
+## gc shell install
+
+Install or update the gc shell completion hook.
+
+If no shell is specified, the shell is detected from $SHELL.
+The completion script is written to ~/.gc/completions/ and a source line
+is added to your shell RC file.
+
+```
+gc shell install [bash|zsh|fish]
+```
+
+## gc shell remove
+
+Remove the gc shell completion hook from your shell RC file and delete the completion script.
+
+```
+gc shell remove
+```
+
+## gc shell status
+
+Show shell integration status
+
+```
+gc shell status
 ```
 
 ## gc skill

--- a/release-gates/ga-9shf-gate.md
+++ b/release-gates/ga-9shf-gate.md
@@ -1,0 +1,61 @@
+# Release Gate — ga-9shf (gc port-drift detection)
+
+**Bead:** ga-9shf — Fix: gc should detect/warn on bd-vs-gc port drift in managed-city mode
+**Review bead:** ga-3hgw
+**Branch:** `release/ga-9shf`
+**Commit on branch:** a1e4b49a (cherry-pick of 85957381 onto `origin/main`)
+**Evaluator:** gascity/deployer-1 on 2026-04-23
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | ga-3hgw notes: `review_verdict: pass` from gascity/reviewer-1, single-pass (gemini second-pass disabled). |
+| 2 | Acceptance criteria met | PASS | See matrix below. |
+| 3 | Tests pass | PASS (w/ caveats) | Targeted ga-9shf tests all PASS on `release/ga-9shf`. Two pre-existing failures (`TestSyncConfiguredDoltPortFilesSkipsNonBDProviders`, `TestDoRigSetEndpointRejectsNonBDProvider`) are confirmed to fail on `origin/main` at `adaa6f47` as well, so they are not regressions from this change. |
+| 4 | No high-severity review findings open | PASS | All three findings in ga-3hgw are `severity: info` (ux-message polish, doc-consistency, PID-recycle race — reviewer marked not blocking). |
+| 5 | Final branch is clean | PASS | `git status` clean (no tracked modifications). One untracked `.gitkeep` is not part of the release; not staged. |
+| 6 | Branch diverges cleanly from main | PASS | `git log origin/main..HEAD` = one commit, no merge conflicts with `origin/main`. |
+
+## Acceptance criteria matrix (ga-9shf done-when)
+
+| Criterion | Met | Evidence |
+|-----------|-----|----------|
+| `gc doctor` drift detector covers three drift patterns and exits non-zero | YES | `cmd/gc/cmd_doctor_drift.go` registers `dolt-drift` check; covers Case A (live rig-local Dolt under inherited_city → Error), Case B (port-file mismatch → Error, names both ports), Case C (stale sql-server.info → Warning). Tests: `TestDoltDriftCheck*` all pass. |
+| `gc start` logs WARN for each rig whose port file it rewrote | YES | `writeDoltPortFile` now accepts a warn writer; `startBeadsLifecycle → normalizeCanonicalBdScopeFiles → syncConfiguredDoltPortFiles` threads stderr through. Silent callers pass `io.Discard`. Test: `TestSyncConfiguredDoltPortFilesWarnsOnRigPortFileRewrite` passes. |
+| `gc rig set-endpoint --self` under managed_city requires `--force` | YES | `cmd/gc/cmd_rig_endpoint.go` adds `--self/--port/--force` flags; validation rejects `--self+host/user`, requires `--port`, rejects `--force` outside `--self`. Managed-city guard emits one-line WARN on success. Tests: `TestValidateRigEndpointOptionsSelf*`, `TestDoRigSetEndpointSelf*` pass. |
+| Integration tests exist for detector and start-time warning | YES | `cmd/gc/cmd_doctor_drift_test.go`, `cmd/gc/beads_provider_lifecycle_test.go` (warn test), `cmd/gc/cmd_rig_endpoint_test.go` (self/force tests). |
+| No behavior change to `syncConfiguredDoltPortFiles` rewrite semantics | YES | Only warn-writer plumbing added; rewrite path untouched (reviewer confirmed by tests on unmodified defense checks). |
+
+## Test evidence
+
+```
+$ go test ./cmd/gc -run "TestDoltDriftCheck|TestRigLocalDoltPIDFromSQLServerInfo|TestSyncConfiguredDoltPortFiles|TestValidateRigEndpointOptions|TestDoRigSetEndpoint" -count=1
+... 2 FAILURES: TestSyncConfiguredDoltPortFilesSkipsNonBDProviders, TestDoRigSetEndpointRejectsNonBDProvider
+```
+
+Baseline check at `origin/main` (adaa6f47):
+
+```
+$ git checkout origin/main
+$ go test ./cmd/gc -run "TestSyncConfiguredDoltPortFilesSkipsNonBDProviders|TestDoRigSetEndpointRejectsNonBDProvider" -count=1
+... same 2 FAILURES
+```
+
+Both failures are pre-existing on main and not introduced by a1e4b49a. Reviewer flagged them in ga-3hgw `pre_existing_failures`. A separate bead should track them.
+
+```
+$ go vet ./cmd/gc/...
+(clean)
+
+$ go build ./...
+(clean)
+```
+
+## Security review
+
+From ga-3hgw, OWASP Top 10 walkthrough: no new attack surface. Port parsed via `strconv.Atoi` with `>0` guard. `--force` is an operator-mistake guard, not a security boundary. The change reduces misconfig risk by making silent port-file rewrites visible. No blocking findings.
+
+## Verdict: PASS
+
+Cleared for PR.

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -35,7 +35,7 @@ var docTreeDirs = []string{"contrib", "docs", "engdocs", "specs"}
 // docTreeIgnored lists directories that contain markdown but are not
 // documentation trees (e.g., embedded prompt templates, test fixtures,
 // gitignored scratch space for local work).
-var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "scripts", "test", "tmp"}
+var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "release-gates", "scripts", "test", "tmp"}
 
 // knownBrokenLinks lists links to docs that do not exist yet. These are
 // excluded from TestLocalMarkdownLinks failures but still logged. Remove


### PR DESCRIPTION
## What this changes

Three user-facing protections against a silent-drift class where a rig ends up running its own Dolt on a different port than the managed-city Dolt while still marked `inherited_city`. Previously the next `gc start` would overwrite the rig's `.beads/dolt-server.port` back to the managed-city port without stopping the rig-local Dolt — leaving two live Dolts and slung beads split across databases. The shape that caused hours of mayor confusion before anyone realized what had happened.

### 1. `gc doctor` drift check (new `dolt-drift` check)

Registered only when the workspace is in bd-backed managed-city topology. Detects three cases, each with a named fix hint:

- **Case A (Error):** rig has `gc.endpoint_origin: inherited_city` but a live Dolt PID in `.dolt/sql-server.info`.
- **Case B (Error):** rig's `.beads/dolt-server.port` disagrees with the managed-city port from `.gc/runtime/packs/dolt/dolt-state.json` while still `inherited_city`. Message names both ports.
- **Case C (Warning):** stale `.dolt/sql-server.info` (PID not alive) under an inherited rig.

### 2. Start-time WARN on port-file rewrite

`syncConfiguredDoltPortFiles` used to rewrite `.beads/dolt-server.port` silently. Now every rewrite emits one WARN line naming the rig and both ports. `startBeadsLifecycle` threads stderr through `normalizeCanonicalBdScopeFiles` → `syncConfiguredDoltPortFiles` → `writeDoltPortFile`. Silent callers (runtime publication, rig add) pass `io.Discard`, so the noise only surfaces where the user ran the command.

### 3. `gc rig set-endpoint --self --port <p>` requires `--force` under managed_city

New mode that marks a rig as running its own 127.0.0.1:port Dolt. While the city is in `managed_city` mode, the command refuses without `--force`, and with `--force` it emits a one-line WARN explaining the rig now falls outside `gc start`'s supervision. Option validation rejects `--self`+`--host`/`--user`, requires `--port`, and rejects `--force` outside `--self`.

## Review notes

- No behavior change to `syncConfiguredDoltPortFiles` rewrite semantics — only warn-writer plumbing added. The managed-city architecture contract from `engdocs/design/beads-dolt-contract-redesign.md` is preserved.
- `--force` is an operator-mistake guard, not a security boundary. Operators still need to understand the rig will be re-inherited on next `gc start` unless they flip `gc.endpoint_origin` off `inherited_city` explicitly.
- `bd dolt show` still prints a misleading port-resolution priority (separate beads-rig bug, GH#2372) — not addressed here.
- Two pre-existing test failures remain: `TestSyncConfiguredDoltPortFilesSkipsNonBDProviders` and `TestDoRigSetEndpointRejectsNonBDProvider`. Confirmed they fail on `origin/main` HEAD as well, so they are not regressions — worth a follow-up bead for the test maintainers.

## Test plan

- [x] `go test ./cmd/gc -run "TestDoltDriftCheck|TestRigLocalDoltPIDFromSQLServerInfo|TestSyncConfiguredDoltPortFilesWarnsOnRigPortFileRewrite|TestSyncConfiguredDoltPortFilesSilentOnNoChange|TestValidateRigEndpointOptionsSelf|TestDoRigSetEndpointSelf" -count=1` — all PASS
- [x] `go vet ./cmd/gc/...` clean
- [x] `go build ./...` clean
- [x] Pre-existing failures checked against `origin/main` baseline — not regressions
- [x] Release gate: [`release-gates/ga-9shf-gate.md`](release-gates/ga-9shf-gate.md)

🤖 Deployed by actual-factory