### PR TITLE
test(api): escape order history cursor timestamps

### DIFF
--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -914,7 +915,7 @@ func TestHandleOrderHistoryBeforeUsesBufferedBoundedFetch(t *testing.T) {
 
 	h := newTestCityHandler(t, fs)
 	before := midRun.CreatedAt.Format(time.RFC3339Nano)
-	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+before), nil)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+url.QueryEscape(before)), nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -976,7 +977,7 @@ func TestHandleOrderHistoryBeforeFiltersBeforeStoreLimit(t *testing.T) {
 
 	h := newTestCityHandler(t, fs)
 	before := cursorRun.CreatedAt.Format(time.RFC3339Nano)
-	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+before), nil)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+url.QueryEscape(before)), nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -1042,7 +1043,7 @@ func TestHandleOrderHistoryBeforeFiltersBeforeMergedLimit(t *testing.T) {
 
 	h := newTestCityHandler(t, fs)
 	before := cursorRun.CreatedAt.Format(time.RFC3339Nano)
-	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review:rig:myrig&limit=1&before="+before), nil)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review:rig:myrig&limit=1&before="+url.QueryEscape(before)), nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 


### PR DESCRIPTION
## Summary

- URL-escape RFC3339Nano order-history cursor timestamps in handler tests.
- Prevent local timezones with positive UTC offsets from turning '+' into a space in query strings.

## Root Cause

The tests appended RFC3339 timestamps directly into query strings. In timezones such as Europe/Prague, timestamps include offsets like +02:00, and URL query decoding treats '+' as a space. The handler then correctly rejects the value as non-RFC3339.

## Validation

- go test ./internal/api -run 'TestHandleOrderHistoryBefore' -count=1
- go test ./internal/api -count=1
- make test
- go vet ./...