### PR TITLE
fix: preserve non-dangling script symlinks during legacy cleanup

### DIFF
--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -264,9 +264,13 @@ func (v2ScriptsLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 					[]string{"scripts/"})
 			}
 			if legacyShim {
+				if !hasDanglingSymlinks(path) {
+					return okCheck("v2-scripts-layout",
+						"top-level scripts/ contains legacy symlinks with valid targets (preserved for exec order compatibility)")
+				}
 				return warnCheck("v2-scripts-layout",
-					"top-level scripts/ only contains stale legacy symlinks",
-					"delete scripts/ or rerun gc start/gc supervisor so runtime pruning can remove the old shim",
+					"top-level scripts/ contains dangling legacy symlinks",
+					"rerun gc start/gc supervisor to prune dangling symlinks, or delete scripts/ manually",
 					[]string{"scripts/"})
 			}
 			return warnCheck("v2-scripts-layout",
@@ -316,6 +320,30 @@ func inspectTopLevelScripts(dir string) ([]string, bool, error) {
 	}
 	sort.Strings(realFiles)
 	return realFiles, sawSymlink, nil
+}
+
+// hasDanglingSymlinks returns true if dir contains at least one symlink whose
+// target no longer exists on disk.
+func hasDanglingSymlinks(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		fi, lErr := os.Lstat(path)
+		if lErr != nil {
+			return nil
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return nil
+		}
+		if _, statErr := os.Stat(path); statErr != nil {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 func legacyTopLevelScriptsShim(cityPath string) (bool, error) {

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -102,12 +102,46 @@ schema = 2
 	}
 
 	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
-	if res.Status != doctor.StatusWarning {
-		t.Fatalf("symlink-only scripts/ should warn as stale legacy state; got status=%v message=%q details=%v",
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("non-dangling legacy symlinks should be OK; got status=%v message=%q details=%v",
 			res.Status, res.Message, res.Details)
 	}
-	if !strings.Contains(res.Message, "stale legacy symlinks") {
-		t.Fatalf("symlink-only scripts/ should report stale legacy state, got %q", res.Message)
+	if !strings.Contains(res.Message, "valid targets") {
+		t.Fatalf("non-dangling legacy symlinks should mention valid targets, got %q", res.Message)
+	}
+}
+
+func TestV2ScriptsLayoutWarnsForDanglingLegacySymlinks(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "city"
+schema = 2
+`)
+	// Source file does NOT exist — symlink is dangling.
+	gone := filepath.Join(cityDir, "assets", "scripts", "helper.sh")
+
+	scriptsDir := filepath.Join(cityDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(gone, filepath.Join(scriptsDir, "helper.sh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	res := v2ScriptsLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if res.Status != doctor.StatusWarning {
+		t.Fatalf("dangling legacy symlinks should warn; got status=%v message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(res.Message, "dangling legacy symlinks") {
+		t.Fatalf("dangling legacy symlinks should mention 'dangling', got %q", res.Message)
 	}
 }
 

--- a/cmd/gc/script_resolve.go
+++ b/cmd/gc/script_resolve.go
@@ -36,11 +36,14 @@ func pruneLegacyConfiguredScripts(cityPath string, cfg *config.City, handleErr f
 	}
 }
 
-// pruneLegacyScripts removes a top-level scripts/ directory only when it
-// exactly matches the absolute symlink tree the old ResolveScripts shim would
-// have generated from the legacy origins still represented in the current
-// tree. Real files, foreign symlinks, or user-managed symlink layouts that
-// merely point into pack script directories are preserved as user-owned.
+// pruneLegacyScripts removes dangling symlinks from a top-level scripts/
+// directory that exactly matches the absolute symlink tree the old
+// ResolveScripts shim would have generated. Real files, foreign symlinks,
+// or user-managed symlink layouts are preserved as user-owned.
+//
+// Non-dangling legacy symlinks (target file still exists) are preserved even
+// though they originated from the old shim — removing functional symlinks
+// breaks exec orders that reference $PACK_DIR/scripts/<script>.sh.
 func pruneLegacyScripts(targetDir string, legacySourceDirs []string, fallbackRoots ...string) error {
 	symlinks, ok, err := legacyShimLinks(targetDir, legacySourceDirs, fallbackRoots...)
 	if err != nil {
@@ -51,6 +54,12 @@ func pruneLegacyScripts(targetDir string, legacySourceDirs []string, fallbackRoo
 	}
 
 	for _, path := range symlinks {
+		// Only remove dangling symlinks. Non-dangling legacy symlinks may
+		// still be referenced by exec orders even after a layer
+		// reconfiguration.
+		if _, statErr := os.Stat(path); statErr == nil {
+			continue
+		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing legacy script symlink %q: %w", path, err)
 		}

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -31,7 +31,7 @@ func writeLegacyScriptFile(t *testing.T, dir, relPath, content string) {
 	}
 }
 
-func TestPruneLegacyScripts_RemovesSymlinkOnlyTree(t *testing.T) {
+func TestPruneLegacyScripts_PreservesNonDanglingSymlinkOnlyTree(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
 	packScripts := filepath.Join(dir, "packs/base/assets/scripts")
@@ -57,8 +57,30 @@ func TestPruneLegacyScripts_RemovesSymlinkOnlyTree(t *testing.T) {
 		t.Fatalf("pruneLegacyScripts: %v", err)
 	}
 
+	// Non-dangling legacy symlinks are preserved — removing them would
+	// break exec orders that reference $PACK_DIR/scripts/<script>.sh.
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "helper.sh")); err != nil {
+		t.Fatalf("non-dangling legacy symlink helper.sh should be preserved, err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "checks", "review.sh")); err != nil {
+		t.Fatalf("non-dangling legacy symlink checks/review.sh should be preserved, err=%v", err)
+	}
+}
+
+func TestPruneLegacyScripts_RemovesDanglingSymlinkOnlyTree(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	// Targets are under cityPath but don't exist on disk — symlinks are dangling.
+	gone := filepath.Join(cityPath, "packs", "removed", "assets", "scripts")
+	writeLegacyScriptLink(t, cityPath, "scripts/helper.sh", filepath.Join(gone, "helper.sh"))
+	writeLegacyScriptLink(t, cityPath, "scripts/checks/review.sh", filepath.Join(gone, "checks", "review.sh"))
+
+	if err := pruneLegacyScripts(cityPath, nil); err != nil {
+		t.Fatalf("pruneLegacyScripts: %v", err)
+	}
+
 	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("scripts/ should be removed after pruning, err=%v", err)
+		t.Fatalf("dangling legacy scripts/ should be removed, err=%v", err)
 	}
 }
 
@@ -238,11 +260,12 @@ func TestPruneLegacyConfiguredScripts_PrunesCityAndRigOnly(t *testing.T) {
 		t.Fatalf("pruneLegacyConfiguredScripts warnings: %v", warnings)
 	}
 
-	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("city scripts/ should be pruned, err=%v", err)
+	// Non-dangling legacy symlinks are preserved.
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("non-dangling city scripts/city.sh should be preserved, err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("rig scripts/ should be pruned, err=%v", err)
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
+		t.Fatalf("non-dangling rig scripts/rig.sh should be preserved, err=%v", err)
 	}
 	if _, err := os.Lstat(filepath.Join(dir, "scripts", "cwd.sh")); err != nil {
 		t.Fatalf("blank rig path should not prune cwd scripts, err=%v", err)
@@ -284,11 +307,15 @@ func TestPruneLegacyConfiguredScripts_FallsBackToScopeAssetsWhenPackDirsMissing(
 	if len(warnings) > 0 {
 		t.Fatalf("pruneLegacyConfiguredScripts warnings: %v", warnings)
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("city scripts/ should be pruned via local assets fallback, err=%v", err)
+	// Non-dangling legacy symlinks are preserved even with fallback origins.
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("non-dangling city scripts/city.sh should be preserved via fallback, err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("rig scripts/ should be pruned via local assets fallback, err=%v", err)
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("non-dangling rig scripts/city.sh should be preserved via fallback, err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
+		t.Fatalf("non-dangling rig scripts/rig.sh should be preserved via fallback, err=%v", err)
 	}
 }
 
@@ -348,10 +375,15 @@ func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
 		t.Fatalf("prepareCityForSupervisor: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(cityPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("city scripts/ should be pruned by supervisor start path, err=%v", err)
+	// Non-dangling legacy symlinks are preserved by the supervisor start
+	// path — removing them would break exec orders.
+	if _, err := os.Lstat(filepath.Join(cityPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("non-dangling city scripts/city.sh should be preserved, err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(rigPath, "scripts")); !os.IsNotExist(err) {
-		t.Fatalf("rig scripts/ should be pruned by supervisor start path, err=%v", err)
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "city.sh")); err != nil {
+		t.Fatalf("non-dangling rig scripts/city.sh should be preserved, err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(rigPath, "scripts", "rig.sh")); err != nil {
+		t.Fatalf("non-dangling rig scripts/rig.sh should be preserved, err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `pruneLegacyScripts` now only removes dangling symlinks (target gone), preserving valid symlinks needed by exec orders
- `v2-scripts-layout` doctor check updated to distinguish dangling vs non-dangling symlinks

## Context

The v2-scripts-layout migration removes city-root `scripts/` symlinks, but exec orders in `orders/*.toml` reference `$PACK_DIR/scripts/<script>.sh` through these symlinks. When all 9 maintenance exec orders broke with exit 127, the workaround was absolute paths. This fix preserves non-dangling symlinks during cleanup.

## Test plan

- [x] 18 related tests pass (script_resolve + doctor_v2_checks)

Closes ga-9n6

🤖 Generated with [Claude Code](https://claude.com/claude-code)