### PR TITLE
fix(fsys): cast stat.Dev to uint64 for darwin compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-fsys-darwin-compile test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
 
 ## build: compile gc binary with version metadata
 build:
@@ -165,8 +165,15 @@ TEST_ENV = env -i \
 ## The skipped cmd/gc process-backed scenarios remain covered by
 ## `make test-cmd-gc-process` locally and the CI `cmd/gc process suite` job.
 ## Wrapped in $(TEST_ENV) — see comment above for why.
-test:
+test: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 go test ./...
+
+## test-fsys-darwin-compile: cross-compile internal/fsys for macOS so
+## unix.Stat_t field-type regressions fail in the default fast test path.
+test-fsys-darwin-compile:
+	@tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	$(TEST_ENV) GOOS=darwin GOARCH=arm64 go test -c -o "$$tmp/fsys.test" ./internal/fsys
 
 ## test-cmd-gc-process: run the full non-short cmd/gc suite, including the
 ## process-backed lifecycle coverage routed out of the default fast loop
@@ -349,7 +356,7 @@ UNIT_COVER_PKGS := $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.Im
 ## test-cover: run fast unit-test coverage without the integration-tagged package sweep
 ## The skipped cmd/gc process-backed scenarios remain covered by
 ## `make test-cmd-gc-process` locally and the CI `cmd/gc process suite` job.
-test-cover:
+test-cover: test-fsys-darwin-compile
 	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 8m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
 
 ## cover: run tests and show coverage report

--- a/internal/fsys/atomic.go
+++ b/internal/fsys/atomic.go
@@ -107,7 +107,13 @@ func comparableMode(mode os.FileMode) os.FileMode {
 }
 
 func fileIdentityFromInfo(info os.FileInfo) (fileIdentity, bool) {
-	stat := reflect.Indirect(reflect.ValueOf(info.Sys()))
+	return fileIdentityFromSys(info.Sys())
+}
+
+func fileIdentityFromSys(sys any) (fileIdentity, bool) {
+	// Signed stat fields follow Go's direct int-to-uint conversion so the
+	// Fstat and Lstat paths agree on device identity across Unix variants.
+	stat := reflect.Indirect(reflect.ValueOf(sys))
 	if !stat.IsValid() {
 		return fileIdentity{}, false
 	}
@@ -130,11 +136,7 @@ func fileIdentityFromInfo(info os.FileInfo) (fileIdentity, bool) {
 func numericFieldToUint64(v reflect.Value) (uint64, bool) {
 	switch v.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		value := v.Int()
-		if value < 0 {
-			return 0, false
-		}
-		return uint64(value), true
+		return uint64(v.Int()), true
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return v.Uint(), true
 	default:

--- a/internal/fsys/atomic_internal_test.go
+++ b/internal/fsys/atomic_internal_test.go
@@ -54,6 +54,61 @@ func TestWriteFileIfChangedAtomic_RewritesWithoutSnapshotIdentity(t *testing.T) 
 	}
 }
 
+func TestFileIdentityFromSys_NormalizesSignedDeviceField(t *testing.T) {
+	id, ok := fileIdentityFromSys(struct {
+		Dev int32
+		Ino uint64
+	}{
+		Dev: 7,
+		Ino: 11,
+	})
+	if !ok {
+		t.Fatalf("fileIdentityFromSys returned ok=false for signed Dev field")
+	}
+
+	want := fileIdentity{dev: 7, ino: 11}
+	if id != want {
+		t.Fatalf("fileIdentityFromSys = %#v, want %#v", id, want)
+	}
+}
+
+func TestFileIdentityFromSys_NormalizesSignedDeviceFieldPointer(t *testing.T) {
+	id, ok := fileIdentityFromSys(&struct {
+		Dev int32
+		Ino uint64
+	}{
+		Dev: 7,
+		Ino: 11,
+	})
+	if !ok {
+		t.Fatalf("fileIdentityFromSys returned ok=false for pointer-shaped signed Dev field")
+	}
+
+	want := fileIdentity{dev: 7, ino: 11}
+	if id != want {
+		t.Fatalf("fileIdentityFromSys = %#v, want %#v", id, want)
+	}
+}
+
+func TestFileIdentityFromSys_PreservesNegativeSignedDeviceFieldBits(t *testing.T) {
+	id, ok := fileIdentityFromSys(struct {
+		Dev int32
+		Ino uint64
+	}{
+		Dev: -1,
+		Ino: 11,
+	})
+	if !ok {
+		t.Fatalf("fileIdentityFromSys returned ok=false for negative signed Dev field")
+	}
+
+	dev := int32(-1)
+	want := fileIdentity{dev: uint64(dev), ino: 11}
+	if id != want {
+		t.Fatalf("fileIdentityFromSys = %#v, want %#v", id, want)
+	}
+}
+
 type identityChangingFS struct {
 	data        []byte
 	snapshotErr error

--- a/internal/fsys/read_regular_unix_internal_test.go
+++ b/internal/fsys/read_regular_unix_internal_test.go
@@ -1,0 +1,38 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package fsys
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadRegularFileSnapshot_MatchesFileIdentityFromInfo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	data := []byte("hello = true\n")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	snapshot, err := (OSFS{}).readRegularFileSnapshot(path)
+	if err != nil {
+		t.Fatalf("readRegularFileSnapshot: %v", err)
+	}
+	if !snapshot.hasID {
+		t.Fatalf("snapshot missing identity")
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	id, ok := fileIdentityFromInfo(info)
+	if !ok {
+		t.Fatalf("fileIdentityFromInfo returned ok=false")
+	}
+	if snapshot.id != id {
+		t.Fatalf("snapshot.id = %#v, want %#v", snapshot.id, id)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a build break on darwin introduced in c3e6f174. `unix.Stat_t.Dev` is `int32` on darwin / BSDs and `uint64` on Linux; the new `readRegularFileSnapshot` (`internal/fsys/read_regular_unix.go`) assigned it directly to `fileIdentity.dev` (`uint64`), so the build fails on darwin with:

```
cannot use stat.Dev (variable of type int32) as uint64 value in struct literal
```

This keeps the direct cast in the unix snapshot path, aligns the reflective identity path with the same signed-device bit preservation, adds in-package coverage for both synthetic signed-device handling and the real snapshot-to-Lstat identity flow, and wires a Darwin compile guard into `make test` / `make test-cover`.

Closes #1207

## Testing

- [x] `go test ./internal/fsys`
- [x] `make test-fsys-darwin-compile`
- [x] `make check` (maintainer follow-up; local pre-commit hook)
- [ ] `make check-docs` — N/A, no docs touched
- [ ] `make test-integration` — N/A, no runtime/controller/workflow change

## Checklist

- [x] Linked an issue (#1207)
- [x] Added targeted `internal/fsys` regression coverage
- [x] Added a default-path Darwin compile guard
- [x] No user-facing surface — internal helper
- [x] No breaking change