### PR TITLE
docs: managed-city endpoint runbook for mayors/operators

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -343,6 +343,21 @@ make build
 See [CONTRIBUTING.md](https://github.com/gastownhall/gascity/blob/main/CONTRIBUTING.md)
 for the full contributor setup.
 
+## Slung Beads Not Reaching Agents (managed-city mode)
+
+If `gc sling` accepts work but agents don't process it — especially if
+your supervisor log shows `rigStores=0` or `assignedWorkBeads=0`, or
+your `bd dolt set port` edits keep reverting at the next `gc start` —
+you're likely looking at a rig whose Dolt view has drifted from the
+managed city Dolt. Do **not** edit `.beads/dolt-server.port` or
+`bd dolt set port` directly; both self-revert.
+
+See the
+[Managed-city Dolt endpoints runbook](../runbooks/managed-city-endpoints.md)
+for the mental model, the forbidden edits, the sanctioned escape
+hatches (`gc rig set-endpoint --inherit`/`--self --force`/`--external`),
+and an end-to-end recovery recipe.
+
 ## Still Stuck?
 
 Open an issue at

--- a/docs/runbooks/managed-city-endpoints.md
+++ b/docs/runbooks/managed-city-endpoints.md
@@ -1,0 +1,276 @@
+---
+title: Runbook — Managed-city Dolt endpoints
+description: Mental model, forbidden edits, sanctioned escape hatches, and recovery recipe for the city-level Dolt endpoint architecture.
+---
+
+# Runbook: Managed-city Dolt endpoints
+
+This runbook is for mayors and operators. It covers the endpoint
+architecture introduced in the
+[beads-and-Dolt contract redesign](../../engdocs/design/beads-dolt-contract-redesign.md)
+— specifically the case where rigs **inherit** their Dolt endpoint
+from a single city-managed server. If you came here because `gc sling`
+is dropping work, `supervisor.log` shows `rigStores=0`, or your port
+edits keep reverting, you are in the right place.
+
+> **Rules of thumb** — skip to [What NOT to do](#what-not-to-do) if
+> you are mid-incident. Come back for the mental model after.
+
+## Mental model
+
+A city runs **one** Dolt SQL server. Every rig is a **logical
+database** inside that Dolt. Each rig's `.beads/dolt-server.port` is
+a **compatibility mirror** that lets raw `bd` commands reach the
+city Dolt — it is not the rig's own server.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ city/.gc/runtime/packs/dolt/dolt-state.json                      │
+│   └─ managed Dolt SQL server @ 127.0.0.1:<P>  (one per city)     │
+│        ├─ database "hq"                       (city HQ scope)    │
+│        ├─ database "<rigA-prefix>"            (rig A logical DB) │
+│        ├─ database "<rigB-prefix>"            (rig B logical DB) │
+│        └─ database "<rigC-prefix>"            (rig C logical DB) │
+└──────────────────────────────────────────────────────────────────┘
+
+Per-rig state:
+  <rig>/.beads/config.yaml   — canonical endpoint marker
+  <rig>/.beads/dolt-server.port  — compatibility mirror of port P
+```
+
+### Endpoint origins
+
+Two TOML fields, one per scope, describe endpoint ownership:
+
+| Scope | Field | Values |
+|-------|-------|--------|
+| City | `gc.endpoint_origin` | `managed_city`, `city_canonical` |
+| Rig  | `gc.endpoint_origin` | `inherited_city`, `explicit` |
+
+- **`managed_city`** — The city owns the Dolt lifecycle. `gc start`
+  launches it; `gc stop` shuts it down. This is the default for
+  fresh `bd`-backed cities.
+- **`city_canonical`** — The city declares an explicit, externally
+  managed Dolt. GC does not launch or manage the server.
+- **`inherited_city`** — The rig reuses its parent city's endpoint.
+  No rig-local Dolt. This is the default for rigs added to a
+  `managed_city` city.
+- **`explicit`** — The rig pins its own external endpoint. Use for
+  cross-city rigs or rigs pointing at a shared Dolt cluster.
+
+## What NOT to do
+
+These are the edits mayors try first, all of which self-revert at
+the next `gc start` and waste an afternoon.
+
+### Do not run `bd dolt set port <N>` inside an inherited rig
+
+If `gc.endpoint_origin: inherited_city`, the rig's canonical port
+is whatever the city's managed Dolt is listening on. `bd` will
+accept the `set port` command and update `.beads/config.yaml`, but
+on the next `gc start` the city's normalization pass
+(`syncConfiguredDoltPortFiles`) restores the managed port and
+rewrites `.beads/dolt-server.port` back. Your change disappears.
+
+### Do not hand-edit `.beads/dolt-server.port`
+
+Same reason. The file is a **compatibility mirror** for raw `bd`
+commands — it reflects the city-managed port, not an authoritative
+choice. `gc start` atomically rewrites it to match the managed
+port on each startup.
+
+### Do not delete the `gc.endpoint_origin: inherited_city` line
+
+Deleting the line does not switch the rig to `explicit`. It puts
+the rig into an unverified state. `gc start`'s verification pass
+will re-derive the origin from topology and write the line back.
+
+### Do not run `bd dolt start` inside an inherited rig
+
+Any Dolt server you start this way is orphaned. GC does not track
+it, will not shut it down on `gc stop`, and will not publish its
+port to dependent sessions. If the rig's `.beads/dolt-server.port`
+points at this orphan server, the drift check will flag it on next
+`gc doctor` run (see [Drift symptoms](#drift-symptoms) below).
+
+## Sanctioned escape hatches
+
+When you genuinely need to change a rig's endpoint, use `gc rig
+set-endpoint` — it is the single owning operation for endpoint
+topology, and it refuses footgun configurations up front.
+
+### Make this rig run its own Dolt
+
+```bash
+gc rig set-endpoint <rig> --self --port <P> --force
+```
+
+`--self` marks the rig as running its own `127.0.0.1:<P>` Dolt.
+While the city is in `managed_city` mode the command refuses
+unless `--force` is given, and emits a one-line WARN explaining
+the rig now falls outside `gc start`'s supervision. The rig's
+origin flips to `explicit`; its port file will no longer track
+the managed city Dolt.
+
+### Rejoin the city
+
+```bash
+gc rig set-endpoint <rig> --inherit
+```
+
+Flips the rig back to `inherited_city`. The next `gc start` will
+re-publish the managed city port into `.beads/dolt-server.port`
+and the rig's sessions will talk to the city Dolt again.
+
+### Point at an external Dolt
+
+```bash
+gc rig set-endpoint <rig> --external --host <H> --port <P> --user <U>
+```
+
+Pins `explicit` origin to `<H>:<P>`. Use this for cross-city rigs
+or rigs pointing at a shared/external Dolt cluster. Add
+`--adopt-unverified` if you need to record the endpoint before the
+target is reachable.
+
+### Inspect current state
+
+```bash
+bd dolt show        # bd's view (note: priority-display is under review)
+gc doctor           # run the `dolt-drift` check + other health checks
+```
+
+`gc doctor` is authoritative for GC-side state: it reports the
+managed city port, each rig's resolved endpoint origin, and any
+drift it detects between the two. The `dolt-drift` check only
+registers when the workspace is in `bd`-backed `managed_city`
+topology — if you do not see it, your workspace is not in that
+mode.
+
+## `.beads/dolt-server.port` priority explainer
+
+When raw `bd` commands resolve a port, they consult sources in
+this order (first hit wins):
+
+1. `$BEADS_DOLT_SERVER_PORT` environment variable
+2. `.beads/dolt-server.port` file (the compatibility mirror)
+3. `.beads/config.yaml` `dolt.port` key (or the global beads
+   config equivalent)
+4. `.beads/metadata.json` historical record
+
+GC runtime publishes the managed port into `$BEADS_DOLT_SERVER_PORT`
+for sessions it launches, which is why sessions keep working even
+when the on-disk mirror is transiently out of date. For raw
+interactive `bd` invocations the mirror file is what matters, which
+is why GC aggressively rewrites it during normalization.
+
+The authoritative source for this order is `DefaultConfig` in
+[`beads/internal/doltserver/doltserver.go`](https://github.com/gastownhall/beads/blob/main/internal/doltserver/doltserver.go).
+`bd dolt show` advertises a slightly different order in its output
+text; that is a known cosmetic bug tracked separately in the beads
+repo and does not affect actual resolution.
+
+## Drift symptoms
+
+The `dolt-drift` check (`cmd/gc/cmd_doctor_drift.go`) is registered
+automatically when the workspace is in `bd`-backed `managed_city`
+topology and catches three shapes of drift:
+
+| Shape | Severity | Trigger |
+|-------|----------|---------|
+| Live rig-local Dolt under `inherited_city` | Error | Rig's `.dolt/sql-server.info` lists a PID that is alive, but its canonical origin is still `inherited_city`. |
+| Port mismatch under `inherited_city` | Error | Rig's `.beads/dolt-server.port` disagrees with the managed city port from `.gc/runtime/packs/dolt/dolt-state.json`. |
+| Stale `.dolt/sql-server.info` | Warning | Info file exists under an inherited rig but its PID is no longer alive. |
+
+All three carry `FixHint` text pointing at the specific
+`gc rig set-endpoint` invocation that resolves them.
+
+At `gc start`, the Dolt-port normalization pass also emits a WARN
+line on stderr for each rig whose `.beads/dolt-server.port` it is
+rewriting back to the managed port — that is your early warning
+that a prior edit or orphan server made the mirror drift.
+
+## Recovery recipe — slung beads not reaching agents
+
+If you see `gc sling` accepting work but agents not processing it,
+and the supervisor log reports `rigStores=0` or
+`assignedWorkBeads=0`, that is almost always a symptom of the rig's
+Dolt view diverging from the city's. Work the following sequence:
+
+1. **Stop the city:**
+
+   ```bash
+   gc stop
+   ```
+
+2. **Kill any live rig-local Dolt servers**, rig by rig. For each
+   rig, check `.dolt/sql-server.info` for a PID and verify it:
+
+   ```bash
+   cd <rig>
+   if [ -f .dolt/sql-server.info ]; then
+     pid=$(awk -F= '/^pid=/{print $2}' .dolt/sql-server.info)
+     if kill -0 "$pid" 2>/dev/null; then
+       echo "killing rig-local dolt pid $pid in $(pwd)"
+       kill "$pid"
+     fi
+   fi
+   ```
+
+3. **Confirm the rig's canonical state is `inherited_city` and
+   verified:** each rig's `.beads/config.yaml` should contain:
+
+   ```yaml
+   gc:
+     endpoint_origin: inherited_city
+     endpoint_status: verified
+   ```
+
+   If any rig says something else and you want it to rejoin, run
+   `gc rig set-endpoint <rig> --inherit`.
+
+4. **Delete the compatibility mirror in each rig**, so it is
+   regenerated fresh on next start:
+
+   ```bash
+   rm -f <rig>/.beads/dolt-server.port
+   ```
+
+5. **Start the city:**
+
+   ```bash
+   gc start
+   ```
+
+6. **Verify only one Dolt is running on the managed port**:
+
+   ```bash
+   bd dolt show   # should name the managed city port
+   lsof -iTCP:<managed-port> -sTCP:LISTEN
+   ```
+
+7. **Test a sling end-to-end** and watch the supervisor log for
+   `assignedWorkBeads > 0`:
+
+   ```bash
+   gc sling <template> <test-bead-id>
+   tail -f ~/.gc/supervisor.log
+   ```
+
+If the symptom persists after step 7, the cause is likely not
+endpoint drift. Open an investigator bead referencing this
+runbook and attaching the full `gc doctor --verbose` output plus
+the `supervisor.log` slice covering the last sling attempt.
+
+## References
+
+- Design: [Beads-and-Dolt contract redesign](../../engdocs/design/beads-dolt-contract-redesign.md)
+  — the authoritative architecture document.
+- Code: [`cmd/gc/cmd_doctor_drift.go`](https://github.com/gastownhall/gascity/blob/main/cmd/gc/cmd_doctor_drift.go)
+  — drift detector.
+- Code: [`cmd/gc/cmd_rig_endpoint.go`](https://github.com/gastownhall/gascity/blob/main/cmd/gc/cmd_rig_endpoint.go)
+  — `gc rig set-endpoint` implementation.
+- Code: [`cmd/gc/beads_provider_lifecycle.go`](https://github.com/gastownhall/gascity/blob/main/cmd/gc/beads_provider_lifecycle.go)
+  — `syncConfiguredDoltPortFiles` normalization.
+- Upstream: [`beads/internal/doltserver/doltserver.go`](https://github.com/gastownhall/beads/blob/main/internal/doltserver/doltserver.go)
+  `DefaultConfig` — source of truth for port-resolution priority.


### PR DESCRIPTION
## What this changes

Adds an operator-facing runbook for the managed-city endpoint topology. The runbook answers the question a mayor had to reconstruct by hand last week: **what are the sanctioned ways to move a rig between `inherited_city`, self-hosted, and external endpoints, and how do I recognize drift before `gc start` rewrites my port file silently?**

Pure markdown — no code changes.

New file: `docs/runbooks/managed-city-endpoints.md`. Covers the six sections mayors need:

1. One-sentence mental model of the managed-city topology.
2. Layout diagram: one managed Dolt → logical DBs per rig → per-rig `.beads/config.yaml` markers, with a table of `gc.endpoint_origin` values.
3. What NOT to do — four specific footguns (`bd dolt set port` in an inherited rig, hand-editing `.beads/dolt-server.port`, removing `gc.endpoint_origin`, `bd dolt start` inside an inherited rig).
4. Sanctioned escape hatches with exact commands: `gc rig set-endpoint --inherit`, `--external`, and the new `--self --force` that ga-9shf just added.
5. Port-file resolution priority explainer (env → `.beads/dolt-server.port` → `config.yaml` → `metadata.json`) pointing at upstream `beads/internal/doltserver/doltserver.go` `DefaultConfig` as the source of truth rather than reasserting the order here.
6. Drift-symptoms table aligned 1:1 with the three cases in `cmd/gc/cmd_doctor_drift.go` (live rig-local Dolt under inherited_city, port-file mismatch, stale `sql-server.info`) plus the recovery recipe for the symptom shape the last mayor hit.

Updated: `docs/getting-started/troubleshooting.md` gains a "Slung Beads Not Reaching Agents" section cross-linking to the runbook. `troubleshooting.md` is in `docs.json` navigation under "Start Here", so the runbook is reachable from the top-level docs site.

## Review notes

- CLI syntax matches current `cmd/gc/cmd_rig_endpoint.go` — `--self`/`--force`/`--port` flags from ga-9shf (landed as #1156). Runbook will be accurate the moment that PR merges.
- Drift-symptoms table rows map exactly to `cmd_doctor_drift.go:76-82, 90-103, 83-89` (the three branches).
- Defers port-resolution priority to upstream DefaultConfig rather than reasserting — the known cosmetic `bd dolt show` divergence (GH#2372) is called out honestly.
- Framed for operators, not contributors. No architecture re-documentation — defers to `engdocs/design/beads-dolt-contract-redesign.md`.

## Test plan

- [x] `go build ./...` clean (sanity)
- [x] `go vet ./cmd/gc/...` clean (sanity)
- [x] Cross-links verified: `../../engdocs/design/beads-dolt-contract-redesign.md`, `../runbooks/...`
- [x] Release gate: [`release-gates/ga-qqfg-gate.md`](release-gates/ga-qqfg-gate.md)

🤖 Deployed by actual-factory