### PR TITLE
fix: count creating sessions toward pool deficit + Phase 2 discovery

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -693,7 +693,11 @@ func discoverSessionBeadsWithRoots(
 			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating {
 				continue
 			}
-			if !manualSession && !desiredHasTemplate(desired, template) {
+			// Creating sessions are exempt: the pool deficit accounts for
+			// them (so no new sessions are spawned), but they must still
+			// be discovered here so they appear in desired state with
+			// correct bead-derived identity.
+			if !manualSession && !creating && !desiredHasTemplate(desired, template) {
 				continue
 			}
 		}

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -165,6 +165,9 @@ func computePoolDesiredStates(
 		// Count sessions in "creating" state per template. These are
 		// already being spawned but haven't reached "active" yet, so
 		// they must count toward pool size to prevent unbounded spawning.
+		// Creating sessions are materialized via the session-bead discovery
+		// overlay (Phase 2), not via pool requests, so they reduce the
+		// deficit without needing their own request entries here.
 		creatingCount := make(map[string]int)
 		for _, sb := range sessionBeads {
 			if sb.Status == "closed" {

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -161,6 +161,23 @@ func computePoolDesiredStates(
 		for _, r := range allRequests {
 			beadDriven[r.Template]++
 		}
+
+		// Count sessions in "creating" state per template. These are
+		// already being spawned but haven't reached "active" yet, so
+		// they must count toward pool size to prevent unbounded spawning.
+		creatingCount := make(map[string]int)
+		for _, sb := range sessionBeads {
+			if sb.Status == "closed" {
+				continue
+			}
+			if sb.Metadata["state"] == "creating" {
+				tmpl := strings.TrimSpace(sb.Metadata["template"])
+				if tmpl != "" {
+					creatingCount[tmpl]++
+				}
+			}
+		}
+
 		for _, agent := range cfg.Agents {
 			if agent.Suspended {
 				continue
@@ -170,7 +187,7 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			deficit := scaleCount - beadDriven[template]
+			deficit := scaleCount - beadDriven[template] - creatingCount[template]
 			for j := 0; j < deficit; j++ {
 				allRequests = append(allRequests, SessionRequest{
 					Template: template,

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -618,6 +618,33 @@ func TestComputePoolDesiredStates_RoutedButUnassignedDoesNotSpawnNew(t *testing.
 	}
 }
 
+// Regression: sessions in "creating" state must count toward pool size so
+// the reconciler doesn't keep spawning new sessions while creates are pending.
+func TestComputePoolDesiredStates_CreatingSessionsCountTowardDeficit(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(5), 0)},
+	}
+	// No assigned work beads — all demand comes from scale_check.
+	// But one session is already in "creating" state.
+	sessions := []beads.Bead{
+		{ID: "s-creating", Status: "open", Type: "session", Metadata: map[string]string{
+			"template": "rig/claude", "state": "creating", "pool_managed": "true",
+		}},
+	}
+	scaleCheck := map[string]int{"rig/claude": 2}
+
+	result := ComputePoolDesiredStates(cfg, nil, sessions, scaleCheck)
+
+	total := 0
+	for _, ds := range result {
+		total += len(ds.Requests)
+	}
+	// scale_check=2, 1 creating session already in flight → deficit=1, not 2.
+	if total != 1 {
+		t.Errorf("total requests = %d, want 1 (creating session counted toward deficit)", total)
+	}
+}
+
 // Regression: same as above but for a rig-scoped agent.
 func TestComputePoolDesiredStates_RoutedRigScopedDoesNotSpawnNew(t *testing.T) {
 	cfg := &config.City{


### PR DESCRIPTION
## Summary

Fixes unbounded pool session spawning when sessions get stuck in "creating" state, while preserving correct session identity across desired-state ticks.

**The bug**: `computePoolDesiredStates` didn't count "creating" sessions toward pool size, so the reconciler kept spawning new sessions indefinitely.

**Previous fix attempt** (PR #1219): subtracted `creatingCount` from the deficit. This prevented unbounded spawning but broke fingerprint stability — creating sessions disappeared from desired state because Phase 2 discovery skipped them when `desiredHasTemplate` returned false.

**This fix**: Two complementary changes:
1. **`pool_desired_state.go`**: Keep the `creatingCount` deficit reduction (prevents unbounded spawning)
2. **`build_desired_state.go`**: Exempt creating sessions from the `desiredHasTemplate` check in Phase 2 discovery, so they still appear in desired state with correct bead-derived identity

## Changes

- `cmd/gc/pool_desired_state.go` — clarify that creating sessions are materialized via Phase 2, not pool requests
- `cmd/gc/build_desired_state.go` — add `!creating` to Phase 2's `desiredHasTemplate` gate

## Test plan

- [x] `TestBuildDesiredState_PoolSessionCoreFingerprintStableAcrossTicks` — fingerprint stability preserved
- [x] `TestComputePoolDesiredStates_CreatingSessionsCountTowardDeficit` — creating sessions reduce deficit
- [x] `TestBuildDesiredState_DependencyFloorDoesNotReuseRegularPoolWorkerBead` — dependency floor unaffected
- [x] `TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity` — manual creating sessions use bead identity
- [x] `TestBuildDesiredState_LegacyAliaslessEphemeralPoolSessionFallsBackToSessionNameIdentity` — legacy sessions preserve session_name

Supersedes #1219. Closes ga-468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)