### PR TITLE
fix(orders): qualify pool name with pack binding at dispatch (#1268)

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -488,7 +488,11 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 
 	var pool string
 	if a.Pool != "" {
-		pool = qualifyPool(a.Pool, a.Rig, cfg)
+		pool, err = qualifyOrderPool(a, cfg)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	if a.Pool != "" && cfg != nil {

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -486,8 +486,12 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		return 1
 	}
 
+	var pool string
+	if a.Pool != "" {
+		pool = qualifyPool(a.Pool, a.Rig, cfg)
+	}
+
 	if a.Pool != "" && cfg != nil {
-		pool := qualifyPool(a.Pool, a.Rig)
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", "", store, cityName, cityPath, cfg); err != nil {
 			fmt.Fprintf(stderr, "gc order run: routing decoration failed: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
@@ -512,9 +516,7 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		)
 	}
 	if a.Pool != "" {
-		update.Metadata = map[string]string{
-			"gc.routed_to": qualifyPool(a.Pool, a.Rig),
-		}
+		update.Metadata = map[string]string{"gc.routed_to": pool}
 	}
 	if err := store.Update(rootID, update); err != nil {
 		fmt.Fprintf(stderr, "gc order run: labeling wisp: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -523,7 +525,7 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 
 	fmt.Fprintf(stdout, "Order %q executed: wisp %s", name, rootID) //nolint:errcheck
 	if a.Pool != "" {
-		fmt.Fprintf(stdout, " → gc.routed_to=%s", qualifyPool(a.Pool, a.Rig)) //nolint:errcheck
+		fmt.Fprintf(stdout, " → gc.routed_to=%s", pool) //nolint:errcheck
 	}
 	fmt.Fprintln(stdout) //nolint:errcheck
 	return 0

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -690,6 +690,185 @@ func TestOrderRun(t *testing.T) {
 	}
 }
 
+func TestOrderRunResolvesPackBindingForPool(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", FormulaLayer: sharedTestFormulaDir},
+	}
+	cityDir := t.TempDir()
+	writeOrderRunImportFixture(t, cityDir, "maintenance")
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", cityDir, store, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	results, err := store.ListByLabel("order-run:digest", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	if got := results[0].Metadata["gc.routed_to"]; got != "maintenance.dog" {
+		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
+	}
+	if !strings.Contains(stdout.String(), "gc.routed_to=maintenance.dog") {
+		t.Fatalf("stdout = %q, want binding-qualified route", stdout.String())
+	}
+}
+
+func TestOrderRunResolvesImportedPackPoolAgainstCityShadow(t *testing.T) {
+	cityDir := t.TempDir()
+	writeImportedDogOrderFixture(t, cityDir, true)
+	_, aa := loadImportedDogOrders(t, cityDir)
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", cityDir, store, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	results, err := store.ListByLabel("order-run:digest", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	if got := results[0].Metadata["gc.routed_to"]; got != "maintenance.dog" {
+		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
+	}
+}
+
+func TestOrderRunResolvesImportedPackPoolAgainstSiblingImportCollision(t *testing.T) {
+	cityDir := t.TempDir()
+	writeImportedDogOrderFixture(t, cityDir, false, "gastown")
+	_, aa := loadImportedDogOrders(t, cityDir)
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", cityDir, store, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	results, err := store.ListByLabel("order-run:digest", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	if got := results[0].Metadata["gc.routed_to"]; got != "maintenance.dog" {
+		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
+	}
+}
+
+func TestOrderRunPrefersCityShadowForPool(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", FormulaLayer: sharedTestFormulaDir},
+	}
+	cityDir := t.TempDir()
+	writeOrderRunImportFixture(t, cityDir, "maintenance")
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "shadow-city"
+prefix = "shd"
+
+[[agent]]
+name = "dog"
+`)
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", cityDir, store, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	results, err := store.ListByLabel("order-run:digest", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	if got := results[0].Metadata["gc.routed_to"]; got != "dog" {
+		t.Fatalf("gc.routed_to = %q, want dog", got)
+	}
+	if !strings.Contains(stdout.String(), "gc.routed_to=dog") {
+		t.Fatalf("stdout = %q, want city-local route", stdout.String())
+	}
+}
+
+func TestOrderRunRejectsAmbiguousPackPool(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", FormulaLayer: sharedTestFormulaDir},
+	}
+	cityDir := t.TempDir()
+	writeOrderRunImportFixture(t, cityDir, "gastown", "maintenance")
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "digest", "", cityDir, store, nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderRun = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `ambiguous pool "dog"`) {
+		t.Fatalf("stderr = %q, want ambiguity error", stderr.String())
+	}
+	results, err := store.ListByLabel("order-run:digest", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("store.ListByLabel() len = %d, want 0 (%#v)", len(results), results)
+	}
+}
+
+func writeOrderRunImportFixture(t *testing.T, cityDir string, bindings ...string) {
+	t.Helper()
+
+	packRoot := filepath.Join(cityDir, "packs")
+	if err := os.MkdirAll(packRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `
+[workspace]
+name = "test-city"
+`)
+
+	var packToml strings.Builder
+	packToml.WriteString(`
+[pack]
+name = "test-city"
+schema = 1
+`)
+	for _, binding := range bindings {
+		packDir := filepath.Join(packRoot, binding)
+		if err := os.MkdirAll(packDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(packDir, "pack.toml"), `
+[pack]
+name = "`+binding+`"
+schema = 1
+
+[[agent]]
+name = "dog"
+scope = "city"
+`)
+		packToml.WriteString(`
+[imports.` + binding + `]
+source = "./packs/` + binding + `"
+`)
+	}
+	writeFile(t, filepath.Join(cityDir, "pack.toml"), packToml.String())
+}
+
 func TestOrderRunNoPool(t *testing.T) {
 	aa := []orders.Order{
 		{Name: "cleanup", Formula: "mol-cleanup", Trigger: "cron", Schedule: "0 3 * * *", FormulaLayer: sharedTestFormulaDir},

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -327,7 +328,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 			Subject: scoped,
 			Message: err.Error(),
 		})
-		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
+		m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
 		return
 	}
 	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{}); err != nil {
@@ -337,13 +338,24 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 			Subject: scoped,
 			Message: err.Error(),
 		})
-		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
+		m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
 		return
 	}
 
 	var pool string
 	if a.Pool != "" {
-		pool = qualifyPool(a.Pool, a.Rig, m.cfg)
+		pool, err = qualifyOrderPool(a, m.cfg)
+		if err != nil {
+			logDispatchError(m.stderr, "gc: order %s: %v", scoped, err)
+			m.rec.Record(events.Event{
+				Type:    events.OrderFailed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: err.Error(),
+			})
+			m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
+			return
+		}
 	}
 
 	// Decorate graph workflow recipes with routing metadata so child step
@@ -363,7 +375,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 			Subject: scoped,
 			Message: err.Error(),
 		})
-		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
+		m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
 		return
 	}
 	rootID := cookResult.RootID
@@ -390,7 +402,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 			Subject: scoped,
 			Message: fmt.Sprintf("wisp %s created but label failed: %v", rootID, err),
 		})
-		store.Update(trackingID, beads.UpdateOpts{Labels: []string{"wisp", "wisp-failed"}}) //nolint:errcheck // best-effort
+		m.markTrackingFailure(store, trackingID, scoped, a, headSeq)
 		return
 	}
 
@@ -412,11 +424,31 @@ func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
 	if m.cfg == nil {
 		return false
 	}
-	qualified := qualifyPool(a.Pool, a.Rig, m.cfg)
+	qualified, err := qualifyOrderPool(a, m.cfg)
+	if err != nil {
+		return m.rigSuspendedByName(a.Rig)
+	}
 	rigName, _ := config.ParseQualifiedName(qualified)
 	if rigName == "" {
 		rigName = a.Rig
 	}
+	return m.rigSuspendedByName(rigName)
+}
+
+func (m *memoryOrderDispatcher) markTrackingFailure(store beads.Store, trackingID, scoped string, a orders.Order, headSeq uint64) {
+	labels := []string{"wisp", "wisp-failed"}
+	if a.Trigger == "event" && headSeq > 0 {
+		labels = append(labels,
+			fmt.Sprintf("order:%s", scoped),
+			fmt.Sprintf("seq:%d", headSeq),
+		)
+	}
+	if err := store.Update(trackingID, beads.UpdateOpts{Labels: labels}); err != nil {
+		logDispatchError(m.stderr, "gc: order %s: failed to mark tracking bead %s as failed: %v", scoped, trackingID, err)
+	}
+}
+
+func (m *memoryOrderDispatcher) rigSuspendedByName(rigName string) bool {
 	if rigName == "" {
 		return false
 	}
@@ -541,50 +573,111 @@ func rigExclusiveLayers(rigLayers, cityLayers []string) []string {
 // via gc.routed_to. Three layers of qualification stack:
 //
 //  1. If pool already contains "/" it is rig-qualified — pass through.
-//  2. If pool already contains "." it is binding-qualified — skip the
-//     binding lookup but still stack the rig prefix when present.
-//  3. Otherwise look up agents in cfg.Agents whose Dir matches rig
-//     (city orders use rig=="") and Name matches pool. If one or more
-//     matches are found and all of them share the same non-empty
-//     BindingName, swap pool for the binding-qualified form
-//     ("binding.name") before any rig prefixing. This handles V2 pack
-//     imports where the dispatched wisp must carry "binding.name" so the
-//     agent's default scale_check matches its own qualified name.
+//  2. If pool exactly matches a configured binding-qualified target
+//     ("binding.name"), preserve that target and still stack the rig prefix
+//     when present.
+//  3. If the order came from an imported pack, prefer same-source agents when
+//     resolving a bare pool name so pack-local orders stay pack-local even if
+//     other scopes also export the same bare agent name.
+//  4. Otherwise look up agents in cfg.Agents whose Dir matches rig
+//     (city orders use rig=="") and Name matches pool. If exactly one target
+//     resolves, swap pool for the binding-qualified form ("binding.name")
+//     before any rig prefixing. This handles V2 pack imports where the
+//     dispatched wisp must carry "binding.name" so the agent's default
+//     scale_check matches its own qualified name.
 //
-// Ambiguity (multiple matching agents with different bindings) falls back
-// to the unqualified pool to avoid silently picking by slice declaration
-// order. Duplicate matches with the same non-empty binding are treated as
-// equivalent and still qualify. nil cfg preserves the rig-only behavior so
-// call sites without a loaded city remain stable.
-func qualifyPool(pool, rig string, cfg *config.City) string {
+// Ambiguity is a hard failure: silently stamping the bare pool string would
+// recreate the exact route/scaler mismatch this helper exists to prevent.
+// nil cfg preserves the rig-only behavior so call sites without a loaded
+// city remain stable. Dotted values that do not match a configured bound
+// target are preserved for backward compatibility.
+func qualifyOrderPool(a orders.Order, cfg *config.City) (string, error) {
+	return qualifyPool(a.Pool, a.Rig, cfg, orderPoolSourceDirHint(a))
+}
+
+func orderPoolSourceDirHint(a orders.Order) string {
+	if a.FormulaLayer == "" {
+		return ""
+	}
+	return filepath.Clean(filepath.Dir(a.FormulaLayer))
+}
+
+func qualifyPool(pool, rig string, cfg *config.City, sourceDirHint string) (string, error) {
 	if strings.Contains(pool, "/") {
-		return pool
+		return pool, nil
+	}
+	if cfg == nil {
+		if rig == "" {
+			return pool, nil
+		}
+		return rig + "/" + pool, nil
 	}
 
 	qualified := pool
-	if !strings.Contains(pool, ".") && cfg != nil {
-		var match *config.Agent
-		ambiguous := false
-		for i := range cfg.Agents {
-			a := &cfg.Agents[i]
-			if a.Dir != rig || a.Name != pool {
-				continue
-			}
-			if match != nil && match.BindingName != a.BindingName {
-				ambiguous = true
-				break
-			}
-			match = a
+	scope := "city order"
+	if rig != "" {
+		scope = fmt.Sprintf("rig %q", rig)
+	}
+
+	var exactQualified []string
+	var sourceScopedMatches []string
+	var localBareMatches []string
+	var bareMatches []string
+	cleanHint := ""
+	if sourceDirHint != "" {
+		cleanHint = filepath.Clean(sourceDirHint)
+	}
+	for i := range cfg.Agents {
+		a := &cfg.Agents[i]
+		if a.Dir != rig {
+			continue
 		}
-		if !ambiguous && match != nil && match.BindingName != "" {
-			qualified = match.BindingQualifiedName()
+		switch {
+		case strings.Contains(pool, ".") && a.BindingQualifiedName() == pool:
+			exactQualified = appendUniquePoolTarget(exactQualified, a.BindingQualifiedName())
+		case a.Name == pool:
+			bareMatches = appendUniquePoolTarget(bareMatches, a.BindingQualifiedName())
+			if a.BindingName == "" {
+				localBareMatches = appendUniquePoolTarget(localBareMatches, a.BindingQualifiedName())
+			}
+			if cleanHint != "" && filepath.Clean(a.SourceDir) == cleanHint {
+				sourceScopedMatches = appendUniquePoolTarget(sourceScopedMatches, a.BindingQualifiedName())
+			}
 		}
 	}
 
-	if rig == "" {
-		return qualified
+	switch {
+	case len(exactQualified) == 1:
+		qualified = exactQualified[0]
+	case len(exactQualified) > 1:
+		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(exactQualified, ", "))
+	case len(sourceScopedMatches) == 1:
+		qualified = sourceScopedMatches[0]
+	case len(sourceScopedMatches) > 1:
+		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(sourceScopedMatches, ", "))
+	case len(localBareMatches) == 1:
+		qualified = localBareMatches[0]
+	case len(localBareMatches) > 1:
+		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(localBareMatches, ", "))
+	case len(bareMatches) == 1:
+		qualified = bareMatches[0]
+	case len(bareMatches) > 1:
+		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(bareMatches, ", "))
 	}
-	return rig + "/" + qualified
+
+	if rig == "" {
+		return qualified, nil
+	}
+	return rig + "/" + qualified, nil
+}
+
+func appendUniquePoolTarget(values []string, want string) []string {
+	for _, value := range values {
+		if value == want {
+			return values
+		}
+	}
+	return append(values, want)
 }
 
 // convertOverrides converts config.OrderOverride to orders.Override.

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -341,10 +341,14 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 
+	var pool string
+	if a.Pool != "" {
+		pool = qualifyPool(a.Pool, a.Rig, m.cfg)
+	}
+
 	// Decorate graph workflow recipes with routing metadata so child step
 	// beads get gc.routed_to set before instantiation.
 	if a.Pool != "" {
-		pool := qualifyPool(a.Pool, a.Rig)
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", "", store, m.cityName, cityPath, m.cfg); err != nil {
 			logDispatchError(m.stderr, "gc: order %s: routing decoration failed: %v", scoped, err)
 			// Non-fatal — molecule still works, just without step-level routing.
@@ -374,7 +378,6 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		)
 	}
 	if a.Pool != "" {
-		pool := qualifyPool(a.Pool, a.Rig)
 		update.Metadata = map[string]string{"gc.routed_to": pool}
 	}
 	if err := store.Update(rootID, update); err != nil {
@@ -409,7 +412,7 @@ func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
 	if m.cfg == nil {
 		return false
 	}
-	qualified := qualifyPool(a.Pool, a.Rig)
+	qualified := qualifyPool(a.Pool, a.Rig, m.cfg)
 	rigName, _ := config.ParseQualifiedName(qualified)
 	if rigName == "" {
 		rigName = a.Rig
@@ -533,14 +536,55 @@ func rigExclusiveLayers(rigLayers, cityLayers []string) []string {
 	return rigLayers[len(cityLayers):]
 }
 
-// qualifyPool prefixes an unqualified pool name with the rig name for
-// rig-scoped orders. Already-qualified names (containing "/") are
-// returned as-is. City orders (empty rig) are unchanged.
-func qualifyPool(pool, rig string) string {
-	if rig == "" || strings.Contains(pool, "/") {
+// qualifyPool resolves a raw pool name from an order TOML to the qualified
+// form used by Agent.QualifiedName() — the same string the scaler queries
+// via gc.routed_to. Three layers of qualification stack:
+//
+//  1. If pool already contains "/" it is rig-qualified — pass through.
+//  2. If pool already contains "." it is binding-qualified — skip the
+//     binding lookup but still stack the rig prefix when present.
+//  3. Otherwise look up agents in cfg.Agents whose Dir matches rig
+//     (city orders use rig=="") and Name matches pool. If one or more
+//     matches are found and all of them share the same non-empty
+//     BindingName, swap pool for the binding-qualified form
+//     ("binding.name") before any rig prefixing. This handles V2 pack
+//     imports where the dispatched wisp must carry "binding.name" so the
+//     agent's default scale_check matches its own qualified name.
+//
+// Ambiguity (multiple matching agents with different bindings) falls back
+// to the unqualified pool to avoid silently picking by slice declaration
+// order. Duplicate matches with the same non-empty binding are treated as
+// equivalent and still qualify. nil cfg preserves the rig-only behavior so
+// call sites without a loaded city remain stable.
+func qualifyPool(pool, rig string, cfg *config.City) string {
+	if strings.Contains(pool, "/") {
 		return pool
 	}
-	return rig + "/" + pool
+
+	qualified := pool
+	if !strings.Contains(pool, ".") && cfg != nil {
+		var match *config.Agent
+		ambiguous := false
+		for i := range cfg.Agents {
+			a := &cfg.Agents[i]
+			if a.Dir != rig || a.Name != pool {
+				continue
+			}
+			if match != nil && match.BindingName != a.BindingName {
+				ambiguous = true
+				break
+			}
+			match = a
+		}
+		if !ambiguous && match != nil && match.BindingName != "" {
+			qualified = match.BindingQualifiedName()
+		}
+	}
+
+	if rig == "" {
+		return qualified
+	}
+	return rig + "/" + qualified
 }
 
 // convertOverrides converts config.OrderOverride to orders.Override.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -168,6 +168,265 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {
+	store := beads.NewMemStore()
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog"},
+			{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance"},
+		},
+	}
+
+	aa := []orders.Order{{
+		Name:         "mol-dog-doctor",
+		Trigger:      "cooldown",
+		Interval:     "5m",
+		Formula:      "test-formula",
+		Pool:         "dog",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+
+	m := &memoryOrderDispatcher{
+		aa: aa,
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     events.Discard,
+		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	work := workBeadByOrderLabel(t, store, "order-run:mol-dog-doctor")
+	if got := work.Metadata["gc.routed_to"]; got != "dog" {
+		t.Errorf("gc.routed_to = %q, want %q (city-local shadow should stay local)", got, "dog")
+	}
+}
+
+func TestOrderDispatchRejectsAmbiguousPackPool(t *testing.T) {
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+			{Name: "dog", BindingName: "maintenance"},
+		},
+	}
+
+	aa := []orders.Order{{
+		Name:         "mol-dog-doctor",
+		Trigger:      "cooldown",
+		Interval:     "5m",
+		Formula:      "test-formula",
+		Pool:         "dog",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+
+	m := &memoryOrderDispatcher{
+		aa: aa,
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event for ambiguous pool")
+	}
+	if !strings.Contains(stderr.String(), `ambiguous pool "dog"`) {
+		t.Fatalf("stderr = %q, want ambiguity error", stderr.String())
+	}
+	all := trackingBeads(t, store, "order-run:mol-dog-doctor")
+	var workCount int
+	for _, bead := range all {
+		if !strings.HasPrefix(bead.Title, "order:") {
+			workCount++
+		}
+	}
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label = %d, want 1", len(all))
+	}
+	if workCount != 0 {
+		t.Fatalf("work bead count = %d, want 0", workCount)
+	}
+
+	// An ambiguous failure should still count as the authoritative last run,
+	// so the next patrol tick within the cooldown interval must not create a
+	// second tracking bead or emit another order.failed event.
+	failedEvents := 0
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed && event.Subject == "mol-dog-doctor" {
+			failedEvents++
+		}
+	}
+	if failedEvents != 1 {
+		t.Fatalf("order.failed count after first dispatch = %d, want 1", failedEvents)
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now().Add(10*time.Second))
+	time.Sleep(50 * time.Millisecond)
+
+	all = trackingBeads(t, store, "order-run:mol-dog-doctor")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after second dispatch = %d, want 1", len(all))
+	}
+	failedEvents = 0
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed && event.Subject == "mol-dog-doctor" {
+			failedEvents++
+		}
+	}
+	if failedEvents != 1 {
+		t.Fatalf("order.failed count after second dispatch = %d, want 1", failedEvents)
+	}
+}
+
+func TestOrderDispatchRejectsAmbiguousEventPoolOncePerEvent(t *testing.T) {
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var stderr bytes.Buffer
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+			{Name: "dog", BindingName: "maintenance"},
+		},
+	}
+
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+
+	aa := []orders.Order{{
+		Name:         "release-watch",
+		Trigger:      "event",
+		On:           events.BeadClosed,
+		Formula:      "test-formula",
+		Pool:         "dog",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+
+	m := &memoryOrderDispatcher{
+		aa: aa,
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		ep:      eventLog,
+		execRun: shellExecRunner,
+		rec:     &rec,
+		stderr:  &stderr,
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	all := trackingBeads(t, store, "order-run:release-watch")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after first dispatch = %d, want 1", len(all))
+	}
+	if !slicesContain(all[0].Labels, "order:release-watch") {
+		t.Fatalf("tracking bead labels = %v, want order cursor label", all[0].Labels)
+	}
+	if !slicesContain(all[0].Labels, fmt.Sprintf("seq:%d", headSeq)) {
+		t.Fatalf("tracking bead labels = %v, want seq:%d", all[0].Labels, headSeq)
+	}
+
+	failedEvents := 0
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed && event.Subject == "release-watch" {
+			failedEvents++
+		}
+	}
+	if failedEvents != 1 {
+		t.Fatalf("order.failed count after first dispatch = %d, want 1", failedEvents)
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now().Add(10*time.Second))
+	time.Sleep(50 * time.Millisecond)
+
+	all = trackingBeads(t, store, "order-run:release-watch")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after second dispatch = %d, want 1", len(all))
+	}
+	failedEvents = 0
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed && event.Subject == "release-watch" {
+			failedEvents++
+		}
+	}
+	if failedEvents != 1 {
+		t.Fatalf("order.failed count after second dispatch = %d, want 1", failedEvents)
+	}
+}
+
+func TestOrderDispatchResolvesImportedPackPoolAgainstCityShadow(t *testing.T) {
+	cityDir := t.TempDir()
+	writeImportedDogOrderFixture(t, cityDir, true)
+	cfg, aa := loadImportedDogOrders(t, cityDir)
+	store := beads.NewMemStore()
+
+	m := &memoryOrderDispatcher{
+		aa: aa,
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     events.Discard,
+		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), cityDir, time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	work := workBeadByOrderLabel(t, store, "order-run:digest")
+	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
+		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
+	}
+}
+
+func TestOrderDispatchResolvesImportedPackPoolAgainstSiblingImportCollision(t *testing.T) {
+	cityDir := t.TempDir()
+	writeImportedDogOrderFixture(t, cityDir, false, "gastown")
+	cfg, aa := loadImportedDogOrders(t, cityDir)
+	store := beads.NewMemStore()
+
+	m := &memoryOrderDispatcher{
+		aa: aa,
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     events.Discard,
+		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), cityDir, time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	work := workBeadByOrderLabel(t, store, "order-run:digest")
+	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
+		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
+	}
+}
+
 func TestOrderDispatchCooldownNotDue(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -1411,6 +1670,23 @@ func TestOrderRigSuspended(t *testing.T) {
 	}
 }
 
+func TestOrderRigSuspendedFallsBackToOrderRigOnPoolResolutionError(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "frozen", Path: "/tmp/frozen", Suspended: true},
+		},
+		Agents: []config.Agent{
+			{Name: "dog", Dir: "frozen", BindingName: "alpha"},
+			{Name: "dog", Dir: "frozen", BindingName: "beta"},
+		},
+	}
+	m := &memoryOrderDispatcher{cfg: cfg}
+
+	if got := m.orderRigSuspended(orders.Order{Rig: "frozen", Pool: "dog"}); !got {
+		t.Fatal("orderRigSuspended() = false, want true for suspended rig when pool resolution fails")
+	}
+}
+
 // --- orphaned tracking bead sweep tests (#520) ---
 
 func TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads(t *testing.T) {
@@ -1916,46 +2192,77 @@ func TestQualifyPool(t *testing.T) {
 		{Name: "dog", BindingName: "gastown"},
 		{Name: "dog", BindingName: "maintenance"},
 	}}
+	importedOnlyCollisionCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance"},
+		{Name: "dog", BindingName: "gastown", SourceDir: "/city/packs/gastown"},
+	}}
+	importedShadowCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog"},
+		{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance"},
+		{Name: "dog", BindingName: "gastown", SourceDir: "/city/packs/gastown"},
+	}}
 	dirIsolatedCfg := &config.City{Agents: []config.Agent{
 		// City-level binding agent should NOT match a rig-scoped order.
 		{Name: "dog", BindingName: "maintenance"},
 	}}
 
 	tests := []struct {
-		name      string
-		cfg       *config.City
-		pool, rig string
-		want      string
+		name          string
+		cfg           *config.City
+		pool, rig     string
+		sourceDirHint string
+		want          string
+		wantErr       string
 	}{
 		// Existing behavior preserved when cfg is nil (call sites that
 		// don't have a loaded city, e.g. TestOrderRun fixtures).
-		{"nil cfg city order", nil, "dog", "", "dog"},
-		{"nil cfg rig order", nil, "polecat", "demo-repo", "demo-repo/polecat"},
-		{"nil cfg pre-rig-qualified", nil, "demo-repo/polecat", "demo-repo", "demo-repo/polecat"},
+		{"nil cfg city order", nil, "dog", "", "", "dog", ""},
+		{"nil cfg rig order", nil, "polecat", "demo-repo", "", "demo-repo/polecat", ""},
+		{"nil cfg pre-rig-qualified", nil, "demo-repo/polecat", "demo-repo", "", "demo-repo/polecat", ""},
 
 		// Already-qualified passthroughs.
-		{"already rig-qualified passthrough", cityBindingCfg, "demo-repo/dog", "", "demo-repo/dog"},
-		{"already binding-qualified passthrough", cityBindingCfg, "maintenance.dog", "", "maintenance.dog"},
-		{"binding-qualified gets rig prefix", cityBindingCfg, "maintenance.dog", "api", "api/maintenance.dog"},
+		{"already rig-qualified passthrough", cityBindingCfg, "demo-repo/dog", "", "", "demo-repo/dog", ""},
+		{"already binding-qualified passthrough", cityBindingCfg, "maintenance.dog", "", "", "maintenance.dog", ""},
+		{"binding-qualified gets rig prefix", rigBindingCfg, "foo.dog", "api", "", "api/foo.dog", ""},
 
 		// City-order binding lookup (the bug fix).
-		{"city order resolves binding", cityBindingCfg, "dog", "", "maintenance.dog"},
-		{"city order no binding agent", cityNoBindingCfg, "dog", "", "dog"},
-		{"city order miss falls through", cityBindingCfg, "wolf", "", "wolf"},
+		{"city order resolves binding", cityBindingCfg, "dog", "", "", "maintenance.dog", ""},
+		{"city order no binding agent", cityNoBindingCfg, "dog", "", "", "dog", ""},
+		{"city order miss falls through", cityBindingCfg, "wolf", "", "", "wolf", ""},
+		{"city local shadow wins without hint", importedShadowCfg, "dog", "", "", "dog", ""},
+		{"no hint stays ambiguous", importedOnlyCollisionCfg, "dog", "", "", "", `ambiguous pool "dog" for city order: matches maintenance.dog, gastown.dog`},
+		{"source hint beats city shadow", importedShadowCfg, "dog", "", "/city/packs/maintenance", "maintenance.dog", ""},
+		{"source hint beats sibling import collision", importedShadowCfg, "dog", "", "/city/packs/gastown", "gastown.dog", ""},
 
 		// Rig-order binding lookup.
-		{"rig order resolves binding", rigBindingCfg, "dog", "api", "api/foo.dog"},
-		{"rig order isolated from city agent", dirIsolatedCfg, "dog", "api", "api/dog"},
+		{"rig order resolves binding", rigBindingCfg, "dog", "api", "", "api/foo.dog", ""},
+		{"rig order isolated from city agent", dirIsolatedCfg, "dog", "api", "", "api/dog", ""},
 
-		// Ambiguity falls back to unqualified to avoid silent picks.
-		{"ambiguous bindings fall through", ambiguousCfg, "dog", "", "dog"},
+		// Ambiguity is a hard failure — dispatch must not recreate the
+		// original bare-name route/scaler mismatch.
+		{"ambiguous bindings fail", ambiguousCfg, "dog", "", "", "", `ambiguous pool "dog" for city order: matches gastown.dog, maintenance.dog`},
+
+		// Unresolved dotted pools preserve the legacy pass-through behavior.
+		{"unresolved dotted pool passes through", cityBindingCfg, "team.alpha", "", "", "team.alpha", ""},
 
 		// Empty/edge cases.
-		{"empty cfg agents", &config.City{}, "dog", "", "dog"},
+		{"empty cfg agents", &config.City{}, "dog", "", "", "dog", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := qualifyPool(tt.pool, tt.rig, tt.cfg)
+			got, err := qualifyPool(tt.pool, tt.rig, tt.cfg, tt.sourceDirHint)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("qualifyPool(%q, %q, cfg) error = nil, want %q", tt.pool, tt.rig, tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("qualifyPool(%q, %q, cfg) error = %q, want %q", tt.pool, tt.rig, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("qualifyPool(%q, %q, cfg) error = %v", tt.pool, tt.rig, err)
+			}
 			if got != tt.want {
 				t.Errorf("qualifyPool(%q, %q, cfg) = %q, want %q", tt.pool, tt.rig, got, tt.want)
 			}
@@ -2588,6 +2895,97 @@ func writeFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeImportedDogOrderFixture(t *testing.T, cityDir string, includeCityDog bool, extraBindings ...string) {
+	t.Helper()
+
+	const orderBinding = "maintenance"
+	packRoot := filepath.Join(cityDir, "packs")
+	if err := os.MkdirAll(packRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cityToml := `
+[workspace]
+name = "test-city"
+`
+	if includeCityDog {
+		cityToml += `
+
+[[agent]]
+name = "dog"
+scope = "city"
+`
+	}
+	writeFile(t, filepath.Join(cityDir, "city.toml"), cityToml)
+
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(test-formula): %v", err)
+	}
+
+	allBindings := append([]string{orderBinding}, extraBindings...)
+	var packToml strings.Builder
+	packToml.WriteString(`
+[pack]
+name = "test-city"
+schema = 1
+`)
+
+	for _, binding := range allBindings {
+		packDir := filepath.Join(packRoot, binding)
+		if err := os.MkdirAll(filepath.Join(packDir, "orders"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(packDir, "formulas"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(packDir, "pack.toml"), `
+[pack]
+name = "`+binding+`"
+schema = 1
+
+[[agent]]
+name = "dog"
+scope = "city"
+`)
+		if binding == orderBinding {
+			writeFile(t, filepath.Join(packDir, "orders", "digest.toml"), `
+[order]
+formula = "test-formula"
+trigger = "cooldown"
+interval = "24h"
+pool = "dog"
+`)
+			writeFile(t, filepath.Join(packDir, "formulas", "test-formula.formula.toml"), string(formulaText))
+		}
+		packToml.WriteString(`
+[imports.` + binding + `]
+source = "./packs/` + binding + `"
+`)
+	}
+
+	writeFile(t, filepath.Join(cityDir, "pack.toml"), packToml.String())
+}
+
+func loadImportedDogOrders(t *testing.T, cityDir string) (*config.City, []orders.Order) {
+	t.Helper()
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	aa, err := scanAllOrders(cityDir, cfg, &stderr, "gc order list")
+	if err != nil {
+		t.Fatalf("scanAllOrders: %v; stderr: %s", err, stderr.String())
+	}
+	if len(aa) != 1 {
+		t.Fatalf("scanAllOrders() len = %d, want 1 (%#v)", len(aa), aa)
+	}
+	return cfg, aa
 }
 
 // memRecorder records events in memory for test assertions.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -125,6 +125,49 @@ func TestOrderDispatchCooldownDue(t *testing.T) {
 	}
 }
 
+// TestOrderDispatchResolvesPackBindingForPool reproduces issue #1268: a
+// pack-imported agent has BindingName set, so its qualified name is
+// "binding.name". A city-level order with pool="<name>" must resolve to the
+// binding-qualified value at dispatch so the wisp's gc.routed_to matches what
+// the scaler queries via Agent.QualifiedName().
+func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
+	store := beads.NewMemStore()
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "maintenance"},
+		},
+	}
+
+	aa := []orders.Order{{
+		Name:         "mol-dog-doctor",
+		Trigger:      "cooldown",
+		Interval:     "5m",
+		Formula:      "test-formula",
+		Pool:         "dog",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+
+	m := &memoryOrderDispatcher{
+		aa: aa,
+		storeFn: func(_ execStoreTarget) (beads.Store, error) {
+			return store, nil
+		},
+		execRun: shellExecRunner,
+		rec:     events.Discard,
+		stderr:  &bytes.Buffer{},
+		cfg:     cfg,
+	}
+
+	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	work := workBeadByOrderLabel(t, store, "order-run:mol-dog-doctor")
+	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
+		t.Errorf("gc.routed_to = %q, want %q (pack binding must qualify pool target)", got, "maintenance.dog")
+	}
+}
+
 func TestOrderDispatchCooldownNotDue(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -1860,18 +1903,63 @@ func TestRigExclusiveLayersNoCityPrefix(t *testing.T) {
 }
 
 func TestQualifyPool(t *testing.T) {
+	cityBindingCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog", BindingName: "maintenance"},
+	}}
+	cityNoBindingCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog"},
+	}}
+	rigBindingCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog", BindingName: "foo", Dir: "api"},
+	}}
+	ambiguousCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog", BindingName: "gastown"},
+		{Name: "dog", BindingName: "maintenance"},
+	}}
+	dirIsolatedCfg := &config.City{Agents: []config.Agent{
+		// City-level binding agent should NOT match a rig-scoped order.
+		{Name: "dog", BindingName: "maintenance"},
+	}}
+
 	tests := []struct {
-		pool, rig, want string
+		name      string
+		cfg       *config.City
+		pool, rig string
+		want      string
 	}{
-		{"polecat", "demo-repo", "demo-repo/polecat"},
-		{"demo-repo/polecat", "demo-repo", "demo-repo/polecat"}, // already qualified
-		{"dog", "", "dog"}, // city order
+		// Existing behavior preserved when cfg is nil (call sites that
+		// don't have a loaded city, e.g. TestOrderRun fixtures).
+		{"nil cfg city order", nil, "dog", "", "dog"},
+		{"nil cfg rig order", nil, "polecat", "demo-repo", "demo-repo/polecat"},
+		{"nil cfg pre-rig-qualified", nil, "demo-repo/polecat", "demo-repo", "demo-repo/polecat"},
+
+		// Already-qualified passthroughs.
+		{"already rig-qualified passthrough", cityBindingCfg, "demo-repo/dog", "", "demo-repo/dog"},
+		{"already binding-qualified passthrough", cityBindingCfg, "maintenance.dog", "", "maintenance.dog"},
+		{"binding-qualified gets rig prefix", cityBindingCfg, "maintenance.dog", "api", "api/maintenance.dog"},
+
+		// City-order binding lookup (the bug fix).
+		{"city order resolves binding", cityBindingCfg, "dog", "", "maintenance.dog"},
+		{"city order no binding agent", cityNoBindingCfg, "dog", "", "dog"},
+		{"city order miss falls through", cityBindingCfg, "wolf", "", "wolf"},
+
+		// Rig-order binding lookup.
+		{"rig order resolves binding", rigBindingCfg, "dog", "api", "api/foo.dog"},
+		{"rig order isolated from city agent", dirIsolatedCfg, "dog", "api", "api/dog"},
+
+		// Ambiguity falls back to unqualified to avoid silent picks.
+		{"ambiguous bindings fall through", ambiguousCfg, "dog", "", "dog"},
+
+		// Empty/edge cases.
+		{"empty cfg agents", &config.City{}, "dog", "", "dog"},
 	}
 	for _, tt := range tests {
-		got := qualifyPool(tt.pool, tt.rig)
-		if got != tt.want {
-			t.Errorf("qualifyPool(%q, %q) = %q, want %q", tt.pool, tt.rig, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := qualifyPool(tt.pool, tt.rig, tt.cfg)
+			if got != tt.want {
+				t.Errorf("qualifyPool(%q, %q, cfg) = %q, want %q", tt.pool, tt.rig, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/orders/runtime_helpers_test.go
+++ b/internal/orders/runtime_helpers_test.go
@@ -1,0 +1,55 @@
+package orders
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestLastRunFuncForStoreReturnsLatestRun(t *testing.T) {
+	store := beads.NewMemStore()
+
+	first, err := store.Create(beads.Bead{
+		Title:  "order:digest",
+		Status: "closed",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	second, err := store.Create(beads.Bead{
+		Title:  "order:digest",
+		Status: "closed",
+		Labels: []string{"order-run:digest", "wisp-failed"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LastRunFuncForStore(store)("digest")
+	if err != nil {
+		t.Fatalf("LastRunFuncForStore(): %v", err)
+	}
+	if !got.Equal(second.CreatedAt) {
+		t.Fatalf("LastRunFuncForStore() = %s, want %s (latest run should remain authoritative)", got, second.CreatedAt)
+	}
+	if !second.CreatedAt.After(first.CreatedAt) {
+		t.Fatalf("test setup invalid: second.CreatedAt=%s, first.CreatedAt=%s", second.CreatedAt, first.CreatedAt)
+	}
+}
+
+func TestLastRunFuncForStoreReturnsZeroWhenNoRunsExist(t *testing.T) {
+	store := beads.NewMemStore()
+
+	got, err := LastRunFuncForStore(store)("digest")
+	if err != nil {
+		t.Fatalf("LastRunFuncForStore(): %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("LastRunFuncForStore() = %s, want zero time", got)
+	}
+}


### PR DESCRIPTION
## Summary

Pack-imported orders declare `pool = \"<name>\"` (e.g. `pool = \"dog\"`), but
the dispatch path stamped the bare name onto `gc.routed_to`. The agent's
default `scale_check` queries via `Agent.QualifiedName()` which includes the
binding prefix (e.g. `gastown.dog`/`maintenance.dog`), so the scaler returned
0 forever and beads piled up on every cooldown tick.

Fixes #1268.

## Repro

Confirmed independently in the wild by @bsandmann on stock gascity 1.0.0 +
gastown pack. The 24h-cooldown periodic order `mol-digest-generate` stamped
4 beads with `gc.routed_to: dog`, scaler queried `gc.routed_to=gastown.dog`,
mismatch is the entire signal:

```
$ bd ready --metadata-field gc.routed_to=gastown.dog --unassigned --json | jq length
0   # what the scaler asks for

$ bd ready --metadata-field gc.routed_to=dog --unassigned --json | jq length
4   # what's actually there
```

Detected by deacon's doctor patrol as `stale-routed-config: routes to missing
config target \"dog\"`.

## Fix

`qualifyPool` (`cmd/gc/order_dispatch.go`) now takes the city config and
resolves binding qualification at dispatch time. Three layers stack:

1. Pool already contains `/` → pass through (rig-qualified).
2. Pool already contains `.` → pass through binding side; stack rig prefix
   if present.
3. Otherwise look up `cfg.Agents` by `Dir == rig && Name == pool`. If
   exactly one match has a non-empty `BindingName`, swap pool for the
   canonical `BindingQualifiedName()` (`binding.name`) before any rig
   prefixing.

Ambiguity (multiple matching agents with different bindings) falls back to
the unqualified pool to avoid silently picking by slice declaration order.
`nil cfg` preserves the rig-only behavior so call sites without a loaded
city remain stable.

All 6 production call sites updated (`order_dispatch.go` × 3,
`cmd_order.go` × 3 — hoisted to a single binding for DRY).

## Scope

**Forward-only.** In-flight beads stamped pre-fix continue to require
manual remediation. Doctor auto-heal is out of scope here.

The `gastown` pack's `mol-deacon-patrol.toml` formula has a separate
pre-existing issue: prompt instructions hardcode `gc.routed_to=dog` for
both reads (`bd list --metadata-field`) and writes (`bd create --set-metadata`).
This was already broken pre-fix — bare \"dog\" never matched any scaler. Will
file as a follow-up since a proper fix needs a binding-aware template
variable (the pack doesn't know its importer's binding name at authoring
time).

## Test plan

- [x] `TestQualifyPool` extended from 3 → 13 cases covering: nil-cfg
      passthroughs, pre-rig-qualified, pre-binding-qualified (with and
      without rig stack), city-order binding lookup, no-binding agent
      fallback, lookup miss, rig-order binding lookup, dir-isolation,
      multi-binding ambiguity fallback, empty cfg.
- [x] `TestOrderDispatchResolvesPackBindingForPool` exercises the full
      `m.dispatch` → `dispatchOne` → `dispatchWisp` → `store.Update` write
      path with a binding-named agent, asserts `gc.routed_to ==
      \"maintenance.dog\"`.
- [x] `go test ./...` clean.
- [x] `go vet ./...` clean.
- [x] `make build`, `make check` clean.

## Review

Multi-model verification before push:
- **Codex** (gpt-5.4) and **Copilot** (gpt-5.3-codex) independently verified
  6 correctness questions: hoist preserves `m.cfg` invariant, `\".\"` heuristic
  safe (no checked-in TOML pool names contain `\".\"`),
  `ParseQualifiedName(\"binding.name\")` returns `(\"\", \"binding.name\")` so
  `orderRigSuspended` fallback to `a.Rig` still works, ambiguity branch
  reachable via `cmd_agent.go` `loadCityConfig` (which skips
  `ValidateAgents`), test exercises real production write path, read side
  in `pool_desired_state.go` does exact match against
  `agent.QualifiedName()`.
- Three Anthropic specialists (reuse / quality / efficiency) flagged 2
  minors which are addressed in the second commit.

## Risks

- The 6 `examples/{dolt,gastown}/orders/*.toml` orders that ship `pool =
  \"dog\"` will now stamp `<binding>.dog` instead of bare `dog`. This is
  the intended fix — they were broken before. No example will newly error.
- CLI output of `gc order run` for pool-routed orders changes: `→
  gc.routed_to=<binding>.dog` instead of `→ gc.routed_to=dog`.