### PR TITLE
fix(dolt-health): exclude rig-local Dolt servers from zombie scan

### DIFF
--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -235,6 +235,9 @@ fi
 # positives from processes that merely mention "dolt" in their args
 # (e.g., Claude sessions whose prompt text contains "dolt sql-server").
 #
+# Rig-local Dolt servers (configured via dolt.port in config.yaml)
+# are legitimate — exclude any PID listening on a known rig port.
+#
 # GC_HEALTH_SKIP_ZOMBIE_SCAN is a test-only escape hatch. Zombie
 # enumeration spawns one `ps` per matching process, which on shared
 # dev machines with many accumulated dolt processes dominates the
@@ -244,8 +247,22 @@ fi
 zombie_count=0
 zombie_pids=""
 if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
+  # Collect PIDs of legitimate rig-local Dolt servers.
+  rig_dolt_pids=""
+  while IFS= read -r meta; do
+    [ -f "$meta" ] || continue
+    config_file="$(dirname "$meta")/config.yaml"
+    [ -f "$config_file" ] || continue
+    rig_port=$(grep '^dolt\.port:' "$config_file" 2>/dev/null | sed 's/^dolt\.port:[[:space:]]*//' | head -1)
+    case "$rig_port" in ''|*[!0-9]*) continue ;; esac
+    [ "$rig_port" = "$GC_DOLT_PORT" ] && continue
+    rig_pid=$(managed_runtime_listener_pid "$rig_port" || true)
+    [ -n "$rig_pid" ] && rig_dolt_pids="$rig_dolt_pids $rig_pid "
+  done < "$_meta_cache"
+
   for p in $(pgrep -x dolt 2>/dev/null || true); do
     [ "$p" = "$server_pid" ] && continue
+    case "$rig_dolt_pids" in *" $p "*) continue ;; esac
     cmd=$(ps -p "$p" -o args= 2>/dev/null || true)
     case "$cmd" in
       *sql-server*) ;;

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -253,7 +253,7 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
     [ -f "$meta" ] || continue
     config_file="$(dirname "$meta")/config.yaml"
     [ -f "$config_file" ] || continue
-    rig_port=$(grep '^dolt\.port:' "$config_file" 2>/dev/null | sed 's/^dolt\.port:[[:space:]]*//' | head -1)
+    rig_port=$(grep '^dolt\.port:' "$config_file" 2>/dev/null | sed "s/^dolt\\.port:[[:space:]]*//; s/[[:space:]]*#.*$//; s/['\\\"]//g; s/[[:space:]]*$//" | head -1)
     case "$rig_port" in ''|*[!0-9]*) continue ;; esac
     [ "$rig_port" = "$GC_DOLT_PORT" ] && continue
     rig_pid=$(managed_runtime_listener_pid "$rig_port" || true)

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -688,6 +688,119 @@ func writeExecutable(t *testing.T, path, contents string) {
 	}
 }
 
+// TestHealthScriptZombieScanExcludesRigLocalServers verifies that
+// Dolt processes on rig-configured ports are not flagged as zombies.
+// Regression guard for the bug where deacon patrol killed rig-local
+// Dolt servers because the zombie scan treated every non-city-server
+// dolt sql-server PID as a zombie.
+func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
+	cityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19901"
+	rigPort := "19902"
+
+	mainPID := "424201"
+	rigPID := "424202"
+	zombiePID := "424203"
+
+	// City .beads directory with metadata.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rig directory with config.yaml containing dolt.port.
+	rigBeads := filepath.Join(cityPath, "rigs", "enterprise", ".beads")
+	if err := os.MkdirAll(rigBeads, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"),
+		[]byte(`{"dolt_database":"enterprise"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeads, "config.yaml"),
+		[]byte("dolt.port: "+rigPort+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake gc: fail so metadata_files() falls back to find.
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake pgrep: returns rig PID and zombie PID (main PID excluded
+	// by server_pid check, not by pgrep filtering).
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\necho %s\n", mainPID, rigPID, zombiePID))
+
+	// Fake lsof: maps ports to PIDs.
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID, rigPort, rigPID))
+
+	// Fake ps: handles pid_is_running (-o pid=) and zombie scan (-o args=).
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), `#!/bin/sh
+if [ "$1" = "-p" ] && [ "$3" = "-o" ]; then
+  case "$4" in
+    pid=) printf ' %s\n' "$2"; exit 0 ;;
+    args=) echo "dolt sql-server"; exit 0 ;;
+  esac
+fi
+exit 1
+`)
+
+	// Fake nc: unreachable (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake dolt: SELECT 1 fails (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+
+	// The true zombie (424203) should be counted.
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1; got:\n%s", output)
+	}
+
+	// The rig PID (424202) must NOT appear in zombie_pids.
+	if strings.Contains(output, rigPID) {
+		t.Errorf("rig-local Dolt PID %s should not be in zombie_pids; got:\n%s", rigPID, output)
+	}
+
+	// The true zombie PID (424203) must appear in zombie_pids.
+	if !strings.Contains(output, zombiePID) {
+		t.Errorf("true zombie PID %s should be in zombie_pids; got:\n%s", zombiePID, output)
+	}
+}
+
 // TestHealthScriptJSONAlwaysExitsZero guards the JSON-mode exit
 // contract. Automation consumers (notably the deacon patrol formula)
 // parse the JSON payload and key health decisions off `server.reachable`.

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -693,7 +693,7 @@ func writeExecutable(t *testing.T, path, contents string) {
 // Regression guard for the bug where deacon patrol killed rig-local
 // Dolt servers because the zombie scan treated every non-city-server
 // dolt sql-server PID as a zombie.
-func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
+func runHealthScriptZombieScanExcludesRigLocalServers(t *testing.T, rigConfig string) {
 	cityPath := t.TempDir()
 	fakeBin := t.TempDir()
 
@@ -723,7 +723,7 @@ func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(rigBeads, "config.yaml"),
-		[]byte("dolt.port: "+rigPort+"\n"), 0o644); err != nil {
+		[]byte(rigConfig), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -798,6 +798,28 @@ exit 1
 	// The true zombie PID (424203) must appear in zombie_pids.
 	if !strings.Contains(output, zombiePID) {
 		t.Errorf("true zombie PID %s should be in zombie_pids; got:\n%s", zombiePID, output)
+	}
+}
+
+func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
+	tests := []struct {
+		name      string
+		rigConfig string
+	}{
+		{
+			name:      "bare port",
+			rigConfig: "dolt.port: 19902\n",
+		},
+		{
+			name:      "quoted port",
+			rigConfig: "dolt.port: \"19902\"\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runHealthScriptZombieScanExcludesRigLocalServers(t, tc.rigConfig)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The dolt-health zombie scan (`examples/dolt/commands/health/`) flagged every `dolt sql-server` PID except the main city server as a zombie. Rig-local Dolt servers — configured via `dolt.port` in a rig's `config.yaml` — are legitimate but appeared as zombies to the scan, so operators following the runbook would kill them and break those rigs.

This PR has the scan read rig configs from the metadata cache and exclude PIDs listening on known rig ports.

Closes #1217

## Tests

Bundled at `examples/dolt/health_test.go` (113 lines). Cover:
- PID on city port — not flagged
- PID on rig port — not flagged
- PID on unknown port — flagged

## Testing

- [x] `go test ./examples/dolt/...` — green
- [x] `make check` — verified locally (note: must currently be stacked on top of #1208 to build on darwin; Linux CI is unaffected)
- [ ] `make check-docs` — N/A
- [ ] `make test-integration` — N/A (the fix is to a runbook script + adjacent test; runtime behavior unchanged)

## Checklist

- [x] Linked an issue (#1217)
- [x] Tests cover the new behavior
- [x] No breaking change — only narrows the zombie classification to exclude legitimate rig-local servers