### PR TITLE
fix: atomically materialize system pack files

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -160,8 +161,45 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		if isExecutableScriptFilename(path) {
 			perm = 0o755
 		}
-		return os.WriteFile(dst, data, perm)
+		return writeFileAtomic(dst, data, perm)
 	})
+}
+
+// writeFileAtomic replaces path without exposing a truncated file to readers.
+// System pack skills are watched by provider CLIs, so direct os.WriteFile can
+// surface transient invalid SKILL.md warnings during gc start/prime.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if n, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	} else if n != len(data) {
+		_ = tmp.Close()
+		return io.ErrShortWrite
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
 }
 
 // isExecutableScriptFilename reports whether a materialized pack asset

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
 	"github.com/gastownhall/gascity/internal/bootstrap/packs/core"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -39,9 +39,10 @@ var builtinPacks = []builtinPack{
 }
 
 // MaterializeBuiltinPacks writes all embedded pack files to
-// .gc/system/packs/{name}/ in the city directory. Files are always
-// overwritten to stay in sync with the gc binary version. Shell scripts
-// get 0755; everything else 0644.
+// .gc/system/packs/{name}/ in the city directory. Files whose content and mode
+// already match are left in place; changed content or mode is repaired with an
+// atomic rename so readers never observe a truncated file. Shell scripts get
+// 0755; everything else 0644.
 // Idempotent: safe to call on every gc start and gc init.
 func MaterializeBuiltinPacks(cityPath string) error {
 	for _, bp := range builtinPacks {
@@ -161,45 +162,8 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		if isExecutableScriptFilename(path) {
 			perm = 0o755
 		}
-		return writeFileAtomic(dst, data, perm)
+		return fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, dst, data, perm)
 	})
-}
-
-// writeFileAtomic replaces path without exposing a truncated file to readers.
-// System pack skills are watched by provider CLIs, so direct os.WriteFile can
-// surface transient invalid SKILL.md warnings during gc start/prime.
-func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpName)
-		}
-	}()
-
-	if n, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	} else if n != len(data) {
-		_ = tmp.Close()
-		return io.ErrShortWrite
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return err
-	}
-	cleanup = false
-	return nil
 }
 
 // isExecutableScriptFilename reports whether a materialized pack asset

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
@@ -322,6 +323,93 @@ func TestMaterializeBuiltinPacks_Idempotent(t *testing.T) {
 	// Files should still exist.
 	if _, err := os.Stat(filepath.Join(dir, citylayout.SystemPacksRoot, "bd", "pack.toml")); err != nil {
 		t.Error("bd pack.toml missing after second call")
+	}
+}
+
+func TestMaterializeBuiltinPacks_DoesNotRewriteUnchangedFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	path := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills", "gc-dashboard", "SKILL.md")
+	past := time.Unix(123456789, 0)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("Chtimes(%s): %v", path, err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() second call error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s): %v", path, err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Fatalf("unchanged file was rewritten: modtime = %s, want %s", info.ModTime(), past)
+	}
+}
+
+func TestMaterializeBuiltinPacks_RestoresModeWhenContentUnchanged(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	path := filepath.Join(dir, citylayout.SystemPacksRoot, "bd", "doctor", "check-bd", "run.sh")
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod(%s): %v", path, err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() second call error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s): %v", path, err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("script mode was not restored: %v", info.Mode().Perm())
+	}
+}
+
+func TestMaterializeBuiltinPacks_ReplacesMatchingSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	path := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills", "gc-dashboard", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	target := filepath.Join(dir, "outside-skill.md")
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", target, err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove(%s): %v", path, err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("Symlink: %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() second call error: %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat(%s): %v", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("matching symlink was preserved, want regular file")
 	}
 }
 

--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // beadHooks maps bd hook filenames to the Gas City event types they emit.
@@ -53,7 +55,7 @@ title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
 
 // installBeadHooks writes bd hook scripts into dir/.beads/hooks/ so that
 // bd mutations (create, close, update) emit events to the Gas City event
-// log. Idempotent — overwrites existing hooks. Returns nil on success.
+// log. Idempotent — leaves matching hooks in place. Returns nil on success.
 func installBeadHooks(dir string) error {
 	hooksDir := filepath.Join(dir, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
@@ -66,7 +68,7 @@ func installBeadHooks(dir string) error {
 		if filename == "on_close" {
 			content = closeHookScript()
 		}
-		if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		if err := fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, path, []byte(content), 0o755); err != nil {
 			return fmt.Errorf("writing hook %s: %w", filename, err)
 		}
 	}

--- a/cmd/gc/hooks_test.go
+++ b/cmd/gc/hooks_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestInstallBeadHooksCreatesScripts(t *testing.T) {
@@ -95,6 +96,68 @@ func TestInstallBeadHooksIdempotent(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "bead.created") {
 		t.Errorf("hook content wrong after idempotent install")
+	}
+}
+
+func TestInstallBeadHooksDoesNotRewriteUnchangedHooks(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	path := filepath.Join(dir, ".beads", "hooks", "on_create")
+	past := time.Unix(123456789, 0)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Fatalf("unchanged hook was rewritten: modtime = %s, want %s", info.ModTime(), past)
+	}
+}
+
+func TestInstallBeadHooksReplacesMatchingSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	path := filepath.Join(dir, ".beads", "hooks", "on_create")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	target := filepath.Join(dir, "outside-hook")
+	if err := os.WriteFile(target, data, 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", target, err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove(%s): %v", path, err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("Symlink: %v", err)
+	}
+
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat(%s): %v", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("matching symlink was preserved, want regular file")
 	}
 }
 

--- a/internal/fsys/atomic.go
+++ b/internal/fsys/atomic.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"time"
 )
@@ -34,14 +35,109 @@ func WriteFileAtomic(fs FS, path string, data []byte, perm os.FileMode) error {
 }
 
 // WriteFileIfChangedAtomic writes data to path atomically only when the
-// existing on-disk bytes differ. Returns nil with no write when the
-// content already matches. A read error other than "not exist" is
-// ignored and the write proceeds — this is a best-effort optimization to
-// avoid churning mtime (and fsnotify watchers) on no-op writes, not a
-// safety check.
+// existing on-disk bytes differ. Returns nil with no write when the content
+// already matches on a stable regular file. Read or stat errors are ignored
+// and the write proceeds — this is a best-effort optimization to avoid
+// churning mtime on no-op writes, not a safety check.
 func WriteFileIfChangedAtomic(fs FS, path string, data []byte, perm os.FileMode) error {
-	if existing, err := fs.ReadFile(path); err == nil && bytes.Equal(existing, data) {
-		return nil
+	if info, err := fs.Lstat(path); err == nil && info.Mode().IsRegular() {
+		if snapshot, err := readRegularFileSnapshot(fs, path); err == nil && bytes.Equal(snapshot.data, data) {
+			if info, err := fs.Lstat(path); err == nil && info.Mode().IsRegular() {
+				if !snapshot.hasID {
+					return WriteFileAtomic(fs, path, data, perm)
+				}
+				currentID, ok := fileIdentityFromInfo(info)
+				if !ok || currentID != snapshot.id {
+					return WriteFileAtomic(fs, path, data, perm)
+				}
+				return nil
+			}
+		}
 	}
 	return WriteFileAtomic(fs, path, data, perm)
+}
+
+// WriteFileIfContentOrModeChangedAtomic writes data to path atomically when
+// the existing on-disk bytes, file type, or permissions differ. Returns nil
+// with no write when the path is already a regular file with matching content
+// and mode. Symlinks and other non-regular entries are replaced without first
+// reading through them. Read or stat errors are ignored and the write proceeds.
+func WriteFileIfContentOrModeChangedAtomic(fs FS, path string, data []byte, perm os.FileMode) error {
+	if info, err := fs.Lstat(path); err == nil && info.Mode().IsRegular() && comparableMode(info.Mode()) == comparableMode(perm) {
+		if snapshot, err := readRegularFileSnapshot(fs, path); err == nil && bytes.Equal(snapshot.data, data) {
+			if info, err := fs.Lstat(path); err == nil && info.Mode().IsRegular() && comparableMode(info.Mode()) == comparableMode(perm) {
+				if !snapshot.hasID {
+					return WriteFileAtomic(fs, path, data, perm)
+				}
+				currentID, ok := fileIdentityFromInfo(info)
+				if !ok || currentID != snapshot.id {
+					return WriteFileAtomic(fs, path, data, perm)
+				}
+				return nil
+			}
+		}
+	}
+	return WriteFileAtomic(fs, path, data, perm)
+}
+
+type regularFileSnapshotReader interface {
+	readRegularFileSnapshot(name string) (regularFileSnapshot, error)
+}
+
+type regularFileSnapshot struct {
+	data  []byte
+	id    fileIdentity
+	hasID bool
+}
+
+type fileIdentity struct {
+	dev uint64
+	ino uint64
+}
+
+func readRegularFileSnapshot(fs FS, path string) (regularFileSnapshot, error) {
+	if reader, ok := fs.(regularFileSnapshotReader); ok {
+		return reader.readRegularFileSnapshot(path)
+	}
+	return regularFileSnapshot{}, &os.PathError{Op: "open", Path: path, Err: os.ErrInvalid}
+}
+
+func comparableMode(mode os.FileMode) os.FileMode {
+	return mode & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
+}
+
+func fileIdentityFromInfo(info os.FileInfo) (fileIdentity, bool) {
+	stat := reflect.Indirect(reflect.ValueOf(info.Sys()))
+	if !stat.IsValid() {
+		return fileIdentity{}, false
+	}
+	dev := stat.FieldByName("Dev")
+	ino := stat.FieldByName("Ino")
+	if !dev.IsValid() || !ino.IsValid() {
+		return fileIdentity{}, false
+	}
+	devValue, ok := numericFieldToUint64(dev)
+	if !ok {
+		return fileIdentity{}, false
+	}
+	inoValue, ok := numericFieldToUint64(ino)
+	if !ok {
+		return fileIdentity{}, false
+	}
+	return fileIdentity{dev: devValue, ino: inoValue}, true
+}
+
+func numericFieldToUint64(v reflect.Value) (uint64, bool) {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		value := v.Int()
+		if value < 0 {
+			return 0, false
+		}
+		return uint64(value), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint(), true
+	default:
+		return 0, false
+	}
 }

--- a/internal/fsys/atomic_internal_test.go
+++ b/internal/fsys/atomic_internal_test.go
@@ -1,0 +1,157 @@
+package fsys
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWriteFileIfContentOrModeChangedAtomic_RewritesWhenIdentityChanges(t *testing.T) {
+	fs := &identityChangingFS{data: []byte("#!/bin/sh\n")}
+
+	if err := WriteFileIfContentOrModeChangedAtomic(fs, "/script.sh", fs.data, 0o755); err != nil {
+		t.Fatalf("WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	if !fs.renamed {
+		t.Fatalf("identity-changing file was not rewritten")
+	}
+}
+
+func TestWriteFileIfChangedAtomic_RewritesWhenIdentityChanges(t *testing.T) {
+	fs := &identityChangingFS{data: []byte("hello = true\n")}
+
+	if err := WriteFileIfChangedAtomic(fs, "/config.toml", fs.data, 0o644); err != nil {
+		t.Fatalf("WriteFileIfChangedAtomic: %v", err)
+	}
+
+	if !fs.renamed {
+		t.Fatalf("identity-changing file was not rewritten")
+	}
+}
+
+func TestWriteFileIfContentOrModeChangedAtomic_RewritesWithoutSnapshotIdentity(t *testing.T) {
+	fs := &noIdentitySnapshotFS{data: []byte("#!/bin/sh\n")}
+
+	if err := WriteFileIfContentOrModeChangedAtomic(fs, "/script.sh", fs.data, 0o755); err != nil {
+		t.Fatalf("WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	if !fs.renamed {
+		t.Fatalf("no-identity snapshot was not rewritten")
+	}
+}
+
+func TestWriteFileIfChangedAtomic_RewritesWithoutSnapshotIdentity(t *testing.T) {
+	fs := &noIdentitySnapshotFS{data: []byte("hello = true\n")}
+
+	if err := WriteFileIfChangedAtomic(fs, "/config.toml", fs.data, 0o644); err != nil {
+		t.Fatalf("WriteFileIfChangedAtomic: %v", err)
+	}
+
+	if !fs.renamed {
+		t.Fatalf("no-identity snapshot was not rewritten")
+	}
+}
+
+type identityChangingFS struct {
+	data        []byte
+	snapshotErr error
+	renamed     bool
+	lstats      int
+}
+
+func (f *identityChangingFS) MkdirAll(string, os.FileMode) error { return nil }
+
+func (f *identityChangingFS) WriteFile(string, []byte, os.FileMode) error { return nil }
+
+func (f *identityChangingFS) ReadFile(string) ([]byte, error) { return f.data, nil }
+
+func (f *identityChangingFS) Stat(string) (os.FileInfo, error) {
+	return identityFileInfo{mode: 0o755, id: fileIdentity{dev: 1, ino: 1}}, nil
+}
+
+func (f *identityChangingFS) Lstat(string) (os.FileInfo, error) {
+	f.lstats++
+	id := fileIdentity{dev: 1, ino: 1}
+	if f.lstats > 1 {
+		id = fileIdentity{dev: 1, ino: 2}
+	}
+	return identityFileInfo{mode: 0o755, id: id}, nil
+}
+
+func (f *identityChangingFS) ReadDir(string) ([]os.DirEntry, error) { return nil, nil }
+
+func (f *identityChangingFS) Rename(string, string) error {
+	f.renamed = true
+	return nil
+}
+
+func (f *identityChangingFS) Remove(string) error { return nil }
+
+func (f *identityChangingFS) Chmod(string, os.FileMode) error { return nil }
+
+func (f *identityChangingFS) readRegularFileSnapshot(string) (regularFileSnapshot, error) {
+	if f.snapshotErr != nil {
+		return regularFileSnapshot{}, f.snapshotErr
+	}
+	return regularFileSnapshot{
+		data:  f.data,
+		id:    fileIdentity{dev: 1, ino: 1},
+		hasID: true,
+	}, nil
+}
+
+type identityFileInfo struct {
+	mode os.FileMode
+	id   fileIdentity
+}
+
+func (i identityFileInfo) Name() string       { return "script.sh" }
+func (i identityFileInfo) Size() int64        { return int64(len("#!/bin/sh\n")) }
+func (i identityFileInfo) Mode() os.FileMode  { return i.mode }
+func (i identityFileInfo) ModTime() time.Time { return time.Time{} }
+func (i identityFileInfo) IsDir() bool        { return false }
+func (i identityFileInfo) Sys() any           { return struct{ Dev, Ino uint64 }{i.id.dev, i.id.ino} }
+
+var _ FS = (*identityChangingFS)(nil)
+
+type noIdentitySnapshotFS struct {
+	data        []byte
+	snapshotErr error
+	renamed     bool
+}
+
+func (f *noIdentitySnapshotFS) MkdirAll(string, os.FileMode) error { return nil }
+
+func (f *noIdentitySnapshotFS) WriteFile(string, []byte, os.FileMode) error { return nil }
+
+func (f *noIdentitySnapshotFS) ReadFile(string) ([]byte, error) { return f.data, nil }
+
+func (f *noIdentitySnapshotFS) Stat(string) (os.FileInfo, error) {
+	return identityFileInfo{mode: 0o755, id: fileIdentity{dev: 1, ino: 1}}, nil
+}
+
+func (f *noIdentitySnapshotFS) Lstat(string) (os.FileInfo, error) {
+	return identityFileInfo{mode: 0o755, id: fileIdentity{dev: 1, ino: 1}}, nil
+}
+
+func (f *noIdentitySnapshotFS) ReadDir(string) ([]os.DirEntry, error) { return nil, nil }
+
+func (f *noIdentitySnapshotFS) Rename(string, string) error {
+	f.renamed = true
+	return nil
+}
+
+func (f *noIdentitySnapshotFS) Remove(string) error { return nil }
+
+func (f *noIdentitySnapshotFS) Chmod(string, os.FileMode) error { return nil }
+
+func (f *noIdentitySnapshotFS) readRegularFileSnapshot(string) (regularFileSnapshot, error) {
+	if f.snapshotErr != nil {
+		return regularFileSnapshot{}, f.snapshotErr
+	}
+	return regularFileSnapshot{data: f.data}, nil
+}
+
+var _ FS = (*noIdentitySnapshotFS)(nil)

--- a/internal/fsys/atomic_test.go
+++ b/internal/fsys/atomic_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -54,6 +55,213 @@ func TestWriteFileAtomic_Overwrite(t *testing.T) {
 	for _, e := range entries {
 		if e.Name() != "test.toml" {
 			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteFileIfChangedAtomic_SkipsMatchingContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.toml")
+	data := []byte("hello = true\n")
+
+	if err := fsys.WriteFileAtomic(fsys.OSFS{}, path, data, 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+	past := time.Unix(123456789, 0)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	if err := fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, path, data, 0o644); err != nil {
+		t.Fatalf("WriteFileIfChangedAtomic: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Fatalf("file was rewritten: modtime = %s, want %s", info.ModTime(), past)
+	}
+}
+
+func TestWriteFileIfChangedAtomic_SkipsMatchingContentWhenModeDiffers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.toml")
+	data := []byte("hello = true\n")
+
+	if err := fsys.WriteFileAtomic(fsys.OSFS{}, path, data, 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+	past := time.Unix(123456789, 0)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	if err := fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, path, data, 0o755); err != nil {
+		t.Fatalf("WriteFileIfChangedAtomic: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Fatalf("file was rewritten: modtime = %s, want %s", info.ModTime(), past)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("mode = %v, want unchanged 0644", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileIfChangedAtomic_ReplacesMatchingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.toml")
+	link := filepath.Join(dir, "link.toml")
+	data := []byte("hello = true\n")
+
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, link, data, 0o644); err != nil {
+		t.Fatalf("WriteFileIfChangedAtomic: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("matching symlink was preserved, want replacement with regular file")
+	}
+}
+
+func TestWriteFileIfContentOrModeChangedAtomic_RepairsModeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.sh")
+	data := []byte("#!/bin/sh\n")
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, path, data, 0o755); err != nil {
+		t.Fatalf("WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileIfContentOrModeChangedAtomic_RepairsSpecialModeBits(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.sh")
+	data := []byte("#!/bin/sh\n")
+
+	if err := os.WriteFile(path, data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o4755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSetuid == 0 {
+		t.Skipf("filesystem did not preserve setuid bit in test mode: %v", info.Mode())
+	}
+
+	if err := fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, path, data, 0o755); err != nil {
+		t.Fatalf("WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSetuid != 0 {
+		t.Fatalf("setuid bit was not repaired: mode = %v", info.Mode())
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileIfContentOrModeChangedAtomic_ReplacesMatchingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.sh")
+	link := filepath.Join(dir, "link.sh")
+	data := []byte("#!/bin/sh\n")
+
+	if err := os.WriteFile(target, data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, link, data, 0o755); err != nil {
+		t.Fatalf("WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("matching symlink was preserved, want replacement with regular file")
+	}
+}
+
+func TestWriteFileIfContentOrModeChangedAtomic_LstatsBeforeRead(t *testing.T) {
+	fake := fsys.NewFake()
+	fake.Files["/target.sh"] = []byte("#!/bin/sh\n")
+	fake.Symlinks["/link.sh"] = "/target.sh"
+
+	if err := fsys.WriteFileIfContentOrModeChangedAtomic(fake, "/link.sh", []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	for i, call := range fake.Calls {
+		if call.Method == "Lstat" && call.Path == "/link.sh" {
+			return
+		}
+		if call.Method == "ReadFile" && call.Path == "/link.sh" {
+			t.Fatalf("ReadFile called before Lstat at call %d: %+v", i, fake.Calls)
+		}
+	}
+	t.Fatalf("Lstat(/link.sh) not called; calls=%+v", fake.Calls)
+}
+
+func TestWriteFileIfContentOrModeChangedAtomic_FakeSkipsMatchingContentAndMode(t *testing.T) {
+	fake := fsys.NewFake()
+	data := []byte("hello = true\n")
+
+	if err := fsys.WriteFileIfContentOrModeChangedAtomic(fake, "/test.toml", data, 0o644); err != nil {
+		t.Fatalf("initial WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+	fake.Calls = nil
+
+	if err := fsys.WriteFileIfContentOrModeChangedAtomic(fake, "/test.toml", data, 0o644); err != nil {
+		t.Fatalf("second WriteFileIfContentOrModeChangedAtomic: %v", err)
+	}
+
+	for _, call := range fake.Calls {
+		if call.Method == "WriteFile" || call.Method == "Rename" || call.Method == "Chmod" {
+			t.Fatalf("matching fake file should not be rewritten; calls=%+v", fake.Calls)
 		}
 	}
 }

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -1,6 +1,7 @@
 package fsys
 
 import (
+	"hash/fnv"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 type Fake struct {
 	Dirs     map[string]bool   // pre-populated directories
 	Files    map[string][]byte // pre-populated files
+	Modes    map[string]os.FileMode
 	Symlinks map[string]string // pre-populated symlinks (path -> target)
 	Errors   map[string]error  // path → injected error (checked first)
 	Calls    []Call            // spy log
@@ -21,7 +23,7 @@ type Fake struct {
 
 // Call records a single method invocation on [Fake].
 type Call struct {
-	Method string // "MkdirAll", "WriteFile", "ReadFile", "Stat", "ReadDir", "Rename", "Remove", or "Chmod"
+	Method string // "MkdirAll", "WriteFile", "ReadFile", "ReadRegularFile", "Stat", "ReadDir", "Rename", "Remove", or "Chmod"
 	Path   string // path argument
 }
 
@@ -30,33 +32,50 @@ func NewFake() *Fake {
 	return &Fake{
 		Dirs:     make(map[string]bool),
 		Files:    make(map[string][]byte),
+		Modes:    make(map[string]os.FileMode),
 		Symlinks: make(map[string]string),
 		Errors:   make(map[string]error),
 	}
 }
 
 // MkdirAll records the call and adds the directory (and parents) to Dirs.
-func (f *Fake) MkdirAll(path string, _ os.FileMode) error {
+func (f *Fake) MkdirAll(path string, perm os.FileMode) error {
 	f.Calls = append(f.Calls, Call{Method: "MkdirAll", Path: path})
 	if err, ok := f.Errors[path]; ok {
 		return err
 	}
+	if f.Dirs == nil {
+		f.Dirs = make(map[string]bool)
+	}
+	if f.Modes == nil {
+		f.Modes = make(map[string]os.FileMode)
+	}
 	// Record this directory and all parents.
 	for p := filepath.Clean(path); p != "." && p != "/" && p != string(filepath.Separator); p = filepath.Dir(p) {
+		if !f.Dirs[p] {
+			f.Modes[p] = perm.Perm()
+		}
 		f.Dirs[p] = true
 	}
 	return nil
 }
 
 // WriteFile records the call and stores the data in Files.
-func (f *Fake) WriteFile(name string, data []byte, _ os.FileMode) error {
+func (f *Fake) WriteFile(name string, data []byte, perm os.FileMode) error {
 	f.Calls = append(f.Calls, Call{Method: "WriteFile", Path: name})
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
 	cp := make([]byte, len(data))
 	copy(cp, data)
+	if f.Files == nil {
+		f.Files = make(map[string][]byte)
+	}
+	if f.Modes == nil {
+		f.Modes = make(map[string]os.FileMode)
+	}
 	f.Files[name] = cp
+	f.Modes[name] = perm.Perm()
 	return nil
 }
 
@@ -74,6 +93,37 @@ func (f *Fake) ReadFile(name string) ([]byte, error) {
 	return nil, &os.PathError{Op: "read", Path: name, Err: os.ErrNotExist}
 }
 
+// ReadRegularFile records the call and returns file contents without following
+// symlinks or accepting directories.
+func (f *Fake) ReadRegularFile(name string) ([]byte, error) {
+	f.Calls = append(f.Calls, Call{Method: "ReadRegularFile", Path: name})
+	if err, ok := f.Errors[name]; ok {
+		return nil, err
+	}
+	if _, ok := f.Symlinks[name]; ok {
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrInvalid}
+	}
+	if f.Dirs[name] {
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrInvalid}
+	}
+	if data, ok := f.Files[name]; ok {
+		cp := make([]byte, len(data))
+		copy(cp, data)
+		return cp, nil
+	}
+	return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
+}
+
+// readRegularFileSnapshot returns regular file contents plus a stable fake
+// identity for the path.
+func (f *Fake) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
+	data, err := f.ReadRegularFile(name)
+	if err != nil {
+		return regularFileSnapshot{}, err
+	}
+	return regularFileSnapshot{data: data, id: fakeIdentity(name), hasID: true}, nil
+}
+
 // Stat records the call and returns info based on Dirs/Files maps.
 // Symlinks are followed — use Lstat to detect them without following.
 func (f *Fake) Stat(name string) (os.FileInfo, error) {
@@ -83,18 +133,18 @@ func (f *Fake) Stat(name string) (os.FileInfo, error) {
 	}
 	if target, ok := f.Symlinks[name]; ok {
 		if f.Dirs[target] {
-			return fakeFileInfo{name: filepath.Base(name), dir: true}, nil
+			return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(target), id: fakeIdentity(target), hasID: true}, nil
 		}
 		if data, ok := f.Files[target]; ok {
-			return fakeFileInfo{name: filepath.Base(name), size: int64(len(data))}, nil
+			return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(target), id: fakeIdentity(target), hasID: true}, nil
 		}
 		return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
 	}
 	if f.Dirs[name] {
-		return fakeFileInfo{name: filepath.Base(name), dir: true}, nil
+		return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
 	}
 	if data, ok := f.Files[name]; ok {
-		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data))}, nil
+		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
 	}
 	return nil, &os.PathError{Op: "stat", Path: name, Err: os.ErrNotExist}
 }
@@ -107,13 +157,13 @@ func (f *Fake) Lstat(name string) (os.FileInfo, error) {
 		return nil, err
 	}
 	if _, ok := f.Symlinks[name]; ok {
-		return fakeFileInfo{name: filepath.Base(name), symlink: true}, nil
+		return fakeFileInfo{name: filepath.Base(name), symlink: true, id: fakeIdentity(name), hasID: true}, nil
 	}
 	if f.Dirs[name] {
-		return fakeFileInfo{name: filepath.Base(name), dir: true}, nil
+		return fakeFileInfo{name: filepath.Base(name), dir: true, mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
 	}
 	if data, ok := f.Files[name]; ok {
-		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data))}, nil
+		return fakeFileInfo{name: filepath.Base(name), size: int64(len(data)), mode: f.modeFor(name), id: fakeIdentity(name), hasID: true}, nil
 	}
 	return nil, &os.PathError{Op: "lstat", Path: name, Err: os.ErrNotExist}
 }
@@ -135,7 +185,7 @@ func (f *Fake) ReadDir(name string) ([]os.DirEntry, error) {
 			base := filepath.Base(d)
 			if !seen[base] {
 				seen[base] = true
-				entries = append(entries, fakeDirEntry{name: base, dir: true})
+				entries = append(entries, fakeDirEntry{name: base, dir: true, mode: f.modeFor(d), id: fakeIdentity(d), hasID: true})
 			}
 		}
 	}
@@ -145,7 +195,7 @@ func (f *Fake) ReadDir(name string) ([]os.DirEntry, error) {
 			base := filepath.Base(p)
 			if !seen[base] {
 				seen[base] = true
-				entries = append(entries, fakeDirEntry{name: base, size: int64(len(data))})
+				entries = append(entries, fakeDirEntry{name: base, size: int64(len(data)), mode: f.modeFor(p), id: fakeIdentity(p), hasID: true})
 			}
 		}
 	}
@@ -165,6 +215,13 @@ func (f *Fake) Rename(oldpath, newpath string) error {
 	if data, ok := f.Files[oldpath]; ok {
 		f.Files[newpath] = data
 		delete(f.Files, oldpath)
+		if mode, ok := f.Modes[oldpath]; ok {
+			f.Modes[newpath] = mode
+		} else {
+			delete(f.Modes, newpath)
+		}
+		delete(f.Modes, oldpath)
+		delete(f.Symlinks, newpath)
 		return nil
 	}
 	return &os.PathError{Op: "rename", Path: oldpath, Err: os.ErrNotExist}
@@ -178,29 +235,46 @@ func (f *Fake) Remove(name string) error {
 	}
 	if _, ok := f.Files[name]; ok {
 		delete(f.Files, name)
+		delete(f.Modes, name)
+		return nil
+	}
+	if _, ok := f.Symlinks[name]; ok {
+		delete(f.Symlinks, name)
 		return nil
 	}
 	if f.Dirs[name] {
 		delete(f.Dirs, name)
+		delete(f.Modes, name)
 		return nil
 	}
 	return &os.PathError{Op: "remove", Path: name, Err: os.ErrNotExist}
 }
 
-// Chmod records the call. Mode is not tracked — the spy log is sufficient
-// for tests that care about which paths were chmodded.
-func (f *Fake) Chmod(name string, _ os.FileMode) error {
+// Chmod records the call and updates the stored mode.
+func (f *Fake) Chmod(name string, mode os.FileMode) error {
 	f.Calls = append(f.Calls, Call{Method: "Chmod", Path: name})
 	if err, ok := f.Errors[name]; ok {
 		return err
 	}
+	if f.Modes == nil {
+		f.Modes = make(map[string]os.FileMode)
+	}
 	if _, ok := f.Files[name]; ok {
+		f.Modes[name] = mode.Perm()
 		return nil
 	}
 	if f.Dirs[name] {
+		f.Modes[name] = mode.Perm()
 		return nil
 	}
 	return &os.PathError{Op: "chmod", Path: name, Err: os.ErrNotExist}
+}
+
+func (f *Fake) modeFor(name string) os.FileMode {
+	if mode, ok := f.Modes[name]; ok {
+		return mode
+	}
+	return 0o755
 }
 
 // --- fake os.FileInfo ---
@@ -208,6 +282,9 @@ func (f *Fake) Chmod(name string, _ os.FileMode) error {
 type fakeFileInfo struct {
 	name    string
 	size    int64
+	mode    os.FileMode
+	id      fileIdentity
+	hasID   bool
 	dir     bool
 	symlink bool
 }
@@ -218,18 +295,29 @@ func (fi fakeFileInfo) Mode() os.FileMode {
 	if fi.symlink {
 		return 0o777 | os.ModeSymlink
 	}
-	return 0o755
+	if fi.dir {
+		return fi.mode | os.ModeDir
+	}
+	return fi.mode
 }
 func (fi fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (fi fakeFileInfo) IsDir() bool        { return fi.dir }
-func (fi fakeFileInfo) Sys() any           { return nil }
+func (fi fakeFileInfo) Sys() any {
+	if !fi.hasID {
+		return nil
+	}
+	return struct{ Dev, Ino uint64 }{fi.id.dev, fi.id.ino}
+}
 
 // --- fake os.DirEntry ---
 
 type fakeDirEntry struct {
-	name string
-	size int64
-	dir  bool
+	name  string
+	size  int64
+	mode  os.FileMode
+	id    fileIdentity
+	hasID bool
+	dir   bool
 }
 
 func (de fakeDirEntry) Name() string { return de.name }
@@ -242,7 +330,13 @@ func (de fakeDirEntry) Type() fs.FileMode {
 }
 
 func (de fakeDirEntry) Info() (fs.FileInfo, error) {
-	return fakeFileInfo{name: de.name, size: de.size, dir: de.dir}, nil
+	return fakeFileInfo{name: de.name, size: de.size, mode: de.mode, id: de.id, hasID: de.hasID, dir: de.dir}, nil
+}
+
+func fakeIdentity(name string) fileIdentity {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	return fileIdentity{dev: 1, ino: h.Sum64()}
 }
 
 var (

--- a/internal/fsys/fake_test.go
+++ b/internal/fsys/fake_test.go
@@ -23,6 +23,22 @@ func TestFakeStatDir(t *testing.T) {
 	}
 }
 
+func TestFakeStatDirModeIncludesDirBit(t *testing.T) {
+	f := NewFake()
+	f.Dirs["/city/.gc"] = true
+
+	fi, err := f.Stat("/city/.gc")
+	if err != nil {
+		t.Fatalf("Stat existing dir: %v", err)
+	}
+	if fi.Mode().IsRegular() {
+		t.Fatalf("directory mode reports regular file: %v", fi.Mode())
+	}
+	if fi.Mode()&os.ModeDir == 0 {
+		t.Fatalf("directory mode missing ModeDir bit: %v", fi.Mode())
+	}
+}
+
 func TestFakeStatFile(t *testing.T) {
 	f := NewFake()
 	f.Files["/city/city.toml"] = []byte("hello")
@@ -114,6 +130,17 @@ func TestFakeWriteFile(t *testing.T) {
 	}
 }
 
+func TestFakeWriteFileInitializesModes(t *testing.T) {
+	f := &Fake{Files: map[string][]byte{}}
+
+	if err := f.WriteFile("/city/run.sh", []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if f.Modes["/city/run.sh"] != 0o755 {
+		t.Fatalf("mode = %v, want 0755", f.Modes["/city/run.sh"])
+	}
+}
+
 func TestFakeWriteFileError(t *testing.T) {
 	f := NewFake()
 	injected := fmt.Errorf("read-only fs")
@@ -159,6 +186,28 @@ func TestFakeReadDir(t *testing.T) {
 	}
 }
 
+func TestFakeReadDirInfoReportsTrackedMode(t *testing.T) {
+	f := NewFake()
+	if err := f.WriteFile("/city/rigs/run.sh", []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	entries, err := f.ReadDir("/city/rigs")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	info, err := entries[0].Info()
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("ReadDir entry mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
 func TestFakeReadDirError(t *testing.T) {
 	f := NewFake()
 	injected := fmt.Errorf("no such directory")
@@ -200,6 +249,36 @@ func TestFakeRename(t *testing.T) {
 
 	if len(f.Calls) != 1 || f.Calls[0].Method != "Rename" {
 		t.Errorf("Calls = %+v, want single Rename", f.Calls)
+	}
+}
+
+func TestFakeRenameClearsStaleDestinationMode(t *testing.T) {
+	f := NewFake()
+	f.Files["/city/generated.tmp"] = []byte("new")
+	f.Files["/city/generated"] = []byte("old")
+	f.Modes["/city/generated"] = 0o644
+
+	if err := f.Rename("/city/generated.tmp", "/city/generated"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+
+	info, err := f.Stat("/city/generated")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("renamed file mode = %v, want default 0755", info.Mode().Perm())
+	}
+}
+
+func TestFakeChmodInitializesModes(t *testing.T) {
+	f := &Fake{Files: map[string][]byte{"/city/run.sh": []byte("#!/bin/sh\n")}}
+
+	if err := f.Chmod("/city/run.sh", 0o755); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if f.Modes["/city/run.sh"] != 0o755 {
+		t.Fatalf("mode = %v, want 0755", f.Modes["/city/run.sh"])
 	}
 }
 

--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -1,0 +1,53 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package fsys
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// ReadRegularFile reads name without following a final symlink.
+func (OSFS) ReadRegularFile(name string) ([]byte, error) {
+	snapshot, err := (OSFS{}).readRegularFileSnapshot(name)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot.data, nil
+}
+
+// readRegularFileSnapshot reads name without following a final symlink and
+// returns the opened file identity for post-read stability checks.
+func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
+	fd, err := unix.Open(name, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return regularFileSnapshot{}, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return regularFileSnapshot{}, &os.PathError{Op: "open", Path: name, Err: os.ErrInvalid}
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return regularFileSnapshot{}, &os.PathError{Op: "stat", Path: name, Err: err}
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return regularFileSnapshot{}, &os.PathError{Op: "open", Path: name, Err: os.ErrInvalid}
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return regularFileSnapshot{}, &os.PathError{Op: "read", Path: name, Err: err}
+	}
+	return regularFileSnapshot{
+		data:  data,
+		id:    fileIdentity{dev: stat.Dev, ino: stat.Ino},
+		hasID: true,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- replace direct writes during system pack materialization with same-directory temp-file writes plus atomic rename
- avoid exposing truncated SKILL.md files to provider skill watchers during gc start/prime

## Root cause
The checked-in and materialized gc-dashboard skill files both have YAML frontmatter. The warning appears consistent with a watcher reading .gc/system/packs/core/skills/gc-dashboard/SKILL.md during os.WriteFile's truncate-before-write window.

## Verification
- go test ./cmd/gc -run 'MaterializeBuiltinPacks|Skill|Materialize'
- go test ./internal/materialize