### PR TITLE
fix(config): mark City.agent optional in schema + regen docs

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -15,7 +15,7 @@ City is the top-level configuration for a Gas City instance.
 | `providers` | map[string]ProviderSpec |  |  | Providers defines named provider presets for agent startup. |
 | `packs` | map[string]PackSource |  |  | Packs defines named remote pack sources fetched via git (V1 mechanism). |
 | `imports` | map[string]Import |  |  | Imports defines named pack imports (V2 mechanism). Each key is a binding name; the value specifies the source and optional version, export, and transitive controls. Processed during ExpandCityPacks. |
-| `agent` | []Agent | **yes** |  | Agents lists all configured agents in this city. |
+| `agent` | []Agent |  |  | Agents lists all configured agents in this city. Optional: PackV2 cities compose agents through [imports.*] and ship without any [[agent]] block. |
 | `named_session` | []NamedSession |  |  | NamedSessions lists canonical alias-backed sessions built from reusable agent templates. |
 | `rigs` | []Rig |  |  | Rigs lists external projects registered in the city. |
 | `patches` | Patches |  |  | Patches holds targeted modifications applied after fragment merge. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -915,7 +915,7 @@
             "$ref": "#/$defs/Agent"
           },
           "type": "array",
-          "description": "Agents lists all configured agents in this city."
+          "description": "Agents lists all configured agents in this city. Optional: PackV2\ncities compose agents through [imports.*] and ship without any\n[[agent]] block."
         },
         "named_session": {
           "items": {
@@ -1002,8 +1002,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "workspace",
-        "agent"
+        "workspace"
       ],
       "description": "City is the top-level configuration for a Gas City instance."
     },

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -915,7 +915,7 @@
             "$ref": "#/$defs/Agent"
           },
           "type": "array",
-          "description": "Agents lists all configured agents in this city."
+          "description": "Agents lists all configured agents in this city. Optional: PackV2\ncities compose agents through [imports.*] and ship without any\n[[agent]] block."
         },
         "named_session": {
           "items": {
@@ -1002,8 +1002,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "workspace",
-        "agent"
+        "workspace"
       ],
       "description": "City is the top-level configuration for a Gas City instance."
     },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,8 +139,10 @@ type City struct {
 	// binding name; the value specifies the source and optional version,
 	// export, and transitive controls. Processed during ExpandCityPacks.
 	Imports map[string]Import `toml:"imports,omitempty"`
-	// Agents lists all configured agents in this city.
-	Agents []Agent `toml:"agent"`
+	// Agents lists all configured agents in this city. Optional: PackV2
+	// cities compose agents through [imports.*] and ship without any
+	// [[agent]] block.
+	Agents []Agent `toml:"agent,omitempty"`
 	// NamedSessions lists canonical alias-backed sessions built from
 	// reusable agent templates.
 	NamedSessions []NamedSession `toml:"named_session,omitempty"`

--- a/internal/docgen/schema_test.go
+++ b/internal/docgen/schema_test.go
@@ -187,6 +187,36 @@ func TestCitySchemaOrderOverrideIncludesLegacyGateAlias(t *testing.T) {
 	}
 }
 
+// TestCitySchemaCityAgentNotRequired guards against the regression where
+// City.Agents was reflected as a required property because its TOML tag
+// lacked omitempty. Real cities use [imports.*] (PackV2) and ship without
+// any [[agent]] block; the schema must reflect that.
+func TestCitySchemaCityAgentNotRequired(t *testing.T) {
+	s, err := GenerateCitySchema()
+	if err != nil {
+		t.Fatalf("GenerateCitySchema: %v", err)
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	defs := raw["$defs"].(map[string]interface{})
+	city := defs["City"].(map[string]interface{})
+	required, _ := city["required"].([]interface{})
+	for _, r := range required {
+		if r == "agent" {
+			t.Errorf("City.required includes %q; PackV2 cities ship without [[agent]] blocks — Agents needs omitempty", "agent")
+		}
+	}
+}
+
 func TestCitySchemaAgentDefinition(t *testing.T) {
 	s, err := GenerateCitySchema()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds \`omitempty\` to \`config.City.Agents\` so the reflected JSON schema no longer lists \`agent\` as a required city property.
- Adds a regression test in \`internal/docgen/schema_test.go\` that fails without the fix.
- Regenerates \`docs/schema/city-schema.json\`, \`docs/schema/city-schema.txt\`, and \`docs/reference/config.md\` via \`go run ./cmd/genschema\`.

PackV2 cities (every \`examples/*\` city) ship without any \`[[agent]]\` block — they compose agents through \`[imports.*]\`. The schema's own City description already says so. The required-list was a reflection artifact from a missing \`omitempty\`.

Fixes #1224
Stacked on #1226 (build fix is needed to run \`go test\` on darwin/amd64 — once #1226 lands, this PR rebases cleanly to a 2-commit branch).

## Test plan

- [x] \`go test ./internal/docgen/ ./internal/config/\` — passes
- [x] \`go run ./cmd/genschema\` — regenerated schema removes \`agent\` from \`City.required\`
- [x] All other schema test assertions (which check property *presence*, not required-ness) still pass