### PR TITLE
fix: resolve false positives in gc doctor config-refs check

### DIFF
--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -213,46 +212,6 @@ func expandSessionSetup(cmds []string, ctx SessionSetupContext) []string {
 		result[i] = buf.String()
 	}
 	return result
-}
-
-// resolveSetupScript resolves a session_setup_script path for runtime use.
-// Absolute paths pass through unchanged. "//" paths resolve against cityPath.
-// Other relative paths resolve against sourceDir when present; otherwise they
-// resolve against cityPath. City-root-relative strings produced by older
-// composition code remain supported during the transition.
-func resolveSetupScript(script, sourceDir, cityPath string) string {
-	if strings.HasPrefix(script, "//") {
-		return filepath.Join(cityPath, strings.TrimPrefix(script, "//"))
-	}
-	if script == "" || filepath.IsAbs(script) {
-		return script
-	}
-	if sourceDir != "" {
-		relSource, err := filepath.Rel(cityPath, sourceDir)
-		if err == nil {
-			relSource = filepath.Clean(relSource)
-			cleanScript := filepath.Clean(script)
-			if relSource != "." && relSource != "" && !strings.HasPrefix(relSource, "..") &&
-				(cleanScript == relSource || strings.HasPrefix(cleanScript, relSource+string(os.PathSeparator))) {
-				return filepath.Join(cityPath, cleanScript)
-			}
-		}
-		sourceCandidate := filepath.Join(sourceDir, script)
-		cityCandidate := filepath.Join(cityPath, filepath.Clean(script))
-		if fileExists(cityCandidate) && !fileExists(sourceCandidate) {
-			return cityCandidate
-		}
-		return sourceCandidate
-	}
-	return filepath.Join(cityPath, script)
-}
-
-func fileExists(path string) bool {
-	if path == "" {
-		return false
-	}
-	_, err := os.Stat(path)
-	return err == nil
 }
 
 // deepCopyAgent creates a deep copy of a config.Agent with a new name and dir.

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -688,21 +688,21 @@ func TestExpandSessionSetup_Empty(t *testing.T) {
 }
 
 func TestResolveSetupScript_Relative(t *testing.T) {
-	got := resolveSetupScript("scripts/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	got := config.ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "scripts/setup.sh")
 	if got != "/home/user/city/packs/gastown/scripts/setup.sh" {
 		t.Errorf("got %q, want absolute path", got)
 	}
 }
 
 func TestResolveSetupScript_DoubleSlashUsesCityRoot(t *testing.T) {
-	got := resolveSetupScript("//scripts/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	got := config.ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "//scripts/setup.sh")
 	if got != "/home/user/city/scripts/setup.sh" {
 		t.Errorf("got %q, want city-root path", got)
 	}
 }
 
 func TestResolveSetupScript_LegacyCityRelativeStillWorks(t *testing.T) {
-	got := resolveSetupScript("packs/gastown/scripts/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	got := config.ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "packs/gastown/scripts/setup.sh")
 	if got != "/home/user/city/packs/gastown/scripts/setup.sh" {
 		t.Errorf("got %q, want legacy city-root-relative path to remain supported", got)
 	}
@@ -722,21 +722,21 @@ func TestResolveSetupScript_LegacySharedCityRelativeFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := resolveSetupScript("packs/shared/scripts/setup.sh", sourceDir, cityPath)
+	got := config.ResolveSessionSetupScriptPath(cityPath, sourceDir, "packs/shared/scripts/setup.sh")
 	if got != cityScript {
 		t.Errorf("got %q, want legacy shared city-root-relative path to remain supported", got)
 	}
 }
 
 func TestResolveSetupScript_Absolute(t *testing.T) {
-	got := resolveSetupScript("/usr/local/bin/setup.sh", "/home/user/city/packs/gastown", "/home/user/city")
+	got := config.ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "/usr/local/bin/setup.sh")
 	if got != "/usr/local/bin/setup.sh" {
 		t.Errorf("got %q, want unchanged absolute path", got)
 	}
 }
 
 func TestResolveSetupScript_Empty(t *testing.T) {
-	got := resolveSetupScript("", "/home/user/city/packs/gastown", "/home/user/city")
+	got := config.ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "")
 	if got != "" {
 		t.Errorf("got %q, want empty", got)
 	}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -408,7 +408,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		command = expanded[0]
 	}
 	expandedSetup := expandSessionSetup(cfgAgent.SessionSetup, setupCtx)
-	resolvedScript := resolveSetupScript(cfgAgent.SessionSetupScript, cfgAgent.SourceDir, p.cityPath)
+	resolvedScript := config.ResolveSessionSetupScriptPath(p.cityPath, cfgAgent.SourceDir, cfgAgent.SessionSetupScript)
 	expandedPreStart := expandSessionSetup(cfgAgent.PreStart, setupCtx)
 	expandedLive := expandSessionSetup(cfgAgent.SessionLive, setupCtx)
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -145,7 +145,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `env` | map[string]string |  |  | Env adds or overrides environment variables. |
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
-| `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
+| `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session` | string |  |  | Session overrides the session transport ("acp"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
@@ -163,7 +163,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `session_setup` | []string |  |  | SessionSetup overrides the agent's session_setup commands. |
 | `session_setup_script` | string |  |  | SessionSetupScript overrides the agent's session_setup_script path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session_live` | []string |  |  | SessionLive overrides the agent's session_live commands. |
-| `overlay_dir` | string |  |  | OverlayDir overrides the agent's overlay_dir path. Copies contents additively into the agent's working directory at startup. Relative paths resolve against the city directory. |
+| `overlay_dir` | string |  |  | OverlayDir overrides the agent's overlay_dir path. Copies contents additively into the agent's working directory at startup. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula overrides the default sling formula. |
 | `inject_fragments` | []string |  |  | InjectFragments overrides the agent's inject_fragments list. Leave this field unset to keep inherited fragments; JSON callers may send null for the same no-op. Set an empty list to clear fragments; set a populated list to replace fragments. |
 | `append_fragments` | []string |  |  | AppendFragments appends named template fragments to this agent's rendered prompt. It is the V2 spelling for per-agent fragment selection. |
@@ -198,7 +198,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `env` | map[string]string |  |  | Env adds or overrides environment variables. |
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove after merging. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
-| `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
+| `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session` | string |  |  | Session overrides the session transport ("acp" or "tmux"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
@@ -218,7 +218,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `session_setup` | []string |  |  | SessionSetup overrides the agent's session_setup commands. |
 | `session_setup_script` | string |  |  | SessionSetupScript overrides the agent's session_setup_script path. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `session_live` | []string |  |  | SessionLive overrides the agent's session_live commands. |
-| `overlay_dir` | string |  |  | OverlayDir overrides the agent's overlay_dir path. Copies contents additively into the agent's working directory at startup. Relative paths resolve against the city directory. |
+| `overlay_dir` | string |  |  | OverlayDir overrides the agent's overlay_dir path. Copies contents additively into the agent's working directory at startup. Relative paths resolve against the declaring config file's directory (pack-safe). Paths prefixed with "//" resolve against the city root. |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula overrides the default sling formula. |
 | `inject_fragments` | []string |  |  | InjectFragments overrides the agent's inject_fragments list. Leave this field unset to keep inherited fragments; JSON callers may send null for the same no-op. Set an empty list to clear fragments; set a populated list to replace fragments. |
 | `append_fragments` | []string |  |  | AppendFragments overrides the agent's append_fragments list. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -430,7 +430,7 @@
         },
         "prompt_template": {
           "type": "string",
-          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
+          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session": {
           "type": "string",
@@ -520,7 +520,7 @@
         },
         "overlay_dir": {
           "type": "string",
-          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the city directory."
+          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "default_sling_formula": {
           "type": "string",
@@ -688,7 +688,7 @@
         },
         "prompt_template": {
           "type": "string",
-          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
+          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session": {
           "type": "string",
@@ -792,7 +792,7 @@
         },
         "overlay_dir": {
           "type": "string",
-          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the city directory."
+          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "default_sling_formula": {
           "type": "string",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -430,7 +430,7 @@
         },
         "prompt_template": {
           "type": "string",
-          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
+          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session": {
           "type": "string",
@@ -520,7 +520,7 @@
         },
         "overlay_dir": {
           "type": "string",
-          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the city directory."
+          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "default_sling_formula": {
           "type": "string",
@@ -688,7 +688,7 @@
         },
         "prompt_template": {
           "type": "string",
-          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
+          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "session": {
           "type": "string",
@@ -792,7 +792,7 @@
         },
         "overlay_dir": {
           "type": "string",
-          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the city directory."
+          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
         },
         "default_sling_formula": {
           "type": "string",

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -714,10 +714,10 @@ func adjustPatchPaths(patches *Patches, declDir, cityRoot string) {
 	}
 }
 
-// adjustRigOverridePaths resolves rig override session_setup_script values to
-// absolute paths rooted at the declaring config directory. Once overrides are
-// applied to pack-stamped agents, runtime only sees the target agent's
-// SourceDir, so relative override paths must be normalized during composition.
+// adjustRigOverridePaths resolves rig override path fields to stable forms
+// rooted at the declaring config directory. Once overrides are applied to
+// pack-stamped agents, runtime only sees the target agent's SourceDir, so
+// relative override paths must be normalized during composition.
 func adjustRigOverridePaths(rigs []Rig, declDir, cityRoot string) {
 	for i := range rigs {
 		adjustAgentOverridePaths(rigs[i].Overrides, declDir, cityRoot)
@@ -728,11 +728,18 @@ func adjustRigOverridePaths(rigs []Rig, declDir, cityRoot string) {
 func adjustAgentOverridePaths(overrides []AgentOverride, declDir, cityRoot string) {
 	for i := range overrides {
 		ov := &overrides[i]
-		if ov.SessionSetupScript == nil || *ov.SessionSetupScript == "" {
-			continue
+		if ov.SessionSetupScript != nil && *ov.SessionSetupScript != "" {
+			v := resolveConfigPath(*ov.SessionSetupScript, declDir, cityRoot)
+			ov.SessionSetupScript = &v
 		}
-		v := resolveConfigPath(*ov.SessionSetupScript, declDir, cityRoot)
-		ov.SessionSetupScript = &v
+		if ov.PromptTemplate != nil && *ov.PromptTemplate != "" {
+			v := adjustFragmentPath(*ov.PromptTemplate, declDir, cityRoot)
+			ov.PromptTemplate = &v
+		}
+		if ov.OverlayDir != nil && *ov.OverlayDir != "" {
+			v := adjustFragmentPath(*ov.OverlayDir, declDir, cityRoot)
+			ov.OverlayDir = &v
+		}
 	}
 }
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -698,19 +698,25 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	return root, prov, nil
 }
 
-// adjustPatchPaths resolves patch session_setup_script values to absolute
-// paths rooted at the declaring config directory. Patches do not retain
-// independent source provenance after merge, so runtime cannot otherwise
-// distinguish whether a relative override came from the target agent's source
-// or from the patch file itself.
+// adjustPatchPaths resolves patch path fields rooted at the declaring config
+// directory. Patches do not retain independent source provenance after merge,
+// so runtime cannot otherwise distinguish whether a relative override came
+// from the target agent's source or from the patch file itself.
 func adjustPatchPaths(patches *Patches, declDir, cityRoot string) {
 	for i := range patches.Agents {
 		p := &patches.Agents[i]
-		if p.SessionSetupScript == nil || *p.SessionSetupScript == "" {
-			continue
+		if p.SessionSetupScript != nil && *p.SessionSetupScript != "" {
+			v := resolveConfigPath(*p.SessionSetupScript, declDir, cityRoot)
+			p.SessionSetupScript = &v
 		}
-		v := resolveConfigPath(*p.SessionSetupScript, declDir, cityRoot)
-		p.SessionSetupScript = &v
+		if p.PromptTemplate != nil && *p.PromptTemplate != "" {
+			v := adjustFragmentPath(*p.PromptTemplate, declDir, cityRoot)
+			p.PromptTemplate = &v
+		}
+		if p.OverlayDir != nil && *p.OverlayDir != "" {
+			v := adjustFragmentPath(*p.OverlayDir, declDir, cityRoot)
+			p.OverlayDir = &v
+		}
 	}
 }
 

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -1326,6 +1326,58 @@ session_setup_script = "scripts/theme.sh"
 	}
 }
 
+func TestLoadWithIncludes_FragmentPatchPromptTemplateAndOverlayDirResolvedFromFragmentDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+include = ["fragments/patch.toml"]
+
+[workspace]
+name = "test"
+includes = ["packs/base"]
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+`)
+	writeFile("fragments/patch.toml", `
+[[patches.agent]]
+name = "worker"
+prompt_template = "prompts/theme.md"
+overlay_dir = "overlays/theme"
+`)
+	writeFile("fragments/prompts/theme.md", "fragment prompt\n")
+	writeFile("fragments/overlays/theme/.keep", "")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	if cfg.Agents[0].PromptTemplate != "fragments/prompts/theme.md" {
+		t.Fatalf("PromptTemplate = %q, want fragments/prompts/theme.md", cfg.Agents[0].PromptTemplate)
+	}
+	if cfg.Agents[0].OverlayDir != "fragments/overlays/theme" {
+		t.Fatalf("OverlayDir = %q, want fragments/overlays/theme", cfg.Agents[0].OverlayDir)
+	}
+}
+
 func TestLoadWithIncludes_RootPatchSessionSetupScriptResolvedFromCityDir(t *testing.T) {
 	dir := t.TempDir()
 	writeFile := func(rel, data string) {
@@ -1368,6 +1420,113 @@ scope = "city"
 	want := filepath.Join(dir, "scripts/local.sh")
 	if cfg.Agents[0].SessionSetupScript != want {
 		t.Fatalf("SessionSetupScript = %q, want %q", cfg.Agents[0].SessionSetupScript, want)
+	}
+}
+
+func TestLoadWithIncludes_RootPatchPromptTemplateAndOverlayDirResolvedFromCityDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+[workspace]
+name = "test"
+includes = ["packs/base"]
+
+[[patches.agent]]
+name = "worker"
+prompt_template = "prompts/local.md"
+overlay_dir = "overlays/local"
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+`)
+	writeFile("prompts/local.md", "city prompt\n")
+	writeFile("overlays/local/.keep", "")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	if cfg.Agents[0].PromptTemplate != "prompts/local.md" {
+		t.Fatalf("PromptTemplate = %q, want prompts/local.md", cfg.Agents[0].PromptTemplate)
+	}
+	if cfg.Agents[0].OverlayDir != "overlays/local" {
+		t.Fatalf("OverlayDir = %q, want overlays/local", cfg.Agents[0].OverlayDir)
+	}
+}
+
+func TestLoadWithIncludes_FragmentRigOverridePromptTemplateAndOverlayDirApplyEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, data string) {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	writeFile("city.toml", `
+include = ["fragments/rig.toml"]
+
+[workspace]
+name = "test"
+`)
+	writeFile("fragments/rig.toml", `
+[[rigs]]
+name = "hw"
+path = "rig"
+includes = ["packs/base"]
+
+  [[rigs.overrides]]
+  agent = "worker"
+  prompt_template = "prompts/rig-worker.md"
+  overlay_dir = "overlays/rig-worker"
+`)
+	writeFile("packs/base/pack.toml", `
+[pack]
+name = "base"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "rig"
+prompt_template = "prompts/base-worker.md"
+overlay_dir = "overlays/base-worker"
+`)
+	writeFile("fragments/prompts/rig-worker.md", "rig override prompt\n")
+	writeFile("fragments/overlays/rig-worker/.keep", "")
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("len(cfg.Agents) = %d, want 1", len(cfg.Agents))
+	}
+	if cfg.Agents[0].PromptTemplate != "fragments/prompts/rig-worker.md" {
+		t.Fatalf("PromptTemplate = %q, want fragments/prompts/rig-worker.md", cfg.Agents[0].PromptTemplate)
+	}
+	if cfg.Agents[0].OverlayDir != "fragments/overlays/rig-worker" {
+		t.Fatalf("OverlayDir = %q, want fragments/overlays/rig-worker", cfg.Agents[0].OverlayDir)
 	}
 }
 

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -1494,6 +1494,65 @@ func TestAdjustAgentPaths_OverlayDirAdjusted(t *testing.T) {
 	}
 }
 
+func TestAdjustAgentOverridePaths_AllFields(t *testing.T) {
+	promptRel := "prompts/custom.md"
+	overlayRel := "overlays/custom"
+	scriptRel := "scripts/setup.sh"
+	promptAbs := "/abs/prompt.md"
+	overlayAbs := "/abs/overlay"
+	scriptAbs := "/abs/setup.sh"
+	promptCity := "//prompts/global.md"
+	overlayCity := "//overlays/global"
+
+	overrides := []AgentOverride{
+		// Relative paths should be adjusted.
+		{Agent: "worker", PromptTemplate: &promptRel, OverlayDir: &overlayRel, SessionSetupScript: &scriptRel},
+		// Absolute paths pass through unchanged.
+		{Agent: "abs", PromptTemplate: &promptAbs, OverlayDir: &overlayAbs, SessionSetupScript: &scriptAbs},
+		// "//" paths resolve to city root.
+		{Agent: "city", PromptTemplate: &promptCity, OverlayDir: &overlayCity},
+		// Nil fields: unchanged.
+		{Agent: "empty"},
+	}
+	adjustAgentOverridePaths(overrides, "/city/packs/mypack", "/city")
+
+	// Relative paths: prompt_template/overlay_dir → city-root-relative via adjustFragmentPath.
+	if *overrides[0].PromptTemplate != "packs/mypack/prompts/custom.md" {
+		t.Errorf("worker prompt = %q, want packs/mypack/prompts/custom.md", *overrides[0].PromptTemplate)
+	}
+	if *overrides[0].OverlayDir != "packs/mypack/overlays/custom" {
+		t.Errorf("worker overlay = %q, want packs/mypack/overlays/custom", *overrides[0].OverlayDir)
+	}
+	// session_setup_script → absolute via resolveConfigPath.
+	if *overrides[0].SessionSetupScript != "/city/packs/mypack/scripts/setup.sh" {
+		t.Errorf("worker script = %q, want /city/packs/mypack/scripts/setup.sh", *overrides[0].SessionSetupScript)
+	}
+
+	// Absolute paths unchanged.
+	if *overrides[1].PromptTemplate != "/abs/prompt.md" {
+		t.Errorf("abs prompt = %q, want /abs/prompt.md", *overrides[1].PromptTemplate)
+	}
+	if *overrides[1].OverlayDir != "/abs/overlay" {
+		t.Errorf("abs overlay = %q, want /abs/overlay", *overrides[1].OverlayDir)
+	}
+
+	// "//" paths resolve to city root.
+	if *overrides[2].PromptTemplate != "prompts/global.md" {
+		t.Errorf("city prompt = %q, want prompts/global.md", *overrides[2].PromptTemplate)
+	}
+	if *overrides[2].OverlayDir != "overlays/global" {
+		t.Errorf("city overlay = %q, want overlays/global", *overrides[2].OverlayDir)
+	}
+
+	// Nil fields stay nil.
+	if overrides[3].PromptTemplate != nil {
+		t.Errorf("empty prompt = %v, want nil", overrides[3].PromptTemplate)
+	}
+	if overrides[3].OverlayDir != nil {
+		t.Errorf("empty overlay = %v, want nil", overrides[3].OverlayDir)
+	}
+}
+
 func TestLoadWithIncludes_MultipleCityPacks(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/packs/alpha/pack.toml"] = []byte(`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -541,7 +541,8 @@ type AgentOverride struct {
 	// PreStart overrides the agent's pre_start commands.
 	PreStart []string `toml:"pre_start,omitempty"`
 	// PromptTemplate overrides the prompt template path.
-	// Relative paths resolve against the city directory.
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
 	// Session overrides the session transport ("acp").
 	Session *string `toml:"session,omitempty"`
@@ -589,7 +590,8 @@ type AgentOverride struct {
 	SessionLive []string `toml:"session_live,omitempty"`
 	// OverlayDir overrides the agent's overlay_dir path. Copies contents
 	// additively into the agent's working directory at startup.
-	// Relative paths resolve against the city directory.
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
 	OverlayDir *string `toml:"overlay_dir,omitempty"`
 	// DefaultSlingFormula overrides the default sling formula.
 	DefaultSlingFormula *string `toml:"default_sling_formula,omitempty"`

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -37,7 +37,8 @@ type AgentPatch struct {
 	// PreStart overrides the agent's pre_start commands.
 	PreStart []string `toml:"pre_start,omitempty"`
 	// PromptTemplate overrides the prompt template path.
-	// Relative paths resolve against the city directory.
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
 	// Session overrides the session transport ("acp" or "tmux").
 	Session *string `toml:"session,omitempty"`
@@ -97,7 +98,8 @@ type AgentPatch struct {
 	SessionLive []string `toml:"session_live,omitempty"`
 	// OverlayDir overrides the agent's overlay_dir path. Copies contents
 	// additively into the agent's working directory at startup.
-	// Relative paths resolve against the city directory.
+	// Relative paths resolve against the declaring config file's directory
+	// (pack-safe). Paths prefixed with "//" resolve against the city root.
 	OverlayDir *string `toml:"overlay_dir,omitempty"`
 	// DefaultSlingFormula overrides the default sling formula.
 	DefaultSlingFormula *string `toml:"default_sling_formula,omitempty"`

--- a/internal/config/session_setup_path.go
+++ b/internal/config/session_setup_path.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveSessionSetupScriptPath resolves a session_setup_script path for
+// runtime and validation. Paths prefixed with "//" resolve against cityPath.
+// Relative paths resolve against sourceDir when present, with legacy
+// city-root-relative strings still supported during the transition.
+func ResolveSessionSetupScriptPath(cityPath, sourceDir, script string) string {
+	if strings.HasPrefix(script, "//") {
+		return filepath.Join(cityPath, strings.TrimPrefix(script, "//"))
+	}
+	if script == "" || filepath.IsAbs(script) {
+		return script
+	}
+	if sourceDir != "" {
+		relSource, err := filepath.Rel(cityPath, sourceDir)
+		if err == nil {
+			relSource = filepath.Clean(relSource)
+			cleanScript := filepath.Clean(script)
+			if relSource != "." && relSource != "" && !strings.HasPrefix(relSource, "..") &&
+				(cleanScript == relSource || strings.HasPrefix(cleanScript, relSource+string(os.PathSeparator))) {
+				return filepath.Join(cityPath, cleanScript)
+			}
+		}
+
+		sourceCandidate := filepath.Join(sourceDir, script)
+		cityCandidate := filepath.Join(cityPath, filepath.Clean(script))
+		if sessionSetupScriptPathExists(cityCandidate) && !sessionSetupScriptPathExists(sourceCandidate) {
+			return cityCandidate
+		}
+		return sourceCandidate
+	}
+	return filepath.Join(cityPath, script)
+}
+
+func sessionSetupScriptPathExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/config/session_setup_path_test.go
+++ b/internal/config/session_setup_path_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSessionSetupScriptPath_RelativeUsesSourceDir(t *testing.T) {
+	got := ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "scripts/setup.sh")
+	if got != "/home/user/city/packs/gastown/scripts/setup.sh" {
+		t.Errorf("got %q, want source-dir-relative absolute path", got)
+	}
+}
+
+func TestResolveSessionSetupScriptPath_DoubleSlashUsesCityRoot(t *testing.T) {
+	got := ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "//scripts/setup.sh")
+	if got != "/home/user/city/scripts/setup.sh" {
+		t.Errorf("got %q, want city-root path", got)
+	}
+}
+
+func TestResolveSessionSetupScriptPath_LegacyCityRelativeStillWorks(t *testing.T) {
+	got := ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "packs/gastown/scripts/setup.sh")
+	if got != "/home/user/city/packs/gastown/scripts/setup.sh" {
+		t.Errorf("got %q, want legacy city-root-relative path to remain supported", got)
+	}
+}
+
+func TestResolveSessionSetupScriptPath_LegacySharedCityRelativeFallback(t *testing.T) {
+	cityPath := t.TempDir()
+	sourceDir := filepath.Join(cityPath, "packs", "feature")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityScript := filepath.Join(cityPath, "packs", "shared", "scripts", "setup.sh")
+	if err := os.MkdirAll(filepath.Dir(cityScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cityScript, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ResolveSessionSetupScriptPath(cityPath, sourceDir, "packs/shared/scripts/setup.sh")
+	if got != cityScript {
+		t.Errorf("got %q, want legacy shared city-root-relative path to remain supported", got)
+	}
+}
+
+func TestResolveSessionSetupScriptPath_Absolute(t *testing.T) {
+	got := ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "/usr/local/bin/setup.sh")
+	if got != "/usr/local/bin/setup.sh" {
+		t.Errorf("got %q, want unchanged absolute path", got)
+	}
+}
+
+func TestResolveSessionSetupScriptPath_Empty(t *testing.T) {
+	got := ResolveSessionSetupScriptPath("/home/user/city", "/home/user/city/packs/gastown", "")
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -178,7 +178,7 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 			}
 		}
 		if a.SessionSetupScript != "" {
-			path := resolveConfigRefPath(c.cityPath, a.SessionSetupScript)
+			path := resolveSessionSetupScriptPath(c.cityPath, a.SourceDir, a.SessionSetupScript)
 			if _, err := os.Stat(path); err != nil {
 				issues = append(issues, fmt.Sprintf("agent %q: session_setup_script %q not found", qn, path))
 			}
@@ -223,6 +223,22 @@ func (c *ConfigRefsCheck) Fix(_ *CheckContext) error { return nil }
 func resolveConfigRefPath(cityPath, p string) string {
 	if filepath.IsAbs(p) {
 		return p
+	}
+	return filepath.Join(cityPath, p)
+}
+
+// resolveSessionSetupScriptPath resolves a session_setup_script path.
+// Unlike prompt_template and overlay_dir, session_setup_script is left
+// as-authored during composition and resolved at runtime against the
+// agent's SourceDir. The doctor check mirrors that resolution: relative
+// paths resolve against SourceDir when available, falling back to cityPath
+// for inline agents that have no SourceDir.
+func resolveSessionSetupScriptPath(cityPath, sourceDir, p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	if sourceDir != "" {
+		return filepath.Join(sourceDir, p)
 	}
 	return filepath.Join(cityPath, p)
 }

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -227,20 +227,44 @@ func resolveConfigRefPath(cityPath, p string) string {
 	return filepath.Join(cityPath, p)
 }
 
-// resolveSessionSetupScriptPath resolves a session_setup_script path.
-// Unlike prompt_template and overlay_dir, session_setup_script is left
-// as-authored during composition and resolved at runtime against the
-// agent's SourceDir. The doctor check mirrors that resolution: relative
-// paths resolve against SourceDir when available, falling back to cityPath
-// for inline agents that have no SourceDir.
+// resolveSessionSetupScriptPath resolves a session_setup_script path. Unlike
+// prompt_template and overlay_dir, session_setup_script is left as-authored
+// during composition and resolved at runtime against the agent's SourceDir.
+// The doctor check mirrors that runtime resolution.
 func resolveSessionSetupScriptPath(cityPath, sourceDir, p string) string {
-	if filepath.IsAbs(p) {
+	if strings.HasPrefix(p, "//") {
+		return filepath.Join(cityPath, strings.TrimPrefix(p, "//"))
+	}
+	if p == "" || filepath.IsAbs(p) {
 		return p
 	}
 	if sourceDir != "" {
-		return filepath.Join(sourceDir, p)
+		relSource, err := filepath.Rel(cityPath, sourceDir)
+		if err == nil {
+			relSource = filepath.Clean(relSource)
+			cleanPath := filepath.Clean(p)
+			if relSource != "." && relSource != "" && !strings.HasPrefix(relSource, "..") &&
+				(cleanPath == relSource || strings.HasPrefix(cleanPath, relSource+string(os.PathSeparator))) {
+				return filepath.Join(cityPath, cleanPath)
+			}
+		}
+
+		sourceCandidate := filepath.Join(sourceDir, p)
+		cityCandidate := filepath.Join(cityPath, filepath.Clean(p))
+		if pathExists(cityCandidate) && !pathExists(sourceCandidate) {
+			return cityCandidate
+		}
+		return sourceCandidate
 	}
 	return filepath.Join(cityPath, p)
+}
+
+func pathExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // BuiltinPackFamilyCheck fails when a city overrides only one member of the

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -178,7 +178,7 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 			}
 		}
 		if a.SessionSetupScript != "" {
-			path := resolveSessionSetupScriptPath(c.cityPath, a.SourceDir, a.SessionSetupScript)
+			path := config.ResolveSessionSetupScriptPath(c.cityPath, a.SourceDir, a.SessionSetupScript)
 			if _, err := os.Stat(path); err != nil {
 				issues = append(issues, fmt.Sprintf("agent %q: session_setup_script %q not found", qn, path))
 			}
@@ -225,46 +225,6 @@ func resolveConfigRefPath(cityPath, p string) string {
 		return p
 	}
 	return filepath.Join(cityPath, p)
-}
-
-// resolveSessionSetupScriptPath resolves a session_setup_script path. Unlike
-// prompt_template and overlay_dir, session_setup_script is left as-authored
-// during composition and resolved at runtime against the agent's SourceDir.
-// The doctor check mirrors that runtime resolution.
-func resolveSessionSetupScriptPath(cityPath, sourceDir, p string) string {
-	if strings.HasPrefix(p, "//") {
-		return filepath.Join(cityPath, strings.TrimPrefix(p, "//"))
-	}
-	if p == "" || filepath.IsAbs(p) {
-		return p
-	}
-	if sourceDir != "" {
-		relSource, err := filepath.Rel(cityPath, sourceDir)
-		if err == nil {
-			relSource = filepath.Clean(relSource)
-			cleanPath := filepath.Clean(p)
-			if relSource != "." && relSource != "" && !strings.HasPrefix(relSource, "..") &&
-				(cleanPath == relSource || strings.HasPrefix(cleanPath, relSource+string(os.PathSeparator))) {
-				return filepath.Join(cityPath, cleanPath)
-			}
-		}
-
-		sourceCandidate := filepath.Join(sourceDir, p)
-		cityCandidate := filepath.Join(cityPath, filepath.Clean(p))
-		if pathExists(cityCandidate) && !pathExists(sourceCandidate) {
-			return cityCandidate
-		}
-		return sourceCandidate
-	}
-	return filepath.Join(cityPath, p)
-}
-
-func pathExists(path string) bool {
-	if path == "" {
-		return false
-	}
-	_, err := os.Stat(path)
-	return err == nil
 }
 
 // BuiltinPackFamilyCheck fails when a city overrides only one member of the

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -405,6 +405,37 @@ func TestConfigRefsCheck_AbsolutePaths(t *testing.T) {
 	}
 }
 
+// session_setup_script is left as-authored (pack-relative) during
+// composition — resolving it against cityPath produces a false positive
+// when the script lives in the pack directory, not the city root.
+func TestConfigRefsCheck_SessionSetupScriptSourceDir(t *testing.T) {
+	cityDir := t.TempDir()
+	packDir := t.TempDir()
+
+	// Create a setup script inside the pack directory.
+	scriptPath := filepath.Join(packDir, "scripts", "setup.sh")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name: "worker",
+			// As-authored: pack-relative, not city-root-relative.
+			SessionSetupScript: "scripts/setup.sh",
+			SourceDir:          packDir,
+		}},
+	}
+	c := NewConfigRefsCheck(cfg, cityDir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
 // --- BuiltinPackFamilyCheck ---
 
 func TestBuiltinPackFamilyCheck_Unmodified(t *testing.T) {

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -405,6 +405,38 @@ func TestConfigRefsCheck_AbsolutePaths(t *testing.T) {
 	}
 }
 
+// City-root-relative paths (produced by adjustFragmentPath during
+// composition) resolve correctly against cityPath.
+func TestConfigRefsCheck_CityRootRelativePaths(t *testing.T) {
+	cityDir := t.TempDir()
+
+	// Create files at city-root-relative locations (as produced by pack composition).
+	promptDir := filepath.Join(cityDir, "packs", "mypack", "agents", "worker")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "prompt.template.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overlayDir := filepath.Join(cityDir, "packs", "mypack", "overlays", "custom")
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:           "worker",
+			PromptTemplate: "packs/mypack/agents/worker/prompt.template.md",
+			OverlayDir:     "packs/mypack/overlays/custom",
+		}},
+	}
+	c := NewConfigRefsCheck(cfg, cityDir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
 // session_setup_script is left as-authored (pack-relative) during
 // composition — resolving it against cityPath produces a false positive
 // when the script lives in the pack directory, not the city root.

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -468,6 +468,73 @@ func TestConfigRefsCheck_SessionSetupScriptSourceDir(t *testing.T) {
 	}
 }
 
+func TestConfigRefsCheck_SessionSetupScriptDoubleSlashUsesCityRoot(t *testing.T) {
+	cityDir := t.TempDir()
+	sourceDir := filepath.Join(cityDir, "packs", "feature")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(cityDir, "scripts", "setup.sh")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:               "worker",
+			SessionSetupScript: "//scripts/setup.sh",
+			SourceDir:          sourceDir,
+		}},
+	}
+	c := NewConfigRefsCheck(cfg, cityDir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
+func TestConfigRefsCheck_SessionSetupScriptLegacyCityRelativeWithSourceDir(t *testing.T) {
+	cityDir := t.TempDir()
+	sourceDir := filepath.Join(cityDir, "packs", "feature")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		script string
+	}{
+		{name: "same pack", script: "packs/feature/scripts/setup.sh"},
+		{name: "shared pack", script: "packs/shared/scripts/setup.sh"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scriptPath := filepath.Join(cityDir, filepath.FromSlash(tc.script))
+			if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(scriptPath, []byte("#!/bin/sh"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := &config.City{
+				Agents: []config.Agent{{
+					Name:               "worker",
+					SessionSetupScript: tc.script,
+					SourceDir:          sourceDir,
+				}},
+			}
+			c := NewConfigRefsCheck(cfg, cityDir)
+			r := c.Run(&CheckContext{})
+			if r.Status != StatusOK {
+				t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+			}
+		})
+	}
+}
+
 // --- BuiltinPackFamilyCheck ---
 
 func TestBuiltinPackFamilyCheck_Unmodified(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `gc doctor config-refs` reporting false positives for existing `prompt_template` and `overlay_dir` paths
- Resolve `session_setup_script` against agent's `SourceDir` (not city root) in doctor check, matching runtime behavior
- Normalize `prompt_template` and `overlay_dir` paths in rig overrides during composition so they survive agent SourceDir rebasing

## Details

Two root causes for the 25 false positive warnings:

1. **`session_setup_script` resolved against wrong base**: The doctor check resolved relative `session_setup_script` paths against `cityPath`, but runtime resolves them against the agent's `SourceDir`. Added `resolveSessionSetupScriptPath()` that mirrors runtime resolution.

2. **Rig override `prompt_template`/`overlay_dir` not adjusted during composition**: `adjustAgentOverridePaths()` only handled `session_setup_script`. Extended it to also normalize `prompt_template` and `overlay_dir` via `adjustFragmentPath()`, preventing them from becoming dangling relative paths after override application.

## Test plan

- [x] `TestAdjustAgentOverridePaths_AllFields` — verifies all three path fields are normalized
- [x] `TestConfigRefsCheck_SessionSetupScriptSourceDir` — verifies SourceDir-relative resolution
- [x] All existing config and doctor tests pass
- [x] `go vet` clean

Closes ga-9vr

🤖 Generated with [Claude Code](https://claude.com/claude-code)