### PR TITLE
fix: config-refs check treats builtin providers as valid (ga-4i8)

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -190,7 +190,9 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 			}
 		}
 		if a.Provider != "" && len(c.cfg.Providers) > 0 {
-			if _, ok := c.cfg.Providers[a.Provider]; !ok {
+			_, declared := c.cfg.Providers[a.Provider]
+			_, builtin := config.BuiltinProviders()[a.Provider]
+			if !declared && !builtin {
 				issues = append(issues, fmt.Sprintf("agent %q: provider %q not defined in [providers]", qn, a.Provider))
 			}
 		}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -167,6 +167,7 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	var issues []string
 
+	builtinProviders := config.BuiltinProviders()
 	for _, a := range c.cfg.Agents {
 		qn := a.QualifiedName()
 		if a.PromptTemplate != "" {
@@ -191,7 +192,7 @@ func (c *ConfigRefsCheck) Run(_ *CheckContext) *CheckResult {
 		}
 		if a.Provider != "" && len(c.cfg.Providers) > 0 {
 			_, declared := c.cfg.Providers[a.Provider]
-			_, builtin := config.BuiltinProviders()[a.Provider]
+			_, builtin := builtinProviders[a.Provider]
 			if !declared && !builtin {
 				issues = append(issues, fmt.Sprintf("agent %q: provider %q not defined in [providers]", qn, a.Provider))
 			}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -262,6 +262,24 @@ func TestConfigRefsCheck_UndefinedProvider(t *testing.T) {
 	}
 }
 
+func TestConfigRefsCheck_BuiltinProviderNotFlagged(t *testing.T) {
+	// Builtin providers (e.g. "claude") should not be flagged as undefined
+	// even when custom providers are declared in [providers].
+	dir := t.TempDir()
+	cfg := &config.City{
+		Providers: map[string]config.ProviderSpec{"ollama-local": {}},
+		Agents: []config.Agent{
+			{Name: "worker", Provider: "claude"},
+			{Name: "coder", Provider: "codex"},
+		},
+	}
+	c := NewConfigRefsCheck(cfg, dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (builtin providers are implicitly valid); details = %v", r.Status, r.Details)
+	}
+}
+
 func TestConfigRefsCheck_NoProvidersDefined(t *testing.T) {
 	// When no providers section exists, agent provider refs are not checked.
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Fixes false positive in `gc doctor` config-refs check for built-in providers (e.g., `claude`)
- `config.BuiltinProviders()` is now consulted before flagging a provider as undefined
- Adds test `TestConfigRefsCheck_BuiltinProviderNotFlagged` covering the fix
- Includes cross-platform lint fix for `stat.Dev` cast in `fsys/read_regular_unix.go`

## Test plan

- [x] `go test ./internal/doctor/ -run TestConfigRefsCheck` — all pass
- [x] `go vet ./internal/doctor/ ./internal/fsys/` — clean
- [x] New test verifies builtin providers not flagged when custom providers exist

Closes ga-4i8