### PR TITLE
fix(beads): evict closed beads from active cache at all retention sites

### DIFF
--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -68,13 +68,16 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		delete(c.deletedSeq, b.ID)
 		mutated = true
 	case "bead.closed":
-		c.noteMutationLocked(b.ID)
-		if _, exists := c.beads[b.ID]; !exists {
-			c.updateStatsLocked()
-		}
-		c.beads[b.ID] = cloneBead(b)
+		// Closed beads do not belong in the active-only cache. Evict any
+		// stale entry and record the deletion seq so concurrent readers
+		// see the close. Reads for closed beads fall through to backing.
+		seq := c.noteMutationLocked(b.ID)
+		delete(c.beads, b.ID)
+		delete(c.deps, b.ID)
 		delete(c.dirty, b.ID)
-		delete(c.deletedSeq, b.ID)
+		delete(c.beadSeq, b.ID)
+		c.deletedSeq[b.ID] = seq
+		c.updateStatsLocked()
 		mutated = true
 	default:
 		return

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -702,3 +702,125 @@ func (s *closeAllRefreshFailingStore) List(query ListQuery) ([]Bead, error) {
 	s.listCalls++
 	return s.Store.List(query)
 }
+
+// TestCachingStoreApplyEventBeadClosedDeletesFromActiveCache reproduces the
+// closed-bead retention bug at caching_store_events.go:73-80. The active cache
+// is meant to hold only open/in-progress beads (per PrimeActive at :121), but
+// ApplyEvent("bead.closed") writes the closed bead into c.beads instead of
+// deleting it. Until the next reconciler sweep, dead entries pile up.
+func TestCachingStoreApplyEventBeadClosedDeletesFromActiveCache(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "Test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	cache.mu.RLock()
+	_, before := cache.beads[bead.ID]
+	cache.mu.RUnlock()
+	if !before {
+		t.Fatalf("bead %q expected in cache before close event", bead.ID)
+	}
+
+	// Pre-close in backing (matches production lifecycle: bd close runs
+	// before the hook event arrives).
+	if err := backing.Close(bead.ID); err != nil {
+		t.Fatalf("Close backing: %v", err)
+	}
+
+	closed := bead
+	closed.Status = "closed"
+	payload, err := json.Marshal(closed)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	cache.ApplyEvent("bead.closed", payload)
+
+	cache.mu.RLock()
+	_, after := cache.beads[bead.ID]
+	deletedSeq, hasDeletedSeq := cache.deletedSeq[bead.ID]
+	cache.mu.RUnlock()
+	if after {
+		t.Fatalf("bead %q should be evicted from active cache after close event", bead.ID)
+	}
+	if !hasDeletedSeq || deletedSeq == 0 {
+		t.Fatalf("deletedSeq[%q] should be set, got %d (present=%v)", bead.ID, deletedSeq, hasDeletedSeq)
+	}
+}
+
+// TestCachingStoreCloseDeletesFromActiveCache reproduces the same bug at
+// caching_store_writes.go:83-91 (the in-cache branch of Close()).
+func TestCachingStoreCloseDeletesFromActiveCache(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "Test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := cache.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cache.mu.RLock()
+	_, after := cache.beads[bead.ID]
+	deletedSeq, hasDeletedSeq := cache.deletedSeq[bead.ID]
+	cache.mu.RUnlock()
+	if after {
+		t.Fatalf("bead %q should be evicted from active cache after Close()", bead.ID)
+	}
+	if !hasDeletedSeq || deletedSeq == 0 {
+		t.Fatalf("deletedSeq[%q] should be set, got %d (present=%v)", bead.ID, deletedSeq, hasDeletedSeq)
+	}
+}
+
+// TestCachingStoreCloseAllDeletesClosedFromActiveCache reproduces the same bug
+// at caching_store_writes.go:140-153 (the CloseAll inner loop).
+func TestCachingStoreCloseAllDeletesClosedFromActiveCache(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead1, err := backing.Create(Bead{Title: "Test1"})
+	if err != nil {
+		t.Fatalf("Create 1: %v", err)
+	}
+	bead2, err := backing.Create(Bead{Title: "Test2"})
+	if err != nil {
+		t.Fatalf("Create 2: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if _, err := cache.CloseAll([]string{bead1.ID, bead2.ID}, nil); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+
+	for _, id := range []string{bead1.ID, bead2.ID} {
+		cache.mu.RLock()
+		_, after := cache.beads[id]
+		deletedSeq, hasDeletedSeq := cache.deletedSeq[id]
+		cache.mu.RUnlock()
+		if after {
+			t.Fatalf("bead %q should be evicted from active cache after CloseAll", id)
+		}
+		if !hasDeletedSeq || deletedSeq == 0 {
+			t.Fatalf("deletedSeq[%q] should be set, got %d (present=%v)", id, deletedSeq, hasDeletedSeq)
+		}
+	}
+}

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -943,6 +943,10 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	payload, _ = json.Marshal(closed)
 	cs.ApplyEvent("bead.closed", payload)
 
+	// Closed beads are evicted from the active-only cache by ApplyEvent.
+	// Reads fall through to the backing store, which is authoritative for
+	// closed-bead state. Anything we assert here must be consistent with
+	// what the backing store actually holds for the closed bead.
 	got = requireCachedBead(t, cs, b1.ID, true)
 	if got.Status != "closed" {
 		t.Fatalf("status after close event = %q, want closed", got.Status)
@@ -955,9 +959,6 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 	if got.Metadata["gc.outcome"] != "pass" {
 		t.Fatalf("outcome = %q, want pass", got.Metadata["gc.outcome"])
-	}
-	if got.Metadata["gc.step_ref"] != "" {
-		t.Fatalf("close event should replace stale metadata, got %v", got.Metadata)
 	}
 }
 

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -79,20 +79,26 @@ func (c *CachingStore) Close(id string) error {
 	}
 
 	c.mu.Lock()
-	c.noteMutationLocked(id)
+	seq := c.noteMutationLocked(id)
 	if b, ok := c.beads[id]; ok {
+		// Snapshot the closed bead before eviction so the post-unlock
+		// notifyChange has a payload. Closed beads don't belong in the
+		// active-only cache; reads fall through to backing.
 		b.Status = "closed"
-		c.beads[id] = b
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
 		closed = cloneBead(b)
 		found = true
+		delete(c.beads, id)
+		delete(c.deps, id)
+		delete(c.dirty, id)
+		delete(c.beadSeq, id)
+		c.deletedSeq[id] = seq
 		c.markFreshLocked(time.Now())
 		c.updateStatsLocked()
 	} else if found {
-		c.beads[id] = cloneBead(closed)
-		delete(c.dirty, id)
-		delete(c.deletedSeq, id)
+		// Bead exists in backing but wasn't cached. The earlier
+		// backing.Get already populated `closed`. Don't add to cache
+		// just to evict — backing remains authoritative for closed beads.
+		c.deletedSeq[id] = seq
 		c.markFreshLocked(time.Now())
 		c.updateStatsLocked()
 	}
@@ -130,7 +136,7 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 
 	notifications := make([]cacheNotification, 0, len(refreshed))
 	c.mu.Lock()
-	c.noteMutationLocked(ids...)
+	seq := c.noteMutationLocked(ids...)
 	if refreshErr != nil {
 		c.recordProblemLocked("close-all refresh", refreshErr)
 	}
@@ -139,11 +145,17 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 	}
 	for _, item := range refreshed {
 		previous, hadPrevious := c.beads[item.id]
-		c.beads[item.id] = cloneBead(item.bead)
-		delete(c.dirty, item.id)
-		delete(c.deletedSeq, item.id)
 		if item.bead.Status == "closed" {
+			// Closed beads don't belong in the active-only cache.
+			delete(c.beads, item.id)
 			delete(c.deps, item.id)
+			delete(c.dirty, item.id)
+			delete(c.beadSeq, item.id)
+			c.deletedSeq[item.id] = seq
+		} else {
+			c.beads[item.id] = cloneBead(item.bead)
+			delete(c.dirty, item.id)
+			delete(c.deletedSeq, item.id)
 		}
 		if hadPrevious && previous.Status != "closed" && item.bead.Status == "closed" {
 			notifications = append(notifications, cacheNotification{


### PR DESCRIPTION
## Summary

The `CachingStore` is documented as an active-only cache (see comment at `internal/beads/caching_store.go:13-23`; `PrimeActive` at `:121` only loads `open` and `in_progress` beads). Closed-bead reads should fall through to the backing store. Four code paths violated this contract by writing closed beads back into `c.beads` instead of evicting them:

- `caching_store_events.go` — `ApplyEvent("bead.closed")`
- `caching_store_writes.go` — `Close()` in-cache branch
- `caching_store_writes.go` — `Close()` not-in-cache fallback (introduced by 584c265b — never needed; backing already has the closed payload via the earlier `backing.Get`)
- `caching_store_writes.go` — `CloseAll()` inner loop (already cleaned `c.deps` but kept `c.beads`)

Closed entries lingered in `c.beads` until the next reconciler sweep (30/60/120 s adaptive). Under high-frequency close workloads this caused dead entries to coexist with the active set, and the reconciler's missing-from-`freshByID` loop emitted redundant `bead.closed` notifications.

This PR uses the same eviction pattern `Delete()` already uses at `caching_store_writes.go:264-279`: `noteMutationLocked(id)` to capture a seq, delete from `c.beads` / `c.deps` / `c.dirty` / `c.beadSeq`, then set `c.deletedSeq[id] = seq`. `Close()` snapshots `closed` before evicting so the post-unlock `notifyChange` has a payload.

`TestCachingStoreApplyEvent` (`caching_store_test.go`) is updated: the prior assertion that the close event "replaces stale metadata" in the cache was encoding the buggy behavior. With the fix, reads fall through to the backing store, which is authoritative for closed-bead state.

Closes #1210

## Commits

- `test(beads): reproduce closed-bead retention in active-only cache` — three failing tests covering the three code paths (event, Close, CloseAll). Each asserts the bead is absent from `c.beads` after the close path runs and that `c.deletedSeq` is set.
- `fix(beads): evict closed beads from active cache at all retention sites` — applies the eviction pattern at all four sites; updates `TestCachingStoreApplyEvent` to reflect the corrected contract.

## Regression check

The reconciler's missing-from-`freshByID` loop is preserved as the safety net for dropped close events on still-open cached entries. The fix only deletes when we *see* a close — a dropped close event leaves the cache entry in place and the reconciler still detects it on the next sweep. Verified by walking three close scenarios:

1. **Normal close via `Close()`** — eviction immediate, single `bead.closed` notification.
2. **External `bd close` with working hook** — `ApplyEvent("bead.closed")` evicts; reconciler later sees nothing to evict; single notification.
3. **External `bd close` with dropped hook** — cache still holds the open entry; reconciler later finds it missing from `freshByID` and emits `bead.closed`; safety net preserved.

## Testing

- [x] `go test ./internal/beads/...` — green (full beads suite, including 3 new tests + updated `TestCachingStoreApplyEvent`)
- [x] `make check` — verified locally; **note:** must currently be stacked on top of #1208 to build on darwin (one-line type cast in `internal/fsys/`)
- [ ] `make check-docs` — N/A, no docs changed
- [ ] `make test-integration` — runtime/controller behavior unchanged

## Note on dependency

This branch is logically independent and currently does not build on darwin without #1208. Linux CI is unaffected. If #1208 lands first, no rebase needed (this branch is already on top of `upstream/main`).

There is also a related PR #1211 (cache `bead.updated` dedup) that touches the same file (`caching_store_events.go`) at a different `case` branch. Either PR can land first; the second will need at most a trivial context-line rebase.

## Checklist

- [x] Linked an issue (#1210)
- [x] Added tests that reproduce each variant of the bug
- [x] Updated `TestCachingStoreApplyEvent` to reflect the new contract (operator's note: prior assertion encoded buggy behavior)
- [x] No user-facing surface change
- [x] No breaking change — cache contract is preserved; readers see the same data via fallthrough