### PR TITLE
fix(prompt): scan city pack template-fragments/ for prompt rendering

### DIFF
--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -110,6 +110,13 @@ func renderPromptWithMeta(fs fsys.FS, cityPath, cityName, templatePath string, c
 		loadSharedTemplates(fs, tmpl, fragDir, stderr)
 	}
 
+	// V2: city pack's own template-fragments/. The city pack is the root of
+	// composition (per docs/packv2/doc-pack-v2.md) and its convention-discovered
+	// dirs apply pack-wide. The city pack wins over its imports but is
+	// overridden by per-agent fragments scanned below.
+	cityFragDir := filepath.Join(cityPath, "template-fragments")
+	loadSharedTemplates(fs, tmpl, cityFragDir, stderr)
+
 	// Load shared templates from sibling shared/ directory (highest priority —
 	// wins on name collision with cross-pack templates).
 	sharedDir := filepath.Join(filepath.Dir(sourcePath), "shared")

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -185,6 +185,37 @@ append_fragments = ["footer"]
 	}
 }
 
+// TestRenderPromptCityPackTemplateFragmentsLoad pins the contract from
+// docs/packv2/doc-pack-v2.md (line 50, 325, 394) and doc-directory-conventions.md
+// (line 429): the city pack's own top-level template-fragments/ directory is a
+// convention-discovered, pack-wide source of fragments. Without this scan,
+// fragments at <cityRoot>/template-fragments/ load only when the city itself is
+// imported as a pack — which is not how city packs work in V2 (they are the
+// root of composition, not an import target).
+func TestRenderPromptCityPackTemplateFragmentsLoad(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/agents/mayor/prompt.template.md"] = []byte("Hello")
+	f.Files["/city/template-fragments/footer.template.md"] = []byte(`{{ define "footer" }}Goodbye{{ end }}`)
+	got := renderPrompt(f, "/city", "", "agents/mayor/prompt.template.md", PromptContext{}, "", io.Discard, nil, []string{"footer"}, nil)
+	if got != "Hello\n\nGoodbye" {
+		t.Errorf("renderPrompt(city template-fragments) = %q, want %q", got, "Hello\n\nGoodbye")
+	}
+}
+
+// TestRenderPromptCityPackFragmentsBeatImports pins the precedence from
+// doc-pack-v2.md line 352: "the importing pack always wins over its imports".
+// City pack's template-fragments override imported pack fragments by name.
+func TestRenderPromptCityPackFragmentsBeatImports(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/agents/mayor/prompt.template.md"] = []byte("Hello")
+	f.Files["/city/imports/pkg/template-fragments/footer.template.md"] = []byte(`{{ define "footer" }}from-import{{ end }}`)
+	f.Files["/city/template-fragments/footer.template.md"] = []byte(`{{ define "footer" }}from-city{{ end }}`)
+	got := renderPrompt(f, "/city", "", "agents/mayor/prompt.template.md", PromptContext{}, "", io.Discard, []string{"/city/imports/pkg"}, []string{"footer"}, nil)
+	if got != "Hello\n\nfrom-city" {
+		t.Errorf("renderPrompt(city beats import) = %q, want %q", got, "Hello\n\nfrom-city")
+	}
+}
+
 func TestRenderPromptPatchedTemplateSuffixRenders(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files["/city/patches/gastown-mayor-prompt.template.md"] = []byte("Hello {{ .AgentName }}")


### PR DESCRIPTION
## Summary

The renderer never scans the city pack's own `template-fragments/` directory, so any fragment referenced via `[agent_defaults] append_fragments` from the city's `pack.toml` silently fails with `template not found`. The packv2 spec defines `template-fragments/` as a convention-discovered, pack-wide directory that applies to "the current city pack" — and the underlying convention-discovery is already wired for hashing/watching, just not for prompt rendering.

This PR adds one `loadSharedTemplates` call against `<cityPath>/template-fragments` in `cmd/gc/prompt.go`, between the imported-packs loop (lower priority) and the per-agent scans (higher priority). Order matches the spec's "the importing pack always wins over its imports" (`doc-pack-v2.md` line 352): city pack > imports, agent-local > city pack.

Two regression tests pin the new behavior.

Fixes #1261.

## Testing

- [x] `make check` (passes for the changed package; the unrelated `internal/fsys/read_regular_unix.go` lint warning surfaced by `make check` is from a separate fix in flight as #1208 / #1222 and is independent of this PR)
- [ ] `make check-docs` — N/A (no doc/nav/link changes)
- [ ] `make test-integration` — N/A (no runtime/controller behavior change; only fragment template discovery for prompt rendering)
- [x] Targeted unit tests:
  ```
  $ go test ./cmd/gc -run "TestRenderPromptCityPack|TestRenderPromptAgentDefaultsAppendFragmentsAffectRenderedPrompt" -v
  --- PASS: TestRenderPromptAgentDefaultsAppendFragmentsAffectRenderedPrompt (0.00s)
  --- PASS: TestRenderPromptCityPackTemplateFragmentsLoad (0.00s)
  --- PASS: TestRenderPromptCityPackFragmentsBeatImports (0.00s)
  PASS
  ```
- [x] End-to-end verification in a real city: built `gc` from this branch, restarted supervisor, confirmed (a) zero `inject_fragment "X": template not found` lines in supervisor.log after restart, (b) fragment content from `<cityRoot>/template-fragments/*.template.md` now reaches rendered prompts.

## Checklist

- [x] Linked an issue (#1261)
- [x] Added tests for behavior change (two new tests in `cmd/gc/prompt_test.go`)
- [ ] Updated docs — N/A (current docs already describe the intended behavior; this PR brings the implementation in line with them)
- [x] Called out breaking changes or migration notes — none. Cities that don't have `<cityRoot>/template-fragments/` are unaffected (the dir simply doesn't exist; `loadSharedTemplates` no-ops). Cities that DO have it gain working fragments instead of silent skips.