### PR TITLE
test(cmd/gc): clear inherited GC_BEADS env in city.toml test writers

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3828,11 +3828,13 @@ func TestCityRuntimeShutdownWarnsWhenSessionListingIsPartial(t *testing.T) {
 
 func writeCityRuntimeConfig(t *testing.T, tomlPath, provider string) {
 	t.Helper()
+	clearInheritedBeadsEnv(t)
 	writeCityRuntimeConfigNamed(t, tomlPath, "test-city", provider)
 }
 
 func writeCityRuntimeConfigNamed(t *testing.T, tomlPath, name, provider string) {
 	t.Helper()
+	clearInheritedBeadsEnv(t)
 	data := []byte("[workspace]\nname = \"" + name + "\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"" + provider + "\"\n")
 	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -3858,6 +3860,7 @@ func warningsContain(warnings []string, substr string) bool {
 
 func writeCityRuntimeConfigWithIncludes(t *testing.T, tomlPath string, includes []string) {
 	t.Helper()
+	clearInheritedBeadsEnv(t)
 	var quoted []string
 	for _, include := range includes {
 		quoted = append(quoted, fmt.Sprintf("%q", include))

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -378,6 +378,7 @@ func TestSendControllerCommandWithTimeoutsTimesOutOnRead(t *testing.T) {
 // writeCityTOML is a test helper that writes a city.toml with the given agents.
 func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...string) string {
 	t.Helper()
+	clearInheritedBeadsEnv(t)
 	tomlPath := filepath.Join(dir, "city.toml")
 	var buf bytes.Buffer
 	buf.WriteString("[workspace]\nname = " + `"` + cityName + `"` + "\n\n")
@@ -394,6 +395,7 @@ func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...stri
 
 func writeControllerNamedSessionCityTOML(t *testing.T, dir, cityName, mode, idleTimeout string) string {
 	t.Helper()
+	clearInheritedBeadsEnv(t)
 	tomlPath := filepath.Join(dir, "city.toml")
 	var buf bytes.Buffer
 	buf.WriteString("[workspace]\nname = " + `"` + cityName + `"` + "\n\n")

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -19,3 +19,27 @@ func shortSocketTempDir(t *testing.T, prefix string) string {
 	t.Helper()
 	return testutil.ShortTempDir(t, prefix)
 }
+
+// clearInheritedBeadsEnv prevents tests that explicitly write
+// [beads]\nprovider = "file" from being silently overridden by an agent
+// session's inherited GC_BEADS=bd, which would trigger gc-beads-bd.sh and
+// leak an orphan dolt sql-server because test cleanup paths do not call
+// shutdownBeadsProvider.
+func clearInheritedBeadsEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GC_BEADS",
+		"GC_DOLT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_PASSWORD",
+		"GC_BEADS_SCOPE_ROOT",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/release-gates/ga-onjy-gate.md
+++ b/release-gates/ga-onjy-gate.md
@@ -1,0 +1,78 @@
+# Release Gate — ga-onjy (clear inherited GC_BEADS env in test config writers)
+
+**Bead:** ga-onjy (review of ga-y64o)
+**Originating work:** ga-y64o — tests inherit `GC_BEADS=bd` from agent env, leaking orphan `dolt sql-server` processes
+**Branch:** `release/ga-onjy` — cherry-pick of `e16ccf1f` onto `origin/main`
+**Evaluator:** gascity/deployer on 2026-04-24
+**Verdict:** **PASS**
+
+## Deploy strategy note
+
+Single-bead deploy. The builder's source branch (`gc-builder-1-01561d4fb9ea`)
+carries unrelated in-flight work ahead of `origin/main`, so the gate uses the
+rollup-ship cherry-pick recipe to land just `e16ccf1f` on a fresh
+`release/ga-onjy` cut from `origin/main`. No `EXCLUDES` needed — the commit
+only touches three test files in `cmd/gc/`.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | ga-onjy notes: `Reviewer verdict: PASS` from `gascity/reviewer-1` on builder commit `e16ccf1f`. Rubric covered style, security (OWASP), spec compliance, coverage; "Findings: None". Mail `gm-wisp-syrr` (subject "ready for release gate") confirms handoff. Single-pass sufficient while gemini second-pass is disabled. |
+| 2 | Acceptance criteria met | PASS | `clearInheritedBeadsEnv(t)` helper added to `cmd/gc/path_helpers_test.go:22-45` — name, comment, 11-key env list, and loop body match the investigator spec byte-for-byte. All five required call sites updated: `writeCityRuntimeConfig`, `writeCityRuntimeConfigNamed`, `writeCityRuntimeConfigWithIncludes` in `cmd/gc/city_runtime_test.go`; `writeCityTOML`, `writeControllerNamedSessionCityTOML` in `cmd/gc/controller_test.go` (verified by `grep -rn 'clearInheritedBeadsEnv(t)' cmd/gc` → 5 hits). No new tests added — existing `TestCityRuntimeReload\|TestControllerReloads` regress-test the leak via pgrep delta. "Do not touch" list (`cr.shutdown`, `configuredBeadsProviderValue`, `gc-beads-bd.sh`) honored. |
+| 3 | Tests pass | PASS | `go vet ./...` clean. Targeted `go test ./cmd/gc/ -run 'TestCityRuntimeReload\|TestControllerReloads' -count=1` passes (0.309s) with `pgrep -af 'dolt sql-server.*--config /tmp/'` delta = 0 (19 → 19). Broader `cmd/gc/` suite shows 4 pre-existing failures unrelated to this change: `TestOpenStoreAtForCityExecProjectsConfiguredTargets`, `TestOpenStoreAtForCityExecBeadsBdProjectsScopedExternalDoltEnv`, `TestOpenStoreAtForCityExecUsesUniversalStoreTargetEnv`, `TestControllerQueryRuntimeEnvReturnsNilForNonBD`. Reproduced byte-for-byte on `origin/main` baseline (deployer re-ran with `git checkout origin/main -- cmd/gc/`); same four FAILs with identical messages. None of the 4 touch the env-clearing surface in this change. |
+| 4 | No high-severity review findings open | PASS | Zero HIGH findings. Reviewer notes "Findings: None". |
+| 5 | Final branch is clean | PASS | `git status` on tracked tree clean after the cherry-pick. Only `.gitkeep` untracked (pre-existing scaffold marker, unrelated). |
+| 6 | Branch diverges cleanly from main | PASS | 1 commit ahead of `origin/main` after cherry-pick (plus this gate commit once added). Cherry-pick of `e16ccf1f` applied with auto-merge of `cmd/gc/city_runtime_test.go`, no conflicts. |
+
+## Cherry-pick log
+
+| Source SHA | Branch SHA | Summary |
+|------------|------------|---------|
+| e16ccf1f | 97dee9e7 | test(cmd/gc): clear inherited GC_BEADS/dolt env in city.toml writers (ga-y64o) |
+
+No `EXCLUDES`. The commit touches only three test files; `issues.jsonl` is not in the diff.
+
+## Acceptance criteria — ga-y64o done-when
+
+- [x] `clearInheritedBeadsEnv` helper exists in a `_test.go` file in `cmd/gc/` (`cmd/gc/path_helpers_test.go:22-45`).
+- [x] All five test-config helpers call `clearInheritedBeadsEnv(t)` (verified via grep, 5 call sites).
+- [x] From an agent session with `GC_BEADS=bd` set, `go test ./cmd/gc/ -run "TestCityRuntimeReload|TestControllerReloads" -count=1` passes AND `pgrep -af 'dolt sql-server.*--config /tmp/'` count does not grow during the run (deployer measured 19 → 19).
+- [x] No new tests added unless they reproduce the leak — diff is +29/-0 across 3 files, no new `Test*` functions.
+- [x] `go vet ./...` clean. `go test ./cmd/gc/...` passes for everything not pre-existing-broken.
+
+## Test evidence
+
+```
+$ go vet ./...
+(clean)
+
+$ pgrep -af 'dolt sql-server.*--config /tmp/' | wc -l
+19
+
+$ go test ./cmd/gc/ -run 'TestCityRuntimeReload|TestControllerReloads' -count=1 -timeout 120s
+ok   github.com/gastownhall/gascity/cmd/gc   0.309s
+
+$ pgrep -af 'dolt sql-server.*--config /tmp/' | wc -l
+19
+
+$ go test ./cmd/gc/ -run 'TestCityRuntime|TestController|TestOpenStoreAt|TestPathHelpers' -count=1 -timeout 300s
+--- FAIL: TestOpenStoreAtForCityExecProjectsConfiguredTargets         (pre-existing on origin/main)
+--- FAIL: TestOpenStoreAtForCityExecBeadsBdProjectsScopedExternalDoltEnv (pre-existing on origin/main)
+--- FAIL: TestOpenStoreAtForCityExecUsesUniversalStoreTargetEnv       (pre-existing on origin/main)
+--- FAIL: TestControllerQueryRuntimeEnvReturnsNilForNonBD             (pre-existing on origin/main)
+FAIL   github.com/gastownhall/gascity/cmd/gc   110.166s
+
+$ git checkout origin/main -- cmd/gc/   # baseline check
+$ go test ./cmd/gc/ -run '<the 4 above>' -count=1 -timeout 120s
+--- FAIL: ... (same 4 fail identically — confirmed pre-existing)
+```
+
+## Pre-existing failures (not deploy blockers)
+
+The 4 failures listed above reproduce on `origin/main` baseline with byte-for-byte
+identical assertion messages. They concern store-target env file resolution
+(`store_target_exec_test.go`) and a controller-runtime-env probe
+(`work_query_probe_test.go:172`) — none touch `GC_BEADS` env clearing or the
+test-config writers modified by ga-y64o. Worth separate beads if not already
+tracked.


### PR DESCRIPTION
## What this changes

Tests under `cmd/gc/` that generate a `city.toml` containing
`[beads]\nprovider = "file"` were being silently overridden when run from
an agent session that sets `GC_BEADS=bd` in env.
`configuredBeadsProviderValue` in `cmd/gc/providers.go` checks the env
var **before** peeking at the generated `city.toml`, so the test got the
`bd` provider instead of `file`. That triggered `gc-beads-bd.sh`'s start
op, which spawns a detached `dolt sql-server`. Test teardown (`t.TempDir`
cleanup, `cr.shutdown()`) does not call `shutdownBeadsProvider`, so the
dolt was orphaned with a vanished config file — leaking 1-2 dolts per
affected test run on developer/CI machines.

This PR adds a `clearInheritedBeadsEnv(t)` test helper that
`t.Setenv`-clears `GC_BEADS`, `GC_DOLT*`, `BEADS_DOLT_*`, and
`GC_BEADS_SCOPE_ROOT` for the duration of the test, and calls it from
the five `city.toml` writers used by the affected tests
(`writeCityRuntimeConfig{,Named,WithIncludes}`, `writeCityTOML`,
`writeControllerNamedSessionCityTOML`).

After the change, the targeted suite leaks zero dolt processes per run.

## Why this design

- `t.Setenv("", "")` rather than direct unset → keeps Go's automatic
  per-test env restoration. Verified equivalent: every consumer
  (`providers.go`, `beads_provider_lifecycle.go`, `cmd_rig.go`) treats
  empty as unset (`strings.TrimSpace(...) != ""` or `== "skip"`).
- Clearing in the **writer helpers** rather than at every test site
  means no individual tests had to change. Five helpers cover every
  currently-leaking caller.
- Production code is unchanged. `cr.shutdown()` keeping its current
  behavior is intentional — `gc start`/`gc stop` are separate processes
  that each own half of the bead-provider lifecycle, and merging that
  into the in-process shutdown path would change production semantics.

## Review notes

- Test-only change. No production source files touched.
- Helper lives in `cmd/gc/path_helpers_test.go` next to the existing
  `shortSocketTempDir` helper.
- The reviewer flagged that `writeCityRuntimeConfig` already calls
  `writeCityRuntimeConfigNamed`, so `clearInheritedBeadsEnv` runs twice
  on that path. `t.Setenv` is idempotent, so this is intentional —
  direct callers of either helper get covered.
- The `cmd/gc/...` package has four pre-existing failures on
  `origin/main` (`TestOpenStoreAtForCityExec*`,
  `TestControllerQueryRuntimeEnvReturnsNilForNonBD`); they reproduce
  byte-for-byte on baseline and are documented in the gate checklist.
  None touch the env-clearing surface.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./cmd/gc/ -run 'TestCityRuntimeReload|TestControllerReloads' -count=1`
      passes (0.309s)
- [x] `pgrep -af 'dolt sql-server.*--config /tmp/'` delta = 0 across the
      targeted suite (19 → 19 on this machine)
- [x] 4 pre-existing failures in broader `cmd/gc/` suite reproduced on
      `origin/main` baseline — confirmed unrelated
- [x] Release gate: [`release-gates/ga-onjy-gate.md`](release-gates/ga-onjy-gate.md)

🤖 Deployed by actual-factory