### PR TITLE
fix(doctor): recognize built-in providers in config-refs check

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -166,6 +166,7 @@ func (c *ConfigRefsCheck) Name() string { return "config-refs" }
 func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	var issues []string
+	builtins := config.BuiltinProviders()
 
 	for _, a := range c.cfg.Agents {
 		qn := a.QualifiedName()
@@ -190,7 +191,9 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 			}
 		}
 		if a.Provider != "" && len(c.cfg.Providers) > 0 {
-			if _, ok := c.cfg.Providers[a.Provider]; !ok {
+			_, inCustom := c.cfg.Providers[a.Provider]
+			_, inBuiltin := builtins[a.Provider]
+			if !inCustom && !inBuiltin {
 				issues = append(issues, fmt.Sprintf("agent %q: provider %q not defined in [providers]", qn, a.Provider))
 			}
 		}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -262,6 +262,34 @@ func TestConfigRefsCheck_UndefinedProvider(t *testing.T) {
 	}
 }
 
+func TestConfigRefsCheck_BuiltinProviderNotFlagged(t *testing.T) {
+	// When custom providers exist but an agent references a built-in provider
+	// (e.g. "claude"), the check must not flag it as undefined.
+	dir := t.TempDir()
+	builtins := config.BuiltinProviders()
+	if len(builtins) == 0 {
+		t.Skip("no built-in providers registered")
+	}
+	// Pick the first built-in name.
+	var builtinName string
+	for name := range builtins {
+		builtinName = name
+		break
+	}
+	cfg := &config.City{
+		Providers: map[string]config.ProviderSpec{"custom-only": {}},
+		Agents: []config.Agent{
+			{Name: "worker", Provider: builtinName},
+		},
+	}
+	c := NewConfigRefsCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; built-in provider %q should not be flagged; details = %v",
+			r.Status, builtinName, r.Details)
+	}
+}
+
 func TestConfigRefsCheck_NoProvidersDefined(t *testing.T) {
 	// When no providers section exists, agent provider refs are not checked.
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

`gc doctor --verbose` reports false-positive warnings when agents reference the built-in `claude` provider and a custom provider (e.g. `ollama-local`) is also configured:

```
agent "claude": provider "claude" not defined in [providers]
agent "dotfiles/claude": provider "claude" not defined in [providers]
(+ 3 more rig-scoped claude agents)
```

The config-refs check validates all provider references exist in `[providers]`, but `claude` is a built-in implicit provider that gc recognizes natively (shows as `builtin:claude` in `gc config show`). When a custom provider is present, the check fires on system-generated agents without checking builtins.

## Solution

Check both custom and built-in provider maps before flagging. Built-in provider names are now whitelisted in the config-refs validation path.

## Test

All 9 `ConfigRefsCheck` tests pass.

Fixes ga-w4z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)