### PR TITLE
fix: count creating sessions toward pool deficit in scale_check

### DIFF
--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -161,6 +161,23 @@ func computePoolDesiredStates(
 		for _, r := range allRequests {
 			beadDriven[r.Template]++
 		}
+
+		// Count sessions in "creating" state per template. These are
+		// already being spawned but haven't reached "active" yet, so
+		// they must count toward pool size to prevent unbounded spawning.
+		creatingCount := make(map[string]int)
+		for _, sb := range sessionBeads {
+			if sb.Status == "closed" {
+				continue
+			}
+			if sb.Metadata["state"] == "creating" {
+				tmpl := strings.TrimSpace(sb.Metadata["template"])
+				if tmpl != "" {
+					creatingCount[tmpl]++
+				}
+			}
+		}
+
 		for _, agent := range cfg.Agents {
 			if agent.Suspended {
 				continue
@@ -170,7 +187,7 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			deficit := scaleCount - beadDriven[template]
+			deficit := scaleCount - beadDriven[template] - creatingCount[template]
 			for j := 0; j < deficit; j++ {
 				allRequests = append(allRequests, SessionRequest{
 					Template: template,

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -618,6 +618,33 @@ func TestComputePoolDesiredStates_RoutedButUnassignedDoesNotSpawnNew(t *testing.
 	}
 }
 
+// Regression: sessions in "creating" state must count toward pool size so
+// the reconciler doesn't keep spawning new sessions while creates are pending.
+func TestComputePoolDesiredStates_CreatingSessionsCountTowardDeficit(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(5), 0)},
+	}
+	// No assigned work beads — all demand comes from scale_check.
+	// But one session is already in "creating" state.
+	sessions := []beads.Bead{
+		{ID: "s-creating", Status: "open", Type: "session", Metadata: map[string]string{
+			"template": "rig/claude", "state": "creating", "pool_managed": "true",
+		}},
+	}
+	scaleCheck := map[string]int{"rig/claude": 2}
+
+	result := ComputePoolDesiredStates(cfg, nil, sessions, scaleCheck)
+
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
+	}
+	// scale_check=2, 1 creating session already in flight → deficit=1, not 2.
+	if total != 1 {
+		t.Errorf("total requests = %d, want 1 (creating session counted toward deficit)", total)
+	}
+}
+
 // Regression: same as above but for a rig-scoped agent.
 func TestComputePoolDesiredStates_RoutedRigScopedDoesNotSpawnNew(t *testing.T) {
 	cfg := &config.City{


### PR DESCRIPTION
## Summary

- Fixes unbounded pool spawning when sessions get stuck in "creating" state
- Counts sessions in "creating" state per template and subtracts from pool deficit calculation in `computePoolDesiredStates`
- Adds regression test verifying creating sessions reduce the deficit

Closes ga-468

## Test plan

- [x] Regression test: `TestComputePoolDesiredStates_CreatingSessionsCountTowardDeficit`
- [ ] CI passes
- [ ] Manual verification with a city that has creating sessions