### PR TITLE
fix: skip clearWakeFailures write when values already cleared

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -569,6 +569,10 @@ func recordWakeFailure(session *beads.Bead, store beads.Store, clk clock.Clock) 
 
 // clearWakeFailures resets crash counter and quarantine for a stable session.
 func clearWakeFailures(session *beads.Bead, store beads.Store) {
+	attempts := session.Metadata["wake_attempts"]
+	if (attempts == "" || attempts == "0") && session.Metadata["quarantined_until"] == "" {
+		return
+	}
 	batch := map[string]string{
 		"wake_attempts":     "0",
 		"quarantined_until": "",

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1072,6 +1072,49 @@ func TestClearWakeFailures(t *testing.T) {
 	}
 }
 
+func TestClearWakeFailures_SkipsWriteWhenAlreadyClear(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    map[string]string
+		wantNil bool
+	}{
+		{
+			name:    "zero attempts and empty quarantine",
+			meta:    map[string]string{"wake_attempts": "0", "quarantined_until": ""},
+			wantNil: true,
+		},
+		{
+			name:    "missing attempts and empty quarantine",
+			meta:    map[string]string{},
+			wantNil: true,
+		},
+		{
+			name:    "nonzero attempts triggers write",
+			meta:    map[string]string{"wake_attempts": "3", "quarantined_until": ""},
+			wantNil: false,
+		},
+		{
+			name:    "quarantine set triggers write",
+			meta:    map[string]string{"wake_attempts": "0", "quarantined_until": "2026-03-08T12:00:00Z"},
+			wantNil: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore()
+			session := makeBead("b1", tt.meta)
+			clearWakeFailures(&session, store)
+			wrote := len(store.metadata["b1"]) > 0
+			if tt.wantNil && wrote {
+				t.Errorf("expected no store write, but got %v", store.metadata["b1"])
+			}
+			if !tt.wantNil && !wrote {
+				t.Error("expected a store write, but none occurred")
+			}
+		})
+	}
+}
+
 func TestStableLongEnough(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2175,6 +2175,44 @@ func TestReconcileSessionBeads_StableClearsFailures(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_StableAlreadyClearDoesNotWriteMetadata(t *testing.T) {
+	env := newReconcilerTestEnv()
+	countingStore := newCountingMetadataStore()
+	env.store = countingStore
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	stableWake := env.clk.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"state":             "active",
+		"wake_attempts":     "3",
+		"last_woke_at":      stableWake,
+		"quarantined_until": "",
+	})
+
+	countingStore.singleCalls = 0
+	countingStore.batchCalls = 0
+	env.reconcile([]beads.Bead{session})
+	if countingStore.batchCalls == 0 {
+		t.Fatal("first stable tick should write metadata to clear wake failures")
+	}
+
+	cleared, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("getting session bead: %v", err)
+	}
+	if cleared.Metadata["wake_attempts"] != "0" {
+		t.Fatalf("wake_attempts after first tick = %q, want 0", cleared.Metadata["wake_attempts"])
+	}
+
+	countingStore.singleCalls = 0
+	countingStore.batchCalls = 0
+	env.reconcile([]beads.Bead{cleared})
+	if got := countingStore.singleCalls + countingStore.batchCalls; got != 0 {
+		t.Fatalf("second stable tick performed %d metadata write(s), want 0", got)
+	}
+}
+
 func TestReconcileSessionBeads_NoAgentNotWoken(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{}


### PR DESCRIPTION
For stable running sessions (alive + past stabilityThreshold), clearWakeFailures was called on every reconciler tick and always wrote wake_attempts=0 and quarantined_until="" unconditionally — even when both fields were already at their default/cleared values. Each no-op write caused the beads layer to record an `updated` event and create a Dolt commit, producing ~1 commit every 3 seconds per active session.

Over 42 hours this generated ~24,683 events for a single named session and 1.4 GB of Dolt history in the hq database.

Add an early-return guard (matching the existing clearChurn pattern) so the store write is skipped when wake_attempts is already "0"/empty and quarantined_until is already empty.

Fixes #1205

## Summary

- Explain the change and why it is needed.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [ ] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes

