### PR TITLE
Preflight Dolt author identity before managed bd init

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -203,7 +203,7 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 	provider := beadsProvider(cityPath)
 	if cityUsesBdStoreContract(cityPath) {
-		if os.Getenv("GC_DOLT") == "skip" {
+		if gcDoltSkip() {
 			// Defer to controller/startup without forcing a new dolt_database:
 			// preserve existing metadata identity when present.
 			if err := seedDeferredManagedBeadsErr(cityPath, dir, prefix, ""); err != nil {
@@ -612,7 +612,7 @@ func resolveRigPaths(cityPath string, rigs []config.Rig) {
 // Acquires a per-city semaphore to prevent concurrent start operations
 // from causing spawn storms.
 func ensureBeadsProvider(cityPath string) error {
-	if cityUsesBdStoreContract(cityPath) && strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
 		return nil
 	}
 	provider := beadsProvider(cityPath)
@@ -654,7 +654,7 @@ func ensureBeadsProvider(cityPath string) error {
 // Called by gc stop after agents have been terminated.
 // For exec providers, fires "stop". For file providers, always available.
 func shutdownBeadsProvider(cityPath string) error {
-	if cityUsesBdStoreContract(cityPath) && strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
 		return clearManagedDoltRuntimeStateIfOwned(cityPath)
 	}
 	provider := beadsProvider(cityPath)
@@ -688,7 +688,7 @@ func shutdownBeadsProvider(cityPath string) error {
 // providers that run bd init elsewhere (for example gc-beads-k8s inside the
 // pod) must set it in their own wrapper before invoking bd init.
 func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
-	if cityUsesBdStoreContract(cityPath) && os.Getenv("GC_DOLT") == "skip" {
+	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
 		if err := seedDeferredManagedBeadsErr(cityPath, dir, prefix, doltDatabase); err != nil {
 			return err
 		}
@@ -877,7 +877,7 @@ func initFileStoreForDir(cityPath, dir string) error {
 // Acquires a per-city semaphore to prevent concurrent health/recovery
 // operations from causing a thundering herd when dolt bounces.
 func healthBeadsProvider(cityPath string) error {
-	if cityUsesBdStoreContract(cityPath) && strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
 		return nil
 	}
 	provider := beadsProvider(cityPath)

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -50,7 +49,7 @@ health. Use --fix to attempt automatic repairs.`,
 
 // doDoctor runs all health checks and prints results.
 func doctorSkipsDoltChecks(cityPath string) bool {
-	if os.Getenv("GC_DOLT") == "skip" {
+	if gcDoltSkip() {
 		return true
 	}
 	cfg, err := loadCityConfig(cityPath, io.Discard)
@@ -78,7 +77,7 @@ func workspaceNeedsCityDoltCheck(cityPath string, cfg *config.City) bool {
 }
 
 func managedDoltOpsCheckSkip(cityPath string, cfg *config.City, cfgErr error) bool {
-	if os.Getenv("GC_DOLT") == "skip" {
+	if gcDoltSkip() {
 		return true
 	}
 	return !doctor.ManagedLocalDoltChecksApplicableForConfig(cityPath, cfg, cfgErr)
@@ -206,7 +205,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(newV2RoutedToNamespaceCheck(cfg, cityPath, storeFactory))
 		d.Register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
-	skipCityDoltCheck := os.Getenv("GC_DOLT") == "skip" || (!scopeUsesManagedBdStoreContract(cityPath, cityPath) && !workspaceNeedsCityDoltCheck(cityPath, cfg))
+	skipCityDoltCheck := gcDoltSkip() || (!scopeUsesManagedBdStoreContract(cityPath, cityPath) && !workspaceNeedsCityDoltCheck(cityPath, cfg))
 	d.Register(newDoctorDoltServerCheck(cityPath, skipCityDoltCheck))
 	// Managed Dolt ops checks (PR 3). Size + config drift are only
 	// meaningful when the workspace uses the managed bd/Dolt backend; rigs
@@ -247,7 +246,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 			d.Register(doctor.NewRigGitCheck(rig))
 			d.Register(doctor.NewRigBDSplitStoreCheck(cityPath, rig))
 			d.Register(doctor.NewRigBeadsCheck(cityPath, rig, storeFactory))
-			d.Register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || os.Getenv("GC_DOLT") == "skip"))
+			d.Register(newDoctorRigDoltServerCheck(cityPath, rig, !rigUsesManagedBdStoreContract(cityPath, rig) || gcDoltSkip()))
 			// Custom types check — rig store.
 			d.Register(doctor.NewCustomTypesCheck(rig.Path, rig.Name))
 		}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -461,7 +461,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			return 1
 		}
 		if deferred {
-			if cityUsesBdStoreContract(cityPath) && os.Getenv("GC_DOLT") == "skip" {
+			if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
 				w("  Beads init deferred to controller")
 			} else if err := initAndHookDir(cityPath, rigPath, prefix); err != nil {
 				w("  Beads init deferred to controller")

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -360,6 +360,10 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 		fmt.Fprintln(stderr, "gc start: install the missing dependencies, then try again") //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if status := checkDoltAuthorIdentity(cityPath); status.blocked() {
+		printDoltAuthorIdentityBlock(stderr, "gc start", status)
+		return 1
+	}
 	if code := registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, "gc start", true); code != 0 {
 		return code
 	}
@@ -425,6 +429,23 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	}
 	if err := ensureCityScaffold(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc start: runtime scaffold: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if missing := checkHardDependencies(cityPath); len(missing) > 0 {
+		fmt.Fprintf(stderr, "gc start: missing required dependencies:\n\n") //nolint:errcheck // best-effort stderr
+		for _, dep := range missing {
+			fmt.Fprintf(stderr, "  - %s", dep.name) //nolint:errcheck // best-effort stderr
+			if dep.installHint != "" {
+				fmt.Fprintf(stderr, "\n    Install: %s", dep.installHint) //nolint:errcheck // best-effort stderr
+			}
+			fmt.Fprintln(stderr) //nolint:errcheck // best-effort stderr
+		}
+		fmt.Fprintln(stderr)                                                               //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "gc start: install the missing dependencies, then try again") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if status := checkDoltAuthorIdentity(cityPath); status.blocked() {
+		printDoltAuthorIdentityBlock(stderr, "gc start", status)
 		return 1
 	}
 	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {

--- a/cmd/gc/dolt_env.go
+++ b/cmd/gc/dolt_env.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+func gcDoltSkip() bool {
+	return strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip"
+}

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -55,6 +55,10 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		fmt.Fprintf(stderr, "%s: install the missing dependencies, then run 'gc start'\n", opts.commandName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if missingKeys := checkDoltAuthorIdentity(cityPath); len(missingKeys) > 0 {
+		printMissingDoltAuthorIdentity(stderr, opts.commandName, missingKeys)
+		return 1
+	}
 
 	if opts.showProgress {
 		if opts.skipProviderReadiness {
@@ -449,6 +453,17 @@ var initRunVersionCommandContext = exec.CommandContext
 
 var initRunVersionTimeout = 2 * time.Second
 
+var initRunDoltConfigGet = func(key string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), initRunVersionTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "dolt", "config", "--global", "--get", key).Output()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "", fmt.Errorf("dolt config probe timed out after %s", initRunVersionTimeout)
+	}
+	return strings.TrimSpace(string(out)), err
+}
+
 // initRunVersion runs "<binary> version" and returns the first line.
 // Tests can override this.
 var initRunVersion = func(binary string) (string, error) {
@@ -567,6 +582,56 @@ func checkHardDependencies(cityPath string) []missingDep {
 		}
 	}
 	return missing
+}
+
+func checkDoltAuthorIdentity(cityPath string) []string {
+	if !initNeedsLocalDoltIdentity(cityPath) {
+		return nil
+	}
+	if _, err := initLookPath("dolt"); err != nil {
+		return nil
+	}
+	var missing []string
+	for _, key := range []string{"user.name", "user.email"} {
+		value, err := initRunDoltConfigGet(key)
+		if err != nil && strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+			continue
+		}
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+func initNeedsLocalDoltIdentity(cityPath string) bool {
+	if strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+		return false
+	}
+	if !initNeedsBdTooling(cityPath) {
+		return false
+	}
+	if cityUsesBdStoreContract(cityPath) && isExternalDolt(cityPath) {
+		return false
+	}
+	return true
+}
+
+func printMissingDoltAuthorIdentity(stderr io.Writer, commandName string, missingKeys []string) {
+	fmt.Fprintf(stderr, "%s: city created, but startup is blocked by Dolt author identity\n\n", commandName) //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "Managed bd storage requires Dolt author identity before it can initialize.")       //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "")                                                                                 //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "Missing Dolt config:")                                                             //nolint:errcheck // best-effort stderr
+	for _, key := range missingKeys {
+		fmt.Fprintf(stderr, "  - %s\n", key) //nolint:errcheck // best-effort stderr
+	}
+	fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, `Set it with:`)                                                 //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, `  dolt config --global --add user.name "Your Name"`)           //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, `  dolt config --global --add user.email "you@example.com"`)    //nolint:errcheck // best-effort stderr
+	fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: set the Dolt identity, then run 'gc start'\n", commandName) //nolint:errcheck // best-effort stderr
 }
 
 func initAnyToolAvailable(names ...string) bool {

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 var (
 	initProbeProvidersReadiness = api.ProbeProviders
 	errInitProviderPreflight    = errors.New("provider readiness preflight failed")
+	errDoltConfigKeyMissing     = errors.New("dolt config key missing")
 )
 
 type initFinalizeOptions struct {
@@ -55,8 +57,8 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		fmt.Fprintf(stderr, "%s: install the missing dependencies, then run 'gc start'\n", opts.commandName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if missingKeys := checkDoltAuthorIdentity(cityPath); len(missingKeys) > 0 {
-		printMissingDoltAuthorIdentity(stderr, opts.commandName, missingKeys)
+	if status := checkDoltAuthorIdentity(cityPath); status.blocked() {
+		printDoltAuthorIdentityBlock(stderr, opts.commandName, status)
 		return 1
 	}
 
@@ -457,11 +459,27 @@ var initRunDoltConfigGet = func(key string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), initRunVersionTimeout)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, "dolt", "config", "--global", "--get", key).Output()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "dolt", "config", "--global", "--get", key)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return "", fmt.Errorf("dolt config probe timed out after %s", initRunVersionTimeout)
 	}
-	return strings.TrimSpace(string(out)), err
+	value := strings.TrimSpace(stdout.String())
+	if err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && value == "" && stderrText == "" {
+			return "", errDoltConfigKeyMissing
+		}
+		if stderrText != "" {
+			return value, fmt.Errorf("%w: %s", err, stderrText)
+		}
+		return value, err
+	}
+	return value, nil
 }
 
 // initRunVersion runs "<binary> version" and returns the first line.
@@ -584,54 +602,140 @@ func checkHardDependencies(cityPath string) []missingDep {
 	return missing
 }
 
-func checkDoltAuthorIdentity(cityPath string) []string {
+type doltAuthorIdentityProbeError struct {
+	key string
+	err error
+}
+
+type doltAuthorIdentityStatus struct {
+	missingKeys []string
+	probeErrors []doltAuthorIdentityProbeError
+}
+
+func (s doltAuthorIdentityStatus) blocked() bool {
+	return len(s.missingKeys) > 0 || len(s.probeErrors) > 0
+}
+
+func checkDoltAuthorIdentity(cityPath string) doltAuthorIdentityStatus {
 	if !initNeedsLocalDoltIdentity(cityPath) {
-		return nil
+		return doltAuthorIdentityStatus{}
 	}
 	if _, err := initLookPath("dolt"); err != nil {
-		return nil
+		return doltAuthorIdentityStatus{}
 	}
-	var missing []string
+	var status doltAuthorIdentityStatus
 	for _, key := range []string{"user.name", "user.email"} {
 		value, err := initRunDoltConfigGet(key)
-		if err != nil && strings.TrimSpace(value) == "" {
-			missing = append(missing, key)
+		value = strings.TrimSpace(value)
+		if errors.Is(err, errDoltConfigKeyMissing) && value == "" {
+			status.missingKeys = append(status.missingKeys, key)
 			continue
 		}
-		if strings.TrimSpace(value) == "" {
-			missing = append(missing, key)
+		if err != nil {
+			status.probeErrors = append(status.probeErrors, doltAuthorIdentityProbeError{
+				key: key,
+				err: err,
+			})
+			continue
+		}
+		if value == "" {
+			status.missingKeys = append(status.missingKeys, key)
 		}
 	}
-	return missing
+	return status
 }
 
 func initNeedsLocalDoltIdentity(cityPath string) bool {
-	if strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
+	if gcDoltSkip() {
 		return false
 	}
-	if !initNeedsBdTooling(cityPath) {
+
+	cfg, ok := initConfigForBdTooling(cityPath)
+	var cityCfg *config.City
+	if ok {
+		cityCfg = cfg
+	}
+	if cityUsesBdStoreContract(cityPath) && !initScopeUsesExternalDolt(cityPath, cityPath, cityCfg) {
+		return true
+	}
+	if !ok {
 		return false
 	}
-	if cityUsesBdStoreContract(cityPath) && isExternalDolt(cityPath) {
-		return false
+	for _, rig := range cfg.Rigs {
+		if rigUsesManagedBdStoreContract(cityPath, rig) && !initScopeUsesExternalDolt(cityPath, rig.Path, cfg) {
+			return true
+		}
 	}
-	return true
+	return false
 }
 
-func printMissingDoltAuthorIdentity(stderr io.Writer, commandName string, missingKeys []string) {
+func initScopeUsesExternalDolt(cityPath, scopeRoot string, cfg *config.City) bool {
+	if samePath(scopeRoot, cityPath) {
+		if target, ok, err := canonicalScopeDoltTarget(cityPath, cityPath); ok {
+			if err != nil {
+				return false
+			}
+			return target.External
+		}
+		if isExternalDolt(cityPath) {
+			return true
+		}
+		if cfg != nil {
+			host, port := configuredExternalDoltTargetForCity(cfg.Dolt)
+			return host != "" || port != ""
+		}
+		return false
+	}
+
+	target, ok, err := canonicalScopeDoltTarget(cityPath, scopeRoot)
+	if err == nil && ok {
+		return target.External
+	}
+	if cfg == nil {
+		return isExternalDolt(cityPath)
+	}
+	for _, rig := range cfg.Rigs {
+		if samePath(rig.Path, scopeRoot) {
+			host, port := configuredExternalDoltTargetForRig(rig)
+			if host != "" || port != "" {
+				return true
+			}
+			break
+		}
+	}
+	host, port := configuredExternalDoltTargetForCity(cfg.Dolt)
+	return host != "" || port != "" || isExternalDolt(cityPath)
+}
+
+func printDoltAuthorIdentityBlock(stderr io.Writer, commandName string, status doltAuthorIdentityStatus) {
 	fmt.Fprintf(stderr, "%s: city created, but startup is blocked by Dolt author identity\n\n", commandName) //nolint:errcheck // best-effort stderr
 	fmt.Fprintln(stderr, "Managed bd storage requires Dolt author identity before it can initialize.")       //nolint:errcheck // best-effort stderr
-	fmt.Fprintln(stderr, "")                                                                                 //nolint:errcheck // best-effort stderr
-	fmt.Fprintln(stderr, "Missing Dolt config:")                                                             //nolint:errcheck // best-effort stderr
-	for _, key := range missingKeys {
-		fmt.Fprintf(stderr, "  - %s\n", key) //nolint:errcheck // best-effort stderr
+
+	if len(status.probeErrors) > 0 {
+		fmt.Fprintln(stderr, "")                                //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "Could not verify Dolt identity:") //nolint:errcheck // best-effort stderr
+		for _, probeErr := range status.probeErrors {
+			fmt.Fprintf(stderr, "  - %s: %v\n", probeErr.key, probeErr.err) //nolint:errcheck // best-effort stderr
+		}
 	}
-	fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
-	fmt.Fprintln(stderr, `Set it with:`)                                                 //nolint:errcheck // best-effort stderr
-	fmt.Fprintln(stderr, `  dolt config --global --add user.name "Your Name"`)           //nolint:errcheck // best-effort stderr
-	fmt.Fprintln(stderr, `  dolt config --global --add user.email "you@example.com"`)    //nolint:errcheck // best-effort stderr
-	fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
-	fmt.Fprintf(stderr, "%s: set the Dolt identity, then run 'gc start'\n", commandName) //nolint:errcheck // best-effort stderr
+
+	if len(status.missingKeys) > 0 {
+		fmt.Fprintln(stderr, "")                     //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "Missing Dolt config:") //nolint:errcheck // best-effort stderr
+		for _, key := range status.missingKeys {
+			fmt.Fprintf(stderr, "  - %s\n", key) //nolint:errcheck // best-effort stderr
+		}
+		fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, `Set it with:`)                                                 //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, `  dolt config --global --add user.name "Your Name"`)           //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, `  dolt config --global --add user.email "you@example.com"`)    //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "")                                                             //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: set the Dolt identity, then run 'gc start'\n", commandName) //nolint:errcheck // best-effort stderr
+		return
+	}
+
+	fmt.Fprintln(stderr, "")                                                                             //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: resolve the Dolt identity probe error, then run 'gc start'\n", commandName) //nolint:errcheck // best-effort stderr
 }
 
 func initAnyToolAvailable(names ...string) bool {
@@ -647,20 +751,27 @@ func initNeedsBdTooling(cityPath string) bool {
 	if providerUsesBdStoreContract(rawBeadsProvider(cityPath)) {
 		return true
 	}
+	cfg, ok := initConfigForBdTooling(cityPath)
+	if !ok {
+		return false
+	}
+	return workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs)
+}
 
+func initConfigForBdTooling(cityPath string) (*config.City, bool) {
 	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
-		return false
+		return nil, false
 	}
 	cfg, err := config.Parse(data)
 	if err != nil {
-		return false
+		return nil, false
 	}
 	if _, err := config.ApplySiteBindings(fsys.OSFS{}, cityPath, cfg); err != nil {
-		return false
+		return nil, false
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
-	return workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs)
+	return cfg, true
 }
 
 func depMeetsMinVersion(binary, minVersion string) (string, bool) {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -25,6 +25,41 @@ func disableBootstrapForTests(t *testing.T) {
 	t.Cleanup(func() { bootstrap.BootstrapPacks = old })
 }
 
+func stubInitDependencyChecks(t *testing.T) {
+	t.Helper()
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version " + bdMinVersion, nil
+		case "dolt":
+			return "dolt version " + doltMinVersion, nil
+		default:
+			return binary + " version", nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+}
+
+func stubInitDoltAuthorIdentity(t *testing.T, values map[string]string) {
+	t.Helper()
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(key string) (string, error) {
+		value := strings.TrimSpace(values[key])
+		if value == "" {
+			return "", os.ErrNotExist
+		}
+		return value, nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+}
+
 func TestMaybePrintWizardProviderGuidanceNeedsAuth(t *testing.T) {
 	oldProbe := initProbeProvidersReadiness
 	initProbeProvidersReadiness = func(_ context.Context, _ []string, fresh bool) (map[string]api.ReadinessItem, error) {
@@ -883,9 +918,57 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	}
 }
 
+func TestFinalizeInitBlocksManagedBdWhenDoltIdentityMissing(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "")
+	disableBootstrapForTests(t)
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{})
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	var initStdout, initStderr bytes.Buffer
+	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
+		configName: "minimal",
+		provider:   "claude",
+	}, "", &initStdout, &initStderr)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
+	}
+
+	oldProbe := initProbeProvidersReadiness
+	initProbeProvidersReadiness = func(context.Context, []string, bool) (map[string]api.ReadinessItem, error) {
+		t.Fatal("provider readiness should not run before Dolt identity is configured")
+		return nil, nil
+	}
+	t.Cleanup(func() { initProbeProvidersReadiness = oldProbe })
+
+	var stdout, stderr bytes.Buffer
+	code = finalizeInit(cityPath, &stdout, &stderr, initFinalizeOptions{commandName: "gc init"})
+	if code != 1 {
+		t.Fatalf("finalizeInit = %d, want 1", code)
+	}
+	text := stderr.String()
+	for _, want := range []string{
+		"startup is blocked by Dolt author identity",
+		"user.name",
+		"user.email",
+		`dolt config --global --add user.name "Your Name"`,
+		`dolt config --global --add user.email "you@example.com"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	configureIsolatedRuntimeEnv(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{
+		"user.name":  "gc-test",
+		"user.email": "gc-test@test.local",
+	})
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
@@ -935,6 +1018,10 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip
 func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_DOLT", "")
+	stubInitDoltAuthorIdentity(t, map[string]string{
+		"user.name":  "gc-test",
+		"user.email": "gc-test@test.local",
+	})
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -53,11 +54,28 @@ func stubInitDoltAuthorIdentity(t *testing.T, values map[string]string) {
 	initRunDoltConfigGet = func(key string) (string, error) {
 		value := strings.TrimSpace(values[key])
 		if value == "" {
-			return "", os.ErrNotExist
+			return "", errDoltConfigKeyMissing
 		}
 		return value, nil
 	}
 	t.Cleanup(func() { initRunDoltConfigGet = old })
+}
+
+func writeBootstrappedManagedBdCity(t *testing.T) string {
+	t.Helper()
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "bright-lights"
+
+[beads]
+provider = "bd"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cityPath
 }
 
 func TestMaybePrintWizardProviderGuidanceNeedsAuth(t *testing.T) {
@@ -931,7 +949,7 @@ func TestFinalizeInitBlocksManagedBdWhenDoltIdentityMissing(t *testing.T) {
 	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
 		configName: "minimal",
 		provider:   "claude",
-	}, "", &initStdout, &initStderr)
+	}, "", &initStdout, &initStderr, false)
 	if code != 0 {
 		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
 	}
@@ -959,6 +977,386 @@ func TestFinalizeInitBlocksManagedBdWhenDoltIdentityMissing(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("stderr missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestDoStartBlocksManagedBdWhenDoltIdentityMissingBeforeSupervisorRegistration(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_DOLT", "")
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{})
+
+	cityPath := writeBootstrappedManagedBdCity(t)
+
+	calledRegister := false
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
+		calledRegister = true
+		return true, 0
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	var stdout, stderr bytes.Buffer
+	code := doStart([]string{cityPath}, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doStart code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if calledRegister {
+		t.Fatal("registerCityWithSupervisor should not run before Dolt identity is configured")
+	}
+	text := stderr.String()
+	for _, want := range []string{
+		"gc start: city created, but startup is blocked by Dolt author identity",
+		"user.name",
+		"user.email",
+		`dolt config --global --add user.name "Your Name"`,
+		`dolt config --global --add user.email "you@example.com"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestDoStartForegroundBlocksManagedBdWhenDoltIdentityMissingBeforeLifecycle(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_DOLT", "")
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{})
+
+	cityPath := writeBootstrappedManagedBdCity(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doStart([]string{cityPath}, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doStart --foreground code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	text := stderr.String()
+	for _, want := range []string{
+		"gc start: city created, but startup is blocked by Dolt author identity",
+		"user.name",
+		"user.email",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, `hint: run "gc doctor"`) {
+		t.Fatalf("stderr shows lifecycle failure instead of identity preflight:\n%s", text)
+	}
+}
+
+func TestDoStartForegroundReportsHardDependenciesBeforeDoltIdentity(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_DOLT", "")
+
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		if name == "bd" {
+			return "", os.ErrNotExist
+		}
+		return "/usr/bin/" + name, nil
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version " + bdMinVersion, nil
+		case "dolt":
+			return "dolt version " + doltMinVersion, nil
+		default:
+			return binary + " version", nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+
+	oldDoltConfigGet := initRunDoltConfigGet
+	initRunDoltConfigGet = func(string) (string, error) {
+		t.Fatal("Dolt identity should not be probed before hard dependency failures are reported")
+		return "", nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = oldDoltConfigGet })
+
+	cityPath := writeBootstrappedManagedBdCity(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doStart([]string{cityPath}, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doStart --foreground code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	text := stderr.String()
+	for _, want := range []string{
+		"gc start: missing required dependencies:",
+		"bd",
+		"gc start: install the missing dependencies, then try again",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "startup is blocked by Dolt author identity") {
+		t.Fatalf("stderr reports identity before hard dependencies:\n%s", text)
+	}
+}
+
+func TestCheckDoltAuthorIdentitySkipsWhenGCDoltSkip(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", " skip ")
+	stubInitDependencyChecks(t)
+
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(string) (string, error) {
+		t.Fatal("Dolt identity should not be probed when GC_DOLT=skip")
+		return "", nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+
+	if status := checkDoltAuthorIdentity(t.TempDir()); status.blocked() {
+		t.Fatalf("checkDoltAuthorIdentity blocked with GC_DOLT=skip: %#v", status)
+	}
+}
+
+func TestGCDoltSkipTrimsWhitespace(t *testing.T) {
+	t.Setenv("GC_DOLT", " skip ")
+
+	if !gcDoltSkip() {
+		t.Fatal("gcDoltSkip() = false, want true for whitespace-padded skip")
+	}
+}
+
+func TestCheckDoltAuthorIdentityReportsPartialMissingKey(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{"user.name": "Test User"})
+
+	status := checkDoltAuthorIdentity(t.TempDir())
+	if len(status.probeErrors) != 0 {
+		t.Fatalf("probe errors = %#v, want none", status.probeErrors)
+	}
+	if got, want := strings.Join(status.missingKeys, ","), "user.email"; got != want {
+		t.Fatalf("missing keys = %q, want %q", got, want)
+	}
+}
+
+func TestCheckDoltAuthorIdentitySkipsWhenDoltMissing(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		if name == "dolt" {
+			return "", os.ErrNotExist
+		}
+		return "/usr/bin/" + name, nil
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(string) (string, error) {
+		t.Fatal("Dolt identity should not be probed when dolt is not on PATH")
+		return "", nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+
+	if status := checkDoltAuthorIdentity(t.TempDir()); status.blocked() {
+		t.Fatalf("checkDoltAuthorIdentity blocked without dolt on PATH: %#v", status)
+	}
+}
+
+func TestCheckDoltAuthorIdentitySkipsRigExternalDoltUnderFileCity(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	stubInitDependencyChecks(t)
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+dolt_host = "rig-db.example.com"
+dolt_port = "3307"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"fe"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(string) (string, error) {
+		t.Fatal("rig-only external Dolt should not require local identity")
+		return "", nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+
+	if status := checkDoltAuthorIdentity(cityDir); status.blocked() {
+		t.Fatalf("checkDoltAuthorIdentity blocked for rig external Dolt: %#v", status)
+	}
+}
+
+func TestCheckDoltAuthorIdentitySkipsCityExternalDoltFromConfig(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	stubInitDependencyChecks(t)
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+
+[dolt]
+host = "city-db.example.com"
+port = 3307
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(string) (string, error) {
+		t.Fatal("city external Dolt should not require local identity")
+		return "", nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+
+	if status := checkDoltAuthorIdentity(cityDir); status.blocked() {
+		t.Fatalf("checkDoltAuthorIdentity blocked for city external Dolt: %#v", status)
+	}
+}
+
+func TestCheckDoltAuthorIdentityUsesCanonicalManagedCityOverStaleExternalConfig(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	stubInitDependencyChecks(t)
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+
+[dolt]
+host = "stale-db.example.com"
+port = 3307
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "config.yaml"), []byte(`issue_prefix: gc
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stubInitDoltAuthorIdentity(t, map[string]string{})
+
+	status := checkDoltAuthorIdentity(cityDir)
+	if got, want := strings.Join(status.missingKeys, ","), "user.name,user.email"; got != want {
+		t.Fatalf("missing keys = %q, want %q", got, want)
+	}
+	if len(status.probeErrors) != 0 {
+		t.Fatalf("probe errors = %#v, want none", status.probeErrors)
+	}
+}
+
+func TestCheckDoltAuthorIdentityReportsProbeErrorsSeparately(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+	stubInitDependencyChecks(t)
+
+	old := initRunDoltConfigGet
+	initRunDoltConfigGet = func(key string) (string, error) {
+		if key == "user.name" {
+			return "", fmt.Errorf("dolt config probe timed out after 2s")
+		}
+		return "test@example.com", nil
+	}
+	t.Cleanup(func() { initRunDoltConfigGet = old })
+
+	status := checkDoltAuthorIdentity(t.TempDir())
+	if len(status.missingKeys) != 0 {
+		t.Fatalf("missing keys = %#v, want none", status.missingKeys)
+	}
+	if len(status.probeErrors) != 1 || status.probeErrors[0].key != "user.name" {
+		t.Fatalf("probe errors = %#v, want user.name probe error", status.probeErrors)
+	}
+
+	var stderr bytes.Buffer
+	printDoltAuthorIdentityBlock(&stderr, "gc init", status)
+	text := stderr.String()
+	for _, want := range []string{
+		"Could not verify Dolt identity:",
+		"user.name: dolt config probe timed out after 2s",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "Missing Dolt config:") {
+		t.Fatalf("stderr misreported probe error as missing config:\n%s", text)
+	}
+}
+
+func TestInitRunDoltConfigGetReportsExitStderrAsProbeError(t *testing.T) {
+	binDir := t.TempDir()
+	doltPath := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(doltPath, []byte("#!/bin/sh\necho 'unreadable global config' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	value, err := initRunDoltConfigGet("user.name")
+	if value != "" {
+		t.Fatalf("value = %q, want empty", value)
+	}
+	if err == nil {
+		t.Fatal("initRunDoltConfigGet error = nil, want probe error")
+	}
+	if errors.Is(err, errDoltConfigKeyMissing) {
+		t.Fatalf("initRunDoltConfigGet error = %v, want probe error not missing-key sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "unreadable global config") {
+		t.Fatalf("initRunDoltConfigGet error = %v, want stderr detail", err)
+	}
+}
+
+func TestInitRunDoltConfigGetTreatsSilentEmptyExitAsMissingKey(t *testing.T) {
+	binDir := t.TempDir()
+	doltPath := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(doltPath, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	value, err := initRunDoltConfigGet("user.name")
+	if value != "" {
+		t.Fatalf("value = %q, want empty", value)
+	}
+	if !errors.Is(err, errDoltConfigKeyMissing) {
+		t.Fatalf("initRunDoltConfigGet error = %v, want missing-key sentinel", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preflight Dolt `user.name` / `user.email` before managed bd initialization during `gc init`, with direct setup commands when identity is missing.

Split out from #1269 (closing in favor of focused PRs per issue).

Fixes #1267.

## Verification

- `go test ./cmd/gc -run 'TestFinalizeInitBlocksManagedBdWhenDoltIdentityMissing|TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip|TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock'`
- `git diff --check`

Local broader checks that are not green in this checkout (pre-existing, unrelated to this change — same caveats called out on #1269):

- `make test` fails in `cmd/gc` at `TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag` (`session name already exists: "mayor" already active in runtime`). Reproduces standalone.
- `make test` fails in `internal/api` at `TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary` because this machine has a real `gh` visible and the probe reports `needs_auth` instead of `not_installed`.