### PR TITLE
docs: rename Agent Protocol primitive to Session in architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,13 @@ mechanism is provably composable from the primitives.
 
 **Five primitives (Layer 0-1):**
 
-1. **Agent Protocol** — start/stop/prompt/observe agents regardless of
-   provider. Identity, pools, sandboxes, resume, crash adoption.
+1. **Session** — start/stop/prompt/observe sessions regardless of
+   provider. Identity (via `agent.SessionNameFor`), pools, sandboxes,
+   resume, crash adoption. Lifecycle is a bead-backed projection
+   (`internal/session/lifecycle_projection.go`). Runtime providers
+   (tmux, subprocess, exec, k8s, fake) plus routing layers (acp,
+   auto, hybrid) live under `internal/runtime/` and plug in behind
+   the Session surface.
 2. **Task Store (Beads)** — CRUD + Hook + Dependencies + Labels + Query
    over work units. Everything is a bead: tasks, mail, molecules, convoys.
 3. **Event Bus** — append-only pub/sub log of all system activity. Two
@@ -55,13 +60,16 @@ mechanism is provably composable from the primitives.
 **Four derived mechanisms (Layer 2-4):**
 
 6. **Messaging** — Mail = `TaskStore.Create(bead{type:"message"})`.
-   Nudge = `AgentProtocol.SendPrompt()`. No new primitive needed.
+   Nudge = a session-layer operation implemented via
+   `runtime.Provider.Nudge()` (and exposed through
+   `worker.SessionHandle.Nudge()` at the worker boundary). No new
+   primitive needed.
 7. **Formulas & Molecules** — Formula = TOML parsed by Config. Molecule =
    root bead + child step beads in Task Store. Wisps = ephemeral molecules.
    Orders = formulas with gate conditions on Event Bus.
 8. **Dispatch (Sling)** — composed: find/spawn agent → select formula →
    create molecule → hook to agent → nudge → create convoy → log event.
-9. **Health Patrol** — ping agents (Agent Protocol), compare thresholds
+9. **Health Patrol** — probe sessions (Session), compare thresholds
    (Config), publish stalls (Event Bus), restart with backoff.
 
 ### Layering invariants
@@ -78,16 +86,16 @@ mechanism is provably composable from the primitives.
 
 Capabilities activate progressively via config presence.
 
-| Level | Adds                   |
-| ----- | ---------------------- |
-| 0-1   | Agent + tasks          |
-| 2     | Task loop              |
-| 3     | Multiple agents + pool |
-| 4     | Messaging              |
-| 5     | Formulas & molecules   |
-| 6     | Health monitoring      |
-| 7     | Orders                 |
-| 8     | Full orchestration     |
+| Level | Adds                    |
+| ----- | ----------------------- |
+| 0-1   | Session + tasks         |
+| 2     | Task loop               |
+| 3     | Multiple agents + pool  |
+| 4     | Messaging               |
+| 5     | Formulas & molecules    |
+| 6     | Health monitoring       |
+| 7     | Orders                  |
+| 8     | Full orchestration      |
 
 ## Architecture docs
 
@@ -108,10 +116,11 @@ Load-bearing invariants enforced by CI (violating any fails the
 build; full rationale is in the architecture docs):
 
 - **Object model at the center.** `internal/{beads, mail, convoy,
-formula, agent, events, session, sling, ...}` is the canonical
+  formula, events, session, worker, sling, ...}` is the canonical
   domain. The CLI (`cmd/gc/`) and the HTTP+SSE API
   (`internal/api/`) are projections over it. Neither re-implements
-  domain logic.
+  domain logic. `internal/agent/` is a small helper package
+  (session-name utilities, startup hints) — not a primitive.
 - **Typed wire.** No hand-written JSON on any HTTP or SSE wire
   path; no `map[string]any` or `json.RawMessage` on wire types
   (documented exceptions live in the API control-plane doc). All
@@ -123,6 +132,31 @@ formula, agent, events, session, sling, ...}` is the canonical
   `events.NoPayload` for events whose envelope fields alone
   capture the semantics. Enforced by
   `TestEveryKnownEventTypeHasRegisteredPayload`.
+
+## Active migrations
+
+These migrations are in flight. New code on affected paths must take
+the canonical route, not the legacy route.
+
+- **Worker boundary (started `12a0a848` on Apr 17 2026, in progress).**
+  `internal/worker/handle.go` is the canonical boundary for session
+  creation and lifecycle operations. Production `cmd/gc/*.go` files
+  must route through `worker.Handle` — enforced by
+  `TestGCNonTestFilesStayOnWorkerBoundary` in
+  `cmd/gc/worker_boundary_import_test.go`, which forbids non-test
+  files from importing `session.NewManager(`, `worker.SessionHandle`,
+  `sessionlog`, and similar bypass paths. The remaining production
+  callers of `session.Manager.Create*` directly are
+  `internal/api/session_manager.go` and the package-internal helpers
+  in `internal/session/`. Tests may construct `session.Manager`
+  directly. Do not add new non-test direct `session.Manager.Create*`
+  call sites in `cmd/gc/`.
+- **Session-first (completed `dd90ac0a` on Mar 8 2026).** The former
+  Agent Protocol primitive was removed; responsibilities moved to
+  `internal/session/` (lifecycle) and `internal/runtime/` (providers).
+  `internal/agent/` is now a helper package with session-name utilities
+  and startup hints — not a primitive. Do not reconstruct the
+  `Agent` / `Handle` interfaces.
 
 ## Design decisions (settled)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ mechanism is provably composable from the primitives.
 6. **Messaging** — Mail = `TaskStore.Create(bead{type:"message"})`.
    Nudge = a session-layer operation implemented via
    `runtime.Provider.Nudge()` (and exposed through
-   `worker.SessionHandle.Nudge()` at the worker boundary). No new
+   `worker.Handle.Nudge()` at the worker boundary). No new
    primitive needed.
 7. **Formulas & Molecules** — Formula = TOML parsed by Config. Molecule =
    root bead + child step beads in Task Store. Wisps = ephemeral molecules.
@@ -145,12 +145,17 @@ the canonical route, not the legacy route.
   `TestGCNonTestFilesStayOnWorkerBoundary` in
   `cmd/gc/worker_boundary_import_test.go`, which forbids non-test
   files from importing `session.NewManager(`, `worker.SessionHandle`,
-  `sessionlog`, and similar bypass paths. The remaining production
-  callers of `session.Manager.Create*` directly are
-  `internal/api/session_manager.go` and the package-internal helpers
-  in `internal/session/`. Tests may construct `session.Manager`
-  directly. Do not add new non-test direct `session.Manager.Create*`
-  call sites in `cmd/gc/`.
+  `sessionlog`, and similar bypass paths in `cmd/gc`. The remaining
+  manager-construction/direct-create bypasses are split by category:
+  `internal/api/session_manager.go` constructs `session.Manager` values
+  for API handlers, and `internal/api/session_resolution.go` still calls
+  `mgr.CreateAliasedNamedWithTransportAndMetadata(...)` directly. This
+  list is not a sessionlog read-site inventory; stream and transcript
+  readers in `internal/api/` and `internal/session/` still read
+  session logs directly. Package-internal helpers in `internal/session/`
+  may construct and use `session.Manager`; tests may construct it
+  directly. Do not add new non-test direct `session.Manager.Create*` call
+  sites outside the worker boundary.
 - **Session-first (completed `dd90ac0a` on Mar 8 2026).** The former
   Agent Protocol primitive was removed; responsibilities moved to
   `internal/session/` (lifecycle) and `internal/runtime/` (providers).

--- a/engdocs/architecture/controller.md
+++ b/engdocs/architecture/controller.md
@@ -3,7 +3,7 @@ title: "Controller"
 ---
 
 
-> Last verified against code: 2026-03-01
+> Last verified against code: 2026-04-25
 
 ## Summary
 
@@ -53,7 +53,7 @@ automations, and garbage-collects expired wisps.
 
 The controller is implemented entirely in `cmd/gc/` as a set of
 collaborating functions and interfaces -- not as a standalone package.
-It composes primitives (Agent Protocol, Config, Event Bus, Beads, Prompts)
+It composes primitives (Session, Config, Event Bus, Beads, Prompts)
 into the runtime orchestration loop.
 
 ### Data Flow

--- a/engdocs/architecture/controller.md
+++ b/engdocs/architecture/controller.md
@@ -83,7 +83,7 @@ gc start --foreground
   │           └─ ticker loop:
   │                 ├─ if dirty: tryReloadConfig() + rebuild trackers
   │                 ├─ buildAgents(cfg)  →  evaluate pools in parallel
-  │                 ├─ doReconcileAgents()
+  │                 ├─ reconcileSessionBeads()
   │                 ├─ wispGC.runGC()
   │                 └─ orderDispatcher.dispatch()
   │
@@ -111,8 +111,8 @@ Each tick of `controllerLoop()` (`cmd/gc/controller.go:268-320`) performs:
    individually. Each agent gets its environment, prompt, hooks, overlay,
    and session setup expanded.
 
-3. **Reconciliation** (`doReconcileAgents()`): Declarative convergence --
-   make running sessions match the desired list. See
+3. **Reconciliation** (`reconcileSessionBeads()`): Declarative convergence --
+   make session beads and running sessions match the desired list. See
    [Health Patrol](health-patrol.md) for the reconciliation state machine,
    crash loop quarantine, and idle tracking details.
 
@@ -179,7 +179,7 @@ indicate bugs.
   goroutines. Results are processed sequentially after `wg.Wait()`.
 
 - **Supervisor-managed and standalone runtimes share reconciliation code**:
-  `CityRuntime.run()` and `doReconcileAgents()` power both the
+  `CityRuntime.run()` and `reconcileSessionBeads()` power both the
   machine-wide supervisor path and the hidden standalone
   `gc start --foreground` path.
 
@@ -235,7 +235,8 @@ All controller implementation lives in `cmd/gc/`:
 | `cmd/gc/cmd_supervisor.go` | Machine-wide supervisor lifecycle, registry reconciliation, API hosting, and child `CityRuntime` management |
 | `cmd/gc/cmd_stop.go` | `cmdStop()`, `tryStopController()` (Unix socket IPC), `doStop()`, `gracefulStopAll()` |
 | `cmd/gc/cmd_suspend.go` | `doSuspendCity()` (sets `workspace.suspended` in TOML), `citySuspended()`, `isAgentEffectivelySuspended()` |
-| `cmd/gc/reconcile.go` | `reconcileOps` interface, `doReconcileAgents()` (4-state reconciliation + parallel starts + orphan cleanup) |
+| `cmd/gc/session_reconciler.go` | `reconcileSessionBeads()` bead-driven state machine for desired/live convergence, orphan/suspended drains, crash handling, idle drains, and config-drift repair |
+| `cmd/gc/session_lifecycle_parallel.go` | Dependency-aware bounded parallel session starts and force-stops |
 | `cmd/gc/pool.go` | `evaluatePool()`, `poolAgents()`, `expandSessionSetup()`, `expandDirTemplate()` |
 | `cmd/gc/providers.go` | `newSessionProvider()`, `beadsProvider()`, `newMailProvider()`, `newEventsProvider()` |
 | `cmd/gc/beads_provider_lifecycle.go` | `ensureBeadsProvider()`, `shutdownBeadsProvider()`, `initBeadsForDir()` |
@@ -305,7 +306,8 @@ Controller tests use in-memory fakes and require no external infrastructure:
 | Test file | Coverage |
 |---|---|
 | `cmd/gc/controller_test.go` | Controller loop tick behavior, config reload, dirty flag, fsnotify debounce, tracker rebuild on reload, order dispatch integration |
-| `cmd/gc/reconcile_test.go` | All reconciliation states, parallel starts, zombie capture, crash quarantine integration, idle restart, pool drain, suspended agent handling, orphan cleanup |
+| `cmd/gc/session_reconciler_test.go` | Session reconciliation states, zombie capture, crash quarantine integration, idle drains, pool drain, suspended session handling, orphan cleanup |
+| `cmd/gc/session_lifecycle_parallel_test.go` | Dependency-aware bounded parallel starts and force-stops |
 | `cmd/gc/pool_test.go` | `evaluatePool()` (clamping, error handling), `poolAgents()` (naming, deep-copy), `expandSessionSetup()`, `expandDirTemplate()` |
 | `cmd/gc/formula_resolve_test.go` | Layer priority, symlink creation/update/cleanup, idempotence, real file preservation |
 | `cmd/gc/wisp_gc_test.go` | TTL-based purging, `shouldRun()` interval, empty list handling |

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -2,12 +2,12 @@
 title: "Dispatch (Sling)"
 ---
 
-> Last verified against code: 2026-03-01
+> Last verified against code: 2026-04-25
 
 ## Summary
 
 Dispatch is Gas City's work routing mechanism -- a Layer 2-4 derived
-mechanism that composes primitives (Agent Protocol, Bead Store, Event Bus,
+mechanism that composes primitives (Session, Bead Store, Event Bus,
 Config) to route work to agents. The `gc sling` command resolves a target
 agent or pool, optionally instantiates a formula as a wisp, executes the
 agent's sling query to route each bead, optionally wraps single beads in

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -183,7 +183,8 @@ CLI layer (cmd/gc/cmd_sling.go)
 | `internal/beads` (Store) | `MolCook` for wisp instantiation, `Create` for auto-convoy, `Get`/`Children` for container expansion, `Update` for ParentID linking, `SetMetadata` for merge strategy |
 | `internal/config` | Agent resolution, `EffectiveSlingQuery`, pool detection via `IsPool`, `PoolConfig` for sizing, `Suspended` flag |
 | `internal/runtime` | `Provider.IsRunning` and `Provider.Nudge` for agent nudging via `doSlingNudge` |
-| `internal/agent` | `SessionNameFor` to compute session names, `agent.New` + `Nudge` to deliver nudge text |
+| `internal/agent` | `SessionNameFor` to compute session names |
+| `internal/worker` | `Handle.Nudge` at the worker boundary for direct nudge delivery |
 | `internal/telemetry` | `RecordSling` for metrics and log events on every dispatch |
 | `cmd/gc/cmd_agent.go` | `resolveAgentIdentity` for 2-step target resolution (literal then contextual) |
 

--- a/engdocs/architecture/event-bus.md
+++ b/engdocs/architecture/event-bus.md
@@ -3,7 +3,7 @@ title: "Event Bus"
 ---
 
 
-> Last verified against code: 2026-03-01
+> Last verified against code: 2026-04-25
 
 ## Summary
 
@@ -223,7 +223,7 @@ are enforced by the conformance suite in
 | Depended on by | How |
 |---|---|
 | `cmd/gc/controller.go` | Records `controller.started` and `controller.stopped` events at lifecycle boundaries; passes `Recorder` to reconciliation and shutdown |
-| `cmd/gc/reconcile.go` | Records `agent.started`, `agent.stopped`, `agent.crashed`, `agent.idle_killed`, `agent.quarantined`, `agent.suspended` events during reconciliation |
+| `cmd/gc/session_lifecycle_parallel.go` | Records `session.woke`, `session.stopped`, `session.crashed`, `session.idle_killed`, `session.quarantined`, `session.suspended` events during the session lifecycle (renamed from `agent.*` by `be8debd8`) |
 | `cmd/gc/order_dispatch.go` | Records `order.fired`, `order.completed`, `order.failed` events during order dispatch |
 | `cmd/gc/cmd_events.go` | CLI `gc events` command: reads and displays events with filtering (`--type`, `--since`), watch mode (`--watch`), and sequence query (`--seq`) |
 | `cmd/gc/cmd_event_emit.go` | CLI `gc event emit` command: records custom events from scripts and bd hooks (best-effort, always exits 0) |
@@ -256,14 +256,15 @@ All event type constants are defined in `internal/events/events.go`:
 
 | Constant | Value | Emitted by |
 |---|---|---|
-| `AgentStarted` | `agent.started` | Controller reconciliation on agent start |
-| `AgentStopped` | `agent.stopped` | Controller reconciliation on agent stop, shutdown, or drain completion |
-| `AgentCrashed` | `agent.crashed` | Controller reconciliation when a running agent's process is gone |
-| `AgentDraining` | `agent.draining` | Agent drain command |
-| `AgentUndrained` | `agent.undrained` | Agent undrain command |
-| `AgentQuarantined` | `agent.quarantined` | Controller when crash loop threshold exceeded |
-| `AgentIdleKilled` | `agent.idle_killed` | Controller when idle timeout exceeded |
-| `AgentSuspended` | `agent.suspended` | Controller when agent is suspended via config |
+| `SessionWoke` | `session.woke` | Controller reconciliation on session start |
+| `SessionStopped` | `session.stopped` | Controller reconciliation on session stop, shutdown, or drain completion |
+| `SessionCrashed` | `session.crashed` | Controller reconciliation when a running session's process is gone |
+| `SessionDraining` | `session.draining` | Session drain command |
+| `SessionUndrained` | `session.undrained` | Session undrain command |
+| `SessionQuarantined` | `session.quarantined` | Controller when crash loop threshold exceeded |
+| `SessionIdleKilled` | `session.idle_killed` | Controller when idle timeout exceeded |
+| `SessionSuspended` | `session.suspended` | Controller when session is suspended via config |
+| `SessionUpdated` | `session.updated` | Controller on session config drift detection |
 | `BeadCreated` | `bead.created` | Bead creation hooks |
 | `BeadClosed` | `bead.closed` | Bead close hooks |
 | `BeadUpdated` | `bead.updated` | Bead update hooks |
@@ -275,9 +276,9 @@ All event type constants are defined in `internal/events/events.go`:
 | `ControllerStopped` | `controller.stopped` | Controller shutdown |
 | `CitySuspended` | `city.suspended` | City suspend command |
 | `CityResumed` | `city.resumed` | City resume command |
-| `AutomationFired` | `order.fired` | Order dispatch when a trigger is due |
-| `AutomationCompleted` | `order.completed` | Order dispatch on successful completion |
-| `AutomationFailed` | `order.failed` | Order dispatch on failure |
+| `OrderFired` | `order.fired` | Order dispatch when a trigger is due |
+| `OrderCompleted` | `order.completed` | Order dispatch on successful completion |
+| `OrderFailed` | `order.failed` | Order dispatch on failure |
 
 ## Configuration
 
@@ -303,7 +304,7 @@ is a complete, self-contained JSON object:
 
 ```json
 {"seq":1,"type":"controller.started","ts":"2026-03-01T10:00:00Z","actor":"gc"}
-{"seq":2,"type":"agent.started","ts":"2026-03-01T10:00:01Z","actor":"gc","subject":"worker-1","message":"agent started successfully"}
+{"seq":2,"type":"session.woke","ts":"2026-03-01T10:00:01Z","actor":"gc","subject":"worker-1","message":"session woke successfully"}
 {"seq":3,"type":"bead.created","ts":"2026-03-01T10:00:05Z","actor":"human","subject":"gc-42","payload":{"title":"Fix bug","labels":["urgent"]}}
 ```
 

--- a/engdocs/architecture/event-bus.md
+++ b/engdocs/architecture/event-bus.md
@@ -223,13 +223,16 @@ are enforced by the conformance suite in
 | Depended on by | How |
 |---|---|
 | `cmd/gc/controller.go` | Records `controller.started` and `controller.stopped` events at lifecycle boundaries; passes `Recorder` to reconciliation and shutdown |
-| `cmd/gc/session_lifecycle_parallel.go` | Records `session.woke`, `session.stopped`, `session.crashed`, `session.idle_killed`, `session.quarantined`, `session.suspended` events during the session lifecycle (renamed from `agent.*` by `be8debd8`) |
+| `cmd/gc/session_lifecycle_parallel.go` | Records `session.woke` and parallel lifecycle `session.stopped` events (renamed from `agent.*` by `be8debd8`) |
+| `cmd/gc/session_reconciler.go` | Records `session.crashed`, `session.draining`, `session.idle_killed`, `session.stopped`, and `session.updated` while reconciling session beads |
+| `cmd/gc/cmd_runtime_drain.go` | Records manual `session.draining` and `session.undrained` events |
+| `cmd/gc/cmd_handoff.go` | Records handoff-related `session.draining` and `session.stopped` events |
 | `cmd/gc/order_dispatch.go` | Records `order.fired`, `order.completed`, `order.failed` events during order dispatch |
 | `cmd/gc/cmd_events.go` | CLI `gc events` command: reads and displays events with filtering (`--type`, `--since`), watch mode (`--watch`), and sequence query (`--seq`) |
 | `cmd/gc/cmd_event_emit.go` | CLI `gc event emit` command: records custom events from scripts and bd hooks (best-effort, always exits 0) |
-| `cmd/gc/cmd_agent.go` | Records agent lifecycle events during start/stop/restart operations |
+| `cmd/gc/cmd_agent.go` | Records session lifecycle events during start/stop/restart operations |
 | `cmd/gc/cmd_suspend.go` | Records `city.suspended` and `city.resumed` events |
-| `cmd/gc/cmd_mail.go` | Records `mail.sent` and `mail.read` events |
+| `cmd/gc/cmd_mail.go` | Records CLI `mail.*` events for send, read, archive, reply, mark-read/unread, and delete operations |
 | `cmd/gc/cmd_convoy.go` | Records `convoy.created` and `convoy.closed` events |
 | `internal/orders/triggers.go` | Event triggers query the Provider via `List(Filter{Type, AfterSeq})` to check if matching events exist since the last cursor position |
 
@@ -252,33 +255,57 @@ are enforced by the conformance suite in
 
 ### Event Type Constants
 
-All event type constants are defined in `internal/events/events.go`:
+All event type constants in `events.KnownEventTypes` are defined in
+`internal/events/events.go` and must have a registered payload for the
+API/SSE projection:
 
 | Constant | Value | Emitted by |
 |---|---|---|
-| `SessionWoke` | `session.woke` | Controller reconciliation on session start |
-| `SessionStopped` | `session.stopped` | Controller reconciliation on session stop, shutdown, or drain completion |
-| `SessionCrashed` | `session.crashed` | Controller reconciliation when a running session's process is gone |
-| `SessionDraining` | `session.draining` | Session drain command |
-| `SessionUndrained` | `session.undrained` | Session undrain command |
-| `SessionQuarantined` | `session.quarantined` | Controller when crash loop threshold exceeded |
-| `SessionIdleKilled` | `session.idle_killed` | Controller when idle timeout exceeded |
-| `SessionSuspended` | `session.suspended` | Controller when session is suspended via config |
-| `SessionUpdated` | `session.updated` | Controller on session config drift detection |
+| `SessionWoke` | `session.woke` | `cmd/gc/session_lifecycle_parallel.go` when a reconciler start succeeds |
+| `SessionStopped` | `session.stopped` | `cmd/gc/session_lifecycle_parallel.go`, `cmd/gc/session_reconciler.go`, `cmd/gc/controller.go`, `cmd/gc/cmd_handoff.go`, `cmd/gc/cmd_session.go` |
+| `SessionCrashed` | `session.crashed` | `cmd/gc/session_reconciler.go` when a runtime exists but the expected child process is gone |
+| `SessionDraining` | `session.draining` | `cmd/gc/session_reconciler.go`, `cmd/gc/cmd_runtime_drain.go`, `cmd/gc/cmd_handoff.go` |
+| `SessionUndrained` | `session.undrained` | `cmd/gc/cmd_runtime_drain.go` |
+| `SessionQuarantined` | `session.quarantined` | Registered/reserved; no production emitter today |
+| `SessionIdleKilled` | `session.idle_killed` | `cmd/gc/session_reconciler.go` when idle timeout handling stops a session |
+| `SessionSuspended` | `session.suspended` | Registered/reserved; no production emitter today |
+| `SessionUpdated` | `session.updated` | `cmd/gc/session_reconciler.go` on live-only config drift repair |
 | `BeadCreated` | `bead.created` | Bead creation hooks |
 | `BeadClosed` | `bead.closed` | Bead close hooks |
 | `BeadUpdated` | `bead.updated` | Bead update hooks |
-| `MailSent` | `mail.sent` | Mail send command |
+| `MailSent` | `mail.sent` | Mail send/API handlers and handoff command |
 | `MailRead` | `mail.read` | Mail read command |
+| `MailArchived` | `mail.archived` | Mail archive command and API handler |
+| `MailMarkedRead` | `mail.marked_read` | Mail mark-read command and API handler |
+| `MailMarkedUnread` | `mail.marked_unread` | Mail mark-unread command and API handler |
+| `MailReplied` | `mail.replied` | Mail reply command and API handler |
+| `MailDeleted` | `mail.deleted` | Mail delete command and API handler |
 | `ConvoyCreated` | `convoy.created` | Convoy creation |
 | `ConvoyClosed` | `convoy.closed` | Convoy close |
 | `ControllerStarted` | `controller.started` | Controller startup |
 | `ControllerStopped` | `controller.stopped` | Controller shutdown |
 | `CitySuspended` | `city.suspended` | City suspend command |
 | `CityResumed` | `city.resumed` | City resume command |
+| `RequestResultCityCreate` | `request.result.city.create` | Supervisor/API city create completion |
+| `RequestResultCityUnregister` | `request.result.city.unregister` | Supervisor city unregister completion |
+| `RequestResultSessionCreate` | `request.result.session.create` | API async session create completion |
+| `RequestResultSessionMessage` | `request.result.session.message` | API async session message completion |
+| `RequestResultSessionSubmit` | `request.result.session.submit` | API async session submit completion |
+| `RequestFailed` | `request.failed` | Supervisor/API async request failure handlers |
+| `CityCreated` | `city.created` | City init lifecycle diagnostics |
+| `CityUnregisterRequested` | `city.unregister_requested` | City unregister lifecycle diagnostics |
 | `OrderFired` | `order.fired` | Order dispatch when a trigger is due |
 | `OrderCompleted` | `order.completed` | Order dispatch on successful completion |
 | `OrderFailed` | `order.failed` | Order dispatch on failure |
+| `ProviderSwapped` | `provider.swapped` | Controller provider-swap reload path |
+| `WorkerOperation` | `worker.operation` | Worker session handle and runtime handle operation tracing |
+| `ExtMsgBound` | `extmsg.bound` | External messaging bind handler |
+| `ExtMsgUnbound` | `extmsg.unbound` | External messaging unbind handler |
+| `ExtMsgGroupCreated` | `extmsg.group_created` | External messaging group ensure handler |
+| `ExtMsgAdapterAdded` | `extmsg.adapter_added` | External messaging adapter registration handler |
+| `ExtMsgAdapterRemoved` | `extmsg.adapter_removed` | External messaging adapter unregister handler |
+| `ExtMsgInbound` | `extmsg.inbound` | External messaging inbound adapter pipeline |
+| `ExtMsgOutbound` | `extmsg.outbound` | External messaging outbound adapter pipeline |
 
 ## Configuration
 
@@ -418,7 +445,7 @@ suite against a stateful jq-based mock script.
 - [Architecture glossary](glossary.md) -- authoritative definitions of
   event bus, order, trigger, and other terms used in this document
 - [Health Patrol architecture](health-patrol.md) -- how the controller
-  reconciliation loop records agent lifecycle events on every tick
+  reconciliation loop records session lifecycle events on every tick
 - [Bead Store architecture](beads.md) -- the other Layer 0-1 primitive;
   events and beads together provide persistence + observation
 - [Config architecture](config.md) -- how `[events].provider` is

--- a/engdocs/architecture/glossary.md
+++ b/engdocs/architecture/glossary.md
@@ -6,15 +6,20 @@ Authoritative definitions of Gas City terms. If a term's usage
 elsewhere conflicts with this glossary, this glossary wins and the
 other source should be updated.
 
-> Last verified against code: 2026-03-01
+> Last verified against code: 2026-04-25
 
 ## Primitives
 
-- **Agent Protocol**: Start/stop/prompt/observe agents regardless of
-  session provider. Covers identity, pools, sandboxes, resume, and
-  crash adoption. Layer 0-1 primitive. See
-  [`internal/agent/`](https://github.com/gastownhall/gascity/tree/main/internal/agent/) and
+- **Session**: Start/stop/prompt/observe sessions regardless of
+  provider. Covers identity, pools, sandboxes, resume, and crash
+  adoption. Layer 0-1 primitive. Lifecycle lives in
+  [`internal/session/`](https://github.com/gastownhall/gascity/tree/main/internal/session/);
+  the runtime boundary is `runtime.Provider` in
   [`internal/runtime/`](https://github.com/gastownhall/gascity/tree/main/internal/runtime/).
+  Naming and startup hints live in
+  [`internal/agent/`](https://github.com/gastownhall/gascity/tree/main/internal/agent/).
+  Renamed from "Agent Protocol" by the session-first migration
+  (commit `dd90ac0a`, Mar 8 2026).
 
 - **Bead**: A single unit of work. Everything is a bead: tasks, mail,
   molecules, convoys, and epics. Defined in the `Bead` struct with ID,
@@ -70,7 +75,7 @@ other source should be updated.
   invocation only). See
   [`internal/orders/triggers.go`](https://github.com/gastownhall/gascity/blob/main/internal/orders/triggers.go).
 
-- **Health Patrol**: Ping agents (Agent Protocol), compare thresholds
+- **Health Patrol**: Probe sessions (Session), compare thresholds
   (Config), publish stalls (Event Bus), restart with backoff. The
   supervision model follows Erlang/OTP patterns.
 
@@ -87,8 +92,10 @@ other source should be updated.
   queryable by label via `ListByLabel`.
 
 - **Messaging**: Inter-agent communication composed from primitives.
-  Mail = `TaskStore.Create(bead{type:"message"})`. Nudge =
-  `AgentProtocol.SendPrompt()`. No new primitive needed.
+  Mail = `TaskStore.Create(bead{type:"message"})`. Nudge = a
+  session-layer operation implemented via `runtime.Provider.Nudge()`
+  (and exposed through `worker.SessionHandle.Nudge()` at the worker
+  boundary). No new primitive needed.
 
 - **Molecule**: A formula instantiated at runtime: one root bead plus
   zero or more provider-managed step beads. Progress is tracked by closing

--- a/engdocs/architecture/glossary.md
+++ b/engdocs/architecture/glossary.md
@@ -94,7 +94,7 @@ other source should be updated.
 - **Messaging**: Inter-agent communication composed from primitives.
   Mail = `TaskStore.Create(bead{type:"message"})`. Nudge = a
   session-layer operation implemented via `runtime.Provider.Nudge()`
-  (and exposed through `worker.SessionHandle.Nudge()` at the worker
+  (and exposed through `worker.Handle.Nudge()` at the worker
   boundary). No new primitive needed.
 
 - **Molecule**: A formula instantiated at runtime: one root bead plus
@@ -134,8 +134,8 @@ other source should be updated.
 - **Provider** (Session): Manages agent sessions. The `Provider`
   interface defines lifecycle (Start, Stop, Interrupt), querying
   (IsRunning, ProcessAlive), communication (Attach, Nudge, SendKeys),
-  and metadata (SetMeta, GetMeta). Implementations: tmux (production),
-  subprocess (remote), k8s (Kubernetes), Fake (test). See
+  and metadata (SetMeta, GetMeta). Implementations: tmux, subprocess,
+  exec, k8s, acp, auto, hybrid, and Fake (test). See
   [`internal/runtime/runtime.go`](https://github.com/gastownhall/gascity/blob/main/internal/runtime/runtime.go).
 
 - **Rig**: An external project directory registered in the city. Each

--- a/engdocs/architecture/health-patrol.md
+++ b/engdocs/architecture/health-patrol.md
@@ -76,11 +76,11 @@ use):
                      │  └──────────────┬──────────────┘   │
                      │                 ▼                   │
                      │  ┌─────────────────────────────┐   │
-                     │  │ doReconcileAgents()          │   │
-                     │  │ (reconcile.go)               │   │
+                     │  │ reconcileSessionBeads()      │   │
+                     │  │ (session_reconciler.go)      │   │
                      │  │   ├─ crashTracker            │   │
                      │  │   ├─ idleTracker             │   │
-                     │  │   ├─ reconcileOps (drift)    │   │
+                     │  │   ├─ config drift repair     │   │
                      │  │   └─ drainOps (pool scaling) │   │
                      │  └──────────────┬──────────────┘   │
                      │                 ▼                   │
@@ -108,7 +108,7 @@ A single controller tick proceeds as follows:
 2. **Agent list build**. `buildFn(cfg)` re-evaluates the desired agent
    set, including pool `check` commands for elastic scaling.
 
-3. **Reconciliation** (`doReconcileAgents()`). The core state machine.
+3. **Reconciliation** (`reconcileSessionBeads()`). The core state machine.
    For each desired agent, determines the correct action. See the
    Reconciliation State Machine below.
 
@@ -121,18 +121,17 @@ A single controller tick proceeds as follows:
 
 ### Reconciliation State Machine
 
-`doReconcileAgents()` in `cmd/gc/reconcile.go` classifies each agent
-into one of four states and takes action:
+`reconcileSessionBeads()` in `cmd/gc/session_reconciler.go` reconciles
+session beads, runtime liveness, and desired config state:
 
 ```
 ┌──────────────────────────────────────────────────────────┐
 │ State              │ Condition         │ Action          │
 ├──────────────────────────────────────────────────────────┤
-│ Not running        │ !IsRunning()      │ Start           │
-│ Healthy            │ hash matches      │ Skip            │
-│ Orphan             │ running, not in   │ Stop            │
-│                    │ desired set       │                 │
-│ Drifted            │ hash differs      │ Stop + Start    │
+│ Not alive          │ should wake       │ Start           │
+│ Healthy            │ alive + desired   │ Skip            │
+│ Orphan/suspended   │ not desired       │ Drain or close  │
+│ Drifted            │ hash differs      │ Drain + restart │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -141,18 +140,24 @@ Additional sub-states within "running" are checked in order:
 1. **Restart requested**: Agent self-requested restart (context
    exhaustion). Stop + start.
 2. **Idle timeout exceeded**: `idleTracker.checkIdle()` returns true.
-   Stop + start, emit `session.idle_killed` event.
+   Stop the idle session and emit `session.idle_killed`.
 3. **Config drift**: Stored hash differs from current. Stop + start.
 
 Agents not running are subject to **crash loop quarantine**: if
 `crashTracker.isQuarantined()` returns true, the agent is skipped
-silently (the quarantine event was emitted when the threshold was first
-hit).
+silently. `session.quarantined` is a registered/reserved event type, but
+there is no production emitter today. Operators that need this signal
+must read the crash tracker quarantine state; subscribing to
+`session.quarantined` will not observe transitions yet.
 
 **Orphan cleanup** (Phase 2) handles sessions with the city prefix that
 are not in the desired set:
 - Pool excess members are drained gracefully via `drainOps`.
-- Suspended agents are stopped with a `session.suspended` event.
+- Suspended agents are drained or closed as not desired; `session.suspended`
+  is a registered/reserved event type, but there is no production emitter
+  today. Suspension state is derived from `workspace.suspended`, rig
+  suspension, and agent suspension through `isAgentEffectivelySuspended()`,
+  not from `session.suspended` events.
 - True orphans are killed immediately.
 
 **Dependency-aware bounded parallel starts** (Phase 1b): The bead-driven
@@ -177,10 +182,9 @@ waves with bounded parallelism.
   `runtime.Provider.GetLastActivity()` and compares against per-agent
   timeout durations.
 
-- **`reconcileOps`** (`cmd/gc/reconcile.go`): Interface for
-  session-level operations needed by reconciliation: `listRunning()`,
-  `storeConfigHash()`, `configHash()`. Backed by
-  `runtime.Provider.SetMeta()`/`GetMeta()` for hash persistence.
+- **Session bead reconciler** (`cmd/gc/session_reconciler.go`):
+  Bead-driven convergence over desired config, session bead state, runtime
+  liveness, drain metadata, config hashes, and wake decisions.
 
 - **`orderDispatcher`** (`cmd/gc/order_dispatch.go`): Interface
   for order trigger evaluation and dispatch. Production impl
@@ -201,7 +205,7 @@ indicate bugs.
   by `flock(LOCK_EX|LOCK_NB)` on `.gc/controller.lock`. A second
   `gc start` fails immediately.
 
-- **Reconciliation is idempotent**: Running `doReconcileAgents()` with
+- **Reconciliation is idempotent**: Running `reconcileSessionBeads()` with
   the same config and same running set produces no side effects. A
   healthy running agent with a matching hash is always skipped.
 
@@ -267,7 +271,7 @@ Health Patrol follows Erlang/OTP patterns mapped to Gas City:
 |---|---|
 | `internal/config` | Parses `DaemonConfig` for patrol interval, max restarts, restart window, shutdown timeout. Provides `Revision()` for config reload detection. |
 | `internal/runtime` | `Provider` interface for Start/Stop/IsRunning/ListRunning/GetLastActivity/SetMeta/GetMeta. `ConfigFingerprint()` for drift detection. |
-| `internal/events` | `Recorder` interface for emitting lifecycle events (`session.woke`, `session.stopped`, `session.crashed`, `session.quarantined`, `session.idle_killed`, `session.suspended`, `controller.started`, `controller.stopped`, `order.fired`, `order.completed`, `order.failed`). `Provider` interface for event trigger queries. Event names were renamed from the `agent.*` prefix by commit `be8debd8`. |
+| `internal/events` | `Recorder` interface for emitted lifecycle events (`session.woke`, `session.stopped`, `session.crashed`, `session.draining`, `session.undrained`, `session.idle_killed`, `session.updated`, `controller.started`, `controller.stopped`, `order.fired`, `order.completed`, `order.failed`). `session.quarantined` and `session.suspended` are registered/reserved but currently un-emitted. `Provider` interface for event trigger queries. Event names were renamed from the `agent.*` prefix by commit `be8debd8`. |
 | `internal/beads` | `Store` interface for order tracking beads (create, update, list by label). `CommandRunner` for bd CLI invocation. |
 | `internal/orders` | `Scan()` to discover orders from formula layers. `CheckTrigger()` to evaluate trigger conditions. `Order` struct for dispatch metadata. |
 | `internal/agent` | `SessionNameFor()` for session name computation and `StartupHints` for runtime config assembly (`internal/agent/` is now a small helper package; the former `Agent` / `Handle` interfaces were removed by `dd90ac0a`). |
@@ -285,7 +289,8 @@ All Health Patrol implementation lives in `cmd/gc/`:
 | File | Responsibility |
 |---|---|
 | `cmd/gc/controller.go` | Controller lock, Unix socket, fsnotify config watcher, `controllerLoop()`, `tryReloadConfig()`, `runController()`, `gracefulStopAll()` |
-| `cmd/gc/reconcile.go` | `reconcileOps` interface, `doReconcileAgents()` (4-state reconciliation + parallel starts + orphan cleanup), `doStopOrphans()` |
+| `cmd/gc/session_reconciler.go` | `reconcileSessionBeads()` bead-driven state machine for desired/live convergence, orphan/suspended drains, crash handling, idle drains, config-drift repair, and pool slot cleanup |
+| `cmd/gc/session_lifecycle_parallel.go` | Dependency-aware bounded parallel session starts and force-stops |
 | `cmd/gc/crash_tracker.go` | `crashTracker` interface, `memoryCrashTracker` (in-memory restart history with sliding window pruning) |
 | `cmd/gc/idle_tracker.go` | `idleTracker` interface, `memoryIdleTracker` (per-agent timeout + GetLastActivity query) |
 | `cmd/gc/order_dispatch.go` | `orderDispatcher` interface, `memoryOrderDispatcher` (trigger evaluation, exec dispatch, wisp dispatch, tracking bead lifecycle) |
@@ -329,7 +334,8 @@ Each Health Patrol component has dedicated unit tests:
 | Test file | Coverage |
 |---|---|
 | `cmd/gc/controller_test.go` | Controller loop tick behavior, config reload, dirty flag, fsnotify debounce, order dispatch integration |
-| `cmd/gc/reconcile_test.go` | All four reconciliation states (not running/healthy/orphan/drifted), parallel starts, zombie capture, crash loop quarantine integration, idle restart, pool drain, suspended agent handling |
+| `cmd/gc/session_reconciler_test.go` | Session reconciliation states, zombie capture, crash loop quarantine integration, idle drains, pool drain, suspended session handling |
+| `cmd/gc/session_lifecycle_parallel_test.go` | Dependency-aware bounded parallel starts and force-stops |
 | `cmd/gc/crash_tracker_test.go` | Sliding window pruning, quarantine threshold, clear history, nil-guard (disabled tracker) |
 | `cmd/gc/idle_tracker_test.go` | Timeout detection, zero time handling, per-agent timeout configuration, nil-guard |
 | `cmd/gc/order_dispatch_test.go` | Trigger evaluation (cooldown, cron, condition, event, manual), exec dispatch, wisp dispatch, tracking bead creation, timeout capping, rig-scoped orders |

--- a/engdocs/architecture/health-patrol.md
+++ b/engdocs/architecture/health-patrol.md
@@ -3,7 +3,7 @@ title: "Health Patrol"
 ---
 
 
-> Last verified against code: 2026-03-18
+> Last verified against code: 2026-04-25
 
 ## Summary
 
@@ -141,7 +141,7 @@ Additional sub-states within "running" are checked in order:
 1. **Restart requested**: Agent self-requested restart (context
    exhaustion). Stop + start.
 2. **Idle timeout exceeded**: `idleTracker.checkIdle()` returns true.
-   Stop + start, emit `agent.idle_killed` event.
+   Stop + start, emit `session.idle_killed` event.
 3. **Config drift**: Stored hash differs from current. Stop + start.
 
 Agents not running are subject to **crash loop quarantine**: if
@@ -152,7 +152,7 @@ hit).
 **Orphan cleanup** (Phase 2) handles sessions with the city prefix that
 are not in the desired set:
 - Pool excess members are drained gracefully via `drainOps`.
-- Suspended agents are stopped with an `agent.suspended` event.
+- Suspended agents are stopped with a `session.suspended` event.
 - True orphans are killed immediately.
 
 **Dependency-aware bounded parallel starts** (Phase 1b): The bead-driven
@@ -251,7 +251,7 @@ Health Patrol follows Erlang/OTP patterns mapped to Gas City:
 | Erlang/OTP concept       | Gas City equivalent                       |
 |--------------------------|-------------------------------------------|
 | Supervisor               | Controller (`controllerLoop`)             |
-| Worker                   | Agent (any role)                          |
+| Worker                   | Session running an `[[agent]]` role       |
 | Child spec               | `[[agent]]` entry in `city.toml`         |
 | one_for_one restart      | Restart dead agent only (no cascade)      |
 | max_restarts/max_seconds | `max_restarts` / `restart_window`         |
@@ -267,10 +267,10 @@ Health Patrol follows Erlang/OTP patterns mapped to Gas City:
 |---|---|
 | `internal/config` | Parses `DaemonConfig` for patrol interval, max restarts, restart window, shutdown timeout. Provides `Revision()` for config reload detection. |
 | `internal/runtime` | `Provider` interface for Start/Stop/IsRunning/ListRunning/GetLastActivity/SetMeta/GetMeta. `ConfigFingerprint()` for drift detection. |
-| `internal/events` | `Recorder` interface for emitting lifecycle events (`agent.started`, `agent.stopped`, `agent.crashed`, `agent.quarantined`, `agent.idle_killed`, `agent.suspended`, `controller.started`, `controller.stopped`, `order.fired`, `order.completed`, `order.failed`). `Provider` interface for event trigger queries. |
+| `internal/events` | `Recorder` interface for emitting lifecycle events (`session.woke`, `session.stopped`, `session.crashed`, `session.quarantined`, `session.idle_killed`, `session.suspended`, `controller.started`, `controller.stopped`, `order.fired`, `order.completed`, `order.failed`). `Provider` interface for event trigger queries. Event names were renamed from the `agent.*` prefix by commit `be8debd8`. |
 | `internal/beads` | `Store` interface for order tracking beads (create, update, list by label). `CommandRunner` for bd CLI invocation. |
 | `internal/orders` | `Scan()` to discover orders from formula layers. `CheckTrigger()` to evaluate trigger conditions. `Order` struct for dispatch metadata. |
-| `internal/agent` | `Agent` interface wrapping config + session provider for `Start()`/`Stop()`/`IsRunning()`/`SessionName()` operations. |
+| `internal/agent` | `SessionNameFor()` for session name computation and `StartupHints` for runtime config assembly (`internal/agent/` is now a small helper package; the former `Agent` / `Handle` interfaces were removed by `dd90ac0a`). |
 | `github.com/fsnotify/fsnotify` | File system watcher for config directory change detection. |
 
 | Depended on by | How |

--- a/engdocs/architecture/index.md
+++ b/engdocs/architecture/index.md
@@ -28,8 +28,8 @@ multi-agent orchestration system.
    activity
 5. **[Config System](./config.md)** — TOML loading, progressive activation,
    multi-layer override resolution
-6. **[Agent Protocol](./agent-protocol.md)** — agent lifecycle backed by
-   session providers (tmux, subprocess, k8s)
+6. **[Session](./session.md)** — session lifecycle backed by runtime
+   providers (tmux, subprocess, exec, k8s)
 7. **[Prompt Templates](./prompt-templates.md)** — Go `text/template` in
    Markdown defining role behavior
 
@@ -38,7 +38,7 @@ multi-agent orchestration system.
 Each is provably composable from the primitives.
 
 8. **[Messaging](./messaging.md)** — inter-agent mail via beads + nudge
-   via agent protocol
+   via the Session primitive
 9. **[Formulas & Molecules](./formulas.md)** — work definitions (TOML) and
    their runtime instances (bead trees)
 10. **[Dispatch](./dispatch.md)** — sling: agent selection + formula

--- a/engdocs/architecture/life-of-a-bead.md
+++ b/engdocs/architecture/life-of-a-bead.md
@@ -224,8 +224,9 @@ operations.
 
 ### Health patrol during execution
 
-While the agent works, the controller's reconciliation loop
-(`doReconcileAgents()` in `cmd/gc/reconcile.go`) monitors agent health.
+While the agent works, the controller's bead-driven session reconciler
+(`reconcileSessionBeads()` in `cmd/gc/session_reconciler.go`) monitors
+session health.
 If an agent crashes mid-execution, the bead persists in its current state
 (NDI -- Nondeterministic Idempotence). When the agent restarts, it
 rediscovers the in-progress bead through its hook and resumes. The bead

--- a/engdocs/architecture/messaging.md
+++ b/engdocs/architecture/messaging.md
@@ -2,14 +2,14 @@
 title: "Messaging"
 ---
 
-> Last verified against code: 2026-03-04
+> Last verified against code: 2026-04-25
 
 ## Summary
 
 Messaging is a Layer 2-4 derived mechanism that provides inter-agent
 communication without introducing new primitives. Mail is composed
 from the Bead Store (`TaskStore.Create(bead{type:"message"})`), and
-nudge is composed from the Agent Protocol
+nudge is composed from the Session primitive
 (`runtime.Provider.Nudge()`). No new infrastructure is needed — messaging
 is a thin composition layer proving the primitives are sufficient.
 
@@ -193,6 +193,6 @@ Send → [unread, open]
 
 - [Bead Store](beads.md) — messages are stored as beads; understanding
   bead lifecycle explains mail lifecycle
-- [Agent Protocol](agent-protocol.md) — Nudge() delivery mechanism
+- [Session](session.md) — Nudge() delivery mechanism
 - [Glossary](glossary.md) — authoritative definitions of mail, nudge,
   and related terms

--- a/engdocs/architecture/nine-concepts.md
+++ b/engdocs/architecture/nine-concepts.md
@@ -2,7 +2,7 @@
 title: "Nine Concepts"
 ---
 
-> Last verified against code: 2026-03-01
+> Last verified against code: 2026-04-25
 
 ## Summary
 
@@ -28,19 +28,26 @@ Before adding a new primitive, apply three necessary conditions (see
 
 These are irreducible. Each has a dedicated architecture doc.
 
-### 1. Agent Protocol
+### 1. Session
 
-Start/stop/prompt/observe agents regardless of session provider.
-Covers identity, pools, sandboxes, resume, and crash adoption.
+Start/stop/prompt/observe sessions regardless of provider. Covers
+identity, pools, sandboxes, resume, and crash adoption.
 
-- **Interface**: `runtime.Provider` with naming and startup hints from
-  `internal/agent/`
+- **Interface**: `runtime.Provider` (low-level) plus
+  `internal/session/` for bead-backed lifecycle and naming/startup
+  hints from `internal/agent/`
 - **Implementations**: tmux (production), subprocess (remote),
-  k8s (Kubernetes), Fake (test)
-- **Key insight**: The SDK manages agent lifecycle. The prompt defines
-  agent behavior. These concerns never cross.
+  exec (script), k8s (Kubernetes), Fake (test); acp / auto / hybrid
+  routing layers compose these
+- **Key insight**: The SDK manages session lifecycle. The prompt
+  defines agent behavior. These concerns never cross.
 
-**Details**: [Agent Protocol](agent-protocol.md)
+**Details**: [Session](session.md)
+
+> **History.** This primitive was named "Agent Protocol" and exposed
+> a dedicated `agent.Agent` / `agent.Handle` interface until commit
+> `dd90ac0a` (Mar 8 2026). The interface was removed; responsibilities
+> live in `internal/session/` and `internal/runtime/`.
 
 ### 2. Task Store (Beads)
 
@@ -111,7 +118,7 @@ Mail + nudge. No new primitive needed.
 - **Nudge derivation**: `runtime.Provider.Nudge(text)` → text typed
   into the agent's session. Fire-and-forget.
 - **Proof**: Mail uses only Bead Store (primitive 2). Nudge uses only
-  Agent Protocol (primitive 1). No new infrastructure.
+  Session (primitive 1). No new infrastructure.
 
 **Details**: [Messaging](messaging.md)
 
@@ -139,8 +146,8 @@ formulas with trigger conditions on Event Bus.
 Find/spawn agent → select formula → create molecule → hook to agent →
 nudge → create convoy → log event.
 
-- **Derivation**: Agent Protocol (find/spawn) + Config (select formula)
-  + Bead Store (create molecule, convoy) + Agent Protocol (nudge) +
+- **Derivation**: Session (find/spawn) + Config (select formula)
+  + Bead Store (create molecule, convoy) + Session (nudge) +
   Event Bus (log event).
 - **Proof**: Pure composition of primitives 1-4. No new infrastructure.
 
@@ -148,15 +155,14 @@ nudge → create convoy → log event.
 
 ### 9. Health Patrol
 
-Ping agents (Agent Protocol), compare thresholds (Config), publish
-stalls (Event Bus), restart with backoff.
+Probe sessions (Session), compare thresholds (Config), publish stalls
+(Event Bus), restart with backoff.
 
-- **Derivation**: Agent Protocol (primitive 1) for liveness. Config
+- **Derivation**: Session (primitive 1) for liveness. Config
   (primitive 4) for thresholds and backoff parameters. Event Bus
   (primitive 3) for stall publication.
-- **Proof**: Uses Agent Protocol, Config, and Event Bus. The
-  controller drives all operations — no user-configured agent role
-  is required.
+- **Proof**: Uses Session, Config, and Event Bus. The controller
+  drives all operations — no user-configured agent role is required.
 
 **Details**: [Health Patrol](health-patrol.md)
 
@@ -178,7 +184,7 @@ Capabilities activate based on config section presence:
 
 | Level | Config Required | Adds |
 |---|---|---|
-| 0-1 | `[workspace]` + `[[agent]]` | Agent + tasks |
+| 0-1 | `[workspace]` + `[[agent]]` | Session + tasks |
 | 2 | `[daemon]` | Task loop (controller) |
 | 3 | `[[agent]]` with `[agent.pool]` | Multiple agents + pool |
 | 4 | `[mail]` | Messaging |

--- a/engdocs/architecture/prompt-templates.md
+++ b/engdocs/architecture/prompt-templates.md
@@ -214,7 +214,7 @@ prompt:
 
 ## See Also
 
-- [Agent Protocol](agent-protocol.md) — how rendered prompts are
+- [Session](session.md) — how rendered prompts are
   delivered to agents via runtime.Provider
 - [Config System](config.md) — how Agent.PromptTemplate and Agent.Env
   are resolved through override layers

--- a/engdocs/architecture/session.md
+++ b/engdocs/architecture/session.md
@@ -1,26 +1,39 @@
 ---
-title: "Agent Protocol"
+title: "Session"
 ---
 
 
-> Last verified against code: 2026-03-17
+> Last verified against code: 2026-04-25
 
 ## Summary
 
-Gas City's agent runtime boundary lives in `internal/runtime/`.
-`runtime.Provider` is the low-level contract for starting, stopping,
-attaching to, nudging, and observing agent sessions. The surrounding pieces
-that make that usable at the product level are:
+Session is Gas City's Layer 0-1 primitive for starting, stopping,
+prompting, and observing sessions regardless of provider. It covers
+identity, pools, sandboxes, resume, and crash adoption. The runtime
+boundary lives in `internal/runtime/`; `runtime.Provider` is the
+low-level contract that pluggable providers (tmux, subprocess, exec,
+k8s, acp/auto/hybrid routing) implement. The surrounding pieces that
+make the primitive usable at the product level are:
 
 - `internal/agent/` for session naming and startup hints
 - `cmd/gc/template_resolve.go` for building runtime start configs
-- `internal/session/` for session bead records, waits, and blocked-turn state
+- `internal/session/` for the bead-backed lifecycle projection
+  (`lifecycle_projection.go`), session bead records, waits, and
+  blocked-turn state
 
 The important current-state split is:
 
 - **runtime** manages live sessions and I/O
 - **agent helpers** define naming and startup-hint data
 - **session helpers** manage higher-level session bookkeeping
+
+> **History.** Until commit `dd90ac0a` (Mar 8 2026, "session-first
+> migration"), this primitive was named "Agent Protocol" and exposed a
+> dedicated `agent.Agent` / `agent.Handle` interface. That interface
+> was removed; responsibilities now live in `internal/session/`
+> (lifecycle) and `internal/runtime/` (providers). `internal/agent/`
+> remains as a small helper package for session-name utilities and
+> startup hints — not a primitive.
 
 ## Key Concepts
 

--- a/engdocs/architecture/session.md
+++ b/engdocs/architecture/session.md
@@ -153,7 +153,7 @@ Optional provider extensions also live in `runtime/runtime.go`:
 | Depended on by | How |
 |---|---|
 | `cmd/gc/cmd_start.go` | Starts runtimes for configured agents |
-| `cmd/gc/reconcile.go` | Uses runtime liveness and drift signals |
+| `cmd/gc/session_reconciler.go` | Uses runtime liveness and drift signals for bead-driven session reconciliation |
 | `cmd/gc/cmd_session.go` | Attach, list, inspect, and session-level commands |
 | `cmd/gc/cmd_nudge.go` | Idle-aware and queued nudge delivery |
 | `internal/api/` | Session-aware API surfaces and status views |

--- a/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
@@ -102,9 +102,9 @@ gc bd list --label=incident --created-after=$SINCE --json
 
 **3. Collect town-level data:**
 
-a) **Agent events:**
+a) **Session lifecycle events:**
 ```bash
-gc events --since=$SINCE --type=agent.started,agent.stopped,agent.crashed --json
+gc events --since=$SINCE --type=session.woke,session.stopped,session.crashed --json
 ```
 
 b) **Escalations:**

--- a/test/integration/E2E-PROVIDER-GAPS.md
+++ b/test/integration/E2E-PROVIDER-GAPS.md
@@ -146,15 +146,15 @@ minutes — far beyond the 10-minute test timeout.
 
 ---
 
-### RC-3: Agent lifecycle events not emitted with exec provider (MEDIUM)
+### RC-3: Session lifecycle events not emitted with exec provider (MEDIUM)
 
 **Impact:** 1 Docker failure (TestE2E_AgentLifecycleEvents)
 
-`gc events --type agent.started` returns empty output after `gc start`.
+`gc events --type session.woke` returns empty output after `gc start`.
 The events may only be emitted by the controller loop (not one-shot
 start), or the exec provider path in `doStart` may skip event recording.
 
-**Investigation needed:** Check if `doStart` records agent.started events
+**Investigation needed:** Check if `doStart` records `session.woke` events
 for exec session providers. The one-shot path may return before events
 are flushed.
 
@@ -271,7 +271,7 @@ Remaining failures would be:
    Use `-timeout 120m` for K8s runs, or create a K8s-specific test
    subset.
 
-4. **[P2] Investigate agent.started event emission for exec providers**
+4. **[P2] Investigate `session.woke` event emission for exec providers**
    May need to record events in the one-shot `doStart` path.
 
 5. **[P2] Consider test parallelization**


### PR DESCRIPTION
## Summary

The session-first migration (`dd90ac0a`, Mar 8 2026) deleted the Agent Protocol primitive (`internal/agent/agent.go` and the `Agent`/`Handle` interfaces) and moved its responsibilities into `internal/session/` (lifecycle) and `internal/runtime/` (providers). Commit `be8debd8` then renamed `agent.*` events to `session.*`. The primitive list in AGENTS.md and the architecture docs in `engdocs/architecture/` continued to describe the deleted abstraction — for ~50 days.

This PR aligns the docs with HEAD. **No code changes.**

## Changes

- **Renamed** `engdocs/architecture/agent-protocol.md` → `session.md` (88% similarity preserved by `git mv`). Title and summary rewritten to frame as primitive #1 (Session) with a History note pointing at `dd90ac0a`.
- **AGENTS.md**:
  - Renamed primitive #1 from "Agent Protocol" to "Session"; reference `agent.SessionNameFor` (in the `agent` helper package, not `session`)
  - Fixed Messaging derivation: `Session.Nudge()` (delegating to `runtime.Provider.Nudge()`) — `SendPrompt()` doesn't exist
  - Fixed Health Patrol derivation language
  - Updated progressive capability table (Level 0-1: Agent → Session)
  - Replaced `agent` with `worker` in the canonical-domain list; footnoted `internal/agent/` as a small helper package
  - Added new **"Active migrations"** subsection documenting:
    - Worker boundary migration (started `12a0a848`, in progress) — names the CI test `TestGCNonTestFilesStayOnWorkerBoundary` that enforces non-test `cmd/gc/` files route through `worker.Handle`
    - Session-first migration (completed `dd90ac0a`)
- **`engdocs/architecture/`**: updated `nine-concepts.md`, `index.md`, `glossary.md`, `messaging.md`, `dispatch.md`, `controller.md`, `prompt-templates.md` — Agent Protocol references replaced with Session, broken links fixed.
- **`event-bus.md`**: rewrote the event-type constants table from `Agent*`/`agent.*` to `Session*`/`session.*` (matching `internal/events/events.go:20-38` exactly, including the new `SessionUpdated` constant the old table was missing). Renamed `AutomationFired`/`Completed`/`Failed` to `OrderFired`/`Completed`/`Failed`. Updated the storage-format example.
- **`health-patrol.md`**: fixed six event names renamed by `be8debd8` (`agent.*` → `session.*`); replaced obsolete description of the removed `internal/agent.Agent` interface with current helper-package responsibilities; disambiguated the Erlang/OTP table's "Worker" row from gascity's `internal/worker/` package.
- **`test/integration/E2E-PROVIDER-GAPS.md`**: three references to `agent.started` → `session.woke`.
- **`examples/gastown/packs/gastown/formulas/mol-digest-generate.toml`**: runnable formula's `gc events --type=...` filter updated from broken `agent.*` event names to current `session.*` names.
- Refreshed "Last verified against code" stamps on all touched docs to 2026-04-25.

## Why

The spec maintenance rule (originally in `specs/architecture.md`, now distributed across the per-doc "Last verified" stamps) requires updating docs in the same commit as referenced symbol renames. That discipline wasn't honored on `dd90ac0a` or `be8debd8`, leaving the doc set describing a deleted primitive. A new contributor reading AGENTS.md was being directed to look for an abstraction that doesn't exist.

## Test plan

- [x] `make build` clean
- [x] `make check` clean (full `./...` suite green)
- [x] `make check-docs` clean
- [x] Repo-wide grep for `agent-protocol.md` returns 0 hits (no broken cross-doc links)
- [x] All `Agent Protocol` references that remain are in intentional History/migration footnotes (4 files)
- [x] All `session.*` event constants in docs match `internal/events/events.go:20-38` exactly
- [x] `agent.*` event references remain only in `engdocs/archive/` (3 files, deliberately preserved historical analysis)

## Pre-flight review

Multi-agent review pipeline (3 Anthropic reviewers + Gas City contributor checker) iterated 2 rounds before convergence. Iteration 1 caught a blocker (the worker-boundary claim was factually wrong) plus 5 majors; iteration 2 verified all fixes and approved with zero remaining findings. Codex and Copilot CLI were unresponsive in this session and skipped per the review skill's documented fallback policy.