### PR TITLE
fix(beads): write issue_prefix via dolt SQL when bd config set rejects it (#1232)

### DIFF
--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -155,6 +155,37 @@ server_sql() {
         sql -q "$1"
 }
 
+# ensure_issue_prefix sets the issue_prefix row in bd's `config` table.
+#
+# bd 1.0.3+ rejects `bd config set issue_prefix` because the key is reserved
+# for the init/bootstrap path; the previous `2>/dev/null || true` swallowed
+# that rejection silently, leaving the runtime config row absent. `bd ready`
+# (which reads from a different code path) keeps working, but `bd create`
+# fails with "database not initialized: issue_prefix config is missing" on the
+# very first sling. See gastownhall/gascity#1232.
+#
+# Strategy: try the bd CLI first so we keep working with older bd versions
+# that still allow `config set issue_prefix`. If bd rejects it, fall back to
+# writing the row directly through the dolt server we already control. The
+# `config` table is the authoritative read path bd uses at create time, so
+# this is the same value bd would have written had it accepted the command.
+ensure_issue_prefix() {
+    local dir="$1"
+    local prefix="$2"
+    local dolt_database="$3"
+
+    if run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null; then
+        return 0
+    fi
+
+    # Escape single quotes for safe SQL embedding (POSIX-compatible).
+    local quoted_prefix
+    quoted_prefix=$(printf '%s' "$prefix" | sed "s/'/''/g")
+    local quoted_db
+    quoted_db=$(printf '%s' "$dolt_database" | sed 's/`/``/g')
+    server_sql "USE \`$quoted_db\`; INSERT INTO config (\`key\`, value) VALUES ('issue_prefix', '$quoted_prefix') ON DUPLICATE KEY UPDATE value='$quoted_prefix'; CALL DOLT_COMMIT('-Am', 'set issue_prefix');" >/dev/null 2>&1 || true
+}
+
 # is_retryable_error checks if an error message is a transient Dolt failure worth retrying.
 # Matches the 7 patterns from upstream isDoltRetryableError().
 is_retryable_error() {
@@ -1746,7 +1777,7 @@ op_init() {
             # and bd-specific bootstrap only.
             ensure_beads_dir_permissions "$dir"
             normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
-            run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null || true
+            ensure_issue_prefix "$dir" "$prefix" "$dolt_database"
             run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
             backfill_project_id_if_missing "$dir"
             exit 0
@@ -1791,7 +1822,9 @@ op_init() {
 
     # Keep bd's runtime config in sync with GC's canonical prefix. This is
     # compatibility state for raw bd operations, not a second GC authority.
-    run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null || true
+    # Falls back to direct SQL when bd 1.0.3+ rejects `config set issue_prefix`
+    # (gastownhall/gascity#1232).
+    ensure_issue_prefix "$dir" "$prefix" "$dolt_database"
 
     # Configure custom bead types (required since beads v0.46.0).
     run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fix for #1232. bd 1.0.3+ rejects `bd config set issue_prefix` because the key is reserved for the init/bootstrap path. The previous `2>/dev/null || true` in `op_init` swallowed that rejection silently, so init returned 0 with the runtime config row absent. `bd ready` (different read path) kept working, but `bd create` failed on the very first sling with:

```
database not initialized: issue_prefix config is missing
(run 'bd init --prefix <prefix>' for a new project, or 'bd bootstrap' to clone an existing remote)
```

Both call sites in `op_init` (the "already initialized on disk" branch and the fresh-init branch) now route through a new `ensure_issue_prefix` helper that tries `bd config set` first, preserving behavior on older bd versions that still accept the call, and falls back to writing the `config` table row directly through the dolt server we already control.

The `config` table is the authoritative read path bd uses at create time, so this writes the same value bd would have written had it accepted the command. The fallback is idempotent (`ON DUPLICATE KEY UPDATE`) and silently swallows transient SQL errors to match the existing "best-effort sync" semantics on these lines.

## Why this fix shape

A few alternatives I considered and rejected:

- **Always go through SQL.** Cleanest, but breaks compatibility with bd versions that still accept `config set issue_prefix` and adds an extra dolt round-trip on the happy path for them.
- **Detect the specific bd error message.** Brittle; if upstream rephrases the error, the fallback stops firing.
- **Write the row before calling bd.** Doesn't help: `bd init` is what creates the table in the fresh-init branch, so we need to wait until after.

Try-then-fallback keeps the existing call as-is and only escalates when bd refuses.

## Test plan

- [x] Bash syntax check (`bash -n examples/bd/assets/scripts/gc-beads-bd.sh`)
- [x] Manual repro: with bd 1.0.3, `gc init` -> `gc rig add` -> `gc sling` previously failed with the issue_prefix error in every db; with this patch applied to the running supervisor's copy and rigs re-added, `bd create` and `gc sling` succeed without manual SQL repair.
- [ ] (Reviewer) `make check` — I did not run this locally; please confirm the existing Go tests around `BdStore.ConfigSet` and the k8s `assertCallNotContains(... "config set issue_prefix")` are unaffected. The Go tests are at the API layer above this script and the k8s assertion is for `gc-beads-k8s`, a different script in `contrib/beads-scripts/`, so I expect no impact, but happy to follow up if anything goes red.

## Notes for reviewers

- The single-quote escape in `quoted_prefix` uses POSIX `sed` rather than bash `${var//}` so the helper is portable to whatever shell the integration tests invoke.
- `dolt_database` is already in scope at both call sites (it's the third arg of `op_init`).
- The original reporter of #1232 mentioned testing a local patch that does roughly this. If they have a more polished version in flight, happy to defer / close this PR.