### PR TITLE
feat(formula): add step-level provider hint field

### DIFF
--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -411,6 +411,15 @@ func flattenSteps(steps []*Step, parentID string, idMapping map[string]string, o
 			rs.Labels = append(rs.Labels, "gate:"+step.WaitsFor)
 		}
 
+		// Inject provider hint into metadata so the runtime can route to a
+		// matching agent without inspecting the formula layer.
+		if step.Provider != "" {
+			if rs.Metadata == nil {
+				rs.Metadata = make(map[string]string)
+			}
+			rs.Metadata["gc.provider"] = step.Provider
+		}
+
 		*out = append(*out, rs)
 
 		// Ralph-generated graph nodes intentionally avoid parent-child semantics.

--- a/internal/formula/expand.go
+++ b/internal/formula/expand.go
@@ -256,6 +256,7 @@ func expandStep(target *Step, template []*Step, depth int, vars map[string]strin
 		expanded.Description = substituteVars(substituteTargetPlaceholders(tmpl.Description, target), vars)
 		expanded.Notes = substituteVars(substituteTargetPlaceholders(tmpl.Notes, target), vars)
 		expanded.Assignee = substituteVars(tmpl.Assignee, vars)
+		expanded.Provider = substituteVars(tmpl.Provider, vars)
 		// Keep condition expressions intact for the normal condition-filtering
 		// pass, which understands the {{var}} syntax. Eager single-brace var
 		// substitution here can corrupt "!{{flag}}" into "!{value}".

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1,6 +1,7 @@
 package formula
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -2853,5 +2854,95 @@ title = "Test"
 		if v.Description != "A required variable" {
 			t.Errorf("required_var.Description = %q, want 'A required variable'", v.Description)
 		}
+	}
+}
+
+// --- Provider field tests ---
+
+func TestParseProvider_TOML(t *testing.T) {
+	src := `
+formula = "mol-vote"
+version  = 1
+type     = "workflow"
+contract = "graph.v2"
+
+[[steps]]
+id       = "ask"
+title    = "Ask voter"
+provider = "groq"
+`
+	p := NewParser()
+	f, err := p.ParseTOML([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseTOML: %v", err)
+	}
+	if len(f.Steps) == 0 {
+		t.Fatal("expected steps")
+	}
+	if f.Steps[0].Provider != "groq" {
+		t.Errorf("Provider = %q, want %q", f.Steps[0].Provider, "groq")
+	}
+}
+
+func TestValidate_ProviderValid(t *testing.T) {
+	f := &Formula{
+		Formula: "mol-vote",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{ID: "ask", Title: "Ask voter", Provider: "cerebras"},
+		},
+	}
+	if err := f.Validate(); err != nil {
+		t.Errorf("valid provider should pass: %v", err)
+	}
+}
+
+func TestValidate_ProviderWithWhitespace(t *testing.T) {
+	f := &Formula{
+		Formula: "mol-vote",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Steps: []*Step{
+			{ID: "ask", Title: "Ask voter", Provider: "groq cerebras"},
+		},
+	}
+	if err := f.Validate(); err == nil {
+		t.Error("provider with whitespace should fail validation")
+	}
+}
+
+func TestCompile_ProviderInjectsGCMetadata(t *testing.T) {
+	SetFormulaV2Enabled(true)
+	t.Cleanup(func() { SetFormulaV2Enabled(false) })
+
+	src := `
+formula  = "mol-vote"
+version  = 1
+type     = "workflow"
+contract = "graph.v2"
+
+[[steps]]
+id       = "ask"
+title    = "Ask voter"
+provider = "groq"
+`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mol-vote.toml"), []byte(src), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	r, err := Compile(context.Background(), "mol-vote", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	var found bool
+	for _, step := range r.Steps {
+		if step.Metadata["gc.provider"] == "groq" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected gc.provider=groq in compiled recipe metadata")
 	}
 }

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -291,6 +291,13 @@ type Step struct {
 	// Overrides DefaultGateTimeout (5m) unless check.timeout is set.
 	Timeout string `json:"timeout,omitempty" toml:"timeout,omitempty"`
 
+	// Provider hints which inference provider should handle this step.
+	// Must match a provider name registered in the workspace (e.g., "groq",
+	// "cerebras", "claude"). The runtime resolves this hint to a concrete
+	// agent assignment via the gc.provider metadata key. Unset means the
+	// step inherits the agent that owns the workflow.
+	Provider string `json:"provider,omitempty" toml:"provider,omitempty"`
+
 	// Source tracing fields: track where this step came from.
 	// These are set during parsing/transformation and copied to Issues during cooking.
 
@@ -398,6 +405,7 @@ type stepTOMLAlias struct {
 	Ralph           json.RawMessage   `json:"ralph,omitempty"`
 	Retry           *RetrySpec        `json:"retry,omitempty"`
 	Timeout         string            `json:"timeout,omitempty"`
+	Provider        string            `json:"provider,omitempty"`
 }
 
 type loopTOMLAlias struct {
@@ -472,6 +480,7 @@ func (a stepTOMLAlias) toStep() (Step, error) {
 		Ralph:           ralph,
 		Retry:           a.Retry,
 		Timeout:         a.Timeout,
+		Provider:        a.Provider,
 	}, nil
 }
 
@@ -1054,6 +1063,12 @@ func (f *Formula) Validate() error {
 		if step.OnComplete != nil {
 			validateOnComplete(step.OnComplete, &errs, fmt.Sprintf("steps[%d] (%s)", i, step.ID))
 		}
+		// Validate provider field
+		if step.Provider != "" {
+			if err := validateProvider(step.Provider); err != nil {
+				errs = append(errs, fmt.Sprintf("steps[%d] (%s): provider: %s", i, step.ID, err.Error()))
+			}
+		}
 		// Validate children's depends_on and needs recursively
 		validateChildDependsOn(step.Children, stepIDLocations, &errs, fmt.Sprintf("steps[%d]", i))
 	}
@@ -1281,6 +1296,16 @@ func validateWaitsFor(value string, stepIDLocations map[string]string) error {
 	}
 
 	return fmt.Errorf("waits_for has invalid value %q (must be all-children, any-children, or children-of(step-id))", value)
+}
+
+// validateProvider checks that a provider hint is syntactically valid.
+// It does not verify that the named provider is registered in the workspace —
+// that check happens at dispatch time via the gc.provider metadata key.
+func validateProvider(name string) error {
+	if strings.ContainsAny(name, " \t\n\r") {
+		return fmt.Errorf("must not contain whitespace")
+	}
+	return nil
 }
 
 // validateChildDependsOn recursively validates depends_on and needs references for children.


### PR DESCRIPTION
## Summary

- Adds `provider string` to `Formula.Step` (TOML/JSON: `provider = "groq"`).
- During compilation, a non-empty provider is written as `gc.provider` in the `RecipeStep.Metadata` map.
- Variable substitution is applied so `provider = "{{provider}}"` works in template formulas.
- Validation rejects providers with embedded whitespace; runtime provider-list enforcement is deferred to dispatch time to avoid import cycles.

## Motivation

Fast inference providers (Groq, Cerebras) have dramatically lower latency for swarm consensus workloads. Without a per-step hint, the only way to route to a specific provider is a separate formula per provider, which explodes the formula count for N-voter swarms.

Related: #321, #1184.

## Testing

- [x] `TestParseProvider_TOML` — round-trips `provider = "groq"` through TOML parser.
- [x] `TestValidate_ProviderValid` — `cerebras` passes validation.
- [x] `TestValidate_ProviderWithWhitespace` — `"groq cerebras"` fails validation.
- [x] `TestCompile_ProviderInjectsGCMetadata` — `gc.provider=groq` appears in compiled recipe metadata.
- [x] `go test ./internal/formula/...`

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #321, #1184.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

🧙 Built with [WOZCODE](https://wozcode.com)
