### PR TITLE
fix(fsys): cast Stat_t.Dev/Ino to uint64 for darwin/amd64 build

### DIFF
--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -47,7 +47,7 @@ func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
 	}
 	return regularFileSnapshot{
 		data:  data,
-		id:    fileIdentity{dev: stat.Dev, ino: stat.Ino},
+		id:    fileIdentity{dev: uint64(stat.Dev), ino: uint64(stat.Ino)},
 		hasID: true,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Fixes the darwin/amd64 build break introduced in c3e6f174.

\`golang.org/x/sys/unix.Stat_t.Dev\` is \`int32\` on darwin/amd64 but \`uint64\` on darwin/arm64 and linux. The new \`fileIdentity{dev: stat.Dev, ino: stat.Ino}\` literal in \`readRegularFileSnapshot\` failed to compile on Intel Macs.

This mirrors the widening that \`fileIdentityFromInfo\` already performs via \`numericFieldToUint64\`.

Fixes #1225

## Test plan

- [x] \`GOOS=darwin GOARCH=amd64 go build ./...\` — passes
- [x] \`go test ./internal/fsys/...\` — passes
- [ ] CI on linux/darwin-arm64 should still pass (uint64→uint64 is a no-op)