### PR TITLE
Fix Pi hook extension for current Pi

### DIFF
--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -326,6 +326,82 @@ func TestMaterializeBuiltinPacks_Idempotent(t *testing.T) {
 	}
 }
 
+func TestMaterializeBuiltinPacksPiHookUsesCurrentExtensionAPI(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	data := readMaterializedPiHook(t, dir)
+	for _, want := range []string{
+		"module.exports = function gascityPiExtension(pi)",
+		`pi.on("session_start"`,
+		`pi.on("session_compact"`,
+		`pi.on("session_shutdown"`,
+		`pi.on("before_agent_start"`,
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("materialized Pi hook missing current extension API marker %q:\n%s", want, data)
+		}
+	}
+	for _, legacy := range []string{
+		"module.exports = {",
+		`"session.created"`,
+		`"session.compacted"`,
+		`"session.deleted"`,
+		`"experimental.chat.system.transform"`,
+	} {
+		if strings.Contains(data, legacy) {
+			t.Errorf("materialized Pi hook still contains legacy API marker %q:\n%s", legacy, data)
+		}
+	}
+}
+
+func TestMaterializeBuiltinPacksReplacesStaleMaterializedPiHook(t *testing.T) {
+	dir := t.TempDir()
+	hookPath := materializedPiHookPath(dir)
+	if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(hookPath), err)
+	}
+	stale := []byte(`// Gas City hooks for Pi Coding Agent.
+module.exports = {
+  name: "gascity",
+  events: { "session.created": () => "" },
+  hooks: { "experimental.chat.system.transform": (system) => system },
+};
+`)
+	if err := os.WriteFile(hookPath, stale, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", hookPath, err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	data := readMaterializedPiHook(t, dir)
+	if data == string(stale) {
+		t.Fatal("stale materialized Pi hook was preserved; expected core pack materialization to repair it")
+	}
+	if !strings.Contains(data, `pi.on("session_start"`) {
+		t.Fatalf("repaired materialized Pi hook does not use current extension API:\n%s", data)
+	}
+}
+
+func materializedPiHookPath(dir string) string {
+	return filepath.Join(dir, citylayout.SystemPacksRoot, "core", "overlay", "per-provider", "pi", ".pi", "extensions", "gc-hooks.js")
+}
+
+func readMaterializedPiHook(t *testing.T, dir string) string {
+	t.Helper()
+	path := materializedPiHookPath(dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
+}
+
 func TestMaterializeBuiltinPacks_DoesNotRewriteUnchangedFiles(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js
@@ -1,20 +1,24 @@
 // Gas City hooks for Pi Coding Agent.
 // Installed by gc into {workDir}/.pi/extensions/gc-hooks.js
 //
+// Pi 0.70+ extension API uses a factory function and pi.on(...)
+// subscriptions. Keep this file as .js for existing Gas City provider args
+// and auto-discovery paths.
+//
 // Events:
-//   session.created    → gc prime (load context)
-//   session.compacted  → gc prime (reload after compaction)
-//   session.deleted    → gc hook --inject (pick up work on exit)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+//   session_start    → gc prime --hook (load context side effects)
+//   session_compact  → gc prime --hook (reload after compaction)
+//   session_shutdown → gc hook --inject on process quit
+//   before_agent_start → gc nudge drain --inject + gc mail check --inject
 
-const { execSync } = require("child_process");
+const { execFileSync } = require("node:child_process");
 
-const PATH_PREFIX =
-  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
+const PATH_PREFIX = `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
-function run(cmd) {
+function run(args, cwd) {
   try {
-    return execSync(cmd, {
+    return execFileSync("gc", args, {
+      cwd: cwd || process.cwd(),
       encoding: "utf-8",
       timeout: 30000,
       env: { ...process.env, PATH: PATH_PREFIX + (process.env.PATH || "") },
@@ -24,24 +28,35 @@ function run(cmd) {
   }
 }
 
-module.exports = {
-  name: "gascity",
+function appendSystemPrompt(systemPrompt, additions) {
+  const extras = additions.filter(Boolean);
+  if (extras.length === 0) {
+    return systemPrompt;
+  }
+  return [systemPrompt, ...extras].filter(Boolean).join("\n\n");
+}
 
-  events: {
-    "session.created": () => run("gc prime --hook"),
-    "session.compacted": () => run("gc prime --hook"),
-    "session.deleted": () => run("gc hook --inject"),
-  },
+module.exports = function gascityPiExtension(pi) {
+  pi.on("session_start", (_event, ctx) => {
+    run(["prime", "--hook"], ctx.cwd);
+  });
 
-  hooks: {
-    "experimental.chat.system.transform": (system) => {
-      const nudges = run("gc nudge drain --inject");
-      const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
-      if (extras.length > 0) {
-        return system + "\n\n" + extras.join("\n\n");
-      }
-      return system;
-    },
-  },
+  pi.on("session_compact", (_event, ctx) => {
+    run(["prime", "--hook"], ctx.cwd);
+  });
+
+  pi.on("session_shutdown", (event, ctx) => {
+    if (event.reason === "quit") {
+      run(["hook", "--inject"], ctx.cwd);
+    }
+  });
+
+  pi.on("before_agent_start", (event, ctx) => {
+    const nudges = run(["nudge", "drain", "--inject"], ctx.cwd);
+    const mail = run(["mail", "check", "--inject"], ctx.cwd);
+    const systemPrompt = appendSystemPrompt(event.systemPrompt, [nudges, mail]);
+    if (systemPrompt !== event.systemPrompt) {
+      return { systemPrompt };
+    }
+  });
 };

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -150,8 +150,34 @@ func installOverlayManaged(fs fsys.FS, workDir, provider string) error {
 			return fmt.Errorf("reading %s: %w", name, err)
 		}
 		dst := filepath.Join(workDir, filepath.FromSlash(rel))
-		return writeEmbeddedManaged(fs, dst, data, nil)
+		return writeEmbeddedManaged(fs, dst, data, overlayManagedNeedsUpgrade(provider, rel))
 	})
+}
+
+func overlayManagedNeedsUpgrade(provider, rel string) func([]byte) bool {
+	if provider == "pi" && rel == path.Join(".pi", "extensions", "gc-hooks.js") {
+		return piHookNeedsUpgrade
+	}
+	return nil
+}
+
+func piHookNeedsUpgrade(existing []byte) bool {
+	content := string(existing)
+	if !strings.Contains(content, "Gas City hooks for Pi Coding Agent") {
+		return false
+	}
+	for _, marker := range []string{
+		"module.exports = {",
+		`"session.created"`,
+		`"session.compacted"`,
+		`"session.deleted"`,
+		`"experimental.chat.system.transform"`,
+	} {
+		if strings.Contains(content, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // installClaude writes the runtime settings file (.gc/settings.json) in the

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -686,6 +686,77 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 }
 
+func TestInstallPiHookUsesCurrentExtensionAPI(t *testing.T) {
+	fs := fsys.NewFake()
+	if err := Install(fs, "/city", "/work", []string{"pi"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/work/.pi/extensions/gc-hooks.js"])
+	for _, want := range []string{
+		"module.exports = function gascityPiExtension(pi)",
+		`pi.on("session_start"`,
+		`pi.on("session_compact"`,
+		`pi.on("session_shutdown"`,
+		`pi.on("before_agent_start"`,
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("Pi hook missing current extension API marker %q:\n%s", want, data)
+		}
+	}
+	for _, legacy := range []string{
+		"module.exports = {",
+		`"session.created"`,
+		`"session.compacted"`,
+		`"session.deleted"`,
+		`"experimental.chat.system.transform"`,
+	} {
+		if strings.Contains(data, legacy) {
+			t.Errorf("Pi hook still contains legacy API marker %q:\n%s", legacy, data)
+		}
+	}
+}
+
+func TestInstallPiHookUpgradesLegacyObjectExport(t *testing.T) {
+	fs := fsys.NewFake()
+	legacy := []byte(`// Gas City hooks for Pi Coding Agent.
+module.exports = {
+  name: "gascity",
+  events: { "session.created": () => "" },
+  hooks: { "experimental.chat.system.transform": (system) => system },
+};
+`)
+	fs.Files["/work/.pi/extensions/gc-hooks.js"] = legacy
+
+	if err := Install(fs, "/city", "/work", []string{"pi"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/work/.pi/extensions/gc-hooks.js"])
+	if data == string(legacy) {
+		t.Fatal("legacy Pi object-export hook was preserved; expected managed upgrade")
+	}
+	if !strings.Contains(data, `pi.on("session_start"`) {
+		t.Fatalf("upgraded Pi hook does not use current extension API:\n%s", data)
+	}
+}
+
+func TestInstallPiHookPreservesUserAuthoredFile(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := []byte(`module.exports = function customPiExtension(pi) {
+  pi.on("session_start", () => {});
+};
+`)
+	fs.Files["/work/.pi/extensions/gc-hooks.js"] = custom
+
+	if err := Install(fs, "/city", "/work", []string{"pi"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if got := string(fs.Files["/work/.pi/extensions/gc-hooks.js"]); got != string(custom) {
+		t.Fatalf("user-authored Pi hook was overwritten:\n%s", got)
+	}
+}
+
 func TestInstallMultipleProviders(t *testing.T) {
 	fs := fsys.NewFake()
 	// Claude writes city-level files; overlay-managed names write their


### PR DESCRIPTION
## Summary

- Update the generated Pi hook overlay to the current Pi extension factory API (`module.exports = function (pi) { ... }`).
- Register current Pi events with `pi.on(...)` for startup, compaction, shutdown, and per-turn system-prompt injection.
- Add managed upgrade detection so old Gas City Pi object-export hooks are replaced while user-authored hook files remain preserved.

Fixes #1233.

## Validation

- `go test ./internal/hooks ./internal/worker/builtin`
- `go vet ./...`
- `pi -e internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js --list-models` with Pi `0.70.2`