### PR TITLE
fix: improve formula runtime var validation UX

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -111,9 +111,14 @@ Examples:
 			if err != nil {
 				return err
 			}
-			recipe, err := formula.Compile(cmd.Context(), name, searchPaths, compileVars)
+			recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), name, searchPaths, compileVars)
 			if err != nil {
 				return err
+			}
+			if len(vars) > 0 {
+				if err := formula.ValidateProvidedVarDefs(recipe.Vars, vars); err != nil {
+					return err
+				}
 			}
 
 			// Apply var substitution for display only when --var flags were provided.
@@ -274,7 +279,7 @@ bead into a sub-workflow at runtime.`,
 			cookVars := parseFormulaVars(vars)
 
 			if attach != "" {
-				recipe, err := formula.Compile(cmd.Context(), args[0], scope.searchPaths, cookVars)
+				recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
 				if err != nil {
 					return fmt.Errorf("compile: %w", err)
 				}

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -141,20 +141,48 @@ Examples:
 				_, _ = fmt.Fprintln(stdout, "Root only: true")
 			}
 			if len(recipe.Vars) > 0 {
-				_, _ = fmt.Fprintln(stdout, "\nVariables:")
-				for vname, def := range recipe.Vars {
-					var attrs []string
-					if def.Required {
-						attrs = append(attrs, "required")
+				names := make([]string, 0, len(recipe.Vars))
+				for name := range recipe.Vars {
+					names = append(names, name)
+				}
+				slices.Sort(names)
+
+				requiredNames := make([]string, 0, len(names))
+				optionalNames := make([]string, 0, len(names))
+				for _, name := range names {
+					def := recipe.Vars[name]
+					if def != nil && def.Required {
+						requiredNames = append(requiredNames, name)
+						continue
 					}
-					if def.Default != nil {
-						attrs = append(attrs, "default="+*def.Default)
+					optionalNames = append(optionalNames, name)
+				}
+
+				if len(requiredNames) > 0 {
+					_, _ = fmt.Fprintln(stdout, "\nRequired vars:")
+					for _, name := range requiredNames {
+						def := recipe.Vars[name]
+						_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s\n", name, def.Description)
 					}
-					attrStr := ""
-					if len(attrs) > 0 {
-						attrStr = " (" + strings.Join(attrs, ", ") + ")"
+				}
+				if len(optionalNames) > 0 {
+					header := "\nVariables:"
+					if len(requiredNames) > 0 {
+						header = "\nOptional vars:"
 					}
-					_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s%s\n", vname, def.Description, attrStr)
+					_, _ = fmt.Fprintln(stdout, header)
+					for _, name := range optionalNames {
+						def := recipe.Vars[name]
+						var attrs []string
+						if def != nil && def.Default != nil {
+							attrs = append(attrs, "default="+*def.Default)
+						}
+						attrStr := ""
+						if len(attrs) > 0 {
+							attrStr = " (" + strings.Join(attrs, ", ") + ")"
+						}
+						_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s%s\n", name, def.Description, attrStr)
+					}
 				}
 			}
 

--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -137,6 +137,52 @@ title = "[{{epic}}] Implement: {{feature}}"
 	}
 }
 
+func TestFormulaShowHighlightsRequiredVars(t *testing.T) {
+	cityDir := writeTutorialFormulaCity(t, "required-vars", `
+formula = "required-vars"
+description = "Formula with required vars"
+
+[vars.epic]
+description = "Epic ticket ID"
+required = true
+
+[vars.feature]
+description = "Feature slug"
+required = true
+
+[vars.branch]
+description = "Target branch"
+default = "main"
+
+[[steps]]
+id = "implement"
+title = "[{{epic}}] Implement: {{feature}}"
+`)
+
+	t.Chdir(cityDir)
+
+	var stdout bytes.Buffer
+	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
+	cmd.SetArgs([]string{"required-vars"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula show should succeed without --var flags on required-var formulas: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Required vars:") {
+		t.Fatalf("formula show should surface a Required vars section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "{{epic}}: Epic ticket ID") || !strings.Contains(out, "{{feature}}: Feature slug") {
+		t.Fatalf("formula show should list each required var in the dedicated section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Optional vars:") {
+		t.Fatalf("formula show should keep optional vars distinct from required vars, got:\n%s", out)
+	}
+	if !strings.Contains(out, "{{branch}}: Target branch (default=main)") {
+		t.Fatalf("formula show should preserve optional var details, got:\n%s", out)
+	}
+}
+
 func writeTutorialFormulaCity(t *testing.T, formulaName, formulaBody string) string {
 	t.Helper()
 

--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -183,6 +183,76 @@ title = "[{{epic}}] Implement: {{feature}}"
 	}
 }
 
+func TestFormulaShowWithPartialVarsStillShowsRequiredVars(t *testing.T) {
+	cityDir := writeTutorialFormulaCity(t, "required-vars", `
+formula = "required-vars"
+description = "Formula with required vars"
+
+[vars.epic]
+description = "Epic ticket ID"
+required = true
+
+[vars.feature]
+description = "Feature slug"
+required = true
+
+[[steps]]
+id = "implement"
+title = "[{{epic}}] Implement: {{feature}}"
+`)
+
+	t.Chdir(cityDir)
+
+	var stdout bytes.Buffer
+	cmd := newFormulaShowCmd(&stdout, &bytes.Buffer{})
+	cmd.SetArgs([]string{"required-vars", "--var", "epic=CLOUD-99999"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("formula show should succeed with partial --var flags: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "[CLOUD-99999] Implement: {{feature}}") {
+		t.Fatalf("formula show should substitute provided vars and leave missing placeholders intact, got:\n%s", out)
+	}
+	if !strings.Contains(out, "{{feature}}: Feature slug") {
+		t.Fatalf("formula show should still list missing required vars, got:\n%s", out)
+	}
+}
+
+func TestFormulaShowValidatesProvidedVarsWithoutRequiringMissingVars(t *testing.T) {
+	cityDir := writeTutorialFormulaCity(t, "enum-vars", `
+formula = "enum-vars"
+description = "Formula with enum var"
+
+[vars.epic]
+description = "Epic ticket ID"
+required = true
+
+[vars.env]
+description = "Environment"
+enum = ["dev", "prod"]
+
+[[steps]]
+id = "implement"
+title = "[{{epic}}] Deploy {{env}}"
+`)
+
+	t.Chdir(cityDir)
+
+	cmd := newFormulaShowCmd(&bytes.Buffer{}, &bytes.Buffer{})
+	cmd.SetArgs([]string{"enum-vars", "--var", "env=staging"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("formula show should reject invalid provided vars")
+	}
+	if !strings.Contains(err.Error(), `variable "env": value "staging" not in allowed values`) {
+		t.Fatalf("error = %v, want invalid env", err)
+	}
+	if strings.Contains(err.Error(), `variable "epic" is required`) {
+		t.Fatalf("formula show should not require missing runtime vars while validating provided vars: %v", err)
+	}
+}
+
 func writeTutorialFormulaCity(t *testing.T, formulaName, formulaBody string) string {
 	t.Helper()
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -476,7 +476,7 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 	if a.FormulaLayer != "" {
 		searchPaths = []string{a.FormulaLayer}
 	}
-	recipe, err := formula.Compile(context.Background(), a.Formula, searchPaths, nil)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), a.Formula, searchPaths, nil)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -481,6 +481,10 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{}); err != nil {
+		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	if a.Pool != "" && cfg != nil {
 		pool := qualifyPool(a.Pool, a.Rig)

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -719,6 +719,56 @@ func TestOrderRunNoPool(t *testing.T) {
 	}
 }
 
+func TestOrderRunReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	dir := t.TempDir()
+	formulaBody := `
+formula = "order-required-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{target_id}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "order-required-vars.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:         "digest",
+		Formula:      "order-required-vars",
+		Trigger:      "cooldown",
+		Interval:     "24h",
+		FormulaLayer: dir,
+	}}
+
+	store := beads.NewMemStore()
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", "/city", store, nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderRun = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "target_id" is required`) {
+		t.Fatalf("stderr = %q, want missing target_id reported", errText)
+	}
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "bead title contains unresolved variable(s)") {
+		t.Fatalf("stderr = %q, want consolidated required-var validation instead of title-only failure", errText)
+	}
+}
+
 func TestOrderRunGraphWorkflowDecoratesStepRouting(t *testing.T) {
 	cityDir := t.TempDir()
 	formulaDir := t.TempDir()

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2445,6 +2445,102 @@ func TestOnFormulaCookMissingFormula(t *testing.T) {
 	}
 }
 
+func TestFormulaSlingReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "repro-required-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{target_id}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "repro.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "repro")
+	opts.IsFormula = true
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSling returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "target_id" is required`) {
+		t.Fatalf("stderr = %q, want missing target_id reported", errText)
+	}
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "bead title contains unresolved variable(s)") {
+		t.Fatalf("stderr = %q, want consolidated required-var validation instead of title-only failure", errText)
+	}
+}
+
+func TestFormulaSlingReportsRequiredAndResidualTitleVarsWhenSomeVarsProvided(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "repro-mixed-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{title}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "repro-mixed-vars.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "repro-mixed-vars")
+	opts.IsFormula = true
+	opts.Vars = []string{"target_id=BL-42"}
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSling returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if !strings.Contains(errText, `step "repro-mixed-vars.do-work": bead title contains unresolved variable(s) title`) {
+		t.Fatalf("stderr = %q, want unresolved title variable reported", errText)
+	}
+}
+
 func TestOnFormulaExistingMoleculeErrors(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2571,6 +2571,53 @@ func TestOnFormulaExistingMoleculeErrors(t *testing.T) {
 	}
 }
 
+func TestOnFormulaMissingRequiredVarsBeforeExistingMolecule(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "agent-one", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "requires-workspace"
+version = 1
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Work in {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "requires-workspace.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["BL-42"] = beads.Bead{ID: "BL-42", Type: "task", Status: "open", Assignee: "other-agent"}
+	q.childrenOf["BL-42"] = []beads.Bead{
+		{ID: "MOL-1", Type: "molecule", Status: "open"},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "requires-workspace"
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSling returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "already has attached molecule") {
+		t.Fatalf("stderr = %q, missing required vars should not be masked by attachment conflict", errText)
+	}
+}
+
 func TestOnFormulaExistingWispErrors(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
@@ -2767,6 +2814,46 @@ func TestOnFormulaOutput(t *testing.T) {
 	}
 }
 
+func TestOnFormulaTitleOverrideBypassesRootTitlePlaceholder(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "agent-one", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "root-title-placeholder"
+version = 1
+
+[vars.title]
+description = "Root title"
+
+[[steps]]
+id = "work"
+title = "Work"
+`
+	if err := os.WriteFile(filepath.Join(dir, "root-title-placeholder.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["BL-42"] = beads.Bead{ID: "BL-42", Type: "task", Status: "open"}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "root-title-placeholder"
+	opts.Title = "Reviewed work"
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "bead title contains unresolved variable") {
+		t.Fatalf("stderr = %q, title override should satisfy root placeholder", stderr.String())
+	}
+}
+
 func TestBatchOnConvoy(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
@@ -2814,6 +2901,100 @@ func TestBatchOnConvoy(t *testing.T) {
 	}
 	if !strings.Contains(out, "Slung 3/3 children") {
 		t.Errorf("stdout = %q, want summary", out)
+	}
+}
+
+func TestBatchOnFormulaRequiredIssueVarsUseChildID(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "agent-one", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "requires-issue"
+version = 1
+
+[vars.issue]
+description = "Source bead ID"
+required = true
+
+[[steps]]
+id = "work"
+title = "Work {{issue}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "requires-issue.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["CVY-1"] = beads.Bead{ID: "CVY-1", Type: "convoy", Status: "open"}
+	q.childrenOf["CVY-1"] = []beads.Bead{
+		{ID: "BL-1", Type: "task", Status: "open"},
+		{ID: "BL-2", Type: "task", Status: "open"},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "CVY-1")
+	opts.OnFormula = "requires-issue"
+	code := doSlingBatch(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSlingBatch returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), `variable "issue" is required`) {
+		t.Fatalf("stderr = %q, batch graph classification should not validate before child vars are available", stderr.String())
+	}
+}
+
+func TestBatchOnFormulaMissingRequiredVarsBeforeExistingMolecule(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{Name: "agent-one", MaxActiveSessions: intPtr(1)}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "batch-requires-workspace"
+version = 1
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "work"
+title = "Work {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "batch-requires-workspace.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q := newFakeChildQuerier()
+	q.beadsByID["CVY-1"] = beads.Bead{ID: "CVY-1", Type: "convoy", Status: "open"}
+	q.childrenOf["CVY-1"] = []beads.Bead{
+		{ID: "BL-1", Type: "task", Status: "open"},
+	}
+	q.childrenOf["BL-1"] = []beads.Bead{
+		{ID: "MOL-1", Type: "molecule", Status: "open"},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "CVY-1")
+	opts.OnFormula = "batch-requires-workspace"
+	code := doSlingBatch(opts, deps, q, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSlingBatch returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "already has attached molecule") || strings.Contains(errText, "cannot use --on") {
+		t.Fatalf("stderr = %q, missing required vars should not be masked by attachment conflict", errText)
 	}
 }
 
@@ -4395,6 +4576,52 @@ func TestDefaultFormulaNoFormulaOverride(t *testing.T) {
 		t.Fatalf("got %d runner calls, want 0 for built-in routing: %v", len(runner.calls), runner.calls)
 	}
 	assertStoreRoutedTo(t, deps.Store, "HW-42", "hw/polecat")
+}
+
+func TestDefaultFormulaMissingRequiredVarsBeforeExistingMolecule(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+
+	dir := testFormulaDir(t)
+	cfg.FormulaLayers.City = []string{dir}
+	formulaBody := `
+formula = "default-requires-workspace"
+version = 1
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Work in {{workspace}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "default-requires-workspace.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "agent-two", Dir: "hw", DefaultSlingFormula: strPtr("default-requires-workspace")}
+	q := newFakeChildQuerier()
+	q.beadsByID["HW-42"] = beads.Bead{ID: "HW-42", Type: "task", Status: "open", Assignee: "hw/agent-two"}
+	q.childrenOf["HW-42"] = []beads.Bead{
+		{ID: "MOL-1", Type: "molecule", Status: "open"},
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "HW-42")
+	code := doSling(opts, deps, q, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("doSling returned %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("stderr = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "already has attached molecule") {
+		t.Fatalf("stderr = %q, missing required vars should not be masked by attachment conflict", errText)
+	}
 }
 
 func TestDefaultFormulaExplicitOnOverrides(t *testing.T) {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -308,7 +308,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if a.FormulaLayer != "" {
 		searchPaths = []string{a.FormulaLayer}
 	}
-	recipe, err := formula.Compile(ctx, a.Formula, searchPaths, nil)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, a.Formula, searchPaths, nil)
 	if err != nil {
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -319,6 +319,16 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
 		return
 	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{}); err != nil {
+		m.rec.Record(events.Event{
+			Type:    events.OrderFailed,
+			Actor:   "controller",
+			Subject: scoped,
+			Message: err.Error(),
+		})
+		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
+		return
+	}
 
 	// Decorate graph workflow recipes with routing metadata so child step
 	// beads get gc.routed_to set before instantiation.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -353,6 +353,84 @@ func TestOrderDispatchFormulaCookFailureLabelsTrackingBead(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	store := beads.NewMemStore()
+	var rec memRecorder
+
+	formulaDir := t.TempDir()
+	writeFile(t, filepath.Join(formulaDir, "order-required-vars.formula.toml"), `
+formula = "order-required-vars"
+version = 1
+
+[vars.target_id]
+description = "Bead being worked on"
+required = true
+
+[vars.workspace]
+description = "Workspace path"
+required = true
+
+[[steps]]
+id = "do-work"
+title = "Do work for {{target_id}}"
+description = "Target: {{target_id}}, workspace: {{workspace}}"
+`)
+
+	aa := []orders.Order{{
+		Name:         "fail-formula-vars",
+		Trigger:      "cooldown",
+		Interval:     "2m",
+		Formula:      "order-required-vars",
+		FormulaLayer: formulaDir,
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	mad := ad.(*memoryOrderDispatcher)
+	mad.rec = &rec
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(100 * time.Millisecond)
+
+	all := trackingBeads(t, store, "order-run:fail-formula-vars")
+	hasFailed := false
+	for _, b := range all {
+		for _, l := range b.Labels {
+			if l == "wisp-failed" {
+				hasFailed = true
+			}
+		}
+	}
+	if !hasFailed {
+		t.Error("tracking bead missing wisp-failed label after validation failure")
+	}
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event")
+	}
+
+	var failedMessage string
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed && event.Subject == "fail-formula-vars" {
+			failedMessage = event.Message
+			break
+		}
+	}
+	if failedMessage == "" {
+		t.Fatal("missing order.failed message for formula validation failure")
+	}
+	if !strings.Contains(failedMessage, `variable "target_id" is required`) {
+		t.Fatalf("order.failed message = %q, want missing target_id reported", failedMessage)
+	}
+	if !strings.Contains(failedMessage, `variable "workspace" is required`) {
+		t.Fatalf("order.failed message = %q, want missing workspace reported", failedMessage)
+	}
+	if strings.Contains(failedMessage, "bead title contains unresolved variable(s)") {
+		t.Fatalf("order.failed message = %q, want consolidated required-var validation instead of title-only failure", failedMessage)
+	}
+}
+
 func TestOrderDispatchFormulaLabelFailureLabelsTrackingBead(t *testing.T) {
 	store := beads.NewMemStore()
 	var rec memRecorder

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -180,7 +180,7 @@ func buildFormulaDetail(ctx context.Context, name string, paths []string, _ stri
 	if err != nil {
 		return nil, err
 	}
-	recipe, err := formula.Compile(ctx, name, paths, vars)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, name, paths, vars)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/molecule"
 )
 
 var (
@@ -170,7 +171,7 @@ func buildFormulaRuns(state State, formulaName, requestedScopeKind, requestedSco
 	}, nil
 }
 
-func buildFormulaDetail(ctx context.Context, name string, paths []string, _ string, vars map[string]string) (*formulaDetailResponse, error) {
+func buildFormulaDetail(ctx context.Context, name string, paths []string, _ string, vars map[string]string, validateRuntimeVars bool) (*formulaDetailResponse, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("%w: %q not in search paths", errFormulaNotFound, name)
 	}
@@ -182,6 +183,11 @@ func buildFormulaDetail(ctx context.Context, name string, paths []string, _ stri
 	recipe, err := formula.Compile(ctx, name, paths, vars)
 	if err != nil {
 		return nil, err
+	}
+	if validateRuntimeVars {
+		if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: vars}); err != nil {
+			return nil, fmt.Errorf("formula %q: %w", name, err)
+		}
 	}
 	displayVars := formula.ApplyDefaults(resolved, vars)
 

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -624,6 +624,96 @@ metadata = { "gc.kind" = "run", "gc.scope_ref" = "body" }
 	}
 }
 
+func TestFormulaPreviewRejectsMissingRequiredVars(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-preview", `
+description = "Preview {{issue}}"
+formula = "mol-preview"
+version = 2
+
+[vars]
+[vars.issue]
+description = "Issue bead ID"
+required = true
+
+[[steps]]
+id = "prep"
+title = "Prep {{issue}}"
+`)
+
+	body := bytes.NewBufferString(`{"scope_kind":"city","scope_ref":"test-city","target":"worker","vars":{"other":"BD-123"}}`)
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodPost, cityURL(state, "/formulas/mol-preview/preview"), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem): %v", err)
+	}
+	if !strings.Contains(problem.Detail, `variable "issue" is required`) {
+		t.Fatalf("detail = %q, want missing issue validation error", problem.Detail)
+	}
+}
+
+func TestFormulaPreviewRejectsMissingRequiredVarsWithoutVarsBody(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "mol-preview", `
+description = "Preview {{issue}}"
+formula = "mol-preview"
+version = 2
+
+[vars]
+[vars.issue]
+description = "Issue bead ID"
+required = true
+
+[[steps]]
+id = "prep"
+title = "Prep {{issue}}"
+`)
+
+	body := bytes.NewBufferString(`{"scope_kind":"city","scope_ref":"test-city","target":"worker"}`)
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodPost, cityURL(state, "/formulas/mol-preview/preview"), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("Decode(problem): %v", err)
+	}
+	if !strings.Contains(problem.Detail, `variable "issue" is required`) {
+		t.Fatalf("detail = %q, want missing issue validation error", problem.Detail)
+	}
+}
+
 // TestFormulaDetailRejectsLegacyVarQueryParams pins the §3.5.1 migration
 // behavior: undeclared var.* query parameters on the GET detail endpoint
 // are now rejected with a 4xx + migration hint pointing at POST /preview.

--- a/internal/api/huma_handlers_formulas.go
+++ b/internal/api/huma_handlers_formulas.go
@@ -102,7 +102,7 @@ func (s *Server) humaHandleFormulaDetail(ctx context.Context, input *FormulaDeta
 	Body formulaDetailResponse
 }, error,
 ) {
-	return s.formulaDetail(ctx, input.Name, input.ScopeKind, input.ScopeRef, input.Target, nil)
+	return s.formulaDetail(ctx, input.Name, input.ScopeKind, input.ScopeRef, input.Target, nil, false)
 }
 
 // humaHandleFormulaPreview is the Huma-typed handler for
@@ -113,14 +113,14 @@ func (s *Server) humaHandleFormulaPreview(ctx context.Context, input *FormulaPre
 	Body formulaDetailResponse
 }, error,
 ) {
-	return s.formulaDetail(ctx, input.Name, input.Body.ScopeKind, input.Body.ScopeRef, input.Body.Target, input.Body.Vars)
+	return s.formulaDetail(ctx, input.Name, input.Body.ScopeKind, input.Body.ScopeRef, input.Body.Target, input.Body.Vars, true)
 }
 
 // formulaDetail is the shared backing implementation for the GET detail
 // and POST preview endpoints. The two endpoints differ only in how they
 // receive the variable dictionary: GET compiles with defaults, POST
 // accepts a caller-supplied map.
-func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawScopeRef, rawTarget string, vars map[string]string) (*struct {
+func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawScopeRef, rawTarget string, vars map[string]string, validateRuntimeVars bool) (*struct {
 	Body formulaDetailResponse
 }, error,
 ) {
@@ -149,7 +149,7 @@ func (s *Server) formulaDetail(ctx context.Context, rawName, rawScopeKind, rawSc
 		return nil, huma.Error400BadRequest(msg)
 	}
 
-	detail, err := buildFormulaDetail(ctx, name, paths, target, vars)
+	detail, err := buildFormulaDetail(ctx, name, paths, target, vars, validateRuntimeVars)
 	if err != nil {
 		if errors.Is(err, errFormulaNotWorkflow) || errors.Is(err, errFormulaNotFound) {
 			return nil, huma.Error404NotFound(err.Error())

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"regexp"
 	"strings"
 	"sync/atomic"
 )
@@ -12,9 +13,11 @@ import (
 // The returned Recipe contains {{variable}} placeholders — substitution
 // happens at instantiation time, not compilation time.
 //
-// vars is used only for compile-time step condition filtering: steps whose
-// condition field evaluates to false given vars are excluded. Pass nil to
-// use formula-defined variable defaults for condition evaluation.
+// vars is used for compile-time template expansion and step condition
+// filtering. Passing nil or an empty map leaves required runtime vars
+// unresolved for later display/instantiation paths, but required vars used by
+// compile-time operators such as loop ranges must still be provided.
+// Passing a non-empty map validates that all required vars are present.
 //
 // The pipeline stages are:
 //  1. LoadByName — load formula TOML from search paths
@@ -29,6 +32,20 @@ import (
 //  10. ApplyRalph — expand inline Ralph run/check steps
 //  11. toRecipe — flatten step tree to Recipe
 func Compile(_ context.Context, name string, searchPaths []string, vars map[string]string) (*Recipe, error) {
+	return compileFormula(name, searchPaths, vars, true)
+}
+
+// CompileWithoutRuntimeVarValidation compiles a formula while deferring
+// required runtime-var checks to the caller. Required vars used by compile-time
+// operators are still validated during compilation. Use this for read-only
+// display surfaces and runtime paths that need recipe-level validation to
+// preserve idempotency or report residual title placeholders alongside missing
+// vars.
+func CompileWithoutRuntimeVarValidation(_ context.Context, name string, searchPaths []string, vars map[string]string) (*Recipe, error) {
+	return compileFormula(name, searchPaths, vars, false)
+}
+
+func compileFormula(name string, searchPaths []string, vars map[string]string, validateRuntimeVars bool) (*Recipe, error) {
 	parser := NewParser(searchPaths...)
 
 	// Stage 1: Load formula by name
@@ -42,6 +59,11 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 	if err != nil {
 		return nil, fmt.Errorf("resolving formula %q: %w", name, err)
 	}
+	if validateRuntimeVars && len(vars) > 0 {
+		if err := ValidateVars(resolved, vars); err != nil {
+			return nil, err
+		}
+	}
 
 	compileVars := make(map[string]string)
 	for vname, def := range resolved.Vars {
@@ -52,9 +74,12 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 	for k, v := range vars {
 		compileVars[k] = v
 	}
+	if err := validateCompileTimeVars(resolved, vars); err != nil {
+		return nil, err
+	}
 
 	// Stage 3: Apply control flow operators — loops, branches, gates
-	controlFlowSteps, err := ApplyControlFlow(resolved.Steps, resolved.Compose)
+	controlFlowSteps, err := ApplyControlFlowWithVars(resolved.Steps, resolved.Compose, compileVars)
 	if err != nil {
 		return nil, fmt.Errorf("applying control flow to %q: %w", name, err)
 	}
@@ -150,6 +175,61 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 
 	// Stage 13: Flatten to Recipe
 	return toRecipeWithGraph(resolved, graphWorkflow)
+}
+
+func validateCompileTimeVars(f *Formula, values map[string]string) error {
+	if f == nil || len(f.Vars) == 0 {
+		return nil
+	}
+	refs := make(map[string]bool)
+	collectCompileTimeVarRefs(f.Steps, refs)
+	collectCompileTimeVarRefs(f.Template, refs)
+	if len(refs) == 0 {
+		return nil
+	}
+	defs := make(map[string]*VarDef)
+	for name := range refs {
+		def := f.Vars[name]
+		if def != nil {
+			defs[name] = def
+		}
+	}
+	return ValidateVarDefs(defs, ApplyDefaults(f, values))
+}
+
+func collectCompileTimeVarRefs(steps []*Step, refs map[string]bool) {
+	for _, step := range steps {
+		if step == nil {
+			continue
+		}
+		if step.Loop != nil && step.Loop.Range != "" {
+			for _, match := range rangeVarPattern.FindAllStringSubmatch(step.Loop.Range, -1) {
+				refs[match[1]] = true
+			}
+		}
+		collectStepConditionVarRefs(step.Condition, refs)
+		collectCompileTimeVarRefs(step.Children, refs)
+		if step.Loop != nil {
+			collectCompileTimeVarRefs(step.Loop.Body, refs)
+		}
+	}
+}
+
+func collectStepConditionVarRefs(condition string, refs map[string]bool) {
+	condition = strings.TrimSpace(condition)
+	if condition == "" {
+		return
+	}
+	for _, pattern := range []*regexp.Regexp{
+		stepCondVarPattern,
+		stepCondNegatedVarPattern,
+		stepCondComparePattern,
+	} {
+		if match := pattern.FindStringSubmatch(condition); match != nil {
+			refs[match[1]] = true
+			return
+		}
+	}
 }
 
 func toRecipeWithGraph(f *Formula, graphWorkflow bool) (*Recipe, error) {

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -43,16 +43,6 @@ func Compile(_ context.Context, name string, searchPaths []string, vars map[stri
 		return nil, fmt.Errorf("resolving formula %q: %w", name, err)
 	}
 
-	// Validate required vars only when the caller explicitly provided them.
-	// nil = include-all-steps mode (order dispatch); empty = read-only display
-	// (formula show). Both skip validation. Non-empty = user-supplied vars from
-	// sling, cook, or API — validate.
-	if len(vars) > 0 {
-		if err := ValidateVars(resolved, vars); err != nil {
-			return nil, fmt.Errorf("formula %q: %w", name, err)
-		}
-	}
-
 	compileVars := make(map[string]string)
 	for vname, def := range resolved.Vars {
 		if def != nil && def.Default != nil {

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -124,6 +124,131 @@ condition = "{{mode}} == slow"
 	}
 }
 
+func TestCompileWithoutRuntimeVarValidationReportsMissingCompileTimeRangeVar(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "range-demo"
+version = 1
+
+[vars.n]
+description = "Loop count"
+required = true
+
+[[steps]]
+id = "loop"
+title = "Loop"
+
+[steps.loop]
+range = "1..{n}"
+
+[[steps.loop.body]]
+id = "work"
+title = "Work {i}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "range-demo.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := CompileWithoutRuntimeVarValidation(context.Background(), "range-demo", []string{dir}, nil)
+	if err == nil {
+		t.Fatal("CompileWithoutRuntimeVarValidation should reject missing compile-time range var")
+	}
+	if !strings.Contains(err.Error(), `variable "n" is required`) {
+		t.Fatalf("error = %v, want required n", err)
+	}
+
+	recipe, err := CompileWithoutRuntimeVarValidation(context.Background(), "range-demo", []string{dir}, map[string]string{"n": "2"})
+	if err != nil {
+		t.Fatalf("CompileWithoutRuntimeVarValidation with n: %v", err)
+	}
+	if len(recipe.Steps) != 3 {
+		t.Fatalf("len(recipe.Steps) = %d, want root plus two loop iterations", len(recipe.Steps))
+	}
+}
+
+func TestCompileWithoutRuntimeVarValidationValidatesCompileTimeRangeVarDefs(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "range-demo"
+version = 1
+
+[vars.n]
+description = "Loop count"
+default = "2"
+enum = ["1", "2", "3"]
+
+[[steps]]
+id = "loop"
+title = "Loop"
+
+[steps.loop]
+range = "1..{n}"
+
+[[steps.loop.body]]
+id = "work"
+title = "Work {i}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "range-demo.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recipe, err := CompileWithoutRuntimeVarValidation(context.Background(), "range-demo", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("CompileWithoutRuntimeVarValidation with default n: %v", err)
+	}
+	if len(recipe.Steps) != 3 {
+		t.Fatalf("len(recipe.Steps) = %d, want root plus two loop iterations", len(recipe.Steps))
+	}
+
+	_, err = CompileWithoutRuntimeVarValidation(context.Background(), "range-demo", []string{dir}, map[string]string{"n": "4"})
+	if err == nil {
+		t.Fatal("CompileWithoutRuntimeVarValidation should reject invalid compile-time range var")
+	}
+	if !strings.Contains(err.Error(), `variable "n": value "4" not in allowed values`) {
+		t.Fatalf("error = %v, want enum validation for n", err)
+	}
+}
+
+func TestCompileWithoutRuntimeVarValidationReportsMissingCompileTimeConditionVar(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "condition-demo"
+version = 1
+
+[vars.mode]
+description = "Build mode"
+required = true
+
+[[steps]]
+id = "always"
+title = "Always"
+
+[[steps]]
+id = "slow"
+title = "Slow path"
+condition = "{{mode}} == slow"
+`
+	if err := os.WriteFile(filepath.Join(dir, "condition-demo.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := CompileWithoutRuntimeVarValidation(context.Background(), "condition-demo", []string{dir}, nil)
+	if err == nil {
+		t.Fatal("CompileWithoutRuntimeVarValidation should reject missing compile-time condition var")
+	}
+	if !strings.Contains(err.Error(), `variable "mode" is required`) {
+		t.Fatalf("error = %v, want required mode", err)
+	}
+
+	recipe, err := CompileWithoutRuntimeVarValidation(context.Background(), "condition-demo", []string{dir}, map[string]string{"mode": "slow"})
+	if err != nil {
+		t.Fatalf("CompileWithoutRuntimeVarValidation with mode: %v", err)
+	}
+	if len(recipe.Steps) != 3 {
+		t.Fatalf("len(recipe.Steps) = %d, want root plus two included steps", len(recipe.Steps))
+	}
+}
+
 func TestCompileNilVarsAppliesDefaults(t *testing.T) {
 	dir := t.TempDir()
 	formulaContent := `

--- a/internal/formula/controlflow.go
+++ b/internal/formula/controlflow.go
@@ -20,6 +20,12 @@ import (
 // Conditional loops expand once and add a "loop:until" label for runtime evaluation.
 // Returns a new steps slice with loops expanded.
 func ApplyLoops(steps []*Step) ([]*Step, error) {
+	return ApplyLoopsWithVars(steps, nil)
+}
+
+// ApplyLoopsWithVars expands loop bodies in a formula's steps using vars for
+// computed range expressions.
+func ApplyLoopsWithVars(steps []*Step, vars map[string]string) ([]*Step, error) {
 	result := make([]*Step, 0, len(steps))
 
 	for _, step := range steps {
@@ -27,7 +33,7 @@ func ApplyLoops(steps []*Step) ([]*Step, error) {
 			// No loop - recursively process children
 			clone := cloneStep(step)
 			if len(step.Children) > 0 {
-				children, err := ApplyLoops(step.Children)
+				children, err := ApplyLoopsWithVars(step.Children, vars)
 				if err != nil {
 					return nil, err
 				}
@@ -43,7 +49,7 @@ func ApplyLoops(steps []*Step) ([]*Step, error) {
 		}
 
 		// Expand the loop
-		expanded, err := expandLoop(step)
+		expanded, err := expandLoopWithVars(step, vars)
 		if err != nil {
 			return nil, err
 		}
@@ -107,11 +113,6 @@ func validateLoopSpec(loop *LoopSpec, stepID string) error {
 	return nil
 }
 
-// expandLoop expands a loop step into its constituent steps.
-func expandLoop(step *Step) ([]*Step, error) {
-	return expandLoopWithVars(step, nil)
-}
-
 // expandLoopWithVars expands a loop step using the given variable context.
 // The vars map is used to resolve range expressions with variables.
 func expandLoopWithVars(step *Step, vars map[string]string) ([]*Step, error) {
@@ -130,7 +131,7 @@ func expandLoopWithVars(step *Step, vars map[string]string) ([]*Step, error) {
 
 		// Recursively expand any nested loops FIRST
 		var err error
-		result, err = ApplyLoops(result)
+		result, err = ApplyLoopsWithVars(result, vars)
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +172,7 @@ func expandLoopWithVars(step *Step, vars map[string]string) ([]*Step, error) {
 		}
 
 		// Recursively expand any nested loops FIRST
-		result, err = ApplyLoops(result)
+		result, err = ApplyLoopsWithVars(result, vars)
 		if err != nil {
 			return nil, err
 		}
@@ -551,10 +552,16 @@ func applyGatesWithMap(stepMap map[string]*Step, compose *ComposeRules) error {
 //
 // Returns a new steps slice. The original steps slice is not modified.
 func ApplyControlFlow(steps []*Step, compose *ComposeRules) ([]*Step, error) {
+	return ApplyControlFlowWithVars(steps, compose, nil)
+}
+
+// ApplyControlFlowWithVars applies all control flow operators using vars for
+// compile-time computed loop ranges.
+func ApplyControlFlowWithVars(steps []*Step, compose *ComposeRules, vars map[string]string) ([]*Step, error) {
 	var err error
 
 	// Apply loops first (expands steps) - ApplyLoops already returns new slice
-	steps, err = ApplyLoops(steps)
+	steps, err = ApplyLoopsWithVars(steps, vars)
 	if err != nil {
 		return nil, fmt.Errorf("applying loops: %w", err)
 	}

--- a/internal/formula/fragment.go
+++ b/internal/formula/fragment.go
@@ -43,6 +43,9 @@ func CompileExpansionFragment(_ context.Context, name string, searchPaths []stri
 	}
 
 	expansionVars := ApplyDefaults(resolved, vars)
+	if err := validateCompileTimeVars(resolved, vars); err != nil {
+		return nil, fmt.Errorf("expansion %q: %w", name, err)
+	}
 	if err := MaterializeExpansionForTarget(resolved, target, expansionVars); err != nil {
 		return nil, err
 	}
@@ -52,7 +55,7 @@ func CompileExpansionFragment(_ context.Context, name string, searchPaths []stri
 	}
 	resolved.Steps = filteredSteps
 
-	controlFlowSteps, err := ApplyControlFlow(resolved.Steps, resolved.Compose)
+	controlFlowSteps, err := ApplyControlFlowWithVars(resolved.Steps, resolved.Compose, expansionVars)
 	if err != nil {
 		return nil, fmt.Errorf("applying control flow to expansion %q: %w", name, err)
 	}

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -494,11 +494,28 @@ func ValidateVarDefs(defs map[string]*VarDef, values map[string]string) error {
 	return formatVarValidationErrors(errs)
 }
 
+// ValidateProvidedVarDefs validates constraints for values the caller supplied
+// without requiring every required variable to be present.
+func ValidateProvidedVarDefs(defs map[string]*VarDef, values map[string]string) error {
+	providedDefs := make(map[string]*VarDef)
+	for name := range values {
+		if def, ok := defs[name]; ok {
+			providedDefs[name] = def
+		}
+	}
+	errs, _ := collectVarValidationErrors(providedDefs, values, false)
+	return formatVarValidationErrors(errs)
+}
+
 // CollectVarValidationErrors validates explicit var definitions against the
 // provided values and returns raw error strings plus the set of missing
 // required vars. Callers that need the historical wrapped error can pass the
 // returned error strings through formatVarValidationErrors.
 func CollectVarValidationErrors(defs map[string]*VarDef, values map[string]string) ([]string, map[string]bool) {
+	return collectVarValidationErrors(defs, values, true)
+}
+
+func collectVarValidationErrors(defs map[string]*VarDef, values map[string]string, requireMissing bool) ([]string, map[string]bool) {
 	var errs []string
 	missingRequired := make(map[string]bool)
 	names := make([]string, 0, len(defs))
@@ -509,10 +526,13 @@ func CollectVarValidationErrors(defs map[string]*VarDef, values map[string]strin
 
 	for _, name := range names {
 		def := defs[name]
+		if def == nil {
+			continue
+		}
 		val, provided := values[name]
 
 		// Check required
-		if def.Required && !provided {
+		if requireMissing && def.Required && !provided {
 			errs = append(errs, fmt.Sprintf("variable %q is required", name))
 			missingRequired[name] = true
 			continue

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -482,25 +482,39 @@ func CheckResidualTimeoutVars(s string) []string {
 // ValidateVars checks that all required variables are provided
 // and all values pass their constraints.
 func ValidateVars(formula *Formula, values map[string]string) error {
-	return validateVarDefs(formula.Vars, values)
+	errs, _ := CollectVarValidationErrors(formula.Vars, values)
+	return formatVarValidationErrors(errs)
 }
 
 // ValidateVarDefs validates explicit var definitions against provided values.
 // This is the recipe-level equivalent of ValidateVars, used after formula
 // compilation when only the remaining VarDef map is available.
 func ValidateVarDefs(defs map[string]*VarDef, values map[string]string) error {
-	return validateVarDefs(defs, values)
+	errs, _ := CollectVarValidationErrors(defs, values)
+	return formatVarValidationErrors(errs)
 }
 
-func validateVarDefs(defs map[string]*VarDef, values map[string]string) error {
+// CollectVarValidationErrors validates explicit var definitions against the
+// provided values and returns raw error strings plus the set of missing
+// required vars. Callers that need the historical wrapped error can pass the
+// returned error strings through formatVarValidationErrors.
+func CollectVarValidationErrors(defs map[string]*VarDef, values map[string]string) ([]string, map[string]bool) {
 	var errs []string
+	missingRequired := make(map[string]bool)
+	names := make([]string, 0, len(defs))
+	for name := range defs {
+		names = append(names, name)
+	}
+	slices.Sort(names)
 
-	for name, def := range defs {
+	for _, name := range names {
+		def := defs[name]
 		val, provided := values[name]
 
 		// Check required
 		if def.Required && !provided {
 			errs = append(errs, fmt.Sprintf("variable %q is required", name))
+			missingRequired[name] = true
 			continue
 		}
 
@@ -539,11 +553,17 @@ func validateVarDefs(defs map[string]*VarDef, values map[string]string) error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	if len(missingRequired) == 0 {
+		missingRequired = nil
 	}
+	return errs, missingRequired
+}
 
-	return nil
+func formatVarValidationErrors(errs []string) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 }
 
 // ApplyDefaults returns a new map with default values filled in.

--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -619,3 +619,64 @@ func TestAttachEpochWithIdempotency(t *testing.T) {
 		t.Fatal("second should be duplicate")
 	}
 }
+
+func TestAttachIdempotentDuplicateSkipsRuntimeVarValidation(t *testing.T) {
+	store := beads.NewMemStore()
+	root := setupWorkflow(t, store)
+	control := setupWorkflowChild(t, store, root.ID, "Control")
+
+	recipe := &formula.Recipe{
+		Name: "attempt-required-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "attempt-required-vars", Title: "Attempt {{target_id}}", Type: "task", IsRoot: true},
+			{ID: "attempt-required-vars.run", Title: "Run in {{workspace}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "attempt-required-vars.run", DependsOnID: "attempt-required-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"target_id": {Description: "Bead being worked on", Required: true},
+			"workspace": {Description: "Workspace path", Required: true},
+		},
+	}
+
+	result1, err := Attach(context.Background(), store, recipe, control.ID, AttachOptions{
+		IdempotencyKey: "retry:control:attempt-required-vars:1",
+		Vars: map[string]string{
+			"target_id": control.ID,
+			"workspace": "/tmp/repro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Attach 1: %v", err)
+	}
+	if result1.Duplicate {
+		t.Fatal("first attach should not be duplicate")
+	}
+
+	result2, err := Attach(context.Background(), store, &formula.Recipe{
+		Name: "attempt-required-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "attempt-required-vars", Title: "Attempt {{target_id}}", Type: "task", IsRoot: true},
+			{ID: "attempt-required-vars.run", Title: "Run in {{workspace}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "attempt-required-vars.run", DependsOnID: "attempt-required-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"target_id": {Description: "Bead being worked on", Required: true},
+			"workspace": {Description: "Workspace path", Required: true},
+		},
+	}, control.ID, AttachOptions{
+		IdempotencyKey: "retry:control:attempt-required-vars:1",
+	})
+	if err != nil {
+		t.Fatalf("Duplicate attach should return existing sub-DAG before re-validating vars: %v", err)
+	}
+	if !result2.Duplicate {
+		t.Fatal("second attach should be duplicate")
+	}
+	if result2.RootID != result1.RootID {
+		t.Fatalf("duplicate attach root = %q, want %q", result2.RootID, result1.RootID)
+	}
+}

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -138,7 +138,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				node.Type = "molecule"
 			}
 			if opts.Title != "" {
-				node.Title = opts.Title
+				node.Title = formula.Substitute(opts.Title, vars)
 			}
 			if opts.ParentID != "" && step.Metadata["gc.kind"] != "workflow" {
 				node.ParentID = opts.ParentID

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -127,7 +127,7 @@ func Cook(ctx context.Context, store beads.Store, formulaName string, searchPath
 	if compileVars == nil {
 		compileVars = map[string]string{}
 	}
-	recipe, err := formula.Compile(ctx, formulaName, searchPaths, compileVars)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, formulaName, searchPaths, compileVars)
 	if err != nil {
 		return nil, fmt.Errorf("compiling formula %q: %w", formulaName, err)
 	}
@@ -422,7 +422,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			}
 			b.Ref = recipe.Name
 			if opts.Title != "" {
-				b.Title = opts.Title
+				b.Title = formula.Substitute(opts.Title, vars)
 			}
 			if opts.ParentID != "" && step.Metadata["gc.kind"] != "workflow" {
 				b.ParentID = opts.ParentID
@@ -916,29 +916,43 @@ func applyVarDefaults(vars map[string]string, defs map[string]*formula.VarDef) m
 	return result
 }
 
+// ValidateRecipeRuntimeVars validates runtime variables for a compiled recipe.
+// It checks declared formula vars, unresolved title placeholders, and avoids
+// duplicating title errors for vars that were already reported as required.
 func ValidateRecipeRuntimeVars(recipe *formula.Recipe, opts Options) error {
-	validationErrs, missingRequired := formula.CollectVarValidationErrors(recipe.Vars, opts.Vars)
-	titleErrs := unresolvedTitleValidationErrors(recipe, opts, missingRequired)
-	switch {
-	case len(validationErrs) == 0 && len(titleErrs) == 0:
+	validationVars := runtimeValidationVars(recipe, opts)
+	validationErrs, missingRequired := formula.CollectVarValidationErrors(recipe.Vars, validationVars)
+	titleErrs := unresolvedTitleValidationErrorsWithVars(recipe, opts, validationVars, missingRequired)
+	if len(validationErrs) == 0 && len(titleErrs) == 0 {
 		return nil
-	case len(validationErrs) == 0 && len(titleErrs) == 1:
-		return fmt.Errorf("%s", titleErrs[0])
-	case len(validationErrs) == 0:
-		return fmt.Errorf("title variable validation failed:\n  - %s", strings.Join(titleErrs, "\n  - "))
-	default:
-		errs := make([]string, 0, len(validationErrs)+len(titleErrs))
-		errs = append(errs, validationErrs...)
-		errs = append(errs, titleErrs...)
-		return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 	}
+	errs := make([]string, 0, len(validationErrs)+len(titleErrs))
+	errs = append(errs, validationErrs...)
+	errs = append(errs, titleErrs...)
+	return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 }
 
-func unresolvedTitleValidationErrors(recipe *formula.Recipe, opts Options, missingRequired map[string]bool) []string {
+func runtimeValidationVars(recipe *formula.Recipe, opts Options) map[string]string {
+	if opts.Title == "" || recipe == nil || recipe.Vars == nil {
+		return opts.Vars
+	}
+	if _, ok := recipe.Vars["title"]; !ok {
+		return opts.Vars
+	}
+	vars := applyVarDefaults(opts.Vars, recipe.Vars)
+	result := make(map[string]string, len(vars)+1)
+	for k, v := range vars {
+		result[k] = v
+	}
+	result["title"] = formula.Substitute(opts.Title, vars)
+	return result
+}
+
+func unresolvedTitleValidationErrorsWithVars(recipe *formula.Recipe, opts Options, providedVars map[string]string, missingRequired map[string]bool) []string {
 	if recipe == nil || len(recipe.Steps) == 0 {
 		return nil
 	}
-	vars := applyVarDefaults(opts.Vars, recipe.Vars)
+	vars := applyVarDefaults(providedVars, recipe.Vars)
 	errs := make([]string, 0)
 	for i, step := range recipe.Steps {
 		if recipe.RootOnly && i > 0 {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -131,6 +131,9 @@ func Cook(ctx context.Context, store beads.Store, formulaName string, searchPath
 	if err != nil {
 		return nil, fmt.Errorf("compiling formula %q: %w", formulaName, err)
 	}
+	if err := ValidateRecipeRuntimeVars(recipe, opts); err != nil {
+		return nil, err
+	}
 	return Instantiate(ctx, store, recipe, opts)
 }
 
@@ -250,6 +253,9 @@ func Attach(ctx context.Context, store beads.Store, recipe *formula.Recipe, atta
 		if currentEpoch != opts.ExpectedEpoch {
 			return nil, ErrEpochConflict
 		}
+	}
+	if err := ValidateRecipeRuntimeVars(recipe, Options{Title: opts.Title, Vars: opts.Vars}); err != nil {
+		return nil, fmt.Errorf("validate runtime vars: %w", err)
 	}
 
 	// Stamp every step with the parent workflow's graph metadata.
@@ -908,6 +914,60 @@ func applyVarDefaults(vars map[string]string, defs map[string]*formula.VarDef) m
 		result[k] = v
 	}
 	return result
+}
+
+func ValidateRecipeRuntimeVars(recipe *formula.Recipe, opts Options) error {
+	validationErrs, missingRequired := formula.CollectVarValidationErrors(recipe.Vars, opts.Vars)
+	titleErrs := unresolvedTitleValidationErrors(recipe, opts, missingRequired)
+	switch {
+	case len(validationErrs) == 0 && len(titleErrs) == 0:
+		return nil
+	case len(validationErrs) == 0 && len(titleErrs) == 1:
+		return fmt.Errorf("%s", titleErrs[0])
+	case len(validationErrs) == 0:
+		return fmt.Errorf("title variable validation failed:\n  - %s", strings.Join(titleErrs, "\n  - "))
+	default:
+		errs := make([]string, 0, len(validationErrs)+len(titleErrs))
+		errs = append(errs, validationErrs...)
+		errs = append(errs, titleErrs...)
+		return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+}
+
+func unresolvedTitleValidationErrors(recipe *formula.Recipe, opts Options, missingRequired map[string]bool) []string {
+	if recipe == nil || len(recipe.Steps) == 0 {
+		return nil
+	}
+	vars := applyVarDefaults(opts.Vars, recipe.Vars)
+	errs := make([]string, 0)
+	for i, step := range recipe.Steps {
+		if recipe.RootOnly && i > 0 {
+			break
+		}
+		rawTitle := step.Title
+		if step.IsRoot && opts.Title != "" {
+			rawTitle = opts.Title
+		}
+		title := formula.Substitute(rawTitle, vars)
+		if !strings.Contains(title, "{{") {
+			continue
+		}
+		residual := formula.CheckResidualVars(title)
+		unexplained := make([]string, 0, len(residual))
+		for _, name := range residual {
+			if missingRequired[name] {
+				continue
+			}
+			unexplained = append(unexplained, name)
+		}
+		if len(unexplained) == 0 {
+			continue
+		}
+		errs = append(errs,
+			fmt.Sprintf(`step %q: bead title contains unresolved variable(s) %s — missing or misspelled --var(s)?`,
+				step.ID, strings.Join(unexplained, ", ")))
+	}
+	return errs
 }
 
 // markFailed sets "molecule_failed" metadata on all created beads.

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1821,6 +1821,27 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 		}
 	})
 
+	t.Run("root title override substitutes provided vars", func(t *testing.T) {
+		result, err := Instantiate(context.Background(), store, &formula.Recipe{
+			Name: "root-override-vars",
+			Steps: []formula.RecipeStep{
+				{ID: "root-override-vars", Title: "fallback", Type: "molecule", IsRoot: true},
+			},
+			Vars: map[string]*formula.VarDef{
+				"env": {Description: "Deployment environment", Required: true},
+			},
+		}, Options{
+			Title: "Deploy {{env}}",
+			Vars:  map[string]string{"env": "prod"},
+		})
+		if err != nil {
+			t.Fatalf("should succeed with substituted title override: %v", err)
+		}
+		if result.Created != 1 {
+			t.Errorf("Created = %d, want 1", result.Created)
+		}
+	})
+
 	t.Run("graph-apply path rejects unresolved vars", func(t *testing.T) {
 		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
 		prev := IsGraphApplyEnabled()
@@ -1841,6 +1862,44 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 			t.Errorf("error should mention 'feature': %v", err)
 		}
 	})
+}
+
+func TestAttachReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "Parent", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(parent): %v", err)
+	}
+
+	recipe := &formula.Recipe{
+		Name: "attach-required-vars",
+		Steps: []formula.RecipeStep{
+			{ID: "attach-required-vars", Title: "Attach required vars", Type: "task", IsRoot: true},
+			{ID: "attach-required-vars.step", Title: "Do work for {{target_id}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "attach-required-vars.step", DependsOnID: "attach-required-vars", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"target_id": {Description: "Bead being worked on", Required: true},
+			"workspace": {Description: "Workspace path", Required: true},
+		},
+	}
+
+	_, err = Attach(context.Background(), store, recipe, parent.ID, AttachOptions{})
+	if err == nil {
+		t.Fatal("Attach should reject missing required vars")
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, `variable "target_id" is required`) {
+		t.Fatalf("Attach error = %q, want missing target_id reported", errText)
+	}
+	if !strings.Contains(errText, `variable "workspace" is required`) {
+		t.Fatalf("Attach error = %q, want missing workspace reported", errText)
+	}
+	if strings.Contains(errText, "bead title contains unresolved variable(s)") {
+		t.Fatalf("Attach error = %q, want consolidated required-var validation instead of title-only failure", errText)
+	}
 }
 
 func TestInstantiateRejectsResidualTimeoutVars(t *testing.T) {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1842,6 +1842,24 @@ func TestInstantiateRejectsResidualTitleVars(t *testing.T) {
 		}
 	})
 
+	t.Run("root title override satisfies required title var", func(t *testing.T) {
+		result, err := Instantiate(context.Background(), store, &formula.Recipe{
+			Name: "root-required-title",
+			Steps: []formula.RecipeStep{
+				{ID: "root-required-title", Title: "{{title}}", Type: "molecule", IsRoot: true},
+			},
+			Vars: map[string]*formula.VarDef{
+				"title": {Description: "Root title", Required: true},
+			},
+		}, Options{Title: "Reviewed work"})
+		if err != nil {
+			t.Fatalf("should succeed with required title override: %v", err)
+		}
+		if result.Created != 1 {
+			t.Errorf("Created = %d, want 1", result.Created)
+		}
+	})
+
 	t.Run("graph-apply path rejects unresolved vars", func(t *testing.T) {
 		gaStore := &graphApplySpyStore{MemStore: beads.NewMemStore()}
 		prev := IsGraphApplyEnabled()

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -666,6 +666,10 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 		SlingTracef("instantiate compile-error formula=%s dur=%s err=%v", formulaName, time.Since(compileStart), err)
 		return nil, err
 	}
+	if err := molecule.ValidateRecipeRuntimeVars(recipe, opts); err != nil {
+		SlingTracef("instantiate validate-error formula=%s err=%v", formulaName, err)
+		return nil, err
+	}
 	SlingTracef("instantiate compiled formula=%s dur=%s steps=%d", formulaName, time.Since(compileStart), len(recipe.Steps))
 	if err := ApplyGraphRouting(recipe, &a, a.QualifiedName(), opts.Vars, sourceBeadID, scopeKind, scopeRef, deps.StoreRef, deps.Store, deps.CityName, deps.Cfg, deps); err != nil {
 		SlingTracef("instantiate decorate-error formula=%s err=%v", formulaName, err)

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -661,7 +661,7 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 		opts.PriorityOverride = BeadPriorityOverride(deps.Store, sourceBeadID)
 	}
 	compileStart := time.Now()
-	recipe, err := formula.Compile(ctx, formulaName, searchPaths, opts.Vars)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, formulaName, searchPaths, opts.Vars)
 	if err != nil {
 		SlingTracef("instantiate compile-error formula=%s dur=%s err=%v", formulaName, time.Since(compileStart), err)
 		return nil, err

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -146,6 +146,12 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 	if err != nil {
 		return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
 	}
+	if err := validateSlingFormulaRuntimeVars(context.Background(), opts.OnFormula, searchPaths, molecule.Options{
+		Title: opts.Title,
+		Vars:  formulaVars,
+	}); err != nil {
+		return result, fmt.Errorf("instantiating formula %q on %s: %w", opts.OnFormula, beadID, err)
+	}
 	checkAttachments := CheckNoMoleculeChildren
 	if isGraph && opts.Force {
 		checkAttachments = CheckNoMoleculeChildrenAllowLiveWorkflow
@@ -202,6 +208,12 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 	searchPaths := SlingFormulaSearchPaths(deps, a)
 	isGraph, err := isGraphSlingFormula(context.Background(), defaultFormula, searchPaths, defaultVars)
 	if err != nil {
+		return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
+	}
+	if err := validateSlingFormulaRuntimeVars(context.Background(), defaultFormula, searchPaths, molecule.Options{
+		Title: opts.Title,
+		Vars:  defaultVars,
+	}); err != nil {
 		return result, fmt.Errorf("instantiating default formula %q on %s: %w", defaultFormula, beadID, err)
 	}
 	checkAttachments := CheckNoMoleculeChildren
@@ -682,11 +694,32 @@ func attachBatchFormula(ctx context.Context, opts SlingOpts, deps SlingDeps, chi
 }
 
 func isGraphSlingFormula(ctx context.Context, formulaName string, searchPaths []string, vars map[string]string) (bool, error) {
-	recipe, err := formula.Compile(ctx, formulaName, searchPaths, vars)
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, formulaName, searchPaths, vars)
 	if err != nil {
 		return false, err
 	}
 	return IsCompiledGraphWorkflow(recipe), nil
+}
+
+func validateSlingFormulaRuntimeVars(ctx context.Context, formulaName string, searchPaths []string, opts molecule.Options) error {
+	recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, formulaName, searchPaths, opts.Vars)
+	if err != nil {
+		return err
+	}
+	return molecule.ValidateRecipeRuntimeVars(recipe, opts)
+}
+
+func validateBatchSlingFormulaRuntimeVars(ctx context.Context, formulaName string, searchPaths []string, opts SlingOpts, open []beads.Bead, a config.Agent, deps SlingDeps) error {
+	for _, child := range open {
+		childVars := BuildSlingFormulaVars(formulaName, child.ID, opts.Vars, a, deps)
+		if err := validateSlingFormulaRuntimeVars(ctx, formulaName, searchPaths, molecule.Options{
+			Title: opts.Title,
+			Vars:  childVars,
+		}); err != nil {
+			return fmt.Errorf("child %s: %w", child.ID, err)
+		}
+	}
+	return nil
 }
 
 func sourceWorkflowLockScope(deps SlingDeps) string {
@@ -804,6 +837,9 @@ func DoSlingBatch(opts SlingOpts, deps SlingDeps, querier BeadChildQuerier) (Sli
 		var err error
 		isGraph, err = isGraphSlingFormula(context.Background(), useFormula, searchPaths, formulaVars)
 		if err != nil {
+			return SlingResult{}, fmt.Errorf("instantiating formula %q on %s %s: %w", useFormula, b.Type, b.ID, err)
+		}
+		if err := validateBatchSlingFormulaRuntimeVars(context.Background(), useFormula, searchPaths, opts, open, a, deps); err != nil {
 			return SlingResult{}, fmt.Errorf("instantiating formula %q on %s %s: %w", useFormula, b.Type, b.ID, err)
 		}
 		checkAttachments := CheckBatchNoMoleculeChildren


### PR DESCRIPTION
## Summary

Supersedes #1153.

Credit: Original fix by @julianknutsen. The contributor work is preserved as the first commit on this branch with original authorship.

- Surface required formula vars without breaking `gc formula show` display paths.
- Validate runtime vars at sling, order, attach, cook, and API preview boundaries so missing required vars are reported together instead of being masked by residual title placeholders.
- Preserve title override substitution and duplicate-attach idempotency while adding compile-time var validation for loop ranges and step conditions.

Fixes #1100

## Testing

- [x] `go vet ./...`
- [x] `go test -timeout 20m ./...`
- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

Migration note: orders that point at formulas with `required = true` runtime vars now fail fast with a validation error instead of creating beads with unresolved `{{var}}` placeholders. Existing order configs should be audited for formulas that require caller-supplied vars.
