### PR TITLE
fix(config): skip SCM/state dirs in PackContentHashRecursive

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2501,6 +2501,10 @@ func PackContentHashRecursive(fs fsys.FS, topoDir string) string {
 }
 
 // collectFiles recursively collects file paths relative to base.
+// Skips SCM working-copy directories and gascity-internal state
+// directories — these are never pack content, and a rig configured with
+// `source = "."` would otherwise pull the entire working copy (including
+// gigabytes of git history and Dolt data) into the pack hash.
 func collectFiles(fs fsys.FS, base, prefix string, out *[]string) {
 	dir := base
 	if prefix != "" {
@@ -2511,6 +2515,9 @@ func collectFiles(fs fsys.FS, base, prefix string, out *[]string) {
 		return
 	}
 	for _, e := range entries {
+		if e.IsDir() && skipPackContentDir(e.Name()) {
+			continue
+		}
 		rel := e.Name()
 		if prefix != "" {
 			rel = prefix + "/" + e.Name()
@@ -2521,6 +2528,20 @@ func collectFiles(fs fsys.FS, base, prefix string, out *[]string) {
 			*out = append(*out, rel)
 		}
 	}
+}
+
+// skipPackContentDir reports whether a directory name should be skipped
+// when walking pack content. The set is intentionally narrow: only SCM
+// working-copy directories and gascity-internal state directories that
+// are never legitimate pack content. Hidden directories that DO appear
+// in published packs (.claude, .gemini, .cursor, .codex, .github, .omp,
+// .gitkeep parents, ...) are not in this list and continue to be hashed.
+func skipPackContentDir(name string) bool {
+	switch name {
+	case ".git", ".hg", ".svn", ".bzr", ".gc", ".beads":
+		return true
+	}
+	return false
 }
 
 // resolveNamedPacks translates named pack references to cache paths.

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -641,6 +641,54 @@ func TestPackContentHashRecursive(t *testing.T) {
 	}
 }
 
+// TestPackContentHashRecursive_SkipsScmAndStateDirectories verifies that
+// SCM working-copy directories (.git, .hg, .svn) and gascity-internal
+// state directories (.gc, .beads) do not contribute to the pack content
+// hash. These are not pack content; including them turns Revision into a
+// recursive walk over potentially gigabytes of git history and dolt data,
+// causing supervisor RSS to spike to tens of GB on cities whose rig pack
+// source is `.` (the rig root).
+//
+// Legitimate hidden files inside non-excluded directories (e.g.
+// overlay/.claude, overlay/.gitkeep, overlay/.gemini used by per-provider
+// pack overlays) must continue to be included.
+func TestPackContentHashRecursive_SkipsScmAndStateDirectories(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pack.toml", "test")
+	writeFile(t, dir, "prompts/a.md", "prompt a")
+	// Legitimate hidden content inside an overlay directory (per-provider
+	// configs follow this pattern in the bootstrap core pack).
+	writeFile(t, dir, "overlay/.claude/settings.json", `{"k":"v"}`)
+	writeFile(t, dir, "overlay/.gitkeep", "")
+
+	baseline := PackContentHashRecursive(fsys.OSFS{}, dir)
+
+	// Adding files under SCM/state directories must not change the hash —
+	// they are not pack content.
+	writeFile(t, dir, ".git/HEAD", "ref: refs/heads/main")
+	writeFile(t, dir, ".git/objects/pack/pack-abcdef.idx", "fake pack idx")
+	writeFile(t, dir, ".beads/dolt/some-blob", "lots of bytes here")
+	writeFile(t, dir, ".gc/runtime/dolt/data.bin", "more bytes")
+	writeFile(t, dir, ".hg/store/data", "mercurial state")
+	writeFile(t, dir, ".svn/wc.db", "svn state")
+
+	withScmState := PackContentHashRecursive(fsys.OSFS{}, dir)
+
+	if baseline != withScmState {
+		t.Errorf("PackContentHashRecursive must skip .git/, .beads/, .gc/, .hg/, .svn/.\n  baseline:        %s\n  with scm/state:  %s", baseline, withScmState)
+	}
+
+	// Sanity: legitimate hidden files (overlay/.claude/...) must still
+	// contribute to the hash. Removing one should change the hash.
+	if err := os.Remove(filepath.Join(dir, "overlay", ".claude", "settings.json")); err != nil {
+		t.Fatalf("remove overlay/.claude/settings.json: %v", err)
+	}
+	withoutLegit := PackContentHashRecursive(fsys.OSFS{}, dir)
+	if withoutLegit == baseline {
+		t.Error("hash should change when legitimate hidden pack-content file (overlay/.claude/settings.json) is removed; the fix must NOT skip arbitrary hidden files, only specific SCM/state directories")
+	}
+}
+
 func TestExpandPacks_ViaLoadWithIncludes(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes the SHA256 hot-loop / RSS runaway reported in #1220.

`PackContentHashRecursive` (`internal/config/pack.go:2484`) walks every file in a pack tree and feeds the content through SHA-256 to compute a deterministic revision hash. The walker, `collectFiles` (`:2504`), recursed into every subdirectory without exclusion. When a city or rig pack is configured with `source = \".\"` in `city.toml` — i.e. the rig root *is* the pack root — the walker reads and hashes the entire working copy. That means gigabytes of `.git/objects/` pack history and gigabytes of `.beads/dolt/` database storage get fed to SHA-256 on every `Revision` call.

The visible symptom on a workstation supervisor (and what was observed in #1220):

- `starting_bead_store` completes
- the city runtime ticks once and calls `config.Revision`
- supervisor RSS spikes from ~45 MB to **42.8 GB** (peak observed) within seconds
- CPU pinned at 99–100% on a goroutine tight-looping in `crypto/internal/fips140/sha256.blockAVX2`

This PR adds a narrow skip list for directories that are never legitimate pack content:

- **SCM working-copy state**: `.git`, `.hg`, `.svn`, `.bzr`
- **gascity-internal state**: `.gc`, `.beads`

Hidden directories that **do** appear in published packs — `.claude`, `.gemini`, `.cursor`, `.codex`, `.github`, `.omp`, `.gitkeep` parents — are *not* in the skip list and continue to contribute to the hash. The bundled test pins this behavior so a future broader \"skip all hidden\" rewrite would have to update it deliberately.

Closes #1220

## Commits

- `test(config): reproduce PackContentHashRecursive walking SCM/state dirs` — fails on main: adding files under `.git/`, `.beads/`, `.gc/`, `.hg/`, `.svn/` changes the hash. Also asserts hidden files in `overlay/.claude/...` continue to count.
- `fix(config): skip SCM/state dirs in PackContentHashRecursive` — adds `skipPackContentDir(name)` helper consulted in `collectFiles`. 21 lines of additions; no other behavior change.

## Testing

- [x] `go test ./internal/config/...` — green (full config suite, including new test + existing `TestPackContentHashRecursive`)
- [x] `go test ./internal/beads/...` — green
- [x] `make check` — verified locally; **note**: this branch does not build on darwin without #1208 (one-line `stat.Dev` cast in `internal/fsys/read_regular_unix.go`). Linux CI is unaffected.
- [ ] `make check-docs` — N/A
- [ ] `make test-integration` — config-layer change; integration behavior unchanged for legitimate pack trees.

## Note on dependency

This branch is logically independent and currently does not build on darwin without #1208. Linux CI is unaffected. If #1208 lands first, no rebase needed (this branch is already on top of `upstream/main`).

## Checklist

- [x] Linked an issue (#1220)
- [x] Added a test that reproduces the bug
- [x] Test also pins the boundary: legitimate hidden pack content still contributes to the hash
- [x] No user-facing surface change for properly-configured packs
- [x] No breaking change — pack hashes for trees that did NOT contain `.git/.beads/.gc/.hg/.svn/` are unchanged