### PR TITLE
Fix Dolt identity preflight and optional gh doctor check

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Gas City requires the following tools on your system. `gc init` and
 | dolt | Beads provider `bd` | 1.86.1 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
 | bd | Beads provider `bd` | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | Beads provider `bd` | — | `brew install flock` | `apt install util-linux` |
+| gh | Optional GitHub gates | — | `brew install gh` | [cli.github.com](https://cli.github.com/) |
 | claude / codex / gemini | Per provider | — | See provider docs | See provider docs |
 
 The `bd` (beads) provider is the default. To use a file-based store instead

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -55,6 +55,10 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		fmt.Fprintf(stderr, "%s: install the missing dependencies, then run 'gc start'\n", opts.commandName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if missingKeys := checkDoltAuthorIdentity(cityPath); len(missingKeys) > 0 {
+		printMissingDoltAuthorIdentity(stderr, opts.commandName, missingKeys)
+		return 1
+	}
 
 	if opts.showProgress {
 		if opts.skipProviderReadiness {
@@ -449,6 +453,17 @@ var initRunVersionCommandContext = exec.CommandContext
 
 var initRunVersionTimeout = 2 * time.Second
 
+var initRunDoltConfigGet = func(key string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), initRunVersionTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "dolt", "config", "--global", "--get", key).Output()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "", fmt.Errorf("dolt config probe timed out after %s", initRunVersionTimeout)
+	}
+	return strings.TrimSpace(string(out)), err
+}
+
 // initRunVersion runs "<binary> version" and returns the first line.
 // Tests can override this.
 var initRunVersion = func(binary string) (string, error) {
@@ -569,6 +584,56 @@ func checkHardDependencies(cityPath string) []missingDep {
 		}
 	}
 	return missing
+}
+
+func checkDoltAuthorIdentity(cityPath string) []string {
+	if !initNeedsLocalDoltIdentity(cityPath) {
+		return nil
+	}
+	if _, err := initLookPath("dolt"); err != nil {
+		return nil
+	}
+	var missing []string
+	for _, key := range []string{"user.name", "user.email"} {
+		value, err := initRunDoltConfigGet(key)
+		if err != nil && strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+			continue
+		}
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+func initNeedsLocalDoltIdentity(cityPath string) bool {
+	if strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+		return false
+	}
+	if !initNeedsBdTooling(cityPath) {
+		return false
+	}
+	if cityUsesBdStoreContract(cityPath) && isExternalDolt(cityPath) {
+		return false
+	}
+	return true
+}
+
+func printMissingDoltAuthorIdentity(stderr io.Writer, commandName string, missingKeys []string) {
+	fmt.Fprintf(stderr, "%s: city created, but startup is blocked by Dolt author identity\n\n", commandName) //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "Managed bd storage requires Dolt author identity before it can initialize.")       //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "")                                                                                 //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "Missing Dolt config:")                                                             //nolint:errcheck // best-effort stderr
+	for _, key := range missingKeys {
+		fmt.Fprintf(stderr, "  - %s\n", key) //nolint:errcheck // best-effort stderr
+	}
+	fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, `Set it with:`)                                                 //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, `  dolt config --global --add user.name "Your Name"`)           //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, `  dolt config --global --add user.email "you@example.com"`)    //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: set the Dolt identity, then run 'gc start'\n", commandName) //nolint:errcheck // best-effort stderr
 }
 
 func initAnyToolAvailable(names ...string) bool {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -25,6 +25,41 @@ func disableBootstrapForTests(t *testing.T) {
 	t.Cleanup(func() { bootstrap.BootstrapPacks = old })
 }
 
+func stubInitDependencyChecks(t *testing.T) {
+	t.Helper()
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version " + bdMinVersion, nil
+		case "dolt":
+			return "dolt version " + doltMinVersion, nil
+		default:
+			return binary + " version", nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+}
+
+func stubInitDoltAuthorIdentity(t *testing.T, values map[string]string) {
+	t.Helper()
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(key string) (string, error) {
+		value := strings.TrimSpace(values[key])
+		if value == "" {
+			return "", os.ErrNotExist
+		}
+		return value, nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+}
+
 func TestMaybePrintWizardProviderGuidanceNeedsAuth(t *testing.T) {
 	oldProbe := initProbeProvidersReadiness
 	initProbeProvidersReadiness = func(_ context.Context, _ []string, fresh bool) (map[string]api.ReadinessItem, error) {
@@ -841,9 +876,57 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	}
 }
 
+func TestFinalizeInitBlocksManagedBdWhenDoltIdentityMissing(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "")
+	disableBootstrapForTests(t)
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{})
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	var initStdout, initStderr bytes.Buffer
+	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
+		configName: "minimal",
+		provider:   "claude",
+	}, "", &initStdout, &initStderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
+	}
+
+	oldProbe := initProbeProvidersReadiness
+	initProbeProvidersReadiness = func(context.Context, []string, bool) (map[string]api.ReadinessItem, error) {
+		t.Fatal("provider readiness should not run before Dolt identity is configured")
+		return nil, nil
+	}
+	t.Cleanup(func() { initProbeProvidersReadiness = oldProbe })
+
+	var stdout, stderr bytes.Buffer
+	code = finalizeInit(cityPath, &stdout, &stderr, initFinalizeOptions{commandName: "gc init"})
+	if code != 1 {
+		t.Fatalf("finalizeInit = %d, want 1", code)
+	}
+	text := stderr.String()
+	for _, want := range []string{
+		"startup is blocked by Dolt author identity",
+		"user.name",
+		"user.email",
+		`dolt config --global --add user.name "Your Name"`,
+		`dolt config --global --add user.email "you@example.com"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	configureIsolatedRuntimeEnv(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{
+		"user.name":  "gc-test",
+		"user.email": "gc-test@test.local",
+	})
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
@@ -893,6 +976,10 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip
 func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_DOLT", "")
+	stubInitDoltAuthorIdentity(t, map[string]string{
+		"user.name":  "gc-test",
+		"user.email": "gc-test@test.local",
+	})
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ description: Install Gas City from Homebrew, a release tarball, or source.
 
 | Method | Best for | Installs deps? | Auto-upgrades? |
 |--------|----------|----------------|----------------|
-| [Homebrew](#homebrew-recommended) | macOS / Linux daily use | Yes (all 6) | `brew upgrade` |
+| [Homebrew](#homebrew-recommended) | macOS / Linux daily use | Yes (runtime deps) | `brew upgrade` |
 | [Direct download](#direct-download) | CI, containers, air-gapped hosts | No | Manual |
 | [Source build](#build-from-source) | Contributors, bleeding-edge | No | Manual |
 
@@ -29,6 +29,7 @@ for you; the other methods require manual installation.
 | dolt | Yes | 1.86.1 | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
 | bd (Beads CLI) | Yes | 1.0.0 | `brew install beads` | [releases](https://github.com/gastownhall/beads/releases) | Issue tracking |
 | flock | Yes | — | `brew install flock` | (built-in via util-linux) | File locking |
+| gh | Optional | — | `brew install gh` | [cli.github.com](https://cli.github.com/) | GitHub gate checks |
 | Go 1.25+ | Source only | 1.25 | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
 | make | Source only | — | (built-in) | `apt install make` (or `build-essential`) | Drives `make install` |
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -100,6 +100,15 @@ check.
 | bd | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | -- | `brew install flock` | `apt install util-linux` |
 
+### Optional for GitHub gates
+
+| Tool | macOS | Linux |
+|------|-------|-------|
+| gh | `brew install gh` | [cli.github.com](https://cli.github.com/) |
+
+Gas City can run without `gh`. Maintenance skips GitHub gate checks when the
+GitHub CLI is not installed.
+
 If you do not want to install dolt, bd, and flock, switch to the file-based
 store:
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -15,6 +15,32 @@ import (
 
 var rawDoltSQLCallRe = regexp.MustCompile(`(?m)(^|[^A-Za-z0-9_-])dolt(?:[ \t]+|[ \t]*\\[ \t]*\r?\n[ \t]*)+sql([ \t]|$)`)
 
+func TestMaintenanceCheckBinariesTreatsGhAsOptional(t *testing.T) {
+	binDir := t.TempDir()
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+	if err := os.Symlink(bashPath, filepath.Join(binDir, "bash")); err != nil {
+		t.Fatalf("Symlink(bash): %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "jq"), "#!/bin/sh\nexit 0\n")
+
+	cmd := exec.Command(filepath.Join(exampleDir(), "packs", "maintenance", "doctor", "check-binaries", "run.sh"))
+	cmd.Env = mergeTestEnv(map[string]string{"PATH": binDir})
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-binaries failed without gh: %v\n%s", err, out)
+	}
+	text := string(out)
+	if !strings.Contains(text, "all required binaries available (jq)") {
+		t.Fatalf("output = %q, want required jq success", text)
+	}
+	if !strings.Contains(text, "optional gh not found") {
+		t.Fatalf("output = %q, want optional gh warning", text)
+	}
+}
+
 func TestMaintenanceDoltScriptsUseProjectedConnectionTarget(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/examples/gastown/packs/maintenance/doctor/check-binaries/doctor.toml
+++ b/examples/gastown/packs/maintenance/doctor/check-binaries/doctor.toml
@@ -1,1 +1,1 @@
-description = "Verify required binaries (jq, gh) are available"
+description = "Verify required maintenance binaries are available"

--- a/examples/gastown/packs/maintenance/doctor/check-binaries/run.sh
+++ b/examples/gastown/packs/maintenance/doctor/check-binaries/run.sh
@@ -5,19 +5,33 @@
 # stdout: first line=message, rest=details
 
 missing=()
-for bin in jq gh; do
+for bin in jq; do
     if ! command -v "$bin" >/dev/null 2>&1; then
         missing+=("$bin")
     fi
 done
 
-if [ ${#missing[@]} -eq 0 ]; then
-    echo "all required binaries available (jq, gh)"
+gh_available=1
+if ! command -v gh >/dev/null 2>&1; then
+    gh_available=0
+fi
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "${#missing[@]} required binary(ies) missing"
+    for bin in "${missing[@]}"; do
+        echo "$bin not found in PATH"
+    done
+    if [ "$gh_available" -eq 0 ]; then
+        echo "gh not found in PATH; GitHub gate checks will be skipped"
+    fi
+    exit 2
+fi
+
+if [ "$gh_available" -eq 0 ]; then
+    echo "all required binaries available (jq)"
+    echo "optional gh not found in PATH; GitHub gate checks will be skipped"
     exit 0
 fi
 
-echo "${#missing[@]} required binary(ies) missing"
-for bin in "${missing[@]}"; do
-    echo "$bin not found in PATH"
-done
-exit 2
+echo "all required binaries available (jq); optional gh available"
+exit 0


### PR DESCRIPTION
## Summary

- Treat `gh` as optional in the maintenance `check-binaries` doctor check so users without GitHub gates do not fail `gc doctor` solely because GitHub CLI is absent.
- Document `gh` as optional for GitHub gate checks in README and install/troubleshooting docs.
- Preflight Dolt `user.name` / `user.email` before managed bd initialization during `gc init`, with direct setup commands when identity is missing.

Fixes #1266.
Fixes #1267.

## Verification

- `go test ./cmd/gc -run 'TestFinalizeInitBlocksManagedBdWhenDoltIdentityMissing|TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip|TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock'`
- `go test ./examples/gastown -run TestMaintenanceCheckBinariesTreatsGhAsOptional`
- `go test ./examples/gastown`
- `git diff --check`
- `make check-docs`

Local broader checks that are not green in this checkout:

- `make test` fails in `cmd/gc` at `TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag` (`session name already exists: "mayor" already active in runtime`). This test also fails when rerun standalone.
- `make test` also fails in `internal/api` at `TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary` because this machine has a real `gh` visible and the probe reports `needs_auth` instead of `not_installed`.
