### PR TITLE
managed dolt: disable upstream load-avg auto-GC scheduler (workaround dolt#10944)

### DIFF
--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -73,6 +73,7 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 		cmd.Stderr = logFile
 		cmd.Stdin = nil
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Env = doltServerEnv(os.Environ())
 		if err := cmd.Start(); err != nil {
 			_ = logFile.Close()
 			return report, fmt.Errorf("start dolt sql-server: %w", err)
@@ -207,4 +208,21 @@ func terminateManagedDoltPID(pid int) error {
 	_ = process.Signal(syscall.SIGKILL)
 	time.Sleep(250 * time.Millisecond)
 	return nil
+}
+
+// doltServerEnv augments the parent environment with overrides we need
+// applied to every managed dolt sql-server we launch. Currently it
+// disables Dolt's load-average auto-GC scheduler, which on multi-core
+// hosts (>~16 CPUs) silently prevents auto-GC from ever running. See
+// https://github.com/dolthub/dolt/issues/10944. Users who explicitly
+// set DOLT_GC_SCHEDULER are respected.
+func doltServerEnv(parent []string) []string {
+	const key = "DOLT_GC_SCHEDULER"
+	prefix := key + "="
+	for _, kv := range parent {
+		if strings.HasPrefix(kv, prefix) {
+			return parent
+		}
+	}
+	return append(append([]string(nil), parent...), prefix+"NONE")
 }

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func TestDoltServerEnv_AppendsDefaultWhenMissing(t *testing.T) {
+	parent := []string{"PATH=/usr/bin", "HOME=/home/test"}
+	out := doltServerEnv(parent)
+
+	want := "DOLT_GC_SCHEDULER=NONE"
+	found := false
+	for _, kv := range out {
+		if kv == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q in env, got %v", want, out)
+	}
+	// Original entries preserved.
+	for _, kv := range parent {
+		var hit bool
+		for _, got := range out {
+			if got == kv {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			t.Fatalf("parent entry %q missing from output env %v", kv, out)
+		}
+	}
+}
+
+func TestDoltServerEnv_RespectsUserOverride(t *testing.T) {
+	parent := []string{"PATH=/usr/bin", "DOLT_GC_SCHEDULER=LOADAVG", "HOME=/home/test"}
+	out := doltServerEnv(parent)
+
+	// User-provided value must be preserved exactly.
+	count := 0
+	for _, kv := range out {
+		if kv == "DOLT_GC_SCHEDULER=LOADAVG" {
+			count++
+		}
+		if kv == "DOLT_GC_SCHEDULER=NONE" {
+			t.Fatalf("user override clobbered by default: %v", out)
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one DOLT_GC_SCHEDULER=LOADAVG entry, got %d in %v", count, out)
+	}
+}
+
+func TestDoltServerEnv_RespectsEmptyUserValue(t *testing.T) {
+	// An explicit empty value (DOLT_GC_SCHEDULER=) is still a user
+	// override and we must not replace it.
+	parent := []string{"DOLT_GC_SCHEDULER="}
+	out := doltServerEnv(parent)
+	for _, kv := range out {
+		if kv == "DOLT_GC_SCHEDULER=NONE" {
+			t.Fatalf("explicit empty-value override clobbered: %v", out)
+		}
+	}
+}

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
 
 func TestDoltServerEnv_AppendsDefaultWhenMissing(t *testing.T) {
 	parent := []string{"PATH=/usr/bin", "HOME=/home/test"}
@@ -60,5 +66,25 @@ func TestDoltServerEnv_RespectsEmptyUserValue(t *testing.T) {
 		if kv == "DOLT_GC_SCHEDULER=NONE" {
 			t.Fatalf("explicit empty-value override clobbered: %v", out)
 		}
+	}
+}
+
+func TestGCBeadsBDScript_RespectsEmptyUserValue(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	scriptPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptPath, err)
+	}
+	script := string(data)
+
+	if !strings.Contains(script, `${DOLT_GC_SCHEDULER=NONE}`) {
+		t.Fatalf("gc-beads-bd.sh must default DOLT_GC_SCHEDULER only when unset")
+	}
+	if strings.Contains(script, `${DOLT_GC_SCHEDULER:=NONE}`) {
+		t.Fatalf("gc-beads-bd.sh must not clobber an explicitly empty DOLT_GC_SCHEDULER")
 	}
 }

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -86,14 +86,17 @@ If GC finishes but the size barely moves, the chunks are nearly all live
   heuristics and default archive compression.
 - **Let the dolt pack's `dolt-gc-nudge` order run continuously.** It
   ships embedded in the dolt pack and fires `CALL DOLT_GC()` every 1h
-  by default, unconditionally. Empirical evidence (beads perf harness,
-  2026-04) shows Dolt's auto-GC does not fire under bd's fork-per-op
-  CLI workload even with `auto_gc_behavior.enable: true`, so the nudge
-  is the only mechanism bounding commit-graph growth. GC is idempotent
-  and near-free when there's nothing to reclaim, so running it every
-  hour is cheap. To opt out on a given city, add `dolt-gc-nudge` to the
-  city's `[orders] skip = [...]` list (or to a rig-level
-  `[[order.override]]`). To skip GC on small databases, set
+  by default, unconditionally. Gas City's managed-Dolt launch path now
+  forces `DOLT_GC_SCHEDULER=NONE`, which restores Dolt's configured
+  auto-GC behavior on multi-core hosts affected by
+  [dolthub/dolt#10944](https://github.com/dolthub/dolt/issues/10944).
+  The hourly nudge remains valuable as a belt-and-suspenders backstop
+  for the bd workload and as an unconditional recovery path if the
+  threshold-triggered auto-GC has nothing to do for a while. GC is
+  idempotent and near-free when there's nothing to reclaim, so running
+  it every hour is cheap. To opt out on a given city, add
+  `dolt-gc-nudge` to the city's `[orders] skip = [...]` list (or to a
+  rig-level `[[order.override]]`). To skip GC on small databases, set
   `GC_DOLT_GC_THRESHOLD_BYTES` to a positive byte count in the city's
   environment (default: 0 — run unconditionally).
 - **Mind `orders.max_timeout` if you set one.** The nudge order asks

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1511,6 +1511,17 @@ op_start() {
             log_offset=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
         fi
 
+        # Disable Dolt's load-average auto-GC scheduler. Dolt 1.86.0+
+        # ships a loadAvgGCScheduler whose threshold formula scales
+        # inversely with CPU count (10/CPUs), so on multi-core hosts the
+        # gate is essentially always tripped and CALL DOLT_GC() is
+        # queued but never executed; auto_gc_behavior.enable: true in
+        # config.yaml has no effect. See
+        # https://github.com/dolthub/dolt/issues/10944. Users who
+        # explicitly set DOLT_GC_SCHEDULER are respected.
+        : "${DOLT_GC_SCHEDULER:=NONE}"
+        export DOLT_GC_SCHEDULER
+
         # Start dolt sql-server with config file. Close the startup lock fd in
         # the child so the flock is released when this starter exits.
         nohup sh -c 'exec 9>&-; exec dolt sql-server --config "$1"' sh "$CONFIG_FILE" >> "$LOG_FILE" 2>&1 &

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1519,7 +1519,7 @@ op_start() {
         # config.yaml has no effect. See
         # https://github.com/dolthub/dolt/issues/10944. Users who
         # explicitly set DOLT_GC_SCHEDULER are respected.
-        : "${DOLT_GC_SCHEDULER:=NONE}"
+        : "${DOLT_GC_SCHEDULER=NONE}"
         export DOLT_GC_SCHEDULER
 
         # Start dolt sql-server with config file. Close the startup lock fd in

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 # gc dolt gc-nudge — periodic CALL DOLT_GC() to bound the Dolt commit graph.
 #
-# Why this exists: empirical evidence (beads perf harness, 2026-04) shows
-# Dolt's auto-GC does not fire under the beads-CLI fork-per-op workload even
-# with `auto_gc_behavior.enable: true`. Unbounded commit-graph growth causes
-# both disk bloat (~120 GB after a few days) and tail-latency degradation
-# (p99 at 143 MB of history → 16.9s, extrapolates to minutes at GB scale).
-# Manual CALL DOLT_GC() reclaims ~43% in seconds, so a periodic nudge is
-# both necessary and cheap.
+# Why this exists: Gas City's managed-Dolt launch path now forces
+# `DOLT_GC_SCHEDULER=NONE` to work around
+# https://github.com/dolthub/dolt/issues/10944, so threshold-triggered
+# auto-GC can fire again on multi-core hosts. We still keep an hourly
+# nudge because the bd workload can accumulate history quickly, and an
+# unconditional `CALL DOLT_GC()` remains a cheap belt-and-suspenders
+# backstop for reclaiming orphan chunks before they turn into disk bloat
+# and tail-latency spikes.
 #
 # Policy: fire CALL DOLT_GC() unconditionally on every cooldown tick
 # (default 1h). The GC is idempotent and near-free when there's nothing


### PR DESCRIPTION
## Summary

Inject `DOLT_GC_SCHEDULER=NONE` into the environment of every `dolt sql-server` we launch (managed mode), to work around [dolthub/dolt#10944](https://github.com/dolthub/dolt/issues/10944).

## Why

Dolt 1.86.0+ ships a `loadAvgGCScheduler` whose threshold formula (`10/CPUs`) scales **inversely** with CPU count. On a multi-core city host (>16 CPUs), the gate is essentially always tripped, so:

- The auto-GC commit hook correctly enqueues `CALL DOLT_GC()` requests.
- The scheduler's `WaitForNextRun` blocks (polling every 60s) waiting for `loadavg.Load1 <= 10/CPUs`, which never holds in practice.
- `c.doWork` is never called → no `sqle/auto_gc:` log lines, no reclamation.
- `auto_gc_behavior.enable: true` in our managed `config.yaml` has no effect.

Empirical: on a 192-CPU host (load1 ≈ 118, threshold 0.052 = ~2275× over), bloat grew linearly from 6 MB → 172 MB across 3500 writes with zero GC log output. Manual `CALL DOLT_GC()` against the same DB reclaimed 43% in 4.6 s.

`DOLT_GC_SCHEDULER=NONE` selects the immediate-pass scheduler, restoring the documented `auto_gc_behavior.enable: true` semantics.

## Where this is set

Two launch sites:

- **Go-side** (`cmd/gc/dolt_start_managed.go`) — used by managed-runtime starts. New helper `doltServerEnv` augments `os.Environ()` with `DOLT_GC_SCHEDULER=NONE` only when the variable is unset.
- **Shell example** (`examples/bd/assets/scripts/gc-beads-bd.sh`) — same pattern via `: "${DOLT_GC_SCHEDULER:=NONE}"; export`.

In both cases users who explicitly set `DOLT_GC_SCHEDULER` (to any value, including empty) are respected.

## Why this is safe

1. Auto-GC is already throttled by post-GC heuristics in Dolt's `shouldRequestGC`: after a GC, the next can't fire until both elapsed time exceeds the prior GC's runtime AND the store has grown by the prior new-gen size. So removing the load-avg gate doesn't introduce runaway-GC risk.
2. The dolt-gc-nudge order (PR #1196) still runs an unconditional hourly `CALL DOLT_GC()` regardless of auto-GC state. With this PR, the auto-GC threshold trigger ALSO works (firing at 128 MiB-of-growth between nudges), giving us belt-and-suspenders.

## Relationship to upstream

This is a workaround, not a fix. The upstream issue ([dolthub/dolt#10944](https://github.com/dolthub/dolt/issues/10944)) tracks the inverted formula. When that's fixed and we bump the Dolt floor accordingly, this workaround can be removed.

## Test plan

- [x] `go test ./cmd/gc/ -run TestDoltServerEnv -count=1` passes (3 cases: default, user override preserved, explicit empty value preserved).
- [x] `go test ./cmd/gc/...` passes overall.
- [x] Empirical: with `DOLT_GC_SCHEDULER=NONE` set in the dolt server's env, auto-GC fires on a multi-core host that previously never saw it (verified against a patched-dolt binary that has the same effect).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
