### PR TITLE
Fixing link in quickstart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -56,4 +56,4 @@ bd show <bead-id> --watch
 ```
 
 For a fuller walkthrough of the same path, continue to
-[Tutorial 01](/tutorials/01-cities-and-rigs).
+[Tutorial 01](/docs/tutorials/01-cities-and-rigs).


### PR DESCRIPTION
## Summary

-  existing link in quickstart doesn't resolve; just a typo fix