### PR TITLE
perf(session): bound alias resolve list calls via metadata filters

### DIFF
--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -57,11 +57,14 @@ func resolveConfiguredNamedSessionID(
 	if !ok {
 		return "", false, fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 	}
-	candidates, err := session.NamedSessionResolutionCandidates(store, spec)
+	canonicalCandidates, err := store.List(beads.ListQuery{
+		Label:    session.LabelSession,
+		Metadata: map[string]string{namedSessionIdentityMetadata: spec.Identity},
+	})
 	if err != nil {
-		return "", true, err
+		return "", true, fmt.Errorf("listing canonical named session candidates: %w", err)
 	}
-	if bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec); ok {
+	if bead, ok := session.FindCanonicalNamedSessionBead(canonicalCandidates, spec); ok {
 		return bead.ID, true, nil
 	}
 	// When materializing, check for a closed bead with this identity and
@@ -73,7 +76,22 @@ func resolveConfiguredNamedSessionID(
 			return bead.ID, true, nil
 		}
 	}
-	if bead, conflict := session.FindNamedSessionConflict(candidates, spec); conflict {
+	sessionNameConflicts, err := store.List(beads.ListQuery{
+		Label:    session.LabelSession,
+		Metadata: map[string]string{"session_name": spec.SessionName},
+	})
+	if err != nil {
+		return "", true, fmt.Errorf("listing session_name conflicts: %w", err)
+	}
+	aliasConflicts, err := store.List(beads.ListQuery{
+		Label:    session.LabelSession,
+		Metadata: map[string]string{"alias": spec.Identity},
+	})
+	if err != nil {
+		return "", true, fmt.Errorf("listing alias conflicts: %w", err)
+	}
+	conflictCandidates := append(append([]beads.Bead{}, sessionNameConflicts...), aliasConflicts...)
+	if bead, conflict := session.FindNamedSessionConflict(conflictCandidates, spec); conflict {
 		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errNamedSessionConflict, identifier, spec.Identity, bead.ID)
 	}
 	if !opts.materialize {

--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -57,22 +57,12 @@ func resolveConfiguredNamedSessionID(
 	if !ok {
 		return "", false, fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 	}
-	canonicalCandidates, err := store.List(beads.ListQuery{
-		Label:    session.LabelSession,
-		Metadata: map[string]string{namedSessionIdentityMetadata: spec.Identity},
-	})
+	lookup, err := session.LookupConfiguredNamedSession(store, spec)
 	if err != nil {
-		return "", true, fmt.Errorf("listing canonical named session candidates: %w", err)
+		return "", true, fmt.Errorf("looking up configured named session: %w", err)
 	}
-	if bead, ok := session.FindCanonicalNamedSessionBead(canonicalCandidates, spec); ok {
-		return bead.ID, true, nil
-	}
-	canonicalCandidates, err = appendCanonicalRuntimeSessionNameCandidates(store, canonicalCandidates, spec)
-	if err != nil {
-		return "", true, err
-	}
-	if bead, ok := session.FindCanonicalNamedSessionBead(canonicalCandidates, spec); ok {
-		return bead.ID, true, nil
+	if lookup.HasCanonical {
+		return lookup.Canonical.ID, true, nil
 	}
 	// When materializing, check for a closed bead with this identity and
 	// reopen it (preserves bead ID for reference continuity).
@@ -83,23 +73,8 @@ func resolveConfiguredNamedSessionID(
 			return bead.ID, true, nil
 		}
 	}
-	sessionNameConflicts, err := store.List(beads.ListQuery{
-		Label:    session.LabelSession,
-		Metadata: map[string]string{"session_name": spec.SessionName},
-	})
-	if err != nil {
-		return "", true, fmt.Errorf("listing session_name conflicts: %w", err)
-	}
-	aliasConflicts, err := store.List(beads.ListQuery{
-		Label:    session.LabelSession,
-		Metadata: map[string]string{"alias": spec.Identity},
-	})
-	if err != nil {
-		return "", true, fmt.Errorf("listing alias conflicts: %w", err)
-	}
-	conflictCandidates := append(append([]beads.Bead{}, sessionNameConflicts...), aliasConflicts...)
-	if bead, conflict := session.FindNamedSessionConflict(conflictCandidates, spec); conflict {
-		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errNamedSessionConflict, identifier, spec.Identity, bead.ID)
+	if lookup.HasConflict {
+		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errNamedSessionConflict, identifier, spec.Identity, lookup.Conflict.ID)
 	}
 	if !opts.materialize {
 		return "", false, fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
@@ -108,36 +83,6 @@ func resolveConfiguredNamedSessionID(
 		materializeMetadata: opts.materializeMetadata,
 	})
 	return id, true, err
-}
-
-func appendCanonicalRuntimeSessionNameCandidates(store beads.Store, candidates []beads.Bead, spec session.NamedSessionSpec) ([]beads.Bead, error) {
-	seen := make(map[string]bool, len(candidates))
-	for _, b := range candidates {
-		seen[b.ID] = true
-	}
-	queriedValues := map[string]bool{}
-	for _, value := range []string{spec.SessionName, spec.Identity} {
-		value = strings.TrimSpace(value)
-		if value == "" || queriedValues[value] {
-			continue
-		}
-		queriedValues[value] = true
-		matches, err := store.List(beads.ListQuery{
-			Label:    session.LabelSession,
-			Metadata: map[string]string{"session_name": value},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("listing canonical named session candidates by session_name: %w", err)
-		}
-		for _, b := range matches {
-			if seen[b.ID] {
-				continue
-			}
-			candidates = append(candidates, b)
-			seen[b.ID] = true
-		}
-	}
-	return candidates, nil
 }
 
 func resolveSessionIDWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {

--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -67,6 +67,13 @@ func resolveConfiguredNamedSessionID(
 	if bead, ok := session.FindCanonicalNamedSessionBead(canonicalCandidates, spec); ok {
 		return bead.ID, true, nil
 	}
+	canonicalCandidates, err = appendCanonicalRuntimeSessionNameCandidates(store, canonicalCandidates, spec)
+	if err != nil {
+		return "", true, err
+	}
+	if bead, ok := session.FindCanonicalNamedSessionBead(canonicalCandidates, spec); ok {
+		return bead.ID, true, nil
+	}
 	// When materializing, check for a closed bead with this identity and
 	// reopen it (preserves bead ID for reference continuity).
 	if opts.materialize {
@@ -101,6 +108,36 @@ func resolveConfiguredNamedSessionID(
 		materializeMetadata: opts.materializeMetadata,
 	})
 	return id, true, err
+}
+
+func appendCanonicalRuntimeSessionNameCandidates(store beads.Store, candidates []beads.Bead, spec session.NamedSessionSpec) ([]beads.Bead, error) {
+	seen := make(map[string]bool, len(candidates))
+	for _, b := range candidates {
+		seen[b.ID] = true
+	}
+	queriedValues := map[string]bool{}
+	for _, value := range []string{spec.SessionName, spec.Identity} {
+		value = strings.TrimSpace(value)
+		if value == "" || queriedValues[value] {
+			continue
+		}
+		queriedValues[value] = true
+		matches, err := store.List(beads.ListQuery{
+			Label:    session.LabelSession,
+			Metadata: map[string]string{"session_name": value},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing canonical named session candidates by session_name: %w", err)
+		}
+		for _, b := range matches {
+			if seen[b.ID] {
+				continue
+			}
+			candidates = append(candidates, b)
+			seen[b.ID] = true
+		}
+	}
+	return candidates, nil
 }
 
 func resolveSessionIDWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,80 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
+
+type listQueryCaptureStore struct {
+	beads.Store
+	listCalls []beads.ListQuery
+}
+
+func (s *listQueryCaptureStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls = append(s.listCalls, q)
+	return s.Store.List(q)
+}
+
+func TestResolveConfiguredNamedSessionID_BoundedListCalls(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+		}},
+	}
+	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	spec, ok := findNamedSessionSpec(cfg, cityName, "mayor")
+	if !ok {
+		t.Fatal("findNamedSessionSpec(mayor) = false")
+	}
+
+	inner := beads.NewMemStore()
+	for i := 0; i < 200; i++ {
+		_, _ = inner.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"session_name": fmt.Sprintf("worker-%d", i),
+			},
+		})
+	}
+	target, err := inner.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":               spec.SessionName,
+			"alias":                      "mayor",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     spec.Mode,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(canonical): %v", err)
+	}
+
+	store := &listQueryCaptureStore{Store: inner}
+	id, matched, err := resolveConfiguredNamedSessionID(cityPath, cfg, store, "mayor", namedSessionResolveOptions{})
+	if err != nil {
+		t.Fatalf("resolveConfiguredNamedSessionID: %v", err)
+	}
+	if !matched {
+		t.Fatalf("matched = false, want true")
+	}
+	if id != target.ID {
+		t.Fatalf("got %q, want canonical %q", id, target.ID)
+	}
+	if len(store.listCalls) == 0 {
+		t.Fatalf("expected at least one List call")
+	}
+	for i, q := range store.listCalls {
+		if len(q.Metadata) == 0 {
+			t.Fatalf("List call #%d has no metadata filter (would scan all beads): %+v", i, q)
+		}
+	}
+}
 
 func TestResolveSessionID_BeadID(t *testing.T) {
 	store := beads.NewMemStore()

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -81,6 +81,65 @@ func TestResolveConfiguredNamedSessionID_BoundedListCalls(t *testing.T) {
 	if len(store.listCalls) == 0 {
 		t.Fatalf("expected at least one List call")
 	}
+	if len(store.listCalls) != 1 {
+		t.Fatalf("List calls = %d, want 1 canonical lookup", len(store.listCalls))
+	}
+	for i, q := range store.listCalls {
+		if len(q.Metadata) == 0 {
+			t.Fatalf("List call #%d has no metadata filter (would scan all beads): %+v", i, q)
+		}
+	}
+}
+
+func TestResolveConfiguredNamedSessionID_BoundedConflictListCalls(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+		}},
+	}
+	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	spec, ok := findNamedSessionSpec(cfg, cityName, "mayor")
+	if !ok {
+		t.Fatal("findNamedSessionSpec(mayor) = false")
+	}
+
+	inner := beads.NewMemStore()
+	_, err := inner.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": spec.SessionName,
+			"template":     "other",
+			"agent_name":   "other",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(conflict): %v", err)
+	}
+
+	store := &listQueryCaptureStore{Store: inner}
+	_, matched, err := resolveConfiguredNamedSessionID(cityPath, cfg, store, "mayor", namedSessionResolveOptions{})
+	if err == nil {
+		t.Fatal("resolveConfiguredNamedSessionID succeeded, want conflict")
+	}
+	if !matched {
+		t.Fatalf("matched = false, want true")
+	}
+	if !errors.Is(err, errNamedSessionConflict) {
+		t.Fatalf("error = %v, want errNamedSessionConflict", err)
+	}
+	if len(store.listCalls) == 0 {
+		t.Fatalf("expected at least one List call")
+	}
+	if len(store.listCalls) > 5 {
+		t.Fatalf("List calls = %d, want bounded small constant", len(store.listCalls))
+	}
 	for i, q := range store.listCalls {
 		if len(q.Metadata) == 0 {
 			t.Fatalf("List call #%d has no metadata filter (would scan all beads): %+v", i, q)
@@ -696,6 +755,50 @@ func TestResolveSessionIDMaterializingNamed_AdoptsCanonicalRuntimeSessionNameBea
 	id, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, "mayor")
 	if err != nil {
 		t.Fatalf("resolveSessionIDMaterializingNamed(mayor): %v", err)
+	}
+	if id != bead.ID {
+		t.Fatalf("resolved ID = %q, want adopted bead %q", id, bead.ID)
+	}
+}
+
+func TestResolveConfiguredNamedSessionID_AdoptsCanonicalRuntimeSessionNameBeadWithoutIdentityMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+		}},
+	}
+	spec, ok := findNamedSessionSpec(cfg, config.EffectiveCityName(cfg, filepath.Base(cityPath)), "mayor")
+	if !ok {
+		t.Fatal("findNamedSessionSpec(mayor) = false")
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": spec.SessionName,
+			"template":     "mayor",
+			"agent_name":   "mayor",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(): %v", err)
+	}
+
+	id, matched, err := resolveConfiguredNamedSessionID(cityPath, cfg, store, "mayor", namedSessionResolveOptions{})
+	if err != nil {
+		t.Fatalf("resolveConfiguredNamedSessionID(mayor): %v", err)
+	}
+	if !matched {
+		t.Fatalf("matched = false, want true")
 	}
 	if id != bead.ID {
 		t.Fatalf("resolved ID = %q, want adopted bead %q", id, bead.ID)

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -27,7 +27,7 @@ func (s *listQueryCaptureStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 func TestResolveConfiguredNamedSessionID_BoundedListCalls(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{
-		Workspace: config.Workspace{Name: "test-city"},
+		Workspace: config.Workspace{Name: "test-city", SessionTemplate: "{{.City}}--{{.Agent}}"},
 		Agents: []config.Agent{{
 			Name:         "mayor",
 			StartCommand: "true",
@@ -94,7 +94,7 @@ func TestResolveConfiguredNamedSessionID_BoundedListCalls(t *testing.T) {
 func TestResolveConfiguredNamedSessionID_BoundedConflictListCalls(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{
-		Workspace: config.Workspace{Name: "test-city"},
+		Workspace: config.Workspace{Name: "test-city", SessionTemplate: "{{.City}}--{{.Agent}}"},
 		Agents: []config.Agent{{
 			Name:         "mayor",
 			StartCommand: "true",
@@ -137,8 +137,8 @@ func TestResolveConfiguredNamedSessionID_BoundedConflictListCalls(t *testing.T) 
 	if len(store.listCalls) == 0 {
 		t.Fatalf("expected at least one List call")
 	}
-	if len(store.listCalls) > 5 {
-		t.Fatalf("List calls = %d, want bounded small constant", len(store.listCalls))
+	if len(store.listCalls) > 4 {
+		t.Fatalf("List calls = %d, want bounded small constant without duplicate session_name lookup", len(store.listCalls))
 	}
 	for i, q := range store.listCalls {
 		if len(q.Metadata) == 0 {

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -3970,11 +3970,8 @@ func assertSessionResolverMetadataFilteredListCalls(t *testing.T, calls []beads.
 		t.Fatal("expected at least one List call")
 	}
 	for i, query := range calls {
-		if query.Label != session.LabelSession {
-			t.Fatalf("List call #%d Label = %q, want %q", i, query.Label, session.LabelSession)
-		}
 		if len(query.Metadata) == 0 {
-			t.Fatalf("List call #%d has no metadata filter (would scan all session beads): %+v", i, query)
+			t.Fatalf("List call #%d has no metadata filter (would scan broad bead sets): %+v", i, query)
 		}
 	}
 }

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -217,6 +217,16 @@ func (s *cachedOnlyListStoreForSessionTest) CachedList(query beads.ListQuery) ([
 	return rows, true
 }
 
+type apiListQueryCaptureStore struct {
+	beads.Store
+	listCalls []beads.ListQuery
+}
+
+func (s *apiListQueryCaptureStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls = append(s.listCalls, query)
+	return s.Store.List(query)
+}
+
 type partialPrimeSessionStore struct {
 	*beads.MemStore
 	partialRows    []beads.Bead
@@ -3854,6 +3864,118 @@ func TestResolveSessionIDMaterializingNamed_QualifiedAliasBasenameDoesNotStealNa
 	}
 	if got := bead.Metadata[apiNamedSessionMetadataKey]; got != "true" {
 		t.Fatalf("configured_named_session = %q, want true", got)
+	}
+}
+
+func TestResolveConfiguredNamedSessionIDWithContext_BoundedListCalls(t *testing.T) {
+	fs := newSessionFakeState(t)
+	store := &apiListQueryCaptureStore{Store: beads.NewMemStore()}
+	fs.cityBeadStore = store
+	srv := New(fs)
+
+	spec, ok, err := srv.findNamedSessionSpecForTarget(store, "worker")
+	if err != nil {
+		t.Fatalf("findNamedSessionSpecForTarget(worker): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected named session spec for worker")
+	}
+	for i := 0; i < 200; i++ {
+		if _, err := store.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"session_name": fmt.Sprintf("worker-%d", i),
+			},
+		}); err != nil {
+			t.Fatalf("create irrelevant session %d: %v", i, err)
+		}
+	}
+	target, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":             spec.SessionName,
+			"alias":                    spec.Identity,
+			apiNamedSessionMetadataKey: "true",
+			apiNamedSessionIdentityKey: spec.Identity,
+			apiNamedSessionModeKey:     spec.Mode,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create canonical named session: %v", err)
+	}
+
+	id, matched, err := srv.resolveConfiguredNamedSessionIDWithContext(context.Background(), store, "worker", apiSessionResolveOptions{})
+	if err != nil {
+		t.Fatalf("resolveConfiguredNamedSessionIDWithContext(worker): %v", err)
+	}
+	if !matched {
+		t.Fatal("matched = false, want true")
+	}
+	if id != target.ID {
+		t.Fatalf("id = %q, want canonical %q", id, target.ID)
+	}
+	if len(store.listCalls) != 1 {
+		t.Fatalf("List calls = %d, want 1 canonical lookup", len(store.listCalls))
+	}
+	assertSessionResolverMetadataFilteredListCalls(t, store.listCalls)
+}
+
+func TestResolveConfiguredNamedSessionIDWithContext_BoundedConflictListCalls(t *testing.T) {
+	fs := newSessionFakeState(t)
+	store := &apiListQueryCaptureStore{Store: beads.NewMemStore()}
+	fs.cityBeadStore = store
+	srv := New(fs)
+
+	spec, ok, err := srv.findNamedSessionSpecForTarget(store, "worker")
+	if err != nil {
+		t.Fatalf("findNamedSessionSpecForTarget(worker): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected named session spec for worker")
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": spec.SessionName,
+			"template":     "other/worker",
+			"agent_name":   "other/worker",
+			"state":        "asleep",
+		},
+	}); err != nil {
+		t.Fatalf("create wrong-template runtime bead: %v", err)
+	}
+
+	_, matched, err := srv.resolveConfiguredNamedSessionIDWithContext(context.Background(), store, "worker", apiSessionResolveOptions{})
+	if err == nil {
+		t.Fatal("resolveConfiguredNamedSessionIDWithContext(worker) succeeded, want conflict")
+	}
+	if !matched {
+		t.Fatal("matched = false, want true")
+	}
+	if !errors.Is(err, errConfiguredNamedSessionConflict) {
+		t.Fatalf("error = %v, want errConfiguredNamedSessionConflict", err)
+	}
+	if len(store.listCalls) > 4 {
+		t.Fatalf("List calls = %d, want bounded small constant without duplicate session_name lookup", len(store.listCalls))
+	}
+	assertSessionResolverMetadataFilteredListCalls(t, store.listCalls)
+}
+
+func assertSessionResolverMetadataFilteredListCalls(t *testing.T, calls []beads.ListQuery) {
+	t.Helper()
+	if len(calls) == 0 {
+		t.Fatal("expected at least one List call")
+	}
+	for i, query := range calls {
+		if query.Label != session.LabelSession {
+			t.Fatalf("List call #%d Label = %q, want %q", i, query.Label, session.LabelSession)
+		}
+		if len(query.Metadata) == 0 {
+			t.Fatalf("List call #%d has no metadata filter (would scan all session beads): %+v", i, query)
+		}
 	}
 }
 

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -136,11 +136,10 @@ func (s *Server) findCanonicalNamedSession(store beads.Store, spec apiNamedSessi
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
-	candidates, err := session.NamedSessionResolutionCandidates(store, spec)
+	bead, ok, err := session.FindCanonicalConfiguredNamedSessionBead(store, spec)
 	if err != nil {
-		return beads.Bead{}, false, fmt.Errorf("listing named session candidates: %w", err)
+		return beads.Bead{}, false, fmt.Errorf("looking up canonical named session: %w", err)
 	}
-	bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec)
 	return bead, ok, nil
 }
 
@@ -227,20 +226,15 @@ func (s *Server) resolveConfiguredNamedSessionIDWithContext(ctx context.Context,
 	if !ok {
 		return "", false, fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 	}
-	bead, hasCanonical, err := s.findCanonicalNamedSession(store, spec)
+	lookup, err := session.LookupConfiguredNamedSession(store, spec)
 	if err != nil {
-		return "", true, err
+		return "", true, fmt.Errorf("looking up configured named session: %w", err)
 	}
-	if hasCanonical {
-		return bead.ID, true, nil
+	if lookup.HasCanonical {
+		return lookup.Canonical.ID, true, nil
 	}
-
-	all, err := session.NamedSessionResolutionCandidates(store, spec)
-	if err != nil {
-		return "", true, fmt.Errorf("listing named session candidates: %w", err)
-	}
-	if bead, conflict := session.FindNamedSessionConflict(all, spec); conflict {
-		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errConfiguredNamedSessionConflict, identifier, spec.Identity, bead.ID)
+	if lookup.HasConflict {
+		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errConfiguredNamedSessionConflict, identifier, spec.Identity, lookup.Conflict.ID)
 	}
 
 	if !opts.materialize {

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -214,6 +214,133 @@ func BeadConflictsWithNamedSession(b beads.Bead, spec NamedSessionSpec) bool {
 	return false
 }
 
+// ConfiguredNamedSessionLookup is the bounded lookup result for a configured named session.
+type ConfiguredNamedSessionLookup struct {
+	Canonical    beads.Bead
+	HasCanonical bool
+	Conflict     beads.Bead
+	HasConflict  bool
+}
+
+// FindCanonicalConfiguredNamedSessionBead finds the live bead that owns a
+// configured named session using exact metadata-filtered store queries.
+func FindCanonicalConfiguredNamedSessionBead(store beads.Store, spec NamedSessionSpec) (beads.Bead, bool, error) {
+	lookup, err := lookupConfiguredNamedSession(store, spec, false)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	return lookup.Canonical, lookup.HasCanonical, nil
+}
+
+// LookupConfiguredNamedSession finds the canonical bead or first live conflict
+// for a configured named session using exact metadata-filtered store queries.
+func LookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec) (ConfiguredNamedSessionLookup, error) {
+	return lookupConfiguredNamedSession(store, spec, true)
+}
+
+func lookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec, includeConflict bool) (ConfiguredNamedSessionLookup, error) {
+	if store == nil {
+		return ConfiguredNamedSessionLookup{}, nil
+	}
+	spec.Identity = NormalizeNamedSessionTarget(spec.Identity)
+	spec.SessionName = strings.TrimSpace(spec.SessionName)
+	if spec.Identity == "" && spec.SessionName == "" {
+		return ConfiguredNamedSessionLookup{}, nil
+	}
+
+	candidates := make([]beads.Bead, 0, 4)
+	seen := make(map[string]bool)
+	var runtimeSessionNameMatches []beads.Bead
+
+	if spec.Identity != "" {
+		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, NamedSessionIdentityMetadata, spec.Identity)
+		if err != nil {
+			return ConfiguredNamedSessionLookup{}, fmt.Errorf("listing canonical named session candidates: %w", err)
+		}
+		candidates = appendUniqueNamedSessionCandidates(candidates, seen, matches)
+		if bead, ok := FindCanonicalNamedSessionBead(candidates, spec); ok {
+			return ConfiguredNamedSessionLookup{Canonical: bead, HasCanonical: true}, nil
+		}
+	}
+
+	if spec.SessionName != "" {
+		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, "session_name", spec.SessionName)
+		if err != nil {
+			return ConfiguredNamedSessionLookup{}, fmt.Errorf("listing canonical named session candidates by session_name: %w", err)
+		}
+		runtimeSessionNameMatches = matches
+		candidates = appendUniqueNamedSessionCandidates(candidates, seen, matches)
+		if bead, ok := FindCanonicalNamedSessionBead(candidates, spec); ok {
+			return ConfiguredNamedSessionLookup{Canonical: bead, HasCanonical: true}, nil
+		}
+	}
+
+	if spec.Identity != "" && spec.Identity != spec.SessionName {
+		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, "session_name", spec.Identity)
+		if err != nil {
+			return ConfiguredNamedSessionLookup{}, fmt.Errorf("listing canonical named session candidates by bare identity: %w", err)
+		}
+		candidates = appendUniqueNamedSessionCandidates(candidates, seen, matches)
+		if bead, ok := FindCanonicalNamedSessionBead(candidates, spec); ok {
+			return ConfiguredNamedSessionLookup{Canonical: bead, HasCanonical: true}, nil
+		}
+	}
+
+	if !includeConflict {
+		return ConfiguredNamedSessionLookup{}, nil
+	}
+
+	conflictCandidates := append([]beads.Bead{}, runtimeSessionNameMatches...)
+	if spec.Identity != "" {
+		matches, err := listConfiguredNamedSessionBeadsByMetadata(store, "alias", spec.Identity)
+		if err != nil {
+			return ConfiguredNamedSessionLookup{}, fmt.Errorf("listing alias conflicts: %w", err)
+		}
+		conflictCandidates = appendUniqueNamedSessionCandidates(conflictCandidates, make(map[string]bool, len(conflictCandidates)+len(matches)), matches)
+	}
+	if bead, conflict := FindNamedSessionConflict(conflictCandidates, spec); conflict {
+		return ConfiguredNamedSessionLookup{Conflict: bead, HasConflict: true}, nil
+	}
+	return ConfiguredNamedSessionLookup{}, nil
+}
+
+func listConfiguredNamedSessionBeadsByMetadata(store beads.Store, key, value string) ([]beads.Bead, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	items, err := store.List(beads.ListQuery{
+		Label:    LabelSession,
+		Metadata: map[string]string{key: value},
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := items[:0]
+	for _, b := range items {
+		if !IsSessionBeadOrRepairable(b) {
+			continue
+		}
+		RepairEmptyType(store, &b)
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+func appendUniqueNamedSessionCandidates(dst []beads.Bead, seen map[string]bool, src []beads.Bead) []beads.Bead {
+	for _, b := range dst {
+		seen[b.ID] = true
+	}
+	for _, b := range src {
+		if seen[b.ID] {
+			continue
+		}
+		dst = append(dst, b)
+		seen[b.ID] = true
+	}
+	return dst
+}
+
 // NamedSessionResolutionCandidates returns the live session beads that can own
 // or conflict with the configured named-session spec.
 //
@@ -229,7 +356,8 @@ func BeadConflictsWithNamedSession(b beads.Bead, spec NamedSessionSpec) bool {
 // the four metadata predicates into one label-scoped scan caps per-resolve
 // bd invocations at one and bounds the candidate set by the active
 // session count, which is small. Measured under 20-parallel load on a
-// representative city: 5.2s → 1.3s.
+// representative city: 5.2s → 1.3s. Interactive session-targeting paths
+// that must avoid label-wide scans use LookupConfiguredNamedSession instead.
 func NamedSessionResolutionCandidates(store beads.Store, spec NamedSessionSpec) ([]beads.Bead, error) {
 	if store == nil {
 		return nil, nil

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -234,6 +234,9 @@ func FindCanonicalConfiguredNamedSessionBead(store beads.Store, spec NamedSessio
 
 // LookupConfiguredNamedSession finds the canonical bead or first live conflict
 // for a configured named session using exact metadata-filtered store queries.
+// The result is stitched from several sequential store reads; downstream
+// uniqueness and claim serialization remain the authority under concurrent
+// bead mutation.
 func LookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec) (ConfiguredNamedSessionLookup, error) {
 	return lookupConfiguredNamedSession(store, spec, true)
 }
@@ -305,18 +308,18 @@ func lookupConfiguredNamedSession(store beads.Store, spec NamedSessionSpec, incl
 }
 
 func listConfiguredNamedSessionBeadsByMetadata(store beads.Store, key, value string) ([]beads.Bead, error) {
+	key = strings.TrimSpace(key)
 	value = strings.TrimSpace(value)
-	if value == "" {
+	if key == "" || value == "" {
 		return nil, nil
 	}
 	items, err := store.List(beads.ListQuery{
-		Label:    LabelSession,
 		Metadata: map[string]string{key: value},
 	})
 	if err != nil {
 		return nil, err
 	}
-	out := items[:0]
+	out := make([]beads.Bead, 0, len(items))
 	for _, b := range items {
 		if !IsSessionBeadOrRepairable(b) {
 			continue

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -393,6 +393,63 @@ func (s *listCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	return s.MemStore.List(query)
 }
 
+func TestLookupConfiguredNamedSession_BoundedConflictQueries(t *testing.T) {
+	store := &listCountingStore{MemStore: beads.NewMemStore()}
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	conflict, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": spec.SessionName,
+			"template":     "other",
+			"agent_name":   "other",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(conflict): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if !lookup.HasConflict {
+		t.Fatal("HasConflict = false, want true")
+	}
+	if lookup.Conflict.ID != conflict.ID {
+		t.Fatalf("Conflict.ID = %q, want %q", lookup.Conflict.ID, conflict.ID)
+	}
+	if len(store.queries) > 4 {
+		t.Fatalf("List calls = %d, want bounded small constant without duplicate session_name lookup", len(store.queries))
+	}
+	for i, query := range store.queries {
+		if query.Label != LabelSession {
+			t.Fatalf("query #%d Label = %q, want %q", i, query.Label, LabelSession)
+		}
+		if len(query.Metadata) == 0 {
+			t.Fatalf("query #%d has no metadata filter: %+v", i, query)
+		}
+	}
+}
+
+func TestLookupConfiguredNamedSession_EmptySpecNoListCall(t *testing.T) {
+	store := &listCountingStore{MemStore: beads.NewMemStore()}
+
+	lookup, err := LookupConfiguredNamedSession(store, NamedSessionSpec{})
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession(empty): %v", err)
+	}
+	if lookup.HasCanonical || lookup.HasConflict {
+		t.Fatalf("lookup = %+v, want empty result", lookup)
+	}
+	if len(store.queries) != 0 {
+		t.Fatalf("List calls = %d, want 0", len(store.queries))
+	}
+}
+
 func TestNamedSessionResolutionCandidates_SingleListByLabel(t *testing.T) {
 	store := &listCountingStore{MemStore: beads.NewMemStore()}
 	canonical, err := store.Create(beads.Bead{

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -426,12 +426,82 @@ func TestLookupConfiguredNamedSession_BoundedConflictQueries(t *testing.T) {
 		t.Fatalf("List calls = %d, want bounded small constant without duplicate session_name lookup", len(store.queries))
 	}
 	for i, query := range store.queries {
-		if query.Label != LabelSession {
-			t.Fatalf("query #%d Label = %q, want %q", i, query.Label, LabelSession)
-		}
 		if len(query.Metadata) == 0 {
 			t.Fatalf("query #%d has no metadata filter: %+v", i, query)
 		}
+	}
+}
+
+func TestLookupConfiguredNamedSession_AcceptsTypeOnlyCanonicalBead(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	canonical, err := store.Create(beads.Bead{
+		Type: BeadType,
+		Metadata: map[string]string{
+			NamedSessionMetadataKey:      "true",
+			NamedSessionIdentityMetadata: spec.Identity,
+			"session_name":               spec.SessionName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(canonical): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if !lookup.HasCanonical {
+		t.Fatal("HasCanonical = false, want true")
+	}
+	if lookup.Canonical.ID != canonical.ID {
+		t.Fatalf("Canonical.ID = %q, want %q", lookup.Canonical.ID, canonical.ID)
+	}
+}
+
+func TestLookupConfiguredNamedSession_ReportsSessionNameConflictBeforeAliasConflict(t *testing.T) {
+	store := beads.NewMemStore()
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	aliasConflict, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias":      spec.Identity,
+			"template":   "other",
+			"agent_name": "other",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(alias conflict): %v", err)
+	}
+	sessionNameConflict, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": spec.SessionName,
+			"template":     "other",
+			"agent_name":   "other",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session_name conflict): %v", err)
+	}
+
+	lookup, err := LookupConfiguredNamedSession(store, spec)
+	if err != nil {
+		t.Fatalf("LookupConfiguredNamedSession: %v", err)
+	}
+	if !lookup.HasConflict {
+		t.Fatal("HasConflict = false, want true")
+	}
+	if lookup.Conflict.ID != sessionNameConflict.ID {
+		t.Fatalf("Conflict.ID = %q, want session_name conflict %q before alias conflict %q", lookup.Conflict.ID, sessionNameConflict.ID, aliasConflict.ID)
 	}
 }
 

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -20,6 +20,9 @@ var (
 // live identifiers: open exact session_name matches first, then open exact
 // current alias matches. Normal session targeting does not fall through to
 // template, agent_name, or historical alias compatibility identifiers.
+// When a bead has both alias and session_name equal to the identifier, a
+// separate session_name-only bead owns the identifier; the dual bead remains
+// the session_name match only when no other session_name match exists.
 //
 // Returns ErrSessionNotFound if no live match is found, or ErrAmbiguous
 // (wrapped with details) if multiple sessions match the identifier.
@@ -58,29 +61,51 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		return "", err
 	}
 
-	bySessionName, err := listSessionBeadsByMetadata(store, "session_name", identifier, allowClosed)
+	lookupIdentifier := strings.TrimSpace(identifier)
+	if lookupIdentifier == "" {
+		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
+	}
+
+	bySessionName, err := listSessionBeadsByMetadata(store, "session_name", lookupIdentifier, false)
 	if err != nil {
 		return "", fmt.Errorf("listing sessions by session_name: %w", err)
 	}
-	byAlias, err := listSessionBeadsByMetadata(store, "alias", identifier, allowClosed)
+	bySessionName = filterOutAliasMatches(bySessionName, lookupIdentifier)
+	if len(bySessionName) > 0 {
+		return chooseSessionMatch(identifier, bySessionName)
+	}
+
+	byAlias, err := listSessionBeadsByMetadata(store, "alias", lookupIdentifier, false)
 	if err != nil {
 		return "", fmt.Errorf("listing sessions by alias: %w", err)
 	}
-	bySessionName = filterOutAliasMatches(bySessionName, identifier)
-
-	openSessionName, closedSessionName := splitOpen(bySessionName)
-	if len(openSessionName) > 0 {
-		return chooseSessionMatch(identifier, openSessionName)
-	}
-	openAlias, closedAlias := splitOpen(byAlias)
-	if len(openAlias) > 0 {
-		return chooseSessionMatch(identifier, openAlias)
+	if len(byAlias) > 0 {
+		return chooseSessionMatch(identifier, byAlias)
 	}
 	if !allowClosed {
 		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
 	}
+
+	bySessionName, err = listSessionBeadsByMetadata(store, "session_name", lookupIdentifier, true)
+	if err != nil {
+		return "", fmt.Errorf("listing closed sessions by session_name: %w", err)
+	}
+	bySessionName = filterOutAliasMatches(bySessionName, lookupIdentifier)
+	openSessionName, closedSessionName := splitOpen(bySessionName)
+	if len(openSessionName) > 0 {
+		return chooseSessionMatch(identifier, openSessionName)
+	}
 	if len(closedSessionName) > 0 {
 		return chooseSessionMatch(identifier, closedSessionName)
+	}
+
+	byAlias, err = listSessionBeadsByMetadata(store, "alias", lookupIdentifier, true)
+	if err != nil {
+		return "", fmt.Errorf("listing closed sessions by alias: %w", err)
+	}
+	openAlias, closedAlias := splitOpen(byAlias)
+	if len(openAlias) > 0 {
+		return chooseSessionMatch(identifier, openAlias)
 	}
 	if len(closedAlias) > 0 {
 		return chooseSessionMatch(identifier, closedAlias)
@@ -89,15 +114,19 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 }
 
 func listSessionBeadsByMetadata(store beads.Store, key, value string, allowClosed bool) ([]beads.Bead, error) {
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		return nil, nil
+	}
 	raw, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
 		Metadata:      map[string]string{key: value},
 		IncludeClosed: allowClosed,
 	})
 	if err != nil {
 		return nil, err
 	}
-	out := raw[:0]
+	out := make([]beads.Bead, 0, len(raw))
 	for _, b := range raw {
 		if !IsSessionBeadOrRepairable(b) {
 			continue

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -66,6 +66,7 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 	if err != nil {
 		return "", fmt.Errorf("listing sessions by alias: %w", err)
 	}
+	bySessionName = filterOutAliasMatches(bySessionName, identifier)
 
 	openSessionName, closedSessionName := splitOpen(bySessionName)
 	if len(openSessionName) > 0 {
@@ -105,6 +106,17 @@ func listSessionBeadsByMetadata(store beads.Store, key, value string, allowClose
 		out = append(out, b)
 	}
 	return out, nil
+}
+
+func filterOutAliasMatches(in []beads.Bead, identifier string) []beads.Bead {
+	out := in[:0]
+	for _, b := range in {
+		if strings.TrimSpace(b.Metadata["alias"]) == identifier {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
 }
 
 func splitOpen(in []beads.Bead) (open, closed []beads.Bead) {

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -109,6 +109,18 @@ func listSessionBeadsByMetadata(store beads.Store, key, value string, allowClose
 }
 
 func filterOutAliasMatches(in []beads.Bead, identifier string) []beads.Bead {
+	hasSessionNameOnlyMatch := false
+	for _, b := range in {
+		if strings.TrimSpace(b.Metadata["alias"]) != identifier {
+			hasSessionNameOnlyMatch = true
+			break
+		}
+	}
+	if !hasSessionNameOnlyMatch {
+		return in
+	}
+	// Demote dual alias/session_name beads only when another session_name
+	// match can own the identifier; otherwise session_name still wins.
 	out := in[:0]
 	for _, b := range in {
 		if strings.TrimSpace(b.Metadata["alias"]) == identifier {

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -58,43 +58,64 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		return "", err
 	}
 
-	openSessionNameMatches, err := ExactMetadataSessionCandidates(store, false, map[string]string{"session_name": identifier})
+	bySessionName, err := listSessionBeadsByMetadata(store, "session_name", identifier, allowClosed)
 	if err != nil {
-		return "", fmt.Errorf("listing sessions: %w", err)
+		return "", fmt.Errorf("listing sessions by session_name: %w", err)
 	}
-	openAliasMatches, err := ExactMetadataSessionCandidates(store, false, map[string]string{"alias": identifier})
+	byAlias, err := listSessionBeadsByMetadata(store, "alias", identifier, allowClosed)
 	if err != nil {
-		return "", fmt.Errorf("listing sessions: %w", err)
+		return "", fmt.Errorf("listing sessions by alias: %w", err)
 	}
 
-	for _, matches := range [][]beads.Bead{
-		openSessionNameMatches,
-		openAliasMatches,
-	} {
-		if len(matches) > 0 {
-			return chooseSessionMatch(identifier, matches)
-		}
+	openSessionName, closedSessionName := splitOpen(bySessionName)
+	if len(openSessionName) > 0 {
+		return chooseSessionMatch(identifier, openSessionName)
+	}
+	openAlias, closedAlias := splitOpen(byAlias)
+	if len(openAlias) > 0 {
+		return chooseSessionMatch(identifier, openAlias)
 	}
 	if !allowClosed {
 		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
 	}
-	closedSessionNameMatches, err := ExactMetadataSessionCandidatesWithStatus(store, "closed", map[string]string{"session_name": identifier})
-	if err != nil {
-		return "", fmt.Errorf("listing sessions: %w", err)
+	if len(closedSessionName) > 0 {
+		return chooseSessionMatch(identifier, closedSessionName)
 	}
-	closedAliasMatches, err := ExactMetadataSessionCandidatesWithStatus(store, "closed", map[string]string{"alias": identifier})
-	if err != nil {
-		return "", fmt.Errorf("listing sessions: %w", err)
-	}
-	for _, matches := range [][]beads.Bead{
-		closedSessionNameMatches,
-		closedAliasMatches,
-	} {
-		if len(matches) > 0 {
-			return chooseSessionMatch(identifier, matches)
-		}
+	if len(closedAlias) > 0 {
+		return chooseSessionMatch(identifier, closedAlias)
 	}
 	return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
+}
+
+func listSessionBeadsByMetadata(store beads.Store, key, value string, allowClosed bool) ([]beads.Bead, error) {
+	raw, err := store.List(beads.ListQuery{
+		Label:         LabelSession,
+		Metadata:      map[string]string{key: value},
+		IncludeClosed: allowClosed,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := raw[:0]
+	for _, b := range raw {
+		if !IsSessionBeadOrRepairable(b) {
+			continue
+		}
+		RepairEmptyType(store, &b)
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+func splitOpen(in []beads.Bead) (open, closed []beads.Bead) {
+	for _, b := range in {
+		if b.Status == "closed" {
+			closed = append(closed, b)
+			continue
+		}
+		open = append(open, b)
+	}
+	return open, closed
 }
 
 func chooseSessionMatch(identifier string, matches []beads.Bead) (string, error) {

--- a/internal/session/resolve_test.go
+++ b/internal/session/resolve_test.go
@@ -250,6 +250,73 @@ func TestResolveSessionID_SessionNameExactMatch(t *testing.T) {
 	}
 }
 
+func TestResolveSessionID_SessionNameExactMatchAcceptsTypeOnlySessionBead(t *testing.T) {
+	store := beads.NewMemStore()
+	b, _ := store.Create(beads.Bead{
+		Type: session.BeadType,
+		Metadata: map[string]string{
+			"session_name": "s-gc-legacy",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, "s-gc-legacy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
+func TestResolveSessionID_AliasExactMatchAcceptsTypeOnlySessionBead(t *testing.T) {
+	store := beads.NewMemStore()
+	b, _ := store.Create(beads.Bead{
+		Type: session.BeadType,
+		Metadata: map[string]string{
+			"alias": "legacy",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, "legacy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
+func TestResolveSessionID_TrimsMetadataIdentifier(t *testing.T) {
+	store := beads.NewMemStore()
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, " worker ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
+func TestResolveSessionID_WhitespaceOnlyIdentifierDoesNotList(t *testing.T) {
+	store := &listCountingStore{Store: beads.NewMemStore()}
+
+	_, err := session.ResolveSessionID(store, "   ")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("ResolveSessionID(whitespace) = %v, want ErrSessionNotFound", err)
+	}
+	if len(store.listCalls) != 0 {
+		t.Fatalf("List calls = %d, want 0 for empty trimmed metadata identifier", len(store.listCalls))
+	}
+}
+
 func TestResolveSessionID_PrefersSessionNameOverAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{
@@ -414,6 +481,33 @@ func TestResolveSessionIDAllowClosed_ResolvesClosedSessionName(t *testing.T) {
 	}
 	if id != b.ID {
 		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
+func TestResolveSessionIDAllowClosed_OpenHitStaysCacheServed(t *testing.T) {
+	backing := &listCountingStore{Store: beads.NewMemStore()}
+	b, _ := backing.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	backing.listCalls = nil
+
+	id, err := session.ResolveSessionIDAllowClosed(cache, "sky")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+	if len(backing.listCalls) != 0 {
+		t.Fatalf("backing List calls = %d, want 0 for cached open match: %+v", len(backing.listCalls), backing.listCalls)
 	}
 }
 

--- a/internal/session/resolve_test.go
+++ b/internal/session/resolve_test.go
@@ -304,6 +304,33 @@ func TestResolveSessionID_PrefersSessionNameOverDualAliasSessionNameBead(t *test
 	}
 }
 
+func TestResolveSessionID_DualAliasSessionNameBeadWinsWhenNoOtherSessionNameMatch(t *testing.T) {
+	store := beads.NewMemStore()
+	dual, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "worker",
+		},
+	})
+	_, _ = store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias": "worker",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, "worker")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != dual.ID {
+		t.Fatalf("got %q, want dual session-name match %q", id, dual.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveHistoricalAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{

--- a/internal/session/resolve_test.go
+++ b/internal/session/resolve_test.go
@@ -277,6 +277,33 @@ func TestResolveSessionID_PrefersSessionNameOverAlias(t *testing.T) {
 	}
 }
 
+func TestResolveSessionID_PrefersSessionNameOverDualAliasSessionNameBead(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "worker",
+		},
+	})
+	named, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, "worker")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != named.ID {
+		t.Fatalf("got %q, want session-name-only match %q", id, named.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveHistoricalAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{
@@ -688,6 +715,9 @@ func TestResolveSessionID_BoundedListCalls(t *testing.T) {
 	}
 	if len(store.listCalls) == 0 {
 		t.Fatalf("expected at least one List call")
+	}
+	if len(store.listCalls) != 2 {
+		t.Fatalf("List calls = %d, want 2", len(store.listCalls))
 	}
 	for i, q := range store.listCalls {
 		if len(q.Metadata) == 0 {

--- a/internal/session/resolve_test.go
+++ b/internal/session/resolve_test.go
@@ -2,11 +2,22 @@ package session_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/session"
 )
+
+type listCountingStore struct {
+	beads.Store
+	listCalls []beads.ListQuery
+}
+
+func (s *listCountingStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls = append(s.listCalls, q)
+	return s.Store.List(q)
+}
 
 func TestResolveSessionID_DirectLookup(t *testing.T) {
 	store := beads.NewMemStore()
@@ -651,6 +662,37 @@ func TestRepairEmptyType_NoopForNonEmpty(t *testing.T) {
 	session.RepairEmptyType(store, &b)
 	if b.Type != session.BeadType {
 		t.Errorf("type = %q, want %q", b.Type, session.BeadType)
+	}
+}
+
+func TestResolveSessionID_BoundedListCalls(t *testing.T) {
+	inner := beads.NewMemStore()
+	for i := 0; i < 200; i++ {
+		_, _ = inner.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"session_name": fmt.Sprintf("worker-%d", i),
+			},
+		})
+	}
+	target, _ := inner.Create(beads.Bead{
+		Type:     session.BeadType,
+		Labels:   []string{session.LabelSession},
+		Metadata: map[string]string{"alias": "mayor"},
+	})
+	store := &listCountingStore{Store: inner}
+	id, err := session.ResolveSessionID(store, "mayor")
+	if err != nil || id != target.ID {
+		t.Fatalf("resolve failed: id=%q err=%v", id, err)
+	}
+	if len(store.listCalls) == 0 {
+		t.Fatalf("expected at least one List call")
+	}
+	for i, q := range store.listCalls {
+		if len(q.Metadata) == 0 {
+			t.Fatalf("List call #%d has no metadata filter (would scan all beads): %+v", i, q)
+		}
 	}
 }
 

--- a/release-gates/ga-3m01-bounded-session-resolve-gate.md
+++ b/release-gates/ga-3m01-bounded-session-resolve-gate.md
@@ -1,55 +1,67 @@
-# Release gate — bound session resolve list calls (ga-3m01)
+# Release gate - bound session resolve list calls (ga-3m01)
 
-**Verdict:** PASS
+**Verdict:** LOCAL FIXES READY FOR RE-REVIEW
 
-Branch: `release/ga-3m01-bounded-session-resolve` (cut fresh off `origin/main` @ `07005b57`)
-Commit (cherry-picked): `2977299d` — perf(session): bound alias resolve list calls via metadata filters (ga-3m01)
+Branch: `release/ga-3m01-bounded-session-resolve`
+Base: `origin/main` at adopted PR creation
+PR: `gastownhall/gascity#1241`
 
-Source SHA on builder branch (fork/gc-builder-1-01561d4fb9ea): `515f2f92`. Cherry-picked clean (zero conflicts).
+Final adopted branch scope:
 
-Diff vs `origin/main`: 4 files changed, +184/-51 lines:
-- `cmd/gc/session_resolve.go` (+22/-4)
-- `cmd/gc/session_resolve_test.go` (+75/-0)
-- `internal/session/resolve.go` (+45/-47)
-- `internal/session/resolve_test.go` (+42/-0)
+- `e5718407c` - perf(session): bound alias resolve list calls via metadata filters
+- `18eb8268a` - fix(session): preserve bounded resolver semantics
+- `5d5db8a09` - fix(session): share bounded named-session lookup
+- Maintainer review fixup - restore trimmed metadata lookup semantics, preserve type-only session bead recovery, keep allow-closed open hits cache-served, document the resolver precedence rules, and refresh this gate evidence.
 
-## Review
+Current diff vs `refs/adopt-pr/ga-houfq0/upstream-base` spans these files:
 
-| Review bead | Reviews   | Verdict | Reviewer             |
-|-------------|-----------|---------|----------------------|
-| ga-lixd     | ga-3m01   | PASS    | gascity/reviewer-1   |
+- `cmd/gc/session_resolve.go`
+- `cmd/gc/session_resolve_test.go`
+- `internal/api/handler_sessions_test.go`
+- `internal/api/session_resolution.go`
+- `internal/session/named_config.go`
+- `internal/session/named_config_test.go`
+- `internal/session/resolve.go`
+- `internal/session/resolve_test.go`
+- `release-gates/ga-3m01-bounded-session-resolve-gate.md`
 
-Reviewer message (`gm-wisp-buz`): *"ga-lixd PASS. The fix bounds resolveSessionID and resolveConfiguredNamedSessionID via metadata-keyed store.List queries; resolveOpenQualifiedAliasBasename intentionally unchanged per spec exception. All resolver tests pass; preexisting cmd/gc failures (mail / city-flag / nudge-materialize) reproduce on baseline HEAD without this commit and are not regressions."*
+## Review State
 
-Gemini second-pass: disabled per current rig configuration.
+The original reviewer pass applied only to the first cherry-picked perf commit. Adopt-PR review attempt 2 later requested changes for whitespace normalization, the allow-closed cache path, resolver contract documentation, deterministic conflict coverage, and this stale gate evidence. Review attempt 3 then caught that exact metadata lookups had become label-prefiltered and no longer reached legacy type-only session beads.
+
+This local fixup addresses those findings. A fresh synthesis and quality scorecard still need to approve the local HEAD before the workflow can move to human approval or merge.
 
 ## Criteria
 
-| # | Criterion                             | Verdict | Evidence |
-|---|---------------------------------------|---------|----------|
-| 1 | Review PASS present                   | PASS    | reviewer-1 PASS on ga-lixd via mail `gm-wisp-buz`. |
-| 2 | Acceptance criteria met               | PASS    | Done-when items from ga-3m01 all green: `TestResolveSessionID_BoundedListCalls` and `TestResolveConfiguredNamedSessionID_BoundedListCalls` pass; existing tests in `internal/session/resolve_test.go` and `cmd/gc/session_resolve_test.go` unchanged and passing; `go vet ./...` clean; `resolveOpenQualifiedAliasBasename` left intact per spec exception. |
-| 3 | Tests pass                            | PASS    | Targeted: `go test ./internal/session/ -count=1` → ok 4.4s; `go test -run 'TestResolveSessionID\|TestResolveConfiguredNamedSessionID' ./cmd/gc/ -count=1` → ok 0.075s. Full `./...` has the same package-level failures in `cmd/gc`, `internal/doctor`, `internal/runtime/k8s` as `origin/main` baseline — preexisting, no regressions (see below). |
-| 4 | No high-severity review findings open | PASS    | Reviewer reported no findings. resolveOpenQualifiedAliasBasename exception is acknowledged in the bead spec. |
-| 5 | Final branch is clean                 | PASS    | `git status` clean (only this gate file untracked at write time). |
-| 6 | Branch diverges cleanly from main     | PASS    | `git cherry-pick 515f2f92` onto fresh branch off `origin/main` applied with zero conflicts. |
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Resolver lookups remain bounded | PASS | `TestResolveSessionID_BoundedListCalls`, `TestResolveConfiguredNamedSessionID_BoundedListCalls`, API configured-session tests, and named-session lookup tests assert metadata-filtered queries instead of broad session scans. |
+| 2 | Existing identifier semantics preserved | PASS | `TestResolveSessionID_TrimsMetadataIdentifier` covers the old trim-before-metadata-lookup behavior; `TestResolveSessionID_WhitespaceOnlyIdentifierDoesNotList` covers empty trimmed inputs. |
+| 3 | Type-only session beads remain recoverable | PASS | `TestResolveSessionID_SessionNameExactMatchAcceptsTypeOnlySessionBead`, `TestResolveSessionID_AliasExactMatchAcceptsTypeOnlySessionBead`, and `TestLookupConfiguredNamedSession_AcceptsTypeOnlyCanonicalBead` cover metadata matches on `Type == "session"` beads without the `gc:session` label. |
+| 4 | Allow-closed open hits stay cache-served | PASS | `TestResolveSessionIDAllowClosed_OpenHitStaysCacheServed` primes a `CachingStore` and asserts an open allow-closed hit does not issue backing `List` calls. |
+| 5 | Dual alias/session-name precedence is documented | PASS | `ResolveSessionID` godoc now states that a session-name-only bead owns the identifier over a dual alias/session-name bead, while a single dual bead still resolves. |
+| 6 | Configured named-session conflicts are deterministic | PASS | `TestLookupConfiguredNamedSession_ReportsSessionNameConflictBeforeAliasConflict` pins session-name conflicts before alias conflicts. |
+| 7 | Release evidence covers final branch | PASS | This gate lists the post-review branch files and validation commands instead of the original four-file cherry-pick only. |
+| 8 | Fresh review approval | PENDING | Required by the adopt-PR workflow after this local fixup. |
 
-## Build / vet
+## Validation
 
-- `go vet ./...` → clean
-- Cherry-pick clean (no conflicts)
+Commands run on the adopted worktree:
 
-## Pre-existing failures (not introduced)
+- `go test ./internal/session -run 'TestResolveSessionID_TrimsMetadataIdentifier|TestResolveSessionID_WhitespaceOnlyIdentifierDoesNotList|TestResolveSessionIDAllowClosed_OpenHitStaysCacheServed|TestLookupConfiguredNamedSession_ReportsSessionNameConflictBeforeAliasConflict' -count=1` -> pass
+- `go test ./internal/session -run 'TestResolveSessionID_SessionNameExactMatchAcceptsTypeOnlySessionBead|TestResolveSessionID_AliasExactMatchAcceptsTypeOnlySessionBead|TestLookupConfiguredNamedSession_AcceptsTypeOnlyCanonicalBead' -count=1` -> pass
+- `go test ./internal/session -count=1` -> pass
+- `git diff --check` -> pass
+- `go test ./internal/api -run 'TestResolveConfiguredNamedSessionIDWithContext|TestHandleSessionSubmitMaterializesNamedSession|TestFindNamedSessionSpecForTarget' -count=1` -> pass
+- `go test ./cmd/gc -run 'TestResolveSessionID|TestResolveConfiguredNamedSessionID' -count=1` -> pass
+- `make test` -> pass
 
-Full-suite test on the branch shows 109 individual `--- FAIL` lines across 3 packages (`cmd/gc`, `internal/doctor`, `internal/runtime/k8s`); baseline `origin/main` shows 106. The three differential tests are:
+## Performance Evidence
 
-- `TestControllerReloadCommandReloadsConfigImmediately`
-- `TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout`
-- `TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabaseMissing`
+This gate no longer claims the older `5.2s -> 1.3s` wall-clock measurement for the new `LookupConfiguredNamedSession` path. The current evidence is structural: resolver tests assert bounded metadata-filtered query shapes and prevent broad session scans. A separate benchmark or production trace is required before publishing a wall-clock improvement number for this specific path.
 
-All three reproduce identically on `origin/main` when run targeted (no full-suite timeout). Failure mode in all three: `Error 1146 (HY000): table not found: metadata` from `gc dolt-state ensure-project-id` — unrelated to session-resolve, root cause is the same dolt-schema issue on both branches. The 109/106 differential is full-suite cmd/gc 600s timeout cutoff noise (which tests run before the timeout differs run-to-run), not a regression.
+The dispatcher attempt-route binding path intentionally remains on `NamedSessionResolutionCandidates`, whose one label-scoped scan is documented separately for high-concurrency dispatcher load. Migrating or remeasuring that path is outside this PR and should be handled as follow-up work if needed.
 
-## Push target
+## Push Target
 
-`fork` (quad341/gascity) — `origin` (gastownhall/gascity) is read-only from this rig (`git push --dry-run origin HEAD` → 403).
-PR cross-repo: `--head quad341:release/ga-3m01-bounded-session-resolve --base main`.
+Do not push from review-fix iterations. The finalize step owns any push, follow-up PR creation, or merge after fresh review and human approval.

--- a/release-gates/ga-3m01-bounded-session-resolve-gate.md
+++ b/release-gates/ga-3m01-bounded-session-resolve-gate.md
@@ -1,0 +1,55 @@
+# Release gate — bound session resolve list calls (ga-3m01)
+
+**Verdict:** PASS
+
+Branch: `release/ga-3m01-bounded-session-resolve` (cut fresh off `origin/main` @ `07005b57`)
+Commit (cherry-picked): `2977299d` — perf(session): bound alias resolve list calls via metadata filters (ga-3m01)
+
+Source SHA on builder branch (fork/gc-builder-1-01561d4fb9ea): `515f2f92`. Cherry-picked clean (zero conflicts).
+
+Diff vs `origin/main`: 4 files changed, +184/-51 lines:
+- `cmd/gc/session_resolve.go` (+22/-4)
+- `cmd/gc/session_resolve_test.go` (+75/-0)
+- `internal/session/resolve.go` (+45/-47)
+- `internal/session/resolve_test.go` (+42/-0)
+
+## Review
+
+| Review bead | Reviews   | Verdict | Reviewer             |
+|-------------|-----------|---------|----------------------|
+| ga-lixd     | ga-3m01   | PASS    | gascity/reviewer-1   |
+
+Reviewer message (`gm-wisp-buz`): *"ga-lixd PASS. The fix bounds resolveSessionID and resolveConfiguredNamedSessionID via metadata-keyed store.List queries; resolveOpenQualifiedAliasBasename intentionally unchanged per spec exception. All resolver tests pass; preexisting cmd/gc failures (mail / city-flag / nudge-materialize) reproduce on baseline HEAD without this commit and are not regressions."*
+
+Gemini second-pass: disabled per current rig configuration.
+
+## Criteria
+
+| # | Criterion                             | Verdict | Evidence |
+|---|---------------------------------------|---------|----------|
+| 1 | Review PASS present                   | PASS    | reviewer-1 PASS on ga-lixd via mail `gm-wisp-buz`. |
+| 2 | Acceptance criteria met               | PASS    | Done-when items from ga-3m01 all green: `TestResolveSessionID_BoundedListCalls` and `TestResolveConfiguredNamedSessionID_BoundedListCalls` pass; existing tests in `internal/session/resolve_test.go` and `cmd/gc/session_resolve_test.go` unchanged and passing; `go vet ./...` clean; `resolveOpenQualifiedAliasBasename` left intact per spec exception. |
+| 3 | Tests pass                            | PASS    | Targeted: `go test ./internal/session/ -count=1` → ok 4.4s; `go test -run 'TestResolveSessionID\|TestResolveConfiguredNamedSessionID' ./cmd/gc/ -count=1` → ok 0.075s. Full `./...` has the same package-level failures in `cmd/gc`, `internal/doctor`, `internal/runtime/k8s` as `origin/main` baseline — preexisting, no regressions (see below). |
+| 4 | No high-severity review findings open | PASS    | Reviewer reported no findings. resolveOpenQualifiedAliasBasename exception is acknowledged in the bead spec. |
+| 5 | Final branch is clean                 | PASS    | `git status` clean (only this gate file untracked at write time). |
+| 6 | Branch diverges cleanly from main     | PASS    | `git cherry-pick 515f2f92` onto fresh branch off `origin/main` applied with zero conflicts. |
+
+## Build / vet
+
+- `go vet ./...` → clean
+- Cherry-pick clean (no conflicts)
+
+## Pre-existing failures (not introduced)
+
+Full-suite test on the branch shows 109 individual `--- FAIL` lines across 3 packages (`cmd/gc`, `internal/doctor`, `internal/runtime/k8s`); baseline `origin/main` shows 106. The three differential tests are:
+
+- `TestControllerReloadCommandReloadsConfigImmediately`
+- `TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout`
+- `TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabaseMissing`
+
+All three reproduce identically on `origin/main` when run targeted (no full-suite timeout). Failure mode in all three: `Error 1146 (HY000): table not found: metadata` from `gc dolt-state ensure-project-id` — unrelated to session-resolve, root cause is the same dolt-schema issue on both branches. The 109/106 differential is full-suite cmd/gc 600s timeout cutoff noise (which tests run before the timeout differs run-to-run), not a regression.
+
+## Push target
+
+`fork` (quad341/gascity) — `origin` (gastownhall/gascity) is read-only from this rig (`git push --dry-run origin HEAD` → 403).
+PR cross-repo: `--head quad341:release/ga-3m01-bounded-session-resolve --base main`.


### PR DESCRIPTION
## What this changes

`gc session attach <name>` and every command that resolves a session by
identifier (peek, kill, nudge, submit, suspend, etc.) used to issue 2-3
unbounded `store.List(Label: gc:session)` calls per invocation to map
an alias or session name to a session ID. On a beads store where `bd
list` falls into the slow hydrate-labels query path, each unbounded
list inherits a 120s timeout, so attach (and friends) wedge waiting
for bd to scan every session bead.

This bounds the resolver to metadata-keyed queries. `resolveSessionID`
now does two targeted lists (`{session_name: <id>}` and
`{alias: <id>}`) instead of one label-wide scan, and
`resolveConfiguredNamedSessionID` does three (canonical-by-identity +
session_name conflicts + alias conflicts) instead of loading the full
session-bead snapshot. Each list returns at most a handful of beads,
so resolver latency is constant in the size of the city's session
history.

Behavior is preserved:

- ordering invariant — open `session_name` outranks open `alias`,
  closed `session_name` outranks closed `alias`
- `allowClosed=false` still hides closed beads
- `ErrAmbiguous` still returned on duplicate matches
- `ErrSessionNotFound` still returned on miss
- `FindCanonicalNamedSessionBead` and `FindNamedSessionConflict`
  signatures unchanged — they get bounded slices instead of a full
  snapshot

## Review notes

- **One documented exception kept:** `resolveOpenQualifiedAliasBasename`
  (`cmd/gc/session_resolve.go:204`) still does a label-only list. It is
  only reached when both prior steps fail AND the identifier has no
  slash, so it is not on the hot path for configured named sessions or
  most manual aliases. Removing it requires either a new
  `alias_basename` derived metadata key (with backfill) or a `LIKE`
  query that bd does not support — separate bead.
- **No new exported API.** `listSessionBeadsByMetadata` and `splitOpen`
  are unexported helpers in `internal/session/resolve.go`.
- **Tests assert the perf invariant directly.** Both
  `TestResolveSessionID_BoundedListCalls` and
  `TestResolveConfiguredNamedSessionID_BoundedListCalls` seed a 200-bead
  store, wrap it with a List-counting decorator, and assert every List
  call carries a non-empty `Metadata` filter. Without the fix the
  decorator records label-only queries and the tests fail.

## Test plan

- [x] `go test ./internal/session/ -count=1` — passes (4.4s).
- [x] `go test -run 'TestResolveSessionID|TestResolveConfiguredNamedSessionID' ./cmd/gc/ -count=1` — passes (0.075s).
- [x] `go vet ./...` clean.
- [x] Full `./...` suite has no new failures vs `origin/main` baseline (the 3 differential tests reproduce identically on baseline with the same `Error 1146 (HY000): table not found: metadata` failure mode — unrelated dolt-schema issue, not a regression).
- [x] Release gate: [`release-gates/ga-3m01-bounded-session-resolve-gate.md`](release-gates/ga-3m01-bounded-session-resolve-gate.md)