### PR TITLE
fix(reconciler): prevent re-writing stable session beads each tick

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -569,6 +569,12 @@ func recordWakeFailure(session *beads.Bead, store beads.Store, clk clock.Clock) 
 
 // clearWakeFailures resets crash counter and quarantine for a stable session.
 func clearWakeFailures(session *beads.Bead, store beads.Store) {
+	// Idempotent: writing here would form a self-poke loop via
+	// applyBeadEventToStores. See #1205. Mirrors clearChurn below.
+	wa := session.Metadata["wake_attempts"]
+	if (wa == "" || wa == "0") && session.Metadata["quarantined_until"] == "" {
+		return
+	}
 	batch := map[string]string{
 		"wake_attempts":     "0",
 		"quarantined_until": "",

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1072,6 +1072,51 @@ func TestClearWakeFailures(t *testing.T) {
 	}
 }
 
+// TestClearWakeFailures_NoopWhenCleared verifies the idempotency guard:
+// when wake_attempts and quarantined_until are already at their cleared
+// targets, clearWakeFailures must not write to the store. Without the
+// guard, every reconciler tick on a stable session emits a redundant
+// bd.update which self-pokes the reconciler via applyBeadEventToStores
+// — see #1205.
+func TestClearWakeFailures_NoopWhenCleared(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+	}{
+		{
+			name: "explicitly cleared values",
+			metadata: map[string]string{
+				"wake_attempts":     "0",
+				"quarantined_until": "",
+			},
+		},
+		{
+			name:     "fields absent",
+			metadata: map[string]string{},
+		},
+		{
+			name: "wake_attempts absent, quarantined_until empty",
+			metadata: map[string]string{
+				"quarantined_until": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore()
+			session := makeBead("b1", tt.metadata)
+
+			clearWakeFailures(&session, store)
+
+			// Should not have written to store (no-op).
+			if _, ok := store.metadata["b1"]; ok {
+				t.Error("clearWakeFailures should be a no-op when values are already cleared")
+			}
+		})
+	}
+}
+
 func TestStableLongEnough(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}


### PR DESCRIPTION
## Summary

- Add an idempotency guard to `clearWakeFailures` (`cmd/gc/session_reconcile.go:571`) so it skips its `SetMetadataBatch` write when `wake_attempts` and `quarantined_until` are already at their cleared targets.
- Mirrors the existing `clearChurn` early-exit pattern in the same file (line 699).
- Fixes #1205.

## Why

`clearWakeFailures` runs every reconciler tick on stable sessions. Pre-patch, it unconditionally calls `SetMetadataBatch` even when the values are already in place. Each no-op write produces a `bead.updated` event that the controller's own watcher (`cmd/gc/api_state.go:applyBeadEventToStores`) interprets as work and calls `cs.Poke()`, ticking the reconciler again. The result is a self-amplifying loop with tick latency as the only governor — measured at ~30 events/min on a macOS host and ~80 events/min in a clean Ubuntu 24.04 container with OAuth Claude.

Audited the 14 other `SetMetadata{,Batch}` sites on the reconciler tick path; `clearWakeFailures` is the only steady-state unconditional writer. All others are properly gated by `len(batch) > 0` or branch conditions.

Validated locally: 13 events flat for 10 min on host with the patch, vs. 162 events at t+6min unpatched. Same shape in the container (13 flat vs. 480 unpatched after ~8 min).

## Edge cases verified

- `wake_attempts == "00"` / whitespace / unicode: not reachable. Only writers are `recordWakeFailure` via `strconv.Itoa()` and `clearWakeFailures` itself which writes the literal `"0"`.
- `quarantined_until == "0001-01-01T00:00:00Z"`: not reachable. Only writer formats `clk.Now().Add(...).UTC().Format(time.RFC3339)`.
- Concurrent reads: `clearChurn` has the same shape with no reported race; the reconciler tick goroutine owns the session pointer for the duration of the tick.
- Absent fields: post-patch, an absent field stays absent rather than being force-set to `"0"`/`""`. All in-tree readers (`strconv.Atoi("")` → 0; `sessionIsQuarantined` checks non-empty) handle absent correctly.

## Testing

New regression test `TestClearWakeFailures_NoopWhenCleared` (table-driven, three subcases) asserts no store write occurs when fields are already at cleared targets. Mirrors `TestClearChurn_NoopWhenZero`.

## Checklist

- [x] Linked an issue, or explained why one is not needed: Fixes #1205
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — N/A (internal reconciler behavior)
- [x] Called out breaking changes or migration notes — none. Behavior delta: an absent metadata field stays absent rather than being force-set to `"0"` / `""`. All in-tree readers handle absent correctly.
