### PR TITLE
feat(events): add subject/until/limit filters and count helpers

### DIFF
--- a/engdocs/architecture/event-bus.md
+++ b/engdocs/architecture/event-bus.md
@@ -393,19 +393,22 @@ suite against a stateful jq-based mock script.
   compaction. For long-running cities, manual truncation or external
   log rotation is needed.
 
-- **ReadFiltered scans the entire file.** Every `List` call reads all
-  events from disk and filters in memory. There are no indexes. This
-  is acceptable at current scale but will degrade with very large event
-  logs. `ReadFrom` with byte offsets provides incremental reading for
-  the Watch path.
+- **ReadFiltered streams without indexes.** `ReadFiltered` scans the
+  JSONL file once, applies `Filter` as it reads, and stops early when a
+  positive direct-provider `Limit` is reached. There are still no
+  indexes, so broad time/type/actor/subject queries remain linear in the
+  event log until their limit is satisfied. `ReadFrom` with byte offsets
+  provides incremental reading for the Watch path.
 
 - **No event schema validation.** Event types are string constants with
   no runtime validation. Recording an event with a misspelled type
   succeeds silently.
 
-- **Filter does not support Subject.** The Filter struct supports Type,
-  Actor, Since, and AfterSeq but not Subject. Filtering by subject
-  requires post-filtering in the caller.
+- **Multiplexer limits are global post-merge caps.** The multiplexer
+  clears per-provider `Filter.Limit`, merges and sorts provider results,
+  then applies the global limit so cross-city ordering stays correct.
+  This means a multiplexer `Limit` does not cap work inside each
+  provider.
 
 - **Exec provider Watch is subprocess-lifetime-bound.** The exec
   watcher reads from a long-running subprocess's stdout. If the
@@ -416,6 +419,9 @@ suite against a stateful jq-based mock script.
 
 - [Architecture glossary](glossary.md) -- authoritative definitions of
   event bus, order, trigger, and other terms used in this document
+- [Event query primitives](event-query.md) -- `Filter` fields,
+  streaming read semantics, multiplexer limit behavior, and aggregation
+  helpers
 - [Health Patrol architecture](health-patrol.md) -- how the controller
   reconciliation loop records agent lifecycle events on every tick
 - [Bead Store architecture](beads.md) -- the other Layer 0-1 primitive;

--- a/engdocs/architecture/event-query.md
+++ b/engdocs/architecture/event-query.md
@@ -1,0 +1,94 @@
+# Event Query Primitives
+
+The `events` package provides a read-only query layer over the event bus.
+These primitives are pure functions — no I/O, no subscriptions — making them
+easy to compose and test.
+
+## Extended Filter
+
+`Filter` now supports five predicates instead of four:
+
+```go
+type Filter struct {
+    Type     string    // match events with this Type (e.g. "bead.created")
+    Actor    string    // match events with this Actor
+    Subject  string    // match events with this Subject (e.g. a bead ID)
+    Since    time.Time // match events at or after this time (inclusive)
+    Until    time.Time // match events at or before this time (inclusive)
+    AfterSeq uint64    // match events with Seq > AfterSeq
+    Limit    int       // cap results at this count (0 = unlimited)
+}
+```
+
+Zero values are always ignored, so existing callers that set only `Type` or
+`Actor` continue to work without change.
+
+### Subject filter
+
+The most common diagnostic query: "what happened to bead gc-42?"
+
+```go
+evts, err := provider.List(events.Filter{Subject: "gc-42"})
+```
+
+### Until filter
+
+Pair `Since` and `Until` to query a time window:
+
+```go
+evts, err := provider.List(events.Filter{
+    Since: start,
+    Until: end,
+})
+```
+
+### Limit
+
+`Limit` caps the result slice and stops scanning as soon as the cap is reached.
+Useful for dashboards that only need the first N matches:
+
+```go
+recent, err := provider.List(events.Filter{
+    Type:  events.BeadCreated,
+    Limit: 10,
+})
+```
+
+## Aggregation Helpers
+
+Three pure functions produce frequency maps over a `[]Event` slice:
+
+```go
+// CountByType returns type → count.
+func CountByType(evts []Event) map[string]int
+
+// CountByActor returns actor → count.
+func CountByActor(evts []Event) map[string]int
+
+// CountBySubject returns subject → count.
+func CountBySubject(evts []Event) map[string]int
+```
+
+These are intentionally simple. The caller drives composition:
+
+```go
+all, _ := provider.List(events.Filter{Since: yesterday})
+byType := events.CountByType(all)
+// byType["bead.created"] == 17
+// byType["session.woke"] == 5
+```
+
+## Implementation
+
+| Artifact | Purpose |
+|---|---|
+| `internal/events/reader.go` | `Filter` extended with `Subject`, `Until`, `Limit`; `matchesFilter` helper; `ReadFiltered` updated |
+| `internal/events/fake.go` | `Fake.List` updated to use `matchesFilter` and apply `Limit` |
+| `internal/events/query.go` | `CountByType`, `CountByActor`, `CountBySubject` |
+| `internal/events/query_test.go` | 11 tests covering all new filter predicates and count helpers |
+
+`matchesFilter` is an unexported helper shared by `ReadFiltered` and
+`Fake.List`, ensuring both code paths enforce the same predicate logic.
+The `exec` provider passes `Filter` to an external script as JSON — new fields
+are marshalled automatically; scripts that don't recognize them return
+unfiltered data (the in-process caller applies the filter on its side).

--- a/engdocs/architecture/event-query.md
+++ b/engdocs/architecture/event-query.md
@@ -6,7 +6,7 @@ easy to compose and test.
 
 ## Extended Filter
 
-`Filter` now supports five predicates instead of four:
+`Filter` now supports six predicates plus a result cap:
 
 ```go
 type Filter struct {
@@ -46,14 +46,20 @@ evts, err := provider.List(events.Filter{
 
 `Limit` caps the result slice to the first N matches in chronological scan
 order and stops scanning as soon as the cap is reached when the provider can do
-so locally. Use caller-side tail slicing when a view needs the latest N events:
+so locally. This is the earliest matching window, not the latest N events; use
+`ListTail` or caller-side tail slicing when a view needs the trailing window:
 
 ```go
-recent, err := provider.List(events.Filter{
+firstCreated, err := provider.List(events.Filter{
     Type:  events.BeadCreated,
     Limit: 10,
 })
 ```
+
+For `Multiplexer` calls, `Limit` is applied after provider results are merged
+and sorted by timestamp, city, then sequence. That preserves one deterministic
+global earliest-window ordering across cities, but it also means the cap does
+not bound each provider's local scan work.
 
 ## Aggregation Helpers
 
@@ -85,15 +91,15 @@ byType := events.CountByType(all)
 |---|---|
 | `internal/events/reader.go` | `Filter` extended with `Subject`, `Until`, `Limit`; `matchesFilter` helper; `ReadFiltered` updated |
 | `internal/events/fake.go` | `Fake.List` updated to use `matchesFilter` and apply `Limit` |
-| `internal/events/exec/exec.go` | Exec provider applies SDK-side filtering after script output so old scripts cannot bypass new filter fields |
-| `internal/events/multiplexer.go` | Multiplexer applies `Limit` globally after merging and sorting provider results |
+| `internal/events/exec/exec.go` | Exec provider keeps the legacy script filter JSON shape and applies SDK-side filtering after script output so old scripts cannot bypass new filter fields |
+| `internal/events/multiplexer.go` | Multiplexer applies `Limit` globally after deterministically merging and sorting provider results |
 | `internal/events/query.go` | `CountByType`, `CountByActor`, `CountBySubject` |
 | `internal/events/query_test.go` | Tests covering all new filter predicates and count helpers |
 
 `matchesFilter` is the predicate used by `ApplyFilter`, `ReadFiltered`, and the
 in-memory provider, ensuring code paths enforce the same predicate logic. The
-`exec` provider still passes `Filter` to an external script as JSON for
-provider-side narrowing, but asks scripts for an unbounded result set and then
-applies the SDK filter locally. Scripts that don't recognize new fields can
-return unfiltered data; the in-process caller enforces `Subject`, `Until`, and
-`Limit` on its side.
+`exec` provider still passes the legacy `Type`/`Actor`/`Since`/`AfterSeq`
+filter shape to an external script as JSON for provider-side narrowing, but
+asks scripts for an unbounded result set and then applies the SDK filter
+locally. Scripts that don't recognize new fields can return unfiltered data;
+the in-process caller enforces `Subject`, `Until`, and `Limit` on its side.

--- a/engdocs/architecture/event-query.md
+++ b/engdocs/architecture/event-query.md
@@ -16,7 +16,7 @@ type Filter struct {
     Since    time.Time // match events at or after this time (inclusive)
     Until    time.Time // match events at or before this time (inclusive)
     AfterSeq uint64    // match events with Seq > AfterSeq
-    Limit    int       // cap results at this count (0 = unlimited)
+    Limit    int       // cap results at this count (0 or negative = unlimited)
 }
 ```
 
@@ -44,8 +44,9 @@ evts, err := provider.List(events.Filter{
 
 ### Limit
 
-`Limit` caps the result slice and stops scanning as soon as the cap is reached.
-Useful for dashboards that only need the first N matches:
+`Limit` caps the result slice to the first N matches in chronological scan
+order and stops scanning as soon as the cap is reached when the provider can do
+so locally. Use caller-side tail slicing when a view needs the latest N events:
 
 ```go
 recent, err := provider.List(events.Filter{
@@ -84,11 +85,15 @@ byType := events.CountByType(all)
 |---|---|
 | `internal/events/reader.go` | `Filter` extended with `Subject`, `Until`, `Limit`; `matchesFilter` helper; `ReadFiltered` updated |
 | `internal/events/fake.go` | `Fake.List` updated to use `matchesFilter` and apply `Limit` |
+| `internal/events/exec/exec.go` | Exec provider applies SDK-side filtering after script output so old scripts cannot bypass new filter fields |
+| `internal/events/multiplexer.go` | Multiplexer applies `Limit` globally after merging and sorting provider results |
 | `internal/events/query.go` | `CountByType`, `CountByActor`, `CountBySubject` |
-| `internal/events/query_test.go` | 11 tests covering all new filter predicates and count helpers |
+| `internal/events/query_test.go` | Tests covering all new filter predicates and count helpers |
 
-`matchesFilter` is an unexported helper shared by `ReadFiltered` and
-`Fake.List`, ensuring both code paths enforce the same predicate logic.
-The `exec` provider passes `Filter` to an external script as JSON — new fields
-are marshalled automatically; scripts that don't recognize them return
-unfiltered data (the in-process caller applies the filter on its side).
+`matchesFilter` is the predicate used by `ApplyFilter`, `ReadFiltered`, and the
+in-memory provider, ensuring code paths enforce the same predicate logic. The
+`exec` provider still passes `Filter` to an external script as JSON for
+provider-side narrowing, but asks scripts for an unbounded result set and then
+applies the SDK filter locally. Scripts that don't recognize new fields can
+return unfiltered data; the in-process caller enforces `Subject`, `Until`, and
+`Limit` on its side.

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -645,7 +645,7 @@ func (sm *SupervisorMux) humaHandleEventList(_ context.Context, input *Superviso
 }
 
 func supervisorEventListFilterIsEmpty(filter events.Filter) bool {
-	return filter.Type == "" && filter.Actor == "" && filter.Since.IsZero() && filter.AfterSeq == 0
+	return filter == (events.Filter{})
 }
 
 func (sm *SupervisorMux) currentSupervisorEventTotal() int {

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -658,6 +658,32 @@ func TestSupervisorEventListsIncludeCustomEventTypes(t *testing.T) {
 	}
 }
 
+func TestSupervisorEventListFilterIsEmptyMatchesEventsFilterZeroValue(t *testing.T) {
+	if !supervisorEventListFilterIsEmpty(events.Filter{}) {
+		t.Fatal("zero-value filter reported non-empty")
+	}
+
+	tests := []struct {
+		name   string
+		filter events.Filter
+	}{
+		{name: "type", filter: events.Filter{Type: events.BeadCreated}},
+		{name: "actor", filter: events.Filter{Actor: "human"}},
+		{name: "subject", filter: events.Filter{Subject: "gc-1"}},
+		{name: "since", filter: events.Filter{Since: time.Unix(1, 0)}},
+		{name: "until", filter: events.Filter{Until: time.Unix(1, 0)}},
+		{name: "after_seq", filter: events.Filter{AfterSeq: 1}},
+		{name: "limit", filter: events.Filter{Limit: 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if supervisorEventListFilterIsEmpty(tt.filter) {
+				t.Fatalf("filter %+v reported empty", tt.filter)
+			}
+		})
+	}
+}
+
 func TestSupervisorGlobalEventListWithFilter(t *testing.T) {
 	s1 := newFakeState(t)
 	s1.cityName = "alpha"

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -560,6 +560,56 @@ func TestReadFiltered(t *testing.T) {
 	})
 }
 
+func TestReadFilteredMissingFile(t *testing.T) {
+	got, err := ReadFiltered(filepath.Join(t.TempDir(), "missing.jsonl"), Filter{})
+	if err != nil {
+		t.Fatalf("ReadFiltered(missing): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("ReadFiltered(missing) = %v, want nil", got)
+	}
+}
+
+func TestReadFilteredSkipsMalformedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	data := strings.Join([]string{
+		`not-json`,
+		`{"seq":1,"type":"bead.created","ts":"2025-06-15T10:30:00Z","actor":"actor-a","subject":"gc-1"}`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFiltered(path, Filter{})
+	if err != nil {
+		t.Fatalf("ReadFiltered: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1", len(got))
+	}
+	if got[0].Subject != "gc-1" {
+		t.Errorf("Subject = %q, want gc-1", got[0].Subject)
+	}
+}
+
+func TestReadFilteredScannerError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 1024*1024+1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadFiltered(path, Filter{})
+	if err == nil {
+		t.Fatal("ReadFiltered returned nil error, want scanner error")
+	}
+	if !strings.Contains(err.Error(), "scanning events") {
+		t.Fatalf("ReadFiltered error = %q, want scanning events context", err.Error())
+	}
+}
+
 func TestReadFilteredLimitStopsScanning(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -597,16 +597,24 @@ func TestReadFilteredSkipsMalformedLines(t *testing.T) {
 func TestReadFilteredScannerError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
-	if err := os.WriteFile(path, []byte(strings.Repeat("x", 1024*1024+1)), 0o644); err != nil {
+	first := `{"seq":1,"type":"bead.created","ts":"2025-06-15T10:30:00Z","actor":"actor-a","subject":"gc-1"}` + "\n"
+	oversizedLine := strings.Repeat("x", 1024*1024+1)
+	if err := os.WriteFile(path, []byte(first+oversizedLine), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := ReadFiltered(path, Filter{})
+	got, err := ReadFiltered(path, Filter{})
 	if err == nil {
 		t.Fatal("ReadFiltered returned nil error, want scanner error")
 	}
 	if !strings.Contains(err.Error(), "scanning events") {
 		t.Fatalf("ReadFiltered error = %q, want scanning events context", err.Error())
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d partial events, want 1", len(got))
+	}
+	if got[0].Subject != "gc-1" {
+		t.Errorf("partial Subject = %q, want gc-1", got[0].Subject)
 	}
 }
 

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -80,7 +81,7 @@ func TestFileRecorderPayloadRoundTrip(t *testing.T) {
 	payload := json.RawMessage(`{"type":"merge-request","title":"Fix bug","labels":["urgent"]}`)
 	rec.Record(Event{
 		Type:    BeadCreated,
-		Actor:   "polecat",
+		Actor:   "actor-payload",
 		Subject: "gc-42",
 		Payload: payload,
 	})
@@ -335,7 +336,7 @@ func TestFakeList(t *testing.T) {
 	f := NewFake()
 	f.Record(Event{Type: BeadCreated, Actor: "human", Subject: "gc-1"})
 	f.Record(Event{Type: BeadClosed, Actor: "human", Subject: "gc-1"})
-	f.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "mayor"})
+	f.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "session-alpha"})
 
 	all, err := f.List(Filter{})
 	if err != nil {
@@ -495,7 +496,7 @@ func TestReadFiltered(t *testing.T) {
 	past := now.Add(-2 * time.Hour)
 	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "gc-1", Ts: past})
 	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "gc-1", Ts: past})
-	rec.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "mayor", Ts: now})
+	rec.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "session-alpha", Ts: now})
 	rec.Close() //nolint:errcheck // test cleanup
 
 	t.Run("by_type", func(t *testing.T) {
@@ -557,6 +558,27 @@ func TestReadFiltered(t *testing.T) {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
+}
+
+func TestReadFilteredLimitStopsScanning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	first := `{"seq":1,"type":"bead.created","ts":"2025-06-15T10:30:00Z","actor":"actor-a","subject":"gc-1"}` + "\n"
+	oversizedLine := strings.Repeat("x", 1024*1024+1) + "\n"
+	if err := os.WriteFile(path, []byte(first+oversizedLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFiltered(path, Filter{Limit: 1})
+	if err != nil {
+		t.Fatalf("ReadFiltered: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1", len(got))
+	}
+	if got[0].Seq != 1 {
+		t.Errorf("got[0].Seq = %d, want 1", got[0].Seq)
+	}
 }
 
 func TestReadFilteredAfterSeq(t *testing.T) {
@@ -835,7 +857,7 @@ func TestReadFrom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rec2.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "mayor"})
+	rec2.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "session-alpha"})
 	rec2.Close() //nolint:errcheck // test cleanup
 
 	// Read from mid-file offset → only new event
@@ -911,7 +933,7 @@ func TestFileRecorderList(t *testing.T) {
 
 	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "gc-1"})
 	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "gc-1"})
-	rec.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "mayor"})
+	rec.Record(Event{Type: SessionWoke, Actor: "gc", Subject: "session-alpha"})
 
 	// List all
 	all, err := rec.List(Filter{})

--- a/internal/events/eventstest/conformance.go
+++ b/internal/events/eventstest/conformance.go
@@ -357,9 +357,16 @@ func RunProviderTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 		p, cleanup := newProvider(t)
 		defer cleanup()
 
-		p.Record(events.Event{Type: events.BeadCreated, Actor: "human"}) // seq 1
-		p.Record(events.Event{Type: events.BeadClosed, Actor: "human"})  // seq 2
-		p.Record(events.Event{Type: events.BeadCreated, Actor: "human"}) // seq 3
+		base := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+		p.Record(events.Event{Type: events.MailSent, Actor: "seed", Subject: "seed", Ts: base})                           // seq 1
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: "gc-1", Ts: base.Add(2 * time.Hour)})    // after Until
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: "gc-1", Ts: base.Add(-2 * time.Hour)})   // before Since
+		p.Record(events.Event{Type: events.BeadClosed, Actor: "human", Subject: "gc-1", Ts: base.Add(10 * time.Minute)})  // wrong Type
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "agent", Subject: "gc-1", Ts: base.Add(20 * time.Minute)}) // wrong Actor
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: "gc-2", Ts: base.Add(30 * time.Minute)}) // wrong Subject
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: "gc-1", Ts: base.Add(40 * time.Minute)}) // match 1
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: "gc-1", Ts: base.Add(50 * time.Minute)}) // match 2
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "human", Subject: "gc-1", Ts: base.Add(55 * time.Minute)}) // limited out
 
 		// Get all to find seq of first event.
 		all, err := p.List(events.Filter{})
@@ -370,16 +377,28 @@ func RunProviderTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 			t.Fatal("need at least 1 event")
 		}
 
-		// Type + AfterSeq combined: bead.created with seq > first event.
-		got, err := p.List(events.Filter{Type: events.BeadCreated, AfterSeq: all[0].Seq})
+		got, err := p.List(events.Filter{
+			Type:     events.BeadCreated,
+			Actor:    "human",
+			Subject:  "gc-1",
+			Since:    base.Add(-time.Hour),
+			Until:    base.Add(time.Hour),
+			AfterSeq: all[0].Seq,
+			Limit:    2,
+		})
 		if err != nil {
 			t.Fatalf("List(combined): %v", err)
 		}
-		if len(got) != 1 {
-			t.Fatalf("List(Type+AfterSeq) returned %d events, want 1", len(got))
+		if len(got) != 2 {
+			t.Fatalf("List(all predicates) returned %d events, want 2", len(got))
 		}
-		if got[0].Type != events.BeadCreated {
-			t.Errorf("Type = %q, want %q", got[0].Type, events.BeadCreated)
+		for _, e := range got {
+			if e.Type != events.BeadCreated || e.Actor != "human" || e.Subject != "gc-1" {
+				t.Fatalf("event = %+v, want bead.created by human for gc-1", e)
+			}
+			if e.Ts.Before(base.Add(-time.Hour)) || e.Ts.After(base.Add(time.Hour)) {
+				t.Fatalf("event Ts = %s, want within combined window", e.Ts)
+			}
 		}
 	})
 

--- a/internal/events/eventstest/conformance.go
+++ b/internal/events/eventstest/conformance.go
@@ -282,6 +282,77 @@ func RunProviderTests(t *testing.T, newProvider func(t *testing.T) (events.Provi
 		}
 	})
 
+	t.Run("ListFilterBySubject", func(t *testing.T) {
+		p, cleanup := newProvider(t)
+		defer cleanup()
+
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "actor-a", Subject: "gc-1"})
+		p.Record(events.Event{Type: events.BeadClosed, Actor: "actor-a", Subject: "gc-2"})
+		p.Record(events.Event{Type: events.BeadUpdated, Actor: "actor-b", Subject: "gc-1"})
+
+		got, err := p.List(events.Filter{Subject: "gc-1"})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("List(Subject) returned %d events, want 2", len(got))
+		}
+		for _, e := range got {
+			if e.Subject != "gc-1" {
+				t.Errorf("Subject = %q, want gc-1", e.Subject)
+			}
+		}
+	})
+
+	t.Run("ListFilterByUntil", func(t *testing.T) {
+		p, cleanup := newProvider(t)
+		defer cleanup()
+
+		cutoff := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+		before := cutoff.Add(-time.Minute)
+		after := cutoff.Add(time.Minute)
+		p.Record(events.Event{Type: events.BeadCreated, Actor: "actor-a", Subject: "before", Ts: before})
+		p.Record(events.Event{Type: events.BeadUpdated, Actor: "actor-a", Subject: "boundary", Ts: cutoff})
+		p.Record(events.Event{Type: events.BeadClosed, Actor: "actor-a", Subject: "after", Ts: after})
+
+		got, err := p.List(events.Filter{Until: cutoff})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("List(Until) returned %d events, want 2", len(got))
+		}
+		if got[0].Subject != "before" {
+			t.Errorf("got[0].Subject = %q, want before", got[0].Subject)
+		}
+		if got[1].Subject != "boundary" {
+			t.Errorf("got[1].Subject = %q, want boundary", got[1].Subject)
+		}
+	})
+
+	t.Run("ListFilterByLimit", func(t *testing.T) {
+		p, cleanup := newProvider(t)
+		defer cleanup()
+
+		for _, subject := range []string{"gc-1", "gc-2", "gc-3", "gc-4"} {
+			p.Record(events.Event{Type: events.BeadCreated, Actor: "actor-a", Subject: subject})
+		}
+
+		got, err := p.List(events.Filter{Limit: 2})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("List(Limit) returned %d events, want 2", len(got))
+		}
+		if got[0].Subject != "gc-1" {
+			t.Errorf("got[0].Subject = %q, want gc-1", got[0].Subject)
+		}
+		if got[1].Subject != "gc-2" {
+			t.Errorf("got[1].Subject = %q, want gc-2", got[1].Subject)
+		}
+	})
+
 	t.Run("ListFilterCombined", func(t *testing.T) {
 		p, cleanup := newProvider(t)
 		defer cleanup()

--- a/internal/events/exec/exec.go
+++ b/internal/events/exec/exec.go
@@ -32,6 +32,13 @@ type Provider struct {
 	stderr  io.Writer
 }
 
+type listScriptFilter struct {
+	Type     string
+	Actor    string
+	Since    time.Time
+	AfterSeq uint64
+}
+
 // NewProvider returns an exec events provider that delegates to the given script.
 // Errors from best-effort operations (Record) are logged to stderr.
 func NewProvider(script string, stderr io.Writer) *Provider {
@@ -60,8 +67,12 @@ func (p *Provider) Record(e events.Event) {
 // SDK filter locally so optional script filtering cannot weaken the contract.
 func (p *Provider) List(filter events.Filter) ([]events.Event, error) {
 	p.ensureRunning()
-	scriptFilter := filter
-	scriptFilter.Limit = 0
+	scriptFilter := listScriptFilter{
+		Type:     filter.Type,
+		Actor:    filter.Actor,
+		Since:    filter.Since,
+		AfterSeq: filter.AfterSeq,
+	}
 	data, err := json.Marshal(scriptFilter)
 	if err != nil {
 		return nil, fmt.Errorf("exec events provider: marshal filter: %w", err)

--- a/internal/events/exec/exec.go
+++ b/internal/events/exec/exec.go
@@ -56,10 +56,13 @@ func (p *Provider) Record(e events.Event) {
 	}
 }
 
-// List delegates to: script list with JSON filter on stdin.
+// List delegates to: script list with JSON filter on stdin, then applies the
+// SDK filter locally so optional script filtering cannot weaken the contract.
 func (p *Provider) List(filter events.Filter) ([]events.Event, error) {
 	p.ensureRunning()
-	data, err := json.Marshal(filter)
+	scriptFilter := filter
+	scriptFilter.Limit = 0
+	data, err := json.Marshal(scriptFilter)
 	if err != nil {
 		return nil, fmt.Errorf("exec events provider: marshal filter: %w", err)
 	}
@@ -70,7 +73,11 @@ func (p *Provider) List(filter events.Filter) ([]events.Event, error) {
 	if out == "" {
 		return nil, nil
 	}
-	return unmarshalEvents(out)
+	evts, err := unmarshalEvents(out)
+	if err != nil {
+		return nil, err
+	}
+	return events.ApplyFilter(evts, filter), nil
 }
 
 // LatestSeq delegates to: script latest-seq

--- a/internal/events/exec/exec_test.go
+++ b/internal/events/exec/exec_test.go
@@ -161,6 +161,73 @@ esac
 	}
 }
 
+func TestListAppliesSDKFilterAndStripsScriptLimit(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "stdin.json")
+	script := writeScript(t, dir, `
+case "$1" in
+  ensure-running) exit 2 ;;
+  list) cat > "`+outFile+`"
+    echo '[{"seq":1,"type":"bead.created","ts":"2025-06-15T10:30:00Z","actor":"actor-a","subject":"gc-1"},{"seq":2,"type":"bead.created","ts":"2025-06-15T10:31:00Z","actor":"actor-a","subject":"gc-1"},{"seq":3,"type":"bead.created","ts":"2025-06-15T10:32:00Z","actor":"actor-a","subject":"gc-2"}]'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script, os.Stderr)
+	until := time.Date(2025, 6, 15, 10, 31, 0, 0, time.UTC)
+
+	evts, err := p.List(events.Filter{Subject: "gc-1", Until: until, Limit: 1})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("List returned %d events, want 1", len(evts))
+	}
+	if evts[0].Seq != 1 {
+		t.Errorf("Seq = %d, want 1", evts[0].Seq)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read filter: %v", err)
+	}
+	var f events.Filter
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("unmarshal filter: %v", err)
+	}
+	if f.Subject != "gc-1" {
+		t.Errorf("script filter Subject = %q, want gc-1", f.Subject)
+	}
+	if !f.Until.Equal(until) {
+		t.Errorf("script filter Until = %v, want %v", f.Until, until)
+	}
+	if f.Limit != 0 {
+		t.Errorf("script filter Limit = %d, want 0", f.Limit)
+	}
+}
+
+func TestListInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	script := writeScript(t, dir, `
+case "$1" in
+  ensure-running) exit 2 ;;
+  list) cat > /dev/null
+    echo 'not-json'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script, os.Stderr)
+
+	_, err := p.List(events.Filter{})
+	if err == nil {
+		t.Fatal("List returned nil error, want unmarshal error")
+	}
+	if !strings.Contains(err.Error(), "unmarshal events") {
+		t.Fatalf("List error = %q, want unmarshal context", err.Error())
+	}
+}
+
 func TestLatestSeq(t *testing.T) {
 	dir := t.TempDir()
 	script := writeScript(t, dir, allOpsScript())

--- a/internal/events/exec/exec_test.go
+++ b/internal/events/exec/exec_test.go
@@ -195,14 +195,46 @@ esac
 	if err := json.Unmarshal(data, &f); err != nil {
 		t.Fatalf("unmarshal filter: %v", err)
 	}
-	if f.Subject != "gc-1" {
-		t.Errorf("script filter Subject = %q, want gc-1", f.Subject)
+	if f.Subject != "" {
+		t.Errorf("script filter Subject = %q, want empty legacy value", f.Subject)
 	}
-	if !f.Until.Equal(until) {
-		t.Errorf("script filter Until = %v, want %v", f.Until, until)
+	if !f.Until.IsZero() {
+		t.Errorf("script filter Until = %v, want zero legacy value", f.Until)
 	}
 	if f.Limit != 0 {
 		t.Errorf("script filter Limit = %d, want 0", f.Limit)
+	}
+}
+
+func TestListUsesLegacyScriptFilterShape(t *testing.T) {
+	dir := t.TempDir()
+	script := writeScript(t, dir, `
+case "$1" in
+  ensure-running) exit 2 ;;
+  list)
+    input="$(cat)"
+    case "$input" in
+      *'"Subject"'*|*'"Until"'*|*'"Limit"'*)
+        echo "unknown filter key in $input" >&2
+        exit 1
+        ;;
+    esac
+    echo '[{"seq":1,"type":"bead.created","ts":"2025-06-15T10:30:00Z","actor":"actor-a","subject":"gc-1"},{"seq":2,"type":"bead.created","ts":"2025-06-15T10:31:00Z","actor":"actor-a","subject":"gc-2"}]'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	p := NewProvider(script, os.Stderr)
+
+	evts, err := p.List(events.Filter{Subject: "gc-1", Limit: 1})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("List returned %d events, want 1", len(evts))
+	}
+	if evts[0].Subject != "gc-1" {
+		t.Fatalf("List returned subject %q, want gc-1", evts[0].Subject)
 	}
 }
 

--- a/internal/events/fake.go
+++ b/internal/events/fake.go
@@ -58,6 +58,9 @@ func (f *Fake) List(filter Filter) ([]Event, error) {
 	for _, e := range f.Events {
 		if eventMatchesFilter(e, filter) {
 			result = append(result, e)
+			if filter.Limit > 0 && len(result) >= filter.Limit {
+				break
+			}
 		}
 	}
 	return result, nil

--- a/internal/events/fake.go
+++ b/internal/events/fake.go
@@ -54,16 +54,7 @@ func (f *Fake) List(filter Filter) ([]Event, error) {
 	if f.broken {
 		return nil, fmt.Errorf("events provider unavailable")
 	}
-	var result []Event
-	for _, e := range f.Events {
-		if eventMatchesFilter(e, filter) {
-			result = append(result, e)
-			if filter.Limit > 0 && len(result) >= filter.Limit {
-				break
-			}
-		}
-	}
-	return result, nil
+	return ApplyFilter(f.Events, filter), nil
 }
 
 // ListTail returns the trailing matching events from the in-memory store.
@@ -76,7 +67,7 @@ func (f *Fake) ListTail(filter Filter, limit int) ([]Event, error) {
 	if limit <= 0 {
 		var result []Event
 		for _, e := range f.Events {
-			if eventMatchesFilter(e, filter) {
+			if matchesFilter(e, filter) {
 				result = append(result, e)
 			}
 		}
@@ -85,7 +76,7 @@ func (f *Fake) ListTail(filter Filter, limit int) ([]Event, error) {
 	reversed := make([]Event, 0, limit)
 	for i := len(f.Events) - 1; i >= 0 && len(reversed) < limit; i-- {
 		e := f.Events[i]
-		if eventMatchesFilter(e, filter) {
+		if matchesFilter(e, filter) {
 			reversed = append(reversed, e)
 		}
 	}

--- a/internal/events/multiplexer.go
+++ b/internal/events/multiplexer.go
@@ -75,9 +75,11 @@ func (m *Multiplexer) snapshot() map[string]Provider {
 // timestamp. Each event is tagged with its source city.
 func (m *Multiplexer) ListAll(filter Filter) ([]TaggedEvent, error) {
 	providers := m.snapshot()
+	providerFilter := filter
+	providerFilter.Limit = 0
 	var all []TaggedEvent
 	for city, p := range providers {
-		evts, err := p.List(filter)
+		evts, err := p.List(providerFilter)
 		if err != nil {
 			continue // best-effort: skip cities with errors
 		}
@@ -88,6 +90,9 @@ func (m *Multiplexer) ListAll(filter Filter) ([]TaggedEvent, error) {
 	sort.Slice(all, func(i, j int) bool {
 		return all[i].Ts.Before(all[j].Ts)
 	})
+	if filter.Limit > 0 && len(all) > filter.Limit {
+		all = all[:filter.Limit]
+	}
 	return all, nil
 }
 

--- a/internal/events/multiplexer.go
+++ b/internal/events/multiplexer.go
@@ -72,7 +72,9 @@ func (m *Multiplexer) snapshot() map[string]Provider {
 }
 
 // ListAll returns events from all cities matching the filter, sorted by
-// timestamp. Each event is tagged with its source city.
+// timestamp, city, and sequence. Each event is tagged with its source city.
+// A positive filter Limit returns the earliest matching events after that
+// global sort; callers needing the latest matching events should use ListTail.
 func (m *Multiplexer) ListAll(filter Filter) ([]TaggedEvent, error) {
 	providers := m.snapshot()
 	providerFilter := filter
@@ -88,7 +90,7 @@ func (m *Multiplexer) ListAll(filter Filter) ([]TaggedEvent, error) {
 		}
 	}
 	sort.Slice(all, func(i, j int) bool {
-		return all[i].Ts.Before(all[j].Ts)
+		return taggedEventLess(all[i], all[j])
 	})
 	if filter.Limit > 0 && len(all) > filter.Limit {
 		all = all[:filter.Limit]
@@ -104,14 +106,16 @@ func (m *Multiplexer) ListTail(filter Filter, limit int) ([]TaggedEvent, error) 
 		return m.ListAll(filter)
 	}
 	providers := m.snapshot()
+	providerFilter := filter
+	providerFilter.Limit = 0
 	var all []TaggedEvent
 	for city, p := range providers {
 		var evts []Event
 		var err error
 		if tail, ok := p.(TailProvider); ok {
-			evts, err = tail.ListTail(filter, limit)
+			evts, err = tail.ListTail(providerFilter, limit)
 		} else {
-			evts, err = p.List(filter)
+			evts, err = p.List(providerFilter)
 			if limit < len(evts) {
 				evts = evts[len(evts)-limit:]
 			}
@@ -125,12 +129,22 @@ func (m *Multiplexer) ListTail(filter Filter, limit int) ([]TaggedEvent, error) 
 		}
 	}
 	sort.Slice(all, func(i, j int) bool {
-		return all[i].Ts.Before(all[j].Ts)
+		return taggedEventLess(all[i], all[j])
 	})
 	if limit < len(all) {
 		all = all[len(all)-limit:]
 	}
 	return all, nil
+}
+
+func taggedEventLess(left, right TaggedEvent) bool {
+	if !left.Ts.Equal(right.Ts) {
+		return left.Ts.Before(right.Ts)
+	}
+	if left.City != right.City {
+		return left.City < right.City
+	}
+	return left.Seq < right.Seq
 }
 
 // LatestCursor returns the current highest sequence number for each provider.

--- a/internal/events/multiplexer_test.go
+++ b/internal/events/multiplexer_test.go
@@ -82,6 +82,44 @@ func TestMultiplexerListAllAppliesGlobalLimitAfterMerge(t *testing.T) {
 	}
 }
 
+func TestMultiplexerListAllOrdersEqualTimestampsDeterministically(t *testing.T) {
+	m := NewMultiplexer()
+	ts := time.Unix(1, 0)
+
+	alpha := NewFake()
+	alpha.Events = []Event{
+		{Seq: 5, Type: SessionWoke, Subject: "alpha", Ts: ts},
+	}
+
+	beta := NewFake()
+	beta.Events = []Event{
+		{Seq: 2, Type: SessionWoke, Subject: "beta-two", Ts: ts},
+		{Seq: 1, Type: SessionWoke, Subject: "beta-one", Ts: ts},
+	}
+
+	m.Add("beta", beta)
+	m.Add("alpha", alpha)
+
+	evts, err := m.ListAll(Filter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 3 {
+		t.Fatalf("got %d events, want 3", len(evts))
+	}
+	got := []string{
+		evts[0].City + ":" + evts[0].Subject,
+		evts[1].City + ":" + evts[1].Subject,
+		evts[2].City + ":" + evts[2].Subject,
+	}
+	want := []string{"alpha:alpha", "beta:beta-one", "beta:beta-two"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestMultiplexerListTailLimitsAcrossCities(t *testing.T) {
 	m := NewMultiplexer()
 
@@ -105,6 +143,43 @@ func TestMultiplexerListTailLimitsAcrossCities(t *testing.T) {
 	}
 	if evts[0].Subject != "new-a" || evts[1].Subject != "new-b" {
 		t.Fatalf("subjects = [%s %s], want [new-a new-b]", evts[0].Subject, evts[1].Subject)
+	}
+}
+
+func TestMultiplexerListTailOrdersEqualTimestampsDeterministically(t *testing.T) {
+	m := NewMultiplexer()
+	ts := time.Unix(1, 0)
+
+	alpha := NewFake()
+	alpha.Events = []Event{
+		{Seq: 5, Type: SessionWoke, Subject: "alpha", Ts: ts},
+	}
+
+	beta := NewFake()
+	beta.Events = []Event{
+		{Seq: 2, Type: SessionWoke, Subject: "beta-two", Ts: ts},
+		{Seq: 1, Type: SessionWoke, Subject: "beta-one", Ts: ts},
+	}
+
+	m.Add("beta", beta)
+	m.Add("alpha", alpha)
+
+	evts, err := m.ListTail(Filter{}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 2 {
+		t.Fatalf("got %d events, want 2", len(evts))
+	}
+	got := []string{
+		evts[0].City + ":" + evts[0].Subject,
+		evts[1].City + ":" + evts[1].Subject,
+	}
+	want := []string{"beta:beta-one", "beta:beta-two"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events = %v, want %v", got, want)
+		}
 	}
 }
 
@@ -134,6 +209,31 @@ func TestMultiplexerListTailUsesFallbackAndSkipsErrors(t *testing.T) {
 	}
 	got := []string{evts[0].Subject, evts[1].Subject, evts[2].Subject}
 	want := []string{"list-middle", "tail-new", "list-new"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("subjects = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestMultiplexerListTailIgnoresFilterLimitForListOnlyProviders(t *testing.T) {
+	m := NewMultiplexer()
+
+	listOnly := NewFake()
+	listOnly.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "old", Ts: time.Unix(1, 0)})
+	listOnly.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "middle", Ts: time.Unix(2, 0)})
+	listOnly.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "new", Ts: time.Unix(3, 0)})
+	m.Add("list-only", &providerWithoutTail{fake: listOnly})
+
+	evts, err := m.ListTail(Filter{Type: SessionWoke, Limit: 1}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 2 {
+		t.Fatalf("got %d events, want 2", len(evts))
+	}
+	got := []string{evts[0].Subject, evts[1].Subject}
+	want := []string{"middle", "new"}
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("subjects = %v, want %v", got, want)

--- a/internal/events/multiplexer_test.go
+++ b/internal/events/multiplexer_test.go
@@ -53,6 +53,35 @@ func TestMultiplexerListAllWithFilter(t *testing.T) {
 	}
 }
 
+func TestMultiplexerListAllAppliesGlobalLimitAfterMerge(t *testing.T) {
+	m := NewMultiplexer()
+
+	f1 := NewFake()
+	f1.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "first", Ts: time.Unix(1, 0)})
+	f1.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "fourth", Ts: time.Unix(4, 0)})
+
+	f2 := NewFake()
+	f2.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "second", Ts: time.Unix(2, 0)})
+	f2.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "third", Ts: time.Unix(3, 0)})
+
+	m.Add("city-a", f1)
+	m.Add("city-b", f2)
+
+	evts, err := m.ListAll(Filter{Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 2 {
+		t.Fatalf("got %d events, want 2", len(evts))
+	}
+	if evts[0].Subject != "first" {
+		t.Errorf("evts[0].Subject = %q, want first", evts[0].Subject)
+	}
+	if evts[1].Subject != "second" {
+		t.Errorf("evts[1].Subject = %q, want second", evts[1].Subject)
+	}
+}
+
 func TestMultiplexerListTailLimitsAcrossCities(t *testing.T) {
 	m := NewMultiplexer()
 
@@ -286,14 +315,14 @@ func TestWrapForSSE(t *testing.T) {
 	w := WrapForSSE(mw)
 	defer w.Close() //nolint:errcheck
 
-	f1.Record(Event{Type: SessionWoke, Actor: "mayor"})
+	f1.Record(Event{Type: SessionWoke, Actor: "actor-a"})
 
 	e, err := w.Next()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if e.Actor != "city-a/mayor" {
-		t.Errorf("Actor = %q, want %q", e.Actor, "city-a/mayor")
+	if e.Actor != "city-a/actor-a" {
+		t.Errorf("Actor = %q, want %q", e.Actor, "city-a/actor-a")
 	}
 }
 

--- a/internal/events/query.go
+++ b/internal/events/query.go
@@ -1,0 +1,29 @@
+package events
+
+// CountByType returns a map of event type → count for the given events.
+func CountByType(evts []Event) map[string]int {
+	counts := make(map[string]int, len(evts))
+	for _, e := range evts {
+		counts[e.Type]++
+	}
+	return counts
+}
+
+// CountByActor returns a map of actor → count for the given events.
+func CountByActor(evts []Event) map[string]int {
+	counts := make(map[string]int, len(evts))
+	for _, e := range evts {
+		counts[e.Actor]++
+	}
+	return counts
+}
+
+// CountBySubject returns a map of subject → count for the given events.
+// Events with an empty Subject are counted under the empty-string key.
+func CountBySubject(evts []Event) map[string]int {
+	counts := make(map[string]int, len(evts))
+	for _, e := range evts {
+		counts[e.Subject]++
+	}
+	return counts
+}

--- a/internal/events/query_test.go
+++ b/internal/events/query_test.go
@@ -1,0 +1,166 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+// --- matchesFilter unit tests ---
+
+func TestMatchesFilter_Subject(t *testing.T) {
+	e := Event{Type: BeadCreated, Actor: "mayor", Subject: "gc-42"}
+
+	if !matchesFilter(e, Filter{Subject: "gc-42"}) {
+		t.Error("expected match on Subject gc-42")
+	}
+	if matchesFilter(e, Filter{Subject: "gc-99"}) {
+		t.Error("expected no match on Subject gc-99")
+	}
+	if !matchesFilter(e, Filter{}) {
+		t.Error("empty filter should match everything")
+	}
+}
+
+func TestMatchesFilter_Until(t *testing.T) {
+	now := time.Now()
+	e := Event{Type: BeadCreated, Ts: now}
+
+	if !matchesFilter(e, Filter{Until: now.Add(time.Second)}) {
+		t.Error("event before Until should match")
+	}
+	if !matchesFilter(e, Filter{Until: now}) {
+		t.Error("event exactly at Until should match (not After)")
+	}
+	if matchesFilter(e, Filter{Until: now.Add(-time.Second)}) {
+		t.Error("event after Until should not match")
+	}
+}
+
+func TestMatchesFilter_Limit_AppliedByReadFiltered(t *testing.T) {
+	// Create a fake with 5 events and request only 3.
+	f := NewFake()
+	for i := 0; i < 5; i++ {
+		f.Record(Event{Type: BeadCreated, Actor: "worker"})
+	}
+
+	got, err := f.List(Filter{Limit: 3})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("List(Limit:3) returned %d events, want 3", len(got))
+	}
+}
+
+func TestMatchesFilter_SubjectFilter_ViaFake(t *testing.T) {
+	f := NewFake()
+	f.Record(Event{Type: BeadCreated, Subject: "gc-1"})
+	f.Record(Event{Type: BeadCreated, Subject: "gc-2"})
+	f.Record(Event{Type: BeadClosed, Subject: "gc-1"})
+
+	got, err := f.List(Filter{Subject: "gc-1"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("List(Subject:gc-1) returned %d events, want 2", len(got))
+	}
+}
+
+func TestMatchesFilter_UntilFilter_ViaFake(t *testing.T) {
+	cutoff := time.Now()
+	past := cutoff.Add(-time.Minute)
+	future := cutoff.Add(time.Minute)
+
+	f := NewFake()
+	f.Record(Event{Type: BeadCreated, Ts: past, Subject: "old"})
+	f.Record(Event{Type: BeadCreated, Ts: future, Subject: "new"})
+
+	got, err := f.List(Filter{Until: cutoff})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].Subject != "old" {
+		t.Errorf("List(Until:cutoff) = %v, want 1 old event", got)
+	}
+}
+
+// --- CountByType ---
+
+func TestCountByType_Empty(t *testing.T) {
+	counts := CountByType(nil)
+	if len(counts) != 0 {
+		t.Errorf("CountByType(nil) = %v, want empty map", counts)
+	}
+}
+
+func TestCountByType(t *testing.T) {
+	evts := []Event{
+		{Type: BeadCreated},
+		{Type: BeadCreated},
+		{Type: BeadClosed},
+		{Type: SessionWoke},
+	}
+	counts := CountByType(evts)
+	if counts[BeadCreated] != 2 {
+		t.Errorf("CountByType[BeadCreated] = %d, want 2", counts[BeadCreated])
+	}
+	if counts[BeadClosed] != 1 {
+		t.Errorf("CountByType[BeadClosed] = %d, want 1", counts[BeadClosed])
+	}
+	if counts[SessionWoke] != 1 {
+		t.Errorf("CountByType[SessionWoke] = %d, want 1", counts[SessionWoke])
+	}
+}
+
+// --- CountByActor ---
+
+func TestCountByActor_Empty(t *testing.T) {
+	counts := CountByActor(nil)
+	if len(counts) != 0 {
+		t.Errorf("CountByActor(nil) = %v, want empty map", counts)
+	}
+}
+
+func TestCountByActor(t *testing.T) {
+	evts := []Event{
+		{Actor: "mayor"},
+		{Actor: "mayor"},
+		{Actor: "worker"},
+	}
+	counts := CountByActor(evts)
+	if counts["mayor"] != 2 {
+		t.Errorf("CountByActor[mayor] = %d, want 2", counts["mayor"])
+	}
+	if counts["worker"] != 1 {
+		t.Errorf("CountByActor[worker] = %d, want 1", counts["worker"])
+	}
+}
+
+// --- CountBySubject ---
+
+func TestCountBySubject_Empty(t *testing.T) {
+	counts := CountBySubject(nil)
+	if len(counts) != 0 {
+		t.Errorf("CountBySubject(nil) = %v, want empty map", counts)
+	}
+}
+
+func TestCountBySubject(t *testing.T) {
+	evts := []Event{
+		{Subject: "gc-1"},
+		{Subject: "gc-1"},
+		{Subject: "gc-2"},
+		{Subject: ""},
+	}
+	counts := CountBySubject(evts)
+	if counts["gc-1"] != 2 {
+		t.Errorf("CountBySubject[gc-1] = %d, want 2", counts["gc-1"])
+	}
+	if counts["gc-2"] != 1 {
+		t.Errorf("CountBySubject[gc-2] = %d, want 1", counts["gc-2"])
+	}
+	if counts[""] != 1 {
+		t.Errorf("CountBySubject[\"\"] = %d, want 1 (no-subject events)", counts[""])
+	}
+}

--- a/internal/events/query_test.go
+++ b/internal/events/query_test.go
@@ -8,7 +8,7 @@ import (
 // --- matchesFilter unit tests ---
 
 func TestMatchesFilter_Subject(t *testing.T) {
-	e := Event{Type: BeadCreated, Actor: "mayor", Subject: "gc-42"}
+	e := Event{Type: BeadCreated, Actor: "actor-a", Subject: "gc-42"}
 
 	if !matchesFilter(e, Filter{Subject: "gc-42"}) {
 		t.Error("expected match on Subject gc-42")
@@ -36,11 +36,11 @@ func TestMatchesFilter_Until(t *testing.T) {
 	}
 }
 
-func TestMatchesFilter_Limit_AppliedByReadFiltered(t *testing.T) {
+func TestFakeList_Limit(t *testing.T) {
 	// Create a fake with 5 events and request only 3.
 	f := NewFake()
 	for i := 0; i < 5; i++ {
-		f.Record(Event{Type: BeadCreated, Actor: "worker"})
+		f.Record(Event{Type: BeadCreated, Actor: "actor-a"})
 	}
 
 	got, err := f.List(Filter{Limit: 3})
@@ -124,16 +124,16 @@ func TestCountByActor_Empty(t *testing.T) {
 
 func TestCountByActor(t *testing.T) {
 	evts := []Event{
-		{Actor: "mayor"},
-		{Actor: "mayor"},
-		{Actor: "worker"},
+		{Actor: "actor-a"},
+		{Actor: "actor-a"},
+		{Actor: "actor-b"},
 	}
 	counts := CountByActor(evts)
-	if counts["mayor"] != 2 {
-		t.Errorf("CountByActor[mayor] = %d, want 2", counts["mayor"])
+	if counts["actor-a"] != 2 {
+		t.Errorf("CountByActor[actor-a] = %d, want 2", counts["actor-a"])
 	}
-	if counts["worker"] != 1 {
-		t.Errorf("CountByActor[worker] = %d, want 1", counts["worker"])
+	if counts["actor-b"] != 1 {
+		t.Errorf("CountByActor[actor-b] = %d, want 1", counts["actor-b"])
 	}
 }
 

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -14,8 +14,11 @@ import (
 type Filter struct {
 	Type     string    // match events with this Type
 	Actor    string    // match events with this Actor
+	Subject  string    // match events with this Subject
 	Since    time.Time // match events at or after this time
+	Until    time.Time // match events at or before this time
 	AfterSeq uint64    // match events with Seq > AfterSeq (0 = no filter)
+	Limit    int       // cap results at this count (0 = unlimited)
 }
 
 // ReadAll reads all events from the JSONL file at path.
@@ -59,6 +62,9 @@ func ReadFiltered(path string, filter Filter) ([]Event, error) {
 	for _, e := range all {
 		if eventMatchesFilter(e, filter) {
 			result = append(result, e)
+			if filter.Limit > 0 && len(result) >= filter.Limit {
+				break
+			}
 		}
 	}
 	return result, nil
@@ -147,10 +153,22 @@ func eventMatchesFilter(e Event, filter Filter) bool {
 	if filter.Actor != "" && e.Actor != filter.Actor {
 		return false
 	}
+	if filter.Subject != "" && e.Subject != filter.Subject {
+		return false
+	}
 	if !filter.Since.IsZero() && e.Ts.Before(filter.Since) {
 		return false
 	}
+	if !filter.Until.IsZero() && e.Ts.After(filter.Until) {
+		return false
+	}
 	return true
+}
+
+// matchesFilter reports whether e satisfies all non-zero predicates in f.
+// It does not enforce Limit; callers apply that after appending matches.
+func matchesFilter(e Event, f Filter) bool {
+	return eventMatchesFilter(e, f)
 }
 
 // ReadLatestSeq returns the latest complete event Seq in the events file, or

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -95,7 +95,8 @@ func ReadAll(path string) ([]Event, error) {
 
 // ReadFiltered reads events from path and returns only those matching
 // all non-zero fields in filter. Returns (nil, nil) if the file is
-// missing or empty.
+// missing or empty. Scanner errors return the events parsed before the
+// error alongside the error.
 func ReadFiltered(path string, filter Filter) ([]Event, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -199,10 +200,6 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 		reversed[i], reversed[j] = reversed[j], reversed[i]
 	}
 	return reversed, nil
-}
-
-func eventMatchesFilter(e Event, filter Filter) bool {
-	return matchesFilter(e, filter)
 }
 
 // ReadLatestSeq returns the latest complete event Seq in the events file, or

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -18,7 +18,51 @@ type Filter struct {
 	Since    time.Time // match events at or after this time
 	Until    time.Time // match events at or before this time
 	AfterSeq uint64    // match events with Seq > AfterSeq (0 = no filter)
-	Limit    int       // cap results at this count (0 = unlimited)
+	Limit    int       // cap results at this count (0 or negative = unlimited)
+}
+
+// matchesFilter reports whether e satisfies all non-zero predicates in f.
+// It does not enforce Limit — that is applied by the caller.
+func matchesFilter(e Event, f Filter) bool {
+	if f.AfterSeq > 0 && e.Seq <= f.AfterSeq {
+		return false
+	}
+	if f.Type != "" && e.Type != f.Type {
+		return false
+	}
+	if f.Actor != "" && e.Actor != f.Actor {
+		return false
+	}
+	if f.Subject != "" && e.Subject != f.Subject {
+		return false
+	}
+	if !f.Since.IsZero() && e.Ts.Before(f.Since) {
+		return false
+	}
+	if !f.Until.IsZero() && e.Ts.After(f.Until) {
+		return false
+	}
+	return true
+}
+
+// ApplyFilter returns events matching all non-zero predicates in filter.
+// It preserves input order and applies a positive Limit after matching.
+func ApplyFilter(evts []Event, filter Filter) []Event {
+	var result []Event
+	for _, e := range evts {
+		if !matchesFilter(e, filter) {
+			continue
+		}
+		result = append(result, e)
+		if limitReached(len(result), filter) {
+			break
+		}
+	}
+	return result
+}
+
+func limitReached(count int, filter Filter) bool {
+	return filter.Limit > 0 && count >= filter.Limit
 }
 
 // ReadAll reads all events from the JSONL file at path.
@@ -53,19 +97,33 @@ func ReadAll(path string) ([]Event, error) {
 // all non-zero fields in filter. Returns (nil, nil) if the file is
 // missing or empty.
 func ReadFiltered(path string, filter Filter) ([]Event, error) {
-	all, err := ReadAll(path)
+	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading events: %w", err)
 	}
+	defer f.Close() //nolint:errcheck // read-only file
 
 	var result []Event
-	for _, e := range all {
-		if eventMatchesFilter(e, filter) {
-			result = append(result, e)
-			if filter.Limit > 0 && len(result) >= filter.Limit {
-				break
-			}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // handle lines up to 1MB
+	for scanner.Scan() {
+		var e Event
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue // skip malformed lines
 		}
+		if !matchesFilter(e, filter) {
+			continue
+		}
+		result = append(result, e)
+		if limitReached(len(result), filter) {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return result, fmt.Errorf("scanning events: %w", err)
 	}
 	return result, nil
 }
@@ -131,7 +189,7 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 			if err := json.Unmarshal(line, &e); err != nil {
 				continue
 			}
-			if eventMatchesFilter(e, filter) {
+			if matchesFilter(e, filter) {
 				reversed = append(reversed, e)
 			}
 		}
@@ -144,31 +202,7 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 }
 
 func eventMatchesFilter(e Event, filter Filter) bool {
-	if filter.AfterSeq > 0 && e.Seq <= filter.AfterSeq {
-		return false
-	}
-	if filter.Type != "" && e.Type != filter.Type {
-		return false
-	}
-	if filter.Actor != "" && e.Actor != filter.Actor {
-		return false
-	}
-	if filter.Subject != "" && e.Subject != filter.Subject {
-		return false
-	}
-	if !filter.Since.IsZero() && e.Ts.Before(filter.Since) {
-		return false
-	}
-	if !filter.Until.IsZero() && e.Ts.After(filter.Until) {
-		return false
-	}
-	return true
-}
-
-// matchesFilter reports whether e satisfies all non-zero predicates in f.
-// It does not enforce Limit; callers apply that after appending matches.
-func matchesFilter(e Event, f Filter) bool {
-	return eventMatchesFilter(e, f)
+	return matchesFilter(e, filter)
 }
 
 // ReadLatestSeq returns the latest complete event Seq in the events file, or


### PR DESCRIPTION
## Summary

- Adds three new `Filter` fields (`Subject`, `Until`, `Limit`) that are zero-value no-ops for backward compatibility
- Extracts `matchesFilter()` as a shared predicate to prevent drift between `ReadFiltered` and `Fake.List`
- Adds three pure aggregation helpers: `CountByType`, `CountByActor`, `CountBySubject`

## Motivation

The existing `Filter` covered type, actor, and time lower-bound. The common diagnostic queries that were missing:

| Query | Before | After |
|---|---|---|
| All events for bead gc-42 | Manual loop | `Filter{Subject: "gc-42"}` |
| Events in time window | Manual loop | `Filter{Since: s, Until: u}` |
| First N matches | Manual slice | `Filter{Limit: 10}` |
| Event type histogram | Manual loop | `CountByType(evts)` |
| Per-bead event counts | Manual loop | `CountBySubject(evts)` |

## New files

| File | Purpose |
|---|---|
| `internal/events/query.go` | `CountByType`, `CountByActor`, `CountBySubject` |
| `internal/events/query_test.go` | 11 tests for all new filter predicates and count helpers |
| `engdocs/architecture/event-query.md` | Filter reference, usage examples, implementation notes |

## Modified files

| File | Change |
|---|---|
| `internal/events/reader.go` | `Filter` + `Subject`/`Until`/`Limit`; `matchesFilter` helper; `ReadFiltered` refactored |
| `internal/events/fake.go` | `Fake.List` uses `matchesFilter` + applies `Limit` |

Related: #488, #1184.

## Testing

- [x] `go test ./internal/events/` — all 11 new tests pass, existing suite clean
- [x] `golangci-lint run ./internal/events/...` — 0 issues
- [x] `internal/events/exec` test failures are pre-existing on `main` (require an external event provider script not present in CI) — not caused by this PR

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #488, #1184.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

🧙 Built with [WOZCODE](https://wozcode.com)
