### PR TITLE
tune dolt-gc-nudge: unconditional GC every 1h (perf evidence)

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -85,13 +85,17 @@ If GC finishes but the size barely moves, the chunks are nearly all live
   floor; newer releases ship improved auto-GC
   heuristics and default archive compression.
 - **Let the dolt pack's `dolt-gc-nudge` order run continuously.** It
-  ships embedded in the dolt pack and fires every 6h by default. The
-  nudge catches the "bloated-but-stable" corner case where no single
-  write burst crosses Dolt's 125 MB auto-GC threshold. To opt out on a
-  given city, add `dolt-gc-nudge` to the city's `[orders] skip = [...]`
-  list (or to a rig-level `[[order.override]]`). Tune the trigger size
-  via the `GC_DOLT_GC_THRESHOLD_BYTES` environment variable
-  (default: 2 GiB) in the city's environment.
+  ships embedded in the dolt pack and fires `CALL DOLT_GC()` every 1h
+  by default, unconditionally. Empirical evidence (beads perf harness,
+  2026-04) shows Dolt's auto-GC does not fire under bd's fork-per-op
+  CLI workload even with `auto_gc_behavior.enable: true`, so the nudge
+  is the only mechanism bounding commit-graph growth. GC is idempotent
+  and near-free when there's nothing to reclaim, so running it every
+  hour is cheap. To opt out on a given city, add `dolt-gc-nudge` to the
+  city's `[orders] skip = [...]` list (or to a rig-level
+  `[[order.override]]`). To skip GC on small databases, set
+  `GC_DOLT_GC_THRESHOLD_BYTES` to a positive byte count in the city's
+  environment (default: 0 — run unconditionally).
 - **Mind `orders.max_timeout` if you set one.** The nudge order asks
   for a 24-hour timeout to accommodate serialized `CALL DOLT_GC()` runs
   on large stores. A city-level `orders.max_timeout` below 24h will cap the

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -1,16 +1,19 @@
 #!/bin/sh
-# gc dolt gc-nudge — Size-triggered CALL DOLT_GC() to compact a bloated
-# Dolt database.
+# gc dolt gc-nudge — periodic CALL DOLT_GC() to bound the Dolt commit graph.
 #
-# Why this exists: Dolt's auto-GC (default-on in 1.75+) fires on *growth*
-# — 125 MB delta since last GC. A database that bloated once and then
-# stabilized never auto-GCs on its own. This command closes that corner:
-# it checks disk size on each registered rig's Dolt database, and if any
-# are above the configured threshold, issues CALL DOLT_GC() against the
-# managed sql-server.
+# Why this exists: empirical evidence (beads perf harness, 2026-04) shows
+# Dolt's auto-GC does not fire under the beads-CLI fork-per-op workload even
+# with `auto_gc_behavior.enable: true`. Unbounded commit-graph growth causes
+# both disk bloat (~120 GB after a few days) and tail-latency degradation
+# (p99 at 143 MB of history → 16.9s, extrapolates to minutes at GB scale).
+# Manual CALL DOLT_GC() reclaims ~43% in seconds, so a periodic nudge is
+# both necessary and cheap.
 #
-# Runs from the dolt pack's dolt-gc-nudge order on a slow cooldown (6h by
-# default). Intended to be idempotent and cheap when nothing needs GC.
+# Policy: fire CALL DOLT_GC() unconditionally on every cooldown tick
+# (default 1h). The GC is idempotent and near-free when there's nothing
+# to reclaim. A threshold knob remains as an optional escape hatch.
+#
+# Runs from the dolt pack's dolt-gc-nudge order.
 #
 # Environment:
 #   GC_CITY_PATH         (required) — city root
@@ -19,8 +22,9 @@
 #   GC_DOLT_USER         (default: root)
 #   GC_DOLT_PASSWORD     (optional)
 #   GC_DOLT_GC_THRESHOLD_BYTES
-#     (default: 2147483648 = 2 GiB) — minimum .dolt/ size that triggers GC.
-#     Set to 0 to force GC on every tick (useful for tests).
+#     (default: 0 — run unconditionally). Set a positive byte count to
+#     skip GC on databases below that size; useful for test suites that
+#     don't want GC noise on tiny fixtures.
 #   GC_DOLT_GC_CALL_TIMEOUT_SECS
 #     (default: 1800) — wall-clock bound for one `CALL DOLT_GC()` invocation.
 #   GC_DOLT_GC_DRY_RUN   (optional) — when set, prints what would happen
@@ -90,7 +94,7 @@ fi
 : "${GC_DOLT_USER:=root}"
 
 host="${GC_DOLT_HOST:-127.0.0.1}"
-threshold="${GC_DOLT_GC_THRESHOLD_BYTES:-2147483648}"
+threshold="${GC_DOLT_GC_THRESHOLD_BYTES:-0}"
 gc_call_timeout="${GC_DOLT_GC_CALL_TIMEOUT_SECS:-1800}"
 dry_run="${GC_DOLT_GC_DRY_RUN:-}"
 

--- a/examples/dolt/orders/dolt-gc-nudge.toml
+++ b/examples/dolt/orders/dolt-gc-nudge.toml
@@ -1,6 +1,6 @@
 [order]
-description = "Size-triggered CALL DOLT_GC() when a Dolt database grows past threshold"
+description = "Periodic CALL DOLT_GC() to bound commit-graph size (Dolt's auto-GC doesn't fire on bd workloads)"
 trigger = "cooldown"
-interval = "6h"
+interval = "1h"
 exec = "gc dolt gc-nudge"
 timeout = "24h"


### PR DESCRIPTION
## Summary

- Change `dolt-gc-nudge` interval from **6h → 1h**
- Change default `GC_DOLT_GC_THRESHOLD_BYTES` from **2 GiB → 0** (run unconditionally; knob preserved as optional escape hatch)
- Update runbook + script comments with empirical evidence

## Why

A beads perf harness run (2026-04) shows Dolt's auto-GC **does not fire under bd's fork-per-op CLI workload** even with `auto_gc_behavior.enable: true` and the managed `config.yaml` we ship. Unbounded commit-graph growth causes two prod symptoms:

- Disk bloat — ~120 GB after a few days of agent work
- Tail latency — at 143 MB of accumulated history: **p99 = 16.9s, max = 18.6s**; cost scales roughly linearly with history size, extrapolating to multi-minute ops at GB scale

Manual `CALL DOLT_GC()` on a 148 MB store reclaims 43% in 4.6s, so a periodic nudge is both necessary and cheap.

The pre-tune defaults (2 GiB threshold + 6h cooldown) allow bloat to climb well into the tail-latency danger zone between nudges. At 1h unconditional GC, the commit graph stays bounded and p99 stays low.

## Test plan

- [x] `go test ./cmd/gc/ -run 'DoltGCNudge|Order'` passes locally (existing tests already set `GC_DOLT_GC_THRESHOLD_BYTES=0` explicitly, so no test changes needed)
- [ ] CI green
- [ ] Prod observation post-merge: `gc doctor` reports clean `dolt-noms-size` on cities that previously bloated

🤖 Generated with [Claude Code](https://claude.com/claude-code)