### PR TITLE
fix(runtime): replace empty select{} with signal-channel block

### DIFF
--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/events"
@@ -458,8 +461,16 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 	})
 	fmt.Fprintln(stdout, "Restart requested. Blocking until controller kills this session...") //nolint:errcheck // best-effort stdout
 
-	// Block forever. The controller will kill the entire process tree.
-	select {}
+	// Block until the controller kills this process tree (or sends a signal).
+	// `select {}` would trip Go's runtime deadlock detector ("all goroutines
+	// are asleep") because the runtime can't see anything that could wake
+	// us. Wait on a signal channel instead — SIGTERM/SIGINT/SIGHUP are
+	// externally observable and don't trigger the detector.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+	defer signal.Stop(sigCh)
+	<-sigCh
+	return 0
 }
 
 // doRuntimeDrainAck sets the drain-ack flag on the session. The controller

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -485,6 +486,59 @@ func TestDoRuntimeRequestRestartError(t *testing.T) {
 	}
 	if got := stderr.String(); got != "gc runtime request-restart: tmux borked\n" {
 		t.Errorf("stderr = %q", got)
+	}
+}
+
+// TestDoRuntimeRequestRestartBlocksUntilSignal exercises the block path:
+// after setting the restart flag, the function must block until SIGTERM
+// (or SIGINT/SIGHUP) is delivered, then return 0. Pre-fix this path was
+// `select {}` which Go's runtime deadlock detector treats as a panic
+// when no other goroutine could wake the main one.
+func TestDoRuntimeRequestRestartBlocksUntilSignal(t *testing.T) {
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	done := make(chan int, 1)
+	go func() {
+		done <- doRuntimeRequestRestart(dops, nil, events.Discard, "worker", "worker", &stdout, &stderr)
+	}()
+
+	// Give the goroutine a moment to install its signal.Notify handler.
+	// signal.Notify must be in place before SIGTERM fires, otherwise the
+	// runtime's default SIGTERM handler kills the test process.
+	time.Sleep(100 * time.Millisecond)
+
+	// Sanity check: the function must still be blocking. If it returned,
+	// either the block path is broken or the signal handler fired before
+	// we sent anything.
+	select {
+	case code := <-done:
+		t.Fatalf("returned prematurely with code %d (block path broken?)", code)
+	default:
+	}
+
+	// Send SIGTERM to ourselves. The function's signal.Notify handler
+	// captures it before the runtime's default handler runs.
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("Signal: %v", err)
+	}
+
+	// The function should observe the signal and return 0 promptly.
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not return within 2s of SIGTERM")
+	}
+
+	if !strings.Contains(stdout.String(), "Restart requested") {
+		t.Errorf("stdout = %q, want 'Restart requested' message", stdout.String())
 	}
 }
 


### PR DESCRIPTION
Closes #1276.

## Summary

- `gc runtime request-restart` is documented as "block forever; the controller will kill the entire process tree" but ships as `select {}` with no cases. Go's runtime deadlock detector treats this as an unrecoverable deadlock and panics instead of blocking. Reported in production by two long-lived agents on the same day.
- Replace the empty select with a `signal.Notify` wait on SIGTERM/SIGINT/SIGHUP. Externally observable signals don't trip the detector, the function still blocks until the controller kills the process tree, and we return 0 cleanly if the controller sends SIGTERM.
- Add a regression test (`TestDoRuntimeRequestRestartBlocksUntilSignal`) that exercises the block path the existing tests don't reach. The existing tests both return *before* `select{}` (error path / named-on-demand short-circuit), which is why the bug shipped.

## Why the existing tests didn't catch it

| Test | What it exercises | Reaches the block? |
|---|---|---|
| `TestDoRuntimeRequestRestartError` | `setRestartRequested` returns an error, function returns 1 | No |
| `TestRuntimeRequestRestartNamedOnDemandReturnsWithoutBlocking` | Named on-demand sessions return early via "Restart skipped for named session" | No |

The new test spawns `doRuntimeRequestRestart` in a goroutine, sleeps 100ms to let `signal.Notify` install, asserts the function is still blocking, sends SIGTERM to the test process, and asserts a clean return (code 0) within 2 seconds. Verified to **fail** on `select{}` (signal: terminated kills the test process via the default SIGTERM handler) and **pass** on the new code.

## Test plan

- [x] `go build ./cmd/gc/...` passes.
- [x] `go test ./cmd/gc/ -run TestDoRuntimeRequestRestart` — 2 passed (error path + new block path).
- [x] Manual revert of the source change → test fails with `signal: terminated` as expected.

## Notes

- Added `defer signal.Stop(sigCh)` so the signal handler deregisters on return. No behavior change in production (the process is being killed anyway), but it matters for the in-process test — without it, repeated `signal.Notify` calls would chain.
- Imports add `os`, `os/signal`, `syscall` to `cmd/gc/cmd_runtime_drain.go` and `syscall` to the test file. No third-party deps.