### PR TITLE
test(cmd/gc): scrub inherited rig env vars in TestMain

### DIFF
--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -38,20 +38,10 @@ func shortSocketTempDir(t *testing.T, prefix string) string {
 // shutdownBeadsProvider.
 func clearInheritedBeadsEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{
-		"GC_BEADS",
-		"GC_BIN",
-		"GC_DOLT",
-		"GC_DOLT_HOST",
-		"GC_DOLT_PORT",
-		"GC_DOLT_USER",
-		"GC_DOLT_PASSWORD",
-		"BEADS_DOLT_SERVER_HOST",
-		"BEADS_DOLT_SERVER_PORT",
-		"BEADS_DOLT_SERVER_USER",
-		"BEADS_DOLT_PASSWORD",
-		"GC_BEADS_SCOPE_ROOT",
-	} {
+	for _, key := range liveEnvKeysForTests() {
+		if key == "GC_HOME" {
+			continue
+		}
 		t.Setenv(key, "")
 	}
 }

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -88,6 +88,62 @@ func clearProcessLiveEnvForTests() {
 	}
 }
 
+func TestClearProcessLiveEnvForTestsUnsetsInheritedState(t *testing.T) {
+	cleared := []string{
+		"BEADS_ACTOR",
+		"BEADS_DIR",
+		"DOLT_CONFIG_PATH",
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_CITY_PATH",
+		"GC_DOLT_HOST",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+		"GC_SESSION_NAME",
+	}
+	preserved := []string{
+		"GC_FAST_UNIT",
+		"GC_TEST_KEEP",
+	}
+
+	for _, key := range append(cleared, preserved...) {
+		t.Setenv(key, "from-parent-session")
+	}
+
+	clearProcessLiveEnvForTests()
+
+	for _, key := range cleared {
+		if value, ok := os.LookupEnv(key); ok {
+			t.Errorf("%s survived scrub with value %q", key, value)
+		}
+	}
+	for _, key := range preserved {
+		if value := os.Getenv(key); value != "from-parent-session" {
+			t.Errorf("%s = %q, want preserved test-control value", key, value)
+		}
+	}
+}
+
+func TestIsTestscriptCommandInvocation(t *testing.T) {
+	tests := []struct {
+		name string
+		arg0 string
+		want bool
+	}{
+		{name: "gc helper", arg0: "/tmp/testscript-main/bin/gc", want: true},
+		{name: "bd helper", arg0: "/tmp/testscript-main/bin/bd", want: true},
+		{name: "windows gc helper", arg0: `C:\Temp\testscript-main\bin\gc.exe`, want: true},
+		{name: "top level test binary", arg0: "/tmp/go-build/cmd/gc.test", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTestscriptCommandInvocation(tt.arg0); got != tt.want {
+				t.Fatalf("isTestscriptCommandInvocation(%q) = %v, want %v", tt.arg0, got, tt.want)
+			}
+		})
+	}
+}
+
 func liveEnvKeysForTests() []string {
 	keys := make(map[string]struct{})
 	for _, group := range [][]string{gcEnvVars, inheritedCityRoutingEnvVars, liveTestEnvVars} {

--- a/release-gates/ga-bhjb-gate.md
+++ b/release-gates/ga-bhjb-gate.md
@@ -1,0 +1,88 @@
+# Release gate: ga-bhjb — TestMain rig env scrub (ga-d02c)
+
+Feature bead: **ga-d02c** (closed) — Fix: scrub gc rig env vars in cmd/gc TestMain to stop dolt sql-server orphans
+Review bead: **ga-bhjb** (needs-deploy)
+Branch: `release/ga-bhjb` (cherry-picked b94dcffd onto `origin/main`, commit `7065bc48`)
+
+## Criteria
+
+| # | Criterion | Result |
+|---|-----------|--------|
+| 1 | Review PASS present | **PASS** |
+| 2 | Acceptance criteria met | **PASS** |
+| 3 | Tests pass | **PASS** |
+| 4 | No high-severity review findings open | **PASS** |
+| 5 | Final branch is clean | **PASS** |
+| 6 | Branch diverges cleanly from main | **PASS** |
+
+### 1. Review PASS present
+
+Two independent PASS verdicts recorded on ga-bhjb:
+
+- `gascity/reviewer-1` (gm-p97d2b6): PASS. Style, security OWASP walk, spec compliance, coverage, scope note — all clean. No findings.
+- `gascity/reviewer` (via gm-wisp-e4lh): PASS. Independently verified orphan delta=0 across reproducer + leaking-test set + t.Setenv consumer tests under GC_BEADS=bd. No blockers.
+
+### 2. Acceptance criteria met
+
+From ga-d02c done-when:
+
+- [x] `cmd/gc/testmain_test.go` exists with a `TestMain`-equivalent scrub helper. Builder adapted spec: cmd/gc already has a `TestMain` in `main_test.go` (Go permits one per package), so the helper `scrubInheritedRigEnv()` lives in `cmd/gc/testmain_test.go` and is called on the first line of the existing `TestMain`. Semantically equivalent to the spec.
+- [x] `go test -count=1 ./cmd/gc/...` passes from a clean shell — verified by reviewer-1; not re-run here because full-package timeout is pre-existing flakiness unrelated to this change (see note below).
+- [x] With `GC_BEADS=bd` set, targeted tests produce zero new `dolt sql-server --config /tmp/` orphans — verified independently on `release/ga-bhjb` (see criterion 3).
+- [x] Existing `t.Setenv("GC_BEADS", ...)` tests still pass — verified on this branch.
+
+### 3. Tests pass
+
+Re-verified on `release/ga-bhjb` from the deployer seat with `GC_BEADS=bd` in env:
+
+```
+go vet ./cmd/gc/...                 clean
+go build ./...                      clean
+
+Reproducer:
+go test -run TestCityRuntimeReloadProviderSwapPreservesDrainTracker ./cmd/gc/
+  ok github.com/gastownhall/gascity/cmd/gc 0.021s
+  pgrep dolt sql-server --config /tmp/  delta 28 -> 28
+
+Leaking-test set:
+go test -run 'TestCityRuntimeReload|TestControllerReload' ./cmd/gc/
+  ok github.com/gastownhall/gascity/cmd/gc 0.430s
+  pgrep delta 33 -> 33
+
+t.Setenv consumer tests:
+go test -run 'TestBdEnv|TestBeadsProvider|TestApiState|TestBuildDesiredState|TestCmdGraph|TestInitProviderReadiness|TestOrderDispatch|TestCmdSessionReset|TestCmdBdStoreBridge' ./cmd/gc/
+  ok github.com/gastownhall/gascity/cmd/gc 9.218s
+  pgrep delta 33 -> 33
+```
+
+**Pre-existing flaky test (not a regression):** `TestLocalInitializerInitScaffoldsAndFinalizes` fails with `Init: finalize failed (exit 1)` on this branch. Confirmed the same failure reproduces on `origin/main` without this change, so it is environment-specific / pre-existing, not introduced by ga-d02c. Reviewer-1's verification run (from /tmp worktree) observed the test passing — consistent with environment sensitivity. Orthogonal to the fix.
+
+### 4. No high-severity review findings open
+
+Both reviewers: zero findings blocking. One informational out-of-scope observation (typo `BEADS_DOLT_PASSWORD` vs `BEADS_DOLT_SERVER_PASSWORD` at path_helpers_test.go:40, pre-existing from ga-y64o). Not blocking.
+
+### 5. Final branch is clean
+
+```
+$ git status
+On branch release/ga-bhjb
+Your branch is ahead of 'origin/main' by 1 commit.
+  (use "git push" to publish your local commits)
+Untracked files: .gitkeep
+nothing added to commit but untracked files present
+```
+
+`.gitkeep` is pre-existing worktree scaffolding, not part of this change.
+
+### 6. Branch diverges cleanly from main
+
+```
+$ git log --oneline origin/main..HEAD
+7065bc48 test(cmd/gc): scrub inherited rig env vars in TestMain (ga-d02c)
+```
+
+Single commit cherry-picked from `b94dcffd` on the builder branch `gc-builder-1-01561d4fb9ea`. Source builder branch additionally contained `e16ccf1f` (ga-y64o), but that commit is already open as PR #1197 (release/ga-onjy); deployer cherry-picked only the ga-d02c commit to keep this PR independent and reviewable on its own.
+
+## Disposition
+
+All criteria PASS — cleared for push and PR.

--- a/release-gates/ga-bhjb-gate.md
+++ b/release-gates/ga-bhjb-gate.md
@@ -1,88 +1,60 @@
-# Release gate: ga-bhjb — TestMain rig env scrub (ga-d02c)
+# Release gate: ga-bhjb - TestMain rig env scrub (ga-d02c)
 
-Feature bead: **ga-d02c** (closed) — Fix: scrub gc rig env vars in cmd/gc TestMain to stop dolt sql-server orphans
+Feature bead: **ga-d02c** (closed) - Fix: scrub gc rig env vars in cmd/gc TestMain to stop dolt sql-server orphans
 Review bead: **ga-bhjb** (needs-deploy)
-Branch: `release/ga-bhjb` (cherry-picked b94dcffd onto `origin/main`, commit `7065bc48`)
+PR: <https://github.com/gastownhall/gascity/pull/1199>
+Branch: `release/ga-bhjb`, rebased onto `origin/main` at `0c60ee793`
 
-## Criteria
+## Rebase disposition
 
-| # | Criterion | Result |
-|---|-----------|--------|
-| 1 | Review PASS present | **PASS** |
-| 2 | Acceptance criteria met | **PASS** |
-| 3 | Tests pass | **PASS** |
-| 4 | No high-severity review findings open | **PASS** |
-| 5 | Final branch is clean | **PASS** |
-| 6 | Branch diverges cleanly from main | **PASS** |
+PR #1199 originally added a cmd/gc `TestMain` scrub helper. Current `main`
+already contains the generalized test-environment scrub helpers, so the rebase
+keeps the canonical `cmd/gc/testenv_test.go` implementation and adapts the PR
+coverage to that shape:
 
-### 1. Review PASS present
+- `cmd/gc/testenv_test.go` now covers `clearProcessLiveEnvForTests` scrubbing
+  inherited GC/BEADS/DOLT state while preserving test-control variables.
+- `cmd/gc/testenv_test.go` keeps coverage for `isTestscriptCommandInvocation`
+  so testscript command reinvocations are not scrubbed.
+- `cmd/gc/path_helpers_test.go` routes `clearInheritedBeadsEnv` through
+  `liveEnvKeysForTests()` and preserves `GC_HOME`, which cmd/gc package tests
+  require during supervisor registry setup.
 
-Two independent PASS verdicts recorded on ga-bhjb:
+The duplicate pre-rebase helper file (`cmd/gc/testmain_test.go`) is no longer
+needed after the rebase because the canonical helper already lives in
+`cmd/gc/testenv_test.go`.
 
-- `gascity/reviewer-1` (gm-p97d2b6): PASS. Style, security OWASP walk, spec compliance, coverage, scope note — all clean. No findings.
-- `gascity/reviewer` (via gm-wisp-e4lh): PASS. Independently verified orphan delta=0 across reproducer + leaking-test set + t.Setenv consumer tests under GC_BEADS=bd. No blockers.
+## Verification
 
-### 2. Acceptance criteria met
+| Check | Result |
+|-------|--------|
+| Rebase onto current `origin/main` | PASS |
+| Focused pre-rebase PR tests | PASS |
+| Focused post-conflict regression tests | PASS |
+| Pre-commit hook | PASS |
+| Branch working tree | Clean |
 
-From ga-d02c done-when:
+Focused tests run after resolving conflicts:
 
-- [x] `cmd/gc/testmain_test.go` exists with a `TestMain`-equivalent scrub helper. Builder adapted spec: cmd/gc already has a `TestMain` in `main_test.go` (Go permits one per package), so the helper `scrubInheritedRigEnv()` lives in `cmd/gc/testmain_test.go` and is called on the first line of the existing `TestMain`. Semantically equivalent to the spec.
-- [x] `go test -count=1 ./cmd/gc/...` passes from a clean shell — verified by reviewer-1; not re-run here because full-package timeout is pre-existing flakiness unrelated to this change (see note below).
-- [x] With `GC_BEADS=bd` set, targeted tests produce zero new `dolt sql-server --config /tmp/` orphans — verified independently on `release/ga-bhjb` (see criterion 3).
-- [x] Existing `t.Setenv("GC_BEADS", ...)` tests still pass — verified on this branch.
-
-### 3. Tests pass
-
-Re-verified on `release/ga-bhjb` from the deployer seat with `GC_BEADS=bd` in env:
-
-```
-go vet ./cmd/gc/...                 clean
-go build ./...                      clean
-
-Reproducer:
-go test -run TestCityRuntimeReloadProviderSwapPreservesDrainTracker ./cmd/gc/
-  ok github.com/gastownhall/gascity/cmd/gc 0.021s
-  pgrep dolt sql-server --config /tmp/  delta 28 -> 28
-
-Leaking-test set:
-go test -run 'TestCityRuntimeReload|TestControllerReload' ./cmd/gc/
-  ok github.com/gastownhall/gascity/cmd/gc 0.430s
-  pgrep delta 33 -> 33
-
-t.Setenv consumer tests:
-go test -run 'TestBdEnv|TestBeadsProvider|TestApiState|TestBuildDesiredState|TestCmdGraph|TestInitProviderReadiness|TestOrderDispatch|TestCmdSessionReset|TestCmdBdStoreBridge' ./cmd/gc/
-  ok github.com/gastownhall/gascity/cmd/gc 9.218s
-  pgrep delta 33 -> 33
+```text
+go test ./cmd/gc -run 'TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot|Test(ClearProcessLiveEnvForTestsUnsetsInheritedState|IsTestscriptCommandInvocation)' -count=1
 ```
 
-**Pre-existing flaky test (not a regression):** `TestLocalInitializerInitScaffoldsAndFinalizes` fails with `Init: finalize failed (exit 1)` on this branch. Confirmed the same failure reproduces on `origin/main` without this change, so it is environment-specific / pre-existing, not introduced by ga-d02c. Reviewer-1's verification run (from /tmp worktree) observed the test passing — consistent with environment sensitivity. Orthogonal to the fix.
+The first post-rebase `go test ./cmd/gc -count=1` exposed a conflict-resolution
+bug where `clearInheritedBeadsEnv` scrubbed `GC_HOME` too broadly. The final
+branch fixes that by preserving `GC_HOME`, then the focused regression above
+passed.
 
-### 4. No high-severity review findings open
+The local pre-commit hook also passed with:
 
-Both reviewers: zero findings blocking. One informational out-of-scope observation (typo `BEADS_DOLT_PASSWORD` vs `BEADS_DOLT_SERVER_PASSWORD` at path_helpers_test.go:40, pre-existing from ga-y64o). Not blocking.
-
-### 5. Final branch is clean
-
-```
-$ git status
-On branch release/ga-bhjb
-Your branch is ahead of 'origin/main' by 1 commit.
-  (use "git push" to publish your local commits)
-Untracked files: .gitkeep
-nothing added to commit but untracked files present
-```
-
-`.gitkeep` is pre-existing worktree scaffolding, not part of this change.
-
-### 6. Branch diverges cleanly from main
-
-```
-$ git log --oneline origin/main..HEAD
-7065bc48 test(cmd/gc): scrub inherited rig env vars in TestMain (ga-d02c)
-```
-
-Single commit cherry-picked from `b94dcffd` on the builder branch `gc-builder-1-01561d4fb9ea`. Source builder branch additionally contained `e16ccf1f` (ga-y64o), but that commit is already open as PR #1197 (release/ga-onjy); deployer cherry-picked only the ga-d02c commit to keep this PR independent and reviewable on its own.
+- `lint-changed: ./cmd/gc`
+- OpenAPI/schema sync checks
+- `go vet ./...`
+- observable fast unit sweep: `GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...`
+- docs sync tests
+- dashboard generation, build, typecheck, and `go test ./cmd/gc/dashboard/...`
 
 ## Disposition
 
-All criteria PASS — cleared for push and PR.
+Release gate remains PASS after rebase. The PR branch is ready to push back to
+`quad341:release/ga-bhjb`.


### PR DESCRIPTION
## What this changes

Adds a once-at-startup scrub of gc rig environment variables in `cmd/gc`'s `TestMain`, preventing `go test ./cmd/gc/` from orphaning `dolt sql-server` processes when invoked from inside a gc agent rig session.

`configuredBeadsProviderValue` in `cmd/gc/providers.go` reads `GC_BEADS` from env **before** consulting `city.toml`. A gc agent rig exports `GC_BEADS=bd` (plus `GC_DOLT_*`, `BEADS_DOLT_*`, `GC_BEADS_SCOPE_ROOT`, `GC_CITY_RUNTIME_DIR`), so tests that write `[beads] provider = "file"` into their toml were silently engaging the managed-dolt lifecycle anyway. The lifecycle's `start` op spawns `dolt sql-server` as a detached `Setpgid` process; the tests don't register a `t.Cleanup` that calls `shutdownBeadsProvider`, so the dolts leak once the test binary exits.

Fix: a new `scrubInheritedRigEnv()` helper in `cmd/gc/testmain_test.go` unsets 25 rig env keys at process start. Existing `TestMain` in `cmd/gc/main_test.go` calls it on its first line, before any other setup. Tests that legitimately need these env vars continue to set them with `t.Setenv`, which is independent of the once-only `os.Unsetenv`.

## Review notes

- **New file:** `cmd/gc/testmain_test.go` (42 lines) — `scrubInheritedRigEnv()` with the env key list and a doc comment pointing at `t.Setenv` for legitimate per-test needs.
- **Modified:** `cmd/gc/main_test.go` — one-line call to `scrubInheritedRigEnv()` at the top of the existing `TestMain` (the package already had one from testscript setup; Go permits only one per package, hence the adaptation).
- Env key list covers everything a gc rig exports: `GC_BEADS*`, `GC_DOLT*`, `GC_CITY_RUNTIME_DIR`, `GC_PACK_STATE_DIR`, `BEADS_DOLT_SERVER_*`, `BEADS_CREDENTIALS_FILE`, `BEADS_DIR`, `BEADS_ACTOR`.
- No production code changes. Pure test-infrastructure hardening.

## Test plan

- [x] `go vet ./cmd/gc/...` clean
- [x] `go build ./...` clean
- [x] Reproducer `TestCityRuntimeReloadProviderSwapPreservesDrainTracker` passes with `GC_BEADS=bd` in env; `pgrep dolt sql-server --config /tmp/` delta = 0
- [x] Leaking-test set (`TestCityRuntimeReload|TestControllerReload`) passes with `GC_BEADS=bd`; pgrep delta = 0
- [x] `t.Setenv` consumer tests (`TestBdEnv|TestBeadsProvider|TestApiState|TestBuildDesiredState|TestCmdGraph|TestInitProviderReadiness|TestOrderDispatch|TestCmdSessionReset|TestCmdBdStoreBridge`) pass with `GC_BEADS=bd`; pgrep delta = 0
- [x] Release gate: [`release-gates/ga-bhjb-gate.md`](release-gates/ga-bhjb-gate.md)

Originating bead: ga-d02c