### PR TITLE
Treat gh as optional in maintenance check-binaries doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Gas City requires the following tools on your system. `gc init` and
 | dolt | Beads provider `bd` | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
 | bd | Beads provider `bd` | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | Beads provider `bd` | — | `brew install flock` | `apt install util-linux` |
+| gh | Optional GitHub gates | — | `brew install gh` | [cli.github.com](https://cli.github.com/) |
 | claude / codex / gemini | Per provider | — | See provider docs | See provider docs |
 
 The `bd` (beads) provider is the default. To use a file-based store instead

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ description: Install Gas City from Homebrew, a release tarball, or source.
 
 | Method | Best for | Installs deps? | Auto-upgrades? |
 |--------|----------|----------------|----------------|
-| [Homebrew](#homebrew-recommended) | macOS / Linux daily use | Yes (all 6) | `brew upgrade` |
+| [Homebrew](#homebrew-recommended) | macOS / Linux daily use | Yes (runtime deps) | `brew upgrade` |
 | [Direct download](#direct-download) | CI, containers, air-gapped hosts | No | Manual |
 | [Source build](#build-from-source) | Contributors, bleeding-edge | No | Manual |
 
@@ -29,6 +29,7 @@ for you; the other methods require manual installation.
 | dolt | Yes | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
 | bd (Beads CLI) | Yes | 1.0.0 | `brew install beads` | [releases](https://github.com/gastownhall/beads/releases) | Issue tracking |
 | flock | Yes | — | `brew install flock` | (built-in via util-linux) | File locking |
+| gh | Optional | — | `brew install gh` | [cli.github.com](https://cli.github.com/) | GitHub gate checks |
 | Go 1.25+ | Source only | 1.25 | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
 | make | Source only | — | (built-in) | `apt install make` (or `build-essential`) | Drives `make install` |
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -100,6 +100,15 @@ check.
 | bd | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | -- | `brew install flock` | `apt install util-linux` |
 
+### Optional for GitHub gates
+
+| Tool | macOS | Linux |
+|------|-------|-------|
+| gh | `brew install gh` | [cli.github.com](https://cli.github.com/) |
+
+Gas City can run without `gh`. Maintenance skips GitHub gate checks when the
+GitHub CLI is not installed.
+
 If you do not want to install dolt, bd, and flock, switch to the file-based
 store:
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -24,6 +24,32 @@ var (
 	rawDurationIntervalRe = regexp.MustCompile(`(?i)\bINTERVAL\s+\{\{(?:max_age|purge_age|stale_issue_age)\}\}`)
 )
 
+func TestMaintenanceCheckBinariesTreatsGhAsOptional(t *testing.T) {
+	binDir := t.TempDir()
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+	if err := os.Symlink(bashPath, filepath.Join(binDir, "bash")); err != nil {
+		t.Fatalf("Symlink(bash): %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "jq"), "#!/bin/sh\nexit 0\n")
+
+	cmd := exec.Command(filepath.Join(exampleDir(), "packs", "maintenance", "doctor", "check-binaries", "run.sh"))
+	cmd.Env = mergeTestEnv(map[string]string{"PATH": binDir})
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check-binaries failed without gh: %v\n%s", err, out)
+	}
+	text := string(out)
+	if !strings.Contains(text, "all required binaries available (jq)") {
+		t.Fatalf("output = %q, want required jq success", text)
+	}
+	if !strings.Contains(text, "optional gh not found") {
+		t.Fatalf("output = %q, want optional gh warning", text)
+	}
+}
+
 func TestMaintenanceDoltScriptsUseProjectedConnectionTarget(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/examples/gastown/packs/maintenance/doctor/check-binaries/doctor.toml
+++ b/examples/gastown/packs/maintenance/doctor/check-binaries/doctor.toml
@@ -1,1 +1,1 @@
-description = "Verify required binaries (jq, gh) are available"
+description = "Verify required maintenance binaries are available"

--- a/examples/gastown/packs/maintenance/doctor/check-binaries/run.sh
+++ b/examples/gastown/packs/maintenance/doctor/check-binaries/run.sh
@@ -5,19 +5,33 @@
 # stdout: first line=message, rest=details
 
 missing=()
-for bin in jq gh; do
+for bin in jq; do
     if ! command -v "$bin" >/dev/null 2>&1; then
         missing+=("$bin")
     fi
 done
 
-if [ ${#missing[@]} -eq 0 ]; then
-    echo "all required binaries available (jq, gh)"
+gh_available=1
+if ! command -v gh >/dev/null 2>&1; then
+    gh_available=0
+fi
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "${#missing[@]} required binary(ies) missing"
+    for bin in "${missing[@]}"; do
+        echo "$bin not found in PATH"
+    done
+    if [ "$gh_available" -eq 0 ]; then
+        echo "gh not found in PATH; GitHub gate checks will be skipped"
+    fi
+    exit 2
+fi
+
+if [ "$gh_available" -eq 0 ]; then
+    echo "all required binaries available (jq)"
+    echo "optional gh not found in PATH; GitHub gate checks will be skipped"
     exit 0
 fi
 
-echo "${#missing[@]} required binary(ies) missing"
-for bin in "${missing[@]}"; do
-    echo "$bin not found in PATH"
-done
-exit 2
+echo "all required binaries available (jq); optional gh available"
+exit 0


### PR DESCRIPTION
## Summary

- Treat `gh` as optional in the maintenance `check-binaries` doctor check so users without GitHub gates do not fail `gc doctor` solely because GitHub CLI is absent.
- Document `gh` as optional for GitHub gate checks in README and install/troubleshooting docs.

Split out from #1269 (closing in favor of focused PRs per issue).

Fixes #1266.

## Verification

- `go test ./examples/gastown -run TestMaintenanceCheckBinariesTreatsGhAsOptional`
- `go test ./examples/gastown`
- `git diff --check`
- `make check-docs`

Local broader checks that are not green in this checkout (pre-existing, unrelated to this change — same caveats called out on #1269):

- `make test` fails in `cmd/gc` at `TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag` (`session name already exists: "mayor" already active in runtime`). Reproduces standalone.
- `make test` fails in `internal/api` at `TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary` because this machine has a real `gh` visible and the probe reports `needs_auth` instead of `not_installed`.