### PR TITLE
fix(acp): protocolVersion + per-transport command plumbing (#1008)

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -223,7 +223,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	if err != nil {
 		titleProvider = nil
 	}
-	sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil)
+	sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil, found.Session)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -401,11 +401,11 @@ func maybeAutoTitle(store beads.Store, beadID, userTitle, titleHint string, prov
 	})
 }
 
-func resolvedSessionCommand(cityPath string, resolved *config.ResolvedProvider, optionOverrides map[string]string) (string, error) {
+func resolvedSessionCommand(cityPath string, resolved *config.ResolvedProvider, optionOverrides map[string]string, transport string) (string, error) {
 	if resolved == nil {
 		return "", fmt.Errorf("resolved provider is nil")
 	}
-	launchCommand, err := config.BuildProviderLaunchCommand(cityPath, resolved, optionOverrides)
+	launchCommand, err := config.BuildProviderLaunchCommandForTransport(cityPath, resolved, optionOverrides, transport)
 	if err != nil {
 		return "", fmt.Errorf("resolving provider launch command: %w", err)
 	}
@@ -922,21 +922,21 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 // sessionKind mirrors the mc_session_kind bead metadata: "provider" means
 // the session was created from a bare provider name (not an agent template),
 // so the agent-template lookup should be skipped. This matches the guard in
-// the API handler (handler_session_chat.go).
+// the API runtime reconstruction path.
 func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, sessionKind string, stderr io.Writer) (string, runtime.Config) {
 	cmd := session.BuildResumeCommand(info)
 	if cfg == nil {
 		return cmd, runtime.Config{WorkDir: info.WorkDir}
 	}
 
-	buildResolved := func(resolved *config.ResolvedProvider) (string, runtime.Config) {
+	buildResolved := func(resolved *config.ResolvedProvider, transport string) (string, runtime.Config) {
 		if resolved == nil {
 			return cmd, runtime.Config{WorkDir: info.WorkDir}
 		}
 		resolvedInfo := info
 		// Build command with default args and settings, matching the
 		// reconciler's template_resolve.go command construction.
-		command := resolved.CommandString()
+		command := resolved.CommandStringForTransport(transport == "acp")
 		if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
 			command = command + " " + shellquote.Join(defaultArgs)
 		}
@@ -983,14 +983,18 @@ func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, se
 		// stored command text so submit/restart paths honor provider overrides.
 		if found, ok := resolveAgentIdentity(cfg, info.Template, ""); ok {
 			if resolved, err := config.ResolveProvider(&found, &cfg.Workspace, cfg.Providers, exec.LookPath); err == nil {
-				return buildResolved(resolved)
+				transport := found.Session
+				if strings.TrimSpace(transport) == "" {
+					transport = strings.TrimSpace(info.Transport)
+				}
+				return buildResolved(resolved, transport)
 			}
 		}
 	}
 
 	// Fallback for provider-only sessions whose Template is a provider name.
 	if resolved, err := config.ResolveProvider(&config.Agent{Provider: info.Template}, &cfg.Workspace, cfg.Providers, exec.LookPath); err == nil {
-		return buildResolved(resolved)
+		return buildResolved(resolved, strings.TrimSpace(info.Transport))
 	}
 
 	return cmd, runtime.Config{WorkDir: info.WorkDir}

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -605,6 +605,108 @@ func TestBuildResumeCommandUsesResolvedProviderCommand(t *testing.T) {
 	}
 }
 
+func TestBuildResumeCommandUsesACPTransportCommand(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "reviewer", Provider: "opencode", Session: "acp"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				DisplayName: "OpenCode",
+				Command:     "opencode",
+				ACPCommand:  "opencode",
+				ACPArgs:     []string{"acp"},
+				PathCheck:   "true",
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+			},
+		},
+	}
+
+	info := session.Info{
+		Template:   "reviewer",
+		Command:    "opencode",
+		Provider:   "opencode",
+		WorkDir:    "/tmp/workdir",
+		SessionKey: "sess-key",
+	}
+
+	cmd, _ := buildResumeCommand(t.TempDir(), cfg, info, "", io.Discard)
+	if got, want := cmd, "opencode acp --resume sess-key"; got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}
+
+func TestBuildResumeCommandSkipsAgentResolutionForProviderSessions(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "shell", Provider: "wrapped"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"wrapped": {
+				DisplayName: "Wrapped Shell",
+				Command:     "wrapped-cli",
+				PathCheck:   "true",
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+			},
+			"shell": {
+				DisplayName: "Shell Provider",
+				Command:     "provider-cli",
+				PathCheck:   "true",
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+			},
+		},
+	}
+
+	info := session.Info{
+		Template:   "shell",
+		Command:    "provider-cli",
+		Provider:   "shell",
+		WorkDir:    "/tmp/workdir",
+		SessionKey: "sess-key",
+	}
+
+	cmd, _ := buildResumeCommand(t.TempDir(), cfg, info, "provider", io.Discard)
+	if got, want := cmd, "provider-cli --resume sess-key"; got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}
+
+func TestBuildResumeCommandUsesACPTransportForProviderSessions(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				DisplayName: "OpenCode",
+				Command:     "opencode",
+				ACPCommand:  "opencode",
+				ACPArgs:     []string{"acp"},
+				PathCheck:   "true",
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+			},
+		},
+	}
+
+	info := session.Info{
+		Template:   "opencode",
+		Provider:   "opencode",
+		Transport:  "acp",
+		Command:    "opencode",
+		WorkDir:    "/tmp/workdir",
+		SessionKey: "sess-key",
+	}
+
+	cmd, _ := buildResumeCommand(t.TempDir(), cfg, info, "provider", io.Discard)
+	if got, want := cmd, "opencode acp --resume sess-key"; got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}
+
 func TestBuildResumeCommandIncludesSettingsAndDefaultArgs(t *testing.T) {
 	cityDir := t.TempDir()
 	// Write a .gc/settings.json so settingsArgs finds it.
@@ -1297,7 +1399,7 @@ func TestResolvedSessionCommandIncludesDefaultsAndSettings(t *testing.T) {
 		EffectiveDefaults: config.ComputeEffectiveDefaults(claude.OptionsSchema, claude.OptionDefaults, nil),
 	}
 
-	got, err := resolvedSessionCommand(cityPath, resolved, nil)
+	got, err := resolvedSessionCommand(cityPath, resolved, nil, "")
 	if err != nil {
 		t.Fatalf("resolvedSessionCommand: %v", err)
 	}
@@ -1326,7 +1428,7 @@ func TestResolvedSessionCommandAppliesOverridesOverDefaults(t *testing.T) {
 	got, err := resolvedSessionCommand(cityPath, resolved, map[string]string{
 		"permission_mode": "plan",
 		"effort":          "low",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("resolvedSessionCommand: %v", err)
 	}
@@ -1338,5 +1440,22 @@ func TestResolvedSessionCommandAppliesOverridesOverDefaults(t *testing.T) {
 	}
 	if !strings.Contains(got, "--effort low") {
 		t.Fatalf("command %q should include effort=low override", got)
+	}
+}
+
+func TestResolvedSessionCommandUsesACPTransportCommand(t *testing.T) {
+	resolved := &config.ResolvedProvider{
+		Name:       "opencode",
+		Command:    "opencode",
+		ACPCommand: "opencode",
+		ACPArgs:    []string{"acp"},
+	}
+
+	got, err := resolvedSessionCommand("", resolved, nil, "acp")
+	if err != nil {
+		t.Fatalf("resolvedSessionCommand: %v", err)
+	}
+	if got != "opencode acp" {
+		t.Fatalf("command = %q, want %q", got, "opencode acp")
 	}
 }

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -119,7 +119,7 @@ func materializeSessionForTemplateWithOptions(
 		if err != nil {
 			return "", err
 		}
-		sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil)
+		sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil, spec.Agent.Session)
 		if err != nil {
 			return "", err
 		}
@@ -272,7 +272,7 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 	if err != nil {
 		return "", err
 	}
-	sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil)
+	sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil, agentCfg.Session)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -147,7 +147,12 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 
 	// Step 5: Build copy_files and command with settings args + schema defaults.
 	var copyFiles []runtime.CopyEntry
-	command := resolved.CommandString()
+	// Pick the ACP-mode command line when session="acp" and the provider
+	// declares a distinct ACP entrypoint (e.g. OpenCode's `opencode acp`).
+	// Providers without ACPCommand/ACPArgs get the tmux command line
+	// unchanged, preserving Claude Code's auto-detect behavior.
+	isACP := cfgAgent.Session == "acp"
+	command := resolved.CommandStringForTransport(isACP)
 	// Append schema-derived default args (e.g., --dangerously-skip-permissions
 	// from EffectiveDefaults["permission_mode"] = "unrestricted").
 	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
@@ -502,7 +507,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		RigName:          rigName,
 		RigRoot:          rigRoot,
 		WakeMode:         cfgAgent.WakeMode,
-		IsACP:            cfgAgent.Session == "acp",
+		IsACP:            isACP,
 		HookEnabled:      hasHooks,
 	}, nil
 }

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -125,7 +125,7 @@ func resolvedWorkerSessionConfigWithConfig(
 	}
 	command = strings.TrimSpace(command)
 	if command == "" {
-		command = strings.TrimSpace(resolved.CommandString())
+		command = strings.TrimSpace(resolved.CommandStringForTransport(transport == "acp"))
 	}
 	providerName := strings.TrimSpace(resolved.Name)
 	if providerName == "" {
@@ -317,15 +317,16 @@ func resolvedWorkerRuntimeWithConfig(cityPath string, cfg *config.City, info ses
 	if cfg == nil {
 		return nil
 	}
-	resolved := resolveWorkerRuntimeWithConfig(cfg, info, sessionKind)
+	resolved, transport := resolveWorkerRuntimeWithConfig(cfg, info, sessionKind)
 	if resolved == nil {
 		return nil
 	}
 
 	command := strings.TrimSpace(info.Command)
-	if !shouldPreserveStoredRuntimeCommand(command, resolved.CommandString()) {
-		launchCommand, err := config.BuildProviderLaunchCommand(cityPath, resolved, nil)
-		command = resolved.CommandString()
+	resolvedCommand := resolved.CommandStringForTransport(transport == "acp")
+	if !shouldPreserveStoredRuntimeCommand(command, resolvedCommand) {
+		launchCommand, err := config.BuildProviderLaunchCommandForTransport(cityPath, resolved, nil, transport)
+		command = resolvedCommand
 		if err == nil {
 			command = launchCommand.Command
 		}
@@ -378,22 +379,26 @@ func shouldPreserveStoredRuntimeCommand(storedCommand, resolvedCommand string) b
 	return strings.HasPrefix(storedCommand, resolvedCommand+" ")
 }
 
-func resolveWorkerRuntimeWithConfig(cfg *config.City, info session.Info, sessionKind string) *config.ResolvedProvider {
+func resolveWorkerRuntimeWithConfig(cfg *config.City, info session.Info, sessionKind string) (*config.ResolvedProvider, string) {
 	if cfg == nil {
-		return nil
+		return nil, ""
 	}
 	if sessionKind != "provider" {
 		if found, ok := resolveAgentIdentity(cfg, info.Template, ""); ok {
 			if resolved, err := config.ResolveProvider(&found, &cfg.Workspace, cfg.Providers, exec.LookPath); err == nil {
-				return resolved
+				transport := found.Session
+				if strings.TrimSpace(transport) == "" {
+					transport = strings.TrimSpace(info.Transport)
+				}
+				return resolved, transport
 			}
 		}
 	}
 	resolved, err := config.ResolveProvider(&config.Agent{Provider: info.Template}, &cfg.Workspace, cfg.Providers, exec.LookPath)
 	if err != nil {
-		return nil
+		return nil, ""
 	}
-	return resolved
+	return resolved, strings.TrimSpace(info.Transport)
 }
 
 func workerDeliveryIntentForSubmitIntent(intent session.SubmitIntent) worker.DeliveryIntent {

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -515,6 +515,32 @@ func TestResolvedWorkerSessionConfigWithConfigFallsBackToProviderArgForCommand(t
 	}
 }
 
+func TestResolvedWorkerSessionConfigWithConfigUsesACPTransportCommandFallback(t *testing.T) {
+	cfg, err := resolvedWorkerSessionConfigWithConfig(
+		"",
+		"",
+		"/tmp/work",
+		"worker",
+		"",
+		"worker",
+		"Worker",
+		"acp",
+		&config.ResolvedProvider{
+			Name:       "opencode",
+			Command:    "opencode",
+			ACPCommand: "opencode",
+			ACPArgs:    []string{"acp"},
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolvedWorkerSessionConfigWithConfig: %v", err)
+	}
+	if got, want := cfg.Runtime.Command, "opencode acp"; got != want {
+		t.Fatalf("Runtime.Command = %q, want %q", got, want)
+	}
+}
+
 func TestResolvedWorkerRuntimeWithConfigFallsBackToCityPathAndSyncsHintsWorkDir(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]
@@ -554,6 +580,41 @@ ready_delay_ms = 250
 		t.Fatalf("Provider = %q, want %q", got, want)
 	}
 	if got, want := runtimeCfg.Command, "/bin/echo"; got != want {
+		t.Fatalf("Command = %q, want %q", got, want)
+	}
+}
+
+func TestResolvedWorkerRuntimeWithConfigUsesInfoTransportForProviderSessions(t *testing.T) {
+	cityDir := t.TempDir()
+	writePhase0InterfaceCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[providers.opencode]
+command = "opencode"
+acp_command = "opencode"
+acp_args = ["acp"]
+path_check = "true"
+`)
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	runtimeCfg := resolvedWorkerRuntimeWithConfig(cityDir, cfg, session.Info{
+		Template:  "opencode",
+		Provider:  "opencode",
+		Transport: "acp",
+		Command:   "opencode",
+		WorkDir:   t.TempDir(),
+	}, "provider")
+	if runtimeCfg == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
+	}
+	if got, want := runtimeCfg.Command, "opencode acp"; got != want {
 		t.Fatalf("Command = %q, want %q", got, want)
 	}
 }

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -435,6 +435,8 @@ ProviderPatch modifies an existing provider identified by Name.
 | `base` | string |  |  | Base overrides the provider's inheritance parent (presence-aware). Pointer to a pointer so the patch can distinguish "no change" (double-nil) from "clear to inherit default" (single-nil value in outer pointer) from "set to explicit empty opt-out" (value "" in inner pointer) from "set to &lt;name&gt;". Callers use:   nil          = patch does not touch Base   &(*string)(nil) = patch clears Base to absent   &(&"")       = patch sets Base = "" (explicit opt-out)   &(&"builtin:codex") = patch sets Base to that value |
 | `command` | string |  |  | Command overrides the provider command. |
 | `args` | []string |  |  | Args overrides the provider args. |
+| `acp_command` | string |  |  | ACPCommand overrides the provider's ACP-mode command. |
+| `acp_args` | []string |  |  | ACPArgs overrides the provider's ACP-mode args. An explicit empty list is not representable through a patch — use a city-level [providers.X] block if you need to clear ACPArgs. |
 | `args_append` | []string |  |  | ArgsAppend overrides the provider args_append list. |
 | `options_schema_merge` | string |  |  | OptionsSchemaMerge overrides the options_schema merge mode. |
 | `prompt_mode` | string |  |  | PromptMode overrides prompt delivery mode. Enum: `arg`, `flag`, `none` |
@@ -456,6 +458,8 @@ ProviderSpec defines a named provider's startup parameters.
 | `display_name` | string |  |  | DisplayName is the human-readable name shown in UI and logs. |
 | `command` | string |  |  | Command is the executable to run for this provider. |
 | `args` | []string |  |  | Args are default command-line arguments passed to the provider. |
+| `acp_command` | string |  |  | ACPCommand overrides Command when the agent runs with session="acp". Empty means "reuse Command for ACP too" (correct for providers that auto-detect ACP on stdin, e.g. Claude Code). Providers that need a distinct subcommand in ACP mode set it explicitly so tmux transport keeps a usable interactive command. Example: "opencode" with ACPArgs = ["acp"] for OpenCode. |
+| `acp_args` | []string |  |  | ACPArgs overrides Args under session="acp". A nil/absent value means "reuse Args"; an explicit empty list means "no args in ACP mode". |
 | `prompt_mode` | string |  | `arg` | PromptMode controls how prompts are delivered: "arg", "flag", or "none". Enum: `arg`, `flag`, `none` |
 | `prompt_flag` | string |  |  | PromptFlag is the CLI flag used when prompt_mode is "flag" (e.g. "--prompt"). |
 | `ready_delay_ms` | integer |  |  | ReadyDelayMs is milliseconds to wait after launch before the provider is considered ready. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1498,6 +1498,17 @@
           "type": "array",
           "description": "Args overrides the provider args."
         },
+        "acp_command": {
+          "type": "string",
+          "description": "ACPCommand overrides the provider's ACP-mode command."
+        },
+        "acp_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ACPArgs overrides the provider's ACP-mode args. An explicit empty\nlist is not representable through a patch — use a city-level\n[providers.X] block if you need to clear ACPArgs."
+        },
         "args_append": {
           "items": {
             "type": "string"
@@ -1588,6 +1599,17 @@
           },
           "type": "array",
           "description": "Args are default command-line arguments passed to the provider."
+        },
+        "acp_command": {
+          "type": "string",
+          "description": "ACPCommand overrides Command when the agent runs with session=\"acp\".\nEmpty means \"reuse Command for ACP too\" (correct for providers that\nauto-detect ACP on stdin, e.g. Claude Code). Providers that need a\ndistinct subcommand in ACP mode set it explicitly so tmux transport\nkeeps a usable interactive command. Example: \"opencode\" with\nACPArgs = [\"acp\"] for OpenCode."
+        },
+        "acp_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ACPArgs overrides Args under session=\"acp\". A nil/absent value means\n\"reuse Args\"; an explicit empty list means \"no args in ACP mode\"."
         },
         "prompt_mode": {
           "type": "string",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1498,6 +1498,17 @@
           "type": "array",
           "description": "Args overrides the provider args."
         },
+        "acp_command": {
+          "type": "string",
+          "description": "ACPCommand overrides the provider's ACP-mode command."
+        },
+        "acp_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ACPArgs overrides the provider's ACP-mode args. An explicit empty\nlist is not representable through a patch — use a city-level\n[providers.X] block if you need to clear ACPArgs."
+        },
         "args_append": {
           "items": {
             "type": "string"
@@ -1588,6 +1599,17 @@
           },
           "type": "array",
           "description": "Args are default command-line arguments passed to the provider."
+        },
+        "acp_command": {
+          "type": "string",
+          "description": "ACPCommand overrides Command when the agent runs with session=\"acp\".\nEmpty means \"reuse Command for ACP too\" (correct for providers that\nauto-detect ACP on stdin, e.g. Claude Code). Providers that need a\ndistinct subcommand in ACP mode set it explicitly so tmux transport\nkeeps a usable interactive command. Example: \"opencode\" with\nACPArgs = [\"acp\"] for OpenCode."
+        },
+        "acp_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ACPArgs overrides Args under session=\"acp\". A nil/absent value means\n\"reuse Args\"; an explicit empty list means \"no args in ACP mode\"."
         },
         "prompt_mode": {
           "type": "string",

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -4598,6 +4598,21 @@
       "ProviderPatch": {
         "additionalProperties": false,
         "properties": {
+          "ACPArgs": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "ACPCommand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "Args": {
             "items": {
               "type": "string"
@@ -4680,6 +4695,8 @@
           "Base",
           "Command",
           "Args",
+          "ACPCommand",
+          "ACPArgs",
           "ArgsAppend",
           "OptionsSchemaMerge",
           "PromptMode",

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -4598,6 +4598,21 @@
       "ProviderPatch": {
         "additionalProperties": false,
         "properties": {
+          "ACPArgs": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "ACPCommand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "Args": {
             "items": {
               "type": "string"
@@ -4680,6 +4695,8 @@
           "Base",
           "Command",
           "Args",
+          "ACPCommand",
+          "ACPArgs",
           "ArgsAppend",
           "OptionsSchemaMerge",
           "PromptMode",

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -1813,6 +1813,8 @@ type ProviderOptionDTO struct {
 
 // ProviderPatch defines model for ProviderPatch.
 type ProviderPatch struct {
+	ACPArgs            *[]string         `json:"ACPArgs"`
+	ACPCommand         *string           `json:"ACPCommand"`
 	Args               *[]string         `json:"Args"`
 	ArgsAppend         *[]string         `json:"ArgsAppend"`
 	Base               *string           `json:"Base"`

--- a/internal/api/handler_session_chat_test.go
+++ b/internal/api/handler_session_chat_test.go
@@ -170,3 +170,77 @@ func TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent(t *testin
 		t.Fatalf("resume command missing settings arg:\n  got: %s", cmd)
 	}
 }
+
+func TestBuildSessionResumeUsesACPTransportCommandWhenStoredCommandIsStale(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "reviewer", Provider: "opencode", Session: "acp"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				DisplayName: "OpenCode",
+				Command:     "opencode",
+				ACPCommand:  "opencode",
+				ACPArgs:     []string{"acp"},
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+				PathCheck:   "true",
+			},
+		},
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:          "gc-2",
+		Template:    "reviewer",
+		Command:     "opencode",
+		Provider:    "opencode",
+		WorkDir:     "/tmp/workdir",
+		SessionKey:  "sess-key",
+		ResumeFlag:  "--resume",
+		ResumeStyle: "flag",
+	}
+
+	cmd, _ := srv.buildSessionResume(info)
+	if got, want := cmd, "opencode acp --resume sess-key"; got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}
+
+func TestBuildSessionResumeUsesACPTransportForProviderSessions(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				DisplayName: "OpenCode",
+				Command:     "opencode",
+				ACPCommand:  "opencode",
+				ACPArgs:     []string{"acp"},
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+				PathCheck:   "true",
+			},
+		},
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:          "gc-provider",
+		Template:    "opencode",
+		Provider:    "opencode",
+		Transport:   "acp",
+		Command:     "opencode",
+		WorkDir:     "/tmp/workdir",
+		SessionKey:  "sess-key",
+		ResumeFlag:  "--resume",
+		ResumeStyle: "flag",
+	}
+
+	cmd, _ := srv.buildSessionResume(info)
+	if got, want := cmd, "opencode acp --resume sess-key"; got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
+	}
+}

--- a/internal/api/handler_session_create.go
+++ b/internal/api/handler_session_create.go
@@ -127,7 +127,7 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	command := sessionCreateAgentCommand(resolved)
+	command := sessionCreateAgentCommand(resolved, transport)
 
 	// Build template_overrides metadata. Includes schema overrides AND
 	// the initial message (as "initial_message" key). The reconciler
@@ -359,8 +359,8 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 	writeJSON(w, statusCode, resp)
 }
 
-func sessionCreateAgentCommand(resolved *config.ResolvedProvider) string {
-	return firstNonEmptyString(resolved.CommandString(), resolved.Name)
+func sessionCreateAgentCommand(resolved *config.ResolvedProvider, transport string) string {
+	return firstNonEmptyString(resolved.CommandStringForTransport(transport == "acp"), resolved.Name)
 }
 
 func sessionTemplateOverridesMetadata(options map[string]string, message string) map[string]string {

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -105,7 +105,7 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
-	command := sessionCreateAgentCommand(resolved)
+	command := sessionCreateAgentCommand(resolved, transport)
 	extraMeta := sessionTemplateOverridesMetadata(body.Options, body.Message)
 
 	mgr := s.sessionManager(store)

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -4598,6 +4598,21 @@
       "ProviderPatch": {
         "additionalProperties": false,
         "properties": {
+          "ACPArgs": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "ACPCommand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "Args": {
             "items": {
               "type": "string"
@@ -4680,6 +4695,8 @@
           "Base",
           "Command",
           "Args",
+          "ACPCommand",
+          "ACPArgs",
           "ArgsAppend",
           "OptionsSchemaMerge",
           "PromptMode",

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -285,7 +285,7 @@ func (s *Server) materializeNamedSessionWithContext(ctx context.Context, store b
 	if err != nil {
 		return "", err
 	}
-	launchCommand, err := config.BuildProviderLaunchCommand(s.state.CityPath(), resolved, nil)
+	launchCommand, err := config.BuildProviderLaunchCommandForTransport(s.state.CityPath(), resolved, nil, transport)
 	if err != nil {
 		return "", err
 	}

--- a/internal/api/session_resolved_config.go
+++ b/internal/api/session_resolved_config.go
@@ -25,7 +25,7 @@ func resolvedSessionConfigForProvider(
 		Transport:    transport,
 		Metadata:     metadata,
 		Runtime: worker.ResolvedRuntime{
-			Command:    firstNonEmptyString(command, resolved.CommandString(), resolved.Name),
+			Command:    firstNonEmptyString(command, resolved.CommandStringForTransport(transport == "acp"), resolved.Name),
 			WorkDir:    workDir,
 			Provider:   resolved.Name,
 			SessionEnv: resolved.Env,

--- a/internal/api/session_resolved_config_test.go
+++ b/internal/api/session_resolved_config_test.go
@@ -82,3 +82,31 @@ func TestResolvedSessionConfigForProviderRejectsNilProvider(t *testing.T) {
 		t.Fatal("resolvedSessionConfigForProvider() error = nil, want error")
 	}
 }
+
+func TestResolvedSessionConfigForProviderUsesACPTransportCommandFallback(t *testing.T) {
+	resolved := &config.ResolvedProvider{
+		Name:       "opencode",
+		Command:    "opencode",
+		ACPCommand: "opencode",
+		ACPArgs:    []string{"acp"},
+	}
+
+	cfg, err := resolvedSessionConfigForProvider(
+		"worker",
+		"",
+		"myrig/worker",
+		"Worker",
+		"acp",
+		nil,
+		resolved,
+		"",
+		"/tmp/workdir",
+	)
+	if err != nil {
+		t.Fatalf("resolvedSessionConfigForProvider: %v", err)
+	}
+
+	if got, want := cfg.Runtime.Command, "opencode acp"; got != want {
+		t.Fatalf("Runtime.Command = %q, want %q", got, want)
+	}
+}

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -113,15 +113,15 @@ func (s *Server) resolveSessionTemplate(template string) (*config.ResolvedProvid
 
 func (s *Server) buildSessionResume(info session.Info) (string, runtime.Config) {
 	cmd := session.BuildResumeCommand(info)
-	resolved, workDir := s.resolveSessionRuntime(info)
+	resolved, workDir, transport := s.resolveSessionRuntime(info)
 	if resolved == nil {
 		return cmd, runtime.Config{WorkDir: info.WorkDir}
 	}
 	resolvedInfo := info
-	if command, err := s.resolvedSessionRuntimeCommand(resolved, info.Command); err == nil {
+	if command, err := s.resolvedSessionRuntimeCommand(resolved, info.Command, transport); err == nil {
 		resolvedInfo.Command = command
 	} else {
-		resolvedInfo.Command = firstNonEmptyString(info.Command, resolved.CommandString(), resolved.Name)
+		resolvedInfo.Command = firstNonEmptyString(info.Command, resolved.CommandStringForTransport(transport == "acp"), resolved.Name)
 	}
 	resolvedInfo.Provider = resolved.Name
 	resolvedInfo.ResumeFlag = resolved.ResumeFlag
@@ -130,15 +130,16 @@ func (s *Server) buildSessionResume(info session.Info) (string, runtime.Config) 
 	return session.BuildResumeCommand(resolvedInfo), sessionResumeHints(resolved, workDir)
 }
 
-func (s *Server) resolvedSessionRuntimeCommand(resolved *config.ResolvedProvider, storedCommand string) (string, error) {
-	if command := strings.TrimSpace(storedCommand); shouldPreserveStoredRuntimeCommand(command, resolved.CommandString()) {
+func (s *Server) resolvedSessionRuntimeCommand(resolved *config.ResolvedProvider, storedCommand string, transport string) (string, error) {
+	resolvedCommand := resolved.CommandStringForTransport(transport == "acp")
+	if command := strings.TrimSpace(storedCommand); shouldPreserveStoredRuntimeCommand(command, resolvedCommand) {
 		return command, nil
 	}
-	launchCommand, err := config.BuildProviderLaunchCommand(s.state.CityPath(), resolved, nil)
+	launchCommand, err := config.BuildProviderLaunchCommandForTransport(s.state.CityPath(), resolved, nil, transport)
 	if err != nil {
 		return "", fmt.Errorf("building provider launch command: %w", err)
 	}
-	return firstNonEmptyString(launchCommand.Command, resolved.CommandString(), resolved.Name), nil
+	return firstNonEmptyString(launchCommand.Command, resolvedCommand, resolved.Name), nil
 }
 
 func shouldPreserveStoredRuntimeCommand(storedCommand, resolvedCommand string) bool {
@@ -163,11 +164,11 @@ func shouldPreserveStoredRuntimeCommand(storedCommand, resolvedCommand string) b
 }
 
 func (s *Server) resolveWorkerSessionRuntime(info session.Info, _ string) (*worker.ResolvedRuntime, error) {
-	resolved, workDir := s.resolveSessionRuntime(info)
+	resolved, workDir, transport := s.resolveSessionRuntime(info)
 	if resolved == nil {
 		return nil, nil
 	}
-	command, err := s.resolvedSessionRuntimeCommand(resolved, info.Command)
+	command, err := s.resolvedSessionRuntimeCommand(resolved, info.Command, transport)
 	if err != nil {
 		return nil, err
 	}
@@ -190,27 +191,30 @@ func (s *Server) resolveWorkerSessionRuntime(info session.Info, _ string) (*work
 	return &runtimeCfg, nil
 }
 
-func (s *Server) resolveSessionRuntime(info session.Info) (*config.ResolvedProvider, string) {
+func (s *Server) resolveSessionRuntime(info session.Info) (*config.ResolvedProvider, string, string) {
 	kind := s.sessionKind(info.ID)
 	if kind != "provider" {
-		resolved, workDir, _, _, err := s.resolveSessionTemplate(info.Template)
+		resolved, workDir, transport, _, err := s.resolveSessionTemplate(info.Template)
 		if err == nil {
 			if info.WorkDir != "" {
 				workDir = info.WorkDir
 			}
-			return resolved, workDir
+			if strings.TrimSpace(transport) == "" {
+				transport = strings.TrimSpace(info.Transport)
+			}
+			return resolved, workDir, transport
 		}
 	}
 
 	resolved, err := s.resolveBareProvider(info.Template)
 	if err != nil {
-		return nil, ""
+		return nil, "", ""
 	}
 	workDir := info.WorkDir
 	if workDir == "" {
 		workDir = s.state.CityPath()
 	}
-	return resolved, workDir
+	return resolved, workDir, strings.TrimSpace(info.Transport)
 }
 
 // sessionKind reads the persisted mc_session_kind from bead metadata.

--- a/internal/api/worker_factory_test.go
+++ b/internal/api/worker_factory_test.go
@@ -135,6 +135,78 @@ func TestResolveWorkerSessionRuntimeUsesResolvedCommandWhenPersistedCommandIsSta
 	}
 }
 
+func TestResolveWorkerSessionRuntimeUsesACPTransportCommandWhenPersistedCommandIsStale(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Agents[0].Provider = "opencode"
+	fs.cfg.Agents[0].Session = "acp"
+	fs.cfg.Providers["opencode"] = config.ProviderSpec{
+		DisplayName:       "OpenCode",
+		Command:           "opencode",
+		ACPCommand:        "opencode",
+		ACPArgs:           []string{"acp"},
+		ReadyPromptPrefix: "resolved-ready>",
+		ReadyDelayMs:      321,
+		PathCheck:         "true",
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:       "sess-1",
+		Template: "myrig/worker",
+		Command:  "opencode",
+		Provider: "opencode",
+		WorkDir:  t.TempDir(),
+	}
+
+	runtimeCfg, err := srv.resolveWorkerSessionRuntime(info, "")
+	if err != nil {
+		t.Fatalf("resolveWorkerSessionRuntime: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolveWorkerSessionRuntime() = nil")
+	}
+	if got, want := runtimeCfg.Command, "opencode acp"; got != want {
+		t.Fatalf("Command = %q, want %q", got, want)
+	}
+}
+
+func TestResolveWorkerSessionRuntimeUsesInfoTransportForProviderSessions(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				DisplayName: "OpenCode",
+				Command:     "opencode",
+				ACPCommand:  "opencode",
+				ACPArgs:     []string{"acp"},
+				PathCheck:   "true",
+			},
+		},
+	}
+
+	srv := New(fs)
+	info := session.Info{
+		ID:        "provider-1",
+		Template:  "opencode",
+		Provider:  "opencode",
+		Transport: "acp",
+		Command:   "opencode",
+		WorkDir:   t.TempDir(),
+	}
+
+	runtimeCfg, err := srv.resolveWorkerSessionRuntime(info, "")
+	if err != nil {
+		t.Fatalf("resolveWorkerSessionRuntime: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolveWorkerSessionRuntime() = nil")
+	}
+	if got, want := runtimeCfg.Command, "opencode acp"; got != want {
+		t.Fatalf("Command = %q, want %q", got, want)
+	}
+}
+
 func TestWorkerFactorySessionByIDUsesResolvedTemplateRuntime(t *testing.T) {
 	fs := newSessionFakeState(t)
 	fs.cfg.Agents[0].Provider = "resolved-worker"

--- a/internal/config/launch_command.go
+++ b/internal/config/launch_command.go
@@ -23,11 +23,17 @@ type ProviderLaunchCommand struct {
 // schema-managed defaults plus any explicit option overrides, and appends a
 // provider-owned settings file when present.
 func BuildProviderLaunchCommand(cityPath string, resolved *ResolvedProvider, optionOverrides map[string]string) (ProviderLaunchCommand, error) {
+	return BuildProviderLaunchCommandForTransport(cityPath, resolved, optionOverrides, "")
+}
+
+// BuildProviderLaunchCommandForTransport composes the final provider launch
+// command for a specific transport.
+func BuildProviderLaunchCommandForTransport(cityPath string, resolved *ResolvedProvider, optionOverrides map[string]string, transport string) (ProviderLaunchCommand, error) {
 	if resolved == nil {
 		return ProviderLaunchCommand{}, fmt.Errorf("resolved provider is nil")
 	}
 
-	command := resolved.CommandString()
+	command := resolved.CommandStringForTransport(strings.TrimSpace(transport) == "acp")
 	if len(resolved.OptionsSchema) > 0 {
 		mergedOptions := make(map[string]string, len(resolved.EffectiveDefaults)+len(optionOverrides))
 		for key, value := range resolved.EffectiveDefaults {

--- a/internal/config/launch_command_test.go
+++ b/internal/config/launch_command_test.go
@@ -75,3 +75,21 @@ func TestBuildProviderLaunchCommandIgnoresInitialMessageOverride(t *testing.T) {
 		t.Fatalf("Command = %q, want %q", got.Command, want)
 	}
 }
+
+func TestBuildProviderLaunchCommandForTransportUsesACPCommand(t *testing.T) {
+	rp := &ResolvedProvider{
+		Name:       "opencode",
+		Command:    "opencode",
+		ACPCommand: "opencode",
+		ACPArgs:    []string{"acp"},
+	}
+
+	got, err := BuildProviderLaunchCommandForTransport("", rp, nil, "acp")
+	if err != nil {
+		t.Fatalf("BuildProviderLaunchCommandForTransport: %v", err)
+	}
+
+	if got.Command != "opencode acp" {
+		t.Fatalf("Command = %q, want %q", got.Command, "opencode acp")
+	}
+}

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1552,10 +1552,13 @@ func deepCopyProviderSpecs(in map[string]ProviderSpec) map[string]ProviderSpec {
 func deepCopyProviderSpec(in ProviderSpec) ProviderSpec {
 	out := in
 	out.Args = append([]string(nil), in.Args...)
-	// ACPArgs preserves nil-vs-empty: nil means "reuse Args" and must
-	// survive the copy, so don't widen a nil slice to an empty one.
+	// ACPArgs preserves nil-vs-empty: nil means "reuse Args" and an
+	// explicit empty slice means "no args in ACP mode" — they are not
+	// interchangeable. `append([]string(nil), empty...)` collapses empty
+	// to nil, so use make+copy to keep the empty case empty.
 	if in.ACPArgs != nil {
-		out.ACPArgs = append([]string(nil), in.ACPArgs...)
+		out.ACPArgs = make([]string, len(in.ACPArgs))
+		copy(out.ACPArgs, in.ACPArgs)
 	}
 	out.ArgsAppend = append([]string(nil), in.ArgsAppend...)
 	out.ProcessNames = append([]string(nil), in.ProcessNames...)

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1552,6 +1552,11 @@ func deepCopyProviderSpecs(in map[string]ProviderSpec) map[string]ProviderSpec {
 func deepCopyProviderSpec(in ProviderSpec) ProviderSpec {
 	out := in
 	out.Args = append([]string(nil), in.Args...)
+	// ACPArgs preserves nil-vs-empty: nil means "reuse Args" and must
+	// survive the copy, so don't widen a nil slice to an empty one.
+	if in.ACPArgs != nil {
+		out.ACPArgs = append([]string(nil), in.ACPArgs...)
+	}
 	out.ArgsAppend = append([]string(nil), in.ArgsAppend...)
 	out.ProcessNames = append([]string(nil), in.ProcessNames...)
 	out.Env = deepCopyStringMap(in.Env)

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -4126,3 +4126,45 @@ depends_on = ["db"]
 		t.Errorf("ValidateAgents failed after pack expansion: %v", err)
 	}
 }
+
+// TestDeepCopyProviderSpecACPArgs guards the nil-vs-empty distinction on
+// ACPArgs through deepCopyProviderSpec. Nil means "reuse Args at resolve
+// time"; an explicit empty slice means "no args in ACP mode" — they are
+// not interchangeable, so the copy must preserve which one the caller had.
+func TestDeepCopyProviderSpecACPArgs(t *testing.T) {
+	t.Run("nil_stays_nil", func(t *testing.T) {
+		in := ProviderSpec{Command: "p", ACPArgs: nil}
+		out := deepCopyProviderSpec(in)
+		if out.ACPArgs != nil {
+			t.Errorf("ACPArgs = %v, want nil", out.ACPArgs)
+		}
+	})
+	t.Run("empty_stays_empty_not_nil", func(t *testing.T) {
+		in := ProviderSpec{Command: "p", ACPArgs: []string{}}
+		out := deepCopyProviderSpec(in)
+		if out.ACPArgs == nil {
+			t.Error("ACPArgs = nil, want empty non-nil")
+		}
+		if len(out.ACPArgs) != 0 {
+			t.Errorf("len(ACPArgs) = %d, want 0", len(out.ACPArgs))
+		}
+	})
+	t.Run("populated_is_independent_copy", func(t *testing.T) {
+		in := ProviderSpec{Command: "p", ACPArgs: []string{"acp", "--flag"}}
+		out := deepCopyProviderSpec(in)
+		if len(out.ACPArgs) != 2 || out.ACPArgs[0] != "acp" || out.ACPArgs[1] != "--flag" {
+			t.Fatalf("ACPArgs = %v, want [acp --flag]", out.ACPArgs)
+		}
+		out.ACPArgs[0] = "mutated"
+		if in.ACPArgs[0] != "acp" {
+			t.Error("mutating copy changed source — not a deep copy")
+		}
+	})
+	t.Run("acp_command_copied", func(t *testing.T) {
+		in := ProviderSpec{Command: "p", ACPCommand: "p-acp"}
+		out := deepCopyProviderSpec(in)
+		if out.ACPCommand != "p-acp" {
+			t.Errorf("ACPCommand = %q, want %q", out.ACPCommand, "p-acp")
+		}
+	})
+}

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -182,6 +182,12 @@ type ProviderPatch struct {
 	Command *string `toml:"command,omitempty"`
 	// Args overrides the provider args.
 	Args []string `toml:"args,omitempty"`
+	// ACPCommand overrides the provider's ACP-mode command.
+	ACPCommand *string `toml:"acp_command,omitempty"`
+	// ACPArgs overrides the provider's ACP-mode args. An explicit empty
+	// list is not representable through a patch — use a city-level
+	// [providers.X] block if you need to clear ACPArgs.
+	ACPArgs []string `toml:"acp_args,omitempty"`
 	// ArgsAppend overrides the provider args_append list.
 	ArgsAppend []string `toml:"args_append,omitempty"`
 	// OptionsSchemaMerge overrides the options_schema merge mode.
@@ -455,6 +461,13 @@ func applyProviderPatch(cfg *City, patch *ProviderPatch) error {
 			newSpec.Args = make([]string, len(patch.Args))
 			copy(newSpec.Args, patch.Args)
 		}
+		if patch.ACPCommand != nil {
+			newSpec.ACPCommand = *patch.ACPCommand
+		}
+		if len(patch.ACPArgs) > 0 {
+			newSpec.ACPArgs = make([]string, len(patch.ACPArgs))
+			copy(newSpec.ACPArgs, patch.ACPArgs)
+		}
 		if len(patch.ArgsAppend) > 0 {
 			newSpec.ArgsAppend = make([]string, len(patch.ArgsAppend))
 			copy(newSpec.ArgsAppend, patch.ArgsAppend)
@@ -490,6 +503,13 @@ func applyProviderPatch(cfg *City, patch *ProviderPatch) error {
 	if len(patch.Args) > 0 {
 		spec.Args = make([]string, len(patch.Args))
 		copy(spec.Args, patch.Args)
+	}
+	if patch.ACPCommand != nil {
+		spec.ACPCommand = *patch.ACPCommand
+	}
+	if len(patch.ACPArgs) > 0 {
+		spec.ACPArgs = make([]string, len(patch.ACPArgs))
+		copy(spec.ACPArgs, patch.ACPArgs)
 	}
 	if len(patch.ArgsAppend) > 0 {
 		spec.ArgsAppend = make([]string, len(patch.ArgsAppend))

--- a/internal/config/patch_test.go
+++ b/internal/config/patch_test.go
@@ -328,6 +328,124 @@ func TestApplyPatches_ProviderReplace(t *testing.T) {
 	}
 }
 
+// TestApplyPatches_ProviderDeepMergeACPFields verifies that ACPCommand /
+// ACPArgs flow through the deep-merge branch of applyProviderPatch. The
+// merge must (a) only replace ACPCommand when patch sets it, (b) replace
+// ACPArgs only when the patch list is non-empty, and (c) leave the
+// source patch slice unaliased — the spec must own its own ACPArgs copy.
+func TestApplyPatches_ProviderDeepMergeACPFields(t *testing.T) {
+	cfg := &City{
+		Providers: map[string]ProviderSpec{
+			"opencode": {
+				Command:    "opencode",
+				ACPCommand: "old-acp",
+				ACPArgs:    []string{"old"},
+			},
+		},
+	}
+	patchArgs := []string{"acp", "--strict"}
+	err := ApplyPatches(cfg, Patches{
+		Providers: []ProviderPatch{
+			{
+				Name:       "opencode",
+				ACPCommand: ptrStr("opencode"),
+				ACPArgs:    patchArgs,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPatches: %v", err)
+	}
+	p := cfg.Providers["opencode"]
+	if p.ACPCommand != "opencode" {
+		t.Errorf("ACPCommand = %q, want %q", p.ACPCommand, "opencode")
+	}
+	if len(p.ACPArgs) != 2 || p.ACPArgs[0] != "acp" || p.ACPArgs[1] != "--strict" {
+		t.Errorf("ACPArgs = %v, want [acp --strict]", p.ACPArgs)
+	}
+	patchArgs[0] = "mutated"
+	if cfg.Providers["opencode"].ACPArgs[0] != "acp" {
+		t.Error("patch slice aliased into spec; deep-merge did not copy ACPArgs")
+	}
+}
+
+// TestApplyPatches_ProviderDeepMergeACPUnset verifies that omitting
+// ACPCommand and ACPArgs from a patch leaves existing values untouched.
+func TestApplyPatches_ProviderDeepMergeACPUnset(t *testing.T) {
+	cfg := &City{
+		Providers: map[string]ProviderSpec{
+			"opencode": {
+				Command:    "opencode",
+				ACPCommand: "opencode",
+				ACPArgs:    []string{"acp"},
+			},
+		},
+	}
+	err := ApplyPatches(cfg, Patches{
+		Providers: []ProviderPatch{
+			{Name: "opencode", Command: ptrStr("opencode-v2")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPatches: %v", err)
+	}
+	p := cfg.Providers["opencode"]
+	if p.Command != "opencode-v2" {
+		t.Errorf("Command = %q, want %q", p.Command, "opencode-v2")
+	}
+	if p.ACPCommand != "opencode" {
+		t.Errorf("ACPCommand = %q, want %q (unchanged)", p.ACPCommand, "opencode")
+	}
+	if len(p.ACPArgs) != 1 || p.ACPArgs[0] != "acp" {
+		t.Errorf("ACPArgs = %v, want [acp] (unchanged)", p.ACPArgs)
+	}
+}
+
+// TestApplyPatches_ProviderReplaceACPFields verifies the Replace branch
+// rebuilds the spec with patch ACP fields, dropping anything not in the
+// patch. Distinct from deep-merge because Replace ignores existing spec
+// state.
+func TestApplyPatches_ProviderReplaceACPFields(t *testing.T) {
+	cfg := &City{
+		Providers: map[string]ProviderSpec{
+			"opencode": {
+				Command:    "old-cmd",
+				ACPCommand: "old-acp",
+				ACPArgs:    []string{"old-acp-arg"},
+			},
+		},
+	}
+	patchArgs := []string{"acp"}
+	err := ApplyPatches(cfg, Patches{
+		Providers: []ProviderPatch{
+			{
+				Name:       "opencode",
+				Replace:    true,
+				Command:    ptrStr("opencode"),
+				ACPCommand: ptrStr("opencode"),
+				ACPArgs:    patchArgs,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPatches: %v", err)
+	}
+	p := cfg.Providers["opencode"]
+	if p.Command != "opencode" {
+		t.Errorf("Command = %q, want %q", p.Command, "opencode")
+	}
+	if p.ACPCommand != "opencode" {
+		t.Errorf("ACPCommand = %q, want %q", p.ACPCommand, "opencode")
+	}
+	if len(p.ACPArgs) != 1 || p.ACPArgs[0] != "acp" {
+		t.Errorf("ACPArgs = %v, want [acp]", p.ACPArgs)
+	}
+	patchArgs[0] = "mutated"
+	if cfg.Providers["opencode"].ACPArgs[0] != "acp" {
+		t.Error("patch slice aliased into spec; Replace did not copy ACPArgs")
+	}
+}
+
 func TestApplyPatches_ProviderNotFound(t *testing.T) {
 	cfg := &City{
 		Providers: map[string]ProviderSpec{},

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -52,6 +52,16 @@ type ProviderSpec struct {
 	Command string `toml:"command,omitempty"`
 	// Args are default command-line arguments passed to the provider.
 	Args []string `toml:"args,omitempty"`
+	// ACPCommand overrides Command when the agent runs with session="acp".
+	// Empty means "reuse Command for ACP too" (correct for providers that
+	// auto-detect ACP on stdin, e.g. Claude Code). Providers that need a
+	// distinct subcommand in ACP mode set it explicitly so tmux transport
+	// keeps a usable interactive command. Example: "opencode" with
+	// ACPArgs = ["acp"] for OpenCode.
+	ACPCommand string `toml:"acp_command,omitempty"`
+	// ACPArgs overrides Args under session="acp". A nil/absent value means
+	// "reuse Args"; an explicit empty list means "no args in ACP mode".
+	ACPArgs []string `toml:"acp_args,omitempty"`
 	// PromptMode controls how prompts are delivered: "arg", "flag", or "none".
 	PromptMode string `toml:"prompt_mode,omitempty" jsonschema:"enum=arg,enum=flag,enum=none,default=arg"`
 	// PromptFlag is the CLI flag used when prompt_mode is "flag" (e.g. "--prompt").
@@ -166,9 +176,14 @@ type ResolvedProvider struct {
 	// Chain records the resolved ancestry from leaf (index 0) to root.
 	Chain []HopIdentity
 	// Provenance records per-field and per-map-key layer attribution.
-	Provenance             ProviderProvenance
-	Command                string
-	Args                   []string
+	Provenance ProviderProvenance
+	Command    string
+	Args       []string
+	// ACPCommand / ACPArgs mirror the ProviderSpec fields. See
+	// CommandStringForTransport for how they are picked over Command/Args
+	// when a session uses the ACP transport.
+	ACPCommand             string
+	ACPArgs                []string
 	PromptMode             string
 	PromptFlag             string
 	ReadyDelayMs           int
@@ -195,11 +210,39 @@ type ResolvedProvider struct {
 }
 
 // CommandString returns the full command line: command followed by args.
+// It is equivalent to CommandStringForTransport(false) and exists for
+// call sites that do not yet care about the ACP vs tmux split.
 func (rp *ResolvedProvider) CommandString() string {
-	if len(rp.Args) == 0 {
-		return rp.Command
+	return rp.CommandStringForTransport(false)
+}
+
+// CommandStringForTransport returns the full command line, selecting
+// ACPCommand/ACPArgs when isACP is true and they are configured.
+//
+// A provider may configure neither (single command serves both
+// transports, e.g. Claude Code), Command only (tmux-only), or both
+// (OpenCode: `opencode` for tmux, `opencode acp` for ACP). When isACP
+// is true we use ACPCommand if set and ACPArgs if non-nil; missing
+// fields fall back to Command/Args respectively. This split matters for
+// providers whose ACP-mode entrypoint is a subcommand — invoking the
+// tmux command in ACP mode yields a headless JSON-RPC server stuck in
+// a terminal pane, and invoking the ACP subcommand in tmux mode yields
+// an uninteractive server with no prompt.
+func (rp *ResolvedProvider) CommandStringForTransport(isACP bool) string {
+	cmd := rp.Command
+	args := rp.Args
+	if isACP {
+		if rp.ACPCommand != "" {
+			cmd = rp.ACPCommand
+		}
+		if rp.ACPArgs != nil {
+			args = rp.ACPArgs
+		}
 	}
-	return rp.Command + " " + shellquote.Join(rp.Args)
+	if len(args) == 0 {
+		return cmd
+	}
+	return cmd + " " + shellquote.Join(args)
 }
 
 // TitleModelFlagArgs resolves the TitleModel key against the "model"
@@ -287,6 +330,8 @@ func providerSpecFromWorker(spec workerbuiltin.BuiltinProviderSpec) ProviderSpec
 		DisplayName:            spec.DisplayName,
 		Command:                spec.Command,
 		Args:                   cloneStrings(spec.Args),
+		ACPCommand:             spec.ACPCommand,
+		ACPArgs:                cloneStrings(spec.ACPArgs),
 		PromptMode:             spec.PromptMode,
 		PromptFlag:             spec.PromptFlag,
 		ReadyDelayMs:           spec.ReadyDelayMs,

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -257,6 +257,76 @@ func TestCommandStringMultipleArgs(t *testing.T) {
 	}
 }
 
+func TestCommandStringForTransport(t *testing.T) {
+	tests := []struct {
+		name  string
+		rp    ResolvedProvider
+		isACP bool
+		want  string
+	}{
+		{
+			name:  "tmux_no_acp_override_uses_command",
+			rp:    ResolvedProvider{Command: "claude"},
+			isACP: false,
+			want:  "claude",
+		},
+		{
+			name:  "acp_no_override_uses_command",
+			rp:    ResolvedProvider{Command: "claude"},
+			isACP: true,
+			want:  "claude",
+		},
+		{
+			name: "acp_with_distinct_subcommand",
+			rp: ResolvedProvider{
+				Command:    "opencode",
+				ACPCommand: "opencode",
+				ACPArgs:    []string{"acp"},
+			},
+			isACP: true,
+			want:  "opencode acp",
+		},
+		{
+			name: "tmux_ignores_acp_fields",
+			rp: ResolvedProvider{
+				Command:    "opencode",
+				ACPCommand: "opencode",
+				ACPArgs:    []string{"acp"},
+			},
+			isACP: false,
+			want:  "opencode",
+		},
+		{
+			name: "acp_inherits_args_when_acpargs_nil",
+			rp: ResolvedProvider{
+				Command:    "tool",
+				Args:       []string{"--shared"},
+				ACPCommand: "tool-acp",
+				// ACPArgs: nil → reuse Args
+			},
+			isACP: true,
+			want:  "tool-acp --shared",
+		},
+		{
+			name: "acp_empty_slice_clears_args",
+			rp: ResolvedProvider{
+				Command: "tool",
+				Args:    []string{"--shared"},
+				ACPArgs: []string{}, // explicit empty, not nil
+			},
+			isACP: true,
+			want:  "tool",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rp.CommandStringForTransport(tc.isACP); got != tc.want {
+				t.Errorf("CommandStringForTransport(%v) = %q, want %q", tc.isACP, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCommandStringQuotesShellMetacharacters(t *testing.T) {
 	rp := &ResolvedProvider{
 		Command: "codex",

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -205,6 +205,9 @@ func MergeProviderOverBuiltin(base, city ProviderSpec) ProviderSpec {
 	if city.Command != "" {
 		result.Command = city.Command
 	}
+	if city.ACPCommand != "" {
+		result.ACPCommand = city.ACPCommand
+	}
 	if city.PromptMode != "" {
 		result.PromptMode = city.PromptMode
 	}
@@ -254,6 +257,9 @@ func MergeProviderOverBuiltin(base, city ProviderSpec) ProviderSpec {
 	// Slice fields: replace entirely when non-nil.
 	if city.Args != nil {
 		result.Args = city.Args
+	}
+	if city.ACPArgs != nil {
+		result.ACPArgs = city.ACPArgs
 	}
 	if city.ArgsAppend != nil {
 		result.ArgsAppend = append(append([]string(nil), base.ArgsAppend...), city.ArgsAppend...)
@@ -473,6 +479,7 @@ func specToResolved(name string, spec *ProviderSpec) *ResolvedProvider {
 	rp := &ResolvedProvider{
 		Name:                   name,
 		Command:                spec.Command,
+		ACPCommand:             spec.ACPCommand,
 		PromptMode:             spec.PromptMode,
 		PromptFlag:             spec.PromptFlag,
 		ReadyDelayMs:           spec.ReadyDelayMs,
@@ -512,6 +519,13 @@ func specToResolved(name string, spec *ProviderSpec) *ResolvedProvider {
 	if len(spec.Args) > 0 {
 		rp.Args = make([]string, len(spec.Args))
 		copy(rp.Args, spec.Args)
+	}
+	// ACPArgs: preserve nil-vs-empty distinction. A non-nil ACPArgs
+	// (including an explicit []) means "use this for ACP"; nil means
+	// "reuse Args".
+	if spec.ACPArgs != nil {
+		rp.ACPArgs = make([]string, len(spec.ACPArgs))
+		copy(rp.ACPArgs, spec.ACPArgs)
 	}
 
 	// Strip schema-managed flags from Args. This handles backward compatibility:
@@ -652,6 +666,12 @@ func resolvedChainToSpec(r ResolvedProvider, leaf ProviderSpec) ProviderSpec {
 	out.Command = r.Command
 	if r.Args != nil {
 		out.Args = append([]string(nil), r.Args...)
+	}
+	if r.ACPCommand != "" {
+		out.ACPCommand = r.ACPCommand
+	}
+	if r.ACPArgs != nil {
+		out.ACPArgs = append([]string(nil), r.ACPArgs...)
 	}
 	if r.PromptMode != "" {
 		out.PromptMode = r.PromptMode

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -209,6 +209,49 @@ func TestResolveProviderAutoDetect(t *testing.T) {
 	}
 }
 
+// TestResolveProviderOpenCodeACPFields verifies that the builtin
+// OpenCode profile's ACPCommand/ACPArgs survive resolution, so ACP
+// sessions launch `opencode acp` while tmux sessions stay on plain
+// `opencode`.
+func TestResolveProviderOpenCodeACPFields(t *testing.T) {
+	agent := &Agent{Name: "worker", Provider: "opencode"}
+	rp, err := ResolveProvider(agent, nil, nil, lookPathAll)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	if got := rp.CommandStringForTransport(false); got != "opencode" {
+		t.Errorf("tmux command = %q, want %q", got, "opencode")
+	}
+	if got := rp.CommandStringForTransport(true); got != "opencode acp" {
+		t.Errorf("acp command = %q, want %q", got, "opencode acp")
+	}
+}
+
+// TestResolveProviderACPOverrideFromCity verifies that a city.toml
+// [providers.X] block can set acp_command / acp_args and have them
+// flow through MergeProviderOverBuiltin and specToResolved.
+func TestResolveProviderACPOverrideFromCity(t *testing.T) {
+	agent := &Agent{Name: "worker", Provider: "my-opencode"}
+	cityProviders := map[string]ProviderSpec{
+		"my-opencode": {
+			Base:       basePtr("builtin:opencode"),
+			Command:    "wrap-opencode",
+			ACPCommand: "wrap-opencode",
+			ACPArgs:    []string{"serve", "--acp"},
+		},
+	}
+	rp, err := ResolveProvider(agent, nil, cityProviders, lookPathAll)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	if got := rp.CommandStringForTransport(true); got != "wrap-opencode serve --acp" {
+		t.Errorf("acp command = %q, want %q", got, "wrap-opencode serve --acp")
+	}
+	if got := rp.CommandStringForTransport(false); got != "wrap-opencode" {
+		t.Errorf("tmux command = %q, want %q", got, "wrap-opencode")
+	}
+}
+
 func TestResolveProviderAutoDetectNone(t *testing.T) {
 	agent := &Agent{Name: "worker"}
 	_, err := ResolveProvider(agent, nil, nil, lookPathNone)
@@ -1219,6 +1262,8 @@ func TestMergeProviderOverBuiltinFieldSync(t *testing.T) {
 		DisplayName:            "Custom",
 		Command:                "custom-cmd",
 		Args:                   []string{"--flag"},
+		ACPCommand:             "custom-acp",
+		ACPArgs:                []string{"acp"},
 		PromptMode:             "flag",
 		PromptFlag:             "--prompt",
 		ReadyDelayMs:           5000,

--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -65,9 +65,18 @@ type ServerInfo struct {
 }
 
 // InitializeParams is the params for the "initialize" request.
+//
+// ProtocolVersion is REQUIRED by the ACP spec — strict servers (e.g.
+// OpenCode) reject the handshake with "expected number, received
+// undefined" when it is omitted. Claude Code is lenient and masked the
+// non-compliance historically.
 type InitializeParams struct {
-	ClientInfo ClientInfo `json:"clientInfo"`
+	ProtocolVersion int        `json:"protocolVersion"`
+	ClientInfo      ClientInfo `json:"clientInfo"`
 }
+
+// acpProtocolVersion is the ACP protocol version this client implements.
+const acpProtocolVersion = 1
 
 // InitializeResult is the result of the "initialize" request.
 type InitializeResult struct {
@@ -123,7 +132,8 @@ func newNotification(method string) JSONRPCMessage {
 // newInitializeRequest creates an "initialize" request.
 func newInitializeRequest() (JSONRPCMessage, int64) {
 	return newRequest("initialize", InitializeParams{
-		ClientInfo: ClientInfo{Name: "gc", Version: "1.0"},
+		ProtocolVersion: acpProtocolVersion,
+		ClientInfo:      ClientInfo{Name: "gc", Version: "1.0"},
 	})
 }
 

--- a/internal/runtime/acp/protocol_test.go
+++ b/internal/runtime/acp/protocol_test.go
@@ -39,6 +39,24 @@ func TestJSONRPCMessage_RequestRoundTrip(t *testing.T) {
 	if params.ClientInfo.Name != "gc" {
 		t.Errorf("clientInfo.name = %q, want %q", params.ClientInfo.Name, "gc")
 	}
+	if params.ProtocolVersion != acpProtocolVersion {
+		t.Errorf("protocolVersion = %d, want %d", params.ProtocolVersion, acpProtocolVersion)
+	}
+
+	// Strict ACP servers (e.g. OpenCode) require protocolVersion on the
+	// wire as a number. Ensure it is present in the marshaled JSON,
+	// not only decodable into the struct.
+	var raw map[string]any
+	if err := json.Unmarshal(decoded.Params, &raw); err != nil {
+		t.Fatalf("Unmarshal raw params: %v", err)
+	}
+	pv, ok := raw["protocolVersion"]
+	if !ok {
+		t.Fatalf("protocolVersion missing from initialize params; strict ACP servers reject this")
+	}
+	if n, ok := pv.(float64); !ok || int(n) != acpProtocolVersion {
+		t.Errorf("protocolVersion wire value = %v, want number %d", pv, acpProtocolVersion)
+	}
 }
 
 func TestJSONRPCMessage_NotificationOmitsID(t *testing.T) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -65,6 +65,7 @@ type Info struct {
 	Title         string
 	Alias         string
 	Provider      string
+	Transport     string
 	Command       string // resolved command stored at creation
 	WorkDir       string
 	SessionName   string // tmux session name
@@ -1138,8 +1139,11 @@ func (m *Manager) infoFromBead(b beads.Bead) Info {
 		sessName = sessionNameFor(b.ID)
 	}
 	closed := b.Status == "closed"
+	transport := transportFromMetadata(b)
 	if !closed {
-		transport, _ := m.transportForBead(b, sessName)
+		if transport == "" {
+			transport, _ = m.transportForBead(b, sessName)
+		}
 		_ = m.routeACPIfNeeded(b.Metadata["provider"], transport, sessName)
 	}
 
@@ -1160,6 +1164,7 @@ func (m *Manager) infoFromBead(b beads.Bead) Info {
 		Title:         b.Title,
 		Alias:         b.Metadata["alias"],
 		Provider:      b.Metadata["provider"],
+		Transport:     transport,
 		Command:       b.Metadata["command"],
 		WorkDir:       b.Metadata["work_dir"],
 		SessionName:   sessName,

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -32,9 +32,18 @@ type BuiltinOptionChoice struct {
 //
 //nolint:revive // Mirrors the config boundary naming intentionally.
 type BuiltinProviderSpec struct {
-	DisplayName            string
-	Command                string
-	Args                   []string
+	DisplayName string
+	Command     string
+	Args        []string
+	// ACPCommand overrides Command when the agent runs with session="acp".
+	// Empty means "reuse Command for ACP too" — correct for providers that
+	// auto-detect ACP on stdin (e.g. Claude Code). Providers that need a
+	// distinct subcommand in ACP mode (e.g. OpenCode's `opencode acp`) set
+	// it explicitly so tmux transport keeps a usable interactive command.
+	ACPCommand string
+	// ACPArgs overrides Args under session="acp" when non-nil. A nil slice
+	// means "reuse Args"; an empty slice means "no args in ACP mode".
+	ACPArgs                []string
 	PromptMode             string
 	PromptFlag             string
 	ReadyDelayMs           int
@@ -292,9 +301,15 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		InstructionsFile: "AGENTS.md",
 	},
 	"opencode": {
-		DisplayName:      "OpenCode",
-		Command:          "opencode",
-		Args:             []string{},
+		DisplayName: "OpenCode",
+		Command:     "opencode",
+		Args:        []string{},
+		// OpenCode's BubbleTea TUI is the interactive entrypoint; its ACP
+		// server lives behind `opencode acp`. Use the subcommand for ACP
+		// sessions and leave plain `opencode` for tmux so the pane is
+		// actually interactive.
+		ACPCommand:       "opencode",
+		ACPArgs:          []string{"acp"},
 		PromptMode:       "none",
 		ReadyDelayMs:     8000,
 		ProcessNames:     []string{"opencode", "node", "bun"},
@@ -383,6 +398,7 @@ func newProfileIdentity(profile, family, transport string) ProfileIdentity {
 
 func cloneBuiltinProviderSpec(spec BuiltinProviderSpec) BuiltinProviderSpec {
 	spec.Args = cloneStrings(spec.Args)
+	spec.ACPArgs = cloneStrings(spec.ACPArgs)
 	spec.ProcessNames = cloneStrings(spec.ProcessNames)
 	spec.Env = cloneStringMap(spec.Env)
 	spec.PermissionModes = cloneStringMap(spec.PermissionModes)


### PR DESCRIPTION
Closes #1008.

## Summary

Two-commit fix for ACP strict-validator support:

1. **`fix(acp): include protocolVersion in initialize handshake`** — ACP spec requires `protocolVersion` on the initialize request. Claude Code has been lenient, but strict servers (OpenCode) reject the handshake with `Invalid params: expected number, received undefined`. Adds `ProtocolVersion int` to `InitializeParams` and sends `1` in the handshake.

2. **`feat(acp): per-transport provider command via ACPCommand/ACPArgs`** — The same `Command` field was reused for both tmux and ACP transports, forcing providers like OpenCode (which autostarts an interactive session with no args but needs `opencode acp` for JSON-RPC) to pick one. Adds optional `ACPCommand` / `ACPArgs` to provider specs with nil-fallback to `Command`/`Args`, plumbed through the whole resolution pipeline. The opencode builtin now ships with `ACPCommand=opencode, ACPArgs=[acp]`; city.toml overrides flow through `[providers.X] acp_command` / `acp_args`.

Together these unblock OpenCode and any other strict-validating ACP provider.

## Changes

- `internal/runtime/acp/protocol.go` — `ProtocolVersion` field + wire value 1.
- `internal/runtime/acp/protocol_test.go` — wire-format assertion that `protocolVersion` is present as a JSON number. Also fixes `marshalled` → `marshaled` (misspell lint).
- `internal/config/provider.go` — `ACPCommand`/`ACPArgs` on `ProviderSpec` and `ResolvedProvider`; new `CommandStringForTransport(isACP bool)`.
- `internal/config/resolve.go` — `specToResolved`, `MergeProviderOverBuiltin`, `resolvedChainToSpec` all propagate the new fields (preserving nil-vs-empty-slice semantics).
- `internal/config/patch.go` — `ProviderPatch` gains `ACPCommand` / `ACPArgs`; both Replace and deep-merge branches apply them.
- `internal/config/pack.go` — `deepCopyProviderSpec` clones `ACPArgs`.
- `internal/worker/builtin/profiles.go` — opencode builtin sets `ACPCommand: "opencode", ACPArgs: []string{"acp"}`; `cloneBuiltinProviderSpec` clones.
- `cmd/gc/template_resolve.go` — switches to `CommandStringForTransport(isACP)` so tmux and ACP sessions render the correct command.

## Test plan

- [x] `go test ./internal/config/... ./internal/runtime/acp/... ./internal/worker/builtin/...` — green
- [x] `go test ./cmd/gc/ -run '^TestResolveTemplate'` — green
- [x] `go build ./... && go vet ./internal/config/... ./internal/runtime/acp/... ./internal/worker/builtin/... ./cmd/gc/` — clean
- [x] New unit tests: `TestCommandStringForTransport` (6 cases), `TestResolveProviderOpenCodeACPFields`, `TestResolveProviderACPOverrideFromCity`
- [x] Existing `TestProviderFieldSync` + `TestMergeProviderOverBuiltinFieldSync` guardrails pass, fixture updated
- [ ] Manual: launch an OpenCode ACP session and confirm the handshake no longer rejects
