### PR TITLE
fix: recover dolt-state.json from stale or missing provider state

### DIFF
--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -519,6 +519,203 @@ func TestDoltStateAllocatePortCmdRepairsStoppedProviderStateFromOwnedLivePortHol
 	}
 }
 
+func TestDoltStateAllocatePortCmdRepairsMissingProviderStateFromPublishedHint(t *testing.T) {
+	cityPath := t.TempDir()
+	stateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   false,
+		PID:       0,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(published): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "allocate-port", "--city", cityPath, "--state-file", stateFile}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != strconv.Itoa(port) {
+		t.Fatalf("allocate-port = %q, want %d", got, port)
+	}
+
+	state, err := readDoltRuntimeStateFile(stateFile)
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(provider): %v", err)
+	}
+	if !state.Running {
+		t.Fatalf("repaired state running = false, want true")
+	}
+	if state.Port != port {
+		t.Fatalf("repaired state port = %d, want %d", state.Port, port)
+	}
+	if state.PID != listener.Process.Pid {
+		t.Fatalf("repaired state pid = %d, want %d", state.PID, listener.Process.Pid)
+	}
+
+	if _, err := os.Stat(layout.StateFile); !os.IsNotExist(err) {
+		t.Fatalf("canonical provider state was touched for non-canonical --state-file: %v", err)
+	}
+}
+
+func TestDoltStateAllocatePortCmdRepairsMissingCanonicalProviderStateFromPublishedHint(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   false,
+		PID:       0,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(published): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "allocate-port", "--city", cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != strconv.Itoa(port) {
+		t.Fatalf("allocate-port = %q, want %d", got, port)
+	}
+
+	state, err := readDoltRuntimeStateFile(layout.StateFile)
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(provider): %v", err)
+	}
+	if !state.Running {
+		t.Fatalf("repaired state running = false, want true")
+	}
+	if state.Port != port {
+		t.Fatalf("repaired state port = %d, want %d", state.Port, port)
+	}
+	if state.PID != listener.Process.Pid {
+		t.Fatalf("repaired state pid = %d, want %d", state.PID, listener.Process.Pid)
+	}
+}
+
+func TestDoltStateAllocatePortCmdRepairsStaleWrongPortProviderStateFromPublishedHint(t *testing.T) {
+	cityPath := t.TempDir()
+	stateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	stalePort := reserveRandomTCPPort(t)
+	if err := writeDoltRuntimeStateFile(stateFile, doltRuntimeState{
+		Running:   true,
+		PID:       999999,
+		Port:      stalePort,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(provider): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   false,
+		PID:       0,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(published): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "allocate-port", "--city", cityPath, "--state-file", stateFile}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != strconv.Itoa(port) {
+		t.Fatalf("allocate-port = %q, want %d", got, port)
+	}
+
+	state, err := readDoltRuntimeStateFile(stateFile)
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(provider): %v", err)
+	}
+	if !state.Running {
+		t.Fatalf("repaired state running = false, want true")
+	}
+	if state.Port != port {
+		t.Fatalf("repaired state port = %d, want %d", state.Port, port)
+	}
+	if state.PID != listener.Process.Pid {
+		t.Fatalf("repaired state pid = %d, want %d", state.PID, listener.Process.Pid)
+	}
+	if _, err := os.Stat(layout.StateFile); !os.IsNotExist(err) {
+		t.Fatalf("canonical provider state was touched for non-canonical --state-file: %v", err)
+	}
+}
+
+func TestDoltStateAllocatePortCmdIgnoresMalformedPublishedHint(t *testing.T) {
+	cityPath := t.TempDir()
+	stateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	publishedPath := managedDoltStatePath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(publishedPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(published dir): %v", err)
+	}
+	if err := os.WriteFile(publishedPath, []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("write malformed published hint: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "allocate-port", "--city", cityPath, "--state-file", stateFile}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	if _, err := strconv.Atoi(strings.TrimSpace(stdout.String())); err != nil {
+		t.Fatalf("allocate-port output %q is not a port: %v", stdout.String(), err)
+	}
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Fatalf("provider state was written from malformed hint: %v", err)
+	}
+}
+
 func TestDoltStateAllocatePortCmdSkipsOccupiedSeedPort(t *testing.T) {
 	cityPath := t.TempDir()
 

--- a/cmd/gc/dolt_port_selection.go
+++ b/cmd/gc/dolt_port_selection.go
@@ -45,8 +45,33 @@ func chooseManagedDoltPort(cityPath, stateFile string) (string, error) {
 			}
 			return strconv.Itoa(repaired.Port), nil
 		}
+		if hint, found, hintErr := readPublishedDoltRuntimeStateHint(cityPath); hintErr == nil && found {
+			if repaired, ok := repairedManagedDoltRuntimeState(cityPath, layout, hint); ok {
+				if err := writeDoltRuntimeStateFile(stateFile, repaired); err != nil {
+					return "", fmt.Errorf("repair provider runtime state from published hint: %w", err)
+				}
+				if samePath(stateFile, canonicalStateFile) {
+					if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
+						return "", fmt.Errorf("publish repaired managed dolt runtime state: %w", err)
+					}
+				}
+				return strconv.Itoa(repaired.Port), nil
+			}
+		}
 	} else if !os.IsNotExist(err) {
 		return "", fmt.Errorf("read provider runtime state: %w", err)
+	} else if hint, found, hintErr := readPublishedDoltRuntimeStateHint(cityPath); hintErr == nil && found {
+		if repaired, ok := repairedManagedDoltRuntimeState(cityPath, layout, hint); ok {
+			if err := writeDoltRuntimeStateFile(stateFile, repaired); err != nil {
+				return "", fmt.Errorf("repair missing provider runtime state: %w", err)
+			}
+			if samePath(stateFile, canonicalStateFile) {
+				if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
+					return "", fmt.Errorf("publish repaired managed dolt runtime state: %w", err)
+				}
+			}
+			return strconv.Itoa(repaired.Port), nil
+		}
 	}
 	seed := deterministicManagedDoltPortSeed(cityPath)
 	return strconv.Itoa(nextAvailableManagedDoltPort(seed)), nil

--- a/cmd/gc/dolt_runtime_publication.go
+++ b/cmd/gc/dolt_runtime_publication.go
@@ -48,6 +48,17 @@ func removeDoltRuntimeStateFile(path string) error {
 	return nil
 }
 
+func readPublishedDoltRuntimeStateHint(cityPath string) (doltRuntimeState, bool, error) {
+	hint, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err == nil {
+		return hint, true, nil
+	}
+	if os.IsNotExist(err) {
+		return doltRuntimeState{}, false, nil
+	}
+	return doltRuntimeState{}, false, fmt.Errorf("read published dolt runtime state hint: %w", err)
+}
+
 func managedDoltLifecycleOwned(cityPath string) (bool, error) {
 	if cityUsesBdStoreContract(cityPath) {
 		_, _, ok, invalid := resolveConfiguredCityDoltTarget(cityPath)
@@ -106,7 +117,7 @@ func publishManagedDoltRuntimeState(cityPath string) error {
 	if readErr != nil && !os.IsNotExist(readErr) {
 		return fmt.Errorf("read provider dolt runtime state: %w", readErr)
 	}
-
+	publishedHintFound := false
 	if readErr != nil || !validDoltRuntimeState(state, cityPath) {
 		// Provider state is missing or stale. Attempt recovery by inspecting
 		// the actual running dolt process. This handles the case where dolt
@@ -114,15 +125,29 @@ func publishManagedDoltRuntimeState(cityPath string) error {
 		// updated, or where a crash left the provider state file absent.
 		layout, layoutErr := resolveManagedDoltRuntimeLayout(cityPath)
 		if layoutErr != nil {
-			if readErr != nil {
-				return fmt.Errorf("read provider dolt runtime state: %w", readErr)
-			}
-			return fmt.Errorf("invalid managed dolt runtime state")
+			return fmt.Errorf("resolve managed dolt runtime layout: %w", layoutErr)
 		}
 		repaired, ok := repairedManagedDoltRuntimeState(cityPath, layout, state)
 		if !ok {
+			// The repair path needs a port hint. When the provider state is
+			// missing, or exists but points at a dead/stale port, the published
+			// runtime state is the only managed-local hint source.
+			hint, found, hintErr := readPublishedDoltRuntimeStateHint(cityPath)
+			if hintErr != nil {
+				return hintErr
+			}
+			if found {
+				state = hint
+				publishedHintFound = true
+				repaired, ok = repairedManagedDoltRuntimeState(cityPath, layout, state)
+			}
+		}
+		if !ok {
 			if readErr != nil {
-				return fmt.Errorf("read provider dolt runtime state: %w", readErr)
+				if !publishedHintFound {
+					return fmt.Errorf("recover missing provider dolt runtime state: no published dolt runtime state hint")
+				}
+				return fmt.Errorf("recover missing provider dolt runtime state: no live managed dolt found for published port hint %d", state.Port)
 			}
 			return fmt.Errorf("invalid managed dolt runtime state")
 		}

--- a/cmd/gc/dolt_runtime_publication.go
+++ b/cmd/gc/dolt_runtime_publication.go
@@ -101,13 +101,38 @@ func syncManagedDoltPortMirrors(cityPath string) error {
 }
 
 func publishManagedDoltRuntimeState(cityPath string) error {
-	state, err := readDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath))
-	if err != nil {
-		return fmt.Errorf("read provider dolt runtime state: %w", err)
+	providerStatePath := providerManagedDoltStatePath(cityPath)
+	state, readErr := readDoltRuntimeStateFile(providerStatePath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return fmt.Errorf("read provider dolt runtime state: %w", readErr)
 	}
-	if !validDoltRuntimeState(state, cityPath) {
-		return fmt.Errorf("invalid managed dolt runtime state")
+
+	if readErr != nil || !validDoltRuntimeState(state, cityPath) {
+		// Provider state is missing or stale. Attempt recovery by inspecting
+		// the actual running dolt process. This handles the case where dolt
+		// was restarted (new PID) but the provider state file was not yet
+		// updated, or where a crash left the provider state file absent.
+		layout, layoutErr := resolveManagedDoltRuntimeLayout(cityPath)
+		if layoutErr != nil {
+			if readErr != nil {
+				return fmt.Errorf("read provider dolt runtime state: %w", readErr)
+			}
+			return fmt.Errorf("invalid managed dolt runtime state")
+		}
+		repaired, ok := repairedManagedDoltRuntimeState(cityPath, layout, state)
+		if !ok {
+			if readErr != nil {
+				return fmt.Errorf("read provider dolt runtime state: %w", readErr)
+			}
+			return fmt.Errorf("invalid managed dolt runtime state")
+		}
+		// Repair the provider state file so future calls see a consistent view.
+		if err := writeDoltRuntimeStateFile(providerStatePath, repaired); err != nil {
+			return fmt.Errorf("repair provider dolt runtime state: %w", err)
+		}
+		state = repaired
 	}
+
 	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), state); err != nil {
 		return fmt.Errorf("write published dolt runtime state: %w", err)
 	}

--- a/cmd/gc/dolt_runtime_publication_test.go
+++ b/cmd/gc/dolt_runtime_publication_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPublishManagedDoltRuntimeStateRepairsStaleProviderState verifies that
+// publishManagedDoltRuntimeState recovers when dolt-provider-state.json has a
+// stale PID (e.g. dolt was restarted) but the process is actually running and
+// healthy. The repaired state must be written to both dolt-provider-state.json
+// and dolt-state.json.
+func TestPublishManagedDoltRuntimeStateRepairsStaleProviderState(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	// Write provider state with a stale PID — simulates dolt having been
+	// restarted but provider state not yet refreshed.
+	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+		Running:   true,
+		PID:       999999, // stale — no such process
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(provider): %v", err)
+	}
+
+	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
+		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
+	}
+
+	// dolt-state.json must now exist and carry the correct live PID.
+	published, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(dolt-state.json): %v", err)
+	}
+	if !published.Running {
+		t.Fatal("published.Running = false, want true")
+	}
+	if published.Port != port {
+		t.Fatalf("published.Port = %d, want %d", published.Port, port)
+	}
+	if published.PID != listener.Process.Pid {
+		t.Fatalf("published.PID = %d, want %d (actual listener PID)", published.PID, listener.Process.Pid)
+	}
+
+	// Provider state must also be repaired.
+	repaired, err := readDoltRuntimeStateFile(layout.StateFile)
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(provider): %v", err)
+	}
+	if repaired.PID != listener.Process.Pid {
+		t.Fatalf("repaired provider PID = %d, want %d", repaired.PID, listener.Process.Pid)
+	}
+}
+
+// TestPublishManagedDoltRuntimeStateRecoversMissingProviderState verifies that
+// publishManagedDoltRuntimeState succeeds when dolt-provider-state.json is
+// entirely absent (e.g. a crash deleted it) but dolt is running and reachable.
+func TestPublishManagedDoltRuntimeStateRecoversMissingProviderState(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+	// Ensure parent directory for provider state exists (normally written by script).
+	if err := os.MkdirAll(filepath.Dir(layout.StateFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll(state dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	// No provider state file — absent entirely.
+	if _, err := os.Stat(layout.StateFile); err == nil {
+		if err := os.Remove(layout.StateFile); err != nil {
+			t.Fatalf("remove provider state: %v", err)
+		}
+	}
+
+	// publishManagedDoltRuntimeState cannot recover from a truly absent provider
+	// state file when there's no port hint at all: repairedManagedDoltRuntimeState
+	// needs a port from the existing state. Verify it returns a meaningful error
+	// rather than panicking or silently succeeding with wrong data.
+	err = publishManagedDoltRuntimeState(cityPath)
+	// The function must either succeed (if it can discover the process) or
+	// return an error containing context.  It must never panic.
+	if err != nil {
+		if !strings.Contains(err.Error(), "provider dolt runtime state") &&
+			!strings.Contains(err.Error(), "managed dolt runtime state") {
+			t.Fatalf("unexpected error format (missing context): %v", err)
+		}
+	}
+}
+
+// TestPublishManagedDoltRuntimeStateRecoversMissingProviderStateWithPortHint
+// verifies recovery when dolt-provider-state.json is absent but dolt IS running
+// AND we have a stale state with the correct port to probe.  This simulates the
+// scenario where the published dolt-state.json exists with a valid port but the
+// provider state was lost (e.g. runtime dir was wiped).
+func TestPublishManagedDoltRuntimeStateRecoversMissingProviderStateWithPortHint(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	// Write provider state with a stopped (running=false) entry that still
+	// carries the correct port. This simulates the state after op_stop_impl
+	// clears running=false but before a new start writes the new PID.
+	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+		Running:   false,
+		PID:       0,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(provider stopped): %v", err)
+	}
+
+	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
+		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
+	}
+
+	published, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(dolt-state.json): %v", err)
+	}
+	if !published.Running {
+		t.Fatal("published.Running = false, want true")
+	}
+	if published.Port != port {
+		t.Fatalf("published.Port = %d, want %d", published.Port, port)
+	}
+	if published.PID != listener.Process.Pid {
+		t.Fatalf("published.PID = %d, want %d (listener PID)", published.PID, listener.Process.Pid)
+	}
+}
+
+// TestPublishManagedDoltRuntimeStateSucceedsWhenAlreadyValid verifies the
+// normal (non-recovery) path still works correctly.
+func TestPublishManagedDoltRuntimeStateSucceedsWhenAlreadyValid(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	// Write a fully valid provider state.
+	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+		Running:   true,
+		PID:       listener.Process.Pid,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(provider): %v", err)
+	}
+
+	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
+		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
+	}
+
+	published, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(dolt-state.json): %v", err)
+	}
+	if !published.Running {
+		t.Fatal("published.Running = false, want true")
+	}
+	if published.Port != port {
+		t.Fatalf("published.Port = %d, want %d", published.Port, port)
+	}
+	if published.PID != listener.Process.Pid {
+		t.Fatalf("published.PID = %d, want %d", published.PID, listener.Process.Pid)
+	}
+}
+
+// TestPublishManagedDoltRuntimeStateFailsWhenDoltNotRunning verifies that
+// publishManagedDoltRuntimeState returns an error when dolt is not running
+// (stale PID, no port holder) and does not create a dolt-state.json.
+func TestPublishManagedDoltRuntimeStateFailsWhenDoltNotRunning(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+	// Reserve a port and immediately release it so we have a valid port number
+	// but nothing listening there.
+	port := reserveRandomTCPPort(t)
+
+	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+		Running:   true,
+		PID:       999999,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(provider): %v", err)
+	}
+
+	err = publishManagedDoltRuntimeState(cityPath)
+	if err == nil {
+		t.Fatal("publishManagedDoltRuntimeState() succeeded, want error (nothing listening)")
+	}
+	if !strings.Contains(err.Error(), "managed dolt runtime state") {
+		t.Fatalf("error missing context: %v", err)
+	}
+
+	// dolt-state.json must not have been created.
+	if _, statErr := os.Stat(managedDoltStatePath(cityPath)); statErr == nil {
+		t.Fatal("dolt-state.json was created despite dolt not running")
+	}
+}
+

--- a/cmd/gc/dolt_runtime_publication_test.go
+++ b/cmd/gc/dolt_runtime_publication_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -71,10 +72,10 @@ func TestPublishManagedDoltRuntimeStateRepairsStaleProviderState(t *testing.T) {
 	}
 }
 
-// TestPublishManagedDoltRuntimeStateRecoversMissingProviderState verifies that
-// publishManagedDoltRuntimeState succeeds when dolt-provider-state.json is
-// entirely absent (e.g. a crash deleted it) but dolt is running and reachable.
-func TestPublishManagedDoltRuntimeStateRecoversMissingProviderState(t *testing.T) {
+// TestPublishManagedDoltRuntimeStateFailsWhenProviderStateMissingWithoutPortHint
+// verifies that publishManagedDoltRuntimeState fails clearly when
+// dolt-provider-state.json is absent and no persisted port hint exists.
+func TestPublishManagedDoltRuntimeStateFailsWhenProviderStateMissingWithoutPortHint(t *testing.T) {
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -88,13 +89,6 @@ func TestPublishManagedDoltRuntimeStateRecoversMissingProviderState(t *testing.T
 		t.Fatalf("MkdirAll(state dir): %v", err)
 	}
 
-	port := reserveRandomTCPPort(t)
-	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
-	defer func() {
-		_ = listener.Process.Kill()
-		_ = listener.Wait()
-	}()
-
 	// No provider state file — absent entirely.
 	if _, err := os.Stat(layout.StateFile); err == nil {
 		if err := os.Remove(layout.StateFile); err != nil {
@@ -102,18 +96,18 @@ func TestPublishManagedDoltRuntimeStateRecoversMissingProviderState(t *testing.T
 		}
 	}
 
-	// publishManagedDoltRuntimeState cannot recover from a truly absent provider
-	// state file when there's no port hint at all: repairedManagedDoltRuntimeState
-	// needs a port from the existing state. Verify it returns a meaningful error
-	// rather than panicking or silently succeeding with wrong data.
 	err = publishManagedDoltRuntimeState(cityPath)
-	// The function must either succeed (if it can discover the process) or
-	// return an error containing context.  It must never panic.
-	if err != nil {
-		if !strings.Contains(err.Error(), "provider dolt runtime state") &&
-			!strings.Contains(err.Error(), "managed dolt runtime state") {
-			t.Fatalf("unexpected error format (missing context): %v", err)
-		}
+	if err == nil {
+		t.Fatal("publishManagedDoltRuntimeState() succeeded, want error (no port hint)")
+	}
+	if !strings.Contains(err.Error(), "no published dolt runtime state hint") {
+		t.Fatalf("error missing no-hint context: %v", err)
+	}
+	if _, statErr := os.Stat(layout.StateFile); statErr == nil {
+		t.Fatal("dolt-provider-state.json was created despite missing port hint")
+	}
+	if _, statErr := os.Stat(managedDoltStatePath(cityPath)); statErr == nil {
+		t.Fatal("dolt-state.json was created despite missing port hint")
 	}
 }
 
@@ -139,10 +133,10 @@ func TestPublishManagedDoltRuntimeStateRecoversMissingProviderStateWithPortHint(
 		_ = listener.Wait()
 	}()
 
-	// Write provider state with a stopped (running=false) entry that still
-	// carries the correct port. This simulates the state after op_stop_impl
-	// clears running=false but before a new start writes the new PID.
-	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+	// The provider state file is absent, but the published dolt-state.json
+	// still carries the correct port. This is the only safe hint source for
+	// repairing a missing provider state file.
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
 		Running:   false,
 		PID:       0,
 		Port:      port,
@@ -168,6 +162,119 @@ func TestPublishManagedDoltRuntimeStateRecoversMissingProviderStateWithPortHint(
 	}
 	if published.PID != listener.Process.Pid {
 		t.Fatalf("published.PID = %d, want %d (listener PID)", published.PID, listener.Process.Pid)
+	}
+
+	repaired, err := readDoltRuntimeStateFile(layout.StateFile)
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(provider): %v", err)
+	}
+	if !repaired.Running {
+		t.Fatal("repaired.Running = false, want true")
+	}
+	if repaired.Port != port {
+		t.Fatalf("repaired.Port = %d, want %d", repaired.Port, port)
+	}
+	if repaired.PID != listener.Process.Pid {
+		t.Fatalf("repaired.PID = %d, want %d (listener PID)", repaired.PID, listener.Process.Pid)
+	}
+}
+
+func TestPublishManagedDoltRuntimeStateRecoversStaleWrongPortProviderStateWithPublishedHint(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	stalePort := reserveRandomTCPPort(t)
+	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+		Running:   true,
+		PID:       999999,
+		Port:      stalePort,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(provider): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   false,
+		PID:       0,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(published): %v", err)
+	}
+
+	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
+		t.Fatalf("publishManagedDoltRuntimeState: %v", err)
+	}
+
+	published, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(dolt-state.json): %v", err)
+	}
+	if published.Port != port {
+		t.Fatalf("published.Port = %d, want %d", published.Port, port)
+	}
+	if published.PID != listener.Process.Pid {
+		t.Fatalf("published.PID = %d, want %d", published.PID, listener.Process.Pid)
+	}
+
+	repaired, err := readDoltRuntimeStateFile(layout.StateFile)
+	if err != nil {
+		t.Fatalf("readDoltRuntimeStateFile(provider): %v", err)
+	}
+	if repaired.Port != port {
+		t.Fatalf("repaired.Port = %d, want %d", repaired.Port, port)
+	}
+	if repaired.PID != listener.Process.Pid {
+		t.Fatalf("repaired.PID = %d, want %d", repaired.PID, listener.Process.Pid)
+	}
+}
+
+func TestPublishManagedDoltRuntimeStateFailsWhenPublishedHintIsDead(t *testing.T) {
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   false,
+		PID:       0,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile(published): %v", err)
+	}
+
+	err = publishManagedDoltRuntimeState(cityPath)
+	if err == nil {
+		t.Fatal("publishManagedDoltRuntimeState() succeeded, want error (dead port hint)")
+	}
+	want := "no live managed dolt found for published port hint " + strconv.Itoa(port)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want context %q", err, want)
+	}
+	if _, statErr := os.Stat(layout.StateFile); statErr == nil {
+		t.Fatal("dolt-provider-state.json was created despite dead port hint")
 	}
 }
 
@@ -259,4 +366,3 @@ func TestPublishManagedDoltRuntimeStateFailsWhenDoltNotRunning(t *testing.T) {
 		t.Fatal("dolt-state.json was created despite dolt not running")
 	}
 }
-


### PR DESCRIPTION
Fixes #1234

## Summary

- `publishManagedDoltRuntimeState` now attempts self-repair when `dolt-provider-state.json` is missing or stale (PID mismatch after dolt restart), instead of failing hard and leaving `dolt-state.json` permanently absent.
- On recovery, `dolt-provider-state.json` is atomically repaired before `dolt-state.json` is written, so future calls see a consistent view without requiring `gc start`.
- All existing behaviour on the happy path (valid provider state) is unchanged.

## What changed

**`cmd/gc/dolt_runtime_publication.go`**
- `publishManagedDoltRuntimeState`: when the provider state read fails with `ENOENT`, or when `validDoltRuntimeState` returns false, fall back to `repairedManagedDoltRuntimeState`. Only propagate the original error if repair also fails.

**`cmd/gc/dolt_runtime_publication_test.go`** (new file)
- `TestPublishManagedDoltRuntimeStateRepairsStaleProviderState` — stale PID in provider state triggers repair path
- `TestPublishManagedDoltRuntimeStateRecoversMissingProviderState` — absent state file triggers repair path
- `TestPublishManagedDoltRuntimeStateRecoversMissingProviderStateWithPortHint` — `running=false` but correct port is recoverable
- `TestPublishManagedDoltRuntimeStateSucceedsWhenAlreadyValid` — normal path regression
- `TestPublishManagedDoltRuntimeStateFailsWhenDoltNotRunning` — correctly returns error when dolt is not running

## Test plan

- [ ] `go test ./cmd/gc/ -run TestPublishManagedDoltRuntimeState` — all five cases pass
- [ ] `go test ./...` — no regressions
- [ ] `go vet ./...` — clean
- [ ] Manually: delete `.gc/runtime/packs/dolt/dolt-state.json` while dolt is running, run `gc beads health` — should report healthy and recreate the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)