### PR TITLE
Reduce cmd/gc test runtime under two minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       packs: ${{ steps.filter.outputs.packs }}
       worker: ${{ steps.filter.outputs.worker }}
       worker_phase2: ${{ steps.filter.outputs.worker_phase2 }}
+      cmd_gc_process: ${{ steps.filter.outputs.cmd_gc_process }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
@@ -70,6 +71,14 @@ jobs:
               - 'internal/runtime/**'
               - 'internal/config/**'
               - 'cmd/gc/**'
+            cmd_gc_process:
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/**'
+              - 'Makefile'
+              - 'cmd/gc/**'
+              - 'internal/**'
+              - 'examples/gastown/packs/**'
 
   # Always runs: lint, fmt, vet, unit tests, docs, acceptance, coverage.
   check:
@@ -151,10 +160,7 @@ jobs:
   cmd-gc-process:
     name: cmd/gc process suite
     needs: changes
-    if: >-
-      needs.changes.outputs.worker_phase2 == 'true' ||
-      needs.changes.outputs.beads == 'true' ||
-      needs.changes.outputs.packs == 'true'
+    if: needs.changes.outputs.cmd_gc_process == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,30 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+  cmd-gc-process:
+    name: cmd/gc process suite
+    needs: changes
+    if: >-
+      needs.changes.outputs.worker_phase2 == 'true' ||
+      needs.changes.outputs.beads == 'true' ||
+      needs.changes.outputs.packs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DOLT_VERSION: "1.86.1"
+      BD_VERSION: "v1.0.0"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Run cmd/gc process suite
+        run: make test-cmd-gc-process
+
   # Runs always, but remains non-blocking while integration/provider paths are still stabilizing.
   integration-shards:
     name: Integration / ${{ matrix.shard_name }}

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ TEST_ENV = env -i \
 
 ## test: run fast unit tests (skip integration-tagged and GC_FAST_UNIT-gated process tests)
 ## The skipped cmd/gc process-backed scenarios remain covered by
-## `make test-cmd-gc-process` locally and the CI `test-integration-packages` shard.
+## `make test-cmd-gc-process` locally and the CI `cmd/gc process suite` job.
 ## Wrapped in $(TEST_ENV) — see comment above for why.
 test:
 	$(TEST_ENV) GC_FAST_UNIT=1 go test ./...
@@ -171,7 +171,7 @@ test:
 ## test-cmd-gc-process: run the full non-short cmd/gc suite, including the
 ## process-backed lifecycle coverage routed out of the default fast loop
 test-cmd-gc-process:
-	$(TEST_ENV) GC_FAST_UNIT=0 go test ./cmd/gc
+	$(TEST_ENV) GC_FAST_UNIT=0 go test -count=1 -timeout 20m ./cmd/gc
 
 ## test-worker-core: run deterministic worker transcript and continuation conformance
 test-worker-core:
@@ -348,7 +348,7 @@ UNIT_COVER_PKGS := $(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.Im
 
 ## test-cover: run fast unit-test coverage without the integration-tagged package sweep
 ## The skipped cmd/gc process-backed scenarios remain covered by
-## `make test-cmd-gc-process` locally and the CI `test-integration-packages` shard.
+## `make test-cmd-gc-process` locally and the CI `cmd/gc process suite` job.
 test-cover:
 	$(TEST_ENV) GC_FAST_UNIT=1 go test -timeout 8m -coverprofile=coverage.txt $(UNIT_COVER_PKGS)
 

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -130,6 +130,9 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 	if err := cs.PrimeActive(); err != nil {
 		log.Printf("caching-store: pre-prime failed: %v", err)
 	}
+	if ctx.Done() == nil {
+		return cs
+	}
 	// Full prime runs async — backfills remaining beads for List()
 	// callers (convergence reconcile, sweep, API handlers).
 	go func() {

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -429,7 +429,7 @@ func ensureBeadsProvider(cityPath string) error {
 // For exec providers, fires "stop". For file providers, always available.
 func shutdownBeadsProvider(cityPath string) error {
 	if cityUsesBdStoreContract(cityPath) && strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
-		return nil
+		return clearManagedDoltRuntimeStateIfOwned(cityPath)
 	}
 	provider := beadsProvider(cityPath)
 	if strings.HasPrefix(provider, "exec:") {

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -428,6 +428,9 @@ func ensureBeadsProvider(cityPath string) error {
 // Called by gc stop after agents have been terminated.
 // For exec providers, fires "stop". For file providers, always available.
 func shutdownBeadsProvider(cityPath string) error {
+	if cityUsesBdStoreContract(cityPath) && strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+		return nil
+	}
 	provider := beadsProvider(cityPath)
 	if strings.HasPrefix(provider, "exec:") {
 		if providerUsesBdStoreContract(provider) && isExternalDolt(cityPath) {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -758,6 +758,31 @@ func TestShutdownBeadsProvider_bd_skip(t *testing.T) {
 	}
 }
 
+func TestShutdownBeadsProviderBdSkipClearsPublishedRuntimeState(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	MaterializeBuiltinPacks(dir) //nolint:errcheck
+	if err := writeDoltState(dir, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      33123,
+		DataDir:   filepath.Join(dir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltState: %v", err)
+	}
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	if err := shutdownBeadsProvider(dir); err != nil {
+		t.Fatalf("shutdownBeadsProvider() error = %v", err)
+	}
+	if _, err := os.Stat(managedDoltStatePath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("published dolt runtime state still present, stat err = %v", err)
+	}
+}
+
 func TestCurrentDoltPortPrefersRuntimeState(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3613,6 +3613,7 @@ esac
 }
 
 func TestGcBeadsBdInitBackfillsRepoIDMigrationWhenMetadataExistsWithoutProjectID(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs the materialized gc-beads-bd init script with GC_BIN helper; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -5967,13 +5968,36 @@ func TestGcBeadsBdStartConcurrentWaitPassesRemainingExistingManagedBudget(t *tes
 		t.Fatal(err)
 	}
 	invocationFile := filepath.Join(t.TempDir(), "gc-invocation")
+	nowFile := filepath.Join(t.TempDir(), "gc-now-ms")
 	fakeGC := filepath.Join(binDir, "gc")
 	fakeGCScript := fmt.Sprintf(`#!/bin/sh
 set -eu
 invocation_file=%q
+now_file=%q
 subcmd="$1 $2"
 shift 2
 case "$subcmd" in
+  "dolt-state now-ms")
+    if [ -f "$now_file" ]; then
+      step=$(cat "$now_file")
+    else
+      step=0
+    fi
+    case "$step" in
+      0)
+        printf '1000000\n'
+        printf '1\n' > "$now_file"
+        ;;
+      1)
+        printf '1000000\n'
+        printf '2\n' > "$now_file"
+        ;;
+      *)
+        printf '1001000\n'
+        printf '3\n' > "$now_file"
+        ;;
+    esac
+    ;;
   "dolt-state runtime-layout")
     while [ "$#" -gt 0 ]; do
       case "$1" in
@@ -6044,7 +6068,7 @@ case "$subcmd" in
     exit 64
     ;;
 esac
-`, invocationFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
+`, invocationFile, nowFile, layout.PackStateDir, layout.DataDir, layout.LogFile, layout.StateFile, layout.PIDFile, layout.LockFile, layout.ConfigFile)
 	if err := os.WriteFile(fakeGC, []byte(fakeGCScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -6353,6 +6377,7 @@ func TestGcBeadsBdRecoverHelperPreservesReadOnlyWarning(t *testing.T) {
 }
 
 func TestManagedDoltConfigGoWriterMatchesShellFallbackSemantics(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the materialized gc-beads-bd shell fallback; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -7763,6 +7788,7 @@ func TestNormalizeCanonicalBdScopeFilesMaterializesMissingMetadata(t *testing.T)
 }
 
 func TestGcBeadsBdStartFallsBackToShellManagedConfigWriterWhenGCBinUnset(t *testing.T) {
+	skipSlowCmdGCTest(t, "starts the materialized gc-beads-bd shell fallback; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -536,6 +536,7 @@ func TestBuildDesiredState_RoutedQueueDoesNotCreateOneSessionPerBead(t *testing.
 }
 
 func TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession(t *testing.T) {
+	skipSlowCmdGCTest(t, "uses real bd subprocesses for routed-work scale checks; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
 	if err != nil {
 		t.Skip("bd not installed")
@@ -2207,6 +2208,7 @@ func TestBuildDesiredState_PoolCheckUsesExplicitRigPassword(t *testing.T) {
 }
 
 func TestBuildDesiredState_PoolCheckUsesManagedCityDoltPortWhenRigHasNoOverride(t *testing.T) {
+	skipSlowCmdGCTest(t, "uses a live managed-dolt port probe for scale_check coverage; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "myrig")

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -271,14 +271,17 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		lastProviderName = v
 	}
 
-	cityRoot := filepath.Dir(cr.tomlPath)
+	cityRoot := cr.cityPath
+	if cityRoot == "" && cr.tomlPath != "" {
+		cityRoot = filepath.Dir(cr.tomlPath)
+	}
 
 	// Enforce restrictive permissions on .gc/ and its subdirectories.
 	enforceGCPermissions(cr.cityPath, cr.stderr)
 
 	// Open standalone city bead store when controllerState is unavailable.
 	// When controllerState is present, it manages the cached city store.
-	if cr.cs == nil {
+	if cr.cs == nil && cityRoot != "" {
 		if store, err := openCityStoreAt(cityRoot); err != nil {
 			fmt.Fprintf(cr.stderr, "%s: city bead store: %v (auto-suspend disabled)\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 		} else {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1216,6 +1216,7 @@ func TestCityRuntimeBeadReconcileTick_SweepRespectsLiveAssignedWork(t *testing.T
 }
 
 func TestCityRuntimeTick_RefreshesManualSessionOverlayAfterSync(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs a full runtime tick/reconcile path; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, "prompts"), 0o755); err != nil {
 		t.Fatalf("mkdir prompts: %v", err)

--- a/cmd/gc/cityinit_impl_test.go
+++ b/cmd/gc/cityinit_impl_test.go
@@ -298,6 +298,7 @@ func TestLocalInitializerScaffoldPreservesExistingDirectoryWhenRegisterFails(t *
 }
 
 func TestLocalInitializerInitScaffoldsAndFinalizes(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs the full local init scaffold/finalize path; run make test-cmd-gc-process for full coverage")
 	configureTestDoltIdentityEnv(t)
 	cityPath := filepath.Join(t.TempDir(), "init-city")
 

--- a/cmd/gc/cmd_beads_city_test.go
+++ b/cmd/gc/cmd_beads_city_test.go
@@ -87,6 +87,7 @@ func TestDoBeadsCityEndpointSupportsExecGcBeadsBdProvider(t *testing.T) {
 }
 
 func TestDoBeadsCityUseExternalWritesVerifiedCityAndInheritedRigs(t *testing.T) {
+	skipSlowCmdGCTest(t, "exercises managed bd provider transition behavior; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 
 	cityDir := t.TempDir()
@@ -184,6 +185,7 @@ func TestDoBeadsCityUseExternalWritesVerifiedCityAndInheritedRigs(t *testing.T) 
 }
 
 func TestDoBeadsCityUseExternalUpdatesIncludedInheritedRigs(t *testing.T) {
+	skipSlowCmdGCTest(t, "exercises managed bd provider transition behavior; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 
 	cityDir := t.TempDir()
@@ -414,6 +416,7 @@ func TestDoBeadsCityUseExternalStopFailureKeepsExternalConfig(t *testing.T) {
 }
 
 func TestDoBeadsCityUseExternalRewritesCompatRigWithRelativePath(t *testing.T) {
+	skipSlowCmdGCTest(t, "exercises managed bd provider transition behavior; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 
 	cityDir := t.TempDir()
@@ -509,6 +512,7 @@ func TestDoBeadsCityUseExternalPreservesCompatOnlyExplicitRigs(t *testing.T) {
 }
 
 func TestDoBeadsCityUseExternalAdoptUnverifiedSkipsValidation(t *testing.T) {
+	skipSlowCmdGCTest(t, "exercises managed bd provider transition behavior; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 
 	cityDir := t.TempDir()

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -328,6 +328,7 @@ func TestDoltStateAllocatePortCmdReusesLiveProviderState(t *testing.T) {
 }
 
 func TestStartTCPListenerProcessInDirRegistersCleanup(t *testing.T) {
+	skipSlowCmdGCTest(t, "spawns a TCP listener process and verifies cleanup; run make test-cmd-gc-process for full coverage")
 	port := reserveRandomTCPPort(t)
 	dir := t.TempDir()
 	var proc *exec.Cmd
@@ -1202,7 +1203,7 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 }
 
 func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
-	skipSlowCmdGCTest(t, "spawns managed dolt holder processes; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "spawns managed dolt holder processes; run make test-cmd-gc-process for full coverage")
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
@@ -1249,6 +1250,7 @@ func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 
 func startTCPListenerProcessInDir(t *testing.T, port int, dir string) *exec.Cmd {
 	t.Helper()
+	skipSlowCmdGCTest(t, "spawns a TCP listener process to emulate managed dolt; run make test-cmd-gc-process for full coverage")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", dir, err)
 	}
@@ -1297,6 +1299,7 @@ while True:
 
 func startLockedDelayedTCPListenerProcessInDir(t *testing.T, lockFile string, port int, dir string, delay time.Duration) *exec.Cmd {
 	t.Helper()
+	skipSlowCmdGCTest(t, "spawns a delayed TCP listener process to emulate managed dolt recovery; run make test-cmd-gc-process for full coverage")
 	if err := os.MkdirAll(filepath.Dir(lockFile), 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(lockFile), err)
 	}
@@ -2131,7 +2134,7 @@ func TestDoltStateStopManagedCmdDoesNotKillImposterPortHolder(t *testing.T) {
 }
 
 func TestDoltStateRecoverManagedCmdReportsReadOnlyAndRestarts(t *testing.T) {
-	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -2488,7 +2491,7 @@ esac
 }
 
 func TestDoltStateRecoverManagedCmdClearsPublishedStateWhenPreflightCleanupFails(t *testing.T) {
-	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -2563,7 +2566,7 @@ func TestDoltStateRecoverManagedCmdClearsPublishedStateWhenPreflightCleanupFails
 }
 
 func TestDoltStateRecoverManagedCmdFailsWhenPostStartHealthFails(t *testing.T) {
-	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -529,8 +529,8 @@ func resolveMailTargetsForCommand(identifier string, stderr io.Writer, cmdName s
 	if identifier == "" || identifier == "human" {
 		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, true
 	}
-	if rawTarget, ok := resolveRawMailTargetForStorelessProvider(identifier, stderr, cmdName); ok {
-		return rawTarget, true
+	if isStorelessMailProvider() {
+		return resolveRawMailTargetForStorelessProvider(identifier, stderr, cmdName)
 	}
 	store, code := openCityStore(stderr, cmdName)
 	if store == nil {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -489,6 +489,11 @@ func TestResolveDefaultMailTargetsForCommand_StorelessProviderUsesFirstCandidate
 	t.Setenv("GC_ALIAS", "codeprobe-worker-1")
 	t.Setenv("GC_SESSION_ID", "codeprobe-worker-gc-1941")
 	t.Setenv("GC_AGENT", "codeprobe-worker")
+	prev := openMailTargetStore
+	openMailTargetStore = func() (beads.Store, error) {
+		return nil, fmt.Errorf("not in a city directory")
+	}
+	t.Cleanup(func() { openMailTargetStore = prev })
 
 	var stderr bytes.Buffer
 	target, ok := resolveDefaultMailTargetsForCommand(&stderr, "gc mail inbox")
@@ -568,6 +573,11 @@ func TestDefaultMailIdentityFallsBackToHumanWithoutAliasSessionOrAgent(t *testin
 
 func TestResolveMailAddressForCommand_AllowsStorelessMailProvider(t *testing.T) {
 	t.Setenv("GC_MAIL", "fake")
+	prev := openMailTargetStore
+	openMailTargetStore = func() (beads.Store, error) {
+		return nil, fmt.Errorf("not in a city directory")
+	}
+	t.Cleanup(func() { openMailTargetStore = prev })
 
 	var stderr bytes.Buffer
 	address, ok := resolveMailAddressForCommand("robot", &stderr, "gc mail inbox")

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1066,7 +1066,7 @@ func TestCanonicalValidationPasswordUsesCredentialsFileOverride(t *testing.T) {
 }
 
 func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T) {
-	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run make test-cmd-gc-process for full coverage")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")
@@ -1167,7 +1167,7 @@ func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T
 }
 
 func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) {
-	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run make test-cmd-gc-process for full coverage")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")
@@ -1271,7 +1271,7 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 }
 
 func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
-	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run make test-cmd-gc-process for full coverage")
 	doltPath, err := exec.LookPath("dolt")
 	if err != nil {
 		t.Skip("dolt not installed")

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -306,6 +306,7 @@ func TestResolveSessionLogPathFallsBackWhenSessionKeyFileMissing(t *testing.T) {
 }
 
 func TestResolveStoredSessionLogSource_UniqueWorkDirFallsBackBeyondLatestAlias(t *testing.T) {
+	skipSlowCmdGCTest(t, "probes provider transcript lookup before workdir fallback; run make test-cmd-gc-process for full coverage")
 	store := beads.NewMemStore()
 	workDir := t.TempDir()
 	searchBase := t.TempDir()

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -126,6 +126,7 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 }
 
 func TestStopCityManagedBeadsProviderIfRunningStopsDefaultBD(t *testing.T) {
+	skipSlowCmdGCTest(t, "exercises managed bd provider shutdown; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 
 	cityDir := t.TempDir()

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -215,7 +215,7 @@ func TestRegisterCityWithSupervisorRetriesControllerLockInitFailure(t *testing.T
 }
 
 func TestRegisterCityWithSupervisorKeepsRegistrationWhenReloadFails(t *testing.T) {
-	skipSlowCmdGCTest(t, "exercises supervisor registration retry behavior; run without -short for scenario coverage")
+	skipSlowCmdGCTest(t, "exercises supervisor registration retry behavior; run make test-cmd-gc-process for scenario coverage")
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
 

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -72,7 +72,7 @@ func waitTestEnv(overrides map[string]string) []string {
 
 func waitTestRealBDPath(t *testing.T) string {
 	t.Helper()
-	skipSlowCmdGCTest(t, "requires a managed bd lifecycle city; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed bd lifecycle city; run make test-cmd-gc-process for full coverage")
 	waitTestRealBDPathOnce.Do(func() {
 		for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 			if strings.TrimSpace(dir) == "" {
@@ -1270,6 +1270,7 @@ func setupFreshManagedBdWaitTestCity(t *testing.T) (string, string) {
 
 func setupManagedBdWaitTestCity(t *testing.T) (string, string) {
 	t.Helper()
+	skipSlowCmdGCTest(t, "requires a managed bd/dolt lifecycle city; run make test-cmd-gc-process for full coverage")
 	configureIsolatedRuntimeEnv(t)
 
 	bdPath := waitTestRealBDPath(t)

--- a/cmd/gc/dolt_gc_nudge_script_test.go
+++ b/cmd/gc/dolt_gc_nudge_script_test.go
@@ -286,6 +286,7 @@ func TestDoltGCNudgeDefaultCallTimeoutMatchesOrderBudget(t *testing.T) {
 }
 
 func TestDoltGCNudgeBoundsGCCall(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs dolt GC nudge shell timeout coverage; run make test-cmd-gc-process for full coverage")
 	if _, err := exec.LookPath("timeout"); err != nil {
 		if _, gtimeoutErr := exec.LookPath("gtimeout"); gtimeoutErr != nil {
 			t.Skip("timeout/gtimeout not available")
@@ -344,6 +345,7 @@ func TestDoltGCNudgeFailsClosedWithoutBoundedRunner(t *testing.T) {
 }
 
 func TestDoltGCNudgeFallbackLockHonorsFlockHolder(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs dolt GC nudge shell lock contention coverage; run make test-cmd-gc-process for full coverage")
 	cityPath := writeDoltGCNudgeCity(t)
 	sleepPath, err := exec.LookPath("sleep")
 	if err != nil {
@@ -396,6 +398,7 @@ func TestDoltGCNudgeFallbackLockHonorsFlockHolder(t *testing.T) {
 }
 
 func TestDoltGCNudgeLockNormalizesLocalHostAliases(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs dolt GC nudge shell lock contention coverage; run make test-cmd-gc-process for full coverage")
 	cityPath := writeDoltGCNudgeCity(t)
 	sleepPath, err := exec.LookPath("sleep")
 	if err != nil {
@@ -453,6 +456,7 @@ func TestDoltGCNudgeLockNormalizesLocalHostAliases(t *testing.T) {
 }
 
 func TestDoltGCNudgeLockIgnoresDifferentTmpDirs(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs dolt GC nudge shell lock contention coverage; run make test-cmd-gc-process for full coverage")
 	cityPath := writeDoltGCNudgeCity(t)
 	sleepPath, err := exec.LookPath("sleep")
 	if err != nil {

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -83,6 +83,7 @@ func TestFileOpenedByAnyProcessBoundsLsof(t *testing.T) {
 }
 
 func TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs managed-dolt preflight cleanup against filesystem locks; run make test-cmd-gc-process for full coverage")
 	dataDir := t.TempDir()
 	lockFile := filepath.Join(dataDir, "hq", ".dolt", "noms", "LOCK")
 	if err := os.MkdirAll(filepath.Dir(lockFile), 0o755); err != nil {

--- a/cmd/gc/dolt_project_id_test.go
+++ b/cmd/gc/dolt_project_id_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabaseMissing(t *testing.T) {
-	skipSlowCmdGCTest(t, "requires a managed dolt server; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
 	doltPath := os.Getenv("GC_DOLT_REAL_BINARY")
 	var err error
 	if doltPath == "" {
@@ -258,7 +258,7 @@ func TestManagedDoltWaitReadyWithPasswordUsesDirectQueryProbe(t *testing.T) {
 }
 
 func TestRecoverManagedDoltProcessWithPasswordUsesDirectHelpersAgainstRealServer(t *testing.T) {
-	skipSlowCmdGCTest(t, "requires a managed dolt server; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -305,7 +305,7 @@ func TestRecoverManagedDoltProcessWithPasswordUsesDirectHelpersAgainstRealServer
 }
 
 func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWithPasswordedServer(t *testing.T) {
-	skipSlowCmdGCTest(t, "requires a managed dolt server; run without -short or via integration packages")
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
 	cityDir := t.TempDir()
 	metadataPath := filepath.Join(cityDir, ".beads", "metadata.json")
 	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o755); err != nil {

--- a/cmd/gc/fast_loop_helpers_test.go
+++ b/cmd/gc/fast_loop_helpers_test.go
@@ -14,7 +14,10 @@ import (
 
 func skipSlowCmdGCTest(t *testing.T, reason string) {
 	t.Helper()
-	if os.Getenv("GC_FAST_UNIT") == "1" || testing.Short() {
+	if testing.Short() || strings.TrimSpace(os.Getenv("GC_FAST_UNIT")) != "0" {
+		if strings.TrimSpace(os.Getenv("GC_FAST_UNIT")) == "" && !strings.Contains(reason, "test-cmd-gc-process") {
+			reason += "; set GC_FAST_UNIT=0 or run make test-cmd-gc-process for full process coverage"
+		}
 		t.Skip(reason)
 	}
 }
@@ -80,6 +83,7 @@ func reserveRandomTCPPort(t *testing.T) int {
 
 func startTCPListenerProcess(t *testing.T, port int) *exec.Cmd {
 	t.Helper()
+	skipSlowCmdGCTest(t, "spawns a TCP listener process to emulate managed dolt; run make test-cmd-gc-process for full coverage")
 	cmd := exec.Command("python3", "-c", `
 import signal
 import socket

--- a/cmd/gc/live_submit_probe_test.go
+++ b/cmd/gc/live_submit_probe_test.go
@@ -21,7 +21,7 @@ import (
 
 func preferRealBDOnPath(t *testing.T) {
 	t.Helper()
-	skipSlowCmdGCTest(t, "requires a live bd-managed session probe; run without -short")
+	skipSlowCmdGCTest(t, "requires a live bd-managed session probe; run make test-cmd-gc-process for full coverage")
 
 	currentPath := os.Getenv("PATH")
 	pathEntries := filepath.SplitList(currentPath)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -275,6 +275,9 @@ var cliStoreCache struct {
 // agents don't open the store repeatedly. Silently falls back to legacy
 // naming if the store is unavailable.
 func cliSessionName(cityPath, cityName, agentName, sessionTemplate string) string {
+	if strings.TrimSpace(cityPath) == "" {
+		return sessionName(nil, cityName, agentName, sessionTemplate)
+	}
 	cliStoreCache.mu.Lock()
 	if cliStoreCache.path != cityPath {
 		cliStoreCache.store, _ = openCityStoreAt(cityPath)

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -160,6 +160,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestTutorial01(t *testing.T) {
+	skipSlowCmdGCTest(t, "runs tutorial testscript scenarios; run make test-cmd-gc-process for full coverage")
 	testscript.Run(t, newTestscriptParams(t))
 }
 

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -101,6 +101,7 @@ func TestEvaluatePoolNonInteger(t *testing.T) {
 }
 
 func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
+	skipSlowCmdGCTest(t, "uses real bd and jq for default scale_check coverage; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
 	if err != nil {
 		t.Skip("bd not installed")
@@ -144,6 +145,7 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
 }
 
 func TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork(t *testing.T) {
+	skipSlowCmdGCTest(t, "uses real bd and jq for default scale_check coverage; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
 	if err != nil {
 		t.Skip("bd not installed")

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -541,6 +541,7 @@ func TestPrepareStartCandidate_UsesSessionIDForTaskWorkDir(t *testing.T) {
 }
 
 func TestExecutePlannedStarts_FreshWakeAfterDrainRetainsStartupContext(t *testing.T) {
+	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := runtime.NewFake()
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)}
@@ -2134,6 +2135,7 @@ func (p *dieAfterStartProvider) IsRunning(name string) bool {
 }
 
 func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
+	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
 	item := preparedStart{
 		candidate: startCandidate{

--- a/cmd/gc/test_gc_binary_test.go
+++ b/cmd/gc/test_gc_binary_test.go
@@ -24,9 +24,6 @@ func currentGCBinaryForTests(t *testing.T) string {
 			return
 		}
 		binPath := filepath.Join(buildDir, "gc")
-		goModCache := filepath.Join(buildDir, "gomodcache")
-		goCache := filepath.Join(buildDir, "gocache")
-		goPath := filepath.Join(buildDir, "gopath")
 		wd, err := os.Getwd()
 		if err != nil {
 			testGCBinaryErr = fmt.Errorf("getwd: %w", err)
@@ -34,11 +31,6 @@ func currentGCBinaryForTests(t *testing.T) string {
 		}
 		cmd := exec.Command("go", "build", "-o", binPath, ".")
 		cmd.Dir = wd
-		cmd.Env = append(os.Environ(),
-			"GOMODCACHE="+goModCache,
-			"GOCACHE="+goCache,
-			"GOPATH="+goPath,
-		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			testGCBinaryErr = fmt.Errorf("go build -o %s .: %w\n%s", binPath, err, string(out))

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -29,6 +29,7 @@ func (s *failingSessionLookupStore) List(beads.ListQuery) ([]beads.Bead, error) 
 }
 
 func TestWorkerHandleForSessionWithConfigUsesResolvedProviderOnFirstStart(t *testing.T) {
+	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]
 name = "test-city"
@@ -143,6 +144,7 @@ func TestResolvedWorkerRuntimeWithConfigUsesProviderLaunchCommand(t *testing.T) 
 }
 
 func TestWorkerHandleForSessionWithConfigUsesResolvedProviderOnResume(t *testing.T) {
+	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]
 name = "test-city"


### PR DESCRIPTION
## Summary
- preserve the original `cmd/gc` fast-loop/runtime cleanup changes from #1245 as a single contributor-authored commit
- add a maintainer follow-up so the `cmd/gc process suite` CI lane tracks the actual `cmd/gc` dependency surface instead of the narrower `worker_phase2` signal
- keep `shutdownBeadsProvider(..., GC_DOLT=skip)` clearing published managed-Dolt runtime state, with a regression test

Supersedes #1245.

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

## Validation
- pre-commit hook: generated docs checks, `golangci-lint run ./...`, `go vet ./...`, and `GC_FAST_UNIT=1 go test ./...`
- `go test ./cmd/gc -run 'TestShutdownBeadsProvider_(file|exec|bd_skip)$|TestShutdownBeadsProviderBdSkipClearsPublishedRuntimeState' -count=1`
