### PR TITLE
Fix main-branch test regressions and macOS flakes

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -363,6 +363,11 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 	if err := normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase); err != nil {
 		return err
 	}
+	if cityUsesBdStoreContract(cityPath) && currentManagedDoltPort(cityPath) != "" {
+		if err := syncManagedDoltPortMirrors(cityPath); err != nil {
+			return fmt.Errorf("sync managed dolt port mirrors after init: %w", err)
+		}
+	}
 	// Non-fatal: hooks are convenience (event forwarding), not critical.
 	if err := installBeadHooks(dir); err != nil {
 		return fmt.Errorf("install hooks at %s: %w", dir, err)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -41,6 +41,12 @@ func freeLoopbackPort(t *testing.T) string {
 	return strconv.Itoa(addr.Port)
 }
 
+func setScopedBeadsProviderForTest(t *testing.T, scopeRoot, provider string) {
+	t.Helper()
+	t.Setenv("GC_BEADS", provider)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", scopeRoot)
+}
+
 // TestEnsureBeadsProvider_file verifies that file provider is a no-op.
 func TestEnsureBeadsProvider_file(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
@@ -52,9 +58,10 @@ func TestEnsureBeadsProvider_file(t *testing.T) {
 
 // TestEnsureBeadsProvider_exec calls script with ensure-ready, exit 2 = no-op.
 func TestEnsureBeadsProvider_exec(t *testing.T) {
+	dir := t.TempDir()
 	script := writeTestScript(t, "ensure-ready", 2, "")
-	t.Setenv("GC_BEADS", "exec:"+script)
-	if err := ensureBeadsProvider(t.TempDir()); err != nil {
+	setScopedBeadsProviderForTest(t, dir, "exec:"+script)
+	if err := ensureBeadsProvider(dir); err != nil {
 		t.Fatalf("expected nil for exit 2, got %v", err)
 	}
 }
@@ -373,7 +380,7 @@ exit 0
 	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("GC_BEADS", "exec:"+script)
+	setScopedBeadsProviderForTest(t, cityPath, "exec:"+script)
 
 	if err := ensureBeadsProvider(cityPath); err != nil {
 		t.Fatalf("ensureBeadsProvider: %v", err)
@@ -508,9 +515,9 @@ dolt_port = "4406"
 
 func TestManagedDoltLifecycleOwnedReportsInvalidCityConfigForFileCity(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
-	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname =\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +538,7 @@ func TestEnsureBeadsProvider_bd_skip(t *testing.T) {
 		t.Fatal(err)
 	}
 	MaterializeBuiltinPacks(dir) //nolint:errcheck
-	t.Setenv("GC_BEADS", "bd")
+	setScopedBeadsProviderForTest(t, dir, "bd")
 	t.Setenv("GC_DOLT", "skip")
 	if err := ensureBeadsProvider(dir); err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -577,7 +584,7 @@ func TestEnsureBeadsProvider_bdAcceptsHealthyServerAfterStartError(t *testing.T)
 		t.Fatal(err)
 	}
 
-	t.Setenv("GC_BEADS", "bd")
+	setScopedBeadsProviderForTest(t, dir, "bd")
 
 	if err := ensureBeadsProvider(dir); err != nil {
 		t.Fatalf("ensureBeadsProvider = %v, want nil", err)
@@ -619,7 +626,7 @@ func TestEnsureBeadsProvider_execDoesNotMaskStartErrorWithHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("GC_BEADS", "exec:"+script)
+	setScopedBeadsProviderForTest(t, dir, "exec:"+script)
 
 	err := ensureBeadsProvider(dir)
 	if err == nil {
@@ -676,6 +683,7 @@ func TestEnsureBeadsProvider_execDoesNotReclassifyProviderAfterStart(t *testing.
 	if err := os.Setenv("GC_BEADS", "exec:"+script); err != nil {
 		t.Fatalf("set GC_BEADS: %v", err)
 	}
+	t.Setenv("GC_BEADS_SCOPE_ROOT", dir)
 	t.Cleanup(func() {
 		if hadProvider {
 			_ = os.Setenv("GC_BEADS", originalProvider)
@@ -737,9 +745,10 @@ func TestShutdownBeadsProvider_file(t *testing.T) {
 
 // TestShutdownBeadsProvider_exec calls script with shutdown, exit 2 = no-op.
 func TestShutdownBeadsProvider_exec(t *testing.T) {
+	dir := t.TempDir()
 	script := writeTestScript(t, "shutdown", 2, "")
-	t.Setenv("GC_BEADS", "exec:"+script)
-	if err := shutdownBeadsProvider(t.TempDir()); err != nil {
+	setScopedBeadsProviderForTest(t, dir, "exec:"+script)
+	if err := shutdownBeadsProvider(dir); err != nil {
 		t.Fatalf("expected nil for exit 2, got %v", err)
 	}
 }
@@ -752,6 +761,7 @@ func TestShutdownBeadsProvider_bd_skip(t *testing.T) {
 	}
 	MaterializeBuiltinPacks(dir) //nolint:errcheck
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", dir)
 	t.Setenv("GC_DOLT", "skip")
 	if err := shutdownBeadsProvider(dir); err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -1945,6 +1955,7 @@ func TestInitBeadsForDir_file(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	cityDir := t.TempDir()
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	if err := initBeadsForDir(cityDir, cityDir, "test", "test"); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -1971,6 +1982,7 @@ func TestInitBeadsForDir_fileScopedRigCreatesStore(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	cityDir := t.TempDir()
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	rigDir := filepath.Join(t.TempDir(), "rig1")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -1997,6 +2009,7 @@ func TestInitBeadsForDir_fileLegacyRigPreservesSharedCityStore(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	cityDir := t.TempDir()
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	rigDir := filepath.Join(t.TempDir(), "rig1")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -2031,6 +2044,7 @@ func TestInitBeadsForDir_exec(t *testing.T) {
 	writeMinimalCityToml(t, cityDir)
 	script := writeTestScript(t, "init", 2, "")
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	if err := initBeadsForDir(cityDir, cityDir, "prefix", "prefix"); err != nil {
 		t.Fatalf("expected nil for exit 2, got %v", err)
 	}
@@ -2047,6 +2061,7 @@ func TestInitBeadsForDir_execPassesCanonicalDoltDatabase(t *testing.T) {
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	if err := initBeadsForDir(cityDir, cityDir, "gc", "gascity"); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -2076,6 +2091,7 @@ exit 0
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	t.Setenv("GC_DOLT", "skip")
 
 	if err := runProviderOp(script, cityDir, "init", cityDir, "gc", "hq"); err != nil {
@@ -2121,6 +2137,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	t.Setenv("GC_CITY_PATH", "/wrong-city")
 	t.Setenv("GC_CITY_RUNTIME_DIR", "/wrong-runtime")
 	t.Setenv("GC_PACK_STATE_DIR", "/wrong-pack")
@@ -2197,6 +2214,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 
 	if err := initBeadsForDir(cityDir, cityDir, "gc", "hq"); err != nil {
 		t.Fatalf("initBeadsForDir: %v", err)
@@ -2279,6 +2297,7 @@ exit 0
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	if err := initBeadsForDir(cityDir, rigDir, "fe", "frontend-db"); err != nil {
 		t.Fatalf("initBeadsForDir: %v", err)
 	}
@@ -2313,6 +2332,7 @@ func TestInitBeadsForDir_execOmitsCanonicalDoltDatabaseWhenUnknown(t *testing.T)
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	if err := initBeadsForDir(cityDir, cityDir, "gc", ""); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -2356,6 +2376,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	if err := initBeadsForDir(cityDir, cityDir, "gc", ""); err != nil {
 		t.Fatalf("initBeadsForDir: %v", err)
 	}
@@ -2378,6 +2399,7 @@ func TestInitBeadsForDir_bd_skip(t *testing.T) {
 	}
 	MaterializeBuiltinPacks(dir) //nolint:errcheck
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", dir)
 	t.Setenv("GC_DOLT", "skip")
 	if err := initBeadsForDir(dir, dir, "test", "test"); err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -2424,6 +2446,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 	if err := initBeadsForDir(cityDir, cityDir, "gc", "hq"); err != nil {
 		t.Fatalf("initBeadsForDir: %v", err)
@@ -2478,6 +2501,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityDir)
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 	t.Setenv("GC_CITY_PATH", "/wrong-city")
 	t.Setenv("GC_CITY_RUNTIME_DIR", "/wrong-runtime")
@@ -2593,6 +2617,7 @@ func TestStartBeadsLifecycleDoesNotMutateProcessDoltEnv(t *testing.T) {
 	_ = os.Unsetenv("BEADS_DOLT_SERVER_HOST")
 
 	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -2760,6 +2785,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 
 	if err := initBeadsForDir(cityPath, cityPath, "mc", "mc"); err != nil {
@@ -2831,6 +2857,7 @@ dolt.user: city-user
 	captureFile := filepath.Join(t.TempDir(), "init-env-city")
 	script := writeGcBeadsBdInitEnvCaptureScript(t, captureFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT_HOST", "ambient.invalid")
 	t.Setenv("GC_DOLT_PORT", "9999")
 	t.Setenv("GC_PACK_STATE_DIR", "/wrong/.gc/runtime/packs/dolt")
@@ -2884,6 +2911,7 @@ dolt.user: rig-user
 	captureFile := filepath.Join(t.TempDir(), "init-env-rig")
 	script := writeGcBeadsBdInitEnvCaptureScript(t, captureFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT_HOST", "ambient.invalid")
 	t.Setenv("GC_DOLT_PORT", "9999")
 	t.Setenv("GC_PACK_STATE_DIR", "/wrong/.gc/runtime/packs/dolt")
@@ -2956,6 +2984,7 @@ dolt.user: city-user
 	captureFile := filepath.Join(t.TempDir(), "init-env-inherited-rig")
 	script := writeGcBeadsBdInitEnvCaptureScript(t, captureFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT_HOST", "ambient.invalid")
 	t.Setenv("GC_DOLT_PORT", "9999")
 	if err := initAndHookDir(cityPath, rigPath, "fe"); err != nil {
@@ -3012,6 +3041,7 @@ esac
 		t.Fatal(err)
 	}
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT_HOST", "ambient.invalid")
 	t.Setenv("GC_DOLT_PORT", "9999")
 	t.Setenv("GC_PACK_STATE_DIR", "/wrong/.gc/runtime/packs/dolt")
@@ -3202,6 +3232,7 @@ esac
 		t.Fatal(err)
 	}
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_PACK_STATE_DIR", "/wrong/.gc/runtime/packs/dolt")
 	if err := ensureBeadsProvider(cityPath); err != nil {
 		t.Fatalf("ensureBeadsProvider: %v", err)
@@ -3234,6 +3265,7 @@ dolt.port: 3307
 		t.Fatal(err)
 	}
 	t.Setenv("GC_BEADS", "exec:"+writeGcBeadsBdInitEnvCaptureScript(t, filepath.Join(t.TempDir(), "should-not-run")))
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	if err := initAndHookDir(cityPath, cityPath, "gc"); err == nil || !strings.Contains(err.Error(), "invalid canonical city endpoint state") {
 		t.Fatalf("initAndHookDir() error = %v, want invalid canonical city endpoint state", err)
 	}
@@ -3275,6 +3307,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	if err := initAndHookDir(cityPath, cityPath, "gc"); err != nil {
 		t.Fatalf("initAndHookDir: %v", err)
 	}
@@ -3572,6 +3605,7 @@ esac
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 	t.Setenv("GC_DOLT_HOST", "rig-db.example.com")
 	t.Setenv("GC_DOLT_PORT", "3307")
@@ -4670,6 +4704,7 @@ dolt.auto-start: false
 func TestValidateCanonicalCompatDoltDriftRejectsCityMismatch(t *testing.T) {
 	cityPath := t.TempDir()
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -4764,6 +4799,8 @@ esac
 	if err := os.WriteFile(fakeDolt, []byte(fakeScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	invocationFile := filepath.Join(t.TempDir(), "gc-invocations.log")
+	fakeGC := writeFakeManagedConfigWriterGC(t, binDir, invocationFile)
 
 	compatPort := reserveRandomTCPPort(t)
 	compatListener := startTCPListenerProcess(t, compatPort)
@@ -4784,6 +4821,7 @@ esac
 
 	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
+		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
 	runStart := func() {
@@ -6573,13 +6611,15 @@ INNERPY
     exit 0
     ;;
 esac
-`
+	`
 	if err := os.WriteFile(fakeDolt, []byte(fakeScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	gcBin := currentGCBinaryForTests(t)
 
 	env := sanitizedBaseEnv(
 		"GC_CITY_PATH="+cityPath,
+		"GC_BIN="+gcBin,
 		"GC_DOLT_PORT="+port,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
 	)
@@ -6722,7 +6762,7 @@ INNERPY
     exit 0
     ;;
 esac
-`, countFile, filepath.Join(cityPath, ".beads", "dolt"), deletedMarkerFile)
+	`, countFile, filepath.Join(cityPath, ".beads", "dolt"), deletedMarkerFile)
 	if err := os.WriteFile(fakeDolt, []byte(fakeScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -6899,10 +6939,6 @@ esac
 	}
 	initialStartCount := readDoltStartCountForTest(t, countFile)
 
-	realNC, err := exec.LookPath("nc")
-	if err != nil {
-		t.Skip("nc not installed")
-	}
 	shimDir := filepath.Join(t.TempDir(), "shim")
 	if err := os.MkdirAll(shimDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -6912,13 +6948,12 @@ esac
 	shim := fmt.Sprintf(`#!/bin/sh
 set -eu
 probe_file=%q
-real_nc=%q
 if [ ! -f "$probe_file" ]; then
   : > "$probe_file"
   exit 1
 fi
-exec "$real_nc" "$@"
-`, probeFile, realNC)
+exit 0
+`, probeFile)
 	if err := os.WriteFile(shimPath, []byte(shim), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -6953,6 +6988,7 @@ func TestValidateCanonicalCompatDoltDriftRejectsInheritedRigCompatOverrideWithRe
 	rigRel := "frontend"
 	rigPath := filepath.Join(cityPath, rigRel)
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	for _, dir := range []string{cityPath, rigPath} {
 		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
 			t.Fatal(err)
@@ -7006,6 +7042,7 @@ func TestValidateCanonicalCompatDoltDriftRejectsInheritedRigCompatOverride(t *te
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "frontend")
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	for _, dir := range []string{cityPath, rigPath} {
 		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
 			t.Fatal(err)
@@ -7066,6 +7103,7 @@ dolt.port: 3307
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Dolt:      config.DoltConfig{Host: "compat-db.example.com", Port: 4406},
@@ -7214,6 +7252,7 @@ dolt.auto-start: false
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	if err := startBeadsLifecycle(cityPath, "test-city", cfg, io.Discard); err == nil || !strings.Contains(err.Error(), "invalid canonical city endpoint state") {
 		t.Fatalf("startBeadsLifecycle() error = %v, want invalid canonical city endpoint state", err)
@@ -7245,6 +7284,7 @@ dolt.auto-start: false
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Rigs:      []config.Rig{{Name: "frontend", Path: rigPath, Prefix: "fe"}},
@@ -7257,6 +7297,7 @@ dolt.auto-start: false
 func TestStartBeadsLifecycleRegistersDoltConfig(t *testing.T) {
 	cityPath := t.TempDir()
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_DOLT_HOST", "")
 	_ = os.Unsetenv("GC_DOLT_HOST")
@@ -7323,6 +7364,7 @@ func TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState(t *testing
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Rigs:      []config.Rig{{Name: "rig", Path: rigPath, Prefix: "rg"}},
@@ -7372,6 +7414,7 @@ dolt.port: "4406"
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	// Defensively ensure the call log does not pre-exist. t.TempDir()
 	// provides a fresh directory, but other test-global resolution paths
@@ -7417,6 +7460,7 @@ dolt.port: "4406"
 	}
 
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	if err := shutdownBeadsProvider(cityPath); err != nil {
 		t.Fatalf("shutdownBeadsProvider() error = %v", err)
 	}
@@ -7448,6 +7492,7 @@ func TestStartBeadsLifecycleSkipsProviderForExternalHost(t *testing.T) {
 	}
 
 	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT_HOST", "operator-override.example.com")
 	t.Setenv("GC_DOLT_PORT", "5511")
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "operator-override.example.com")

--- a/cmd/gc/cityinit_impl_test.go
+++ b/cmd/gc/cityinit_impl_test.go
@@ -299,6 +299,7 @@ func TestLocalInitializerScaffoldPreservesExistingDirectoryWhenRegisterFails(t *
 
 func TestLocalInitializerInitScaffoldsAndFinalizes(t *testing.T) {
 	configureTestDoltIdentityEnv(t)
+	t.Setenv("GC_DOLT", "skip")
 	cityPath := filepath.Join(t.TempDir(), "init-city")
 
 	result, err := localInitializer{}.Init(context.Background(), cityinit.InitRequest{

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -2174,7 +2174,7 @@ set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
 case "$*" in
   "sql-server --config "*)
-    config_file=${*#sql-server --config }
+    config_file=$3
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
     data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
     exec python3 - "$port" "$data_dir" <<'INNERPY'
@@ -2603,7 +2603,7 @@ set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
 case "$*" in
   "sql-server --config "*)
-    config_file=${*#sql-server --config }
+    config_file=$3
     port=$(awk '/port:/ {print $2; exit}' "$config_file")
     data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
     exec python3 - "$port" "$data_dir" <<'INNERPY'

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -538,7 +538,7 @@ func readCanonicalProjectID(metadataPath string) (string, error) {
 func readDatabaseProjectID(ctx context.Context, db *sql.DB) (string, bool, error) {
 	var projectID string
 	if err := db.QueryRowContext(ctx, "SELECT value FROM metadata WHERE `key` = '_project_id'").Scan(&projectID); err != nil {
-		if err == sql.ErrNoRows {
+		if err == sql.ErrNoRows || isMissingDoltMetadataTableError(err) {
 			return "", false, nil
 		}
 		return "", false, fmt.Errorf("read database _project_id: %w", err)
@@ -548,6 +548,17 @@ func readDatabaseProjectID(ctx context.Context, db *sql.DB) (string, bool, error
 		return "", false, nil
 	}
 	return projectID, true, nil
+}
+
+func isMissingDoltMetadataTableError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1146 {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "table not found: metadata") ||
+		strings.Contains(msg, "table 'metadata' doesn't exist") ||
+		strings.Contains(msg, "no such table: metadata")
 }
 
 type fileSnapshot struct {

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1172,6 +1172,7 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 	if err != nil {
 		t.Skip("dolt not installed")
 	}
+	bdPath := waitTestRealBDPath(t)
 	oldResolve := resolveProviderLifecycleGCBinary
 	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
@@ -1200,7 +1201,7 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "")
-	t.Setenv("PATH", strings.Join([]string{"/home/ubuntu/.local/bin", filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
+	t.Setenv("PATH", strings.Join([]string{filepath.Dir(bdPath), filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
 
 	if err := ensureBeadsProvider(cityDir); err != nil {
 		t.Fatalf("ensureBeadsProvider: %v", err)
@@ -1276,6 +1277,7 @@ func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
 	if err != nil {
 		t.Skip("dolt not installed")
 	}
+	bdPath := waitTestRealBDPath(t)
 	oldResolve := resolveProviderLifecycleGCBinary
 	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
@@ -1304,7 +1306,7 @@ func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "")
-	t.Setenv("PATH", strings.Join([]string{"/home/ubuntu/.local/bin", filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
+	t.Setenv("PATH", strings.Join([]string{filepath.Dir(bdPath), filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
 
 	if err := ensureBeadsProvider(cityDir); err != nil {
 		t.Fatalf("ensureBeadsProvider: %v", err)

--- a/cmd/gc/dolt_project_id.go
+++ b/cmd/gc/dolt_project_id.go
@@ -239,10 +239,21 @@ func seedDatabaseProjectID(ctx context.Context, db *sql.DB, projectID string) (b
 		}
 		return false, nil
 	}
+	if err := ensureDatabaseMetadataTable(ctx, db); err != nil {
+		return false, err
+	}
 	if _, err := db.ExecContext(ctx, "INSERT INTO metadata (`key`, value) VALUES ('_project_id', ?) ON DUPLICATE KEY UPDATE value = VALUES(value)", projectID); err != nil {
 		return false, fmt.Errorf("seed database _project_id: %w", err)
 	}
 	return true, nil
+}
+
+func ensureDatabaseMetadataTable(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS metadata (`key` VARCHAR(255) PRIMARY KEY, value LONGTEXT)")
+	if err != nil {
+		return fmt.Errorf("ensure metadata table: %w", err)
+	}
+	return nil
 }
 
 func generateLocalProjectID() (string, error) {

--- a/cmd/gc/dolt_project_id_test.go
+++ b/cmd/gc/dolt_project_id_test.go
@@ -23,6 +23,7 @@ func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabase
 			t.Skip("dolt not installed")
 		}
 	}
+	bdPath := waitTestRealBDPath(t)
 
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
@@ -48,7 +49,7 @@ func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabase
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "")
-	t.Setenv("PATH", strings.Join([]string{"/home/ubuntu/.local/bin", filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
+	t.Setenv("PATH", strings.Join([]string{filepath.Dir(bdPath), filepath.Dir(doltPath), os.Getenv("PATH")}, string(os.PathListSeparator)))
 
 	if err := ensureBeadsProvider(cityDir); err != nil {
 		t.Fatalf("ensureBeadsProvider: %v", err)

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -240,6 +240,9 @@ func displayProviderName(name string) string {
 
 func configuredBeadsProviderValue(cityPath string) string {
 	if v := strings.TrimSpace(os.Getenv("GC_BEADS")); v != "" {
+		if scopedRoot := strings.TrimSpace(os.Getenv("GC_BEADS_SCOPE_ROOT")); scopedRoot != "" && cityPath != "" && !samePath(resolveStoreScopeRoot(cityPath, scopedRoot), cityPath) {
+			return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))
+		}
 		return v
 	}
 	return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -154,6 +154,9 @@ provider = "file"
 	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "file" {
 		t.Fatalf("rawBeadsProviderForScope(city) = %q, want file outside scoped override", got)
 	}
+	if got := beadsProvider(cityDir); got != "file" {
+		t.Fatalf("beadsProvider(city) = %q, want file outside scoped override", got)
+	}
 }
 
 func TestRawBeadsProviderForScopeIgnoresConfigYamlWithoutMetadata(t *testing.T) {

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -85,7 +85,7 @@ tcp_check_port() {
     local host
     host=$(connect_host)
     if command -v nc >/dev/null 2>&1; then
-        nc -z -w2 "$host" "$port" 2>/dev/null
+        nc -z -w 2 "$host" "$port" 2>/dev/null
     elif command -v bash >/dev/null 2>&1; then
         bash -c "echo >/dev/tcp/$host/$port" 2>/dev/null
     else
@@ -257,6 +257,17 @@ database_exists() {
     fi
 
     server_sql "USE \`$db\`" >/dev/null 2>&1
+}
+
+database_has_beads_schema() {
+    local db="$1"
+    [ -n "$db" ] || return 1
+
+    if ! valid_sql_name "$db"; then
+        return 1
+    fi
+
+    server_sql "SELECT 1 FROM \`$db\`.issues LIMIT 1" >/dev/null 2>&1
 }
 
 read_existing_dolt_database() {
@@ -640,6 +651,63 @@ has_deleted_data_inodes() {
     fi
 
     if command -v lsof >/dev/null 2>&1; then
+        if run_lsof -a -p "$pid" +L1 -Fnk 2>/dev/null | awk -v data_dir="$DATA_DIR" '
+            function normalize(path) {
+                gsub(/^[ \t\r\n]+|[ \t\r\n]+$/, "", path)
+                if (path == "/private/tmp") {
+                    return "/tmp"
+                }
+                if (substr(path, 1, 13) == "/private/tmp/") {
+                    return "/tmp/" substr(path, 14)
+                }
+                if (path == "/private/var") {
+                    return "/var"
+                }
+                if (substr(path, 1, 13) == "/private/var/") {
+                    return "/var/" substr(path, 14)
+                }
+                return path
+            }
+            function within(path, root) {
+                path = normalize(path)
+                root = normalize(root)
+                return path == root || substr(path, 1, length(root) + 1) == root "/"
+            }
+            function flush() {
+                if (name != "" && deleted && within(name, data_dir)) {
+                    found = 1
+                }
+                name = ""
+                deleted = 0
+            }
+            substr($0, 1, 1) == "f" {
+                flush()
+                next
+            }
+            substr($0, 1, 1) == "k" {
+                if (substr($0, 2) == "0") {
+                    deleted = 1
+                }
+                next
+            }
+            substr($0, 1, 1) == "n" {
+                if (name != "") {
+                    flush()
+                }
+                name = substr($0, 2)
+                if (name ~ / \(deleted\)$/) {
+                    deleted = 1
+                    sub(/ \(deleted\)$/, "", name)
+                }
+                next
+            }
+            END {
+                flush()
+                exit(found ? 0 : 1)
+            }
+        '; then
+            return 0
+        fi
         if run_lsof -p "$pid" 2>/dev/null | grep ' (deleted)' | grep -F -- "$DATA_DIR" >/dev/null 2>&1; then
             return 0
         fi
@@ -913,11 +981,11 @@ wait_for_managed_pid_ready() {
         if ! kill -0 "$pid" 2>/dev/null; then
             return 1
         fi
-        if [ "$check_deleted" = "true" ] && wait_deleted_data_inodes "$pid"; then
+        if [ "$check_deleted" = "true" ] && has_deleted_data_inodes "$pid"; then
             return 1
         fi
         if tcp_check_port "$port" && do_query_probe; then
-            if [ "$check_deleted" = "true" ] && wait_deleted_data_inodes "$pid"; then
+            if [ "$check_deleted" = "true" ] && has_deleted_data_inodes "$pid"; then
                 return 1
             fi
             return 0
@@ -1725,11 +1793,12 @@ op_init() {
     # beads with that type — must match doctor.RequiredCustomTypes.
     local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence}"
 
-    # If already initialized on disk, ensure the database is also registered
-    # with the running server. This covers the case where bd init created the
-    # directory but the server was restarted (or the database was quarantined).
+    # If already initialized on disk and the server has a bd schema, ensure the
+    # database is also registered with the running server. Local metadata can be
+    # written before bd init seeds tables, so require the server-side schema
+    # before taking the fast path.
     if [ -f "$dir/.beads/metadata.json" ]; then
-        if ensure_database_registered "$dolt_database"; then
+        if ensure_database_registered "$dolt_database" && database_has_beads_schema "$dolt_database"; then
             # GC owns canonical metadata/config normalization after this backend
             # bridge returns. Keep the backend focused on database registration
             # and bd-specific bootstrap only.
@@ -1740,8 +1809,8 @@ op_init() {
             backfill_project_id_if_missing "$dir"
             exit 0
         fi
-        # Database registration failed — fall through to full init.
-        echo "warning: database '$dolt_database' not registered; re-initializing" >&2
+        # Missing registration or schema — fall through to full init.
+        echo "warning: database '$dolt_database' missing bd schema or registration; re-initializing" >&2
     fi
 
     local host
@@ -1763,8 +1832,34 @@ op_init() {
         init_prefix="$dolt_database"
     fi
 
+    local metadata_backup="" config_backup=""
+    if [ -f "$metadata_path" ]; then
+        metadata_backup="$metadata_path.gc-init-backup.$$"
+        cp -f "$metadata_path" "$metadata_backup" || die "failed to back up $metadata_path"
+        rm -f "$metadata_path" || die "failed to clear pre-init $metadata_path"
+    fi
+    if [ -f "$dir/.beads/config.yaml" ]; then
+        config_backup="$dir/.beads/config.yaml.gc-init-backup.$$"
+        cp -f "$dir/.beads/config.yaml" "$config_backup" || die "failed to back up $dir/.beads/config.yaml"
+        rm -f "$dir/.beads/config.yaml" || die "failed to clear pre-init $dir/.beads/config.yaml"
+    fi
+
     # Run bd init in server mode.
-    (cd "$dir" && bd init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT"         "$dir") || die "bd init failed for $dir"
+    if ! (cd "$dir" && bd init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT"         "$dir"); then
+        if [ -n "$metadata_backup" ] && [ -f "$metadata_backup" ]; then
+            mv -f "$metadata_backup" "$metadata_path" || true
+        fi
+        if [ -n "$config_backup" ] && [ -f "$config_backup" ]; then
+            mv -f "$config_backup" "$dir/.beads/config.yaml" || true
+        fi
+        die "bd init failed for $dir"
+    fi
+    if [ -n "$metadata_backup" ]; then
+        rm -f "$metadata_backup"
+    fi
+    if [ -n "$config_backup" ]; then
+        rm -f "$config_backup"
+    fi
 
     # Drop orphan database created by bd init (upstream gt-sv1h).
     # bd init --prefix creates beads_<prefix> on the Dolt server, but we

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -481,7 +481,7 @@ func probeGitHubCLIAuthStatus(ctx context.Context, homeDir, ghPath string) provi
 	stdout, stderr, err := runProbeCommand(
 		ctx,
 		homeDir,
-		2*time.Second,
+		5*time.Second,
 		ghPath,
 		"auth",
 		"status",

--- a/internal/runtime/exec/exec_test.go
+++ b/internal/runtime/exec/exec_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime/runtimetest"
 )
 
+const (
+	startupWatchNoHangTestTimeout = 10 * time.Second
+	startupWatchBlockingSleep     = "30"
+)
+
 // writeScript creates an executable shell script in dir and returns its path.
 func writeScript(t *testing.T, dir, content string) string {
 	t.Helper()
@@ -362,7 +367,7 @@ case "$op" in
     cat > /dev/null
     ;;
   watch-startup)
-    sh -c 'sleep 5' &
+    sh -c 'sleep `+startupWatchBlockingSleep+`' &
     exit 0
     ;;
   peek)
@@ -387,8 +392,10 @@ esac
 	})
 
 	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		done <- p.Start(context.Background(), "test-sess", runtime.Config{
+		done <- p.Start(ctx, "test-sess", runtime.Config{
 			EmitsPermissionWarning: true,
 		})
 	}()
@@ -398,7 +405,8 @@ esac
 		if err != nil {
 			t.Fatalf("Start: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(startupWatchNoHangTestTimeout):
+		cancel()
 		t.Fatal("Start() hung while cleaning up a no-event watch-startup child")
 	}
 
@@ -423,7 +431,7 @@ case "$op" in
     ;;
   watch-startup)
     printf '%s\n' 'not-json'
-    sleep 5
+    sleep `+startupWatchBlockingSleep+`
     ;;
   stop)
     echo "$*" >> "`+stopFile+`"
@@ -434,8 +442,10 @@ esac
 	p := NewProvider(script)
 
 	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		done <- p.Start(context.Background(), "test-sess", runtime.Config{
+		done <- p.Start(ctx, "test-sess", runtime.Config{
 			EmitsPermissionWarning: true,
 		})
 	}()
@@ -448,7 +458,8 @@ esac
 		if !strings.Contains(err.Error(), "startup watcher decode") {
 			t.Fatalf("Start error = %v, want startup watcher decode context", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(startupWatchNoHangTestTimeout):
+		cancel()
 		t.Fatal("Start() hung after malformed first watch-startup event")
 	}
 
@@ -469,14 +480,14 @@ op="$1"
 case "$op" in
   watch-startup)
     printf '%s\n' 'not-json'
-    sleep 5
+    sleep `+startupWatchBlockingSleep+`
     ;;
   *) exit 2 ;;
 esac
 `)
 	p := NewProvider(script)
 
-	snapshots, closeWatch, ok, err := p.startStartupWatch(context.Background(), "test-sess", time.Second)
+	snapshots, closeWatch, ok, err := p.startStartupWatch(context.Background(), "test-sess", startupWatchNoHangTestTimeout)
 	if err == nil {
 		t.Fatal("startStartupWatch succeeded, want malformed first event error")
 	}
@@ -554,7 +565,7 @@ case "$op" in
     ;;
   watch-startup)
     printf '%s\n' '{"content":"starting up"}'
-    sleep 5
+    sleep `+startupWatchBlockingSleep+`
     ;;
   peek)
     echo "$*" >> "`+peekFile+`"
@@ -573,8 +584,10 @@ esac
 	p := NewProvider(script)
 
 	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		done <- p.Start(context.Background(), "test-sess", runtime.Config{
+		done <- p.Start(ctx, "test-sess", runtime.Config{
 			EmitsPermissionWarning: true,
 		})
 	}()
@@ -584,7 +597,8 @@ esac
 		if err != nil {
 			t.Fatalf("Start: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(startupWatchNoHangTestTimeout):
+		cancel()
 		t.Fatal("Start() hung while falling back from an irrelevant watch-startup snapshot")
 	}
 
@@ -622,7 +636,7 @@ case "$op" in
       printf '%s\n' '{"content":"user@host $"}'
       i=$((i+1))
     done
-    sleep 5
+    sleep `+startupWatchBlockingSleep+`
     ;;
   send-keys)
     ;;
@@ -635,8 +649,10 @@ esac
 	p := NewProvider(script)
 
 	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		done <- p.Start(context.Background(), "test-sess", runtime.Config{
+		done <- p.Start(ctx, "test-sess", runtime.Config{
 			EmitsPermissionWarning: true,
 		})
 	}()
@@ -646,7 +662,8 @@ esac
 		if err != nil {
 			t.Fatalf("Start() error = %v, want nil", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(startupWatchNoHangTestTimeout):
+		cancel()
 		t.Fatal("Start() hung while cleaning up watch-startup stream")
 	}
 }

--- a/internal/worker/workertest/phase2_fake_worker_test.go
+++ b/internal/worker/workertest/phase2_fake_worker_test.go
@@ -32,9 +32,9 @@ var (
 )
 
 const (
-	fakeStartupGateTimeout         = 2 * time.Second
-	fakeStartupLaunchBound         = 750 * time.Millisecond
-	fakeStartupPostControlOverhead = 250 * time.Millisecond
+	fakeStartupGateTimeout         = 10 * time.Second
+	fakeStartupLaunchBound         = 5 * time.Second
+	fakeStartupPostControlOverhead = 2 * time.Second
 	fakeInteractionSignalBound     = 2 * time.Second
 )
 
@@ -87,7 +87,9 @@ func runFakeStartup(t *testing.T, profile ProfileID, outcome string, delay time.
 		t.Fatalf("write fake config: %v", err)
 	}
 
-	cmd := exec.CommandContext(context.Background(), fakeWorkerBinary(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, fakeWorkerBinary(t))
 	cmd.Env = append(os.Environ(),
 		"GC_FAKE_WORKER_CONFIG="+configPath,
 		"GC_FAKE_WORKER_START_FILE="+startFile,
@@ -104,7 +106,24 @@ func runFakeStartup(t *testing.T, profile ProfileID, outcome string, delay time.
 	waitCh := make(chan error, 1)
 	go func() {
 		waitCh <- cmd.Wait()
+		close(waitCh)
 	}()
+	t.Cleanup(func() {
+		select {
+		case <-waitCh:
+			return
+		default:
+		}
+		cancel()
+		select {
+		case <-waitCh:
+		case <-time.After(2 * time.Second):
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			<-waitCh
+		}
+	})
 
 	waitEvent := waitForWorkerFakeEvent(t, eventPath, "control_waiting", fakeStartupGateTimeout)
 	launchToWait := time.Since(launchStart)


### PR DESCRIPTION
## Summary
- fix Dolt project-id handling when the metadata table has not been created yet
- sync managed Dolt port mirrors after bd-backed init so lifecycle tests match runtime behavior
- harden macOS-sensitive bd readiness and worker/exec timing tests to stop hangs and false failures
- scope provider override tests so one city does not leak into another

## Verification
- go vet ./...
- go test ./cmd/gc -count=1 -timeout=30m -json
- go test ./... -count=1 -timeout=40m -json