### PR TITLE
fix: config-refs check treats builtin providers as valid

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -190,7 +190,9 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 			}
 		}
 		if a.Provider != "" && len(c.cfg.Providers) > 0 {
-			if _, ok := c.cfg.Providers[a.Provider]; !ok {
+			_, declared := c.cfg.Providers[a.Provider]
+			_, builtin := config.BuiltinProviders()[a.Provider]
+			if !declared && !builtin {
 				issues = append(issues, fmt.Sprintf("agent %q: provider %q not defined in [providers]", qn, a.Provider))
 			}
 		}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -262,6 +262,24 @@ func TestConfigRefsCheck_UndefinedProvider(t *testing.T) {
 	}
 }
 
+func TestConfigRefsCheck_BuiltinProviderNotFlagged(t *testing.T) {
+	// Builtin providers (e.g. "claude") should not be flagged as undefined
+	// even when custom providers are declared in [providers].
+	dir := t.TempDir()
+	cfg := &config.City{
+		Providers: map[string]config.ProviderSpec{"ollama-local": {}},
+		Agents: []config.Agent{
+			{Name: "worker", Provider: "claude"},
+			{Name: "coder", Provider: "codex"},
+		},
+	}
+	c := NewConfigRefsCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (builtin providers are implicitly valid); details = %v", r.Status, r.Details)
+	}
+}
+
 func TestConfigRefsCheck_NoProvidersDefined(t *testing.T) {
 	// When no providers section exists, agent provider refs are not checked.
 	dir := t.TempDir()

--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -47,7 +47,7 @@ func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
 	}
 	return regularFileSnapshot{
 		data:  data,
-		id:    fileIdentity{dev: stat.Dev, ino: stat.Ino},
+		id:    fileIdentity{dev: uint64(stat.Dev), ino: stat.Ino},
 		hasID: true,
 	}, nil
 }

--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -47,7 +47,7 @@ func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
 	}
 	return regularFileSnapshot{
 		data:  data,
-		id:    fileIdentity{dev: uint64(stat.Dev), ino: stat.Ino},
+		id:    fileIdentity{dev: uint64(stat.Dev), ino: stat.Ino}, //nolint:unconvert // int32 on darwin, uint64 on linux
 		hasID: true,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- `gc doctor` config-refs check now consults `config.BuiltinProviders()` before flagging agent provider references as undefined — fixes false positive for `"claude"`, `"codex"`, and other built-in providers
- Fixes `stat.Dev` int32→uint64 type mismatch on darwin/arm64 in fsys `readRegularFileSnapshot`

Closes ga-4i8

## Test plan

- [x] `TestConfigRefsCheck_BuiltinProviderNotFlagged` — builtin providers not flagged when custom providers exist
- [x] `TestConfigRefsCheck_UndefinedProvider` — truly undefined providers still flagged
- [x] `go vet` clean
- [x] `internal/fsys` tests pass (darwin uint64 cast)