### PR TITLE
Default Codex model to GPT-5.5

### DIFF
--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	workertest "github.com/gastownhall/gascity/internal/worker/workertest"
 )
@@ -178,11 +179,11 @@ func inputOverrideDefaultsResult(tc phase2ProviderCase, prepared *preparedStart)
 		return workertest.Fail(tc.profileID, workertest.RequirementInputOverrideDefaults,
 			"ResolvedProvider = nil, want provider defaults for override comparison").WithEvidence(evidence)
 	}
-	defaultArgs := prepared.candidate.tp.ResolvedProvider.ResolveDefaultArgs()
+	defaultArgs := defaultArgsExceptOption(prepared.candidate.tp.ResolvedProvider, "model")
 	switch {
 	case !containsOrderedArgs(prepared.cfg.Command, defaultArgs):
 		return workertest.Fail(tc.profileID, workertest.RequirementInputOverrideDefaults,
-			fmt.Sprintf("Command = %q, want default args %v", prepared.cfg.Command, defaultArgs)).WithEvidence(evidence)
+			fmt.Sprintf("Command = %q, want non-model default args %v", prepared.cfg.Command, defaultArgs)).WithEvidence(evidence)
 	case !containsOrderedArgs(prepared.cfg.Command, tc.wantModelOverrideArgs):
 		return workertest.Fail(tc.profileID, workertest.RequirementInputOverrideDefaults,
 			fmt.Sprintf("Command = %q, want model override args %v", prepared.cfg.Command, tc.wantModelOverrideArgs)).WithEvidence(evidence)
@@ -196,6 +197,49 @@ func inputOverrideDefaultsResult(tc phase2ProviderCase, prepared *preparedStart)
 		return workertest.Pass(tc.profileID, workertest.RequirementInputOverrideDefaults,
 			"provider default launch flags survive schema overrides while first-input delivery stays exact-once").WithEvidence(evidence)
 	}
+}
+
+func defaultArgsExceptOption(provider *config.ResolvedProvider, optionKey string) []string {
+	if provider == nil {
+		return nil
+	}
+	defaultArgs := provider.ResolveDefaultArgs()
+	defaultValue := provider.EffectiveDefaults[optionKey]
+	for _, opt := range provider.OptionsSchema {
+		if opt.Key == optionKey && defaultValue == "" {
+			defaultValue = opt.Default
+		}
+		if opt.Key != optionKey || defaultValue == "" {
+			continue
+		}
+		for _, choice := range opt.Choices {
+			if choice.Value == defaultValue {
+				return removeContiguousArgs(defaultArgs, choice.FlagArgs)
+			}
+		}
+	}
+	return defaultArgs
+}
+
+func removeContiguousArgs(args, remove []string) []string {
+	if len(args) == 0 || len(remove) == 0 || len(remove) > len(args) {
+		return args
+	}
+	for i := 0; i <= len(args)-len(remove); i++ {
+		matched := true
+		for j := range remove {
+			if args[i+j] != remove[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			out := append([]string{}, args[:i]...)
+			out = append(out, args[i+len(remove):]...)
+			return out
+		}
+	}
+	return args
 }
 
 func phase2TemplateEvidence(tc phase2ProviderCase, tp TemplateParams) map[string]string {

--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -67,7 +67,7 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 		{
 			profileID:             "codex/tmux-cli",
 			family:                "codex",
-			wantCommand:           "codex --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort=xhigh",
+			wantCommand:           "codex --dangerously-bypass-approvals-and-sandbox --model gpt-5.5 -c model_reasoning_effort=xhigh",
 			wantReadyDelayMs:      3000,
 			wantReadyPromptPrefix: "› ",
 			wantProcessNames:      []string{"codex"},

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -714,6 +714,13 @@ func TestBuiltinProviders_CodexHasNilArgsAndOptionDefaults(t *testing.T) {
 		t.Errorf("codex OptionDefaults[permission_mode] = %q, want unrestricted",
 			codex.OptionDefaults["permission_mode"])
 	}
+	if codex.OptionDefaults["model"] != "gpt-5.5" {
+		t.Errorf("codex OptionDefaults[model] = %q, want gpt-5.5",
+			codex.OptionDefaults["model"])
+	}
+	if !schemaHasChoice(codex.OptionsSchema, "model", "gpt-5.5") {
+		t.Error("codex OptionsSchema missing model choice gpt-5.5")
+	}
 }
 
 func TestBuiltinProviders_GeminiHasNilArgsAndOptionDefaults(t *testing.T) {
@@ -768,4 +775,18 @@ func TestValidateOptionDefaults_InvalidValue(t *testing.T) {
 	if !strings.Contains(err.Error(), "not a valid choice") {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+func schemaHasChoice(schema []ProviderOption, key, value string) bool {
+	for _, opt := range schema {
+		if opt.Key != key {
+			continue
+		}
+		for _, choice := range opt.Choices {
+			if choice.Value == value {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -112,7 +112,11 @@ func TestResolveProviderWorkspaceProvider(t *testing.T) {
 		t.Errorf("CommandString() = %q, want %q", rp.CommandString(), "codex")
 	}
 	defaultArgs := rp.ResolveDefaultArgs()
-	codexWantArgs := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "model_reasoning_effort=xhigh"}
+	codexWantArgs := []string{
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--model", "gpt-5.5",
+		"-c", "model_reasoning_effort=xhigh",
+	}
 	if len(defaultArgs) != len(codexWantArgs) {
 		t.Errorf("ResolveDefaultArgs() = %v, want %v", defaultArgs, codexWantArgs)
 	} else {

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -149,6 +149,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		Command:     "codex",
 		OptionDefaults: map[string]string{
 			"permission_mode": "unrestricted",
+			"model":           "gpt-5.5",
 			"effort":          "xhigh",
 		},
 		PromptMode:        "arg",
@@ -184,6 +185,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
+					{Value: "gpt-5.5", Label: "GPT-5.5", FlagArgs: []string{"--model", "gpt-5.5"}},
 					{Value: "o3", Label: "o3", FlagArgs: []string{"--model", "o3"}},
 					{Value: "o4-mini", Label: "o4-mini", FlagArgs: []string{"--model", "o4-mini"}},
 				},


### PR DESCRIPTION
## Summary
- add `gpt-5.5` as a Codex model schema choice
- make `gpt-5.5` the built-in Codex model default
- update provider/default-command tests for the new default

## Tests
- `go test ./internal/worker/builtin ./internal/config`
- `go test ./cmd/gc -run 'TestPhase2|TestResolveProvider|TestTemplate'`\n