### PR TITLE
fix(provider): codex SessionIDFlag + resume diagnostic for non-Claude providers

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -344,6 +344,9 @@ func buildPreparedStart(
 		firstStart := session.Metadata["started_config_hash"] == ""
 		forceFresh := session.Metadata["wake_mode"] == "fresh"
 		agentCfg.Command = resolveSessionCommand(agentCfg.Command, sk, tp.ResolvedProvider, firstStart, forceFresh)
+		if !firstStart && !forceFresh && tp.ResolvedProvider.ResumeFlag == "" && tp.ResolvedProvider.ResumeCommand == "" {
+			log.Printf("session %s: provider %q has no resume mechanism (ResumeFlag and ResumeCommand both empty); launching a fresh process — prior in-memory session will be lost", session.ID, tp.ResolvedProvider.Name)
+		}
 	}
 	firstStart := session.Metadata["started_config_hash"] == ""
 	forceFresh := session.Metadata["wake_mode"] == "fresh"

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -160,6 +160,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		InstructionsFile:  "AGENTS.md",
 		ResumeFlag:        "resume",
 		ResumeStyle:       "subcommand",
+		SessionIDFlag:     "--session-id",
 		PrintArgs:         []string{"exec"},
 		TitleModel:        "o4-mini",
 		PermissionModes: map[string]string{

--- a/internal/worker/builtin/profiles_test.go
+++ b/internal/worker/builtin/profiles_test.go
@@ -29,6 +29,17 @@ func TestBuiltinProvidersAndOrder(t *testing.T) {
 	}
 }
 
+func TestCodexSessionIDFlag(t *testing.T) {
+	providers := BuiltinProviders()
+	codex, ok := providers["codex"]
+	if !ok {
+		t.Fatal("BuiltinProviders() missing codex")
+	}
+	if codex.SessionIDFlag != "--session-id" {
+		t.Errorf("codex.SessionIDFlag = %q, want %q (Generate-and-Pass strategy needs session-id assignment)", codex.SessionIDFlag, "--session-id")
+	}
+}
+
 func TestBuiltinProvidersReturnClonedData(t *testing.T) {
 	a := BuiltinProviders()
 	b := BuiltinProviders()


### PR DESCRIPTION
Two non-Claude provider parity gaps from the audit (`engdocs/archive/analysis/non-claude-provider-parity-audit.md`, w-7ed35a727f, gh#672).

## Summary

1. **codex now declares `SessionIDFlag="--session-id"`** (`internal/worker/builtin/profiles.go`). Without this, `resolveSessionCommand` couldn't pre-assign session keys for codex, forcing post-hoc discovery. Closes audit gap 2 (gt-ftk5).

2. **`session_lifecycle_parallel` emits a `log.Printf` warning** when a session is being resumed (`firstStart=false`, not `forceFresh`) but the resolved provider has *no* resume mechanism (both `ResumeFlag` and `ResumeCommand` empty). Previously, `resolveResumeCommand` silently returned the original command and the reconciler launched a fresh process — user lost the in-memory session with no error, no warning. Addresses the diagnostic requirement of audit gap 1 (gt-j9zo).

## Out of scope (follow-ups)

Populating `ResumeFlag`/`ResumeStyle` for cursor, copilot, amp, opencode, auggie, pi, omp still requires per-CLI investigation. Tracked under gt-j9zo for follow-up. The diagnostic landed in this PR catches the silent-skip case for any of those providers in the meantime.

The amp/auggie nudge-drain gap (gt-716l, audit gap 4) is unchanged here.

## Test plan

- [x] `go test ./internal/worker/builtin/... ./internal/config/... ./cmd/gc/` — green (cmd/gc full suite: ok in 347s)
- [x] `go vet ./internal/worker/builtin/... ./cmd/gc/...` — clean
- [x] New `TestCodexSessionIDFlag` — asserts codex.SessionIDFlag == `--session-id`
- [x] Existing `TestResolveSessionCommand` and `TestResolveResumeCommand` — green
- [ ] Manual: trigger a wake on a provider with no `ResumeFlag` and confirm warning hits the reconciler stderr