### PR TITLE
fix: make HQ addressable via --rig <hq-name> (#1242)

### DIFF
--- a/cmd/gc/hq_addressable_test.go
+++ b/cmd/gc/hq_addressable_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hqAddressable_ResolveByName verifies the regression fix for #1242: a
+// city's HQ name passed as `--rig` resolves to a context with empty
+// RigName (the HQ identity is the city scope itself).
+func TestHQAddressable_ResolveByName(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "redhat-takehome")
+	registerCityForRigResolution(t, gcHome, cityPath, "redhat-takehome")
+
+	rigFlag = "redhat-takehome"
+	ctx, err := resolveContext()
+	if err != nil {
+		t.Fatalf("resolveContext: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, cityPath)
+	if ctx.RigName != "" {
+		t.Errorf("HQ should resolve with empty RigName (city scope); got %q", ctx.RigName)
+	}
+}
+
+// TestHQAddressable_RigNamePrecedenceWins guards the precedence: when a
+// rig and an HQ happen to share a name, rig-by-name resolves first.
+// This protects existing rig-name lookups from being shadowed.
+func TestHQAddressable_RigNamePrecedenceWins(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	// City whose HQ name happens to be "shared".
+	cityA := setupCity(t, "shared")
+	registerCityForRigResolution(t, gcHome, cityA, "shared")
+
+	// Different city has a rig also named "shared".
+	cityB := setupCity(t, "other-city")
+	rigDir := filepath.Join(t.TempDir(), "shared-rig")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registerRigBindingForResolution(t, gcHome, cityB, "other-city", "shared", rigDir)
+
+	rigFlag = "shared"
+	ctx, err := resolveContext()
+	if err != nil {
+		t.Fatalf("resolveContext: %v", err)
+	}
+	// Rig-by-name match wins; ctx points to cityB and the rig identity
+	// "shared". HQ match for cityA is never reached.
+	assertSameTestPath(t, ctx.CityPath, cityB)
+	if ctx.RigName != "shared" {
+		t.Errorf("rig-by-name should win over HQ-by-name; got RigName=%q", ctx.RigName)
+	}
+}
+
+// TestHQAddressable_ResolveByLiveWorkspaceName confirms we honor a
+// drift-tolerant match: even if the registry stored a stale name, the
+// live workspace.name from city.toml still resolves the HQ correctly.
+func TestHQAddressable_ResolveByLiveWorkspaceName(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "renamed-live")
+	// Register under a stale name; the live workspace.name above is
+	// what `gc rig list` displays under (HQ).
+	registerCityForRigResolution(t, gcHome, cityPath, "stale-registry-name")
+
+	rigFlag = "renamed-live"
+	ctx, err := resolveContext()
+	if err != nil {
+		t.Fatalf("resolveContext: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, cityPath)
+	if ctx.RigName != "" {
+		t.Errorf("HQ should resolve with empty RigName; got %q", ctx.RigName)
+	}
+}
+
+// TestHQAddressable_ResolveByRegistryNameWhenLiveDiffers covers the
+// reverse drift: registry knows the name, live config doesn't match.
+// Either source resolves the HQ.
+func TestHQAddressable_ResolveByRegistryNameWhenLiveDiffers(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "live-name")
+	registerCityForRigResolution(t, gcHome, cityPath, "registry-name")
+
+	rigFlag = "registry-name"
+	ctx, err := resolveContext()
+	if err != nil {
+		t.Fatalf("resolveContext: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, cityPath)
+}
+
+// TestHQAddressable_NoMatchYieldsClearError confirms the original
+// error path still fires for a name that matches neither rig nor HQ.
+func TestHQAddressable_NoMatchYieldsClearError(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "real-city")
+	registerCityForRigResolution(t, gcHome, cityPath, "real-city")
+
+	rigFlag = "ghost"
+	_, err := resolveContext()
+	if err == nil {
+		t.Fatal("expected error for unknown name")
+	}
+	if !strings.Contains(err.Error(), `rig "ghost" is not registered`) {
+		t.Errorf("expected the canonical not-registered error, got %v", err)
+	}
+}
+
+// TestHQAddressable_AmbiguousHQNameDiagnostic checks the multi-match
+// diagnostic — two registered cities whose live workspace.name happens
+// to be identical surface a clear "specify by path" hint rather than
+// picking arbitrarily. The registry refuses duplicate registry names,
+// but live workspace.name drift can produce the same effective HQ
+// from two distinct registrations.
+func TestHQAddressable_AmbiguousHQNameDiagnostic(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	// Both cities have workspace.name = "twin" in their city.toml,
+	// but each is registered under a distinct registry name.
+	cityA := setupCity(t, "twin")
+	cityB := setupCity(t, "twin")
+	registerCityForRigResolution(t, gcHome, cityA, "registry-a")
+	registerCityForRigResolution(t, gcHome, cityB, "registry-b")
+
+	rigFlag = "twin"
+	_, err := resolveContext()
+	if err == nil {
+		t.Fatal("expected ambiguity error for duplicated HQ workspace.name")
+	}
+	if !strings.Contains(err.Error(), "registered for multiple cities") {
+		t.Errorf("expected ambiguity wording, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "--city") {
+		t.Errorf("error should suggest --city escape hatch, got %v", err)
+	}
+}
+
+// TestRegisteredHQByName_Empty confirms the helper returns nil/empty for
+// blank names — guards against panics on invalid CLI input.
+func TestRegisteredHQByName_Empty(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	matches, err := registeredHQByName("", true)
+	if err != nil {
+		t.Fatalf("empty name should not error, got: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("empty name should yield no matches, got: %+v", matches)
+	}
+}
+
+// TestRegisteredHQByName_NoCities confirms graceful behavior when no
+// cities are registered yet.
+func TestRegisteredHQByName_NoCities(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	matches, err := registeredHQByName("anything", true)
+	if err != nil {
+		t.Fatalf("empty registry should not error, got: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("empty registry should yield no matches, got %d", len(matches))
+	}
+}
+
+// TestRegisteredHQByName_DedupesIdenticalCity guards against double-
+// counting when both the registry name and the live config name match.
+// The same city must contribute only one binding.
+func TestRegisteredHQByName_DedupesIdenticalCity(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "matchme")
+	registerCityForRigResolution(t, gcHome, cityPath, "matchme")
+
+	matches, err := registeredHQByName("matchme", true)
+	if err != nil {
+		t.Fatalf("registeredHQByName: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1 (dedup must collapse registry+live duplicates)", len(matches))
+	}
+	assertSameTestPath(t, matches[0].City.Path, cityPath)
+}
+
+// TestResolveHQBindingMatches_ZeroMatches must surface no error when
+// resolveRigToContext walks past it — only the final fallback in the
+// caller chain should produce the not-registered error.
+func TestResolveHQBindingMatches_ZeroMatches(t *testing.T) {
+	// Calling resolveHQBindingMatches with zero matches is a programming
+	// error in the caller; the function panics or returns garbage. The
+	// call sites guard with len(matches) > 0 first. We only test the
+	// non-empty branches. This test is kept as a placeholder so future
+	// refactors that add a no-match branch get a coverage signal.
+	_ = resolveHQBindingMatches // compile-time reference
+}
+
+// TestHQAddressable_ResolveContextFromPath confirms passing the city
+// root as a positional path arg already worked (existing behavior) —
+// guards against a regression on the path side from the new
+// HQ-by-name code.
+func TestHQAddressable_ResolveContextFromPath(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := setupCity(t, "by-path")
+	registerCityForRigResolution(t, gcHome, cityPath, "by-path")
+
+	ctx, err := resolveContextFromPath(cityPath)
+	if err != nil {
+		t.Fatalf("resolveContextFromPath: %v", err)
+	}
+	assertSameTestPath(t, ctx.CityPath, cityPath)
+	if ctx.RigName != "" {
+		t.Errorf("city-root path should resolve with empty RigName; got %q", ctx.RigName)
+	}
+}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -451,6 +451,15 @@ func validateCityPath(p string) (string, error) {
 
 // resolveRigToContext resolves a rig name or path to a full context by scanning
 // registered cities and their machine-local .gc/site.toml rig bindings.
+//
+// Resolution order:
+//  1. Match against rig names in any registered city's [[rigs]] table.
+//  2. Match against the absolute path of any registered rig.
+//  3. Match against the HQ name of any registered city. The HQ is the
+//     city itself; matching it returns a context with empty RigName,
+//     mirroring how `cwd discovery from the city root` resolves. This
+//     closes #1242 — `gc rig list` shows HQ identically to other rigs,
+//     so addressability via `--rig <hq-name>` should work too.
 func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	if matches, err := registeredRigBindingsByName(nameOrPath, true); err != nil {
 		return resolvedContext{}, err
@@ -468,7 +477,95 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 		return resolveRigBindingMatches(abs, matches)
 	}
 
+	if matches, err := registeredHQByName(nameOrPath, true); err != nil {
+		return resolvedContext{}, err
+	} else if len(matches) > 0 {
+		return resolveHQBindingMatches(nameOrPath, matches)
+	}
+
 	return resolvedContext{}, fmt.Errorf("rig %q is not registered in any city", nameOrPath)
+}
+
+// registeredHQBinding identifies a registered city by HQ name match.
+// Distinct from registeredRigBinding so the two name-spaces stay
+// independent — a rig and an HQ may coincidentally share a name in
+// different cities.
+type registeredHQBinding struct {
+	City supervisor.CityEntry
+}
+
+// registeredHQByName returns the registered cities whose HQ name matches
+// name. The HQ name is sourced from two places, both compared to name:
+//
+//   - The registry entry's stored EffectiveName (what `gc cities list`
+//     displays).
+//   - The live workspace name from city.toml (what `gc rig list` shows
+//     under "(HQ)").
+//
+// Comparing both protects against drift between the registry record
+// and the on-disk config (e.g., after editing workspace.name without
+// re-registering).
+//
+// failOnLoadError mirrors the rig-binding helper's contract: load
+// failures bubble up only when at least one match was found or the
+// caller demands loud failures, so name lookups don't break just
+// because an unrelated city's config is malformed.
+func registeredHQByName(name string, failOnLoadError bool) ([]registeredHQBinding, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, nil
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	cities, err := reg.List()
+	if err != nil {
+		return nil, err
+	}
+	var matched []registeredHQBinding
+	var loadErrors []string
+	seen := make(map[string]struct{}, len(cities))
+	for _, c := range cities {
+		if c.EffectiveName() == name {
+			if _, dup := seen[c.Path]; !dup {
+				matched = append(matched, registeredHQBinding{City: c})
+				seen[c.Path] = struct{}{}
+			}
+			continue
+		}
+		cfg, err := loadCityConfigSuppressDeprecatedOrderWarnings(c.Path, io.Discard)
+		if err != nil {
+			loadErrors = append(loadErrors, fmt.Sprintf("%s: %v", registeredCityLabel(c), err))
+			continue
+		}
+		if loadedCityName(cfg, c.Path) == name {
+			if _, dup := seen[c.Path]; !dup {
+				matched = append(matched, registeredHQBinding{City: c})
+				seen[c.Path] = struct{}{}
+			}
+		}
+	}
+	if len(loadErrors) > 0 && (failOnLoadError || len(matched) > 0) {
+		return nil, fmt.Errorf("loading registered city HQ names: %s", strings.Join(loadErrors, "; "))
+	}
+	return matched, nil
+}
+
+// resolveHQBindingMatches collapses one or more HQ matches into a
+// resolvedContext. The RigName is intentionally empty — the HQ has no
+// rig identity; commands operating against it see the city scope, the
+// same context cwd discovery from the city root produces.
+func resolveHQBindingMatches(value string, matches []registeredHQBinding) (resolvedContext, error) {
+	if len(matches) == 1 {
+		return resolvedContext{CityPath: matches[0].City.Path, RigName: ""}, nil
+	}
+	cityNames := make([]string, 0, len(matches))
+	for _, m := range matches {
+		cityNames = append(cityNames, registeredCityLabel(m.City))
+	}
+	sort.Strings(cityNames)
+	return resolvedContext{}, fmt.Errorf(
+		"HQ name %q is registered for multiple cities: %s\n  Specify by path:  gc --city <path> <command>",
+		value,
+		strings.Join(cityNames, ", "))
 }
 
 func resolveRigPathToContext(dir string) (resolvedContext, bool, error) {


### PR DESCRIPTION
## Summary

Closes #1242. `gc rig list` displays the city HQ identically to other rigs, but `gc --rig <hq-name>` rejected it with `"rig is not registered in any city"`. The HQ was reachable only via cwd discovery from the city root. This PR makes `--rig <hq-name>` work consistently with non-HQ rigs.

## Repro before

```
$ gc rig list
Rigs in /Users/me/redhat:
  redhat-takehome (HQ):
    Prefix: rt
    Beads:  initialized
  learned-aggregator:
    ...

$ gc --rig redhat-takehome convoy create my-convoy --owned
gc convoy create: rig "redhat-takehome" is not registered in any city
```

## Root cause

`resolveRigToContext` walked only `cfg.Rigs` (the explicit rig list). The HQ — the city itself — never appeared there. The name match failed even though `gc rig list` happily printed it.

## Fix

Extended `resolveRigToContext` with a third lookup tier that runs after rig-by-name and rig-by-path. `registeredHQByName` walks the supervisor registry and matches against both:

1. `CityEntry.EffectiveName` — the registry's stored name (`gc cities list` view).
2. The live `workspace.name` from `city.toml` — what `gc rig list` displays under `(HQ)`.

Both sources are checked so a name change on either side still resolves correctly. A match returns `resolvedContext{CityPath, RigName: ""}` — the same shape cwd discovery from the city root produces, so every downstream command that already understood "city scope" accepts the HQ name as input without further changes.

**Precedence:** rig-by-name still wins. A rig named `shared` in city B shadows an HQ named `shared` in city A. Preserves existing behavior.

**Ambiguity:** two cities with the same live `workspace.name` produce a clear diagnostic mirroring the rig-name path's wording: `"HQ name X is registered for multiple cities: ... Specify by path: gc --city <path> <command>"`.

## Tests

11 tests in `cmd/gc/hq_addressable_test.go`:

- `TestHQAddressable_ResolveByName` — the bug fix itself
- `TestHQAddressable_RigNamePrecedenceWins` — rig name wins shared-name collisions
- `TestHQAddressable_ResolveByLiveWorkspaceName` — drift-tolerant live match
- `TestHQAddressable_ResolveByRegistryNameWhenLiveDiffers` — drift-tolerant registry match
- `TestHQAddressable_NoMatchYieldsClearError` — original error preserved
- `TestHQAddressable_AmbiguousHQNameDiagnostic` — multi-city ambiguity message
- `TestRegisteredHQByName_Empty` — empty-name guard
- `TestRegisteredHQByName_NoCities` — empty-registry guard
- `TestRegisteredHQByName_DedupesIdenticalCity` — registry+live double-count guard
- `TestResolveHQBindingMatches_ZeroMatches` — placeholder
- `TestHQAddressable_ResolveContextFromPath` — existing path-based resolution unaffected

## Test plan

- [x] `go test ./cmd/gc -run TestHQAddressable|TestRegisteredHQByName|TestResolveHQBindingMatches|TestRigAnywhere` — all green
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)