### PR TITLE
fix(gc bd): diagnostic error when scope resolves to non-bd provider

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -108,8 +108,11 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if !providerUsesBdStoreContract(rawBeadsProviderForScope(target.ScopeRoot, cityPath)) {
-		fmt.Fprintln(stderr, "gc bd: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
+	if provider := rawBeadsProviderForScope(target.ScopeRoot, cityPath); !providerUsesBdStoreContract(provider) {
+		fmt.Fprintf(stderr, "gc bd: only supported for bd-backed beads providers (resolved %q for %s)\n", provider, target.ScopeRoot) //nolint:errcheck // best-effort stderr
+		if hint := bdProviderMismatchHint(target.ScopeRoot, provider); hint != "" {
+			fmt.Fprintf(stderr, "  hint: %s\n", hint) //nolint:errcheck // best-effort stderr
+		}
 		return 1
 	}
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -614,6 +614,61 @@ provider = "file"
 	}
 }
 
+// TestGcBdRejectsStaleFileMarkerWithDiagnosticHint asserts the error when
+// a scope has a stale .gc/beads.json (file-store marker) but no
+// .beads/metadata.json (bd-store marker): gc rejects with a hint that
+// names the offending marker and suggests the fix. Regression for the
+// post-#899 behavior change where stale migration artifacts silently
+// reclassified rigs as file-backed with no diagnostic.
+func TestGcBdRejectsStaleFileMarkerWithDiagnosticHint(t *testing.T) {
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	defer func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	}()
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "legacy-rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+
+[[rigs]]
+name = "legacy-rig"
+path = "legacy-rig"
+prefix = "lg"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".gc", "beads.json"), []byte(`{"seq":1,"beads":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if got := doBd([]string{"--rig", "legacy-rig", "list"}, &stdout, &stderr); got == 0 {
+		t.Fatalf("doBd() = %d, want non-zero", got)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, `resolved "file"`) {
+		t.Fatalf("stderr = %q, want named provider in error", out)
+	}
+	if !strings.Contains(out, ".gc/beads.json") {
+		t.Fatalf("stderr = %q, want named marker in hint", out)
+	}
+	if !strings.Contains(out, ".beads/metadata.json") {
+		t.Fatalf("stderr = %q, want named fix in hint", out)
+	}
+}
+
 func TestGcBdAllowsRigPassthroughForBdBackedRigUnderFileCity(t *testing.T) {
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -568,6 +568,27 @@ func scopeUsesFileStoreContract(scopeRoot string) bool {
 	return err == nil
 }
 
+// bdProviderMismatchHint returns an actionable diagnostic when gc bd
+// rejects a scope as non-bd-backed. It names the marker that tipped
+// the resolver and suggests a fix. Returns "" when the cause is not
+// a local scope-marker issue (e.g., explicit city/env provider).
+func bdProviderMismatchHint(scopeRoot, resolvedProvider string) string {
+	if resolvedProvider == "file" && scopeUsesFileStoreContract(scopeRoot) {
+		return fmt.Sprintf(
+			"%s/.gc/beads.json exists, which marks this scope as file-backed. "+
+				"If it is a stale artifact from a previous city or pre-migration "+
+				"layout, move it aside (e.g., rename to .gc/beads.json.bak). To "+
+				"positively mark this scope as bd-backed, add "+
+				"%s/.beads/metadata.json (with backend=dolt and the dolt_database "+
+				"name).",
+			scopeRoot, scopeRoot)
+	}
+	if strings.TrimSpace(os.Getenv("GC_BEADS")) != "" {
+		return "GC_BEADS env var overrides the provider. Unset it, or set GC_BEADS=bd for this scope."
+	}
+	return "check city.toml [beads].provider and any per-rig provider overrides."
+}
+
 // beadsProvider returns the bead store provider name for lifecycle operations.
 // Maps "bd" → "exec:<cityPath>/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh"
 // so all lifecycle operations route through the exec: protocol. Other providers


### PR DESCRIPTION
## Summary

When `gc bd` rejects a scope as non-bd-backed, the current error message is:

```
gc bd: only supported for bd-backed beads providers
```

No provider name, no scope path, no hint at what's wrong. Users have no way to diagnose the rejection without reading `cmd/gc/providers.go` source.

This PR makes the error actionable:

```
gc bd: only supported for bd-backed beads providers (resolved "file" for /path/to/rig)
  hint: /path/to/rig/.gc/beads.json exists, which marks this scope as file-backed. If it is a stale artifact from a previous city or pre-migration layout, move it aside (e.g., rename to .gc/beads.json.bak). To positively mark this scope as bd-backed, add /path/to/rig/.beads/metadata.json (with backend=dolt and the dolt_database name).
```

## Why this matters — there was an effective regression

PR #899 `fix: route beads providers by scope in mixed workspaces` (merged 2026-04-19, introducing `scopeUsesFileStoreContract`) changed scope-resolution behavior in a way that silently broke rigs carrying stale `.gc/beads.json` files from pre-migration cities. Before #899, that file was ignored. After #899, it's authoritative: if `.beads/metadata.json` is absent, `.gc/beads.json` wins and the rig is reclassified as file-backed, and `gc bd --rig <name>` starts rejecting with the uninformative error above.

This repro'd in the wild on a contributor setup whose `gascity` rig was previously its own city. Diagnosis required tracing `rawBeadsProviderForScope` through `cmd/gc/providers.go` to find the marker check. An operator with a working `gc bd --rig gascity` yesterday, then a broken one today after a `gc` rebuild, has no signal that scope-detection policy tightened under them.

The new error prevents that class of confusion going forward by naming the marker and the specific fix.

/cc @julianknutsen — flagging as an effective regression from #899 so you see the ergonomic fallout, not just the routing correctness fix.

## Scope

- `cmd/gc/cmd_bd.go`: name resolved provider in the error, add optional hint line
- `cmd/gc/providers.go`: new `bdProviderMismatchHint` helper (file-marker case, GC_BEADS override case, fallback to city.toml)
- `cmd/gc/cmd_bd_test.go`: new `TestGcBdRejectsStaleFileMarkerWithDiagnosticHint` regression test; existing tests unchanged (the substring "only supported for bd-backed beads providers" remains in the error, so their assertions still hold)

No behavior change on the passing path. Only the error text changes when the existing guard rejects.

## Test plan

- [x] `go build ./cmd/gc/` clean
- [x] `go test -run 'TestGcBd' -count=1 ./cmd/gc/` — all pass (47.4s)
- [ ] Reviewer: verify the new hint reads well on a real stale-file-marker repro

## HARD RULE
PR only, no direct-to-main for gascity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)