### PR TITLE
fix: cast stat.Dev/Ino to uint64 for darwin cross-compilation

### DIFF
--- a/internal/fsys/read_regular_unix.go
+++ b/internal/fsys/read_regular_unix.go
@@ -47,7 +47,7 @@ func (OSFS) readRegularFileSnapshot(name string) (regularFileSnapshot, error) {
 	}
 	return regularFileSnapshot{
 		data:  data,
-		id:    fileIdentity{dev: stat.Dev, ino: stat.Ino},
+		id:    fileIdentity{dev: uint64(stat.Dev), ino: uint64(stat.Ino)},
 		hasID: true,
 	}, nil
 }


### PR DESCRIPTION
Fixes #1287.

`unix.Stat_t.Dev` is `int32` on Darwin but `uint64` on Linux. Without
an explicit cast the struct literal in `readRegularFileSnapshot` fails
when cross-compiling for macOS from a Linux host:

```
internal/fsys/read_regular_unix.go:50:28: cannot use stat.Dev (variable of type int32) as uint64 value in struct literal
```

`stat.Ino` is also cast for consistency — its width varies by platform.

## Test plan

- [ ] `GOOS=darwin GOARCH=amd64 go build ./internal/fsys/` compiles clean
- [ ] `GOOS=darwin GOARCH=arm64 go build ./internal/fsys/` compiles clean
- [ ] `go test ./internal/fsys/...` passes on Linux