### PR TITLE
feat(providers): add Cerebras OpenCode preset

### DIFF
--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -9,9 +9,10 @@ description: Create a city, sling work to an agent, add a rig, and configure mul
 First, you'll need to install at least one CLI coding agent (which Gas City
 calls "providers") and make sure that they're on the PATH. Gas City supports
 many providers, including but not limited to Claude Code (`claude`), Codex
-(`codex`) and Gemini (`gemini`). Make sure you've configured each of your chosen
-providers (the more the merrier!) with the appropriate token and/or API key so
-that they can each run and do things for you.
+(`codex`), Gemini (`gemini`), OpenCode (`opencode`), and Cerebras
+(`cerebras`). Make sure you've configured each of your chosen providers (the
+more the merrier!) with the appropriate token and/or API key so that they can
+each run and do things for you.
 
 Next, you'll need to get the Gas City CLI installed and on your PATH:
 
@@ -70,10 +71,11 @@ Choose your coding agent:
   5. GitHub Copilot
   6. Sourcegraph AMP
   7. OpenCode
-  8. Auggie CLI
-  9. Pi Coding Agent
-  10. Oh My Pi (OMP)
-  11. Custom command
+  8. Cerebras (OpenCode)
+  9. Auggie CLI
+  10. Pi Coding Agent
+  11. Oh My Pi (OMP)
+  12. Custom command
 Agent [1]:
 [1/8] Creating runtime scaffold
 [2/8] Installing hooks (Claude Code)

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -9,12 +9,12 @@ func TestBuiltinProviders(t *testing.T) {
 	providers := BuiltinProviders()
 	order := BuiltinProviderOrder()
 
-	// Must have exactly 13 built-in providers.
-	if len(providers) != 13 {
-		t.Fatalf("len(BuiltinProviders()) = %d, want 13", len(providers))
+	// Must have exactly 14 built-in providers.
+	if len(providers) != 14 {
+		t.Fatalf("len(BuiltinProviders()) = %d, want 14", len(providers))
 	}
-	if len(order) != 13 {
-		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 13", len(order))
+	if len(order) != 14 {
+		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 14", len(order))
 	}
 
 	// Every entry in order must exist in providers.
@@ -404,6 +404,50 @@ func TestBuiltinProvidersSessionIDFlag(t *testing.T) {
 		if got := providers[name].SessionIDFlag; got != "" {
 			t.Errorf("%s SessionIDFlag = %q, want empty (no documented start-with-id flag)", name, got)
 		}
+	}
+}
+
+func TestBuiltinProvidersCerebrasOpenCodePreset(t *testing.T) {
+	p := BuiltinProviders()["cerebras"]
+	if p.Command != "opencode" {
+		t.Errorf("Command = %q, want %q", p.Command, "opencode")
+	}
+	if p.PromptMode != "none" {
+		t.Errorf("PromptMode = %q, want %q", p.PromptMode, "none")
+	}
+	if p.InstructionsFile != "AGENTS.md" {
+		t.Errorf("InstructionsFile = %q, want %q", p.InstructionsFile, "AGENTS.md")
+	}
+	if !derefBool(p.SupportsACP) {
+		t.Fatal("SupportsACP = false, want true")
+	}
+	if !derefBool(p.SupportsHooks) {
+		t.Fatal("SupportsHooks = false, want true")
+	}
+	if !reflect.DeepEqual(p.ACPArgs, []string{"acp"}) {
+		t.Fatalf("ACPArgs = %v, want [acp]", p.ACPArgs)
+	}
+	if p.OptionDefaults["model"] != "cerebras/gpt-oss-120b" {
+		t.Fatalf("OptionDefaults[model] = %q, want cerebras/gpt-oss-120b", p.OptionDefaults["model"])
+	}
+
+	rp := specToResolved("cerebras", &p)
+	if got := rp.ProviderSessionCreateTransport(); got != "acp" {
+		t.Fatalf("ProviderSessionCreateTransport() = %q, want acp", got)
+	}
+	if got, want := rp.ResolveDefaultArgs(), []string{"--model", "cerebras/gpt-oss-120b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveDefaultArgs() = %v, want %v", got, want)
+	}
+	if got, want := rp.TitleModelFlagArgs(), []string{"--model", "cerebras/gpt-oss-120b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("TitleModelFlagArgs() = %v, want %v", got, want)
+	}
+
+	launch, err := BuildProviderLaunchCommand("", rp, nil, "acp")
+	if err != nil {
+		t.Fatalf("BuildProviderLaunchCommand: %v", err)
+	}
+	if want := "opencode acp --model cerebras/gpt-oss-120b"; launch.Command != want {
+		t.Fatalf("Command = %q, want %q", launch.Command, want)
 	}
 }
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -29,7 +29,7 @@ var configFS embed.FS
 
 // supported lists provider names that have hook support wired into
 // Gas Town's installer.
-var supported = []string{"claude", "codex", "gemini", "kiro", "opencode", "copilot", "cursor", "pi", "omp"}
+var supported = []string{"claude", "codex", "gemini", "kiro", "opencode", "cerebras", "copilot", "cursor", "pi", "omp"}
 
 const (
 	managedPiHookVersion       = 4
@@ -156,6 +156,8 @@ func InstallWithResolver(fs fsys.FS, cityDir, workDir string, providers []string
 			err = installClaude(fs, cityDir)
 		case "codex", "gemini", "kiro", "opencode", "copilot", "cursor", "pi", "omp":
 			err = installOverlayManaged(fs, workDir, family)
+		case "cerebras":
+			err = installOverlayManaged(fs, workDir, "opencode")
 		default:
 			return fmt.Errorf("unsupported hook provider %q", p)
 		}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -53,7 +53,7 @@ func TestSupportedProviders(t *testing.T) {
 	got := SupportedProviders()
 	want := map[string]bool{
 		"claude": true, "codex": true, "gemini": true, "kiro": true, "opencode": true,
-		"copilot": true, "cursor": true, "pi": true, "omp": true,
+		"cerebras": true, "copilot": true, "cursor": true, "pi": true, "omp": true,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("SupportedProviders() = %v, want %d entries", got, len(want))
@@ -1564,6 +1564,16 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 	if strings.Contains(string(fs.Files["/work/.kiro/agents/gascity.json"]), "gc handoff") {
 		t.Error("Kiro agent config should not install unsupported compaction handoff hooks")
+	}
+}
+
+func TestInstallCerebrasUsesOpenCodeOverlay(t *testing.T) {
+	fs := fsys.NewFake()
+	if err := Install(fs, "/city", "/work", []string{"cerebras"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, ok := fs.Files["/work/.opencode/plugins/gascity.js"]; !ok {
+		t.Fatal("expected Cerebras provider to materialize the OpenCode hook plugin")
 	}
 }
 

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -82,7 +82,7 @@ const (
 
 var builtinProviderOrder = []string{
 	"claude", "codex", "gemini", "kimi", "kiro", "cursor", "copilot",
-	"amp", "opencode", "auggie", "pi", "omp", "antigravity",
+	"amp", "opencode", "cerebras", "auggie", "pi", "omp", "antigravity",
 }
 
 var builtinProviderSpecs = map[string]BuiltinProviderSpec{
@@ -399,6 +399,35 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 					{Value: "opencode/deepseek-v4-flash-free", Label: "DeepSeek V4 Flash Free", FlagArgs: []string{"--model", "opencode/deepseek-v4-flash-free"}, FlagAliases: [][]string{{"-m", "opencode/deepseek-v4-flash-free"}}},
 					{Value: "opencode/nemotron-3-super-free", Label: "Nemotron 3 Super Free", FlagArgs: []string{"--model", "opencode/nemotron-3-super-free"}, FlagAliases: [][]string{{"-m", "opencode/nemotron-3-super-free"}}},
 					{Value: "opencode/big-pickle", Label: "Big Pickle", FlagArgs: []string{"--model", "opencode/big-pickle"}, FlagAliases: [][]string{{"-m", "opencode/big-pickle"}}},
+				},
+			},
+		},
+	},
+	"cerebras": {
+		DisplayName: "Cerebras (OpenCode)",
+		Command:     "opencode",
+		OptionDefaults: map[string]string{
+			"model": "cerebras/gpt-oss-120b",
+		},
+		PromptMode:       "none",
+		ReadyDelayMs:     8000,
+		ProcessNames:     []string{"opencode", "node", "bun"},
+		Env:              map[string]string{"OPENCODE_PERMISSION": `{"*":"allow"}`},
+		SupportsACP:      true,
+		SupportsHooks:    true,
+		InstructionsFile: "AGENTS.md",
+		ACPArgs:          []string{"acp"},
+		TitleModel:       "cerebras/gpt-oss-120b",
+		OptionsSchema: []BuiltinProviderOption{
+			{
+				Key:   "model",
+				Label: "Model",
+				Type:  "select",
+				Choices: []BuiltinOptionChoice{
+					{Value: "", Label: "Default"},
+					{Value: "cerebras/gpt-oss-120b", Label: "GPT-OSS 120B", FlagArgs: []string{"--model", "cerebras/gpt-oss-120b"}},
+					{Value: "cerebras/zai-glm-4.7", Label: "GLM 4.7", FlagArgs: []string{"--model", "cerebras/zai-glm-4.7"}},
+					{Value: "cerebras/qwen-3-235b-a22b-instruct-2507", Label: "Qwen 3 235B A22B Instruct", FlagArgs: []string{"--model", "cerebras/qwen-3-235b-a22b-instruct-2507"}},
 				},
 			},
 		},

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -8,11 +8,11 @@ func TestBuiltinProvidersAndOrder(t *testing.T) {
 	providers := BuiltinProviders()
 	order := BuiltinProviderOrder()
 
-	if len(providers) != 13 {
-		t.Fatalf("len(BuiltinProviders()) = %d, want 13", len(providers))
+	if len(providers) != 14 {
+		t.Fatalf("len(BuiltinProviders()) = %d, want 14", len(providers))
 	}
-	if len(order) != 13 {
-		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 13", len(order))
+	if len(order) != 14 {
+		t.Fatalf("len(BuiltinProviderOrder()) = %d, want 14", len(order))
 	}
 
 	for _, name := range order {


### PR DESCRIPTION
## Summary

- Add `cerebras` as a built-in provider preset backed by `opencode acp`.
- Default to `cerebras/gpt-oss-120b` and expose current Cerebras model choices through the existing provider options schema.
- Reuse the OpenCode hook overlay for Cerebras-backed sessions and update the `gc init` tutorial provider list.

Related: #672

## Testing

- `go test ./internal/worker/builtin ./internal/config ./internal/hooks -count=1`
- `make check-docs`
- `make lint`
- `TMPDIR=/tmp make check` was attempted; changed packages passed, but the repo-wide sweep is currently blocked by unrelated runtime test failures in `internal/runtime/acp`, `internal/runtime/exec`, and `internal/worker/workertest`.

## Checklist

- Linked an issue.
- Added tests for the provider launch path and hook overlay routing.
- Updated docs for the user-facing provider list.
- No breaking changes or migration steps.