### PR TITLE
fix(mail): derive default title for replies to avoid bd validation error

### DIFF
--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -160,7 +160,7 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 	labels := []string{"thread:" + threadID, "reply-to:" + id}
 
 	b, err := p.store.Create(beads.Bead{
-		Title:       subject,
+		Title:       deriveReplyTitle(subject, original.Title, body),
 		Description: body,
 		Type:        "message",
 		Assignee:    original.From, // reply goes back to sender
@@ -171,6 +171,32 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
 	}
 	return beadToMessage(b), nil
+}
+
+// deriveReplyTitle returns a non-empty title for a reply message. Callers
+// that go through bd create fail validation ("title is required") if the
+// reply's title is empty, so this fallback chain always returns a usable
+// string. Precedence: explicit subject → "Re: <original>" (deduped) →
+// first line of reply body → literal "(reply)".
+func deriveReplyTitle(subject, originalTitle, body string) string {
+	if subject != "" {
+		return subject
+	}
+	if originalTitle != "" {
+		trimmed := strings.TrimLeft(originalTitle, " \t")
+		if strings.HasPrefix(strings.ToLower(trimmed), "re:") {
+			return originalTitle
+		}
+		return "Re: " + originalTitle
+	}
+	snippet := strings.SplitN(body, "\n", 2)[0]
+	if len(snippet) > 80 {
+		snippet = snippet[:77] + "..."
+	}
+	if snippet != "" {
+		return snippet
+	}
+	return "(reply)"
 }
 
 // Thread returns all messages sharing a thread ID, ordered by creation time.

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -561,6 +561,144 @@ func TestReply(t *testing.T) {
 	}
 }
 
+// TestReplyDerivesSubjectFromOriginal ensures an empty subject is replaced
+// with "Re: <original-subject>", so underlying stores that require a
+// non-empty title (e.g. BdStore → `bd create`) don't reject the reply.
+func TestReplyDerivesSubjectFromOriginal(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "Hello", "first message")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reply, err := p.Reply(sent.ID, "bob", "", "reply body")
+	if err != nil {
+		t.Fatalf("Reply with empty subject: %v", err)
+	}
+	if reply.Subject != "Re: Hello" {
+		t.Errorf("Reply Subject = %q, want %q", reply.Subject, "Re: Hello")
+	}
+}
+
+// TestReplyPreservesExplicitSubject ensures an explicit subject is passed
+// through unchanged — no automatic "Re:" prefixing.
+func TestReplyPreservesExplicitSubject(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "Hello", "first message")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reply, err := p.Reply(sent.ID, "bob", "Custom subject", "reply body")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if reply.Subject != "Custom subject" {
+		t.Errorf("Reply Subject = %q, want %q", reply.Subject, "Custom subject")
+	}
+}
+
+// TestReplyAvoidsDoubleRePrefix ensures that replying to a message whose
+// subject already starts with "Re:" does not produce "Re: Re: ..." when
+// the caller omits the subject.
+func TestReplyAvoidsDoubleRePrefix(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "Re: Hello", "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reply, err := p.Reply(sent.ID, "bob", "", "reply body")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if reply.Subject != "Re: Hello" {
+		t.Errorf("Reply Subject = %q, want %q (no double prefix)", reply.Subject, "Re: Hello")
+	}
+}
+
+// TestReplyFallsBackToBodyWhenOriginalTitleEmpty covers the degenerate case
+// where an original message somehow has no title (possible in stores that
+// don't enforce title). The reply still gets a non-empty title.
+func TestReplyFallsBackToBodyWhenOriginalTitleEmpty(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	// Create a message bead directly without a title.
+	orig, err := store.Create(beads.Bead{
+		Type:     "message",
+		Assignee: "bob",
+		From:     "alice",
+		Labels:   []string{"thread:t1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reply, err := p.Reply(orig.ID, "bob", "", "a terse reply body")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if reply.Subject == "" {
+		t.Error("Reply Subject is empty; must be non-empty so bd create won't reject")
+	}
+	if reply.Subject != "a terse reply body" {
+		t.Errorf("Reply Subject = %q, want %q (first line of body)", reply.Subject, "a terse reply body")
+	}
+}
+
+// TestReplyAgainstBdStoreValidatesTitle is a regression test that exercises
+// the real BdStore code path: the fake runner emulates `bd create`'s
+// title-required validation. Without a derived title, Reply would fail here.
+func TestReplyAgainstBdStoreValidatesTitle(t *testing.T) {
+	// Fake runner that rejects `bd create` with empty positional title,
+	// the same way the real bd binary does.
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			return nil, errors.New("unexpected command: " + name)
+		}
+		switch args[0] {
+		case "create":
+			// args: create --json <title> -t <type> [flags...]
+			if len(args) < 3 {
+				return nil, errors.New("bd create: too few args")
+			}
+			title := args[2]
+			if title == "" {
+				return nil, errors.New(`exit status 1: {"error":"validation failed for issue : title is required"}`)
+			}
+			// Return a minimal issue JSON.
+			id := "bd-" + title
+			return []byte(`{"id":"` + id + `","title":"` + title + `","status":"open","issue_type":"message","created_at":"2026-04-24T00:00:00Z"}`), nil
+		case "show":
+			// bd show --json returns a JSON array.
+			return []byte(`[{"id":"bd-Hello","title":"Hello","status":"open","issue_type":"message","assignee":"bob","from":"alice","created_at":"2026-04-24T00:00:00Z","labels":["thread:t1"]}]`), nil
+		case "update":
+			return []byte(`{}`), nil
+		case "list":
+			return []byte(`[]`), nil
+		}
+		return nil, errors.New("unexpected bd subcommand: " + args[0])
+	}
+	p := New(beads.NewBdStore(t.TempDir(), runner))
+
+	// Reply with empty subject — must succeed because the provider derives
+	// "Re: Hello" from the original message.
+	reply, err := p.Reply("bd-Hello", "bob", "", "reply body")
+	if err != nil {
+		t.Fatalf("Reply should derive a non-empty title to pass bd validation: %v", err)
+	}
+	if reply.Subject != "Re: Hello" {
+		t.Errorf("Reply Subject = %q, want %q", reply.Subject, "Re: Hello")
+	}
+}
+
 // --- Thread ---
 
 func TestThread(t *testing.T) {


### PR DESCRIPTION
## Summary

`gc mail reply <id> <body>` failed on every invocation with

```
beadmail reply: bd create: exit status 1: {"error":"validation failed for issue : title is required"}
```

because `beadmail.Reply` passed the `-s` flag value straight through as the bead `Title`. When callers omit `-s`, that value is empty, and `bd create` rejects empty titles. The MemStore used in unit tests does not validate, so the gap went unnoticed.

## Fix

Add `deriveReplyTitle(subject, originalTitle, body)` in `internal/mail/beadmail/beadmail.go` and use it to build the reply bead's Title. Precedence:

1. explicit `subject` (unchanged behavior),
2. `"Re: <originalTitle>"` (deduped if the parent already starts with `Re:`/`RE:` etc.),
3. first line of the reply body (truncated to 80 chars, same shape as `Send`'s existing fallback),
4. literal `"(reply)"` as a last-resort non-empty placeholder.

## Test plan

- [x] `go test ./internal/mail/...` — new cases:
  - `TestReplyDerivesSubjectFromOriginal` — empty subject → `"Re: Hello"`.
  - `TestReplyPreservesExplicitSubject` — explicit subject passes through.
  - `TestReplyAvoidsDoubleRePrefix` — original already has `Re:` prefix.
  - `TestReplyFallsBackToBodyWhenOriginalTitleEmpty` — body-snippet fallback.
  - `TestReplyAgainstBdStoreValidatesTitle` — end-to-end regression using `BdStore` with a fake runner that emulates `bd create`'s `"title is required"` validation. Fails before the patch, passes after.
- [x] `go vet ./internal/mail/...` clean.
- [x] `go build ./...` clean.
- [x] Existing `TestReply`, conformance suite, and `cmd/gc` mail-reply tests still green.

## Out of scope

- Threading / conversation-view UX improvements (called out as OOS in the originating bead).
- Equivalent fallback for `Send` when both subject and body are empty.

Refs: `ga-xj0a`