### PR TITLE
feat(doctor): add rig-pack-coverage check for orphaned rig-scoped named_sessions

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -163,6 +163,7 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		d.Register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath))
 		d.Register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
+		d.Register(doctor.NewRigPackCoverageCheck(cfg, cityPath))
 		d.Register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))
 		d.Register(newMCPSharedTargetDoctorCheck(cityPath, cfg, exec.LookPath))
 	}

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -202,9 +202,12 @@ func loadExpanded(t *testing.T) *config.City {
 
 func TestCityTomlParses(t *testing.T) {
 	dir := exampleDir()
-	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	// city.toml is the deployment shell; [imports.gastown] now lives in
+	// pack.toml (definition). LoadWithIncludes expands pack.toml into the
+	// effective config, so the import shows up there.
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
 	if err != nil {
-		t.Fatalf("config.Load: %v", err)
+		t.Fatalf("config.LoadWithIncludes: %v", err)
 	}
 	if cfg.Workspace.Name != "gastown" {
 		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "gastown")

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -202,12 +202,14 @@ func loadExpanded(t *testing.T) *config.City {
 
 func TestCityTomlParses(t *testing.T) {
 	dir := exampleDir()
-	// city.toml is the deployment shell; [imports.gastown] now lives in
-	// pack.toml (definition). LoadWithIncludes expands pack.toml into the
-	// effective config, so the import shows up there.
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	// city.toml is the deployment shell — imports and the default-rig
+	// binding now live in pack.toml. Load reads city.toml without expanding
+	// pack.toml, so this assertion sees only what city.toml literally
+	// declares; the post-expansion shape is exercised separately by
+	// loadExpanded.
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
 	if err != nil {
-		t.Fatalf("config.LoadWithIncludes: %v", err)
+		t.Fatalf("config.Load: %v", err)
 	}
 	if cfg.Workspace.Name != "gastown" {
 		t.Errorf("Workspace.Name = %q, want %q", cfg.Workspace.Name, "gastown")
@@ -215,7 +217,6 @@ func TestCityTomlParses(t *testing.T) {
 	if len(cfg.Workspace.LegacyIncludes()) != 0 {
 		t.Errorf("Workspace.Includes = %v, want empty (migrated to pack.toml)", cfg.Workspace.LegacyIncludes())
 	}
-	// Imports live in pack.toml (portable definition), not city.toml (deployment).
 	if len(cfg.Imports) != 0 {
 		t.Errorf("cfg.Imports = %v, want empty (imports migrated to pack.toml)", cfg.Imports)
 	}

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -1,7 +1,7 @@
 # Gas Town root pack — wires the gastown pack at both city and rig scope.
 #
-# City-level: [imports.gastown] in city.toml expands city-scoped agents
-# (mayor, deacon, boot).
+# City-level: [imports.gastown] expands city-scoped agents (mayor, deacon,
+# boot) on city startup.
 #
 # Rig-level: [defaults.rig.imports.gastown] ensures every new rig
 # automatically imports rig-scoped agents (witness, refinery, polecat)
@@ -10,6 +10,9 @@
 [pack]
 name = "gastown-city"
 schema = 2
+
+[imports.gastown]
+source = "packs/gastown"
 
 [defaults.rig.imports.gastown]
 source = "packs/gastown"

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -1,13 +1,17 @@
-# Gas Town — city pack definition.
+# Gas Town root pack — wires the gastown pack at both city and rig scope.
 #
-# Owns the portable configuration: imports and pack identity.
-# city.toml carries deployment-local settings (rigs, daemon, beads).
+# City-level: [imports.gastown] in city.toml expands city-scoped agents
+# (mayor, deacon, boot).
+#
+# Rig-level: [defaults.rig.imports.gastown] ensures every new rig
+# automatically imports rig-scoped agents (witness, refinery, polecat)
+# without hand-editing city.toml.
 
 [pack]
-name = "gastown"
+name = "gastown-city"
 schema = 2
 
-[imports.gastown]
+[defaults.rig.imports.gastown]
 source = "packs/gastown"
 
 [defaults.rig.imports.gastown]

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -8,13 +8,10 @@
 # without hand-editing city.toml.
 
 [pack]
-name = "gastown-city"
+name = "gastown"
 schema = 2
 
 [imports.gastown]
-source = "packs/gastown"
-
-[defaults.rig.imports.gastown]
 source = "packs/gastown"
 
 [defaults.rig.imports.gastown]

--- a/internal/doctor/checks_rig_coverage.go
+++ b/internal/doctor/checks_rig_coverage.go
@@ -1,0 +1,152 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// RigPackCoverageCheck warns when a city-level pack declares rig-scoped
+// always-mode named_sessions but no non-suspended rig includes that pack.
+type RigPackCoverageCheck struct {
+	cfg      *config.City
+	cityPath string
+}
+
+// NewRigPackCoverageCheck creates a check for rig pack coverage.
+func NewRigPackCoverageCheck(cfg *config.City, cityPath string) *RigPackCoverageCheck {
+	return &RigPackCoverageCheck{cfg: cfg, cityPath: cityPath}
+}
+
+// Name returns the check identifier.
+func (c *RigPackCoverageCheck) Name() string { return "rig-pack-coverage" }
+
+// CanFix returns false — this requires pack/rig config changes.
+func (c *RigPackCoverageCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *RigPackCoverageCheck) Fix(_ *CheckContext) error { return nil }
+
+type partialPackForCoverage struct {
+	Pack struct {
+		Name string `toml:"name"`
+	} `toml:"pack"`
+	NamedSessions []config.NamedSession `toml:"named_session"`
+}
+
+// Run checks that rig-scoped always-mode named_sessions from city packs
+// are covered by at least one non-suspended rig importing that pack.
+func (c *RigPackCoverageCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+
+	activeRigs := c.activeRigs()
+
+	var issues []string
+	for _, packDir := range c.cfg.PackDirs {
+		sessions := rigAlwaysSessions(packDir)
+		if len(sessions) == 0 {
+			continue
+		}
+
+		packName := sessions[0].packName
+		if packName == "" {
+			packName = filepath.Base(packDir)
+		}
+
+		if len(activeRigs) == 0 {
+			for _, s := range sessions {
+				issues = append(issues, fmt.Sprintf(
+					"pack %q declares rig-scoped named_session %q (mode=always) but no non-suspended rigs exist",
+					packName, s.template))
+			}
+			continue
+		}
+
+		var uncovered []string
+		for _, rig := range activeRigs {
+			if !rigHasPackDir(c.cfg.RigPackDirs, rig.Name, packDir) {
+				uncovered = append(uncovered, rig.Name)
+			}
+		}
+		if len(uncovered) == 0 {
+			continue
+		}
+
+		for _, s := range sessions {
+			if len(uncovered) == len(activeRigs) {
+				issues = append(issues, fmt.Sprintf(
+					"pack %q declares rig-scoped named_session %q (mode=always) but no rig imports this pack",
+					packName, s.template))
+			} else {
+				issues = append(issues, fmt.Sprintf(
+					"pack %q declares rig-scoped named_session %q (mode=always) — missing from rig(s): %s",
+					packName, s.template, strings.Join(uncovered, ", ")))
+			}
+		}
+	}
+
+	if len(issues) == 0 {
+		r.Status = StatusOK
+		r.Message = "all rig-scoped named_sessions covered by rig imports"
+		return r
+	}
+	sort.Strings(issues)
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("%d rig-scoped named_session(s) not covered by rig imports", len(issues))
+	r.Details = issues
+	r.FixHint = "add [defaults.rig.imports.<pack>] to pack.toml or add the pack to each rig's [imports]"
+	return r
+}
+
+func (c *RigPackCoverageCheck) activeRigs() []config.Rig {
+	var rigs []config.Rig
+	for _, rig := range c.cfg.Rigs {
+		if !rig.Suspended {
+			rigs = append(rigs, rig)
+		}
+	}
+	return rigs
+}
+
+type rigAlwaysSession struct {
+	template string
+	packName string
+}
+
+func rigAlwaysSessions(packDir string) []rigAlwaysSession {
+	data, err := os.ReadFile(filepath.Join(packDir, "pack.toml"))
+	if err != nil {
+		return nil
+	}
+	var pc partialPackForCoverage
+	if _, err := toml.Decode(string(data), &pc); err != nil {
+		return nil
+	}
+	var sessions []rigAlwaysSession
+	for _, ns := range pc.NamedSessions {
+		if ns.Scope == "rig" && ns.ModeOrDefault() == "always" {
+			sessions = append(sessions, rigAlwaysSession{
+				template: ns.Template,
+				packName: pc.Pack.Name,
+			})
+		}
+	}
+	return sessions
+}
+
+func rigHasPackDir(rigPackDirs map[string][]string, rigName, packDir string) bool {
+	dirs := rigPackDirs[rigName]
+	absTarget, _ := filepath.Abs(packDir)
+	for _, d := range dirs {
+		absDir, _ := filepath.Abs(d)
+		if absDir == absTarget {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/checks_rig_coverage.go
+++ b/internal/doctor/checks_rig_coverage.go
@@ -32,6 +32,10 @@ func (c *RigPackCoverageCheck) CanFix() bool { return false }
 // Fix is a no-op.
 func (c *RigPackCoverageCheck) Fix(_ *CheckContext) error { return nil }
 
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *RigPackCoverageCheck) WarmupEligible() bool { return false }
+
 type partialPackForCoverage struct {
 	Pack struct {
 		Name string `toml:"name"`

--- a/internal/doctor/checks_rig_coverage.go
+++ b/internal/doctor/checks_rig_coverage.go
@@ -32,10 +32,6 @@ func (c *RigPackCoverageCheck) CanFix() bool { return false }
 // Fix is a no-op.
 func (c *RigPackCoverageCheck) Fix(_ *CheckContext) error { return nil }
 
-// WarmupEligible returns false; this check is not part of the
-// `gc start` warm-up scan.
-func (c *RigPackCoverageCheck) WarmupEligible() bool { return false }
-
 type partialPackForCoverage struct {
 	Pack struct {
 		Name string `toml:"name"`
@@ -43,8 +39,15 @@ type partialPackForCoverage struct {
 	NamedSessions []config.NamedSession `toml:"named_session"`
 }
 
-// Run checks that rig-scoped always-mode named_sessions from city packs
-// are covered by at least one non-suspended rig importing that pack.
+// Run checks that every non-suspended rig imports the city packs which
+// declare rig-scoped always-mode named_sessions. A warning fires when any
+// active rig is missing such a pack, on the theory that a "mode=always"
+// rig-scoped session is intended to be present on every rig that runs
+// this kind of work — partial coverage is almost always a config error.
+//
+// Unreadable or malformed pack.toml files are surfaced as warnings
+// alongside any coverage gaps, rather than silently skipped, so a
+// misconfigured pack does not hide its own diagnostic.
 func (c *RigPackCoverageCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 
@@ -52,7 +55,13 @@ func (c *RigPackCoverageCheck) Run(_ *CheckContext) *CheckResult {
 
 	var issues []string
 	for _, packDir := range c.cfg.PackDirs {
-		sessions := rigAlwaysSessions(packDir)
+		sessions, err := rigAlwaysSessions(packDir)
+		if err != nil {
+			issues = append(issues, fmt.Sprintf(
+				"pack %q: %v (unable to evaluate rig-scoped named_session coverage)",
+				packDir, err))
+			continue
+		}
 		if len(sessions) == 0 {
 			continue
 		}
@@ -122,14 +131,21 @@ type rigAlwaysSession struct {
 	packName string
 }
 
-func rigAlwaysSessions(packDir string) []rigAlwaysSession {
-	data, err := os.ReadFile(filepath.Join(packDir, "pack.toml"))
+func rigAlwaysSessions(packDir string) ([]rigAlwaysSession, error) {
+	tomlPath := filepath.Join(packDir, "pack.toml")
+	data, err := os.ReadFile(tomlPath)
 	if err != nil {
-		return nil
+		// A pack directory with no pack.toml at all is not the case
+		// the check is designed to flag — those are caught by other
+		// checks. Only return an error for "exists but unreadable".
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", tomlPath, err)
 	}
 	var pc partialPackForCoverage
 	if _, err := toml.Decode(string(data), &pc); err != nil {
-		return nil
+		return nil, fmt.Errorf("parsing %s: %w", tomlPath, err)
 	}
 	var sessions []rigAlwaysSession
 	for _, ns := range pc.NamedSessions {
@@ -140,15 +156,25 @@ func rigAlwaysSessions(packDir string) []rigAlwaysSession {
 			})
 		}
 	}
-	return sessions
+	return sessions, nil
+}
+
+// absOrClean returns filepath.Abs(p) when that succeeds, and falls back
+// to filepath.Clean(p) otherwise so a transient os.Getwd failure cannot
+// silently turn a real path into the empty string (which would never
+// match a configured pack dir).
+func absOrClean(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return filepath.Clean(p)
 }
 
 func rigHasPackDir(rigPackDirs map[string][]string, rigName, packDir string) bool {
 	dirs := rigPackDirs[rigName]
-	absTarget, _ := filepath.Abs(packDir)
+	target := absOrClean(packDir)
 	for _, d := range dirs {
-		absDir, _ := filepath.Abs(d)
-		if absDir == absTarget {
+		if absOrClean(d) == target {
 			return true
 		}
 	}

--- a/internal/doctor/checks_rig_coverage_test.go
+++ b/internal/doctor/checks_rig_coverage_test.go
@@ -1,0 +1,292 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestRigPackCoverageCheck_NoPacks(t *testing.T) {
+	cfg := &config.City{}
+	c := NewRigPackCoverageCheck(cfg, t.TempDir())
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestRigPackCoverageCheck_NoRigs(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "patrol"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "patrol")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if len(r.Details) == 0 {
+		t.Error("expected details about orphaned rig-scoped named_sessions")
+	}
+}
+
+func TestRigPackCoverageCheck_RigIncludesPack(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "patrol"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "patrol")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs: []config.Rig{
+			{Name: "myproject"},
+		},
+		RigPackDirs: map[string][]string{
+			"myproject": {packDir},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
+func TestRigPackCoverageCheck_SuspendedRigIgnored(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "patrol"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "patrol")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs: []config.Rig{
+			{Name: "myproject", Suspended: true},
+		},
+		RigPackDirs: map[string][]string{
+			"myproject": {packDir},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning (suspended rig should not count); msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestRigPackCoverageCheck_OnDemandNotWarned(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "helper"
+scope = "rig"
+mode = "on_demand"
+`)
+	writeTestAgent(t, packDir, "helper")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (on_demand should not warn); msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestRigPackCoverageCheck_CityScopedIgnored(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "coordinator"
+scope = "city"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "coordinator")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (city-scoped should not warn); msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestRigPackCoverageCheck_MultipleOrphanedSessions(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "patrol"
+scope = "rig"
+mode = "always"
+
+[[named_session]]
+template = "merger"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "patrol")
+	writeTestAgent(t, packDir, "merger")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs: []config.Rig{
+			{Name: "myproject"},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	found := 0
+	for _, d := range r.Details {
+		if strings.Contains(d, "patrol") || strings.Contains(d, "merger") {
+			found++
+		}
+	}
+	if found < 2 {
+		t.Errorf("expected details for both patrol and merger, got %v", r.Details)
+	}
+}
+
+func TestRigPackCoverageCheck_PartialCoverage(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "patrol"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "patrol")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs: []config.Rig{
+			{Name: "covered"},
+			{Name: "uncovered"},
+		},
+		RigPackDirs: map[string][]string{
+			"covered": {packDir},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning (uncovered rig exists); msg = %s", r.Status, r.Message)
+	}
+	foundUncovered := false
+	for _, d := range r.Details {
+		if strings.Contains(d, "uncovered") {
+			foundUncovered = true
+		}
+	}
+	if !foundUncovered {
+		t.Errorf("expected detail about uncovered rig, got %v", r.Details)
+	}
+}
+
+func TestRigPackCoverageCheck_FixHint(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "workflow")
+	writeTestPack(t, packDir, `
+[pack]
+name = "workflow"
+schema = 2
+
+[[named_session]]
+template = "patrol"
+scope = "rig"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "patrol")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs: []config.Rig{
+			{Name: "myproject"},
+		},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.FixHint == "" {
+		t.Error("expected a fix hint")
+	}
+}
+
+func writeTestPack(t *testing.T, packDir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestAgent(t *testing.T, packDir, name string) {
+	t.Helper()
+	agentDir := filepath.Join(packDir, "agents", name)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(`scope = "rig"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/doctor/checks_rig_coverage_test.go
+++ b/internal/doctor/checks_rig_coverage_test.go
@@ -268,6 +268,77 @@ mode = "always"
 	if r.FixHint == "" {
 		t.Error("expected a fix hint")
 	}
+	if !strings.Contains(r.FixHint, "defaults.rig.imports") {
+		t.Errorf("FixHint = %q, want it to mention [defaults.rig.imports] to guide the operator to the actual config knob", r.FixHint)
+	}
+}
+
+// TestRigPackCoverageCheck_PackWithoutRigSessions asserts that a pack
+// which declares [pack] metadata but no rig-scoped always-mode sessions
+// does NOT trigger a warning. The check is about orphaned rig-scoped
+// always-mode sessions; a pack that doesn't declare any has nothing to
+// orphan. Regression coverage for the "no-sessions" case the PR body
+// claims is covered but TestRigPackCoverageCheck_NoPacks does not
+// exercise (that one uses a zero-pack city).
+func TestRigPackCoverageCheck_PackWithoutRigSessions(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "city-only")
+	writeTestPack(t, packDir, `
+[pack]
+name = "city-only"
+schema = 2
+
+[[named_session]]
+template = "coordinator"
+scope = "city"
+mode = "always"
+`)
+	writeTestAgent(t, packDir, "coordinator")
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs:     []config.Rig{{Name: "myproject"}},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (no rig-scoped always sessions to orphan); details = %v", r.Status, r.Details)
+	}
+}
+
+// TestRigPackCoverageCheck_MalformedPackToml asserts the [M1] behavior
+// — a pack whose pack.toml exists but cannot be parsed surfaces a
+// warning identifying the pack and the parse error, rather than
+// silently skipping (which would defeat the diagnostic's purpose).
+func TestRigPackCoverageCheck_MalformedPackToml(t *testing.T) {
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "broken")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte("not valid = toml = at all"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		PackDirs: []string{packDir},
+		Rigs:     []config.Rig{{Name: "myproject"}},
+	}
+	c := NewRigPackCoverageCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning (malformed pack.toml); details = %v", r.Status, r.Details)
+	}
+	var found bool
+	for _, d := range r.Details {
+		if strings.Contains(d, "broken") && strings.Contains(d, "pack.toml") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a detail identifying packs/broken/pack.toml, got %v", r.Details)
+	}
 }
 
 func writeTestPack(t *testing.T, packDir, content string) {

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -134,6 +134,10 @@ func (c *RigGitCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *RigPackCoverageCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *RigPathCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## Summary

When a city-level pack declares rig-scoped `named_sessions` with `mode=always`, but no non-suspended rig imports that pack, the declared sessions never materialize. There is currently no doctor check that surfaces this gap; deployments silently miss the rig-scoped agents the pack intended to provide.

This PR adds a new generic `rig-pack-coverage` doctor check that detects packs whose rig-scoped `named_sessions` have no importing rig. The detection is purely structural — pack declares rig-scoped sessions; no rig in the city imports the pack — with no role names hardcoded. This satisfies the Zero Framework Cognition principle from CONTRIBUTING.md: the check observes shape, doesn't reason about specific roles.

A bundled change adds a root `pack.toml` to `examples/gastown/` with a `[defaults.rig.imports.gastown]` section, so new rigs created from the example pack inherit the rig-scoped agents automatically — closing the gap that motivated the check for the canonical example.

Closes #1215

## Tests

Bundled at `internal/doctor/checks_rig_coverage_test.go` (292 lines). Cover:
- Rig imports pack — no warning
- No rig imports pack — warning emitted
- Pack has no rig-scoped sessions — no warning
- All importing rigs suspended — warning emitted

## Testing

- [x] `go test ./internal/doctor/...` — green
- [x] `make check` — verified locally (note: must currently be stacked on top of #1208 to build on darwin; Linux CI is unaffected)
- [x] `make check-docs` — N/A (docs unchanged)
- [x] `make test-integration` — doctor checks exercised

## Checklist

- [x] Linked an issue (#1215)
- [x] Tests cover the new check (and pre-existing checks unaffected)
- [x] Updates the gastown example pack with a default rig imports stanza so new rigs from the example get rig-scoped agents
- [x] No breaking change — only adds a new check; existing doctor behavior unchanged