### PR TITLE
fix: persist supervisor provider env vars

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -981,7 +981,7 @@ func passthroughEnv() map[string]string {
 	} else if home := os.Getenv("HOME"); home != "" {
 		m["XDG_STATE_HOME"] = filepath.Join(home, ".local", "state")
 	}
-	// Pass through all GC_* and ANTHROPIC_* vars. Agent credentials are
+	// Pass through GC_* vars and provider credential env. Agent credentials are
 	// included in the global baseline because the SDK cannot know which
 	// agent uses which provider (zero hardcoded roles); the trust boundary
 	// is the managed session itself.
@@ -990,7 +990,7 @@ func passthroughEnv() map[string]string {
 		if !ok || val == "" {
 			continue
 		}
-		if strings.HasPrefix(key, "GC_") || strings.HasPrefix(key, "ANTHROPIC_") {
+		if strings.HasPrefix(key, "GC_") || isProviderCredentialEnv(key) {
 			m[key] = val
 		}
 	}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -211,6 +211,32 @@ func TestPassthroughEnvIncludesClaudeAuthContext(t *testing.T) {
 	}
 }
 
+func TestPassthroughEnvIncludesProviderCredentialEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-123")
+	t.Setenv("OPENAI_API_KEY", "sk-openai-123")
+	t.Setenv("OPENAI_BASE_URL", "https://openai.example.test")
+	t.Setenv("GEMINI_API_KEY", "gemini-123")
+	t.Setenv("GOOGLE_API_KEY", "google-123")
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/google-credentials.json")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "gc-project")
+
+	got := passthroughEnv()
+
+	for key, want := range map[string]string{
+		"ANTHROPIC_API_KEY":              "sk-ant-123",
+		"OPENAI_API_KEY":                 "sk-openai-123",
+		"OPENAI_BASE_URL":                "https://openai.example.test",
+		"GEMINI_API_KEY":                 "gemini-123",
+		"GOOGLE_API_KEY":                 "google-123",
+		"GOOGLE_APPLICATION_CREDENTIALS": "/tmp/google-credentials.json",
+		"GOOGLE_CLOUD_PROJECT":           "gc-project",
+	} {
+		if got[key] != want {
+			t.Errorf("passthroughEnv()[%s] = %q, want %q", key, got[key], want)
+		}
+	}
+}
+
 func TestPassthroughEnvXDGFallbackFromHOME(t *testing.T) {
 	t.Setenv("HOME", "/tmp/gc-home")
 	// Explicitly unset XDG vars so fallback logic fires.

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -43,6 +43,8 @@ var (
 	}
 )
 
+const supervisorServiceFileMode os.FileMode = 0o600
+
 func newSupervisorRunCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "run",
@@ -592,6 +594,20 @@ func renderSupervisorTemplate(tmplStr string, data *supervisorServiceData) (stri
 	return buf.String(), nil
 }
 
+func writeSupervisorServiceFile(path string, content []byte) error {
+	if _, err := os.Stat(path); err == nil {
+		if err := os.Chmod(path, supervisorServiceFileMode); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.WriteFile(path, content, supervisorServiceFileMode); err != nil {
+		return err
+	}
+	return os.Chmod(path, supervisorServiceFileMode)
+}
+
 func supervisorLaunchdPlistPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
@@ -809,7 +825,7 @@ func rollbackNewSupervisorLaunchdInstall(path string, restoreLegacy bool) error 
 func restorePreviousSupervisorLaunchdInstall(path string, previousContent []byte) error {
 	var errs []error
 	_ = supervisorLaunchctlRun("unload", path)
-	if err := os.WriteFile(path, previousContent, 0o644); err != nil {
+	if err := writeSupervisorServiceFile(path, previousContent); err != nil {
 		errs = append(errs, fmt.Errorf("restoring previous plist %s: %w", path, err))
 	} else if err := supervisorLaunchctlRun("load", path); err != nil {
 		errs = append(errs, fmt.Errorf("reloading previous plist %s: %w", path, err))
@@ -840,7 +856,7 @@ func restorePreviousSupervisorSystemdInstall(path, service string, previousConte
 	if restart {
 		_ = supervisorSystemctlRun("--user", "stop", service)
 	}
-	if err := os.WriteFile(path, previousContent, 0o644); err != nil {
+	if err := writeSupervisorServiceFile(path, previousContent); err != nil {
 		errs = append(errs, fmt.Errorf("restoring previous unit %s: %w", path, err))
 		return errors.Join(errs...)
 	}
@@ -877,7 +893,7 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := writeSupervisorServiceFile(path, []byte(content)); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: writing plist: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -944,7 +960,7 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 		return 1
 	}
 	contentChanged := string(existing) != content
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := writeSupervisorServiceFile(path, []byte(content)); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: writing unit: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	goruntime "runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -337,6 +338,12 @@ type supervisorServiceData struct {
 	LaunchdLabel  string
 	SafeName      string
 	Path          string
+	ExtraEnv      []supervisorServiceEnvVar
+}
+
+type supervisorServiceEnvVar struct {
+	Name  string
+	Value string
 }
 
 func buildSupervisorServiceData() (*supervisorServiceData, error) {
@@ -358,6 +365,7 @@ func buildSupervisorServiceData() (*supervisorServiceData, error) {
 		LaunchdLabel:  supervisorLaunchdLabel(),
 		SafeName:      sanitizeServiceName(filepath.Base(home)),
 		Path:          searchpath.ExpandPath(homeDir, goruntime.GOOS, os.Getenv("PATH")),
+		ExtraEnv:      supervisorServiceExtraEnv(),
 	}, nil
 }
 
@@ -366,6 +374,103 @@ func sanitizeServiceName(name string) string {
 	re := regexp.MustCompile(`[^a-z0-9]+`)
 	name = re.ReplaceAllString(name, "-")
 	return strings.Trim(name, "-")
+}
+
+var supervisorServiceEnvNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// Keep persistent service-file env narrow. Provider credentials and user
+// context need to survive launchd/systemd startup; arbitrary shell state can
+// be opted in with GC_SUPERVISOR_ENV.
+var supervisorServiceEnvKeys = map[string]bool{
+	"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": true,
+	"CLAUDE_CODE_EFFORT_LEVEL":                 true,
+	"CLAUDE_CODE_OAUTH_TOKEN":                  true,
+	"CLAUDE_CODE_SUBAGENT_MODEL":               true,
+	"CLAUDE_CONFIG_DIR":                        true,
+	"HOME":                                     true,
+	"LANG":                                     true,
+	"LC_ALL":                                   true,
+	"LC_CTYPE":                                 true,
+	"LOGNAME":                                  true,
+	"SHELL":                                    true,
+	"USER":                                     true,
+	"XDG_CONFIG_HOME":                          true,
+	"XDG_STATE_HOME":                           true,
+}
+
+var providerCredentialEnvPrefixes = []string{
+	"ANTHROPIC_",
+	"GEMINI_",
+	"GOOGLE_",
+	"OPENAI_",
+}
+
+var supervisorServiceFixedEnvKeys = map[string]bool{
+	"GC_HOME":         true,
+	"PATH":            true,
+	"XDG_RUNTIME_DIR": true,
+}
+
+func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
+	env := make(map[string]string)
+	for _, entry := range os.Environ() {
+		key, val, ok := strings.Cut(entry, "=")
+		if !ok || val == "" || !shouldPersistSupervisorEnv(key) {
+			continue
+		}
+		env[key] = val
+	}
+	for _, key := range supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV")) {
+		if val := os.Getenv(key); val != "" {
+			env[key] = val
+		}
+	}
+
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]supervisorServiceEnvVar, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, supervisorServiceEnvVar{Name: key, Value: env[key]})
+	}
+	return out
+}
+
+func shouldPersistSupervisorEnv(key string) bool {
+	if !supervisorServiceEnvNameRE.MatchString(key) || supervisorServiceFixedEnvKeys[key] {
+		return false
+	}
+	if supervisorServiceEnvKeys[key] {
+		return true
+	}
+	return isProviderCredentialEnv(key)
+}
+
+func isProviderCredentialEnv(key string) bool {
+	for _, prefix := range providerCredentialEnvPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func supervisorServiceExplicitEnvKeys(raw string) []string {
+	fields := strings.Fields(strings.NewReplacer(",", " ", ";", " ").Replace(raw))
+	out := make([]string, 0, len(fields))
+	seen := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		key := strings.TrimSpace(field)
+		if key == "" || seen[key] || !supervisorServiceEnvNameRE.MatchString(key) || supervisorServiceFixedEnvKeys[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
 }
 
 const (
@@ -436,6 +541,10 @@ const supervisorLaunchdTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         {{end}}
         <key>PATH</key>
         <string>{{xmlesc .Path}}</string>
+        {{range .ExtraEnv}}
+        <key>{{xmlesc .Name}}</key>
+        <string>{{xmlesc .Value}}</string>
+        {{end}}
     </dict>
 </dict>
 </plist>
@@ -454,6 +563,8 @@ StandardError=append:{{.LogPath}}
 Environment=GC_HOME="{{.GCHome}}"
 {{if .XDGRuntimeDir}}Environment=XDG_RUNTIME_DIR="{{.XDGRuntimeDir}}"
 {{end}}Environment=PATH="{{.Path}}"
+{{range .ExtraEnv}}Environment={{systemdenv .Name .Value}}
+{{end}}
 
 [Install]
 WantedBy=default.target
@@ -464,8 +575,12 @@ func xmlEscape(s string) string {
 	return r.Replace(s)
 }
 
+func systemdEnv(name, value string) string {
+	return name + "=" + strconv.Quote(value)
+}
+
 func renderSupervisorTemplate(tmplStr string, data *supervisorServiceData) (string, error) {
-	funcMap := template.FuncMap{"xmlesc": xmlEscape}
+	funcMap := template.FuncMap{"xmlesc": xmlEscape, "systemdenv": systemdEnv}
 	tmpl, err := template.New("service").Funcs(funcMap).Parse(tmplStr)
 	if err != nil {
 		return "", err

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -637,6 +637,57 @@ func TestInstallSupervisorSystemdRestartsWhenUnitChangesAndServiceActive(t *test
 	if strings.Contains(joined, "--user start gascity-supervisor.service") {
 		t.Fatalf("systemctl calls = %v, should restart instead of start when unit changes under an active service", calls)
 	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("systemd unit mode after warm upgrade = %03o, want 600", got)
+	}
+}
+
+func TestInstallSupervisorSystemdWritesPrivateUnitFile(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	data := &supervisorServiceData{
+		GCPath:  "/tmp/gc-new",
+		LogPath: "/tmp/gc-home/supervisor.log",
+		GCHome:  "/tmp/gc-home",
+		Path:    "/usr/local/bin:/usr/bin:/bin",
+		ExtraEnv: []supervisorServiceEnvVar{
+			{Name: "OPENAI_API_KEY", Value: "sk-openai-123"},
+		},
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	supervisorSystemctlRun = func(_ ...string) error {
+		return nil
+	}
+	supervisorSystemctlActive = func(_ string) bool {
+		return false
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	info, err := os.Stat(supervisorSystemdServicePath())
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", supervisorSystemdServicePath(), err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("systemd unit mode = %03o, want 600", got)
+	}
 }
 
 func TestInstallSupervisorSystemdStartsInactiveService(t *testing.T) {
@@ -1252,6 +1303,13 @@ func TestInstallSupervisorSystemdRestoresPreviousCurrentUnitWhenUpdateFails(t *t
 	if !bytes.Equal(gotContent, oldContent) {
 		t.Fatalf("restored systemd unit = %q, want original %q", gotContent, oldContent)
 	}
+	info, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", currentPath, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("restored systemd unit mode = %03o, want 600", got)
+	}
 	if startCalls != 2 {
 		t.Fatalf("systemctl start call count = %d, want 2 (failed install + rollback restore); calls=%v", startCalls, calls)
 	}
@@ -1415,6 +1473,45 @@ func TestInstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedGCH
 		if !strings.Contains(joined, want) {
 			t.Fatalf("launchctl calls = %v, want %q", calls, want)
 		}
+	}
+}
+
+func TestInstallSupervisorLaunchdWritesPrivatePlist(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	data := &supervisorServiceData{
+		GCPath:       "/tmp/gc-new",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: supervisorLaunchdLabel(),
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+		ExtraEnv: []supervisorServiceEnvVar{
+			{Name: "OPENAI_API_KEY", Value: "sk-openai-123"},
+		},
+	}
+
+	oldRun := supervisorLaunchctlRun
+	supervisorLaunchctlRun = func(_ ...string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	path := supervisorLaunchdPlistPath()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("launchd plist mode = %03o, want 600", got)
 	}
 }
 
@@ -1591,6 +1688,13 @@ func TestInstallSupervisorLaunchdRestoresPreviousCurrentPlistWhenUpdateFails(t *
 	}
 	if !bytes.Equal(gotContent, oldContent) {
 		t.Fatalf("restored launchd plist = %q, want original %q", gotContent, oldContent)
+	}
+	info, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", currentPath, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("restored launchd plist mode = %03o, want 600", got)
 	}
 	if loadCalls != 2 {
 		t.Fatalf("launchctl load call count = %d, want 2 (failed install + rollback restore); calls=%v", loadCalls, calls)

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -203,6 +203,10 @@ func TestRenderSupervisorLaunchdTemplate(t *testing.T) {
 		XDGRuntimeDir: "/tmp/gc-run",
 		LaunchdLabel:  defaultSupervisorLaunchdLabel,
 		Path:          "/usr/local/bin:/usr/bin:/bin",
+		ExtraEnv: []supervisorServiceEnvVar{
+			{Name: "ANTHROPIC_API_KEY", Value: `sk-&<"'>`},
+			{Name: "OPENAI_API_KEY", Value: "sk-openai-123"},
+		},
 	}
 
 	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, data)
@@ -220,6 +224,10 @@ func TestRenderSupervisorLaunchdTemplate(t *testing.T) {
 		"XDG_RUNTIME_DIR",
 		"/tmp/gc-run",
 		"<key>PATH</key>",
+		"<key>ANTHROPIC_API_KEY</key>",
+		"<string>sk-&amp;&lt;&quot;&apos;&gt;</string>",
+		"<key>OPENAI_API_KEY</key>",
+		"<string>sk-openai-123</string>",
 	} {
 		if !strings.Contains(content, check) {
 			t.Fatalf("launchd template missing %q", check)
@@ -235,6 +243,10 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 		XDGRuntimeDir: "/tmp/gc-run",
 		LaunchdLabel:  defaultSupervisorLaunchdLabel,
 		Path:          "/usr/local/bin:/usr/bin:/bin",
+		ExtraEnv: []supervisorServiceEnvVar{
+			{Name: "ANTHROPIC_API_KEY", Value: `sk-"ant"\value`},
+			{Name: "OPENAI_API_KEY", Value: "sk-openai-123"},
+		},
 	}
 
 	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, data)
@@ -249,11 +261,64 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 		`Environment=GC_HOME="/home/user/.gc"`,
 		`Environment=XDG_RUNTIME_DIR="/tmp/gc-run"`,
 		`Environment=PATH="/usr/local/bin:/usr/bin:/bin"`,
+		`Environment=ANTHROPIC_API_KEY="sk-\"ant\"\\value"`,
+		`Environment=OPENAI_API_KEY="sk-openai-123"`,
 	} {
 		if !strings.Contains(content, check) {
 			t.Fatalf("systemd template missing %q", check)
 		}
 	}
+}
+
+func TestBuildSupervisorServiceDataIncludesProviderEnv(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-123")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://anthropic.example.test")
+	t.Setenv("OPENAI_API_KEY", "sk-openai-123")
+	t.Setenv("GEMINI_API_KEY", "gemini-123")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "gc-project")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(homeDir, ".claude"))
+	t.Setenv("GC_SUPERVISOR_ENV", "CUSTOM_PROVIDER_TOKEN,IGNORED_EMPTY")
+	t.Setenv("CUSTOM_PROVIDER_TOKEN", "custom-token")
+	t.Setenv("IGNORED_EMPTY", "")
+	t.Setenv("UNRELATED_SECRET", "do-not-persist")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for key, want := range map[string]string{
+		"ANTHROPIC_API_KEY":     "sk-ant-123",
+		"ANTHROPIC_BASE_URL":    "https://anthropic.example.test",
+		"OPENAI_API_KEY":        "sk-openai-123",
+		"GEMINI_API_KEY":        "gemini-123",
+		"GOOGLE_CLOUD_PROJECT":  "gc-project",
+		"CLAUDE_CONFIG_DIR":     filepath.Join(homeDir, ".claude"),
+		"CUSTOM_PROVIDER_TOKEN": "custom-token",
+	} {
+		if got[key] != want {
+			t.Fatalf("ExtraEnv[%s] = %q, want %q (all env: %#v)", key, got[key], want, got)
+		}
+	}
+	for _, key := range []string{"GC_HOME", "PATH", "XDG_RUNTIME_DIR", "IGNORED_EMPTY", "UNRELATED_SECRET"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("ExtraEnv should not include %s: %#v", key, got)
+		}
+	}
+}
+
+func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
+	m := make(map[string]string, len(vars))
+	for _, item := range vars {
+		m[item.Name] = item.Value
+	}
+	return m
 }
 
 func TestBuildSupervisorServiceDataExpandsUserManagedPath(t *testing.T) {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -17,16 +18,36 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		return
 	}
 
-	b, err := decodeCacheEvent(payload)
+	patch, fields, err := decodeCacheEvent(payload)
 	if err != nil {
 		c.recordProblem(fmt.Sprintf("apply %s event", eventType), err)
 		return
+	}
+
+	c.mu.RLock()
+	if c.state != cacheLive {
+		c.mu.RUnlock()
+		return
+	}
+	_, cached := c.beads[patch.ID]
+	c.mu.RUnlock()
+
+	b := patch
+	if !cached {
+		if fresh, err := c.backing.Get(patch.ID); err == nil {
+			b = fresh
+		} else if !errors.Is(err, ErrNotFound) {
+			c.recordProblem(fmt.Sprintf("refresh %s event", eventType), err)
+		}
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.state != cacheLive {
 		return
+	}
+	if current, ok := c.beads[patch.ID]; ok {
+		b = mergeCacheEventPatch(current, patch, fields)
 	}
 
 	mutated := false
@@ -37,9 +58,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			c.beads[b.ID] = cloneBead(b)
 			delete(c.dirty, b.ID)
 			delete(c.deletedSeq, b.ID)
-			c.updateStatsLocked()
-			mutated = true
 		}
+		c.updateStatsLocked()
+		mutated = true
 	case "bead.updated":
 		c.noteMutationLocked(b.ID)
 		c.beads[b.ID] = cloneBead(b)
@@ -80,27 +101,83 @@ func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	c.updateStatsLocked()
 }
 
-func decodeCacheEvent(payload json.RawMessage) (Bead, error) {
+func mergeCacheEventPatch(base, patch Bead, fields map[string]json.RawMessage) Bead {
+	merged := cloneBead(base)
+	if hasCacheEventField(fields, "title") {
+		merged.Title = patch.Title
+	}
+	if hasCacheEventField(fields, "status") {
+		merged.Status = patch.Status
+	}
+	if hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type") {
+		merged.Type = patch.Type
+	}
+	if hasCacheEventField(fields, "priority") {
+		merged.Priority = cloneIntPtr(patch.Priority)
+	}
+	if hasCacheEventField(fields, "created_at") {
+		merged.CreatedAt = patch.CreatedAt
+	}
+	if hasCacheEventField(fields, "assignee") {
+		merged.Assignee = patch.Assignee
+	}
+	if hasCacheEventField(fields, "from") {
+		merged.From = patch.From
+	}
+	if hasCacheEventField(fields, "parent") {
+		merged.ParentID = patch.ParentID
+	}
+	if hasCacheEventField(fields, "ref") {
+		merged.Ref = patch.Ref
+	}
+	if hasCacheEventField(fields, "needs") {
+		merged.Needs = slices.Clone(patch.Needs)
+	}
+	if hasCacheEventField(fields, "description") {
+		merged.Description = patch.Description
+	}
+	if hasCacheEventField(fields, "labels") {
+		merged.Labels = slices.Clone(patch.Labels)
+	}
+	if hasCacheEventField(fields, "metadata") {
+		merged.Metadata = maps.Clone(patch.Metadata)
+	}
+	if hasCacheEventField(fields, "dependencies") {
+		merged.Dependencies = slices.Clone(patch.Dependencies)
+	}
+	return merged
+}
+
+func hasCacheEventField(fields map[string]json.RawMessage, name string) bool {
+	_, ok := fields[name]
+	return ok
+}
+
+func decodeCacheEvent(payload json.RawMessage) (Bead, map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return Bead{}, nil, err
+	}
 	var wire struct {
 		Bead
 		Metadata   StringMap `json:"metadata,omitempty"`
 		TypeCompat string    `json:"type,omitempty"`
 	}
 	if err := json.Unmarshal(payload, &wire); err != nil {
-		return Bead{}, err
+		return Bead{}, nil, err
 	}
 	b := wire.Bead
 	if wire.Metadata != nil {
 		b.Metadata = map[string]string(wire.Metadata)
 	}
 	if b.ID == "" {
-		return Bead{}, fmt.Errorf("missing bead id")
+		return Bead{}, nil, fmt.Errorf("missing bead id")
 	}
 	// bd hook payloads use "issue_type" while exec-style payloads may use "type".
 	if b.Type == "" && wire.TypeCompat != "" {
 		b.Type = wire.TypeCompat
 	}
-	return b, nil
+	return b, fields, nil
 }
 
 func (c *CachingStore) notifyChange(eventType string, b Bead) {

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -902,7 +902,14 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 
 	// Apply an update event.
-	updated := beads.Bead{ID: b1.ID, Title: "Modified by agent", Status: "open", Metadata: map[string]string{"gc.step_ref": "mol.review"}}
+	updatedTitle := "Modified by agent"
+	if err := mem.Update(b1.ID, beads.UpdateOpts{
+		Title:    &updatedTitle,
+		Metadata: map[string]string{"gc.step_ref": "mol.review"},
+	}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+	updated := beads.Bead{ID: b1.ID, Title: updatedTitle, Status: "open", Metadata: map[string]string{"gc.step_ref": "mol.review"}}
 	payload, _ = json.Marshal(updated)
 	cs.ApplyEvent("bead.updated", payload)
 
@@ -915,9 +922,20 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 
 	// Apply a close event with the full closed bead payload.
+	closedTitle := "Closed by agent"
+	if err := mem.Update(b1.ID, beads.UpdateOpts{
+		Title:    &closedTitle,
+		Labels:   []string{"done"},
+		Metadata: map[string]string{"gc.outcome": "pass"},
+	}); err != nil {
+		t.Fatalf("Update backing before close: %v", err)
+	}
+	if err := mem.Close(b1.ID); err != nil {
+		t.Fatalf("Close backing: %v", err)
+	}
 	closed := beads.Bead{
 		ID:       b1.ID,
-		Title:    "Closed by agent",
+		Title:    closedTitle,
 		Status:   "closed",
 		Labels:   []string{"done"},
 		Metadata: map[string]string{"gc.outcome": "pass"},
@@ -943,13 +961,80 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 }
 
+func TestCachingStoreApplyEventRefreshesPartialHookPayload(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	parent, err := mem.Create(beads.Bead{Title: "parent"})
+	if err != nil {
+		t.Fatalf("Create parent: %v", err)
+	}
+	child, err := mem.Create(beads.Bead{
+		Title:    "child",
+		ParentID: parent.ID,
+		Labels:   []string{"mc-live-contract"},
+	})
+	if err != nil {
+		t.Fatalf("Create child: %v", err)
+	}
+
+	backing := &eventGetFailStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.failGet = true
+
+	updatedTitle := "child updated externally"
+	if err := mem.Update(child.ID, beads.UpdateOpts{Title: &updatedTitle}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"id":         child.ID,
+		"title":      updatedTitle,
+		"status":     "open",
+		"issue_type": "task",
+		"owner":      "agent@example.com",
+		"updated_at": "2026-04-25T04:45:55Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	cs.ApplyEvent("bead.updated", payload)
+	if stats := cs.Stats(); stats.ProblemCount != 0 {
+		t.Fatalf("ProblemCount = %d, want 0 (last problem: %s)", stats.ProblemCount, stats.LastProblem)
+	}
+
+	labeled, err := cs.List(beads.ListQuery{Label: "mc-live-contract"})
+	if err != nil {
+		t.Fatalf("List(label): %v", err)
+	}
+	if len(labeled) != 1 || labeled[0].ID != child.ID {
+		t.Fatalf("labeled = %#v, want child %s", labeled, child.ID)
+	}
+	if labeled[0].ParentID != parent.ID {
+		t.Fatalf("ParentID = %q, want %q", labeled[0].ParentID, parent.ID)
+	}
+	if labeled[0].Title != updatedTitle {
+		t.Fatalf("Title = %q, want %q", labeled[0].Title, updatedTitle)
+	}
+}
+
+type eventGetFailStore struct {
+	beads.Store
+	failGet bool
+}
+
+func (s *eventGetFailStore) Get(id string) (beads.Bead, error) {
+	if s.failGet {
+		return beads.Bead{}, errors.New("unexpected event backing get")
+	}
+	return s.Store.Get(id)
+}
+
 func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
-	b1, err := mem.Create(beads.Bead{Title: "Existing"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
 
 	cs := beads.NewCachingStoreForTest(mem, nil)
 	if err := cs.Prime(context.Background()); err != nil {
@@ -957,7 +1042,7 @@ func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 	}
 
 	payload, err := json.Marshal(map[string]any{
-		"id":         b1.ID,
+		"id":         "ext-1",
 		"title":      "mayor",
 		"status":     "open",
 		"issue_type": "session",
@@ -979,7 +1064,7 @@ func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 		t.Fatalf("ProblemCount = %d, want 0 (last problem: %s)", stats.ProblemCount, stats.LastProblem)
 	}
 
-	got := requireCachedBead(t, cs, b1.ID, false)
+	got := requireCachedBead(t, cs, "ext-1", false)
 	if got.Type != "session" {
 		t.Fatalf("Type = %q, want session", got.Type)
 	}


### PR DESCRIPTION
## Summary

- Persist allowlisted provider credential env vars into generated supervisor launchd/systemd service files so launchd/systemd-started supervisors can pass credentials to agent sessions.
- Include stable user/provider context and support explicit custom service env names through `GC_SUPERVISOR_ENV`.
- Extend agent session passthrough to provider credential prefixes beyond Anthropic (`OPENAI_`, `GEMINI_`, `GOOGLE_`).

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test ./cmd/gc -run 'Test(RenderSupervisor|BuildSupervisorServiceData|PassthroughEnv)'`
- [x] `go test ./cmd/gc -run 'Test(InstallSupervisorLaunchd|InstallSupervisorSystemd|UninstallSupervisorLaunchd|UninstallSupervisorSystemd|LegacySupervisor|SupervisorService|SupervisorLaunchd|SupervisorSystemd)'`
- [x] `git diff --check`

Note: `go test ./cmd/gc` was stopped after several minutes in an unrelated beads-provider startup path.

## Checklist

- [x] Linked an issue, or explained why one is not needed: bead `ga-vafvp`
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes: no breaking changes expected