### PR TITLE
fix(sling): config-aware bead-id parsing for hyphenated rig prefixes

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -239,7 +239,7 @@ func resolveBdScopeTarget(cfg *config.City, cityPath, rigName string, args []str
 }
 
 func bdRigForArg(cfg *config.City, arg string) (config.Rig, bool) {
-	if prefix := beadPrefix(arg); prefix != "" {
+	if prefix := beadPrefix(cfg, arg); prefix != "" {
 		return findRigByPrefix(cfg, prefix)
 	}
 	return config.Rig{}, false

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -831,7 +831,7 @@ func TestManagedBdRigProviderStoreRecoversAfterHardKillPortRebind(t *testing.T) 
 	if err != nil {
 		t.Fatalf("providerStore.Create after rebind: %v", err)
 	}
-	if got := beadPrefix(rebound.ID); got != "fe" {
+	if got := beadPrefix(nil, rebound.ID); got != "fe" {
 		t.Fatalf("provider rebind bead prefix = %q, want %q", got, "fe")
 	}
 
@@ -882,7 +882,7 @@ func TestManagedBdRigStoreConsistentAcrossRawBdGcBdAndProviderStore(t *testing.T
 	if err != nil {
 		t.Fatalf("providerStore.Create: %v", err)
 	}
-	if got := beadPrefix(providerBead.ID); got != "fe" {
+	if got := beadPrefix(nil, providerBead.ID); got != "fe" {
 		t.Fatalf("provider rig bead prefix = %q, want %q", got, "fe")
 	}
 	rawShow := runRawBDFromDir(t, bdPath, rawDir, "show", "--json", providerBead.ID)
@@ -1010,7 +1010,7 @@ func TestManagedBdCityStoreConsistentAcrossRawBdGcBdAndProviderStore(t *testing.
 	}
 
 	rawID := parseCreatedBeadID(t, runRawBDFromDir(t, bdPath, rawDir, "create", "--json", "raw city bead", "-t", "task"))
-	if got := beadPrefix(rawID); got != "gc" {
+	if got := beadPrefix(nil, rawID); got != "gc" {
 		t.Fatalf("raw city bead prefix = %q, want %q", got, "gc")
 	}
 	providerStore, err := openStoreAtForCity(cityPath, cityPath)
@@ -1036,7 +1036,7 @@ func TestManagedBdCityStoreConsistentAcrossRawBdGcBdAndProviderStore(t *testing.
 	if err != nil {
 		t.Fatalf("providerStore.Create: %v", err)
 	}
-	if got := beadPrefix(providerBead.ID); got != "gc" {
+	if got := beadPrefix(nil, providerBead.ID); got != "gc" {
 		t.Fatalf("provider city bead prefix = %q, want %q", got, "gc")
 	}
 	rawShow := runRawBDFromDir(t, bdPath, rawDir, "show", "--json", providerBead.ID)
@@ -1072,7 +1072,7 @@ func TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix(t *testing.
 		t.Fatalf("MkdirAll(rawDir): %v", err)
 	}
 	rawID := parseCreatedBeadID(t, runRawBDFromDir(t, bdPath, rawDir, "create", "--json", "fresh city bead", "-t", "task"))
-	if got := beadPrefix(rawID); got != "gc" {
+	if got := beadPrefix(nil, rawID); got != "gc" {
 		t.Fatalf("raw city bead prefix = %q, want %q", got, "gc")
 	}
 	providerStore, err := openStoreAtForCity(cityPath, cityPath)
@@ -1083,7 +1083,7 @@ func TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix(t *testing.
 	if err != nil {
 		t.Fatalf("providerStore.Create: %v", err)
 	}
-	if got := beadPrefix(providerBead.ID); got != "gc" {
+	if got := beadPrefix(nil, providerBead.ID); got != "gc" {
 		t.Fatalf("provider city bead prefix = %q, want %q", got, "gc")
 	}
 }

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1507,6 +1507,14 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 		// does not exist yet, so the "no existing children" claim
 		// would be vacuously true and misleading.
 		preCheck := !opts.InlineText
+		// In inline-text mode the live path creates a fresh bead first
+		// and operates on the new ID; reuse a placeholder in preview
+		// commands so operators don't read the inline title as the bead
+		// ID a real run would attach to or route.
+		previewBeadID := opts.BeadOrFormula
+		if opts.InlineText {
+			previewBeadID = "<new-bead-id>"
+		}
 		if opts.OnFormula != "" {
 			if preCheck {
 				if rc := dryRunReportBlockingMolecule(opts, deps, querier, stderr); rc != 0 {
@@ -1519,7 +1527,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			w("  bead. The agent receives the original bead with the workflow")
 			w("  attached, rather than a standalone wisp.")
 			w("")
-			cookCmd := fmt.Sprintf("bd mol cook --formula=%s --on=%s", opts.OnFormula, opts.BeadOrFormula)
+			cookCmd := fmt.Sprintf("bd mol cook --formula=%s --on=%s", opts.OnFormula, previewBeadID)
 			if opts.Title != "" {
 				cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 			}
@@ -1539,7 +1547,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			w("  Target " + a.QualifiedName() + " has a default_sling_formula configured.")
 			w("  A wisp will be attached automatically (use --no-formula to suppress).")
 			w("")
-			cookCmd := fmt.Sprintf("bd mol cook --formula=%s --on=%s", a.EffectiveDefaultSlingFormula(), opts.BeadOrFormula)
+			cookCmd := fmt.Sprintf("bd mol cook --formula=%s --on=%s", a.EffectiveDefaultSlingFormula(), previewBeadID)
 			if opts.Title != "" {
 				cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 			}
@@ -1550,7 +1558,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			w("")
 		}
 
-		routeCmd := sling.BuildSlingCommandForAgent("sling_query", a.EffectiveSlingQuery(), opts.BeadOrFormula, deps.CityPath, deps.CityName, a, deps.Cfg.Rigs, stderr)
+		routeCmd := sling.BuildSlingCommandForAgent("sling_query", a.EffectiveSlingQuery(), previewBeadID, deps.CityPath, deps.CityName, a, deps.Cfg.Rigs, stderr)
 		w("Route command (not executed):")
 		w("  " + routeCmd)
 		if !sling.IsCustomSlingQuery(a) {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -215,7 +215,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 			fmt.Fprintf(stderr, "gc sling: inline text requires explicit target\n  usage: gc sling <target> %q\n", beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		bp := sling.BeadPrefix(beadOrFormula)
+		bp := sling.BeadPrefixForCity(cfg, beadOrFormula)
 		if bp == "" {
 			fmt.Fprintf(stderr, "gc sling: cannot derive rig from bead %q (no prefix)\n", beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
@@ -362,8 +362,13 @@ func findRigByPrefix(cfg *config.City, prefix string) (config.Rig, bool) {
 	return sling.FindRigByPrefix(cfg, prefix)
 }
 
-func beadPrefix(beadID string) string {
-	return sling.BeadPrefix(beadID)
+// beadPrefix returns the rig prefix for beadID, preferring the longest
+// configured prefix when cfg is non-nil. Pass cfg whenever the caller
+// needs hyphenated rig prefixes (e.g. "agent-diagnostics-hnn") to
+// resolve correctly; otherwise the underlying sling.BeadPrefix's
+// first-dash split is used.
+func beadPrefix(cfg *config.City, beadID string) string {
+	return sling.BeadPrefixForCity(cfg, beadID)
 }
 
 func rigDirForBead(cfg *config.City, beadID string) string {
@@ -391,7 +396,7 @@ func resolveSlingStoreRoot(cfg *config.City, cityPath, beadOrFormula string, a c
 	// resolveStoreScopeRoot would silently alias them to the city
 	// scope. Skip them so sling falls back to the agent's rig_dir or
 	// the city store instead of operating on the wrong store.
-	if bp := beadPrefix(beadOrFormula); bp != "" && !looksLikeInlineText(cfg, beadOrFormula) {
+	if bp := beadPrefix(cfg, beadOrFormula); bp != "" && !looksLikeInlineText(cfg, beadOrFormula) {
 		if sling.IsHQPrefix(cfg, bp) {
 			return storeDir
 		}
@@ -957,7 +962,7 @@ func formatBeadLabel(id, title string) string {
 // printCrossRigSection prints the Cross-rig dry-run section if applicable.
 func printCrossRigSection(w func(string), beadID string, a config.Agent, cfg *config.City) {
 	if msg := checkCrossRig(beadID, a, cfg); msg != "" {
-		bp := sling.BeadPrefix(beadID)
+		bp := sling.BeadPrefixForCity(cfg, beadID)
 		rp := rigPrefixForAgent(a, cfg)
 		w("Cross-rig:")
 		w(fmt.Sprintf("  Bead %s (prefix %q) targets %s (rig prefix %q).", beadID, bp, a.QualifiedName(), rp))
@@ -1481,28 +1486,32 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 		w("  The wisp root bead (not the formula name) is routed to the agent.")
 		w("")
 	} else {
-		// Work section (bead info).
-		printBeadInfo(w, querier, opts.BeadOrFormula)
-
-		// Cross-rig section.
-		printCrossRigSection(w, opts.BeadOrFormula, a, deps.Cfg)
-
-		// Idempotency section -- use preflight result instead of re-querying.
-		check := sling.CheckBeadState(querier, opts.BeadOrFormula, a, deps)
-		if check.Idempotent {
-			w("Idempotency:")
-			w("  Bead " + opts.BeadOrFormula + " is already routed to " + a.QualifiedName() + ".")
-			w("  Without --force, sling would skip routing (exit 0).")
+		if opts.InlineText {
+			w("Work:")
+			w("  Would create new task bead with title=" + fmt.Sprintf("%q", opts.BeadOrFormula))
 			w("")
+		} else {
+			printBeadInfo(w, querier, opts.BeadOrFormula)
+			printCrossRigSection(w, opts.BeadOrFormula, a, deps.Cfg)
+
+			check := sling.CheckBeadState(querier, opts.BeadOrFormula, a, deps)
+			if check.Idempotent {
+				w("Idempotency:")
+				w("  Bead " + opts.BeadOrFormula + " is already routed to " + a.QualifiedName() + ".")
+				w("  Without --force, sling would skip routing (exit 0).")
+				w("")
+			}
 		}
 
-		// Attach formula section (--on or default).
-		// Dry-run does NOT auto-burn molecules (no mutations).
+		// Inline-text previews skip the molecule pre-check: the bead
+		// does not exist yet, so the "no existing children" claim
+		// would be vacuously true and misleading.
+		preCheck := !opts.InlineText
 		if opts.OnFormula != "" {
-			// Read-only check: does the bead already have an attached molecule?
-			if label, id := sling.FindBlockingMolecule(querier, opts.BeadOrFormula, deps.Store); label != "" {
-				fmt.Fprintf(stderr, "gc sling: bead %s already has attached %s %s\n", opts.BeadOrFormula, label, id) //nolint:errcheck
-				return 1
+			if preCheck {
+				if rc := dryRunReportBlockingMolecule(opts, deps, querier, stderr); rc != 0 {
+					return rc
+				}
 			}
 			w("Attach formula:")
 			w("  Formula: " + opts.OnFormula)
@@ -1515,12 +1524,15 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 				cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 			}
 			w("  Would run: " + cookCmd)
-			w("  Pre-check: " + opts.BeadOrFormula + " has no existing molecule/wisp children ✓")
+			if preCheck {
+				w("  Pre-check: " + opts.BeadOrFormula + " has no existing molecule/wisp children ✓")
+			}
 			w("")
 		} else if !opts.NoFormula && a.EffectiveDefaultSlingFormula() != "" {
-			if label, id := sling.FindBlockingMolecule(querier, opts.BeadOrFormula, deps.Store); label != "" {
-				fmt.Fprintf(stderr, "gc sling: bead %s already has attached %s %s\n", opts.BeadOrFormula, label, id) //nolint:errcheck
-				return 1
+			if preCheck {
+				if rc := dryRunReportBlockingMolecule(opts, deps, querier, stderr); rc != 0 {
+					return rc
+				}
 			}
 			w("Default formula:")
 			w("  Formula: " + a.EffectiveDefaultSlingFormula())
@@ -1532,7 +1544,9 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 				cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 			}
 			w("  Would run: " + cookCmd)
-			w("  Pre-check: " + opts.BeadOrFormula + " has no existing molecule/wisp children ✓")
+			if preCheck {
+				w("  Pre-check: " + opts.BeadOrFormula + " has no existing molecule/wisp children ✓")
+			}
 			w("")
 		}
 
@@ -1698,6 +1712,18 @@ func printBeadInfo(w func(string), q BeadQuerier, beadID string) {
 	w("")
 }
 
+// dryRunReportBlockingMolecule returns 1 (and emits a stderr diagnostic)
+// when the bead already has an attached molecule that would block
+// formula attachment, otherwise 0.
+func dryRunReportBlockingMolecule(opts slingOpts, deps slingDeps, querier BeadQuerier, stderr io.Writer) int {
+	label, id := sling.FindBlockingMolecule(querier, opts.BeadOrFormula, deps.Store)
+	if label == "" {
+		return 0
+	}
+	fmt.Fprintf(stderr, "gc sling: bead %s already has attached %s %s\n", opts.BeadOrFormula, label, id) //nolint:errcheck // best-effort stderr
+	return 1
+}
+
 // printNudgePreview prints the Nudge section for dry-run output.
 func printNudgePreview(w func(string), a config.Agent, cityName string,
 	sp runtime.Provider, store beads.Store, cfg *config.City,
@@ -1727,8 +1753,11 @@ func isCustomSlingQuery(a config.Agent) bool {
 // "gc-r5sr6bm"). Short suffixes (1-4 chars) are accepted
 // unconditionally. Longer suffixes (5-8 chars) must contain at least
 // one digit to distinguish base36 hashes from English words like
-// "hello-world". Strings with spaces or multiple dashes (like
-// "code-review") are treated as inline text for ad-hoc bead creation.
+// "hello-world". This is the cfg-free heuristic and rejects bead IDs
+// whose rig prefix contains a hyphen ("agent-diagnostics-hnn"); those
+// are accepted by looksLikeConfiguredBeadID, which consults cfg.Rigs.
+// Multi-dash strings with no matching configured rig prefix are
+// treated as inline text for ad-hoc bead creation.
 func looksLikeBeadID(s string) bool {
 	_, baseSuffix, ok := sling.BeadIDParts(s)
 	if !ok || len(baseSuffix) > 8 {
@@ -1765,22 +1794,7 @@ func looksLikeInlineText(cfg *config.City, beadOrFormula string) bool {
 }
 
 func looksLikeConfiguredBeadID(cfg *config.City, s string) bool {
-	prefix, baseSuffix, ok := sling.BeadIDParts(s)
-	if !ok || len(baseSuffix) > 8 {
-		return false
-	}
-	if cfg == nil {
-		return false
-	}
-	if strings.EqualFold(prefix, config.EffectiveHQPrefix(cfg)) {
-		return true
-	}
-	for i := range cfg.Rigs {
-		if strings.EqualFold(prefix, cfg.Rigs[i].EffectivePrefix()) {
-			return true
-		}
-	}
-	return false
+	return sling.LooksLikeConfiguredBeadID(cfg, s)
 }
 
 // rigPrefixForAgent returns the effective bead prefix for the rig that an
@@ -1802,7 +1816,7 @@ func rigPrefixForAgent(a config.Agent, cfg *config.City) string {
 // doesn't match the target agent's rig prefix. Returns "" when the check
 // passes or can't be performed (missing prefix, city-wide agent, no rig).
 func checkCrossRig(beadID string, a config.Agent, cfg *config.City) string {
-	bp := sling.BeadPrefix(beadID)
+	bp := sling.BeadPrefixForCity(cfg, beadID)
 	if bp == "" {
 		return ""
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -114,12 +114,58 @@ func (s *slingTestStore) Get(id string) (beads.Bead, error) {
 	}
 	b, ok := s.synthetic[id]
 	if !ok {
-		if _, _, looksLikeBead := sling.BeadIDParts(id); !looksLikeBead {
+		if !slingTestLooksLikeBeadID(id) {
 			return beads.Bead{}, err
 		}
 		return s.ensureSynthetic(id), nil
 	}
 	return b, nil
+}
+
+// slingTestLooksLikeBeadID accepts the same single-dash shapes as
+// sling.BeadIDParts plus multi-dash shapes whose trailing token has the
+// bead-suffix shape: alphanumeric, ≤8 chars, and either ≤4 chars long
+// or containing at least one digit. The digit-or-≤4 rule mirrors
+// looksLikeBeadIDSuffix and prevents prose like "code-review-please"
+// (suffix "please" — 6 chars, no digit) from being silently fabricated
+// as a synthetic bead and masking the auto-create-text-bead branch in
+// tests. Tests that rely on multi-dash bead IDs whose suffix violates
+// this shape must seed beads explicitly.
+func slingTestLooksLikeBeadID(id string) bool {
+	if _, _, ok := sling.BeadIDParts(id); ok {
+		return true
+	}
+	id = strings.TrimSpace(id)
+	if id == "" || strings.ContainsAny(id, " \t\n") {
+		return false
+	}
+	last := strings.LastIndex(id, "-")
+	if last <= 0 || last == len(id)-1 {
+		return false
+	}
+	suffix := id[last+1:]
+	base := suffix
+	if dot := strings.IndexByte(suffix, '.'); dot > 0 {
+		base = suffix[:dot]
+	}
+	if base == "" || len(base) > 8 {
+		return false
+	}
+	hasDigit := false
+	for _, c := range base {
+		switch {
+		case c >= '0' && c <= '9':
+			hasDigit = true
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		default:
+			return false
+		}
+	}
+	if len(base) > 4 && !hasDigit {
+		return false
+	}
+	return true
 }
 
 func (s *slingTestStore) SetMetadata(id, key, value string) error {
@@ -1163,6 +1209,54 @@ func TestCmdSlingDryRunPreviewsInlineText(t *testing.T) {
 	}
 }
 
+// TestCmdSlingDryRunInlineTextHasNoFalsePositivePreCheck verifies that
+// inline-text dry-runs print a "Would create new task bead" hint and
+// suppress the Pre-check ✓ line (which would be vacuously true for a
+// bead that does not exist yet).
+func TestCmdSlingDryRunInlineTextHasNoFalsePositivePreCheck(t *testing.T) {
+	cityDir := setupCmdSlingBeadExistsFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"frontend/worker", "write docs"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, true,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling dry-run returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "has no existing molecule/wisp children ✓") {
+		t.Fatalf("dry-run stdout still emits false-positive Pre-check ✓ for inline text:\n%s", out)
+	}
+	if !strings.Contains(out, "Would create new task bead") {
+		t.Fatalf("dry-run stdout missing inline-text creation hint:\n%s", out)
+	}
+	// Pre-existing footer must still be present.
+	if !strings.Contains(out, "No side effects executed (--dry-run).") {
+		t.Fatalf("dry-run stdout missing dry-run footer:\n%s", out)
+	}
+
+	// Sanity: city/frontend stores must remain empty (no bead created).
+	for _, dir := range []string{cityDir, filepath.Join(cityDir, "frontend")} {
+		store, err := openStoreAtForCity(dir, cityDir)
+		if err != nil {
+			t.Fatalf("openStoreAtForCity(%s): %v", dir, err)
+		}
+		bs, err := store.List(beads.ListQuery{AllowScan: true})
+		if err != nil {
+			t.Fatalf("List(%s): %v", dir, err)
+		}
+		if len(bs) != 0 {
+			t.Fatalf("store %s has %d beads after dry-run, want 0: %#v", dir, len(bs), bs)
+		}
+	}
+}
+
 func TestResolveInlineBeadActionDryRunInlineTextDoesNotProbeStore(t *testing.T) {
 	create, inlineText := resolveInlineBeadAction(&config.City{}, "write docs", true)
 	if create {
@@ -1200,6 +1294,49 @@ func TestResolveInlineBeadActionBeadIDDoesNotProbeStore(t *testing.T) {
 	}
 	if inlineText {
 		t.Fatal("inlineText = true, want false")
+	}
+}
+
+func TestResolveInlineBeadActionHyphenatedRigPrefixIsBeadID(t *testing.T) {
+	// Bead IDs whose configured rig prefix contains a hyphen
+	// (agent-diagnostics-hnn from rig "agent-diagnostics") must
+	// classify as bead IDs, not inline text.
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent-diagnostics", Path: "/tmp/agent-diag", Prefix: "agent-diagnostics"},
+		},
+	}
+
+	create, inlineText := resolveInlineBeadAction(cfg, "agent-diagnostics-hnn", false)
+	if create {
+		t.Fatal("create = true, want false for configured hyphenated bead ID")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false outside dry-run")
+	}
+
+	create, inlineText = resolveInlineBeadAction(cfg, "agent-diagnostics-hnn", true)
+	if create {
+		t.Fatal("create = true, want false during dry-run")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false for configured bead ID even in dry-run")
+	}
+}
+
+func TestResolveInlineBeadActionUnknownHyphenatedTextStillCreates(t *testing.T) {
+	// Inline text shaped like "<unknown-prefix>-<word>" must still create
+	// an inline task bead. Only inputs that match a CONFIGURED rig prefix
+	// are protected from the auto-create branch.
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "fe", Path: "/fe", Prefix: "fe"}},
+	}
+	create, inlineText := resolveInlineBeadAction(cfg, "code-review-please", false)
+	if !create {
+		t.Fatal("create = false, want true for non-configured hyphenated text")
+	}
+	if inlineText {
+		t.Fatal("inlineText = true, want false outside dry-run")
 	}
 }
 
@@ -1314,6 +1451,106 @@ dir = "orders"
 	}
 	if len(ordersBeads) != 0 {
 		t.Fatalf("orders store bead count = %d, want 0: %#v", len(ordersBeads), ordersBeads)
+	}
+}
+
+// TestCmdSlingHyphenatedRigPrefixExistingBeadDoesNotOrphan verifies
+// that an existing bead in a rig whose configured prefix contains a
+// hyphen ("agent-diagnostics-hnn" in rig "agent-diagnostics") routes
+// to the rig store without auto-creating a city orphan.
+func TestCmdSlingHyphenatedRigPrefixExistingBeadDoesNotOrphan(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "agent-diagnostics")
+	otherDir := filepath.Join(cityDir, "other")
+	for _, dir := range []string{rigDir, otherDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, rigDir, otherDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	writeTestFileStoreBeads(t, rigDir, []beads.Bead{{
+		ID:       "agent-diagnostics-hnn",
+		Title:    "existing diagnostics work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{},
+	}})
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "agent-diagnostics"
+path = "agent-diagnostics"
+prefix = "agent-diagnostics"
+
+[[rigs]]
+name = "other"
+path = "other"
+prefix = "OT"
+
+[[agent]]
+name = "worker"
+dir = "agent-diagnostics"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"agent-diagnostics/worker", "agent-diagnostics-hnn"},
+		false, false, true,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	// The pre-fix bug printed a "Created gc-NNN — \"agent-diagnostics-hnn\""
+	// line because the live path took the auto-create-text-bead branch.
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("orphan auto-create regression: stdout = %q", stdout.String())
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get("agent-diagnostics-hnn")
+	if err != nil {
+		t.Fatalf("rigStore.Get(agent-diagnostics-hnn): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "agent-diagnostics/worker" {
+		t.Fatalf("rig bead gc.routed_to = %q, want agent-diagnostics/worker (routing must land on the existing bead, not an orphan)", routed.Metadata["gc.routed_to"])
+	}
+
+	// City store must NOT contain a stray bead from the auto-create path.
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	cityBeads, err := cityStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("cityStore.List: %v", err)
+	}
+	for _, b := range cityBeads {
+		if b.Title == "agent-diagnostics-hnn" {
+			t.Fatalf("city store has orphan bead %q (title %q): inline-text auto-create fired for a known-rig bead ID", b.ID, b.Title)
+		}
 	}
 }
 
@@ -2898,6 +3135,33 @@ func TestResolveSlingStoreRootUsesPrefixRigForConfiguredAllAlphaBeadID(t *testin
 	want := filepath.Join(cityPath, "rigs", "frontend")
 	if got != want {
 		t.Fatalf("resolveSlingStoreRoot() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSlingStoreRootHonorsHyphenatedRigPrefix(t *testing.T) {
+	// A rig whose configured prefix itself contains a hyphen must
+	// receive its own beads — the longest configured prefix wins
+	// over a shorter prefix that also matches the bead-ID head.
+	cityPath := filepath.Join(t.TempDir(), "city")
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent", Path: filepath.Join("rigs", "agent"), Prefix: "agent"},
+			{Name: "agent-diagnostics", Path: filepath.Join("rigs", "agent-diag"), Prefix: "agent-diagnostics"},
+		},
+	}
+
+	got := resolveSlingStoreRoot(cfg, cityPath, "agent-diagnostics-hnn", config.Agent{Dir: "agent"})
+	want := filepath.Join(cityPath, "rigs", "agent-diag")
+	if got != want {
+		t.Fatalf("resolveSlingStoreRoot(agent-diagnostics-hnn) = %q, want %q (longest configured prefix should win)", got, want)
+	}
+
+	// Sanity check: a bead under the shorter "agent" prefix still resolves
+	// to that rig.
+	got = resolveSlingStoreRoot(cfg, cityPath, "agent-x1", config.Agent{Dir: "agent-diagnostics"})
+	want = filepath.Join(cityPath, "rigs", "agent")
+	if got != want {
+		t.Fatalf("resolveSlingStoreRoot(agent-x1) = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1236,6 +1236,16 @@ func TestCmdSlingDryRunInlineTextHasNoFalsePositivePreCheck(t *testing.T) {
 	if !strings.Contains(out, "Would create new task bead") {
 		t.Fatalf("dry-run stdout missing inline-text creation hint:\n%s", out)
 	}
+	// Cook/route preview commands must use a placeholder rather than
+	// the inline title: the live path creates a bead first and uses
+	// the new ID, so showing "write docs" as the bead-id arg would
+	// describe a command that wouldn't actually run.
+	if strings.Contains(out, "--on=write docs") || strings.Contains(out, "--on='write docs'") {
+		t.Fatalf("dry-run stdout uses inline title as bead ID in --on=...:\n%s", out)
+	}
+	if !strings.Contains(out, "<new-bead-id>") {
+		t.Fatalf("dry-run stdout missing <new-bead-id> placeholder:\n%s", out)
+	}
 	// Pre-existing footer must still be present.
 	if !strings.Contains(out, "No side effects executed (--dry-run).") {
 		t.Fatalf("dry-run stdout missing dry-run footer:\n%s", out)

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -1360,7 +1360,7 @@ func TestCmdSessionWait_AllowsRigDependencyBeads(t *testing.T) {
 	if err := rigStore.Close(dep.ID); err != nil {
 		t.Fatalf("close rig dep bead: %v", err)
 	}
-	if got := beadPrefix(dep.ID); got != "fe" {
+	if got := beadPrefix(nil, dep.ID); got != "fe" {
 		t.Fatalf("rig dep prefix = %q, want %q", got, "fe")
 	}
 
@@ -1436,7 +1436,7 @@ func TestPrepareWaitWakeState_ResolvesRigDependencyBeads(t *testing.T) {
 	if err := rigStore.Close(dep.ID); err != nil {
 		t.Fatalf("close rig dep bead: %v", err)
 	}
-	if got := beadPrefix(dep.ID); got != "fe" {
+	if got := beadPrefix(nil, dep.ID); got != "fe" {
 		t.Fatalf("rig dep prefix = %q, want %q", got, "fe")
 	}
 	cityStore, err = openCityStoreAt(cityPath)

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -267,14 +267,15 @@ func (s *Server) slingStoreScopeForBead(beadID string) (rigName string, cityScop
 	if beadID == "" {
 		return "", false
 	}
-	prefix := sling.BeadPrefix(beadID)
+	cfg := s.state.Config()
+	prefix := sling.BeadPrefixForCity(cfg, beadID)
 	if prefix == "" {
 		return "", false
 	}
-	if sling.IsHQPrefix(s.state.Config(), prefix) {
+	if sling.IsHQPrefix(cfg, prefix) {
 		return "", true
 	}
-	rig, ok := sling.FindRigByPrefix(s.state.Config(), prefix)
+	rig, ok := sling.FindRigByPrefix(cfg, prefix)
 	if !ok {
 		return "", false
 	}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -324,9 +324,10 @@ func IsHQPrefix(cfg *config.City, prefix string) bool {
 }
 
 // RigDirForBead resolves the rig directory for a bead ID by extracting
-// the bead prefix and looking up the rig path.
+// the bead prefix and looking up the rig path. Honors hyphenated rig
+// prefixes via BeadPrefixForCity.
 func RigDirForBead(cfg *config.City, beadID string) string {
-	bp := BeadPrefix(beadID)
+	bp := BeadPrefixForCity(cfg, beadID)
 	if bp == "" {
 		return ""
 	}
@@ -395,12 +396,114 @@ func FormatBeadLabel(id, title string) string {
 // BeadPrefix extracts the rig prefix from a bead ID by taking the lowercase
 // letters before the first dash. "HW-7" → "hw", "FE-123" → "fe".
 // Returns "" if the ID has no dash (can't determine prefix).
+//
+// This is a config-free heuristic. For inputs whose rig prefix may itself
+// contain hyphens ("agent-diagnostics-hnn" routed to rig "agent-diagnostics"),
+// callers must use BeadPrefixForCity, which resolves the longest matching
+// configured prefix.
 func BeadPrefix(beadID string) string {
 	i := strings.Index(beadID, "-")
 	if i <= 0 {
 		return ""
 	}
 	return strings.ToLower(beadID[:i])
+}
+
+// BeadPrefixForCity returns the configured rig (or HQ) prefix that beadID
+// belongs to, preferring the longest match so hyphenated rig prefixes
+// resolve correctly. Falls back to BeadPrefix when no configured prefix
+// matches. Returns "" if the bead has no dash and no configured-prefix
+// match.
+func BeadPrefixForCity(cfg *config.City, beadID string) string {
+	if p := matchConfiguredBeadPrefix(cfg, beadID); p != "" {
+		return p
+	}
+	return BeadPrefix(beadID)
+}
+
+// LooksLikeConfiguredBeadID reports whether s parses as a bead ID whose
+// prefix matches the city's HQ prefix or any configured rig's effective
+// prefix. Unlike BeadIDParts, it accepts hyphenated rig prefixes
+// (e.g. "agent-diagnostics-hnn" with rig "agent-diagnostics"). The
+// trailing suffix must be alphanumeric (allowing an optional ".child"
+// hierarchical part) and at most 8 characters long.
+func LooksLikeConfiguredBeadID(cfg *config.City, s string) bool {
+	return matchConfiguredBeadPrefix(cfg, s) != ""
+}
+
+// matchConfiguredBeadPrefix returns the longest configured prefix
+// (HQ or rig) that beadID begins with, provided the trailing suffix
+// passes the bead-suffix shape gate. Match is case-insensitive on the
+// prefix; the returned value is the lower-cased configured prefix.
+// Returns "" if no configured prefix matches.
+func matchConfiguredBeadPrefix(cfg *config.City, beadID string) string {
+	beadID = strings.TrimSpace(beadID)
+	if cfg == nil || beadID == "" || strings.ContainsAny(beadID, " \t\n") {
+		return ""
+	}
+	candidates := configuredBeadPrefixes(cfg)
+	// Track the longest matching prefix; equal-length ties keep the first
+	// match, matching the order semantics of FindRigByPrefix.
+	best := ""
+	bestLen := 0
+	lower := strings.ToLower(beadID)
+	for _, p := range candidates {
+		lp := strings.ToLower(p)
+		if len(lp) <= bestLen {
+			continue
+		}
+		if !strings.HasPrefix(lower, lp+"-") {
+			continue
+		}
+		suffix := beadID[len(lp)+1:]
+		if !validBeadSuffix(suffix) {
+			continue
+		}
+		best = lp
+		bestLen = len(lp)
+	}
+	return best
+}
+
+// configuredBeadPrefixes returns every prefix the city accepts for bead
+// IDs: the city's HQ prefix plus each rig's effective prefix. Empty
+// entries are skipped. Order is not significant — the caller picks the
+// longest match.
+func configuredBeadPrefixes(cfg *config.City) []string {
+	if cfg == nil {
+		return nil
+	}
+	out := make([]string, 0, len(cfg.Rigs)+1)
+	if hq := config.EffectiveHQPrefix(cfg); hq != "" {
+		out = append(out, hq)
+	}
+	for i := range cfg.Rigs {
+		if p := cfg.Rigs[i].EffectivePrefix(); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// validBeadSuffix reports whether suffix is a plausible bead-ID suffix:
+// a non-empty alphanumeric base of at most 8 characters, optionally
+// followed by ".child" hierarchical parts. The hierarchical portion is
+// not validated, matching BeadIDParts which truncates at the first dot
+// before validating the base.
+func validBeadSuffix(suffix string) bool {
+	base := suffix
+	if dot := strings.IndexByte(suffix, '.'); dot > 0 {
+		base = suffix[:dot]
+	}
+	if base == "" || len(base) > 8 {
+		return false
+	}
+	for _, c := range base {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+			return false
+		}
+	}
+	return true
 }
 
 // RigPrefixForAgent returns the rig prefix that an agent's rig uses for bead IDs.
@@ -445,7 +548,7 @@ func CrossRigRouteError(beadID string, a config.Agent, cfg *config.City) *CrossR
 	if cfg == nil || a.Dir == "" {
 		return nil
 	}
-	bp := BeadPrefix(beadID)
+	bp := BeadPrefixForCity(cfg, beadID)
 	if bp == "" {
 		return nil
 	}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -467,8 +467,11 @@ func matchConfiguredBeadPrefix(cfg *config.City, beadID string) string {
 
 // configuredBeadPrefixes returns every prefix the city accepts for bead
 // IDs: the city's HQ prefix plus each rig's effective prefix. Empty
-// entries are skipped. Order is not significant — the caller picks the
-// longest match.
+// entries are skipped. The caller picks the longest match; order only
+// matters when equal-length matches tie, in which case the first match
+// (HQ before rigs, then cfg.Rigs declaration order) is kept. Note that
+// config validation rejects duplicate prefixes, so ties should not
+// appear in valid configs.
 func configuredBeadPrefixes(cfg *config.City) []string {
 	if cfg == nil {
 		return nil

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -429,6 +429,76 @@ func TestLooksLikeConfiguredBeadIDAcceptsHQPrefix(t *testing.T) {
 	}
 }
 
+// Underscored rig prefixes (e.g. "live_docs") are common in real cities
+// but were rejected by BeadIDParts' alpha-only prefix charset. The
+// config-aware path matches against cfg.Rigs literally, so the broken
+// charset gate is bypassed for any prefix the city has actually
+// declared. Coverage parallels the bug-report cases: live_docs,
+// migration_evals, scix_experiments, EnterpriseBench.
+func TestLooksLikeConfiguredBeadIDAcceptsUnderscoredPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "live_docs", Path: "/ld", Prefix: "live_docs"},
+			{Name: "migration_evals", Path: "/me", Prefix: "migration_evals"},
+			{Name: "scix_experiments", Path: "/sx", Prefix: "scix_experiments"},
+			{Name: "EnterpriseBench", Path: "/eb", Prefix: "EnterpriseBench"},
+		},
+	}
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"live_docs-5du", true},
+		{"migration_evals-cns", true},
+		{"scix_experiments-wqr.9.3", true}, // hierarchical .child suffix.
+		{"EnterpriseBench-0rv.18", true},
+		{"EnterpriseBench-0rv", true},
+		{"live_docs-", false},    // empty suffix.
+		{"live_docs", false},     // no suffix dash.
+		{"unknown_rig-7", false}, // not in config.
+	}
+	for _, tt := range tests {
+		got := LooksLikeConfiguredBeadID(cfg, tt.id)
+		if got != tt.want {
+			t.Errorf("LooksLikeConfiguredBeadID(%q) = %v, want %v", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestBeadPrefixForCityHandlesUnderscoredPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "live_docs", Path: "/ld", Prefix: "live_docs"},
+			{Name: "migration_evals", Path: "/me", Prefix: "migration_evals"},
+		},
+	}
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{"live_docs-5du", "live_docs"},
+		{"migration_evals-cns", "migration_evals"},
+		{"migration_evals-cns.1", "migration_evals"},
+	}
+	for _, tt := range tests {
+		got := BeadPrefixForCity(cfg, tt.id)
+		if got != tt.want {
+			t.Errorf("BeadPrefixForCity(%q) = %q, want %q", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestRigDirForBeadHonorsUnderscoredPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "live_docs", Path: "/live-docs-rig", Prefix: "live_docs"},
+		},
+	}
+	if got := RigDirForBead(cfg, "live_docs-5du"); got != "/live-docs-rig" {
+		t.Errorf("RigDirForBead(live_docs-5du) = %q, want /live-docs-rig", got)
+	}
+}
+
 func TestRigDirForBeadHonorsHyphenatedPrefix(t *testing.T) {
 	cfg := &config.City{
 		Rigs: []config.Rig{

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -499,6 +499,52 @@ func TestRigDirForBeadHonorsUnderscoredPrefix(t *testing.T) {
 	}
 }
 
+// RigDirForBead returns "" in two distinct ways: the prefix doesn't
+// parse at all (BeadPrefixForCity returns "") and the prefix parses
+// but doesn't match any configured rig (BeadPrefix falls back to
+// first-dash split for unknown prefixes). Cover both so a regression
+// that conflates the branches is caught.
+func TestRigDirForBeadEmptyPrefixAndUnknownRig(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "fe", Path: "/fe", Prefix: "fe"}},
+	}
+	// Empty input → BeadPrefixForCity returns "", short-circuits.
+	if got := RigDirForBead(cfg, ""); got != "" {
+		t.Errorf("RigDirForBead(\"\") = %q, want \"\"", got)
+	}
+	// Unknown prefix that BeadPrefix's fallback parses ("unknown")
+	// but is not a configured rig: hits the FindRigByPrefix=false
+	// branch.
+	if got := RigDirForBead(cfg, "unknown-7"); got != "" {
+		t.Errorf("RigDirForBead(unknown-7) = %q, want \"\" (no matching rig)", got)
+	}
+}
+
+// configuredBeadPrefixes skips rigs whose effective prefix is empty.
+// Reaching that branch requires both an empty Name and Prefix —
+// validated configs reject this, but the guard exists so a malformed
+// or partially-applied config can't produce an "" entry that confuses
+// equal-length tiebreaks in matchConfiguredBeadPrefix.
+func TestConfiguredBeadPrefixesSkipsEmptyRigPrefix(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test", Prefix: "HQ"},
+		Rigs: []config.Rig{
+			{Name: "fe", Path: "/fe", Prefix: "fe"},
+			{Name: "", Path: "/empty", Prefix: ""},
+		},
+	}
+	got := configuredBeadPrefixes(cfg)
+	want := []string{"HQ", "fe"}
+	if len(got) != len(want) {
+		t.Fatalf("configuredBeadPrefixes = %v, want %v (empty-prefix rig must be skipped)", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("configuredBeadPrefixes[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestRigDirForBeadHonorsHyphenatedPrefix(t *testing.T) {
 	cfg := &config.City{
 		Rigs: []config.Rig{

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -311,6 +311,156 @@ func TestBeadPrefixSling(t *testing.T) {
 	}
 }
 
+func TestBeadPrefixForCityLongestMatch(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent", Path: "/agent", Prefix: "agent"},
+			{Name: "agent-diagnostics", Path: "/ad", Prefix: "agent-diagnostics"},
+			{Name: "fe", Path: "/fe", Prefix: "fe"},
+		},
+	}
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{"agent-diagnostics-hnn", "agent-diagnostics"},
+		{"agent-x1", "agent"},
+		{"fe-42", "fe"},
+		{"unknown-7", "unknown"}, // falls back to BeadPrefix.
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := BeadPrefixForCity(cfg, tt.id)
+		if got != tt.want {
+			t.Errorf("BeadPrefixForCity(%q) = %q, want %q", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestBeadPrefixForCityFallsBackToBeadPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "fe", Path: "/fe", Prefix: "fe"}},
+	}
+	// Unknown prefix → fall back to BeadPrefix's first-dash split.
+	if got := BeadPrefixForCity(cfg, "unknown-7"); got != "unknown" {
+		t.Errorf("BeadPrefixForCity(unknown-7) = %q, want unknown", got)
+	}
+	// Nil cfg → fall back to BeadPrefix.
+	if got := BeadPrefixForCity(nil, "fe-42"); got != "fe" {
+		t.Errorf("BeadPrefixForCity(nil, fe-42) = %q, want fe", got)
+	}
+}
+
+func TestLooksLikeConfiguredBeadIDAcceptsHyphenatedPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent-diagnostics", Path: "/ad", Prefix: "agent-diagnostics"},
+		},
+	}
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"agent-diagnostics-hnn", true},
+		{"agent-diagnostics-h1", true},
+		{"agent-diagnostics-12345678", true},   // 8-char numeric suffix.
+		{"agent-diagnostics-123456789", false}, // 9-char suffix exceeds cap.
+		{"agent-diagnostics-", false},          // empty suffix.
+		{"agent-diagnostics-h.1", true},        // hierarchical .child.
+		{"agent-diagnostics-h.x", true},
+		{"agent-diagnostics-h.", true}, // trailing dot accepted (matches BeadIDParts).
+		{"agent-diagnostics", false},   // no suffix dash.
+	}
+	for _, tt := range tests {
+		got := LooksLikeConfiguredBeadID(cfg, tt.id)
+		if got != tt.want {
+			t.Errorf("LooksLikeConfiguredBeadID(%q) = %v, want %v", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestLooksLikeConfiguredBeadIDPrefersLongestPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent", Path: "/agent", Prefix: "agent"},
+			{Name: "agent-diagnostics", Path: "/ad", Prefix: "agent-diagnostics"},
+		},
+	}
+	// Both prefixes can match "agent-diagnostics-h1" via the prefix-then-validate
+	// rule, but matchConfiguredBeadPrefix must pick the longest.
+	if !LooksLikeConfiguredBeadID(cfg, "agent-diagnostics-h1") {
+		t.Fatal("LooksLikeConfiguredBeadID(agent-diagnostics-h1) = false, want true")
+	}
+	// "agent-x1" only matches the shorter "agent" prefix.
+	if !LooksLikeConfiguredBeadID(cfg, "agent-x1") {
+		t.Fatal("LooksLikeConfiguredBeadID(agent-x1) = false, want true")
+	}
+}
+
+func TestLooksLikeConfiguredBeadIDRejectsUnknownPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "fe", Path: "/fe", Prefix: "fe"}},
+	}
+	cases := []string{
+		"unknown-42",
+		"code-review-please", // no rig "code" or "code-review" configured.
+		"hello-world",
+		"",
+		"   ",
+		"fe foo",  // whitespace.
+		"fe-foo!", // non-alphanumeric suffix char.
+	}
+	for _, c := range cases {
+		if LooksLikeConfiguredBeadID(cfg, c) {
+			t.Errorf("LooksLikeConfiguredBeadID(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestLooksLikeConfiguredBeadIDAcceptsHQPrefix(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test", Prefix: "HQ"},
+	}
+	if !LooksLikeConfiguredBeadID(cfg, "HQ-42") {
+		t.Fatal("HQ-42 should be a configured bead ID")
+	}
+	if !LooksLikeConfiguredBeadID(cfg, "hq-abc") {
+		t.Fatal("hq-abc should match HQ prefix case-insensitively")
+	}
+}
+
+func TestRigDirForBeadHonorsHyphenatedPrefix(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent", Path: "/agent", Prefix: "agent"},
+			{Name: "agent-diagnostics", Path: "/agent-diag", Prefix: "agent-diagnostics"},
+		},
+	}
+	if got := RigDirForBead(cfg, "agent-diagnostics-hnn"); got != "/agent-diag" {
+		t.Errorf("RigDirForBead = %q, want /agent-diag (longest configured prefix)", got)
+	}
+	if got := RigDirForBead(cfg, "agent-x1"); got != "/agent" {
+		t.Errorf("RigDirForBead = %q, want /agent", got)
+	}
+}
+
+func TestCheckCrossRigDetectsHyphenatedPrefixMismatch(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "agent", Path: "/agent", Prefix: "agent"},
+			{Name: "agent-diagnostics", Path: "/ad", Prefix: "agent-diagnostics"},
+		},
+	}
+	// First-dash BeadPrefix yields "agent" for "agent-diagnostics-hnn",
+	// which falsely matches a worker in rig "agent" and lets cross-rig
+	// routing through silently. The longest-prefix resolver returns
+	// "agent-diagnostics", so the guard fires correctly.
+	a := config.Agent{Name: "worker", Dir: "agent"}
+	if msg := CheckCrossRig("agent-diagnostics-hnn", a, cfg); msg == "" {
+		t.Error("expected cross-rig warning: bead in rig 'agent-diagnostics' routed to worker in rig 'agent' must not be silently permitted")
+	}
+}
+
 func TestCheckCrossRigSling(t *testing.T) {
 	cfg := &config.City{
 		Rigs: []config.Rig{


### PR DESCRIPTION
## Summary

`gc sling <target> <bead-id>` silently auto-created a stray city-level text bead when the bead's rig had a configured prefix containing a hyphen (e.g. `agent-diagnostics-hnn` routed to rig `agent-diagnostics`). The dry-run output misleadingly painted `Bead: <id> ... Pre-check ✓` lines that suggested successful resolution; the live path took the inline-text auto-create branch and produced an orphan with `title=<bead-id>`.

## Root cause

- `internal/sling/sling.go:BeadIDParts` requires exactly one dash (`strings.Count(s, "-") != 1`), so any bead ID whose rig prefix contains a hyphen fails the parse.
- `internal/sling/sling.go:BeadPrefix` splits on the FIRST dash, so `BeadPrefix("agent-diagnostics-hnn")` returns `"agent"` — matching the wrong rig (or no rig) and bypassing the existence check added in #1141.
- `cmd/gc/cmd_sling.go:looksLikeConfiguredBeadID` then returned false even though `cfg.Rigs` contained `agent-diagnostics`, so `looksLikeInlineText` returned true and the live path created a new task bead.

Confirmed by direct test of `BeadIDParts`:

| input | ok? |
|---|---|
| `codeprobe-q0ol`          | ✓ (one dash) |
| `gc-42837`                | ✓ (one dash) |
| `agent-diagnostics-hnn`   | ✗ (two dashes) |

## Changes

- New `sling.BeadPrefixForCity(cfg, beadID)` returns the longest configured rig (or HQ) prefix that `beadID` begins with, falling back to `BeadPrefix` on miss.
- New `sling.LooksLikeConfiguredBeadID(cfg, s)` walks `cfg.Rigs` + HQ prefix to disambiguate hyphenated-rig bead IDs from inline text. Suffix-shape gate (alphanumeric, ≤8) matches `BeadIDParts`.
- `cmd/gc/cmd_sling.go:looksLikeConfiguredBeadID` delegates to the new helper. Four `BeadPrefix` call sites switched to `BeadPrefixForCity`: one-arg default-target inference, store-scope resolution, cross-rig preview, cross-rig guard.
- `internal/api/handler_sling.go:slingStoreScopeForBead` switched to the new resolver so dashboard sling and CLI sling agree on store scope.
- `dryRunSingle` now prints `Would create new task bead with title=…` for inline-text previews and suppresses the false-positive `Pre-check ✓` line. Extracted `dryRunReportBlockingMolecule` helper to flatten the conditional structure.

## Tests

**internal/sling/sling_test.go**
- `TestBeadPrefixForCityLongestMatch` / `…FallsBackToBeadPrefix`
- `TestLooksLikeConfiguredBeadID{Accepts,Prefers,Rejects,AcceptsHQ}*` (4)
- `TestRigDirForBeadHonorsHyphenatedPrefix`
- `TestCheckCrossRigDetectsHyphenatedPrefixMismatch` — uses agent in rig \"agent\"; verified pre-fix would NOT warn (silent permissive — \`bp=rp=\"agent\"\`), post-fix warns correctly.

**cmd/gc/cmd_sling_test.go**
- `TestResolveInlineBeadActionHyphenatedRigPrefixIsBeadID`
- `TestResolveInlineBeadActionUnknownHyphenatedTextStillCreates` (regression guard for \`code-review-please\`-style inline text)
- `TestResolveSlingStoreRootHonorsHyphenatedRigPrefix`
- `TestCmdSlingHyphenatedRigPrefixExistingBeadDoesNotOrphan` — full e2e against a file store: routes to existing rig bead and asserts no city orphan
- `TestCmdSlingDryRunInlineTextHasNoFalsePositivePreCheck`
- Tightened the \`slingTestStore.Get\` test shim to require digit-or-≤4-char trailing token base, mirroring \`looksLikeBeadIDSuffix\`, so prose cannot silently auto-fabricate synthetic beads and mask regressions.

## Verification

- \`go build ./...\` ✓
- \`go vet ./...\` ✓
- \`make check\` (lint + tests) ✓ — pre-existing \`TestPhase0Doctor*\` and \`TestNewSessionProvider_Preregister*\` chdir-leak flakes (from \`TestInstallBeadHooksRigAddIntegration\`) are baseline, unrelated to this PR.
- \`make check-docs\` N/A (no docs touched).
- Race-clean for sling/api packages on focused tests.

## Cross-provider review

- **Codex (gpt-5.4):** approve after iteration 2 (4/4 majors verified resolved).
- **Copilot (gpt-5.3-codex):** approve (7/7 verifications passed on iter 1).
- **Anthropic semantic:** 0 blockers, 0 majors.

## Out of scope (follow-up)

\`internal/api/handler_beads.go:beadPrefix\` and \`internal/api/convoy_sql.go\` use a separate alpha-only prefix algorithm with a \`routes.jsonl\` + legacy-scan fallback. The fallback locates hyphenated-prefix beads correctly (no orphan risk), but it takes a less-direct path than \`BeadPrefixForCity\` would. Will track separately.

## Test plan

- [x] \`go test ./internal/sling/ ./cmd/gc/ -run 'Sling|Bead|Cross|Looks' -count=1\`
- [x] \`make build\`
- [x] \`make check\`
- [x] Cross-provider review (Codex + Copilot + Anthropic)
- [x] 29-rule contributor audit (\`gascity-checker\`)