### PR TITLE
feat(docgen): generate JSON schema for pack.toml (PackV2 manifest)

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -343,8 +343,14 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 
-	// Step 10: Merge environment layers.
-	env := convergence.ScrubTokenEnv(mergeEnv(passthroughEnv(), expandEnvMap(resolved.Env), expandEnvMap(cfgAgent.Env), agentEnv))
+	// Step 10: Merge environment layers. Workspace.Env sits between
+	// passthrough and provider so a per-provider/agent/patch entry can
+	// still override a workspace-wide default.
+	var workspaceEnv map[string]string
+	if p.workspace != nil {
+		workspaceEnv = p.workspace.Env
+	}
+	env := convergence.ScrubTokenEnv(mergeEnv(passthroughEnv(), expandEnvMap(workspaceEnv), expandEnvMap(resolved.Env), expandEnvMap(cfgAgent.Env), agentEnv))
 
 	// Step 11: Expand session setup templates.
 	configDir := p.cityPath

--- a/cmd/gc/template_resolve_workspace_env_test.go
+++ b/cmd/gc/template_resolve_workspace_env_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveTemplateMergesWorkspaceEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+
+	params := &agentBuildParams{
+		cityName: "city",
+		cityPath: cityPath,
+		workspace: &config.Workspace{
+			Provider: "test",
+			Env: map[string]string{
+				"GC_TARGET_BRANCH": "boylec/develop",
+				"FROM_WORKSPACE":   "ws",
+			},
+		},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+	agent := &config.Agent{Name: "mayor"}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if got := tp.Env["GC_TARGET_BRANCH"]; got != "boylec/develop" {
+		t.Errorf("GC_TARGET_BRANCH = %q, want %q", got, "boylec/develop")
+	}
+	if got := tp.Env["FROM_WORKSPACE"]; got != "ws" {
+		t.Errorf("FROM_WORKSPACE = %q, want %q", got, "ws")
+	}
+}
+
+func TestResolveTemplateAgentEnvWinsOverWorkspaceEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+
+	params := &agentBuildParams{
+		cityName: "city",
+		cityPath: cityPath,
+		workspace: &config.Workspace{
+			Provider: "test",
+			Env: map[string]string{
+				"GC_TARGET_BRANCH": "boylec/develop",
+			},
+		},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+	agent := &config.Agent{
+		Name: "mayor",
+		Env:  map[string]string{"GC_TARGET_BRANCH": "boylec/special"},
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if got := tp.Env["GC_TARGET_BRANCH"]; got != "boylec/special" {
+		t.Errorf("GC_TARGET_BRANCH = %q, want %q (agent env must override workspace env)", got, "boylec/special")
+	}
+}

--- a/cmd/genschema/main.go
+++ b/cmd/genschema/main.go
@@ -7,6 +7,8 @@
 //
 //	docs/schema/city-schema.json
 //	docs/schema/city-schema.txt
+//	docs/schema/pack-schema.json
+//	docs/schema/pack-schema.txt
 //	docs/reference/config.md
 //	docs/reference/cli.md
 package main
@@ -47,11 +49,21 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("generating city schema: %w", err)
 	}
-	// Write JSON schema.
 	if err := writeSchema("docs/schema/city-schema.json", citySchema); err != nil {
 		return err
 	}
 	if err := writeSchema("docs/schema/city-schema.txt", citySchema); err != nil {
+		return err
+	}
+
+	packSchema, err := docgen.GeneratePackSchema()
+	if err != nil {
+		return fmt.Errorf("generating pack schema: %w", err)
+	}
+	if err := writeSchema("docs/schema/pack-schema.json", packSchema); err != nil {
+		return err
+	}
+	if err := writeSchema("docs/schema/pack-schema.txt", packSchema); err != nil {
 		return err
 	}
 
@@ -71,6 +83,8 @@ func run() error {
 	files := []string{
 		"docs/schema/city-schema.json",
 		"docs/schema/city-schema.txt",
+		"docs/schema/pack-schema.json",
+		"docs/schema/pack-schema.txt",
 		"docs/reference/config.md",
 		"docs/reference/cli.md",
 	}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -612,4 +612,5 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 | `global_fragments` | []string |  |  | GlobalFragments lists named template fragments injected into every agent's rendered prompt. Applied before per-agent InjectFragments. Each name must match a &#123;&#123; define "name" &#125;&#125; block from a pack's prompts/shared/ directory. |
 | `includes` | []string |  |  | Includes lists pack directories or URLs to compose into this workspace. Replaces the older pack/packs fields. Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
 | `default_rig_includes` | []string |  |  | DefaultRigIncludes lists pack directories applied to new rigs when "gc rig add" is called without --include. Allows cities to define a default pack for all rigs. |
+| `env` | map[string]string |  |  | Env defines workspace-wide environment variables applied to every managed session. Lowest config-precedence — overridden by provider, agent, and patch env. Use for cross-cutting variables like GC_TARGET_BRANCH that every agent should inherit. |
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -2098,6 +2098,13 @@
           },
           "type": "array",
           "description": "DefaultRigIncludes lists pack directories applied to new rigs when\n\"gc rig add\" is called without --include. Allows cities to define\na default pack for all rigs."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env defines workspace-wide environment variables applied to every\nmanaged session. Lowest config-precedence — overridden by provider,\nagent, and patch env. Use for cross-cutting variables like\nGC_TARGET_BRANCH that every agent should inherit."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -2098,6 +2098,13 @@
           },
           "type": "array",
           "description": "DefaultRigIncludes lists pack directories applied to new rigs when\n\"gc rig add\" is called without --include. Allows cities to define\na default pack for all rigs."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env defines workspace-wide environment variables applied to every\nmanaged session. Lowest config-precedence — overridden by provider,\nagent, and patch env. Use for cross-cutting variables like\nGC_TARGET_BRANCH that every agent should inherit."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -1,0 +1,1360 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/gastownhall/gascity/internal/config/pack-config",
+  "$ref": "#/$defs/PackConfig",
+  "$defs": {
+    "Agent": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the unique identifier for this agent."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is a human-readable description shown in MC's session creation UI."
+        },
+        "dir": {
+          "type": "string",
+          "description": "Dir is the identity prefix for rig-scoped agents and the default\nworking directory when WorkDir is not set."
+        },
+        "work_dir": {
+          "type": "string",
+          "description": "WorkDir overrides the session working directory without changing the\nagent's qualified identity. Relative paths resolve against city root\nand may use the same template placeholders as session_setup."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope defines where this agent is instantiated: \"city\" (one per city)\nor \"rig\" (one per rig, the default). Only meaningful for pack-defined\nagents; inline agents in city.toml use Dir directly."
+        },
+        "suspended": {
+          "type": "boolean",
+          "description": "Suspended prevents the reconciler from spawning this agent. Toggle with gc agent suspend/resume."
+        },
+        "pre_start": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreStart is a list of shell commands run before session creation.\nCommands run on the target filesystem: locally for tmux, inside the\npod/container for exec providers. Template variables same as session_setup."
+        },
+        "prompt_template": {
+          "type": "string",
+          "description": "PromptTemplate is the path to this agent's prompt template file.\nRelative paths resolve against the city directory."
+        },
+        "nudge": {
+          "type": "string",
+          "description": "Nudge is text typed into the agent's tmux session after startup.\nUsed for CLI agents that don't accept command-line prompts."
+        },
+        "session": {
+          "type": "string",
+          "enum": [
+            "acp"
+          ],
+          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the city-level session provider (typically tmux).\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio).\nThe agent's resolved provider must have supports_acp = true."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider names the provider preset to use for this agent."
+        },
+        "start_command": {
+          "type": "string",
+          "description": "StartCommand overrides the provider's command for this agent."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments."
+        },
+        "prompt_mode": {
+          "type": "string",
+          "enum": [
+            "arg",
+            "flag",
+            "none"
+          ],
+          "description": "PromptMode controls how prompts are delivered: \"arg\", \"flag\", or \"none\".",
+          "default": "arg"
+        },
+        "prompt_flag": {
+          "type": "string",
+          "description": "PromptFlag is the CLI flag used to pass prompts when prompt_mode is \"flag\"."
+        },
+        "ready_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ReadyDelayMs is milliseconds to wait after launch before considering the agent ready."
+        },
+        "ready_prompt_prefix": {
+          "type": "string",
+          "description": "ReadyPromptPrefix is the string prefix that indicates the agent is ready for input."
+        },
+        "process_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ProcessNames lists process names to look for when checking if the agent is running."
+        },
+        "emits_permission_warning": {
+          "type": "boolean",
+          "description": "EmitsPermissionWarning indicates whether the agent emits permission prompts that should be suppressed."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env sets additional environment variables for the agent process."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults overrides the provider's effective schema defaults\nfor this agent. Keys are option keys, values are choice values.\nApplied on top of the provider's OptionDefaults (agent keys win).\nExample: option_defaults = { permission_mode = \"plan\", model = \"sonnet\" }"
+        },
+        "max_active_sessions": {
+          "type": "integer",
+          "description": "MaxActiveSessions is the agent-level cap on concurrent sessions.\nNil means inherit from rig, then workspace, then unlimited.\nReplaces pool.max."
+        },
+        "min_active_sessions": {
+          "type": "integer",
+          "description": "MinActiveSessions is the minimum number of sessions to keep alive.\nAgent-level only. Counts against rig/workspace caps. Replaces pool.min."
+        },
+        "scale_check": {
+          "type": "string",
+          "description": "ScaleCheck is a shell command template whose output determines desired\nsession count. Optional override — when set, its output is the desired\ncount (still clamped by all cap levels). If it contains Go template\nplaceholders, gc expands them using the same PathContext fields as\nwork_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot,\nCityName) before running the command."
+        },
+        "drain_timeout": {
+          "type": "string",
+          "description": "DrainTimeout is the maximum time to wait for a session to finish its\ncurrent work before force-killing it during scale-down. Duration string\n(e.g., \"5m\", \"30m\", \"1h\"). Defaults to \"5m\".",
+          "default": "5m"
+        },
+        "on_boot": {
+          "type": "string",
+          "description": "OnBoot is a shell command template run once at controller startup for\nthis agent. If it contains Go template placeholders, gc expands them\nusing the same PathContext fields as work_dir and session_setup\n(Agent, AgentBase, Rig, RigRoot, CityRoot, CityName) before running\nthe command."
+        },
+        "on_death": {
+          "type": "string",
+          "description": "OnDeath is a shell command template run when a session dies unexpectedly.\nIf it contains Go template placeholders, gc expands them using the same\nPathContext fields as work_dir and session_setup (Agent, AgentBase,\nRig, RigRoot, CityRoot, CityName) before running the command."
+        },
+        "namepool": {
+          "type": "string",
+          "description": "Namepool is the path to a plain text file with one name per line.\nWhen set, sessions use names from the file as display aliases."
+        },
+        "work_query": {
+          "type": "string",
+          "description": "WorkQuery is the shell command template to find available work for this\nagent. If it contains Go template placeholders, gc expands them using\nthe same PathContext fields as work_dir and session_setup (Agent,\nAgentBase, Rig, RigRoot, CityRoot, CityName) before probe, hook, and\nprompt-context execution. Used by gc hook and available in prompt\ntemplates as {{.WorkQuery}}.\nIf unset, Gas City uses a three-tier default query:\n  1. in_progress work assigned to this session/alias (crash recovery)\n  2. ready work assigned to this session/alias (pre-assigned work)\n  3. ready unassigned work with gc.routed_to=\u003cqualified-name\u003e\nWhen the controller probes for demand without session context, only the\nrouted_to tier applies. Override to integrate with external task systems."
+        },
+        "sling_query": {
+          "type": "string",
+          "description": "SlingQuery is the command template to route a bead to this session config.\nIf it contains Go template placeholders, gc expands them using the same\nPathContext fields as work_dir and session_setup (Agent, AgentBase,\nRig, RigRoot, CityRoot, CityName) before replacing {} with the bead\nID. Used by gc sling to make a bead visible to the target's work_query.\nThe placeholder {} is replaced with the bead ID at runtime.\nDefault for all agents:\n\"bd update {} --set-metadata gc.routed_to=\u003cqualified-name\u003e\".\nRouting is metadata-based; sling stamps the target template and the\nreconciler/scale_check paths decide when sessions are created.\nCustom sling_query and work_query can be overridden independently."
+        },
+        "idle_timeout": {
+          "type": "string",
+          "description": "IdleTimeout is the maximum time an agent session can be inactive before\nthe controller kills and restarts it. Duration string (e.g., \"15m\", \"1h\").\nEmpty (default) disables idle checking."
+        },
+        "sleep_after_idle": {
+          "type": "string",
+          "description": "SleepAfterIdle overrides idle sleep policy for this agent. Accepts a\nduration string (e.g., \"30s\") or \"off\"."
+        },
+        "install_agent_hooks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InstallAgentHooks overrides workspace-level install_agent_hooks for this agent.\nWhen set, replaces (not adds to) the workspace default."
+        },
+        "skills": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Skills is a tombstone field retained for v0.15.1 backwards\ncompatibility. Accepted during parse for migration visibility, but\nattachment-list fields are accepted but ignored by the active\nmaterializer."
+        },
+        "mcp": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\nAccepted during parse for migration visibility, but attachment-list\nfields are accepted but ignored by the active materializer."
+        },
+        "hooks_installed": {
+          "type": "boolean",
+          "description": "HooksInstalled overrides automatic hook detection. Set to true when hooks\nare manually installed (e.g., merged into the project's own hook config)\nand auto-installation via install_agent_hooks is not desired. When true,\nthe agent is treated as hook-enabled for startup behavior: no prime\ninstruction in beacon and no delayed nudge. Interacts with\ninstall_agent_hooks — set this instead when hooks are pre-installed."
+        },
+        "session_setup": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionSetup is a list of shell commands run after session creation.\nEach command is a template string supporting placeholders:\n{{.Session}}, {{.Agent}}, {{.AgentBase}}, {{.Rig}}, {{.RigRoot}},\n{{.CityRoot}}, {{.CityName}}, {{.WorkDir}}.\nCommands run in gc's process (not inside the agent session) via sh -c."
+        },
+        "session_setup_script": {
+          "type": "string",
+          "description": "SessionSetupScript is the path to a script run after session_setup commands.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root.\nThe script receives context via environment variables (GC_SESSION plus\nexisting GC_* vars)."
+        },
+        "session_live": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionLive is a list of shell commands that are safe to re-apply\nwithout restarting the agent. Run at startup (after session_setup)\nand re-applied on config change without triggering a restart.\nMust be idempotent. Typical use: tmux theming, keybindings, status bars.\nSame template placeholders as session_setup."
+        },
+        "overlay_dir": {
+          "type": "string",
+          "description": "OverlayDir is a directory whose contents are recursively copied (additive)\ninto the agent's working directory at startup. Existing files are not\noverwritten. Relative paths resolve against the declaring config file's\ndirectory (pack-safe)."
+        },
+        "default_sling_formula": {
+          "type": "string",
+          "description": "DefaultSlingFormula is the formula name automatically applied via --on\nwhen beads are slung to this agent, unless --no-formula is set.\nExample: \"mol-polecat-work\""
+        },
+        "inject_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InjectFragments lists named template fragments to append to this agent's\nrendered prompt. Fragments come from shared template directories across\nall loaded packs. Each name must match a {{ define \"name\" }} block."
+        },
+        "append_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AppendFragments is the V2 per-agent alias for prompt fragment injection.\nIt layers after InjectFragments and before inherited/default fragments."
+        },
+        "inject_assigned_skills": {
+          "type": "boolean",
+          "description": "InjectAssignedSkills controls whether gc appends an\n\"assigned skills\" appendix to the agent's rendered prompt. The\nappendix lists every skill visible to this agent, partitioned\ninto (assigned-to-you, shared-with-every-agent), so agents\nsharing a scope-root sink can tell which skills are their\nspecialization vs which are the city-wide set.\n\nPointer tri-state:\n  nil   -\u003e inherit: inject when the agent has a vendor sink\n  *true -\u003e explicitly inject (equivalent to the default)\n  *false -\u003e disable; the template is responsible for rendering\n            any skill guidance itself"
+        },
+        "attach": {
+          "type": "boolean",
+          "description": "Attach controls whether the agent's session supports interactive\nattachment (e.g., tmux attach). When false, the agent can use a\nlighter runtime (subprocess instead of tmux). Defaults to true."
+        },
+        "fallback": {
+          "type": "boolean",
+          "description": "Fallback marks this agent as a fallback definition. During pack\ncomposition, a non-fallback agent with the same name wins silently.\nWhen two fallbacks collide, the first loaded (depth-first) wins."
+        },
+        "depends_on": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "DependsOn lists agent names that must be awake before this agent wakes.\nUsed for dependency-ordered startup and shutdown. Validated for cycles\nat config load time."
+        },
+        "resume_command": {
+          "type": "string",
+          "description": "ResumeCommand is the full shell command to run when resuming this agent.\nSupports {{.SessionKey}} template variable. When set, takes precedence\nover the provider's ResumeFlag/ResumeStyle. Example:\n  \"claude --resume {{.SessionKey}} --dangerously-skip-permissions\""
+        },
+        "wake_mode": {
+          "type": "string",
+          "enum": [
+            "resume",
+            "fresh"
+          ],
+          "description": "WakeMode controls context freshness across sleep/wake cycles.\n\"resume\" (default): reuse provider session key for conversation continuity.\n\"fresh\": start a new provider session on every wake (polecat pattern)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "Agent defines a configured agent in the city."
+    },
+    "AgentDefaults": {
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
+        },
+        "wake_mode": {
+          "type": "string",
+          "enum": [
+            "resume",
+            "fresh"
+          ],
+          "description": "WakeMode is the parsed/composed default wake mode (\"resume\" or\n\"fresh\"), but it is not yet auto-applied at runtime."
+        },
+        "default_sling_formula": {
+          "type": "string",
+          "description": "DefaultSlingFormula is the city-level default formula used for agents\nthat inherit [agent_defaults]. Explicit agents only receive this value\nwhen agent_defaults.default_sling_formula is set; implicit multi-session\nconfigs are seeded with \"mol-do-work\" elsewhere when no explicit default is set."
+        },
+        "allow_overlay": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AllowOverlay is parsed and composed as a city-level allowlist for\nsession overlays, but it is not yet inherited onto agents\nautomatically at runtime."
+        },
+        "allow_env_override": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AllowEnvOverride is parsed and composed as a city-level allowlist for\nsession env overrides, but it is not yet inherited onto agents\nautomatically at runtime. Names must match ^[A-Z][A-Z0-9_]{0,127}$."
+        },
+        "append_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AppendFragments lists named template fragments to auto-append to\n.template.md prompts after rendering. Legacy .md.tmpl prompts are\nstill supported during the transition; plain .md remains inert.\nV2 migration convenience — replaces global_fragments/inject_fragments\nfor city-wide defaults."
+        },
+        "skills": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Skills is a tombstone field retained for v0.15.1 backwards\ncompatibility. Parsed and composed for migration visibility, but\nattachment-list fields are accepted but ignored by the active\nmaterializer."
+        },
+        "mcp": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\nParsed and composed for migration visibility, but attachment-list\nfields are accepted but ignored by the active materializer."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "AgentDefaults provides city-level agent defaults declared via [agent_defaults] in city.toml."
+    },
+    "AgentPatch": {
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Dir is the targeting key (required with Name). Identifies the agent's\nworking directory scope. Empty for city-scoped agents."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name is the targeting key (required). Must match an existing agent's name."
+        },
+        "work_dir": {
+          "type": "string",
+          "description": "WorkDir overrides the agent's session working directory."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope overrides the agent's scope (\"city\" or \"rig\")."
+        },
+        "suspended": {
+          "type": "boolean",
+          "description": "Suspended overrides the agent's suspended state."
+        },
+        "pool": {
+          "$ref": "#/$defs/PoolOverride",
+          "description": "Pool overrides legacy [pool] fields that map to session scaling."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env adds or overrides environment variables."
+        },
+        "env_remove": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "EnvRemove lists env var keys to remove after merging."
+        },
+        "pre_start": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreStart overrides the agent's pre_start commands."
+        },
+        "prompt_template": {
+          "type": "string",
+          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
+        },
+        "session": {
+          "type": "string",
+          "description": "Session overrides the session transport (\"acp\")."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider overrides the provider name."
+        },
+        "start_command": {
+          "type": "string",
+          "description": "StartCommand overrides the start command."
+        },
+        "nudge": {
+          "type": "string",
+          "description": "Nudge overrides the nudge text."
+        },
+        "idle_timeout": {
+          "type": "string",
+          "description": "IdleTimeout overrides the idle timeout. Duration string (e.g., \"30s\", \"5m\", \"1h\")."
+        },
+        "sleep_after_idle": {
+          "type": "string",
+          "description": "SleepAfterIdle overrides idle sleep policy for this agent. Accepts a\nduration string or \"off\"."
+        },
+        "install_agent_hooks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InstallAgentHooks overrides the agent's install_agent_hooks list."
+        },
+        "skills": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Skills is a tombstone field retained for v0.15.1 backwards compatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "mcp": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "skills_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SkillsAppend is a tombstone field retained for v0.15.1 backwards\ncompatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "mcp_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCPAppend is a tombstone field retained for v0.15.1 backwards\ncompatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "hooks_installed": {
+          "type": "boolean",
+          "description": "HooksInstalled overrides automatic hook detection."
+        },
+        "inject_assigned_skills": {
+          "type": "boolean",
+          "description": "InjectAssignedSkills overrides per-agent appendix injection\n(see Agent.InjectAssignedSkills)."
+        },
+        "session_setup": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionSetup overrides the agent's session_setup commands."
+        },
+        "session_setup_script": {
+          "type": "string",
+          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
+        },
+        "session_live": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionLive overrides the agent's session_live commands."
+        },
+        "overlay_dir": {
+          "type": "string",
+          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the city directory."
+        },
+        "default_sling_formula": {
+          "type": "string",
+          "description": "DefaultSlingFormula overrides the default sling formula."
+        },
+        "inject_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InjectFragments overrides the agent's inject_fragments list."
+        },
+        "append_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AppendFragments overrides the agent's append_fragments list."
+        },
+        "attach": {
+          "type": "boolean",
+          "description": "Attach overrides the agent's attach setting."
+        },
+        "depends_on": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "DependsOn overrides the agent's dependency list."
+        },
+        "resume_command": {
+          "type": "string",
+          "description": "ResumeCommand overrides the agent's resume_command template."
+        },
+        "wake_mode": {
+          "type": "string",
+          "enum": [
+            "resume",
+            "fresh"
+          ],
+          "description": "WakeMode overrides the agent's wake mode (\"resume\" or \"fresh\")."
+        },
+        "pre_start_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreStartAppend appends commands to the agent's pre_start list\n(instead of replacing). Applied after PreStart if both are set."
+        },
+        "session_setup_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionSetupAppend appends commands to the agent's session_setup list."
+        },
+        "session_live_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionLiveAppend appends commands to the agent's session_live list."
+        },
+        "install_agent_hooks_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InstallAgentHooksAppend appends to the agent's install_agent_hooks list."
+        },
+        "inject_fragments_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InjectFragmentsAppend appends to the agent's inject_fragments list."
+        },
+        "max_active_sessions": {
+          "type": "integer",
+          "description": "MaxActiveSessions overrides the agent-level cap on concurrent sessions."
+        },
+        "min_active_sessions": {
+          "type": "integer",
+          "description": "MinActiveSessions overrides the minimum number of sessions to keep alive."
+        },
+        "scale_check": {
+          "type": "string",
+          "description": "ScaleCheck overrides the command template whose output determines desired\nsession count. Supports the same Go template placeholders as\nAgent.scale_check."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults adds or overrides provider option defaults for this agent.\nKeys are option keys, values are choice values. Merges additively\n(patch keys win over existing agent keys).\nExample: option_defaults = { model = \"sonnet\" }"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "dir",
+        "name"
+      ],
+      "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
+    },
+    "FormulasConfig": {
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Dir is the path to the formulas directory. Defaults to \"formulas\".",
+          "default": "formulas"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "FormulasConfig holds formula directory settings."
+    },
+    "Import": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Source is the pack location: a local relative path (e.g.,\n\"./assets/imports/gastown\") or a remote URL (e.g.,\n\"github.com/gastownhall/gastown\"). Local paths have no version."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version is a semver constraint for remote imports (e.g., \"^1.2\").\nEmpty for local paths. \"sha:\u003chex\u003e\" for commit pinning."
+        },
+        "export": {
+          "type": "boolean",
+          "description": "Export re-exports this import's contents into the parent pack's\nnamespace. Consumers of the parent get this import's agents\nflattened under the parent's binding name."
+        },
+        "transitive": {
+          "type": "boolean",
+          "description": "Transitive controls whether this import's own imports are visible\nto the consumer. Defaults to true (transitive). Set to false to\nsuppress transitive resolution for this specific import."
+        },
+        "shadow": {
+          "type": "string",
+          "enum": [
+            "warn",
+            "silent"
+          ],
+          "description": "Shadow controls shadow warnings when the importer defines an agent\nwith the same name as one from this import. \"warn\" (default) emits\na warning; \"silent\" suppresses it."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "source"
+      ],
+      "description": "Import defines a named import of another pack."
+    },
+    "NamedSession": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the configured public session identity. When omitted, Template\nremains the compatibility identity."
+        },
+        "template": {
+          "type": "string",
+          "description": "Template is the referenced agent template name. Root declarations may\ntarget imported PackV2 agents via \"binding.agent\"."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope defines where this named session is instantiated in pack\nexpansion: \"city\" (one per city) or \"rig\" (one per rig)."
+        },
+        "dir": {
+          "type": "string",
+          "description": "Dir is the identity prefix for rig-scoped named sessions after pack\nexpansion. Empty means city-scoped."
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "on_demand",
+            "always"
+          ],
+          "description": "Mode controls controller behavior for this named session.\n\"on_demand\" (default): reserve identity and materialize when work or\nan explicit reference requires it.\n\"always\": keep the canonical session controller-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "template"
+      ],
+      "description": "NamedSession defines a canonical persistent session backed by an agent template."
+    },
+    "OptionChoice": {
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "flag_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "FlagArgs are the CLI arguments injected when this choice is selected.\njson:\"-\" is intentional: FlagArgs must never appear in the public API DTO\n(security boundary — prevents clients from seeing internal CLI flags)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "value",
+        "label",
+        "flag_args"
+      ],
+      "description": "OptionChoice is one allowed value for a \"select\" option."
+    },
+    "PackCommandEntry": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the subcommand name (e.g. \"status\", \"audit\")."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is a short one-line description shown in help listings."
+        },
+        "long_description": {
+          "type": "string",
+          "description": "LongDescription is a path (relative to pack dir) to a text file\nwith the full help text shown by gc \u003cpack\u003e \u003ccommand\u003e --help."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script is the path to the script (relative to pack dir).\nSupports Go text/template variables: {{.CityRoot}}, {{.ConfigDir}}, etc."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "long_description",
+        "script"
+      ],
+      "description": "PackCommandEntry declares a CLI subcommand provided by a pack."
+    },
+    "PackConfig": {
+      "properties": {
+        "pack": {
+          "$ref": "#/$defs/PackMeta"
+        },
+        "imports": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Import"
+          },
+          "type": "object"
+        },
+        "agent_defaults": {
+          "$ref": "#/$defs/AgentDefaults"
+        },
+        "defaults": {
+          "$ref": "#/$defs/PackDefaults"
+        },
+        "agent": {
+          "items": {
+            "$ref": "#/$defs/Agent"
+          },
+          "type": "array"
+        },
+        "named_session": {
+          "items": {
+            "$ref": "#/$defs/NamedSession"
+          },
+          "type": "array"
+        },
+        "service": {
+          "items": {
+            "$ref": "#/$defs/Service"
+          },
+          "type": "array"
+        },
+        "providers": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ProviderSpec"
+          },
+          "type": "object"
+        },
+        "formulas": {
+          "$ref": "#/$defs/FormulasConfig"
+        },
+        "patches": {
+          "$ref": "#/$defs/Patches"
+        },
+        "doctor": {
+          "items": {
+            "$ref": "#/$defs/PackDoctorEntry"
+          },
+          "type": "array"
+        },
+        "commands": {
+          "items": {
+            "$ref": "#/$defs/PackCommandEntry"
+          },
+          "type": "array"
+        },
+        "global": {
+          "$ref": "#/$defs/PackGlobal"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pack"
+      ],
+      "description": "PackConfig is the TOML structure of a pack.toml file."
+    },
+    "PackDefaults": {
+      "properties": {
+        "rig": {
+          "$ref": "#/$defs/PackRigDefaults"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackDefaults holds [defaults] entries declared by a pack — used by cities that compose this pack to seed rig configuration."
+    },
+    "PackDoctorEntry": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is a short identifier for the check (e.g. \"check-binaries\").\nThe full check name shown in doctor output is \"\u003cpack\u003e:\u003cname\u003e\"."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script is the path to the check script, relative to the pack\ndirectory. The script must be executable and follow the exit-code\nprotocol: 0=OK, 1=Warning, 2=Error. First line of stdout is the\nmessage; remaining lines are details (shown in verbose mode)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is an optional human-readable description of the check."
+        },
+        "fix": {
+          "type": "string",
+          "description": "Fix is an optional path to a remediation script, relative to the pack\ndirectory. When set, the check opts into `gc doctor --fix`."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "script"
+      ],
+      "description": "PackDoctorEntry declares a diagnostic check shipped with a pack."
+    },
+    "PackGlobal": {
+      "properties": {
+        "session_live": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackGlobal defines commands a pack applies to all agents in scope."
+    },
+    "PackMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the pack's identifier."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version is a semver-style version string."
+        },
+        "schema": {
+          "type": "integer",
+          "description": "Schema is the pack format version (currently 1)."
+        },
+        "requires_gc": {
+          "type": "string",
+          "description": "RequiresGC is an optional minimum gc version requirement."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is an optional human-readable summary of the pack."
+        },
+        "includes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Includes lists other packs to compose into this one (V1 mechanism).\nEach entry is a local relative path (e.g. \"../maintenance\") or a\nremote git URL (SSH or HTTPS) with optional //subpath and #ref."
+        },
+        "requires": {
+          "items": {
+            "$ref": "#/$defs/PackRequirement"
+          },
+          "type": "array",
+          "description": "Requires declares agents that must exist in the expanded config\nfor this pack's formulas/orders to function. Validated\nafter all packs are expanded."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "schema"
+      ],
+      "description": "PackMeta holds metadata from a pack's [pack] header."
+    },
+    "PackRequirement": {
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope is the agent scope: \"city\" or \"rig\"."
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent is the name of the required agent."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "scope",
+        "agent"
+      ],
+      "description": "PackRequirement declares an agent that must exist in the expanded config for this pack's formulas/orders to function."
+    },
+    "PackRigDefaults": {
+      "properties": {
+        "imports": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Import"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
+    },
+    "Patches": {
+      "properties": {
+        "agent": {
+          "items": {
+            "$ref": "#/$defs/AgentPatch"
+          },
+          "type": "array",
+          "description": "Agents targets agents by (dir, name)."
+        },
+        "rigs": {
+          "items": {
+            "$ref": "#/$defs/RigPatch"
+          },
+          "type": "array",
+          "description": "Rigs targets rigs by name."
+        },
+        "providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderPatch"
+          },
+          "type": "array",
+          "description": "Providers targets providers by name."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Patches holds all patch blocks from composition."
+    },
+    "PoolOverride": {
+      "properties": {
+        "min": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Min overrides the minimum number of sessions."
+        },
+        "max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max overrides the maximum number of sessions. 0 means no sessions can claim routed work."
+        },
+        "check": {
+          "type": "string",
+          "description": "Check overrides the session scale check command template. Supports the\nsame Go template placeholders as Agent.scale_check."
+        },
+        "drain_timeout": {
+          "type": "string",
+          "description": "DrainTimeout overrides the drain timeout. Duration string (e.g., \"5m\", \"30m\", \"1h\")."
+        },
+        "on_death": {
+          "type": "string",
+          "description": "OnDeath overrides the on_death command template. Supports the same Go\ntemplate placeholders as Agent.on_death."
+        },
+        "on_boot": {
+          "type": "string",
+          "description": "OnBoot overrides the on_boot command template. Supports the same Go\ntemplate placeholders as Agent.on_boot."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PoolOverride modifies legacy [pool] fields that map to session scaling."
+    },
+    "ProviderOption": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "\"select\" only (v1)"
+        },
+        "default": {
+          "type": "string"
+        },
+        "choices": {
+          "items": {
+            "$ref": "#/$defs/OptionChoice"
+          },
+          "type": "array"
+        },
+        "omit": {
+          "type": "boolean",
+          "description": "Omit is the removal sentinel for options_schema_merge = \"by_key\".\nWhen set on a child layer's entry, the matching Key inherited from\na parent layer is pruned from the resolved schema."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key",
+        "label",
+        "type",
+        "default",
+        "choices"
+      ],
+      "description": "ProviderOption declares a single configurable option for a provider."
+    },
+    "ProviderPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the targeting key (required). Must match an existing provider's name."
+        },
+        "base": {
+          "type": "string",
+          "description": "Base overrides the provider's inheritance parent (presence-aware).\nPointer to a pointer so the patch can distinguish \"no change\"\n(double-nil) from \"clear to inherit default\" (single-nil value in\nouter pointer) from \"set to explicit empty opt-out\" (value \"\" in\ninner pointer) from \"set to \u003cname\u003e\". Callers use:\n  nil          = patch does not touch Base\n  \u0026(*string)(nil) = patch clears Base to absent\n  \u0026(\u0026\"\")       = patch sets Base = \"\" (explicit opt-out)\n  \u0026(\u0026\"builtin:codex\") = patch sets Base to that value"
+        },
+        "command": {
+          "type": "string",
+          "description": "Command overrides the provider command."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider args."
+        },
+        "args_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ArgsAppend overrides the provider args_append list."
+        },
+        "options_schema_merge": {
+          "type": "string",
+          "description": "OptionsSchemaMerge overrides the options_schema merge mode."
+        },
+        "prompt_mode": {
+          "type": "string",
+          "enum": [
+            "arg",
+            "flag",
+            "none"
+          ],
+          "description": "PromptMode overrides prompt delivery mode."
+        },
+        "prompt_flag": {
+          "type": "string",
+          "description": "PromptFlag overrides the prompt flag."
+        },
+        "ready_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ReadyDelayMs overrides the ready delay in milliseconds."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env adds or overrides environment variables."
+        },
+        "env_remove": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "EnvRemove lists env var keys to remove."
+        },
+        "_replace": {
+          "type": "boolean",
+          "description": "Replace replaces the entire provider block instead of deep-merging."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "ProviderPatch modifies an existing provider identified by Name."
+    },
+    "ProviderSpec": {
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "Base names the parent provider this spec inherits from. Supported\nforms:\n  \"\u003cname\u003e\"          - custom first (self-excluded), then built-in\n  \"builtin:\u003cname\u003e\"  - force built-in lookup\n  \"provider:\u003cname\u003e\" - force custom lookup\n  \"\"                - explicit standalone opt-out\n  nil               - field absent; no explicit declaration"
+        },
+        "args_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ArgsAppend accumulates extra args after each layer's Args replacement."
+        },
+        "options_schema_merge": {
+          "type": "string",
+          "enum": [
+            "replace",
+            "by_key"
+          ],
+          "description": "OptionsSchemaMerge controls OptionsSchema merge mode across the\nchain: \"replace\" (default) or \"by_key\"."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "DisplayName is the human-readable name shown in UI and logs."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command is the executable to run for this provider."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args are default command-line arguments passed to the provider."
+        },
+        "prompt_mode": {
+          "type": "string",
+          "enum": [
+            "arg",
+            "flag",
+            "none"
+          ],
+          "description": "PromptMode controls how prompts are delivered: \"arg\", \"flag\", or \"none\".",
+          "default": "arg"
+        },
+        "prompt_flag": {
+          "type": "string",
+          "description": "PromptFlag is the CLI flag used when prompt_mode is \"flag\" (e.g. \"--prompt\")."
+        },
+        "ready_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ReadyDelayMs is milliseconds to wait after launch before the provider is considered ready."
+        },
+        "ready_prompt_prefix": {
+          "type": "string",
+          "description": "ReadyPromptPrefix is the string prefix that indicates the provider is ready for input."
+        },
+        "process_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ProcessNames lists process names to look for when checking if the provider is running."
+        },
+        "emits_permission_warning": {
+          "type": "boolean",
+          "description": "EmitsPermissionWarning is tri-state: nil = inherit, \u0026true = enable,\n\u0026false = explicit disable."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env sets additional environment variables for the provider process."
+        },
+        "path_check": {
+          "type": "string",
+          "description": "PathCheck overrides the binary name used for PATH detection.\nWhen set, lookupProvider and detectProviderName use this instead\nof Command for exec.LookPath checks. Useful when Command is a\nshell wrapper (e.g. sh -c '...') but we need to verify the real\nbinary is installed."
+        },
+        "supports_acp": {
+          "type": "boolean",
+          "description": "SupportsACP indicates the binary speaks the Agent Client Protocol\n(JSON-RPC 2.0 over stdio). When an agent sets session = \"acp\",\nits resolved provider must have SupportsACP = true."
+        },
+        "supports_hooks": {
+          "type": "boolean",
+          "description": "SupportsHooks indicates the provider has an executable hook mechanism\n(settings.json, plugins, etc.) for lifecycle events."
+        },
+        "instructions_file": {
+          "type": "string",
+          "description": "InstructionsFile is the filename the provider reads for project instructions\n(e.g., \"CLAUDE.md\", \"AGENTS.md\"). Empty defaults to \"AGENTS.md\"."
+        },
+        "resume_flag": {
+          "type": "string",
+          "description": "ResumeFlag is the CLI flag for resuming a session by ID.\nEmpty means the provider does not support resume.\nExamples: \"--resume\" (claude), \"resume\" (codex)"
+        },
+        "resume_style": {
+          "type": "string",
+          "description": "ResumeStyle controls how ResumeFlag is applied:\n  \"flag\"       → command --resume \u003ckey\u003e              (default)\n  \"subcommand\" → command resume \u003ckey\u003e"
+        },
+        "resume_command": {
+          "type": "string",
+          "description": "ResumeCommand is the full shell command to run when resuming a session.\nSupports {{.SessionKey}} template variable. When set, takes precedence\nover ResumeFlag/ResumeStyle. Example:\n  \"claude --resume {{.SessionKey}} --dangerously-skip-permissions\""
+        },
+        "session_id_flag": {
+          "type": "string",
+          "description": "SessionIDFlag is the CLI flag for creating a session with a specific ID.\nEnables the Generate \u0026 Pass strategy for session key management.\nExample: \"--session-id\" (claude)"
+        },
+        "permission_modes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "PermissionModes maps permission mode names to CLI flags.\nExample: {\"unrestricted\": \"--dangerously-skip-permissions\", \"plan\": \"--permission-mode plan\"}\nThis is a config-only lookup table consumed by external clients\n(e.g., Mission Control) to populate permission mode dropdowns.\nLaunch-time flag substitution is planned for a follow-up PR —\ncurrently no runtime code reads this field."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults overrides the Default value in OptionsSchema entries\nwithout redefining the schema itself. Keys are option keys (e.g.,\n\"permission_mode\"), values are choice values (e.g., \"unrestricted\").\ncity.toml users set this to customize provider behavior without\ntouching Args or OptionsSchema."
+        },
+        "options_schema": {
+          "items": {
+            "$ref": "#/$defs/ProviderOption"
+          },
+          "type": "array",
+          "description": "OptionsSchema declares the configurable options this provider supports.\nEach option maps to CLI args via its Choices[].FlagArgs field.\nSerialized via a dedicated DTO (not directly to JSON) so FlagArgs stays server-side."
+        },
+        "print_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PrintArgs are CLI arguments that enable one-shot non-interactive mode.\nThe provider prints its response to stdout and exits. When empty, the\nprovider does not support one-shot invocation.\nExamples: [\"-p\"] (claude, gemini), [\"exec\"] (codex)"
+        },
+        "title_model": {
+          "type": "string",
+          "description": "TitleModel is the OptionsSchema model key used for title generation.\nResolved via the \"model\" option in OptionsSchema to get FlagArgs.\nDefaults to the cheapest/fastest model for each provider.\nExamples: \"haiku\" (claude), \"o4-mini\" (codex), \"gemini-2.5-flash\" (gemini)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ProviderSpec defines a named provider's startup parameters."
+    },
+    "RigPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the targeting key (required). Must match an existing rig's name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path overrides the rig's filesystem path."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Prefix overrides the bead ID prefix."
+        },
+        "suspended": {
+          "type": "boolean",
+          "description": "Suspended overrides the rig's suspended state."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "RigPatch modifies an existing rig identified by Name."
+    },
+    "Service": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the unique service identifier within a workspace."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow",
+            "proxy_process"
+          ],
+          "description": "Kind selects how the service is implemented."
+        },
+        "publish_mode": {
+          "type": "string",
+          "enum": [
+            "private",
+            "direct"
+          ],
+          "description": "PublishMode declares how the service is intended to be published.\nv0 supports private services and direct reuse of the API listener."
+        },
+        "state_root": {
+          "type": "string",
+          "description": "StateRoot overrides the managed service state root. Defaults to\n.gc/services/{name}. The path must stay within .gc/services/."
+        },
+        "publication": {
+          "$ref": "#/$defs/ServicePublicationConfig",
+          "description": "Publication declares generic publication intent. The platform decides\nwhether and how that intent becomes a public route."
+        },
+        "workflow": {
+          "$ref": "#/$defs/ServiceWorkflowConfig",
+          "description": "Workflow configures controller-owned workflow services."
+        },
+        "process": {
+          "$ref": "#/$defs/ServiceProcessConfig",
+          "description": "Process configures controller-supervised proxy services."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "Service declares a workspace-owned HTTP service mounted under /svc/{name}."
+    },
+    "ServiceProcessConfig": {
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command is the argv used to start the local service process."
+        },
+        "health_path": {
+          "type": "string",
+          "description": "HealthPath, when set, is probed on the local listener before the\nservice is marked ready."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ServiceProcessConfig configures a controller-supervised local process that is reverse-proxied under /svc/{name}."
+    },
+    "ServicePublicationConfig": {
+      "properties": {
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "private",
+            "public",
+            "tenant"
+          ],
+          "description": "Visibility selects whether the service is private to the workspace,\navailable publicly, or gated by tenant auth at the platform edge."
+        },
+        "hostname": {
+          "type": "string",
+          "description": "Hostname overrides the default hostname label derived from service.name."
+        },
+        "allow_websockets": {
+          "type": "boolean",
+          "description": "AllowWebSockets permits websocket upgrades on the published route."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ServicePublicationConfig declares platform-neutral publication intent."
+    },
+    "ServiceWorkflowConfig": {
+      "properties": {
+        "contract": {
+          "type": "string",
+          "description": "Contract selects the built-in workflow handler."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ServiceWorkflowConfig configures controller-owned workflow services."
+    }
+  },
+  "title": "Gas City Pack Manifest",
+  "description": "Schema for pack.toml — the PackV2 manifest that declares a pack's metadata, agents, providers, services, commands, and import surface. Cities and rigs compose packs via [imports.*]."
+}

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -1,0 +1,1360 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/gastownhall/gascity/internal/config/pack-config",
+  "$ref": "#/$defs/PackConfig",
+  "$defs": {
+    "Agent": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the unique identifier for this agent."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is a human-readable description shown in MC's session creation UI."
+        },
+        "dir": {
+          "type": "string",
+          "description": "Dir is the identity prefix for rig-scoped agents and the default\nworking directory when WorkDir is not set."
+        },
+        "work_dir": {
+          "type": "string",
+          "description": "WorkDir overrides the session working directory without changing the\nagent's qualified identity. Relative paths resolve against city root\nand may use the same template placeholders as session_setup."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope defines where this agent is instantiated: \"city\" (one per city)\nor \"rig\" (one per rig, the default). Only meaningful for pack-defined\nagents; inline agents in city.toml use Dir directly."
+        },
+        "suspended": {
+          "type": "boolean",
+          "description": "Suspended prevents the reconciler from spawning this agent. Toggle with gc agent suspend/resume."
+        },
+        "pre_start": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreStart is a list of shell commands run before session creation.\nCommands run on the target filesystem: locally for tmux, inside the\npod/container for exec providers. Template variables same as session_setup."
+        },
+        "prompt_template": {
+          "type": "string",
+          "description": "PromptTemplate is the path to this agent's prompt template file.\nRelative paths resolve against the city directory."
+        },
+        "nudge": {
+          "type": "string",
+          "description": "Nudge is text typed into the agent's tmux session after startup.\nUsed for CLI agents that don't accept command-line prompts."
+        },
+        "session": {
+          "type": "string",
+          "enum": [
+            "acp"
+          ],
+          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the city-level session provider (typically tmux).\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio).\nThe agent's resolved provider must have supports_acp = true."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider names the provider preset to use for this agent."
+        },
+        "start_command": {
+          "type": "string",
+          "description": "StartCommand overrides the provider's command for this agent."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider's default arguments."
+        },
+        "prompt_mode": {
+          "type": "string",
+          "enum": [
+            "arg",
+            "flag",
+            "none"
+          ],
+          "description": "PromptMode controls how prompts are delivered: \"arg\", \"flag\", or \"none\".",
+          "default": "arg"
+        },
+        "prompt_flag": {
+          "type": "string",
+          "description": "PromptFlag is the CLI flag used to pass prompts when prompt_mode is \"flag\"."
+        },
+        "ready_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ReadyDelayMs is milliseconds to wait after launch before considering the agent ready."
+        },
+        "ready_prompt_prefix": {
+          "type": "string",
+          "description": "ReadyPromptPrefix is the string prefix that indicates the agent is ready for input."
+        },
+        "process_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ProcessNames lists process names to look for when checking if the agent is running."
+        },
+        "emits_permission_warning": {
+          "type": "boolean",
+          "description": "EmitsPermissionWarning indicates whether the agent emits permission prompts that should be suppressed."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env sets additional environment variables for the agent process."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults overrides the provider's effective schema defaults\nfor this agent. Keys are option keys, values are choice values.\nApplied on top of the provider's OptionDefaults (agent keys win).\nExample: option_defaults = { permission_mode = \"plan\", model = \"sonnet\" }"
+        },
+        "max_active_sessions": {
+          "type": "integer",
+          "description": "MaxActiveSessions is the agent-level cap on concurrent sessions.\nNil means inherit from rig, then workspace, then unlimited.\nReplaces pool.max."
+        },
+        "min_active_sessions": {
+          "type": "integer",
+          "description": "MinActiveSessions is the minimum number of sessions to keep alive.\nAgent-level only. Counts against rig/workspace caps. Replaces pool.min."
+        },
+        "scale_check": {
+          "type": "string",
+          "description": "ScaleCheck is a shell command template whose output determines desired\nsession count. Optional override — when set, its output is the desired\ncount (still clamped by all cap levels). If it contains Go template\nplaceholders, gc expands them using the same PathContext fields as\nwork_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot,\nCityName) before running the command."
+        },
+        "drain_timeout": {
+          "type": "string",
+          "description": "DrainTimeout is the maximum time to wait for a session to finish its\ncurrent work before force-killing it during scale-down. Duration string\n(e.g., \"5m\", \"30m\", \"1h\"). Defaults to \"5m\".",
+          "default": "5m"
+        },
+        "on_boot": {
+          "type": "string",
+          "description": "OnBoot is a shell command template run once at controller startup for\nthis agent. If it contains Go template placeholders, gc expands them\nusing the same PathContext fields as work_dir and session_setup\n(Agent, AgentBase, Rig, RigRoot, CityRoot, CityName) before running\nthe command."
+        },
+        "on_death": {
+          "type": "string",
+          "description": "OnDeath is a shell command template run when a session dies unexpectedly.\nIf it contains Go template placeholders, gc expands them using the same\nPathContext fields as work_dir and session_setup (Agent, AgentBase,\nRig, RigRoot, CityRoot, CityName) before running the command."
+        },
+        "namepool": {
+          "type": "string",
+          "description": "Namepool is the path to a plain text file with one name per line.\nWhen set, sessions use names from the file as display aliases."
+        },
+        "work_query": {
+          "type": "string",
+          "description": "WorkQuery is the shell command template to find available work for this\nagent. If it contains Go template placeholders, gc expands them using\nthe same PathContext fields as work_dir and session_setup (Agent,\nAgentBase, Rig, RigRoot, CityRoot, CityName) before probe, hook, and\nprompt-context execution. Used by gc hook and available in prompt\ntemplates as {{.WorkQuery}}.\nIf unset, Gas City uses a three-tier default query:\n  1. in_progress work assigned to this session/alias (crash recovery)\n  2. ready work assigned to this session/alias (pre-assigned work)\n  3. ready unassigned work with gc.routed_to=\u003cqualified-name\u003e\nWhen the controller probes for demand without session context, only the\nrouted_to tier applies. Override to integrate with external task systems."
+        },
+        "sling_query": {
+          "type": "string",
+          "description": "SlingQuery is the command template to route a bead to this session config.\nIf it contains Go template placeholders, gc expands them using the same\nPathContext fields as work_dir and session_setup (Agent, AgentBase,\nRig, RigRoot, CityRoot, CityName) before replacing {} with the bead\nID. Used by gc sling to make a bead visible to the target's work_query.\nThe placeholder {} is replaced with the bead ID at runtime.\nDefault for all agents:\n\"bd update {} --set-metadata gc.routed_to=\u003cqualified-name\u003e\".\nRouting is metadata-based; sling stamps the target template and the\nreconciler/scale_check paths decide when sessions are created.\nCustom sling_query and work_query can be overridden independently."
+        },
+        "idle_timeout": {
+          "type": "string",
+          "description": "IdleTimeout is the maximum time an agent session can be inactive before\nthe controller kills and restarts it. Duration string (e.g., \"15m\", \"1h\").\nEmpty (default) disables idle checking."
+        },
+        "sleep_after_idle": {
+          "type": "string",
+          "description": "SleepAfterIdle overrides idle sleep policy for this agent. Accepts a\nduration string (e.g., \"30s\") or \"off\"."
+        },
+        "install_agent_hooks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InstallAgentHooks overrides workspace-level install_agent_hooks for this agent.\nWhen set, replaces (not adds to) the workspace default."
+        },
+        "skills": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Skills is a tombstone field retained for v0.15.1 backwards\ncompatibility. Accepted during parse for migration visibility, but\nattachment-list fields are accepted but ignored by the active\nmaterializer."
+        },
+        "mcp": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\nAccepted during parse for migration visibility, but attachment-list\nfields are accepted but ignored by the active materializer."
+        },
+        "hooks_installed": {
+          "type": "boolean",
+          "description": "HooksInstalled overrides automatic hook detection. Set to true when hooks\nare manually installed (e.g., merged into the project's own hook config)\nand auto-installation via install_agent_hooks is not desired. When true,\nthe agent is treated as hook-enabled for startup behavior: no prime\ninstruction in beacon and no delayed nudge. Interacts with\ninstall_agent_hooks — set this instead when hooks are pre-installed."
+        },
+        "session_setup": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionSetup is a list of shell commands run after session creation.\nEach command is a template string supporting placeholders:\n{{.Session}}, {{.Agent}}, {{.AgentBase}}, {{.Rig}}, {{.RigRoot}},\n{{.CityRoot}}, {{.CityName}}, {{.WorkDir}}.\nCommands run in gc's process (not inside the agent session) via sh -c."
+        },
+        "session_setup_script": {
+          "type": "string",
+          "description": "SessionSetupScript is the path to a script run after session_setup commands.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root.\nThe script receives context via environment variables (GC_SESSION plus\nexisting GC_* vars)."
+        },
+        "session_live": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionLive is a list of shell commands that are safe to re-apply\nwithout restarting the agent. Run at startup (after session_setup)\nand re-applied on config change without triggering a restart.\nMust be idempotent. Typical use: tmux theming, keybindings, status bars.\nSame template placeholders as session_setup."
+        },
+        "overlay_dir": {
+          "type": "string",
+          "description": "OverlayDir is a directory whose contents are recursively copied (additive)\ninto the agent's working directory at startup. Existing files are not\noverwritten. Relative paths resolve against the declaring config file's\ndirectory (pack-safe)."
+        },
+        "default_sling_formula": {
+          "type": "string",
+          "description": "DefaultSlingFormula is the formula name automatically applied via --on\nwhen beads are slung to this agent, unless --no-formula is set.\nExample: \"mol-polecat-work\""
+        },
+        "inject_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InjectFragments lists named template fragments to append to this agent's\nrendered prompt. Fragments come from shared template directories across\nall loaded packs. Each name must match a {{ define \"name\" }} block."
+        },
+        "append_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AppendFragments is the V2 per-agent alias for prompt fragment injection.\nIt layers after InjectFragments and before inherited/default fragments."
+        },
+        "inject_assigned_skills": {
+          "type": "boolean",
+          "description": "InjectAssignedSkills controls whether gc appends an\n\"assigned skills\" appendix to the agent's rendered prompt. The\nappendix lists every skill visible to this agent, partitioned\ninto (assigned-to-you, shared-with-every-agent), so agents\nsharing a scope-root sink can tell which skills are their\nspecialization vs which are the city-wide set.\n\nPointer tri-state:\n  nil   -\u003e inherit: inject when the agent has a vendor sink\n  *true -\u003e explicitly inject (equivalent to the default)\n  *false -\u003e disable; the template is responsible for rendering\n            any skill guidance itself"
+        },
+        "attach": {
+          "type": "boolean",
+          "description": "Attach controls whether the agent's session supports interactive\nattachment (e.g., tmux attach). When false, the agent can use a\nlighter runtime (subprocess instead of tmux). Defaults to true."
+        },
+        "fallback": {
+          "type": "boolean",
+          "description": "Fallback marks this agent as a fallback definition. During pack\ncomposition, a non-fallback agent with the same name wins silently.\nWhen two fallbacks collide, the first loaded (depth-first) wins."
+        },
+        "depends_on": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "DependsOn lists agent names that must be awake before this agent wakes.\nUsed for dependency-ordered startup and shutdown. Validated for cycles\nat config load time."
+        },
+        "resume_command": {
+          "type": "string",
+          "description": "ResumeCommand is the full shell command to run when resuming this agent.\nSupports {{.SessionKey}} template variable. When set, takes precedence\nover the provider's ResumeFlag/ResumeStyle. Example:\n  \"claude --resume {{.SessionKey}} --dangerously-skip-permissions\""
+        },
+        "wake_mode": {
+          "type": "string",
+          "enum": [
+            "resume",
+            "fresh"
+          ],
+          "description": "WakeMode controls context freshness across sleep/wake cycles.\n\"resume\" (default): reuse provider session key for conversation continuity.\n\"fresh\": start a new provider session on every wake (polecat pattern)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "Agent defines a configured agent in the city."
+    },
+    "AgentDefaults": {
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
+        },
+        "wake_mode": {
+          "type": "string",
+          "enum": [
+            "resume",
+            "fresh"
+          ],
+          "description": "WakeMode is the parsed/composed default wake mode (\"resume\" or\n\"fresh\"), but it is not yet auto-applied at runtime."
+        },
+        "default_sling_formula": {
+          "type": "string",
+          "description": "DefaultSlingFormula is the city-level default formula used for agents\nthat inherit [agent_defaults]. Explicit agents only receive this value\nwhen agent_defaults.default_sling_formula is set; implicit multi-session\nconfigs are seeded with \"mol-do-work\" elsewhere when no explicit default is set."
+        },
+        "allow_overlay": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AllowOverlay is parsed and composed as a city-level allowlist for\nsession overlays, but it is not yet inherited onto agents\nautomatically at runtime."
+        },
+        "allow_env_override": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AllowEnvOverride is parsed and composed as a city-level allowlist for\nsession env overrides, but it is not yet inherited onto agents\nautomatically at runtime. Names must match ^[A-Z][A-Z0-9_]{0,127}$."
+        },
+        "append_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AppendFragments lists named template fragments to auto-append to\n.template.md prompts after rendering. Legacy .md.tmpl prompts are\nstill supported during the transition; plain .md remains inert.\nV2 migration convenience — replaces global_fragments/inject_fragments\nfor city-wide defaults."
+        },
+        "skills": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Skills is a tombstone field retained for v0.15.1 backwards\ncompatibility. Parsed and composed for migration visibility, but\nattachment-list fields are accepted but ignored by the active\nmaterializer."
+        },
+        "mcp": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\nParsed and composed for migration visibility, but attachment-list\nfields are accepted but ignored by the active materializer."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "AgentDefaults provides city-level agent defaults declared via [agent_defaults] in city.toml."
+    },
+    "AgentPatch": {
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Dir is the targeting key (required with Name). Identifies the agent's\nworking directory scope. Empty for city-scoped agents."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name is the targeting key (required). Must match an existing agent's name."
+        },
+        "work_dir": {
+          "type": "string",
+          "description": "WorkDir overrides the agent's session working directory."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope overrides the agent's scope (\"city\" or \"rig\")."
+        },
+        "suspended": {
+          "type": "boolean",
+          "description": "Suspended overrides the agent's suspended state."
+        },
+        "pool": {
+          "$ref": "#/$defs/PoolOverride",
+          "description": "Pool overrides legacy [pool] fields that map to session scaling."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env adds or overrides environment variables."
+        },
+        "env_remove": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "EnvRemove lists env var keys to remove after merging."
+        },
+        "pre_start": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreStart overrides the agent's pre_start commands."
+        },
+        "prompt_template": {
+          "type": "string",
+          "description": "PromptTemplate overrides the prompt template path.\nRelative paths resolve against the city directory."
+        },
+        "session": {
+          "type": "string",
+          "description": "Session overrides the session transport (\"acp\")."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider overrides the provider name."
+        },
+        "start_command": {
+          "type": "string",
+          "description": "StartCommand overrides the start command."
+        },
+        "nudge": {
+          "type": "string",
+          "description": "Nudge overrides the nudge text."
+        },
+        "idle_timeout": {
+          "type": "string",
+          "description": "IdleTimeout overrides the idle timeout. Duration string (e.g., \"30s\", \"5m\", \"1h\")."
+        },
+        "sleep_after_idle": {
+          "type": "string",
+          "description": "SleepAfterIdle overrides idle sleep policy for this agent. Accepts a\nduration string or \"off\"."
+        },
+        "install_agent_hooks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InstallAgentHooks overrides the agent's install_agent_hooks list."
+        },
+        "skills": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Skills is a tombstone field retained for v0.15.1 backwards compatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "mcp": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "skills_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SkillsAppend is a tombstone field retained for v0.15.1 backwards\ncompatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "mcp_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "MCPAppend is a tombstone field retained for v0.15.1 backwards\ncompatibility.\n\nDeprecated: removed in v0.16. Tombstone — accepted but ignored. See\nengdocs/proposals/skill-materialization.md"
+        },
+        "hooks_installed": {
+          "type": "boolean",
+          "description": "HooksInstalled overrides automatic hook detection."
+        },
+        "inject_assigned_skills": {
+          "type": "boolean",
+          "description": "InjectAssignedSkills overrides per-agent appendix injection\n(see Agent.InjectAssignedSkills)."
+        },
+        "session_setup": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionSetup overrides the agent's session_setup commands."
+        },
+        "session_setup_script": {
+          "type": "string",
+          "description": "SessionSetupScript overrides the agent's session_setup_script path.\nRelative paths resolve against the declaring config file's directory\n(pack-safe). Paths prefixed with \"//\" resolve against the city root."
+        },
+        "session_live": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionLive overrides the agent's session_live commands."
+        },
+        "overlay_dir": {
+          "type": "string",
+          "description": "OverlayDir overrides the agent's overlay_dir path. Copies contents\nadditively into the agent's working directory at startup.\nRelative paths resolve against the city directory."
+        },
+        "default_sling_formula": {
+          "type": "string",
+          "description": "DefaultSlingFormula overrides the default sling formula."
+        },
+        "inject_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InjectFragments overrides the agent's inject_fragments list."
+        },
+        "append_fragments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AppendFragments overrides the agent's append_fragments list."
+        },
+        "attach": {
+          "type": "boolean",
+          "description": "Attach overrides the agent's attach setting."
+        },
+        "depends_on": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "DependsOn overrides the agent's dependency list."
+        },
+        "resume_command": {
+          "type": "string",
+          "description": "ResumeCommand overrides the agent's resume_command template."
+        },
+        "wake_mode": {
+          "type": "string",
+          "enum": [
+            "resume",
+            "fresh"
+          ],
+          "description": "WakeMode overrides the agent's wake mode (\"resume\" or \"fresh\")."
+        },
+        "pre_start_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreStartAppend appends commands to the agent's pre_start list\n(instead of replacing). Applied after PreStart if both are set."
+        },
+        "session_setup_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionSetupAppend appends commands to the agent's session_setup list."
+        },
+        "session_live_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SessionLiveAppend appends commands to the agent's session_live list."
+        },
+        "install_agent_hooks_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InstallAgentHooksAppend appends to the agent's install_agent_hooks list."
+        },
+        "inject_fragments_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "InjectFragmentsAppend appends to the agent's inject_fragments list."
+        },
+        "max_active_sessions": {
+          "type": "integer",
+          "description": "MaxActiveSessions overrides the agent-level cap on concurrent sessions."
+        },
+        "min_active_sessions": {
+          "type": "integer",
+          "description": "MinActiveSessions overrides the minimum number of sessions to keep alive."
+        },
+        "scale_check": {
+          "type": "string",
+          "description": "ScaleCheck overrides the command template whose output determines desired\nsession count. Supports the same Go template placeholders as\nAgent.scale_check."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults adds or overrides provider option defaults for this agent.\nKeys are option keys, values are choice values. Merges additively\n(patch keys win over existing agent keys).\nExample: option_defaults = { model = \"sonnet\" }"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "dir",
+        "name"
+      ],
+      "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
+    },
+    "FormulasConfig": {
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Dir is the path to the formulas directory. Defaults to \"formulas\".",
+          "default": "formulas"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "FormulasConfig holds formula directory settings."
+    },
+    "Import": {
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Source is the pack location: a local relative path (e.g.,\n\"./assets/imports/gastown\") or a remote URL (e.g.,\n\"github.com/gastownhall/gastown\"). Local paths have no version."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version is a semver constraint for remote imports (e.g., \"^1.2\").\nEmpty for local paths. \"sha:\u003chex\u003e\" for commit pinning."
+        },
+        "export": {
+          "type": "boolean",
+          "description": "Export re-exports this import's contents into the parent pack's\nnamespace. Consumers of the parent get this import's agents\nflattened under the parent's binding name."
+        },
+        "transitive": {
+          "type": "boolean",
+          "description": "Transitive controls whether this import's own imports are visible\nto the consumer. Defaults to true (transitive). Set to false to\nsuppress transitive resolution for this specific import."
+        },
+        "shadow": {
+          "type": "string",
+          "enum": [
+            "warn",
+            "silent"
+          ],
+          "description": "Shadow controls shadow warnings when the importer defines an agent\nwith the same name as one from this import. \"warn\" (default) emits\na warning; \"silent\" suppresses it."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "source"
+      ],
+      "description": "Import defines a named import of another pack."
+    },
+    "NamedSession": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the configured public session identity. When omitted, Template\nremains the compatibility identity."
+        },
+        "template": {
+          "type": "string",
+          "description": "Template is the referenced agent template name. Root declarations may\ntarget imported PackV2 agents via \"binding.agent\"."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope defines where this named session is instantiated in pack\nexpansion: \"city\" (one per city) or \"rig\" (one per rig)."
+        },
+        "dir": {
+          "type": "string",
+          "description": "Dir is the identity prefix for rig-scoped named sessions after pack\nexpansion. Empty means city-scoped."
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "on_demand",
+            "always"
+          ],
+          "description": "Mode controls controller behavior for this named session.\n\"on_demand\" (default): reserve identity and materialize when work or\nan explicit reference requires it.\n\"always\": keep the canonical session controller-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "template"
+      ],
+      "description": "NamedSession defines a canonical persistent session backed by an agent template."
+    },
+    "OptionChoice": {
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "flag_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "FlagArgs are the CLI arguments injected when this choice is selected.\njson:\"-\" is intentional: FlagArgs must never appear in the public API DTO\n(security boundary — prevents clients from seeing internal CLI flags)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "value",
+        "label",
+        "flag_args"
+      ],
+      "description": "OptionChoice is one allowed value for a \"select\" option."
+    },
+    "PackCommandEntry": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the subcommand name (e.g. \"status\", \"audit\")."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is a short one-line description shown in help listings."
+        },
+        "long_description": {
+          "type": "string",
+          "description": "LongDescription is a path (relative to pack dir) to a text file\nwith the full help text shown by gc \u003cpack\u003e \u003ccommand\u003e --help."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script is the path to the script (relative to pack dir).\nSupports Go text/template variables: {{.CityRoot}}, {{.ConfigDir}}, etc."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "long_description",
+        "script"
+      ],
+      "description": "PackCommandEntry declares a CLI subcommand provided by a pack."
+    },
+    "PackConfig": {
+      "properties": {
+        "pack": {
+          "$ref": "#/$defs/PackMeta"
+        },
+        "imports": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Import"
+          },
+          "type": "object"
+        },
+        "agent_defaults": {
+          "$ref": "#/$defs/AgentDefaults"
+        },
+        "defaults": {
+          "$ref": "#/$defs/PackDefaults"
+        },
+        "agent": {
+          "items": {
+            "$ref": "#/$defs/Agent"
+          },
+          "type": "array"
+        },
+        "named_session": {
+          "items": {
+            "$ref": "#/$defs/NamedSession"
+          },
+          "type": "array"
+        },
+        "service": {
+          "items": {
+            "$ref": "#/$defs/Service"
+          },
+          "type": "array"
+        },
+        "providers": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ProviderSpec"
+          },
+          "type": "object"
+        },
+        "formulas": {
+          "$ref": "#/$defs/FormulasConfig"
+        },
+        "patches": {
+          "$ref": "#/$defs/Patches"
+        },
+        "doctor": {
+          "items": {
+            "$ref": "#/$defs/PackDoctorEntry"
+          },
+          "type": "array"
+        },
+        "commands": {
+          "items": {
+            "$ref": "#/$defs/PackCommandEntry"
+          },
+          "type": "array"
+        },
+        "global": {
+          "$ref": "#/$defs/PackGlobal"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pack"
+      ],
+      "description": "PackConfig is the TOML structure of a pack.toml file."
+    },
+    "PackDefaults": {
+      "properties": {
+        "rig": {
+          "$ref": "#/$defs/PackRigDefaults"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackDefaults holds [defaults] entries declared by a pack — used by cities that compose this pack to seed rig configuration."
+    },
+    "PackDoctorEntry": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is a short identifier for the check (e.g. \"check-binaries\").\nThe full check name shown in doctor output is \"\u003cpack\u003e:\u003cname\u003e\"."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script is the path to the check script, relative to the pack\ndirectory. The script must be executable and follow the exit-code\nprotocol: 0=OK, 1=Warning, 2=Error. First line of stdout is the\nmessage; remaining lines are details (shown in verbose mode)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is an optional human-readable description of the check."
+        },
+        "fix": {
+          "type": "string",
+          "description": "Fix is an optional path to a remediation script, relative to the pack\ndirectory. When set, the check opts into `gc doctor --fix`."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "script"
+      ],
+      "description": "PackDoctorEntry declares a diagnostic check shipped with a pack."
+    },
+    "PackGlobal": {
+      "properties": {
+        "session_live": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackGlobal defines commands a pack applies to all agents in scope."
+    },
+    "PackMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the pack's identifier."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version is a semver-style version string."
+        },
+        "schema": {
+          "type": "integer",
+          "description": "Schema is the pack format version (currently 1)."
+        },
+        "requires_gc": {
+          "type": "string",
+          "description": "RequiresGC is an optional minimum gc version requirement."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is an optional human-readable summary of the pack."
+        },
+        "includes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Includes lists other packs to compose into this one (V1 mechanism).\nEach entry is a local relative path (e.g. \"../maintenance\") or a\nremote git URL (SSH or HTTPS) with optional //subpath and #ref."
+        },
+        "requires": {
+          "items": {
+            "$ref": "#/$defs/PackRequirement"
+          },
+          "type": "array",
+          "description": "Requires declares agents that must exist in the expanded config\nfor this pack's formulas/orders to function. Validated\nafter all packs are expanded."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "version",
+        "schema"
+      ],
+      "description": "PackMeta holds metadata from a pack's [pack] header."
+    },
+    "PackRequirement": {
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": [
+            "city",
+            "rig"
+          ],
+          "description": "Scope is the agent scope: \"city\" or \"rig\"."
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent is the name of the required agent."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "scope",
+        "agent"
+      ],
+      "description": "PackRequirement declares an agent that must exist in the expanded config for this pack's formulas/orders to function."
+    },
+    "PackRigDefaults": {
+      "properties": {
+        "imports": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Import"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
+    },
+    "Patches": {
+      "properties": {
+        "agent": {
+          "items": {
+            "$ref": "#/$defs/AgentPatch"
+          },
+          "type": "array",
+          "description": "Agents targets agents by (dir, name)."
+        },
+        "rigs": {
+          "items": {
+            "$ref": "#/$defs/RigPatch"
+          },
+          "type": "array",
+          "description": "Rigs targets rigs by name."
+        },
+        "providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderPatch"
+          },
+          "type": "array",
+          "description": "Providers targets providers by name."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Patches holds all patch blocks from composition."
+    },
+    "PoolOverride": {
+      "properties": {
+        "min": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Min overrides the minimum number of sessions."
+        },
+        "max": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Max overrides the maximum number of sessions. 0 means no sessions can claim routed work."
+        },
+        "check": {
+          "type": "string",
+          "description": "Check overrides the session scale check command template. Supports the\nsame Go template placeholders as Agent.scale_check."
+        },
+        "drain_timeout": {
+          "type": "string",
+          "description": "DrainTimeout overrides the drain timeout. Duration string (e.g., \"5m\", \"30m\", \"1h\")."
+        },
+        "on_death": {
+          "type": "string",
+          "description": "OnDeath overrides the on_death command template. Supports the same Go\ntemplate placeholders as Agent.on_death."
+        },
+        "on_boot": {
+          "type": "string",
+          "description": "OnBoot overrides the on_boot command template. Supports the same Go\ntemplate placeholders as Agent.on_boot."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PoolOverride modifies legacy [pool] fields that map to session scaling."
+    },
+    "ProviderOption": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "\"select\" only (v1)"
+        },
+        "default": {
+          "type": "string"
+        },
+        "choices": {
+          "items": {
+            "$ref": "#/$defs/OptionChoice"
+          },
+          "type": "array"
+        },
+        "omit": {
+          "type": "boolean",
+          "description": "Omit is the removal sentinel for options_schema_merge = \"by_key\".\nWhen set on a child layer's entry, the matching Key inherited from\na parent layer is pruned from the resolved schema."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key",
+        "label",
+        "type",
+        "default",
+        "choices"
+      ],
+      "description": "ProviderOption declares a single configurable option for a provider."
+    },
+    "ProviderPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the targeting key (required). Must match an existing provider's name."
+        },
+        "base": {
+          "type": "string",
+          "description": "Base overrides the provider's inheritance parent (presence-aware).\nPointer to a pointer so the patch can distinguish \"no change\"\n(double-nil) from \"clear to inherit default\" (single-nil value in\nouter pointer) from \"set to explicit empty opt-out\" (value \"\" in\ninner pointer) from \"set to \u003cname\u003e\". Callers use:\n  nil          = patch does not touch Base\n  \u0026(*string)(nil) = patch clears Base to absent\n  \u0026(\u0026\"\")       = patch sets Base = \"\" (explicit opt-out)\n  \u0026(\u0026\"builtin:codex\") = patch sets Base to that value"
+        },
+        "command": {
+          "type": "string",
+          "description": "Command overrides the provider command."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args overrides the provider args."
+        },
+        "args_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ArgsAppend overrides the provider args_append list."
+        },
+        "options_schema_merge": {
+          "type": "string",
+          "description": "OptionsSchemaMerge overrides the options_schema merge mode."
+        },
+        "prompt_mode": {
+          "type": "string",
+          "enum": [
+            "arg",
+            "flag",
+            "none"
+          ],
+          "description": "PromptMode overrides prompt delivery mode."
+        },
+        "prompt_flag": {
+          "type": "string",
+          "description": "PromptFlag overrides the prompt flag."
+        },
+        "ready_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ReadyDelayMs overrides the ready delay in milliseconds."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env adds or overrides environment variables."
+        },
+        "env_remove": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "EnvRemove lists env var keys to remove."
+        },
+        "_replace": {
+          "type": "boolean",
+          "description": "Replace replaces the entire provider block instead of deep-merging."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "ProviderPatch modifies an existing provider identified by Name."
+    },
+    "ProviderSpec": {
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "Base names the parent provider this spec inherits from. Supported\nforms:\n  \"\u003cname\u003e\"          - custom first (self-excluded), then built-in\n  \"builtin:\u003cname\u003e\"  - force built-in lookup\n  \"provider:\u003cname\u003e\" - force custom lookup\n  \"\"                - explicit standalone opt-out\n  nil               - field absent; no explicit declaration"
+        },
+        "args_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ArgsAppend accumulates extra args after each layer's Args replacement."
+        },
+        "options_schema_merge": {
+          "type": "string",
+          "enum": [
+            "replace",
+            "by_key"
+          ],
+          "description": "OptionsSchemaMerge controls OptionsSchema merge mode across the\nchain: \"replace\" (default) or \"by_key\"."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "DisplayName is the human-readable name shown in UI and logs."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command is the executable to run for this provider."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args are default command-line arguments passed to the provider."
+        },
+        "prompt_mode": {
+          "type": "string",
+          "enum": [
+            "arg",
+            "flag",
+            "none"
+          ],
+          "description": "PromptMode controls how prompts are delivered: \"arg\", \"flag\", or \"none\".",
+          "default": "arg"
+        },
+        "prompt_flag": {
+          "type": "string",
+          "description": "PromptFlag is the CLI flag used when prompt_mode is \"flag\" (e.g. \"--prompt\")."
+        },
+        "ready_delay_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ReadyDelayMs is milliseconds to wait after launch before the provider is considered ready."
+        },
+        "ready_prompt_prefix": {
+          "type": "string",
+          "description": "ReadyPromptPrefix is the string prefix that indicates the provider is ready for input."
+        },
+        "process_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ProcessNames lists process names to look for when checking if the provider is running."
+        },
+        "emits_permission_warning": {
+          "type": "boolean",
+          "description": "EmitsPermissionWarning is tri-state: nil = inherit, \u0026true = enable,\n\u0026false = explicit disable."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env sets additional environment variables for the provider process."
+        },
+        "path_check": {
+          "type": "string",
+          "description": "PathCheck overrides the binary name used for PATH detection.\nWhen set, lookupProvider and detectProviderName use this instead\nof Command for exec.LookPath checks. Useful when Command is a\nshell wrapper (e.g. sh -c '...') but we need to verify the real\nbinary is installed."
+        },
+        "supports_acp": {
+          "type": "boolean",
+          "description": "SupportsACP indicates the binary speaks the Agent Client Protocol\n(JSON-RPC 2.0 over stdio). When an agent sets session = \"acp\",\nits resolved provider must have SupportsACP = true."
+        },
+        "supports_hooks": {
+          "type": "boolean",
+          "description": "SupportsHooks indicates the provider has an executable hook mechanism\n(settings.json, plugins, etc.) for lifecycle events."
+        },
+        "instructions_file": {
+          "type": "string",
+          "description": "InstructionsFile is the filename the provider reads for project instructions\n(e.g., \"CLAUDE.md\", \"AGENTS.md\"). Empty defaults to \"AGENTS.md\"."
+        },
+        "resume_flag": {
+          "type": "string",
+          "description": "ResumeFlag is the CLI flag for resuming a session by ID.\nEmpty means the provider does not support resume.\nExamples: \"--resume\" (claude), \"resume\" (codex)"
+        },
+        "resume_style": {
+          "type": "string",
+          "description": "ResumeStyle controls how ResumeFlag is applied:\n  \"flag\"       → command --resume \u003ckey\u003e              (default)\n  \"subcommand\" → command resume \u003ckey\u003e"
+        },
+        "resume_command": {
+          "type": "string",
+          "description": "ResumeCommand is the full shell command to run when resuming a session.\nSupports {{.SessionKey}} template variable. When set, takes precedence\nover ResumeFlag/ResumeStyle. Example:\n  \"claude --resume {{.SessionKey}} --dangerously-skip-permissions\""
+        },
+        "session_id_flag": {
+          "type": "string",
+          "description": "SessionIDFlag is the CLI flag for creating a session with a specific ID.\nEnables the Generate \u0026 Pass strategy for session key management.\nExample: \"--session-id\" (claude)"
+        },
+        "permission_modes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "PermissionModes maps permission mode names to CLI flags.\nExample: {\"unrestricted\": \"--dangerously-skip-permissions\", \"plan\": \"--permission-mode plan\"}\nThis is a config-only lookup table consumed by external clients\n(e.g., Mission Control) to populate permission mode dropdowns.\nLaunch-time flag substitution is planned for a follow-up PR —\ncurrently no runtime code reads this field."
+        },
+        "option_defaults": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "OptionDefaults overrides the Default value in OptionsSchema entries\nwithout redefining the schema itself. Keys are option keys (e.g.,\n\"permission_mode\"), values are choice values (e.g., \"unrestricted\").\ncity.toml users set this to customize provider behavior without\ntouching Args or OptionsSchema."
+        },
+        "options_schema": {
+          "items": {
+            "$ref": "#/$defs/ProviderOption"
+          },
+          "type": "array",
+          "description": "OptionsSchema declares the configurable options this provider supports.\nEach option maps to CLI args via its Choices[].FlagArgs field.\nSerialized via a dedicated DTO (not directly to JSON) so FlagArgs stays server-side."
+        },
+        "print_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PrintArgs are CLI arguments that enable one-shot non-interactive mode.\nThe provider prints its response to stdout and exits. When empty, the\nprovider does not support one-shot invocation.\nExamples: [\"-p\"] (claude, gemini), [\"exec\"] (codex)"
+        },
+        "title_model": {
+          "type": "string",
+          "description": "TitleModel is the OptionsSchema model key used for title generation.\nResolved via the \"model\" option in OptionsSchema to get FlagArgs.\nDefaults to the cheapest/fastest model for each provider.\nExamples: \"haiku\" (claude), \"o4-mini\" (codex), \"gemini-2.5-flash\" (gemini)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ProviderSpec defines a named provider's startup parameters."
+    },
+    "RigPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the targeting key (required). Must match an existing rig's name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path overrides the rig's filesystem path."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Prefix overrides the bead ID prefix."
+        },
+        "suspended": {
+          "type": "boolean",
+          "description": "Suspended overrides the rig's suspended state."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "RigPatch modifies an existing rig identified by Name."
+    },
+    "Service": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the unique service identifier within a workspace."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow",
+            "proxy_process"
+          ],
+          "description": "Kind selects how the service is implemented."
+        },
+        "publish_mode": {
+          "type": "string",
+          "enum": [
+            "private",
+            "direct"
+          ],
+          "description": "PublishMode declares how the service is intended to be published.\nv0 supports private services and direct reuse of the API listener."
+        },
+        "state_root": {
+          "type": "string",
+          "description": "StateRoot overrides the managed service state root. Defaults to\n.gc/services/{name}. The path must stay within .gc/services/."
+        },
+        "publication": {
+          "$ref": "#/$defs/ServicePublicationConfig",
+          "description": "Publication declares generic publication intent. The platform decides\nwhether and how that intent becomes a public route."
+        },
+        "workflow": {
+          "$ref": "#/$defs/ServiceWorkflowConfig",
+          "description": "Workflow configures controller-owned workflow services."
+        },
+        "process": {
+          "$ref": "#/$defs/ServiceProcessConfig",
+          "description": "Process configures controller-supervised proxy services."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "Service declares a workspace-owned HTTP service mounted under /svc/{name}."
+    },
+    "ServiceProcessConfig": {
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command is the argv used to start the local service process."
+        },
+        "health_path": {
+          "type": "string",
+          "description": "HealthPath, when set, is probed on the local listener before the\nservice is marked ready."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ServiceProcessConfig configures a controller-supervised local process that is reverse-proxied under /svc/{name}."
+    },
+    "ServicePublicationConfig": {
+      "properties": {
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "private",
+            "public",
+            "tenant"
+          ],
+          "description": "Visibility selects whether the service is private to the workspace,\navailable publicly, or gated by tenant auth at the platform edge."
+        },
+        "hostname": {
+          "type": "string",
+          "description": "Hostname overrides the default hostname label derived from service.name."
+        },
+        "allow_websockets": {
+          "type": "boolean",
+          "description": "AllowWebSockets permits websocket upgrades on the published route."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ServicePublicationConfig declares platform-neutral publication intent."
+    },
+    "ServiceWorkflowConfig": {
+      "properties": {
+        "contract": {
+          "type": "string",
+          "description": "Contract selects the built-in workflow handler."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ServiceWorkflowConfig configures controller-owned workflow services."
+    }
+  },
+  "title": "Gas City Pack Manifest",
+  "description": "Schema for pack.toml — the PackV2 manifest that declares a pack's metadata, agents, providers, services, commands, and import surface. Cities and rigs compose packs via [imports.*]."
+}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1123,7 +1123,7 @@ func LoadRootPackDefaultRigImports(fs fsys.FS, cityRoot string) ([]BoundImport, 
 		}
 		return nil, fmt.Errorf("loading city pack.toml: %w", err)
 	}
-	var pc packConfig
+	var pc PackConfig
 	md, err := toml.Decode(string(packData), &pc)
 	if err != nil {
 		return nil, fmt.Errorf("parsing city pack.toml: %w", err)
@@ -1134,7 +1134,7 @@ func LoadRootPackDefaultRigImports(fs fsys.FS, cityRoot string) ([]BoundImport, 
 	return defaultRigImportsFromPackDefaults(pc.Defaults, md)
 }
 
-func defaultRigImportsFromPackDefaults(defaults packDefaults, md toml.MetaData) ([]BoundImport, error) {
+func defaultRigImportsFromPackDefaults(defaults PackDefaults, md toml.MetaData) ([]BoundImport, error) {
 	if len(defaults.Rig.Imports) == 0 {
 		return nil, nil
 	}
@@ -1151,7 +1151,7 @@ func defaultRigImportsFromPackDefaults(defaults packDefaults, md toml.MetaData) 
 	return imports, nil
 }
 
-func defaultRigIncludesFromPackDefaults(defaults packDefaults, md toml.MetaData) ([]string, error) {
+func defaultRigIncludesFromPackDefaults(defaults PackDefaults, md toml.MetaData) ([]string, error) {
 	imports, err := defaultRigImportsFromPackDefaults(defaults, md)
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -835,6 +835,11 @@ type Workspace struct {
 	// "gc rig add" is called without --include. Allows cities to define
 	// a default pack for all rigs.
 	DefaultRigIncludes []string `toml:"default_rig_includes,omitempty"`
+	// Env defines workspace-wide environment variables applied to every
+	// managed session. Lowest config-precedence — overridden by provider,
+	// agent, and patch env. Use for cross-cutting variables like
+	// GC_TARGET_BRANCH that every agent should inherit.
+	Env map[string]string `toml:"env,omitempty"`
 }
 
 // BeadsConfig holds bead store settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -238,6 +238,27 @@ mcp = ["city-mcp"]
 	}
 }
 
+func TestParseWorkspaceEnv(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "bright-lights"
+
+[workspace.env]
+GC_TARGET_BRANCH = "boylec/develop"
+FOO = "bar"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := cfg.Workspace.Env["GC_TARGET_BRANCH"]; got != "boylec/develop" {
+		t.Errorf("Workspace.Env[GC_TARGET_BRANCH] = %q, want %q", got, "boylec/develop")
+	}
+	if got := cfg.Workspace.Env["FOO"]; got != "bar" {
+		t.Errorf("Workspace.Env[FOO] = %q, want %q", got, "bar")
+	}
+}
+
 func TestParseNoAgents(t *testing.T) {
 	data := []byte(`
 [workspace]

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -22,15 +22,15 @@ const packFile = "pack.toml"
 // currentPackSchema is the supported pack schema version.
 const currentPackSchema = 2
 
-// packConfig is the TOML structure of a pack.toml file.
+// PackConfig is the TOML structure of a pack.toml file.
 // It has a [pack] metadata header and agent definitions.
-type packConfig struct {
-	Pack           PackMeta                `toml:"pack"`
+type PackConfig struct {
+	Pack           PackMeta                `toml:"pack" jsonschema:"required"`
 	Imports        map[string]Import       `toml:"imports,omitempty"`
 	AgentDefaults  AgentDefaults           `toml:"agent_defaults,omitempty"`
 	AgentsDefaults AgentDefaults           `toml:"agents,omitempty" jsonschema:"-"`
-	Defaults       packDefaults            `toml:"defaults,omitempty"`
-	Agents         []Agent                 `toml:"agent"`
+	Defaults       PackDefaults            `toml:"defaults,omitempty"`
+	Agents         []Agent                 `toml:"agent,omitempty"`
 	NamedSessions  []NamedSession          `toml:"named_session,omitempty"`
 	Services       []Service               `toml:"service,omitempty"`
 	Providers      map[string]ProviderSpec `toml:"providers,omitempty"`
@@ -41,11 +41,15 @@ type packConfig struct {
 	Global         PackGlobal              `toml:"global,omitempty"`
 }
 
-type packDefaults struct {
-	Rig packRigDefaults `toml:"rig,omitempty"`
+// PackDefaults holds [defaults] entries declared by a pack — used by
+// cities that compose this pack to seed rig configuration.
+type PackDefaults struct {
+	Rig PackRigDefaults `toml:"rig,omitempty"`
 }
 
-type packRigDefaults struct {
+// PackRigDefaults holds the [defaults.rig] block — defaults applied
+// to rigs created from this pack.
+type PackRigDefaults struct {
 	Imports map[string]Import `toml:"imports,omitempty"`
 }
 
@@ -994,16 +998,16 @@ type packLoadResult struct {
 	warnings       []string
 }
 
-func parsePackConfigWithMeta(data []byte, source string) (packConfig, []string, error) {
+func parsePackConfigWithMeta(data []byte, source string) (PackConfig, []string, error) {
 	cfg, _, warnings, err := parsePackConfigWithMetadata(data, source)
 	return cfg, warnings, err
 }
 
-func parsePackConfigWithMetadata(data []byte, source string) (packConfig, toml.MetaData, []string, error) {
-	var cfg packConfig
+func parsePackConfigWithMetadata(data []byte, source string) (PackConfig, toml.MetaData, []string, error) {
+	var cfg PackConfig
 	md, err := toml.Decode(string(data), &cfg)
 	if err != nil {
-		return packConfig{}, md, nil, err
+		return PackConfig{}, md, nil, err
 	}
 	normalizePackAgentDefaultsAlias(&cfg, md)
 	warnings := agentDefaultsCompatibilityWarnings(md, source)
@@ -1011,7 +1015,7 @@ func parsePackConfigWithMetadata(data []byte, source string) (packConfig, toml.M
 	return cfg, md, warnings, nil
 }
 
-func normalizePackAgentDefaultsAlias(cfg *packConfig, meta toml.MetaData) {
+func normalizePackAgentDefaultsAlias(cfg *PackConfig, meta toml.MetaData) {
 	if !meta.IsDefined("agents") {
 		cfg.AgentsDefaults = AgentDefaults{}
 		return
@@ -2626,7 +2630,7 @@ func packSummaryOne(fs fsys.FS, ref, cityRoot string) string {
 	if err != nil {
 		return ref + " (unreadable)"
 	}
-	var tc packConfig
+	var tc PackConfig
 	if _, err := toml.Decode(string(data), &tc); err != nil {
 		return ref + " (parse error)"
 	}
@@ -2679,7 +2683,7 @@ func LoadPackDoctorEntries(fs fsys.FS, topoDirs []string) []PackDoctorInfo {
 			continue
 		}
 
-		var tc packConfig
+		var tc PackConfig
 		if _, err := toml.Decode(string(data), &tc); err != nil {
 			continue
 		}
@@ -2730,7 +2734,7 @@ func LoadPackCommandEntries(fs fsys.FS, packDirs []string) []PackCommandInfo {
 			continue
 		}
 
-		var tc packConfig
+		var tc PackConfig
 		if _, err := toml.Decode(string(data), &tc); err != nil {
 			continue
 		}

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -196,7 +196,7 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(ServiceWorkflowConfig{}),
 		reflect.TypeOf(ServiceProcessConfig{}),
 		reflect.TypeOf(AgentDefaults{}),
-		reflect.TypeOf(packConfig{}),
+		reflect.TypeOf(PackConfig{}),
 		reflect.TypeOf(PackMeta{}),
 		reflect.TypeOf(Import{}),
 		reflect.TypeOf(NamedSession{}),
@@ -204,8 +204,8 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(PackDoctorEntry{}),
 		reflect.TypeOf(PackCommandEntry{}),
 		reflect.TypeOf(PackGlobal{}),
-		reflect.TypeOf(packDefaults{}),
-		reflect.TypeOf(packRigDefaults{}),
+		reflect.TypeOf(PackDefaults{}),
+		reflect.TypeOf(PackRigDefaults{}),
 	}
 	for _, t := range types {
 		collectTOMLTags(t, seen)

--- a/internal/docgen/schema.go
+++ b/internal/docgen/schema.go
@@ -76,3 +76,19 @@ func GenerateCitySchema() (*jsonschema.Schema, error) {
 		"Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility."
 	return s, nil
 }
+
+// GeneratePackSchema produces a JSON Schema for the pack.toml manifest
+// format (PackV2). It reflects the config.PackConfig struct using TOML
+// field names and extracts doc comments as descriptions.
+func GeneratePackSchema() (*jsonschema.Schema, error) {
+	r, err := newReflector()
+	if err != nil {
+		return nil, err
+	}
+	s := r.Reflect(&config.PackConfig{})
+	s.Title = "Gas City Pack Manifest"
+	s.Description = "Schema for pack.toml — the PackV2 manifest that declares " +
+		"a pack's metadata, agents, providers, services, commands, and import surface. " +
+		"Cities and rigs compose packs via [imports.*]."
+	return s, nil
+}

--- a/internal/docgen/schema_test.go
+++ b/internal/docgen/schema_test.go
@@ -187,6 +187,78 @@ func TestCitySchemaOrderOverrideIncludesLegacyGateAlias(t *testing.T) {
 	}
 }
 
+func TestGeneratePackSchema(t *testing.T) {
+	s, err := GeneratePackSchema()
+	if err != nil {
+		t.Fatalf("GeneratePackSchema: %v", err)
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	props := defProperties(t, raw, "PackConfig")
+	for _, expected := range []string{"pack", "imports", "agent", "providers", "service", "commands"} {
+		if _, ok := props[expected]; !ok {
+			t.Errorf("missing PackConfig property %q", expected)
+		}
+	}
+}
+
+func TestPackSchemaPackMetaRequired(t *testing.T) {
+	s, err := GeneratePackSchema()
+	if err != nil {
+		t.Fatalf("GeneratePackSchema: %v", err)
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	defs := raw["$defs"].(map[string]interface{})
+	pack := defs["PackConfig"].(map[string]interface{})
+	required, _ := pack["required"].([]interface{})
+	found := false
+	for _, r := range required {
+		if r == "pack" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("PackConfig.required = %v, want to include %q ([pack] block is mandatory in pack.toml)", required, "pack")
+	}
+}
+
+func TestPackSchemaAliasFieldHidden(t *testing.T) {
+	s, err := GeneratePackSchema()
+	if err != nil {
+		t.Fatalf("GeneratePackSchema: %v", err)
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	props := defProperties(t, raw, "PackConfig")
+	if _, ok := props["agents"]; ok {
+		t.Errorf("PackConfig should hide the legacy %q alias (jsonschema:\"-\") for agent_defaults", "agents")
+	}
+}
+
 func TestCitySchemaAgentDefinition(t *testing.T) {
 	s, err := GenerateCitySchema()
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a generated \`docs/schema/pack-schema.json\` (and \`.txt\` mirror) so editors give the same autocomplete + validation for \`pack.toml\` that they already give for \`city.toml\`. PackV2 is the primary composition mechanism — the prior absence of a pack schema was a glaring gap for anyone authoring packs in \`examples/\`, \`contrib/\`, or downstream repos.

Three pieces, one PR:

1. **Export the manifest types** in \`internal/config/pack.go\`:
   - \`packConfig\` → \`PackConfig\`
   - \`packDefaults\` → \`PackDefaults\`
   - \`packRigDefaults\` → \`PackRigDefaults\`
   
   \`invopop/jsonschema\` only reflects exported types. All callers live in \`internal/config/\` itself and update transparently. Also marks \`PackConfig.Pack\` required (every pack.toml must have a \`[pack]\` block) and adds \`omitempty\` to \`Agents\` (many packs are pure import bundles).

2. **\`docgen.GeneratePackSchema()\`** parallel to \`GenerateCitySchema\`. Sub-types (\`Agent\`, \`Import\`, \`PackMeta\`, etc.) are already exported and reflected as \`\$defs\` in city-schema, so the pack schema reuses them automatically.

3. **\`cmd/genschema/main.go\`** wired to write \`pack-schema.json\` and \`pack-schema.txt\` alongside the city outputs.

Fixes #1238

Stacked on #1230 (workspace.env) — both touch \`cmd/genschema/main.go\`. Will rebase to \`upstream/main\` once #1230 lands.

## Test plan

- [x] \`go test ./internal/docgen/ -run \"TestGeneratePackSchema|TestPackSchema\"\` — three new tests pass
- [x] \`go test ./internal/config/ ./internal/docgen/\` — no regressions
- [x] \`go run ./cmd/genschema\` — generates \`docs/schema/pack-schema.json\` (~58KB)
- [x] Spot-check: \`PackConfig.required = [\"pack\"]\`; properties include \`agent\`, \`imports\`, \`commands\`, \`providers\`, \`service\`, \`global\`; legacy \`agents\` alias hidden; \`\$defs.Agent\`/\`\$defs.Import\` reused (not duplicated)

## Out of scope

- \`pack.lock\` schema (separate file, separate concern)
- Shipping a default \`.taplo.toml\` rule from upstream (downstream consumers add their own \`include = [\"**/pack.toml\"]\` rule pointing at the new file)