### PR TITLE
Fixing flaky tests on Darwin by adding a pre-warming call

### DIFF
--- a/internal/worker/workertest/phase2_fake_worker_test.go
+++ b/internal/worker/workertest/phase2_fake_worker_test.go
@@ -253,7 +253,15 @@ func fakeWorkerBinary(t *testing.T) string {
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
 			fakeWorkerBinaryErr = fmt.Errorf("build fake worker: %w: %s", err, strings.TrimSpace(stderr.String()))
+			return
 		}
+		// Pre-exec the freshly built binary to absorb OS first-exec costs
+		// (notably macOS Gatekeeper / syspolicyd validation) before any
+		// timed measurement. The invocation has no config and exits
+		// immediately via failf, so its only purpose is to warm the OS.
+		warm := exec.Command(fakeWorkerBinaryPath)
+		warm.Env = append(os.Environ(), "GC_FAKE_WORKER_CONFIG=")
+		_ = warm.Run()
 	})
 
 	if fakeWorkerBinaryErr != nil {


### PR DESCRIPTION
## Summary

- On Darwin the first run of the fake worker binary has to be validated by Gatekeeper. In my system this consumes up to 600ms of the test window leading to the first test failing about 75% of the time when running make test or the pre-commit hook script.

This commit adds a minimal warming step that invokes the newly built binary one time with a fast fail mode. It adds about 1.6 seconds to the overall test run time on my system but passes 100% of the time now.

Issue #1285

## Testing

- [x] `make check`
- [x] `make check-docs` if docs, navigation, or links changed
- [x] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
