### PR TITLE
test(gc-status): regression test for pre-fetch session beads once (ga-jwtz)

### DIFF
--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -269,6 +269,18 @@ func (s *failingListStatusStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
 	return nil, errors.New("unexpected list")
 }
 
+type listCountingStatusStore struct {
+	*beads.MemStore
+	sessionLabelLists int
+}
+
+func (s *listCountingStatusStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession {
+		s.sessionLabelLists++
+	}
+	return s.MemStore.List(query)
+}
+
 type blockingListStatusStore struct {
 	*beads.MemStore
 	started chan struct{}
@@ -310,6 +322,30 @@ func TestCityStatusAgentObservationDoesNotResolveRuntimeNamesThroughStore(t *tes
 	}
 	if len(store.ids) != 0 {
 		t.Fatalf("status observation performed bead Get calls for runtime names: %v", store.ids)
+	}
+}
+
+func TestCityStatusFallbackListsSessionsOnce(t *testing.T) {
+	store := &listCountingStatusStore{MemStore: beads.NewMemStore()}
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "city"}}
+	const agentCount = 20
+	for i := 0; i < agentCount; i++ {
+		cfg.Agents = append(cfg.Agents, config.Agent{
+			Name:              fmt.Sprintf("agent-%02d", i),
+			MaxActiveSessions: intPtr(1),
+		})
+	}
+
+	var stderr bytes.Buffer
+	cityPath := filepath.Join(t.TempDir(), "city")
+	snapshot := collectCityStatusSnapshot(sp, cfg, cityPath, store, &stderr)
+
+	if got := store.sessionLabelLists; got != 1 {
+		t.Fatalf("List(session label) calls = %d, want 1", got)
+	}
+	if got := len(snapshot.Agents); got != agentCount {
+		t.Fatalf("snapshot agents = %d, want %d", got, agentCount)
 	}
 }
 


### PR DESCRIPTION
## What this is

A focused **regression test** — `TestCityStatusFallbackListsSessionsOnce` — guarding the `gc status` fallback path so it pre-fetches session beads **once** (via `loadStatusSessionSnapshot`) instead of re-listing per agent. The original symptom: a ~74s `gc status` hang on 37-agent cities caused by N×~2s per-agent SessionID resolves (bead ga-jwtz / ga-bxq5).

## Status: ready to merge

The two prerequisites this PR originally tracked have **both landed**:

- #1147 — read-path routing enabler (merged 2026-05-22)
- #1149 — read-path routing + StoreHealth / ADR 0001 (merged 2026-05-22)

The pre-fetch-once **implementation already landed upstream** as part of that read-path work: on current `main`, `collectCityStatusSnapshot` calls `loadStatusSessionSnapshot(store, …)` exactly once and threads the resulting snapshot through `statusObservationTargetForIdentity` per agent. The only remaining delta in this PR is the **regression test** guarding that property, which was not otherwise upstreamed.

## Verification (rebased onto current main)

Branch re-rebased onto current `main` (the test commit applies cleanly — `cmd/gc/city_status_snapshot_test.go` is otherwise unchanged on main):

- `go test ./cmd/gc -run TestCityStatusFallbackListsSessionsOnce -count=1` → **PASS**
- `go vet ./cmd/gc` → clean

This supersedes the earlier "intentionally broken / do not merge / CI will fail" tracking-draft state — that no longer applies.
