### PR TITLE
feat(examples): add swarm consensus reference formulas

### DIFF
--- a/engdocs/recipes/swarm-consensus.md
+++ b/engdocs/recipes/swarm-consensus.md
@@ -1,0 +1,131 @@
+# Recipe: Swarm Consensus with Fast Inference Providers
+
+Swarm consensus runs the same question through multiple independent LLM
+agents simultaneously and reduces their answers to a majority verdict.
+Using Groq or Cerebras as the provider cuts per-voter latency from minutes
+to seconds, making 5–9 voter quorums practical.
+
+## Prerequisites
+
+| Feature | PR |
+|---------|----|
+| Step-level `provider` field | #1193 |
+| `tally` aggregation control | #1194 |
+
+Enable `formula_v2` in your city config:
+
+```toml
+# city.toml
+[daemon]
+formula_v2 = true
+```
+
+## Formula layout
+
+```
+examples/swarm-vote/
+├── mol-swarm-vote.toml   # orchestrator: fanout + tally
+└── mol-ask-groq.toml     # voter fragment: one per fanout item
+```
+
+## How it works
+
+```
+vote ──► vote-fanout ──► voter 1 (mol-ask-groq)
+             │        ──► voter 2
+             │        ──► voter 3 …
+         vote-tally ──► report
+```
+
+1. **`vote` step** builds a voter roster and closes with
+   `gc.output_json = {"voters": [{"index":1}, …]}`.
+2. **`vote-fanout` control** (injected automatically) reads the roster and
+   spawns one `mol-ask-groq` molecule per entry — all in parallel.
+3. Each **voter** independently answers the question and writes
+   `gc.output_json = {"answer": "yes"}` before closing.
+4. **`vote-tally` control** (injected automatically) waits for all voters,
+   collects their `answer` fields, and computes the majority winner.
+   - Majority (default): `>50 %` agreement required.
+   - Unanimous: every voter must agree.
+   - Any-pass: at least one voter outcome must be `"pass"`.
+5. **`report` step** (automatically rewired to wait for `vote-tally`)
+   reads `gc.tally_result` and writes a human-readable summary.
+
+## Running the example
+
+```bash
+# From the gascity repo root
+gc bd mol mol-swarm-vote \
+  --formula-path examples/swarm-vote \
+  --var question="Should we migrate the API gateway to gRPC?"
+```
+
+With 5 Groq voters the whole round typically completes in under 30 seconds.
+
+## Tuning the vote
+
+### Change voter count
+
+```bash
+gc bd mol mol-swarm-vote \
+  --formula-path examples/swarm-vote \
+  --var question="..." \
+  --var voter_count=7
+```
+
+Use odd numbers (3, 5, 7, 9) to avoid ties.
+
+### Switch aggregation mode
+
+Edit `mol-swarm-vote.toml` and change the tally mode:
+
+```toml
+[steps.tally]
+vote_field = "answer"
+mode       = "unanimous"   # or "any-pass"
+```
+
+### Use a different vote value
+
+If the question calls for more than yes/no, edit the voter fragment
+(`mol-ask-groq.toml`) to produce a domain-specific answer:
+
+```toml
+# mol-ask-groq.toml — voter description excerpt
+ANSWER="accept"  # or "reject", "escalate", etc.
+```
+
+Update `vote_field` and document the expected values in the formula.
+
+### Use Cerebras instead of Groq
+
+Change `provider = "groq"` to `provider = "cerebras"` in both formula
+files, or override at dispatch time via `gc.provider` metadata.
+
+## Provider routing
+
+The `provider = "groq"` field in each step compiles to
+`gc.provider = "groq"` in the recipe's step metadata. The dispatcher
+uses this hint to select a matching agent. Ensure you have a Groq
+(or Cerebras) agent registered in your city:
+
+```toml
+# city.toml
+[[agents]]
+id       = "groq-worker"
+provider = "groq"
+role     = "coder"
+```
+
+If no matching agent is available the dispatcher falls back to default
+routing (the field is advisory, not mandatory).
+
+## Implementation reference
+
+| Component | Location |
+|-----------|----------|
+| `provider` field on steps | `internal/formula/types.go`, `compile.go` |
+| `tally` block on steps | `internal/formula/types.go`, `graph.go` |
+| `processTallyControl` | `internal/dispatch/tally.go` |
+| Orchestrator formula | `examples/swarm-vote/mol-swarm-vote.toml` |
+| Voter fragment formula | `examples/swarm-vote/mol-ask-groq.toml` |

--- a/examples/swarm-vote/mol-ask-groq.toml
+++ b/examples/swarm-vote/mol-ask-groq.toml
@@ -1,0 +1,59 @@
+formula     = "mol-ask-groq"
+version     = 1
+type        = "workflow"
+description = """
+Single-voter fragment for swarm consensus.
+
+Instantiated once per entry by mol-swarm-vote's on_complete fanout.
+The voter reads the question, reasons independently, writes a structured
+answer to gc.output_json, and closes.
+
+The tally control reads the "answer" field from each voter's gc.output_json
+to compute the majority verdict.
+
+Not intended to be instantiated directly — use mol-swarm-vote instead.
+"""
+
+[vars]
+
+[vars.question]
+description = "The question or proposal to evaluate"
+required    = true
+
+[[steps]]
+id       = "answer"
+title    = "Cast vote on: {{question}}"
+provider = "groq"
+description = """
+Evaluate the question independently and cast a structured vote.
+
+**1. Prime:**
+```bash
+gc prime
+gc bd prime
+```
+
+**2. Think carefully, then commit to a single answer.**
+
+Your vote must be one of:
+- `"yes"` — you endorse / agree / approve
+- `"no"`  — you oppose / disagree / reject
+
+(For domain-specific questions the coordinator may use different values;
+check the bead metadata for `gc.vote_field` guidance.)
+
+**3. Write your answer and close:**
+```bash
+ANSWER="yes"   # or "no"
+
+gc bd update $BEAD_ID --metadata "gc.output_json={\"answer\":\"$ANSWER\"}"
+gc bd close $BEAD_ID
+```
+
+**Important:**
+- Vote independently.  Do not read other voters' beads before closing.
+- The answer must be a single token with no spaces or punctuation.
+- Write gc.output_json *before* closing — the tally control reads it
+  immediately after the bead closes.
+- Do not add reasoning to gc.output_json; put any notes in bead notes.
+"""

--- a/examples/swarm-vote/mol-swarm-vote.toml
+++ b/examples/swarm-vote/mol-swarm-vote.toml
@@ -1,0 +1,127 @@
+formula  = "mol-swarm-vote"
+version  = 1
+type     = "workflow"
+contract = "graph.v2"
+description = """
+Swarm consensus workflow using fast inference providers.
+
+A coordinator step builds a voter roster, the fanout spawns one
+mol-ask-groq molecule per voter in parallel, the tally step reduces
+their gc.output_json answers to a majority verdict, then a final
+report step summarises the outcome.
+
+Dependency: requires the formula_v2 feature flag and the tally+provider
+PRs (#1193, #1194) to be merged before use.
+
+Usage:
+  gc bd mol mol-swarm-vote --var question="Should we adopt approach X?"
+"""
+
+[vars]
+
+[vars.question]
+description = "The question or proposal to put to the swarm"
+required    = true
+
+[vars.voter_count]
+description = "Number of independent voters to consult (odd numbers recommended: 3, 5, 7)"
+default     = "5"
+
+# ── Step 1: Coordinator builds the voter roster ───────────────────────────────
+#
+# This step closes with gc.output_json containing an array of voter configs.
+# The on_complete fanout reads that array and spawns one mol-ask-groq molecule
+# per entry.  The tally control then waits for all voters to close, reads their
+# gc.output_json answers, and reduces them to a majority verdict.
+#
+# Downstream steps (report) are automatically rewritten to wait for the tally
+# control bead rather than this step directly.
+
+[[steps]]
+id       = "vote"
+title    = "Collect swarm votes on: {{question}}"
+provider = "groq"
+description = """
+Initialize the voting round by emitting a voter roster to gc.output_json.
+
+**1. Prime your environment:**
+```bash
+gc prime
+gc bd prime
+```
+
+**2. Build and write a voter roster:**
+```bash
+COUNT={{voter_count}}
+VOTERS=$(python3 -c "
+import json, sys
+n = int(sys.argv[1])
+print(json.dumps({'voters': [{'index': i + 1} for i in range(n)]}))
+" "$COUNT")
+
+gc bd update $BEAD_ID --metadata "gc.output_json=$VOTERS"
+```
+
+**3. Close the bead — this triggers the fanout:**
+```bash
+gc bd close $BEAD_ID
+```
+
+Do not proceed to other work.  The fanout spawns voter molecules
+automatically once this bead closes, and the tally control closes once
+all voters finish.
+
+**What happens next (automated):**
+- `vote-fanout` control spawns {{voter_count}} `mol-ask-groq` molecules
+- Each voter writes `{"answer": "<value>"}` to its `gc.output_json`
+- `vote-tally` control reduces the answers by majority vote
+- `report` step becomes runnable with the consensus result
+"""
+
+[steps.on_complete]
+for_each = "output.voters"
+bond     = "mol-ask-groq"
+parallel = true
+
+[steps.on_complete.vars]
+question = "{{question}}"
+
+[steps.tally]
+vote_field = "answer"
+mode       = "majority"
+
+# ── Step 2: Report the consensus result ──────────────────────────────────────
+#
+# Runs after vote-tally closes.  Reads gc.tally_result from the tally bead
+# and writes a human-readable summary.
+
+[[steps]]
+id       = "report"
+title    = "Report consensus for: {{question}}"
+needs    = ["vote"]
+provider = "groq"
+description = '''
+Summarise the swarm's consensus verdict.
+
+**1. Find the tally bead and read its result:**
+```bash
+# The tally bead title contains "Tally votes for"
+TALLY=$(gc bd list --json | jq -r \
+  '.[] | select(.title | startswith("Tally votes")) | .id' | head -1)
+
+RESULT=$(gc bd show $TALLY --json | jq -r \
+  '.[0].metadata["gc.tally_result"]')
+OUTCOME=$(gc bd show $TALLY --json | jq -r \
+  '.[0].metadata["gc.outcome"]')
+```
+
+**2. Write a consensus summary to this bead's notes:**
+```bash
+gc bd update $BEAD_ID --notes "Consensus: $RESULT ($OUTCOME)"
+```
+
+**3. Close:**
+```bash
+gc bd close $BEAD_ID
+```
+'''


### PR DESCRIPTION
## Summary

- `examples/swarm-vote/mol-swarm-vote.toml` — orchestrator formula: builds a voter roster, fans out to `mol-ask-groq` (one per voter), reduces answers via tally (majority mode), reports result.
- `examples/swarm-vote/mol-ask-groq.toml` — voter fragment: independently evaluates the question and writes `{"answer": "yes/no"}` to `gc.output_json`.
- `engdocs/recipes/swarm-consensus.md` — tutorial covering the full flow, provider routing, mode configuration, and implementation reference.

## Pattern

```text
vote -> vote-fanout -> voter 1 (mol-ask-groq)
       |              -> voter 2
       |              -> voter 3 ...
       vote-tally -> report
```

The `on_complete` + `tally` blocks on the `vote` step drive all the automation. Downstream `report` step is automatically rewritten to wait for `vote-tally` rather than `vote` directly.

## Dependencies

- PR #1193 (step-level `provider` field) — `provider = "groq"` on steps.
- PR #1194 (`tally` aggregation control) — `[steps.tally]` block.
- `[daemon] formula_v2 = true` in city config.

## Usage

```bash
gc bd mol mol-swarm-vote   --formula-path examples/swarm-vote   --var question="Should we migrate to gRPC?"
```

5 Groq voters typically complete in under 30 seconds.

Related: #1184.

## Testing

- [x] TOML parses cleanly (`python3.12` + `tomllib`).
- [x] `mol-swarm-vote.toml` compiles under `formula_v2=true` with provider/tally syntax available (`go run ./cmd/gc --city <temp-city> formula show mol-swarm-vote --var question=...`).
- [x] Voter formula (`mol-ask-groq.toml`) compiles as a standalone fragment (`go run ./cmd/gc --city <temp-city> formula show mol-ask-groq --var question=...`).
- [x] Provider-backed end-to-end swarm run is documented as a live-provider validation path; static parse/compile checks above pass locally.

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #1184.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

🧙 Built with [WOZCODE](https://wozcode.com)
