### PR TITLE
fix: use --use-db in gc-nudge dolt invocation + darwin stat.Dev cast

### DIFF
--- a/cmd/gc/dolt_gc_nudge_script_test.go
+++ b/cmd/gc/dolt_gc_nudge_script_test.go
@@ -597,10 +597,10 @@ func TestDoltGCNudgeSkipsExternalRigDatabaseWithoutLocalData(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("dolt argv lines = %d, want 1 for local managed db only:\n%s", len(lines), argv)
 	}
-	if !strings.Contains(lines[0], "--database testdb") {
+	if !strings.Contains(lines[0], "--use-db testdb") {
 		t.Fatalf("dolt argv = %q, want local managed testdb", lines[0])
 	}
-	if strings.Contains(argv, "--database extdb") {
+	if strings.Contains(argv, "--use-db extdb") {
 		t.Fatalf("dolt argv should not target external rig db:\n%s", argv)
 	}
 }
@@ -634,7 +634,7 @@ func TestDoltGCNudgeDefaultsMissingDatabaseMetadataToBeads(t *testing.T) {
 	}
 
 	argv := strings.TrimSpace(readFileString(t, argvCapture))
-	if !strings.Contains(argv, "--database beads") {
+	if !strings.Contains(argv, "--use-db beads") {
 		t.Fatalf("dolt argv = %q, want default beads database", argv)
 	}
 }
@@ -673,10 +673,10 @@ func TestDoltGCNudgeSkipsInvalidDatabaseMetadata(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("dolt argv lines = %d, want 1 valid database:\n%s", len(lines), argv)
 	}
-	if !strings.Contains(lines[0], "--database testdb") {
+	if !strings.Contains(lines[0], "--use-db testdb") {
 		t.Fatalf("dolt argv = %q, want local managed testdb", lines[0])
 	}
-	if strings.Contains(argv, "--database --help") {
+	if strings.Contains(argv, "--use-db --help") {
 		t.Fatalf("dolt argv should not target invalid database:\n%s", argv)
 	}
 }
@@ -714,10 +714,10 @@ func TestDoltGCNudgeSkipsSystemDatabaseMetadata(t *testing.T) {
 	}
 
 	argv := strings.TrimSpace(readFileString(t, argvCapture))
-	if strings.Contains(argv, "--database mysql") {
+	if strings.Contains(argv, "--use-db mysql") {
 		t.Fatalf("dolt argv should not target system database:\n%s", argv)
 	}
-	if !strings.Contains(argv, "--database testdb") {
+	if !strings.Contains(argv, "--use-db testdb") {
 		t.Fatalf("dolt argv = %q, want valid testdb", argv)
 	}
 }
@@ -751,7 +751,7 @@ func TestDoltGCNudgeAllowsHyphenatedDatabaseMetadata(t *testing.T) {
 	}
 
 	argv := strings.TrimSpace(readFileString(t, argvCapture))
-	if !strings.Contains(argv, "--database frontend-db") {
+	if !strings.Contains(argv, "--use-db frontend-db") {
 		t.Fatalf("dolt argv = %q, want hyphenated database", argv)
 	}
 }
@@ -790,7 +790,7 @@ func TestDoltGCNudgeHonorsDataDirOverride(t *testing.T) {
 	}
 
 	argv := strings.TrimSpace(readFileString(t, argvCapture))
-	if !strings.Contains(argv, "--database testdb") {
+	if !strings.Contains(argv, "--use-db testdb") {
 		t.Fatalf("dolt argv = %q, want override-backed testdb", argv)
 	}
 }
@@ -821,7 +821,7 @@ func TestDoltGCNudgeDiscoversOrphanDatabaseDirs(t *testing.T) {
 	}
 
 	argv := strings.TrimSpace(readFileString(t, argvCapture))
-	if !strings.Contains(argv, "--database orphan-db") {
+	if !strings.Contains(argv, "--use-db orphan-db") {
 		t.Fatalf("dolt argv = %q, want orphan database", argv)
 	}
 }
@@ -873,7 +873,7 @@ func TestDoltGCNudgeAggregateThresholdTriggersSubthresholdDatabases(t *testing.T
 	}
 
 	argv := strings.TrimSpace(readFileString(t, argvCapture))
-	if !strings.Contains(argv, "--database testdb") || !strings.Contains(argv, "--database rigdb") {
+	if !strings.Contains(argv, "--use-db testdb") || !strings.Contains(argv, "--use-db rigdb") {
 		t.Fatalf("dolt argv = %q, want both subthreshold databases under aggregate trigger", argv)
 	}
 }
@@ -915,10 +915,10 @@ func TestDoltGCNudgeFallbackFindsLocalRigOutsideRigsDir(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("dolt argv lines = %d, want 2 databases from fallback scan:\n%s", len(lines), argv)
 	}
-	if !strings.Contains(argv, "--database testdb") {
+	if !strings.Contains(argv, "--use-db testdb") {
 		t.Fatalf("dolt argv = %q, want city database", argv)
 	}
-	if !strings.Contains(argv, "--database frontenddb") {
+	if !strings.Contains(argv, "--use-db frontenddb") {
 		t.Fatalf("dolt argv = %q, want rig database outside rigs/ dir", argv)
 	}
 }
@@ -944,7 +944,7 @@ func TestDoltGCNudgeWarnsWhenRigListFailsBeforeFallback(t *testing.T) {
 	if !strings.Contains(string(out), "gc rig list failed rc=7") {
 		t.Fatalf("gc-nudge output = %q, want rig-list failure warning", out)
 	}
-	if !strings.Contains(readFileString(t, argvCapture), "--database testdb") {
+	if !strings.Contains(readFileString(t, argvCapture), "--use-db testdb") {
 		t.Fatalf("gc-nudge did not fall back to local metadata scan; output:\n%s", out)
 	}
 }

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -296,7 +296,8 @@ run_dolt_gc_for_db() {
   run_bounded "$gc_call_timeout" \
     dolt --host "$host" --port "$GC_DOLT_PORT" \
     --user "$GC_DOLT_USER" --no-tls \
-    sql --database "$db" -q "CALL DOLT_GC()" || cmd_rc=$?
+    --use-db "$db" \
+    sql -q "CALL DOLT_GC()" || cmd_rc=$?
   elapsed=$(( $(date +%s) - start ))
 
   after=$(dir_bytes "$db_dir")

--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -47,7 +47,7 @@ func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
 	}
 	return regularFileSnapshot{
 		data:  data,
-		id:    fileIdentity{dev: stat.Dev, ino: stat.Ino},
+		id:    fileIdentity{dev: uint64(stat.Dev), ino: stat.Ino},
 		hasID: true,
 	}, nil
 }

--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -47,7 +47,7 @@ func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
 	}
 	return regularFileSnapshot{
 		data:  data,
-		id:    fileIdentity{dev: uint64(stat.Dev), ino: stat.Ino},
+		id:    fileIdentity{dev: uint64(stat.Dev), ino: stat.Ino}, //nolint:unconvert // int32 on darwin, uint64 on linux
 		hasID: true,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Fix `gc-nudge` DOLT_GC() failure: replace `--database` (invalid in dolt 1.86.3) with `--use-db` flag
- Fix darwin build: cast `stat.Dev` from `int32` to `uint64` in `fsys.readRegularFileSnapshot`

## Changes

- `examples/dolt/commands/gc-nudge/run.sh` — use `--use-db` instead of `--database` when calling `dolt sql`
- `internal/fsys/read_regular_unix.go` — cast `stat.Dev` to `uint64` for darwin compatibility
- `cmd/gc/dolt_gc_nudge_script_test.go` — update test assertions to match new flag

## Test plan

- [x] All gc-nudge script tests updated and pass
- [x] `stat.Dev` cast verified on darwin

Closes ga-66a

🤖 Generated with [Claude Code](https://claude.com/claude-code)